### PR TITLE
refactor(app): split App.tsx into lazy-panel, modal-host, bootstrap modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,8 +37,6 @@ import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
 import { useKeepMounted } from "./hooks/useKeepMounted";
-import { stashViewFileRequest } from "./components/FileViewer/pendingViewFileRequest";
-import { stashViewDiffRequest } from "./components/Worktree/pendingViewDiffRequest";
 import { useMcpBridge } from "./hooks/useMcpBridge";
 import { useMcpAnomalyStats } from "./hooks/useMcpAnomalyStats";
 import { usePluginBridge } from "./hooks/usePluginBridge";
@@ -92,6 +90,7 @@ import { TooltipProvider } from "./components/ui/tooltip";
 import { primeRadix } from "./components/ui/radix-loader";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 import { useE2EBridges } from "./hooks/app/useE2EBridges";
+import { useModalResetKeys } from "./hooks/app/useModalResetKeys";
 
 import {
   loadJetbrainsMono500,
@@ -167,15 +166,6 @@ import {
   usePreferencesStore,
   usePluginManagerStore,
 } from "./store";
-import { useRecipeConflictStore } from "./store/recipeConflictStore";
-import { useGitPushConfirmStore } from "./store/gitPushConfirmStore";
-import { useGitPullRebaseConfirmStore } from "./store/gitPullRebaseConfirmStore";
-import { usePanelLimitStore } from "./store/panelLimitStore";
-import { useMcpConfirmStore } from "./store/mcpConfirmStore";
-import { usePluginConfirmStore } from "./store/pluginConfirmStore";
-import { usePluginMcpConfirmStore } from "./store/pluginMcpConfirmStore";
-import { usePluginCapabilityConfirmStore } from "./store/pluginCapabilityConfirmStore";
-import { useDiagnosticsReviewStore } from "./store/diagnosticsReviewStore";
 // Eager side-effect import: auto-discovers every built-in plugin renderer and
 // registers its builtin view slots at module-eval time, before first render.
 // Must stay static — a deferred/idle import races the user, so getBuiltinView
@@ -387,54 +377,20 @@ function AppInner() {
     if (isStateLoaded) removeStartupSkeleton();
   }, [isStateLoaded]);
 
-  // ErrorBoundary reset signals for the always-mounted dialog hosts (#9918).
-  // A static `[Number(isStateLoaded)]` collapses to `[1]` after hydration and
-  // never changes, so a host that crashes once stays dead for the session (and
-  // its deferred promise leaks). Each host instead resets on its own
-  // pending-request signal, so a fresh request remounts the crashed boundary:
-  //   - request-counter stores bump `requestSeq` on every request (covers the
-  //     back-to-back supersede case where `pendingConfirm` never returns to null)
-  //   - FIFO-queue stores key off the live `current.requestId` UUID
-  //   - the diagnostics host toggles on its own `isOpen`
-  //   - the event-driven hosts (terminal-info, file-viewer) hold no store state,
-  //     so a local counter increments on each open event below.
-  const gitPushResetKey = useGitPushConfirmStore((s) => s.requestSeq);
-  const gitPullRebaseResetKey = useGitPullRebaseConfirmStore((s) => s.requestSeq);
-  const panelLimitResetKey = usePanelLimitStore((s) => s.requestSeq);
-  const recipeConflictResetKey = useRecipeConflictStore((s) => s.requestSeq);
-  const mcpConfirmResetKey = useMcpConfirmStore((s) => s.current?.requestId ?? "");
-  const pluginConfirmResetKey = usePluginConfirmStore((s) => s.current?.requestId ?? "");
-  const pluginMcpConfirmResetKey = usePluginMcpConfirmStore((s) => s.current?.requestId ?? "");
-  const pluginCapabilityConfirmResetKey = usePluginCapabilityConfirmStore(
-    (s) => s.current?.requestId ?? ""
-  );
-  const diagnosticsReviewResetKey = useDiagnosticsReviewStore((s) => s.requestSeq);
-  const [terminalInfoResetKey, setTerminalInfoResetKey] = useState(0);
-  const [fileViewerResetKey, setFileViewerResetKey] = useState(0);
-  const [diffViewerResetKey, setDiffViewerResetKey] = useState(0);
-  useEffect(() => {
-    const onTerminalInfo = () => setTerminalInfoResetKey((k) => k + 1);
-    const onViewFile = (e: Event) => {
-      // Stash for FileViewerModalHost's mount replay — the host's own listener
-      // lives in a lazy chunk and may not be registered yet.
-      stashViewFileRequest(e);
-      setFileViewerResetKey((k) => k + 1);
-    };
-    const onViewDiff = (e: Event) => {
-      // Stash for DiffViewerModalHost's mount replay — same lazy-chunk race as
-      // the file viewer above.
-      stashViewDiffRequest(e);
-      setDiffViewerResetKey((k) => k + 1);
-    };
-    window.addEventListener("daintree:open-terminal-info", onTerminalInfo);
-    window.addEventListener("daintree:view-file", onViewFile);
-    window.addEventListener("daintree:view-diff", onViewDiff);
-    return () => {
-      window.removeEventListener("daintree:open-terminal-info", onTerminalInfo);
-      window.removeEventListener("daintree:view-file", onViewFile);
-      window.removeEventListener("daintree:view-diff", onViewDiff);
-    };
-  }, []);
+  const {
+    gitPushResetKey,
+    gitPullRebaseResetKey,
+    panelLimitResetKey,
+    recipeConflictResetKey,
+    mcpConfirmResetKey,
+    pluginConfirmResetKey,
+    pluginMcpConfirmResetKey,
+    pluginCapabilityConfirmResetKey,
+    diagnosticsReviewResetKey,
+    terminalInfoResetKey,
+    fileViewerResetKey,
+    diffViewerResetKey,
+  } = useModalResetKeys();
   // Cross-project focus intent receiver. Subscribes unconditionally so the
   // listener is registered before `notifyViewPainted` fires, then defers the
   // local `agent.focusNextWaiting` dispatch until hydration completes (the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,6 @@ import { usePluginAgents } from "./hooks/usePluginAgents";
 import { usePluginKeybindings } from "./hooks/usePluginKeybindings";
 import { usePluginMcpConsentBridge } from "./hooks/usePluginMcpConsentBridge";
 import { usePluginCapabilityConsentBridge } from "./hooks/usePluginCapabilityConsentBridge";
-import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
 
 import { useActionPalette } from "./hooks/useActionPalette";
@@ -42,26 +41,13 @@ import { useMcpAnomalyStats } from "./hooks/useMcpAnomalyStats";
 import { usePluginBridge } from "./hooks/usePluginBridge";
 import { usePluginPromptBridge } from "./hooks/usePluginPromptBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
-import { notifyViewPainted, removeStartupSkeleton } from "./utils/removeStartupSkeleton";
-import { useAppBoot } from "./hooks/app/useAppBoot";
-import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
+import { notifyViewPainted } from "./utils/removeStartupSkeleton";
 import {
-  useAppHydration,
-  useShortcutHints,
   usePanelStoreBootstrap,
   useSemanticWorkerLifecycle,
   useCloudSyncWarning,
   useRosettaWarning,
   useAccessibilityAnnouncements,
-  useGettingStartedChecklist,
-  useOrchestrationMilestones,
-  useAgentWaitingNudge,
-  useForgeEnableRecommendation,
-  useFocusOnActivateIntent,
-  useBackgroundWindowResize,
-  useClearSwitchBusyStateOnReveal,
-  usePluginDeepLink,
-  useNotificationHistoryPruning,
   useUnloadCleanup,
   useHomeDir,
   usePerformanceMonitors,
@@ -87,49 +73,32 @@ import { AccessibilityAnnouncer } from "./components/Accessibility/Accessibility
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
-import { primeRadix } from "./components/ui/radix-loader";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 import { useE2EBridges } from "./hooks/app/useE2EBridges";
 import { useModalResetKeys } from "./hooks/app/useModalResetKeys";
+import { useAppBootstrap } from "./hooks/app/useAppBootstrap";
 
 import {
-  loadJetbrainsMono500,
-  loadJetbrainsMono600,
-  preloadFileViewerModal,
   LazyWelcomeScreen,
   preloadSettingsDialog,
   LazySettingsDialog,
-  preloadWorktreePalette,
   LazyWorktreePalette,
-  preloadWorktreeOverviewModal,
   LazyWorktreeOverviewModal,
-  preloadQuickCreatePalette,
   LazyQuickCreatePalette,
-  preloadCrossWorktreeDiff,
   LazyCrossWorktreeDiff,
-  preloadNewTerminalPalette,
   LazyNewTerminalPalette,
-  preloadSendToAgentPalette,
   LazySendToAgentPalette,
-  preloadPanelPalette,
   LazyPanelPalette,
-  preloadActionPalette,
   LazyActionPalette,
-  preloadQuickSwitcher,
   LazyQuickSwitcher,
-  preloadProjectSwitcherPalette,
   LazyProjectSwitcherPalette,
   LazyGitInitDialog,
   LazyCloneRepoDialog,
   LazyCreateProjectFolderDialog,
-  preloadThemePalette,
   LazyThemePalette,
   LazyResumeSessionsPalette,
-  preloadLogLevelPalette,
   LazyLogLevelPalette,
-  preloadShortcutReferenceDialog,
   LazyShortcutReferenceDialog,
-  preloadPluginManagerView,
   LazyPluginManagerView,
   LazyOnboardingFlow,
   LazyGettingStartedChecklist,
@@ -162,7 +131,6 @@ import {
   useWorktreeSelectionStore,
   useProjectStore,
   usePaletteStore,
-  useNotificationSettingsStore,
   usePreferencesStore,
   usePluginManagerStore,
 } from "./store";
@@ -180,7 +148,7 @@ import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { useRenderProfiler } from "./utils/renderProfiler";
 import { logError } from "./utils/logger";
 
-import { SidebarContent, preloadNewWorktreeDialog, E2EFaultInjector } from "./components/Sidebar";
+import { SidebarContent, E2EFaultInjector } from "./components/Sidebar";
 import { ensureHydrationBootstrap } from "./utils/stateHydration/bootstrapGuard";
 
 // Kick the hydration-bootstrap IPC pair (keybinding overrides + user-agent
@@ -347,35 +315,16 @@ function AppInner() {
 
   usePerformanceMonitors();
 
-  // Batched cold-start payload — replaces the legacy fan-out of
-  // crash-recovery:get-pending + crash-recovery:get-config + app:hydrate +
-  // terminal-config:get into a single IPC round-trip (#8620). The IPC is fired
-  // at module-eval time and read here via `use()` (#8820); a boot failure
-  // resolves to `{ ok: false }` so the app still renders its cold-start chrome.
-  const safeBoot = useAppBoot();
-  const bootResult = safeBoot.ok ? safeBoot.result : null;
-
-  // Crash recovery gate — must resolve before hydration runs
   const {
-    state: crashState,
-    resolve: resolveCrash,
-    updateConfig: updateCrashConfig,
-  } = useCrashRecoveryGate(bootResult);
-
-  const crashResolved = crashState.status !== "loading" && crashState.status !== "pending";
-
-  // When crash recovery was pending at boot, the resolve path (`restoreBackup`
-  // or `resetToFresh` in CrashRecoveryService) mutates `store.appState` after
-  // `bootResult` was captured. Passing the stale prefetched payload would
-  // hydrate from the pre-resolution terminal list and skip the one-shot
-  // `consumePanelFilter` the restore path queued. Force the live IPC path in
-  // that case so hydration reads the post-resolution store.
-  const hadPendingCrash = bootResult?.crashPending != null;
-  // App lifecycle hooks
-  const { isStateLoaded } = useAppHydration(crashResolved, hadPendingCrash ? null : bootResult);
-  useEffect(() => {
-    if (isStateLoaded) removeStartupSkeleton();
-  }, [isStateLoaded]);
+    bootResult,
+    crashState,
+    resolveCrash,
+    updateCrashConfig,
+    crashResolved,
+    isStateLoaded,
+    pluginDeepLink,
+    gettingStarted,
+  } = useAppBootstrap();
 
   const {
     gitPushResetKey,
@@ -391,115 +340,6 @@ function AppInner() {
     fileViewerResetKey,
     diffViewerResetKey,
   } = useModalResetKeys();
-  // Cross-project focus intent receiver. Subscribes unconditionally so the
-  // listener is registered before `notifyViewPainted` fires, then defers the
-  // local `agent.focusNextWaiting` dispatch until hydration completes (the
-  // paint signal arrives before panel state is loaded — a direct dispatch
-  // would silently no-op against an empty panelStore).
-  useFocusOnActivateIntent(isStateLoaded);
-  // Background window-resize receiver — keeps PTY geometry tracking the
-  // window while this project view is detached (#10415).
-  useBackgroundWindowResize();
-  // Clears the stale switch busy flags when this cached view is reactivated, so
-  // a view that switched away never resurfaces a stuck ProjectSwitcher spinner
-  // on return (#10736).
-  useClearSwitchBusyStateOnReveal();
-  // `daintree://` deep-link receiver (#9559). Surfaces the intent once hydration
-  // settles; the effect below opens the Plugin Manager, which consumes it.
-  const pluginDeepLink = usePluginDeepLink(isStateLoaded);
-  useEffect(() => {
-    if (!pluginDeepLink.intent) return;
-    // Opening the manager also closes Settings via the open-transition effect
-    // above, so the two surfaces don't stack when the deep link arrives.
-    usePluginManagerStore.getState().open();
-  }, [pluginDeepLink.intent]);
-  // The skeleton is z-index 9999 and intercepts pointer events. The crash
-  // recovery dialog is rendered before hydration completes, so without this
-  // the dialog would be visible but unclickable until hydration finishes
-  // (which it can't, since the user must resolve the crash first).
-  useEffect(() => {
-    if (crashState.status === "pending" || crashState.status === "failed") {
-      removeStartupSkeleton();
-    }
-  }, [crashState.status]);
-  useEffect(() => {
-    void useNotificationSettingsStore.getState().hydrate();
-    // Subscribe to OS DND transitions before hydrate resolves so a transition
-    // mid-hydration cannot be missed. Push events from main are tolerant of
-    // an `undefined` namespace at preload (renderer harness in tests).
-    const unsubscribe = window.electron?.osDnd?.onStateChanged?.((payload) => {
-      useNotificationSettingsStore.getState().setOsDndActive(payload.osDndActive);
-    });
-    return () => unsubscribe?.();
-  }, []);
-  // Defers the post-hydration housekeeping IPC reads (shortcut-hint counts,
-  // milestones, forge-recommendation plugin/remotes probes) out of the
-  // synchronous isStateLoaded effect flush: their sends would otherwise land
-  // on main ahead of the loaded-frame paint and compete with the
-  // deferred-services drain. The flag flips from the background-priority task
-  // below, so the gated hooks hydrate at idle; each reconciles current store
-  // state on attach, so nothing observable is lost in the gap.
-  const [idleHousekeepingReady, setIdleHousekeepingReady] = useState(false);
-  useShortcutHints(isStateLoaded && idleHousekeepingReady);
-  const gettingStarted = useGettingStartedChecklist(isStateLoaded);
-  const onboardingOverlayActive = gettingStarted.visible || gettingStarted.showCelebration;
-  useUpdateListener(onboardingOverlayActive);
-  useOrchestrationMilestones(isStateLoaded && idleHousekeepingReady);
-  useAgentWaitingNudge(isStateLoaded);
-  useForgeEnableRecommendation(isStateLoaded && idleHousekeepingReady);
-  useNotificationHistoryPruning();
-
-  useEffect(() => {
-    if (!isStateLoaded) return;
-
-    const controller = new AbortController();
-
-    const execute = () => {
-      if (controller.signal.aborted) return;
-      setIdleHousekeepingReady(true);
-      void preloadSettingsDialog();
-      void preloadNewWorktreeDialog();
-      void preloadActionPalette();
-      void preloadQuickSwitcher();
-      preloadProjectSwitcherPalette().catch(() => {});
-      void preloadWorktreePalette();
-      void preloadNewTerminalPalette();
-      void preloadPanelPalette();
-      void preloadThemePalette();
-      void preloadSendToAgentPalette();
-      void preloadQuickCreatePalette();
-      void preloadLogLevelPalette();
-      void preloadPluginManagerView();
-      void preloadWorktreeOverviewModal();
-      void preloadShortcutReferenceDialog();
-      void preloadCrossWorktreeDiff();
-      loadJetbrainsMono500().catch(() => {});
-      loadJetbrainsMono600().catch(() => {});
-      // Warm the FileViewerModal/DiffViewer chunk split out of the eager
-      // closure (#8626). It is reached through a lazy boundary in
-      // `Worktree/FileDiffModal.tsx`, so an explicit post-paint prefetch keeps
-      // it snappy on first use.
-      preloadFileViewerModal().catch(() => {});
-      // Warm the shared Radix overlay primitives chunk (`radix-deferred`) so the
-      // ProjectSwitcherPalette popover and context menus are ready on first
-      // interaction in a freshly loaded project view. Otherwise this chunk is
-      // only demand-loaded on the first pointer/focus gesture (#10752). Each
-      // WebContentsView has its own module cache, so this fires per view.
-      primeRadix().catch(() => {});
-    };
-
-    if (typeof scheduler !== "undefined" && typeof scheduler.postTask === "function") {
-      void scheduler
-        .postTask(execute, { priority: "background", signal: controller.signal })
-        .catch(() => {});
-    } else {
-      const id = requestIdleCallback(execute, { timeout: 5000 });
-      const cancel = () => cancelIdleCallback(id);
-      controller.signal.addEventListener("abort", cancel, { once: true });
-    }
-
-    return () => controller.abort();
-  }, [isStateLoaded]);
 
   const handlePreloadSettings = useCallback(() => {
     void preloadSettingsDialog();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,9 +91,9 @@ import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { primeRadix } from "./components/ui/radix-loader";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
+import { useE2EBridges } from "./hooks/app/useE2EBridges";
 
 import {
-  loadE2ENotificationBackdoor,
   loadJetbrainsMono500,
   loadJetbrainsMono600,
   preloadFileViewerModal,
@@ -162,15 +162,11 @@ import {
   usePanelStore,
   useWorktreeSelectionStore,
   useProjectStore,
-  useErrorStore,
   usePaletteStore,
   useNotificationSettingsStore,
   usePreferencesStore,
   usePluginManagerStore,
-  useDiagnosticsStore,
-  usePerformanceModeStore,
 } from "./store";
-import { usePerfMetricsStore } from "./store/perfMetricsStore";
 import { useRecipeConflictStore } from "./store/recipeConflictStore";
 import { useGitPushConfirmStore } from "./store/gitPushConfirmStore";
 import { useGitPullRebaseConfirmStore } from "./store/gitPullRebaseConfirmStore";
@@ -189,7 +185,7 @@ import { useShallow } from "zustand/react/shallow";
 import { LazyMotion, MotionConfig } from "framer-motion";
 import { useMacroFocusStore } from "./store/macroFocusStore";
 import type { BuiltInPanelKind } from "./types";
-import { actionService, installE2EActionDispatchBridge } from "./services/ActionService";
+import { actionService } from "./services/ActionService";
 import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { useRenderProfiler } from "./utils/renderProfiler";
 import { logError } from "./utils/logger";
@@ -211,90 +207,7 @@ function AppInner() {
   useUnloadCleanup();
   useResourceProfile();
 
-  useEffect(() => {
-    installE2EActionDispatchBridge();
-  }, []);
-
-  useEffect(() => {
-    // All E2E renderer backdoors are gated on the preload-injected
-    // __DAINTREE_E2E_MODE__ flag (set only under DAINTREE_E2E_MODE=1 on
-    // non-packaged builds) so none of these store accessors attach in
-    // production sessions.
-    if (window.__DAINTREE_E2E_MODE__ === true) {
-      window.__DAINTREE_E2E_ERROR_STORE__ = () =>
-        useErrorStore.getState().errors.map((e) => ({
-          id: e.id,
-          source: e.source,
-          message: e.message,
-          fromPreviousSession: e.fromPreviousSession,
-        }));
-      window.__DAINTREE_E2E_ADD_ERROR__ = (message: string) => {
-        useErrorStore.getState().addError({
-          type: "unknown",
-          message,
-          retryability: "none",
-          source: "e2e-test",
-        });
-      };
-      window.__DAINTREE_E2E_CLEAR_ERRORS__ = () => {
-        useErrorStore.getState().reset();
-      };
-      // Parks a synthetic in-repo recipe stale-write conflict so E2E can exercise
-      // the RecipeConflictDialog without racing a real on-disk file mutation. The
-      // returned promise resolves with the user's choice; tests don't await it —
-      // they assert the dialog renders and that reload/overwrite dismiss it.
-      window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__ = (recipeName: string) => {
-        void useRecipeConflictStore.getState().requestConflict({
-          recipeId: `inrepo-${recipeName}`,
-          recipeName,
-          updates: { name: recipeName },
-        });
-      };
-
-      // Per-window store accessors for the multi-window isolation spec (#9599).
-      // Each project view is its own V8 context, so these Zustand singletons are
-      // per-window — mutating one window's store must not leak into another's.
-      window.__DAINTREE_E2E_DIAGNOSTICS_STATE__ = () => ({
-        isOpen: useDiagnosticsStore.getState().isOpen,
-      });
-      window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__ = () => useDiagnosticsStore.getState().openDock();
-      window.__DAINTREE_E2E_PERF_METRICS_STATE__ = () => {
-        const s = usePerfMetricsStore.getState();
-        return { fps: s.fps, lafCount30s: s.lafCount30s, cls30s: s.cls30s };
-      };
-      window.__DAINTREE_E2E_SET_PERF_METRIC__ = (fps: number) =>
-        usePerfMetricsStore.getState().setLiveMetrics({ fps, lafCount30s: 0, cls30s: 0 });
-      window.__DAINTREE_E2E_PERF_MODE_STATE__ = () => ({
-        performanceMode: usePerformanceModeStore.getState().performanceMode,
-      });
-      window.__DAINTREE_E2E_SET_PERF_MODE__ = (enabled: boolean) =>
-        usePerformanceModeStore.getState().setPerformanceMode(enabled);
-
-      // Lazy-load the notification backdoor only under E2E so its module closure
-      // stays out of the production first-paint chunk. Fire-and-forget: the helper
-      // side in e2e/helpers/notifications.ts waits for __daintreeNotificationsE2E
-      // before use, so the async resolve doesn't need to block the effect.
-      void loadE2ENotificationBackdoor()
-        .then(({ installE2ENotificationBackdoor }) => {
-          installE2ENotificationBackdoor();
-        })
-        .catch(() => {});
-    }
-
-    return () => {
-      delete window.__DAINTREE_E2E_ERROR_STORE__;
-      delete window.__DAINTREE_E2E_ADD_ERROR__;
-      delete window.__DAINTREE_E2E_CLEAR_ERRORS__;
-      delete window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__;
-      delete window.__DAINTREE_E2E_DIAGNOSTICS_STATE__;
-      delete window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__;
-      delete window.__DAINTREE_E2E_PERF_METRICS_STATE__;
-      delete window.__DAINTREE_E2E_SET_PERF_METRIC__;
-      delete window.__DAINTREE_E2E_PERF_MODE_STATE__;
-      delete window.__DAINTREE_E2E_SET_PERF_MODE__;
-      delete window.__daintreeNotificationsE2E;
-    };
-  }, []);
+  useE2EBridges();
 
   const { crossDiffDialog, closeCrossWorktreeDiff } = useWorktreeSelectionStore(
     useShallow((state) => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,6 @@ import "@xterm/xterm/css/xterm.css";
 import {
   isElectronAvailable,
   useAgentLauncher,
-  useWorktrees,
-  useNewTerminalPalette,
-  usePanelPalette,
-  useProjectSwitcherPalette,
   useTerminalConfig,
   useAppThemeConfig,
   useGlobalKeybindings,
@@ -29,12 +25,6 @@ import { usePluginMcpConsentBridge } from "./hooks/usePluginMcpConsentBridge";
 import { usePluginCapabilityConsentBridge } from "./hooks/usePluginCapabilityConsentBridge";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
 
-import { useActionPalette } from "./hooks/useActionPalette";
-import { useQuickSwitcher } from "./hooks/useQuickSwitcher";
-import { useWorktreePalette } from "./hooks/useWorktreePalette";
-import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
-import { useDoubleShift } from "./hooks/useDoubleShift";
-import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
 import { useKeepMounted } from "./hooks/useKeepMounted";
 import { useMcpBridge } from "./hooks/useMcpBridge";
 import { useMcpAnomalyStats } from "./hooks/useMcpAnomalyStats";
@@ -70,13 +60,13 @@ import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
 import { useResumeAgentSession } from "./hooks/useResumeAgentSession";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
-import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 import { useE2EBridges } from "./hooks/app/useE2EBridges";
 import { useModalResetKeys } from "./hooks/app/useModalResetKeys";
 import { useAppBootstrap } from "./hooks/app/useAppBootstrap";
+import { usePaletteWiring } from "./hooks/app/usePaletteWiring";
 
 import {
   LazyWelcomeScreen,
@@ -199,15 +189,32 @@ function AppInner() {
   // Grid navigation hook for directional terminal switching
   const { findNearest, findByIndex, findDockByIndex, getCurrentLocation } = useGridNavigation();
 
-  const { worktrees, worktreeMap, isLoading } = useWorktrees();
-  const newTerminalPalette = useNewTerminalPalette({ worktreeMap });
-  const panelPalette = usePanelPalette();
-  const projectSwitcherPalette = useProjectSwitcherPalette();
-  const actionPalette = useActionPalette();
-  const quickSwitcher = useQuickSwitcher();
-  const sendToAgentPalette = useSendToAgentPalette();
-  useDoubleShift(actionPalette.toggle);
-  useProjectMruSwitcher();
+  const {
+    worktrees,
+    isLoading,
+    newTerminalPalette,
+    panelPalette,
+    projectSwitcherPalette,
+    actionPalette,
+    quickSwitcher,
+    sendToAgentPalette,
+    worktreePalette,
+    quickCreatePalette,
+    isThemePaletteOpen,
+    isLogLevelPaletteOpen,
+    isResumeSessionsPaletteOpen,
+    isProjectSwitcherModalOpen,
+    shouldMountQuickSwitcher,
+    shouldMountSendToAgentPalette,
+    shouldMountNewTerminalPalette,
+    shouldMountWorktreePalette,
+    shouldMountQuickCreatePalette,
+    shouldMountPanelPalette,
+    shouldMountThemePalette,
+    shouldMountResumeSessionsPalette,
+    shouldMountLogLevelPalette,
+    shouldMountActionPalette,
+  } = usePaletteWiring();
   const currentProject = useProjectStore((state) => state.currentProject);
   const gitInitDialogOpen = useProjectStore((state) => state.gitInitDialogOpen);
   const gitInitDirectoryPath = useProjectStore((state) => state.gitInitDirectoryPath);
@@ -245,9 +252,6 @@ function AppInner() {
   useAgentActivityBroadcast();
   const resumeSession = useResumeAgentSession();
 
-  const worktreePalette = useWorktreePalette({ worktrees });
-  const quickCreatePalette = useQuickCreatePalette();
-
   const {
     isSettingsOpen,
     settingsTab,
@@ -278,8 +282,6 @@ function AppInner() {
     prevPluginManagerOpenRef.current = isPluginManagerOpen;
     if (!wasOpen && isPluginManagerOpen) setIsSettingsOpen(false);
   }, [isPluginManagerOpen, setIsSettingsOpen]);
-  const isThemePaletteOpen = usePaletteStore((state) => state.activePaletteId === "theme");
-  const isLogLevelPaletteOpen = usePaletteStore((state) => state.activePaletteId === "log-level");
   const {
     isWorktreeOverviewOpen,
     toggleWorktreeOverview,
@@ -287,26 +289,6 @@ function AppInner() {
     closeWorktreeOverview,
   } = useWorktreeOverview();
 
-  // Keep each palette/dialog mounted after its first open so its exit animation
-  // (driven by useAnimatedPresence) can run — gating directly on `isOpen`
-  // unmounts in the same React commit that flips it false, killing the exit
-  // (#9917). The component still receives `isOpen` and gates its own DOM via
-  // `shouldRender`.
-  const isProjectSwitcherModalOpen =
-    projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal";
-  const shouldMountQuickSwitcher = useKeepMounted(quickSwitcher.isOpen);
-  const shouldMountSendToAgentPalette = useKeepMounted(sendToAgentPalette.isOpen);
-  const shouldMountNewTerminalPalette = useKeepMounted(newTerminalPalette.isOpen);
-  const shouldMountWorktreePalette = useKeepMounted(worktreePalette.isOpen);
-  const shouldMountQuickCreatePalette = useKeepMounted(quickCreatePalette.isOpen);
-  const shouldMountPanelPalette = useKeepMounted(panelPalette.isOpen);
-  const shouldMountThemePalette = useKeepMounted(isThemePaletteOpen);
-  const isResumeSessionsPaletteOpen = usePaletteStore(
-    (state) => state.activePaletteId === "resume-sessions"
-  );
-  const shouldMountResumeSessionsPalette = useKeepMounted(isResumeSessionsPaletteOpen);
-  const shouldMountLogLevelPalette = useKeepMounted(isLogLevelPaletteOpen);
-  const shouldMountActionPalette = useKeepMounted(actionPalette.isOpen);
   const shouldMountCrossDiffDialog = useKeepMounted(crossDiffDialog.isOpen);
   const shouldMountShortcutsDialog = useKeepMounted(isShortcutsOpen);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Profiler, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
+import { Profiler, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import {
   isElectronAvailable,
@@ -92,278 +92,66 @@ import { TooltipProvider } from "./components/ui/tooltip";
 import { primeRadix } from "./components/ui/radix-loader";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 
-// Module-scope loaders: raw import() expressions inside component effects bail
-// React Compiler memoization for AppInner; hoisting keeps the specifiers
-// static for chunking while letting the component compile.
-const loadE2ENotificationBackdoor = () => import("./lib/e2eNotificationBackdoor");
-const loadJetbrainsMono500 = () => import("@fontsource/jetbrains-mono/latin-500.css");
-const loadJetbrainsMono600 = () => import("@fontsource/jetbrains-mono/latin-600.css");
-const preloadFileViewerModal = () => import("@/components/FileViewer/FileViewerModal");
-
-// Direct file import (not the Project barrel) so the lazy chunk doesn't pull
-// in barrel siblings. Renders only when no project is open, so it stays off
-// the returning-user first-paint path.
-function preloadWelcomeScreen() {
-  return import("./components/Project/WelcomeScreen");
-}
-const LazyWelcomeScreen = lazy(() =>
-  preloadWelcomeScreen().then((m) => ({ default: m.WelcomeScreen }))
-);
-
-function preloadSettingsDialog() {
-  return import("./components/Settings/SettingsDialog");
-}
-const LazySettingsDialog = lazy(() =>
-  preloadSettingsDialog().then((m) => ({ default: m.SettingsDialog }))
-);
-
-function preloadWorktreePalette() {
-  return import("./components/Worktree/WorktreePalette");
-}
-const LazyWorktreePalette = lazy(() =>
-  preloadWorktreePalette().then((m) => ({ default: m.WorktreePalette }))
-);
-
-function preloadWorktreeOverviewModal() {
-  return import("./components/Worktree/WorktreeOverviewModal");
-}
-const LazyWorktreeOverviewModal = lazy(() =>
-  preloadWorktreeOverviewModal().then((m) => ({ default: m.WorktreeOverviewModal }))
-);
-
-function preloadQuickCreatePalette() {
-  return import("./components/Worktree/QuickCreatePalette");
-}
-const LazyQuickCreatePalette = lazy(() =>
-  preloadQuickCreatePalette().then((m) => ({ default: m.QuickCreatePalette }))
-);
-
-function preloadCrossWorktreeDiff() {
-  return import("./components/Worktree/CrossWorktreeDiff");
-}
-const LazyCrossWorktreeDiff = lazy(() =>
-  preloadCrossWorktreeDiff().then((m) => ({ default: m.CrossWorktreeDiff }))
-);
-
-function preloadNewTerminalPalette() {
-  return import("./components/TerminalPalette/NewTerminalPalette");
-}
-const LazyNewTerminalPalette = lazy(() =>
-  preloadNewTerminalPalette().then((m) => ({ default: m.NewTerminalPalette }))
-);
-
-function preloadSendToAgentPalette() {
-  return import("./components/Terminal/SendToAgentPalette");
-}
-const LazySendToAgentPalette = lazy(() =>
-  preloadSendToAgentPalette().then((m) => ({ default: m.SendToAgentPalette }))
-);
-
-function preloadPanelPalette() {
-  return import("./components/PanelPalette/PanelPalette");
-}
-const LazyPanelPalette = lazy(() =>
-  preloadPanelPalette().then((m) => ({ default: m.PanelPalette }))
-);
-
-function preloadActionPalette() {
-  return import("./components/ActionPalette/ActionPalette");
-}
-const LazyActionPalette = lazy(() =>
-  preloadActionPalette().then((m) => ({ default: m.ActionPalette }))
-);
-
-function preloadQuickSwitcher() {
-  return import("./components/QuickSwitcher/QuickSwitcher");
-}
-const LazyQuickSwitcher = lazy(() =>
-  preloadQuickSwitcher().then((m) => ({ default: m.QuickSwitcher }))
-);
-
-function preloadProjectSwitcherPalette() {
-  return import("./components/Project/ProjectSwitcherPalette");
-}
-const LazyProjectSwitcherPalette = lazy(() =>
-  preloadProjectSwitcherPalette().then((m) => ({ default: m.ProjectSwitcherPalette }))
-);
-
-function preloadGitInitDialog() {
-  return import("./components/Project/GitInitDialog");
-}
-const LazyGitInitDialog = lazy(() =>
-  preloadGitInitDialog().then((m) => ({ default: m.GitInitDialog }))
-);
-
-function preloadCloneRepoDialog() {
-  return import("./components/Project/CloneRepoDialog");
-}
-const LazyCloneRepoDialog = lazy(() =>
-  preloadCloneRepoDialog().then((m) => ({ default: m.CloneRepoDialog }))
-);
-
-function preloadCreateProjectFolderDialog() {
-  return import("./components/Project/CreateProjectFolderDialog");
-}
-const LazyCreateProjectFolderDialog = lazy(() =>
-  preloadCreateProjectFolderDialog().then((m) => ({ default: m.CreateProjectFolderDialog }))
-);
-
-function preloadThemePalette() {
-  return import("./components/ThemePalette/ThemePalette");
-}
-const LazyThemePalette = lazy(() =>
-  preloadThemePalette().then((m) => ({ default: m.ThemePalette }))
-);
-const LazyResumeSessionsPalette = lazy(() =>
-  import("./components/Terminal/ResumeSessionsPalette").then((m) => ({
-    default: m.ResumeSessionsPalette,
-  }))
-);
-
-function preloadLogLevelPalette() {
-  return import("./components/LogLevelPalette/LogLevelPalette");
-}
-const LazyLogLevelPalette = lazy(() =>
-  preloadLogLevelPalette().then((m) => ({ default: m.LogLevelPalette }))
-);
-
-function preloadShortcutReferenceDialog() {
-  return import("./components/KeyboardShortcuts/ShortcutReferenceDialog");
-}
-const LazyShortcutReferenceDialog = lazy(() =>
-  preloadShortcutReferenceDialog().then((m) => ({ default: m.ShortcutReferenceDialog }))
-);
-
-function preloadPluginManagerView() {
-  return import("./components/Plugin/PluginManagerView");
-}
-const LazyPluginManagerView = lazy(() =>
-  preloadPluginManagerView().then((m) => ({ default: m.PluginManagerView }))
-);
-
-function preloadOnboardingFlow() {
-  return import("./components/Onboarding/OnboardingFlow");
-}
-const LazyOnboardingFlow = lazy(() =>
-  preloadOnboardingFlow().then((m) => ({ default: m.OnboardingFlow }))
-);
-
-function preloadGettingStartedChecklist() {
-  return import("./components/Onboarding/GettingStartedChecklist");
-}
-const LazyGettingStartedChecklist = lazy(() =>
-  preloadGettingStartedChecklist().then((m) => ({ default: m.GettingStartedChecklist }))
-);
-
-function preloadCelebrationConfetti() {
-  return import("./components/Onboarding/CelebrationConfetti");
-}
-const LazyCelebrationConfetti = lazy(() =>
-  preloadCelebrationConfetti().then((m) => ({ default: m.CelebrationConfetti }))
-);
-
-function preloadFileViewerModalHost() {
-  return import("./components/FileViewer/FileViewerModalHost");
-}
-const LazyFileViewerModalHost = lazy(() =>
-  preloadFileViewerModalHost().then((m) => ({ default: m.FileViewerModalHost }))
-);
-
-function preloadDiffViewerModalHost() {
-  return import("./components/Worktree/DiffViewerModalHost");
-}
-const LazyDiffViewerModalHost = lazy(() =>
-  preloadDiffViewerModalHost().then((m) => ({ default: m.DiffViewerModalHost }))
-);
-
-function preloadMcpConfirmDialog() {
-  return import("./components/McpConfirmDialog");
-}
-const LazyMcpConfirmDialog = lazy(() =>
-  preloadMcpConfirmDialog().then((m) => ({ default: m.McpConfirmDialog }))
-);
-
-function preloadPluginConfirmDialog() {
-  return import("./components/Plugin/PluginConfirmDialog");
-}
-const LazyPluginConfirmDialog = lazy(() =>
-  preloadPluginConfirmDialog().then((m) => ({ default: m.PluginConfirmDialog }))
-);
-
-function preloadPluginMcpConfirmDialog() {
-  return import("./components/Plugin/PluginMcpConfirmDialog");
-}
-const LazyPluginMcpConfirmDialog = lazy(() =>
-  preloadPluginMcpConfirmDialog().then((m) => ({ default: m.PluginMcpConfirmDialog }))
-);
-
-const LazyPluginQuickPickDialog = lazy(() =>
-  import("./components/Plugin/PluginQuickPickDialog").then((m) => ({
-    default: m.PluginQuickPickDialog,
-  }))
-);
-const LazyPluginInputBoxDialog = lazy(() =>
-  import("./components/Plugin/PluginInputBoxDialog").then((m) => ({
-    default: m.PluginInputBoxDialog,
-  }))
-);
-const LazyPluginConfirmPromptDialog = lazy(() =>
-  import("./components/Plugin/PluginConfirmPromptDialog").then((m) => ({
-    default: m.PluginConfirmPromptDialog,
-  }))
-);
-function preloadPluginCapabilityConfirmDialog() {
-  return import("./components/Plugin/PluginCapabilityConfirmDialog");
-}
-const LazyPluginCapabilityConfirmDialog = lazy(() =>
-  preloadPluginCapabilityConfirmDialog().then((m) => ({
-    default: m.PluginCapabilityConfirmDialog,
-  }))
-);
-
-function preloadPanelLimitConfirmDialog() {
-  return import("./components/Terminal/PanelLimitConfirmDialog");
-}
-const LazyPanelLimitConfirmDialog = lazy(() =>
-  preloadPanelLimitConfirmDialog().then((m) => ({ default: m.PanelLimitConfirmDialog }))
-);
-
-function preloadDiagnosticsReviewDialogHost() {
-  return import("./components/Settings/DiagnosticsReviewDialogHost");
-}
-const LazyDiagnosticsReviewDialogHost = lazy(() =>
-  preloadDiagnosticsReviewDialogHost().then((m) => ({ default: m.DiagnosticsReviewDialogHost }))
-);
-
-function preloadGitPushConfirmDialog() {
-  return import("./components/Git/GitPushConfirmDialog");
-}
-const LazyGitPushConfirmDialog = lazy(() =>
-  preloadGitPushConfirmDialog().then((m) => ({ default: m.GitPushConfirmDialog }))
-);
-
-function preloadGitPullRebaseConfirmDialog() {
-  return import("./components/Git/GitPullRebaseConfirmDialog");
-}
-const LazyGitPullRebaseConfirmDialog = lazy(() =>
-  preloadGitPullRebaseConfirmDialog().then((m) => ({
-    default: m.GitPullRebaseConfirmDialog,
-  }))
-);
-
-function preloadRecipeConflictDialog() {
-  return import("./components/TerminalRecipe/RecipeConflictDialog");
-}
-const LazyRecipeConflictDialog = lazy(() =>
-  preloadRecipeConflictDialog().then((m) => ({ default: m.RecipeConflictDialog }))
-);
-
-function preloadCrashRecoveryDialog() {
-  return import("./components/Recovery/CrashRecoveryDialog");
-}
-const LazyCrashRecoveryDialog = lazy(() =>
-  preloadCrashRecoveryDialog().then((m) => ({ default: m.CrashRecoveryDialog }))
-);
+import {
+  loadE2ENotificationBackdoor,
+  loadJetbrainsMono500,
+  loadJetbrainsMono600,
+  preloadFileViewerModal,
+  LazyWelcomeScreen,
+  preloadSettingsDialog,
+  LazySettingsDialog,
+  preloadWorktreePalette,
+  LazyWorktreePalette,
+  preloadWorktreeOverviewModal,
+  LazyWorktreeOverviewModal,
+  preloadQuickCreatePalette,
+  LazyQuickCreatePalette,
+  preloadCrossWorktreeDiff,
+  LazyCrossWorktreeDiff,
+  preloadNewTerminalPalette,
+  LazyNewTerminalPalette,
+  preloadSendToAgentPalette,
+  LazySendToAgentPalette,
+  preloadPanelPalette,
+  LazyPanelPalette,
+  preloadActionPalette,
+  LazyActionPalette,
+  preloadQuickSwitcher,
+  LazyQuickSwitcher,
+  preloadProjectSwitcherPalette,
+  LazyProjectSwitcherPalette,
+  LazyGitInitDialog,
+  LazyCloneRepoDialog,
+  LazyCreateProjectFolderDialog,
+  preloadThemePalette,
+  LazyThemePalette,
+  LazyResumeSessionsPalette,
+  preloadLogLevelPalette,
+  LazyLogLevelPalette,
+  preloadShortcutReferenceDialog,
+  LazyShortcutReferenceDialog,
+  preloadPluginManagerView,
+  LazyPluginManagerView,
+  LazyOnboardingFlow,
+  LazyGettingStartedChecklist,
+  LazyCelebrationConfetti,
+  LazyFileViewerModalHost,
+  LazyDiffViewerModalHost,
+  LazyMcpConfirmDialog,
+  LazyPluginConfirmDialog,
+  LazyPluginMcpConfirmDialog,
+  LazyPluginQuickPickDialog,
+  LazyPluginInputBoxDialog,
+  LazyPluginConfirmPromptDialog,
+  LazyPluginCapabilityConfirmDialog,
+  LazyPanelLimitConfirmDialog,
+  LazyDiagnosticsReviewDialogHost,
+  LazyGitPushConfirmDialog,
+  LazyGitPullRebaseConfirmDialog,
+  LazyRecipeConflictDialog,
+  LazyCrashRecoveryDialog,
+  loadMotionFeatures,
+} from "./lazyPanels";
 
 import { Toaster } from "./components/ui/toaster";
 import { ShortcutHint } from "./components/ui/ShortcutHint";
@@ -417,8 +205,6 @@ import { ensureHydrationBootstrap } from "./utils/stateHydration/bootstrapGuard"
 // a bare void call would surface an unhandled rejection — the swallowed early
 // failure is retried by hydrateAppState's own await.
 void ensureHydrationBootstrap().catch(() => {});
-
-const loadMotionFeatures = () => import("./lib/motionFeatures").then((mod) => mod.default);
 
 function AppInner() {
   useErrors();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,69 +51,27 @@ import {
 } from "./hooks/app";
 import { useResourceProfile } from "./hooks/useResourceProfile";
 import { AppLayout } from "./components/Layout";
-import { PostHydrationListeners } from "./components/PostHydrationListeners";
 import { ContentGrid } from "./components/Terminal";
-import { PanelTransitionOverlay } from "./components/Panel";
 
-import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
-import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
 import { useResumeAgentSession } from "./hooks/useResumeAgentSession";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
-import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 import { useE2EBridges } from "./hooks/app/useE2EBridges";
 import { useModalResetKeys } from "./hooks/app/useModalResetKeys";
 import { useAppBootstrap } from "./hooks/app/useAppBootstrap";
 import { usePaletteWiring } from "./hooks/app/usePaletteWiring";
+import { ModalHostLayer } from "./ModalHostLayer";
 
 import {
   LazyWelcomeScreen,
   preloadSettingsDialog,
-  LazySettingsDialog,
-  LazyWorktreePalette,
-  LazyWorktreeOverviewModal,
-  LazyQuickCreatePalette,
-  LazyCrossWorktreeDiff,
-  LazyNewTerminalPalette,
-  LazySendToAgentPalette,
-  LazyPanelPalette,
-  LazyActionPalette,
-  LazyQuickSwitcher,
-  LazyProjectSwitcherPalette,
-  LazyGitInitDialog,
-  LazyCloneRepoDialog,
-  LazyCreateProjectFolderDialog,
-  LazyThemePalette,
-  LazyResumeSessionsPalette,
-  LazyLogLevelPalette,
-  LazyShortcutReferenceDialog,
-  LazyPluginManagerView,
-  LazyOnboardingFlow,
-  LazyGettingStartedChecklist,
-  LazyCelebrationConfetti,
-  LazyFileViewerModalHost,
-  LazyDiffViewerModalHost,
-  LazyMcpConfirmDialog,
-  LazyPluginConfirmDialog,
-  LazyPluginMcpConfirmDialog,
-  LazyPluginQuickPickDialog,
-  LazyPluginInputBoxDialog,
-  LazyPluginConfirmPromptDialog,
-  LazyPluginCapabilityConfirmDialog,
-  LazyPanelLimitConfirmDialog,
   LazyDiagnosticsReviewDialogHost,
-  LazyGitPushConfirmDialog,
-  LazyGitPullRebaseConfirmDialog,
-  LazyRecipeConflictDialog,
   LazyCrashRecoveryDialog,
   loadMotionFeatures,
 } from "./lazyPanels";
 
-import { Toaster } from "./components/ui/toaster";
-import { ShortcutHint } from "./components/ui/ShortcutHint";
-import { ReEntrySummary } from "./components/ui/ReEntrySummary";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { DndProvider } from "./components/DragDrop";
 import {
@@ -132,8 +90,6 @@ import "@/registry/builtinPluginRenderers";
 import { useShallow } from "zustand/react/shallow";
 import { LazyMotion, MotionConfig } from "framer-motion";
 import { useMacroFocusStore } from "./store/macroFocusStore";
-import type { BuiltInPanelKind } from "./types";
-import { actionService } from "./services/ActionService";
 import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { useRenderProfiler } from "./utils/renderProfiler";
 import { logError } from "./utils/logger";
@@ -553,683 +509,91 @@ function AppInner() {
               </Profiler>
             </DndProvider>
 
-            <ErrorBoundary
-              variant="component"
-              componentName="QuickSwitcher"
-              resetKeys={[Number(quickSwitcher.isOpen)]}
-            >
-              {shouldMountQuickSwitcher && (
-                <Suspense fallback={null}>
-                  <LazyQuickSwitcher
-                    isOpen={quickSwitcher.isOpen}
-                    query={quickSwitcher.query}
-                    results={quickSwitcher.results}
-                    totalResults={quickSwitcher.totalResults}
-                    selectedIndex={quickSwitcher.selectedIndex}
-                    isLoading={quickSwitcher.isLoading}
-                    close={quickSwitcher.close}
-                    setQuery={quickSwitcher.setQuery}
-                    setSelectedIndex={quickSwitcher.setSelectedIndex}
-                    selectPrevious={quickSwitcher.selectPrevious}
-                    selectNext={quickSwitcher.selectNext}
-                    selectItem={quickSwitcher.selectItem}
-                    confirmSelection={quickSwitcher.confirmSelection}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary
-              variant="component"
-              componentName="SendToAgentPalette"
-              resetKeys={[Number(sendToAgentPalette.isOpen)]}
-            >
-              {shouldMountSendToAgentPalette && (
-                <Suspense fallback={null}>
-                  <LazySendToAgentPalette
-                    isOpen={sendToAgentPalette.isOpen}
-                    query={sendToAgentPalette.query}
-                    results={sendToAgentPalette.results}
-                    totalResults={sendToAgentPalette.totalResults}
-                    selectedIndex={sendToAgentPalette.selectedIndex}
-                    close={sendToAgentPalette.close}
-                    setQuery={sendToAgentPalette.setQuery}
-                    selectPrevious={sendToAgentPalette.selectPrevious}
-                    selectNext={sendToAgentPalette.selectNext}
-                    selectItem={sendToAgentPalette.selectItem}
-                    confirmSelection={sendToAgentPalette.confirmSelection}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary
-              variant="component"
-              componentName="NewTerminalPalette"
-              resetKeys={[Number(newTerminalPalette.isOpen)]}
-            >
-              {shouldMountNewTerminalPalette && (
-                <Suspense fallback={null}>
-                  <LazyNewTerminalPalette
-                    isOpen={newTerminalPalette.isOpen}
-                    query={newTerminalPalette.query}
-                    results={newTerminalPalette.results}
-                    selectedIndex={newTerminalPalette.selectedIndex}
-                    onQueryChange={newTerminalPalette.setQuery}
-                    onSelectPrevious={newTerminalPalette.selectPrevious}
-                    onSelectNext={newTerminalPalette.selectNext}
-                    onSelect={newTerminalPalette.handleSelect}
-                    onConfirm={newTerminalPalette.confirmSelection}
-                    onClose={newTerminalPalette.close}
-                    onHoverIndex={newTerminalPalette.setSelectedIndex}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary
-              variant="component"
-              componentName="WorktreePalette"
-              resetKeys={[Number(worktreePalette.isOpen)]}
-            >
-              {shouldMountWorktreePalette && (
-                <Suspense fallback={null}>
-                  <LazyWorktreePalette
-                    isOpen={worktreePalette.isOpen}
-                    query={worktreePalette.query}
-                    results={worktreePalette.results}
-                    totalResults={worktreePalette.totalResults}
-                    activeWorktreeId={worktreePalette.activeWorktreeId}
-                    selectedIndex={worktreePalette.selectedIndex}
-                    isStale={worktreePalette.isStale}
-                    onQueryChange={worktreePalette.setQuery}
-                    onSelectPrevious={worktreePalette.selectPrevious}
-                    onSelectNext={worktreePalette.selectNext}
-                    onSelect={worktreePalette.selectWorktree}
-                    onConfirm={worktreePalette.confirmSelection}
-                    onClose={worktreePalette.close}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary
-              variant="component"
-              componentName="QuickCreatePalette"
-              resetKeys={[Number(quickCreatePalette.isOpen)]}
-            >
-              {shouldMountQuickCreatePalette && (
-                <Suspense fallback={null}>
-                  <LazyQuickCreatePalette palette={quickCreatePalette} />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary
-              variant="component"
-              componentName="PanelPalette"
-              resetKeys={[Number(panelPalette.isOpen)]}
-            >
-              {shouldMountPanelPalette && (
-                <Suspense fallback={null}>
-                  <LazyPanelPalette
-                    isOpen={panelPalette.isOpen}
-                    query={panelPalette.query}
-                    results={panelPalette.results}
-                    totalResults={panelPalette.totalResults}
-                    selectedIndex={panelPalette.selectedIndex}
-                    matchesById={panelPalette.matchesById}
-                    onQueryChange={panelPalette.setQuery}
-                    onSelectPrevious={panelPalette.selectPrevious}
-                    onSelectNext={panelPalette.selectNext}
-                    onSelect={(kind) => {
-                      const result = panelPalette.handleSelect(kind);
-                      if (!result) return;
-                      if (result.resumeSession) {
-                        void resumeSession(result.resumeSession);
-                      } else if (result.id.startsWith("agent:")) {
-                        const agentId = result.id.slice("agent:".length);
-                        if (agentId) {
-                          void handleLaunchAgent(agentId);
-                        }
-                      } else {
-                        addPanel({
-                          kind: result.id as BuiltInPanelKind,
-                          cwd: defaultTerminalCwd,
-                          worktreeId: activeWorktreeId ?? undefined,
-                          location: "grid",
-                        });
-                      }
-                    }}
-                    onConfirm={() => {
-                      const selected = panelPalette.confirmSelection();
-                      if (!selected) return;
-                      if (selected.id === MORE_AGENTS_PANEL_ID) return;
-                      if (selected.resumeSession) {
-                        void resumeSession(selected.resumeSession);
-                      } else if (selected.id.startsWith("agent:")) {
-                        const agentId = selected.id.slice("agent:".length);
-                        if (agentId) {
-                          void handleLaunchAgent(agentId);
-                        }
-                      } else {
-                        addPanel({
-                          kind: selected.id as BuiltInPanelKind,
-                          cwd: defaultTerminalCwd,
-                          worktreeId: activeWorktreeId ?? undefined,
-                          location: "grid",
-                        });
-                      }
-                    }}
-                    onClose={panelPalette.close}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ErrorBoundary
-              variant="component"
-              componentName="ProjectSwitcherPalette"
-              resetKeys={[Number(isProjectSwitcherModalOpen)]}
-            >
-              {isProjectSwitcherModalOpen && (
-                <Suspense fallback={null}>
-                  <LazyProjectSwitcherPalette
-                    isOpen={isProjectSwitcherModalOpen}
-                    query={projectSwitcherPalette.query}
-                    results={projectSwitcherPalette.results}
-                    selectedIndex={projectSwitcherPalette.selectedIndex}
-                    onQueryChange={projectSwitcherPalette.setQuery}
-                    onSelectPrevious={projectSwitcherPalette.selectPrevious}
-                    onSelectNext={projectSwitcherPalette.selectNext}
-                    onSelect={projectSwitcherPalette.selectProject}
-                    onHoverProject={projectSwitcherPalette.onHoverProject}
-                    onHoverProjectEnd={projectSwitcherPalette.onHoverProjectEnd}
-                    onClose={projectSwitcherPalette.close}
-                    onStopProject={(projectId) =>
-                      void projectSwitcherPalette.stopProject(projectId)
-                    }
-                    onCloseProject={(projectId) =>
-                      void projectSwitcherPalette.removeProject(projectId)
-                    }
-                    onFreeMemoryProject={(projectId) =>
-                      void projectSwitcherPalette.freeMemoryProject(projectId)
-                    }
-                    onLocateProject={(projectId) =>
-                      void projectSwitcherPalette.locateProject(projectId)
-                    }
-                    onTogglePinProject={(projectId) =>
-                      void projectSwitcherPalette.togglePinProject(projectId)
-                    }
-                    onCopyPath={projectSwitcherPalette.copyPath}
-                    removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
-                    onRemoveConfirmClose={() =>
-                      projectSwitcherPalette.setRemoveConfirmProject(null)
-                    }
-                    onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
-                    isRemovingProject={projectSwitcherPalette.isRemovingProject}
-                    freeMemoryConfirmProject={projectSwitcherPalette.freeMemoryConfirmProject}
-                    onFreeMemoryConfirmClose={() =>
-                      projectSwitcherPalette.setFreeMemoryConfirmProject(null)
-                    }
-                    onConfirmFreeMemory={projectSwitcherPalette.confirmFreeMemory}
-                    isFreeingMemory={projectSwitcherPalette.isFreeingMemory}
-                    onSelectNewWindow={(project) => {
-                      projectSwitcherPalette.close();
-                      void actionService.dispatch(
-                        "app.newWindow",
-                        { projectPath: project.path },
-                        { source: "user" }
-                      );
-                    }}
-                    scratchResults={projectSwitcherPalette.scratchResults}
-                    onCreateScratch={() => void projectSwitcherPalette.createScratch()}
-                    onSelectScratch={(scratch) =>
-                      void projectSwitcherPalette.selectScratch(scratch)
-                    }
-                    onRemoveScratch={(scratchId) =>
-                      void projectSwitcherPalette.removeScratchAction(scratchId)
-                    }
-                    onSaveAsProject={(scratchId) =>
-                      void projectSwitcherPalette.saveAsProject(scratchId)
-                    }
-                    saveAsProjectConfirm={projectSwitcherPalette.saveAsProjectConfirm}
-                    onDismissSaveAsProjectConfirm={
-                      projectSwitcherPalette.dismissSaveAsProjectConfirm
-                    }
-                    onConfirmDeleteOriginalScratch={() =>
-                      void projectSwitcherPalette.confirmDeleteOriginalScratch()
-                    }
-                    isDeletingOriginalScratch={projectSwitcherPalette.isDeletingOriginalScratch}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-            <ConfirmDialog
-              isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
-              onClose={() => {
-                if (projectSwitcherPalette.isStoppingProject) return;
-                projectSwitcherPalette.setStopConfirmProjectId(null);
-              }}
-              title={`Stop project?`}
-              description="This will terminate all running sessions in this project. This can't be undone."
-              confirmLabel="Stop project"
-              cancelLabel="Cancel"
-              onConfirm={projectSwitcherPalette.confirmStopProject}
-              isConfirmLoading={projectSwitcherPalette.isStoppingProject}
-              variant="destructive"
+            <ModalHostLayer
+              quickSwitcher={quickSwitcher}
+              shouldMountQuickSwitcher={shouldMountQuickSwitcher}
+              sendToAgentPalette={sendToAgentPalette}
+              shouldMountSendToAgentPalette={shouldMountSendToAgentPalette}
+              newTerminalPalette={newTerminalPalette}
+              shouldMountNewTerminalPalette={shouldMountNewTerminalPalette}
+              worktreePalette={worktreePalette}
+              shouldMountWorktreePalette={shouldMountWorktreePalette}
+              quickCreatePalette={quickCreatePalette}
+              shouldMountQuickCreatePalette={shouldMountQuickCreatePalette}
+              panelPalette={panelPalette}
+              shouldMountPanelPalette={shouldMountPanelPalette}
+              resumeSession={resumeSession}
+              handleLaunchAgent={handleLaunchAgent}
+              addPanel={addPanel}
+              defaultTerminalCwd={defaultTerminalCwd}
+              activeWorktreeId={activeWorktreeId}
+              isProjectSwitcherModalOpen={isProjectSwitcherModalOpen}
+              projectSwitcherPalette={projectSwitcherPalette}
+              isThemePaletteOpen={isThemePaletteOpen}
+              shouldMountThemePalette={shouldMountThemePalette}
+              closeThemePalette={closeThemePalette}
+              isResumeSessionsPaletteOpen={isResumeSessionsPaletteOpen}
+              shouldMountResumeSessionsPalette={shouldMountResumeSessionsPalette}
+              isLogLevelPaletteOpen={isLogLevelPaletteOpen}
+              shouldMountLogLevelPalette={shouldMountLogLevelPalette}
+              closeLogLevelPalette={closeLogLevelPalette}
+              actionPalette={actionPalette}
+              shouldMountActionPalette={shouldMountActionPalette}
+              isWorktreeOverviewOpen={isWorktreeOverviewOpen}
+              closeWorktreeOverview={closeWorktreeOverview}
+              worktrees={worktrees}
+              isLoading={isLoading}
+              focusedWorktreeId={focusedWorktreeId}
+              selectWorktree={selectWorktree}
+              overviewWorktreeActions={overviewWorktreeActions}
+              availability={availability}
+              agentSettings={agentSettings}
+              homeDir={homeDir}
+              crossDiffDialog={crossDiffDialog}
+              shouldMountCrossDiffDialog={shouldMountCrossDiffDialog}
+              closeCrossWorktreeDiff={closeCrossWorktreeDiff}
+              isSettingsOpen={isSettingsOpen}
+              shouldMountSettings={shouldMountSettings}
+              setIsSettingsOpen={setIsSettingsOpen}
+              settingsTab={settingsTab}
+              settingsSubtab={settingsSubtab}
+              settingsSectionId={settingsSectionId}
+              refreshSettings={refreshSettings}
+              currentProject={currentProject}
+              isShortcutsOpen={isShortcutsOpen}
+              shouldMountShortcutsDialog={shouldMountShortcutsDialog}
+              setIsShortcutsOpen={setIsShortcutsOpen}
+              isPluginManagerOpen={isPluginManagerOpen}
+              shouldMountPluginManager={shouldMountPluginManager}
+              pluginDeepLink={pluginDeepLink}
+              terminalInfoResetKey={terminalInfoResetKey}
+              isStateLoaded={isStateLoaded}
+              mcpConfirmResetKey={mcpConfirmResetKey}
+              pluginConfirmResetKey={pluginConfirmResetKey}
+              pluginMcpConfirmResetKey={pluginMcpConfirmResetKey}
+              pluginCapabilityConfirmResetKey={pluginCapabilityConfirmResetKey}
+              fileViewerResetKey={fileViewerResetKey}
+              diffViewerResetKey={diffViewerResetKey}
+              panelLimitResetKey={panelLimitResetKey}
+              diagnosticsReviewResetKey={diagnosticsReviewResetKey}
+              gitPushResetKey={gitPushResetKey}
+              gitPullRebaseResetKey={gitPullRebaseResetKey}
+              recipeConflictResetKey={recipeConflictResetKey}
+              gitInitDialogOpen={gitInitDialogOpen}
+              shouldMountGitInitDialog={shouldMountGitInitDialog}
+              effectiveGitInitPath={effectiveGitInitPath}
+              handleGitInitSuccess={handleGitInitSuccess}
+              closeGitInitDialog={closeGitInitDialog}
+              createFolderDialogOpen={createFolderDialogOpen}
+              shouldMountCreateFolderDialog={shouldMountCreateFolderDialog}
+              closeCreateFolderDialog={closeCreateFolderDialog}
+              cloneRepoDialogOpen={cloneRepoDialogOpen}
+              shouldMountCloneRepoDialog={shouldMountCloneRepoDialog}
+              handleCloneSuccess={handleCloneSuccess}
+              closeCloneRepoDialog={closeCloneRepoDialog}
+              reEntrySummary={reEntrySummary}
+              gettingStarted={gettingStarted}
             />
-
-            <ErrorBoundary
-              variant="component"
-              componentName="ThemePalette"
-              resetKeys={[Number(isThemePaletteOpen)]}
-            >
-              {shouldMountThemePalette && (
-                <Suspense fallback={null}>
-                  <LazyThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="ResumeSessionsPalette"
-              resetKeys={[Number(isResumeSessionsPaletteOpen)]}
-            >
-              {shouldMountResumeSessionsPalette && (
-                <Suspense fallback={null}>
-                  <LazyResumeSessionsPalette />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="LogLevelPalette"
-              resetKeys={[Number(isLogLevelPaletteOpen)]}
-            >
-              {shouldMountLogLevelPalette && (
-                <Suspense fallback={null}>
-                  <LazyLogLevelPalette
-                    isOpen={isLogLevelPaletteOpen}
-                    onClose={closeLogLevelPalette}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="ActionPalette"
-              resetKeys={[Number(actionPalette.isOpen)]}
-            >
-              {shouldMountActionPalette && (
-                <Suspense fallback={null}>
-                  <LazyActionPalette
-                    isOpen={actionPalette.isOpen}
-                    query={actionPalette.query}
-                    results={actionPalette.results}
-                    totalResults={actionPalette.totalResults}
-                    selectedIndex={actionPalette.selectedIndex}
-                    isStale={actionPalette.isStale}
-                    pinnedCount={actionPalette.pinnedCount}
-                    close={actionPalette.close}
-                    setQuery={actionPalette.setQuery}
-                    setSelectedIndex={actionPalette.setSelectedIndex}
-                    selectPrevious={actionPalette.selectPrevious}
-                    selectNext={actionPalette.selectNext}
-                    executeAction={actionPalette.executeAction}
-                    confirmSelection={actionPalette.confirmSelection}
-                    pinAction={actionPalette.pinAction}
-                    unpinAction={actionPalette.unpinAction}
-                    hideAction={actionPalette.hideAction}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="WorktreeOverviewModal"
-              resetKeys={[Number(isWorktreeOverviewOpen)]}
-            >
-              {isWorktreeOverviewOpen && (
-                <Suspense fallback={null}>
-                  <LazyWorktreeOverviewModal
-                    isOpen={isWorktreeOverviewOpen}
-                    onClose={closeWorktreeOverview}
-                    worktrees={worktrees}
-                    isLoading={isLoading}
-                    activeWorktreeId={activeWorktreeId}
-                    focusedWorktreeId={focusedWorktreeId}
-                    onSelectWorktree={selectWorktree}
-                    onCopyTree={overviewWorktreeActions.handleCopyTree}
-                    onOpenEditor={overviewWorktreeActions.handleOpenEditor}
-                    onSaveLayout={undefined}
-                    onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
-                    agentAvailability={availability}
-                    agentSettings={agentSettings}
-                    homeDir={homeDir}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="CrossWorktreeDiff"
-              resetKeys={[Number(crossDiffDialog.isOpen)]}
-            >
-              {shouldMountCrossDiffDialog && (
-                <Suspense fallback={null}>
-                  <LazyCrossWorktreeDiff
-                    isOpen={crossDiffDialog.isOpen}
-                    onClose={closeCrossWorktreeDiff}
-                    initialWorktreeId={crossDiffDialog.initialWorktreeId}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="SettingsDialog"
-              resetKeys={[Number(isSettingsOpen)]}
-            >
-              {shouldMountSettings && (
-                <Suspense fallback={null}>
-                  <LazySettingsDialog
-                    isOpen={isSettingsOpen}
-                    onClose={() => setIsSettingsOpen(false)}
-                    defaultTab={settingsTab}
-                    defaultSubtab={settingsSubtab}
-                    defaultSectionId={settingsSectionId}
-                    onSettingsChange={refreshSettings}
-                    projectId={currentProject?.id ?? null}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="ShortcutReferenceDialog"
-              resetKeys={[Number(isShortcutsOpen)]}
-            >
-              {shouldMountShortcutsDialog && (
-                <Suspense fallback={null}>
-                  <LazyShortcutReferenceDialog
-                    isOpen={isShortcutsOpen}
-                    onClose={() => setIsShortcutsOpen(false)}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="PluginManagerView"
-              resetKeys={[Number(isPluginManagerOpen)]}
-              onError={() => usePluginManagerStore.getState().close()}
-            >
-              {shouldMountPluginManager && (
-                <Suspense fallback={null}>
-                  <LazyPluginManagerView
-                    deepLinkIntent={pluginDeepLink.intent}
-                    onDeepLinkConsumed={pluginDeepLink.clear}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="TerminalInfoDialogHost"
-              resetKeys={[terminalInfoResetKey]}
-            >
-              <TerminalInfoDialogHost />
-            </ErrorBoundary>
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="McpConfirmDialog"
-                resetKeys={[mcpConfirmResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyMcpConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="PluginConfirmDialog"
-                resetKeys={[pluginConfirmResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyPluginConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="PluginMcpConfirmDialog"
-                resetKeys={[pluginMcpConfirmResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyPluginMcpConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary variant="component" componentName="PluginQuickPickDialog">
-                <Suspense fallback={null}>
-                  <LazyPluginQuickPickDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary variant="component" componentName="PluginInputBoxDialog">
-                <Suspense fallback={null}>
-                  <LazyPluginInputBoxDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary variant="component" componentName="PluginConfirmPromptDialog">
-                <Suspense fallback={null}>
-                  <LazyPluginConfirmPromptDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="PluginCapabilityConfirmDialog"
-                resetKeys={[pluginCapabilityConfirmResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyPluginCapabilityConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="FileViewerModalHost"
-                resetKeys={[fileViewerResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyFileViewerModalHost />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="DiffViewerModalHost"
-                resetKeys={[diffViewerResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyDiffViewerModalHost />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-
-            <ErrorBoundary
-              variant="component"
-              componentName="GitInitDialog"
-              resetKeys={[Number(gitInitDialogOpen)]}
-            >
-              {shouldMountGitInitDialog && effectiveGitInitPath && (
-                <Suspense fallback={null}>
-                  <LazyGitInitDialog
-                    isOpen={gitInitDialogOpen}
-                    directoryPath={effectiveGitInitPath}
-                    onSuccess={handleGitInitSuccess}
-                    onCancel={closeGitInitDialog}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="CreateProjectFolderDialog"
-              resetKeys={[Number(createFolderDialogOpen)]}
-            >
-              {shouldMountCreateFolderDialog && (
-                <Suspense fallback={null}>
-                  <LazyCreateProjectFolderDialog
-                    isOpen={createFolderDialogOpen}
-                    onClose={closeCreateFolderDialog}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <ErrorBoundary
-              variant="component"
-              componentName="CloneRepoDialog"
-              resetKeys={[Number(cloneRepoDialogOpen)]}
-            >
-              {shouldMountCloneRepoDialog && (
-                <Suspense fallback={null}>
-                  <LazyCloneRepoDialog
-                    isOpen={cloneRepoDialogOpen}
-                    onSuccess={handleCloneSuccess}
-                    onCancel={closeCloneRepoDialog}
-                  />
-                </Suspense>
-              )}
-            </ErrorBoundary>
-
-            <PanelTransitionOverlay />
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="PanelLimitConfirmDialog"
-                resetKeys={[panelLimitResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyPanelLimitConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="DiagnosticsReviewDialogHost"
-                resetKeys={[diagnosticsReviewResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyDiagnosticsReviewDialogHost />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="GitPushConfirmDialog"
-                resetKeys={[gitPushResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyGitPushConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="GitPullRebaseConfirmDialog"
-                resetKeys={[gitPullRebaseResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyGitPullRebaseConfirmDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="RecipeConflictDialog"
-                resetKeys={[recipeConflictResetKey]}
-              >
-                <Suspense fallback={null}>
-                  <LazyRecipeConflictDialog />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-
-            <Toaster />
-            <ShortcutHint />
-            <ReEntrySummary state={reEntrySummary} />
-            {/* Listener hooks deferred out of the first commit flush — mount once
-                hydration settles so their effects stay off the first effect flush (#9769). */}
-            {isStateLoaded && <PostHydrationListeners />}
-            {isStateLoaded && (
-              <ErrorBoundary
-                variant="component"
-                componentName="OnboardingFlow"
-                resetKeys={[Number(isStateLoaded)]}
-              >
-                <Suspense fallback={null}>
-                  <LazyOnboardingFlow
-                    availability={availability}
-                    onRefreshSettings={refreshSettings}
-                    onComplete={gettingStarted.notifyOnboardingComplete}
-                  />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
-              <ErrorBoundary
-                variant="component"
-                componentName="GettingStartedChecklist"
-                resetKeys={[Number(gettingStarted.visible)]}
-              >
-                <Suspense fallback={null}>
-                  <LazyGettingStartedChecklist
-                    checklist={gettingStarted.checklist}
-                    collapsed={gettingStarted.collapsed}
-                    onDismiss={gettingStarted.dismiss}
-                    onToggleCollapse={gettingStarted.toggleCollapse}
-                    onMarkItem={gettingStarted.markItem}
-                  />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-            <ErrorBoundary
-              variant="component"
-              componentName="CelebrationConfetti"
-              resetKeys={[Number(gettingStarted.showCelebration)]}
-            >
-              {gettingStarted.showCelebration && (
-                <Suspense fallback={null}>
-                  <LazyCelebrationConfetti />
-                </Suspense>
-              )}
-            </ErrorBoundary>
           </TooltipProvider>
         </ErrorBoundary>
       </MotionConfig>

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -4,8 +4,7 @@ import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 import type { UseQuickSwitcherReturn } from "./hooks/useQuickSwitcher";
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import type { UseNewTerminalPaletteReturn } from "./hooks/useNewTerminalPalette";
-import type { UsePanelPaletteReturn } from "./hooks/usePanelPalette";
-import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
+import { MORE_AGENTS_PANEL_ID, type UsePanelPaletteReturn } from "./hooks/usePanelPalette";
 import type { UseProjectSwitcherPaletteReturn } from "./hooks/useProjectSwitcherPalette";
 import type { UseActionPaletteReturn } from "./hooks/useActionPalette";
 import type { UseWorktreePaletteReturn } from "./hooks/useWorktreePalette";
@@ -16,7 +15,6 @@ import type { ReEntrySummaryState } from "./hooks/useReEntrySummary";
 import type { UseAgentLauncherReturn } from "./hooks/useAgentLauncher";
 import type { PluginDeepLinkState } from "./hooks/app";
 import type { SettingsTab } from "./components/Settings";
-import type { AddPanelOptions } from "./store";
 import type { BuiltInPanelKind } from "./types";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
@@ -26,7 +24,7 @@ import { ReEntrySummary } from "./components/ui/ReEntrySummary";
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { PostHydrationListeners } from "./components/PostHydrationListeners";
 import { PanelTransitionOverlay } from "./components/Panel";
-import { usePluginManagerStore } from "./store";
+import { usePanelStore, usePluginManagerStore } from "./store";
 import { actionService } from "./services/ActionService";
 import {
   LazyQuickSwitcher,
@@ -82,7 +80,7 @@ interface ModalHostLayerProps {
   shouldMountPanelPalette: boolean;
   resumeSession: (session: AgentSessionRecord) => Promise<void>;
   handleLaunchAgent: (type: string) => void | Promise<void>;
-  addPanel: (options: AddPanelOptions) => unknown;
+  addPanel: ReturnType<typeof usePanelStore.getState>["addPanel"];
   defaultTerminalCwd: string | undefined;
   activeWorktreeId: string | null;
   isProjectSwitcherModalOpen: boolean;

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -1,0 +1,911 @@
+import { Suspense } from "react";
+import type { WorktreeState, Project } from "@shared/types";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+import type { UseQuickSwitcherReturn } from "./hooks/useQuickSwitcher";
+import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
+import type { UseNewTerminalPaletteReturn } from "./hooks/useNewTerminalPalette";
+import type { UsePanelPaletteReturn } from "./hooks/usePanelPalette";
+import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
+import type { UseProjectSwitcherPaletteReturn } from "./hooks/useProjectSwitcherPalette";
+import type { UseActionPaletteReturn } from "./hooks/useActionPalette";
+import type { UseWorktreePaletteReturn } from "./hooks/useWorktreePalette";
+import type { UseQuickCreatePaletteReturn } from "./hooks/useQuickCreatePalette";
+import type { WorktreeActions } from "./hooks/useWorktreeActions";
+import type { GettingStartedChecklistState } from "./hooks/app/useGettingStartedChecklist";
+import type { ReEntrySummaryState } from "./hooks/useReEntrySummary";
+import type { UseAgentLauncherReturn } from "./hooks/useAgentLauncher";
+import type { PluginDeepLinkState } from "./hooks/app";
+import type { SettingsTab } from "./components/Settings";
+import type { AddPanelOptions } from "./store";
+import type { BuiltInPanelKind } from "./types";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { ConfirmDialog } from "./components/ui/ConfirmDialog";
+import { Toaster } from "./components/ui/toaster";
+import { ShortcutHint } from "./components/ui/ShortcutHint";
+import { ReEntrySummary } from "./components/ui/ReEntrySummary";
+import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
+import { PostHydrationListeners } from "./components/PostHydrationListeners";
+import { PanelTransitionOverlay } from "./components/Panel";
+import { usePluginManagerStore } from "./store";
+import { actionService } from "./services/ActionService";
+import {
+  LazyQuickSwitcher,
+  LazySendToAgentPalette,
+  LazyNewTerminalPalette,
+  LazyWorktreePalette,
+  LazyQuickCreatePalette,
+  LazyPanelPalette,
+  LazyProjectSwitcherPalette,
+  LazyThemePalette,
+  LazyResumeSessionsPalette,
+  LazyLogLevelPalette,
+  LazyActionPalette,
+  LazyWorktreeOverviewModal,
+  LazyCrossWorktreeDiff,
+  LazySettingsDialog,
+  LazyShortcutReferenceDialog,
+  LazyPluginManagerView,
+  LazyMcpConfirmDialog,
+  LazyPluginConfirmDialog,
+  LazyPluginMcpConfirmDialog,
+  LazyPluginQuickPickDialog,
+  LazyPluginInputBoxDialog,
+  LazyPluginConfirmPromptDialog,
+  LazyPluginCapabilityConfirmDialog,
+  LazyFileViewerModalHost,
+  LazyDiffViewerModalHost,
+  LazyGitInitDialog,
+  LazyCreateProjectFolderDialog,
+  LazyCloneRepoDialog,
+  LazyPanelLimitConfirmDialog,
+  LazyDiagnosticsReviewDialogHost,
+  LazyGitPushConfirmDialog,
+  LazyGitPullRebaseConfirmDialog,
+  LazyRecipeConflictDialog,
+  LazyOnboardingFlow,
+  LazyGettingStartedChecklist,
+  LazyCelebrationConfetti,
+} from "./lazyPanels";
+
+interface ModalHostLayerProps {
+  quickSwitcher: UseQuickSwitcherReturn;
+  shouldMountQuickSwitcher: boolean;
+  sendToAgentPalette: ReturnType<typeof useSendToAgentPalette>;
+  shouldMountSendToAgentPalette: boolean;
+  newTerminalPalette: UseNewTerminalPaletteReturn;
+  shouldMountNewTerminalPalette: boolean;
+  worktreePalette: UseWorktreePaletteReturn;
+  shouldMountWorktreePalette: boolean;
+  quickCreatePalette: UseQuickCreatePaletteReturn;
+  shouldMountQuickCreatePalette: boolean;
+  panelPalette: UsePanelPaletteReturn;
+  shouldMountPanelPalette: boolean;
+  resumeSession: (session: AgentSessionRecord) => Promise<void>;
+  handleLaunchAgent: (type: string) => void | Promise<void>;
+  addPanel: (options: AddPanelOptions) => unknown;
+  defaultTerminalCwd: string | undefined;
+  activeWorktreeId: string | null;
+  isProjectSwitcherModalOpen: boolean;
+  projectSwitcherPalette: UseProjectSwitcherPaletteReturn;
+  isThemePaletteOpen: boolean;
+  shouldMountThemePalette: boolean;
+  closeThemePalette: () => void;
+  isResumeSessionsPaletteOpen: boolean;
+  shouldMountResumeSessionsPalette: boolean;
+  isLogLevelPaletteOpen: boolean;
+  shouldMountLogLevelPalette: boolean;
+  closeLogLevelPalette: () => void;
+  actionPalette: UseActionPaletteReturn;
+  shouldMountActionPalette: boolean;
+  isWorktreeOverviewOpen: boolean;
+  closeWorktreeOverview: () => void;
+  worktrees: WorktreeState[];
+  isLoading: boolean;
+  focusedWorktreeId: string | null;
+  selectWorktree: (id: string, options?: { source?: "user" | "focus" }) => void;
+  overviewWorktreeActions: WorktreeActions;
+  availability: UseAgentLauncherReturn["availability"];
+  agentSettings: UseAgentLauncherReturn["agentSettings"];
+  homeDir: string | undefined;
+  crossDiffDialog: { isOpen: boolean; initialWorktreeId: string | null };
+  shouldMountCrossDiffDialog: boolean;
+  closeCrossWorktreeDiff: () => void;
+  isSettingsOpen: boolean;
+  shouldMountSettings: boolean;
+  setIsSettingsOpen: (open: boolean) => void;
+  settingsTab: SettingsTab | undefined;
+  settingsSubtab: string | undefined;
+  settingsSectionId: string | undefined;
+  refreshSettings: () => Promise<void>;
+  currentProject: Project | null;
+  isShortcutsOpen: boolean;
+  shouldMountShortcutsDialog: boolean;
+  setIsShortcutsOpen: (open: boolean) => void;
+  isPluginManagerOpen: boolean;
+  shouldMountPluginManager: boolean;
+  pluginDeepLink: PluginDeepLinkState;
+  terminalInfoResetKey: number;
+  isStateLoaded: boolean;
+  mcpConfirmResetKey: string;
+  pluginConfirmResetKey: string;
+  pluginMcpConfirmResetKey: string;
+  pluginCapabilityConfirmResetKey: string;
+  fileViewerResetKey: number;
+  diffViewerResetKey: number;
+  panelLimitResetKey: number;
+  diagnosticsReviewResetKey: number;
+  gitPushResetKey: number;
+  gitPullRebaseResetKey: number;
+  recipeConflictResetKey: number;
+  gitInitDialogOpen: boolean;
+  shouldMountGitInitDialog: boolean;
+  effectiveGitInitPath: string | null;
+  handleGitInitSuccess: () => Promise<void>;
+  closeGitInitDialog: () => void;
+  createFolderDialogOpen: boolean;
+  shouldMountCreateFolderDialog: boolean;
+  closeCreateFolderDialog: () => void;
+  cloneRepoDialogOpen: boolean;
+  shouldMountCloneRepoDialog: boolean;
+  handleCloneSuccess: (clonedPath: string) => Promise<void>;
+  closeCloneRepoDialog: () => void;
+  reEntrySummary: ReEntrySummaryState;
+  gettingStarted: GettingStartedChecklistState;
+}
+
+/**
+ * Every always-mounted or conditionally-lazy palette, dialog, and overlay
+ * host in the app shell — one `ErrorBoundary` + `Suspense` pair per lazy
+ * child, matching the original inline structure 1:1 so each host's fault
+ * isolation and reset-key behavior is unchanged by the move out of AppInner.
+ */
+export function ModalHostLayer({
+  quickSwitcher,
+  shouldMountQuickSwitcher,
+  sendToAgentPalette,
+  shouldMountSendToAgentPalette,
+  newTerminalPalette,
+  shouldMountNewTerminalPalette,
+  worktreePalette,
+  shouldMountWorktreePalette,
+  quickCreatePalette,
+  shouldMountQuickCreatePalette,
+  panelPalette,
+  shouldMountPanelPalette,
+  resumeSession,
+  handleLaunchAgent,
+  addPanel,
+  defaultTerminalCwd,
+  activeWorktreeId,
+  isProjectSwitcherModalOpen,
+  projectSwitcherPalette,
+  isThemePaletteOpen,
+  shouldMountThemePalette,
+  closeThemePalette,
+  isResumeSessionsPaletteOpen,
+  shouldMountResumeSessionsPalette,
+  isLogLevelPaletteOpen,
+  shouldMountLogLevelPalette,
+  closeLogLevelPalette,
+  actionPalette,
+  shouldMountActionPalette,
+  isWorktreeOverviewOpen,
+  closeWorktreeOverview,
+  worktrees,
+  isLoading,
+  focusedWorktreeId,
+  selectWorktree,
+  overviewWorktreeActions,
+  availability,
+  agentSettings,
+  homeDir,
+  crossDiffDialog,
+  shouldMountCrossDiffDialog,
+  closeCrossWorktreeDiff,
+  isSettingsOpen,
+  shouldMountSettings,
+  setIsSettingsOpen,
+  settingsTab,
+  settingsSubtab,
+  settingsSectionId,
+  refreshSettings,
+  currentProject,
+  isShortcutsOpen,
+  shouldMountShortcutsDialog,
+  setIsShortcutsOpen,
+  isPluginManagerOpen,
+  shouldMountPluginManager,
+  pluginDeepLink,
+  terminalInfoResetKey,
+  isStateLoaded,
+  mcpConfirmResetKey,
+  pluginConfirmResetKey,
+  pluginMcpConfirmResetKey,
+  pluginCapabilityConfirmResetKey,
+  fileViewerResetKey,
+  diffViewerResetKey,
+  panelLimitResetKey,
+  diagnosticsReviewResetKey,
+  gitPushResetKey,
+  gitPullRebaseResetKey,
+  recipeConflictResetKey,
+  gitInitDialogOpen,
+  shouldMountGitInitDialog,
+  effectiveGitInitPath,
+  handleGitInitSuccess,
+  closeGitInitDialog,
+  createFolderDialogOpen,
+  shouldMountCreateFolderDialog,
+  closeCreateFolderDialog,
+  cloneRepoDialogOpen,
+  shouldMountCloneRepoDialog,
+  handleCloneSuccess,
+  closeCloneRepoDialog,
+  reEntrySummary,
+  gettingStarted,
+}: ModalHostLayerProps) {
+  return (
+    <>
+      <ErrorBoundary
+        variant="component"
+        componentName="QuickSwitcher"
+        resetKeys={[Number(quickSwitcher.isOpen)]}
+      >
+        {shouldMountQuickSwitcher && (
+          <Suspense fallback={null}>
+            <LazyQuickSwitcher
+              isOpen={quickSwitcher.isOpen}
+              query={quickSwitcher.query}
+              results={quickSwitcher.results}
+              totalResults={quickSwitcher.totalResults}
+              selectedIndex={quickSwitcher.selectedIndex}
+              isLoading={quickSwitcher.isLoading}
+              close={quickSwitcher.close}
+              setQuery={quickSwitcher.setQuery}
+              setSelectedIndex={quickSwitcher.setSelectedIndex}
+              selectPrevious={quickSwitcher.selectPrevious}
+              selectNext={quickSwitcher.selectNext}
+              selectItem={quickSwitcher.selectItem}
+              confirmSelection={quickSwitcher.confirmSelection}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary
+        variant="component"
+        componentName="SendToAgentPalette"
+        resetKeys={[Number(sendToAgentPalette.isOpen)]}
+      >
+        {shouldMountSendToAgentPalette && (
+          <Suspense fallback={null}>
+            <LazySendToAgentPalette
+              isOpen={sendToAgentPalette.isOpen}
+              query={sendToAgentPalette.query}
+              results={sendToAgentPalette.results}
+              totalResults={sendToAgentPalette.totalResults}
+              selectedIndex={sendToAgentPalette.selectedIndex}
+              close={sendToAgentPalette.close}
+              setQuery={sendToAgentPalette.setQuery}
+              selectPrevious={sendToAgentPalette.selectPrevious}
+              selectNext={sendToAgentPalette.selectNext}
+              selectItem={sendToAgentPalette.selectItem}
+              confirmSelection={sendToAgentPalette.confirmSelection}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary
+        variant="component"
+        componentName="NewTerminalPalette"
+        resetKeys={[Number(newTerminalPalette.isOpen)]}
+      >
+        {shouldMountNewTerminalPalette && (
+          <Suspense fallback={null}>
+            <LazyNewTerminalPalette
+              isOpen={newTerminalPalette.isOpen}
+              query={newTerminalPalette.query}
+              results={newTerminalPalette.results}
+              selectedIndex={newTerminalPalette.selectedIndex}
+              onQueryChange={newTerminalPalette.setQuery}
+              onSelectPrevious={newTerminalPalette.selectPrevious}
+              onSelectNext={newTerminalPalette.selectNext}
+              onSelect={newTerminalPalette.handleSelect}
+              onConfirm={newTerminalPalette.confirmSelection}
+              onClose={newTerminalPalette.close}
+              onHoverIndex={newTerminalPalette.setSelectedIndex}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary
+        variant="component"
+        componentName="WorktreePalette"
+        resetKeys={[Number(worktreePalette.isOpen)]}
+      >
+        {shouldMountWorktreePalette && (
+          <Suspense fallback={null}>
+            <LazyWorktreePalette
+              isOpen={worktreePalette.isOpen}
+              query={worktreePalette.query}
+              results={worktreePalette.results}
+              totalResults={worktreePalette.totalResults}
+              activeWorktreeId={worktreePalette.activeWorktreeId}
+              selectedIndex={worktreePalette.selectedIndex}
+              isStale={worktreePalette.isStale}
+              onQueryChange={worktreePalette.setQuery}
+              onSelectPrevious={worktreePalette.selectPrevious}
+              onSelectNext={worktreePalette.selectNext}
+              onSelect={worktreePalette.selectWorktree}
+              onConfirm={worktreePalette.confirmSelection}
+              onClose={worktreePalette.close}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary
+        variant="component"
+        componentName="QuickCreatePalette"
+        resetKeys={[Number(quickCreatePalette.isOpen)]}
+      >
+        {shouldMountQuickCreatePalette && (
+          <Suspense fallback={null}>
+            <LazyQuickCreatePalette palette={quickCreatePalette} />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary
+        variant="component"
+        componentName="PanelPalette"
+        resetKeys={[Number(panelPalette.isOpen)]}
+      >
+        {shouldMountPanelPalette && (
+          <Suspense fallback={null}>
+            <LazyPanelPalette
+              isOpen={panelPalette.isOpen}
+              query={panelPalette.query}
+              results={panelPalette.results}
+              totalResults={panelPalette.totalResults}
+              selectedIndex={panelPalette.selectedIndex}
+              matchesById={panelPalette.matchesById}
+              onQueryChange={panelPalette.setQuery}
+              onSelectPrevious={panelPalette.selectPrevious}
+              onSelectNext={panelPalette.selectNext}
+              onSelect={(kind) => {
+                const result = panelPalette.handleSelect(kind);
+                if (!result) return;
+                if (result.resumeSession) {
+                  void resumeSession(result.resumeSession);
+                } else if (result.id.startsWith("agent:")) {
+                  const agentId = result.id.slice("agent:".length);
+                  if (agentId) {
+                    void handleLaunchAgent(agentId);
+                  }
+                } else {
+                  addPanel({
+                    kind: result.id as BuiltInPanelKind,
+                    cwd: defaultTerminalCwd,
+                    worktreeId: activeWorktreeId ?? undefined,
+                    location: "grid",
+                  });
+                }
+              }}
+              onConfirm={() => {
+                const selected = panelPalette.confirmSelection();
+                if (!selected) return;
+                if (selected.id === MORE_AGENTS_PANEL_ID) return;
+                if (selected.resumeSession) {
+                  void resumeSession(selected.resumeSession);
+                } else if (selected.id.startsWith("agent:")) {
+                  const agentId = selected.id.slice("agent:".length);
+                  if (agentId) {
+                    void handleLaunchAgent(agentId);
+                  }
+                } else {
+                  addPanel({
+                    kind: selected.id as BuiltInPanelKind,
+                    cwd: defaultTerminalCwd,
+                    worktreeId: activeWorktreeId ?? undefined,
+                    location: "grid",
+                  });
+                }
+              }}
+              onClose={panelPalette.close}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary
+        variant="component"
+        componentName="ProjectSwitcherPalette"
+        resetKeys={[Number(isProjectSwitcherModalOpen)]}
+      >
+        {isProjectSwitcherModalOpen && (
+          <Suspense fallback={null}>
+            <LazyProjectSwitcherPalette
+              isOpen={isProjectSwitcherModalOpen}
+              query={projectSwitcherPalette.query}
+              results={projectSwitcherPalette.results}
+              selectedIndex={projectSwitcherPalette.selectedIndex}
+              onQueryChange={projectSwitcherPalette.setQuery}
+              onSelectPrevious={projectSwitcherPalette.selectPrevious}
+              onSelectNext={projectSwitcherPalette.selectNext}
+              onSelect={projectSwitcherPalette.selectProject}
+              onHoverProject={projectSwitcherPalette.onHoverProject}
+              onHoverProjectEnd={projectSwitcherPalette.onHoverProjectEnd}
+              onClose={projectSwitcherPalette.close}
+              onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
+              onCloseProject={(projectId) => void projectSwitcherPalette.removeProject(projectId)}
+              onFreeMemoryProject={(projectId) =>
+                void projectSwitcherPalette.freeMemoryProject(projectId)
+              }
+              onLocateProject={(projectId) => void projectSwitcherPalette.locateProject(projectId)}
+              onTogglePinProject={(projectId) =>
+                void projectSwitcherPalette.togglePinProject(projectId)
+              }
+              onCopyPath={projectSwitcherPalette.copyPath}
+              removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
+              onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
+              onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
+              isRemovingProject={projectSwitcherPalette.isRemovingProject}
+              freeMemoryConfirmProject={projectSwitcherPalette.freeMemoryConfirmProject}
+              onFreeMemoryConfirmClose={() =>
+                projectSwitcherPalette.setFreeMemoryConfirmProject(null)
+              }
+              onConfirmFreeMemory={projectSwitcherPalette.confirmFreeMemory}
+              isFreeingMemory={projectSwitcherPalette.isFreeingMemory}
+              onSelectNewWindow={(project) => {
+                projectSwitcherPalette.close();
+                void actionService.dispatch(
+                  "app.newWindow",
+                  { projectPath: project.path },
+                  { source: "user" }
+                );
+              }}
+              scratchResults={projectSwitcherPalette.scratchResults}
+              onCreateScratch={() => void projectSwitcherPalette.createScratch()}
+              onSelectScratch={(scratch) => void projectSwitcherPalette.selectScratch(scratch)}
+              onRemoveScratch={(scratchId) =>
+                void projectSwitcherPalette.removeScratchAction(scratchId)
+              }
+              onSaveAsProject={(scratchId) => void projectSwitcherPalette.saveAsProject(scratchId)}
+              saveAsProjectConfirm={projectSwitcherPalette.saveAsProjectConfirm}
+              onDismissSaveAsProjectConfirm={projectSwitcherPalette.dismissSaveAsProjectConfirm}
+              onConfirmDeleteOriginalScratch={() =>
+                void projectSwitcherPalette.confirmDeleteOriginalScratch()
+              }
+              isDeletingOriginalScratch={projectSwitcherPalette.isDeletingOriginalScratch}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+      <ConfirmDialog
+        isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
+        onClose={() => {
+          if (projectSwitcherPalette.isStoppingProject) return;
+          projectSwitcherPalette.setStopConfirmProjectId(null);
+        }}
+        title={`Stop project?`}
+        description="This will terminate all running sessions in this project. This can't be undone."
+        confirmLabel="Stop project"
+        cancelLabel="Cancel"
+        onConfirm={projectSwitcherPalette.confirmStopProject}
+        isConfirmLoading={projectSwitcherPalette.isStoppingProject}
+        variant="destructive"
+      />
+
+      <ErrorBoundary
+        variant="component"
+        componentName="ThemePalette"
+        resetKeys={[Number(isThemePaletteOpen)]}
+      >
+        {shouldMountThemePalette && (
+          <Suspense fallback={null}>
+            <LazyThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="ResumeSessionsPalette"
+        resetKeys={[Number(isResumeSessionsPaletteOpen)]}
+      >
+        {shouldMountResumeSessionsPalette && (
+          <Suspense fallback={null}>
+            <LazyResumeSessionsPalette />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="LogLevelPalette"
+        resetKeys={[Number(isLogLevelPaletteOpen)]}
+      >
+        {shouldMountLogLevelPalette && (
+          <Suspense fallback={null}>
+            <LazyLogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="ActionPalette"
+        resetKeys={[Number(actionPalette.isOpen)]}
+      >
+        {shouldMountActionPalette && (
+          <Suspense fallback={null}>
+            <LazyActionPalette
+              isOpen={actionPalette.isOpen}
+              query={actionPalette.query}
+              results={actionPalette.results}
+              totalResults={actionPalette.totalResults}
+              selectedIndex={actionPalette.selectedIndex}
+              isStale={actionPalette.isStale}
+              pinnedCount={actionPalette.pinnedCount}
+              close={actionPalette.close}
+              setQuery={actionPalette.setQuery}
+              setSelectedIndex={actionPalette.setSelectedIndex}
+              selectPrevious={actionPalette.selectPrevious}
+              selectNext={actionPalette.selectNext}
+              executeAction={actionPalette.executeAction}
+              confirmSelection={actionPalette.confirmSelection}
+              pinAction={actionPalette.pinAction}
+              unpinAction={actionPalette.unpinAction}
+              hideAction={actionPalette.hideAction}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="WorktreeOverviewModal"
+        resetKeys={[Number(isWorktreeOverviewOpen)]}
+      >
+        {isWorktreeOverviewOpen && (
+          <Suspense fallback={null}>
+            <LazyWorktreeOverviewModal
+              isOpen={isWorktreeOverviewOpen}
+              onClose={closeWorktreeOverview}
+              worktrees={worktrees}
+              isLoading={isLoading}
+              activeWorktreeId={activeWorktreeId}
+              focusedWorktreeId={focusedWorktreeId}
+              onSelectWorktree={selectWorktree}
+              onCopyTree={overviewWorktreeActions.handleCopyTree}
+              onOpenEditor={overviewWorktreeActions.handleOpenEditor}
+              onSaveLayout={undefined}
+              onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
+              agentAvailability={availability}
+              agentSettings={agentSettings}
+              homeDir={homeDir}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="CrossWorktreeDiff"
+        resetKeys={[Number(crossDiffDialog.isOpen)]}
+      >
+        {shouldMountCrossDiffDialog && (
+          <Suspense fallback={null}>
+            <LazyCrossWorktreeDiff
+              isOpen={crossDiffDialog.isOpen}
+              onClose={closeCrossWorktreeDiff}
+              initialWorktreeId={crossDiffDialog.initialWorktreeId}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="SettingsDialog"
+        resetKeys={[Number(isSettingsOpen)]}
+      >
+        {shouldMountSettings && (
+          <Suspense fallback={null}>
+            <LazySettingsDialog
+              isOpen={isSettingsOpen}
+              onClose={() => setIsSettingsOpen(false)}
+              defaultTab={settingsTab}
+              defaultSubtab={settingsSubtab}
+              defaultSectionId={settingsSectionId}
+              onSettingsChange={refreshSettings}
+              projectId={currentProject?.id ?? null}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="ShortcutReferenceDialog"
+        resetKeys={[Number(isShortcutsOpen)]}
+      >
+        {shouldMountShortcutsDialog && (
+          <Suspense fallback={null}>
+            <LazyShortcutReferenceDialog
+              isOpen={isShortcutsOpen}
+              onClose={() => setIsShortcutsOpen(false)}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="PluginManagerView"
+        resetKeys={[Number(isPluginManagerOpen)]}
+        onError={() => usePluginManagerStore.getState().close()}
+      >
+        {shouldMountPluginManager && (
+          <Suspense fallback={null}>
+            <LazyPluginManagerView
+              deepLinkIntent={pluginDeepLink.intent}
+              onDeepLinkConsumed={pluginDeepLink.clear}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="TerminalInfoDialogHost"
+        resetKeys={[terminalInfoResetKey]}
+      >
+        <TerminalInfoDialogHost />
+      </ErrorBoundary>
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="McpConfirmDialog"
+          resetKeys={[mcpConfirmResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyMcpConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="PluginConfirmDialog"
+          resetKeys={[pluginConfirmResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyPluginConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="PluginMcpConfirmDialog"
+          resetKeys={[pluginMcpConfirmResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyPluginMcpConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary variant="component" componentName="PluginQuickPickDialog">
+          <Suspense fallback={null}>
+            <LazyPluginQuickPickDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary variant="component" componentName="PluginInputBoxDialog">
+          <Suspense fallback={null}>
+            <LazyPluginInputBoxDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary variant="component" componentName="PluginConfirmPromptDialog">
+          <Suspense fallback={null}>
+            <LazyPluginConfirmPromptDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="PluginCapabilityConfirmDialog"
+          resetKeys={[pluginCapabilityConfirmResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyPluginCapabilityConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="FileViewerModalHost"
+          resetKeys={[fileViewerResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyFileViewerModalHost />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="DiffViewerModalHost"
+          resetKeys={[diffViewerResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyDiffViewerModalHost />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+
+      <ErrorBoundary
+        variant="component"
+        componentName="GitInitDialog"
+        resetKeys={[Number(gitInitDialogOpen)]}
+      >
+        {shouldMountGitInitDialog && effectiveGitInitPath && (
+          <Suspense fallback={null}>
+            <LazyGitInitDialog
+              isOpen={gitInitDialogOpen}
+              directoryPath={effectiveGitInitPath}
+              onSuccess={handleGitInitSuccess}
+              onCancel={closeGitInitDialog}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="CreateProjectFolderDialog"
+        resetKeys={[Number(createFolderDialogOpen)]}
+      >
+        {shouldMountCreateFolderDialog && (
+          <Suspense fallback={null}>
+            <LazyCreateProjectFolderDialog
+              isOpen={createFolderDialogOpen}
+              onClose={closeCreateFolderDialog}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <ErrorBoundary
+        variant="component"
+        componentName="CloneRepoDialog"
+        resetKeys={[Number(cloneRepoDialogOpen)]}
+      >
+        {shouldMountCloneRepoDialog && (
+          <Suspense fallback={null}>
+            <LazyCloneRepoDialog
+              isOpen={cloneRepoDialogOpen}
+              onSuccess={handleCloneSuccess}
+              onCancel={closeCloneRepoDialog}
+            />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+
+      <PanelTransitionOverlay />
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="PanelLimitConfirmDialog"
+          resetKeys={[panelLimitResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyPanelLimitConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="DiagnosticsReviewDialogHost"
+          resetKeys={[diagnosticsReviewResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyDiagnosticsReviewDialogHost />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="GitPushConfirmDialog"
+          resetKeys={[gitPushResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyGitPushConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="GitPullRebaseConfirmDialog"
+          resetKeys={[gitPullRebaseResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyGitPullRebaseConfirmDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="RecipeConflictDialog"
+          resetKeys={[recipeConflictResetKey]}
+        >
+          <Suspense fallback={null}>
+            <LazyRecipeConflictDialog />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+
+      <Toaster />
+      <ShortcutHint />
+      <ReEntrySummary state={reEntrySummary} />
+      {/* Listener hooks deferred out of the first commit flush — mount once
+          hydration settles so their effects stay off the first effect flush (#9769). */}
+      {isStateLoaded && <PostHydrationListeners />}
+      {isStateLoaded && (
+        <ErrorBoundary
+          variant="component"
+          componentName="OnboardingFlow"
+          resetKeys={[Number(isStateLoaded)]}
+        >
+          <Suspense fallback={null}>
+            <LazyOnboardingFlow
+              availability={availability}
+              onRefreshSettings={refreshSettings}
+              onComplete={gettingStarted.notifyOnboardingComplete}
+            />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
+        <ErrorBoundary
+          variant="component"
+          componentName="GettingStartedChecklist"
+          resetKeys={[Number(gettingStarted.visible)]}
+        >
+          <Suspense fallback={null}>
+            <LazyGettingStartedChecklist
+              checklist={gettingStarted.checklist}
+              collapsed={gettingStarted.collapsed}
+              onDismiss={gettingStarted.dismiss}
+              onToggleCollapse={gettingStarted.toggleCollapse}
+              onMarkItem={gettingStarted.markItem}
+            />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      <ErrorBoundary
+        variant="component"
+        componentName="CelebrationConfetti"
+        resetKeys={[Number(gettingStarted.showCelebration)]}
+      >
+        {gettingStarted.showCelebration && (
+          <Suspense fallback={null}>
+            <LazyCelebrationConfetti />
+          </Suspense>
+        )}
+      </ErrorBoundary>
+    </>
+  );
+}

--- a/src/hooks/app/__tests__/useE2EBridges.test.tsx
+++ b/src/hooks/app/__tests__/useE2EBridges.test.tsx
@@ -1,9 +1,23 @@
 // @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { NotificationsE2EApi } from "@/lib/e2eNotificationBackdoor";
 
 const installE2EActionDispatchBridgeMock = vi.hoisted(() => vi.fn());
-const installE2ENotificationBackdoorMock = vi.hoisted(() => vi.fn());
+// Sentinel presence-only stub — the test only checks the global is set/cleared,
+// not the shape of the real 16-member NotificationsE2EApi.
+const notificationsE2EApiSentinel = vi.hoisted(
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- deliberate presence-only test sentinel, not a real NotificationsE2EApi
+  () => ({}) as NotificationsE2EApi
+);
+// Mirrors the real installE2ENotificationBackdoor(), which sets this global —
+// needed so the unmount-cleanup test can verify it's actually removed rather
+// than asserting on a key that was never set.
+const installE2ENotificationBackdoorMock = vi.hoisted(() =>
+  vi.fn(() => {
+    window.__daintreeNotificationsE2E = notificationsE2EApiSentinel;
+  })
+);
 const loadE2ENotificationBackdoorMock = vi.hoisted(() =>
   vi.fn(() =>
     Promise.resolve({ installE2ENotificationBackdoor: installE2ENotificationBackdoorMock })
@@ -127,13 +141,16 @@ describe("useE2EBridges", () => {
     });
   });
 
-  it("deletes every E2E global on unmount", () => {
+  it("deletes every E2E global on unmount", async () => {
     window.__DAINTREE_E2E_MODE__ = true;
     const { unmount } = renderHook(() => useE2EBridges());
 
     for (const key of E2E_GLOBAL_KEYS) {
       expect(window[key]).toBeDefined();
     }
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(window.__daintreeNotificationsE2E).toBeDefined();
 
     unmount();
 

--- a/src/hooks/app/__tests__/useE2EBridges.test.tsx
+++ b/src/hooks/app/__tests__/useE2EBridges.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const installE2EActionDispatchBridgeMock = vi.hoisted(() => vi.fn());
+const installE2ENotificationBackdoorMock = vi.hoisted(() => vi.fn());
+const loadE2ENotificationBackdoorMock = vi.hoisted(() =>
+  vi.fn(() =>
+    Promise.resolve({ installE2ENotificationBackdoor: installE2ENotificationBackdoorMock })
+  )
+);
+
+const errorStoreState = vi.hoisted(() => ({
+  errors: [
+    {
+      id: "err-1",
+      source: "test",
+      message: "boom",
+      fromPreviousSession: false,
+    },
+  ],
+  addError: vi.fn(),
+  reset: vi.fn(),
+}));
+const requestConflictMock = vi.hoisted(() => vi.fn());
+const diagnosticsState = vi.hoisted(() => ({ isOpen: false, openDock: vi.fn() }));
+const perfMetricsState = vi.hoisted(() => ({
+  fps: 60,
+  lafCount30s: 0,
+  cls30s: 0,
+  setLiveMetrics: vi.fn(),
+}));
+const performanceModeState = vi.hoisted(() => ({
+  performanceMode: false,
+  setPerformanceMode: vi.fn(),
+}));
+
+vi.mock("@/store", () => ({
+  useErrorStore: { getState: () => errorStoreState },
+  useDiagnosticsStore: { getState: () => diagnosticsState },
+  usePerformanceModeStore: { getState: () => performanceModeState },
+}));
+vi.mock("@/store/recipeConflictStore", () => ({
+  useRecipeConflictStore: { getState: () => ({ requestConflict: requestConflictMock }) },
+}));
+vi.mock("@/store/perfMetricsStore", () => ({
+  usePerfMetricsStore: { getState: () => perfMetricsState },
+}));
+vi.mock("@/services/ActionService", () => ({
+  installE2EActionDispatchBridge: installE2EActionDispatchBridgeMock,
+}));
+vi.mock("@/lazyPanels", () => ({
+  loadE2ENotificationBackdoor: loadE2ENotificationBackdoorMock,
+}));
+
+import { useE2EBridges } from "../useE2EBridges";
+
+const E2E_GLOBAL_KEYS = [
+  "__DAINTREE_E2E_ERROR_STORE__",
+  "__DAINTREE_E2E_ADD_ERROR__",
+  "__DAINTREE_E2E_CLEAR_ERRORS__",
+  "__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__",
+  "__DAINTREE_E2E_DIAGNOSTICS_STATE__",
+  "__DAINTREE_E2E_OPEN_DIAGNOSTICS__",
+  "__DAINTREE_E2E_PERF_METRICS_STATE__",
+  "__DAINTREE_E2E_SET_PERF_METRIC__",
+  "__DAINTREE_E2E_PERF_MODE_STATE__",
+  "__DAINTREE_E2E_SET_PERF_MODE__",
+] as const;
+
+describe("useE2EBridges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.__DAINTREE_E2E_MODE__ = undefined;
+    for (const key of E2E_GLOBAL_KEYS) {
+      delete window[key];
+    }
+    delete window.__daintreeNotificationsE2E;
+  });
+
+  it("always installs the ActionService dispatch bridge, regardless of E2E mode", () => {
+    renderHook(() => useE2EBridges());
+    expect(installE2EActionDispatchBridgeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches no E2E store globals when __DAINTREE_E2E_MODE__ is not true", () => {
+    renderHook(() => useE2EBridges());
+    for (const key of E2E_GLOBAL_KEYS) {
+      expect(window[key]).toBeUndefined();
+    }
+    expect(loadE2ENotificationBackdoorMock).not.toHaveBeenCalled();
+  });
+
+  it("attaches all E2E store globals and lazy-loads the notification backdoor when E2E mode is true", async () => {
+    window.__DAINTREE_E2E_MODE__ = true;
+    renderHook(() => useE2EBridges());
+
+    for (const key of E2E_GLOBAL_KEYS) {
+      expect(typeof window[key]).toBe("function");
+    }
+
+    expect(loadE2ENotificationBackdoorMock).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(installE2ENotificationBackdoorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the error store accessor via __DAINTREE_E2E_ERROR_STORE__", () => {
+    window.__DAINTREE_E2E_MODE__ = true;
+    renderHook(() => useE2EBridges());
+
+    const result = window.__DAINTREE_E2E_ERROR_STORE__?.();
+    expect(result).toEqual([
+      { id: "err-1", source: "test", message: "boom", fromPreviousSession: false },
+    ]);
+  });
+
+  it("routes __DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__ to the recipe conflict store", () => {
+    window.__DAINTREE_E2E_MODE__ = true;
+    renderHook(() => useE2EBridges());
+
+    window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__?.("my-recipe");
+    expect(requestConflictMock).toHaveBeenCalledWith({
+      recipeId: "inrepo-my-recipe",
+      recipeName: "my-recipe",
+      updates: { name: "my-recipe" },
+    });
+  });
+
+  it("deletes every E2E global on unmount", () => {
+    window.__DAINTREE_E2E_MODE__ = true;
+    const { unmount } = renderHook(() => useE2EBridges());
+
+    for (const key of E2E_GLOBAL_KEYS) {
+      expect(window[key]).toBeDefined();
+    }
+
+    unmount();
+
+    for (const key of E2E_GLOBAL_KEYS) {
+      expect(window[key]).toBeUndefined();
+    }
+    expect(window.__daintreeNotificationsE2E).toBeUndefined();
+  });
+});

--- a/src/hooks/app/__tests__/useModalResetKeys.test.tsx
+++ b/src/hooks/app/__tests__/useModalResetKeys.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const gitPushState = vi.hoisted(() => ({ requestSeq: 1 }));
+const gitPullRebaseState = vi.hoisted(() => ({ requestSeq: 2 }));
+const panelLimitState = vi.hoisted(() => ({ requestSeq: 3 }));
+const recipeConflictState = vi.hoisted(() => ({ requestSeq: 4 }));
+const mcpConfirmState = vi.hoisted(() => ({ current: { requestId: "mcp-1" } }));
+const pluginConfirmState = vi.hoisted(() => ({ current: { requestId: "plugin-1" } }));
+const pluginMcpConfirmState = vi.hoisted(() => ({ current: null as { requestId: string } | null }));
+const pluginCapabilityConfirmState = vi.hoisted(() => ({ current: { requestId: "cap-1" } }));
+const diagnosticsReviewState = vi.hoisted(() => ({ requestSeq: 5 }));
+
+const stashViewFileRequestMock = vi.hoisted(() => vi.fn());
+const stashViewDiffRequestMock = vi.hoisted(() => vi.fn());
+
+function selectorMock<T>(state: T) {
+  return vi.fn((selector: (s: T) => unknown) => selector(state));
+}
+
+vi.mock("@/store/gitPushConfirmStore", () => ({
+  useGitPushConfirmStore: selectorMock(gitPushState),
+}));
+vi.mock("@/store/gitPullRebaseConfirmStore", () => ({
+  useGitPullRebaseConfirmStore: selectorMock(gitPullRebaseState),
+}));
+vi.mock("@/store/panelLimitStore", () => ({
+  usePanelLimitStore: selectorMock(panelLimitState),
+}));
+vi.mock("@/store/recipeConflictStore", () => ({
+  useRecipeConflictStore: selectorMock(recipeConflictState),
+}));
+vi.mock("@/store/mcpConfirmStore", () => ({
+  useMcpConfirmStore: selectorMock(mcpConfirmState),
+}));
+vi.mock("@/store/pluginConfirmStore", () => ({
+  usePluginConfirmStore: selectorMock(pluginConfirmState),
+}));
+vi.mock("@/store/pluginMcpConfirmStore", () => ({
+  usePluginMcpConfirmStore: selectorMock(pluginMcpConfirmState),
+}));
+vi.mock("@/store/pluginCapabilityConfirmStore", () => ({
+  usePluginCapabilityConfirmStore: selectorMock(pluginCapabilityConfirmState),
+}));
+vi.mock("@/store/diagnosticsReviewStore", () => ({
+  useDiagnosticsReviewStore: selectorMock(diagnosticsReviewState),
+}));
+vi.mock("@/components/FileViewer/pendingViewFileRequest", () => ({
+  stashViewFileRequest: stashViewFileRequestMock,
+}));
+vi.mock("@/components/Worktree/pendingViewDiffRequest", () => ({
+  stashViewDiffRequest: stashViewDiffRequestMock,
+}));
+
+import { useModalResetKeys } from "../useModalResetKeys";
+
+describe("useModalResetKeys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives reset keys from each store's request signal", () => {
+    const { result } = renderHook(() => useModalResetKeys());
+
+    expect(result.current).toEqual({
+      gitPushResetKey: 1,
+      gitPullRebaseResetKey: 2,
+      panelLimitResetKey: 3,
+      recipeConflictResetKey: 4,
+      mcpConfirmResetKey: "mcp-1",
+      pluginConfirmResetKey: "plugin-1",
+      pluginMcpConfirmResetKey: "",
+      pluginCapabilityConfirmResetKey: "cap-1",
+      diagnosticsReviewResetKey: 5,
+      terminalInfoResetKey: 0,
+      fileViewerResetKey: 0,
+      diffViewerResetKey: 0,
+    });
+  });
+
+  it("increments only terminalInfoResetKey on daintree:open-terminal-info", () => {
+    const { result } = renderHook(() => useModalResetKeys());
+
+    act(() => {
+      window.dispatchEvent(new Event("daintree:open-terminal-info"));
+    });
+
+    expect(result.current.terminalInfoResetKey).toBe(1);
+    expect(result.current.fileViewerResetKey).toBe(0);
+    expect(result.current.diffViewerResetKey).toBe(0);
+  });
+
+  it("stashes and increments only fileViewerResetKey on daintree:view-file", () => {
+    const { result } = renderHook(() => useModalResetKeys());
+    const event = new Event("daintree:view-file");
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(stashViewFileRequestMock).toHaveBeenCalledWith(event);
+    expect(result.current.fileViewerResetKey).toBe(1);
+    expect(result.current.terminalInfoResetKey).toBe(0);
+    expect(result.current.diffViewerResetKey).toBe(0);
+  });
+
+  it("stashes and increments only diffViewerResetKey on daintree:view-diff", () => {
+    const { result } = renderHook(() => useModalResetKeys());
+    const event = new Event("daintree:view-diff");
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(stashViewDiffRequestMock).toHaveBeenCalledWith(event);
+    expect(result.current.diffViewerResetKey).toBe(1);
+    expect(result.current.terminalInfoResetKey).toBe(0);
+    expect(result.current.fileViewerResetKey).toBe(0);
+  });
+
+  it("removes its window listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useModalResetKeys());
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("daintree:open-terminal-info", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("daintree:view-file", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("daintree:view-diff", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -4,6 +4,7 @@ export { useE2EBridges } from "./useE2EBridges";
 export { useModalResetKeys } from "./useModalResetKeys";
 export type { ModalResetKeys } from "./useModalResetKeys";
 export { useAppBootstrap } from "./useAppBootstrap";
+export { usePaletteWiring } from "./usePaletteWiring";
 export { useAppHydration } from "./useAppHydration";
 export { useShortcutHints } from "./useShortcutHints";
 export { usePanelStoreBootstrap } from "./usePanelStoreBootstrap";

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -1,6 +1,8 @@
 export { useAppBoot } from "./useAppBoot";
 export type { SafeBootResult } from "./useAppBoot";
 export { useE2EBridges } from "./useE2EBridges";
+export { useModalResetKeys } from "./useModalResetKeys";
+export type { ModalResetKeys } from "./useModalResetKeys";
 export { useAppHydration } from "./useAppHydration";
 export { useShortcutHints } from "./useShortcutHints";
 export { usePanelStoreBootstrap } from "./usePanelStoreBootstrap";

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -3,6 +3,7 @@ export type { SafeBootResult } from "./useAppBoot";
 export { useE2EBridges } from "./useE2EBridges";
 export { useModalResetKeys } from "./useModalResetKeys";
 export type { ModalResetKeys } from "./useModalResetKeys";
+export { useAppBootstrap } from "./useAppBootstrap";
 export { useAppHydration } from "./useAppHydration";
 export { useShortcutHints } from "./useShortcutHints";
 export { usePanelStoreBootstrap } from "./usePanelStoreBootstrap";

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -1,5 +1,6 @@
 export { useAppBoot } from "./useAppBoot";
 export type { SafeBootResult } from "./useAppBoot";
+export { useE2EBridges } from "./useE2EBridges";
 export { useAppHydration } from "./useAppHydration";
 export { useShortcutHints } from "./useShortcutHints";
 export { usePanelStoreBootstrap } from "./usePanelStoreBootstrap";

--- a/src/hooks/app/useAppBootstrap.ts
+++ b/src/hooks/app/useAppBootstrap.ts
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { useAppBoot } from "./useAppBoot";
+import { useCrashRecoveryGate } from "./useCrashRecoveryGate";
+import { useAppHydration } from "./useAppHydration";
+import { useShortcutHints } from "./useShortcutHints";
+import { useGettingStartedChecklist } from "./useGettingStartedChecklist";
+import { useOrchestrationMilestones } from "./useOrchestrationMilestones";
+import { useAgentWaitingNudge } from "./useAgentWaitingNudge";
+import { useForgeEnableRecommendation } from "./useForgeEnableRecommendation";
+import { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";
+import { useBackgroundWindowResize } from "./useBackgroundWindowResize";
+import { useClearSwitchBusyStateOnReveal } from "./useClearSwitchBusyStateOnReveal";
+import { usePluginDeepLink } from "./usePluginDeepLink";
+import { useNotificationHistoryPruning } from "./useNotificationHistoryPruning";
+import { useUpdateListener } from "@/hooks/useUpdateListener";
+import { removeStartupSkeleton } from "@/utils/removeStartupSkeleton";
+import { useNotificationSettingsStore, usePluginManagerStore } from "@/store";
+import { preloadNewWorktreeDialog } from "@/components/Sidebar";
+import { primeRadix } from "@/components/ui/radix-loader";
+import {
+  preloadSettingsDialog,
+  preloadActionPalette,
+  preloadQuickSwitcher,
+  preloadProjectSwitcherPalette,
+  preloadWorktreePalette,
+  preloadNewTerminalPalette,
+  preloadPanelPalette,
+  preloadThemePalette,
+  preloadSendToAgentPalette,
+  preloadQuickCreatePalette,
+  preloadLogLevelPalette,
+  preloadPluginManagerView,
+  preloadWorktreeOverviewModal,
+  preloadShortcutReferenceDialog,
+  preloadCrossWorktreeDiff,
+  loadJetbrainsMono500,
+  loadJetbrainsMono600,
+  preloadFileViewerModal,
+} from "@/lazyPanels";
+
+/**
+ * Composes the app's cold-start orchestration: batched boot payload, crash
+ * recovery gate, hydration, the deferred post-hydration housekeeping hooks,
+ * and the idle-time prefetch of palette/dialog chunks. Call once from
+ * `AppInner` — the internal hook order here must stay unconditional and
+ * stable across renders, same as any other custom hook.
+ */
+export function useAppBootstrap() {
+  // Batched cold-start payload — replaces the legacy fan-out of
+  // crash-recovery:get-pending + crash-recovery:get-config + app:hydrate +
+  // terminal-config:get into a single IPC round-trip (#8620). The IPC is fired
+  // at module-eval time and read here via `use()` (#8820); a boot failure
+  // resolves to `{ ok: false }` so the app still renders its cold-start chrome.
+  const safeBoot = useAppBoot();
+  const bootResult = safeBoot.ok ? safeBoot.result : null;
+
+  // Crash recovery gate — must resolve before hydration runs
+  const {
+    state: crashState,
+    resolve: resolveCrash,
+    updateConfig: updateCrashConfig,
+  } = useCrashRecoveryGate(bootResult);
+
+  const crashResolved = crashState.status !== "loading" && crashState.status !== "pending";
+
+  // When crash recovery was pending at boot, the resolve path (`restoreBackup`
+  // or `resetToFresh` in CrashRecoveryService) mutates `store.appState` after
+  // `bootResult` was captured. Passing the stale prefetched payload would
+  // hydrate from the pre-resolution terminal list and skip the one-shot
+  // `consumePanelFilter` the restore path queued. Force the live IPC path in
+  // that case so hydration reads the post-resolution store.
+  const hadPendingCrash = bootResult?.crashPending != null;
+  // App lifecycle hooks
+  const { isStateLoaded } = useAppHydration(crashResolved, hadPendingCrash ? null : bootResult);
+  useEffect(() => {
+    if (isStateLoaded) removeStartupSkeleton();
+  }, [isStateLoaded]);
+
+  // Cross-project focus intent receiver. Subscribes unconditionally so the
+  // listener is registered before `notifyViewPainted` fires, then defers the
+  // local `agent.focusNextWaiting` dispatch until hydration completes (the
+  // paint signal arrives before panel state is loaded — a direct dispatch
+  // would silently no-op against an empty panelStore).
+  useFocusOnActivateIntent(isStateLoaded);
+  // Background window-resize receiver — keeps PTY geometry tracking the
+  // window while this project view is detached (#10415).
+  useBackgroundWindowResize();
+  // Clears the stale switch busy flags when this cached view is reactivated, so
+  // a view that switched away never resurfaces a stuck ProjectSwitcher spinner
+  // on return (#10736).
+  useClearSwitchBusyStateOnReveal();
+  // `daintree://` deep-link receiver (#9559). Surfaces the intent once hydration
+  // settles; the effect below opens the Plugin Manager, which consumes it.
+  const pluginDeepLink = usePluginDeepLink(isStateLoaded);
+  useEffect(() => {
+    if (!pluginDeepLink.intent) return;
+    // Opening the manager also closes Settings via the open-transition effect
+    // above, so the two surfaces don't stack when the deep link arrives.
+    usePluginManagerStore.getState().open();
+  }, [pluginDeepLink.intent]);
+  // The skeleton is z-index 9999 and intercepts pointer events. The crash
+  // recovery dialog is rendered before hydration completes, so without this
+  // the dialog would be visible but unclickable until hydration finishes
+  // (which it can't, since the user must resolve the crash first).
+  useEffect(() => {
+    if (crashState.status === "pending" || crashState.status === "failed") {
+      removeStartupSkeleton();
+    }
+  }, [crashState.status]);
+  useEffect(() => {
+    void useNotificationSettingsStore.getState().hydrate();
+    // Subscribe to OS DND transitions before hydrate resolves so a transition
+    // mid-hydration cannot be missed. Push events from main are tolerant of
+    // an `undefined` namespace at preload (renderer harness in tests).
+    const unsubscribe = window.electron?.osDnd?.onStateChanged?.((payload) => {
+      useNotificationSettingsStore.getState().setOsDndActive(payload.osDndActive);
+    });
+    return () => unsubscribe?.();
+  }, []);
+  // Defers the post-hydration housekeeping IPC reads (shortcut-hint counts,
+  // milestones, forge-recommendation plugin/remotes probes) out of the
+  // synchronous isStateLoaded effect flush: their sends would otherwise land
+  // on main ahead of the loaded-frame paint and compete with the
+  // deferred-services drain. The flag flips from the background-priority task
+  // below, so the gated hooks hydrate at idle; each reconciles current store
+  // state on attach, so nothing observable is lost in the gap.
+  const [idleHousekeepingReady, setIdleHousekeepingReady] = useState(false);
+  useShortcutHints(isStateLoaded && idleHousekeepingReady);
+  const gettingStarted = useGettingStartedChecklist(isStateLoaded);
+  const onboardingOverlayActive = gettingStarted.visible || gettingStarted.showCelebration;
+  useUpdateListener(onboardingOverlayActive);
+  useOrchestrationMilestones(isStateLoaded && idleHousekeepingReady);
+  useAgentWaitingNudge(isStateLoaded);
+  useForgeEnableRecommendation(isStateLoaded && idleHousekeepingReady);
+  useNotificationHistoryPruning();
+
+  useEffect(() => {
+    if (!isStateLoaded) return;
+
+    const controller = new AbortController();
+
+    const execute = () => {
+      if (controller.signal.aborted) return;
+      setIdleHousekeepingReady(true);
+      void preloadSettingsDialog();
+      void preloadNewWorktreeDialog();
+      void preloadActionPalette();
+      void preloadQuickSwitcher();
+      preloadProjectSwitcherPalette().catch(() => {});
+      void preloadWorktreePalette();
+      void preloadNewTerminalPalette();
+      void preloadPanelPalette();
+      void preloadThemePalette();
+      void preloadSendToAgentPalette();
+      void preloadQuickCreatePalette();
+      void preloadLogLevelPalette();
+      void preloadPluginManagerView();
+      void preloadWorktreeOverviewModal();
+      void preloadShortcutReferenceDialog();
+      void preloadCrossWorktreeDiff();
+      loadJetbrainsMono500().catch(() => {});
+      loadJetbrainsMono600().catch(() => {});
+      // Warm the FileViewerModal/DiffViewer chunk split out of the eager
+      // closure (#8626). It is reached through a lazy boundary in
+      // `Worktree/FileDiffModal.tsx`, so an explicit post-paint prefetch keeps
+      // it snappy on first use.
+      preloadFileViewerModal().catch(() => {});
+      // Warm the shared Radix overlay primitives chunk (`radix-deferred`) so the
+      // ProjectSwitcherPalette popover and context menus are ready on first
+      // interaction in a freshly loaded project view. Otherwise this chunk is
+      // only demand-loaded on the first pointer/focus gesture (#10752). Each
+      // WebContentsView has its own module cache, so this fires per view.
+      primeRadix().catch(() => {});
+    };
+
+    if (typeof scheduler !== "undefined" && typeof scheduler.postTask === "function") {
+      void scheduler
+        .postTask(execute, { priority: "background", signal: controller.signal })
+        .catch(() => {});
+    } else {
+      const id = requestIdleCallback(execute, { timeout: 5000 });
+      const cancel = () => cancelIdleCallback(id);
+      controller.signal.addEventListener("abort", cancel, { once: true });
+    }
+
+    return () => controller.abort();
+  }, [isStateLoaded]);
+
+  return {
+    bootResult,
+    crashState,
+    resolveCrash,
+    updateCrashConfig,
+    crashResolved,
+    isStateLoaded,
+    pluginDeepLink,
+    gettingStarted,
+  };
+}

--- a/src/hooks/app/useE2EBridges.ts
+++ b/src/hooks/app/useE2EBridges.ts
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+import { useErrorStore, useDiagnosticsStore, usePerformanceModeStore } from "@/store";
+import { useRecipeConflictStore } from "@/store/recipeConflictStore";
+import { usePerfMetricsStore } from "@/store/perfMetricsStore";
+import { installE2EActionDispatchBridge } from "@/services/ActionService";
+import { loadE2ENotificationBackdoor } from "@/lazyPanels";
+
+/**
+ * Installs the E2E renderer backdoors: the ActionService dispatch bridge
+ * (unconditional) and the store accessors gated on the preload-injected
+ * `__DAINTREE_E2E_MODE__` flag (set only under DAINTREE_E2E_MODE=1 on
+ * non-packaged builds) so none of these attach in production sessions.
+ */
+export function useE2EBridges(): void {
+  useEffect(() => {
+    installE2EActionDispatchBridge();
+  }, []);
+
+  useEffect(() => {
+    // All E2E renderer backdoors are gated on the preload-injected
+    // __DAINTREE_E2E_MODE__ flag (set only under DAINTREE_E2E_MODE=1 on
+    // non-packaged builds) so none of these store accessors attach in
+    // production sessions.
+    if (window.__DAINTREE_E2E_MODE__ === true) {
+      window.__DAINTREE_E2E_ERROR_STORE__ = () =>
+        useErrorStore.getState().errors.map((e) => ({
+          id: e.id,
+          source: e.source,
+          message: e.message,
+          fromPreviousSession: e.fromPreviousSession,
+        }));
+      window.__DAINTREE_E2E_ADD_ERROR__ = (message: string) => {
+        useErrorStore.getState().addError({
+          type: "unknown",
+          message,
+          retryability: "none",
+          source: "e2e-test",
+        });
+      };
+      window.__DAINTREE_E2E_CLEAR_ERRORS__ = () => {
+        useErrorStore.getState().reset();
+      };
+      // Parks a synthetic in-repo recipe stale-write conflict so E2E can exercise
+      // the RecipeConflictDialog without racing a real on-disk file mutation. The
+      // returned promise resolves with the user's choice; tests don't await it —
+      // they assert the dialog renders and that reload/overwrite dismiss it.
+      window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__ = (recipeName: string) => {
+        void useRecipeConflictStore.getState().requestConflict({
+          recipeId: `inrepo-${recipeName}`,
+          recipeName,
+          updates: { name: recipeName },
+        });
+      };
+
+      // Per-window store accessors for the multi-window isolation spec (#9599).
+      // Each project view is its own V8 context, so these Zustand singletons are
+      // per-window — mutating one window's store must not leak into another's.
+      window.__DAINTREE_E2E_DIAGNOSTICS_STATE__ = () => ({
+        isOpen: useDiagnosticsStore.getState().isOpen,
+      });
+      window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__ = () => useDiagnosticsStore.getState().openDock();
+      window.__DAINTREE_E2E_PERF_METRICS_STATE__ = () => {
+        const s = usePerfMetricsStore.getState();
+        return { fps: s.fps, lafCount30s: s.lafCount30s, cls30s: s.cls30s };
+      };
+      window.__DAINTREE_E2E_SET_PERF_METRIC__ = (fps: number) =>
+        usePerfMetricsStore.getState().setLiveMetrics({ fps, lafCount30s: 0, cls30s: 0 });
+      window.__DAINTREE_E2E_PERF_MODE_STATE__ = () => ({
+        performanceMode: usePerformanceModeStore.getState().performanceMode,
+      });
+      window.__DAINTREE_E2E_SET_PERF_MODE__ = (enabled: boolean) =>
+        usePerformanceModeStore.getState().setPerformanceMode(enabled);
+
+      // Lazy-load the notification backdoor only under E2E so its module closure
+      // stays out of the production first-paint chunk. Fire-and-forget: the helper
+      // side in e2e/helpers/notifications.ts waits for __daintreeNotificationsE2E
+      // before use, so the async resolve doesn't need to block the effect.
+      void loadE2ENotificationBackdoor()
+        .then(({ installE2ENotificationBackdoor }) => {
+          installE2ENotificationBackdoor();
+        })
+        .catch(() => {});
+    }
+
+    return () => {
+      delete window.__DAINTREE_E2E_ERROR_STORE__;
+      delete window.__DAINTREE_E2E_ADD_ERROR__;
+      delete window.__DAINTREE_E2E_CLEAR_ERRORS__;
+      delete window.__DAINTREE_E2E_TRIGGER_RECIPE_CONFLICT__;
+      delete window.__DAINTREE_E2E_DIAGNOSTICS_STATE__;
+      delete window.__DAINTREE_E2E_OPEN_DIAGNOSTICS__;
+      delete window.__DAINTREE_E2E_PERF_METRICS_STATE__;
+      delete window.__DAINTREE_E2E_SET_PERF_METRIC__;
+      delete window.__DAINTREE_E2E_PERF_MODE_STATE__;
+      delete window.__DAINTREE_E2E_SET_PERF_MODE__;
+      delete window.__daintreeNotificationsE2E;
+    };
+  }, []);
+}

--- a/src/hooks/app/useModalResetKeys.ts
+++ b/src/hooks/app/useModalResetKeys.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
+import { useGitPullRebaseConfirmStore } from "@/store/gitPullRebaseConfirmStore";
+import { usePanelLimitStore } from "@/store/panelLimitStore";
+import { useRecipeConflictStore } from "@/store/recipeConflictStore";
+import { useMcpConfirmStore } from "@/store/mcpConfirmStore";
+import { usePluginConfirmStore } from "@/store/pluginConfirmStore";
+import { usePluginMcpConfirmStore } from "@/store/pluginMcpConfirmStore";
+import { usePluginCapabilityConfirmStore } from "@/store/pluginCapabilityConfirmStore";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
+import { stashViewFileRequest } from "@/components/FileViewer/pendingViewFileRequest";
+import { stashViewDiffRequest } from "@/components/Worktree/pendingViewDiffRequest";
+
+export interface ModalResetKeys {
+  gitPushResetKey: number;
+  gitPullRebaseResetKey: number;
+  panelLimitResetKey: number;
+  recipeConflictResetKey: number;
+  mcpConfirmResetKey: string;
+  pluginConfirmResetKey: string;
+  pluginMcpConfirmResetKey: string;
+  pluginCapabilityConfirmResetKey: string;
+  diagnosticsReviewResetKey: number;
+  terminalInfoResetKey: number;
+  fileViewerResetKey: number;
+  diffViewerResetKey: number;
+}
+
+/**
+ * ErrorBoundary reset signals for the always-mounted dialog hosts (#9918). A
+ * static `[Number(isStateLoaded)]` collapses to `[1]` after hydration and
+ * never changes, so a host that crashes once stays dead for the session (and
+ * its deferred promise leaks). Each host instead resets on its own
+ * pending-request signal, so a fresh request remounts the crashed boundary:
+ *   - request-counter stores bump `requestSeq` on every request (covers the
+ *     back-to-back supersede case where `pendingConfirm` never returns to null)
+ *   - FIFO-queue stores key off the live `current.requestId` UUID
+ *   - the diagnostics host toggles on its own `isOpen`
+ *   - the event-driven hosts (terminal-info, file-viewer) hold no store state,
+ *     so a local counter increments on each open event below.
+ */
+export function useModalResetKeys(): ModalResetKeys {
+  const gitPushResetKey = useGitPushConfirmStore((s) => s.requestSeq);
+  const gitPullRebaseResetKey = useGitPullRebaseConfirmStore((s) => s.requestSeq);
+  const panelLimitResetKey = usePanelLimitStore((s) => s.requestSeq);
+  const recipeConflictResetKey = useRecipeConflictStore((s) => s.requestSeq);
+  const mcpConfirmResetKey = useMcpConfirmStore((s) => s.current?.requestId ?? "");
+  const pluginConfirmResetKey = usePluginConfirmStore((s) => s.current?.requestId ?? "");
+  const pluginMcpConfirmResetKey = usePluginMcpConfirmStore((s) => s.current?.requestId ?? "");
+  const pluginCapabilityConfirmResetKey = usePluginCapabilityConfirmStore(
+    (s) => s.current?.requestId ?? ""
+  );
+  const diagnosticsReviewResetKey = useDiagnosticsReviewStore((s) => s.requestSeq);
+  const [terminalInfoResetKey, setTerminalInfoResetKey] = useState(0);
+  const [fileViewerResetKey, setFileViewerResetKey] = useState(0);
+  const [diffViewerResetKey, setDiffViewerResetKey] = useState(0);
+  useEffect(() => {
+    const onTerminalInfo = () => setTerminalInfoResetKey((k) => k + 1);
+    const onViewFile = (e: Event) => {
+      // Stash for FileViewerModalHost's mount replay — the host's own listener
+      // lives in a lazy chunk and may not be registered yet.
+      stashViewFileRequest(e);
+      setFileViewerResetKey((k) => k + 1);
+    };
+    const onViewDiff = (e: Event) => {
+      // Stash for DiffViewerModalHost's mount replay — same lazy-chunk race as
+      // the file viewer above.
+      stashViewDiffRequest(e);
+      setDiffViewerResetKey((k) => k + 1);
+    };
+    window.addEventListener("daintree:open-terminal-info", onTerminalInfo);
+    window.addEventListener("daintree:view-file", onViewFile);
+    window.addEventListener("daintree:view-diff", onViewDiff);
+    return () => {
+      window.removeEventListener("daintree:open-terminal-info", onTerminalInfo);
+      window.removeEventListener("daintree:view-file", onViewFile);
+      window.removeEventListener("daintree:view-diff", onViewDiff);
+    };
+  }, []);
+
+  return {
+    gitPushResetKey,
+    gitPullRebaseResetKey,
+    panelLimitResetKey,
+    recipeConflictResetKey,
+    mcpConfirmResetKey,
+    pluginConfirmResetKey,
+    pluginMcpConfirmResetKey,
+    pluginCapabilityConfirmResetKey,
+    diagnosticsReviewResetKey,
+    terminalInfoResetKey,
+    fileViewerResetKey,
+    diffViewerResetKey,
+  };
+}

--- a/src/hooks/app/usePaletteWiring.ts
+++ b/src/hooks/app/usePaletteWiring.ts
@@ -1,0 +1,85 @@
+import {
+  useWorktrees,
+  useNewTerminalPalette,
+  usePanelPalette,
+  useProjectSwitcherPalette,
+} from "@/hooks";
+import { useActionPalette } from "@/hooks/useActionPalette";
+import { useQuickSwitcher } from "@/hooks/useQuickSwitcher";
+import { useWorktreePalette } from "@/hooks/useWorktreePalette";
+import { useQuickCreatePalette } from "@/hooks/useQuickCreatePalette";
+import { useSendToAgentPalette } from "@/hooks/useSendToAgentPalette";
+import { useDoubleShift } from "@/hooks/useDoubleShift";
+import { useProjectMruSwitcher } from "@/hooks/useProjectMruSwitcher";
+import { useKeepMounted } from "@/hooks/useKeepMounted";
+import { usePaletteStore } from "@/store";
+
+/**
+ * Composes the app's ~10 palette hooks (new-terminal, panel, project-switcher,
+ * action, quick-switcher, send-to-agent, worktree, quick-create) plus the
+ * theme/log-level/resume-sessions palette-store flags and every palette's
+ * `useKeepMounted` exit-animation latch (#9917) into one typed bag.
+ */
+export function usePaletteWiring() {
+  const { worktrees, worktreeMap, isLoading } = useWorktrees();
+  const newTerminalPalette = useNewTerminalPalette({ worktreeMap });
+  const panelPalette = usePanelPalette();
+  const projectSwitcherPalette = useProjectSwitcherPalette();
+  const actionPalette = useActionPalette();
+  const quickSwitcher = useQuickSwitcher();
+  const sendToAgentPalette = useSendToAgentPalette();
+  useDoubleShift(actionPalette.toggle);
+  useProjectMruSwitcher();
+  const worktreePalette = useWorktreePalette({ worktrees });
+  const quickCreatePalette = useQuickCreatePalette();
+
+  const isThemePaletteOpen = usePaletteStore((state) => state.activePaletteId === "theme");
+  const isLogLevelPaletteOpen = usePaletteStore((state) => state.activePaletteId === "log-level");
+  const isResumeSessionsPaletteOpen = usePaletteStore(
+    (state) => state.activePaletteId === "resume-sessions"
+  );
+  // Keep each palette mounted after its first open so its exit animation
+  // (driven by useAnimatedPresence) can run — gating directly on `isOpen`
+  // unmounts in the same React commit that flips it false, killing the exit
+  // (#9917). The component still receives `isOpen` and gates its own DOM via
+  // `shouldRender`.
+  const isProjectSwitcherModalOpen =
+    projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal";
+  const shouldMountQuickSwitcher = useKeepMounted(quickSwitcher.isOpen);
+  const shouldMountSendToAgentPalette = useKeepMounted(sendToAgentPalette.isOpen);
+  const shouldMountNewTerminalPalette = useKeepMounted(newTerminalPalette.isOpen);
+  const shouldMountWorktreePalette = useKeepMounted(worktreePalette.isOpen);
+  const shouldMountQuickCreatePalette = useKeepMounted(quickCreatePalette.isOpen);
+  const shouldMountPanelPalette = useKeepMounted(panelPalette.isOpen);
+  const shouldMountThemePalette = useKeepMounted(isThemePaletteOpen);
+  const shouldMountResumeSessionsPalette = useKeepMounted(isResumeSessionsPaletteOpen);
+  const shouldMountLogLevelPalette = useKeepMounted(isLogLevelPaletteOpen);
+  const shouldMountActionPalette = useKeepMounted(actionPalette.isOpen);
+
+  return {
+    worktrees,
+    isLoading,
+    newTerminalPalette,
+    panelPalette,
+    projectSwitcherPalette,
+    actionPalette,
+    quickSwitcher,
+    sendToAgentPalette,
+    worktreePalette,
+    quickCreatePalette,
+    isThemePaletteOpen,
+    isLogLevelPaletteOpen,
+    isResumeSessionsPaletteOpen,
+    isProjectSwitcherModalOpen,
+    shouldMountQuickSwitcher,
+    shouldMountSendToAgentPalette,
+    shouldMountNewTerminalPalette,
+    shouldMountWorktreePalette,
+    shouldMountQuickCreatePalette,
+    shouldMountPanelPalette,
+    shouldMountThemePalette,
+    shouldMountResumeSessionsPalette,
+    shouldMountLogLevelPalette,
+    shouldMountActionPalette,
+  };
+}

--- a/src/lazyPanels.ts
+++ b/src/lazyPanels.ts
@@ -1,0 +1,278 @@
+// Module-scope lazy()/preload() declarations for App.tsx's modal, palette,
+// and dialog hosts. These must stay outside any component body — raw import()
+// expressions inside a component effect bail React Compiler memoization — and
+// this module is imported statically (never via its own lazy()/import()) so its
+// code stays in the App.tsx chunk that the V8 compile hint targets by facade path.
+import { lazy } from "react";
+
+export const loadE2ENotificationBackdoor = () => import("./lib/e2eNotificationBackdoor");
+export const loadJetbrainsMono500 = () => import("@fontsource/jetbrains-mono/latin-500.css");
+export const loadJetbrainsMono600 = () => import("@fontsource/jetbrains-mono/latin-600.css");
+export const preloadFileViewerModal = () => import("@/components/FileViewer/FileViewerModal");
+
+// Direct file import (not the Project barrel) so the lazy chunk doesn't pull
+// in barrel siblings. Renders only when no project is open, so it stays off
+// the returning-user first-paint path.
+export function preloadWelcomeScreen() {
+  return import("./components/Project/WelcomeScreen");
+}
+export const LazyWelcomeScreen = lazy(() =>
+  preloadWelcomeScreen().then((m) => ({ default: m.WelcomeScreen }))
+);
+
+export function preloadSettingsDialog() {
+  return import("./components/Settings/SettingsDialog");
+}
+export const LazySettingsDialog = lazy(() =>
+  preloadSettingsDialog().then((m) => ({ default: m.SettingsDialog }))
+);
+
+export function preloadWorktreePalette() {
+  return import("./components/Worktree/WorktreePalette");
+}
+export const LazyWorktreePalette = lazy(() =>
+  preloadWorktreePalette().then((m) => ({ default: m.WorktreePalette }))
+);
+
+export function preloadWorktreeOverviewModal() {
+  return import("./components/Worktree/WorktreeOverviewModal");
+}
+export const LazyWorktreeOverviewModal = lazy(() =>
+  preloadWorktreeOverviewModal().then((m) => ({ default: m.WorktreeOverviewModal }))
+);
+
+export function preloadQuickCreatePalette() {
+  return import("./components/Worktree/QuickCreatePalette");
+}
+export const LazyQuickCreatePalette = lazy(() =>
+  preloadQuickCreatePalette().then((m) => ({ default: m.QuickCreatePalette }))
+);
+
+export function preloadCrossWorktreeDiff() {
+  return import("./components/Worktree/CrossWorktreeDiff");
+}
+export const LazyCrossWorktreeDiff = lazy(() =>
+  preloadCrossWorktreeDiff().then((m) => ({ default: m.CrossWorktreeDiff }))
+);
+
+export function preloadNewTerminalPalette() {
+  return import("./components/TerminalPalette/NewTerminalPalette");
+}
+export const LazyNewTerminalPalette = lazy(() =>
+  preloadNewTerminalPalette().then((m) => ({ default: m.NewTerminalPalette }))
+);
+
+export function preloadSendToAgentPalette() {
+  return import("./components/Terminal/SendToAgentPalette");
+}
+export const LazySendToAgentPalette = lazy(() =>
+  preloadSendToAgentPalette().then((m) => ({ default: m.SendToAgentPalette }))
+);
+
+export function preloadPanelPalette() {
+  return import("./components/PanelPalette/PanelPalette");
+}
+export const LazyPanelPalette = lazy(() =>
+  preloadPanelPalette().then((m) => ({ default: m.PanelPalette }))
+);
+
+export function preloadActionPalette() {
+  return import("./components/ActionPalette/ActionPalette");
+}
+export const LazyActionPalette = lazy(() =>
+  preloadActionPalette().then((m) => ({ default: m.ActionPalette }))
+);
+
+export function preloadQuickSwitcher() {
+  return import("./components/QuickSwitcher/QuickSwitcher");
+}
+export const LazyQuickSwitcher = lazy(() =>
+  preloadQuickSwitcher().then((m) => ({ default: m.QuickSwitcher }))
+);
+
+export function preloadProjectSwitcherPalette() {
+  return import("./components/Project/ProjectSwitcherPalette");
+}
+export const LazyProjectSwitcherPalette = lazy(() =>
+  preloadProjectSwitcherPalette().then((m) => ({ default: m.ProjectSwitcherPalette }))
+);
+
+export function preloadGitInitDialog() {
+  return import("./components/Project/GitInitDialog");
+}
+export const LazyGitInitDialog = lazy(() =>
+  preloadGitInitDialog().then((m) => ({ default: m.GitInitDialog }))
+);
+
+export function preloadCloneRepoDialog() {
+  return import("./components/Project/CloneRepoDialog");
+}
+export const LazyCloneRepoDialog = lazy(() =>
+  preloadCloneRepoDialog().then((m) => ({ default: m.CloneRepoDialog }))
+);
+
+export function preloadCreateProjectFolderDialog() {
+  return import("./components/Project/CreateProjectFolderDialog");
+}
+export const LazyCreateProjectFolderDialog = lazy(() =>
+  preloadCreateProjectFolderDialog().then((m) => ({ default: m.CreateProjectFolderDialog }))
+);
+
+export function preloadThemePalette() {
+  return import("./components/ThemePalette/ThemePalette");
+}
+export const LazyThemePalette = lazy(() =>
+  preloadThemePalette().then((m) => ({ default: m.ThemePalette }))
+);
+export const LazyResumeSessionsPalette = lazy(() =>
+  import("./components/Terminal/ResumeSessionsPalette").then((m) => ({
+    default: m.ResumeSessionsPalette,
+  }))
+);
+
+export function preloadLogLevelPalette() {
+  return import("./components/LogLevelPalette/LogLevelPalette");
+}
+export const LazyLogLevelPalette = lazy(() =>
+  preloadLogLevelPalette().then((m) => ({ default: m.LogLevelPalette }))
+);
+
+export function preloadShortcutReferenceDialog() {
+  return import("./components/KeyboardShortcuts/ShortcutReferenceDialog");
+}
+export const LazyShortcutReferenceDialog = lazy(() =>
+  preloadShortcutReferenceDialog().then((m) => ({ default: m.ShortcutReferenceDialog }))
+);
+
+export function preloadPluginManagerView() {
+  return import("./components/Plugin/PluginManagerView");
+}
+export const LazyPluginManagerView = lazy(() =>
+  preloadPluginManagerView().then((m) => ({ default: m.PluginManagerView }))
+);
+
+export function preloadOnboardingFlow() {
+  return import("./components/Onboarding/OnboardingFlow");
+}
+export const LazyOnboardingFlow = lazy(() =>
+  preloadOnboardingFlow().then((m) => ({ default: m.OnboardingFlow }))
+);
+
+export function preloadGettingStartedChecklist() {
+  return import("./components/Onboarding/GettingStartedChecklist");
+}
+export const LazyGettingStartedChecklist = lazy(() =>
+  preloadGettingStartedChecklist().then((m) => ({ default: m.GettingStartedChecklist }))
+);
+
+export function preloadCelebrationConfetti() {
+  return import("./components/Onboarding/CelebrationConfetti");
+}
+export const LazyCelebrationConfetti = lazy(() =>
+  preloadCelebrationConfetti().then((m) => ({ default: m.CelebrationConfetti }))
+);
+
+export function preloadFileViewerModalHost() {
+  return import("./components/FileViewer/FileViewerModalHost");
+}
+export const LazyFileViewerModalHost = lazy(() =>
+  preloadFileViewerModalHost().then((m) => ({ default: m.FileViewerModalHost }))
+);
+
+export function preloadDiffViewerModalHost() {
+  return import("./components/Worktree/DiffViewerModalHost");
+}
+export const LazyDiffViewerModalHost = lazy(() =>
+  preloadDiffViewerModalHost().then((m) => ({ default: m.DiffViewerModalHost }))
+);
+
+export function preloadMcpConfirmDialog() {
+  return import("./components/McpConfirmDialog");
+}
+export const LazyMcpConfirmDialog = lazy(() =>
+  preloadMcpConfirmDialog().then((m) => ({ default: m.McpConfirmDialog }))
+);
+
+export function preloadPluginConfirmDialog() {
+  return import("./components/Plugin/PluginConfirmDialog");
+}
+export const LazyPluginConfirmDialog = lazy(() =>
+  preloadPluginConfirmDialog().then((m) => ({ default: m.PluginConfirmDialog }))
+);
+
+export function preloadPluginMcpConfirmDialog() {
+  return import("./components/Plugin/PluginMcpConfirmDialog");
+}
+export const LazyPluginMcpConfirmDialog = lazy(() =>
+  preloadPluginMcpConfirmDialog().then((m) => ({ default: m.PluginMcpConfirmDialog }))
+);
+
+export const LazyPluginQuickPickDialog = lazy(() =>
+  import("./components/Plugin/PluginQuickPickDialog").then((m) => ({
+    default: m.PluginQuickPickDialog,
+  }))
+);
+export const LazyPluginInputBoxDialog = lazy(() =>
+  import("./components/Plugin/PluginInputBoxDialog").then((m) => ({
+    default: m.PluginInputBoxDialog,
+  }))
+);
+export const LazyPluginConfirmPromptDialog = lazy(() =>
+  import("./components/Plugin/PluginConfirmPromptDialog").then((m) => ({
+    default: m.PluginConfirmPromptDialog,
+  }))
+);
+export function preloadPluginCapabilityConfirmDialog() {
+  return import("./components/Plugin/PluginCapabilityConfirmDialog");
+}
+export const LazyPluginCapabilityConfirmDialog = lazy(() =>
+  preloadPluginCapabilityConfirmDialog().then((m) => ({
+    default: m.PluginCapabilityConfirmDialog,
+  }))
+);
+
+export function preloadPanelLimitConfirmDialog() {
+  return import("./components/Terminal/PanelLimitConfirmDialog");
+}
+export const LazyPanelLimitConfirmDialog = lazy(() =>
+  preloadPanelLimitConfirmDialog().then((m) => ({ default: m.PanelLimitConfirmDialog }))
+);
+
+export function preloadDiagnosticsReviewDialogHost() {
+  return import("./components/Settings/DiagnosticsReviewDialogHost");
+}
+export const LazyDiagnosticsReviewDialogHost = lazy(() =>
+  preloadDiagnosticsReviewDialogHost().then((m) => ({ default: m.DiagnosticsReviewDialogHost }))
+);
+
+export function preloadGitPushConfirmDialog() {
+  return import("./components/Git/GitPushConfirmDialog");
+}
+export const LazyGitPushConfirmDialog = lazy(() =>
+  preloadGitPushConfirmDialog().then((m) => ({ default: m.GitPushConfirmDialog }))
+);
+
+export function preloadGitPullRebaseConfirmDialog() {
+  return import("./components/Git/GitPullRebaseConfirmDialog");
+}
+export const LazyGitPullRebaseConfirmDialog = lazy(() =>
+  preloadGitPullRebaseConfirmDialog().then((m) => ({
+    default: m.GitPullRebaseConfirmDialog,
+  }))
+);
+
+export function preloadRecipeConflictDialog() {
+  return import("./components/TerminalRecipe/RecipeConflictDialog");
+}
+export const LazyRecipeConflictDialog = lazy(() =>
+  preloadRecipeConflictDialog().then((m) => ({ default: m.RecipeConflictDialog }))
+);
+
+export function preloadCrashRecoveryDialog() {
+  return import("./components/Recovery/CrashRecoveryDialog");
+}
+export const LazyCrashRecoveryDialog = lazy(() =>
+  preloadCrashRecoveryDialog().then((m) => ({ default: m.CrashRecoveryDialog }))
+);
+
+export const loadMotionFeatures = () => import("./lib/motionFeatures").then((mod) => mod.default);


### PR DESCRIPTION
## Summary

- `src/App.tsx` had grown to ~1,795 lines and was really three things stuck together: a lazy-import prelude, one giant bootstrap component, and a wall of near-identical modal-host JSX. This PR splits it into sibling modules, purely mechanical, no behavior change.
- Moved the lazy panel definitions and preload functions to `src/lazyPanels.ts`, the ~40 palette/dialog/confirm modal-host blocks to `src/ModalHostLayer.tsx`, and the boot/hydration/reset-key/E2E-bridge/palette-wiring logic into dedicated hooks under `src/hooks/app/`.
- `App.tsx` is now a small composition root; hook call order and the double-`requestAnimationFrame` `notifyViewPainted` first-paint signal are preserved exactly where they were.

Resolves #10997

## Changes

- `src/lazyPanels.ts`: the `lazy()` panel definitions, matching `preload*` functions, and the idle-preload list.
- `src/ModalHostLayer.tsx`: the palette/dialog/confirm modal-host JSX, grouped into a single component.
- `src/hooks/app/useAppBootstrap.ts`: boot, hydration, crash-gate, and idle-preload orchestration.
- `src/hooks/app/useModalResetKeys.ts`: the dialog-host reset-key selectors.
- `src/hooks/app/useE2EBridges.ts`: the E2E window backdoor effects.
- `src/hooks/app/usePaletteWiring.ts`: the palette hooks plus their `useKeepMounted` latches, returned as one typed bag.

## Testing

- Added unit tests for `useE2EBridges` and `useModalResetKeys`.
- Ran `npm run check` (typecheck, lint, format, codegen/channel/confirm-wiring guards) and the affected test suites.
