### PR TITLE
Fix file viewer panel blowing out the app layout on tall files

### DIFF
--- a/e2e/full/panels/core-file-panel.spec.ts
+++ b/e2e/full/panels/core-file-panel.spec.ts
@@ -31,6 +31,14 @@ const SPEC_MARKDOWN = [
 
 const STYLES_CSS = ".file-panel-fixture { color: rebeccapurple; }\n";
 
+const TALL_TEXT =
+  Array.from(
+    { length: 400 },
+    (_, i) => `tall-line-${String(i + 1).padStart(3, "0")} lorem ipsum dolor sit amet`
+  ).join("\n") + "\n";
+
+const SHORT_TEXT = "short-line-1\nshort-line-2\nshort-line-3\n";
+
 async function dispatchAction(page: Page, actionId: string, args?: unknown): Promise<unknown> {
   return page.evaluate(
     ([id, a]) =>
@@ -67,6 +75,8 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
     fixtureCleanup = cleanup;
     writeFileSync(path.join(dir, "spec.md"), SPEC_MARKDOWN);
     writeFileSync(path.join(dir, "styles.css"), STYLES_CSS);
+    writeFileSync(path.join(dir, "tall.txt"), TALL_TEXT);
+    writeFileSync(path.join(dir, "short.txt"), SHORT_TEXT);
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "File Panel");
   });
@@ -226,5 +236,56 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
     await chip.dblclick();
     await expect(gridFilePanels).toHaveCount(3, { timeout: T_MEDIUM });
     await expect(chip).not.toBeVisible({ timeout: T_MEDIUM });
+  });
+
+  test("a file taller than its pane scrolls internally instead of blowing out the grid", async () => {
+    await dispatchAction(ctx.window, "file.openPanel", { path: "tall.txt" });
+    await expect(filePanes(ctx.window)).toHaveCount(4, { timeout: T_LONG });
+
+    const tallPane = filePanes(ctx.window).filter({ hasText: "tall-line-001" }).first();
+    await expect(tallPane.locator(".cm-content")).toBeVisible({ timeout: T_LONG });
+
+    // #11024: the pane body owns the scroll. Without the grid-item min-height
+    // fix the cell inflates to the file's intrinsic height, so the pane has no
+    // internal scroll and its client height explodes past the window.
+    await expect
+      .poll(
+        () =>
+          tallPane.evaluate((el) => ({
+            scrollsInternally: el.scrollHeight > el.clientHeight,
+            paneBounded: el.clientHeight <= window.innerHeight,
+          })),
+        { timeout: T_MEDIUM }
+      )
+      .toEqual({ scrollsInternally: true, paneBounded: true });
+  });
+
+  test("a short file's editor surface stretches to fill the pane", async () => {
+    await dispatchAction(ctx.window, "file.openPanel", { path: "short.txt" });
+    await expect(filePanes(ctx.window)).toHaveCount(5, { timeout: T_LONG });
+
+    const shortPane = filePanes(ctx.window).filter({ hasText: "short-line-1" }).first();
+    await expect(shortPane.locator(".cm-content")).toBeVisible({ timeout: T_LONG });
+
+    // The min-h-full column mirrors the file viewer dialog: the editor surface
+    // reaches the bottom of the pane, and the pane background resolves to the
+    // same color as the editor background so the fill is seamless.
+    await expect
+      .poll(
+        () =>
+          shortPane.evaluate((el) => {
+            const column = el.firstElementChild;
+            const editor = el.querySelector(".cm-editor");
+            return {
+              columnFillsPane:
+                column instanceof HTMLElement && column.offsetHeight >= el.clientHeight - 1,
+              backgroundsMatch:
+                editor !== null &&
+                getComputedStyle(el).backgroundColor === getComputedStyle(editor).backgroundColor,
+            };
+          }),
+        { timeout: T_MEDIUM }
+      )
+      .toEqual({ columnFillsPane: true, backgroundsMatch: true });
   });
 });

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -819,10 +819,16 @@ export function AppLayout({
             scrolls this row right — shifting sidebar+main left and pushing the
             worktree sidebar off the left edge. `overflow:clip` is not a scroll
             container, so focus can never scroll it. Both the class and the inline
-            style are set because the inline `overflow` wins over the utility. */}
+            style are set because the inline `overflow` wins over the utility.
+
+            min-height MUST be 0 (#11024): because `clip` is not a scroll
+            container, it does not zero the flex automatic minimum size the way
+            `overflow:hidden` does — without it, any panel content with a large
+            intrinsic height (file viewer) inflates this row past the window and
+            wrecks the whole layout. */}
         <div
-          className="flex-1 flex overflow-clip relative"
-          style={{ flex: 1, display: "flex", overflow: "clip", position: "relative" }}
+          className="flex-1 flex overflow-clip relative min-h-0"
+          style={{ flex: 1, display: "flex", overflow: "clip", position: "relative", minHeight: 0 }}
         >
           <div
             className={cn(

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -344,7 +344,10 @@ export function TwoPaneSplitLayout({
           data-grid-container="true"
           data-split-mode="true"
         >
-          <div className="relative min-w-0">
+          {/* min-h-0: the implicit row track is `auto`, so without it a panel
+              with intrinsic-height content (file viewer) sizes the row to the
+              content instead of the container (#11024). */}
+          <div className="relative min-w-0 min-h-0">
             <SortableTerminal
               terminal={terminals[0]}
               sourceLocation="grid"
@@ -372,7 +375,7 @@ export function TwoPaneSplitLayout({
             maxRatio={maxRatio}
           />
 
-          <div className="relative min-w-0">
+          <div className="relative min-w-0 min-h-0">
             <SortableTerminal
               terminal={terminals[1]}
               sourceLocation="grid"

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -550,23 +550,38 @@ export function FilePane({
         {filePath &&
           loadState === "loaded" &&
           content !== null &&
-          (isMarkdown ? (
+          (isMarkdown && viewMode === "rendered" ? (
             <MarkdownViewer
               ref={markdownViewerRef}
               content={content}
               filePath={filePath}
               rootPath={effectiveRootPath}
-              viewMode={viewMode}
+              viewMode="rendered"
               wrapLines={markdownWrapLines}
-              className={cn(viewMode === "source" && "min-h-full")}
             />
           ) : (
-            <CodeViewer
-              ref={codeViewerRef}
-              content={content}
-              filePath={filePath}
-              className="min-h-full"
-            />
+            // min-h-full column (mirrors FileViewerModal): the editor surface
+            // stretches to the bottom of the pane even for files shorter than it.
+            <div className="flex min-h-full flex-col">
+              {isMarkdown ? (
+                <MarkdownViewer
+                  ref={markdownViewerRef}
+                  content={content}
+                  filePath={filePath}
+                  rootPath={effectiveRootPath}
+                  viewMode="source"
+                  wrapLines={markdownWrapLines}
+                  className="flex-1"
+                />
+              ) : (
+                <CodeViewer
+                  ref={codeViewerRef}
+                  content={content}
+                  filePath={filePath}
+                  className="flex-1"
+                />
+              )}
+            </div>
           ))}
       </div>
     </ContentPanel>


### PR DESCRIPTION
Fixes #11024.

This fixes a critical bug where opening a file taller than its file viewer panel inflated the entire app layout to the file's intrinsic height instead of the pane scrolling internally.

The root cause was #10693, which changed the main layout row in `AppLayout.tsx` from `overflow: hidden` to `overflow: clip` to stop focus-driven scrolling. `overflow: hidden` makes a flex item a scroll container, which zeroes the flex automatic minimum size; `overflow: clip` is not a scroll container, so `min-height: auto` re-engaged and the row grew to its content's intrinsic height. The file panel is the first panel kind with real intrinsic content height (CodeMirror hands scroll ownership to its outer wrapper), which is why terminals and browser panels never tripped it. Found by dumping DOM geometry up the ancestor chain in the running app: the row measured 7446px against a 1662px window.

The fix is an explicit `min-height: 0` on that row. The same guard goes on the two-pane split wrappers in `TwoPaneSplitLayout.tsx`, where the implicit `auto` row track has the same latent hole.

While in here, the panel now mirrors the dialog's `min-h-full` column (see `FileViewerModal.tsx`), so the editor surface stretches to the bottom of the pane for files shorter than it instead of stopping mid-pane.

Two e2e regression tests added to `core-file-panel.spec.ts`: a tall file must scroll inside the pane and stay bounded by the window, and a short file's editor surface must fill the pane with the editor background. The tall-file test was verified failing against a build without the `AppLayout` fix.