### PR TITLE
refactor(terminal): split TerminalInstanceService into controllers

### DIFF
--- a/src/components/Demo/DemoCursor.tsx
+++ b/src/components/Demo/DemoCursor.tsx
@@ -1034,8 +1034,7 @@ export function DemoCursor() {
             const terminalDisposables: Array<{ dispose: () => void }> = [];
             for (const panelId of usePanelStore.getState().panelIds) {
               const managed = terminalInstanceService.get(panelId);
-              // Hibernated terminals have a disposed xterm instance — skip them.
-              if (!managed || managed.isHibernated) continue;
+              if (!managed) continue;
               try {
                 terminalDisposables.push(managed.terminal.onWriteParsed(() => resetTimer()));
               } catch {

--- a/src/components/Demo/__tests__/DemoCursor.test.tsx
+++ b/src/components/Demo/__tests__/DemoCursor.test.tsx
@@ -1320,19 +1320,17 @@ describe("DemoCursor", () => {
   describe("waitForIdle", () => {
     type FakeTerminal = {
       managed: {
-        isHibernated: boolean;
         terminal: { onWriteParsed: ReturnType<typeof vi.fn> };
       };
       fireWrite: () => void;
       dispose: ReturnType<typeof vi.fn>;
     };
 
-    function makeTerminal(hibernated = false): FakeTerminal {
+    function makeTerminal(): FakeTerminal {
       const listeners: Array<() => void> = [];
       const dispose = vi.fn();
       return {
         managed: {
-          isHibernated: hibernated,
           terminal: {
             onWriteParsed: vi.fn((cb: () => void) => {
               listeners.push(cb);
@@ -1391,25 +1389,6 @@ describe("DemoCursor", () => {
           expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-term", undefined);
           // Subscription torn down on resolve.
           expect(term.dispose).toHaveBeenCalledTimes(1);
-        },
-        { timeout: 3000, interval: 20 }
-      );
-    });
-
-    it("skips hibernated terminals", async () => {
-      const live = makeTerminal();
-      const hibernated = makeTerminal(true);
-      registerTerminals({ "panel-live": live, "panel-hib": hibernated });
-
-      render(<DemoCursor />);
-      emit("demo:exec-wait-for-idle", { requestId: "req-idle-hib", settleMs: 30, timeoutMs: 2000 });
-
-      expect(live.managed.terminal.onWriteParsed).toHaveBeenCalledTimes(1);
-      expect(hibernated.managed.terminal.onWriteParsed).not.toHaveBeenCalled();
-
-      await vi.waitFor(
-        () => {
-          expect(demoMock.sendCommandDone).toHaveBeenCalledWith("req-idle-hib", undefined);
         },
         { timeout: 3000, interval: 20 }
       );

--- a/src/services/terminal/TerminalBurstController.ts
+++ b/src/services/terminal/TerminalBurstController.ts
@@ -1,0 +1,185 @@
+import type { ManagedTerminal } from "./types";
+import { WRITE_BURST_DECAY_MS } from "./types";
+import { TerminalRefreshTier } from "@/types";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+
+// BURST-tier hold after a wheel scroll before reverting to the computed tier —
+// matches the keystroke input-burst decay so a scroll feels just as responsive.
+const WHEEL_BURST_DECAY_MS = 1000;
+
+// Interactive resource-profile override (symptom B): while actively scrolling a
+// full-screen TUI, ask the main process to hold the profile off efficiency.
+// DURATION must exceed THROTTLE so re-requests overlap and the hold never lapses
+// mid-scroll; both are short so the hold self-expires soon after scrolling stops.
+const INTERACTIVE_OVERRIDE_DURATION_MS = 1500;
+const INTERACTIVE_OVERRIDE_THROTTLE_MS = 500;
+
+export interface TerminalBurstControllerDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  applyRendererPolicy: (id: string, tier: TerminalRefreshTier) => void;
+}
+
+/**
+ * Owns the wheel-scroll and write-driven BURST-tier boosts, plus the
+ * interactive resource-profile override IPC throttle.
+ */
+export class TerminalBurstController {
+  // Which terminal received the most recent alt-buffer wheel event, and when —
+  // drives the ingest service's background-drain hold during a scroll gesture.
+  // Uses the same decay window as the BURST tier so "gesture over" is one
+  // consistent notion across the renderer.
+  private lastActiveWheelId: string | null = null;
+  private lastActiveWheelAt = 0;
+  // Throttle for the interactive resource-profile override IPC (see onActiveWheel).
+  private lastInteractiveOverrideRequestAt = 0;
+
+  constructor(private deps: TerminalBurstControllerDeps) {}
+
+  // Whether a wheel-driven BURST gesture is still within its decay window —
+  // and if so, which terminal it targets. Consumed by the worker-ingest data
+  // buffer to hold its background-drain during an active scroll.
+  getActiveWheelHoldId(): string | null {
+    return this.lastActiveWheelId !== null &&
+      Date.now() - this.lastActiveWheelAt < WHEEL_BURST_DECAY_MS
+      ? this.lastActiveWheelId
+      : null;
+  }
+
+  /**
+   * Active wheel scroll in a focused full-screen mouse-reporting TUI. Scrolling
+   * such a TUI is an app-owned PTY round-trip per line, and a focused-but-idle
+   * pane sits at FOCUSED (10fps): without this the first flick repaints slowly
+   * until the TUI's own redraw output happens to bump the tier. We (1) lift the
+   * renderer to BURST (60fps) for the scroll — reusing the input-burst decay
+   * timer, since a scroll wants the same ~1s revert as a keystroke — and (2) ask
+   * the main process to hold the resource profile at ≥ balanced, so efficiency
+   * mode's stretched port-batch delay (40ms vs 16ms) can't throttle the
+   * returned-redraw stream mid-scroll ("gets slow and stays slow", symptom B).
+   */
+  onActiveWheel(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    this.lastActiveWheelId = id;
+    this.lastActiveWheelAt = Date.now();
+
+    this.deps.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+    if (managed.inputBurstTimer !== undefined) {
+      clearTimeout(managed.inputBurstTimer);
+    }
+    managed.inputBurstTimer = window.setTimeout(() => {
+      const current = this.deps.getInstance(id);
+      if (!current) return;
+      current.inputBurstTimer = undefined;
+      this.deps.applyRendererPolicy(id, current.getRefreshTier());
+    }, WHEEL_BURST_DECAY_MS);
+
+    this.requestInteractiveProfileOverride();
+  }
+
+  /**
+   * Ordinary scrollback wheel/key scrolling (not mouse-reporting forwarding).
+   * Holds the resource profile off efficiency for the same reason as
+   * `onActiveWheel` — a profile downgrade mid-scroll drops the WebGL upper
+   * threshold and can force the visible terminal onto the DOM renderer right
+   * as the user is scrolling it (#10858). Unlike `onActiveWheel`, plain
+   * scrollback is client-side xterm rendering with no PTY round-trip per
+   * line, so there's no renderer-tier boost to apply here.
+   */
+  onUserScrollIntent(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    this.requestInteractiveProfileOverride();
+  }
+
+  /**
+   * Fire-and-forget request that the main process keep the resource profile off
+   * efficiency while the user is actively scrolling. Throttled hard because a
+   * trackpad momentum stream calls this dozens of times/sec; the override window
+   * (INTERACTIVE_OVERRIDE_DURATION_MS) is longer than the throttle so the hold
+   * never lapses between requests, and self-expires shortly after scrolling stops.
+   */
+  private requestInteractiveProfileOverride(): void {
+    const now = Date.now();
+    if (now - this.lastInteractiveOverrideRequestAt < INTERACTIVE_OVERRIDE_THROTTLE_MS) return;
+    this.lastInteractiveOverrideRequestAt = now;
+    try {
+      // safeFireAndForget swallows the ASYNC rejection (channel skew during a
+      // reload, future validation), which a bare synchronous try/catch around a
+      // Promise-returning IPC call would miss; the try/catch still guards a
+      // synchronous throw if `window.electron.system` is absent. Either way the
+      // renderer-side BURST boost above already applied — this is non-critical.
+      safeFireAndForget(
+        window.electron.system.requestInteractiveOverride(INTERACTIVE_OVERRIDE_DURATION_MS),
+        { context: "terminal.requestInteractiveProfileOverride" }
+      );
+    } catch {
+      // window.electron.system unavailable — non-critical.
+    }
+  }
+
+  /**
+   * Write-driven BURST tier: each PTY write extends the burst window in O(1)
+   * by bumping `writeBurstDeadline`. A single self-rearming timer handles
+   * decay — it re-checks the deadline on fire and either reschedules for the
+   * remaining time (if a write extended the window while it was pending) or
+   * reverts the tier via the panel's current `getRefreshTier()`.
+   *
+   * Avoiding per-write clearTimeout/setTimeout matters: at 60fps+ output the
+   * naive pattern thrashes Chromium's timer queue and produces GC pressure.
+   *
+   * `applyRendererPolicy(BURST)` is called on every write: when BURST is
+   * already applied the policy returns early (line 50 of
+   * TerminalRendererPolicy) and as a load-bearing side-effect clears any
+   * pending tierChangeTimer — that cancellation is what prevents a
+   * concurrent focus-loss-scheduled downgrade from firing unopposed and
+   * stranding the terminal at FOCUSED/VISIBLE/BACKGROUND mid-stream.
+   */
+  onPtyWrite(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    managed.writeBurstDeadline = Date.now() + WRITE_BURST_DECAY_MS;
+    this.deps.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+
+    if (managed.writeBurstTimer === undefined) {
+      this.scheduleWriteBurstDecay(id, WRITE_BURST_DECAY_MS);
+    }
+  }
+
+  private scheduleWriteBurstDecay(id: string, delayMs: number): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+    managed.writeBurstTimer = window.setTimeout(() => {
+      const current = this.deps.getInstance(id);
+      if (!current) return;
+      current.writeBurstTimer = undefined;
+      const deadline = current.writeBurstDeadline;
+      const nowFire = Date.now();
+      if (deadline !== undefined && nowFire < deadline) {
+        this.scheduleWriteBurstDecay(id, deadline - nowFire);
+        return;
+      }
+      current.writeBurstDeadline = undefined;
+      this.deps.applyRendererPolicy(id, current.getRefreshTier());
+    }, delayMs);
+  }
+
+  // Clears the wheel-burst and write-burst timers for a destroyed terminal.
+  // Called from `TerminalInstanceService.destroy()`.
+  destroy(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    if (managed.inputBurstTimer !== undefined) {
+      clearTimeout(managed.inputBurstTimer);
+      managed.inputBurstTimer = undefined;
+    }
+    if (managed.writeBurstTimer !== undefined) {
+      clearTimeout(managed.writeBurstTimer);
+      managed.writeBurstTimer = undefined;
+    }
+    managed.writeBurstDeadline = undefined;
+  }
+}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -35,6 +35,7 @@ import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowCont
 import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
 import { TerminalSettleWaiterRegistry } from "./TerminalSettleWaiterRegistry";
+import { TerminalBurstController } from "./TerminalBurstController";
 import { reportFileLinkFailure } from "./FileLinksAddon";
 import {
   installTerminalBoundListeners,
@@ -94,16 +95,6 @@ const WORKER_INGEST_DRAIN_POLL_MS = 10;
 // terminals instead of freezing the renderer for the whole batch.
 const RESIZE_PASS_CHUNK_SIZE = 1;
 
-// Interactive resource-profile override (symptom B): while actively scrolling a
-// full-screen TUI, ask the main process to hold the profile off efficiency.
-// DURATION must exceed THROTTLE so re-requests overlap and the hold never lapses
-// mid-scroll; both are short so the hold self-expires soon after scrolling stops.
-const INTERACTIVE_OVERRIDE_DURATION_MS = 1500;
-const INTERACTIVE_OVERRIDE_THROTTLE_MS = 500;
-// BURST-tier hold after a wheel scroll before reverting to the computed tier —
-// matches the keystroke input-burst decay so a scroll feels just as responsive.
-const WHEEL_BURST_DECAY_MS = 1000;
-
 function canAutoInitializeTerminalIngest(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -121,21 +112,10 @@ class TerminalInstanceService {
   // this after its async addon load and aborts, so a panel torn down mid-build
   // never publishes a stale instance/onData listener for a dead id.
   private cancelledCreations = new Set<string>();
-  // Throttle for the interactive resource-profile override IPC (see onActiveWheel).
-  private lastInteractiveOverrideRequestAt = 0;
-  // Which terminal received the most recent alt-buffer wheel event, and when —
-  // drives the ingest service's background-drain hold during a scroll gesture.
-  // Uses the same decay window as the BURST tier so "gesture over" is one
-  // consistent notion across the renderer.
-  private lastActiveWheelId: string | null = null;
-  private lastActiveWheelAt = 0;
   private dataBuffer = new TerminalOutputIngestService(
     (id, data, chunkCount) => this.writeToTerminal(id, data, chunkCount),
     () => usePanelStore.getState().focusedId,
-    () =>
-      this.lastActiveWheelId !== null && Date.now() - this.lastActiveWheelAt < WHEEL_BURST_DECAY_MS
-        ? this.lastActiveWheelId
-        : null
+    () => this.burstController.getActiveWheelHoldId()
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
@@ -156,6 +136,7 @@ class TerminalInstanceService {
   private reconciliationWatchdog: TerminalReconciliationWatchdog;
   private writeController: TerminalWriteController;
   private settleWaiters: TerminalSettleWaiterRegistry;
+  private burstController: TerminalBurstController;
   private unsubTierChanged: (() => void) | null = null;
   // Live worker-parse ingest (issue #10960), gated by
   // DAINTREE_PAINT_FABRIC_WORKER_INGEST. One controller per terminal that has
@@ -193,6 +174,11 @@ class TerminalInstanceService {
       writeData: (id, data, chunkCount) => this.writeToTerminal(id, data, chunkCount),
     });
 
+    this.burstController = new TerminalBurstController({
+      getInstance: (id) => this.instances.get(id),
+      applyRendererPolicy: (id, tier) => this.rendererPolicy.applyRendererPolicy(id, tier),
+    });
+
     this.writeController = new TerminalWriteController({
       getInstance: (id) => this.instances.get(id),
       acknowledgePortData: (id, bytes, chunkCount) =>
@@ -201,7 +187,7 @@ class TerminalInstanceService {
       notifyWriteComplete: (id, bytes) => this.dataBuffer.notifyWriteComplete(id, bytes),
       incrementUnseen: (id, isScrolledBack) =>
         this.unseenTracker.incrementUnseen(id, isScrolledBack),
-      onWrite: (id) => this.onPtyWrite(id),
+      onWrite: (id) => this.burstController.onPtyWrite(id),
     });
 
     this.reflowController = new TerminalReflowController({
@@ -379,8 +365,8 @@ class TerminalInstanceService {
       clearDirectingState: (id, trigger) =>
         this.agentStateController.clearDirectingState(id, trigger),
       onUserInput: (id, data) => this.onUserInput(id, data),
-      onActiveWheel: (id) => this.onActiveWheel(id),
-      onUserScrollIntent: (id) => this.onUserScrollIntent(id),
+      onActiveWheel: (id) => this.burstController.onActiveWheel(id),
+      onUserScrollIntent: (id) => this.burstController.onUserScrollIntent(id),
       onEnterPressed: (id) => this.onEnterPressed(id),
       updateLastObservedTitle: (id, title) =>
         usePanelStore.getState().updateLastObservedTitle(id, title),
@@ -616,127 +602,6 @@ class TerminalInstanceService {
     }, 1000);
 
     this.agentStateController.onUserInput(id, data);
-  }
-
-  /**
-   * Active wheel scroll in a focused full-screen mouse-reporting TUI. Scrolling
-   * such a TUI is an app-owned PTY round-trip per line, and a focused-but-idle
-   * pane sits at FOCUSED (10fps): without this the first flick repaints slowly
-   * until the TUI's own redraw output happens to bump the tier. We (1) lift the
-   * renderer to BURST (60fps) for the scroll — reusing the input-burst decay
-   * timer, since a scroll wants the same ~1s revert as a keystroke — and (2) ask
-   * the main process to hold the resource profile at ≥ balanced, so efficiency
-   * mode's stretched port-batch delay (40ms vs 16ms) can't throttle the
-   * returned-redraw stream mid-scroll ("gets slow and stays slow", symptom B).
-   */
-  private onActiveWheel(id: string): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-
-    this.lastActiveWheelId = id;
-    this.lastActiveWheelAt = Date.now();
-
-    this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
-    if (managed.inputBurstTimer !== undefined) {
-      clearTimeout(managed.inputBurstTimer);
-    }
-    managed.inputBurstTimer = window.setTimeout(() => {
-      const current = this.instances.get(id);
-      if (!current) return;
-      current.inputBurstTimer = undefined;
-      this.rendererPolicy.applyRendererPolicy(id, current.getRefreshTier());
-    }, WHEEL_BURST_DECAY_MS);
-
-    this.requestInteractiveProfileOverride();
-  }
-
-  /**
-   * Ordinary scrollback wheel/key scrolling (not mouse-reporting forwarding).
-   * Holds the resource profile off efficiency for the same reason as
-   * `onActiveWheel` — a profile downgrade mid-scroll drops the WebGL upper
-   * threshold and can force the visible terminal onto the DOM renderer right
-   * as the user is scrolling it (#10858). Unlike `onActiveWheel`, plain
-   * scrollback is client-side xterm rendering with no PTY round-trip per
-   * line, so there's no renderer-tier boost to apply here.
-   */
-  private onUserScrollIntent(id: string): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-
-    this.requestInteractiveProfileOverride();
-  }
-
-  /**
-   * Fire-and-forget request that the main process keep the resource profile off
-   * efficiency while the user is actively scrolling. Throttled hard because a
-   * trackpad momentum stream calls this dozens of times/sec; the override window
-   * (INTERACTIVE_OVERRIDE_DURATION_MS) is longer than the throttle so the hold
-   * never lapses between requests, and self-expires shortly after scrolling stops.
-   */
-  private requestInteractiveProfileOverride(): void {
-    const now = Date.now();
-    if (now - this.lastInteractiveOverrideRequestAt < INTERACTIVE_OVERRIDE_THROTTLE_MS) return;
-    this.lastInteractiveOverrideRequestAt = now;
-    try {
-      // safeFireAndForget swallows the ASYNC rejection (channel skew during a
-      // reload, future validation), which a bare synchronous try/catch around a
-      // Promise-returning IPC call would miss; the try/catch still guards a
-      // synchronous throw if `window.electron.system` is absent. Either way the
-      // renderer-side BURST boost above already applied — this is non-critical.
-      safeFireAndForget(
-        window.electron.system.requestInteractiveOverride(INTERACTIVE_OVERRIDE_DURATION_MS),
-        { context: "terminal.requestInteractiveProfileOverride" }
-      );
-    } catch {
-      // window.electron.system unavailable — non-critical.
-    }
-  }
-
-  /**
-   * Write-driven BURST tier: each PTY write extends the burst window in O(1)
-   * by bumping `writeBurstDeadline`. A single self-rearming timer handles
-   * decay — it re-checks the deadline on fire and either reschedules for the
-   * remaining time (if a write extended the window while it was pending) or
-   * reverts the tier via the panel's current `getRefreshTier()`.
-   *
-   * Avoiding per-write clearTimeout/setTimeout matters: at 60fps+ output the
-   * naive pattern thrashes Chromium's timer queue and produces GC pressure.
-   *
-   * `applyRendererPolicy(BURST)` is called on every write: when BURST is
-   * already applied the policy returns early (line 50 of
-   * TerminalRendererPolicy) and as a load-bearing side-effect clears any
-   * pending tierChangeTimer — that cancellation is what prevents a
-   * concurrent focus-loss-scheduled downgrade from firing unopposed and
-   * stranding the terminal at FOCUSED/VISIBLE/BACKGROUND mid-stream.
-   */
-  private onPtyWrite(id: string): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-
-    managed.writeBurstDeadline = Date.now() + WRITE_BURST_DECAY_MS;
-    this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
-
-    if (managed.writeBurstTimer === undefined) {
-      this.scheduleWriteBurstDecay(id, WRITE_BURST_DECAY_MS);
-    }
-  }
-
-  private scheduleWriteBurstDecay(id: string, delayMs: number): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-    managed.writeBurstTimer = window.setTimeout(() => {
-      const current = this.instances.get(id);
-      if (!current) return;
-      current.writeBurstTimer = undefined;
-      const deadline = current.writeBurstDeadline;
-      const nowFire = Date.now();
-      if (deadline !== undefined && nowFire < deadline) {
-        this.scheduleWriteBurstDecay(id, deadline - nowFire);
-        return;
-      }
-      current.writeBurstDeadline = undefined;
-      this.rendererPolicy.applyRendererPolicy(id, current.getRefreshTier());
-    }, delayMs);
   }
 
   private onEnterPressed(id: string): void {
@@ -3503,6 +3368,7 @@ class TerminalInstanceService {
     this.cancelAttachReveal(managed);
     this.agentStateController.destroy(id);
     this.restoreController.destroy(id);
+    this.burstController.destroy(id);
 
     managed.scrollbackRestoreState = "none";
 
@@ -3544,15 +3410,6 @@ class TerminalInstanceService {
       clearTimeout(managed.tierChangeTimer);
       managed.tierChangeTimer = undefined;
     }
-    if (managed.inputBurstTimer !== undefined) {
-      clearTimeout(managed.inputBurstTimer);
-      managed.inputBurstTimer = undefined;
-    }
-    if (managed.writeBurstTimer !== undefined) {
-      clearTimeout(managed.writeBurstTimer);
-      managed.writeBurstTimer = undefined;
-    }
-    managed.writeBurstDeadline = undefined;
     if (managed.titleReportTimer !== undefined) {
       clearTimeout(managed.titleReportTimer);
       managed.titleReportTimer = undefined;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -53,13 +53,11 @@ import type { PaintSurface } from "./paintFabric/PaintSurfaceRegistry";
 import { createRoundRobinPlacement } from "./paintFabric/placementPolicies";
 import {
   isPaintFabricEnabled,
-  isPaintFabricWorkerIngestEnabled,
   getPaintFabricSurfaceCount,
   paintFabricAuxSurfaceId,
   PRIMARY_SURFACE_ID,
 } from "./paintFabric/paintFabricConfig";
-import { LiveWorkerIngest } from "./workerParse/LiveWorkerIngest";
-import { createParseWorkerTransport } from "./workerParse/createParseWorkerTransport";
+import { TerminalWorkerIngestController } from "./TerminalWorkerIngestController";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -81,10 +79,6 @@ const WEBGL_RESTORE_DEBOUNCE_MS = 100;
 // multi-terminal hide. Authoritative release paths (tier demotion, agent
 // demotion, destroy, hibernation) cancel this timer and release immediately.
 const WEBGL_HIDE_DWELL_MS = 500;
-
-// Poll interval while the worker-ingest engage barrier waits for the normal
-// pipeline (ingest queue + pending xterm writes) to quiesce (#10960).
-const WORKER_INGEST_DRAIN_POLL_MS = 10;
 
 function canAutoInitializeTerminalIngest(): boolean {
   return (
@@ -129,12 +123,8 @@ class TerminalInstanceService {
   private settleWaiters: TerminalSettleWaiterRegistry;
   private burstController: TerminalBurstController;
   private resizePassScheduler: TerminalResizePassScheduler;
+  private workerIngestController: TerminalWorkerIngestController;
   private unsubTierChanged: (() => void) | null = null;
-  // Live worker-parse ingest (issue #10960), gated by
-  // DAINTREE_PAINT_FABRIC_WORKER_INGEST. One controller per terminal that has
-  // ever gone BACKGROUND while the gate is on; disposed with the terminal.
-  private workerIngest = new Map<string, LiveWorkerIngest>();
-  private unsubWorkerIngestEngaged: (() => void) | null = null;
 
   constructor() {
     if (canAutoInitializeTerminalIngest()) {
@@ -175,6 +165,15 @@ class TerminalInstanceService {
       getInstance: (id) => this.instances.get(id),
       isResizeLocked: (id) => this.resizeController.isResizeLocked(id),
       resize: (id, width, height) => this.resizeController.resize(id, width, height),
+    });
+
+    this.workerIngestController = new TerminalWorkerIngestController({
+      getInstance: (id) => this.instances.get(id),
+      getQueuedBytes: (id) => this.dataBuffer.getQueuedBytes(id),
+      resumeFlush: (id) => this.dataBuffer.resumeFlush(id),
+      incrementUnseen: (id, isScrolledBack) =>
+        this.unseenTracker.incrementUnseen(id, isScrolledBack),
+      fetchAndRestore: (id) => this.restoreController.fetchAndRestore(id),
     });
 
     this.writeController = new TerminalWriteController({
@@ -261,7 +260,7 @@ class TerminalInstanceService {
         // mode via the release path above) — push a fresh diagnostics sample.
         this.scheduleWhySlowReport();
 
-        this.applyWorkerIngestPolicy(id, tier, managed);
+        this.workerIngestController.applyWorkerIngestPolicy(id, tier, managed);
       },
     });
 
@@ -1546,7 +1545,7 @@ class TerminalInstanceService {
       // controller — it acks them immediately and lands them on the mirror
       // through the session's zero-loss buffering, never through the write
       // controller.
-      const ingest = this.workerIngest.get(id);
+      const ingest = this.workerIngestController.getIngest(id);
       if (ingest?.shouldDivert()) {
         ingest.feedDiverted(data);
         return;
@@ -3089,128 +3088,6 @@ class TerminalInstanceService {
     return this.webGLManager.isActive(id);
   }
 
-  /**
-   * Tier-driven worker-ingest policy (issue #10960): BACKGROUND demotes the
-   * terminal's parse into a worker via its dedicated pty-host port; any other
-   * tier (FOCUSED/BURST, and VISIBLE — a visible pane repainting at snapshot
-   * cadence would be a UX regression) promotes back to the main-thread path
-   * through the zero-loss release barrier. No-op unless
-   * DAINTREE_PAINT_FABRIC_WORKER_INGEST=1.
-   */
-  private applyWorkerIngestPolicy(
-    id: string,
-    tier: TerminalRefreshTier,
-    managed: ManagedTerminal
-  ): void {
-    if (!isPaintFabricWorkerIngestEnabled()) return;
-    if (tier === TerminalRefreshTier.BACKGROUND) {
-      let ingest = this.workerIngest.get(id);
-      if (!ingest) {
-        ingest = this.createWorkerIngest(id, managed);
-        this.workerIngest.set(id, ingest);
-      }
-      ingest.setDesired(true);
-    } else {
-      this.workerIngest.get(id)?.setDesired(false);
-    }
-  }
-
-  private createWorkerIngest(id: string, managed: ManagedTerminal): LiveWorkerIngest {
-    if (!this.unsubWorkerIngestEngaged) {
-      this.unsubWorkerIngestEngaged = terminalClient.onWorkerIngestEngaged((terminalId) => {
-        this.workerIngest.get(terminalId)?.handleEngaged();
-      });
-    }
-
-    const utf8ByteLength = (data: string): number => new TextEncoder().encode(data).byteLength;
-
-    const ingest = new LiveWorkerIngest({
-      id,
-      requestPort: () => terminalClient.requestWorkerIngestPort(id),
-      releasePort: () => terminalClient.releaseWorkerIngestPort(id),
-      sendEngage: () => terminalClient.sendWorkerIngestEngage(id),
-      sendRelease: (drainId) => terminalClient.sendWorkerIngestRelease(id, drainId),
-      createTransport: () => createParseWorkerTransport(),
-      mirror: {
-        write: (data, callback) => {
-          const current = this.instances.get(id);
-          if (!current) {
-            callback?.();
-            return;
-          }
-          // Direct write — snapshot applies and replays are pre-acked, so the
-          // write controller's ack bookkeeping must never see them. Unseen
-          // tracking still counts each repaint as output activity.
-          this.unseenTracker.incrementUnseen(id, current.isUserScrolledBack);
-          current.terminal.write(data, callback);
-        },
-      },
-      serializeMirror: () => {
-        const current = this.instances.get(id);
-        return current?.serializeAddon.serialize() ?? "";
-      },
-      getGeometry: () => {
-        const current = this.instances.get(id);
-        return {
-          cols: current?.terminal.cols ?? 80,
-          rows: current?.terminal.rows ?? 24,
-          scrollback: current?.terminal.options.scrollback ?? 1000,
-        };
-      },
-      ackDiverted: (data) => {
-        // Delivery source is encoded in the chunk type (the same invariant
-        // TerminalWriteController's ackBytes rule rests on): port chunks are
-        // always Uint8Array, IPC chunks always strings. Settle exactly one
-        // port-ack FIFO entry per port chunk; never let an IPC chunk shift a
-        // port entry — that would prematurely ack a port chunk still queued.
-        if (typeof data === "string") {
-          terminalClient.acknowledgeData(id, utf8ByteLength(data));
-        } else {
-          terminalClient.acknowledgePortData(id, data.byteLength, 1);
-        }
-      },
-      drainPendingWrites: async () => {
-        // Quiesce the normal pipeline before the engage serialize: queued
-        // ingest chunks, in-flight xterm writes, and serialized-restore
-        // deferrals all still land on the mirror through the write controller
-        // — the serialize must happen after them or they vanish at the next
-        // snapshot apply. Diversion is already on, so no new inflow.
-        const deadline = Date.now() + 5000;
-        for (;;) {
-          const current = this.instances.get(id);
-          if (!current) return false;
-          if (
-            this.dataBuffer.getQueuedBytes(id) === 0 &&
-            (current.pendingWrites ?? 0) === 0 &&
-            !current.isSerializedRestoreInProgress
-          ) {
-            return true;
-          }
-          if (Date.now() > deadline) return false;
-          this.dataBuffer.resumeFlush(id);
-          await new Promise((resolve) => setTimeout(resolve, WORKER_INGEST_DRAIN_POLL_MS));
-        }
-      },
-      requestHostRestore: () => {
-        safeFireAndForget(this.restoreController.fetchAndRestore(id), {
-          context: "worker-ingest fallback restore",
-        });
-      },
-      onDidFallback: (reason) => {
-        logWarn("Worker ingest fell back to main-thread parse", { id, reason });
-      },
-    });
-
-    // Geometry follows the mirror in every mode so demotion re-seeds at the
-    // right size (session forwards resizes only while in worker mode).
-    const resizeDisposable = managed.terminal.onResize(({ cols, rows }) =>
-      ingest.resize(cols, rows)
-    );
-    managed.listeners.push(() => resizeDisposable.dispose());
-
-    return ingest;
-  }
-
   destroy(id: string): void {
     // Cancel an in-flight creation for this id: if the panel is torn down while
     // getOrCreate is still awaiting setupTerminalAddons, the instance isn't in
@@ -3252,14 +3129,7 @@ class TerminalInstanceService {
     this.resizeController.clearResizeJob(managed);
     this.resizeController.clearResizeLock(id);
     this.resizeController.clearSettledTimer(id);
-    // Worker ingest dies with the terminal: dispose terminates the Worker and
-    // closes the dedicated port on every teardown path (kill/trash/project
-    // close/LRU eviction) — a leaked producer port queues unboundedly (#6283).
-    const ingest = this.workerIngest.get(id);
-    if (ingest) {
-      ingest.dispose();
-      this.workerIngest.delete(id);
-    }
+    this.workerIngestController.destroy(id);
     // Renderer-side destroy without a prior kill (project close, LRU
     // eviction of an exited terminal) must still drain the port-ack FIFO
     // before the held queue is wiped (#9910). kill/gracefulKill/trash clear
@@ -3347,8 +3217,7 @@ class TerminalInstanceService {
     this.stopPolling();
     this.unsubTierChanged?.();
     this.unsubTierChanged = null;
-    this.unsubWorkerIngestEngaged?.();
-    this.unsubWorkerIngestEngaged = null;
+    this.workerIngestController.dispose();
     this.resizePassScheduler.dispose();
     this.reflowController.dispose();
     this.reconciliationWatchdog.dispose();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -61,7 +61,6 @@ import {
 import { TerminalWorkerIngestController } from "./TerminalWorkerIngestController";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
-import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
 
 export { isNonKeyboardInput } from "./inputUtils";

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -9,7 +9,6 @@ import {
   AgentStateCallback,
   PostCompleteHook,
   TerminalLink,
-  isWebGLEligibleTier,
 } from "./types";
 import { tallyScrollbackRestoreStates } from "./scrollbackRestoreAggregate";
 import {
@@ -27,6 +26,7 @@ import { TerminalLinkHandler } from "./TerminalLinkHandler";
 import { TerminalResizeController, hasStreamingWrites } from "./TerminalResizeController";
 import { TerminalRendererPolicy } from "./TerminalRendererPolicy";
 import { TerminalWebGLManager } from "./TerminalWebGLManager";
+import { TerminalWebGLPolicy } from "./TerminalWebGLPolicy";
 import { TerminalAgentStateController } from "./TerminalAgentStateController";
 import { TerminalRestoreController } from "./TerminalRestoreController";
 import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
@@ -111,6 +111,7 @@ class TerminalInstanceService {
   private cachedSelections = new Map<string, string>();
   private resizeController: TerminalResizeController;
   private rendererPolicy: TerminalRendererPolicy;
+  private webGLPolicy: TerminalWebGLPolicy;
   private webGLManager = new TerminalWebGLManager();
   // Coalesces "why am I slow?" diagnostics pushes (#10910): multiple tier/create/
   // destroy events in one turn collapse to a single main-process report.
@@ -191,6 +192,12 @@ class TerminalInstanceService {
       getInstances: () => this.instances.values(),
     });
 
+    this.webGLPolicy = new TerminalWebGLPolicy({
+      getMode: () => this.webGLManager.getMode(),
+      getPinnedId: () => this.webGLManager.getPinnedId(),
+      isAltBufferPinned: (id) => this.webGLManager.isAltBufferPinned(id),
+    });
+
     this.rendererPolicy = new TerminalRendererPolicy({
       getInstance: (id) => this.instances.get(id),
       onPostWake: (id) => this.handlePostWake(id),
@@ -220,7 +227,7 @@ class TerminalInstanceService {
           void this.ensureDeferredAddons(id, managed);
         }
 
-        if (this.wantsWebGLAtTier(managed, tier)) {
+        if (this.webGLPolicy.wantsWebGLAtTier(managed, tier)) {
           this.webGLManager.ensureContext(id, managed);
         } else if (
           (managed.webGLHideTimer === undefined && !managed.isVisible) ||
@@ -282,7 +289,7 @@ class TerminalInstanceService {
       hasInFlightWake: () => false,
       hasPendingWake: () => false,
       isWebGLActive: (id) => this.webGLManager.isActive(id),
-      shouldHaveWebGL: (managed) => this.shouldHaveActiveWebGL(managed),
+      shouldHaveWebGL: (managed) => this.webGLPolicy.shouldHaveActiveWebGL(managed),
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
       forceReflow: (element) => forceXtermReflow(element),
       reconcileRevealGeometry: (id) => this.reconcileRevealGeometry(id),
@@ -474,93 +481,6 @@ class TerminalInstanceService {
     if (managed.terminal.options.cursorBlink !== desired) {
       managed.terminal.options.cursorBlink = desired;
     }
-  }
-
-  /**
-   * Whether a terminal wants a WebGL context at the given tier. Agent
-   * terminals are eligible at every WebGL-eligible tier (FOCUSED/BURST/
-   * VISIBLE) — the DOM renderer mangles the block glyphs agent headers use
-   * (see isWebGLEligibleTier in types.ts). Plain terminals are eligible only
-   * while focused: FOCUSED, or a BURST on the focused pane (input bursts and
-   * streaming output must not drop the context mid-use). BURST alone is
-   * write-driven for every terminal, so granting it to unfocused plain shells
-   * would add a want per streaming build/log pane and trip the count-based
-   * mode switch; VISIBLE is excluded for the same budget reason.
-   */
-  private wantsWebGLAtTier(
-    managed: ManagedTerminal,
-    tier: TerminalRefreshTier | undefined,
-    opts?: { trustDomVisibility?: boolean }
-  ): boolean {
-    if (!isWebGLEligibleTier(tier)) return false;
-    // Visibility gates every case: an off-screen pane never wants WebGL, even
-    // an agent streaming at BURST. The want set is fleet-wide per project view,
-    // so hidden streaming agents would otherwise accumulate wants and trip the
-    // count-based mode switch, dropping the whole visible fleet to DOM
-    // (#10671). The reveal path (setVisible(true) → debounced shouldRestoreWebGL
-    // → ensureContext) re-acquires the want once the pane is on-screen again —
-    // and on a warm WebContentsView resume it passes trustDomVisibility because
-    // it has already proven the pane on-screen from DOM truth, so the stale
-    // reactive isVisible flag must not veto the want there.
-    if (!opts?.trustDomVisibility && !managed.isVisible) return false;
-    if (managed.runtimeAgentId) return true;
-    return (
-      tier === TerminalRefreshTier.FOCUSED ||
-      (tier === TerminalRefreshTier.BURST && managed.isFocused)
-    );
-  }
-
-  /**
-   * Eligibility for visibility-driven WebGL restore. Mirrors the gates in
-   * onTierApplied (agent identity / focus + tier) plus liveness checks
-   * (opened, not attaching, not hibernated). Used by the debounced timer in
-   * setVisible() before re-acquiring a context.
-   */
-  private shouldRestoreWebGL(
-    managed: ManagedTerminal,
-    opts?: { trustDomVisibility?: boolean }
-  ): boolean {
-    if (!managed.isOpened) return false;
-    // The reveal path proves visibility from DOM ground truth (isConnected +
-    // checkVisibility + box) before calling, because the reactive isVisible flag
-    // can be stale-false on a warm WebContentsView resume (#10632 item 4). Trust
-    // that here so a dropped WebGL context is reattached on reveal instead of
-    // leaving the pane on the DOM renderer until the ~3s watchdog (which is
-    // itself suppressed for the first ~5s by the project-switch resize lock).
-    if (!opts?.trustDomVisibility && !managed.isVisible) return false;
-    if (managed.isAttaching) return false;
-    return this.wantsWebGLAtTier(
-      managed,
-      managed.lastAppliedTier ?? managed.getRefreshTier?.(),
-      opts
-    );
-  }
-
-  /**
-   * Watchdog-only WebGL eligibility. Identical to {@link shouldRestoreWebGL} but
-   * additionally false for a non-pinned pane in DOM-mode fallback: in DOM mode
-   * the manager only ever attaches the single focus-pinned context, so a
-   * non-pinned pane's context can never become active. Without this the
-   * watchdog's `shouldHaveWebGL && !isWebGLActive` stays permanently true for
-   * every non-pinned agent pane and burns a heavy-repair slot every tick (plus a
-   * spurious "context missing" warning). The reveal / visibility restore paths
-   * deliberately keep using {@link shouldRestoreWebGL} so they still call
-   * `ensureContext` and keep the pane in the manager's `wants` set — which is
-   * what lets a later focus change pin and attach it immediately.
-   */
-  private shouldHaveActiveWebGL(managed: ManagedTerminal): boolean {
-    if (!this.shouldRestoreWebGL(managed)) return false;
-    // In DOM mode the manager only keeps contexts on pinned panes (the focus
-    // pin and alt-buffer pins). A non-pinned pane can never have an active
-    // context, so the watchdog must not treat its absence as a fault.
-    if (
-      this.webGLManager.getMode() === "dom" &&
-      managed.id !== this.webGLManager.getPinnedId() &&
-      !this.webGLManager.isAltBufferPinned(managed.id)
-    ) {
-      return false;
-    }
-    return true;
   }
 
   private onUserInput(id: string, data: string): void {
@@ -761,7 +681,7 @@ class TerminalInstanceService {
           const current = this.instances.get(id);
           if (!current) return;
           current.webGLRestoreTimer = undefined;
-          if (!this.shouldRestoreWebGL(current)) return;
+          if (!this.webGLPolicy.shouldRestoreWebGL(current)) return;
           this.webGLManager.ensureContext(id, current);
         }, WEBGL_RESTORE_DEBOUNCE_MS);
       } else {
@@ -1190,7 +1110,7 @@ class TerminalInstanceService {
     // agent panes on the DOM renderer. Assistant show/hide-transition callers
     // pass nothing, so they keep the isVisible gate — a transform-hidden pane
     // must not accumulate a fleet-wide WebGL want (#10671).
-    if (!this.webGLManager.isActive(id) && this.shouldRestoreWebGL(managed, opts)) {
+    if (!this.webGLManager.isActive(id) && this.webGLPolicy.shouldRestoreWebGL(managed, opts)) {
       this.webGLManager.ensureContext(id, managed);
     }
 
@@ -1948,7 +1868,7 @@ class TerminalInstanceService {
     // visibility (gated separately below). Previously this skipped the addons on
     // background, degrading content for hidden panes.
     void this.ensureDeferredAddons(id, managed);
-    if (this.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
+    if (this.webGLPolicy.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
     }
   }
@@ -2061,7 +1981,7 @@ class TerminalInstanceService {
         if (
           managed.isVisible &&
           !this.webGLManager.isActive(id) &&
-          this.shouldRestoreWebGL(managed)
+          this.webGLPolicy.shouldRestoreWebGL(managed)
         ) {
           this.webGLManager.ensureContext(id, managed);
         }
@@ -3029,7 +2949,7 @@ class TerminalInstanceService {
     // Route through wantsWebGLAtTier so an off-screen promotion (background
     // worktree detected mid-stream) doesn't register a fleet-wide want; the
     // reveal path re-acquires it when the pane comes on-screen (#10671).
-    if (managed.isOpened && this.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
+    if (managed.isOpened && this.webGLPolicy.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
     }
   }
@@ -3047,7 +2967,7 @@ class TerminalInstanceService {
     // focused pane stays WebGL-eligible as a plain terminal, so keep (or
     // acquire) its context instead of churning it through a release.
     this.cancelWebGLHideTimer(managed);
-    if (managed.isOpened && this.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
+    if (managed.isOpened && this.webGLPolicy.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
     } else {
       this.webGLManager.releaseContext(id);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -10,8 +10,6 @@ import {
   PostCompleteHook,
   TerminalLink,
   isWebGLEligibleTier,
-  WRITE_BURST_DECAY_MS,
-  GRID_RESIZE_COALESCE_MS,
 } from "./types";
 import { tallyScrollbackRestoreStates } from "./scrollbackRestoreAggregate";
 import {
@@ -36,6 +34,7 @@ import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog
 import { TerminalWriteController } from "./TerminalWriteController";
 import { TerminalSettleWaiterRegistry } from "./TerminalSettleWaiterRegistry";
 import { TerminalBurstController } from "./TerminalBurstController";
+import { TerminalResizePassScheduler } from "./TerminalResizePassScheduler";
 import { reportFileLinkFailure } from "./FileLinksAddon";
 import {
   installTerminalBoundListeners,
@@ -49,7 +48,6 @@ import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
-import { yieldToScheduler } from "@/lib/schedulerYield";
 import { PaintFabricCompositor } from "./paintFabric/PaintFabricCompositor";
 import type { PaintSurface } from "./paintFabric/PaintSurfaceRegistry";
 import { createRoundRobinPlacement } from "./paintFabric/placementPolicies";
@@ -87,13 +85,6 @@ const WEBGL_HIDE_DWELL_MS = 500;
 // Poll interval while the worker-ingest engage barrier waits for the normal
 // pipeline (ingest queue + pending xterm writes) to quiesce (#10960).
 const WORKER_INGEST_DRAIN_POLL_MS = 10;
-
-// Terminals resized per task inside `runResizePass`, yielding to the scheduler
-// between chunks. xterm.js 6.0 reflows the whole scrollback on a
-// column-changing resize (~15-40ms each), so one-per-task keeps every task
-// under the ~50ms long-task threshold and lets paint + input run between
-// terminals instead of freezing the renderer for the whole batch.
-const RESIZE_PASS_CHUNK_SIZE = 1;
 
 function canAutoInitializeTerminalIngest(): boolean {
   return (
@@ -137,6 +128,7 @@ class TerminalInstanceService {
   private writeController: TerminalWriteController;
   private settleWaiters: TerminalSettleWaiterRegistry;
   private burstController: TerminalBurstController;
+  private resizePassScheduler: TerminalResizePassScheduler;
   private unsubTierChanged: (() => void) | null = null;
   // Live worker-parse ingest (issue #10960), gated by
   // DAINTREE_PAINT_FABRIC_WORKER_INGEST. One controller per terminal that has
@@ -177,6 +169,12 @@ class TerminalInstanceService {
     this.burstController = new TerminalBurstController({
       getInstance: (id) => this.instances.get(id),
       applyRendererPolicy: (id, tier) => this.rendererPolicy.applyRendererPolicy(id, tier),
+    });
+
+    this.resizePassScheduler = new TerminalResizePassScheduler({
+      getInstance: (id) => this.instances.get(id),
+      isResizeLocked: (id) => this.resizeController.isResizeLocked(id),
+      resize: (id, width, height) => this.resizeController.resize(id, width, height),
     });
 
     this.writeController = new TerminalWriteController({
@@ -2336,164 +2334,28 @@ class TerminalInstanceService {
   }
 
   /**
-   * Resize a set of panels in a single read-all / write-all pass (#8597).
-   *
-   * The previous grid-fit batch chained one `fit()` per requestAnimationFrame,
-   * which (a) spread the visual settle across N frames and (b) interleaved
-   * `fitAddon.fit()`'s `getComputedStyle` read with the per-panel xterm write
-   * for every panel — classic layout thrash. Here we phase the work: phase 1
-   * reads `getBoundingClientRect()` for every eligible panel up front (cheap
-   * thanks to per-panel `contain: layout style`), phase 2 calls
-   * `resizeController.resize()` for each collected rect. `resize()` computes
-   * cols/rows from cached cell metrics without touching the DOM, so the write
-   * phase performs no further layout reads. The whole pass completes in a
-   * single task.
-   *
-   * Eligibility guards mirror the per-panel checks the old chained-fit loop
-   * relied on: instance must exist, host element must be connected and
-   * visible (xterm's `fit()` path checks `checkVisibility()`, but `resize()`
-   * does not, so we apply it here), and the panel must not be resize-locked.
-   * Caller is responsible for the `isDragging` guard since the React ref
-   * holding that state is owned by the grid hook.
-   *
-   * Private — this is the synchronous primitive. Callers outside this service
-   * must go through {@link runResizePass} (chunked, cancellable) or
-   * {@link scheduleBatchResize} (coalesced) so a survivor reflow never freezes
-   * the renderer in one task. `executeResizePass` invokes this one id at a time.
-   */
-  private batchResize(ids: string[]): void {
-    if (ids.length === 0) return;
-
-    type Pending = { id: string; width: number; height: number };
-    const seen = new Set<string>();
-    const pending: Pending[] = [];
-
-    for (const id of ids) {
-      if (seen.has(id)) continue;
-      seen.add(id);
-
-      const managed = this.instances.get(id);
-      if (!managed) continue;
-      if (!managed.hostElement.isConnected) continue;
-      if (!managed.hostElement.checkVisibility()) continue;
-      if (this.resizeController.isResizeLocked(id)) continue;
-
-      const rect = managed.hostElement.getBoundingClientRect();
-      if (rect.width < 50 || rect.height < 50) continue;
-
-      pending.push({ id, width: rect.width, height: rect.height });
-    }
-
-    for (const { id, width, height } of pending) {
-      this.resizeController.resize(id, width, height);
-    }
-  }
-
-  private gridResizeTimer: number | undefined;
-  private readonly gridResizePendingIds = new Set<string>();
-  private resizePassAbort: AbortController | undefined;
-
-  /**
-   * Coalesced variant of `batchResize`. A burst of grid open/close events each
-   * union their ids and reset a trailing-edge timer; the actual resize runs
-   * once the burst settles, on the next frame — so it never lands on the
-   * synchronous open/close path the user is waiting on.
+   * Coalesced batch resize for a burst of grid open/close events — runs on
+   * the next frame once the burst settles. See
+   * {@link TerminalResizePassScheduler.scheduleBatchResize}.
    */
   scheduleBatchResize(ids: string[]): void {
-    if (ids.length === 0) return;
-    for (const id of ids) this.gridResizePendingIds.add(id);
-    if (this.gridResizeTimer !== undefined) {
-      clearTimeout(this.gridResizeTimer);
-    }
-    this.gridResizeTimer = window.setTimeout(() => {
-      this.gridResizeTimer = undefined;
-      const pendingIds = [...this.gridResizePendingIds];
-      this.gridResizePendingIds.clear();
-      requestAnimationFrame(() => this.runResizePass(pendingIds));
-    }, GRID_RESIZE_COALESCE_MS);
+    this.resizePassScheduler.scheduleBatchResize(ids);
   }
 
   /**
-   * Resize a set of panels as a chunked, cancellable pass instead of one
-   * synchronous loop. Closing or opening a panel resizes every surviving
-   * xterm; in xterm.js 6.0 a column-changing resize reflows the entire
-   * scrollback (O(scrollback)), so resizing ~15 terminals in a single
-   * synchronous loop freezes the renderer for hundreds of ms — the
-   * "app stops responding" the user feels on Cmd+W.
-   *
-   * This runs `RESIZE_PASS_CHUNK_SIZE` terminal(s) per task and yields to the
-   * scheduler between chunks (see {@link yieldToScheduler}), so paint and
-   * input stay live while the survivors settle progressively. The focused
-   * panel resizes first so the pane the user is looking at settles in the
-   * first frame; far corners of a large grid settle a beat later, unnoticed.
-   *
-   * Each new pass aborts any in-flight one: once a newer pass starts, the
-   * survivor set the old one was resizing is already stale, so its remaining
-   * reflows are cancelled. The trailing-edge debounce in
-   * {@link scheduleBatchResize} coalesces a close/open burst before a pass
-   * starts; this abort handles the case where a burst arrives once a pass is
-   * already running. Fire-and-forget — callers never await it.
+   * Chunked, cancellable resize pass across a set of panels — see
+   * {@link TerminalResizePassScheduler.runResizePass}.
    */
   runResizePass(ids: string[]): void {
-    if (ids.length === 0) return;
-    // A newer pass supersedes any in-flight one — its survivor set is stale.
-    this.resizePassAbort?.abort();
-    const controller = new AbortController();
-    this.resizePassAbort = controller;
-    const run = () => this.executeResizePass(ids, controller);
-    const task =
-      typeof scheduler !== "undefined" && typeof scheduler.postTask === "function"
-        ? scheduler.postTask(run, { priority: "user-visible", signal: controller.signal })
-        : run();
-    void task.catch((error) => {
-      if (error instanceof Error && error.name === "AbortError") return;
-      logError("terminal resize pass failed", error);
-    });
+    this.resizePassScheduler.runResizePass(ids);
   }
 
   /**
-   * Abort any in-flight chunked resize pass without starting a new one. The
-   * paint-fabric compositor uses this to give a multi-surface fabric the same
-   * pass-supersession semantics the single service has: one logical pass spans
-   * every surface, so starting a new pass must cancel stale chunked work on
-   * surfaces that have no ids in the new pass (they'd otherwise keep reflowing
-   * a survivor set that is already stale).
+   * Abort any in-flight chunked resize pass without starting a new one — see
+   * {@link TerminalResizePassScheduler.cancelActiveResizePass}.
    */
   cancelActiveResizePass(): void {
-    this.resizePassAbort?.abort();
-    this.resizePassAbort = undefined;
-  }
-
-  private async executeResizePass(ids: string[], controller: AbortController): Promise<void> {
-    const { signal } = controller;
-    try {
-      const ordered = this.orderFocusedFirst([...new Set(ids)]);
-      for (let i = 0; i < ordered.length; i += RESIZE_PASS_CHUNK_SIZE) {
-        if (signal.aborted) return;
-        // batchResize re-applies every eligibility guard (instance exists,
-        // connected, visible, not resize-locked) and reads fresh geometry —
-        // correct here because layout has settled across the yields.
-        this.batchResize(ordered.slice(i, i + RESIZE_PASS_CHUNK_SIZE));
-        if (i + RESIZE_PASS_CHUNK_SIZE < ordered.length) {
-          await yieldToScheduler();
-        }
-      }
-    } finally {
-      if (this.resizePassAbort === controller) {
-        this.resizePassAbort = undefined;
-      }
-    }
-  }
-
-  /**
-   * Order the resize set so the focused panel settles first. The user's eye
-   * is on the focused pane; resizing it in the first chunk makes the pass
-   * feel instant even though total work is unchanged.
-   */
-  private orderFocusedFirst(ids: string[]): string[] {
-    const focusedId = usePanelStore.getState().focusedId;
-    if (!focusedId || !ids.includes(focusedId)) return ids;
-    return [focusedId, ...ids.filter((id) => id !== focusedId)];
+    this.resizePassScheduler.cancelActiveResizePass();
   }
 
   scrollToBottom(id: string): void {
@@ -3487,10 +3349,7 @@ class TerminalInstanceService {
     this.unsubTierChanged = null;
     this.unsubWorkerIngestEngaged?.();
     this.unsubWorkerIngestEngaged = null;
-    // Abort any in-flight chunked resize pass so its yielded continuation
-    // doesn't resume against a torn-down service.
-    this.resizePassAbort?.abort();
-    this.resizePassAbort = undefined;
+    this.resizePassScheduler.dispose();
     this.reflowController.dispose();
     this.reconciliationWatchdog.dispose();
     this.instances.forEach((_, id) => this.destroy(id));

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -34,7 +34,7 @@ import { TerminalRestoreController } from "./TerminalRestoreController";
 import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
 import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
-import { agentLifecycleLedger } from "./lifecycleLedger";
+import { TerminalSettleWaiterRegistry } from "./TerminalSettleWaiterRegistry";
 import { reportFileLinkFailure } from "./FileLinksAddon";
 import {
   installTerminalBoundListeners,
@@ -87,17 +87,6 @@ const WEBGL_HIDE_DWELL_MS = 500;
 // pipeline (ingest queue + pending xterm writes) to quiesce (#10960).
 const WORKER_INGEST_DRAIN_POLL_MS = 10;
 
-// Default timeout for the restore-aware settle waits (`waitForFullySettled`,
-// `waitForAllFullySettled`). Aligned to the 30s Tier 1→3 promotion rule
-// (CLAUDE.md "Runtime Signals"): a settle that hasn't completed within 30s has
-// stalled past the point where an ambient indicator is appropriate, so the
-// gate gives up and surfaces the still-pending set rather than blocking
-// indefinitely. The wait is notification-driven (scheduler fires on each
-// restore state transition); the timer is only the safety fallback, so
-// Chromium 148 background-timer throttling in a hidden view at most delays the
-// fallback, never the correct completion path.
-const TERMINAL_BATCH_SETTLE_TIMEOUT_MS = 30000;
-
 // Terminals resized per task inside `runResizePass`, yielding to the scheduler
 // between chunks. xterm.js 6.0 reflows the whole scrollback on a
 // column-changing resize (~15-40ms each), so one-per-task keeps every task
@@ -114,12 +103,6 @@ const INTERACTIVE_OVERRIDE_THROTTLE_MS = 500;
 // BURST-tier hold after a wheel scroll before reverting to the computed tier —
 // matches the keystroke input-burst decay so a scroll feels just as responsive.
 const WHEEL_BURST_DECAY_MS = 1000;
-
-interface Waiter {
-  resolve: () => void;
-  reject: (error: Error) => void;
-  timeout: number;
-}
 
 function canAutoInitializeTerminalIngest(): boolean {
   return (
@@ -158,9 +141,6 @@ class TerminalInstanceService {
   private unseenTracker = new TerminalUnseenOutputTracker();
   private scrollbackRestoreListeners = new Set<() => void>();
   private cwdProviders = new Map<string, () => string>();
-  private readinessWaiters = new Map<string, Waiter[]>();
-  private attachSettledWaiters = new Map<string, Waiter[]>();
-  private fullySettledWaiters = new Map<string, Waiter[]>();
   private offscreenManager = new TerminalOffscreenManager();
   private linkHandler = new TerminalLinkHandler();
   private cachedSelections = new Map<string, string>();
@@ -175,6 +155,7 @@ class TerminalInstanceService {
   private reflowController: TerminalReflowController;
   private reconciliationWatchdog: TerminalReconciliationWatchdog;
   private writeController: TerminalWriteController;
+  private settleWaiters: TerminalSettleWaiterRegistry;
   private unsubTierChanged: (() => void) | null = null;
   // Live worker-parse ingest (issue #10960), gated by
   // DAINTREE_PAINT_FABRIC_WORKER_INGEST. One controller per terminal that has
@@ -194,6 +175,17 @@ class TerminalInstanceService {
 
     this.agentStateController = new TerminalAgentStateController({
       getInstance: (id) => this.instances.get(id),
+    });
+
+    this.settleWaiters = new TerminalSettleWaiterRegistry({
+      getInstance: (id) => this.instances.get(id),
+      triggerDeferredVisibilityWake: (id) => {
+        void this.fullWakeForVisibilityRestore(id).catch((error) => {
+          logWarn(`deferred fullWakeForVisibilityRestore failed for ${id}`, {
+            error,
+          });
+        });
+      },
     });
 
     this.restoreController = new TerminalRestoreController({
@@ -1799,7 +1791,7 @@ class TerminalInstanceService {
     // non-focused split, or BACKGROUND prewarms in a non-focused tab).
     this.applyCursorBlinkPolicy(managed);
 
-    this.notifyReadinessWaiters(id);
+    this.settleWaiters.notifyReadinessWaiters(id);
 
     this.scheduleWhySlowReport();
 
@@ -1894,150 +1886,18 @@ class TerminalInstanceService {
   }
 
   waitForInstance(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
-    const existing = this.instances.get(id);
-    if (existing) {
-      return Promise.resolve();
-    }
-
-    const timeoutMs = options.timeoutMs ?? 5000;
-
-    return new Promise<void>((resolve, reject) => {
-      const timeout = window.setTimeout(() => {
-        this.removeReadinessWaiter(id, resolve);
-        reject(new Error(`Terminal ${id} frontend readiness timeout after ${timeoutMs}ms`));
-      }, timeoutMs);
-
-      const waiters = this.readinessWaiters.get(id) || [];
-      waiters.push({ resolve, reject, timeout });
-      this.readinessWaiters.set(id, waiters);
-    });
+    return this.settleWaiters.waitForInstance(id, options);
   }
 
   waitForAttachSettled(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
-    if (this.isAttachSettled(id)) {
-      return Promise.resolve();
-    }
-
-    const timeoutMs = options.timeoutMs ?? 1500;
-
-    return new Promise<void>((resolve, reject) => {
-      const timeout = window.setTimeout(() => {
-        this.removeAttachSettledWaiter(id, resolve);
-        reject(new Error(`Terminal ${id} attach settle timeout after ${timeoutMs}ms`));
-      }, timeoutMs);
-
-      const waiters = this.attachSettledWaiters.get(id) || [];
-      waiters.push({ resolve, reject, timeout });
-      this.attachSettledWaiters.set(id, waiters);
-    });
-  }
-
-  private isAttachSettled(id: string): boolean {
-    const managed = this.instances.get(id);
-    if (!managed) return false;
-    return (
-      managed.isOpened &&
-      managed.isAttaching !== true &&
-      managed.hostElement.isConnected &&
-      managed.terminal.element !== undefined
-    );
-  }
-
-  private notifyReadinessWaiters(id: string): void {
-    const waiters = this.readinessWaiters.get(id);
-    if (!waiters) return;
-
-    for (const waiter of waiters) {
-      clearTimeout(waiter.timeout);
-      waiter.resolve();
-    }
-
-    this.readinessWaiters.delete(id);
-  }
-
-  private removeReadinessWaiter(id: string, resolve: () => void): void {
-    const waiters = this.readinessWaiters.get(id);
-    if (!waiters) return;
-
-    const index = waiters.findIndex((w) => w.resolve === resolve);
-    if (index >= 0) {
-      waiters.splice(index, 1);
-    }
-
-    if (waiters.length === 0) {
-      this.readinessWaiters.delete(id);
-    }
-  }
-
-  private notifyAttachSettledWaiters(id: string): void {
-    if (!this.isAttachSettled(id)) return;
-
-    // Consume a deferred visibility wake that was skipped while this terminal
-    // was mid-attach (#9702). Read and clear the flag before dispatching so a
-    // re-entrant call can't double-fire; fullWakeForVisibilityRestore guards
-    // against stale/replaced instances on its own.
-    const managed = this.instances.get(id);
-    const deferredWake = managed?.pendingVisibilityWake === true;
-    if (managed) managed.pendingVisibilityWake = false;
-
-    // Record the first live-attach geometry in the lifecycle ledger (once per
-    // launch generation — recordFirstAttach ignores later attaches). Pairs
-    // with the 80x24 initial dims stamped at launch so a support bundle can
-    // show whether a pane ever converged from boot geometry.
-    if (managed) {
-      const generation = agentLifecycleLedger.currentGeneration(id);
-      if (generation !== undefined) {
-        agentLifecycleLedger.recordFirstAttach(
-          id,
-          generation,
-          managed.terminal.cols,
-          managed.terminal.rows
-        );
-      }
-    }
-
-    const waiters = this.attachSettledWaiters.get(id);
-    if (waiters) {
-      for (const waiter of waiters) {
-        clearTimeout(waiter.timeout);
-        waiter.resolve();
-      }
-      this.attachSettledWaiters.delete(id);
-    }
-
-    // Visual attach is one half of "fully settled". If restore already
-    // finished while this terminal was mid-attach, attach completing now is
-    // the moment it becomes fully settled — drain those waiters too.
-    this.notifyFullySettledWaitersIfReady(id);
-
-    if (deferredWake) {
-      void this.fullWakeForVisibilityRestore(id).catch((error) => {
-        logWarn(`deferred fullWakeForVisibilityRestore failed for ${id}`, {
-          error,
-        });
-      });
-    }
-  }
-
-  private removeAttachSettledWaiter(id: string, resolve: () => void): void {
-    const waiters = this.attachSettledWaiters.get(id);
-    if (!waiters) return;
-
-    const index = waiters.findIndex((w) => w.resolve === resolve);
-    if (index >= 0) {
-      waiters.splice(index, 1);
-    }
-
-    if (waiters.length === 0) {
-      this.attachSettledWaiters.delete(id);
-    }
+    return this.settleWaiters.waitForAttachSettled(id, options);
   }
 
   /**
-   * Resolves once a terminal is *fully* settled — both visually attached
-   * ({@link isAttachSettled}) and past its scrollback-restore lifecycle. Unlike
-   * {@link waitForAttachSettled}, which only gates on visual attach, this waits
-   * for the restore state machine to leave its in-flux states.
+   * Resolves once a terminal is *fully* settled — both visually attached and
+   * past its scrollback-restore lifecycle. Unlike {@link waitForAttachSettled},
+   * which only gates on visual attach, this waits for the restore state
+   * machine to leave its in-flux states.
    *
    * A restore failure still settles the wait (the terminal is usable, just
    * without restored scrollback); callers that care about success vs. silent
@@ -2049,25 +1909,7 @@ class TerminalInstanceService {
    * `"none"` — there is nothing to wait for from this method's view.
    */
   waitForFullySettled(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
-    if (this.isFullySettled(id)) {
-      return Promise.resolve();
-    }
-
-    const timeoutMs = options.timeoutMs ?? TERMINAL_BATCH_SETTLE_TIMEOUT_MS;
-
-    return new Promise<void>((resolve, reject) => {
-      const timeout = window.setTimeout(() => {
-        this.removeFullySettledWaiter(id, resolve);
-        const state = this.instances.get(id)?.scrollbackRestoreState ?? "missing";
-        reject(
-          new Error(`Terminal ${id} fully-settle timeout after ${timeoutMs}ms (restore: ${state})`)
-        );
-      }, timeoutMs);
-
-      const waiters = this.fullySettledWaiters.get(id) || [];
-      waiters.push({ resolve, reject, timeout });
-      this.fullySettledWaiters.set(id, waiters);
-    });
+    return this.settleWaiters.waitForFullySettled(id, options);
   }
 
   /**
@@ -2079,102 +1921,7 @@ class TerminalInstanceService {
    * silent partial success (hence `Promise.all`, not `allSettled`).
    */
   waitForAllFullySettled(ids: string[], options: { timeoutMs?: number } = {}): Promise<void> {
-    const uniqueIds = Array.from(new Set(ids));
-    if (uniqueIds.length === 0) {
-      return Promise.resolve();
-    }
-
-    const timeoutMs = options.timeoutMs ?? TERMINAL_BATCH_SETTLE_TIMEOUT_MS;
-
-    return new Promise<void>((resolveBatch, rejectBatch) => {
-      let settled = false;
-      // Per-panel resolve handles we registered in `fullySettledWaiters`, so
-      // the shared timeout can detach them in one pass rather than leaving
-      // ghost waiters that fire after the batch has already rejected.
-      const registered: Array<{ id: string; resolve: () => void }> = [];
-
-      const detachAll = () => {
-        for (const entry of registered) {
-          this.removeFullySettledWaiter(entry.id, entry.resolve);
-        }
-      };
-
-      const timeout = window.setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        detachAll();
-        const pending = uniqueIds.filter((id) => !this.isFullySettled(id));
-        rejectBatch(
-          new Error(`Terminals not fully settled after ${timeoutMs}ms: ${pending.join(", ")}`)
-        );
-      }, timeoutMs);
-
-      const perPanel = uniqueIds.map(
-        (id) =>
-          new Promise<void>((resolve, reject) => {
-            if (this.isFullySettled(id)) {
-              resolve();
-              return;
-            }
-            registered.push({ id, resolve });
-            const waiters = this.fullySettledWaiters.get(id) || [];
-            // No per-panel timer — the shared batch timeout above governs the
-            // whole set. `timeout: 0` is never a live handle, so the
-            // `clearTimeout` calls in the notify/destroy drain paths are no-ops.
-            waiters.push({ resolve, reject, timeout: 0 });
-            this.fullySettledWaiters.set(id, waiters);
-          })
-      );
-
-      void Promise.all(perPanel).then(
-        () => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          resolveBatch();
-        },
-        (error: unknown) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          detachAll();
-          rejectBatch(error instanceof Error ? error : new Error(String(error)));
-        }
-      );
-    });
-  }
-
-  private isFullySettled(id: string): boolean {
-    const managed = this.instances.get(id);
-    if (!managed) return false;
-    if (!this.isAttachSettled(id)) return false;
-    // Restore is "settled" once it is no longer in flux — not queued
-    // ("pending") and not running ("in-progress"). "done" is a clean restore;
-    // "none" is terminal from a waiter's view in every case it occurs:
-    // restore was never scheduled (fresh terminal, no scrollback), aborted
-    // before starting (project switch — outcome no longer relevant), or failed
-    // and reset (lastScrollbackRestoreError set). The failure case still
-    // settles: a cosmetic scrollback failure must not strand the wait, and
-    // callers distinguish it via lastScrollbackRestoreError.
-    return managed.scrollbackRestoreState === "done" || managed.scrollbackRestoreState === "none";
-  }
-
-  /**
-   * Drains the fully-settled waiters for a terminal if it has reached the
-   * settled predicate. Reads the instance fresh (never closes over a captured
-   * `managed`) so a stale/replaced instance can't be acted on (#4850).
-   */
-  private notifyFullySettledWaitersIfReady(id: string): void {
-    if (!this.isFullySettled(id)) return;
-
-    const waiters = this.fullySettledWaiters.get(id);
-    if (!waiters) return;
-
-    for (const waiter of waiters) {
-      clearTimeout(waiter.timeout);
-      waiter.resolve();
-    }
-    this.fullySettledWaiters.delete(id);
+    return this.settleWaiters.waitForAllFullySettled(ids, options);
   }
 
   /**
@@ -2184,21 +1931,7 @@ class TerminalInstanceService {
    * scheduler lives in a sibling module and already calls into this singleton.
    */
   notifyRestoreSettledWaiters(id: string): void {
-    this.notifyFullySettledWaitersIfReady(id);
-  }
-
-  private removeFullySettledWaiter(id: string, resolve: () => void): void {
-    const waiters = this.fullySettledWaiters.get(id);
-    if (!waiters) return;
-
-    const index = waiters.findIndex((w) => w.resolve === resolve);
-    if (index >= 0) {
-      waiters.splice(index, 1);
-    }
-
-    if (waiters.length === 0) {
-      this.fullySettledWaiters.delete(id);
-    }
+    this.settleWaiters.notifyRestoreSettledWaiters(id);
   }
 
   private cancelAttachReveal(managed: ManagedTerminal): void {
@@ -2473,7 +2206,7 @@ class TerminalInstanceService {
 
         if (!managed.terminal.element) {
           managed.hostElement.style.opacity = "";
-          this.notifyAttachSettledWaiters(id);
+          this.settleWaiters.notifyAttachSettledWaiters(id);
           return;
         }
 
@@ -2507,7 +2240,7 @@ class TerminalInstanceService {
           if (this.instances.get(id) !== managed) return;
 
           if (earlyResizeApplied) {
-            this.notifyAttachSettledWaiters(id);
+            this.settleWaiters.notifyAttachSettledWaiters(id);
             return;
           }
 
@@ -2521,7 +2254,7 @@ class TerminalInstanceService {
               logDebug(`[TIS.attach] Skipping resize for ${id} — dimensions match after detach`);
               managed.targetCols = undefined;
               managed.targetRows = undefined;
-              this.notifyAttachSettledWaiters(id);
+              this.settleWaiters.notifyAttachSettledWaiters(id);
               return;
             }
           }
@@ -2554,12 +2287,12 @@ class TerminalInstanceService {
               this.resizeController.lockResize(id, true, remainingSuppressionMs);
             }
           }
-          this.notifyAttachSettledWaiters(id);
+          this.settleWaiters.notifyAttachSettledWaiters(id);
         });
       });
     } else {
       managed.isAttaching = false;
-      this.notifyAttachSettledWaiters(id);
+      this.settleWaiters.notifyAttachSettledWaiters(id);
     }
 
     return managed;
@@ -3765,32 +3498,7 @@ class TerminalInstanceService {
     const managed = this.instances.get(id);
     if (!managed) return;
 
-    const waiters = this.readinessWaiters.get(id);
-    if (waiters) {
-      for (const waiter of waiters) {
-        clearTimeout(waiter.timeout);
-        waiter.reject(new Error(`Terminal ${id} destroyed before frontend became ready`));
-      }
-      this.readinessWaiters.delete(id);
-    }
-
-    const attachWaiters = this.attachSettledWaiters.get(id);
-    if (attachWaiters) {
-      for (const waiter of attachWaiters) {
-        clearTimeout(waiter.timeout);
-        waiter.reject(new Error(`Terminal ${id} destroyed before attach settled`));
-      }
-      this.attachSettledWaiters.delete(id);
-    }
-
-    const fullySettledWaiters = this.fullySettledWaiters.get(id);
-    if (fullySettledWaiters) {
-      for (const waiter of fullySettledWaiters) {
-        clearTimeout(waiter.timeout);
-        waiter.reject(new Error(`Terminal ${id} destroyed before fully settled`));
-      }
-      this.fullySettledWaiters.delete(id);
-    }
+    this.settleWaiters.rejectAll(id);
 
     this.cancelAttachReveal(managed);
     this.agentStateController.destroy(id);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -156,7 +156,6 @@ class TerminalInstanceService {
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
-  private hibernationListeners = new Map<string, Set<() => void>>();
   private scrollbackRestoreListeners = new Set<() => void>();
   private cwdProviders = new Map<string, () => string>();
   private readinessWaiters = new Map<string, Waiter[]>();
@@ -555,7 +554,6 @@ class TerminalInstanceService {
     // itself suppressed for the first ~5s by the project-switch resize lock).
     if (!opts?.trustDomVisibility && !managed.isVisible) return false;
     if (managed.isAttaching) return false;
-    if (managed.isHibernated) return false;
     return this.wantsWebGLAtTier(
       managed,
       managed.lastAppliedTier ?? managed.getRefreshTier?.(),
@@ -814,7 +812,7 @@ class TerminalInstanceService {
 
   setVisible(id: string, isVisible: boolean, expectedGeneration?: number): void {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return;
+    if (!managed) return;
 
     // Guard: if a generation was provided and it doesn't match the current
     // attach generation, this is a stale cleanup from a previous mount — skip.
@@ -1089,7 +1087,6 @@ class TerminalInstanceService {
     const panelState = usePanelStore.getState();
     const panel = panelState.panelsById[id];
     const needsRealRestore =
-      managed.isHibernated ||
       managed.needsWake === true ||
       panel?.location === "background" ||
       panelState.backgroundedTerminals.has(id);
@@ -1293,7 +1290,7 @@ class TerminalInstanceService {
    */
   repaintForReveal(id: string, opts?: { trustDomVisibility?: boolean }): boolean {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return false;
+    if (!managed) return false;
     // Health-check on DOM ground truth (isConnected + checkVisibility + size),
     // NOT the reactive `managed.isVisible` flag (#10632 item 4). On a warm
     // WebContentsView resume the attach effect — the one place that force-sets
@@ -1420,7 +1417,7 @@ class TerminalInstanceService {
    */
   reconcileRevealGeometry(id: string): boolean {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return false;
+    if (!managed) return false;
     if (!this.resizeController.reconcileGeometryFresh(id)) return false;
 
     try {
@@ -1445,8 +1442,7 @@ class TerminalInstanceService {
    *
    * Splits the two states a long-dwell return can leave a terminal in:
    *
-   * - **Hibernated or unopened** — a dwell past the hibernation delay tore the
-   *   xterm instance down, and the occluded warm wake could not re-open it
+   * - **Unopened** — the occluded warm wake could not open the xterm instance
    *   (no measurable host box behind the bridge). The lightweight repaint can't
    *   help (it guards on `isOpened`), so run the full
    *   {@link fullWakeForVisibilityRestore}: now that the host has real layout it
@@ -1465,8 +1461,8 @@ class TerminalInstanceService {
     const managed = this.instances.get(id);
     // Gone — nothing to repaint and nothing to retry, so report "settled".
     if (!managed) return true;
-    if (managed.isHibernated || !managed.isOpened) {
-      // A hibernated/unopened pane needs the full open+wake, but
+    if (!managed.isOpened) {
+      // An unopened pane needs the full open+wake, but
       // fullWakeForVisibilityRestore only opens once the host has a real layout
       // box. While the foreground view is still settling that box can read zero
       // (or the host is visibility:hidden), so report "not paintable yet" and
@@ -1484,7 +1480,6 @@ class TerminalInstanceService {
       return (
         !after ||
         (after.isOpened === true &&
-          after.isHibernated !== true &&
           after.isAttaching !== true &&
           after.pendingVisibilityWake !== true)
       );
@@ -1509,7 +1504,7 @@ class TerminalInstanceService {
    */
   injectDataLossMarker(id: string, droppedBytes: number): void {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return;
+    if (!managed) return;
     managed.terminal.write(`\x18\x1b]57301;${droppedBytes};backpressure\x07`);
   }
 
@@ -1517,13 +1512,13 @@ class TerminalInstanceService {
    * Draw the user-visible yellow data-loss marker. Deferred via
    * `queueMicrotask` because it is reached from inside the OSC 57301 parse
    * callback — calling `terminal.write` synchronously during parsing would be
-   * reentrant. Re-checks instance state because hibernation can occur between
-   * the OSC write and this microtask.
+   * reentrant. Re-checks instance state because the terminal can be destroyed
+   * between the OSC write and this microtask.
    */
   private drawDataLossMarker(id: string, droppedBytes: number): void {
     queueMicrotask(() => {
       const managed = this.instances.get(id);
-      if (!managed || managed.isHibernated) return;
+      if (!managed) return;
       const label = droppedBytes > 0 ? `~${droppedBytes} bytes` : "output";
       managed.terminal.write(`\r\n\x1b[33m⚠ Output dropped (${label})\x1b[0m\r\n`);
     });
@@ -1613,7 +1608,7 @@ class TerminalInstanceService {
     if (options) {
       this.updateOptions(managed.id, options);
     }
-    if (launchAgentId !== undefined && !managed.isHibernated) {
+    if (launchAgentId !== undefined) {
       managed.terminal.options.cursorBlink = false;
     }
   }
@@ -1711,7 +1706,7 @@ class TerminalInstanceService {
         return;
       }
       const current = this.instances.get(id);
-      if (current && !current.isHibernated) {
+      if (current) {
         current.terminal.write(`\r\n\x1b[90m[Process exited with code ${exitCode}]\x1b[0m\r\n`);
       }
       exitSubscribers.forEach((cb) => cb(exitCode));
@@ -1939,7 +1934,7 @@ class TerminalInstanceService {
 
   private isAttachSettled(id: string): boolean {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return false;
+    if (!managed) return false;
     return (
       managed.isOpened &&
       managed.isAttaching !== true &&
@@ -2151,7 +2146,7 @@ class TerminalInstanceService {
 
   private isFullySettled(id: string): boolean {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return false;
+    if (!managed) return false;
     if (!this.isAttachSettled(id)) return false;
     // Restore is "settled" once it is no longer in flux — not queued
     // ("pending") and not running ("in-progress"). "done" is a clean restore;
@@ -2576,7 +2571,7 @@ class TerminalInstanceService {
 
   detach(id: string, container: HTMLElement | null): void {
     const managed = this.instances.get(id);
-    if (!managed || !container || managed.isHibernated) {
+    if (!managed || !container) {
       logDebug(`[TIS.detach] Skipping ${id} - no managed:${!managed}, no container:${!container}`);
       return;
     }
@@ -2723,7 +2718,6 @@ class TerminalInstanceService {
     const widthRatio = width / session.basis.width;
     const heightRatio = height / session.basis.height;
     for (const [id, managed] of this.instances) {
-      if (managed.isHibernated) continue;
       if (!managed.isOpened) continue;
       let origin = session.origin.get(id);
       if (!origin) {
@@ -2906,7 +2900,7 @@ class TerminalInstanceService {
 
   scrollToBottom(id: string): void {
     const managed = this.instances.get(id);
-    if (managed && !managed.isHibernated) {
+    if (managed) {
       this.scrollToBottomSafe(managed);
     }
   }
@@ -2924,7 +2918,7 @@ class TerminalInstanceService {
 
   scrollToLastActivity(id: string): void {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return;
+    if (!managed) return;
 
     if (managed.isAltBuffer) {
       managed.terminal.scrollToBottom();
@@ -2950,26 +2944,13 @@ class TerminalInstanceService {
     return this.unseenTracker.subscribe(id, listener);
   }
 
-  // Hibernation no longer occurs (terminals stay fully live in the background),
-  // so `isHibernated` is permanently false and these listeners never fire. The
-  // subscription is retained so `useIsHibernated` keeps a stable
-  // useSyncExternalStore contract while reading the always-false snapshot.
-  subscribeHibernation(id: string, listener: () => void): () => void {
-    let listeners = this.hibernationListeners.get(id);
-    if (!listeners) {
-      listeners = new Set();
-      this.hibernationListeners.set(id, listeners);
-    }
-    listeners.add(listener);
-
-    return () => {
-      const current = this.hibernationListeners.get(id);
-      if (!current) return;
-      current.delete(listener);
-      if (current.size === 0) {
-        this.hibernationListeners.delete(id);
-      }
-    };
+  // Hibernation no longer occurs (terminals stay fully live in the
+  // background). Retained as a no-op so `useIsHibernated` and other direct
+  // callers (e.g. useAccessibilityAnnouncements) keep a stable
+  // useSyncExternalStore contract against the always-false `isHibernated`
+  // snapshot below — the listener is never notified.
+  subscribeHibernation(_id: string, _listener: () => void): () => void {
+    return () => {};
   }
 
   /**
@@ -3210,7 +3191,7 @@ class TerminalInstanceService {
 
   captureBufferText(id: string, maxChars: number = 20000): string {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return "";
+    if (!managed) return "";
 
     const buf = managed.terminal.buffer.active;
     if (buf.length === 0) return "";
@@ -3280,7 +3261,7 @@ class TerminalInstanceService {
     // one context on the pane the user is reading. Focus is tracked here
     // (not in onTierApplied) because same-tier focus moves dedup away the
     // tier application.
-    if (isFocused && !managed.isHibernated) {
+    if (isFocused) {
       this.webGLManager.pinFocus(id, managed);
     }
   }
@@ -3291,7 +3272,7 @@ class TerminalInstanceService {
 
   focus(id: string): void {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return;
+    if (!managed) return;
 
     const terminal = managed.terminal;
     const buffer = terminal.buffer.active;
@@ -3373,7 +3354,7 @@ class TerminalInstanceService {
 
   resetRenderer(id: string): boolean {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return false;
+    if (!managed) return false;
 
     try {
       if (!managed.hostElement.isConnected) {
@@ -3435,7 +3416,6 @@ class TerminalInstanceService {
 
   handleBackendRecovery(): void {
     this.instances.forEach((managed, id) => {
-      if (managed.isHibernated) return;
       try {
         managed.terminal.write("\x1b[!p");
 
@@ -3460,30 +3440,23 @@ class TerminalInstanceService {
     const textMetricKeys = ["fontSize", "fontFamily", "lineHeight", "letterSpacing", "fontWeight"];
     const textMetricsChanged = textMetricKeys.some((key) => key in options);
 
-    if (!managed.isHibernated) {
-      Object.entries(options).forEach(([key, value]) => {
-        // @ts-expect-error xterm options are indexable
-        managed.terminal.options[key] = value;
-      });
-      // Theme/font/etc. updates flow through `BASE_TERMINAL_OPTIONS` which
-      // unconditionally sets cursorBlink:true — re-clamp through the policy
-      // helper so a BACKGROUND/VISIBLE plain terminal doesn't silently start
-      // its blink timer again on a font or theme change.
-      this.applyCursorBlinkPolicy(managed);
-    }
+    Object.entries(options).forEach(([key, value]) => {
+      // @ts-expect-error xterm options are indexable
+      managed.terminal.options[key] = value;
+    });
+    // Theme/font/etc. updates flow through `BASE_TERMINAL_OPTIONS` which
+    // unconditionally sets cursorBlink:true — re-clamp through the policy
+    // helper so a BACKGROUND/VISIBLE plain terminal doesn't silently start
+    // its blink timer again on a font or theme change.
+    this.applyCursorBlinkPolicy(managed);
 
     if (textMetricsChanged) {
       managed.lastWidth = 0;
       managed.lastHeight = 0;
+      this.resizeController.fit(id);
     }
-
-    if (!managed.isHibernated) {
-      if (textMetricsChanged) {
-        this.resizeController.fit(id);
-      }
-      if ("theme" in options) {
-        managed.terminal.refresh(0, managed.terminal.rows - 1);
-      }
+    if ("theme" in options) {
+      managed.terminal.refresh(0, managed.terminal.rows - 1);
     }
   }
 
@@ -3492,29 +3465,22 @@ class TerminalInstanceService {
     const textMetricsChanged = textMetricKeys.some((key) => key in options);
 
     this.instances.forEach((managed, id) => {
-      if (!managed.isHibernated) {
-        Object.entries(options).forEach(([key, value]) => {
-          // @ts-expect-error xterm options are indexable
-          managed.terminal.options[key] = value;
-        });
-        // Same rationale as updateOptions: re-clamp cursorBlink so a global
-        // theme/font change doesn't silently re-enable the blink timer on
-        // backgrounded plain terminals.
-        this.applyCursorBlinkPolicy(managed);
-      }
+      Object.entries(options).forEach(([key, value]) => {
+        // @ts-expect-error xterm options are indexable
+        managed.terminal.options[key] = value;
+      });
+      // Same rationale as updateOptions: re-clamp cursorBlink so a global
+      // theme/font change doesn't silently re-enable the blink timer on
+      // backgrounded plain terminals.
+      this.applyCursorBlinkPolicy(managed);
 
       if (textMetricsChanged) {
         managed.lastWidth = 0;
         managed.lastHeight = 0;
+        this.resizeController.fit(id);
       }
-
-      if (!managed.isHibernated) {
-        if (textMetricsChanged) {
-          this.resizeController.fit(id);
-        }
-        if ("theme" in options) {
-          managed.terminal.refresh(0, managed.terminal.rows - 1);
-        }
+      if ("theme" in options) {
+        managed.terminal.refresh(0, managed.terminal.rows - 1);
       }
     });
   }
@@ -3533,7 +3499,6 @@ class TerminalInstanceService {
    */
   repairFontGrid(): void {
     this.instances.forEach((managed, id) => {
-      if (managed.isHibernated) return;
       try {
         const current = managed.terminal.options.fontFamily ?? DEFAULT_TERMINAL_FONT_FAMILY;
         // A trailing space parses identically in CSS (no visible flicker) but is
@@ -3638,7 +3603,6 @@ class TerminalInstanceService {
   // reduced and is restored by the tier-upgrade path.
   restoreScrollbackAllForeground(): void {
     for (const managed of this.instances.values()) {
-      if (managed.isHibernated) continue;
       const tier = managed.lastAppliedTier ?? managed.getRefreshTier?.();
       if (tier === TerminalRefreshTier.BACKGROUND) continue;
       restoreScrollback(managed);
@@ -3652,8 +3616,10 @@ class TerminalInstanceService {
     return () => managed.exitSubscribers.delete(cb);
   }
 
-  isHibernated(id: string): boolean {
-    return this.instances.get(id)?.isHibernated === true;
+  // Hibernation no longer occurs (terminals stay fully live in the
+  // background) — always false. See subscribeHibernation above.
+  isHibernated(_id: string): boolean {
+    return false;
   }
 
   // Whether this terminal currently holds a live WebGL context (vs the DOM
@@ -3678,10 +3644,6 @@ class TerminalInstanceService {
   ): void {
     if (!isPaintFabricWorkerIngestEnabled()) return;
     if (tier === TerminalRefreshTier.BACKGROUND) {
-      // Hibernated terminals drop output entirely; an alt-buffer TUI repaints
-      // its whole viewport constantly, and snapshot cadence handles that fine —
-      // no exclusion needed beyond hibernation.
-      if (managed.isHibernated) return;
       let ingest = this.workerIngest.get(id);
       if (!ingest) {
         ingest = this.createWorkerIngest(id, managed);
@@ -3712,7 +3674,7 @@ class TerminalInstanceService {
       mirror: {
         write: (data, callback) => {
           const current = this.instances.get(id);
-          if (!current || current.isHibernated) {
+          if (!current) {
             callback?.();
             return;
           }
@@ -3869,7 +3831,6 @@ class TerminalInstanceService {
     terminalClient.discardPortAcks(id);
     this.dataBuffer.resetForTerminal(id);
     this.unseenTracker.destroy(id);
-    this.hibernationListeners.delete(id);
 
     if (managed.tierChangeTimer !== undefined) {
       clearTimeout(managed.tierChangeTimer);
@@ -3915,38 +3876,35 @@ class TerminalInstanceService {
     managed.agentStateSubscribers.clear();
     managed.altBufferListeners.clear();
 
-    if (!managed.isHibernated) {
-      managed.parserHandler?.dispose();
+    managed.parserHandler?.dispose();
 
-      try {
-        managed.fileLinksDisposable?.dispose();
-      } catch (error) {
-        logWarn("Error disposing file links", { error });
-      }
-      try {
-        managed.imageLinksDisposable?.dispose();
-      } catch (error) {
-        logWarn("Error disposing image links", { error });
-      }
-      try {
-        managed.webLinksAddon?.dispose();
-      } catch (error) {
-        logWarn("Error disposing web links addon", { error });
-      }
-      try {
-        managed.imageAddon?.dispose();
-      } catch (error) {
-        logWarn("Error disposing image addon", { error });
-      }
-
-      this.webGLManager.onTerminalDestroyed(id);
-      managed.terminal.dispose();
+    try {
+      managed.fileLinksDisposable?.dispose();
+    } catch (error) {
+      logWarn("Error disposing file links", { error });
+    }
+    try {
+      managed.imageLinksDisposable?.dispose();
+    } catch (error) {
+      logWarn("Error disposing image links", { error });
+    }
+    try {
+      managed.webLinksAddon?.dispose();
+    } catch (error) {
+      logWarn("Error disposing web links addon", { error });
+    }
+    try {
+      managed.imageAddon?.dispose();
+    } catch (error) {
+      logWarn("Error disposing image addon", { error });
     }
 
-    // Detach the host element regardless of hibernation state: a hibernated
-    // terminal's host may have been parked in the shared offscreen container
-    // by detach()/detachForProjectSwitch() (raw child, not a registered slot),
-    // and the gated branch above doesn't reach it (#9909).
+    this.webGLManager.onTerminalDestroyed(id);
+    managed.terminal.dispose();
+
+    // The host may have been parked in the shared offscreen container by
+    // detach()/detachForProjectSwitch() (raw child, not a registered slot) —
+    // detach it regardless of the dispose path above (#9909).
     if (managed.hostElement.parentElement) {
       managed.hostElement.parentElement.removeChild(managed.hostElement);
     }
@@ -3999,9 +3957,7 @@ class TerminalInstanceService {
     if (!managed) return;
 
     managed.isInputLocked = locked;
-    if (!managed.isHibernated) {
-      managed.terminal.options.disableStdin = locked;
-    }
+    managed.terminal.options.disableStdin = locked;
   }
 }
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -27,6 +27,7 @@ import { TerminalResizeController, hasStreamingWrites } from "./TerminalResizeCo
 import { TerminalRendererPolicy } from "./TerminalRendererPolicy";
 import { TerminalWebGLManager } from "./TerminalWebGLManager";
 import { TerminalWebGLPolicy } from "./TerminalWebGLPolicy";
+import { TerminalRevealController } from "./TerminalRevealController";
 import { TerminalAgentStateController } from "./TerminalAgentStateController";
 import { TerminalRestoreController } from "./TerminalRestoreController";
 import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
@@ -67,18 +68,6 @@ export { isNonKeyboardInput } from "./inputUtils";
 // Re-exported so existing consumers (notably tests) that import
 // `forceXtermReflow` from this module don't need to update their imports.
 export { forceXtermReflow };
-
-// Debounce on the visibility-driven WebGL restore path. Show waits this long
-// before re-acquiring so rapid tab/panel toggles don't thrash WebglAddon
-// load/unload (each cycle reallocates GPU resources).
-const WEBGL_RESTORE_DEBOUNCE_MS = 100;
-
-// Release hysteresis on the visibility-driven hide path. Holding the context
-// for this long before releasing covers normal panel-toggle and focus-cycle
-// cadences (~100–300ms) without over-occupying the 12-slot WebGL pool under
-// multi-terminal hide. Authoritative release paths (tier demotion, agent
-// demotion, destroy, hibernation) cancel this timer and release immediately.
-const WEBGL_HIDE_DWELL_MS = 500;
 
 function canAutoInitializeTerminalIngest(): boolean {
   return (
@@ -125,6 +114,7 @@ class TerminalInstanceService {
   private burstController: TerminalBurstController;
   private resizePassScheduler: TerminalResizePassScheduler;
   private workerIngestController: TerminalWorkerIngestController;
+  private revealController: TerminalRevealController;
   private unsubTierChanged: (() => void) | null = null;
 
   constructor() {
@@ -269,6 +259,30 @@ class TerminalInstanceService {
 
         this.workerIngestController.applyWorkerIngestPolicy(id, tier, managed);
       },
+    });
+
+    this.revealController = new TerminalRevealController({
+      getInstance: (id) => this.instances.get(id),
+      hostHasRenderableDims: (managed) => this.hostHasRenderableDims(managed),
+      ensureOpened: (id, managed) => this.ensureOpened(id, managed),
+      handlePostWake: (id) => this.handlePostWake(id),
+      deferGridChangeForStream: (managed, gridWouldChange) =>
+        this.deferGridChangeForStream(managed, gridWouldChange),
+      applyRendererPolicy: (id, tier) => this.rendererPolicy.applyRendererPolicy(id, tier),
+      applyDeferredResize: (id) => this.resizeController.applyDeferredResize(id),
+      lockResize: (id, locked, customTtlMs) =>
+        customTtlMs === undefined
+          ? this.resizeController.lockResize(id, locked)
+          : this.resizeController.lockResize(id, locked, customTtlMs),
+      reconcileGeometryFresh: (id) => this.resizeController.reconcileGeometryFresh(id),
+      resumeFlush: (id) => this.dataBuffer.resumeFlush(id),
+      checkStaleDirecting: (id) => this.agentStateController.checkStaleDirecting(id),
+      shouldRestoreWebGL: (managed, opts) => this.webGLPolicy.shouldRestoreWebGL(managed, opts),
+      isWebGLActive: (id) => this.webGLManager.isActive(id),
+      ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
+      releaseWebGL: (id) => this.webGLManager.releaseContext(id),
+      repairAtlasForReactivation: (id) => this.webGLManager.repairAtlasForReactivation(id),
+      cancelWebGLHideTimer: (managed) => this.cancelWebGLHideTimer(managed),
     });
 
     // Constructed last — its deps reach every other controller. The watchdog
@@ -585,120 +599,7 @@ class TerminalInstanceService {
   }
 
   setVisible(id: string, isVisible: boolean, expectedGeneration?: number): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-
-    // Guard: if a generation was provided and it doesn't match the current
-    // attach generation, this is a stale cleanup from a previous mount — skip.
-    if (expectedGeneration !== undefined && managed.attachGeneration !== expectedGeneration) {
-      return;
-    }
-
-    // Cold-mount observer flaps are not authoritative. XtermAdapter forces
-    // visibility true immediately after attach() so the terminal can paint
-    // before IntersectionObserver settles. During recipe/bulk-open insertion
-    // the grid may briefly report "not intersecting"; persisting that false
-    // value would strand renderer recovery behind visibility guards. Real
-    // unmounts go through detach(), which marks the instance invisible.
-    if (!isVisible && managed.isAttaching) {
-      if (managed.webGLRestoreTimer !== undefined) {
-        clearTimeout(managed.webGLRestoreTimer);
-        managed.webGLRestoreTimer = undefined;
-      }
-      this.cancelWebGLHideTimer(managed);
-      return;
-    }
-
-    const wasVisible = managed.isVisible;
-    if (wasVisible !== isVisible) {
-      managed.isVisible = isVisible;
-      managed.lastActiveTime = Date.now();
-
-      if (managed.webGLRestoreTimer !== undefined) {
-        clearTimeout(managed.webGLRestoreTimer);
-        managed.webGLRestoreTimer = undefined;
-      }
-      this.cancelWebGLHideTimer(managed);
-
-      if (isVisible) {
-        if (managed.isAttaching) {
-          return;
-        }
-
-        // Reconcile xterm's grid with dimensions captured while background
-        // before the renderer policy runs its refresh. The bulk-output
-        // garbling in #7741 manifests when xterm.cols/rows still reflect the
-        // previous active geometry but the PTY (and incoming output) have
-        // already advanced — refreshing into the old grid paints stale glyphs.
-        // Order matters: must precede the lastWidth/lastHeight rect update so
-        // that if cellDims were unavailable during background and latestCols/
-        // latestRows are stale, the rect-update doesn't dedup-poison the next
-        // ResizeObserver tick.
-        this.resizeController.applyDeferredResize(id);
-
-        const rect = managed.hostElement.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) {
-          const widthChanged = Math.abs(managed.lastWidth - rect.width) >= 1;
-          const heightChanged = Math.abs(managed.lastHeight - rect.height) >= 1;
-
-          if (widthChanged || heightChanged) {
-            managed.lastWidth = rect.width;
-            managed.lastHeight = rect.height;
-          }
-        }
-
-        const tier = managed.getRefreshTier
-          ? managed.getRefreshTier()
-          : TerminalRefreshTier.VISIBLE;
-        this.rendererPolicy.applyRendererPolicy(id, tier);
-
-        const termEl = managed.terminal.element;
-        if (termEl && managed.terminal.modes?.synchronizedOutputMode !== true) {
-          forceXtermReflow(termEl);
-        } else if (termEl) {
-          // Defer the unpause reflow while a DEC 2026 synchronized-output block is
-          // open (#10632). forceXtermReflow bypasses xterm's atomic-at-ESU
-          // buffering and would interleave a torn frame — the invariant
-          // TerminalReflowController.maybeReflow enforces at :139. This path IS
-          // reachable on switch-back: the grid IntersectionObserver
-          // (TerminalPane) fires setVisible(id, true) as the pane re-enters the
-          // viewport while an agent is mid-stream. applyDeferredResize above
-          // already synced geometry and applyRendererPolicy still ran; hand the
-          // unpause/repaint to the watchdog's reveal-pending backstop, which
-          // re-runs it once the block closes and the pane is on-screen.
-          managed.revealPendingRepair = true;
-          managed.revealPendingGeneration = managed.attachGeneration;
-        }
-
-        // Debounced WebGL restore for same-tier transitions. If
-        // applyRendererPolicy above triggers a tier upgrade (e.g.
-        // BACKGROUND→VISIBLE), onTierApplied loads the addon immediately
-        // and this timer becomes a (harmless) idempotent re-apply. The
-        // debounce only meaningfully gates rapid hide→show toggles where
-        // the tier doesn't change, since same-tier applyRendererPolicy
-        // is a no-op.
-        managed.webGLRestoreTimer = window.setTimeout(() => {
-          const current = this.instances.get(id);
-          if (!current) return;
-          current.webGLRestoreTimer = undefined;
-          if (!this.webGLPolicy.shouldRestoreWebGL(current)) return;
-          this.webGLManager.ensureContext(id, current);
-        }, WEBGL_RESTORE_DEBOUNCE_MS);
-      } else {
-        // Going offscreen. Hold the WebGL context for WEBGL_HIDE_DWELL_MS so
-        // rapid hide→show cycles (panel toggles, focus oscillation) don't
-        // churn the pool. The timer callback re-fetches `managed` to avoid
-        // stale refs (same pattern as webGLRestoreTimer above) and re-checks
-        // isVisible so a show during the dwell window keeps the context.
-        managed.webGLHideTimer = window.setTimeout(() => {
-          const current = this.instances.get(id);
-          if (!current) return;
-          current.webGLHideTimer = undefined;
-          if (current.isVisible) return;
-          this.webGLManager.releaseContext(id);
-        }, WEBGL_HIDE_DWELL_MS);
-      }
-    }
+    this.revealController.setVisible(id, isVisible, expectedGeneration);
   }
 
   lockResize(id: string, locked: boolean, customTtlMs?: number): void {
@@ -829,440 +730,27 @@ class TerminalInstanceService {
   }
 
   wake(id: string): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-    // A click/focus/reveal of a live pane is a PLAIN REPAINT. The pane stayed
-    // fully live in the background (no suspend/resync anymore), so
-    // repaintForReveal (WebGL reacquire + atlas/refresh + geometry re-fit) is
-    // sufficient and safe. A not-yet-opened pane (a parked dock tab on first
-    // reveal) takes the visibility-restore path, which opens it then repaints.
-    if (!managed.isOpened) {
-      void this.fullWakeForVisibilityRestore(id);
-      return;
-    }
-    this.repaintForReveal(id);
+    this.revealController.wake(id);
   }
 
-  /**
-   * Focus/click-driven wake. The wake-on-focus safety net (51ba86d8d) heals a
-   * frozen/garbled pane on click. `wake()` is now a plain repaint (WebGL
-   * reacquire + atlas/refresh + geometry re-fit), so it is safe for a
-   * main-buffer pane. For a LIVE, foreground alt-screen TUI (OpenCode, any agent
-   * with blockAltScreen disabled) even a geometry reconcile can reflow the
-   * absolutely-positioned frame, so a co-visible alt-screen pane fed by the live
-   * PTY stream is already current and is left untouched. A genuinely off-screen
-   * pane (backgrounded, parked dock tab) still takes the repaint reveal owned by
-   * the visibility path.
-   */
   wakeForFocus(id: string): void {
-    const managed = this.instances.get(id);
-    if (!managed) return;
-
-    const panelState = usePanelStore.getState();
-    const panel = panelState.panelsById[id];
-    const needsRealRestore =
-      managed.needsWake === true ||
-      panel?.location === "background" ||
-      panelState.backgroundedTerminals.has(id);
-
-    if (needsRealRestore || managed.isAltBuffer !== true) {
-      this.wake(id);
-      return;
-    }
-    // Live foreground alt-screen TUI: already current from the live PTY stream.
-    // No geometry reconcile (reflows the frame). The reflow controller's
-    // focus/heartbeat recovery and the reconciliation watchdog handle any
-    // genuine renderer staleness.
+    this.revealController.wakeForFocus(id);
   }
 
-  /**
-   * Run the full reveal repaint on a visible terminal whose project view just
-   * regained visibility (#8562). Hibernation removed: there is no lossy
-   * wake/resync on this path — the pane stays fully live in the background so
-   * its buffer is already current. This method runs `applyDeferredResize`,
-   * `forceXtermReflow`,
-   * `repairAtlasForReactivation`, `xterm.refresh`, `handlePostWake`, and
-   * `dataBuffer.resumeFlush` (open + geometry + repaint, no reset+replay).
-   * Without the full sequence, visible terminals show stale geometry until the
-   * user clicks each pane.
-   *
-   * Bypasses {@link TerminalRendererPolicy.applyRendererPolicy} — that path
-   * early-returns on tier equality and a backgrounded view's terminals stay
-   * at VISIBLE the whole time. Bypasses the resize lock the same way the
-   * attach path does (record remaining suppression TTL, unlock, resize,
-   * relock with remaining TTL) so geometry resync doesn't silently no-op
-   * while project-switch suppression is active.
-   */
-  async fullWakeForVisibilityRestore(id: string): Promise<void> {
-    const current = this.instances.get(id);
-    if (!current) return;
-    if (!current.isOpened) {
-      // A not-yet-opened pane (a parked dock tab, or one whose host had no
-      // measurable layout box at attach time — e.g. behind the warm anti-flash
-      // bridge #9679) deferred its open to "attach() on next mount". But the
-      // React tree is never remounted on a warm project-view return, so attach()
-      // never re-fires and nothing re-opens it — leaving the terminal stuck
-      // blank/wonky until the user clicks it.
-      //
-      // This same method is re-run from the foreground reveal pass
-      // (repaintActiveWorktreeTerminals on `app:view-revealed`, via
-      // revealTerminal). By then the view is foreground-presented and the host
-      // has a real layout box, so finish the open here using attach()'s exact
-      // sequence. While still occluded (zero box) we leave it deferred — the
-      // reveal pass retries once layout is valid.
-      if (this.hostHasRenderableDims(current)) {
-        this.ensureOpened(id, current);
-      }
-      if (!current.isOpened) return;
-    }
-
-    // Set the deferred-wake flag before the geometry sync so an unexpected
-    // throw from applyDeferredResize (e.g. a terminal disposed between the
-    // lookup above and here) can't strand it: while attaching the async wake
-    // must re-run once attach settles, so the flag has to survive a throw. On
-    // the proceed path we clear it again below.
-    current.pendingVisibilityWake = current.isAttaching === true;
-
-    // Geometry sync runs synchronously even while attaching (#10070).
-    // applyDeferredResize only calls terminal.resize() — no buffer reset, no
-    // async — so it is safe mid-attach and corrects the grid before the warm
-    // paint gate releases the bridge view. Without this, an attaching terminal
-    // stays at the default 80x24 until the deferred wake re-runs after the
-    // bridge has already dropped, producing the visible render-small-then-snap.
-    //
-    // EXCEPT for a STREAMING main-buffer pane whose grid would actually change
-    // (#10863's missing half): terminal.resize() re-wraps committed scrollback
-    // while an Ink-style CLI is still repainting its sticky region with
-    // cursor-relative erase math sized for the old grid — the wake-path twin of
-    // the reveal-path re-wrap reconcileGeometryFresh already defers. The
-    // assistant's cold-resume boot is the canonical victim: this sweep fires on
-    // the same switch-back that just spawned it, mid-splash. Defer the geometry
-    // sync to the reconciliation watchdog (the same revealPendingRepair
-    // obligation the sync-block defer below uses); its reveal-pending branch
-    // runs the fresh atomic reconcile once the stream quiesces. A no-change
-    // pass falls through — applyDeferredResize's cache==current early-return
-    // makes it free, and skipping it would strand the #10070 correction.
-    const gridWouldChange =
-      Number.isInteger(current.latestCols) &&
-      Number.isInteger(current.latestRows) &&
-      (current.terminal.cols !== current.latestCols ||
-        current.terminal.rows !== current.latestRows);
-    if (this.deferGridChangeForStream(current, gridWouldChange)) {
-      // Deferred to the watchdog — nothing to do here.
-    } else {
-      // Unlock symmetrically with the relock in the finally below: bypass the
-      // lock whenever resize is suppressed, even if the suppression end time was
-      // already cleared (the timer can fire between switch-back and this deferred
-      // wake). Without the unlock, applyDeferredResize would no-op under the lock
-      // and geometry would stay stale.
-      const needsLockBypass = current.isResizeSuppressed === true;
-      let remainingMs = 0;
-      if (needsLockBypass) {
-        remainingMs = current.resizeSuppressionEndTime
-          ? Math.max(0, current.resizeSuppressionEndTime - Date.now())
-          : 0;
-        this.resizeController.lockResize(id, false);
-      }
-      try {
-        this.resizeController.applyDeferredResize(id);
-      } finally {
-        if (needsLockBypass) {
-          this.resizeController.lockResize(id, true, remainingMs);
-        }
-      }
-    }
-
-    // Attach is in progress — running the async wake now would race the
-    // attach's own post-rAF reconciliation, which calls terminal.reset()
-    // during buffer restore. The geometry sync above is safe to keep, but the
-    // async wake must defer: pendingVisibilityWake was already set true above
-    // so notifyAttachSettledWaiters re-runs this wake once attach settles
-    // (#9702).
-    if (current.isAttaching) {
-      return;
-    }
-
-    // We're proceeding with the full wake now, so clear any stale deferred-wake
-    // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
-    current.pendingVisibilityWake = false;
-
-    // Never interleave the RENDER ops (forceXtermReflow, repairAtlasForReactivation,
-    // the post-wake refresh) into an OPEN DEC 2026 synchronized-output block
-    // (#10632). forceXtermReflow bypasses xterm's atomic-at-ESU buffering and
-    // would paint a partial frame — the exact invariant TerminalReflowController
-    // enforces at maybeReflow. The DATA path stays unconditional: applyDeferredResize
-    // (above), handlePostWake (its only reflow routes through the guarded
-    // maybeReflowTerminal), and the held-byte flush all still run.
-    //
-    // This method has no retry-return like repaintForReveal, so when paint is
-    // deferred hand the obligation to the reconciliation watchdog via
-    // revealPendingRepair: its reveal-pending branch re-runs the atomic repair
-    // (geometry + atlas + unpause) once the block closes and the pane is on-screen.
-    const deferPaintForSync = current.terminal.modes?.synchronizedOutputMode === true;
-
-    const termEl = current.terminal.element;
-    if (termEl && !deferPaintForSync) {
-      try {
-        forceXtermReflow(termEl);
-      } catch (error) {
-        logWarn(`forceXtermReflow failed for ${id}`, { error });
-      }
-    }
-
-    // Repair the stale local WebGL glyph model synchronously, before the view's
-    // first composited frame. On warm project-view reactivation the compositor
-    // can flash the pre-freeze atlas state; resetting the local model here (no
-    // breaker, no shared-atlas churn) clears it in place. No-op for DOM-renderer
-    // terminals. Deferred mid-block.
-    if (!deferPaintForSync) {
-      this.webGLManager.repairAtlasForReactivation(id);
-    }
-
-    // Hibernation removed: a visibility restore is a PLAIN REPAINT. The pane
-    // stayed fully live in the background, so its buffer is already current —
-    // geometry was re-fit (applyDeferredResize above) and the atlas/reflow
-    // repaired; here we repaint the live buffer, run the post-wake reflow/unpause
-    // (handlePostWake — never reset+replays; a no-op for alt-screen), and flush
-    // any straggler bytes.
-    if (!deferPaintForSync) {
-      current.terminal.refresh(0, current.terminal.rows - 1);
-    }
-    this.handlePostWake(id);
-    this.dataBuffer.resumeFlush(id);
-
-    // Paint was deferred to avoid interleaving an open synchronized-output block.
-    // The watchdog's reveal-pending branch re-runs the full atomic repair once
-    // the block closes and the pane is on-screen — the durable backstop this
-    // retry-less method otherwise lacks.
-    if (deferPaintForSync) {
-      current.revealPendingRepair = true;
-      current.revealPendingGeneration = current.attachGeneration;
-    }
+  fullWakeForVisibilityRestore(id: string): Promise<void> {
+    return this.revealController.fullWakeForVisibilityRestore(id);
   }
 
-  /**
-   * Post-reveal repaint for a visible terminal whose project view has just been
-   * detached from the warm anti-flash bridge and focused as the foreground
-   * surface (#10362).
-   *
-   * `fullWakeForVisibilityRestore` runs the redraw on visibilitychange/resume —
-   * while the cached view is still occluded BEHIND the bridge (#9679). Chromium
-   * culls paints for a non-foreground WebContentsView, so that repair can fail
-   * to stick and agent terminals stay garbled until the user clicks each pane.
-   * This re-runs the render repair once the compositor will actually present
-   * the frame, driven by the `app:view-revealed` signal.
-   *
-   * Self-heals both failure modes a manual click fixes: a WebGL context the
-   * freeze/thaw cycle dropped (VRAM reclaim) is re-attached, then the stale
-   * local glyph model is repaired (or a DOM-renderer pane plain-refreshed) and
-   * the grid re-fit. Unlike a click it does NOT call `terminal.focus()` —
-   * focusing every pane would steal DOM focus and emit focus-reporting
-   * sequences into every agent; exactly one pane owns focus, this is a
-   * fleet-wide repaint. The byte-pull is intentionally skipped: the headless
-   * mirror sync already ran behind the bridge (IPC data is not culled like a
-   * paint is), so only the repaint needs replaying.
-   */
   repaintForReveal(id: string, opts?: { trustDomVisibility?: boolean }): boolean {
-    const managed = this.instances.get(id);
-    if (!managed) return false;
-    // Health-check on DOM ground truth (isConnected + checkVisibility + size),
-    // NOT the reactive `managed.isVisible` flag (#10632 item 4). On a warm
-    // WebContentsView resume the attach effect — the one place that force-sets
-    // isVisible=true (XtermAdapter) — does not re-run, and the
-    // IntersectionObserver that would flip it can lag a frame or be culled while
-    // the view un-occludes, so a stale isVisible=false would no-op the exact
-    // repaint the reveal needs. resetRenderer (manual Redraw) already keys off
-    // connected+size for this reason; unify on the same DOM-truth signal here.
-    // The element.isConnected + checkVisibility + >=50px box guards below are the
-    // real preconditions.
-    if (!managed.isOpened) return false;
-
-    const element = managed.terminal.element;
-    if (!element || !element.isConnected) return false;
-
-    // A not-yet-laid-out, content-visibility:hidden, or zero/occluded host has no
-    // model worth repainting — its first real resize builds it fresh. Use the
-    // same hostHasRenderableDims gate (isConnected + checkVisibility + box) that
-    // ensureOpened/fit rely on, then refine with resetRenderer's >=50px floor.
-    // Report "not paintable yet" (false) so the reveal sweep retries on a later
-    // frame once the foreground view has settled its layout, rather than burning
-    // its one shot against a zero box.
-    if (!this.hostHasRenderableDims(managed)) return false;
-    if (managed.hostElement.clientWidth < 50 || managed.hostElement.clientHeight < 50) {
-      return false;
-    }
-
-    // Never repaint into an OPEN DEC 2026 synchronized-output block (#10632). The
-    // atlas repair, forceXtermReflow, and reconcileGeometryFresh below would each
-    // interleave a paint with the buffered range and corrupt a live agent frame.
-    // The watchdog repair path already defers on this; the reveal path must too —
-    // dropping the !isVisible guard above made repaintForReveal more reachable, so
-    // the never-interleave-mid-block guarantee has to hold here as well. Report
-    // "not paintable yet" so the reveal sweep retries on a later frame once the
-    // block closes; the reconciliation watchdog is the backstop if it outlasts
-    // the sweep.
-    if (managed.terminal.modes?.synchronizedOutputMode === true) return false;
-
-    // Re-attach a WebGL context the freeze/thaw cycle may have dropped before
-    // repairing the local model. The warm view-reveal caller (revealTerminal)
-    // passes trustDomVisibility so a stale reactive isVisible=false on warm
-    // WebContentsView resume doesn't skip the reattach and strand non-focused
-    // agent panes on the DOM renderer. Assistant show/hide-transition callers
-    // pass nothing, so they keep the isVisible gate — a transform-hidden pane
-    // must not accumulate a fleet-wide WebGL want (#10671).
-    if (!this.webGLManager.isActive(id) && this.webGLPolicy.shouldRestoreWebGL(managed, opts)) {
-      this.webGLManager.ensureContext(id, managed);
-    }
-
-    // Drop the stale local glyph model and repaint. repairAtlasForReactivation
-    // returns false for DOM-renderer terminals — fall back to a plain refresh so
-    // the pane still repaints.
-    try {
-      if (!this.webGLManager.repairAtlasForReactivation(id)) {
-        managed.terminal.refresh(0, managed.terminal.rows - 1);
-      }
-    } catch (error) {
-      logWarn(`repaintForReveal repair failed for ${id}`, { error });
-    }
-
-    // Force a layout reflow so a renderer xterm paused while the view was
-    // occluded actually resumes drawing. This is the exact step a manual Redraw
-    // (resetRenderer) and a click both supply, and the one repaintForReveal was
-    // missing: handlePostWake unpauses standard agents via maybeReflowTerminal,
-    // but EARLY-RETURNS for settled-strategy agents (Codex, Gemini, Cursor,
-    // Copilot, …), so for those the atlas repair above landed in a still-paused
-    // renderer and the pane stayed garbled until the next write, the 3s
-    // heartbeat, or a click. Without this the reveal was not click-equivalent
-    // for most agent terminals.
-    try {
-      forceXtermReflow(element);
-    } catch (error) {
-      logWarn(`repaintForReveal reflow failed for ${id}`, { error });
-    }
-
-    // Reconcile geometry from a FRESH DOM measurement. handlePostWake could not
-    // do this on reveal: the project-switch resize lock is still active here
-    // (reveal fires ~0.5–1.5s after the switch, lock TTL 5s), so its fit()
-    // returns null under isResizeLocked and falls back to a PTY-only resize; and
-    // for settled-strategy agents (Codex, Gemini, …) it skips fit() entirely and
-    // only re-sends CACHED dims. Either way xterm's grid was never re-fit, so a
-    // container size change that happened while the view was backgrounded left
-    // the buffer wrapping at the wrong column until a manual Redraw fired after
-    // the lock expired (the long-standing garbled-line-flow-on-return bug).
-    // reconcileGeometryFresh measures the live box, ignores the lock for this one
-    // reveal correction WITHOUT clearing it (so the ResizeObserver-storm damping
-    // the lock provides survives), and resizes xterm + PTY atomically — safe for
-    // settled agents. It returns false on an unmeasurable transitional box
-    // (zero/occluded), so report "not paintable yet" and let the reveal sweep
-    // retry on a later frame.
-    // Clear any stale "directing" agent state the wake path would have cleared.
-    // Runs before the geometry guard so it still fires on a not-yet-measurable
-    // box, matching the old handlePostWake ordering.
-    this.agentStateController.checkStaleDirecting(id);
-
-    if (!this.resizeController.reconcileGeometryFresh(id)) return false;
-
-    // Clear the reflow throttle so the next write or the 3s heartbeat reflows
-    // immediately rather than being debounced away (mirrors resetRenderer).
-    managed.lastReflowAt = 0;
-
-    return true;
+    return this.revealController.repaintForReveal(id, opts);
   }
 
-  /**
-   * Watchdog-driven, alt-buffer-safe reveal repair (#10632) — the closed-loop
-   * "is it correct now" correction that the open-loop reveal backstops never
-   * reliably delivered. This is the ATOMIC half of a manual Redraw: re-fit
-   * geometry from a FRESH DOM measurement (xterm + PTY resized together via
-   * {@link TerminalResizeController.reconcileGeometryFresh}) and repair the local
-   * WebGL glyph model (or plain-refresh a DOM-renderer pane).
-   *
-   * Deliberately omits `forceXtermReflow`: a layout reflow mid DEC 2026
-   * synchronized-output block would interleave a paint with the buffered range,
-   * so the watchdog gates the unpause reflow on `synchronizedOutputMode`
-   * separately and only calls this once a block has closed. The atomic resize is
-   * safe for settled-strategy agents (no 500ms xterm/PTY split).
-   *
-   * Returns reconcileGeometryFresh's verdict: false on an unmeasurable /
-   * transitional box (zero/occluded/content-visibility:hidden) so the watchdog
-   * keeps the reveal-pending obligation and retries on a later tick once the
-   * foreground view has settled — the present-ordering guarantee that a repaint
-   * is never issued into an occluded surface.
-   */
   reconcileRevealGeometry(id: string): boolean {
-    const managed = this.instances.get(id);
-    if (!managed) return false;
-    if (!this.resizeController.reconcileGeometryFresh(id)) return false;
-
-    try {
-      if (!this.webGLManager.repairAtlasForReactivation(id)) {
-        managed.terminal.refresh(0, managed.terminal.rows - 1);
-      }
-    } catch (error) {
-      logWarn(`reconcileRevealGeometry repair failed for ${id}`, { error });
-    }
-
-    // Clear the reflow throttle so a follow-up unpause reflow (the watchdog's
-    // render-pause branch, or the next write/heartbeat) fires immediately.
-    managed.lastReflowAt = 0;
-    return true;
+    return this.revealController.reconcileRevealGeometry(id);
   }
 
-  /**
-   * Foreground reveal entry point for a single grid terminal, driven by the
-   * `app:view-revealed` fan-out ({@link repaintActiveWorktreeTerminals}) once
-   * the cached project view is detached from the anti-flash bridge and actually
-   * presented.
-   *
-   * Splits the two states a long-dwell return can leave a terminal in:
-   *
-   * - **Unopened** — the occluded warm wake could not open the xterm instance
-   *   (no measurable host box behind the bridge). The lightweight repaint can't
-   *   help (it guards on `isOpened`), so run the full
-   *   {@link fullWakeForVisibilityRestore}: now that the host has real layout it
-   *   opens, pulls the missed range from the headless mirror, and repaints. This
-   *   is the gap the older reveal patches (#10362) left open for the long-dwell
-   *   case.
-   * - **Already opened and woken** (the common warm path) — only the culled
-   *   paint needs replaying, so take the cheap {@link repaintForReveal}.
-   *
-   * @returns `true` when the terminal was paintable and the repaint/open ran
-   * (or the terminal is gone — nothing to retry); `false` when it isn't paintable
-   * yet (host not laid out / not visible) and the caller should retry on a later
-   * frame. {@link repaintActiveWorktreeTerminals} drives that retry.
-   */
-  async revealTerminal(id: string): Promise<boolean> {
-    const managed = this.instances.get(id);
-    // Gone — nothing to repaint and nothing to retry, so report "settled".
-    if (!managed) return true;
-    if (!managed.isOpened) {
-      // An unopened pane needs the full open+wake, but
-      // fullWakeForVisibilityRestore only opens once the host has a real layout
-      // box. While the foreground view is still settling that box can read zero
-      // (or the host is visibility:hidden), so report "not paintable yet" and
-      // let the reveal sweep retry on a later frame rather than spending the
-      // open attempt against an unmeasurable host.
-      if (!this.hostHasRenderableDims(managed)) return false;
-      await this.fullWakeForVisibilityRestore(id);
-      const after = this.instances.get(id);
-      // Gone mid-wake → nothing left to retry. Otherwise it's settled only once
-      // the pane actually opened AND the wake wasn't merely DEFERRED:
-      // fullWakeForVisibilityRestore sets pendingVisibilityWake and returns early
-      // while an attach is in flight (notifyAttachSettledWaiters re-runs it on
-      // settle). Report "retry" until the open+wake has truly landed so the
-      // sweep's confirm paints aren't spent against a not-yet-revealed pane.
-      return (
-        !after ||
-        (after.isOpened === true &&
-          after.isAttaching !== true &&
-          after.pendingVisibilityWake !== true)
-      );
-    }
-    // The warm view-reveal sweep has confirmed the foreground view is presented,
-    // so trust DOM-truth visibility for the WebGL reattach — the reactive
-    // isVisible flag is stale-false on a warm resume. Assistant-transition
-    // callers of repaintForReveal deliberately do NOT trust it.
-    return this.repaintForReveal(id, { trustDomVisibility: true });
+  revealTerminal(id: string): Promise<boolean> {
+    return this.revealController.revealTerminal(id);
   }
 
   /**

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -217,7 +217,6 @@ export class TerminalReconciliationWatchdog {
    */
   private diagnoseGeometryDivergence(id: string, managed: ManagedTerminal): void {
     if (!import.meta.env?.DEV) return;
-    if (managed.isHibernated) return;
     try {
       const proposal = managed.fitAddon.proposeDimensions?.();
       if (!proposal || proposal.cols <= 1 || proposal.rows <= 1) return;
@@ -570,8 +569,7 @@ export class TerminalReconciliationWatchdog {
       inFlightWake: this.deps.hasInFlightWake(id),
       pendingWake: this.deps.hasPendingWake(id),
       webglActive: this.deps.isWebGLActive(id),
-      isHibernated: managed.isHibernated === true,
-      xtermPaused: managed.isHibernated ? undefined : isXtermRenderPaused(managed.terminal),
+      xtermPaused: isXtermRenderPaused(managed.terminal),
       isFocused: managed.isFocused,
       isAttaching: managed.isAttaching === true,
       isDetached: managed.isDetached === true,

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -116,12 +116,11 @@ export class TerminalReflowController {
    * Applies to agent terminals too: xterm 6's pause gate lives in the core
    * RenderService, so a WebGL-rendered terminal is just as susceptible as a
    * DOM one (and after a webglcontextlost it falls back to the DOM renderer
-   * with no requeue). Skips: hibernated/invisible/attaching terminals,
-   * alt-buffer (TUI) sessions, and terminals without a rendered element.
-   * Throttled per terminal.
+   * with no requeue). Skips: invisible/attaching terminals, alt-buffer (TUI)
+   * sessions, and terminals without a rendered element. Throttled per
+   * terminal.
    */
   maybeReflow(managed: ManagedTerminal): void {
-    if (managed.isHibernated) return;
     if (!managed.isVisible) return;
     if (managed.isAttaching) return;
     if (managed.isAltBuffer) return;

--- a/src/services/terminal/TerminalResizePassScheduler.ts
+++ b/src/services/terminal/TerminalResizePassScheduler.ts
@@ -1,0 +1,180 @@
+import type { ManagedTerminal } from "./types";
+import { GRID_RESIZE_COALESCE_MS } from "./types";
+import { usePanelStore } from "@/store/panelStore";
+import { logError } from "@/utils/logger";
+import { yieldToScheduler } from "@/lib/schedulerYield";
+
+// Terminals resized per task inside `runResizePass`, yielding to the scheduler
+// between chunks. xterm.js 6.0 reflows the whole scrollback on a
+// column-changing resize (~15-40ms each), so one-per-task keeps every task
+// under the ~50ms long-task threshold and lets paint + input run between
+// terminals instead of freezing the renderer for the whole batch.
+const RESIZE_PASS_CHUNK_SIZE = 1;
+
+export interface TerminalResizePassSchedulerDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  isResizeLocked: (id: string) => boolean;
+  resize: (id: string, width: number, height: number) => unknown;
+}
+
+/**
+ * Multi-terminal batch/chunking resize orchestrator sitting above the
+ * single-terminal `TerminalResizeController`. Owns the coalesced
+ * (`scheduleBatchResize`) and chunked-cancellable (`runResizePass`) resize
+ * passes that keep a large-grid close/open from freezing the renderer.
+ */
+export class TerminalResizePassScheduler {
+  private gridResizeTimer: number | undefined;
+  private readonly gridResizePendingIds = new Set<string>();
+  private resizePassAbort: AbortController | undefined;
+
+  constructor(private deps: TerminalResizePassSchedulerDeps) {}
+
+  /**
+   * Synchronous resize primitive: re-applies every eligibility guard
+   * (instance exists, connected, visible, not resize-locked) and reads fresh
+   * geometry before resizing. Private — callers outside this class must go
+   * through {@link runResizePass} (chunked, cancellable) or
+   * {@link scheduleBatchResize} (coalesced) so a survivor reflow never
+   * freezes the renderer in one task. `executeResizePass` invokes this one
+   * id at a time.
+   */
+  private batchResize(ids: string[]): void {
+    if (ids.length === 0) return;
+
+    type Pending = { id: string; width: number; height: number };
+    const seen = new Set<string>();
+    const pending: Pending[] = [];
+
+    for (const id of ids) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+
+      const managed = this.deps.getInstance(id);
+      if (!managed) continue;
+      if (!managed.hostElement.isConnected) continue;
+      if (!managed.hostElement.checkVisibility()) continue;
+      if (this.deps.isResizeLocked(id)) continue;
+
+      const rect = managed.hostElement.getBoundingClientRect();
+      if (rect.width < 50 || rect.height < 50) continue;
+
+      pending.push({ id, width: rect.width, height: rect.height });
+    }
+
+    for (const { id, width, height } of pending) {
+      this.deps.resize(id, width, height);
+    }
+  }
+
+  /**
+   * Coalesced variant of `batchResize`. A burst of grid open/close events each
+   * union their ids and reset a trailing-edge timer; the actual resize runs
+   * once the burst settles, on the next frame — so it never lands on the
+   * synchronous open/close path the user is waiting on.
+   */
+  scheduleBatchResize(ids: string[]): void {
+    if (ids.length === 0) return;
+    for (const id of ids) this.gridResizePendingIds.add(id);
+    if (this.gridResizeTimer !== undefined) {
+      clearTimeout(this.gridResizeTimer);
+    }
+    this.gridResizeTimer = window.setTimeout(() => {
+      this.gridResizeTimer = undefined;
+      const pendingIds = [...this.gridResizePendingIds];
+      this.gridResizePendingIds.clear();
+      requestAnimationFrame(() => this.runResizePass(pendingIds));
+    }, GRID_RESIZE_COALESCE_MS);
+  }
+
+  /**
+   * Resize a set of panels as a chunked, cancellable pass instead of one
+   * synchronous loop. Closing or opening a panel resizes every surviving
+   * xterm; in xterm.js 6.0 a column-changing resize reflows the entire
+   * scrollback (O(scrollback)), so resizing ~15 terminals in a single
+   * synchronous loop freezes the renderer for hundreds of ms — the
+   * "app stops responding" the user feels on Cmd+W.
+   *
+   * This runs `RESIZE_PASS_CHUNK_SIZE` terminal(s) per task and yields to the
+   * scheduler between chunks (see {@link yieldToScheduler}), so paint and
+   * input stay live while the survivors settle progressively. The focused
+   * panel resizes first so the pane the user is looking at settles in the
+   * first frame; far corners of a large grid settle a beat later, unnoticed.
+   *
+   * Each new pass aborts any in-flight one: once a newer pass starts, the
+   * survivor set the old one was resizing is already stale, so its remaining
+   * reflows are cancelled. The trailing-edge debounce in
+   * {@link scheduleBatchResize} coalesces a close/open burst before a pass
+   * starts; this abort handles the case where a burst arrives once a pass is
+   * already running. Fire-and-forget — callers never await it.
+   */
+  runResizePass(ids: string[]): void {
+    if (ids.length === 0) return;
+    // A newer pass supersedes any in-flight one — its survivor set is stale.
+    this.resizePassAbort?.abort();
+    const controller = new AbortController();
+    this.resizePassAbort = controller;
+    const run = () => this.executeResizePass(ids, controller);
+    const task =
+      typeof scheduler !== "undefined" && typeof scheduler.postTask === "function"
+        ? scheduler.postTask(run, { priority: "user-visible", signal: controller.signal })
+        : run();
+    void task.catch((error) => {
+      if (error instanceof Error && error.name === "AbortError") return;
+      logError("terminal resize pass failed", error);
+    });
+  }
+
+  /**
+   * Abort any in-flight chunked resize pass without starting a new one. The
+   * paint-fabric compositor uses this to give a multi-surface fabric the same
+   * pass-supersession semantics the single service has: one logical pass spans
+   * every surface, so starting a new pass must cancel stale chunked work on
+   * surfaces that have no ids in the new pass (they'd otherwise keep reflowing
+   * a survivor set that is already stale).
+   */
+  cancelActiveResizePass(): void {
+    this.resizePassAbort?.abort();
+    this.resizePassAbort = undefined;
+  }
+
+  private async executeResizePass(ids: string[], controller: AbortController): Promise<void> {
+    const { signal } = controller;
+    try {
+      const ordered = this.orderFocusedFirst([...new Set(ids)]);
+      for (let i = 0; i < ordered.length; i += RESIZE_PASS_CHUNK_SIZE) {
+        if (signal.aborted) return;
+        // batchResize re-applies every eligibility guard (instance exists,
+        // connected, visible, not resize-locked) and reads fresh geometry —
+        // correct here because layout has settled across the yields.
+        this.batchResize(ordered.slice(i, i + RESIZE_PASS_CHUNK_SIZE));
+        if (i + RESIZE_PASS_CHUNK_SIZE < ordered.length) {
+          await yieldToScheduler();
+        }
+      }
+    } finally {
+      if (this.resizePassAbort === controller) {
+        this.resizePassAbort = undefined;
+      }
+    }
+  }
+
+  /**
+   * Order the resize set so the focused panel settles first. The user's eye
+   * is on the focused pane; resizing it in the first chunk makes the pass
+   * feel instant even though total work is unchanged.
+   */
+  private orderFocusedFirst(ids: string[]): string[] {
+    const focusedId = usePanelStore.getState().focusedId;
+    if (!focusedId || !ids.includes(focusedId)) return ids;
+    return [focusedId, ...ids.filter((id) => id !== focusedId)];
+  }
+
+  // Abort any in-flight chunked resize pass so its yielded continuation
+  // doesn't resume against a torn-down service. Called from
+  // `TerminalInstanceService.dispose()`.
+  dispose(): void {
+    this.resizePassAbort?.abort();
+    this.resizePassAbort = undefined;
+  }
+}

--- a/src/services/terminal/TerminalRevealController.ts
+++ b/src/services/terminal/TerminalRevealController.ts
@@ -1,0 +1,607 @@
+import type { ManagedTerminal } from "./types";
+import { TerminalRefreshTier } from "@/types";
+import { forceXtermReflow } from "./TerminalReflowController";
+import { usePanelStore } from "@/store/panelStore";
+import { logWarn } from "@/utils/logger";
+
+// Debounce on the visibility-driven WebGL restore path. Show waits this long
+// before re-acquiring so rapid tab/panel toggles don't thrash WebglAddon
+// load/unload (each cycle reallocates GPU resources).
+const WEBGL_RESTORE_DEBOUNCE_MS = 100;
+
+// Release hysteresis on the visibility-driven hide path. Holding the context
+// for this long before releasing covers normal panel-toggle and focus-cycle
+// cadences (~100–300ms) without over-occupying the 12-slot WebGL pool under
+// multi-terminal hide. Authoritative release paths (tier demotion, agent
+// demotion, destroy, hibernation) cancel this timer and release immediately.
+const WEBGL_HIDE_DWELL_MS = 500;
+
+export interface TerminalRevealControllerDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  hostHasRenderableDims: (managed: ManagedTerminal) => boolean;
+  ensureOpened: (id: string, managed: ManagedTerminal) => void;
+  handlePostWake: (id: string) => void;
+  deferGridChangeForStream: (managed: ManagedTerminal, gridWouldChange: boolean) => boolean;
+  applyRendererPolicy: (id: string, tier: TerminalRefreshTier) => void;
+  applyDeferredResize: (id: string) => void;
+  lockResize: (id: string, locked: boolean, customTtlMs?: number) => void;
+  reconcileGeometryFresh: (id: string) => boolean;
+  resumeFlush: (id: string) => void;
+  checkStaleDirecting: (id: string) => void;
+  shouldRestoreWebGL: (
+    managed: ManagedTerminal,
+    opts?: { trustDomVisibility?: boolean }
+  ) => boolean;
+  isWebGLActive: (id: string) => boolean;
+  ensureWebGL: (id: string, managed: ManagedTerminal) => void;
+  releaseWebGL: (id: string) => void;
+  repairAtlasForReactivation: (id: string) => boolean;
+  cancelWebGLHideTimer: (managed: ManagedTerminal) => void;
+}
+
+/**
+ * Owns visibility, wake, and reveal/repaint ordering — `setVisible` straddles
+ * WebGL + resize + reflow. Two past incidents (#5878 want-membership,
+ * #7762 backgrounded-terminal geometry corruption from reveal/resize/reflow
+ * ordering) shipped in exactly this code; treat any change here as
+ * high-risk, not a routine edit. Preserve call order verbatim, especially
+ * "reconcile geometry before repaint" and the wake-resync bypass of the
+ * settled debounce.
+ */
+export class TerminalRevealController {
+  constructor(private deps: TerminalRevealControllerDeps) {}
+
+  setVisible(id: string, isVisible: boolean, expectedGeneration?: number): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    // Guard: if a generation was provided and it doesn't match the current
+    // attach generation, this is a stale cleanup from a previous mount — skip.
+    if (expectedGeneration !== undefined && managed.attachGeneration !== expectedGeneration) {
+      return;
+    }
+
+    // Cold-mount observer flaps are not authoritative. XtermAdapter forces
+    // visibility true immediately after attach() so the terminal can paint
+    // before IntersectionObserver settles. During recipe/bulk-open insertion
+    // the grid may briefly report "not intersecting"; persisting that false
+    // value would strand renderer recovery behind visibility guards. Real
+    // unmounts go through detach(), which marks the instance invisible.
+    if (!isVisible && managed.isAttaching) {
+      if (managed.webGLRestoreTimer !== undefined) {
+        clearTimeout(managed.webGLRestoreTimer);
+        managed.webGLRestoreTimer = undefined;
+      }
+      this.deps.cancelWebGLHideTimer(managed);
+      return;
+    }
+
+    const wasVisible = managed.isVisible;
+    if (wasVisible !== isVisible) {
+      managed.isVisible = isVisible;
+      managed.lastActiveTime = Date.now();
+
+      if (managed.webGLRestoreTimer !== undefined) {
+        clearTimeout(managed.webGLRestoreTimer);
+        managed.webGLRestoreTimer = undefined;
+      }
+      this.deps.cancelWebGLHideTimer(managed);
+
+      if (isVisible) {
+        if (managed.isAttaching) {
+          return;
+        }
+
+        // Reconcile xterm's grid with dimensions captured while background
+        // before the renderer policy runs its refresh. The bulk-output
+        // garbling in #7741 manifests when xterm.cols/rows still reflect the
+        // previous active geometry but the PTY (and incoming output) have
+        // already advanced — refreshing into the old grid paints stale glyphs.
+        // Order matters: must precede the lastWidth/lastHeight rect update so
+        // that if cellDims were unavailable during background and latestCols/
+        // latestRows are stale, the rect-update doesn't dedup-poison the next
+        // ResizeObserver tick.
+        this.deps.applyDeferredResize(id);
+
+        const rect = managed.hostElement.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          const widthChanged = Math.abs(managed.lastWidth - rect.width) >= 1;
+          const heightChanged = Math.abs(managed.lastHeight - rect.height) >= 1;
+
+          if (widthChanged || heightChanged) {
+            managed.lastWidth = rect.width;
+            managed.lastHeight = rect.height;
+          }
+        }
+
+        const tier = managed.getRefreshTier
+          ? managed.getRefreshTier()
+          : TerminalRefreshTier.VISIBLE;
+        this.deps.applyRendererPolicy(id, tier);
+
+        const termEl = managed.terminal.element;
+        if (termEl && managed.terminal.modes?.synchronizedOutputMode !== true) {
+          forceXtermReflow(termEl);
+        } else if (termEl) {
+          // Defer the unpause reflow while a DEC 2026 synchronized-output block is
+          // open (#10632). forceXtermReflow bypasses xterm's atomic-at-ESU
+          // buffering and would interleave a torn frame — the invariant
+          // TerminalReflowController.maybeReflow enforces at :139. This path IS
+          // reachable on switch-back: the grid IntersectionObserver
+          // (TerminalPane) fires setVisible(id, true) as the pane re-enters the
+          // viewport while an agent is mid-stream. applyDeferredResize above
+          // already synced geometry and applyRendererPolicy still ran; hand the
+          // unpause/repaint to the watchdog's reveal-pending backstop, which
+          // re-runs it once the block closes and the pane is on-screen.
+          managed.revealPendingRepair = true;
+          managed.revealPendingGeneration = managed.attachGeneration;
+        }
+
+        // Debounced WebGL restore for same-tier transitions. If
+        // applyRendererPolicy above triggers a tier upgrade (e.g.
+        // BACKGROUND→VISIBLE), onTierApplied loads the addon immediately
+        // and this timer becomes a (harmless) idempotent re-apply. The
+        // debounce only meaningfully gates rapid hide→show toggles where
+        // the tier doesn't change, since same-tier applyRendererPolicy
+        // is a no-op.
+        managed.webGLRestoreTimer = window.setTimeout(() => {
+          const current = this.deps.getInstance(id);
+          if (!current) return;
+          current.webGLRestoreTimer = undefined;
+          if (!this.deps.shouldRestoreWebGL(current)) return;
+          this.deps.ensureWebGL(id, current);
+        }, WEBGL_RESTORE_DEBOUNCE_MS);
+      } else {
+        // Going offscreen. Hold the WebGL context for WEBGL_HIDE_DWELL_MS so
+        // rapid hide→show cycles (panel toggles, focus oscillation) don't
+        // churn the pool. The timer callback re-fetches `managed` to avoid
+        // stale refs (same pattern as webGLRestoreTimer above) and re-checks
+        // isVisible so a show during the dwell window keeps the context.
+        managed.webGLHideTimer = window.setTimeout(() => {
+          const current = this.deps.getInstance(id);
+          if (!current) return;
+          current.webGLHideTimer = undefined;
+          if (current.isVisible) return;
+          this.deps.releaseWebGL(id);
+        }, WEBGL_HIDE_DWELL_MS);
+      }
+    }
+  }
+
+  wake(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+    // A click/focus/reveal of a live pane is a PLAIN REPAINT. The pane stayed
+    // fully live in the background (no suspend/resync anymore), so
+    // repaintForReveal (WebGL reacquire + atlas/refresh + geometry re-fit) is
+    // sufficient and safe. A not-yet-opened pane (a parked dock tab on first
+    // reveal) takes the visibility-restore path, which opens it then repaints.
+    if (!managed.isOpened) {
+      void this.fullWakeForVisibilityRestore(id);
+      return;
+    }
+    this.repaintForReveal(id);
+  }
+
+  /**
+   * Focus/click-driven wake. The wake-on-focus safety net (51ba86d8d) heals a
+   * frozen/garbled pane on click. `wake()` is now a plain repaint (WebGL
+   * reacquire + atlas/refresh + geometry re-fit), so it is safe for a
+   * main-buffer pane. For a LIVE, foreground alt-screen TUI (OpenCode, any agent
+   * with blockAltScreen disabled) even a geometry reconcile can reflow the
+   * absolutely-positioned frame, so a co-visible alt-screen pane fed by the live
+   * PTY stream is already current and is left untouched. A genuinely off-screen
+   * pane (backgrounded, parked dock tab) still takes the repaint reveal owned by
+   * the visibility path.
+   */
+  wakeForFocus(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    const panelState = usePanelStore.getState();
+    const panel = panelState.panelsById[id];
+    const needsRealRestore =
+      managed.needsWake === true ||
+      panel?.location === "background" ||
+      panelState.backgroundedTerminals.has(id);
+
+    if (needsRealRestore || managed.isAltBuffer !== true) {
+      this.wake(id);
+      return;
+    }
+    // Live foreground alt-screen TUI: already current from the live PTY stream.
+    // No geometry reconcile (reflows the frame). The reflow controller's
+    // focus/heartbeat recovery and the reconciliation watchdog handle any
+    // genuine renderer staleness.
+  }
+
+  /**
+   * Run the full reveal repaint on a visible terminal whose project view just
+   * regained visibility (#8562). Hibernation removed: there is no lossy
+   * wake/resync on this path — the pane stays fully live in the background so
+   * its buffer is already current. This method runs `applyDeferredResize`,
+   * `forceXtermReflow`,
+   * `repairAtlasForReactivation`, `xterm.refresh`, `handlePostWake`, and
+   * `dataBuffer.resumeFlush` (open + geometry + repaint, no reset+replay).
+   * Without the full sequence, visible terminals show stale geometry until the
+   * user clicks each pane.
+   *
+   * Bypasses {@link TerminalRendererPolicy.applyRendererPolicy} — that path
+   * early-returns on tier equality and a backgrounded view's terminals stay
+   * at VISIBLE the whole time. Bypasses the resize lock the same way the
+   * attach path does (record remaining suppression TTL, unlock, resize,
+   * relock with remaining TTL) so geometry resync doesn't silently no-op
+   * while project-switch suppression is active.
+   */
+  async fullWakeForVisibilityRestore(id: string): Promise<void> {
+    const current = this.deps.getInstance(id);
+    if (!current) return;
+    if (!current.isOpened) {
+      // A not-yet-opened pane (a parked dock tab, or one whose host had no
+      // measurable layout box at attach time — e.g. behind the warm anti-flash
+      // bridge #9679) deferred its open to "attach() on next mount". But the
+      // React tree is never remounted on a warm project-view return, so attach()
+      // never re-fires and nothing re-opens it — leaving the terminal stuck
+      // blank/wonky until the user clicks it.
+      //
+      // This same method is re-run from the foreground reveal pass
+      // (repaintActiveWorktreeTerminals on `app:view-revealed`, via
+      // revealTerminal). By then the view is foreground-presented and the host
+      // has a real layout box, so finish the open here using attach()'s exact
+      // sequence. While still occluded (zero box) we leave it deferred — the
+      // reveal pass retries once layout is valid.
+      if (this.deps.hostHasRenderableDims(current)) {
+        this.deps.ensureOpened(id, current);
+      }
+      if (!current.isOpened) return;
+    }
+
+    // Set the deferred-wake flag before the geometry sync so an unexpected
+    // throw from applyDeferredResize (e.g. a terminal disposed between the
+    // lookup above and here) can't strand it: while attaching the async wake
+    // must re-run once attach settles, so the flag has to survive a throw. On
+    // the proceed path we clear it again below.
+    current.pendingVisibilityWake = current.isAttaching === true;
+
+    // Geometry sync runs synchronously even while attaching (#10070).
+    // applyDeferredResize only calls terminal.resize() — no buffer reset, no
+    // async — so it is safe mid-attach and corrects the grid before the warm
+    // paint gate releases the bridge view. Without this, an attaching terminal
+    // stays at the default 80x24 until the deferred wake re-runs after the
+    // bridge has already dropped, producing the visible render-small-then-snap.
+    //
+    // EXCEPT for a STREAMING main-buffer pane whose grid would actually change
+    // (#10863's missing half): terminal.resize() re-wraps committed scrollback
+    // while an Ink-style CLI is still repainting its sticky region with
+    // cursor-relative erase math sized for the old grid — the wake-path twin of
+    // the reveal-path re-wrap reconcileGeometryFresh already defers. The
+    // assistant's cold-resume boot is the canonical victim: this sweep fires on
+    // the same switch-back that just spawned it, mid-splash. Defer the geometry
+    // sync to the reconciliation watchdog (the same revealPendingRepair
+    // obligation the sync-block defer below uses); its reveal-pending branch
+    // runs the fresh atomic reconcile once the stream quiesces. A no-change
+    // pass falls through — applyDeferredResize's cache==current early-return
+    // makes it free, and skipping it would strand the #10070 correction.
+    const gridWouldChange =
+      Number.isInteger(current.latestCols) &&
+      Number.isInteger(current.latestRows) &&
+      (current.terminal.cols !== current.latestCols ||
+        current.terminal.rows !== current.latestRows);
+    if (this.deps.deferGridChangeForStream(current, gridWouldChange)) {
+      // Deferred to the watchdog — nothing to do here.
+    } else {
+      // Unlock symmetrically with the relock in the finally below: bypass the
+      // lock whenever resize is suppressed, even if the suppression end time was
+      // already cleared (the timer can fire between switch-back and this deferred
+      // wake). Without the unlock, applyDeferredResize would no-op under the lock
+      // and geometry would stay stale.
+      const needsLockBypass = current.isResizeSuppressed === true;
+      let remainingMs = 0;
+      if (needsLockBypass) {
+        remainingMs = current.resizeSuppressionEndTime
+          ? Math.max(0, current.resizeSuppressionEndTime - Date.now())
+          : 0;
+        this.deps.lockResize(id, false);
+      }
+      try {
+        this.deps.applyDeferredResize(id);
+      } finally {
+        if (needsLockBypass) {
+          this.deps.lockResize(id, true, remainingMs);
+        }
+      }
+    }
+
+    // Attach is in progress — running the async wake now would race the
+    // attach's own post-rAF reconciliation, which calls terminal.reset()
+    // during buffer restore. The geometry sync above is safe to keep, but the
+    // async wake must defer: pendingVisibilityWake was already set true above
+    // so notifyAttachSettledWaiters re-runs this wake once attach settles
+    // (#9702).
+    if (current.isAttaching) {
+      return;
+    }
+
+    // We're proceeding with the full wake now, so clear any stale deferred-wake
+    // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
+    current.pendingVisibilityWake = false;
+
+    // Never interleave the RENDER ops (forceXtermReflow, repairAtlasForReactivation,
+    // the post-wake refresh) into an OPEN DEC 2026 synchronized-output block
+    // (#10632). forceXtermReflow bypasses xterm's atomic-at-ESU buffering and
+    // would paint a partial frame — the exact invariant TerminalReflowController
+    // enforces at maybeReflow. The DATA path stays unconditional: applyDeferredResize
+    // (above), handlePostWake (its only reflow routes through the guarded
+    // maybeReflowTerminal), and the held-byte flush all still run.
+    //
+    // This method has no retry-return like repaintForReveal, so when paint is
+    // deferred hand the obligation to the reconciliation watchdog via
+    // revealPendingRepair: its reveal-pending branch re-runs the atomic repair
+    // (geometry + atlas + unpause) once the block closes and the pane is on-screen.
+    const deferPaintForSync = current.terminal.modes?.synchronizedOutputMode === true;
+
+    const termEl = current.terminal.element;
+    if (termEl && !deferPaintForSync) {
+      try {
+        forceXtermReflow(termEl);
+      } catch (error) {
+        logWarn(`forceXtermReflow failed for ${id}`, { error });
+      }
+    }
+
+    // Repair the stale local WebGL glyph model synchronously, before the view's
+    // first composited frame. On warm project-view reactivation the compositor
+    // can flash the pre-freeze atlas state; resetting the local model here (no
+    // breaker, no shared-atlas churn) clears it in place. No-op for DOM-renderer
+    // terminals. Deferred mid-block.
+    if (!deferPaintForSync) {
+      this.deps.repairAtlasForReactivation(id);
+    }
+
+    // Hibernation removed: a visibility restore is a PLAIN REPAINT. The pane
+    // stayed fully live in the background, so its buffer is already current —
+    // geometry was re-fit (applyDeferredResize above) and the atlas/reflow
+    // repaired; here we repaint the live buffer, run the post-wake reflow/unpause
+    // (handlePostWake — never reset+replays; a no-op for alt-screen), and flush
+    // any straggler bytes.
+    if (!deferPaintForSync) {
+      current.terminal.refresh(0, current.terminal.rows - 1);
+    }
+    this.deps.handlePostWake(id);
+    this.deps.resumeFlush(id);
+
+    // Paint was deferred to avoid interleaving an open synchronized-output block.
+    // The watchdog's reveal-pending branch re-runs the full atomic repair once
+    // the block closes and the pane is on-screen — the durable backstop this
+    // retry-less method otherwise lacks.
+    if (deferPaintForSync) {
+      current.revealPendingRepair = true;
+      current.revealPendingGeneration = current.attachGeneration;
+    }
+  }
+
+  /**
+   * Post-reveal repaint for a visible terminal whose project view has just been
+   * detached from the warm anti-flash bridge and focused as the foreground
+   * surface (#10362).
+   *
+   * `fullWakeForVisibilityRestore` runs the redraw on visibilitychange/resume —
+   * while the cached view is still occluded BEHIND the bridge (#9679). Chromium
+   * culls paints for a non-foreground WebContentsView, so that repair can fail
+   * to stick and agent terminals stay garbled until the user clicks each pane.
+   * This re-runs the render repair once the compositor will actually present
+   * the frame, driven by the `app:view-revealed` signal.
+   *
+   * Self-heals both failure modes a manual click fixes: a WebGL context the
+   * freeze/thaw cycle dropped (VRAM reclaim) is re-attached, then the stale
+   * local glyph model is repaired (or a DOM-renderer pane plain-refreshed) and
+   * the grid re-fit. Unlike a click it does NOT call `terminal.focus()` —
+   * focusing every pane would steal DOM focus and emit focus-reporting
+   * sequences into every agent; exactly one pane owns focus, this is a
+   * fleet-wide repaint. The byte-pull is intentionally skipped: the headless
+   * mirror sync already ran behind the bridge (IPC data is not culled like a
+   * paint is), so only the repaint needs replaying.
+   */
+  repaintForReveal(id: string, opts?: { trustDomVisibility?: boolean }): boolean {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return false;
+    // Health-check on DOM ground truth (isConnected + checkVisibility + size),
+    // NOT the reactive `managed.isVisible` flag (#10632 item 4). On a warm
+    // WebContentsView resume the attach effect — the one place that force-sets
+    // isVisible=true (XtermAdapter) — does not re-run, and the
+    // IntersectionObserver that would flip it can lag a frame or be culled while
+    // the view un-occludes, so a stale isVisible=false would no-op the exact
+    // repaint the reveal needs. resetRenderer (manual Redraw) already keys off
+    // connected+size for this reason; unify on the same DOM-truth signal here.
+    // The element.isConnected + checkVisibility + >=50px box guards below are the
+    // real preconditions.
+    if (!managed.isOpened) return false;
+
+    const element = managed.terminal.element;
+    if (!element || !element.isConnected) return false;
+
+    // A not-yet-laid-out, content-visibility:hidden, or zero/occluded host has no
+    // model worth repainting — its first real resize builds it fresh. Use the
+    // same hostHasRenderableDims gate (isConnected + checkVisibility + box) that
+    // ensureOpened/fit rely on, then refine with resetRenderer's >=50px floor.
+    // Report "not paintable yet" (false) so the reveal sweep retries on a later
+    // frame once the foreground view has settled its layout, rather than burning
+    // its one shot against a zero box.
+    if (!this.deps.hostHasRenderableDims(managed)) return false;
+    if (managed.hostElement.clientWidth < 50 || managed.hostElement.clientHeight < 50) {
+      return false;
+    }
+
+    // Never repaint into an OPEN DEC 2026 synchronized-output block (#10632). The
+    // atlas repair, forceXtermReflow, and reconcileGeometryFresh below would each
+    // interleave a paint with the buffered range and corrupt a live agent frame.
+    // The watchdog repair path already defers on this; the reveal path must too —
+    // dropping the !isVisible guard above made repaintForReveal more reachable, so
+    // the never-interleave-mid-block guarantee has to hold here as well. Report
+    // "not paintable yet" so the reveal sweep retries on a later frame once the
+    // block closes; the reconciliation watchdog is the backstop if it outlasts
+    // the sweep.
+    if (managed.terminal.modes?.synchronizedOutputMode === true) return false;
+
+    // Re-attach a WebGL context the freeze/thaw cycle may have dropped before
+    // repairing the local model. The warm view-reveal caller (revealTerminal)
+    // passes trustDomVisibility so a stale reactive isVisible=false on warm
+    // WebContentsView resume doesn't skip the reattach and strand non-focused
+    // agent panes on the DOM renderer. Assistant show/hide-transition callers
+    // pass nothing, so they keep the isVisible gate — a transform-hidden pane
+    // must not accumulate a fleet-wide WebGL want (#10671).
+    if (!this.deps.isWebGLActive(id) && this.deps.shouldRestoreWebGL(managed, opts)) {
+      this.deps.ensureWebGL(id, managed);
+    }
+
+    // Drop the stale local glyph model and repaint. repairAtlasForReactivation
+    // returns false for DOM-renderer terminals — fall back to a plain refresh so
+    // the pane still repaints.
+    try {
+      if (!this.deps.repairAtlasForReactivation(id)) {
+        managed.terminal.refresh(0, managed.terminal.rows - 1);
+      }
+    } catch (error) {
+      logWarn(`repaintForReveal repair failed for ${id}`, { error });
+    }
+
+    // Force a layout reflow so a renderer xterm paused while the view was
+    // occluded actually resumes drawing. This is the exact step a manual Redraw
+    // (resetRenderer) and a click both supply, and the one repaintForReveal was
+    // missing: handlePostWake unpauses standard agents via maybeReflowTerminal,
+    // but EARLY-RETURNS for settled-strategy agents (Codex, Gemini, Cursor,
+    // Copilot, …), so for those the atlas repair above landed in a still-paused
+    // renderer and the pane stayed garbled until the next write, the 3s
+    // heartbeat, or a click. Without this the reveal was not click-equivalent
+    // for most agent terminals.
+    try {
+      forceXtermReflow(element);
+    } catch (error) {
+      logWarn(`repaintForReveal reflow failed for ${id}`, { error });
+    }
+
+    // Reconcile geometry from a FRESH DOM measurement. handlePostWake could not
+    // do this on reveal: the project-switch resize lock is still active here
+    // (reveal fires ~0.5–1.5s after the switch, lock TTL 5s), so its fit()
+    // returns null under isResizeLocked and falls back to a PTY-only resize; and
+    // for settled-strategy agents (Codex, Gemini, …) it skips fit() entirely and
+    // only re-sends CACHED dims. Either way xterm's grid was never re-fit, so a
+    // container size change that happened while the view was backgrounded left
+    // the buffer wrapping at the wrong column until a manual Redraw fired after
+    // the lock expired (the long-standing garbled-line-flow-on-return bug).
+    // reconcileGeometryFresh measures the live box, ignores the lock for this one
+    // reveal correction WITHOUT clearing it (so the ResizeObserver-storm damping
+    // the lock provides survives), and resizes xterm + PTY atomically — safe for
+    // settled agents. It returns false on an unmeasurable transitional box
+    // (zero/occluded), so report "not paintable yet" and let the reveal sweep
+    // retry on a later frame.
+    // Clear any stale "directing" agent state the wake path would have cleared.
+    // Runs before the geometry guard so it still fires on a not-yet-measurable
+    // box, matching the old handlePostWake ordering.
+    this.deps.checkStaleDirecting(id);
+
+    if (!this.deps.reconcileGeometryFresh(id)) return false;
+
+    // Clear the reflow throttle so the next write or the 3s heartbeat reflows
+    // immediately rather than being debounced away (mirrors resetRenderer).
+    managed.lastReflowAt = 0;
+
+    return true;
+  }
+
+  /**
+   * Watchdog-driven, alt-buffer-safe reveal repair (#10632) — the closed-loop
+   * "is it correct now" correction that the open-loop reveal backstops never
+   * reliably delivered. This is the ATOMIC half of a manual Redraw: re-fit
+   * geometry from a FRESH DOM measurement (xterm + PTY resized together via
+   * {@link TerminalResizeController.reconcileGeometryFresh}) and repair the local
+   * WebGL glyph model (or plain-refresh a DOM-renderer pane).
+   *
+   * Deliberately omits `forceXtermReflow`: a layout reflow mid DEC 2026
+   * synchronized-output block would interleave a paint with the buffered range,
+   * so the watchdog gates the unpause reflow on `synchronizedOutputMode`
+   * separately and only calls this once a block has closed. The atomic resize is
+   * safe for settled-strategy agents (no 500ms xterm/PTY split).
+   *
+   * Returns reconcileGeometryFresh's verdict: false on an unmeasurable /
+   * transitional box (zero/occluded/content-visibility:hidden) so the watchdog
+   * keeps the reveal-pending obligation and retries on a later tick once the
+   * foreground view has settled — the present-ordering guarantee that a repaint
+   * is never issued into an occluded surface.
+   */
+  reconcileRevealGeometry(id: string): boolean {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return false;
+    if (!this.deps.reconcileGeometryFresh(id)) return false;
+
+    try {
+      if (!this.deps.repairAtlasForReactivation(id)) {
+        managed.terminal.refresh(0, managed.terminal.rows - 1);
+      }
+    } catch (error) {
+      logWarn(`reconcileRevealGeometry repair failed for ${id}`, { error });
+    }
+
+    // Clear the reflow throttle so a follow-up unpause reflow (the watchdog's
+    // render-pause branch, or the next write/heartbeat) fires immediately.
+    managed.lastReflowAt = 0;
+    return true;
+  }
+
+  /**
+   * Foreground reveal entry point for a single grid terminal, driven by the
+   * `app:view-revealed` fan-out ({@link repaintActiveWorktreeTerminals}) once
+   * the cached project view is detached from the anti-flash bridge and actually
+   * presented.
+   *
+   * Splits the two states a long-dwell return can leave a terminal in:
+   *
+   * - **Unopened** — the occluded warm wake could not open the xterm instance
+   *   (no measurable host box behind the bridge). The lightweight repaint can't
+   *   help (it guards on `isOpened`), so run the full
+   *   {@link fullWakeForVisibilityRestore}: now that the host has real layout it
+   *   opens, pulls the missed range from the headless mirror, and repaints. This
+   *   is the gap the older reveal patches (#10362) left open for the long-dwell
+   *   case.
+   * - **Already opened and woken** (the common warm path) — only the culled
+   *   paint needs replaying, so take the cheap {@link repaintForReveal}.
+   *
+   * @returns `true` when the terminal was paintable and the repaint/open ran
+   * (or the terminal is gone — nothing to retry); `false` when it isn't paintable
+   * yet (host not laid out / not visible) and the caller should retry on a later
+   * frame. {@link repaintActiveWorktreeTerminals} drives that retry.
+   */
+  async revealTerminal(id: string): Promise<boolean> {
+    const managed = this.deps.getInstance(id);
+    // Gone — nothing to repaint and nothing to retry, so report "settled".
+    if (!managed) return true;
+    if (!managed.isOpened) {
+      // An unopened pane needs the full open+wake, but
+      // fullWakeForVisibilityRestore only opens once the host has a real layout
+      // box. While the foreground view is still settling that box can read zero
+      // (or the host is visibility:hidden), so report "not paintable yet" and
+      // let the reveal sweep retry on a later frame rather than spending the
+      // open attempt against an unmeasurable host.
+      if (!this.deps.hostHasRenderableDims(managed)) return false;
+      await this.fullWakeForVisibilityRestore(id);
+      const after = this.deps.getInstance(id);
+      // Gone mid-wake → nothing left to retry. Otherwise it's settled only once
+      // the pane actually opened AND the wake wasn't merely DEFERRED:
+      // fullWakeForVisibilityRestore sets pendingVisibilityWake and returns early
+      // while an attach is in flight (notifyAttachSettledWaiters re-runs it on
+      // settle). Report "retry" until the open+wake has truly landed so the
+      // sweep's confirm paints aren't spent against a not-yet-revealed pane.
+      return (
+        !after ||
+        (after.isOpened === true &&
+          after.isAttaching !== true &&
+          after.pendingVisibilityWake !== true)
+      );
+    }
+    // The warm view-reveal sweep has confirmed the foreground view is presented,
+    // so trust DOM-truth visibility for the WebGL reattach — the reactive
+    // isVisible flag is stale-false on a warm resume. Assistant-transition
+    // callers of repaintForReveal deliberately do NOT trust it.
+    return this.repaintForReveal(id, { trustDomVisibility: true });
+  }
+}

--- a/src/services/terminal/TerminalSettleWaiterRegistry.ts
+++ b/src/services/terminal/TerminalSettleWaiterRegistry.ts
@@ -1,0 +1,375 @@
+import type { ManagedTerminal } from "./types";
+import { agentLifecycleLedger } from "./lifecycleLedger";
+
+interface Waiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timeout: number;
+}
+
+// Default timeout for the restore-aware settle waits (`waitForFullySettled`,
+// `waitForAllFullySettled`). Aligned to the 30s Tier 1→3 promotion rule
+// (CLAUDE.md "Runtime Signals"): a settle that hasn't completed within 30s has
+// stalled past the point where an ambient indicator is appropriate, so the
+// gate gives up and surfaces the still-pending set rather than blocking
+// indefinitely. The wait is notification-driven (scheduler fires on each
+// restore state transition); the timer is only the safety fallback, so
+// Chromium 148 background-timer throttling in a hidden view at most delays the
+// fallback, never the correct completion path.
+const TERMINAL_BATCH_SETTLE_TIMEOUT_MS = 30000;
+
+export interface TerminalSettleWaiterRegistryDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  // Fires (synchronously) when an attach-settle notification finds a deferred
+  // visibility wake pending — the reveal machinery lives on the service.
+  triggerDeferredVisibilityWake: (id: string) => void;
+}
+
+/**
+ * Owns the three waiter maps (readiness, attach-settled, fully-settled) that
+ * `TerminalInstanceService` exposes as `waitForInstance` / `waitForAttachSettled`
+ * / `waitForFullySettled` / `waitForAllFullySettled`, plus the settle
+ * predicates (`isAttachSettled`, `isFullySettled`) those waits gate on.
+ */
+export class TerminalSettleWaiterRegistry {
+  private readinessWaiters = new Map<string, Waiter[]>();
+  private attachSettledWaiters = new Map<string, Waiter[]>();
+  private fullySettledWaiters = new Map<string, Waiter[]>();
+
+  constructor(private deps: TerminalSettleWaiterRegistryDeps) {}
+
+  waitForInstance(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
+    const existing = this.deps.getInstance(id);
+    if (existing) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? 5000;
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        this.removeReadinessWaiter(id, resolve);
+        reject(new Error(`Terminal ${id} frontend readiness timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const waiters = this.readinessWaiters.get(id) || [];
+      waiters.push({ resolve, reject, timeout });
+      this.readinessWaiters.set(id, waiters);
+    });
+  }
+
+  waitForAttachSettled(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
+    if (this.isAttachSettled(id)) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? 1500;
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        this.removeAttachSettledWaiter(id, resolve);
+        reject(new Error(`Terminal ${id} attach settle timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const waiters = this.attachSettledWaiters.get(id) || [];
+      waiters.push({ resolve, reject, timeout });
+      this.attachSettledWaiters.set(id, waiters);
+    });
+  }
+
+  isAttachSettled(id: string): boolean {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return false;
+    return (
+      managed.isOpened &&
+      managed.isAttaching !== true &&
+      managed.hostElement.isConnected &&
+      managed.terminal.element !== undefined
+    );
+  }
+
+  notifyReadinessWaiters(id: string): void {
+    const waiters = this.readinessWaiters.get(id);
+    if (!waiters) return;
+
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
+    }
+
+    this.readinessWaiters.delete(id);
+  }
+
+  private removeReadinessWaiter(id: string, resolve: () => void): void {
+    const waiters = this.readinessWaiters.get(id);
+    if (!waiters) return;
+
+    const index = waiters.findIndex((w) => w.resolve === resolve);
+    if (index >= 0) {
+      waiters.splice(index, 1);
+    }
+
+    if (waiters.length === 0) {
+      this.readinessWaiters.delete(id);
+    }
+  }
+
+  notifyAttachSettledWaiters(id: string): void {
+    if (!this.isAttachSettled(id)) return;
+
+    // Consume a deferred visibility wake that was skipped while this terminal
+    // was mid-attach (#9702). Read and clear the flag before dispatching so a
+    // re-entrant call can't double-fire; fullWakeForVisibilityRestore guards
+    // against stale/replaced instances on its own.
+    const managed = this.deps.getInstance(id);
+    const deferredWake = managed?.pendingVisibilityWake === true;
+    if (managed) managed.pendingVisibilityWake = false;
+
+    // Record the first live-attach geometry in the lifecycle ledger (once per
+    // launch generation — recordFirstAttach ignores later attaches). Pairs
+    // with the 80x24 initial dims stamped at launch so a support bundle can
+    // show whether a pane ever converged from boot geometry.
+    if (managed) {
+      const generation = agentLifecycleLedger.currentGeneration(id);
+      if (generation !== undefined) {
+        agentLifecycleLedger.recordFirstAttach(
+          id,
+          generation,
+          managed.terminal.cols,
+          managed.terminal.rows
+        );
+      }
+    }
+
+    const waiters = this.attachSettledWaiters.get(id);
+    if (waiters) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timeout);
+        waiter.resolve();
+      }
+      this.attachSettledWaiters.delete(id);
+    }
+
+    // Visual attach is one half of "fully settled". If restore already
+    // finished while this terminal was mid-attach, attach completing now is
+    // the moment it becomes fully settled — drain those waiters too.
+    this.notifyFullySettledWaitersIfReady(id);
+
+    if (deferredWake) {
+      this.deps.triggerDeferredVisibilityWake(id);
+    }
+  }
+
+  private removeAttachSettledWaiter(id: string, resolve: () => void): void {
+    const waiters = this.attachSettledWaiters.get(id);
+    if (!waiters) return;
+
+    const index = waiters.findIndex((w) => w.resolve === resolve);
+    if (index >= 0) {
+      waiters.splice(index, 1);
+    }
+
+    if (waiters.length === 0) {
+      this.attachSettledWaiters.delete(id);
+    }
+  }
+
+  /**
+   * Resolves once a terminal is *fully* settled — both visually attached
+   * ({@link isAttachSettled}) and past its scrollback-restore lifecycle. Unlike
+   * {@link waitForAttachSettled}, which only gates on visual attach, this waits
+   * for the restore state machine to leave its in-flux states.
+   *
+   * A restore failure still settles the wait (the terminal is usable, just
+   * without restored scrollback); callers that care about success vs. silent
+   * failure inspect `lastScrollbackRestoreError` after the wait resolves.
+   *
+   * Precondition: call this only after restore has had a chance to be
+   * scheduled (state moved to `"pending"`). A brand-new terminal whose restore
+   * has not yet been queued reads as settled because its state is still
+   * `"none"` — there is nothing to wait for from this method's view.
+   */
+  waitForFullySettled(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
+    if (this.isFullySettled(id)) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? TERMINAL_BATCH_SETTLE_TIMEOUT_MS;
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        this.removeFullySettledWaiter(id, resolve);
+        const state = this.deps.getInstance(id)?.scrollbackRestoreState ?? "missing";
+        reject(
+          new Error(`Terminal ${id} fully-settle timeout after ${timeoutMs}ms (restore: ${state})`)
+        );
+      }, timeoutMs);
+
+      const waiters = this.fullySettledWaiters.get(id) || [];
+      waiters.push({ resolve, reject, timeout });
+      this.fullySettledWaiters.set(id, waiters);
+    });
+  }
+
+  /**
+   * Batch variant of {@link waitForFullySettled}: resolves once every panel in
+   * `ids` is fully settled, governed by a single shared timeout. On timeout the
+   * rejection names the still-pending panels. If a panel is destroyed mid-wait
+   * its per-panel waiter rejects, which fails the whole batch — this is a
+   * startup correctness gate, so a missing panel is a hard failure, not a
+   * silent partial success (hence `Promise.all`, not `allSettled`).
+   */
+  waitForAllFullySettled(ids: string[], options: { timeoutMs?: number } = {}): Promise<void> {
+    const uniqueIds = Array.from(new Set(ids));
+    if (uniqueIds.length === 0) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? TERMINAL_BATCH_SETTLE_TIMEOUT_MS;
+
+    return new Promise<void>((resolveBatch, rejectBatch) => {
+      let settled = false;
+      // Per-panel resolve handles we registered in `fullySettledWaiters`, so
+      // the shared timeout can detach them in one pass rather than leaving
+      // ghost waiters that fire after the batch has already rejected.
+      const registered: Array<{ id: string; resolve: () => void }> = [];
+
+      const detachAll = () => {
+        for (const entry of registered) {
+          this.removeFullySettledWaiter(entry.id, entry.resolve);
+        }
+      };
+
+      const timeout = window.setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        detachAll();
+        const pending = uniqueIds.filter((id) => !this.isFullySettled(id));
+        rejectBatch(
+          new Error(`Terminals not fully settled after ${timeoutMs}ms: ${pending.join(", ")}`)
+        );
+      }, timeoutMs);
+
+      const perPanel = uniqueIds.map(
+        (id) =>
+          new Promise<void>((resolve, reject) => {
+            if (this.isFullySettled(id)) {
+              resolve();
+              return;
+            }
+            registered.push({ id, resolve });
+            const waiters = this.fullySettledWaiters.get(id) || [];
+            // No per-panel timer — the shared batch timeout above governs the
+            // whole set. `timeout: 0` is never a live handle, so the
+            // `clearTimeout` calls in the notify/destroy drain paths are no-ops.
+            waiters.push({ resolve, reject, timeout: 0 });
+            this.fullySettledWaiters.set(id, waiters);
+          })
+      );
+
+      void Promise.all(perPanel).then(
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolveBatch();
+        },
+        (error: unknown) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          detachAll();
+          rejectBatch(error instanceof Error ? error : new Error(String(error)));
+        }
+      );
+    });
+  }
+
+  isFullySettled(id: string): boolean {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return false;
+    if (!this.isAttachSettled(id)) return false;
+    // Restore is "settled" once it is no longer in flux — not queued
+    // ("pending") and not running ("in-progress"). "done" is a clean restore;
+    // "none" is terminal from a waiter's view in every case it occurs:
+    // restore was never scheduled (fresh terminal, no scrollback), aborted
+    // before starting (project switch — outcome no longer relevant), or failed
+    // and reset (lastScrollbackRestoreError set). The failure case still
+    // settles: a cosmetic scrollback failure must not strand the wait, and
+    // callers distinguish it via lastScrollbackRestoreError.
+    return managed.scrollbackRestoreState === "done" || managed.scrollbackRestoreState === "none";
+  }
+
+  /**
+   * Drains the fully-settled waiters for a terminal if it has reached the
+   * settled predicate. Reads the instance fresh (never closes over a captured
+   * `managed`) so a stale/replaced instance can't be acted on (#4850).
+   */
+  notifyFullySettledWaitersIfReady(id: string): void {
+    if (!this.isFullySettled(id)) return;
+
+    const waiters = this.fullySettledWaiters.get(id);
+    if (!waiters) return;
+
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
+    }
+    this.fullySettledWaiters.delete(id);
+  }
+
+  /**
+   * Scheduler-facing hook: the scrollback restore scheduler calls this after
+   * each terminal restore state transition (success, failure, or bail) so
+   * fully-settled waiters can re-check the predicate. Public because the
+   * scheduler lives in a sibling module and already calls into this singleton.
+   */
+  notifyRestoreSettledWaiters(id: string): void {
+    this.notifyFullySettledWaitersIfReady(id);
+  }
+
+  private removeFullySettledWaiter(id: string, resolve: () => void): void {
+    const waiters = this.fullySettledWaiters.get(id);
+    if (!waiters) return;
+
+    const index = waiters.findIndex((w) => w.resolve === resolve);
+    if (index >= 0) {
+      waiters.splice(index, 1);
+    }
+
+    if (waiters.length === 0) {
+      this.fullySettledWaiters.delete(id);
+    }
+  }
+
+  // Rejects every pending waiter (readiness, attach-settled, fully-settled)
+  // for a destroyed terminal. Called from `TerminalInstanceService.destroy()`.
+  rejectAll(id: string): void {
+    const waiters = this.readinessWaiters.get(id);
+    if (waiters) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error(`Terminal ${id} destroyed before frontend became ready`));
+      }
+      this.readinessWaiters.delete(id);
+    }
+
+    const attachWaiters = this.attachSettledWaiters.get(id);
+    if (attachWaiters) {
+      for (const waiter of attachWaiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error(`Terminal ${id} destroyed before attach settled`));
+      }
+      this.attachSettledWaiters.delete(id);
+    }
+
+    const fullySettledWaiters = this.fullySettledWaiters.get(id);
+    if (fullySettledWaiters) {
+      for (const waiter of fullySettledWaiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error(`Terminal ${id} destroyed before fully settled`));
+      }
+      this.fullySettledWaiters.delete(id);
+    }
+  }
+}

--- a/src/services/terminal/TerminalWebGLPolicy.ts
+++ b/src/services/terminal/TerminalWebGLPolicy.ts
@@ -1,0 +1,105 @@
+import type { ManagedTerminal } from "./types";
+import { isWebGLEligibleTier } from "./types";
+import { TerminalRefreshTier } from "@/types";
+
+export interface TerminalWebGLPolicyDeps {
+  getMode: () => "webgl" | "dom";
+  getPinnedId: () => string | null;
+  isAltBufferPinned: (id: string) => boolean;
+}
+
+/**
+ * Pure WebGL eligibility decisions — distinct from `TerminalWebGLManager`
+ * (context pool/circuit-breaker/rAF drain) and `TerminalRendererPolicy`
+ * (tier-application state machine). Three past incidents (#10671 want-set
+ * accumulation, the DOM-mode pinned-context circuit breaker, and bulk-attach
+ * staggering) shipped in exactly this logic — treat any future change here
+ * as high-risk, not a routine edit.
+ */
+export class TerminalWebGLPolicy {
+  constructor(private deps: TerminalWebGLPolicyDeps) {}
+
+  /**
+   * Whether a terminal wants a WebGL context at the given tier. Agent
+   * terminals are eligible at every WebGL-eligible tier (FOCUSED/BURST/
+   * VISIBLE) — the DOM renderer mangles the block glyphs agent headers use
+   * (see isWebGLEligibleTier in types.ts). Plain terminals are eligible only
+   * while focused: FOCUSED, or a BURST on the focused pane (input bursts and
+   * streaming output must not drop the context mid-use). BURST alone is
+   * write-driven for every terminal, so granting it to unfocused plain shells
+   * would add a want per streaming build/log pane and trip the count-based
+   * mode switch; VISIBLE is excluded for the same budget reason.
+   */
+  wantsWebGLAtTier(
+    managed: ManagedTerminal,
+    tier: TerminalRefreshTier | undefined,
+    opts?: { trustDomVisibility?: boolean }
+  ): boolean {
+    if (!isWebGLEligibleTier(tier)) return false;
+    // Visibility gates every case: an off-screen pane never wants WebGL, even
+    // an agent streaming at BURST. The want set is fleet-wide per project view,
+    // so hidden streaming agents would otherwise accumulate wants and trip the
+    // count-based mode switch, dropping the whole visible fleet to DOM
+    // (#10671). The reveal path (setVisible(true) → debounced shouldRestoreWebGL
+    // → ensureContext) re-acquires the want once the pane is on-screen again —
+    // and on a warm WebContentsView resume it passes trustDomVisibility because
+    // it has already proven the pane on-screen from DOM truth, so the stale
+    // reactive isVisible flag must not veto the want there.
+    if (!opts?.trustDomVisibility && !managed.isVisible) return false;
+    if (managed.runtimeAgentId) return true;
+    return (
+      tier === TerminalRefreshTier.FOCUSED ||
+      (tier === TerminalRefreshTier.BURST && managed.isFocused)
+    );
+  }
+
+  /**
+   * Eligibility for visibility-driven WebGL restore. Mirrors the gates in
+   * onTierApplied (agent identity / focus + tier) plus liveness checks
+   * (opened, not attaching). Used by the debounced timer in setVisible()
+   * before re-acquiring a context.
+   */
+  shouldRestoreWebGL(managed: ManagedTerminal, opts?: { trustDomVisibility?: boolean }): boolean {
+    if (!managed.isOpened) return false;
+    // The reveal path proves visibility from DOM ground truth (isConnected +
+    // checkVisibility + box) before calling, because the reactive isVisible flag
+    // can be stale-false on a warm WebContentsView resume (#10632 item 4). Trust
+    // that here so a dropped WebGL context is reattached on reveal instead of
+    // leaving the pane on the DOM renderer until the ~3s watchdog (which is
+    // itself suppressed for the first ~5s by the project-switch resize lock).
+    if (!opts?.trustDomVisibility && !managed.isVisible) return false;
+    if (managed.isAttaching) return false;
+    return this.wantsWebGLAtTier(
+      managed,
+      managed.lastAppliedTier ?? managed.getRefreshTier?.(),
+      opts
+    );
+  }
+
+  /**
+   * Watchdog-only WebGL eligibility. Identical to {@link shouldRestoreWebGL} but
+   * additionally false for a non-pinned pane in DOM-mode fallback: in DOM mode
+   * the manager only ever attaches the single focus-pinned context, so a
+   * non-pinned pane's context can never become active. Without this the
+   * watchdog's `shouldHaveWebGL && !isWebGLActive` stays permanently true for
+   * every non-pinned agent pane and burns a heavy-repair slot every tick (plus a
+   * spurious "context missing" warning). The reveal / visibility restore paths
+   * deliberately keep using {@link shouldRestoreWebGL} so they still call
+   * `ensureContext` and keep the pane in the manager's `wants` set — which is
+   * what lets a later focus change pin and attach it immediately.
+   */
+  shouldHaveActiveWebGL(managed: ManagedTerminal): boolean {
+    if (!this.shouldRestoreWebGL(managed)) return false;
+    // In DOM mode the manager only keeps contexts on pinned panes (the focus
+    // pin and alt-buffer pins). A non-pinned pane can never have an active
+    // context, so the watchdog must not treat its absence as a fault.
+    if (
+      this.deps.getMode() === "dom" &&
+      managed.id !== this.deps.getPinnedId() &&
+      !this.deps.isAltBufferPinned(managed.id)
+    ) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/services/terminal/TerminalWorkerIngestController.ts
+++ b/src/services/terminal/TerminalWorkerIngestController.ts
@@ -1,0 +1,174 @@
+import type { ManagedTerminal } from "./types";
+import { TerminalRefreshTier } from "@/types";
+import { terminalClient } from "@/clients";
+import { LiveWorkerIngest } from "./workerParse/LiveWorkerIngest";
+import { createParseWorkerTransport } from "./workerParse/createParseWorkerTransport";
+import { isPaintFabricWorkerIngestEnabled } from "./paintFabric/paintFabricConfig";
+import { logWarn } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+
+// Poll interval while the worker-ingest engage barrier waits for the normal
+// pipeline (ingest queue + pending xterm writes) to quiesce (#10960).
+const WORKER_INGEST_DRAIN_POLL_MS = 10;
+
+export interface TerminalWorkerIngestControllerDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  getQueuedBytes: (id: string) => number;
+  resumeFlush: (id: string) => void;
+  incrementUnseen: (id: string, isScrolledBack: boolean) => void;
+  fetchAndRestore: (id: string) => Promise<boolean>;
+}
+
+/**
+ * Owns the live worker-parse ingest (issue #10960), gated by
+ * DAINTREE_PAINT_FABRIC_WORKER_INGEST. One controller per terminal that has
+ * ever gone BACKGROUND while the gate is on; disposed with the terminal.
+ */
+export class TerminalWorkerIngestController {
+  private workerIngest = new Map<string, LiveWorkerIngest>();
+  private unsubWorkerIngestEngaged: (() => void) | null = null;
+
+  constructor(private deps: TerminalWorkerIngestControllerDeps) {}
+
+  // Current diversion state for a terminal, if any — consumed by the onData
+  // handler to route main-thread chunks into the worker session's mirror
+  // instead of the normal write path while diversion is active.
+  getIngest(id: string): LiveWorkerIngest | undefined {
+    return this.workerIngest.get(id);
+  }
+
+  /**
+   * Tier-driven worker-ingest policy (issue #10960): BACKGROUND demotes the
+   * terminal's parse into a worker via its dedicated pty-host port; any other
+   * tier (FOCUSED/BURST, and VISIBLE — a visible pane repainting at snapshot
+   * cadence would be a UX regression) promotes back to the main-thread path
+   * through the zero-loss release barrier. No-op unless
+   * DAINTREE_PAINT_FABRIC_WORKER_INGEST=1.
+   */
+  applyWorkerIngestPolicy(id: string, tier: TerminalRefreshTier, managed: ManagedTerminal): void {
+    if (!isPaintFabricWorkerIngestEnabled()) return;
+    if (tier === TerminalRefreshTier.BACKGROUND) {
+      let ingest = this.workerIngest.get(id);
+      if (!ingest) {
+        ingest = this.createWorkerIngest(id, managed);
+        this.workerIngest.set(id, ingest);
+      }
+      ingest.setDesired(true);
+    } else {
+      this.workerIngest.get(id)?.setDesired(false);
+    }
+  }
+
+  private createWorkerIngest(id: string, managed: ManagedTerminal): LiveWorkerIngest {
+    if (!this.unsubWorkerIngestEngaged) {
+      this.unsubWorkerIngestEngaged = terminalClient.onWorkerIngestEngaged((terminalId) => {
+        this.workerIngest.get(terminalId)?.handleEngaged();
+      });
+    }
+
+    const utf8ByteLength = (data: string): number => new TextEncoder().encode(data).byteLength;
+
+    const ingest = new LiveWorkerIngest({
+      id,
+      requestPort: () => terminalClient.requestWorkerIngestPort(id),
+      releasePort: () => terminalClient.releaseWorkerIngestPort(id),
+      sendEngage: () => terminalClient.sendWorkerIngestEngage(id),
+      sendRelease: (drainId) => terminalClient.sendWorkerIngestRelease(id, drainId),
+      createTransport: () => createParseWorkerTransport(),
+      mirror: {
+        write: (data, callback) => {
+          const current = this.deps.getInstance(id);
+          if (!current) {
+            callback?.();
+            return;
+          }
+          // Direct write — snapshot applies and replays are pre-acked, so the
+          // write controller's ack bookkeeping must never see them. Unseen
+          // tracking still counts each repaint as output activity.
+          this.deps.incrementUnseen(id, current.isUserScrolledBack);
+          current.terminal.write(data, callback);
+        },
+      },
+      serializeMirror: () => {
+        const current = this.deps.getInstance(id);
+        return current?.serializeAddon.serialize() ?? "";
+      },
+      getGeometry: () => {
+        const current = this.deps.getInstance(id);
+        return {
+          cols: current?.terminal.cols ?? 80,
+          rows: current?.terminal.rows ?? 24,
+          scrollback: current?.terminal.options.scrollback ?? 1000,
+        };
+      },
+      ackDiverted: (data) => {
+        // Delivery source is encoded in the chunk type (the same invariant
+        // TerminalWriteController's ackBytes rule rests on): port chunks are
+        // always Uint8Array, IPC chunks always strings. Settle exactly one
+        // port-ack FIFO entry per port chunk; never let an IPC chunk shift a
+        // port entry — that would prematurely ack a port chunk still queued.
+        if (typeof data === "string") {
+          terminalClient.acknowledgeData(id, utf8ByteLength(data));
+        } else {
+          terminalClient.acknowledgePortData(id, data.byteLength, 1);
+        }
+      },
+      drainPendingWrites: async () => {
+        // Quiesce the normal pipeline before the engage serialize: queued
+        // ingest chunks, in-flight xterm writes, and serialized-restore
+        // deferrals all still land on the mirror through the write controller
+        // — the serialize must happen after them or they vanish at the next
+        // snapshot apply. Diversion is already on, so no new inflow.
+        const deadline = Date.now() + 5000;
+        for (;;) {
+          const current = this.deps.getInstance(id);
+          if (!current) return false;
+          if (
+            this.deps.getQueuedBytes(id) === 0 &&
+            (current.pendingWrites ?? 0) === 0 &&
+            !current.isSerializedRestoreInProgress
+          ) {
+            return true;
+          }
+          if (Date.now() > deadline) return false;
+          this.deps.resumeFlush(id);
+          await new Promise((resolve) => setTimeout(resolve, WORKER_INGEST_DRAIN_POLL_MS));
+        }
+      },
+      requestHostRestore: () => {
+        safeFireAndForget(this.deps.fetchAndRestore(id), {
+          context: "worker-ingest fallback restore",
+        });
+      },
+      onDidFallback: (reason) => {
+        logWarn("Worker ingest fell back to main-thread parse", { id, reason });
+      },
+    });
+
+    // Geometry follows the mirror in every mode so demotion re-seeds at the
+    // right size (session forwards resizes only while in worker mode).
+    const resizeDisposable = managed.terminal.onResize(({ cols, rows }) =>
+      ingest.resize(cols, rows)
+    );
+    managed.listeners.push(() => resizeDisposable.dispose());
+
+    return ingest;
+  }
+
+  // Worker ingest dies with the terminal: dispose terminates the Worker and
+  // closes the dedicated port on every teardown path (kill/trash/project
+  // close/LRU eviction) — a leaked producer port queues unboundedly (#6283).
+  // Called from `TerminalInstanceService.destroy()`.
+  destroy(id: string): void {
+    const ingest = this.workerIngest.get(id);
+    if (ingest) {
+      ingest.dispose();
+      this.workerIngest.delete(id);
+    }
+  }
+
+  dispose(): void {
+    this.unsubWorkerIngestEngaged?.();
+    this.unsubWorkerIngestEngaged = null;
+  }
+}

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -156,7 +156,7 @@ export class TerminalWriteController {
       // Same stale-identity guard as the write callback (#4850): the instance
       // can be replaced/destroyed between scheduling and the frame.
       if (this.deps.getInstance(id) !== managed) continue;
-      if (managed.isHibernated || managed.isAltBuffer) continue;
+      if (managed.isAltBuffer) continue;
       managed.lastActivityMarker?.dispose();
       managed.lastActivityMarker = managed.terminal.registerMarker(0);
     }
@@ -165,19 +165,6 @@ export class TerminalWriteController {
   write(id: string, data: string | Uint8Array, chunkCount = 1): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
-
-    if (managed.isHibernated) {
-      const bytes = typeof data === "string" ? data.length : data.byteLength;
-      this.deps.acknowledgePortData(id, bytes, chunkCount);
-      // Hibernated output is dropped, never replayed — IPC-delivered chunks
-      // (always strings) were charged to the host's IPC ledger, so ack them
-      // here in UTF-8 bytes or the ledger leaks into permanent backpressure.
-      if (typeof data === "string") {
-        this.deps.acknowledgeData(id, utf8ByteLength(data));
-      }
-      this.deps.notifyWriteComplete(id, bytes);
-      return;
-    }
 
     if (managed.isSerializedRestoreInProgress) {
       // Defer WITHOUT settling any ledger. The batch's pending port-ack FIFO

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -184,7 +184,6 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     attachRevealToken: 0,
     ipcListenerCount: 0,
     isAltBuffer: false,
-    isHibernated: false,
     pendingWrites: 0,
     ...overrides,
   } as ManagedTerminal;
@@ -239,21 +238,6 @@ describe("TerminalInstanceService adversarial", () => {
     const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
     TerminalWebGLManager.setWebglThresholds(originalUpperThreshold, originalLowerThreshold);
     vi.useRealTimers();
-  });
-
-  it("HEARTBEAT_SKIPS_HIBERNATED_TERMINAL", () => {
-    const managed = makeManaged({
-      isHibernated: true,
-      lastReflowAt: 123,
-    });
-    document.body.appendChild(managed.hostElement);
-    service.instances.set("t1", managed);
-
-    vi.advanceTimersByTime(3000);
-
-    expect(paddingHistory(managed)).toHaveLength(0);
-    expect(managed.terminal.refresh).not.toHaveBeenCalled();
-    expect(managed.lastReflowAt).toBe(123);
   });
 
   it("CONCURRENT_REFLOW_IS_PER_TERMINAL_NOT_GLOBAL", () => {
@@ -355,28 +339,6 @@ describe("TerminalInstanceService adversarial", () => {
     expect(testState.clientMocks.acknowledgeData).not.toHaveBeenCalled();
     expect(notifyWriteCompleteSpy).not.toHaveBeenCalled();
     expect(managed.terminal.registerMarker).not.toHaveBeenCalled();
-  });
-
-  it("HIBERNATED_WRITE_ONLY_ACKS", () => {
-    const managed = makeManaged({
-      isHibernated: true,
-      terminal: {
-        ...makeManaged().terminal,
-        write: vi.fn(),
-      } as unknown as ManagedTerminal["terminal"],
-    });
-    service.instances.set("t1", managed);
-    const notifyWriteCompleteSpy = vi.spyOn(service.dataBuffer, "notifyWriteComplete");
-
-    service.writeToTerminal("t1", "abc");
-
-    expect(testState.clientMocks.acknowledgePortData).toHaveBeenCalledWith("t1", 3, 1);
-    // Hibernated output is dropped, never replayed — IPC-delivered string
-    // chunks were charged to the host's IPC ledger, so it must be drained here
-    // or it leaks into permanent backpressure (#9893). ASCII "abc" = 3 bytes.
-    expect(testState.clientMocks.acknowledgeData).toHaveBeenCalledWith("t1", 3);
-    expect(notifyWriteCompleteSpy).toHaveBeenCalledWith("t1", 3);
-    expect(managed.terminal.write).not.toHaveBeenCalled();
   });
 
   // Verifies the contract that @xterm/addon-image's async IIPHandler.end() relies on:

--- a/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
@@ -117,7 +117,6 @@ describe("TerminalInstanceService attach reveal", () => {
       isOpened: true,
       isDetached: false,
       isVisible: true,
-      isHibernated: false,
       lastAttachAt: 0,
       lastDetachAt: 0,
       lastWidth: 0,

--- a/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
@@ -65,7 +65,6 @@ type BackgroundResizeTestService = {
 function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
   return {
     isOpened: true,
-    isHibernated: false,
     lastWidth: 800,
     lastHeight: 600,
     ...overrides,
@@ -168,8 +167,7 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
   });
 
-  it("skips hibernated, unopened, and never-measured terminals", () => {
-    service.instances.set("hibernated", makeManaged({ isHibernated: true }));
+  it("skips unopened and never-measured terminals", () => {
     service.instances.set("unopened", makeManaged({ isOpened: false }));
     service.instances.set("unmeasured", makeManaged({ lastWidth: 0, lastHeight: 0 }));
     service.instances.set("eligible", makeManaged());

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -106,7 +106,6 @@ function makeManaged(fixture: ManagedFixture): ManagedTerminal {
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isAttaching: false,
     isUserScrolledBack: false,
     isAltBuffer: false,

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -51,7 +51,7 @@ vi.mock("../TerminalAddonManager", () => ({
 
 type BatchTestService = {
   instances: Map<string, ManagedTerminal>;
-  batchResize: (ids: string[]) => void;
+  resizePassScheduler: { batchResize: (ids: string[]) => void };
   suppressResizesDuringLayoutTransition: (ids: string[], durationMs: number) => void;
   resizeController: {
     resize: (id: string, width: number, height: number) => { cols: number; rows: number } | null;
@@ -164,7 +164,7 @@ describe("TerminalInstanceService batchResize", () => {
 
   it("no-ops on an empty id list", () => {
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
-    service.batchResize([]);
+    service.resizePassScheduler.batchResize([]);
     expect(spy).not.toHaveBeenCalled();
   });
 
@@ -176,7 +176,7 @@ describe("TerminalInstanceService batchResize", () => {
 
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a", "b"]);
+    service.resizePassScheduler.batchResize(["a", "b"]);
 
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenNthCalledWith(1, "a", 800, 600);
@@ -188,7 +188,7 @@ describe("TerminalInstanceService batchResize", () => {
     service.instances.set("a", a);
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a", "a", "a"]);
+    service.resizePassScheduler.batchResize(["a", "a", "a"]);
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -198,7 +198,7 @@ describe("TerminalInstanceService batchResize", () => {
     service.instances.set("a", a);
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a", "missing"]);
+    service.resizePassScheduler.batchResize(["a", "missing"]);
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith("a", expect.any(Number), expect.any(Number));
@@ -209,7 +209,7 @@ describe("TerminalInstanceService batchResize", () => {
     service.instances.set("a", a);
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a"]);
+    service.resizePassScheduler.batchResize(["a"]);
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -219,7 +219,7 @@ describe("TerminalInstanceService batchResize", () => {
     service.instances.set("a", a);
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a"]);
+    service.resizePassScheduler.batchResize(["a"]);
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -230,7 +230,7 @@ describe("TerminalInstanceService batchResize", () => {
     service.resizeController.lockResize("a", true);
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a"]);
+    service.resizePassScheduler.batchResize(["a"]);
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -242,7 +242,7 @@ describe("TerminalInstanceService batchResize", () => {
     service.instances.set("b", b);
     const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a", "b"]);
+    service.resizePassScheduler.batchResize(["a", "b"]);
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -270,7 +270,7 @@ describe("TerminalInstanceService batchResize", () => {
       return null;
     });
 
-    service.batchResize(["a", "b"]);
+    service.resizePassScheduler.batchResize(["a", "b"]);
 
     expect(sequence).toEqual(["read:a", "read:b", "write:a", "write:b"]);
   });
@@ -281,7 +281,7 @@ describe("TerminalInstanceService batchResize", () => {
     const fitSpy = vi.spyOn(service.resizeController, "fit").mockReturnValue(null);
     vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
 
-    service.batchResize(["a"]);
+    service.resizePassScheduler.batchResize(["a"]);
 
     expect(fitSpy).not.toHaveBeenCalled();
   });

--- a/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
@@ -132,38 +132,6 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     terminalInstanceService.destroy("repair-fit-2");
   });
 
-  it("skips hibernated instances", async () => {
-    const { terminalInstanceService } = await import("../TerminalInstanceService");
-    stubMatchMedia();
-
-    const active = await terminalInstanceService.getOrCreate(
-      "repair-active",
-      undefined,
-      {},
-      () => TerminalRefreshTier.FOCUSED,
-      undefined
-    );
-    const hibernated = await terminalInstanceService.getOrCreate(
-      "repair-hibernated",
-      undefined,
-      {},
-      () => TerminalRefreshTier.FOCUSED,
-      undefined
-    );
-    hibernated.isHibernated = true;
-
-    const fActive = vi.spyOn(active.fitAddon, "fit");
-    const fHibernated = vi.spyOn(hibernated.fitAddon, "fit");
-
-    terminalInstanceService.repairFontGrid();
-
-    expect(fActive).toHaveBeenCalled();
-    expect(fHibernated).not.toHaveBeenCalled();
-
-    terminalInstanceService.destroy("repair-active");
-    terminalInstanceService.destroy("repair-hibernated");
-  });
-
   it("pokes fontFamily to a distinct value then restores the original", async () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -66,7 +66,6 @@ vi.mock("../TerminalReflowController", async () => {
 type ManagedTerminalMock = {
   isOpened: boolean;
   isAttaching: boolean;
-  isHibernated: boolean;
   isFocused: boolean;
   isVisible: boolean;
   isResizeSuppressed: boolean;
@@ -124,7 +123,6 @@ function makeInstance(overrides: Partial<ManagedTerminalMock> = {}): ManagedTerm
   return {
     isOpened: true,
     isAttaching: false,
-    isHibernated: false,
     isFocused: false,
     isVisible: true,
     isResizeSuppressed: false,
@@ -692,7 +690,7 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
 
   it("takes the cheap repaint path for an opened, live terminal", async () => {
     const id = "rev-1";
-    service.instances.set(id, makeInstance({ isOpened: true, isHibernated: false }));
+    service.instances.set(id, makeInstance({ isOpened: true }));
 
     const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
     const repaint = vi.spyOn(service, "repaintForReveal").mockImplementation(() => true);
@@ -703,30 +701,9 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     expect(fullWake).not.toHaveBeenCalled();
   });
 
-  it("takes the full rehydration path for a hibernated terminal", async () => {
-    const id = "rev-2";
-    // Hibernated panes route through the full open+wake, but only once the host
-    // is measurable — give it a renderable box so the reveal gate proceeds.
-    service.instances.set(
-      id,
-      makeInstance({ isOpened: false, isHibernated: true, hostElement: renderableHost() })
-    );
-
-    const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
-    const repaint = vi.spyOn(service, "repaintForReveal").mockImplementation(() => true);
-
-    await service.revealTerminal(id);
-
-    expect(fullWake).toHaveBeenCalledWith(id);
-    expect(repaint).not.toHaveBeenCalled();
-  });
-
   it("takes the full rehydration path for an un-opened terminal", async () => {
     const id = "rev-3";
-    service.instances.set(
-      id,
-      makeInstance({ isOpened: false, isHibernated: false, hostElement: renderableHost() })
-    );
+    service.instances.set(id, makeInstance({ isOpened: false, hostElement: renderableHost() }));
 
     const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
     const repaint = vi.spyOn(service, "repaintForReveal").mockImplementation(() => true);
@@ -741,7 +718,6 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     const id = "rev-attach";
     const inst = makeInstance({
       isOpened: false,
-      isHibernated: false,
       hostElement: renderableHost(),
     });
     service.instances.set(id, inst);
@@ -764,7 +740,7 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     const id = "rev-4";
     // Bare, unconnected host → zero box → not paintable yet. The sweep should
     // retry on a later frame instead of opening against an unmeasurable host.
-    service.instances.set(id, makeInstance({ isOpened: false, isHibernated: false }));
+    service.instances.set(id, makeInstance({ isOpened: false }));
 
     const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
 
@@ -811,7 +787,6 @@ describe("TerminalInstanceService.repaintForReveal grid reconcile", () => {
     document.body.appendChild(element);
     return makeInstance({
       isOpened: true,
-      isHibernated: false,
       isVisible: true,
       hostElement: renderableHost(),
       terminal: { cols: 80, rows: 24, element, refresh: vi.fn() },
@@ -840,7 +815,6 @@ describe("TerminalInstanceService.repaintForReveal grid reconcile", () => {
     document.body.appendChild(element);
     return makeInstance({
       isOpened: true,
-      isHibernated: false,
       isVisible: false, // stale on a warm WebContentsView resume (#10632 item 4)
       lastAppliedTier: TerminalRefreshTier.FOCUSED,
       hostElement: renderableHost(), // DOM truth: the pane IS on-screen

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -118,6 +118,10 @@ type FullWakeTestService = {
   fullWakeForVisibilityRestore: (id: string) => Promise<void>;
   repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
   revealTerminal: (id: string) => Promise<boolean>;
+  revealController: {
+    fullWakeForVisibilityRestore: (id: string) => Promise<void>;
+    repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
+  };
   settleWaiters: { notifyAttachSettledWaiters: (id: string) => void };
 };
 
@@ -694,8 +698,12 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     const id = "rev-1";
     service.instances.set(id, makeInstance({ isOpened: true }));
 
-    const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
-    const repaint = vi.spyOn(service, "repaintForReveal").mockImplementation(() => true);
+    const fullWake = vi
+      .spyOn(service.revealController, "fullWakeForVisibilityRestore")
+      .mockResolvedValue(undefined);
+    const repaint = vi
+      .spyOn(service.revealController, "repaintForReveal")
+      .mockImplementation(() => true);
 
     await expect(service.revealTerminal(id)).resolves.toBe(true);
 
@@ -707,8 +715,12 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     const id = "rev-3";
     service.instances.set(id, makeInstance({ isOpened: false, hostElement: renderableHost() }));
 
-    const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
-    const repaint = vi.spyOn(service, "repaintForReveal").mockImplementation(() => true);
+    const fullWake = vi
+      .spyOn(service.revealController, "fullWakeForVisibilityRestore")
+      .mockResolvedValue(undefined);
+    const repaint = vi
+      .spyOn(service.revealController, "repaintForReveal")
+      .mockImplementation(() => true);
 
     await service.revealTerminal(id);
 
@@ -729,11 +741,13 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     // pendingVisibilityWake and leaves isAttaching true. The reveal must report
     // "retry" so the sweep doesn't spend its confirm paints before the deferred
     // wake re-runs on attach-settle.
-    vi.spyOn(service, "fullWakeForVisibilityRestore").mockImplementation(async () => {
-      inst.isOpened = true;
-      inst.isAttaching = true;
-      inst.pendingVisibilityWake = true;
-    });
+    vi.spyOn(service.revealController, "fullWakeForVisibilityRestore").mockImplementation(
+      async () => {
+        inst.isOpened = true;
+        inst.isAttaching = true;
+        inst.pendingVisibilityWake = true;
+      }
+    );
 
     await expect(service.revealTerminal(id)).resolves.toBe(false);
   });
@@ -744,7 +758,9 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
     // retry on a later frame instead of opening against an unmeasurable host.
     service.instances.set(id, makeInstance({ isOpened: false }));
 
-    const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
+    const fullWake = vi
+      .spyOn(service.revealController, "fullWakeForVisibilityRestore")
+      .mockResolvedValue(undefined);
 
     await expect(service.revealTerminal(id)).resolves.toBe(false);
 
@@ -752,8 +768,12 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
   });
 
   it("reports settled (true) when the terminal does not exist", async () => {
-    const fullWake = vi.spyOn(service, "fullWakeForVisibilityRestore").mockResolvedValue(undefined);
-    const repaint = vi.spyOn(service, "repaintForReveal").mockImplementation(() => true);
+    const fullWake = vi
+      .spyOn(service.revealController, "fullWakeForVisibilityRestore")
+      .mockResolvedValue(undefined);
+    const repaint = vi
+      .spyOn(service.revealController, "repaintForReveal")
+      .mockImplementation(() => true);
 
     // Gone → nothing to repaint and nothing to retry.
     await expect(service.revealTerminal("missing")).resolves.toBe(true);

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -116,7 +116,7 @@ type FullWakeTestService = {
   fullWakeForVisibilityRestore: (id: string) => Promise<void>;
   repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
   revealTerminal: (id: string) => Promise<boolean>;
-  notifyAttachSettledWaiters: (id: string) => void;
+  settleWaiters: { notifyAttachSettledWaiters: (id: string) => void };
 };
 
 function makeInstance(overrides: Partial<ManagedTerminalMock> = {}): ManagedTerminalMock {
@@ -555,7 +555,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
-    service.notifyAttachSettledWaiters(id);
+    service.settleWaiters.notifyAttachSettledWaiters(id);
     // The deferred repaint is dispatched as a floating promise; flush microtasks.
     await Promise.resolve();
     await Promise.resolve();
@@ -577,7 +577,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
       .spyOn(service.resizeController, "applyDeferredResize")
       .mockImplementation(() => {});
 
-    service.notifyAttachSettledWaiters(id);
+    service.settleWaiters.notifyAttachSettledWaiters(id);
     await Promise.resolve();
     await Promise.resolve();
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -112,7 +112,9 @@ type FullWakeTestService = {
   rendererPolicy: { applyRendererPolicy: (id: string, tier: number) => void };
   ensureOpened: (id: string, managed: ManagedTerminalMock) => void;
   ensureDeferredAddons: (id: string, managed: ManagedTerminalMock) => void;
-  wantsWebGLAtTier: (managed: ManagedTerminalMock, tier: number | undefined) => boolean;
+  webGLPolicy: {
+    wantsWebGLAtTier: (managed: ManagedTerminalMock, tier: number | undefined) => boolean;
+  };
   fullWakeForVisibilityRestore: (id: string) => Promise<void>;
   repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
   revealTerminal: (id: string) => Promise<boolean>;
@@ -662,7 +664,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     service.instances.set(id, instance);
 
     vi.spyOn(service, "ensureDeferredAddons").mockImplementation(() => {});
-    vi.spyOn(service, "wantsWebGLAtTier").mockReturnValue(false);
+    vi.spyOn(service.webGLPolicy, "wantsWebGLAtTier").mockReturnValue(false);
 
     service.ensureOpened(id, instance);
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -156,7 +156,6 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     restoreGeneration: 0,
     isSerializedRestoreInProgress: false,
     deferredOutput: [] as Array<string | Uint8Array>,
-    isHibernated: false,
     isInputLocked: false,
     ipcListenerCount: 0,
     ...overrides,

--- a/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
@@ -83,7 +83,6 @@ interface MockManaged {
   isSerializedRestoreInProgress: boolean;
   isUserScrolledBack: boolean;
   pendingWrites?: number;
-  isHibernated?: boolean;
   lastAppliedTier?: TerminalRefreshTier;
   getRefreshTier?: () => TerminalRefreshTier;
 }

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -291,42 +291,6 @@ describe("TerminalInstanceService - options", () => {
     terminalInstanceService.destroy("test-options-both");
   });
 
-  it("updateOptions on hibernated terminal calls neither refresh nor fit", async () => {
-    const { terminalInstanceService } = await import("../TerminalInstanceService");
-
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    });
-
-    const managed = await terminalInstanceService.getOrCreate(
-      "test-options-hibernated",
-      undefined,
-      {},
-      () => TerminalRefreshTier.FOCUSED,
-      undefined
-    );
-
-    // Simulate hibernation
-    managed.isHibernated = true;
-
-    const refreshSpy = vi.spyOn(managed.terminal, "refresh");
-    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
-
-    terminalInstanceService.updateOptions("test-options-hibernated", {
-      theme: { foreground: "#ffffff", background: "#000000" },
-      fontSize: 16,
-    });
-
-    expect(refreshSpy).not.toHaveBeenCalled();
-    expect(fitSpy).not.toHaveBeenCalled();
-
-    terminalInstanceService.destroy("test-options-hibernated");
-  });
-
   it("applyGlobalOptions with theme calls refresh on each instance", async () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
 
@@ -403,47 +367,5 @@ describe("TerminalInstanceService - options", () => {
 
     terminalInstanceService.destroy("test-global-font-1");
     terminalInstanceService.destroy("test-global-font-2");
-  });
-
-  it("applyGlobalOptions skips hibernated instances", async () => {
-    const { terminalInstanceService } = await import("../TerminalInstanceService");
-
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    });
-
-    const active = await terminalInstanceService.getOrCreate(
-      "test-global-active",
-      undefined,
-      {},
-      () => TerminalRefreshTier.FOCUSED,
-      undefined
-    );
-    const hibernated = await terminalInstanceService.getOrCreate(
-      "test-global-hibernated",
-      undefined,
-      {},
-      () => TerminalRefreshTier.FOCUSED,
-      undefined
-    );
-    hibernated.isHibernated = true;
-
-    const rActive = vi.spyOn(active.terminal, "refresh");
-    const rHibernated = vi.spyOn(hibernated.terminal, "refresh");
-
-    terminalInstanceService.applyGlobalOptions({
-      theme: { foreground: "#ffffff", background: "#000000" },
-      fontSize: 16,
-    });
-
-    expect(rActive).toHaveBeenCalled();
-    expect(rHibernated).not.toHaveBeenCalled();
-
-    terminalInstanceService.destroy("test-global-active");
-    terminalInstanceService.destroy("test-global-hibernated");
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -95,7 +95,6 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isAttaching: false,
     isUserScrolledBack: false,
     isAltBuffer: false,
@@ -214,12 +213,6 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
     expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBeGreaterThan(0);
-  });
-
-  it("skips hibernated terminals", () => {
-    const managed = makeManaged({ isHibernated: true });
-    service.maybeReflowTerminal(managed);
-    expect(paddingHistory(managed).length).toBe(0);
   });
 
   it("skips invisible terminals", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -95,7 +95,6 @@ function makeManaged(visible = true, id = "term"): ManagedTerminal {
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isAttaching: false,
     isUserScrolledBack: false,
     isAltBuffer: false,

--- a/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
@@ -76,7 +76,6 @@ describe("TerminalInstanceService fully-settled waits", () => {
   const makeManaged = (
     id: string,
     overrides: Partial<{
-      isHibernated: boolean;
       isOpened: boolean;
       isAttaching: boolean;
       scrollbackRestoreState: RestoreState;
@@ -95,7 +94,6 @@ describe("TerminalInstanceService fully-settled waits", () => {
       hostElement,
       isOpened: overrides.isOpened ?? true,
       isAttaching: overrides.isAttaching ?? false,
-      isHibernated: overrides.isHibernated ?? false,
       isVisible: true,
       scrollbackRestoreState: overrides.scrollbackRestoreState ?? "none",
       lastScrollbackRestoreError: overrides.lastScrollbackRestoreError,
@@ -239,13 +237,6 @@ describe("TerminalInstanceService fully-settled waits", () => {
 
     await expect(promise).resolves.toBeUndefined();
     expect(managed.lastScrollbackRestoreError).toBeDefined();
-  });
-
-  it("never settles a hibernated terminal", async () => {
-    makeManaged("t1", { scrollbackRestoreState: "done", isHibernated: true });
-    await expect(service.waitForFullySettled("t1", { timeoutMs: 30 })).rejects.toThrow(
-      /fully-settle timeout/
-    );
   });
 
   it("never settles a terminal that is not visually attached", async () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
@@ -56,8 +56,10 @@ type SettleTestService = {
   waitForFullySettled: (id: string, options?: { timeoutMs?: number }) => Promise<void>;
   waitForAllFullySettled: (ids: string[], options?: { timeoutMs?: number }) => Promise<void>;
   notifyRestoreSettledWaiters: (id: string) => void;
-  notifyAttachSettledWaiters: (id: string) => void;
-  fullySettledWaiters: Map<string, unknown[]>;
+  settleWaiters: {
+    notifyAttachSettledWaiters: (id: string) => void;
+    fullySettledWaiters: Map<string, unknown[]>;
+  };
   destroy: (id: string) => void;
   resizeController: Record<string, (...args: unknown[]) => unknown>;
   webGLManager: Record<string, (...args: unknown[]) => unknown>;
@@ -174,7 +176,7 @@ describe("TerminalInstanceService fully-settled waits", () => {
     service.notifyRestoreSettledWaiters("t1");
     await Promise.resolve();
     expect(settled).toBe(false);
-    expect(service.fullySettledWaiters.has("t1")).toBe(true);
+    expect(service.settleWaiters.fullySettledWaiters.has("t1")).toBe(true);
 
     managed.scrollbackRestoreState = "done";
     service.notifyRestoreSettledWaiters("t1");
@@ -201,7 +203,7 @@ describe("TerminalInstanceService fully-settled waits", () => {
 
     // Attach completes — the attach notifier must also drain fully-settled.
     managed.isAttaching = false;
-    service.notifyAttachSettledWaiters("t1");
+    service.settleWaiters.notifyAttachSettledWaiters("t1");
     await promise;
     expect(settled).toBe(true);
   });
@@ -323,8 +325,8 @@ describe("TerminalInstanceService fully-settled waits", () => {
       );
 
       // The shared timeout must have detached every per-panel waiter.
-      expect(service.fullySettledWaiters.has("p1")).toBe(false);
-      expect(service.fullySettledWaiters.has("p2")).toBe(false);
+      expect(service.settleWaiters.fullySettledWaiters.has("p1")).toBe(false);
+      expect(service.settleWaiters.fullySettledWaiters.has("p2")).toBe(false);
 
       // A late notify on a now-detached panel is a harmless no-op.
       managed.scrollbackRestoreState = "done";

--- a/src/services/terminal/__tests__/TerminalInstanceService.switchBackObligation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.switchBackObligation.test.ts
@@ -98,7 +98,6 @@ function makeManaged(id: string, host: HTMLDivElement, isDetached: boolean) {
     fitAddon: { fit: vi.fn(), proposeDimensions: () => ({ cols: 80, rows: 24 }) },
     isDetached,
     isVisible: !isDetached,
-    isHibernated: false,
     attachGeneration: 7,
     latestCols: 80,
     latestRows: 24,

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -638,18 +638,6 @@ describe("TerminalInstanceService - Activity Tier", () => {
       vi.advanceTimersByTime(1100);
       expect(managed.lastAppliedTier).toBe(tierAtDestroy);
     });
-
-    it("does not fire BURST on the hibernated write path", () => {
-      const managed = makeMockManaged({
-        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
-        isHibernated: true,
-      });
-      service.instances.set("t1", managed as unknown as Record<string, unknown>);
-
-      service.writeController.write("t1", "x");
-
-      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BACKGROUND);
-    });
   });
 
   describe("Scrollback Reduce Cooldown", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -104,7 +104,6 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     isAttaching: false,
     isUserScrolledBack: false,
     isAltBuffer: false,
-    isHibernated: false,
     runtimeAgentId: "claude" as string | undefined,
     launchAgentId: "claude",
     lastActiveTime: Date.now(),
@@ -347,17 +346,6 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     // Timer cleared (won't fire and won't crash)
     vi.advanceTimersByTime(200);
-    expect(service.webGLManager.isActive("t1")).toBe(false);
-  });
-
-  it("hibernated terminal short-circuits — no WebGL changes", () => {
-    const managed = makeMockManaged({ isHibernated: true });
-    service.instances.set("t1", managed as unknown as Record<string, unknown>);
-
-    service.setVisible("t1", false);
-    service.setVisible("t1", true);
-    vi.advanceTimersByTime(100);
-
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -639,13 +639,15 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
   describe("WebGL DOM-mode fallback eligibility (W3)", () => {
     function callShouldRestore(managed: unknown): boolean {
       return (
-        service as unknown as { shouldRestoreWebGL: (m: unknown) => boolean }
-      ).shouldRestoreWebGL(managed);
+        service as unknown as { webGLPolicy: { shouldRestoreWebGL: (m: unknown) => boolean } }
+      ).webGLPolicy.shouldRestoreWebGL(managed);
     }
     function callShouldHaveActive(managed: unknown): boolean {
       return (
-        service as unknown as { shouldHaveActiveWebGL: (m: unknown) => boolean }
-      ).shouldHaveActiveWebGL(managed);
+        service as unknown as {
+          webGLPolicy: { shouldHaveActiveWebGL: (m: unknown) => boolean };
+        }
+      ).webGLPolicy.shouldHaveActiveWebGL(managed);
     }
 
     it("keeps a non-pinned DOM pane RESTORE-eligible so it stays in the manager's wants set", () => {
@@ -734,9 +736,11 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     function callShouldRestore(managed: unknown, opts?: { trustDomVisibility?: boolean }): boolean {
       return (
         service as unknown as {
-          shouldRestoreWebGL: (m: unknown, o?: { trustDomVisibility?: boolean }) => boolean;
+          webGLPolicy: {
+            shouldRestoreWebGL: (m: unknown, o?: { trustDomVisibility?: boolean }) => boolean;
+          };
         }
-      ).shouldRestoreWebGL(managed, opts);
+      ).webGLPolicy.shouldRestoreWebGL(managed, opts);
     }
 
     it("withholds restore for a stale isVisible=false pane by default", () => {

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -155,7 +155,6 @@ function makeMockManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTermi
     scrollbackRestoreState: "none",
     attachGeneration: 0,
     attachRevealToken: 0,
-    isHibernated: false,
     ipcListenerCount: 0,
     ...overrides,
   } as ManagedTerminal;

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -51,7 +51,6 @@ function makeManaged(overrides: ManagedOverrides = {}): ManagedTerminal {
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isAttaching: false,
     isDetached: false,
     isResizeSuppressed: false,

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -42,7 +42,6 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isAttaching: false,
     isUserScrolledBack: false,
     isAltBuffer: false,
@@ -148,12 +147,6 @@ describe("TerminalReflowController.maybeReflow", () => {
 
     expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBeGreaterThan(0);
-  });
-
-  it("skips hibernated terminals", () => {
-    const managed = makeManaged({ isHibernated: true });
-    controller.maybeReflow(managed);
-    expect(paddingHistory(managed).length).toBe(0);
   });
 
   it("skips invisible terminals", () => {

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -132,7 +132,6 @@ function buildManaged(agent: FakeAgent): ManagedTerminal {
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isAttaching: false,
     isDetached: false,
     isResizeSuppressed: false,

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -44,7 +44,6 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     isOpened: true,
     isVisible: true,
     isFocused: false,
-    isHibernated: false,
     isUserScrolledBack: false,
     isAltBuffer: false,
     lastActiveTime: Date.now(),
@@ -105,18 +104,6 @@ describe("TerminalWriteController.write", () => {
     controller.write("unknown", "abc");
     expect(deps.acknowledgePortData).not.toHaveBeenCalled();
     expect(deps.notifyWriteComplete).not.toHaveBeenCalled();
-  });
-
-  it("hibernated path: ack + notify but does not touch the xterm instance", () => {
-    managed.isHibernated = true;
-    controller.write("t1", "hello");
-
-    expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 5, 1);
-    // Hibernated output is dropped, never replayed, so the IPC ledger must be
-    // drained here. ASCII "hello" is 5 UTF-8 bytes == 5 UTF-16 code units.
-    expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 5);
-    expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 5);
-    expect((managed.terminal as unknown as MockTerminal).write).not.toHaveBeenCalled();
   });
 
   it("serialized-restore path: defers output without settling ANY ledger", () => {
@@ -207,22 +194,6 @@ describe("TerminalWriteController.write", () => {
       expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 3);
     });
 
-    it("hibernated path: acks the IPC ledger in UTF-8 bytes for non-ASCII strings", () => {
-      managed.isHibernated = true;
-      controller.write("t1", "│");
-
-      expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 3);
-      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 1, 1);
-    });
-
-    it("hibernated path: does not send an IPC ack for port-delivered Uint8Array chunks", () => {
-      managed.isHibernated = true;
-      controller.write("t1", new Uint8Array([0xe2, 0x94, 0x82]));
-
-      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3, 1);
-      expect(deps.acknowledgeData).not.toHaveBeenCalled();
-    });
-
     it("deferred-restore path: never acks the IPC ledger even for non-ASCII strings", () => {
       // The IPC ledger is drained when the deferred chunk replays through the
       // normal path after restore. Acking here would double-drain it. The
@@ -240,12 +211,6 @@ describe("TerminalWriteController.write", () => {
       controller.write("t1", new Uint8Array([1, 2, 3, 4]), 3);
       expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 4, 3);
       expect(deps.acknowledgeData).not.toHaveBeenCalled();
-    });
-
-    it("hibernated path: forwards the chunk count of dropped coalesced batches", () => {
-      managed.isHibernated = true;
-      controller.write("t1", new Uint8Array([1, 2]), 2);
-      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 2, 2);
     });
 
     it("deferred-restore path: preserves the chunk count on the held batch", () => {
@@ -314,13 +279,6 @@ describe("TerminalWriteController.write", () => {
       expect(
         (replacement.terminal as unknown as MockTerminal).registerMarker
       ).not.toHaveBeenCalled();
-    });
-
-    it("skips the refresh when the terminal hibernated before the frame", () => {
-      controller.write("t1", "x");
-      managed.isHibernated = true;
-      flushFrame();
-      expect((managed.terminal as unknown as MockTerminal).registerMarker).not.toHaveBeenCalled();
     });
   });
 
@@ -455,17 +413,6 @@ describe("TerminalWriteController.write", () => {
       // Load-bearing: onWrite must run BEFORE terminal.write so the tier
       // is BURST at paint time, not one frame late.
       expect(callOrder).toEqual(["onWrite", "terminal.write"]);
-    });
-
-    it("does NOT fire on the hibernated path (ack-only)", () => {
-      managed.isHibernated = true;
-      const onWrite = vi.fn();
-      const localDeps = makeDeps(store, { onWrite });
-      const localController = new TerminalWriteController(localDeps);
-
-      localController.write("t1", "hello");
-
-      expect(onWrite).not.toHaveBeenCalled();
     });
 
     it("does NOT fire on the deferred-restore path", () => {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -148,7 +148,7 @@ export interface ManagedTerminal {
   // Retained as a permanently-false field: the wake/resync machinery was removed
   // (terminals stay fully live in the background), so nothing arms this anymore.
   // The reveal guard (wakeForFocus) and the reconciliation watchdog still read
-  // it; kept false to avoid churning that read surface (mirrors `isHibernated`).
+  // it; kept false to avoid churning that read surface.
   needsWake?: boolean;
 
   // First-paint perf instrumentation (#9809). terminalOpenStartedAt is stamped
@@ -234,10 +234,6 @@ export interface ManagedTerminal {
   attachRevealTimer?: ReturnType<typeof setTimeout>;
   attachRevealDisposable?: { dispose: () => void };
 
-  // Retained as a permanently-false field: terminals are never hibernated
-  // anymore (they stay fully live in the background), but reveal/restore/UI
-  // guards and `useIsHibernated` still read it. No code path sets it true.
-  isHibernated?: boolean;
   ipcListenerCount: number;
 
   // Visibility-driven WebGL restore debounce. Show path waits ~100ms before


### PR DESCRIPTION
## Summary

- Splits `TerminalInstanceService.ts` (~4,210 lines, ~145 methods) into focused sibling controllers, one of a batch of parallel file-splitting refactors
- First pass removes dead hibernation code (`isHibernated` was permanently false, `subscribeHibernation`/`hibernationListeners` never fired, plus a pile of always-true `if` guards), then six extractions move logic out line-for-line with call order and behavior preserved exactly, since this code carries fixes for several past production incidents
- `TerminalInstanceService.ts` keeps thin public delegates for anything reached externally, so no importer needed to change

Resolves #10998

## Changes

- `TerminalSettleWaiterRegistry`: the `waitFor`/`notify`/`remove` waiter maps
- `TerminalBurstController`: wheel-scroll burst boost
- `TerminalResizePassScheduler`: multi-terminal batch/chunked resize orchestration (`batchResize`, `scheduleBatchResize`, `runResizePass`, `cancelActiveResizePass`, `executeResizePass`, `orderFocusedFirst`)
- `TerminalWorkerIngestController`: the flag-isolated live worker-parse ingest from #10960
- `TerminalWebGLPolicy`: WebGL eligibility decisions (`wantsWebGLAtTier`, `shouldRestoreWebGL`, `shouldHaveActiveWebGL`), carrying fixes for #10671's want-set accumulation, the DOM-mode pinned-context circuit breaker, and bulk-attach staggering
- `TerminalRevealController`: `setVisible`, `wake`, `wakeForFocus`, `fullWakeForVisibilityRestore`, `repaintForReveal`, `reconcileRevealGeometry`, `revealTerminal`, preserving the exact ordering from past incidents #5878 (want-membership) and #7762 (backgrounded-terminal geometry corruption)
- Fixed a small `lockResize` deps-forwarding bug that always passed an explicit third argument even when the caller omitted it
- Updated tests that spied on the service's own private methods to spy on the new controllers instead, since that's where the call graph now lives

## Testing

- Mechanical extraction throughout: moved code, didn't change logic
- Ran `npm run check` plus the affected test files after each extraction