### PR TITLE
perf(terminal): keystroke-to-paint interactivity benchmark (PERF-120..122) and focused echo protection under flood

### DIFF
--- a/e2e/full/terminal/interactivity-perf.spec.ts
+++ b/e2e/full/terminal/interactivity-perf.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- window bridges are untyped in Playwright evaluate() */
 import { test, expect } from "@playwright/test";
-import { writeFileSync, mkdirSync } from "fs";
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
 import path from "path";
 import { tmpdir } from "os";
 import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
@@ -109,6 +109,8 @@ interface RoundRecord {
   t1: number | null;
   t4: number | null;
   t5: number | null;
+  /** onRender that confirmed the sentinel (paint scheduled/drawn). */
+  t5r: number | null;
   t6: number | null;
   bytes: number;
   confirmed: boolean;
@@ -127,6 +129,16 @@ interface CellMetrics {
   ptyRoundTripMeanMs: number;
   parseMeanMs: number;
   paintMeanMs: number;
+  /** t5→t5r: parse-complete to the confirming xterm render. */
+  renderScheduleMeanMs: number;
+  /** t5r→t6: confirming render to the next rAF (presentation approximation). */
+  presentMeanMs: number;
+  /** terminalClient write→port-data-arrival (INPUT_ECHO_LATENCY marks): the cross-process transport slice of the round trip. */
+  portEchoMeanMs: number;
+  portEchoP95Ms: number;
+  /** pty-host input-received → echo-dispatched (host-internal turnaround, host clock). */
+  hostTurnaroundMeanMs: number;
+  hostTurnaroundP95Ms: number;
   repaintBytesPerKeystroke: number;
   frameGapP50Ms: number;
   frameGapP95Ms: number;
@@ -301,6 +313,9 @@ function buildRounds(total: number): RoundSpec[] {
 
 async function installProbe(page: any, panelId: string): Promise<void> {
   await page.evaluate((id: string) => {
+    // Seed the perf-marks buffer so markRendererPerformance records
+    // INPUT_ECHO_LATENCY pairs (terminalClient samples every write under E2E).
+    (window as any).__DAINTREE_PERF_MARKS__ ||= [];
     const term = (window as any).__daintreeGetTerminalForE2E?.(id);
     if (!term) throw new Error(`interactivity probe: no terminal for panel ${id}`);
     const probe: any = {
@@ -361,6 +376,7 @@ async function installProbe(page: any, panelId: string): Promise<void> {
       if (!c || c.confirmed || c.t4 === null) return;
       if (!isConfirmedNow()) return;
       c.confirmed = true;
+      c.t5r = performance.now();
       requestAnimationFrame((ts) => {
         c.t6 = ts;
         c.done = true;
@@ -400,6 +416,7 @@ async function installProbe(page: any, panelId: string): Promise<void> {
         t1: null,
         t4: null,
         t5: null,
+        t5r: null,
         t6: null,
         bytes: 0,
         confirmed: false,
@@ -423,6 +440,7 @@ async function installProbe(page: any, panelId: string): Promise<void> {
         t1: c.t1,
         t4: c.t4,
         t5: c.t5,
+        t5r: c.t5r,
         t6: c.t6,
         bytes: c.bytes,
         confirmed: c.confirmed,
@@ -501,8 +519,12 @@ async function runRound(page: any, panelId: string, spec: RoundSpec): Promise<vo
 function computeMetrics(
   rounds: RoundRecord[],
   frameGaps: number[],
-  loaf: { count: number; totalMs: number; max: number }
+  loaf: { count: number; totalMs: number; max: number },
+  portEchoLatencies: number[],
+  hostTurnarounds: number[] = []
 ): CellMetrics {
+  const sortedPortEcho = [...portEchoLatencies].sort((a, b) => a - b);
+  const sortedHost = [...hostTurnarounds].sort((a, b) => a - b);
   const measured = rounds.filter((r) => r.measured);
   const ok = measured.filter((r) => !r.timedOut && r.t6 !== null && (r.stamp ?? r.t0) !== null);
   const start = (r: RoundRecord) => (r.stamp !== null && r.stamp > 0 ? r.stamp : (r.t0 as number));
@@ -523,6 +545,14 @@ function computeMetrics(
     ptyRoundTripMeanMs: seg((r) => (r.t4 !== null && r.t1 !== null ? r.t4 - r.t1 : null)),
     parseMeanMs: seg((r) => (r.t5 !== null && r.t4 !== null ? r.t5 - r.t4 : null)),
     paintMeanMs: seg((r) => (r.t6 !== null && r.t5 !== null ? Math.max(0, r.t6 - r.t5) : null)),
+    renderScheduleMeanMs: seg((r) =>
+      r.t5r !== null && r.t5 !== null ? Math.max(0, r.t5r - r.t5) : null
+    ),
+    presentMeanMs: seg((r) => (r.t6 !== null && r.t5r !== null ? Math.max(0, r.t6 - r.t5r) : null)),
+    portEchoMeanMs: mean(sortedPortEcho),
+    portEchoP95Ms: pct(sortedPortEcho, 95),
+    hostTurnaroundMeanMs: mean(sortedHost),
+    hostTurnaroundP95Ms: pct(sortedHost, 95),
     repaintBytesPerKeystroke: mean(ok.map((r) => r.bytes)),
     frameGapP50Ms: pct(sortedGaps, 50),
     frameGapP95Ms: pct(sortedGaps, 95),
@@ -539,7 +569,7 @@ function fmtCell(r: CellResult): string {
   return (
     `${r.cell.padEnd(15)} n=${String(m.samples).padStart(3)} to=${m.timeouts}` +
     ` paint p50=${m.keystrokePaintP50Ms.toFixed(1).padStart(7)} p95=${m.keystrokePaintP95Ms.toFixed(1).padStart(7)} p99=${m.keystrokePaintP99Ms.toFixed(1).padStart(7)}` +
-    ` | q=${m.inputQueueMeanMs.toFixed(1)} enc=${m.inputEncodeMeanMs.toFixed(1)} rtt=${m.ptyRoundTripMeanMs.toFixed(1)} parse=${m.parseMeanMs.toFixed(1)} paint=${m.paintMeanMs.toFixed(1)}` +
+    ` | q=${m.inputQueueMeanMs.toFixed(1)} enc=${m.inputEncodeMeanMs.toFixed(1)} rtt=${m.ptyRoundTripMeanMs.toFixed(1)} (port=${m.portEchoMeanMs.toFixed(1)} host=${m.hostTurnaroundMeanMs.toFixed(1)}) parse=${m.parseMeanMs.toFixed(1)} paint=${m.paintMeanMs.toFixed(1)} (rs=${m.renderScheduleMeanMs.toFixed(1)}+pr=${m.presentMeanMs.toFixed(1)})` +
     ` | gap p95=${m.frameGapP95Ms.toFixed(1)} fps=${m.fpsDuringMeasurement.toFixed(0)} loaf=${m.loafCount}` +
     ` | bytes/key=${m.repaintBytesPerKeystroke.toFixed(0)} [${r.rendererMode ?? "?"}]`
   );
@@ -562,6 +592,7 @@ perfDescribe("Perf: keystroke-to-paint interactivity (PERF-120..122)", () => {
       mkdirSync(scriptsDir, { recursive: true });
       const composerSimPath = path.join(scriptsDir, "composer-sim.js");
       const replayPath = path.join(scriptsDir, "corpus-replay.js");
+      const hostMarksPath = path.join(scriptsDir, "perf-marks.ndjson");
       writeFileSync(composerSimPath, composerSimSource());
       writeFileSync(replayPath, corpusReplaySource());
 
@@ -570,8 +601,16 @@ perfDescribe("Perf: keystroke-to-paint interactivity (PERF-120..122)", () => {
         // enableWebgl matches production rendering and keeps the GPU process
         // out-of-process — the local-macOS --in-process-gpu default makes a
         // compositor fault under sustained terminal streaming fatal to the app
-        // (see store-fanout-perf.spec.ts).
-        ctx = await launchApp({ enableWebgl: true });
+        // (see store-fanout-perf.spec.ts). PERF_CAPTURE arms the terminalClient
+        // echo probe (write→port-arrival INPUT_ECHO_LATENCY marks, sampled
+        // every write under E2E) for transport attribution.
+        ctx = await launchApp({
+          enableWebgl: true,
+          env: {
+            DAINTREE_PERF_CAPTURE: "1",
+            DAINTREE_PERF_METRICS_FILE: hostMarksPath,
+          },
+        });
         ctx.window = await openAndOnboardProject(
           ctx.app,
           ctx.window,
@@ -687,6 +726,51 @@ perfDescribe("Perf: keystroke-to-paint interactivity (PERF-120..122)", () => {
           return snap;
         })) as { rounds: RoundRecord[]; frameGaps: number[]; loaf: any };
 
+        // Host-internal turnaround: pair each pty-host input-received mark with
+        // the first interactive echo-dispatch that follows it (same process, so
+        // elapsedMs values subtract cleanly). Diagnostic only.
+        const hostTurnarounds: number[] = [];
+        if (existsSync(hostMarksPath)) {
+          const inputMarks: number[] = [];
+          const echoMarks: number[] = [];
+          for (const line of readFileSync(hostMarksPath, "utf8").trim().split("\n")) {
+            if (!line) continue;
+            try {
+              const rec = JSON.parse(line) as {
+                mark?: string;
+                elapsedMs?: number;
+                meta?: { terminalId?: string };
+              };
+              if (rec.meta?.terminalId !== measuredPanelId) continue;
+              if (rec.mark === "terminal_port_input_written") inputMarks.push(rec.elapsedMs ?? -1);
+              if (rec.mark === "terminal_interactive_echo_dispatched")
+                echoMarks.push(rec.elapsedMs ?? -1);
+            } catch {
+              // partial line mid-append — skip
+            }
+          }
+          let echoIdx = 0;
+          for (const t of inputMarks) {
+            while (echoIdx < echoMarks.length && echoMarks[echoIdx] < t) echoIdx++;
+            if (echoIdx >= echoMarks.length) break;
+            const delta = echoMarks[echoIdx] - t;
+            if (delta >= 0 && delta < 500) hostTurnarounds.push(delta);
+          }
+        }
+
+        // Transport attribution: terminalClient write→port-arrival pairs for
+        // the measured terminal (diagnostic slice of ptyRoundTripMs).
+        const portEchoLatencies = (await page.evaluate((id: string) => {
+          const marks = ((window as any).__DAINTREE_PERF_MARKS__ ?? []) as Array<{
+            mark: string;
+            meta?: { terminalId?: string; latencyMs?: number };
+          }>;
+          return marks
+            .filter((m) => m.mark === "input_echo_latency" && m.meta?.terminalId === id)
+            .map((m) => m.meta!.latencyMs!)
+            .filter((v) => typeof v === "number" && Number.isFinite(v));
+        }, measuredPanelId)) as number[];
+
         const rendererMode = (await page.evaluate((id: string) => {
           const fn = (window as any).__daintreeGetTerminalWebGLState;
           return typeof fn === "function" ? (fn(id)?.mode ?? null) : null;
@@ -697,7 +781,13 @@ perfDescribe("Perf: keystroke-to-paint interactivity (PERF-120..122)", () => {
         }, measuredPanelId)) as { cols: number; rows: number } | null;
 
         const roundRecords = snapshot.rounds.filter((r) => r.idx >= 0);
-        const metrics = computeMetrics(roundRecords, snapshot.frameGaps, snapshot.loaf);
+        const metrics = computeMetrics(
+          roundRecords,
+          snapshot.frameGaps,
+          snapshot.loaf,
+          portEchoLatencies,
+          hostTurnarounds
+        );
         const result: CellResult = {
           cell: cell.key,
           scenarioId: cell.scenarioId,

--- a/e2e/full/terminal/interactivity-perf.spec.ts
+++ b/e2e/full/terminal/interactivity-perf.spec.ts
@@ -1,0 +1,768 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window bridges are untyped in Playwright evaluate() */
+import { test, expect } from "@playwright/test";
+import { writeFileSync, mkdirSync } from "fs";
+import path from "path";
+import { tmpdir } from "os";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo, type FixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { openTerminal, getGridPanelIds } from "../../helpers/panels";
+import { runTerminalCommand, waitForTerminalReady } from "../../helpers/terminal";
+
+// PERF-120..122 — keystroke-to-paint interactivity benchmark (the integrated
+// analogue of PERF-034's headless echo scenario). Measures what a user feels:
+// press a key in the focused terminal while the rest of the fleet streams, and
+// count the milliseconds until the glyph is painted. The full pipeline
+// (keydown → xterm onData → IPC → pty-host → PTY echo → MessagePort → parse →
+// paint) is exercised in the real renderer via CDP keyboard input.
+//
+// Pipeline timestamps (all on the renderer's performance.now() clock):
+//   stamp  keydown event creation (event.timeStamp — includes input-queue delay)
+//   t0     keydown capture-phase listener runs
+//   t1     xterm onData fires (bytes leave the renderer)
+//   t4     echo bytes reach terminal.write() (transport complete)
+//   t5     parse complete (onWriteParsed) for the confirming chunk
+//   t6     first onRender containing the round's sentinel, stamped at next rAF
+// Headline metric: t6 - stamp (keystrokePaintMs). Segments are attribution
+// aids: inputQueueMs (t0-stamp), inputEncodeMs (t1-t0), ptyRoundTripMs (t4-t1),
+// parseMs (t5-t4), paintMs (t6-t5).
+//
+// Cells:
+//   cat-solo        PERF-120  pure tty echo, 0 background — the floor
+//   sim-solo        PERF-120  composer-sim (ink-style ~1KB repaint/keystroke), 0 bg
+//   sim-fleet       PERF-121  composer-sim + 12 bg terminals × ~32KB/s corpus replay
+//   sim-saturation  PERF-122  composer-sim + 6 bg terminals unthrottled (drain-limited)
+//
+// Opt-in only (multi-minute run, never a CI gate):
+//   npm run build:e2e   # or build:e2e:bench
+//   RUN_PERF_INTERACTIVITY=1 npx playwright test --project=full-terminal \
+//     e2e/full/terminal/interactivity-perf.spec.ts
+//
+// Machines running PARALLEL e2e sessions: launchApp reaps stray e2e Electrons
+// machine-wide (see store-fanout-perf.spec.ts for the ELECTRON_OVERRIDE_DIST_PATH
+// immunization recipe).
+
+const ROUNDS = Math.max(10, Math.floor(Number(process.env.PERF_INTERACTIVITY_ROUNDS) || 40));
+const WARMUP = Math.max(2, Math.floor(Number(process.env.PERF_INTERACTIVITY_WARMUP) || 8));
+const SETTLE_MS = Math.max(50, Math.floor(Number(process.env.PERF_INTERACTIVITY_SETTLE_MS) || 200));
+const ROUND_TIMEOUT_MS = Math.max(
+  500,
+  Math.floor(Number(process.env.PERF_INTERACTIVITY_TIMEOUT_MS) || 2000)
+);
+const OUT_PATH = process.env.PERF_INTERACTIVITY_OUT ?? "";
+const CELL_FILTER = (process.env.PERF_INTERACTIVITY_CELLS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// Anchor typed before any measured round so expected-text checks never collide
+// with shell prompts or box chrome ("==a" is implausible outside the probe).
+const ANCHOR = "==";
+// 22 distinct chars per batch: type them all, then backspace back to the
+// anchor. Backspace rounds are measured too — deletion repaints are part of
+// feel. 24 chars total (anchor + batch) keeps the line well below any
+// realistic pane width, so the expected string never soft-wraps.
+const BATCH_ALPHABET = "abcdefghijklmnopqrstuv";
+
+interface CellDef {
+  key: string;
+  scenarioId: string;
+  workload: "cat" | "composer-sim";
+  background: number;
+  floodMode: "fleet" | "saturation" | null;
+}
+
+const ALL_CELLS: CellDef[] = [
+  { key: "cat-solo", scenarioId: "PERF-120", workload: "cat", background: 0, floodMode: null },
+  {
+    key: "sim-solo",
+    scenarioId: "PERF-120",
+    workload: "composer-sim",
+    background: 0,
+    floodMode: null,
+  },
+  {
+    key: "sim-fleet",
+    scenarioId: "PERF-121",
+    workload: "composer-sim",
+    background: 12,
+    floodMode: "fleet",
+  },
+  {
+    key: "sim-saturation",
+    scenarioId: "PERF-122",
+    workload: "composer-sim",
+    background: 6,
+    floodMode: "saturation",
+  },
+];
+
+const CELLS =
+  CELL_FILTER.length > 0 ? ALL_CELLS.filter((c) => CELL_FILTER.includes(c.key)) : ALL_CELLS;
+
+interface RoundRecord {
+  idx: number;
+  kind: "type" | "backspace";
+  measured: boolean;
+  stamp: number | null;
+  t0: number | null;
+  t1: number | null;
+  t4: number | null;
+  t5: number | null;
+  t6: number | null;
+  bytes: number;
+  confirmed: boolean;
+  timedOut: boolean;
+}
+
+interface CellMetrics {
+  samples: number;
+  timeouts: number;
+  keystrokePaintP50Ms: number;
+  keystrokePaintP95Ms: number;
+  keystrokePaintP99Ms: number;
+  keystrokePaintMaxMs: number;
+  inputQueueMeanMs: number;
+  inputEncodeMeanMs: number;
+  ptyRoundTripMeanMs: number;
+  parseMeanMs: number;
+  paintMeanMs: number;
+  repaintBytesPerKeystroke: number;
+  frameGapP50Ms: number;
+  frameGapP95Ms: number;
+  frameGapP99Ms: number;
+  frameGapMaxMs: number;
+  fpsDuringMeasurement: number;
+  loafCount: number;
+  loafTotalMs: number;
+}
+
+interface CellResult {
+  cell: string;
+  scenarioId: string;
+  workload: string;
+  background: number;
+  floodMode: string | null;
+  rendererMode: string | null;
+  dims: { cols: number; rows: number } | null;
+  metrics: CellMetrics;
+  rounds: RoundRecord[];
+}
+
+function pct(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+function mean(arr: number[]): number {
+  if (arr.length === 0) return 0;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+// Composer-sim: hermetic ink-style agent composer. Raw-mode stdin; every
+// keystroke triggers a deterministic full box repaint (~1KB of ANSI: cursor
+// repositioning, borders, accumulated text, SGR-colored status segments) —
+// magnitude-faithful to a real agent composer redraw without auth or network.
+function composerSimSource(): string {
+  return [
+    "#!/usr/bin/env node",
+    "const out = process.stdout;",
+    "const ESC = '\\u001b';",
+    "const WIDTH = Math.max(24, Math.min(out.columns || 80, 76));",
+    "let text = '';",
+    "function statusSegments() {",
+    "  let s = '';",
+    "  for (let i = 0; i < 36; i++) {",
+    "    s += ESC + '[38;5;' + (100 + ((i * 7) % 120)) + 'm' + '\\u2582' + ESC + '[0m';",
+    "  }",
+    "  return s;",
+    "}",
+    "function frame() {",
+    "  let s = '';",
+    "  s += ESC + '[?25l';",
+    "  s += '\\r' + ESC + '[3A';",
+    "  s += '\\u256d' + '\\u2500'.repeat(WIDTH - 2) + '\\u256e' + ESC + '[K\\n';",
+    "  s += '\\u2502 > ' + text + ESC + '[K\\n';",
+    "  s += '\\u2570' + '\\u2500'.repeat(WIDTH - 2) + '\\u256f' + ESC + '[K\\n';",
+    "  s += '  ' + statusSegments() + ESC + '[2m composer-sim ' + text.length + ' chars' + ESC + '[0m' + ESC + '[K';",
+    "  s += ESC + '[?25h';",
+    "  out.write(s);",
+    "}",
+    "out.write('COMPOSER_SIM_READY\\n\\n\\n\\n');",
+    "frame();",
+    "process.stdin.setRawMode(true);",
+    "process.stdin.resume();",
+    "process.stdin.setEncoding('utf8');",
+    "process.stdin.on('data', (chunk) => {",
+    "  for (const ch of String(chunk)) {",
+    "    if (ch === '\\u0003') { process.stdin.setRawMode(false); process.exit(0); }",
+    "    else if (ch === '\\u007f' || ch === '\\b') text = text.slice(0, -1);",
+    "    else if (ch >= ' ' && ch !== '\\u007f') text += ch;",
+    "  }",
+    "  frame();",
+    "});",
+    "",
+  ].join("\n");
+}
+
+// Background corpus replay: seeded xorshift32 stream of pseudo agent-log lines
+// with SGR color spans, written to stdout at a controlled rate. Bytes traverse
+// the real path (pty-host → MessagePort → parse → paint), not synthetic
+// renderer writes.
+//   fleet:       ~8KB burst every 250ms (~32KB/s) — the "normal busy fleet"
+//   saturation:  continuous 16KB chunks, drain-limited — the lockup regime
+function corpusReplaySource(): string {
+  return [
+    "#!/usr/bin/env node",
+    "const seed = Number(process.argv[2]) || 1;",
+    "const mode = process.argv[3] || 'fleet';",
+    "let s = seed >>> 0 || 1;",
+    "function rnd() {",
+    "  s ^= s << 13; s >>>= 0;",
+    "  s ^= s >> 17; s >>>= 0;",
+    "  s ^= s << 5; s >>>= 0;",
+    "  return s / 4294967296;",
+    "}",
+    "const ESC = '\\u001b';",
+    "const WORDS = ['build', 'parse', 'emit', 'link', 'check', 'trace', 'patch', 'merge', 'scan', 'load'];",
+    "function line() {",
+    "  const c = 30 + Math.floor(rnd() * 8);",
+    "  let l = ESC + '[' + c + 'm[' + Math.floor(rnd() * 100000) + ']' + ESC + '[0m ';",
+    "  const n = 8 + Math.floor(rnd() * 6);",
+    "  for (let i = 0; i < n; i++) l += WORDS[Math.floor(rnd() * WORDS.length)] + '-' + Math.floor(rnd() * 1000) + ' ';",
+    "  return l + '\\n';",
+    "}",
+    "function chunk(bytes) {",
+    "  let out = '';",
+    "  while (out.length < bytes) out += line();",
+    "  return out;",
+    "}",
+    "if (mode === 'saturation') {",
+    "  const pump = () => { while (process.stdout.write(chunk(16384))) {} };",
+    "  process.stdout.on('drain', pump);",
+    "  pump();",
+    "} else {",
+    "  setInterval(() => { process.stdout.write(chunk(8192)); }, 250);",
+    "}",
+    "",
+  ].join("\n");
+}
+
+interface RoundSpec {
+  idx: number;
+  kind: "type" | "backspace";
+  measured: boolean;
+  expectKey: string;
+  expectData: string;
+  expectText: string;
+  forbidText: string | null;
+}
+
+// Deterministic round sequence: type the batch alphabet onto the anchor, then
+// backspace it off, repeating until enough measured rounds exist. The expected
+// buffer text after every round is exact, so paint confirmation is unambiguous.
+function buildRounds(total: number): RoundSpec[] {
+  const rounds: RoundSpec[] = [];
+  let accumulated = "";
+  let idx = 0;
+  while (rounds.length < total) {
+    for (const ch of BATCH_ALPHABET) {
+      if (rounds.length >= total) break;
+      const next = accumulated + ch;
+      rounds.push({
+        idx: idx++,
+        kind: "type",
+        measured: true,
+        expectKey: ch,
+        expectData: ch,
+        expectText: ANCHOR + next,
+        forbidText: null,
+      });
+      accumulated = next;
+    }
+    while (accumulated.length > 0 && rounds.length < total) {
+      const shorter = accumulated.slice(0, -1);
+      rounds.push({
+        idx: idx++,
+        kind: "backspace",
+        measured: true,
+        expectKey: "Backspace",
+        expectData: "",
+        expectText: ANCHOR + shorter,
+        forbidText: ANCHOR + accumulated,
+      });
+      accumulated = shorter;
+    }
+  }
+  for (let i = 0; i < Math.min(WARMUP, rounds.length); i++) rounds[i].measured = false;
+  return rounds;
+}
+
+async function installProbe(page: any, panelId: string): Promise<void> {
+  await page.evaluate((id: string) => {
+    const term = (window as any).__daintreeGetTerminalForE2E?.(id);
+    if (!term) throw new Error(`interactivity probe: no terminal for panel ${id}`);
+    const probe: any = {
+      rounds: [],
+      current: null,
+      disposed: false,
+      frame: { gaps: [], last: 0, rafId: 0 },
+      loaf: { count: 0, totalMs: 0, max: 0 },
+    };
+    const onKeydown = (e: KeyboardEvent) => {
+      const c = probe.current;
+      if (!c || c.t0 !== null) return;
+      if (e.key === c.expectKey) {
+        c.t0 = performance.now();
+        c.stamp = e.timeStamp;
+      }
+    };
+    window.addEventListener("keydown", onKeydown, true);
+    const d1 = term.onData((d: string) => {
+      const c = probe.current;
+      if (c && c.t0 !== null && c.t1 === null && d === c.expectData) c.t1 = performance.now();
+    });
+    const origWrite = term.write.bind(term);
+    term.write = (data: any, cb?: () => void) => {
+      const c = probe.current;
+      if (c && c.t1 !== null && !c.confirmed) {
+        if (c.t4 === null) c.t4 = performance.now();
+        c.bytes += typeof data === "string" ? data.length : (data?.length ?? 0);
+      }
+      return origWrite(data, cb);
+    };
+    const d2 = term.onWriteParsed(() => {
+      const c = probe.current;
+      if (c && c.t4 !== null && !c.confirmed) c.t5 = performance.now();
+    });
+    const regionText = () => {
+      const buf = term.buffer.active;
+      const cursorAbs = buf.baseY + buf.cursorY;
+      const lo = Math.max(0, cursorAbs - 5);
+      const hi = Math.min(buf.length - 1, cursorAbs + 1);
+      const rows: string[] = [];
+      for (let i = lo; i <= hi; i++) {
+        const line = buf.getLine(i);
+        if (line) rows.push(line.translateToString(true));
+      }
+      return rows.join("\n");
+    };
+    const isConfirmedNow = () => {
+      const c = probe.current;
+      if (!c) return false;
+      const text = regionText();
+      if (!text.includes(c.expectText)) return false;
+      if (c.forbidText && text.includes(c.forbidText)) return false;
+      return true;
+    };
+    const d3 = term.onRender(() => {
+      const c = probe.current;
+      if (!c || c.confirmed || c.t4 === null) return;
+      if (!isConfirmedNow()) return;
+      c.confirmed = true;
+      requestAnimationFrame((ts) => {
+        c.t6 = ts;
+        c.done = true;
+      });
+    });
+    const loop = (ts: number) => {
+      if (probe.disposed) return;
+      if (probe.frame.last > 0) probe.frame.gaps.push(ts - probe.frame.last);
+      probe.frame.last = ts;
+      probe.frame.rafId = requestAnimationFrame(loop);
+    };
+    probe.frame.rafId = requestAnimationFrame(loop);
+    let po: PerformanceObserver | null = null;
+    try {
+      po = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          probe.loaf.count++;
+          probe.loaf.totalMs += entry.duration;
+          if (entry.duration > probe.loaf.max) probe.loaf.max = entry.duration;
+        }
+      });
+      po.observe({ type: "long-animation-frame", durationThreshold: 50 } as any);
+    } catch {
+      po = null;
+    }
+    probe.begin = (spec: any): boolean => {
+      probe.current = {
+        idx: spec.idx,
+        kind: spec.kind,
+        measured: spec.measured,
+        expectKey: spec.expectKey === "Backspace" ? "Backspace" : spec.expectKey,
+        expectData: spec.expectData,
+        expectText: spec.expectText,
+        forbidText: spec.forbidText ?? null,
+        stamp: null,
+        t0: null,
+        t1: null,
+        t4: null,
+        t5: null,
+        t6: null,
+        bytes: 0,
+        confirmed: false,
+        done: false,
+      };
+      const ae = document.activeElement as HTMLElement | null;
+      return (
+        !!ae?.classList.contains("xterm-helper-textarea") && !!ae.closest(`[data-panel-id="${id}"]`)
+      );
+    };
+    probe.finish = (timedOut: boolean) => {
+      const c = probe.current;
+      probe.current = null;
+      if (!c) return;
+      probe.rounds.push({
+        idx: c.idx,
+        kind: c.kind,
+        measured: c.measured,
+        stamp: c.stamp,
+        t0: c.t0,
+        t1: c.t1,
+        t4: c.t4,
+        t5: c.t5,
+        t6: c.t6,
+        bytes: c.bytes,
+        confirmed: c.confirmed,
+        timedOut,
+      });
+    };
+    probe.isDone = () => !!(probe.current && probe.current.done);
+    probe.resetPacing = () => {
+      probe.frame.gaps = [];
+      probe.frame.last = 0;
+      probe.loaf = { count: 0, totalMs: 0, max: 0 };
+    };
+    probe.snapshot = () => ({
+      rounds: probe.rounds,
+      frameGaps: probe.frame.gaps,
+      loaf: probe.loaf,
+    });
+    probe.dispose = () => {
+      probe.disposed = true;
+      cancelAnimationFrame(probe.frame.rafId);
+      window.removeEventListener("keydown", onKeydown, true);
+      d1.dispose();
+      d2.dispose();
+      d3.dispose();
+      term.write = origWrite;
+      po?.disconnect();
+    };
+    (window as any).__DAINTREE_INTERACTIVITY_PROBE__ = probe;
+  }, panelId);
+}
+
+async function focusMeasuredPane(page: any, panelId: string): Promise<void> {
+  const panel = page.locator(`[data-panel-id="${panelId}"]`);
+  await panel
+    .locator(".xterm")
+    .first()
+    .click({ position: { x: 30, y: 10 } });
+  await expect
+    .poll(
+      () =>
+        page.evaluate((id: string) => {
+          const ae = document.activeElement as HTMLElement | null;
+          return (
+            !!ae?.classList.contains("xterm-helper-textarea") &&
+            !!ae.closest(`[data-panel-id="${id}"]`)
+          );
+        }, panelId),
+      { timeout: 10_000, intervals: [100, 250, 500] }
+    )
+    .toBe(true);
+}
+
+// One paced round: begin bookkeeping, dispatch a real CDP keystroke, wait for
+// paint confirmation (or timeout), settle while the flood keeps running.
+async function runRound(page: any, panelId: string, spec: RoundSpec): Promise<void> {
+  const focused = await page.evaluate(
+    (s: any) => (window as any).__DAINTREE_INTERACTIVITY_PROBE__.begin(s),
+    spec as any
+  );
+  if (!focused) await focusMeasuredPane(page, panelId);
+  if (spec.kind === "backspace") await page.keyboard.press("Backspace");
+  else await page.keyboard.type(spec.expectKey);
+  try {
+    await page.waitForFunction(
+      () => (window as any).__DAINTREE_INTERACTIVITY_PROBE__.isDone(),
+      undefined,
+      { timeout: ROUND_TIMEOUT_MS, polling: "raf" }
+    );
+    await page.evaluate(() => (window as any).__DAINTREE_INTERACTIVITY_PROBE__.finish(false));
+  } catch {
+    await page.evaluate(() => (window as any).__DAINTREE_INTERACTIVITY_PROBE__.finish(true));
+  }
+  await page.waitForTimeout(SETTLE_MS);
+}
+
+function computeMetrics(
+  rounds: RoundRecord[],
+  frameGaps: number[],
+  loaf: { count: number; totalMs: number; max: number }
+): CellMetrics {
+  const measured = rounds.filter((r) => r.measured);
+  const ok = measured.filter((r) => !r.timedOut && r.t6 !== null && (r.stamp ?? r.t0) !== null);
+  const start = (r: RoundRecord) => (r.stamp !== null && r.stamp > 0 ? r.stamp : (r.t0 as number));
+  const totals = ok.map((r) => Math.max(0, (r.t6 as number) - start(r))).sort((a, b) => a - b);
+  const seg = (f: (r: RoundRecord) => number | null) =>
+    mean(ok.map(f).filter((v): v is number => v !== null && Number.isFinite(v) && v >= 0));
+  const sortedGaps = [...frameGaps].sort((a, b) => a - b);
+  const gapSum = frameGaps.reduce((a, b) => a + b, 0);
+  return {
+    samples: ok.length,
+    timeouts: measured.filter((r) => r.timedOut).length,
+    keystrokePaintP50Ms: pct(totals, 50),
+    keystrokePaintP95Ms: pct(totals, 95),
+    keystrokePaintP99Ms: pct(totals, 99),
+    keystrokePaintMaxMs: totals.length > 0 ? totals[totals.length - 1] : 0,
+    inputQueueMeanMs: seg((r) => (r.t0 !== null && r.stamp !== null ? r.t0 - r.stamp : null)),
+    inputEncodeMeanMs: seg((r) => (r.t1 !== null && r.t0 !== null ? r.t1 - r.t0 : null)),
+    ptyRoundTripMeanMs: seg((r) => (r.t4 !== null && r.t1 !== null ? r.t4 - r.t1 : null)),
+    parseMeanMs: seg((r) => (r.t5 !== null && r.t4 !== null ? r.t5 - r.t4 : null)),
+    paintMeanMs: seg((r) => (r.t6 !== null && r.t5 !== null ? Math.max(0, r.t6 - r.t5) : null)),
+    repaintBytesPerKeystroke: mean(ok.map((r) => r.bytes)),
+    frameGapP50Ms: pct(sortedGaps, 50),
+    frameGapP95Ms: pct(sortedGaps, 95),
+    frameGapP99Ms: pct(sortedGaps, 99),
+    frameGapMaxMs: sortedGaps.length > 0 ? sortedGaps[sortedGaps.length - 1] : 0,
+    fpsDuringMeasurement: gapSum > 0 ? (frameGaps.length / gapSum) * 1000 : 0,
+    loafCount: loaf.count,
+    loafTotalMs: loaf.totalMs,
+  };
+}
+
+function fmtCell(r: CellResult): string {
+  const m = r.metrics;
+  return (
+    `${r.cell.padEnd(15)} n=${String(m.samples).padStart(3)} to=${m.timeouts}` +
+    ` paint p50=${m.keystrokePaintP50Ms.toFixed(1).padStart(7)} p95=${m.keystrokePaintP95Ms.toFixed(1).padStart(7)} p99=${m.keystrokePaintP99Ms.toFixed(1).padStart(7)}` +
+    ` | q=${m.inputQueueMeanMs.toFixed(1)} enc=${m.inputEncodeMeanMs.toFixed(1)} rtt=${m.ptyRoundTripMeanMs.toFixed(1)} parse=${m.parseMeanMs.toFixed(1)} paint=${m.paintMeanMs.toFixed(1)}` +
+    ` | gap p95=${m.frameGapP95Ms.toFixed(1)} fps=${m.fpsDuringMeasurement.toFixed(0)} loaf=${m.loafCount}` +
+    ` | bytes/key=${m.repaintBytesPerKeystroke.toFixed(0)} [${r.rendererMode ?? "?"}]`
+  );
+}
+
+// Exact-value gate: "0"/"false" must not enable a multi-minute benchmark.
+const perfDescribe =
+  process.env.RUN_PERF_INTERACTIVITY === "1" ? test.describe.serial : test.describe.skip;
+
+perfDescribe("Perf: keystroke-to-paint interactivity (PERF-120..122)", () => {
+  const results: CellResult[] = [];
+
+  for (const cell of CELLS) {
+    test(`interactivity: ${cell.key}`, async () => {
+      test.slow();
+      test.setTimeout(900_000);
+
+      const fixture: FixtureRepo = createFixtureRepo({ name: `interactivity-${cell.key}` });
+      const scriptsDir = path.join(fixture.dir, ".perf-scripts");
+      mkdirSync(scriptsDir, { recursive: true });
+      const composerSimPath = path.join(scriptsDir, "composer-sim.js");
+      const replayPath = path.join(scriptsDir, "corpus-replay.js");
+      writeFileSync(composerSimPath, composerSimSource());
+      writeFileSync(replayPath, corpusReplaySource());
+
+      let ctx: AppContext | undefined;
+      try {
+        // enableWebgl matches production rendering and keeps the GPU process
+        // out-of-process — the local-macOS --in-process-gpu default makes a
+        // compositor fault under sustained terminal streaming fatal to the app
+        // (see store-fanout-perf.spec.ts).
+        ctx = await launchApp({ enableWebgl: true });
+        ctx.window = await openAndOnboardProject(
+          ctx.app,
+          ctx.window,
+          fixture.dir,
+          `Interactivity ${cell.key}`
+        );
+        const page = ctx.window;
+
+        // Measured pane first so it keeps grid position 0.
+        await openTerminal(page);
+        const measuredPanel = page.locator('[data-panel-location="grid"]').first();
+        await waitForTerminalReady(page, measuredPanel);
+        const idsAfterFirst = await getGridPanelIds(page);
+        expect(idsAfterFirst.length).toBe(1);
+        const measuredPanelId = idsAfterFirst[0];
+
+        const workloadCmd =
+          cell.workload === "cat" ? "cat" : `node "${composerSimPath.replace(/"/g, '\\"')}"`;
+        await runTerminalCommand(page, measuredPanel, workloadCmd);
+        if (cell.workload === "composer-sim") {
+          await expect
+            .poll(
+              () =>
+                page.evaluate((id: string) => {
+                  const read = (window as any).__daintreeReadTerminalBuffer;
+                  return typeof read === "function" ? (read(id) as string) : "";
+                }, measuredPanelId),
+              { timeout: 30_000, intervals: [200, 500] }
+            )
+            .toContain("COMPOSER_SIM_READY");
+        } else {
+          await page.waitForTimeout(1_200);
+        }
+
+        // Background flood: real PTYs replaying the seeded corpus.
+        if (cell.background > 0) {
+          for (let i = 0; i < cell.background; i++) {
+            const before = await getGridPanelIds(page);
+            await openTerminal(page);
+            await expect
+              .poll(() => getGridPanelIds(page).then((ids) => ids.length), {
+                timeout: 20_000,
+                intervals: [100, 250, 500],
+              })
+              .toBe(before.length + 1);
+            const after = await getGridPanelIds(page);
+            const newId = after.find((id) => !before.includes(id));
+            expect(newId, `background terminal ${i} panel id`).toBeTruthy();
+            const bgPanel = page.locator(`[data-panel-id="${newId}"]`);
+            await waitForTerminalReady(page, bgPanel);
+            await runTerminalCommand(
+              page,
+              bgPanel,
+              `node "${replayPath.replace(/"/g, '\\"')}" ${1000 + i * 97} ${cell.floodMode}`
+            );
+          }
+          // Confirm at least one flood stream is flowing before measuring.
+          const lastBgId = (await getGridPanelIds(page)).at(-1)!;
+          const lenBefore = await page.evaluate((id: string) => {
+            const fn = (window as any).__daintreeGetTerminalBufferLength;
+            return typeof fn === "function" ? (fn(id) as number) : 0;
+          }, lastBgId);
+          await expect
+            .poll(
+              () =>
+                page.evaluate((id: string) => {
+                  const fn = (window as any).__daintreeGetTerminalBufferLength;
+                  return typeof fn === "function" ? (fn(id) as number) : 0;
+                }, lastBgId),
+              { timeout: 20_000, intervals: [250, 500] }
+            )
+            .toBeGreaterThan(lenBefore);
+          // Let the flood reach steady state (renderer tiers, backpressure).
+          await page.waitForTimeout(3_000);
+        }
+
+        await focusMeasuredPane(page, measuredPanelId);
+        await installProbe(page, measuredPanelId);
+
+        // Anchor rounds prime the pipeline and give expected-text checks a
+        // collision-proof prefix. Unmeasured; a timeout here means the echo
+        // pipeline is broken, so fail loudly.
+        for (const [i, ch] of [...ANCHOR].entries()) {
+          const spec: RoundSpec = {
+            idx: -2 + i,
+            kind: "type",
+            measured: false,
+            expectKey: ch,
+            expectData: ch,
+            expectText: ANCHOR.slice(0, i + 1),
+            forbidText: null,
+          };
+          await runRound(page, measuredPanelId, spec);
+        }
+        const anchorRounds = (await page.evaluate(
+          () => (window as any).__DAINTREE_INTERACTIVITY_PROBE__.snapshot().rounds
+        )) as RoundRecord[];
+        const anchorTimeouts = anchorRounds.filter((r) => r.timedOut).length;
+        expect(anchorTimeouts, "anchor keystrokes must echo and paint").toBe(0);
+
+        // Pacing stats cover exactly the round window (warmups + measured).
+        await page.evaluate(() => (window as any).__DAINTREE_INTERACTIVITY_PROBE__.resetPacing());
+
+        const rounds = buildRounds(WARMUP + ROUNDS);
+        for (const spec of rounds) {
+          await runRound(page, measuredPanelId, spec);
+        }
+
+        const snapshot = (await page.evaluate(() => {
+          const probe = (window as any).__DAINTREE_INTERACTIVITY_PROBE__;
+          const snap = probe.snapshot();
+          probe.dispose();
+          return snap;
+        })) as { rounds: RoundRecord[]; frameGaps: number[]; loaf: any };
+
+        const rendererMode = (await page.evaluate((id: string) => {
+          const fn = (window as any).__daintreeGetTerminalWebGLState;
+          return typeof fn === "function" ? (fn(id)?.mode ?? null) : null;
+        }, measuredPanelId)) as string | null;
+        const dims = (await page.evaluate((id: string) => {
+          const fn = (window as any).__daintreeGetTerminalDimensions;
+          return typeof fn === "function" ? fn(id) : null;
+        }, measuredPanelId)) as { cols: number; rows: number } | null;
+
+        const roundRecords = snapshot.rounds.filter((r) => r.idx >= 0);
+        const metrics = computeMetrics(roundRecords, snapshot.frameGaps, snapshot.loaf);
+        const result: CellResult = {
+          cell: cell.key,
+          scenarioId: cell.scenarioId,
+          workload: cell.workload,
+          background: cell.background,
+          floodMode: cell.floodMode,
+          rendererMode,
+          dims,
+          metrics,
+          rounds: roundRecords,
+        };
+        results.push(result);
+        console.log(`──── ${cell.scenarioId} ${cell.key} ────`);
+        console.log(fmtCell(result));
+
+        // Reliability invariants only — latency is reported, never asserted.
+        expect(metrics.samples + metrics.timeouts, "every measured round accounted for").toBe(
+          ROUNDS
+        );
+        if (cell.background === 0) {
+          expect(metrics.timeouts, "solo cells must not time out").toBe(0);
+        } else {
+          expect(metrics.samples, "flood cells must confirm at least one round").toBeGreaterThan(0);
+        }
+      } finally {
+        if (ctx?.app) await closeApp(ctx.app);
+        fixture.cleanup();
+      }
+    });
+  }
+
+  test.afterAll(() => {
+    if (results.length === 0) return;
+    const byCell = new Map(results.map((r) => [r.cell, r]));
+    const solo = byCell.get("sim-solo");
+    const fleet = byCell.get("sim-fleet");
+    const saturation = byCell.get("sim-saturation");
+    const ratio = (a?: CellResult, b?: CellResult) =>
+      a && b && b.metrics.keystrokePaintP99Ms > 0
+        ? a.metrics.keystrokePaintP99Ms / b.metrics.keystrokePaintP99Ms
+        : null;
+    const summary = {
+      generatedAt: new Date().toISOString(),
+      platform: process.platform,
+      rounds: ROUNDS,
+      warmup: WARMUP,
+      settleMs: SETTLE_MS,
+      roundTimeoutMs: ROUND_TIMEOUT_MS,
+      echoDegradationFleetX: ratio(fleet, solo),
+      echoDegradationSaturationX: ratio(saturation, solo),
+      cells: results,
+    };
+    console.log("──── interactivity summary ────");
+    for (const r of results) console.log(fmtCell(r));
+    if (summary.echoDegradationFleetX !== null) {
+      console.log(`echoDegradationX (fleet/solo p99): ${summary.echoDegradationFleetX.toFixed(2)}`);
+    }
+    if (summary.echoDegradationSaturationX !== null) {
+      console.log(
+        `echoDegradationX (saturation/solo p99): ${summary.echoDegradationSaturationX.toFixed(2)}`
+      );
+    }
+    const outPath =
+      OUT_PATH || path.join(tmpdir(), `daintree-interactivity-perf-${Date.now()}.json`);
+    writeFileSync(outPath, JSON.stringify(summary, null, 2));
+    console.log(`interactivity results written to ${outPath}`);
+  });
+});

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -33,6 +33,7 @@ nodeV8.setHeapSnapshotNearHeapLimit(2);
 import { MessagePort } from "node:worker_threads";
 import os from "node:os";
 import { PtyManager } from "./services/PtyManager.js";
+import { markPerformance } from "./utils/performance.js";
 import {
   IdleHeapCompactor,
   IDLE_HEAP_COMPACT_CHECK_INTERVAL_MS,
@@ -912,6 +913,15 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
       const interactive =
         terminalInfo !== undefined &&
         Date.now() - terminalInfo.lastInputTime < PORT_BATCH_INTERACTIVE_INPUT_WINDOW_MS;
+      if (interactive) {
+        // PERF-120 T3 attribution mark (no-op unless DAINTREE_PERF_CAPTURE):
+        // echo output for a just-typed terminal is leaving the host. Paired
+        // with terminal_port_input_written for the host-internal slice.
+        markPerformance("terminal_interactive_echo_dispatched", {
+          terminalId: id,
+          bytes: byteCount,
+        });
+      }
       const saturated: RendererConnection[] = [];
       for (const { windowId, conn } of targets) {
         // An engaged worker-ingest terminal routes to its dedicated port —

--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -91,7 +91,7 @@ describe("PortBatcher", () => {
     expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("abc"), 3);
   });
 
-  it("interactive write in throughput mode swaps the 16ms timer for an immediate", () => {
+  it("interactive write in throughput mode flushes synchronously, cancelling the 16ms timer", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
@@ -99,41 +99,47 @@ describe("PortBatcher", () => {
     batcher.write("t1", bytes("bbb"), 3); // upgrade to throughput (16ms timer)
     batcher.write("t1", bytes("x"), 1, false, true); // keystroke echo
 
-    // Flushes on the immediate, well before the 16ms throughput window —
-    // and the echo byte rides behind the already-queued chunks in order.
-    vi.advanceTimersByTime(1);
+    // Flushes synchronously — no timer advance needed — and the echo byte
+    // rides behind the already-queued chunks in order.
     expect(deps.postMessage).toHaveBeenCalledOnce();
     expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("aaabbbx"), 7);
 
-    // The swapped-out throughput timer must not fire a second flush.
-    vi.advanceTimersByTime(16);
+    // The cancelled throughput timer must not fire a second flush.
+    vi.advanceTimersByTime(17);
     expect(deps.postMessage).toHaveBeenCalledOnce();
   });
 
-  it("interactive write in latency mode keeps the pending immediate (no escalation)", () => {
+  it("interactive write in latency mode flushes synchronously, and the stale immediate no-ops", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
     batcher.write("t1", bytes("a"), 1);
-    batcher.write("t1", bytes("b"), 1, false, true); // would normally escalate to 16ms
+    batcher.write("t1", bytes("b"), 1, false, true); // keystroke echo
 
-    vi.advanceTimersByTime(1);
     expect(deps.postMessage).toHaveBeenCalledOnce();
     expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("ab"), 2);
+
+    // The latency-mode immediate scheduled by the first write fires against an
+    // already-drained map — it must not post again.
+    vi.advanceTimersByTime(1);
+    expect(deps.postMessage).toHaveBeenCalledOnce();
   });
 
-  it("non-interactive write after an interactive swap does not re-escalate the pending immediate", () => {
+  it("non-interactive write after an interactive flush starts a fresh latency-mode batch", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
     batcher.write("t1", bytes("a"), 1);
     batcher.write("t1", bytes("b"), 1); // throughput
-    batcher.write("t1", bytes("c"), 1, false, true); // swap timer → immediate
-    batcher.write("t1", bytes("d"), 1); // mode is still throughput: must not reschedule
+    batcher.write("t1", bytes("c"), 1, false, true); // synchronous echo flush
+    expect(deps.postMessage).toHaveBeenCalledOnce();
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("abc"), 3);
+
+    batcher.write("t1", bytes("d"), 1); // fresh entry: latency-mode immediate
 
     vi.advanceTimersByTime(1);
-    expect(deps.postMessage).toHaveBeenCalledOnce();
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("abcd"), 4);
+    expect(deps.postMessage).toHaveBeenCalledTimes(2);
+    expect(deps.postMessage).toHaveBeenLastCalledWith("t1", bytes("d"), 1);
   });
 
   it("profile-tuned cadence: a longer throughput delay stretches the flush window", () => {

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -1,6 +1,7 @@
 import type { MessagePort } from "node:worker_threads";
 import { SharedRingBuffer } from "../../../shared/utils/SharedRingBuffer.js";
 import { POOL_ENV_EMPTY_HASH, computePoolEnvHash } from "../../services/pty/ptyPoolEnvHash.js";
+import { markPerformance } from "../../utils/performance.js";
 import { PortBatcher, type PortBatcherFailedBatch } from "../index.js";
 import type { HandlerMap, HostContext } from "./types.js";
 
@@ -105,6 +106,13 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
             typeof portMsg.data === "string"
           ) {
             ptyManager.write(portMsg.id, portMsg.data, portMsg.traceId);
+            // PERF-120 T2 attribution mark (no-op unless DAINTREE_PERF_CAPTURE):
+            // paired with terminal_interactive_echo_dispatched to expose the
+            // host-internal slice of the keystroke round trip.
+            markPerformance("terminal_port_input_written", {
+              terminalId: portMsg.id,
+              bytes: portMsg.data.length,
+            });
           } else if (
             portMsg.type === "resize" &&
             typeof portMsg.id === "string" &&

--- a/electron/pty-host/portBatcher.ts
+++ b/electron/pty-host/portBatcher.ts
@@ -107,23 +107,23 @@ export class PortBatcher {
       return true;
     }
 
+    // Echo fast-path: keystroke echo flushes synchronously. Under a saturated
+    // host loop even a setImmediate sits behind milliseconds of pending poll
+    // work, and this is the one chunk the user is actively watching for.
+    // flush() drains the full pending map, so earlier queued output for this
+    // terminal still lands ahead of the echo bytes — the batch is accelerated,
+    // never reordered or bypassed (PERF-121/122 keystroke-to-paint under
+    // flood; mirrors the synchronous threshold flush above).
+    if (interactive) {
+      this.flush();
+      return true;
+    }
+
     // Per-terminal flush cadence: each terminal owns its own (mode, immediate, timeout)
     // so a quiet terminal's first write isn't stalled by a busy sibling's throughput timer.
     if (entry.mode === "idle") {
       entry.immediateHandle = setImmediate(() => this.flush());
       entry.mode = "latency";
-    } else if (interactive) {
-      // Echo fast-path: flush() drains the full pending map, so earlier queued
-      // output for this terminal still lands ahead of the echo bytes — the
-      // batch is accelerated, never reordered or bypassed. In latency mode the
-      // immediate is already pending; in throughput mode swap the timer for an
-      // immediate (mode stays "throughput" so the ladder won't re-escalate the
-      // pending immediate back onto a 16ms timer).
-      if (entry.timeoutHandle !== null) {
-        clearTimeout(entry.timeoutHandle);
-        entry.timeoutHandle = null;
-        entry.immediateHandle = setImmediate(() => this.flush());
-      }
     } else if (entry.mode === "latency") {
       if (entry.immediateHandle !== null) {
         clearImmediate(entry.immediateHandle);

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -112,9 +112,16 @@ const ECHO_PROBE_SAMPLE_INTERVAL = 32;
 const ECHO_PROBE_MAX_PAIR_MS = 250;
 
 function maybeStartEchoProbe(id: string): void {
-  echoProbeEnabled ??= isRendererPerfCaptureEnabled();
+  // DAINTREE_PERF_CAPTURE is a build-time flag in the sandboxed renderer, so
+  // the E2E interactivity bench (launch-time env only) arms the probe via the
+  // preload-injected E2E marker instead; marks still only record once the spec
+  // seeds __DAINTREE_PERF_MARKS__ (see markRendererPerformance's gate).
+  echoProbeEnabled ??= isRendererPerfCaptureEnabled() || window.__DAINTREE_E2E_MODE__ === true;
   if (!echoProbeEnabled) return;
-  if (++echoProbeCounter % ECHO_PROBE_SAMPLE_INTERVAL !== 0) return;
+  // E2E interactivity bench (PERF-120..122): sample every write so each paced
+  // round yields a transport-attribution pair; production keeps 1/32 sampling.
+  const sampleInterval = window.__DAINTREE_E2E_MODE__ === true ? 1 : ECHO_PROBE_SAMPLE_INTERVAL;
+  if (++echoProbeCounter % sampleInterval !== 0) return;
   if (pendingEchoProbes.has(id)) return;
   pendingEchoProbes.set(id, performance.now());
 }

--- a/src/services/terminal/TerminalBurstController.ts
+++ b/src/services/terminal/TerminalBurstController.ts
@@ -7,6 +7,11 @@ import { safeFireAndForget } from "@/utils/safeFireAndForget";
 // matches the keystroke input-burst decay so a scroll feels just as responsive.
 const WHEEL_BURST_DECAY_MS = 1000;
 
+// Background-drain hold window for a pending keystroke echo. An echo normally
+// lands within a frame or two; the cap only bounds the hold when no echo comes
+// back at all (wedged pty, remote shell lag) so sibling drains can't starve.
+const ECHO_PENDING_HOLD_MAX_MS = 150;
+
 // Interactive resource-profile override (symptom B): while actively scrolling a
 // full-screen TUI, ask the main process to hold the profile off efficiency.
 // DURATION must exceed THROTTLE so re-requests overlap and the hold never lapses
@@ -32,8 +37,47 @@ export class TerminalBurstController {
   private lastActiveWheelAt = 0;
   // Throttle for the interactive resource-profile override IPC (see onActiveWheel).
   private lastInteractiveOverrideRequestAt = 0;
+  // Keystroke-echo round trip in flight: input left for the PTY and its echo
+  // has not been delivered yet. While set (bounded by ECHO_PENDING_HOLD_MAX_MS),
+  // the ingest service holds background drains so the echo's port delivery,
+  // parse, and render aren't queued behind sibling parse slices (#10948-class
+  // "focused terminal stops responding under load" regressions).
+  private echoPendingId: string | null = null;
+  private echoPendingAt = 0;
+  private echoPendingGen = 0;
 
   constructor(private deps: TerminalBurstControllerDeps) {}
+
+  /** Keyboard input left for this terminal's PTY — arm the echo-pending hold. */
+  onEchoPendingInput(id: string): void {
+    this.echoPendingId = id;
+    this.echoPendingAt = Date.now();
+    this.echoPendingGen++;
+  }
+
+  /**
+   * Data arrived for the echo-pending terminal. Release siblings one frame
+   * later so the echo's own render gets scheduled ahead of the backlog their
+   * drains are about to enqueue. The generation guard keeps a release scheduled
+   * for keystroke N from clearing a hold re-armed by keystroke N+1.
+   */
+  onEchoData(id: string): void {
+    if (this.echoPendingId !== id) return;
+    const gen = this.echoPendingGen;
+    requestAnimationFrame(() => {
+      if (this.echoPendingGen === gen && this.echoPendingId === id) {
+        this.echoPendingId = null;
+      }
+    });
+  }
+
+  // Which terminal has a keystroke echo in flight (bounded by
+  // ECHO_PENDING_HOLD_MAX_MS), for the ingest service's background-drain hold.
+  getEchoPendingHoldId(): string | null {
+    return this.echoPendingId !== null && Date.now() - this.echoPendingAt < ECHO_PENDING_HOLD_MAX_MS
+      ? this.echoPendingId
+      : null;
+  }
 
   // Whether a wheel-driven BURST gesture is still within its decay window —
   // and if so, which terminal it targets. Consumed by the worker-ingest data

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2842,6 +2842,16 @@ if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
     return "ok";
   };
 
+  // Test-only: hand the live xterm Terminal instance to the interactivity perf
+  // probe (e2e/full/terminal/interactivity-perf.spec.ts) so it can hook
+  // onData/onWriteParsed/onRender and read the buffer without a bridge per
+  // event. Same-realm only — the instance never crosses a serialization
+  // boundary. Object.assign keeps it off the type-assertion lint ratchet.
+  Object.assign(window, {
+    __daintreeGetTerminalForE2E: (panelId: string): Terminal | null =>
+      terminalInstanceService.getInstanceForE2E(panelId)?.terminal ?? null,
+  });
+
   // Test-only WebGL leak-regression bridges (#9540). Attached via Object.assign
   // (not a window cast) so they don't add to the no-unsafe-type-assertion lint
   // ratchet. All are harmless in production and reach private state only for the

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -88,7 +88,10 @@ class TerminalInstanceService {
   private dataBuffer = new TerminalOutputIngestService(
     (id, data, chunkCount) => this.writeToTerminal(id, data, chunkCount),
     () => usePanelStore.getState().focusedId,
-    () => this.burstController.getActiveWheelHoldId()
+    // Background drains are held both during an active wheel gesture and while
+    // a keystroke echo is in flight — the same "focused feel beats background
+    // throughput" contract, applied to the two sustained interactions.
+    () => this.burstController.getActiveWheelHoldId() ?? this.burstController.getEchoPendingHoldId()
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
@@ -501,6 +504,7 @@ class TerminalInstanceService {
     if (!managed) return;
 
     this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+    this.burstController.onEchoPendingInput(id);
 
     // A paused-backpressure pane shows a "Paused" pill; typing should refresh
     // it promptly. Fire a wake() repaint, mirroring the focus path — the held
@@ -946,6 +950,7 @@ class TerminalInstanceService {
     this.ensureHostTierSubscription();
 
     const unsubData = terminalClient.onData(id, (data: string | Uint8Array) => {
+      this.burstController.onEchoData(id);
       if (this.dataBuffer.isPolling()) return;
       // Worker-ingest diversion (issue #10960): while a terminal is in (or
       // transitioning through) worker mode, main-thread chunks route into the

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -13,6 +13,17 @@ import { yieldToScheduler } from "@/lib/schedulerYield";
 const RENDERER_HIGH_WATERMARK_BYTES = 128 * 1024;
 const RENDERER_LOW_WATERMARK_BYTES = 32 * 1024;
 const COALESCE_BATCH_CAP_BYTES = 256 * 1024;
+// Background (non-focused) terminals get a much smaller in-flight window and
+// batch size: bytes already handed to xterm.write() are un-holdable parse
+// backlog (xterm chews them in ~12ms main-thread slices), so a flood pane
+// fed 128KB+256KB keeps blocking the thread long after a focused-echo hold
+// engages (#10948-class feel regressions). A 32KB window keeps the per-pane
+// un-holdable backlog to roughly one parse slice while costing throughput
+// only one extra drain wakeup per 32KB — background floods are parse-bound,
+// not scheduling-bound.
+const BACKGROUND_HIGH_WATERMARK_BYTES = 32 * 1024;
+const BACKGROUND_LOW_WATERMARK_BYTES = 16 * 1024;
+const BACKGROUND_COALESCE_CAP_BYTES = 32 * 1024;
 const IPC_LOOKBACK_CHARS = 32;
 const INK_ERASE_LINE_PATTERN = "\x1b[2K\x1b[1A";
 
@@ -124,7 +135,10 @@ export class TerminalOutputIngestService {
     const queue = this.queues.get(id);
     if (!queue) return;
     queue.inFlightBytes = Math.max(0, queue.inFlightBytes - bytes);
-    if (queue.inFlightBytes <= RENDERER_LOW_WATERMARK_BYTES && queue.chunks.length > 0) {
+    const lowWatermark = this.shouldDeferDrain(id)
+      ? BACKGROUND_LOW_WATERMARK_BYTES
+      : RENDERER_LOW_WATERMARK_BYTES;
+    if (queue.inFlightBytes <= lowWatermark && queue.chunks.length > 0) {
       this.scheduleOrDrain(id, queue);
     }
   }
@@ -355,8 +369,13 @@ export class TerminalOutputIngestService {
   }
 
   private tryDrain(id: string, queue: TerminalIngestQueue): void {
-    while (queue.chunks.length > 0 && queue.inFlightBytes < RENDERER_HIGH_WATERMARK_BYTES) {
-      const batch = this.coalesceBatch(queue);
+    const deferred = this.shouldDeferDrain(id);
+    const highWatermark = deferred
+      ? BACKGROUND_HIGH_WATERMARK_BYTES
+      : RENDERER_HIGH_WATERMARK_BYTES;
+    const batchCap = deferred ? BACKGROUND_COALESCE_CAP_BYTES : COALESCE_BATCH_CAP_BYTES;
+    while (queue.chunks.length > 0 && queue.inFlightBytes < highWatermark) {
+      const batch = this.coalesceBatch(queue, batchCap);
       const batchBytes = this.chunkByteSize(batch.data);
       queue.inFlightBytes += batchBytes;
       this.writeToTerminal(id, batch.data, batch.chunkCount);
@@ -364,13 +383,16 @@ export class TerminalOutputIngestService {
   }
 
   // Merge the longest same-type chunk prefix into one write, capped at
-  // COALESCE_BATCH_CAP_BYTES (#4853 — xterm yields between write-buffer
-  // entries, not within one chunk, so an unbounded merge would block the main
-  // thread). The first chunk is always taken even when it alone exceeds the
-  // cap. Uint8Array prefixes merge into one freshly-allocated array — the
-  // MessagePort path delivers binary chunks, so without this branch a
-  // backpressure/wake backlog drains as hundreds of per-chunk writes.
-  private coalesceBatch(queue: TerminalIngestQueue): CoalescedBatch {
+  // `batchCap` (#4853 — xterm yields between write-buffer entries, not within
+  // one chunk, so an unbounded merge would block the main thread). The first
+  // chunk is always taken even when it alone exceeds the cap. Uint8Array
+  // prefixes merge into one freshly-allocated array — the MessagePort path
+  // delivers binary chunks, so without this branch a backpressure/wake backlog
+  // drains as hundreds of per-chunk writes.
+  private coalesceBatch(
+    queue: TerminalIngestQueue,
+    batchCap: number = COALESCE_BATCH_CAP_BYTES
+  ): CoalescedBatch {
     if (queue.chunks.length === 1) {
       const chunk = queue.chunks[0]!;
       queue.chunks.length = 0;
@@ -386,7 +408,7 @@ export class TerminalOutputIngestService {
       const next = queue.chunks[count]!;
       if ((typeof next === "string") !== firstIsString) break;
       const size = this.chunkByteSize(next);
-      if (taken + size > COALESCE_BATCH_CAP_BYTES) break;
+      if (taken + size > batchCap) break;
       taken += size;
       count++;
     }

--- a/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
@@ -67,6 +67,7 @@ const E2E_TERMINAL_GLOBALS = [
   "__daintreeTriggerTerminalLink",
   "__daintreeGetTerminalWebGLState",
   "__daintreePromoteTerminalToAgentForE2E",
+  "__daintreeGetTerminalForE2E",
 ] as const;
 
 function windowProp(name: string): unknown {


### PR DESCRIPTION
This adds an opt-in Playwright benchmark that measures keystroke-to-paint latency in the real renderer while other terminals are busy streaming output, plus three terminal pipeline changes that significantly improve the saturated case.

## The benchmark

Every terminal-feel number the perf harness gates today is a simulated slice. PERF-034 runs headless xterm instances inside a Node process, so nothing measured the integrated path a user actually feels: keydown, IPC, pty-host, PTY echo, MessagePort, parse, paint. That path is the metric behind most of our recent feel regressions, so this PR measures it directly.

`e2e/full/terminal/interactivity-perf.spec.ts` (PERF-120 to PERF-122) drives the built app with real CDP keyboard input, one paced keystroke per round, and stamps every segment of the pipeline (input queue, encode, pty round trip, parse, render, present) on the renderer clock. It also records frame gaps, long animation frames, and echo timeouts during the flood window, and pairs new pty-host marks (`terminal_port_input_written` / `terminal_interactive_echo_dispatched`) for host-side attribution. Four cells:

- `cat-solo`: pure tty echo, no background load. This is the floor.
- `sim-solo`: a hermetic composer-sim agent that repaints a ~1.2KB ANSI box per keystroke.
- `sim-fleet`: composer-sim plus 12 background terminals replaying a seeded corpus at ~32KB/s.
- `sim-saturation`: composer-sim plus 6 unthrottled background streams. This is the lockup regime.

The benchmark is opt-in and never gates CI:

```bash
npm run build:e2e
RUN_PERF_INTERACTIVITY=1 npx playwright test --project=full-terminal \
  e2e/full/terminal/interactivity-perf.spec.ts
```

## Pipeline changes

The segment attribution pointed at three fixes. They're all variations on the same theme: the echo byte was never slow, it was queued behind bulk freight.

1. **Echo-pending background hold.** While a keystroke's echo round trip is in flight, background terminals' parse drains are held on the existing wheel-hold machinery (bounded at 150ms so nothing starves, released one frame after the echo lands). The echo's port delivery, parse, and render no longer queue behind sibling parse slices.
2. **Smaller feed windows for unfocused terminals.** Bytes already handed to `xterm.write()` are un-holdable main-thread parse backlog, so unfocused terminals now feed 32KB in-flight / 32KB batches instead of 128KB / 256KB. This is what restores 60fps frame pacing under saturation.
3. **Synchronous flush for echo output.** The pty-host port batcher flushes keystroke echo chunks synchronously instead of via `setImmediate`, which can sit behind milliseconds of poll work on a saturated host loop.

## Results

Under saturation (composer-sim plus 6 unthrottled background streams, 40 rounds, M-series macOS):

| Metric | Before | After |
| --- | --- | --- |
| Keystroke to paint p50 | 56.1ms | 45.1ms |
| Keystroke to paint p95 | 84.0ms | 52.2ms |
| Keystroke to paint p99 | 94.7ms | 56.0ms |
| PTY round trip (mean) | 47.3ms | 19.2ms |
| Frame gap p95 | 50.0ms | 18.5ms |
| FPS while typing | 33 | 60 |
| Long animation frames | 7 (394ms) | 0 |

Echo degradation vs solo drops from 2.1x to roughly 1.2x, which puts us in range of the paint fabric's acceptance gate #1 (`docs/architecture/terminal-paint-fabric.md`) ahead of the fabric's heavy phases.

Solo and 12-terminal fleet numbers are unchanged, and the benchmark shows why: keydowns arrive frame-aligned and the echo already paints on the first possible frame, so the only real headroom was under saturation. The host marks show pty-host turnaround is sub-millisecond even under full load. The remaining flood latency is MessagePort hop scheduling, which is Phase 4 territory (a dedicated focused-terminal port on the #10960 infrastructure).

## Testing

- Full `npm run check`, plus the terminal, client, and pty-host unit suites (`portBatcher` tests updated for the new synchronous flush semantics).
- `core-output-flood.spec.ts`, including the "terminal remains interactive after flood" guard.
- Two full benchmark replicates agreeing within ~2ms on every metric.

One deliberate trade to be aware of: background panes update slightly later during active typing (bounded 150ms holds plus smaller feed batches). That's the "focused feel beats background throughput" contract applied to keystrokes, same as we already do for wheel scrolls.
