### PR TITLE
refactor(dev-preview): split DevPreviewPane.tsx into hooks and parts

### DIFF
--- a/src/components/DevPreview/DevPreviewBanners.tsx
+++ b/src/components/DevPreview/DevPreviewBanners.tsx
@@ -1,0 +1,140 @@
+import { AlertTriangle, RotateCw, WifiOff } from "lucide-react";
+import { InlineStatusBanner, type BannerAction } from "../Terminal/InlineStatusBanner";
+import { BannerOverflowMenu } from "../Terminal/BannerOverflowMenu";
+import type { UseDevServerReturn } from "@/hooks/useDevServer";
+
+const STUCK_REMEDY_LABELS: Record<string, string> = {
+  "devPreview.restartAndClearCache": "Restart and clear cache",
+  "devPreview.reinstallAndRestart": "Reinstall dependencies",
+};
+
+interface DevPreviewStuckBannerProps {
+  tier: 2 | 3;
+  error: UseDevServerReturn["error"];
+  /** Disables the banner actions while a restart is already in flight. */
+  isRestarting: boolean;
+  /**
+   * When `"Compiling"` at Tier 3, the banner swaps to long-compile copy
+   * instead of the generic "didn't start" framing — the server clearly
+   * started, the first compile is just slow.
+   */
+  phaseLabel?: "Compiling";
+  onRestart: () => void;
+  onRemedy: (actionId: string) => void;
+}
+
+/**
+ * Staged stuck-start escalation banner (#8276, copy retuned #9099). Replaces
+ * the old silent auto-restart with a user-driven signal: Tier 2 is a warning
+ * that the server is slow (suppressed by the hook while `phaseLabel ===
+ * "Compiling"` — compile evidence isn't "stuck"), Tier 3 an error that names
+ * likely causes and, when the dev server emitted a recognised error, offers
+ * a variant-specific remedy (`error.recommendedActionId`) alongside a plain
+ * restart. At Tier 3 with `phaseLabel === "Compiling"` the copy switches to
+ * a long-compile framing instead of the "didn't start" framing.
+ */
+export function DevPreviewStuckBanner({
+  tier,
+  error,
+  isRestarting,
+  phaseLabel,
+  onRestart,
+  onRemedy,
+}: DevPreviewStuckBannerProps) {
+  const restartAction: BannerAction = {
+    id: "dev-preview-stuck-restart",
+    label: "Restart dev server",
+    icon: RotateCw,
+    variant: "primary",
+    disabled: isRestarting,
+    onClick: onRestart,
+  };
+
+  if (tier === 2) {
+    return (
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        severity="warning"
+        title="Dev server is slow to start"
+        description="It's been a while without a URL. Check the terminal logs for what it's waiting on — restarting clears those logs."
+        role="status"
+        ariaLive="polite"
+        actions={[restartAction]}
+      />
+    );
+  }
+
+  const remedyId = error?.recommendedActionId;
+  const remedyLabel = remedyId ? STUCK_REMEDY_LABELS[remedyId] : undefined;
+  // When a specific remedy is recommended it's the single primary action and
+  // the generic restart drops into the overflow menu; otherwise restart is the
+  // lone action. Keeps this error banner to one inline action.
+  const hasRemedy = !!(remedyId && remedyLabel);
+  const primaryAction: BannerAction = hasRemedy
+    ? {
+        id: `dev-preview-stuck-remedy-${remedyId}`,
+        label: remedyLabel,
+        icon: RotateCw,
+        variant: "primary",
+        disabled: isRestarting,
+        onClick: () => onRemedy(remedyId),
+      }
+    : restartAction;
+  const overflowActions: BannerAction[] = hasRemedy ? [restartAction] : [];
+
+  const isLongCompile = phaseLabel === "Compiling" && !error?.message;
+  const title = isLongCompile
+    ? "First compile is taking longer than usual"
+    : "Dev server still hasn't started";
+  const description = error?.message
+    ? error.message
+    : isLongCompile
+      ? "The initial compile is still running. Check the terminal logs — large projects can take 45s or more."
+      : "Likely causes: the port is still bound by another process, dependencies are missing, or the build cache is stuck. Check the terminal logs.";
+
+  return (
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      severity="error"
+      title={title}
+      description={description}
+      role="alert"
+      ariaLive="assertive"
+      action={primaryAction}
+      trailingSlot={
+        overflowActions.length > 0 ? (
+          <BannerOverflowMenu actions={overflowActions} ariaLabel="More dev server options" />
+        ) : undefined
+      }
+    />
+  );
+}
+
+/**
+ * Surfaces a dead Vite HMR socket (#9975). The dev server keeps logging
+ * `[vite] hmr update` on every save — which fires the "Compiling" phase and
+ * reads as "live reload is working" — but with a custom `server.hmr.*` config
+ * the browser's socket connects off the proxy origin or fails outright, so
+ * the preview is silently stale. `useDevPreviewConsoleCapture` catches Vite's
+ * own failure log and flips `hmrDead`; this is a Tier 3 running-state failure
+ * with a pane-local recovery (reload reconnects the socket).
+ */
+export function DevPreviewHmrDeadBanner({ onReload }: { onReload: () => void }) {
+  return (
+    <InlineStatusBanner
+      icon={WifiOff}
+      severity="error"
+      title="Live reload disconnected"
+      description="Vite's hot-reload socket dropped, so saved changes won't show up in the preview. Reload to reconnect, or drop the custom server.hmr.* config if it keeps happening."
+      role="alert"
+      ariaLive="assertive"
+      action={{
+        id: "dev-preview-hmr-dead-reload",
+        label: "Reload",
+        icon: RotateCw,
+        variant: "primary",
+        onClick: onReload,
+      }}
+    />
+  );
+}

--- a/src/components/DevPreview/DevPreviewEmptyStates.tsx
+++ b/src/components/DevPreview/DevPreviewEmptyStates.tsx
@@ -1,0 +1,357 @@
+import {
+  AlertTriangle,
+  ChevronDown,
+  ExternalLink,
+  Play,
+  RotateCw,
+  Settings,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
+import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { DevPreviewStatus } from "@/hooks/useDevServer";
+import type { DevServerError } from "@shared/utils/devServerErrors";
+import type { RunCommand } from "@shared/types";
+
+interface DevPreviewEmptyStatesProps {
+  isRestarting: boolean;
+  status: DevPreviewStatus;
+  isProxyUrlPending: boolean;
+  phaseLabel?: "Compiling";
+  error: DevServerError | null;
+  handleRetry: () => void;
+  setDevPreviewConsoleOpen: (id: string, open: boolean) => void;
+  id: string;
+  currentUrl: string;
+  handleOpenExternal: () => void;
+  isUnconfigured: boolean;
+  primaryCandidate: RunCommand | undefined;
+  isAutoDetecting: boolean;
+  isSettingsLoading: boolean;
+  handleAutoDetect: (candidateCommand?: string) => Promise<boolean>;
+  autoDetectFailedCommand: string | null;
+  candidates: RunCommand[];
+  pickerOpen: boolean;
+  setPickerOpen: (open: boolean) => void;
+  handlePickCandidate: (candidate: { command: string }) => void;
+  handleOpenSettings: () => void;
+  commandInput: string;
+  setCommandInput: (value: string) => void;
+  handleSaveCommand: () => Promise<void>;
+  commandInputError: string | null;
+  devCommand: string;
+  handleStartFromRestored: () => void;
+  hasBeenVisible: boolean;
+  isEvicted: boolean;
+}
+
+/**
+ * Renders the non-webview states of the dev-preview surface: the full-pane
+ * loading spinner, dev-server error, unconfigured/restored-stopped/waiting
+ * placeholders, and the not-yet-visible/evicted placeholders. Callers gate
+ * rendering this instead of the live webview via the same condition used
+ * internally here, so the branch order below must stay in sync with that gate.
+ */
+export function DevPreviewEmptyStates({
+  isRestarting,
+  status,
+  isProxyUrlPending,
+  phaseLabel,
+  error,
+  handleRetry,
+  setDevPreviewConsoleOpen,
+  id,
+  currentUrl,
+  handleOpenExternal,
+  isUnconfigured,
+  primaryCandidate,
+  isAutoDetecting,
+  isSettingsLoading,
+  handleAutoDetect,
+  autoDetectFailedCommand,
+  candidates,
+  pickerOpen,
+  setPickerOpen,
+  handlePickCandidate,
+  handleOpenSettings,
+  commandInput,
+  setCommandInput,
+  handleSaveCommand,
+  commandInputError,
+  devCommand,
+  handleStartFromRestored,
+  hasBeenVisible,
+  isEvicted,
+}: DevPreviewEmptyStatesProps) {
+  if (isRestarting || status === "starting" || status === "installing" || isProxyUrlPending) {
+    return (
+      <DevPreviewLoadingState
+        variant="full"
+        isLoading={true}
+        phaseLabel={
+          isRestarting
+            ? "Restarting"
+            : status === "installing"
+              ? "Installing dependencies"
+              : (phaseLabel ?? "Starting dev server")
+        }
+      />
+    );
+  }
+
+  if (status === "error" && error) {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+        <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
+        <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+          {error.type === "port-conflict"
+            ? "Port conflict"
+            : error.type === "missing-dependencies"
+              ? "Missing dependencies"
+              : error.type === "permission"
+                ? "Permission denied"
+                : "Dev server error"}
+        </h3>
+        <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">{error.message}</p>
+        <div className="flex items-center gap-1">
+          <Button
+            onClick={handleRetry}
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 px-2.5 py-1.5 group"
+          >
+            <RotateCw className="h-3.5 w-3.5" />
+            <span className="text-xs">
+              {error.type === "missing-dependencies" ? "Retry install" : "Retry"}
+            </span>
+          </Button>
+          {error.type === "missing-dependencies" || error.type === "permission" ? (
+            <Button
+              onClick={() => setDevPreviewConsoleOpen(id, true)}
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              <span className="text-xs">View terminal</span>
+            </Button>
+          ) : currentUrl ? (
+            <Button
+              onClick={handleOpenExternal}
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              <span className="text-xs">Open external</span>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  if (!currentUrl || status !== "running") {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+        {isUnconfigured ? (
+          <div className="flex flex-col items-center text-center max-w-md">
+            {primaryCandidate ? (
+              <>
+                <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                  Start the dev server
+                </h3>
+                <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
+                  We found a script in your package.json that looks like a dev server.
+                </p>
+                <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
+                  <span className="text-[11px] text-daintree-text/40">Auto-detected</span>
+                  <code className="text-xs text-daintree-text/70 font-mono">
+                    {primaryCandidate.command}
+                  </code>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <Button
+                    onClick={() => void handleAutoDetect(primaryCandidate.command)}
+                    disabled={isAutoDetecting || isSettingsLoading}
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
+                  >
+                    <Play className="h-3.5 w-3.5" />
+                    <span className="text-xs">
+                      {isAutoDetecting ? "Detecting..." : `Run \`${primaryCandidate.command}\``}
+                    </span>
+                  </Button>
+                  {autoDetectFailedCommand !== null && (
+                    <InlineStatusBanner
+                      icon={XCircle}
+                      severity="error"
+                      title="Couldn't start preview"
+                      description="The detected command couldn't be saved to project settings."
+                      className="w-full rounded text-left"
+                      action={{
+                        id: "dev-preview-auto-detect-retry",
+                        label: "Retry",
+                        icon: RotateCw,
+                        variant: "dangerFilled",
+                        onClick: () =>
+                          void handleAutoDetect(
+                            autoDetectFailedCommand || primaryCandidate.command
+                          ),
+                      }}
+                    />
+                  )}
+                  {candidates.length > 1 && (
+                    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 text-xs text-daintree-text/50 hover:text-daintree-text/70 transition-colors"
+                        >
+                          Use a different script...
+                          <ChevronDown className="h-3 w-3" />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent align="center" sideOffset={4} className="w-72 p-1">
+                        <div className="flex flex-col max-h-64 overflow-y-auto">
+                          {candidates.map((c) => (
+                            <button
+                              key={c.id}
+                              type="button"
+                              onClick={() => {
+                                handlePickCandidate(c);
+                                setPickerOpen(false);
+                              }}
+                              className="flex items-center gap-2 px-2 py-1.5 rounded text-xs hover:bg-overlay-subtle transition-colors text-left"
+                            >
+                              <code className="text-daintree-text/70 font-mono text-[11px] flex-1 truncate">
+                                {c.command}
+                              </code>
+                              <span className="text-daintree-text/40 shrink-0">{c.name}</span>
+                            </button>
+                          ))}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                  )}
+                  <Button
+                    onClick={handleOpenSettings}
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                  >
+                    <Settings className="h-3.5 w-3.5" />
+                    <span className="text-xs">Open project settings</span>
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                  Set a dev command
+                </h3>
+                <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
+                  Configure a command to start a local development server.
+                </p>
+                <div className="flex flex-col items-center gap-2 w-full max-w-xs">
+                  <input
+                    type="text"
+                    value={commandInput}
+                    onChange={(e) => setCommandInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        void handleSaveCommand();
+                      }
+                    }}
+                    placeholder="npm run dev"
+                    className="w-full px-2.5 py-1.5 text-xs font-mono bg-overlay-subtle border border-overlay/30 rounded text-daintree-text/70 placeholder:text-text-placeholder focus:outline-hidden focus:border-overlay/50 transition-[border-color,box-shadow]"
+                  />
+                  <Button
+                    onClick={() => void handleSaveCommand()}
+                    disabled={!commandInput.trim() || commandInputError !== null}
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
+                  >
+                    <Play className="h-3.5 w-3.5" />
+                    <span className="text-xs">Run</span>
+                  </Button>
+                  {commandInput.trim() && commandInputError && (
+                    <p className="text-[11px] text-status-warning">{commandInputError}</p>
+                  )}
+                </div>
+                <Button
+                  onClick={handleOpenSettings}
+                  variant="ghost"
+                  size="sm"
+                  className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70 mt-3"
+                >
+                  <Settings className="h-3.5 w-3.5" />
+                  <span className="text-xs">Open project settings</span>
+                </Button>
+              </>
+            )}
+          </div>
+        ) : status === "restored-stopped" ? (
+          <div className="flex flex-col items-center text-center max-w-md">
+            <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+              Dev server was running
+            </h3>
+            <p className="text-xs text-daintree-text/50 mb-3 leading-relaxed">
+              Daintree closed while this dev server was active. It wasn't reattached — restart to
+              run it again.
+            </p>
+            {devCommand && (
+              <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
+                <code className="text-xs text-daintree-text/70 font-mono">{devCommand}</code>
+              </div>
+            )}
+            <Button
+              onClick={handleStartFromRestored}
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
+            >
+              <RotateCw className="h-3.5 w-3.5" />
+              <span className="text-xs">Restart dev server</span>
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center text-center max-w-md">
+            <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+              Waiting for dev server
+            </h3>
+            <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
+              The development server will appear here once it starts and a URL is detected.
+            </p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (!hasBeenVisible) {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text">
+        <p className="text-xs text-daintree-text/50">
+          Preview will load when this panel is first viewed
+        </p>
+      </div>
+    );
+  }
+
+  if (isEvicted) {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+        <p className="text-xs text-daintree-text/50">
+          Preview paused to save memory — will reload when opened
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -435,7 +435,7 @@ export function DevPreviewPane({
     setWebviewLoadError(null);
     clearRetryState();
     setCommandInput("");
-  }, [isUnconfigured, id, setBrowserUrl, setWebviewLoadError, clearRetryState]);
+  }, [isUnconfigured, id, setBrowserUrl, setWebviewLoadError, clearRetryState, setCommandInput]);
 
   const setWebviewNode = useCallback(
     (node: Electron.WebviewTag | null) => {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useRef, useEffect, useMemo, useReducer } from "react";
-import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import { OctagonAlert, RotateCw } from "lucide-react";
 import { DevPreviewDestructiveConfirmDialog } from "./DevPreviewDestructiveConfirmDialog";
 import { usePanelStore } from "@/store";
@@ -10,13 +9,7 @@ import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { BrowserToolbar } from "../Browser/BrowserToolbar";
 import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
 import { DevPreviewStuckBanner, DevPreviewHmrDeadBanner } from "./DevPreviewBanners";
-import { normalizeBrowserUrl } from "../Browser/browserUtils";
-import {
-  goBackBrowserHistory,
-  goForwardBrowserHistory,
-  initializeBrowserHistory,
-  pushBrowserHistory,
-} from "../Browser/historyUtils";
+import { initializeBrowserHistory } from "../Browser/historyUtils";
 import { useDevServer } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
@@ -25,12 +18,11 @@ import { useDevPreviewScrollCapture } from "./useDevPreviewScrollCapture";
 import { useDevPreviewCrashRecovery } from "./useDevPreviewCrashRecovery";
 import { useDevPreviewViewport } from "./useDevPreviewViewport";
 import { DevPreviewWebviewOverlays } from "./DevPreviewWebviewOverlays";
+import { useDevPreviewNavigation } from "./useDevPreviewNavigation";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
-import { computeDevServerUrl } from "./urlSync";
-import { actionService } from "@/services/ActionService";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
@@ -42,7 +34,6 @@ import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import { isDevPreviewPanel } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
-import { notify } from "@/lib/notify";
 import { loadWebviewUrl } from "./loadWebviewUrl";
 import { useDevPreviewLoadLifecycle, type SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
 
@@ -228,7 +219,6 @@ export function DevPreviewPane({
 
   const [blockedNav, dispatchBlockedNav] = useReducer(blockedNavReducer, null);
   const crashReloadRef = useRef<() => void>(() => {});
-  const screenshotInFlightRef = useRef(false);
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
   const CLIPBOARD_FEEDBACK_MS = 2000;
   const [certCopied, setCertCopied] = useState(false);
@@ -481,88 +471,6 @@ export function DevPreviewPane({
     setConsoleTerminalId(terminalId);
   }, [terminalId]);
 
-  useEffect(() => {
-    if (isUnconfigured) return;
-    // Hold navigation until the proxy port resolution settles, otherwise the pane would
-    // briefly adopt the unstable direct-localhost origin before the proxy origin is known (#9100).
-    if (proxyOrigin === undefined) return;
-    const nextUrl = url ? computeDevServerUrl(url, currentUrl, proxyOrigin) : false;
-    if (nextUrl !== false) {
-      // Push history only; the imperative navigation effect (keyed on currentUrl
-      // vs lastSetUrlRef) performs the actual loadURL. Pre-setting lastSetUrlRef
-      // here would make that effect skip — which used to be fine when `src`
-      // re-bound to currentUrl, but src is now seed-only (#9940).
-      setHistory((prev) => pushBrowserHistory(prev, nextUrl));
-    }
-  }, [url, currentUrl, isUnconfigured, proxyOrigin]);
-
-  useEffect(() => {
-    if (isUnconfigured) return;
-    if (currentUrl) {
-      setBrowserUrl(id, currentUrl);
-    }
-  }, [id, currentUrl, setBrowserUrl, isUnconfigured]);
-
-  useEffect(() => {
-    setBrowserHistory(id, history);
-  }, [id, history, setBrowserHistory]);
-
-  useEffect(() => {
-    setBrowserZoom(id, zoomFactor);
-  }, [id, zoomFactor, setBrowserZoom]);
-
-  const handleNavigate = useCallback((rawUrl: string) => {
-    const normalized = normalizeBrowserUrl(rawUrl);
-    if (normalized.url) {
-      // Push history only; the imperative navigation effect drives loadURL now
-      // that `src` is seed-only (#9940). Mirrors handleBack/handleForward.
-      setHistory((prev) => pushBrowserHistory(prev, normalized.url!));
-    }
-  }, []);
-
-  const handleBack = useCallback(() => {
-    if (canGoBack) {
-      setHistory((prev) => goBackBrowserHistory(prev));
-    }
-  }, [canGoBack]);
-
-  const handleForward = useCallback(() => {
-    if (canGoForward) {
-      setHistory((prev) => goForwardBrowserHistory(prev));
-    }
-  }, [canGoForward]);
-
-  const handleReload = useCallback(() => {
-    setWebviewLoadError(null);
-    webviewRef.current?.reload();
-  }, [setWebviewLoadError]);
-
-  const handleCancelLoad = useCallback(() => {
-    clearLoadTimers();
-    setIsLoading(false);
-    try {
-      webviewRef.current?.stop();
-    } catch {
-      // Webview detached
-    }
-    setWebviewLoadError({ code: "aborted", message: "Load cancelled." });
-  }, [clearLoadTimers, setIsLoading, setWebviewLoadError]);
-
-  const handleRetryWebviewLoad = useCallback(() => {
-    setWebviewLoadError(null);
-    setIsLoading(true);
-    if (currentUrl) {
-      // Swallow ERR_ABORTED-class rejections — did-fail-load is the source
-      // of truth for genuine failures.
-      const webview = webviewRef.current;
-      if (webview) {
-        loadWebviewUrl(webview, currentUrl);
-      }
-    } else {
-      webviewRef.current?.reload();
-    }
-  }, [currentUrl, setWebviewLoadError, setIsLoading]);
-
   const performReload = useCallback(() => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
@@ -577,51 +485,6 @@ export function DevPreviewPane({
     }
   }, [isWebviewReady, id, setWebviewLoadError]);
 
-  const handleCaptureScreenshot = useCallback(async () => {
-    const webview = webviewRef.current;
-    if (!webview || !isWebviewReady) return false;
-    let url: string;
-    try {
-      url = webview.getURL();
-    } catch {
-      return false;
-    }
-    if (!url || url === "about:blank") return false;
-    if (screenshotInFlightRef.current) return false;
-    screenshotInFlightRef.current = true;
-    try {
-      const image = await webview.capturePage();
-      const pngData = new Uint8Array(image.toPNG());
-      await window.electron.clipboard.writeImage(pngData);
-      return true;
-    } catch (err) {
-      logError("[DevPreviewPane] Screenshot capture failed", err);
-      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-      notify({
-        type: "error",
-        title: "Screenshot failed",
-        message: "Couldn't copy the screenshot to clipboard",
-      });
-      return false;
-    } finally {
-      screenshotInFlightRef.current = false;
-    }
-  }, [isWebviewReady]);
-
-  const handleToggleDevTools = useCallback(() => {
-    const webview = webviewRef.current;
-    if (!webview || !isWebviewReady) return;
-    if (webview.isDevToolsOpened()) {
-      webview.closeDevTools();
-    } else {
-      webview.openDevTools();
-    }
-  }, [isWebviewReady]);
-
-  const handleToggleConsole = useCallback(() => {
-    setDevPreviewConsoleOpen(id, !isConsoleOpen);
-  }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
-
   const handleHardReload = useCallback(() => {
     resetCrashHistory();
     performReload();
@@ -633,76 +496,42 @@ export function DevPreviewPane({
     crashReloadRef.current = performReload;
   }, [performReload]);
 
-  const handleOpenExternal = useCallback(() => {
-    if (!currentUrl) return;
-
-    // In proxy mode (#9101), hand the system browser a short-lived signed
-    // bootstrap URL on the stable origin instead of the raw dev-server URL: it
-    // lands with a session cookie and survives dev-server restarts that reshuffle
-    // the upstream port. Fall back to the raw URL in legacy mode or if minting
-    // fails, so the button always opens *something*.
-    if (typeof proxyOrigin === "string" && currentProjectId && currentUrl.startsWith(proxyOrigin)) {
-      // Preserve the hash too — hash-router SPAs keep their route in the fragment.
-      const { pathname, search, hash } = new URL(currentUrl);
-      safeFireAndForget(
-        (async () => {
-          try {
-            const { bootstrapUrl } = await window.electron.devPreview.mintBrowserToken({
-              panelId: id,
-              projectId: currentProjectId,
-              redirectPath: `${pathname}${search}${hash}`,
-            });
-            await window.electron.system.openExternal(bootstrapUrl);
-          } catch (err) {
-            logError("[DevPreviewPane] Browser handoff token failed; opening raw URL", err);
-            await window.electron.system.openExternal(currentUrl);
-          }
-        })(),
-        { context: "Opening dev preview URL externally" }
-      );
-      return;
-    }
-
-    safeFireAndForget(window.electron.system.openExternal(currentUrl), {
-      context: "Opening dev preview URL externally",
-    });
-  }, [currentUrl, proxyOrigin, currentProjectId, id]);
-
-  const isPromotingRef = useRef(false);
-  const handlePromoteToPortal = useCallback(() => {
-    if (isPromotingRef.current) return;
-    isPromotingRef.current = true;
-    if (currentUrl) {
-      setBrowserUrl(id, currentUrl);
-    }
-    void actionService
-      .dispatch(
-        "devPreview.promoteToPortal",
-        { panelId: id, projectId: currentProjectId },
-        { source: "user" }
-      )
-      .finally(() => {
-        isPromotingRef.current = false;
-      });
-  }, [currentProjectId, currentUrl, id, setBrowserUrl]);
-
-  const handleZoomChange = useCallback((newZoom: number) => {
-    const clamped = Math.max(0.25, Math.min(2.0, newZoom));
-    setZoomFactor(clamped);
-    if (webviewRef.current) {
-      webviewRef.current.setZoomFactor(clamped);
-    }
-  }, []);
-
-  useBrowserActionListeners(id, {
-    onReload: handleReload,
-    onNavigate: handleNavigate,
-    onBack: handleBack,
-    onForward: handleForward,
-    onSetZoom: handleZoomChange,
-    onCaptureScreenshot: handleCaptureScreenshot,
-    onToggleDevTools: handleToggleDevTools,
-    onToggleConsole: handleToggleConsole,
+  const {
+    handleNavigate,
+    handleBack,
+    handleForward,
+    handleReload,
+    handleCancelLoad,
+    handleRetryWebviewLoad,
+    handleCaptureScreenshot,
+    handleToggleDevTools,
+    handleToggleConsole,
+    handleZoomChange,
+    handleOpenExternal,
+    handlePromoteToPortal,
+  } = useDevPreviewNavigation({
+    id,
+    currentProjectId,
+    currentUrl,
+    canGoBack,
+    canGoForward,
+    history,
+    setHistory,
+    zoomFactor,
+    setZoomFactor,
+    devServerUrl: url,
+    proxyOrigin,
+    isUnconfigured,
+    isWebviewReady,
+    webviewRef,
+    setBrowserUrl,
+    setBrowserHistory,
+    setBrowserZoom,
+    setIsLoading,
+    setWebviewLoadError,
+    clearLoadTimers,
+    isConsoleOpen,
+    setDevPreviewConsoleOpen,
     onHardReload: handleHardReload,
   });
 
@@ -918,7 +747,8 @@ export function DevPreviewPane({
 
   // Activate the dev-preview keybinding scope while focused so Cmd/Ctrl+R maps
   // to devPreview.reloadPreview when the panel chrome (toolbar/header) has focus.
-  // The guest-focused case is covered separately by onReloadShortcut below.
+  // The guest-focused case is covered separately by useDevPreviewNavigation's
+  // onReloadShortcut listener.
   useKeybindingScope("dev-preview", isFocused);
 
   // Listen for blocked navigation events from main process.
@@ -965,47 +795,6 @@ export function DevPreviewPane({
       }
     };
   }, [id, webviewElement]);
-
-  // Listen for the reload shortcut (Cmd/Ctrl+R) forwarded from the focused
-  // webview guest. When the guest has focus, the outer renderer's keybinding
-  // handler never fires, so the main process intercepts the key and forwards it.
-  useEffect(() => {
-    const cleanup = window.electron.webview.onReloadShortcut((payload) => {
-      if (payload.panelId !== id) return;
-      handleHardReload();
-    });
-    return cleanup;
-  }, [id, handleHardReload]);
-
-  // Listen for the close shortcut (Cmd/Ctrl+W) forwarded from the focused
-  // webview guest (#10859). Without this, focus inside the guest bypasses the
-  // host window's setIgnoreMenuShortcuts guard and the native role:"close"
-  // menu accelerator closes the whole window instead of just this panel.
-  useEffect(() => {
-    const cleanup = window.electron.webview.onCloseShortcut((payload) => {
-      if (payload.panelId !== id) return;
-      void actionService.dispatch("terminal.close", { terminalId: id }, { source: "keybinding" });
-    });
-    return cleanup;
-  }, [id]);
-
-  // Listen for action-driven hard-reload events
-  useEffect(() => {
-    const handleHardReloadEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleHardReload();
-      }
-    };
-
-    const controller = new AbortController();
-    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
-      signal: controller.signal,
-    });
-    return () => controller.abort();
-  }, [id, handleHardReload]);
 
   // Mirrors the branch order in DevPreviewEmptyStates: true whenever that
   // ternary chain there would pick one of its non-null branches instead of

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -19,7 +19,6 @@ import { useDevPreviewCrashRecovery } from "./useDevPreviewCrashRecovery";
 import { useDevPreviewViewport } from "./useDevPreviewViewport";
 import { DevPreviewWebviewOverlays } from "./DevPreviewWebviewOverlays";
 import { useDevPreviewNavigation } from "./useDevPreviewNavigation";
-import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -40,6 +40,7 @@ import { useDevServer } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
 import { useDevPreviewCommandConfig } from "./useDevPreviewCommandConfig";
+import { useDevPreviewScrollCapture } from "./useDevPreviewScrollCapture";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
@@ -187,6 +188,13 @@ export function DevPreviewPane({
     turbopackEnabled: projectSettings?.turbopackEnabled ?? true,
   });
 
+  const { captureScrollViaCdp, invalidateScrollCaptures } = useDevPreviewScrollCapture({
+    id,
+    status,
+    webviewElement,
+    setDevPreviewScrollPosition,
+  });
+
   const webviewPartition = useMemo(
     () => buildDevPreviewPartition(currentProjectId, worktreeId, id),
     [currentProjectId, worktreeId, id]
@@ -286,10 +294,6 @@ export function DevPreviewPane({
   // each guest navigation into a redundant full reload (#9940).
   const [webviewSeedUrl, setWebviewSeedUrl] = useState(history.present);
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
-  // Generation token to invalidate in-flight async scroll captures when the
-  // user clears scroll state via hard restart. A pending executeJavaScript
-  // promise that resolves after the clear must NOT write the stale position back.
-  const scrollCaptureGenerationRef = useRef<number>(0);
   const isConsoleOpen = terminal?.devPreviewConsoleOpen ?? false;
   const activeConsoleTab = terminal?.devPreviewConsoleTab ?? "output";
   const [guestWebContentsId, setGuestWebContentsId] = useState<number | undefined>(undefined);
@@ -298,7 +302,6 @@ export function DevPreviewPane({
   const isSettingsLoading = useProjectSettingsStore((state) => state.isLoading);
 
   const isMountedRef = useRef(true);
-  const prevStatusRef = useRef(status);
 
   const loadTimeoutMs =
     Math.min(Math.max(projectSettings?.devServerLoadTimeout ?? 30, 1), 120) * 1000;
@@ -503,31 +506,7 @@ export function DevPreviewPane({
     (node: Electron.WebviewTag | null) => {
       if (!node && webviewRef.current) {
         try {
-          const prevWebview = webviewRef.current;
-          const currentWebviewUrl = prevWebview.getURL();
-          if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
-            const captureGeneration = scrollCaptureGenerationRef.current;
-            // Use main-process CDP Page.getLayoutMetrics instead of
-            // executeJavaScript("window.scrollY"): hidden dock webviews are
-            // frozen by useWebviewThrottle (via Page.setWebLifecycleState) which
-            // suspends the JS task queue, so the executeJavaScript path hangs
-            // when memory-pressure eviction fires while the page is frozen.
-            const wcId = (
-              prevWebview as unknown as { getWebContentsId(): number }
-            ).getWebContentsId();
-            window.electron.webview
-              .getScrollPosition(wcId)
-              .then((scrollY: number) => {
-                if (scrollCaptureGenerationRef.current !== captureGeneration) return;
-                // Guard `> 0`: a CDP error returns 0, and the user being at top
-                // of page has nothing worth restoring — both cases should leave
-                // any prior stored position untouched rather than clobber it.
-                if (typeof scrollY === "number" && Number.isFinite(scrollY) && scrollY > 0) {
-                  setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
-                }
-              })
-              .catch(() => {});
-          }
+          captureScrollViaCdp(webviewRef.current);
         } catch {
           // Webview already detached
         }
@@ -542,7 +521,7 @@ export function DevPreviewPane({
       }
       setWebviewElement(node);
     },
-    [id, setDevPreviewScrollPosition, clearRetryState, effectiveWebviewSeedUrl]
+    [captureScrollViaCdp, clearRetryState, effectiveWebviewSeedUrl]
   );
 
   useEffect(() => {
@@ -551,31 +530,6 @@ export function DevPreviewPane({
       isMountedRef.current = false;
     };
   }, []);
-
-  useEffect(() => {
-    const prevStatus = prevStatusRef.current;
-    prevStatusRef.current = status;
-
-    if (prevStatus === "running" && status !== "running" && webviewElement) {
-      try {
-        const currentWebviewUrl = webviewElement.getURL();
-        if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
-          const captureGeneration = scrollCaptureGenerationRef.current;
-          webviewElement
-            .executeJavaScript("window.scrollY")
-            .then((scrollY: number) => {
-              if (scrollCaptureGenerationRef.current !== captureGeneration) return;
-              if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
-                setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
-              }
-            })
-            .catch(() => {});
-        }
-      } catch {
-        // Webview already detached
-      }
-    }
-  }, [status, id, webviewElement, setDevPreviewScrollPosition]);
 
   useEffect(() => {
     setConsoleTerminalId(terminalId);
@@ -813,7 +767,7 @@ export function DevPreviewPane({
   }, [start]);
 
   const resetPreviewWebviewState = useCallback(() => {
-    scrollCaptureGenerationRef.current += 1;
+    invalidateScrollCaptures();
     setDevPreviewScrollPosition(id, undefined);
     clearLoadTimers();
     setHistory(initializeBrowserHistory(undefined, ""));
@@ -830,6 +784,7 @@ export function DevPreviewPane({
     id,
     setBrowserUrl,
     setDevPreviewScrollPosition,
+    invalidateScrollCaptures,
     clearLoadTimers,
     setIsLoading,
     setIsWebviewReady,
@@ -1021,28 +976,10 @@ export function DevPreviewPane({
     }
     if (isEvicted && webviewRef.current) {
       try {
-        // Save scroll position before eviction. Use the main-process CDP
-        // Page.getLayoutMetrics path rather than executeJavaScript("window.scrollY"):
-        // useWebviewThrottle freezes hidden webviews after 500ms, and frozen pages
-        // suspend the JS task queue so executeJavaScript hangs indefinitely. CDP
-        // reads layout state directly from Blink, bypassing the freeze.
+        // Save scroll position before eviction. See useDevPreviewScrollCapture
+        // for why this uses the CDP path rather than executeJavaScript.
         const wv = webviewRef.current;
-        const currentWebviewUrl = wv.getURL();
-        if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
-          const captureGeneration = scrollCaptureGenerationRef.current;
-          const wcId = (wv as unknown as { getWebContentsId(): number }).getWebContentsId();
-          window.electron.webview
-            .getScrollPosition(wcId)
-            .then((scrollY: number) => {
-              if (scrollCaptureGenerationRef.current !== captureGeneration) return;
-              // See ref-cleanup path above: skip `0` so a CDP error can't
-              // clobber a previously captured position.
-              if (typeof scrollY === "number" && Number.isFinite(scrollY) && scrollY > 0) {
-                setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
-              }
-            })
-            .catch(() => {});
-        }
+        captureScrollViaCdp(wv);
         wv.src = "about:blank";
       } catch {
         // webview may already be detached
@@ -1050,7 +987,7 @@ export function DevPreviewPane({
       clearLoadTimers();
       clearRetryState();
     }
-  }, [isEvicted, id, setDevPreviewScrollPosition, clearLoadTimers, clearRetryState]);
+  }, [isEvicted, captureScrollViaCdp, clearLoadTimers, clearRetryState]);
 
   useWebviewThrottle(id, location, isEvicted ? null : webviewElement, isWebviewReady && !isEvicted);
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -7,9 +7,7 @@ import {
   Copy,
   ExternalLink,
   OctagonAlert,
-  Play,
   RotateCw,
-  Settings,
   XCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -43,6 +41,7 @@ import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
 import { useDevPreviewCommandConfig } from "./useDevPreviewCommandConfig";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
+import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -64,7 +63,6 @@ import {
   computeFitScale,
 } from "@/panels/dev-preview/viewportPresets";
 import { isDevPreviewPanel, type ViewportPresetId } from "@shared/types/panel";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
@@ -1239,6 +1237,20 @@ export function DevPreviewPane({
     return () => controller.abort();
   }, [id, handleHardReload]);
 
+  // Mirrors the branch order in DevPreviewEmptyStates: true whenever that
+  // ternary chain there would pick one of its non-null branches instead of
+  // falling through to the live webview.
+  const showEmptyState =
+    isRestarting ||
+    status === "starting" ||
+    status === "installing" ||
+    isProxyUrlPending ||
+    (status === "error" && !!error) ||
+    !currentUrl ||
+    status !== "running" ||
+    !hasBeenVisible ||
+    isEvicted;
+
   return (
     <ContentPanel
       id={id}
@@ -1322,258 +1334,38 @@ export function DevPreviewPane({
               {viewportFit && fitScale < 1 && ` · ${Math.round(fitScale * 100)}%`}
             </div>
           )}
-          {isRestarting || status === "starting" || status === "installing" || isProxyUrlPending ? (
-            <DevPreviewLoadingState
-              variant="full"
-              isLoading={true}
-              phaseLabel={
-                isRestarting
-                  ? "Restarting"
-                  : status === "installing"
-                    ? "Installing dependencies"
-                    : (phaseLabel ?? "Starting dev server")
-              }
+          {showEmptyState ? (
+            <DevPreviewEmptyStates
+              isRestarting={isRestarting}
+              status={status}
+              isProxyUrlPending={isProxyUrlPending}
+              phaseLabel={phaseLabel}
+              error={error}
+              handleRetry={handleRetry}
+              setDevPreviewConsoleOpen={setDevPreviewConsoleOpen}
+              id={id}
+              currentUrl={currentUrl}
+              handleOpenExternal={handleOpenExternal}
+              isUnconfigured={isUnconfigured}
+              primaryCandidate={primaryCandidate}
+              isAutoDetecting={isAutoDetecting}
+              isSettingsLoading={isSettingsLoading}
+              handleAutoDetect={handleAutoDetect}
+              autoDetectFailedCommand={autoDetectFailedCommand}
+              candidates={candidates}
+              pickerOpen={pickerOpen}
+              setPickerOpen={setPickerOpen}
+              handlePickCandidate={handlePickCandidate}
+              handleOpenSettings={handleOpenSettings}
+              commandInput={commandInput}
+              setCommandInput={setCommandInput}
+              handleSaveCommand={handleSaveCommand}
+              commandInputError={commandInputError}
+              devCommand={devCommand}
+              handleStartFromRestored={handleStartFromRestored}
+              hasBeenVisible={hasBeenVisible}
+              isEvicted={isEvicted}
             />
-          ) : status === "error" && error ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-              <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-              <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                {error.type === "port-conflict"
-                  ? "Port conflict"
-                  : error.type === "missing-dependencies"
-                    ? "Missing dependencies"
-                    : error.type === "permission"
-                      ? "Permission denied"
-                      : "Dev server error"}
-              </h3>
-              <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                {error.message}
-              </p>
-              <div className="flex items-center gap-1">
-                <Button
-                  onClick={handleRetry}
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 px-2.5 py-1.5 group"
-                >
-                  <RotateCw className="h-3.5 w-3.5" />
-                  <span className="text-xs">
-                    {error.type === "missing-dependencies" ? "Retry install" : "Retry"}
-                  </span>
-                </Button>
-                {error.type === "missing-dependencies" || error.type === "permission" ? (
-                  <Button
-                    onClick={() => setDevPreviewConsoleOpen(id, true)}
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                    <span className="text-xs">View terminal</span>
-                  </Button>
-                ) : currentUrl ? (
-                  <Button
-                    onClick={handleOpenExternal}
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                    <span className="text-xs">Open external</span>
-                  </Button>
-                ) : null}
-              </div>
-            </div>
-          ) : !currentUrl || status !== "running" ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-              {isUnconfigured ? (
-                <div className="flex flex-col items-center text-center max-w-md">
-                  {primaryCandidate ? (
-                    <>
-                      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        Start the dev server
-                      </h3>
-                      <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
-                        We found a script in your package.json that looks like a dev server.
-                      </p>
-                      <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
-                        <span className="text-[11px] text-daintree-text/40">Auto-detected</span>
-                        <code className="text-xs text-daintree-text/70 font-mono">
-                          {primaryCandidate.command}
-                        </code>
-                      </div>
-                      <div className="flex flex-col items-center gap-2">
-                        <Button
-                          onClick={() => void handleAutoDetect(primaryCandidate.command)}
-                          disabled={isAutoDetecting || isSettingsLoading}
-                          variant="ghost"
-                          size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
-                        >
-                          <Play className="h-3.5 w-3.5" />
-                          <span className="text-xs">
-                            {isAutoDetecting
-                              ? "Detecting..."
-                              : `Run \`${primaryCandidate.command}\``}
-                          </span>
-                        </Button>
-                        {autoDetectFailedCommand !== null && (
-                          <InlineStatusBanner
-                            icon={XCircle}
-                            severity="error"
-                            title="Couldn't start preview"
-                            description="The detected command couldn't be saved to project settings."
-                            className="w-full rounded text-left"
-                            action={{
-                              id: "dev-preview-auto-detect-retry",
-                              label: "Retry",
-                              icon: RotateCw,
-                              variant: "dangerFilled",
-                              onClick: () =>
-                                void handleAutoDetect(
-                                  autoDetectFailedCommand || primaryCandidate.command
-                                ),
-                            }}
-                          />
-                        )}
-                        {candidates.length > 1 && (
-                          <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-                            <PopoverTrigger asChild>
-                              <button
-                                type="button"
-                                className="inline-flex items-center gap-1 text-xs text-daintree-text/50 hover:text-daintree-text/70 transition-colors"
-                              >
-                                Use a different script...
-                                <ChevronDown className="h-3 w-3" />
-                              </button>
-                            </PopoverTrigger>
-                            <PopoverContent align="center" sideOffset={4} className="w-72 p-1">
-                              <div className="flex flex-col max-h-64 overflow-y-auto">
-                                {candidates.map((c) => (
-                                  <button
-                                    key={c.id}
-                                    type="button"
-                                    onClick={() => {
-                                      handlePickCandidate(c);
-                                      setPickerOpen(false);
-                                    }}
-                                    className="flex items-center gap-2 px-2 py-1.5 rounded text-xs hover:bg-overlay-subtle transition-colors text-left"
-                                  >
-                                    <code className="text-daintree-text/70 font-mono text-[11px] flex-1 truncate">
-                                      {c.command}
-                                    </code>
-                                    <span className="text-daintree-text/40 shrink-0">{c.name}</span>
-                                  </button>
-                                ))}
-                              </div>
-                            </PopoverContent>
-                          </Popover>
-                        )}
-                        <Button
-                          onClick={handleOpenSettings}
-                          variant="ghost"
-                          size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                        >
-                          <Settings className="h-3.5 w-3.5" />
-                          <span className="text-xs">Open project settings</span>
-                        </Button>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        Set a dev command
-                      </h3>
-                      <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
-                        Configure a command to start a local development server.
-                      </p>
-                      <div className="flex flex-col items-center gap-2 w-full max-w-xs">
-                        <input
-                          type="text"
-                          value={commandInput}
-                          onChange={(e) => setCommandInput(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              void handleSaveCommand();
-                            }
-                          }}
-                          placeholder="npm run dev"
-                          className="w-full px-2.5 py-1.5 text-xs font-mono bg-overlay-subtle border border-overlay/30 rounded text-daintree-text/70 placeholder:text-text-placeholder focus:outline-hidden focus:border-overlay/50 transition-[border-color,box-shadow]"
-                        />
-                        <Button
-                          onClick={() => void handleSaveCommand()}
-                          disabled={!commandInput.trim() || commandInputError !== null}
-                          variant="ghost"
-                          size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
-                        >
-                          <Play className="h-3.5 w-3.5" />
-                          <span className="text-xs">Run</span>
-                        </Button>
-                        {commandInput.trim() && commandInputError && (
-                          <p className="text-[11px] text-status-warning">{commandInputError}</p>
-                        )}
-                      </div>
-                      <Button
-                        onClick={handleOpenSettings}
-                        variant="ghost"
-                        size="sm"
-                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70 mt-3"
-                      >
-                        <Settings className="h-3.5 w-3.5" />
-                        <span className="text-xs">Open project settings</span>
-                      </Button>
-                    </>
-                  )}
-                </div>
-              ) : status === "restored-stopped" ? (
-                <div className="flex flex-col items-center text-center max-w-md">
-                  <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Dev server was running
-                  </h3>
-                  <p className="text-xs text-daintree-text/50 mb-3 leading-relaxed">
-                    Daintree closed while this dev server was active. It wasn't reattached — restart
-                    to run it again.
-                  </p>
-                  {devCommand && (
-                    <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
-                      <code className="text-xs text-daintree-text/70 font-mono">{devCommand}</code>
-                    </div>
-                  )}
-                  <Button
-                    onClick={handleStartFromRestored}
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
-                  >
-                    <RotateCw className="h-3.5 w-3.5" />
-                    <span className="text-xs">Restart dev server</span>
-                  </Button>
-                </div>
-              ) : (
-                <div className="flex flex-col items-center text-center max-w-md">
-                  <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Waiting for dev server
-                  </h3>
-                  <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
-                    The development server will appear here once it starts and a URL is detected.
-                  </p>
-                </div>
-              )}
-            </div>
-          ) : !hasBeenVisible ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text">
-              <p className="text-xs text-daintree-text/50">
-                Preview will load when this panel is first viewed
-              </p>
-            </div>
-          ) : isEvicted ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-              <p className="text-xs text-daintree-text/50">
-                Preview paused to save memory — will reload when opened
-              </p>
-            </div>
           ) : (
             <div
               ref={setFitContainerEl}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -42,6 +42,7 @@ import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
 import { useDevPreviewCommandConfig } from "./useDevPreviewCommandConfig";
 import { useDevPreviewScrollCapture } from "./useDevPreviewScrollCapture";
 import { useDevPreviewCrashRecovery } from "./useDevPreviewCrashRecovery";
+import { useDevPreviewViewport } from "./useDevPreviewViewport";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
@@ -59,13 +60,8 @@ import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
-import {
-  getViewportPreset,
-  getEffectiveViewportSize,
-  computeFitScale,
-} from "@/panels/dev-preview/viewportPresets";
-import { isDevPreviewPanel, type ViewportPresetId } from "@shared/types/panel";
-import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
+import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
+import { isDevPreviewPanel } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { loadWebviewUrl } from "./loadWebviewUrl";
@@ -163,9 +159,6 @@ export function DevPreviewPane({
   const viewportRotated = terminal?.viewportRotated ?? false;
   const viewportDpr = terminal?.viewportDpr ?? 1;
   const viewportFit = terminal?.viewportFit ?? false;
-  const effectiveViewport = viewportPreset
-    ? getEffectiveViewportSize(viewportPreset, viewportRotated)
-    : null;
 
   const {
     status,
@@ -835,61 +828,28 @@ export function DevPreviewPane({
     }
   }, []);
 
-  const handleViewportPresetChange = useCallback(
-    (preset: ViewportPresetId | undefined) => {
-      setViewportPreset(id, preset);
-    },
-    [id, setViewportPreset]
-  );
-
-  const handleViewportRotateToggle = useCallback(() => {
-    setViewportRotated(id, !viewportRotated);
-  }, [id, setViewportRotated, viewportRotated]);
-
-  const handleViewportDprChange = useCallback(
-    (dpr: 1 | 2 | 3) => {
-      setViewportDpr(id, dpr);
-    },
-    [id, setViewportDpr]
-  );
-
-  const handleViewportFitToggle = useCallback(() => {
-    setViewportFit(id, !viewportFit);
-  }, [id, setViewportFit, viewportFit]);
-
-  // Measure the available preview area so zoom-to-fit can scale the device
-  // frame down to fit both pane dimensions. A static scale would break on
-  // pane resize, so this tracks the container via ResizeObserver.
-  // Callback ref (not useRef) so the observer effect re-runs when the
-  // fit-container div mounts for the first time — it lives in the webview
-  // branch, which only renders once the dev server reaches "running", long
-  // after viewportFit/viewportPreset may have been set.
-  const [fitContainerEl, setFitContainerEl] = useState<HTMLDivElement | null>(null);
-  const [fitContainerSize, setFitContainerSize] = useState<{ w: number; h: number }>({
-    w: 0,
-    h: 0,
+  const {
+    effectiveViewport,
+    fitScale,
+    setFitContainerEl,
+    handleViewportPresetChange,
+    handleViewportRotateToggle,
+    handleViewportDprChange,
+    handleViewportFitToggle,
+  } = useDevPreviewViewport({
+    id,
+    viewportPreset,
+    viewportRotated,
+    viewportDpr,
+    viewportFit,
+    isWebviewReady,
+    webviewElement,
+    originalUaRef,
+    setViewportPreset,
+    setViewportRotated,
+    setViewportDpr,
+    setViewportFit,
   });
-  useEffect(() => {
-    if (!viewportFit || !viewportPreset || !fitContainerEl) return;
-    const el = fitContainerEl;
-    const measure = () => {
-      setFitContainerSize({ w: el.clientWidth, h: el.clientHeight });
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [viewportFit, viewportPreset, fitContainerEl]);
-
-  const fitScale =
-    viewportFit && effectiveViewport
-      ? computeFitScale(
-          fitContainerSize.w,
-          fitContainerSize.h,
-          effectiveViewport.width,
-          effectiveViewport.height
-        )
-      : 1;
 
   useEffect(() => {
     if (isWebviewReady && currentUrl && currentUrl !== lastSetUrlRef.current) {
@@ -964,47 +924,6 @@ export function DevPreviewPane({
 
   useWebviewThrottle(id, location, isEvicted ? null : webviewElement, isWebviewReady && !isEvicted);
 
-  // Apply device emulation when viewport preset, rotation, or DPR changes.
-  // Uses enableDeviceEmulation which drives CSS media queries and window.innerWidth
-  // without a page reload, preserving in-page state across preset switches.
-  const prevEmulationKeyRef = useRef<string | null>(null);
-  const hasAppliedEmulationRef = useRef(false);
-  useEffect(() => {
-    if (!isWebviewReady || !webviewElement) return;
-    const emulationKey = `${viewportPreset ?? "none"}-${viewportRotated}-${viewportDpr}`;
-    if (prevEmulationKeyRef.current === emulationKey) return;
-    const hadPrevious = hasAppliedEmulationRef.current;
-
-    const wc = getDevPreviewWebContents(webviewElement);
-    if (!wc) return;
-
-    try {
-      if (viewportPreset) {
-        if (originalUaRef.current === null) {
-          originalUaRef.current = wc.getUserAgent();
-        }
-        wc.setUserAgent(getViewportPreset(viewportPreset).userAgent);
-        wc.enableDeviceEmulation(
-          buildEmulationParams(viewportPreset, viewportRotated, viewportDpr)!
-        );
-        prevEmulationKeyRef.current = emulationKey;
-        hasAppliedEmulationRef.current = true;
-      } else if (hadPrevious) {
-        try {
-          wc.disableDeviceEmulation();
-        } catch {
-          // disableDeviceEmulation may throw if emulation was never enabled
-        }
-        if (originalUaRef.current) {
-          wc.setUserAgent(originalUaRef.current);
-        }
-        prevEmulationKeyRef.current = emulationKey;
-        hasAppliedEmulationRef.current = false;
-      }
-    } catch {
-      // WebContents not available (webview detached)
-    }
-  }, [viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement]);
   const { currentDialog, handleDialogRespond } = useWebviewDialog(
     id,
     isEvicted ? null : webviewElement,

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,25 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo, useReducer } from "react";
 import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
-import {
-  AlertTriangle,
-  Check,
-  ChevronDown,
-  Copy,
-  ExternalLink,
-  OctagonAlert,
-  RotateCw,
-  XCircle,
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { OctagonAlert, RotateCw } from "lucide-react";
 import { DevPreviewDestructiveConfirmDialog } from "./DevPreviewDestructiveConfirmDialog";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from "@/components/ui/dropdown-menu";
-import { Spinner } from "@/components/ui/Spinner";
 import { usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
@@ -27,7 +9,6 @@ import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { BrowserToolbar } from "../Browser/BrowserToolbar";
 import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
-import { BannerOverflowMenu } from "../Terminal/BannerOverflowMenu";
 import { DevPreviewStuckBanner, DevPreviewHmrDeadBanner } from "./DevPreviewBanners";
 import { normalizeBrowserUrl } from "../Browser/browserUtils";
 import {
@@ -43,11 +24,11 @@ import { useDevPreviewCommandConfig } from "./useDevPreviewCommandConfig";
 import { useDevPreviewScrollCapture } from "./useDevPreviewScrollCapture";
 import { useDevPreviewCrashRecovery } from "./useDevPreviewCrashRecovery";
 import { useDevPreviewViewport } from "./useDevPreviewViewport";
+import { DevPreviewWebviewOverlays } from "./DevPreviewWebviewOverlays";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { computeDevServerUrl } from "./urlSync";
 import { actionService } from "@/services/ActionService";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
@@ -55,8 +36,6 @@ import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
-import { WebviewDialog } from "../Browser/WebviewDialog";
-import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -65,13 +44,9 @@ import { isDevPreviewPanel } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { loadWebviewUrl } from "./loadWebviewUrl";
-import {
-  useDevPreviewLoadLifecycle,
-  webviewLoadErrorHeading,
-  type SessionStorageEntry,
-} from "./useDevPreviewLoadLifecycle";
+import { useDevPreviewLoadLifecycle, type SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
 
-import { BlockedNavBanner, blockedNavReducer } from "./BlockedNavBanner";
+import { blockedNavReducer } from "./BlockedNavBanner";
 import { looksLikeOAuthUrl } from "@shared/utils/urlUtils";
 import { buildDevPreviewProxyOrigin } from "@shared/utils/devPreviewProxy";
 import { buildDevPreviewPartition } from "@shared/utils/partitionUtils";
@@ -1194,203 +1169,36 @@ export function DevPreviewPane({
                     : undefined
                 }
               >
-                <>
-                  {reconnectAttempt > 0 && !webviewLoadError && (
-                    <div className="absolute bottom-0 left-0 right-0 z-20 flex items-center justify-center gap-2 px-3 py-1.5 text-xs bg-status-info/10 border-t border-status-info/20 text-daintree-text/70">
-                      <Spinner size="xs" />
-                      <span>Reconnecting (attempt {reconnectAttempt} of 5)...</span>
-                    </div>
-                  )}
-                  {webviewLoadError && (
-                    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-                      <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-                      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        {webviewLoadErrorHeading(webviewLoadError.code)}
-                      </h3>
-                      <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                        {webviewLoadError.message}
-                      </p>
-                      <div className="flex items-center gap-1">
-                        {webviewLoadError.code === "cert" && (
-                          <Button
-                            onClick={handleCopyMkcert}
-                            variant="ghost"
-                            size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                          >
-                            {certCopied ? (
-                              <Check className="h-3.5 w-3.5" />
-                            ) : (
-                              <Copy className="h-3.5 w-3.5" />
-                            )}
-                            <span className="text-xs">
-                              {certCopied ? "Copied" : "Copy `mkcert -install`"}
-                            </span>
-                          </Button>
-                        )}
-                        {webviewLoadError.code === "connection_refused" ||
-                        webviewLoadError.code === "proxy_error" ? (
-                          <>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  onClick={handleRestartDevServer}
-                                  variant="ghost"
-                                  size="sm"
-                                  disabled={isRestarting}
-                                  className="gap-1.5 px-2.5 py-1.5 rounded-r-none group"
-                                >
-                                  <RotateCw
-                                    className={cn("h-3.5 w-3.5", isRestarting && "animate-spin")}
-                                  />
-                                  <span className="text-xs">Restart dev server</span>
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">Restart dev server</TooltipContent>
-                            </Tooltip>
-                            <DropdownMenu>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <DropdownMenuTrigger asChild>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      disabled={isRestarting}
-                                      className="px-1.5 rounded-l-none group"
-                                      aria-label="More restart options"
-                                    >
-                                      <ChevronDown className="h-3.5 w-3.5" />
-                                    </Button>
-                                  </DropdownMenuTrigger>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">More restart options</TooltipContent>
-                              </Tooltip>
-                              <DropdownMenuContent
-                                align="end"
-                                sideOffset={4}
-                                className="min-w-[14rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
-                              >
-                                <DropdownMenuItem onSelect={handleHardReload}>
-                                  Reload preview
-                                </DropdownMenuItem>
-                                <DropdownMenuItem onSelect={handleRestartDevServer}>
-                                  Restart dev server
-                                </DropdownMenuItem>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem onSelect={handleRequestRestartAndClearCache}>
-                                  Restart and clear cache
-                                </DropdownMenuItem>
-                                <DropdownMenuItem onSelect={handleRequestReinstallAndRestart}>
-                                  Reinstall dependencies
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </>
-                        ) : (
-                          <Button
-                            onClick={handleRetryWebviewLoad}
-                            variant="ghost"
-                            size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group"
-                          >
-                            <RotateCw className="h-3.5 w-3.5" />
-                            <span className="text-xs">Retry</span>
-                          </Button>
-                        )}
-                        {currentUrl && (
-                          <Button
-                            onClick={handleOpenExternal}
-                            variant="ghost"
-                            size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                            <span className="text-xs">Open external</span>
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  <BlockedNavBanner
-                    state={blockedNav}
-                    panelId={id}
-                    webviewElement={webviewElement}
-                    onDispatch={dispatchBlockedNav}
-                  />
-                  {crashState === "crashed" && (
-                    <InlineStatusBanner
-                      icon={XCircle}
-                      title="Preview process crashed"
-                      description={
-                        crashDetails
-                          ? `Reason: ${crashDetails.reason} (exit code ${crashDetails.exitCode})`
-                          : "The renderer process terminated unexpectedly."
-                      }
-                      severity="error"
-                      animated={false}
-                      action={{
-                        id: "reload",
-                        label: "Reload",
-                        icon: RotateCw,
-                        variant: "dangerFilled",
-                        onClick: handleHardReload,
-                        ariaLabel: "Reload preview page",
-                      }}
-                      trailingSlot={
-                        <BannerOverflowMenu
-                          ariaLabel="More preview recovery options"
-                          actions={[
-                            {
-                              id: "hard-restart",
-                              label: "Hard restart",
-                              icon: RotateCw,
-                              variant: "danger",
-                              onClick: handleRestartDevServer,
-                              ariaLabel: "Hard restart preview",
-                            },
-                          ]}
-                        />
-                      }
-                      onClose={resetCrashHistory}
-                    />
-                  )}
-                  {crashState === "unresponsive" && (
-                    <InlineStatusBanner
-                      icon={AlertTriangle}
-                      title="Preview is not responding"
-                      description="The page may be stuck in a long-running operation."
-                      severity="warning"
-                      animated={false}
-                      actions={[
-                        {
-                          id: "hard-restart",
-                          label: "Hard restart",
-                          icon: RotateCw,
-                          variant: "danger",
-                          onClick: handleRestartDevServer,
-                          ariaLabel: "Hard restart preview",
-                        },
-                      ]}
-                      onClose={clearUnresponsiveState}
-                    />
-                  )}
-                  {isLoading && (
-                    <DevPreviewLoadingState
-                      variant="overlay"
-                      isLoading={isLoading}
-                      phaseLabel="Loading preview"
-                      onCancel={handleCancelLoad}
-                    />
-                  )}
-                  {showRecoverySpinner && !webviewLoadError && (
-                    <DevPreviewLoadingState
-                      variant="overlay"
-                      isLoading={isRecoveringFromEviction}
-                      phaseLabel="Rehydrating preview"
-                    />
-                  )}
-                  {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
-                  {findInPage.isOpen && <FindBar find={findInPage} />}
+                <DevPreviewWebviewOverlays
+                  reconnectAttempt={reconnectAttempt}
+                  webviewLoadError={webviewLoadError}
+                  certCopied={certCopied}
+                  onCopyMkcert={handleCopyMkcert}
+                  isRestarting={isRestarting}
+                  onRestartDevServer={handleRestartDevServer}
+                  onHardReload={handleHardReload}
+                  onRequestRestartAndClearCache={handleRequestRestartAndClearCache}
+                  onRequestReinstallAndRestart={handleRequestReinstallAndRestart}
+                  onRetryWebviewLoad={handleRetryWebviewLoad}
+                  currentUrl={currentUrl}
+                  onOpenExternal={handleOpenExternal}
+                  blockedNav={blockedNav}
+                  panelId={id}
+                  webviewElement={webviewElement}
+                  onDispatchBlockedNav={dispatchBlockedNav}
+                  crashState={crashState}
+                  crashDetails={crashDetails}
+                  onCloseCrash={resetCrashHistory}
+                  onCloseUnresponsive={clearUnresponsiveState}
+                  isLoading={isLoading}
+                  onCancelLoad={handleCancelLoad}
+                  showRecoverySpinner={showRecoverySpinner}
+                  isRecoveringFromEviction={isRecoveringFromEviction}
+                  isDragging={isDragging}
+                  findInPage={findInPage}
+                  currentDialog={currentDialog}
+                  onDialogRespond={handleDialogRespond}
+                >
                   {/* Only the webview is scaled by zoom-to-fit; overlays above
                         stay at full size relative to the outer container so
                         their action buttons remain readable and clickable. */}
@@ -1423,8 +1231,7 @@ export function DevPreviewPane({
                       )}
                     />
                   </div>
-                  <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
-                </>
+                </DevPreviewWebviewOverlays>
               </div>
             </div>
           )}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -10,7 +10,6 @@ import {
   Play,
   RotateCw,
   Settings,
-  WifiOff,
   XCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -29,8 +28,9 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { BrowserToolbar } from "../Browser/BrowserToolbar";
-import { InlineStatusBanner, type BannerAction } from "../Terminal/InlineStatusBanner";
+import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
 import { BannerOverflowMenu } from "../Terminal/BannerOverflowMenu";
+import { DevPreviewStuckBanner, DevPreviewHmrDeadBanner } from "./DevPreviewBanners";
 import { normalizeBrowserUrl } from "../Browser/browserUtils";
 import {
   goBackBrowserHistory,
@@ -38,7 +38,7 @@ import {
   initializeBrowserHistory,
   pushBrowserHistory,
 } from "../Browser/historyUtils";
-import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
+import { useDevServer } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
@@ -121,142 +121,6 @@ async function captureWebviewSessionStorage(
 export interface DevPreviewPaneProps extends BasePanelProps {
   cwd: string;
   worktreeId?: string;
-}
-
-const STUCK_REMEDY_LABELS: Record<string, string> = {
-  "devPreview.restartAndClearCache": "Restart and clear cache",
-  "devPreview.reinstallAndRestart": "Reinstall dependencies",
-};
-
-interface DevPreviewStuckBannerProps {
-  tier: 2 | 3;
-  error: UseDevServerReturn["error"];
-  /** Disables the banner actions while a restart is already in flight. */
-  isRestarting: boolean;
-  /**
-   * When `"Compiling"` at Tier 3, the banner swaps to long-compile copy
-   * instead of the generic "didn't start" framing — the server clearly
-   * started, the first compile is just slow.
-   */
-  phaseLabel?: "Compiling";
-  onRestart: () => void;
-  onRemedy: (actionId: string) => void;
-}
-
-/**
- * Staged stuck-start escalation banner (#8276, copy retuned #9099). Replaces
- * the old silent auto-restart with a user-driven signal: Tier 2 is a warning
- * that the server is slow (suppressed by the hook while `phaseLabel ===
- * "Compiling"` — compile evidence isn't "stuck"), Tier 3 an error that names
- * likely causes and, when the dev server emitted a recognised error, offers
- * a variant-specific remedy (`error.recommendedActionId`) alongside a plain
- * restart. At Tier 3 with `phaseLabel === "Compiling"` the copy switches to
- * a long-compile framing instead of the "didn't start" framing.
- */
-function DevPreviewStuckBanner({
-  tier,
-  error,
-  isRestarting,
-  phaseLabel,
-  onRestart,
-  onRemedy,
-}: DevPreviewStuckBannerProps) {
-  const restartAction: BannerAction = {
-    id: "dev-preview-stuck-restart",
-    label: "Restart dev server",
-    icon: RotateCw,
-    variant: "primary",
-    disabled: isRestarting,
-    onClick: onRestart,
-  };
-
-  if (tier === 2) {
-    return (
-      <InlineStatusBanner
-        icon={AlertTriangle}
-        severity="warning"
-        title="Dev server is slow to start"
-        description="It's been a while without a URL. Check the terminal logs for what it's waiting on — restarting clears those logs."
-        role="status"
-        ariaLive="polite"
-        actions={[restartAction]}
-      />
-    );
-  }
-
-  const remedyId = error?.recommendedActionId;
-  const remedyLabel = remedyId ? STUCK_REMEDY_LABELS[remedyId] : undefined;
-  // When a specific remedy is recommended it's the single primary action and
-  // the generic restart drops into the overflow menu; otherwise restart is the
-  // lone action. Keeps this error banner to one inline action.
-  const hasRemedy = !!(remedyId && remedyLabel);
-  const primaryAction: BannerAction = hasRemedy
-    ? {
-        id: `dev-preview-stuck-remedy-${remedyId}`,
-        label: remedyLabel,
-        icon: RotateCw,
-        variant: "primary",
-        disabled: isRestarting,
-        onClick: () => onRemedy(remedyId),
-      }
-    : restartAction;
-  const overflowActions: BannerAction[] = hasRemedy ? [restartAction] : [];
-
-  const isLongCompile = phaseLabel === "Compiling" && !error?.message;
-  const title = isLongCompile
-    ? "First compile is taking longer than usual"
-    : "Dev server still hasn't started";
-  const description = error?.message
-    ? error.message
-    : isLongCompile
-      ? "The initial compile is still running. Check the terminal logs — large projects can take 45s or more."
-      : "Likely causes: the port is still bound by another process, dependencies are missing, or the build cache is stuck. Check the terminal logs.";
-
-  return (
-    <InlineStatusBanner
-      icon={AlertTriangle}
-      severity="error"
-      title={title}
-      description={description}
-      role="alert"
-      ariaLive="assertive"
-      action={primaryAction}
-      trailingSlot={
-        overflowActions.length > 0 ? (
-          <BannerOverflowMenu actions={overflowActions} ariaLabel="More dev server options" />
-        ) : undefined
-      }
-    />
-  );
-}
-
-/**
- * Surfaces a dead Vite HMR socket (#9975). The dev server keeps logging
- * `[vite] hmr update` on every save — which fires the "Compiling" phase and
- * reads as "live reload is working" — but with a custom `server.hmr.*` config
- * the browser's socket connects off the proxy origin or fails outright, so
- * the preview is silently stale. `useDevPreviewConsoleCapture` catches Vite's
- * own failure log and flips `hmrDead`; this is a Tier 3 running-state failure
- * with a pane-local recovery (reload reconnects the socket).
- */
-function DevPreviewHmrDeadBanner({ onReload }: { onReload: () => void }) {
-  return (
-    <InlineStatusBanner
-      icon={WifiOff}
-      severity="error"
-      title="Live reload disconnected"
-      description="Vite's hot-reload socket dropped, so saved changes won't show up in the preview. Reload to reconnect, or drop the custom server.hmr.* config if it keeps happening."
-      role="alert"
-      ariaLive="assertive"
-      action={{
-        id: "dev-preview-hmr-dead-reload",
-        label: "Reload",
-        icon: RotateCw,
-        variant: "primary",
-        onClick: onReload,
-      }}
-    />
-  );
 }
 
 export function DevPreviewPane({

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -41,15 +41,12 @@ import {
 import { useDevServer } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
+import { useDevPreviewCommandConfig } from "./useDevPreviewCommandConfig";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { computeDevServerUrl } from "./urlSync";
-import { findDevServerCandidate, findAllDevServerCandidates } from "@/utils/devServerDetection";
-import { useProjectSettings } from "@/hooks/useProjectSettings";
-import { projectClient } from "@/clients";
-import { getInvalidCommandMessage } from "@shared/utils/devCommandValidation";
 import { actionService } from "@/services/ActionService";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
@@ -300,31 +297,7 @@ export function DevPreviewPane({
   const [guestWebContentsId, setGuestWebContentsId] = useState<number | undefined>(undefined);
   // Store the original guest UA so we can restore it when clearing a preset
   const originalUaRef = useRef<string | null>(null);
-  const [isAutoDetecting, setIsAutoDetecting] = useState(false);
-  // The command whose auto-detect/save attempt failed; null = no failure shown.
-  // Empty string means the attempt never resolved a command (re-detection found
-  // nothing), so retry falls back to the currently displayed candidate.
-  const [autoDetectFailedCommand, setAutoDetectFailedCommand] = useState<string | null>(null);
-  const autoDetectRef = useRef(false);
-
-  useEffect(() => {
-    if (devCommand) setAutoDetectFailedCommand(null);
-  }, [devCommand]);
-  const { saveSettings } = useProjectSettings();
-  const allDetectedRunners = useProjectSettingsStore((state) => state.allDetectedRunners);
   const isSettingsLoading = useProjectSettingsStore((state) => state.isLoading);
-
-  const candidates = useMemo(
-    () => findAllDevServerCandidates(allDetectedRunners, projectSettings?.turbopackEnabled ?? true),
-    [allDetectedRunners, projectSettings?.turbopackEnabled]
-  );
-  const primaryCandidate = candidates[0];
-  const activeCandidate = candidates.find((c) => c.command.trim() === devCommand.trim());
-  const headerLabel = activeCandidate?.name || devCommand;
-
-  const [commandInput, setCommandInput] = useState("");
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const savingRef = useRef(false);
 
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
@@ -340,6 +313,30 @@ export function DevPreviewPane({
   const canGoForward = history.future.length > 0;
   const isUnconfigured =
     Boolean(currentProjectId) && !isSettingsLoading && projectSettings !== null && !devCommand;
+
+  const {
+    headerContent,
+    candidates,
+    primaryCandidate,
+    isAutoDetecting,
+    autoDetectFailedCommand,
+    handleAutoDetect,
+    handlePickCandidate,
+    pickerOpen,
+    setPickerOpen,
+    commandInput,
+    setCommandInput,
+    commandInputError,
+    handleSaveCommand,
+    handleOpenSettings,
+  } = useDevPreviewCommandConfig({
+    currentProjectId,
+    devCommand,
+    isUnconfigured,
+    projectSettings,
+    stop,
+    isMountedRef,
+  });
 
   // Hold the webview (show the loading state) while the dev server is running but the pane
   // hasn't settled onto the stable proxy origin yet (#9100). Covers two cases: the proxy port
@@ -908,146 +905,6 @@ export function DevPreviewPane({
     } else if (actionId === "devPreview.reinstallAndRestart") {
       setPendingRestartTier("reinstallAndRestart");
     }
-  }, []);
-
-  const handleAutoDetect = useCallback(
-    async (candidateCommand?: string): Promise<boolean> => {
-      if (!currentProjectId || autoDetectRef.current) return false;
-
-      autoDetectRef.current = true;
-      setIsAutoDetecting(true);
-      setAutoDetectFailedCommand(null);
-      let attemptedCommand = candidateCommand ?? "";
-      try {
-        const latestSettings = await projectClient.getSettings(currentProjectId);
-        if (!latestSettings) {
-          if (isMountedRef.current) setAutoDetectFailedCommand(attemptedCommand);
-          return false;
-        }
-
-        let command = candidateCommand;
-        if (!command) {
-          const freshRunners = await projectClient.detectRunners(currentProjectId);
-          command = findDevServerCandidate(
-            freshRunners,
-            latestSettings.turbopackEnabled ?? true
-          )?.command;
-        }
-
-        if (!command) {
-          if (isMountedRef.current) setAutoDetectFailedCommand("");
-          return false;
-        }
-        attemptedCommand = command;
-
-        await saveSettings({
-          ...latestSettings,
-          devServerCommand: command,
-          devServerAutoDetected: true,
-          devServerDismissed: false,
-        });
-
-        return true;
-      } catch (err) {
-        logError("Failed to auto-detect dev server", err);
-        if (isMountedRef.current) setAutoDetectFailedCommand(attemptedCommand);
-        return false;
-      } finally {
-        autoDetectRef.current = false;
-        if (isMountedRef.current) {
-          setIsAutoDetecting(false);
-        }
-      }
-    },
-    [currentProjectId, saveSettings]
-  );
-
-  const handlePickCandidate = useCallback(
-    (candidate: { command: string }) => {
-      void handleAutoDetect(candidate.command);
-    },
-    [handleAutoDetect]
-  );
-
-  const handleHeaderPickCandidate = useCallback(
-    async (candidate: { command: string }) => {
-      if (candidate.command.trim() === devCommand.trim()) return;
-      const saved = await handleAutoDetect(candidate.command);
-      if (saved) stop();
-    },
-    [devCommand, handleAutoDetect, stop]
-  );
-
-  const handleSaveCommand = useCallback(async () => {
-    if (!currentProjectId || savingRef.current) return;
-    const trimmed = commandInput.trim();
-    if (!trimmed || getInvalidCommandMessage(trimmed)) return;
-
-    savingRef.current = true;
-    try {
-      const latestSettings = await projectClient.getSettings(currentProjectId);
-      if (!latestSettings) return;
-
-      await saveSettings({
-        ...latestSettings,
-        devServerCommand: trimmed,
-        devServerAutoDetected: false,
-        devServerDismissed: false,
-      });
-    } catch (err) {
-      logError("Failed to save dev command", err);
-    } finally {
-      savingRef.current = false;
-    }
-  }, [currentProjectId, commandInput, saveSettings]);
-
-  const headerContent = useMemo(() => {
-    if (isUnconfigured || candidates.length === 0) return null;
-
-    return (
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                onPointerDown={(e) => e.stopPropagation()}
-                className="flex h-6 items-center gap-1 px-1.5 rounded-sm hover:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors max-w-[180px]"
-                aria-label="Switch dev script"
-              >
-                <span className="min-w-0 text-xs truncate">{headerLabel}</span>
-                <ChevronDown className="h-3 w-3 shrink-0" />
-              </button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Switch dev script</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent align="end" sideOffset={4} className="w-72 p-1">
-          {candidates.map((c) => {
-            const isActive = c.command.trim() === devCommand.trim();
-            return (
-              <DropdownMenuItem
-                key={c.id}
-                onSelect={() => void handleHeaderPickCandidate(c)}
-                className={isActive ? "bg-overlay-subtle" : ""}
-                aria-current={isActive ? "true" : undefined}
-              >
-                <span className="text-xs font-medium">{c.name}</span>
-                <code className="text-[11px] text-daintree-text/50 truncate ml-auto">
-                  {c.command}
-                </code>
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-  }, [isUnconfigured, candidates, devCommand, headerLabel, handleHeaderPickCandidate]);
-
-  const commandInputError = useMemo(() => getInvalidCommandMessage(commandInput), [commandInput]);
-
-  const handleOpenSettings = useCallback(() => {
-    void actionService.dispatch("project.settings.open", undefined, { source: "user" });
   }, []);
 
   const handleViewportPresetChange = useCallback(

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -41,6 +41,7 @@ import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
 import { useDevPreviewCommandConfig } from "./useDevPreviewCommandConfig";
 import { useDevPreviewScrollCapture } from "./useDevPreviewScrollCapture";
+import { useDevPreviewCrashRecovery } from "./useDevPreviewCrashRecovery";
 import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { DevPreviewEmptyStates } from "./DevPreviewEmptyStates";
 import { useIsDragging } from "@/components/DragDrop";
@@ -258,12 +259,6 @@ export function DevPreviewPane({
   });
 
   const [blockedNav, dispatchBlockedNav] = useReducer(blockedNavReducer, null);
-  const [crashState, setCrashState] = useState<"none" | "crashed" | "unresponsive">("none");
-  const [crashDetails, setCrashDetails] = useState<{
-    reason: string;
-    exitCode: number;
-  } | null>(null);
-  const crashTimestampsRef = useRef<number[]>([]);
   const crashReloadRef = useRef<() => void>(() => {});
   const screenshotInFlightRef = useRef(false);
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -438,34 +433,17 @@ export function DevPreviewPane({
     return () => clearTimeout(timer);
   }, [status, url, phaseLabel, id, setDevPreviewConsoleOpen]);
 
-  const handleRenderProcessGone = useCallback(
-    (details: { reason: string; exitCode: number }) => {
-      const now = Date.now();
-      const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
-      timestamps.push(now);
-      crashTimestampsRef.current = timestamps;
-
-      setCrashDetails(details);
-      setCrashState("crashed");
-
-      if (timestamps.length < 2) {
-        crashReloadRef.current();
-      } else {
-        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-        notify({
-          type: "error",
-          title: "Preview process crashed repeatedly",
-          message: `The dev preview crashed (${details.reason}) twice within 60 seconds. Auto-recovery stopped. Use Reload or Hard restart to recover.`,
-          priority: "high",
-          duration: 0,
-          context: { eventKind: "recovery", panelId: id },
-          supersedeKey: `dev-preview-crash-loop:${id}`,
-          correlationId: id,
-        });
-      }
-    },
-    [id]
-  );
+  const {
+    crashState,
+    crashDetails,
+    handleRenderProcessGone,
+    resetCrashHistory,
+    clearUnresponsiveState,
+  } = useDevPreviewCrashRecovery({
+    id,
+    currentUrl,
+    crashReloadRef,
+  });
 
   const {
     isWebviewReady,
@@ -677,11 +655,9 @@ export function DevPreviewPane({
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
   const handleHardReload = useCallback(() => {
-    setCrashState("none");
-    setCrashDetails(null);
-    crashTimestampsRef.current = [];
+    resetCrashHistory();
     performReload();
-  }, [performReload]);
+  }, [resetCrashHistory, performReload]);
 
   // Keep crashReloadRef in sync so onRenderProcessGone can call performReload
   // before it exists in the lexical scope.
@@ -777,9 +753,7 @@ export function DevPreviewPane({
     setIsLoading(false);
     setIsWebviewReady(false);
     setWebviewLoadError(null);
-    setCrashState("none");
-    setCrashDetails(null);
-    crashTimestampsRef.current = [];
+    resetCrashHistory();
   }, [
     id,
     setBrowserUrl,
@@ -789,6 +763,7 @@ export function DevPreviewPane({
     setIsLoading,
     setIsWebviewReady,
     setWebviewLoadError,
+    resetCrashHistory,
   ]);
 
   const handleRestartDevServer = useCallback(() => {
@@ -970,9 +945,7 @@ export function DevPreviewPane({
     if (isEvicted) {
       // Clear crash state so a restored panel doesn't surface a stale banner.
       // The eviction placeholder owns the visual signal in that window.
-      setCrashState("none");
-      setCrashDetails(null);
-      crashTimestampsRef.current = [];
+      resetCrashHistory();
     }
     if (isEvicted && webviewRef.current) {
       try {
@@ -987,7 +960,7 @@ export function DevPreviewPane({
       clearLoadTimers();
       clearRetryState();
     }
-  }, [isEvicted, captureScrollViaCdp, clearLoadTimers, clearRetryState]);
+  }, [isEvicted, resetCrashHistory, captureScrollViaCdp, clearLoadTimers, clearRetryState]);
 
   useWebviewThrottle(id, location, isEvicted ? null : webviewElement, isWebviewReady && !isEvicted);
 
@@ -1098,40 +1071,6 @@ export function DevPreviewPane({
       }
     };
   }, [id, webviewElement]);
-
-  // Listen for webview unresponsive/responsive events from the main process
-  useEffect(() => {
-    const cleanupUnresponsive = window.electron.webview.onUnresponsive((data) => {
-      if (data.panelId !== id) return;
-      setCrashState((prev) => (prev === "crashed" ? prev : "unresponsive"));
-    });
-    const cleanupResponsive = window.electron.webview.onResponsive((data) => {
-      if (data.panelId !== id) return;
-      setCrashState((prev) => (prev === "unresponsive" ? "none" : prev));
-    });
-    return () => {
-      cleanupUnresponsive();
-      cleanupResponsive();
-    };
-  }, [id]);
-
-  // Clear crash state when the user navigates to a fresh URL. Depending on
-  // crashState here would create an instant-reset loop: the effect would fire
-  // the moment crashState transitions from "none" and clear it back. Track the
-  // last URL we cleared at via a ref so this effect runs only on real URL
-  // transitions.
-  const lastClearedCrashUrlRef = useRef<string>(currentUrl);
-  useEffect(() => {
-    if (currentUrl === lastClearedCrashUrlRef.current) return;
-    lastClearedCrashUrlRef.current = currentUrl;
-    if (currentUrl && currentUrl !== "about:blank") {
-      setCrashState("none");
-      setCrashDetails(null);
-      // Don't carry the prior URL's crash history into the new URL's 60s
-      // window — that would mis-throttle the first auto-recovery there.
-      crashTimestampsRef.current = [];
-    }
-  }, [currentUrl]);
 
   // Listen for the reload shortcut (Cmd/Ctrl+R) forwarded from the focused
   // webview guest. When the guest has focus, the outer renderer's keybinding
@@ -1493,11 +1432,7 @@ export function DevPreviewPane({
                           ]}
                         />
                       }
-                      onClose={() => {
-                        setCrashState("none");
-                        setCrashDetails(null);
-                        crashTimestampsRef.current = [];
-                      }}
+                      onClose={resetCrashHistory}
                     />
                   )}
                   {crashState === "unresponsive" && (
@@ -1517,7 +1452,7 @@ export function DevPreviewPane({
                           ariaLabel: "Hard restart preview",
                         },
                       ]}
-                      onClose={() => setCrashState("none")}
+                      onClose={clearUnresponsiveState}
                     />
                   )}
                   {isLoading && (

--- a/src/components/DevPreview/DevPreviewWebviewOverlays.tsx
+++ b/src/components/DevPreview/DevPreviewWebviewOverlays.tsx
@@ -1,0 +1,299 @@
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  RotateCw,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { Spinner } from "@/components/ui/Spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
+import { BannerOverflowMenu } from "../Terminal/BannerOverflowMenu";
+import { BlockedNavBanner, type BlockedNavState, type BlockedNavAction } from "./BlockedNavBanner";
+import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
+import { webviewLoadErrorHeading, type WebviewLoadError } from "./useDevPreviewLoadLifecycle";
+import { FindBar } from "../Browser/FindBar";
+import type { FindInPageState } from "@/hooks/useFindInPage";
+import { WebviewDialog, type WebviewDialogRequest } from "../Browser/WebviewDialog";
+import { cn } from "@/lib/utils";
+
+interface DevPreviewWebviewOverlaysProps {
+  reconnectAttempt: number;
+  webviewLoadError: WebviewLoadError | null;
+  certCopied: boolean;
+  onCopyMkcert: () => void;
+  isRestarting: boolean;
+  onRestartDevServer: () => void;
+  onHardReload: () => void;
+  onRequestRestartAndClearCache: () => void;
+  onRequestReinstallAndRestart: () => void;
+  onRetryWebviewLoad: () => void;
+  currentUrl: string;
+  onOpenExternal: () => void;
+  blockedNav: BlockedNavState | null;
+  panelId: string;
+  webviewElement: Electron.WebviewTag | null;
+  onDispatchBlockedNav: (action: BlockedNavAction) => void;
+  crashState: "none" | "crashed" | "unresponsive";
+  crashDetails: { reason: string; exitCode: number } | null;
+  onCloseCrash: () => void;
+  onCloseUnresponsive: () => void;
+  isLoading: boolean;
+  onCancelLoad: () => void;
+  showRecoverySpinner: boolean;
+  isRecoveringFromEviction: boolean;
+  isDragging: boolean;
+  findInPage: FindInPageState;
+  currentDialog: WebviewDialogRequest | null;
+  onDialogRespond: (confirmed: boolean, response?: string) => void;
+  /** The scale-wrapper div + `<webview>` element. Kept out of this component
+   * so the ref callback wiring (`setWebviewNode`) and the webview node's
+   * lifetime stay entirely in the parent — see the issue's "Watch" note on
+   * preserving ref lifetimes across this split. */
+  children: React.ReactNode;
+}
+
+/**
+ * Renders every overlay layered on top of the live webview: the reconnect
+ * toast, the load-error recovery panel, the blocked-navigation banner, the
+ * crash/unresponsive banners, the loading and eviction-recovery spinners,
+ * the drag veil, and find-in-page. The webview itself is passed in as
+ * `children` by the parent.
+ */
+export function DevPreviewWebviewOverlays({
+  reconnectAttempt,
+  webviewLoadError,
+  certCopied,
+  onCopyMkcert,
+  isRestarting,
+  onRestartDevServer,
+  onHardReload,
+  onRequestRestartAndClearCache,
+  onRequestReinstallAndRestart,
+  onRetryWebviewLoad,
+  currentUrl,
+  onOpenExternal,
+  blockedNav,
+  panelId,
+  webviewElement,
+  onDispatchBlockedNav,
+  crashState,
+  crashDetails,
+  onCloseCrash,
+  onCloseUnresponsive,
+  isLoading,
+  onCancelLoad,
+  showRecoverySpinner,
+  isRecoveringFromEviction,
+  isDragging,
+  findInPage,
+  currentDialog,
+  onDialogRespond,
+  children,
+}: DevPreviewWebviewOverlaysProps) {
+  return (
+    <>
+      {reconnectAttempt > 0 && !webviewLoadError && (
+        <div className="absolute bottom-0 left-0 right-0 z-20 flex items-center justify-center gap-2 px-3 py-1.5 text-xs bg-status-info/10 border-t border-status-info/20 text-daintree-text/70">
+          <Spinner size="xs" />
+          <span>Reconnecting (attempt {reconnectAttempt} of 5)...</span>
+        </div>
+      )}
+      {webviewLoadError && (
+        <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+          <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
+          <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+            {webviewLoadErrorHeading(webviewLoadError.code)}
+          </h3>
+          <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
+            {webviewLoadError.message}
+          </p>
+          <div className="flex items-center gap-1">
+            {webviewLoadError.code === "cert" && (
+              <Button
+                onClick={onCopyMkcert}
+                variant="ghost"
+                size="sm"
+                className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+              >
+                {certCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                <span className="text-xs">{certCopied ? "Copied" : "Copy `mkcert -install`"}</span>
+              </Button>
+            )}
+            {webviewLoadError.code === "connection_refused" ||
+            webviewLoadError.code === "proxy_error" ? (
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={onRestartDevServer}
+                      variant="ghost"
+                      size="sm"
+                      disabled={isRestarting}
+                      className="gap-1.5 px-2.5 py-1.5 rounded-r-none group"
+                    >
+                      <RotateCw className={cn("h-3.5 w-3.5", isRestarting && "animate-spin")} />
+                      <span className="text-xs">Restart dev server</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Restart dev server</TooltipContent>
+                </Tooltip>
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={isRestarting}
+                          className="px-1.5 rounded-l-none group"
+                          aria-label="More restart options"
+                        >
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">More restart options</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent
+                    align="end"
+                    sideOffset={4}
+                    className="min-w-[14rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+                  >
+                    <DropdownMenuItem onSelect={onHardReload}>Reload preview</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={onRestartDevServer}>
+                      Restart dev server
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onSelect={onRequestRestartAndClearCache}>
+                      Restart and clear cache
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={onRequestReinstallAndRestart}>
+                      Reinstall dependencies
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            ) : (
+              <Button
+                onClick={onRetryWebviewLoad}
+                variant="ghost"
+                size="sm"
+                className="gap-1.5 px-2.5 py-1.5 group"
+              >
+                <RotateCw className="h-3.5 w-3.5" />
+                <span className="text-xs">Retry</span>
+              </Button>
+            )}
+            {currentUrl && (
+              <Button
+                onClick={onOpenExternal}
+                variant="ghost"
+                size="sm"
+                className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                <span className="text-xs">Open external</span>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+      <BlockedNavBanner
+        state={blockedNav}
+        panelId={panelId}
+        webviewElement={webviewElement}
+        onDispatch={onDispatchBlockedNav}
+      />
+      {crashState === "crashed" && (
+        <InlineStatusBanner
+          icon={XCircle}
+          title="Preview process crashed"
+          description={
+            crashDetails
+              ? `Reason: ${crashDetails.reason} (exit code ${crashDetails.exitCode})`
+              : "The renderer process terminated unexpectedly."
+          }
+          severity="error"
+          animated={false}
+          action={{
+            id: "reload",
+            label: "Reload",
+            icon: RotateCw,
+            variant: "dangerFilled",
+            onClick: onHardReload,
+            ariaLabel: "Reload preview page",
+          }}
+          trailingSlot={
+            <BannerOverflowMenu
+              ariaLabel="More preview recovery options"
+              actions={[
+                {
+                  id: "hard-restart",
+                  label: "Hard restart",
+                  icon: RotateCw,
+                  variant: "danger",
+                  onClick: onRestartDevServer,
+                  ariaLabel: "Hard restart preview",
+                },
+              ]}
+            />
+          }
+          onClose={onCloseCrash}
+        />
+      )}
+      {crashState === "unresponsive" && (
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="Preview is not responding"
+          description="The page may be stuck in a long-running operation."
+          severity="warning"
+          animated={false}
+          actions={[
+            {
+              id: "hard-restart",
+              label: "Hard restart",
+              icon: RotateCw,
+              variant: "danger",
+              onClick: onRestartDevServer,
+              ariaLabel: "Hard restart preview",
+            },
+          ]}
+          onClose={onCloseUnresponsive}
+        />
+      )}
+      {isLoading && (
+        <DevPreviewLoadingState
+          variant="overlay"
+          isLoading={isLoading}
+          phaseLabel="Loading preview"
+          onCancel={onCancelLoad}
+        />
+      )}
+      {showRecoverySpinner && !webviewLoadError && (
+        <DevPreviewLoadingState
+          variant="overlay"
+          isLoading={isRecoveringFromEviction}
+          phaseLabel="Rehydrating preview"
+        />
+      )}
+      {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
+      {findInPage.isOpen && <FindBar find={findInPage} />}
+      {/* Only the webview is scaled by zoom-to-fit; overlays above
+            stay at full size relative to the outer container so
+            their action buttons remain readable and clickable. */}
+      {children}
+      <WebviewDialog dialog={currentDialog} onRespond={onDialogRespond} />
+    </>
+  );
+}

--- a/src/components/DevPreview/__tests__/DevPreviewBanners.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewBanners.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { DevPreviewStuckBanner, DevPreviewHmrDeadBanner } from "../DevPreviewBanners";
+import type { UseDevServerReturn } from "@/hooks/useDevServer";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe("DevPreviewStuckBanner", () => {
+  it("renders the tier-2 warning with a single restart action", () => {
+    render(
+      <DevPreviewStuckBanner
+        tier={2}
+        error={null}
+        isRestarting={false}
+        onRestart={vi.fn()}
+        onRemedy={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText("Dev server is slow to start")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /restart dev server/i })).toBeTruthy();
+  });
+
+  it("promotes the recommended remedy to primary and demotes restart to the overflow menu", () => {
+    const error = {
+      recommendedActionId: "devPreview.restartAndClearCache",
+      message: "Stale build cache detected.",
+    } as unknown as UseDevServerReturn["error"];
+    render(
+      <DevPreviewStuckBanner
+        tier={3}
+        error={error}
+        isRestarting={false}
+        onRestart={vi.fn()}
+        onRemedy={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /restart and clear cache/i })).toBeTruthy();
+    // Plain restart is demoted into the overflow menu, not an inline button.
+    expect(screen.queryByRole("button", { name: /^restart dev server$/i })).toBeNull();
+  });
+
+  it("falls back to a single restart action at tier 3 without a recommended remedy", () => {
+    render(
+      <DevPreviewStuckBanner
+        tier={3}
+        error={null}
+        isRestarting={false}
+        onRestart={vi.fn()}
+        onRemedy={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Dev server still hasn't started")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /restart dev server/i })).toBeTruthy();
+  });
+
+  it("switches to long-compile copy at tier 3 while phaseLabel is Compiling and there's no error message", () => {
+    render(
+      <DevPreviewStuckBanner
+        tier={3}
+        error={null}
+        isRestarting={false}
+        phaseLabel="Compiling"
+        onRestart={vi.fn()}
+        onRemedy={vi.fn()}
+      />
+    );
+    expect(screen.getByText("First compile is taking longer than usual")).toBeTruthy();
+  });
+
+  it("disables the restart action while a restart is already in flight", () => {
+    render(
+      <DevPreviewStuckBanner
+        tier={2}
+        error={null}
+        isRestarting={true}
+        onRestart={vi.fn()}
+        onRemedy={vi.fn()}
+      />
+    );
+    const restartButton = screen.getByRole("button", {
+      name: /restart dev server/i,
+    }) as HTMLButtonElement;
+    expect(restartButton.disabled).toBe(true);
+  });
+});
+
+describe("DevPreviewHmrDeadBanner", () => {
+  it("renders the dead-HMR warning and invokes onReload", () => {
+    const onReload = vi.fn();
+    render(<DevPreviewHmrDeadBanner onReload={onReload} />);
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Live reload disconnected")).toBeTruthy();
+    screen.getByRole("button", { name: /reload/i }).click();
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/DevPreview/__tests__/DevPreviewBanners.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewBanners.test.tsx
@@ -5,6 +5,16 @@ import { render, screen } from "@testing-library/react";
 import { DevPreviewStuckBanner, DevPreviewHmrDeadBanner } from "../DevPreviewBanners";
 import type { UseDevServerReturn } from "@/hooks/useDevServer";
 
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="overflow-content">{children}</div>
+  ),
+}));
+
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -23,18 +33,20 @@ beforeAll(() => {
 
 describe("DevPreviewStuckBanner", () => {
   it("renders the tier-2 warning with a single restart action", () => {
+    const onRestart = vi.fn();
     render(
       <DevPreviewStuckBanner
         tier={2}
         error={null}
         isRestarting={false}
-        onRestart={vi.fn()}
+        onRestart={onRestart}
         onRemedy={vi.fn()}
       />
     );
     expect(screen.getByRole("status")).toBeTruthy();
     expect(screen.getByText("Dev server is slow to start")).toBeTruthy();
-    expect(screen.getByRole("button", { name: /restart dev server/i })).toBeTruthy();
+    screen.getByRole("button", { name: /restart dev server/i }).click();
+    expect(onRestart).toHaveBeenCalledTimes(1);
   });
 
   it("promotes the recommended remedy to primary and demotes restart to the overflow menu", () => {
@@ -42,19 +54,29 @@ describe("DevPreviewStuckBanner", () => {
       recommendedActionId: "devPreview.restartAndClearCache",
       message: "Stale build cache detected.",
     } as unknown as UseDevServerReturn["error"];
+    const onRemedy = vi.fn();
+    const onRestart = vi.fn();
     render(
       <DevPreviewStuckBanner
         tier={3}
         error={error}
         isRestarting={false}
-        onRestart={vi.fn()}
-        onRemedy={vi.fn()}
+        onRestart={onRestart}
+        onRemedy={onRemedy}
       />
     );
     expect(screen.getByRole("alert")).toBeTruthy();
-    expect(screen.getByRole("button", { name: /restart and clear cache/i })).toBeTruthy();
-    // Plain restart is demoted into the overflow menu, not an inline button.
-    expect(screen.queryByRole("button", { name: /^restart dev server$/i })).toBeNull();
+    // Plain restart is demoted into the overflow menu, not the inline primary action.
+    const overflow = screen.getByTestId("overflow-content");
+    const restartButton = screen.getByRole("button", { name: /^restart dev server$/i });
+    expect(overflow.contains(restartButton)).toBe(true);
+
+    screen.getByRole("button", { name: /restart and clear cache/i }).click();
+    expect(onRemedy).toHaveBeenCalledWith("devPreview.restartAndClearCache");
+    expect(onRestart).not.toHaveBeenCalled();
+
+    restartButton.click();
+    expect(onRestart).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to a single restart action at tier 3 without a recommended remedy", () => {

--- a/src/components/DevPreview/__tests__/DevPreviewEmptyStates.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewEmptyStates.test.tsx
@@ -150,3 +150,61 @@ describe("DevPreviewEmptyStates", () => {
     expect(container.firstChild).toBeNull();
   });
 });
+
+// DevPreviewPane.tsx gates rendering this component vs. the live webview with a
+// `showEmptyState` boolean that must exactly mirror the branch order below. This
+// duplicates that formula (see DevPreviewPane.tsx) so a regression on either side
+// fails a test instead of silently mounting both the webview and a placeholder,
+// or neither.
+function computeShowEmptyState(props: {
+  isRestarting: boolean;
+  status: string;
+  isProxyUrlPending: boolean;
+  error: unknown;
+  currentUrl: string;
+  hasBeenVisible: boolean;
+  isEvicted: boolean;
+}): boolean {
+  return (
+    props.isRestarting ||
+    props.status === "starting" ||
+    props.status === "installing" ||
+    props.isProxyUrlPending ||
+    (props.status === "error" && !!props.error) ||
+    !props.currentUrl ||
+    props.status !== "running" ||
+    !props.hasBeenVisible ||
+    props.isEvicted
+  );
+}
+
+describe("DevPreviewEmptyStates — parent gate parity", () => {
+  const scenarios: Array<Partial<React.ComponentProps<typeof DevPreviewEmptyStates>>> = [
+    {
+      status: "running",
+      currentUrl: "http://localhost:3000",
+      hasBeenVisible: true,
+      isEvicted: false,
+    },
+    { isRestarting: true },
+    { status: "starting" },
+    { status: "installing" },
+    { isProxyUrlPending: true },
+    { status: "error", error: { type: "unknown", message: "boom" } as DevServerError },
+    { currentUrl: "" },
+    { status: "stopped" },
+    { status: "restored-stopped" },
+    { hasBeenVisible: false },
+    { isEvicted: true },
+  ];
+
+  for (const scenario of scenarios) {
+    it(`agrees with DevPreviewPane's showEmptyState for ${JSON.stringify(scenario)}`, () => {
+      const props = baseProps(scenario);
+      const expectedEmpty = computeShowEmptyState(props);
+      const { container } = render(<DevPreviewEmptyStates {...props} />);
+      const rendersNull = container.firstChild === null;
+      expect(rendersNull).toBe(!expectedEmpty);
+    });
+  }
+});

--- a/src/components/DevPreview/__tests__/DevPreviewEmptyStates.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewEmptyStates.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DevPreviewEmptyStates } from "../DevPreviewEmptyStates";
+import type { DevServerError } from "@shared/utils/devServerErrors";
+import type { RunCommand } from "@shared/types";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+function baseProps(overrides: Partial<React.ComponentProps<typeof DevPreviewEmptyStates>> = {}) {
+  return {
+    isRestarting: false,
+    status: "running" as const,
+    isProxyUrlPending: false,
+    phaseLabel: undefined,
+    error: null,
+    handleRetry: vi.fn(),
+    setDevPreviewConsoleOpen: vi.fn(),
+    id: "pane-1",
+    currentUrl: "http://localhost:3000",
+    handleOpenExternal: vi.fn(),
+    isUnconfigured: false,
+    primaryCandidate: undefined,
+    isAutoDetecting: false,
+    isSettingsLoading: false,
+    handleAutoDetect: vi.fn().mockResolvedValue(true),
+    autoDetectFailedCommand: null,
+    candidates: [],
+    pickerOpen: false,
+    setPickerOpen: vi.fn(),
+    handlePickCandidate: vi.fn(),
+    handleOpenSettings: vi.fn(),
+    commandInput: "",
+    setCommandInput: vi.fn(),
+    handleSaveCommand: vi.fn().mockResolvedValue(undefined),
+    commandInputError: null,
+    devCommand: "",
+    handleStartFromRestored: vi.fn(),
+    hasBeenVisible: true,
+    isEvicted: false,
+    ...overrides,
+  };
+}
+
+function runner(overrides: Partial<RunCommand> = {}): RunCommand {
+  return { id: "dev", name: "dev", command: "npm run dev", ...overrides } as RunCommand;
+}
+
+describe("DevPreviewEmptyStates", () => {
+  it("renders the loading state while restarting", () => {
+    render(<DevPreviewEmptyStates {...baseProps({ isRestarting: true })} />);
+    expect(screen.getByText(/restarting/i)).toBeTruthy();
+  });
+
+  it("renders the loading state while installing dependencies", () => {
+    render(<DevPreviewEmptyStates {...baseProps({ status: "installing" })} />);
+    expect(screen.getByText(/installing dependencies/i)).toBeTruthy();
+  });
+
+  it("renders the dev-server error state with a retry action", () => {
+    const error: DevServerError = { type: "port-conflict", message: "Port 3000 is in use" };
+    render(<DevPreviewEmptyStates {...baseProps({ status: "error", error })} />);
+    expect(screen.getByText("Port conflict")).toBeTruthy();
+    expect(screen.getByText("Port 3000 is in use")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeTruthy();
+  });
+
+  it("offers 'View terminal' instead of retry-install copy for a non-dependency error", () => {
+    const error: DevServerError = { type: "permission", message: "EACCES" };
+    render(<DevPreviewEmptyStates {...baseProps({ status: "error", error })} />);
+    expect(screen.getByRole("button", { name: /view terminal/i })).toBeTruthy();
+  });
+
+  it("shows the auto-detected command prompt when unconfigured with a primary candidate", () => {
+    render(
+      <DevPreviewEmptyStates
+        {...baseProps({ isUnconfigured: true, currentUrl: "", primaryCandidate: runner() })}
+      />
+    );
+    expect(screen.getByText("Start the dev server")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /run `npm run dev`/i })).toBeTruthy();
+  });
+
+  it("shows the manual command form when unconfigured without a detected candidate", () => {
+    render(
+      <DevPreviewEmptyStates
+        {...baseProps({ isUnconfigured: true, currentUrl: "", primaryCandidate: undefined })}
+      />
+    );
+    expect(screen.getByText("Set a dev command")).toBeTruthy();
+    expect(screen.getByPlaceholderText("npm run dev")).toBeTruthy();
+  });
+
+  it("shows the auto-detect failure banner with a retry action", () => {
+    render(
+      <DevPreviewEmptyStates
+        {...baseProps({
+          isUnconfigured: true,
+          currentUrl: "",
+          primaryCandidate: runner(),
+          autoDetectFailedCommand: "npm run dev",
+        })}
+      />
+    );
+    expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+  });
+
+  it("renders the restored-stopped placeholder with the saved command", () => {
+    render(
+      <DevPreviewEmptyStates
+        {...baseProps({ status: "restored-stopped", currentUrl: "", devCommand: "npm run dev" })}
+      />
+    );
+    expect(screen.getByText("Dev server was running")).toBeTruthy();
+    expect(screen.getByText("npm run dev")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /restart dev server/i })).toBeTruthy();
+  });
+
+  it("renders the generic waiting placeholder for any other non-running status", () => {
+    render(<DevPreviewEmptyStates {...baseProps({ status: "stopped", currentUrl: "" })} />);
+    expect(screen.getByText("Waiting for dev server")).toBeTruthy();
+  });
+
+  it("renders the not-yet-visible placeholder once running with a URL but not yet visible", () => {
+    render(<DevPreviewEmptyStates {...baseProps({ hasBeenVisible: false })} />);
+    expect(screen.getByText(/preview will load when this panel is first viewed/i)).toBeTruthy();
+  });
+
+  it("renders the evicted placeholder once running, visible, and evicted", () => {
+    render(<DevPreviewEmptyStates {...baseProps({ isEvicted: true })} />);
+    expect(screen.getByText(/preview paused to save memory/i)).toBeTruthy();
+  });
+
+  it("renders nothing (null) once running with a URL, visible, and not evicted", () => {
+    const { container } = render(<DevPreviewEmptyStates {...baseProps()} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/DevPreview/__tests__/DevPreviewWebviewOverlays.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewWebviewOverlays.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DevPreviewWebviewOverlays } from "../DevPreviewWebviewOverlays";
+import type { WebviewLoadError } from "../useDevPreviewLoadLifecycle";
+import type { FindInPageState } from "@/hooks/useFindInPage";
+
+vi.mock("../BlockedNavBanner", () => ({
+  BlockedNavBanner: ({ state }: { state: unknown }) =>
+    state ? <div data-testid="blocked-nav-banner" /> : null,
+}));
+vi.mock("../../Browser/WebviewDialog", () => ({
+  WebviewDialog: ({ dialog }: { dialog: unknown }) =>
+    dialog ? <div data-testid="webview-dialog" /> : null,
+}));
+vi.mock("../../Browser/FindBar", () => ({
+  FindBar: () => <div data-testid="find-bar" />,
+}));
+vi.mock("../DevPreviewLoadingState", () => ({
+  DevPreviewLoadingState: ({ phaseLabel }: { phaseLabel: string }) => (
+    <div data-testid="loading-state">{phaseLabel}</div>
+  ),
+}));
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const findInPage: FindInPageState = {
+  isOpen: false,
+  query: "",
+  activeMatch: 0,
+  matchCount: 0,
+  matchCase: false,
+  inputRef: { current: null },
+  isComposingRef: { current: false },
+  open: vi.fn(),
+  close: vi.fn(),
+  setQuery: vi.fn(),
+  goNext: vi.fn(),
+  goPrev: vi.fn(),
+  toggleMatchCase: vi.fn(),
+};
+
+function baseProps(
+  overrides: Partial<React.ComponentProps<typeof DevPreviewWebviewOverlays>> = {}
+) {
+  return {
+    reconnectAttempt: 0,
+    webviewLoadError: null,
+    certCopied: false,
+    onCopyMkcert: vi.fn(),
+    isRestarting: false,
+    onRestartDevServer: vi.fn(),
+    onHardReload: vi.fn(),
+    onRequestRestartAndClearCache: vi.fn(),
+    onRequestReinstallAndRestart: vi.fn(),
+    onRetryWebviewLoad: vi.fn(),
+    currentUrl: "http://localhost:3000",
+    onOpenExternal: vi.fn(),
+    blockedNav: null,
+    panelId: "pane-1",
+    webviewElement: null,
+    onDispatchBlockedNav: vi.fn(),
+    crashState: "none" as const,
+    crashDetails: null,
+    onCloseCrash: vi.fn(),
+    onCloseUnresponsive: vi.fn(),
+    isLoading: false,
+    onCancelLoad: vi.fn(),
+    showRecoverySpinner: false,
+    isRecoveringFromEviction: false,
+    isDragging: false,
+    findInPage,
+    currentDialog: null,
+    onDialogRespond: vi.fn(),
+    children: <div data-testid="webview-slot" />,
+    ...overrides,
+  };
+}
+
+describe("DevPreviewWebviewOverlays — reconnect + load-error", () => {
+  it("shows the reconnect toast when attempts are pending and there's no load error", () => {
+    render(<DevPreviewWebviewOverlays {...baseProps({ reconnectAttempt: 2 })} />);
+    expect(screen.getByText(/reconnecting \(attempt 2 of 5\)/i)).toBeTruthy();
+  });
+
+  it("suppresses the reconnect toast once a load error takes over", () => {
+    const error: WebviewLoadError = { code: "timeout", message: "Timed out" };
+    render(
+      <DevPreviewWebviewOverlays {...baseProps({ reconnectAttempt: 2, webviewLoadError: error })} />
+    );
+    expect(screen.queryByText(/reconnecting/i)).toBeNull();
+  });
+
+  it("renders a restart-dropdown for a connection_refused error, not the plain retry button", () => {
+    const error: WebviewLoadError = { code: "connection_refused", message: "Unreachable" };
+    render(<DevPreviewWebviewOverlays {...baseProps({ webviewLoadError: error })} />);
+    expect(screen.getByRole("button", { name: /restart dev server/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^retry$/i })).toBeNull();
+  });
+
+  it("renders a plain retry button for a generic load error", () => {
+    const error: WebviewLoadError = { code: "failed", message: "Page failed to load" };
+    render(<DevPreviewWebviewOverlays {...baseProps({ webviewLoadError: error })} />);
+    expect(screen.getByRole("button", { name: /^retry$/i })).toBeTruthy();
+  });
+
+  it("wires the retry click through to onRetryWebviewLoad for a generic error", () => {
+    const error: WebviewLoadError = { code: "failed", message: "Page failed to load" };
+    const onRetryWebviewLoad = vi.fn();
+    render(
+      <DevPreviewWebviewOverlays {...baseProps({ webviewLoadError: error, onRetryWebviewLoad })} />
+    );
+    screen.getByRole("button", { name: /^retry$/i }).click();
+    expect(onRetryWebviewLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the mkcert copy action only for a cert error", () => {
+    const error: WebviewLoadError = { code: "cert", message: "Cert invalid" };
+    render(<DevPreviewWebviewOverlays {...baseProps({ webviewLoadError: error })} />);
+    expect(screen.getByRole("button", { name: /copy `mkcert -install`/i })).toBeTruthy();
+  });
+});
+
+describe("DevPreviewWebviewOverlays — crash banners", () => {
+  it("renders the crashed banner with details and wires reload/close/hard-restart", () => {
+    const onHardReload = vi.fn();
+    const onCloseCrash = vi.fn();
+    render(
+      <DevPreviewWebviewOverlays
+        {...baseProps({
+          crashState: "crashed",
+          crashDetails: { reason: "crashed", exitCode: 1 },
+          onHardReload,
+          onCloseCrash,
+        })}
+      />
+    );
+    expect(screen.getByText(/reason: crashed \(exit code 1\)/i)).toBeTruthy();
+    screen.getByRole("button", { name: /reload preview page/i }).click();
+    expect(onHardReload).toHaveBeenCalledTimes(1);
+    screen.getByRole("button", { name: /dismiss/i }).click();
+    expect(onCloseCrash).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the unresponsive banner distinctly and wires its own close handler", () => {
+    const onCloseUnresponsive = vi.fn();
+    render(
+      <DevPreviewWebviewOverlays
+        {...baseProps({ crashState: "unresponsive", onCloseUnresponsive })}
+      />
+    );
+    expect(screen.getByText(/preview is not responding/i)).toBeTruthy();
+    screen.getByRole("button", { name: /dismiss/i }).click();
+    expect(onCloseUnresponsive).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders neither crash banner when crashState is none", () => {
+    render(<DevPreviewWebviewOverlays {...baseProps({ crashState: "none" })} />);
+    expect(screen.queryByText(/preview process crashed/i)).toBeNull();
+    expect(screen.queryByText(/preview is not responding/i)).toBeNull();
+  });
+});
+
+describe("DevPreviewWebviewOverlays — loading/eviction/drag/find-in-page", () => {
+  it("shows the loading overlay when isLoading", () => {
+    render(<DevPreviewWebviewOverlays {...baseProps({ isLoading: true })} />);
+    expect(screen.getByText("Loading preview")).toBeTruthy();
+  });
+
+  it("shows the recovery overlay only when there's no load error", () => {
+    render(<DevPreviewWebviewOverlays {...baseProps({ showRecoverySpinner: true })} />);
+    expect(screen.getByText("Rehydrating preview")).toBeTruthy();
+  });
+
+  it("suppresses the recovery overlay once a load error appears", () => {
+    const error: WebviewLoadError = { code: "failed", message: "boom" };
+    render(
+      <DevPreviewWebviewOverlays
+        {...baseProps({ showRecoverySpinner: true, webviewLoadError: error })}
+      />
+    );
+    expect(screen.queryByText("Rehydrating preview")).toBeNull();
+  });
+
+  it("renders the find bar only when findInPage.isOpen", () => {
+    const { rerender } = render(<DevPreviewWebviewOverlays {...baseProps()} />);
+    expect(screen.queryByTestId("find-bar")).toBeNull();
+    rerender(
+      <DevPreviewWebviewOverlays {...baseProps({ findInPage: { ...findInPage, isOpen: true } })} />
+    );
+    expect(screen.getByTestId("find-bar")).toBeTruthy();
+  });
+
+  it("always renders the passed-in webview slot children", () => {
+    render(<DevPreviewWebviewOverlays {...baseProps()} />);
+    expect(screen.getByTestId("webview-slot")).toBeTruthy();
+  });
+});

--- a/src/components/DevPreview/__tests__/useDevPreviewCommandConfig.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewCommandConfig.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { renderHook, waitFor, act, render, screen } from "@testing-library/react";
 import type { RunCommand } from "@shared/types";
 
 const saveSettingsMock = vi.fn().mockResolvedValue(undefined);
@@ -17,6 +17,29 @@ vi.mock("@/clients", () => ({
     getSettings: (...args: unknown[]) => getSettingsMock(...args),
     detectRunners: (...args: unknown[]) => detectRunnersMock(...args),
   },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button onClick={onSelect} role="menuitem">
+      {children}
+    </button>
+  ),
 }));
 
 import { useDevPreviewCommandConfig } from "../useDevPreviewCommandConfig";
@@ -190,5 +213,85 @@ describe("useDevPreviewCommandConfig", () => {
         devServerAutoDetected: false,
       })
     );
+  });
+});
+
+describe("useDevPreviewCommandConfig — header script picker", () => {
+  it("picking the already-active script is a no-op (does not save or stop)", async () => {
+    useProjectSettingsStore.setState({
+      allDetectedRunners: [
+        runner(),
+        runner({ id: "start", name: "start", command: "npm run start" }),
+      ],
+    });
+    const stop = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(
+        baseParams({ isUnconfigured: false, devCommand: "npm run dev", stop })
+      )
+    );
+    render(<>{result.current.headerContent}</>);
+
+    await act(async () => {
+      screen.getByRole("menuitem", { name: /dev.*npm run dev/i }).click();
+      await Promise.resolve();
+    });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("picking a different script saves it and stops the running server", async () => {
+    getSettingsMock.mockResolvedValue({ turbopackEnabled: true });
+    useProjectSettingsStore.setState({
+      allDetectedRunners: [
+        runner(),
+        runner({ id: "start", name: "start", command: "npm run start" }),
+      ],
+    });
+    const stop = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(
+        baseParams({ isUnconfigured: false, devCommand: "npm run dev", stop })
+      )
+    );
+    render(<>{result.current.headerContent}</>);
+
+    await act(async () => {
+      screen.getByRole("menuitem", { name: /start.*npm run start/i }).click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ devServerCommand: "npm run start" })
+    );
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not stop the server when saving the newly picked script fails", async () => {
+    getSettingsMock.mockResolvedValue(null);
+    useProjectSettingsStore.setState({
+      allDetectedRunners: [
+        runner(),
+        runner({ id: "start", name: "start", command: "npm run start" }),
+      ],
+    });
+    const stop = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(
+        baseParams({ isUnconfigured: false, devCommand: "npm run dev", stop })
+      )
+    );
+    render(<>{result.current.headerContent}</>);
+
+    await act(async () => {
+      screen.getByRole("menuitem", { name: /start.*npm run start/i }).click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
   });
 });

--- a/src/components/DevPreview/__tests__/useDevPreviewCommandConfig.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewCommandConfig.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { RunCommand } from "@shared/types";
+
+const saveSettingsMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/hooks/useProjectSettings", () => ({
+  useProjectSettings: () => ({ saveSettings: saveSettingsMock }),
+}));
+
+const getSettingsMock = vi.fn();
+const detectRunnersMock = vi.fn();
+vi.mock("@/clients", () => ({
+  projectClient: {
+    getSettings: (...args: unknown[]) => getSettingsMock(...args),
+    detectRunners: (...args: unknown[]) => detectRunnersMock(...args),
+  },
+}));
+
+import { useDevPreviewCommandConfig } from "../useDevPreviewCommandConfig";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+
+function runner(overrides: Partial<RunCommand> = {}): RunCommand {
+  return {
+    id: "dev",
+    name: "dev",
+    command: "npm run dev",
+    ...overrides,
+  } as RunCommand;
+}
+
+function baseParams(overrides: Partial<Parameters<typeof useDevPreviewCommandConfig>[0]> = {}) {
+  return {
+    currentProjectId: "proj-1",
+    devCommand: "",
+    isUnconfigured: true,
+    projectSettings: { turbopackEnabled: true } as never,
+    stop: vi.fn(),
+    isMountedRef: { current: true },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  saveSettingsMock.mockResolvedValue(undefined);
+  useProjectSettingsStore.setState({ allDetectedRunners: [], settings: null, isLoading: false });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDevPreviewCommandConfig", () => {
+  it("derives candidates from allDetectedRunners and picks the first as primary", () => {
+    useProjectSettingsStore.setState({ allDetectedRunners: [runner()] });
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+    expect(result.current.candidates).toHaveLength(1);
+    expect(result.current.primaryCandidate?.command).toBe("npm run dev");
+  });
+
+  it("returns null headerContent while unconfigured, regardless of candidates", () => {
+    useProjectSettingsStore.setState({ allDetectedRunners: [runner()] });
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(baseParams({ isUnconfigured: true }))
+    );
+    expect(result.current.headerContent).toBeNull();
+  });
+
+  it("returns null headerContent when configured but no candidates were detected", () => {
+    useProjectSettingsStore.setState({ allDetectedRunners: [] });
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(baseParams({ isUnconfigured: false, devCommand: "npm run dev" }))
+    );
+    expect(result.current.headerContent).toBeNull();
+  });
+
+  it("renders headerContent once configured with at least one candidate", () => {
+    useProjectSettingsStore.setState({ allDetectedRunners: [runner()] });
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(baseParams({ isUnconfigured: false, devCommand: "npm run dev" }))
+    );
+    expect(result.current.headerContent).not.toBeNull();
+  });
+
+  it("handleAutoDetect saves the explicit candidate command and returns true on success", async () => {
+    getSettingsMock.mockResolvedValue({ turbopackEnabled: true });
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.handleAutoDetect("npm run dev");
+    });
+
+    expect(outcome).toBe(true);
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        devServerCommand: "npm run dev",
+        devServerAutoDetected: true,
+        devServerDismissed: false,
+      })
+    );
+    expect(detectRunnersMock).not.toHaveBeenCalled();
+  });
+
+  it("handleAutoDetect falls back to freshly detected runners when no candidate is given", async () => {
+    getSettingsMock.mockResolvedValue({ turbopackEnabled: true });
+    detectRunnersMock.mockResolvedValue([runner({ command: "npm run start" })]);
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.handleAutoDetect();
+    });
+
+    expect(outcome).toBe(true);
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ devServerCommand: "npm run start" })
+    );
+  });
+
+  it("handleAutoDetect sets autoDetectFailedCommand to empty string when re-detection finds nothing", async () => {
+    getSettingsMock.mockResolvedValue({ turbopackEnabled: true });
+    detectRunnersMock.mockResolvedValue([]);
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+
+    await act(async () => {
+      await result.current.handleAutoDetect();
+    });
+
+    await waitFor(() => expect(result.current.autoDetectFailedCommand).toBe(""));
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("handleAutoDetect is a no-op without a currentProjectId", async () => {
+    const { result } = renderHook(() =>
+      useDevPreviewCommandConfig(baseParams({ currentProjectId: undefined }))
+    );
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.handleAutoDetect("npm run dev");
+    });
+
+    expect(outcome).toBe(false);
+    expect(getSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("clears a stale autoDetectFailedCommand once devCommand becomes non-empty", () => {
+    const { result, rerender } = renderHook((props) => useDevPreviewCommandConfig(props), {
+      initialProps: baseParams({ devCommand: "" }),
+    });
+    act(() => {
+      result.current.handleSaveCommand();
+    });
+    rerender(baseParams({ devCommand: "npm run dev" }));
+    expect(result.current.autoDetectFailedCommand).toBeNull();
+  });
+
+  it("commandInputError flags a multi-line command string", () => {
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+    act(() => {
+      result.current.setCommandInput("npm run dev\nnpm run other");
+    });
+    expect(result.current.commandInputError).not.toBeNull();
+  });
+
+  it("handleSaveCommand is a no-op for a blank or invalid command", async () => {
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+    await act(async () => {
+      await result.current.handleSaveCommand();
+    });
+    expect(getSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("handleSaveCommand persists a valid trimmed command", async () => {
+    getSettingsMock.mockResolvedValue({ turbopackEnabled: true });
+    const { result } = renderHook(() => useDevPreviewCommandConfig(baseParams()));
+    act(() => {
+      result.current.setCommandInput("  npm run dev  ");
+    });
+    await act(async () => {
+      await result.current.handleSaveCommand();
+    });
+    expect(saveSettingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        devServerCommand: "npm run dev",
+        devServerAutoDetected: false,
+      })
+    );
+  });
+});

--- a/src/components/DevPreview/__tests__/useDevPreviewCrashRecovery.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewCrashRecovery.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const notifyMock = vi.fn();
+vi.mock("@/lib/notify", () => ({ notify: (...args: unknown[]) => notifyMock(...args) }));
+
+import { useDevPreviewCrashRecovery } from "../useDevPreviewCrashRecovery";
+
+const PANE_ID = "pane-1";
+
+let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
+let responsiveCb: ((data: { panelId: string }) => void) | undefined;
+const offUnresponsive = vi.fn();
+const offResponsive = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  unresponsiveCb = undefined;
+  responsiveCb = undefined;
+  (window as unknown as { electron: Record<string, unknown> }).electron = {
+    webview: {
+      onUnresponsive: vi.fn((cb: (data: { panelId: string }) => void) => {
+        unresponsiveCb = cb;
+        return offUnresponsive;
+      }),
+      onResponsive: vi.fn((cb: (data: { panelId: string }) => void) => {
+        responsiveCb = cb;
+        return offResponsive;
+      }),
+    },
+  };
+});
+
+function renderCrashRecovery(currentUrl = "http://localhost:3000/page") {
+  const crashReloadRef = { current: vi.fn() };
+  const view = renderHook(
+    ({ url }) =>
+      useDevPreviewCrashRecovery({
+        id: PANE_ID,
+        currentUrl: url,
+        crashReloadRef,
+      }),
+    { initialProps: { url: currentUrl } }
+  );
+  return { ...view, crashReloadRef };
+}
+
+describe("useDevPreviewCrashRecovery — render-process-gone handling", () => {
+  it("auto-reloads via crashReloadRef on the first crash within the 60s window", () => {
+    const { result, crashReloadRef } = renderCrashRecovery();
+
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+
+    expect(result.current.crashState).toBe("crashed");
+    expect(result.current.crashDetails).toEqual({ reason: "crashed", exitCode: 1 });
+    expect(crashReloadRef.current).toHaveBeenCalledTimes(1);
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("stops auto-reloading and notifies on a second crash within 60 seconds", () => {
+    const { result, crashReloadRef } = renderCrashRecovery();
+
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+
+    expect(crashReloadRef.current).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ supersedeKey: `dev-preview-crash-loop:${PANE_ID}` })
+    );
+  });
+
+  it("reads crashReloadRef.current lazily, so a ref populated after the hook renders still fires", () => {
+    const { result, crashReloadRef } = renderCrashRecovery();
+    // Simulate the parent's separate sync effect assigning performReload later.
+    const laterReload = vi.fn();
+    crashReloadRef.current = laterReload;
+
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+
+    expect(laterReload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDevPreviewCrashRecovery — unresponsive/responsive listeners", () => {
+  it("sets unresponsive on a matching panelId event", () => {
+    const { result } = renderCrashRecovery();
+    act(() => {
+      unresponsiveCb?.({ panelId: PANE_ID });
+    });
+    expect(result.current.crashState).toBe("unresponsive");
+  });
+
+  it("ignores unresponsive/responsive events for a different panelId", () => {
+    const { result } = renderCrashRecovery();
+    act(() => {
+      unresponsiveCb?.({ panelId: "other-pane" });
+    });
+    expect(result.current.crashState).toBe("none");
+  });
+
+  it("does not downgrade a crashed state to unresponsive", () => {
+    const { result } = renderCrashRecovery();
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    act(() => {
+      unresponsiveCb?.({ panelId: PANE_ID });
+    });
+    expect(result.current.crashState).toBe("crashed");
+  });
+
+  it("clears back to none on a matching responsive event", () => {
+    const { result } = renderCrashRecovery();
+    act(() => {
+      unresponsiveCb?.({ panelId: PANE_ID });
+    });
+    act(() => {
+      responsiveCb?.({ panelId: PANE_ID });
+    });
+    expect(result.current.crashState).toBe("none");
+  });
+
+  it("does not clear a crashed state via a responsive event", () => {
+    const { result } = renderCrashRecovery();
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    act(() => {
+      responsiveCb?.({ panelId: PANE_ID });
+    });
+    expect(result.current.crashState).toBe("crashed");
+  });
+
+  it("unsubscribes both listeners on unmount", () => {
+    const { unmount } = renderCrashRecovery();
+    unmount();
+    expect(offUnresponsive).toHaveBeenCalledTimes(1);
+    expect(offResponsive).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDevPreviewCrashRecovery — reset helpers", () => {
+  it("resetCrashHistory clears state, details, and the crash timestamp history", () => {
+    const { result, crashReloadRef } = renderCrashRecovery();
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    act(() => {
+      result.current.resetCrashHistory();
+    });
+    expect(result.current.crashState).toBe("none");
+    expect(result.current.crashDetails).toBeNull();
+
+    // Timestamp history was cleared too: a subsequent crash is treated as
+    // the first one again (auto-reload fires instead of the loop notice).
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    expect(crashReloadRef.current).toHaveBeenCalledTimes(2);
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("clearUnresponsiveState only clears crashState, not crashDetails or history", () => {
+    const { result, crashReloadRef } = renderCrashRecovery();
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    act(() => {
+      result.current.clearUnresponsiveState();
+    });
+    expect(result.current.crashState).toBe("none");
+
+    // Crash history was NOT cleared: a second crash within 60s still trips
+    // the crash-loop notice instead of auto-reloading again.
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    expect(crashReloadRef.current).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDevPreviewCrashRecovery — URL-transition clearing", () => {
+  it("clears crash state on a genuine URL transition", () => {
+    const { result, rerender } = renderCrashRecovery("http://localhost:3000/a");
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    expect(result.current.crashState).toBe("crashed");
+
+    rerender({ url: "http://localhost:3000/b" });
+    expect(result.current.crashState).toBe("none");
+  });
+
+  it("does not clear crash state when the URL is unchanged (no reset loop)", () => {
+    const { result, rerender } = renderCrashRecovery("http://localhost:3000/a");
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    rerender({ url: "http://localhost:3000/a" });
+    expect(result.current.crashState).toBe("crashed");
+  });
+
+  it("does not clear crash state on a transition to about:blank", () => {
+    const { result, rerender } = renderCrashRecovery("http://localhost:3000/a");
+    act(() => {
+      result.current.handleRenderProcessGone({ reason: "crashed", exitCode: 1 });
+    });
+    rerender({ url: "about:blank" });
+    expect(result.current.crashState).toBe("crashed");
+  });
+});

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -83,7 +83,7 @@ describe("useDevPreviewNavigation — history handlers", () => {
     const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ setHistory })));
     act(() => result.current.handleNavigate("localhost:5173/app"));
     expect(setHistory).toHaveBeenCalled();
-    const updater = setHistory.mock.calls[0][0];
+    const updater = setHistory.mock.calls[0]![0];
     const next = updater(initializeBrowserHistory(undefined, ""));
     expect(next.present).toContain("localhost:5173/app");
   });

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -154,15 +154,23 @@ describe("useDevPreviewNavigation — reload/cancel/retry", () => {
   });
 
   it("handleRetryWebviewLoad issues an imperative load when there's a current URL", () => {
+    const setWebviewLoadError = vi.fn();
+    const setIsLoading = vi.fn();
     const webview = makeWebview();
     const { result } = renderHook(() =>
       useDevPreviewNavigation(
-        baseParams({ currentUrl: "http://localhost:3000/x", webviewRef: { current: webview } })
+        baseParams({
+          currentUrl: "http://localhost:3000/x",
+          webviewRef: { current: webview },
+          setWebviewLoadError,
+          setIsLoading,
+        })
       )
     );
     act(() => result.current.handleRetryWebviewLoad());
-    // loadWebviewUrl calls webview.stop()+loadURL internally; getURL is enough
-    // signal here that the webview was addressed rather than blank-reloaded.
+    expect(setWebviewLoadError).toHaveBeenCalledWith(null);
+    expect(setIsLoading).toHaveBeenCalledWith(true);
+    expect(webview.loadURL).toHaveBeenCalledWith("http://localhost:3000/x");
     expect(webview.reload).not.toHaveBeenCalled();
   });
 
@@ -254,6 +262,27 @@ describe("useDevPreviewNavigation — open external / promote to portal", () => 
       expect.objectContaining({ redirectPath: "/path?x=1#frag" })
     );
     expect(window.electron.system.openExternal).toHaveBeenCalledWith("https://bootstrap.example");
+  });
+
+  it("falls back to opening the raw proxy URL when minting the bootstrap token fails", async () => {
+    (window.electron.devPreview.mintBrowserToken as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("mint failed")
+    );
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({
+          currentUrl: "https://proxy.example/path",
+          proxyOrigin: "https://proxy.example",
+        })
+      )
+    );
+    await act(async () => {
+      result.current.handleOpenExternal();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(window.electron.system.openExternal).toHaveBeenCalledWith("https://proxy.example/path");
   });
 
   it("opens the raw URL directly in legacy (non-proxy) mode", () => {

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -1,0 +1,361 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDevPreviewNavigation } from "../useDevPreviewNavigation";
+import { initializeBrowserHistory } from "../../Browser/historyUtils";
+import { actionService } from "@/services/ActionService";
+import type { BrowserHistory } from "@shared/types/browser";
+
+const PANE_ID = "pane-1";
+
+function makeWebview(overrides: Partial<Record<string, unknown>> = {}): Electron.WebviewTag {
+  return {
+    reload: vi.fn(),
+    stop: vi.fn(),
+    loadURL: vi.fn(),
+    getURL: vi.fn(() => "http://localhost:3000/"),
+    getWebContentsId: vi.fn(() => 7),
+    setZoomFactor: vi.fn(),
+    isDevToolsOpened: vi.fn(() => false),
+    openDevTools: vi.fn(),
+    closeDevTools: vi.fn(),
+    capturePage: vi.fn(() =>
+      Promise.resolve({ toPNG: () => new Uint8Array([1, 2, 3]).buffer as unknown as Buffer })
+    ),
+    ...overrides,
+  } as unknown as Electron.WebviewTag;
+}
+
+function baseParams(overrides: Partial<Parameters<typeof useDevPreviewNavigation>[0]> = {}) {
+  const history: BrowserHistory = initializeBrowserHistory(undefined, "http://localhost:3000/");
+  return {
+    id: PANE_ID,
+    currentProjectId: "proj-1",
+    currentUrl: history.present,
+    canGoBack: false,
+    canGoForward: false,
+    history,
+    setHistory: vi.fn(),
+    zoomFactor: 1,
+    setZoomFactor: vi.fn(),
+    devServerUrl: null,
+    proxyOrigin: null,
+    isUnconfigured: false,
+    isWebviewReady: true,
+    webviewRef: { current: makeWebview() },
+    setBrowserUrl: vi.fn(),
+    setBrowserHistory: vi.fn(),
+    setBrowserZoom: vi.fn(),
+    setIsLoading: vi.fn(),
+    setWebviewLoadError: vi.fn(),
+    clearLoadTimers: vi.fn(),
+    isConsoleOpen: false,
+    setDevPreviewConsoleOpen: vi.fn(),
+    onHardReload: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as unknown as { electron: Record<string, unknown> }).electron = {
+    webview: {
+      onReloadShortcut: vi.fn(() => () => {}),
+      onCloseShortcut: vi.fn(() => () => {}),
+      reloadIgnoringCache: vi.fn().mockResolvedValue(undefined),
+    },
+    clipboard: { writeImage: vi.fn().mockResolvedValue(undefined) },
+    system: { openExternal: vi.fn().mockResolvedValue(undefined) },
+    devPreview: {
+      mintBrowserToken: vi.fn().mockResolvedValue({ bootstrapUrl: "https://bootstrap.example" }),
+    },
+  };
+  vi.spyOn(actionService, "dispatch").mockResolvedValue({ ok: true } as Awaited<
+    ReturnType<typeof actionService.dispatch>
+  >);
+});
+
+describe("useDevPreviewNavigation — history handlers", () => {
+  it("handleNavigate pushes a normalized (localhost-only) URL onto history", () => {
+    const setHistory = vi.fn();
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ setHistory })));
+    act(() => result.current.handleNavigate("localhost:5173/app"));
+    expect(setHistory).toHaveBeenCalled();
+    const updater = setHistory.mock.calls[0][0];
+    const next = updater(initializeBrowserHistory(undefined, ""));
+    expect(next.present).toContain("localhost:5173/app");
+  });
+
+  it("handleBack is a no-op when canGoBack is false", () => {
+    const setHistory = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ setHistory, canGoBack: false }))
+    );
+    act(() => result.current.handleBack());
+    expect(setHistory).not.toHaveBeenCalled();
+  });
+
+  it("handleBack navigates back when canGoBack is true", () => {
+    const setHistory = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ setHistory, canGoBack: true }))
+    );
+    act(() => result.current.handleBack());
+    expect(setHistory).toHaveBeenCalled();
+  });
+
+  it("handleForward is a no-op when canGoForward is false", () => {
+    const setHistory = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ setHistory, canGoForward: false }))
+    );
+    act(() => result.current.handleForward());
+    expect(setHistory).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDevPreviewNavigation — reload/cancel/retry", () => {
+  it("handleReload clears the load error and reloads the webview", () => {
+    const setWebviewLoadError = vi.fn();
+    const webview = makeWebview();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ setWebviewLoadError, webviewRef: { current: webview } }))
+    );
+    act(() => result.current.handleReload());
+    expect(setWebviewLoadError).toHaveBeenCalledWith(null);
+    expect(webview.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleCancelLoad clears timers, stops loading, and sets an aborted error", () => {
+    const clearLoadTimers = vi.fn();
+    const setIsLoading = vi.fn();
+    const setWebviewLoadError = vi.fn();
+    const webview = makeWebview();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({
+          clearLoadTimers,
+          setIsLoading,
+          setWebviewLoadError,
+          webviewRef: { current: webview },
+        })
+      )
+    );
+    act(() => result.current.handleCancelLoad());
+    expect(clearLoadTimers).toHaveBeenCalledTimes(1);
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+    expect(webview.stop).toHaveBeenCalledTimes(1);
+    expect(setWebviewLoadError).toHaveBeenCalledWith({
+      code: "aborted",
+      message: "Load cancelled.",
+    });
+  });
+
+  it("handleRetryWebviewLoad issues an imperative load when there's a current URL", () => {
+    const webview = makeWebview();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({ currentUrl: "http://localhost:3000/x", webviewRef: { current: webview } })
+      )
+    );
+    act(() => result.current.handleRetryWebviewLoad());
+    // loadWebviewUrl calls webview.stop()+loadURL internally; getURL is enough
+    // signal here that the webview was addressed rather than blank-reloaded.
+    expect(webview.reload).not.toHaveBeenCalled();
+  });
+
+  it("handleRetryWebviewLoad falls back to a plain reload without a current URL", () => {
+    const webview = makeWebview();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ currentUrl: "", webviewRef: { current: webview } }))
+    );
+    act(() => result.current.handleRetryWebviewLoad());
+    expect(webview.reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDevPreviewNavigation — screenshot/devtools/console/zoom", () => {
+  it("handleCaptureScreenshot copies a PNG to the clipboard and returns true", async () => {
+    const webview = makeWebview();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ webviewRef: { current: webview } }))
+    );
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.handleCaptureScreenshot();
+    });
+    expect(outcome).toBe(true);
+    expect(window.electron.clipboard.writeImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleCaptureScreenshot returns false when the webview is on about:blank", async () => {
+    const webview = makeWebview({ getURL: vi.fn(() => "about:blank") });
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ webviewRef: { current: webview } }))
+    );
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.handleCaptureScreenshot();
+    });
+    expect(outcome).toBe(false);
+  });
+
+  it("handleToggleDevTools opens devtools when closed, closes when open", () => {
+    const webview = makeWebview({ isDevToolsOpened: vi.fn(() => false) });
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ webviewRef: { current: webview } }))
+    );
+    act(() => result.current.handleToggleDevTools());
+    expect(webview.openDevTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleToggleConsole flips setDevPreviewConsoleOpen from the current state", () => {
+    const setDevPreviewConsoleOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ isConsoleOpen: false, setDevPreviewConsoleOpen }))
+    );
+    act(() => result.current.handleToggleConsole());
+    expect(setDevPreviewConsoleOpen).toHaveBeenCalledWith(PANE_ID, true);
+  });
+
+  it("handleZoomChange clamps to [0.25, 2.0] and applies it to the webview", () => {
+    const setZoomFactor = vi.fn();
+    const webview = makeWebview();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ setZoomFactor, webviewRef: { current: webview } }))
+    );
+    act(() => result.current.handleZoomChange(5));
+    expect(setZoomFactor).toHaveBeenCalledWith(2.0);
+    expect(webview.setZoomFactor).toHaveBeenCalledWith(2.0);
+
+    act(() => result.current.handleZoomChange(0.01));
+    expect(setZoomFactor).toHaveBeenCalledWith(0.25);
+  });
+});
+
+describe("useDevPreviewNavigation — open external / promote to portal", () => {
+  it("mints a bootstrap token and opens it when the URL is on the stable proxy origin", async () => {
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({
+          currentUrl: "https://proxy.example/path?x=1#frag",
+          proxyOrigin: "https://proxy.example",
+        })
+      )
+    );
+    await act(async () => {
+      result.current.handleOpenExternal();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(window.electron.devPreview.mintBrowserToken).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectPath: "/path?x=1#frag" })
+    );
+    expect(window.electron.system.openExternal).toHaveBeenCalledWith("https://bootstrap.example");
+  });
+
+  it("opens the raw URL directly in legacy (non-proxy) mode", () => {
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({ currentUrl: "http://localhost:3000/", proxyOrigin: null })
+      )
+    );
+    act(() => result.current.handleOpenExternal());
+    expect(window.electron.devPreview.mintBrowserToken).not.toHaveBeenCalled();
+    expect(window.electron.system.openExternal).toHaveBeenCalledWith("http://localhost:3000/");
+  });
+
+  it("handlePromoteToPortal guards against re-entrant calls while one is in flight", () => {
+    const setBrowserUrl = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ setBrowserUrl, currentUrl: "http://localhost:3000/" }))
+    );
+    // The mount-time URL-persistence effect already called setBrowserUrl once;
+    // isolate the calls made by handlePromoteToPortal itself from here.
+    setBrowserUrl.mockClear();
+    act(() => {
+      result.current.handlePromoteToPortal();
+      result.current.handlePromoteToPortal();
+    });
+    expect(setBrowserUrl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDevPreviewNavigation — persistence effects", () => {
+  it("mirrors history/url/zoom into the panel store", () => {
+    const setBrowserHistory = vi.fn();
+    const setBrowserZoom = vi.fn();
+    const setBrowserUrl = vi.fn();
+    renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({ setBrowserHistory, setBrowserZoom, setBrowserUrl, zoomFactor: 1.5 })
+      )
+    );
+    expect(setBrowserHistory).toHaveBeenCalledWith(PANE_ID, expect.any(Object));
+    expect(setBrowserZoom).toHaveBeenCalledWith(PANE_ID, 1.5);
+    expect(setBrowserUrl).toHaveBeenCalledWith(PANE_ID, "http://localhost:3000/");
+  });
+
+  it("does not push a dev-server URL into history while the proxy origin is still resolving", () => {
+    const setHistory = vi.fn();
+    renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({ setHistory, devServerUrl: "http://127.0.0.1:4000/", proxyOrigin: undefined })
+      )
+    );
+    // Only the plain history-persistence effect may have called setHistory's
+    // setter form; none of those calls may be the pushBrowserHistory updater
+    // that the URL-adoption effect would produce when unguarded.
+    for (const call of setHistory.mock.calls) {
+      expect(typeof call[0]).not.toBe("function");
+    }
+  });
+
+  it("adopts a resolved dev-server URL onto the stable proxy origin once proxyOrigin settles", () => {
+    const setHistory = vi.fn();
+    renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({
+          setHistory,
+          currentUrl: "",
+          devServerUrl: "http://127.0.0.1:4000/",
+          proxyOrigin: "https://proxy.example",
+        })
+      )
+    );
+    const updaterCalls = setHistory.mock.calls.filter((call) => typeof call[0] === "function");
+    expect(updaterCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe("useDevPreviewNavigation — shortcut listeners", () => {
+  it("invokes onHardReload when a matching reload shortcut fires", () => {
+    let shortcutCb: ((payload: { panelId: string }) => void) | undefined;
+    (window.electron.webview.onReloadShortcut as ReturnType<typeof vi.fn>).mockImplementation(
+      (cb: (payload: { panelId: string }) => void) => {
+        shortcutCb = cb;
+        return () => {};
+      }
+    );
+    const onHardReload = vi.fn();
+    renderHook(() => useDevPreviewNavigation(baseParams({ onHardReload })));
+    act(() => shortcutCb?.({ panelId: PANE_ID }));
+    expect(onHardReload).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a reload shortcut for a different panel", () => {
+    let shortcutCb: ((payload: { panelId: string }) => void) | undefined;
+    (window.electron.webview.onReloadShortcut as ReturnType<typeof vi.fn>).mockImplementation(
+      (cb: (payload: { panelId: string }) => void) => {
+        shortcutCb = cb;
+        return () => {};
+      }
+    );
+    const onHardReload = vi.fn();
+    renderHook(() => useDevPreviewNavigation(baseParams({ onHardReload })));
+    act(() => shortcutCb?.({ panelId: "other-pane" }));
+    expect(onHardReload).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDevPreviewScrollCapture } from "../useDevPreviewScrollCapture";
+
+const PANE_ID = "pane-1";
+const WC_ID = 42;
+const getScrollPositionMock = vi.fn();
+
+function makeWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.WebviewTag {
+  return {
+    getURL: vi.fn(() => "http://localhost:3000/page"),
+    getWebContentsId: vi.fn(() => WC_ID),
+    executeJavaScript: vi.fn(() => Promise.resolve(0)),
+    ...overrides,
+  } as unknown as Electron.WebviewTag;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as unknown as { electron: Record<string, unknown> }).electron = {
+    webview: { getScrollPosition: getScrollPositionMock },
+  };
+});
+
+describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) path", () => {
+  it("captures via executeJavaScript when status transitions away from running", async () => {
+    const webview = makeWebview({ executeJavaScript: vi.fn(() => Promise.resolve(120)) });
+    const setDevPreviewScrollPosition = vi.fn();
+    const { rerender } = renderHook(
+      ({ status, webviewElement }) =>
+        useDevPreviewScrollCapture({
+          id: PANE_ID,
+          status,
+          webviewElement,
+          setDevPreviewScrollPosition,
+        }),
+      { initialProps: { status: "running" as const, webviewElement: webview } }
+    );
+
+    await act(async () => {
+      rerender({ status: "stopped" as const, webviewElement: webview });
+      await Promise.resolve();
+    });
+
+    expect(webview.executeJavaScript).toHaveBeenCalledWith("window.scrollY");
+    expect(getScrollPositionMock).not.toHaveBeenCalled();
+    expect(setDevPreviewScrollPosition).toHaveBeenCalledWith(PANE_ID, {
+      url: "http://localhost:3000/page",
+      scrollY: 120,
+    });
+  });
+
+  it("persists a captured scrollY of exactly 0 via executeJavaScript (no >0 guard on this path)", async () => {
+    const webview = makeWebview({ executeJavaScript: vi.fn(() => Promise.resolve(0)) });
+    const setDevPreviewScrollPosition = vi.fn();
+    const { rerender } = renderHook(
+      ({ status, webviewElement }) =>
+        useDevPreviewScrollCapture({
+          id: PANE_ID,
+          status,
+          webviewElement,
+          setDevPreviewScrollPosition,
+        }),
+      { initialProps: { status: "running" as const, webviewElement: webview } }
+    );
+
+    await act(async () => {
+      rerender({ status: "stopped" as const, webviewElement: webview });
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).toHaveBeenCalledWith(PANE_ID, {
+      url: "http://localhost:3000/page",
+      scrollY: 0,
+    });
+  });
+
+  it("does not capture when the status was not previously running", async () => {
+    const webview = makeWebview();
+    const setDevPreviewScrollPosition = vi.fn();
+    const { rerender } = renderHook(
+      ({ status, webviewElement }) =>
+        useDevPreviewScrollCapture({
+          id: PANE_ID,
+          status,
+          webviewElement,
+          setDevPreviewScrollPosition,
+        }),
+      { initialProps: { status: "starting" as const, webviewElement: webview } }
+    );
+
+    await act(async () => {
+      rerender({ status: "stopped" as const, webviewElement: webview });
+      await Promise.resolve();
+    });
+
+    expect(webview.executeJavaScript).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDevPreviewScrollCapture — captureScrollViaCdp (frozen-safe) path", () => {
+  it("captures via CDP getScrollPosition and skips executeJavaScript entirely", async () => {
+    getScrollPositionMock.mockResolvedValue(200);
+    const webview = makeWebview();
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    await act(async () => {
+      result.current.captureScrollViaCdp(webview);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getScrollPositionMock).toHaveBeenCalledWith(WC_ID);
+    expect(webview.executeJavaScript).not.toHaveBeenCalled();
+    expect(setDevPreviewScrollPosition).toHaveBeenCalledWith(PANE_ID, {
+      url: "http://localhost:3000/page",
+      scrollY: 200,
+    });
+  });
+
+  it("does not persist a CDP-returned 0 (error-path guard), unlike the executeJavaScript path", async () => {
+    getScrollPositionMock.mockResolvedValue(0);
+    const webview = makeWebview();
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    await act(async () => {
+      result.current.captureScrollViaCdp(webview);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+
+  it("skips capture entirely when the webview URL is about:blank", async () => {
+    const webview = makeWebview({ getURL: vi.fn(() => "about:blank") });
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    result.current.captureScrollViaCdp(webview);
+    expect(getScrollPositionMock).not.toHaveBeenCalled();
+  });
+
+  it("shares one generation counter across both capture strategies: invalidating rejects a stale CDP resolution", async () => {
+    let resolveScroll: (value: number) => void = () => {};
+    getScrollPositionMock.mockReturnValue(
+      new Promise<number>((resolve) => {
+        resolveScroll = resolve;
+      })
+    );
+    const webview = makeWebview();
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    result.current.captureScrollViaCdp(webview);
+    act(() => {
+      result.current.invalidateScrollCaptures();
+    });
+
+    await act(async () => {
+      resolveScroll(300);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+
+  it("shares one generation counter across both capture strategies: invalidating rejects a stale executeJavaScript resolution", async () => {
+    let resolveScroll: (value: number) => void = () => {};
+    const webview = makeWebview({
+      executeJavaScript: vi.fn(
+        () =>
+          new Promise<number>((resolve) => {
+            resolveScroll = resolve;
+          })
+      ),
+    });
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ status, webviewElement }) =>
+        useDevPreviewScrollCapture({
+          id: PANE_ID,
+          status,
+          webviewElement,
+          setDevPreviewScrollPosition,
+        }),
+      { initialProps: { status: "running" as const, webviewElement: webview } }
+    );
+
+    rerender({ status: "stopped" as const, webviewElement: webview });
+    act(() => {
+      result.current.invalidateScrollCaptures();
+    });
+
+    await act(async () => {
+      resolveScroll(150);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
@@ -35,8 +35,8 @@ describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) p
   it("captures via executeJavaScript when status transitions away from running", async () => {
     const webview = makeWebview({ executeJavaScript: vi.fn(() => Promise.resolve(120)) });
     const setDevPreviewScrollPosition = vi.fn();
-    const { rerender } = renderHook(
-      ({ status, webviewElement }: RenderProps) =>
+    const { rerender } = renderHook<ReturnType<typeof useDevPreviewScrollCapture>, RenderProps>(
+      ({ status, webviewElement }) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,
@@ -62,8 +62,8 @@ describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) p
   it("persists a captured scrollY of exactly 0 via executeJavaScript (no >0 guard on this path)", async () => {
     const webview = makeWebview({ executeJavaScript: vi.fn(() => Promise.resolve(0)) });
     const setDevPreviewScrollPosition = vi.fn();
-    const { rerender } = renderHook(
-      ({ status, webviewElement }: RenderProps) =>
+    const { rerender } = renderHook<ReturnType<typeof useDevPreviewScrollCapture>, RenderProps>(
+      ({ status, webviewElement }) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,
@@ -87,8 +87,8 @@ describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) p
   it("does not capture when the status was not previously running", async () => {
     const webview = makeWebview();
     const setDevPreviewScrollPosition = vi.fn();
-    const { rerender } = renderHook(
-      ({ status, webviewElement }: RenderProps) =>
+    const { rerender } = renderHook<ReturnType<typeof useDevPreviewScrollCapture>, RenderProps>(
+      ({ status, webviewElement }) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,
@@ -216,8 +216,11 @@ describe("useDevPreviewScrollCapture — captureScrollViaCdp (frozen-safe) path"
       ),
     });
     const setDevPreviewScrollPosition = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ status, webviewElement }: RenderProps) =>
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useDevPreviewScrollCapture>,
+      RenderProps
+    >(
+      ({ status, webviewElement }) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,

--- a/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
@@ -4,6 +4,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useDevPreviewScrollCapture } from "../useDevPreviewScrollCapture";
+import type { DevPreviewStatus } from "@/hooks/useDevServer";
+
+interface RenderProps {
+  status: DevPreviewStatus;
+  webviewElement: Electron.WebviewTag | null;
+}
 
 const PANE_ID = "pane-1";
 const WC_ID = 42;
@@ -30,7 +36,7 @@ describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) p
     const webview = makeWebview({ executeJavaScript: vi.fn(() => Promise.resolve(120)) });
     const setDevPreviewScrollPosition = vi.fn();
     const { rerender } = renderHook(
-      ({ status, webviewElement }) =>
+      ({ status, webviewElement }: RenderProps) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,
@@ -57,7 +63,7 @@ describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) p
     const webview = makeWebview({ executeJavaScript: vi.fn(() => Promise.resolve(0)) });
     const setDevPreviewScrollPosition = vi.fn();
     const { rerender } = renderHook(
-      ({ status, webviewElement }) =>
+      ({ status, webviewElement }: RenderProps) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,
@@ -82,7 +88,7 @@ describe("useDevPreviewScrollCapture — status-transition (executeJavaScript) p
     const webview = makeWebview();
     const setDevPreviewScrollPosition = vi.fn();
     const { rerender } = renderHook(
-      ({ status, webviewElement }) =>
+      ({ status, webviewElement }: RenderProps) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,
@@ -211,7 +217,7 @@ describe("useDevPreviewScrollCapture — captureScrollViaCdp (frozen-safe) path"
     });
     const setDevPreviewScrollPosition = vi.fn();
     const { result, rerender } = renderHook(
-      ({ status, webviewElement }) =>
+      ({ status, webviewElement }: RenderProps) =>
         useDevPreviewScrollCapture({
           id: PANE_ID,
           status,

--- a/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDevPreviewViewport } from "../useDevPreviewViewport";
+
+const PANE_ID = "pane-1";
+
+function makeWebContents(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    getUserAgent: vi.fn(() => "original-ua"),
+    setUserAgent: vi.fn(),
+    enableDeviceEmulation: vi.fn(),
+    disableDeviceEmulation: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeWebview(webContents: ReturnType<typeof makeWebContents>): Electron.WebviewTag {
+  return {
+    getWebContents: vi.fn(() => webContents),
+  } as unknown as Electron.WebviewTag;
+}
+
+function baseParams(overrides: Partial<Parameters<typeof useDevPreviewViewport>[0]> = {}) {
+  return {
+    id: PANE_ID,
+    viewportPreset: undefined,
+    viewportRotated: false,
+    viewportDpr: 1 as const,
+    viewportFit: false,
+    isWebviewReady: false,
+    webviewElement: null,
+    originalUaRef: { current: null },
+    setViewportPreset: vi.fn(),
+    setViewportRotated: vi.fn(),
+    setViewportDpr: vi.fn(),
+    setViewportFit: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  class ResizeObserverStub {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+  }
+  (global as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+});
+
+describe("useDevPreviewViewport — handlers", () => {
+  it("delegates preset/rotate/dpr/fit toggles to their setters with the panel id", () => {
+    const setViewportPreset = vi.fn();
+    const setViewportRotated = vi.fn();
+    const setViewportDpr = vi.fn();
+    const setViewportFit = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({ setViewportPreset, setViewportRotated, setViewportDpr, setViewportFit })
+      )
+    );
+
+    act(() => result.current.handleViewportPresetChange("iphone"));
+    expect(setViewportPreset).toHaveBeenCalledWith(PANE_ID, "iphone");
+
+    act(() => result.current.handleViewportRotateToggle());
+    expect(setViewportRotated).toHaveBeenCalledWith(PANE_ID, true);
+
+    act(() => result.current.handleViewportDprChange(2));
+    expect(setViewportDpr).toHaveBeenCalledWith(PANE_ID, 2);
+
+    act(() => result.current.handleViewportFitToggle());
+    expect(setViewportFit).toHaveBeenCalledWith(PANE_ID, true);
+  });
+});
+
+describe("useDevPreviewViewport — effectiveViewport / fitScale", () => {
+  it("is null when no preset is active", () => {
+    const { result } = renderHook(() => useDevPreviewViewport(baseParams()));
+    expect(result.current.effectiveViewport).toBeNull();
+    expect(result.current.fitScale).toBe(1);
+  });
+
+  it("computes effective dimensions for a preset, swapped when rotated", () => {
+    const { result: portrait } = renderHook(() =>
+      useDevPreviewViewport(baseParams({ viewportPreset: "iphone", viewportRotated: false }))
+    );
+    expect(portrait.current.effectiveViewport).toEqual({ width: 393, height: 852 });
+
+    const { result: landscape } = renderHook(() =>
+      useDevPreviewViewport(baseParams({ viewportPreset: "iphone", viewportRotated: true }))
+    );
+    expect(landscape.current.effectiveViewport).toEqual({ width: 852, height: 393 });
+  });
+
+  it("stays at scale 1 when fit mode is off even with a preset active", () => {
+    const { result } = renderHook(() =>
+      useDevPreviewViewport(baseParams({ viewportPreset: "iphone", viewportFit: false }))
+    );
+    expect(result.current.fitScale).toBe(1);
+  });
+});
+
+describe("useDevPreviewViewport — device emulation effect", () => {
+  it("does nothing while the webview isn't ready", () => {
+    const webContents = makeWebContents();
+    const webview = makeWebview(webContents);
+    renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({ viewportPreset: "iphone", isWebviewReady: false, webviewElement: webview })
+      )
+    );
+    expect(webContents.enableDeviceEmulation).not.toHaveBeenCalled();
+  });
+
+  it("enables emulation and seeds originalUaRef once, when ready with a preset", () => {
+    const webContents = makeWebContents();
+    const webview = makeWebview(webContents);
+    const originalUaRef = { current: null as string | null };
+    renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({
+          viewportPreset: "iphone",
+          isWebviewReady: true,
+          webviewElement: webview,
+          originalUaRef,
+        })
+      )
+    );
+
+    expect(webContents.setUserAgent).toHaveBeenCalledWith(expect.stringContaining("iPhone"));
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+    expect(originalUaRef.current).toBe("original-ua");
+  });
+
+  it("does not re-seed originalUaRef if it was already captured", () => {
+    const webContents = makeWebContents();
+    const webview = makeWebview(webContents);
+    const originalUaRef = { current: "already-seeded" };
+    renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({
+          viewportPreset: "iphone",
+          isWebviewReady: true,
+          webviewElement: webview,
+          originalUaRef,
+        })
+      )
+    );
+    expect(originalUaRef.current).toBe("already-seeded");
+  });
+
+  it("disables emulation and restores the original UA when the preset clears", () => {
+    const webContents = makeWebContents();
+    const webview = makeWebview(webContents);
+    const originalUaRef = { current: null as string | null };
+    const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
+      initialProps: baseParams({
+        viewportPreset: "iphone",
+        isWebviewReady: true,
+        webviewElement: webview,
+        originalUaRef,
+      }),
+    });
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+
+    rerender(
+      baseParams({
+        viewportPreset: undefined,
+        isWebviewReady: true,
+        webviewElement: webview,
+        originalUaRef,
+      })
+    );
+
+    expect(webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1);
+    expect(webContents.setUserAgent).toHaveBeenLastCalledWith("original-ua");
+  });
+
+  it("does not re-apply emulation when the preset/rotation/dpr key is unchanged", () => {
+    const webContents = makeWebContents();
+    const webview = makeWebview(webContents);
+    const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
+      initialProps: baseParams({
+        viewportPreset: "iphone",
+        isWebviewReady: true,
+        webviewElement: webview,
+      }),
+    });
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+
+    rerender(
+      baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
+    );
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
@@ -102,6 +102,58 @@ describe("useDevPreviewViewport — effectiveViewport / fitScale", () => {
     );
     expect(result.current.fitScale).toBe(1);
   });
+
+  it("measures the fit container via ResizeObserver.observe and computes fitScale from its size", () => {
+    const observeSpy = vi.fn();
+    class ResizeObserverStub {
+      observe = observeSpy;
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    (global as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+
+    const { result } = renderHook(() =>
+      useDevPreviewViewport(baseParams({ viewportPreset: "iphone", viewportFit: true }))
+    );
+
+    const div = document.createElement("div");
+    Object.defineProperty(div, "clientWidth", { value: 200, configurable: true });
+    Object.defineProperty(div, "clientHeight", { value: 400, configurable: true });
+
+    act(() => {
+      result.current.setFitContainerEl(div);
+    });
+
+    expect(observeSpy).toHaveBeenCalledWith(div);
+    // iphone effective viewport is 393x852; container is 200x400.
+    const expectedScale = Math.min(200 / 393, 400 / 852);
+    expect(result.current.fitScale).toBeCloseTo(expectedScale, 5);
+  });
+
+  it("does not measure or apply a fit scale when fit mode is off, even once a container mounts", () => {
+    const observeSpy = vi.fn();
+    class ResizeObserverStub {
+      observe = observeSpy;
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    (global as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+
+    const { result } = renderHook(() =>
+      useDevPreviewViewport(baseParams({ viewportPreset: "iphone", viewportFit: false }))
+    );
+
+    const div = document.createElement("div");
+    Object.defineProperty(div, "clientWidth", { value: 200, configurable: true });
+    Object.defineProperty(div, "clientHeight", { value: 400, configurable: true });
+
+    act(() => {
+      result.current.setFitContainerEl(div);
+    });
+
+    expect(observeSpy).not.toHaveBeenCalled();
+    expect(result.current.fitScale).toBe(1);
+  });
 });
 
 describe("useDevPreviewViewport — device emulation effect", () => {

--- a/src/components/DevPreview/useDevPreviewCommandConfig.tsx
+++ b/src/components/DevPreview/useDevPreviewCommandConfig.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { findAllDevServerCandidates, findDevServerCandidate } from "@/utils/devServerDetection";
+import { getInvalidCommandMessage } from "@shared/utils/devCommandValidation";
+import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
+import { projectClient } from "@/clients";
+import { useProjectSettings } from "@/hooks/useProjectSettings";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import type { ProjectSettings } from "@shared/types";
+
+interface UseDevPreviewCommandConfigParams {
+  currentProjectId?: string;
+  devCommand: string;
+  isUnconfigured: boolean;
+  projectSettings: ProjectSettings | null;
+  stop: () => void;
+  isMountedRef: React.RefObject<boolean>;
+}
+
+export function useDevPreviewCommandConfig({
+  currentProjectId,
+  devCommand,
+  isUnconfigured,
+  projectSettings,
+  stop,
+  isMountedRef,
+}: UseDevPreviewCommandConfigParams) {
+  const { saveSettings } = useProjectSettings();
+  const allDetectedRunners = useProjectSettingsStore((state) => state.allDetectedRunners);
+  const [isAutoDetecting, setIsAutoDetecting] = useState(false);
+  // The command whose auto-detect/save attempt failed; null = no failure shown.
+  // Empty string means the attempt never resolved a command (re-detection found
+  // nothing), so retry falls back to the currently displayed candidate.
+  const [autoDetectFailedCommand, setAutoDetectFailedCommand] = useState<string | null>(null);
+  const autoDetectRef = useRef(false);
+
+  useEffect(() => {
+    if (devCommand) setAutoDetectFailedCommand(null);
+  }, [devCommand]);
+
+  const candidates = useMemo(
+    () => findAllDevServerCandidates(allDetectedRunners, projectSettings?.turbopackEnabled ?? true),
+    [allDetectedRunners, projectSettings?.turbopackEnabled]
+  );
+  const primaryCandidate = candidates[0];
+  const activeCandidate = candidates.find((c) => c.command.trim() === devCommand.trim());
+  const headerLabel = activeCandidate?.name || devCommand;
+
+  const [commandInput, setCommandInput] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const savingRef = useRef(false);
+
+  const handleAutoDetect = useCallback(
+    async (candidateCommand?: string): Promise<boolean> => {
+      if (!currentProjectId || autoDetectRef.current) return false;
+
+      autoDetectRef.current = true;
+      setIsAutoDetecting(true);
+      setAutoDetectFailedCommand(null);
+      let attemptedCommand = candidateCommand ?? "";
+      try {
+        const latestSettings = await projectClient.getSettings(currentProjectId);
+        if (!latestSettings) {
+          if (isMountedRef.current) setAutoDetectFailedCommand(attemptedCommand);
+          return false;
+        }
+
+        let command = candidateCommand;
+        if (!command) {
+          const freshRunners = await projectClient.detectRunners(currentProjectId);
+          command = findDevServerCandidate(
+            freshRunners,
+            latestSettings.turbopackEnabled ?? true
+          )?.command;
+        }
+
+        if (!command) {
+          if (isMountedRef.current) setAutoDetectFailedCommand("");
+          return false;
+        }
+        attemptedCommand = command;
+
+        await saveSettings({
+          ...latestSettings,
+          devServerCommand: command,
+          devServerAutoDetected: true,
+          devServerDismissed: false,
+        });
+
+        return true;
+      } catch (err) {
+        logError("Failed to auto-detect dev server", err);
+        if (isMountedRef.current) setAutoDetectFailedCommand(attemptedCommand);
+        return false;
+      } finally {
+        autoDetectRef.current = false;
+        if (isMountedRef.current) {
+          setIsAutoDetecting(false);
+        }
+      }
+    },
+    [currentProjectId, saveSettings, isMountedRef]
+  );
+
+  const handlePickCandidate = useCallback(
+    (candidate: { command: string }) => {
+      void handleAutoDetect(candidate.command);
+    },
+    [handleAutoDetect]
+  );
+
+  const handleHeaderPickCandidate = useCallback(
+    async (candidate: { command: string }) => {
+      if (candidate.command.trim() === devCommand.trim()) return;
+      const saved = await handleAutoDetect(candidate.command);
+      if (saved) stop();
+    },
+    [devCommand, handleAutoDetect, stop]
+  );
+
+  const handleSaveCommand = useCallback(async () => {
+    if (!currentProjectId || savingRef.current) return;
+    const trimmed = commandInput.trim();
+    if (!trimmed || getInvalidCommandMessage(trimmed)) return;
+
+    savingRef.current = true;
+    try {
+      const latestSettings = await projectClient.getSettings(currentProjectId);
+      if (!latestSettings) return;
+
+      await saveSettings({
+        ...latestSettings,
+        devServerCommand: trimmed,
+        devServerAutoDetected: false,
+        devServerDismissed: false,
+      });
+    } catch (err) {
+      logError("Failed to save dev command", err);
+    } finally {
+      savingRef.current = false;
+    }
+  }, [currentProjectId, commandInput, saveSettings]);
+
+  const headerContent = useMemo(() => {
+    if (isUnconfigured || candidates.length === 0) return null;
+
+    return (
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                onPointerDown={(e) => e.stopPropagation()}
+                className="flex h-6 items-center gap-1 px-1.5 rounded-sm hover:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors max-w-[180px]"
+                aria-label="Switch dev script"
+              >
+                <span className="min-w-0 text-xs truncate">{headerLabel}</span>
+                <ChevronDown className="h-3 w-3 shrink-0" />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Switch dev script</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" sideOffset={4} className="w-72 p-1">
+          {candidates.map((c) => {
+            const isActive = c.command.trim() === devCommand.trim();
+            return (
+              <DropdownMenuItem
+                key={c.id}
+                onSelect={() => void handleHeaderPickCandidate(c)}
+                className={isActive ? "bg-overlay-subtle" : ""}
+                aria-current={isActive ? "true" : undefined}
+              >
+                <span className="text-xs font-medium">{c.name}</span>
+                <code className="text-[11px] text-daintree-text/50 truncate ml-auto">
+                  {c.command}
+                </code>
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }, [isUnconfigured, candidates, devCommand, headerLabel, handleHeaderPickCandidate]);
+
+  const commandInputError = useMemo(() => getInvalidCommandMessage(commandInput), [commandInput]);
+
+  const handleOpenSettings = useCallback(() => {
+    void actionService.dispatch("project.settings.open", undefined, { source: "user" });
+  }, []);
+
+  return {
+    headerContent,
+    candidates,
+    primaryCandidate,
+    isAutoDetecting,
+    autoDetectFailedCommand,
+    handleAutoDetect,
+    handlePickCandidate,
+    pickerOpen,
+    setPickerOpen,
+    commandInput,
+    setCommandInput,
+    commandInputError,
+    handleSaveCommand,
+    handleOpenSettings,
+  };
+}

--- a/src/components/DevPreview/useDevPreviewCrashRecovery.ts
+++ b/src/components/DevPreview/useDevPreviewCrashRecovery.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { notify } from "@/lib/notify";
+
+interface CrashDetails {
+  reason: string;
+  exitCode: number;
+}
+
+interface UseDevPreviewCrashRecoveryParams {
+  id: string;
+  currentUrl: string;
+  /**
+   * Parent-owned: `handleRenderProcessGone` is created (and must be passed
+   * into `useDevPreviewLoadLifecycle`) before `performReload` exists in the
+   * parent's lexical scope, so the parent keeps this ref and a separate
+   * effect syncing it to `performReload` once that's defined. Reading it
+   * through a ref here defers that dependency to invocation time.
+   */
+  crashReloadRef: React.RefObject<() => void>;
+}
+
+/**
+ * Owns the webview renderer crash/unresponsive state machine: the
+ * `render-process-gone` handler (with its 60s crash-loop notification),
+ * the main-process unresponsive/responsive listeners, and the reset that
+ * clears crash history at each of its trigger points (hard reload, full
+ * webview state reset, eviction, a fresh URL navigation, and the crash
+ * banner's own dismiss action).
+ */
+export function useDevPreviewCrashRecovery({
+  id,
+  currentUrl,
+  crashReloadRef,
+}: UseDevPreviewCrashRecoveryParams) {
+  const [crashState, setCrashState] = useState<"none" | "crashed" | "unresponsive">("none");
+  const [crashDetails, setCrashDetails] = useState<CrashDetails | null>(null);
+  const crashTimestampsRef = useRef<number[]>([]);
+
+  const handleRenderProcessGone = useCallback(
+    (details: CrashDetails) => {
+      const now = Date.now();
+      const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
+      timestamps.push(now);
+      crashTimestampsRef.current = timestamps;
+
+      setCrashDetails(details);
+      setCrashState("crashed");
+
+      if (timestamps.length < 2) {
+        crashReloadRef.current();
+      } else {
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "error",
+          title: "Preview process crashed repeatedly",
+          message: `The dev preview crashed (${details.reason}) twice within 60 seconds. Auto-recovery stopped. Use Reload or Hard restart to recover.`,
+          priority: "high",
+          duration: 0,
+          context: { eventKind: "recovery", panelId: id },
+          supersedeKey: `dev-preview-crash-loop:${id}`,
+          correlationId: id,
+        });
+      }
+    },
+    [id, crashReloadRef]
+  );
+
+  // Listen for webview unresponsive/responsive events from the main process
+  useEffect(() => {
+    const cleanupUnresponsive = window.electron.webview.onUnresponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "crashed" ? prev : "unresponsive"));
+    });
+    const cleanupResponsive = window.electron.webview.onResponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "unresponsive" ? "none" : prev));
+    });
+    return () => {
+      cleanupUnresponsive();
+      cleanupResponsive();
+    };
+  }, [id]);
+
+  const resetCrashHistory = useCallback(() => {
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
+  }, []);
+
+  const clearUnresponsiveState = useCallback(() => {
+    setCrashState("none");
+  }, []);
+
+  // Clear crash state when the user navigates to a fresh URL. Depending on
+  // crashState here would create an instant-reset loop: the effect would fire
+  // the moment crashState transitions from "none" and clear it back. Track the
+  // last URL we cleared at via a ref so this effect runs only on real URL
+  // transitions.
+  const lastClearedCrashUrlRef = useRef<string>(currentUrl);
+  useEffect(() => {
+    if (currentUrl === lastClearedCrashUrlRef.current) return;
+    lastClearedCrashUrlRef.current = currentUrl;
+    if (currentUrl && currentUrl !== "about:blank") {
+      // Don't carry the prior URL's crash history into the new URL's 60s
+      // window — that would mis-throttle the first auto-recovery there.
+      resetCrashHistory();
+    }
+  }, [currentUrl, resetCrashHistory]);
+
+  return {
+    crashState,
+    crashDetails,
+    handleRenderProcessGone,
+    resetCrashHistory,
+    clearUnresponsiveState,
+  };
+}

--- a/src/components/DevPreview/useDevPreviewNavigation.ts
+++ b/src/components/DevPreview/useDevPreviewNavigation.ts
@@ -1,0 +1,344 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
+import type { BrowserHistory } from "@shared/types/browser";
+import { normalizeBrowserUrl } from "../Browser/browserUtils";
+import {
+  goBackBrowserHistory,
+  goForwardBrowserHistory,
+  pushBrowserHistory,
+} from "../Browser/historyUtils";
+import { computeDevServerUrl } from "./urlSync";
+import { loadWebviewUrl } from "./loadWebviewUrl";
+import { actionService } from "@/services/ActionService";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { logError } from "@/utils/logger";
+import { notify } from "@/lib/notify";
+import type { WebviewLoadError } from "./useDevPreviewLoadLifecycle";
+
+interface UseDevPreviewNavigationParams {
+  id: string;
+  currentProjectId?: string;
+  currentUrl: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  history: BrowserHistory;
+  setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
+  zoomFactor: number;
+  setZoomFactor: React.Dispatch<React.SetStateAction<number>>;
+  devServerUrl: string | null;
+  proxyOrigin: string | null | undefined;
+  isUnconfigured: boolean;
+  isWebviewReady: boolean;
+  webviewRef: React.RefObject<Electron.WebviewTag | null>;
+  setBrowserUrl: (id: string, url: string) => void;
+  setBrowserHistory: (id: string, history: BrowserHistory) => void;
+  setBrowserZoom: (id: string, zoom: number) => void;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setWebviewLoadError: React.Dispatch<React.SetStateAction<WebviewLoadError | null>>;
+  clearLoadTimers: () => void;
+  isConsoleOpen: boolean;
+  setDevPreviewConsoleOpen: (id: string, open: boolean) => void;
+  onHardReload: () => void;
+}
+
+/**
+ * Owns the toolbar/navigation action handlers (back/forward/reload/zoom/
+ * screenshot/devtools/console/open-external/promote-to-portal), the
+ * browser-action-listener wiring, the guest reload/close keyboard-shortcut
+ * forwarding, and the URL/history/zoom persistence effects. `history`,
+ * `currentUrl`, and the webview ref stay parent-owned — they're shared with
+ * useDevPreviewLoadLifecycle (called earlier, needs `setHistory` as an
+ * input) and useDevPreviewCrashRecovery, so ownership can't move here
+ * without breaking that ordering.
+ */
+export function useDevPreviewNavigation({
+  id,
+  currentProjectId,
+  currentUrl,
+  canGoBack,
+  canGoForward,
+  history,
+  setHistory,
+  zoomFactor,
+  setZoomFactor,
+  devServerUrl,
+  proxyOrigin,
+  isUnconfigured,
+  isWebviewReady,
+  webviewRef,
+  setBrowserUrl,
+  setBrowserHistory,
+  setBrowserZoom,
+  setIsLoading,
+  setWebviewLoadError,
+  clearLoadTimers,
+  isConsoleOpen,
+  setDevPreviewConsoleOpen,
+  onHardReload,
+}: UseDevPreviewNavigationParams) {
+  const screenshotInFlightRef = useRef(false);
+  const isPromotingRef = useRef(false);
+
+  // Push history only; the imperative navigation effect (keyed on currentUrl
+  // vs lastSetUrlRef) performs the actual loadURL. Pre-setting lastSetUrlRef
+  // here would make that effect skip — which used to be fine when `src`
+  // re-bound to currentUrl, but src is now seed-only (#9940).
+  useEffect(() => {
+    if (isUnconfigured) return;
+    // Hold navigation until the proxy port resolution settles, otherwise the pane would
+    // briefly adopt the unstable direct-localhost origin before the proxy origin is known (#9100).
+    if (proxyOrigin === undefined) return;
+    const nextUrl = devServerUrl
+      ? computeDevServerUrl(devServerUrl, currentUrl, proxyOrigin)
+      : false;
+    if (nextUrl !== false) {
+      setHistory((prev) => pushBrowserHistory(prev, nextUrl));
+    }
+  }, [devServerUrl, currentUrl, isUnconfigured, proxyOrigin, setHistory]);
+
+  useEffect(() => {
+    if (isUnconfigured) return;
+    if (currentUrl) {
+      setBrowserUrl(id, currentUrl);
+    }
+  }, [id, currentUrl, setBrowserUrl, isUnconfigured]);
+
+  useEffect(() => {
+    setBrowserHistory(id, history);
+  }, [id, history, setBrowserHistory]);
+
+  useEffect(() => {
+    setBrowserZoom(id, zoomFactor);
+  }, [id, zoomFactor, setBrowserZoom]);
+
+  const handleNavigate = useCallback(
+    (rawUrl: string) => {
+      const normalized = normalizeBrowserUrl(rawUrl);
+      if (normalized.url) {
+        // Push history only; the imperative navigation effect drives loadURL now
+        // that `src` is seed-only (#9940). Mirrors handleBack/handleForward.
+        setHistory((prev) => pushBrowserHistory(prev, normalized.url!));
+      }
+    },
+    [setHistory]
+  );
+
+  const handleBack = useCallback(() => {
+    if (canGoBack) {
+      setHistory((prev) => goBackBrowserHistory(prev));
+    }
+  }, [canGoBack, setHistory]);
+
+  const handleForward = useCallback(() => {
+    if (canGoForward) {
+      setHistory((prev) => goForwardBrowserHistory(prev));
+    }
+  }, [canGoForward, setHistory]);
+
+  const handleReload = useCallback(() => {
+    setWebviewLoadError(null);
+    webviewRef.current?.reload();
+  }, [setWebviewLoadError, webviewRef]);
+
+  const handleCancelLoad = useCallback(() => {
+    clearLoadTimers();
+    setIsLoading(false);
+    try {
+      webviewRef.current?.stop();
+    } catch {
+      // Webview detached
+    }
+    setWebviewLoadError({ code: "aborted", message: "Load cancelled." });
+  }, [clearLoadTimers, setIsLoading, setWebviewLoadError, webviewRef]);
+
+  const handleRetryWebviewLoad = useCallback(() => {
+    setWebviewLoadError(null);
+    setIsLoading(true);
+    if (currentUrl) {
+      // Swallow ERR_ABORTED-class rejections — did-fail-load is the source
+      // of truth for genuine failures.
+      const webview = webviewRef.current;
+      if (webview) {
+        loadWebviewUrl(webview, currentUrl);
+      }
+    } else {
+      webviewRef.current?.reload();
+    }
+  }, [currentUrl, setWebviewLoadError, setIsLoading, webviewRef]);
+
+  const handleCaptureScreenshot = useCallback(async () => {
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return false;
+    let url: string;
+    try {
+      url = webview.getURL();
+    } catch {
+      return false;
+    }
+    if (!url || url === "about:blank") return false;
+    if (screenshotInFlightRef.current) return false;
+    screenshotInFlightRef.current = true;
+    try {
+      const image = await webview.capturePage();
+      const pngData = new Uint8Array(image.toPNG());
+      await window.electron.clipboard.writeImage(pngData);
+      return true;
+    } catch (err) {
+      logError("[DevPreviewPane] Screenshot capture failed", err);
+      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+      notify({
+        type: "error",
+        title: "Screenshot failed",
+        message: "Couldn't copy the screenshot to clipboard",
+      });
+      return false;
+    } finally {
+      screenshotInFlightRef.current = false;
+    }
+  }, [isWebviewReady, webviewRef]);
+
+  const handleToggleDevTools = useCallback(() => {
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return;
+    if (webview.isDevToolsOpened()) {
+      webview.closeDevTools();
+    } else {
+      webview.openDevTools();
+    }
+  }, [isWebviewReady, webviewRef]);
+
+  const handleToggleConsole = useCallback(() => {
+    setDevPreviewConsoleOpen(id, !isConsoleOpen);
+  }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
+
+  const handleOpenExternal = useCallback(() => {
+    if (!currentUrl) return;
+
+    // In proxy mode (#9101), hand the system browser a short-lived signed
+    // bootstrap URL on the stable origin instead of the raw dev-server URL: it
+    // lands with a session cookie and survives dev-server restarts that reshuffle
+    // the upstream port. Fall back to the raw URL in legacy mode or if minting
+    // fails, so the button always opens *something*.
+    if (typeof proxyOrigin === "string" && currentProjectId && currentUrl.startsWith(proxyOrigin)) {
+      // Preserve the hash too — hash-router SPAs keep their route in the fragment.
+      const { pathname, search, hash } = new URL(currentUrl);
+      safeFireAndForget(
+        (async () => {
+          try {
+            const { bootstrapUrl } = await window.electron.devPreview.mintBrowserToken({
+              panelId: id,
+              projectId: currentProjectId,
+              redirectPath: `${pathname}${search}${hash}`,
+            });
+            await window.electron.system.openExternal(bootstrapUrl);
+          } catch (err) {
+            logError("[DevPreviewPane] Browser handoff token failed; opening raw URL", err);
+            await window.electron.system.openExternal(currentUrl);
+          }
+        })(),
+        { context: "Opening dev preview URL externally" }
+      );
+      return;
+    }
+
+    safeFireAndForget(window.electron.system.openExternal(currentUrl), {
+      context: "Opening dev preview URL externally",
+    });
+  }, [currentUrl, proxyOrigin, currentProjectId, id]);
+
+  const handlePromoteToPortal = useCallback(() => {
+    if (isPromotingRef.current) return;
+    isPromotingRef.current = true;
+    if (currentUrl) {
+      setBrowserUrl(id, currentUrl);
+    }
+    void actionService
+      .dispatch(
+        "devPreview.promoteToPortal",
+        { panelId: id, projectId: currentProjectId },
+        { source: "user" }
+      )
+      .finally(() => {
+        isPromotingRef.current = false;
+      });
+  }, [currentProjectId, currentUrl, id, setBrowserUrl]);
+
+  const handleZoomChange = useCallback(
+    (newZoom: number) => {
+      const clamped = Math.max(0.25, Math.min(2.0, newZoom));
+      setZoomFactor(clamped);
+      if (webviewRef.current) {
+        webviewRef.current.setZoomFactor(clamped);
+      }
+    },
+    [setZoomFactor, webviewRef]
+  );
+
+  useBrowserActionListeners(id, {
+    onReload: handleReload,
+    onNavigate: handleNavigate,
+    onBack: handleBack,
+    onForward: handleForward,
+    onSetZoom: handleZoomChange,
+    onCaptureScreenshot: handleCaptureScreenshot,
+    onToggleDevTools: handleToggleDevTools,
+    onToggleConsole: handleToggleConsole,
+    onHardReload,
+  });
+
+  // Listen for the reload shortcut (Cmd/Ctrl+R) forwarded from the focused
+  // webview guest. When the guest has focus, the outer renderer's keybinding
+  // handler never fires, so the main process intercepts the key and forwards it.
+  useEffect(() => {
+    const cleanup = window.electron.webview.onReloadShortcut((payload) => {
+      if (payload.panelId !== id) return;
+      onHardReload();
+    });
+    return cleanup;
+  }, [id, onHardReload]);
+
+  // Listen for the close shortcut (Cmd/Ctrl+W) forwarded from the focused
+  // webview guest (#10859). Without this, focus inside the guest bypasses the
+  // host window's setIgnoreMenuShortcuts guard and the native role:"close"
+  // menu accelerator closes the whole window instead of just this panel.
+  useEffect(() => {
+    const cleanup = window.electron.webview.onCloseShortcut((payload) => {
+      if (payload.panelId !== id) return;
+      void actionService.dispatch("terminal.close", { terminalId: id }, { source: "keybinding" });
+    });
+    return cleanup;
+  }, [id]);
+
+  // Listen for action-driven hard-reload events
+  useEffect(() => {
+    const handleHardReloadEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        onHardReload();
+      }
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [id, onHardReload]);
+
+  return {
+    handleNavigate,
+    handleBack,
+    handleForward,
+    handleReload,
+    handleCancelLoad,
+    handleRetryWebviewLoad,
+    handleCaptureScreenshot,
+    handleToggleDevTools,
+    handleToggleConsole,
+    handleZoomChange,
+    handleOpenExternal,
+    handlePromoteToPortal,
+  };
+}

--- a/src/components/DevPreview/useDevPreviewScrollCapture.ts
+++ b/src/components/DevPreview/useDevPreviewScrollCapture.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { DevPreviewStatus } from "@/hooks/useDevServer";
+
+interface UseDevPreviewScrollCaptureParams {
+  id: string;
+  status: DevPreviewStatus;
+  webviewElement: Electron.WebviewTag | null;
+  setDevPreviewScrollPosition: (id: string, position?: { url: string; scrollY: number }) => void;
+}
+
+/**
+ * Owns the scroll-capture generation counter and the two distinct capture
+ * strategies used across the pane. The running→not-running transition uses
+ * `executeJavaScript("window.scrollY")`, safe because the page is guaranteed
+ * unfrozen while `status === "running"`. The ref-cleanup and eviction call
+ * sites use the main-process CDP `getScrollPosition` (Page.getLayoutMetrics)
+ * instead: `useWebviewThrottle` freezes hidden webviews, and a frozen page's
+ * suspended JS task queue makes `executeJavaScript` hang indefinitely. These
+ * are deliberately different, not duplicated — do not collapse them into one
+ * strategy.
+ */
+export function useDevPreviewScrollCapture({
+  id,
+  status,
+  webviewElement,
+  setDevPreviewScrollPosition,
+}: UseDevPreviewScrollCaptureParams) {
+  // Generation token to invalidate in-flight async scroll captures when the
+  // user clears scroll state via hard restart. A pending executeJavaScript
+  // promise that resolves after the clear must NOT write the stale position back.
+  const scrollCaptureGenerationRef = useRef<number>(0);
+  const prevStatusRef = useRef(status);
+
+  useEffect(() => {
+    const prevStatus = prevStatusRef.current;
+    prevStatusRef.current = status;
+
+    if (prevStatus === "running" && status !== "running" && webviewElement) {
+      try {
+        const currentWebviewUrl = webviewElement.getURL();
+        if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
+          const captureGeneration = scrollCaptureGenerationRef.current;
+          webviewElement
+            .executeJavaScript("window.scrollY")
+            .then((scrollY: number) => {
+              if (scrollCaptureGenerationRef.current !== captureGeneration) return;
+              if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
+                setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
+              }
+            })
+            .catch(() => {});
+        }
+      } catch {
+        // Webview already detached
+      }
+    }
+  }, [status, id, webviewElement, setDevPreviewScrollPosition]);
+
+  // Callers wrap this in their own try/catch: getURL()/getWebContentsId() can
+  // throw synchronously on an already-detached webview, and each call site
+  // has its own cleanup to run (or skip) when that happens.
+  const captureScrollViaCdp = useCallback(
+    (webview: Electron.WebviewTag): void => {
+      const currentWebviewUrl = webview.getURL();
+      if (!currentWebviewUrl || currentWebviewUrl === "about:blank") return;
+      const captureGeneration = scrollCaptureGenerationRef.current;
+      // Use main-process CDP Page.getLayoutMetrics instead of
+      // executeJavaScript("window.scrollY"): hidden dock webviews are frozen
+      // by useWebviewThrottle (via Page.setWebLifecycleState) which suspends
+      // the JS task queue, so the executeJavaScript path hangs when
+      // memory-pressure eviction fires while the page is frozen.
+      const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
+      window.electron.webview
+        .getScrollPosition(wcId)
+        .then((scrollY: number) => {
+          if (scrollCaptureGenerationRef.current !== captureGeneration) return;
+          // Guard `> 0`: a CDP error returns 0, and the user being at top of
+          // page has nothing worth restoring — both cases should leave any
+          // prior stored position untouched rather than clobber it.
+          if (typeof scrollY === "number" && Number.isFinite(scrollY) && scrollY > 0) {
+            setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
+          }
+        })
+        .catch(() => {});
+    },
+    [id, setDevPreviewScrollPosition]
+  );
+
+  const invalidateScrollCaptures = useCallback((): void => {
+    scrollCaptureGenerationRef.current += 1;
+  }, []);
+
+  return { captureScrollViaCdp, invalidateScrollCaptures };
+}

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -147,7 +147,7 @@ export function useDevPreviewViewport({
     } catch {
       // WebContents not available (webview detached)
     }
-  }, [viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement]);
+  }, [viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement, originalUaRef]);
 
   return {
     effectiveViewport,

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getViewportPreset,
+  getEffectiveViewportSize,
+  computeFitScale,
+} from "@/panels/dev-preview/viewportPresets";
+import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
+import type { ViewportPresetId } from "@shared/types/panel";
+
+interface UseDevPreviewViewportParams {
+  id: string;
+  viewportPreset: ViewportPresetId | undefined;
+  viewportRotated: boolean;
+  viewportDpr: 1 | 2 | 3;
+  viewportFit: boolean;
+  isWebviewReady: boolean;
+  webviewElement: Electron.WebviewTag | null;
+  // Shared with useDevPreviewLoadLifecycle, which re-applies emulation after
+  // cross-origin navigation — the parent owns this ref so both hooks see the
+  // same seeded user agent.
+  originalUaRef: React.MutableRefObject<string | null>;
+  setViewportPreset: (id: string, preset: ViewportPresetId | undefined) => void;
+  setViewportRotated: (id: string, rotated: boolean) => void;
+  setViewportDpr: (id: string, dpr: 1 | 2 | 3) => void;
+  setViewportFit: (id: string, fit: boolean) => void;
+}
+
+/**
+ * Owns viewport-preset device emulation: the toolbar's four change handlers,
+ * the zoom-to-fit container measurement, and the effect that applies/clears
+ * `enableDeviceEmulation` + the spoofed user agent as the preset/rotation/DPR
+ * change. Cross-origin re-apply after navigation lives in
+ * useDevPreviewLoadLifecycle, not here — this effect only reacts to explicit
+ * preset/rotation/DPR changes.
+ */
+export function useDevPreviewViewport({
+  id,
+  viewportPreset,
+  viewportRotated,
+  viewportDpr,
+  viewportFit,
+  isWebviewReady,
+  webviewElement,
+  originalUaRef,
+  setViewportPreset,
+  setViewportRotated,
+  setViewportDpr,
+  setViewportFit,
+}: UseDevPreviewViewportParams) {
+  const effectiveViewport = viewportPreset
+    ? getEffectiveViewportSize(viewportPreset, viewportRotated)
+    : null;
+
+  const handleViewportPresetChange = useCallback(
+    (preset: ViewportPresetId | undefined) => {
+      setViewportPreset(id, preset);
+    },
+    [id, setViewportPreset]
+  );
+
+  const handleViewportRotateToggle = useCallback(() => {
+    setViewportRotated(id, !viewportRotated);
+  }, [id, setViewportRotated, viewportRotated]);
+
+  const handleViewportDprChange = useCallback(
+    (dpr: 1 | 2 | 3) => {
+      setViewportDpr(id, dpr);
+    },
+    [id, setViewportDpr]
+  );
+
+  const handleViewportFitToggle = useCallback(() => {
+    setViewportFit(id, !viewportFit);
+  }, [id, setViewportFit, viewportFit]);
+
+  // Measure the available preview area so zoom-to-fit can scale the device
+  // frame down to fit both pane dimensions. A static scale would break on
+  // pane resize, so this tracks the container via ResizeObserver.
+  // Callback ref (not useRef) so the observer effect re-runs when the
+  // fit-container div mounts for the first time — it lives in the webview
+  // branch, which only renders once the dev server reaches "running", long
+  // after viewportFit/viewportPreset may have been set.
+  const [fitContainerEl, setFitContainerEl] = useState<HTMLDivElement | null>(null);
+  const [fitContainerSize, setFitContainerSize] = useState<{ w: number; h: number }>({
+    w: 0,
+    h: 0,
+  });
+  useEffect(() => {
+    if (!viewportFit || !viewportPreset || !fitContainerEl) return;
+    const el = fitContainerEl;
+    const measure = () => {
+      setFitContainerSize({ w: el.clientWidth, h: el.clientHeight });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [viewportFit, viewportPreset, fitContainerEl]);
+
+  const fitScale =
+    viewportFit && effectiveViewport
+      ? computeFitScale(
+          fitContainerSize.w,
+          fitContainerSize.h,
+          effectiveViewport.width,
+          effectiveViewport.height
+        )
+      : 1;
+
+  // Apply device emulation when viewport preset, rotation, or DPR changes.
+  // Uses enableDeviceEmulation which drives CSS media queries and window.innerWidth
+  // without a page reload, preserving in-page state across preset switches.
+  const prevEmulationKeyRef = useRef<string | null>(null);
+  const hasAppliedEmulationRef = useRef(false);
+  useEffect(() => {
+    if (!isWebviewReady || !webviewElement) return;
+    const emulationKey = `${viewportPreset ?? "none"}-${viewportRotated}-${viewportDpr}`;
+    if (prevEmulationKeyRef.current === emulationKey) return;
+    const hadPrevious = hasAppliedEmulationRef.current;
+
+    const wc = getDevPreviewWebContents(webviewElement);
+    if (!wc) return;
+
+    try {
+      if (viewportPreset) {
+        if (originalUaRef.current === null) {
+          originalUaRef.current = wc.getUserAgent();
+        }
+        wc.setUserAgent(getViewportPreset(viewportPreset).userAgent);
+        wc.enableDeviceEmulation(
+          buildEmulationParams(viewportPreset, viewportRotated, viewportDpr)!
+        );
+        prevEmulationKeyRef.current = emulationKey;
+        hasAppliedEmulationRef.current = true;
+      } else if (hadPrevious) {
+        try {
+          wc.disableDeviceEmulation();
+        } catch {
+          // disableDeviceEmulation may throw if emulation was never enabled
+        }
+        if (originalUaRef.current) {
+          wc.setUserAgent(originalUaRef.current);
+        }
+        prevEmulationKeyRef.current = emulationKey;
+        hasAppliedEmulationRef.current = false;
+      }
+    } catch {
+      // WebContents not available (webview detached)
+    }
+  }, [viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement]);
+
+  return {
+    effectiveViewport,
+    fitScale,
+    setFitContainerEl,
+    handleViewportPresetChange,
+    handleViewportRotateToggle,
+    handleViewportDprChange,
+    handleViewportFitToggle,
+  };
+}

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -124,6 +124,7 @@ export function useDevPreviewViewport({
     try {
       if (viewportPreset) {
         if (originalUaRef.current === null) {
+          // eslint-disable-next-line react-compiler/react-compiler -- originalUaRef is a parent-owned ref threaded in as a hook param; the compiler can't see through the boundary that it's a stable ref, not a prop
           originalUaRef.current = wc.getUserAgent();
         }
         wc.setUserAgent(getViewportPreset(viewportPreset).userAgent);

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -169,7 +169,7 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Browser/WebviewDialog.tsx",
     "src/components/Commands/CommandBuilder.tsx",
     "src/components/Commands/CommandPicker.tsx",
-    "src/components/DevPreview/DevPreviewPane.tsx",
+    "src/components/DevPreview/DevPreviewEmptyStates.tsx",
     "src/components/Diagnostics/DiagnosticsDock.tsx",
     "src/components/Diagnostics/TelemetryContent.tsx",
     "src/components/Fleet/FleetArmingRibbon.tsx",


### PR DESCRIPTION
## Summary
- Splits `src/components/DevPreview/DevPreviewPane.tsx` (previously ~2,188 lines, with the `DevPreviewPane` component itself accounting for ~1,927 lines and ~120 hook calls) into smaller presentational components and custom hooks.
- Public exports and behavior are unchanged, so nothing importing `DevPreviewPane` needs to change.
- Deduplicates CDP scroll-capture logic that was repeated three times in the original component into a single `useDevPreviewScrollCapture` hook.

Resolves #11002

## Changes
- New presentational components: `DevPreviewBanners.tsx`, `DevPreviewEmptyStates.tsx`, `DevPreviewWebviewOverlays.tsx`.
- New hooks: `useDevPreviewCommandConfig`, `useDevPreviewCrashRecovery`, `useDevPreviewNavigation`, `useDevPreviewScrollCapture`, `useDevPreviewViewport`.
- Added a test file for each new component/hook.
- `DevPreviewPane.tsx` now just wires these pieces together.

## Testing
- `npm run check` (typecheck, lint, format) passing.
- Affected test suites for `DevPreview` passing locally.