### PR TITLE
feat(diff): turn the diff viewer into a multi-file review workspace

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -75,6 +75,8 @@ export const CHANNELS = {
   FILES_SEARCH: "files:search",
   FILES_READ: "files:read",
 
+  DIFF_MEDIA_READ_FILE_VERSIONS: "diff-media:read-file-versions",
+
   TERMINAL_ACTIVITY: "terminal:activity",
 
   ARTIFACT_DETECTED: "artifact:detected",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -28,6 +28,7 @@ import { registerWorktreeConfigHandlers } from "./handlers/worktreeConfig.js";
 import { registerNotificationHandlers } from "./handlers/notifications.js";
 import { registerMenuHandlers } from "./handlers/menu.js";
 import { registerFilesHandlers } from "./handlers/files.js";
+import { registerDiffMediaHandlers } from "./handlers/diffMedia.js";
 import { registerSlashCommandHandlers } from "./handlers/slashCommands.js";
 import { registerGeminiHandlers } from "./handlers/gemini.js";
 import { registerEventsHandlers } from "./handlers/events.js";
@@ -122,6 +123,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerWorktreeHandlers(deps));
     register(() => registerTerminalHandlers(deps));
     register(() => registerFilesHandlers());
+    register(() => registerDiffMediaHandlers());
     register(() => registerCopyTreeHandlers(deps));
     register(() => registerAiHandlers(deps));
     register(() => registerSlashCommandHandlers());

--- a/electron/ipc/handlers/__tests__/diffMedia.test.ts
+++ b/electron/ipc/handlers/__tests__/diffMedia.test.ts
@@ -11,6 +11,7 @@ const getGitServiceMock = vi.hoisted(() => vi.fn());
 
 const fileHandleMock = vi.hoisted(() => ({
   readFile: vi.fn(),
+  stat: vi.fn(),
   close: vi.fn(async () => {}),
 }));
 
@@ -29,6 +30,7 @@ vi.mock("../../../services/GitServiceCache.js", () => ({
 
 import { registerDiffMediaHandlers } from "../diffMedia.js";
 import { DIFF_MEDIA_METHOD_CHANNELS } from "../diffMedia.preload.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
 import type { DiffMediaFileVersions } from "../../../../shared/types/ipc/diffMedia.js";
 
 type Handler = (
@@ -59,14 +61,19 @@ describe("diffMedia readFileVersions", () => {
   beforeEach(() => {
     ipcHandlers.clear();
     vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
 
     getGitServiceMock.mockReturnValue({ readFileAtHead: readFileAtHeadMock });
     readFileAtHeadMock.mockResolvedValue({ ok: true, content: HEAD_BUFFER });
 
     fsMock.realpath.mockImplementation(async (p: string) => p);
-    fsMock.stat.mockResolvedValue({ size: WORKING_BUFFER.byteLength });
+    fsMock.stat.mockResolvedValue({ size: WORKING_BUFFER.byteLength, isFile: () => true });
     fsMock.open.mockResolvedValue(fileHandleMock);
     fileHandleMock.readFile.mockResolvedValue(WORKING_BUFFER);
+    fileHandleMock.stat.mockResolvedValue({
+      size: WORKING_BUFFER.byteLength,
+      isFile: () => true,
+    });
     fileHandleMock.close.mockResolvedValue(undefined);
 
     cleanup = registerDiffMediaHandlers();
@@ -96,7 +103,11 @@ describe("diffMedia readFileVersions", () => {
   });
 
   it("rejects null bytes in filePath", async () => {
-    await expect(invoke({ cwd: "/repo", filePath: "img\0.png" })).rejects.toThrow(/null/i);
+    // Caught at the zod boundary (opValidated), whose ValidationError message
+    // is deliberately sanitized — no schema details reach the renderer.
+    await expect(invoke({ cwd: "/repo", filePath: "img\0.png" })).rejects.toThrow(
+      /validation failed/i
+    );
   });
 
   it("rejects a relative cwd", async () => {
@@ -137,7 +148,7 @@ describe("diffMedia readFileVersions", () => {
   });
 
   it("caps the working side at the size limit", async () => {
-    fsMock.stat.mockResolvedValue({ size: 9 * 1024 * 1024 });
+    fsMock.stat.mockResolvedValue({ size: 9 * 1024 * 1024, isFile: () => true });
 
     const result = await invoke({ cwd: "/repo", filePath: "img.png" });
 

--- a/electron/ipc/handlers/__tests__/diffMedia.test.ts
+++ b/electron/ipc/handlers/__tests__/diffMedia.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+const readFileAtHeadMock = vi.hoisted(() => vi.fn());
+const getGitServiceMock = vi.hoisted(() => vi.fn());
+
+const fileHandleMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  close: vi.fn(async () => {}),
+}));
+
+const fsMock = vi.hoisted(() => ({
+  realpath: vi.fn(),
+  stat: vi.fn(),
+  open: vi.fn(),
+  constants: { O_RDONLY: 0, O_NOFOLLOW: 0x100 },
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+vi.mock("fs/promises", () => ({ default: fsMock, ...fsMock }));
+vi.mock("../../../services/GitServiceCache.js", () => ({
+  gitServiceCache: { getGitService: getGitServiceMock },
+}));
+
+import { registerDiffMediaHandlers } from "../diffMedia.js";
+import { DIFF_MEDIA_METHOD_CHANNELS } from "../diffMedia.preload.js";
+import type { DiffMediaFileVersions } from "../../../../shared/types/ipc/diffMedia.js";
+
+type Handler = (
+  event: Electron.IpcMainInvokeEvent,
+  ...args: unknown[]
+) => Promise<DiffMediaFileVersions>;
+
+function getHandler(): Handler {
+  const fn = ipcHandlers.get(DIFF_MEDIA_METHOD_CHANNELS.readFileVersions);
+  if (!fn) throw new Error("handler not registered");
+  return fn as Handler;
+}
+
+function fakeEvent(): Electron.IpcMainInvokeEvent {
+  return { sender: {} as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+function invoke(payload: { cwd: string; filePath: string }): Promise<DiffMediaFileVersions> {
+  return getHandler()(fakeEvent(), payload);
+}
+
+const WORKING_BUFFER = Buffer.from("working-image-bytes");
+const HEAD_BUFFER = Buffer.from("head-image-bytes");
+
+describe("diffMedia readFileVersions", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+
+    getGitServiceMock.mockReturnValue({ readFileAtHead: readFileAtHeadMock });
+    readFileAtHeadMock.mockResolvedValue({ ok: true, content: HEAD_BUFFER });
+
+    fsMock.realpath.mockImplementation(async (p: string) => p);
+    fsMock.stat.mockResolvedValue({ size: WORKING_BUFFER.byteLength });
+    fsMock.open.mockResolvedValue(fileHandleMock);
+    fileHandleMock.readFile.mockResolvedValue(WORKING_BUFFER);
+    fileHandleMock.close.mockResolvedValue(undefined);
+
+    cleanup = registerDiffMediaHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("rejects absolute filePath without touching git or the filesystem", async () => {
+    await expect(invoke({ cwd: "/repo", filePath: "/etc/passwd.png" })).rejects.toThrow(/relative/);
+    expect(getGitServiceMock).not.toHaveBeenCalled();
+    expect(fsMock.open).not.toHaveBeenCalled();
+  });
+
+  it("rejects .. traversal segments", async () => {
+    await expect(invoke({ cwd: "/repo", filePath: "../outside.png" })).rejects.toThrow(
+      /traversal/i
+    );
+    expect(getGitServiceMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects traversal that only appears after normalization", async () => {
+    await expect(invoke({ cwd: "/repo", filePath: "assets/../../outside.png" })).rejects.toThrow(
+      /traversal/i
+    );
+  });
+
+  it("rejects null bytes in filePath", async () => {
+    await expect(invoke({ cwd: "/repo", filePath: "img\0.png" })).rejects.toThrow(/null/i);
+  });
+
+  it("rejects a relative cwd", async () => {
+    await expect(invoke({ cwd: "repo", filePath: "img.png" })).rejects.toThrow(/absolute/i);
+  });
+
+  it("returns UNSUPPORTED for both sides on a non-image extension without I/O", async () => {
+    const result = await invoke({ cwd: "/repo", filePath: "notes.txt" });
+    expect(result.head).toEqual({ ok: false, error: "UNSUPPORTED" });
+    expect(result.working).toEqual({ ok: false, error: "UNSUPPORTED" });
+    expect(getGitServiceMock).not.toHaveBeenCalled();
+    expect(fsMock.realpath).not.toHaveBeenCalled();
+  });
+
+  it("maps a file missing at HEAD to NOT_FOUND while the working side loads", async () => {
+    readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "NOT_FOUND" });
+
+    const result = await invoke({ cwd: "/repo", filePath: "img.png" });
+
+    expect(result.head).toEqual({ ok: false, error: "NOT_FOUND" });
+    expect(result.working).toEqual({
+      ok: true,
+      dataUrl: `data:image/png;base64,${WORKING_BUFFER.toString("base64")}`,
+      byteSize: WORKING_BUFFER.byteLength,
+    });
+  });
+
+  it("maps a missing working-tree file to NOT_FOUND", async () => {
+    fsMock.realpath.mockImplementation(async (p: string) => {
+      if (p === "/repo") return "/repo";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const result = await invoke({ cwd: "/repo", filePath: "img.png" });
+
+    expect(result.working).toEqual({ ok: false, error: "NOT_FOUND" });
+    expect(result.head.ok).toBe(true);
+  });
+
+  it("caps the working side at the size limit", async () => {
+    fsMock.stat.mockResolvedValue({ size: 9 * 1024 * 1024 });
+
+    const result = await invoke({ cwd: "/repo", filePath: "img.png" });
+
+    expect(result.working).toEqual({ ok: false, error: "TOO_LARGE" });
+    expect(fsMock.open).not.toHaveBeenCalled();
+    expect(result.head.ok).toBe(true);
+  });
+
+  it("passes the HEAD-side TOO_LARGE result through", async () => {
+    readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "TOO_LARGE" });
+
+    const result = await invoke({ cwd: "/repo", filePath: "img.png" });
+
+    expect(result.head).toEqual({ ok: false, error: "TOO_LARGE" });
+  });
+
+  it("maps an unexpected git failure to a HEAD-side ERROR instead of rejecting", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    readFileAtHeadMock.mockRejectedValue(new Error("git exploded"));
+
+    const result = await invoke({ cwd: "/repo", filePath: "img.png" });
+
+    expect(result.head).toEqual({ ok: false, error: "ERROR" });
+    expect(result.working.ok).toBe(true);
+  });
+
+  it("returns ERROR for a working-tree file that escapes the root via symlink", async () => {
+    fsMock.realpath.mockImplementation(async (p: string) =>
+      p === "/repo" ? "/repo" : "/elsewhere/img.png"
+    );
+
+    const result = await invoke({ cwd: "/repo", filePath: "img.png" });
+
+    expect(result.working).toEqual({ ok: false, error: "ERROR" });
+    expect(fsMock.open).not.toHaveBeenCalled();
+  });
+
+  it("encodes both sides with the extension's mime type and real byte sizes", async () => {
+    const result = await invoke({ cwd: "/repo", filePath: "logo.svg" });
+
+    expect(result.head).toEqual({
+      ok: true,
+      dataUrl: `data:image/svg+xml;base64,${HEAD_BUFFER.toString("base64")}`,
+      byteSize: HEAD_BUFFER.byteLength,
+    });
+    expect(result.working).toEqual({
+      ok: true,
+      dataUrl: `data:image/svg+xml;base64,${WORKING_BUFFER.toString("base64")}`,
+      byteSize: WORKING_BUFFER.byteLength,
+    });
+    expect(fsMock.open).toHaveBeenCalledWith(
+      "/repo/logo.svg",
+      fsMock.constants.O_RDONLY | fsMock.constants.O_NOFOLLOW
+    );
+  });
+});

--- a/electron/ipc/handlers/diffMedia.preload.ts
+++ b/electron/ipc/handlers/diffMedia.preload.ts
@@ -1,0 +1,24 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const DIFF_MEDIA_METHOD_CHANNELS = {
+  readFileVersions: "diff-media:read-file-versions",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof DIFF_MEDIA_METHOD_CHANNELS;
+
+export type DiffMediaPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildDiffMediaPreloadBindings(invoke: Invoker): DiffMediaPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(DIFF_MEDIA_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = DIFF_MEDIA_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as DiffMediaPreloadBindings;
+}

--- a/electron/ipc/handlers/diffMedia.ts
+++ b/electron/ipc/handlers/diffMedia.ts
@@ -1,35 +1,26 @@
 import path from "path";
 import fs from "fs/promises";
-import { defineIpcNamespace, op } from "../define.js";
+import { defineIpcNamespace, opValidated } from "../define.js";
 import { checkRateLimit } from "../utils.js";
 import { DIFF_MEDIA_METHOD_CHANNELS } from "./diffMedia.preload.js";
+import { isLfsPointer } from "./files.js";
+import { DiffMediaReadFileVersionsPayloadSchema } from "../../schemas/ipc.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
 import { AppError } from "../../utils/errorTypes.js";
 import {
   DIFF_MEDIA_MAX_BYTES,
+  getDiffMediaImageMime,
   type DiffMediaFileVersions,
   type DiffMediaReadFileVersionsPayload,
   type DiffMediaSide,
 } from "../../../shared/types/ipc/diffMedia.js";
 
-const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  bmp: "image/bmp",
-  ico: "image/x-icon",
-  svg: "image/svg+xml",
-};
-
-function getImageMime(filePath: string): string | null {
-  const dot = filePath.lastIndexOf(".");
-  if (dot === -1) return null;
-  return IMAGE_MIME_BY_EXTENSION[filePath.slice(dot + 1).toLowerCase()] ?? null;
-}
-
 function toImageSide(mime: string, content: Buffer): DiffMediaSide {
+  // Git LFS pointer files are text stand-ins for the real blob — served as
+  // image bytes they just render broken.
+  if (isLfsPointer(content)) {
+    return { ok: false, error: "UNSUPPORTED" };
+  }
   return {
     ok: true,
     dataUrl: `data:${mime};base64,${content.toString("base64")}`,
@@ -37,16 +28,18 @@ function toImageSide(mime: string, content: Buffer): DiffMediaSide {
   };
 }
 
+// Semantic path checks (absoluteness, traversal, null bytes) beyond the
+// structural zod validation at the IPC boundary.
 function validatePayload(payload: DiffMediaReadFileVersionsPayload): void {
-  const { cwd, filePath } = payload ?? {};
-  if (typeof cwd !== "string" || !path.isAbsolute(cwd)) {
+  const { cwd, filePath } = payload;
+  if (!path.isAbsolute(cwd)) {
     throw new AppError({
       code: "INVALID_PATH",
       message: "cwd must be an absolute path",
       context: { cwd },
     });
   }
-  if (typeof filePath !== "string" || !filePath.trim()) {
+  if (!filePath.trim()) {
     throw new AppError({
       code: "INVALID_PATH",
       message: "filePath is required",
@@ -130,13 +123,24 @@ async function readWorkingSide(
     }
 
     const stat = await fs.stat(realFile);
+    // Only regular files: a FIFO in the worktree would wedge the read forever.
+    if (!stat.isFile()) {
+      return { ok: false, error: "ERROR" };
+    }
     if (stat.size > DIFF_MEDIA_MAX_BYTES) {
       return { ok: false, error: "TOO_LARGE" };
     }
 
+    // O_NONBLOCK (no-op on Windows) so a file swapped for a FIFO between the
+    // stat and the open can't block the open itself; the fd stat below then
+    // rejects anything that is no longer a regular in-budget file — the
+    // pre-open checks only vetted a path, this vets what was actually opened.
     let fileHandle: Awaited<ReturnType<typeof fs.open>>;
     try {
-      fileHandle = await fs.open(absolutePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+      fileHandle = await fs.open(
+        absolutePath,
+        fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | (fs.constants.O_NONBLOCK ?? 0)
+      );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return { ok: false, error: "NOT_FOUND" };
@@ -146,6 +150,13 @@ async function readWorkingSide(
 
     let content: Buffer;
     try {
+      const fdStat = await fileHandle.stat();
+      if (!fdStat.isFile()) {
+        return { ok: false, error: "ERROR" };
+      }
+      if (fdStat.size > DIFF_MEDIA_MAX_BYTES) {
+        return { ok: false, error: "TOO_LARGE" };
+      }
       content = await fileHandle.readFile();
     } finally {
       await fileHandle.close().catch(() => {});
@@ -164,10 +175,12 @@ async function readWorkingSide(
 async function handleReadFileVersions(
   payload: DiffMediaReadFileVersionsPayload
 ): Promise<DiffMediaFileVersions> {
-  checkRateLimit(DIFF_MEDIA_METHOD_CHANNELS.readFileVersions, 20, 10_000);
+  // Modest budget: each call can return up to ~21 MB of base64 (8 MB raw ×
+  // ~1.33 × two sides), so the window is tighter than the text-diff channels.
+  checkRateLimit(DIFF_MEDIA_METHOD_CHANNELS.readFileVersions, 10, 10_000);
   validatePayload(payload);
 
-  const mime = getImageMime(payload.filePath);
+  const mime = getDiffMediaImageMime(payload.filePath);
   if (!mime) {
     return {
       head: { ok: false, error: "UNSUPPORTED" },
@@ -185,7 +198,11 @@ async function handleReadFileVersions(
 export const diffMediaNamespace = defineIpcNamespace({
   name: "diffMedia",
   ops: {
-    readFileVersions: op(DIFF_MEDIA_METHOD_CHANNELS.readFileVersions, handleReadFileVersions),
+    readFileVersions: opValidated(
+      DIFF_MEDIA_METHOD_CHANNELS.readFileVersions,
+      DiffMediaReadFileVersionsPayloadSchema,
+      handleReadFileVersions
+    ),
   },
 });
 

--- a/electron/ipc/handlers/diffMedia.ts
+++ b/electron/ipc/handlers/diffMedia.ts
@@ -1,0 +1,194 @@
+import path from "path";
+import fs from "fs/promises";
+import { defineIpcNamespace, op } from "../define.js";
+import { checkRateLimit } from "../utils.js";
+import { DIFF_MEDIA_METHOD_CHANNELS } from "./diffMedia.preload.js";
+import { gitServiceCache } from "../../services/GitServiceCache.js";
+import { AppError } from "../../utils/errorTypes.js";
+import {
+  DIFF_MEDIA_MAX_BYTES,
+  type DiffMediaFileVersions,
+  type DiffMediaReadFileVersionsPayload,
+  type DiffMediaSide,
+} from "../../../shared/types/ipc/diffMedia.js";
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  svg: "image/svg+xml",
+};
+
+function getImageMime(filePath: string): string | null {
+  const dot = filePath.lastIndexOf(".");
+  if (dot === -1) return null;
+  return IMAGE_MIME_BY_EXTENSION[filePath.slice(dot + 1).toLowerCase()] ?? null;
+}
+
+function toImageSide(mime: string, content: Buffer): DiffMediaSide {
+  return {
+    ok: true,
+    dataUrl: `data:${mime};base64,${content.toString("base64")}`,
+    byteSize: content.byteLength,
+  };
+}
+
+function validatePayload(payload: DiffMediaReadFileVersionsPayload): void {
+  const { cwd, filePath } = payload ?? {};
+  if (typeof cwd !== "string" || !path.isAbsolute(cwd)) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "cwd must be an absolute path",
+      context: { cwd },
+    });
+  }
+  if (typeof filePath !== "string" || !filePath.trim()) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "filePath is required",
+      context: { filePath },
+    });
+  }
+  if (filePath.includes("\0")) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "filePath contains null bytes",
+      context: {},
+    });
+  }
+  if (path.isAbsolute(filePath)) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "filePath must be relative to cwd",
+      context: { filePath },
+    });
+  }
+  const normalized = path.normalize(filePath);
+  const segments = normalized.split(/[\\/]+/).filter(Boolean);
+  if (segments.includes("..") || normalized.startsWith(path.sep)) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "Path traversal detected",
+      context: { filePath },
+    });
+  }
+}
+
+async function readHeadSide(cwd: string, filePath: string, mime: string): Promise<DiffMediaSide> {
+  try {
+    const result = await gitServiceCache
+      .getGitService(cwd)
+      .readFileAtHead(filePath, DIFF_MEDIA_MAX_BYTES);
+    if (!result.ok) {
+      return { ok: false, error: result.reason };
+    }
+    return toImageSide(mime, result.content);
+  } catch (error) {
+    console.error("[IPC] diff-media HEAD read failed:", error);
+    return { ok: false, error: "ERROR" };
+  }
+}
+
+// Same containment discipline as files:read — realpath containment against the
+// canonicalized root, then an O_NOFOLLOW open of the caller-supplied path so a
+// final-component symlink injected after the realpath check is rejected.
+async function readWorkingSide(
+  cwd: string,
+  filePath: string,
+  mime: string
+): Promise<DiffMediaSide> {
+  try {
+    let realRoot: string;
+    try {
+      realRoot = await fs.realpath(cwd);
+    } catch (error) {
+      console.error("[IPC] diff-media cwd resolution failed:", error);
+      return { ok: false, error: "ERROR" };
+    }
+
+    const absolutePath = path.resolve(cwd, filePath);
+    let realFile: string;
+    try {
+      realFile = await fs.realpath(absolutePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { ok: false, error: "NOT_FOUND" };
+      }
+      return { ok: false, error: "ERROR" };
+    }
+
+    const contained =
+      realRoot === path.sep
+        ? realFile.startsWith(path.sep)
+        : realFile === realRoot || realFile.startsWith(realRoot + path.sep);
+    if (!contained) {
+      return { ok: false, error: "ERROR" };
+    }
+
+    const stat = await fs.stat(realFile);
+    if (stat.size > DIFF_MEDIA_MAX_BYTES) {
+      return { ok: false, error: "TOO_LARGE" };
+    }
+
+    let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+    try {
+      fileHandle = await fs.open(absolutePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { ok: false, error: "NOT_FOUND" };
+      }
+      return { ok: false, error: "ERROR" };
+    }
+
+    let content: Buffer;
+    try {
+      content = await fileHandle.readFile();
+    } finally {
+      await fileHandle.close().catch(() => {});
+    }
+
+    if (content.byteLength > DIFF_MEDIA_MAX_BYTES) {
+      return { ok: false, error: "TOO_LARGE" };
+    }
+    return toImageSide(mime, content);
+  } catch (error) {
+    console.error("[IPC] diff-media working-tree read failed:", error);
+    return { ok: false, error: "ERROR" };
+  }
+}
+
+async function handleReadFileVersions(
+  payload: DiffMediaReadFileVersionsPayload
+): Promise<DiffMediaFileVersions> {
+  checkRateLimit(DIFF_MEDIA_METHOD_CHANNELS.readFileVersions, 20, 10_000);
+  validatePayload(payload);
+
+  const mime = getImageMime(payload.filePath);
+  if (!mime) {
+    return {
+      head: { ok: false, error: "UNSUPPORTED" },
+      working: { ok: false, error: "UNSUPPORTED" },
+    };
+  }
+
+  const [head, working] = await Promise.all([
+    readHeadSide(payload.cwd, payload.filePath, mime),
+    readWorkingSide(payload.cwd, payload.filePath, mime),
+  ]);
+  return { head, working };
+}
+
+export const diffMediaNamespace = defineIpcNamespace({
+  name: "diffMedia",
+  ops: {
+    readFileVersions: op(DIFF_MEDIA_METHOD_CHANNELS.readFileVersions, handleReadFileVersions),
+  },
+});
+
+export function registerDiffMediaHandlers(): () => void {
+  return diffMediaNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -58,6 +58,7 @@ import { buildSentryPreloadBindings } from "./ipc/handlers/sentry.preload.js";
 import { buildPrivacyPreloadBindings } from "./ipc/handlers/privacy.preload.js";
 import { buildTelemetryPreloadBindings } from "./ipc/handlers/telemetry.preload.js";
 import { buildConnectivityPreloadBindings } from "./ipc/handlers/connectivity.preload.js";
+import { buildDiffMediaPreloadBindings } from "./ipc/handlers/diffMedia.preload.js";
 import { buildHibernationPreloadBindings } from "./ipc/handlers/hibernation.preload.js";
 import { buildIdleTerminalPreloadBindings } from "./ipc/handlers/idleTerminals.preload.js";
 import { buildIdleBackgroundAutoClosePreloadBindings } from "./ipc/handlers/idleBackgroundAutoClose.preload.js";
@@ -1278,6 +1279,9 @@ function buildElectronApi(): ElectronAPI {
       search: (payload) => _unwrappingInvoke(CHANNELS.FILES_SEARCH, payload),
       read: (payload) => _unwrappingInvoke(CHANNELS.FILES_READ, payload),
     },
+
+    // Diff media API — HEAD vs working-tree image versions for image compare
+    diffMedia: buildDiffMediaPreloadBindings(_unwrappingInvoke),
 
     // Watchdog API — surfaces the main-process deadlock detector's disabled
     // state to the renderer and exposes a manual restart path.

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -488,6 +488,21 @@ export const FileReadPayloadSchema = z.object({
     .regex(/^[^\x00]*$/, "Null bytes not allowed"),
 });
 
+export const DiffMediaReadFileVersionsPayloadSchema = z.object({
+  cwd: z
+    .string()
+    .min(1)
+    .max(4096)
+    // eslint-disable-next-line no-control-regex
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+  filePath: z
+    .string()
+    .min(1)
+    .max(4096)
+    // eslint-disable-next-line no-control-regex
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+});
+
 export const VoiceInputCorrectPayloadSchema = z.object({
   rawText: z.string(),
   recentContext: z.array(z.string()).optional(),

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -18,6 +18,15 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+export type HeadFileReadResult =
+  | { ok: true; content: Buffer }
+  | { ok: false; reason: "NOT_FOUND" | "TOO_LARGE" };
+
+// Git error text for a path/revision that cannot resolve to a blob at HEAD:
+// missing path, untracked path, empty repo (unborn HEAD), or a non-blob object.
+const MISSING_AT_HEAD_RE =
+  /does not exist in|exists on disk, but not in|invalid object name|not a valid object name|bad revision|bad file/i;
+
 export class GitService {
   private git: Promise<SimpleGit> | null = null;
   private rootPath: string;
@@ -303,6 +312,61 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       });
       throw new Error(`Failed to generate diff: ${(error as Error).message}`);
     }
+  }
+
+  /**
+   * Read a file's blob content at HEAD. Size-checks via `cat-file -s` before
+   * reading so an oversized blob is never loaded, and reads the content with
+   * `binaryCatFile` (Buffer-safe — `raw()` is utf8-lossy for binary blobs).
+   */
+  async readFileAtHead(filePath: string, maxBytes: number): Promise<HeadFileReadResult> {
+    if (isAbsolute(filePath)) {
+      throw new Error("Absolute paths are not allowed");
+    }
+    if (filePath.includes("\0")) {
+      throw new Error("Path contains null bytes");
+    }
+
+    const normalizedPath = normalize(filePath);
+    const pathSegments = normalizedPath.split(/[\\/]+/).filter(Boolean);
+    if (pathSegments.includes("..") || normalizedPath.startsWith(sep)) {
+      throw new Error("Path traversal detected");
+    }
+
+    // Git object specs always use forward slashes, even on Windows. The
+    // `HEAD:` prefix also guarantees the spec never starts with a dash.
+    const objectSpec = `HEAD:${normalizedPath.replaceAll("\\", "/")}`;
+    const git = await this.getGit();
+
+    let sizeRaw: string;
+    try {
+      sizeRaw = await git.raw(["cat-file", "-s", "--end-of-options", objectSpec]);
+    } catch (error) {
+      if (MISSING_AT_HEAD_RE.test((error as Error).message ?? "")) {
+        return { ok: false, reason: "NOT_FOUND" };
+      }
+      throw toGitOperationError(error, { cwd: this.rootPath, op: "read-file-at-head" });
+    }
+
+    const size = Number.parseInt(sizeRaw.trim(), 10);
+    if (Number.isFinite(size) && size > maxBytes) {
+      return { ok: false, reason: "TOO_LARGE" };
+    }
+
+    let content: Buffer;
+    try {
+      content = (await git.binaryCatFile(["blob", objectSpec])) as Buffer;
+    } catch (error) {
+      if (MISSING_AT_HEAD_RE.test((error as Error).message ?? "")) {
+        return { ok: false, reason: "NOT_FOUND" };
+      }
+      throw toGitOperationError(error, { cwd: this.rootPath, op: "read-file-at-head" });
+    }
+
+    if (content.byteLength > maxBytes) {
+      return { ok: false, reason: "TOO_LARGE" };
+    }
+    return { ok: true, content };
   }
 
   async compareWorktrees(

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -525,3 +525,111 @@ describe("GitService", () => {
     expect(logErrorMock).not.toHaveBeenCalled();
   });
 });
+
+describe("GitService.readFileAtHead", () => {
+  let tempDir: string;
+  const binaryCatFileMock = vi.fn();
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-git-head-"));
+    vi.clearAllMocks();
+    createHardenedGitMock.mockImplementation(() => ({
+      ...gitClientMock,
+      binaryCatFile: binaryCatFileMock,
+    }));
+    gitClientMock.raw.mockResolvedValue("");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("rejects absolute paths before touching git", async () => {
+    const service = new GitService(tempDir);
+    await expect(service.readFileAtHead("/etc/passwd", 1024)).rejects.toThrow(/absolute/i);
+    expect(gitClientMock.raw).not.toHaveBeenCalled();
+  });
+
+  it("rejects traversal that only appears after normalization", async () => {
+    const service = new GitService(tempDir);
+    await expect(service.readFileAtHead("assets/../../outside.png", 1024)).rejects.toThrow(
+      /traversal/i
+    );
+    expect(gitClientMock.raw).not.toHaveBeenCalled();
+  });
+
+  it("rejects null bytes", async () => {
+    const service = new GitService(tempDir);
+    await expect(service.readFileAtHead("img\0.png", 1024)).rejects.toThrow(/null/i);
+    expect(gitClientMock.raw).not.toHaveBeenCalled();
+  });
+
+  it("size-probes with --end-of-options and a HEAD: spec so leading-dash names stay inert", async () => {
+    gitClientMock.raw.mockResolvedValue("10\n");
+    binaryCatFileMock.mockResolvedValue(Buffer.from("image-data"));
+    const service = new GitService(tempDir);
+
+    const result = await service.readFileAtHead("-flag.png", 1024);
+
+    expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "cat-file",
+      "-s",
+      "--end-of-options",
+      "HEAD:-flag.png",
+    ]);
+    // binaryCatFile has no --end-of-options; the HEAD: prefix is what keeps
+    // the spec from ever starting with a dash.
+    expect(binaryCatFileMock).toHaveBeenCalledWith(["blob", "HEAD:-flag.png"]);
+    expect(result).toEqual({ ok: true, content: Buffer.from("image-data") });
+  });
+
+  it("converts backslash separators to git's forward-slash object spec", async () => {
+    gitClientMock.raw.mockResolvedValue("4\n");
+    binaryCatFileMock.mockResolvedValue(Buffer.from("data"));
+    const service = new GitService(tempDir);
+
+    await service.readFileAtHead("assets\\logo.png", 1024);
+
+    expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "cat-file",
+      "-s",
+      "--end-of-options",
+      "HEAD:assets/logo.png",
+    ]);
+  });
+
+  it("maps a file missing at HEAD to NOT_FOUND", async () => {
+    gitClientMock.raw.mockRejectedValue(
+      new Error("fatal: path 'new.png' does not exist in 'HEAD'")
+    );
+    const service = new GitService(tempDir);
+
+    await expect(service.readFileAtHead("new.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized blobs from the size probe without reading content", async () => {
+    gitClientMock.raw.mockResolvedValue(String(5 * 1024 * 1024) + "\n");
+    const service = new GitService(tempDir);
+
+    await expect(service.readFileAtHead("big.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "TOO_LARGE",
+    });
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("caps content that slips past a malformed size probe", async () => {
+    gitClientMock.raw.mockResolvedValue("not-a-number\n");
+    binaryCatFileMock.mockResolvedValue(Buffer.alloc(2048));
+    const service = new GitService(tempDir);
+
+    await expect(service.readFileAtHead("odd.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "TOO_LARGE",
+    });
+  });
+});

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -235,6 +235,11 @@ export type {
   FileReadPayload,
   FileReadResult,
   FileReadErrorCode,
+  // Diff media (image compare) types
+  DiffMediaReadFileVersionsPayload,
+  DiffMediaSide,
+  DiffMediaSideError,
+  DiffMediaFileVersions,
   // Electron API
   ElectronAPI,
   NotificationSettings,
@@ -341,6 +346,9 @@ export {
 
 // Per-service connectivity helpers
 export { CONNECTIVITY_SERVICE_KEYS } from "./ipc/connectivity.js";
+
+// Diff media helpers
+export { DIFF_MEDIA_MAX_BYTES } from "./ipc/diffMedia.js";
 
 // MCP server audit log + runtime state + turn outcomes
 export type {

--- a/shared/types/ipc/diffMedia.ts
+++ b/shared/types/ipc/diffMedia.ts
@@ -18,3 +18,25 @@ export interface DiffMediaFileVersions {
 
 /** Per-side byte cap for image compare payloads. */
 export const DIFF_MEDIA_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Single source of truth for compare-eligible image extensions — the main
+ * process derives MIME types from it and the renderer derives eligibility,
+ * so the two can't drift.
+ */
+export const DIFF_MEDIA_IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  svg: "image/svg+xml",
+};
+
+export function getDiffMediaImageMime(filePath: string): string | null {
+  const dot = filePath.lastIndexOf(".");
+  if (dot === -1) return null;
+  return DIFF_MEDIA_IMAGE_MIME_BY_EXTENSION[filePath.slice(dot + 1).toLowerCase()] ?? null;
+}

--- a/shared/types/ipc/diffMedia.ts
+++ b/shared/types/ipc/diffMedia.ts
@@ -1,0 +1,20 @@
+export interface DiffMediaReadFileVersionsPayload {
+  /** Absolute worktree root the file path is resolved against. */
+  cwd: string;
+  /** Repo-relative path of the image file. */
+  filePath: string;
+}
+
+export type DiffMediaSideError = "NOT_FOUND" | "TOO_LARGE" | "UNSUPPORTED" | "ERROR";
+
+export type DiffMediaSide =
+  | { ok: true; dataUrl: string; byteSize: number }
+  | { ok: false; error: DiffMediaSideError };
+
+export interface DiffMediaFileVersions {
+  head: DiffMediaSide;
+  working: DiffMediaSide;
+}
+
+/** Per-side byte cap for image compare payloads. */
+export const DIFF_MEDIA_MAX_BYTES = 8 * 1024 * 1024;

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -138,6 +138,11 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["dev-preview:stop-dev-server-by-worktree"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:stop-dev-server-by-worktree"]["result"]>;
   };
+  diffMedia: {
+    readFileVersions(
+      ...args: IpcInvokeMap["diff-media:read-file-versions"]["args"]
+    ): Promise<IpcInvokeMap["diff-media:read-file-versions"]["result"]>;
+  };
   eventInspector: {
     clear(
       ...args: IpcInvokeMap["event-inspector:clear"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -284,6 +284,10 @@ export interface GeneratedIpcInvokeMap {
     args: [request: import("./devPreview.js").DevPreviewStopDevServerByWorktreeRequest];
     result: import("./devPreview.js").DevPreviewSessionState;
   };
+  "diff-media:read-file-versions": {
+    args: [payload: import("./diffMedia.js").DiffMediaReadFileVersionsPayload];
+    result: import("./diffMedia.js").DiffMediaFileVersions;
+  };
   "editor:discover": {
     args: [];
     result: import("../editor.js").DiscoveredEditor[];

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -17,6 +17,7 @@ export * from "./agentCapabilities.js";
 export * from "./git.js";
 export * from "./gitPush.js";
 export * from "./files.js";
+export * from "./diffMedia.js";
 export * from "./config.js";
 export * from "./devPreview.js";
 export * from "./connectivity.js";

--- a/src/clients/diffMediaClient.ts
+++ b/src/clients/diffMediaClient.ts
@@ -1,0 +1,7 @@
+import type { DiffMediaFileVersions, DiffMediaReadFileVersionsPayload } from "@shared/types";
+
+export const diffMediaClient = {
+  readFileVersions: (payload: DiffMediaReadFileVersionsPayload): Promise<DiffMediaFileVersions> => {
+    return window.electron.diffMedia.readFileVersions(payload);
+  },
+};

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -3,6 +3,7 @@ import { Check, Folder, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { basename, dirname } from "@shared/utils/path";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import { DIFF_STATUS_CONFIG, summarizeChangeSet } from "./diffChangeSet";
 import type { DiffChangeSetEntry } from "./diffChangeSet";
@@ -82,17 +83,22 @@ export function DiffFileSidebar({
   );
 
   // Keep the open file's row in view while stepping with the keyboard.
+  // `groups` is a dependency so the row is re-revealed when a filter that hid
+  // it is cleared.
   useEffect(() => {
     if (currentIndex < 0 || !listRef.current) return;
     const row = listRef.current.querySelector<HTMLElement>(`[data-file-index="${currentIndex}"]`);
     if (typeof row?.scrollIntoView === "function") {
       row.scrollIntoView({ behavior: "instant", block: "nearest" });
     }
-  }, [currentIndex]);
+  }, [currentIndex, groups]);
 
+  // self-stretch (not h-full): a percentage height against the dialog's
+  // content-sized row collapses to content height and lets the dialog
+  // surface show beneath the list — flex stretch always fills the row.
   return (
     <div
-      className="flex h-full w-60 shrink-0 flex-col border-r border-daintree-border bg-daintree-sidebar"
+      className="flex min-h-0 w-60 shrink-0 select-none flex-col self-stretch border-r border-daintree-border bg-daintree-sidebar"
       data-testid="diff-file-sidebar"
     >
       <div className="shrink-0 border-b border-daintree-border px-3 py-2">
@@ -109,27 +115,38 @@ export function DiffFileSidebar({
             )}
           </span>
         </div>
-        <div className="mt-1.5" data-testid="diff-sidebar-progress">
-          <div className="flex items-center justify-between text-[11px] text-text-muted">
-            <span>
-              {viewedCount} of {files.length} viewed
-            </span>
-          </div>
-          <div className="mt-1 h-0.5 overflow-hidden rounded-full bg-daintree-border">
-            <div
-              className="h-full rounded-full bg-status-success/70 transition-[width] duration-150 ease-out"
-              style={{ width: `${files.length ? (viewedCount / files.length) * 100 : 0}%` }}
-            />
-          </div>
+        <div className="mt-1" data-testid="diff-sidebar-progress">
+          <span className="text-[11px] text-text-muted">
+            {viewedCount} of {files.length} viewed
+          </span>
+          {/* The track only appears once review has started — an empty
+              full-width strip at zero progress reads as stray chrome. */}
+          {viewedCount > 0 && (
+            <div className="mt-1 h-0.5 overflow-hidden rounded-full bg-tint/10">
+              <div
+                className="h-full rounded-full bg-status-success/70 transition-[width] duration-150 ease-out"
+                style={{ width: `${files.length ? (viewedCount / files.length) * 100 : 0}%` }}
+              />
+            </div>
+          )}
         </div>
       </div>
 
       <div className="shrink-0 px-2 py-1.5">
-        <div className="flex items-center gap-1.5 rounded border border-daintree-border bg-daintree-bg px-2 py-1 focus-within:border-border-strong">
+        <div className="flex items-center gap-1.5 rounded border border-daintree-border bg-daintree-bg px-2 py-1 focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20">
           <Search className="h-3 w-3 shrink-0 text-text-muted" />
           <input
             value={filter}
             onChange={(event) => setFilter(event.target.value)}
+            onKeyDown={(event) => {
+              // Escape clears an active filter instead of bubbling to the
+              // dialog's escape stack and closing the whole workspace.
+              if (event.key === "Escape" && filter) {
+                event.preventDefault();
+                event.stopPropagation();
+                setFilter("");
+              }
+            }}
             placeholder="Filter files"
             aria-label="Filter files"
             className="w-full bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
@@ -140,7 +157,20 @@ export function DiffFileSidebar({
 
       <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-2">
         {visibleCount === 0 && (
-          <p className="px-1.5 py-2 text-xs text-text-muted">No files match the filter</p>
+          <EmptyState
+            variant="filtered-empty"
+            scale="sidebar"
+            title="No files match the filter"
+            action={
+              <button
+                type="button"
+                onClick={() => setFilter("")}
+                className="text-xs text-daintree-text/60 hover:text-daintree-text transition-colors underline underline-offset-2"
+              >
+                Clear filter
+              </button>
+            }
+          />
         )}
         {groups.map((group) => (
           <div key={group.dir || "(root)"} className="mb-1.5">
@@ -175,7 +205,7 @@ export function DiffFileSidebar({
                       </span>
                       <span
                         className={cn(
-                          "truncate",
+                          "truncate font-medium",
                           viewed ? "text-daintree-text/50" : "text-daintree-text"
                         )}
                       >
@@ -196,11 +226,7 @@ export function DiffFileSidebar({
                           type="button"
                           onClick={() => toggleViewed(worktreePath, file.viewedKey)}
                           aria-pressed={viewed}
-                          aria-label={
-                            viewed
-                              ? `Mark ${file.path} as not viewed`
-                              : `Mark ${file.path} as viewed`
-                          }
+                          aria-label={`Mark ${file.path} as viewed`}
                           className={cn(
                             "ml-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
                             viewed
@@ -212,9 +238,7 @@ export function DiffFileSidebar({
                           <Check className="h-3 w-3" />
                         </button>
                       </TooltipTrigger>
-                      <TooltipContent side="right">
-                        {viewed ? "Viewed" : "Mark as viewed (v)"}
-                      </TooltipContent>
+                      <TooltipContent side="right">Viewed</TooltipContent>
                     </Tooltip>
                   </div>
                 );

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Folder, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { basename, dirname } from "@shared/utils/path";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
+import { DIFF_STATUS_CONFIG, summarizeChangeSet } from "./diffChangeSet";
+import type { DiffChangeSetEntry } from "./diffChangeSet";
+
+export interface DiffFileSidebarProps {
+  files: DiffChangeSetEntry[];
+  /** Index of the open file within `files`; -1 when nothing matches. */
+  currentIndex: number;
+  worktreePath: string;
+  onSelect: (index: number) => void;
+}
+
+interface IndexedEntry extends DiffChangeSetEntry {
+  index: number;
+}
+
+interface DirGroup {
+  dir: string;
+  files: IndexedEntry[];
+}
+
+function formatDir(dir: string, maxSegments = 3): string {
+  if (!dir || dir === ".") return "(root)";
+  const segments = dir.split("/");
+  if (segments.length <= maxSegments) return dir;
+  return "…/" + segments.slice(-maxSegments).join("/");
+}
+
+/**
+ * Changed-files shelf for the diff workspace: changeset summary, review
+ * progress, filter, and a directory-grouped file list with per-file viewed
+ * markers. Selection is a neutral surface lift — the diff canvas owns the
+ * focus accent.
+ */
+export function DiffFileSidebar({
+  files,
+  currentIndex,
+  worktreePath,
+  onSelect,
+}: DiffFileSidebarProps) {
+  const [filter, setFilter] = useState("");
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const viewedSet = useDiffViewedStore(
+    useCallback((state) => selectViewedSet(state, worktreePath), [worktreePath])
+  );
+  const toggleViewed = useDiffViewedStore((state) => state.toggleViewed);
+
+  const summary = useMemo(() => summarizeChangeSet(files), [files]);
+  const viewedCount = useMemo(
+    () => files.reduce((count, file) => (viewedSet.has(file.viewedKey) ? count + 1 : count), 0),
+    [files, viewedSet]
+  );
+
+  const groups = useMemo((): DirGroup[] => {
+    const query = filter.trim().toLowerCase();
+    const grouped = new Map<string, IndexedEntry[]>();
+    files.forEach((file, index) => {
+      if (query && !file.path.toLowerCase().includes(query)) return;
+      const dir = dirname(file.path);
+      const key = !dir || dir === "." ? "" : dir;
+      const bucket = grouped.get(key);
+      if (bucket) bucket.push({ ...file, index });
+      else grouped.set(key, [{ ...file, index }]);
+    });
+    return Array.from(grouped.entries())
+      .map(([dir, groupFiles]) => ({ dir, files: groupFiles }))
+      .sort((a, b) => {
+        if (a.dir === "") return -1;
+        if (b.dir === "") return 1;
+        return a.dir.localeCompare(b.dir);
+      });
+  }, [files, filter]);
+
+  const visibleCount = useMemo(
+    () => groups.reduce((count, group) => count + group.files.length, 0),
+    [groups]
+  );
+
+  // Keep the open file's row in view while stepping with the keyboard.
+  useEffect(() => {
+    if (currentIndex < 0 || !listRef.current) return;
+    const row = listRef.current.querySelector<HTMLElement>(`[data-file-index="${currentIndex}"]`);
+    if (typeof row?.scrollIntoView === "function") {
+      row.scrollIntoView({ behavior: "instant", block: "nearest" });
+    }
+  }, [currentIndex]);
+
+  return (
+    <div
+      className="flex h-full w-60 shrink-0 flex-col border-r border-daintree-border bg-daintree-sidebar"
+      data-testid="diff-file-sidebar"
+    >
+      <div className="shrink-0 border-b border-daintree-border px-3 py-2">
+        <div className="flex items-baseline justify-between gap-2 text-xs">
+          <span className="font-medium text-daintree-text">
+            {files.length} {files.length === 1 ? "file" : "files"}
+          </span>
+          <span className="flex items-center gap-1.5 font-mono text-[11px]">
+            {summary.insertions > 0 && (
+              <span className="text-status-success">+{summary.insertions}</span>
+            )}
+            {summary.deletions > 0 && (
+              <span className="text-status-error">-{summary.deletions}</span>
+            )}
+          </span>
+        </div>
+        <div className="mt-1.5" data-testid="diff-sidebar-progress">
+          <div className="flex items-center justify-between text-[11px] text-text-muted">
+            <span>
+              {viewedCount} of {files.length} viewed
+            </span>
+          </div>
+          <div className="mt-1 h-0.5 overflow-hidden rounded-full bg-daintree-border">
+            <div
+              className="h-full rounded-full bg-status-success/70 transition-[width] duration-150 ease-out"
+              style={{ width: `${files.length ? (viewedCount / files.length) * 100 : 0}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="shrink-0 px-2 py-1.5">
+        <div className="flex items-center gap-1.5 rounded border border-daintree-border bg-daintree-bg px-2 py-1 focus-within:border-border-strong">
+          <Search className="h-3 w-3 shrink-0 text-text-muted" />
+          <input
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder="Filter files"
+            aria-label="Filter files"
+            className="w-full bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
+            data-testid="diff-sidebar-filter"
+          />
+        </div>
+      </div>
+
+      <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-2">
+        {visibleCount === 0 && (
+          <p className="px-1.5 py-2 text-xs text-text-muted">No files match the filter</p>
+        )}
+        {groups.map((group) => (
+          <div key={group.dir || "(root)"} className="mb-1.5">
+            <div className="flex items-center gap-1.5 px-1.5 py-1 text-[11px] text-daintree-text/40">
+              <Folder className="h-3 w-3 shrink-0" />
+              <span className="truncate font-mono">{formatDir(group.dir)}</span>
+            </div>
+            <div className="flex flex-col gap-px">
+              {group.files.map((file) => {
+                const config = DIFF_STATUS_CONFIG[file.status] ?? DIFF_STATUS_CONFIG.untracked;
+                const viewed = viewedSet.has(file.viewedKey);
+                const isCurrent = file.index === currentIndex;
+                return (
+                  <div
+                    key={`${file.viewedKey}-${file.index}`}
+                    data-file-index={file.index}
+                    className={cn(
+                      "group/diffrow flex items-center rounded px-1.5 py-1 text-xs font-mono transition-colors",
+                      isCurrent ? "bg-overlay-subtle" : "hover:bg-tint/5"
+                    )}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => onSelect(file.index)}
+                      aria-current={isCurrent || undefined}
+                      aria-label={`Open ${file.path}`}
+                      className="flex min-w-0 flex-1 items-center text-left focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-daintree-accent"
+                      data-testid="diff-sidebar-file"
+                    >
+                      <span className={cn("w-4 shrink-0 font-bold", config.color)}>
+                        {config.label}
+                      </span>
+                      <span
+                        className={cn(
+                          "truncate",
+                          viewed ? "text-daintree-text/50" : "text-daintree-text"
+                        )}
+                      >
+                        {basename(file.path)}
+                      </span>
+                      <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-[11px]">
+                        {(file.insertions ?? 0) > 0 && (
+                          <span className="text-status-success/80">+{file.insertions}</span>
+                        )}
+                        {(file.deletions ?? 0) > 0 && (
+                          <span className="text-status-error/80">-{file.deletions}</span>
+                        )}
+                      </span>
+                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => toggleViewed(worktreePath, file.viewedKey)}
+                          aria-pressed={viewed}
+                          aria-label={
+                            viewed
+                              ? `Mark ${file.path} as not viewed`
+                              : `Mark ${file.path} as viewed`
+                          }
+                          className={cn(
+                            "ml-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
+                            viewed
+                              ? "border-status-success/60 bg-status-success/20 text-status-success"
+                              : "border-daintree-border text-transparent opacity-0 hover:border-border-strong group-hover/diffrow:opacity-100 focus-visible:opacity-100"
+                          )}
+                          data-testid="diff-sidebar-viewed-toggle"
+                        >
+                          <Check className="h-3 w-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="right">
+                        {viewed ? "Viewed" : "Mark as viewed (v)"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useEffectEvent, useCallback, useState, useRef, useMemo } from "react";
+import type { CSSProperties } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import type { RestoreFocusTarget } from "@/components/ui/AppDialog";
 import { DiffViewer } from "@/components/Worktree/DiffViewer";
@@ -20,22 +21,28 @@ import {
   ChevronUp,
   ChevronDown,
   Grid2x2Plus,
+  PanelLeft,
   Pilcrow,
   Search,
   WrapText,
   X,
 } from "lucide-react";
+import { DiffFileSidebar } from "./DiffFileSidebar";
+import type { DiffChangeSetEntry } from "./diffChangeSet";
+import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
+import { ImageDiffViewer, isImageDiffCandidate } from "./ImageDiffViewer";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import type { GitStatus } from "@shared/types";
 import { isClientAppError } from "@/utils/clientAppError";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 import { createTrustedHTML } from "@/lib/trustedTypesPolicy";
 import { logError } from "@/utils/logger";
 import { usePreferencesStore } from "@/store/preferencesStore";
-import type { DiffViewType } from "@/store/preferencesStore";
+import type { DiffFontSize, DiffViewType } from "@/store/preferencesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { prefersReducedMotion } from "@/lib/appThemeViewTransition";
 
@@ -63,9 +70,31 @@ export interface FileViewerModalProps {
   totalFileCount?: number;
   /** Step to the previous (-1) or next (1) file in the set. */
   onNavigateFile?: (delta: -1 | 1) => void;
+  /**
+   * Full changeset this file belongs to, indexed identically to
+   * `currentFileIndex`/`onSelectFile`. With more than one entry the modal
+   * becomes a review workspace: changed-files sidebar, viewed markers, and
+   * cross-file change navigation.
+   */
+  changeSet?: DiffChangeSetEntry[];
+  /** Jump directly to a file in `changeSet`. */
+  onSelectFile?: (index: number) => void;
+  /**
+   * Git status of the open file, when the opener knows it. Enables the image
+   * compare view (HEAD vs working tree) for changed image files.
+   */
+  fileStatus?: GitStatus;
 }
 
 type ViewMode = "view" | "diff" | "rendered";
+
+const DIFF_FONT_SIZE_PX: Record<DiffFontSize, string> = { s: "11px", m: "12px", l: "14px" };
+const DIFF_FONT_SIZE_ORDER: DiffFontSize[] = ["s", "m", "l"];
+const DIFF_FONT_SIZE_LABEL: Record<DiffFontSize, string> = {
+  s: "Small",
+  m: "Medium",
+  l: "Large",
+};
 type LoadState = "loading" | "loaded" | "error" | "image" | "svg";
 
 const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "ico"]);
@@ -159,6 +188,9 @@ export function FileViewerModal({
   currentFileIndex,
   totalFileCount,
   onNavigateFile,
+  changeSet,
+  onSelectFile,
+  fileStatus,
 }: FileViewerModalProps) {
   // If the file is outside the project root, use its parent directory as the
   // effective root so that the daintree-file:// protocol and files.read IPC
@@ -191,6 +223,10 @@ export function FileViewerModal({
   const setDiffIgnoreWhitespace = usePreferencesStore((s) => s.setDiffIgnoreWhitespace);
   const markdownWrapLines = usePreferencesStore((s) => s.markdownWrapLines);
   const setMarkdownWrapLines = usePreferencesStore((s) => s.setMarkdownWrapLines);
+  const diffShowFileList = usePreferencesStore((s) => s.diffShowFileList);
+  const setDiffShowFileList = usePreferencesStore((s) => s.setDiffShowFileList);
+  const diffFontSize = usePreferencesStore((s) => s.diffFontSize);
+  const setDiffFontSize = usePreferencesStore((s) => s.setDiffFontSize);
   const [diffCopied, setDiffCopied] = useState(false);
   const [pathCopied, setPathCopied] = useState(false);
   const [sanitizedSvg, setSanitizedSvg] = useState<string | null>(null);
@@ -233,6 +269,22 @@ export function FileViewerModal({
 
   const imageFile = isImageFile(filePath);
   const svgFile = isSvgFile(filePath);
+
+  // Review-workspace mode: the opener supplied its full changeset, so the
+  // modal grows a changed-files sidebar, viewed markers, and cross-file
+  // change navigation. Single-file openers keep the classic layout.
+  const isWorkspace = (changeSet?.length ?? 0) > 1;
+  const workspaceEntry =
+    changeSet && currentFileIndex !== undefined ? (changeSet[currentFileIndex] ?? null) : null;
+  const viewedSet = useDiffViewedStore(
+    useCallback((state) => selectViewedSet(state, rootPath), [rootPath])
+  );
+  const setViewed = useDiffViewedStore((state) => state.setViewed);
+  const toggleViewed = useDiffViewedStore((state) => state.toggleViewed);
+  // Cross-file hunk stepping: where to land in the next file once its hunks
+  // render. Carries the expected file index so a manual jump elsewhere (or a
+  // hunkless file) invalidates the target instead of firing late.
+  const pendingHunkTargetRef = useRef<{ fileIndex: number; place: "first" | "last" } | null>(null);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -393,6 +445,31 @@ export function FileViewerModal({
 
   const fileName = filePath.split(/[/\\]/).filter(Boolean).pop() || filePath;
 
+  // Worktree-relative path, when the file lives under rootPath. Feeds the
+  // breadcrumb title (directory muted, basename strong — the Kaleidoscope
+  // path-bar read) and the image compare's git lookups.
+  const workspaceRelPath = useMemo(() => {
+    const fwdPath = filePath.replace(/\\/g, "/");
+    const fwdRootDir = rootPath.replace(/\\/g, "/").replace(/\/$/, "") + "/";
+    return fwdPath.startsWith(fwdRootDir) ? fwdPath.slice(fwdRootDir.length) : null;
+  }, [filePath, rootPath]);
+
+  const relDir = useMemo(() => {
+    if (!workspaceRelPath) return null;
+    const lastSlash = workspaceRelPath.lastIndexOf("/");
+    return lastSlash > 0 ? workspaceRelPath.slice(0, lastSlash) : null;
+  }, [workspaceRelPath]);
+
+  // Changed image files opened from a changeset get the HEAD-vs-working-tree
+  // compare (Two-up / Swipe / Onion skin) instead of the static preview.
+  const imageDiffEligible = Boolean(
+    imageFile && fileStatus && workspaceRelPath && isImageDiffCandidate(filePath)
+  );
+
+  const diffFontStyle: CSSProperties & Record<"--diff-font-size", string> = {
+    "--diff-font-size": DIFF_FONT_SIZE_PX[diffFontSize],
+  };
+
   const canShowView = loadState === "loaded" && content !== null;
   const isImageMode = loadState === "image" || loadState === "svg";
 
@@ -464,14 +541,56 @@ export function FileViewerModal({
     useAnnouncerStore.getState().announce(`Hunk ${next + 1} of ${hunks.length}`);
   }, []);
 
+  // File stepping state is needed by stepHunk's cross-file continuation, so
+  // it is derived above the hunk navigation that consumes it.
+  const canStepFiles = Boolean(onNavigateFile) && (totalFileCount ?? 0) > 1;
+  const hasPrevFile = canStepFiles && (currentFileIndex ?? 0) > 0;
+  const hasNextFile = canStepFiles && (currentFileIndex ?? 0) < (totalFileCount ?? 0) - 1;
+
+  const fileStepAnnouncePendingRef = useRef(false);
+  const navigateFile = useEffectEvent((delta: -1 | 1) => {
+    if (delta === -1 && hasPrevFile) fileStepAnnouncePendingRef.current = true;
+    if (delta === 1 && hasNextFile) fileStepAnnouncePendingRef.current = true;
+    if (delta === -1 && hasPrevFile) onNavigateFile?.(-1);
+    if (delta === 1 && hasNextFile) onNavigateFile?.(1);
+  });
+
   const stepHunk = useCallback(
     (delta: -1 | 1) => {
       const current = currentHunkIndexRef.current;
-      // Stepping from the initial sentinel (-1) lands on the first hunk so
-      // the user gets feedback either way before they've started navigating.
-      scrollToHunkIndex(current < 0 ? 0 : current + delta);
+      if (current < 0) {
+        // Stepping from the initial sentinel (-1) lands on the first hunk so
+        // the user gets feedback either way before they've started navigating.
+        scrollToHunkIndex(0);
+        return;
+      }
+      const next = current + delta;
+      const count =
+        diffViewerRef.current?.querySelectorAll<HTMLElement>("tbody.diff-hunk").length ?? 0;
+      // Past either end of the file, the step flows into the neighboring file
+      // of the changeset (Kaleidoscope-style continuous change navigation).
+      // `onNavigateFile` is called directly (not via the `navigateFile`
+      // effect event — those are effect-only) with the announce ref set so
+      // the landed-on file is still read out.
+      if (next < 0) {
+        if (hasPrevFile) {
+          pendingHunkTargetRef.current = { fileIndex: (currentFileIndex ?? 0) - 1, place: "last" };
+          fileStepAnnouncePendingRef.current = true;
+          onNavigateFile?.(-1);
+        }
+        return;
+      }
+      if (next >= count) {
+        if (hasNextFile) {
+          pendingHunkTargetRef.current = { fileIndex: (currentFileIndex ?? 0) + 1, place: "first" };
+          fileStepAnnouncePendingRef.current = true;
+          onNavigateFile?.(1);
+        }
+        return;
+      }
+      scrollToHunkIndex(next);
     },
-    [scrollToHunkIndex]
+    [scrollToHunkIndex, hasPrevFile, hasNextFile, currentFileIndex, onNavigateFile]
   );
 
   useEffect(() => {
@@ -504,17 +623,7 @@ export function FileViewerModal({
   // `n`/`p` are taken by hunk navigation and the arrow keys conflict with split-
   // diff horizontal scrolling, so brackets (the git-review convention) are the
   // free keys. The handler is a no-op unless the opener wired `onNavigateFile`.
-  const canStepFiles = Boolean(onNavigateFile) && (totalFileCount ?? 0) > 1;
-  const hasPrevFile = canStepFiles && (currentFileIndex ?? 0) > 0;
-  const hasNextFile = canStepFiles && (currentFileIndex ?? 0) < (totalFileCount ?? 0) - 1;
-
-  const fileStepAnnouncePendingRef = useRef(false);
-  const navigateFile = useEffectEvent((delta: -1 | 1) => {
-    if (delta === -1 && hasPrevFile) fileStepAnnouncePendingRef.current = true;
-    if (delta === 1 && hasNextFile) fileStepAnnouncePendingRef.current = true;
-    if (delta === -1 && hasPrevFile) onNavigateFile?.(-1);
-    if (delta === 1 && hasNextFile) onNavigateFile?.(1);
-  });
+  // (State derived above stepHunk, which needs it for cross-file continuation.)
 
   // Announce the landed-on file after a step swaps the dialog contents —
   // aria-labelledby title text changes are not announced by AT on their own.
@@ -553,6 +662,52 @@ export function FileViewerModal({
     };
   }, [isOpen, canStepFiles]);
 
+  // `v` — mark the open file viewed and advance to the next unviewed file
+  // (wrapping), the GitHub-review muscle memory. Workspace mode only.
+  const markViewedAndAdvance = useEffectEvent(() => {
+    if (!workspaceEntry || !changeSet || currentFileIndex === undefined) return;
+    const alreadyViewed = viewedSet.has(workspaceEntry.viewedKey);
+    if (!alreadyViewed) setViewed(rootPath, workspaceEntry.viewedKey, true);
+    useAnnouncerStore.getState().announce("Marked viewed");
+    if (!onSelectFile) return;
+    for (let step = 1; step < changeSet.length; step++) {
+      const index = (currentFileIndex + step) % changeSet.length;
+      const entry = changeSet[index];
+      if (!entry || entry.viewedKey === workspaceEntry.viewedKey) continue;
+      if (!viewedSet.has(entry.viewedKey)) {
+        fileStepAnnouncePendingRef.current = true;
+        onSelectFile(index);
+        return;
+      }
+    }
+  });
+
+  useEffect(() => {
+    if (!isOpen || !isWorkspace) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "v") return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (
+        e.target instanceof HTMLElement &&
+        (e.target.tagName === "INPUT" ||
+          e.target.tagName === "TEXTAREA" ||
+          e.target.tagName === "SELECT" ||
+          e.target.isContentEditable)
+      ) {
+        return;
+      }
+
+      e.preventDefault();
+      markViewedAndAdvance();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, isWorkspace]);
+
   // IntersectionObserver tracks the most-visible hunk during free scrolling.
   // Observes tr:first-child (not tbody — table-row-group collapses to 0 height
   // in Chromium and races with layout). The observer is keyed on diffViewType
@@ -586,6 +741,19 @@ export function FileViewerModal({
     const hunks = container.querySelectorAll<HTMLElement>("tbody.diff-hunk");
     const count = hunks.length;
     setHunkCount(count);
+
+    // Land a cross-file hunk step once the destination file's hunks exist.
+    // A stale target (user jumped elsewhere meanwhile) is dropped instead.
+    const pending = pendingHunkTargetRef.current;
+    if (pending) {
+      if (pending.fileIndex !== (currentFileIndex ?? -1)) {
+        pendingHunkTargetRef.current = null;
+      } else if (count > 0) {
+        pendingHunkTargetRef.current = null;
+        const landingIndex = pending.place === "last" ? count - 1 : 0;
+        requestAnimationFrame(() => scrollToHunkIndex(landingIndex));
+      }
+    }
 
     // Overview rail: one tick per hunk at its proportional scroll position,
     // colored by the hunk's dominant change kind.
@@ -669,7 +837,16 @@ export function FileViewerModal({
       observerDisposedRef.current = true;
       observer.disconnect();
     };
-  }, [isOpen, mode, diff, diffViewType, diffWrapLines, collapseRevision]);
+  }, [
+    isOpen,
+    mode,
+    diff,
+    diffViewType,
+    diffWrapLines,
+    collapseRevision,
+    currentFileIndex,
+    scrollToHunkIndex,
+  ]);
 
   const handleDiffToggleCollapse = useCallback(() => {
     setCollapseRevision((r) => r + 1);
@@ -817,8 +994,14 @@ export function FileViewerModal({
     <AppDialog
       isOpen={isOpen}
       onClose={onClose}
-      size={mode === "diff" && hasDiff && diffViewType === "split" ? "7xl" : "6xl"}
-      maxHeight="max-h-[90vh]"
+      size={
+        isWorkspace
+          ? "workspace"
+          : mode === "diff" && hasDiff && diffViewType === "split"
+            ? "7xl"
+            : "6xl"
+      }
+      maxHeight={isWorkspace ? "max-h-[92vh]" : "max-h-[90vh]"}
       restoreFocusTo={restoreFocusTo}
       data-testid="file-viewer-dialog"
     >
@@ -827,13 +1010,28 @@ export function FileViewerModal({
           <Tooltip>
             <AppDialog.Title className="text-sm font-medium min-w-0">
               <TooltipTrigger asChild>
-                <span className="truncate cursor-default text-daintree-text">{fileName}</span>
+                <span className="truncate cursor-default text-daintree-text">
+                  {relDir && <span className="text-daintree-text/45">{relDir}/</span>}
+                  {fileName}
+                </span>
               </TooltipTrigger>
             </AppDialog.Title>
             <TooltipContent side="bottom" className="max-w-lg break-all">
               {branch ? `${branch} — ${filePath}` : filePath}
             </TooltipContent>
           </Tooltip>
+
+          {workspaceEntry &&
+            ((workspaceEntry.insertions ?? 0) > 0 || (workspaceEntry.deletions ?? 0) > 0) && (
+              <span className="flex shrink-0 items-center gap-1 font-mono text-[11px]">
+                {(workspaceEntry.insertions ?? 0) > 0 && (
+                  <span className="text-status-success">+{workspaceEntry.insertions}</span>
+                )}
+                {(workspaceEntry.deletions ?? 0) > 0 && (
+                  <span className="text-status-error">-{workspaceEntry.deletions}</span>
+                )}
+              </span>
+            )}
 
           {/* Mode toggle: markdown files get Rendered/Source (plus Diff when
               available); other files keep the original View/Diff pair. */}
@@ -945,227 +1143,253 @@ export function FileViewerModal({
         </div>
       </AppDialog.Header>
 
-      <div className="relative flex-1 min-h-0 flex flex-col">
-        <AppDialog.BodyScroll className="p-0 diff-scroll-root">
-          {isImageMode && (
-            <div className="flex items-center justify-center p-6 min-h-[300px]">
-              {loadState === "image" && (
-                <img
-                  key={filePath}
-                  src={buildDaintreeFileUrl(filePath, effectiveRootPath)}
-                  alt={fileName}
-                  className="max-w-full max-h-[70vh] object-contain rounded"
-                  draggable={false}
-                  onError={handleImageError}
+      <div className="flex flex-1 min-h-0">
+        {isWorkspace && diffShowFileList && changeSet && onSelectFile && (
+          <DiffFileSidebar
+            files={changeSet}
+            currentIndex={currentFileIndex ?? -1}
+            worktreePath={rootPath}
+            onSelect={(index) => {
+              fileStepAnnouncePendingRef.current = true;
+              onSelectFile(index);
+            }}
+          />
+        )}
+        <div className="relative flex-1 min-w-0 min-h-0 flex flex-col" style={diffFontStyle}>
+          <AppDialog.BodyScroll className="p-0 diff-scroll-root">
+            {isImageMode && imageDiffEligible && fileStatus && workspaceRelPath && (
+              <div className="h-full min-h-[300px]">
+                <ImageDiffViewer
+                  relPath={workspaceRelPath}
+                  worktreePath={rootPath}
+                  status={fileStatus}
                 />
-              )}
-              {loadState === "svg" && sanitizedSvg && (
-                <div
-                  className="max-w-full max-h-[70vh] overflow-auto [&>svg]:max-w-full [&>svg]:h-auto"
-                  dangerouslySetInnerHTML={{ __html: createTrustedHTML(sanitizedSvg) }}
-                />
-              )}
-            </div>
-          )}
+              </div>
+            )}
 
-          {!isImageMode && (mode === "view" || mode === "rendered") && (
-            <>
-              {loadState === "loading" && (
-                <div className="p-4 space-y-3">
-                  <Skeleton label="Loading file">
-                    <SkeletonBone className="h-5 w-1/3" />
-                    <SkeletonText lines={15} />
-                  </Skeleton>
-                </div>
-              )}
-
-              {loadState === "error" && (displayErrorMessage || errorCode) && (
-                <div className="flex flex-col items-center justify-center h-64 gap-3">
-                  <p className="text-sm text-muted-foreground">
-                    {displayErrorMessage ?? (errorCode ? FILE_READ_ERROR_MESSAGES[errorCode] : "")}
-                  </p>
-                  {imageFile ? (
-                    <button
-                      type="button"
-                      onClick={handleOpenInImageViewer}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
-                    >
-                      <ImageIcon className="w-3.5 h-3.5" />
-                      Open in image viewer
-                    </button>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={handleOpenInEditor}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5" />
-                      Open in editor
-                    </button>
-                  )}
-                </div>
-              )}
-
-              {loadState === "loaded" &&
-                content !== null &&
-                (mode === "rendered" && markdownFile ? (
-                  <MarkdownViewer
-                    content={content}
-                    filePath={filePath}
-                    rootPath={effectiveRootPath}
-                    viewMode="rendered"
+            {isImageMode && !imageDiffEligible && (
+              <div className="flex items-center justify-center p-6 min-h-[300px]">
+                {loadState === "image" && (
+                  <img
+                    key={filePath}
+                    src={buildDaintreeFileUrl(filePath, effectiveRootPath)}
+                    alt={fileName}
+                    className="max-w-full max-h-[70vh] object-contain rounded"
+                    draggable={false}
+                    onError={handleImageError}
                   />
-                ) : (
-                  // min-h-full column: the editor surface stretches to the
-                  // footer even for files shorter than the dialog body.
-                  <div className="flex min-h-full flex-col">
-                    {metadata && (
-                      <div
-                        data-testid="file-viewer-metadata"
-                        className="px-3 py-1 border-b border-daintree-border text-xs text-muted-foreground font-mono shrink-0"
+                )}
+                {loadState === "svg" && sanitizedSvg && (
+                  <div
+                    className="max-w-full max-h-[70vh] overflow-auto [&>svg]:max-w-full [&>svg]:h-auto"
+                    dangerouslySetInnerHTML={{ __html: createTrustedHTML(sanitizedSvg) }}
+                  />
+                )}
+              </div>
+            )}
+
+            {!isImageMode && (mode === "view" || mode === "rendered") && (
+              <>
+                {loadState === "loading" && (
+                  <div className="p-4 space-y-3">
+                    <Skeleton label="Loading file">
+                      <SkeletonBone className="h-5 w-1/3" />
+                      <SkeletonText lines={15} />
+                    </Skeleton>
+                  </div>
+                )}
+
+                {loadState === "error" && (displayErrorMessage || errorCode) && (
+                  <div className="flex flex-col items-center justify-center h-64 gap-3">
+                    <p className="text-sm text-muted-foreground">
+                      {displayErrorMessage ??
+                        (errorCode ? FILE_READ_ERROR_MESSAGES[errorCode] : "")}
+                    </p>
+                    {imageFile ? (
+                      <button
+                        type="button"
+                        onClick={handleOpenInImageViewer}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
                       >
-                        {metadata.lineCount} lines · {metadata.sizeLabel} · UTF-8
-                      </div>
+                        <ImageIcon className="w-3.5 h-3.5" />
+                        Open in image viewer
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={handleOpenInEditor}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
+                      >
+                        <ExternalLink className="w-3.5 h-3.5" />
+                        Open in editor
+                      </button>
                     )}
-                    <CodeViewer
-                      ref={codeViewerRef}
+                  </div>
+                )}
+
+                {loadState === "loaded" &&
+                  content !== null &&
+                  (mode === "rendered" && markdownFile ? (
+                    <MarkdownViewer
                       content={content}
                       filePath={filePath}
-                      initialLine={initialLine}
-                      wrapLines={markdownFile && markdownWrapLines}
-                      className="min-h-[300px] flex-1"
+                      rootPath={effectiveRootPath}
+                      viewMode="rendered"
                     />
-                  </div>
-                ))}
-            </>
-          )}
+                  ) : (
+                    // min-h-full column: the editor surface stretches to the
+                    // footer even for files shorter than the dialog body.
+                    <div className="flex min-h-full flex-col">
+                      {metadata && (
+                        <div
+                          data-testid="file-viewer-metadata"
+                          className="px-3 py-1 border-b border-daintree-border text-xs text-muted-foreground font-mono shrink-0"
+                        >
+                          {metadata.lineCount} lines · {metadata.sizeLabel} · UTF-8
+                        </div>
+                      )}
+                      <CodeViewer
+                        ref={codeViewerRef}
+                        content={content}
+                        filePath={filePath}
+                        initialLine={initialLine}
+                        wrapLines={markdownFile && markdownWrapLines}
+                        className="min-h-[300px] flex-1"
+                      />
+                    </div>
+                  ))}
+              </>
+            )}
 
-          {!isImageMode && mode === "diff" && diff && (
-            <DiffViewer
-              ref={diffViewerRef}
-              diff={diff}
-              viewType={diffViewType}
-              rootPath={rootPath}
-              wrapLines={diffWrapLines}
-              searchQuery={searchActive ? searchQuery : undefined}
-              // Expansion needs the diff's new side to byte-match the loaded
-              // file; an ignore-whitespace diff can show old-side context lines.
-              source={diffMatchesFile && !diffIgnoreWhitespace && canShowView ? content : undefined}
-              onRetry={onRetryDiff}
-              onToggleCollapse={handleDiffToggleCollapse}
-              onTokensRendered={handleTokensRendered}
-            />
-          )}
+            {!isImageMode && mode === "diff" && diff && (
+              <DiffViewer
+                ref={diffViewerRef}
+                diff={diff}
+                viewType={diffViewType}
+                rootPath={rootPath}
+                wrapLines={diffWrapLines}
+                searchQuery={searchActive ? searchQuery : undefined}
+                // Expansion needs the diff's new side to byte-match the loaded
+                // file; an ignore-whitespace diff can show old-side context lines.
+                source={
+                  diffMatchesFile && !diffIgnoreWhitespace && canShowView ? content : undefined
+                }
+                onRetry={onRetryDiff}
+                onToggleCollapse={handleDiffToggleCollapse}
+                onTokensRendered={handleTokensRendered}
+              />
+            )}
 
-          {!isImageMode && mode === "diff" && !diff && (
-            <div className="p-4 space-y-3">
-              <Skeleton label="Loading diff">
-                <SkeletonBone className="h-7 w-3/4" />
-                <SkeletonText lines={8} />
-              </Skeleton>
+            {!isImageMode && mode === "diff" && !diff && (
+              <div className="p-4 space-y-3">
+                <Skeleton label="Loading diff">
+                  <SkeletonBone className="h-7 w-3/4" />
+                  <SkeletonText lines={8} />
+                </Skeleton>
+              </div>
+            )}
+          </AppDialog.BodyScroll>
+
+          {/* In-diff find bar (Cmd+F in diff mode). Floats over the top-right of
+            the diff; Enter / Shift+Enter cycle matches. */}
+          {searchActive && (
+            <div
+              className="absolute top-2 right-7 z-20 flex items-center gap-1 pl-2 pr-1 py-1 rounded-md surface-overlay shadow-[var(--theme-shadow-floating)] focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
+              data-testid="diff-search-bar"
+            >
+              <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+              <input
+                ref={searchInputRef}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={handleSearchKeyDown}
+                placeholder="Find in diff"
+                aria-label="Find in diff"
+                className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
+              />
+              <span
+                className="text-xs text-muted-foreground tabular-nums shrink-0 min-w-0"
+                data-testid="diff-search-count"
+                aria-live="polite"
+              >
+                {searchQuery
+                  ? searchMatchCount === 0
+                    ? "No matches"
+                    : searchMatchIndex >= 0
+                      ? `${searchMatchIndex + 1} of ${searchMatchCount}`
+                      : `${searchMatchCount} ${searchMatchCount === 1 ? "match" : "matches"}`
+                  : ""}
+              </span>
+              <button
+                type="button"
+                onClick={() => stepSearchMatch(-1)}
+                disabled={searchMatchCount === 0}
+                aria-label="Previous match"
+                className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none"
+              >
+                <ChevronUp className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => stepSearchMatch(1)}
+                disabled={searchMatchCount === 0}
+                aria-label="Next match"
+                className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none"
+              >
+                <ChevronDown className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={closeSearch}
+                aria-label="Close search"
+                className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
             </div>
           )}
-        </AppDialog.BodyScroll>
 
-        {/* In-diff find bar (Cmd+F in diff mode). Floats over the top-right of
-            the diff; Enter / Shift+Enter cycle matches. */}
-        {searchActive && (
-          <div
-            className="absolute top-2 right-7 z-20 flex items-center gap-1 pl-2 pr-1 py-1 rounded-md surface-overlay shadow-[var(--theme-shadow-floating)] focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
-            data-testid="diff-search-bar"
-          >
-            <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-            <input
-              ref={searchInputRef}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={handleSearchKeyDown}
-              placeholder="Find in diff"
-              aria-label="Find in diff"
-              className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
-            />
-            <span
-              className="text-xs text-muted-foreground tabular-nums shrink-0 min-w-0"
-              data-testid="diff-search-count"
-              aria-live="polite"
-            >
-              {searchQuery
-                ? searchMatchCount === 0
-                  ? "No matches"
-                  : searchMatchIndex >= 0
-                    ? `${searchMatchIndex + 1} of ${searchMatchCount}`
-                    : `${searchMatchCount} ${searchMatchCount === 1 ? "match" : "matches"}`
-                : ""}
-            </span>
-            <button
-              type="button"
-              onClick={() => stepSearchMatch(-1)}
-              disabled={searchMatchCount === 0}
-              aria-label="Previous match"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none"
-            >
-              <ChevronUp className="w-3.5 h-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => stepSearchMatch(1)}
-              disabled={searchMatchCount === 0}
-              aria-label="Next match"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none"
-            >
-              <ChevronDown className="w-3.5 h-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={closeSearch}
-              aria-label="Close search"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium"
-            >
-              <X className="w-3.5 h-3.5" />
-            </button>
-          </div>
-        )}
-
-        {/* Overview rail: one tick per hunk at its proportional position in the
+          {/* Overview rail: one tick per hunk at its proportional position in the
             scroll run (plus search-match ticks and a viewport thumb); sits left
             of the body scrollbar. */}
-        {mode === "diff" && (hunkMarkers.length > 1 || searchMarkers.length > 0) && (
-          <div
-            className="absolute right-2.5 top-1 bottom-1 w-2 z-10"
-            data-testid="hunk-overview-rail"
-          >
+          {mode === "diff" && (hunkMarkers.length > 1 || searchMarkers.length > 0) && (
             <div
-              ref={viewportIndicatorRef}
-              data-testid="rail-viewport-indicator"
-              className="absolute left-0 right-0 rounded-full bg-tint/10 pointer-events-none"
-            />
-            {hunkMarkers.map((marker, index) => (
-              <button
-                key={index}
-                type="button"
-                aria-label={`Go to hunk ${index + 1} of ${hunkMarkers.length}`}
-                onClick={() => scrollToHunkIndex(index)}
-                style={{ top: `${marker.ratio * 100}%` }}
-                className={cn(
-                  "absolute left-0 right-0 h-[3px] rounded-full transition-colors",
-                  marker.kind === "insert" && "bg-status-success/60 hover:bg-status-success",
-                  marker.kind === "delete" && "bg-status-danger/60 hover:bg-status-danger",
-                  marker.kind === "mixed" &&
-                    "bg-gradient-to-r from-status-success/60 to-status-danger/60",
-                  index === activeHunkIndex && "h-[5px] opacity-100"
-                )}
-              />
-            ))}
-            {searchMarkers.map((ratio, index) => (
+              className="absolute right-2.5 top-1 bottom-1 w-2 z-10"
+              data-testid="hunk-overview-rail"
+            >
               <div
-                key={`search-${index}`}
-                data-testid="rail-search-tick"
-                style={{ top: `${ratio * 100}%` }}
-                className="absolute right-0 w-1 h-[2px] rounded-full bg-text-muted pointer-events-none"
+                ref={viewportIndicatorRef}
+                data-testid="rail-viewport-indicator"
+                className="absolute left-0 right-0 rounded-full bg-tint/10 pointer-events-none"
               />
-            ))}
-          </div>
-        )}
+              {hunkMarkers.map((marker, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  aria-label={`Go to hunk ${index + 1} of ${hunkMarkers.length}`}
+                  onClick={() => scrollToHunkIndex(index)}
+                  style={{ top: `${marker.ratio * 100}%` }}
+                  className={cn(
+                    "absolute left-0 right-0 h-[3px] rounded-full transition-colors",
+                    marker.kind === "insert" && "bg-status-success/60 hover:bg-status-success",
+                    marker.kind === "delete" && "bg-status-danger/60 hover:bg-status-danger",
+                    marker.kind === "mixed" &&
+                      "bg-gradient-to-r from-status-success/60 to-status-danger/60",
+                    index === activeHunkIndex && "h-[5px] opacity-100"
+                  )}
+                />
+              ))}
+              {searchMarkers.map((ratio, index) => (
+                <div
+                  key={`search-${index}`}
+                  data-testid="rail-search-tick"
+                  style={{ top: `${ratio * 100}%` }}
+                  className="absolute right-0 w-1 h-[2px] rounded-full bg-text-muted pointer-events-none"
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Slim footer toolbar: navigation + diff display controls (Kaleidoscope-
@@ -1174,6 +1398,15 @@ export function FileViewerModal({
       {(canStepFiles || (mode === "diff" && hasDiff) || (markdownFile && mode === "view")) && (
         <div className="flex items-center justify-between gap-3 px-4 py-1.5 border-t border-border-strong bg-surface-panel shrink-0">
           <div className="flex items-center gap-1 min-w-0">
+            {isWorkspace && (
+              <IconToggle
+                pressed={diffShowFileList}
+                label="Show file list"
+                onToggle={() => setDiffShowFileList(!diffShowFileList)}
+              >
+                <PanelLeft className="w-4 h-4" />
+              </IconToggle>
+            )}
             {canStepFiles && (
               <>
                 <Tooltip>
@@ -1212,6 +1445,31 @@ export function FileViewerModal({
                 </Tooltip>
               </>
             )}
+            {workspaceEntry && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => toggleViewed(rootPath, workspaceEntry.viewedKey)}
+                    aria-pressed={viewedSet.has(workspaceEntry.viewedKey)}
+                    aria-label="Viewed"
+                    data-testid="diff-viewed-button"
+                    className={cn(
+                      "ml-1 flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors",
+                      viewedSet.has(workspaceEntry.viewedKey)
+                        ? "bg-status-success/15 text-status-success"
+                        : "text-muted-foreground hover:text-daintree-text hover:bg-daintree-border"
+                    )}
+                  >
+                    <Check className="w-3.5 h-3.5" />
+                    Viewed
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  Mark as viewed — v also steps to the next file
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
 
           {mode === "diff" && hasDiff && hunkCount > 0 && (
@@ -1221,7 +1479,7 @@ export function FileViewerModal({
                   <button
                     type="button"
                     onClick={() => stepHunk(-1)}
-                    disabled={hunkCount < 2 || activeHunkIndex === 0}
+                    disabled={activeHunkIndex <= 0 && !hasPrevFile}
                     aria-label="Previous hunk"
                     className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                   >
@@ -1243,7 +1501,7 @@ export function FileViewerModal({
                   <button
                     type="button"
                     onClick={() => stepHunk(1)}
-                    disabled={hunkCount < 2 || activeHunkIndex >= hunkCount - 1}
+                    disabled={activeHunkIndex >= hunkCount - 1 && !hasNextFile}
                     aria-label="Next hunk"
                     className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                   >
@@ -1295,6 +1553,15 @@ export function FileViewerModal({
                 >
                   <Pilcrow className="w-4 h-4" />
                 </IconToggle>
+                <SegmentedToggle
+                  options={DIFF_FONT_SIZE_ORDER.map((size) => ({
+                    value: size,
+                    label: size.toUpperCase(),
+                    ariaLabel: `${DIFF_FONT_SIZE_LABEL[size]} text`,
+                  }))}
+                  value={diffFontSize}
+                  onChange={setDiffFontSize}
+                />
                 <SegmentedToggle
                   options={[
                     { value: "split" as DiffViewType, label: "Split" },

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -270,21 +270,59 @@ export function FileViewerModal({
   const imageFile = isImageFile(filePath);
   const svgFile = isSvgFile(filePath);
 
+  // Worktree-relative path, when the file lives under rootPath. Feeds the
+  // breadcrumb title (directory muted, basename strong — the Kaleidoscope
+  // path-bar read), the image compare's git lookups, and the workspace-entry
+  // identity guard below.
+  const workspaceRelPath = useMemo(() => {
+    const fwdPath = filePath.replace(/\\/g, "/");
+    const fwdRootDir = rootPath.replace(/\\/g, "/").replace(/\/$/, "") + "/";
+    return fwdPath.startsWith(fwdRootDir) ? fwdPath.slice(fwdRootDir.length) : null;
+  }, [filePath, rootPath]);
+
   // Review-workspace mode: the opener supplied its full changeset, so the
   // modal grows a changed-files sidebar, viewed markers, and cross-file
   // change navigation. Single-file openers keep the classic layout.
+  // Defense in depth on the entry: it must describe the OPEN file — an index
+  // that drifted against a refreshed changeset (list re-sorted while the
+  // modal is up) must never mark the wrong file's viewedKey.
   const isWorkspace = (changeSet?.length ?? 0) > 1;
-  const workspaceEntry =
+  const rawWorkspaceEntry =
     changeSet && currentFileIndex !== undefined ? (changeSet[currentFileIndex] ?? null) : null;
-  const viewedSet = useDiffViewedStore(
-    useCallback((state) => selectViewedSet(state, rootPath), [rootPath])
+  const workspaceEntry =
+    rawWorkspaceEntry &&
+    workspaceRelPath !== null &&
+    rawWorkspaceEntry.path.replace(/\\/g, "/") === workspaceRelPath
+      ? rawWorkspaceEntry
+      : null;
+
+  // Changed image files opened from a changeset get the HEAD-vs-working-tree
+  // compare (Two-up / Swipe / Onion skin) instead of the static preview.
+  // Declared before loadFile, which consults it to skip the working-tree read.
+  const imageDiffEligible = Boolean(
+    imageFile && fileStatus && workspaceRelPath && isImageDiffCandidate(filePath)
+  );
+  // Subscribe only to the OPEN file's viewed flag — subscribing to the whole
+  // set would re-render the mounted diff tree on every sidebar checklist
+  // toggle. markViewedAndAdvance reads the full set imperatively instead.
+  const currentViewed = useDiffViewedStore(
+    useCallback(
+      (state) =>
+        workspaceEntry ? selectViewedSet(state, rootPath).has(workspaceEntry.viewedKey) : false,
+      [rootPath, workspaceEntry]
+    )
   );
   const setViewed = useDiffViewedStore((state) => state.setViewed);
   const toggleViewed = useDiffViewedStore((state) => state.toggleViewed);
   // Cross-file hunk stepping: where to land in the next file once its hunks
-  // render. Carries the expected file index so a manual jump elsewhere (or a
-  // hunkless file) invalidates the target instead of firing late.
-  const pendingHunkTargetRef = useRef<{ fileIndex: number; place: "first" | "last" } | null>(null);
+  // render. Carries the expected file index (a manual jump elsewhere
+  // invalidates the target) and the diff that was on screen when the step
+  // was armed (the landing must wait for a different diff to commit).
+  const pendingHunkTargetRef = useRef<{
+    fileIndex: number;
+    place: "first" | "last";
+    armedDiff: string | undefined;
+  } | null>(null);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -309,6 +347,7 @@ export function FileViewerModal({
       requestRef.current++;
       hasSwitchedToDiffRef.current = false;
       currentHunkIndexRef.current = -1;
+      pendingHunkTargetRef.current = null;
       setSearchOpen(false);
       setSearchQuery("");
       const nextMode = defaultMode ?? (hasDiff && !initialLine ? "diff" : "view");
@@ -330,7 +369,10 @@ export function FileViewerModal({
       current === "rendered" && !markdownFile ? (hasDiff ? "diff" : "view") : current
     );
 
-    if (imageFile && !svgFile) {
+    // Image-compare-eligible files (including SVG) never need the working-tree
+    // read — ImageDiffViewer fetches both sides itself, and a deleted image
+    // has no working file to read anyway.
+    if (imageFile && (!svgFile || imageDiffEligible)) {
       setLoadState("image");
       return;
     }
@@ -445,26 +487,11 @@ export function FileViewerModal({
 
   const fileName = filePath.split(/[/\\]/).filter(Boolean).pop() || filePath;
 
-  // Worktree-relative path, when the file lives under rootPath. Feeds the
-  // breadcrumb title (directory muted, basename strong — the Kaleidoscope
-  // path-bar read) and the image compare's git lookups.
-  const workspaceRelPath = useMemo(() => {
-    const fwdPath = filePath.replace(/\\/g, "/");
-    const fwdRootDir = rootPath.replace(/\\/g, "/").replace(/\/$/, "") + "/";
-    return fwdPath.startsWith(fwdRootDir) ? fwdPath.slice(fwdRootDir.length) : null;
-  }, [filePath, rootPath]);
-
   const relDir = useMemo(() => {
     if (!workspaceRelPath) return null;
     const lastSlash = workspaceRelPath.lastIndexOf("/");
     return lastSlash > 0 ? workspaceRelPath.slice(0, lastSlash) : null;
   }, [workspaceRelPath]);
-
-  // Changed image files opened from a changeset get the HEAD-vs-working-tree
-  // compare (Two-up / Swipe / Onion skin) instead of the static preview.
-  const imageDiffEligible = Boolean(
-    imageFile && fileStatus && workspaceRelPath && isImageDiffCandidate(filePath)
-  );
 
   const diffFontStyle: CSSProperties & Record<"--diff-font-size", string> = {
     "--diff-font-size": DIFF_FONT_SIZE_PX[diffFontSize],
@@ -557,6 +584,32 @@ export function FileViewerModal({
 
   const stepHunk = useCallback(
     (delta: -1 | 1) => {
+      const count =
+        diffViewerRef.current?.querySelectorAll<HTMLElement>("tbody.diff-hunk").length ?? 0;
+      // Past either end of the file, the step flows into the neighboring file
+      // of the changeset (Kaleidoscope-style continuous change navigation).
+      // `onNavigateFile` is called directly (not via the `navigateFile`
+      // effect event — those are effect-only) with the announce ref set so
+      // the landed-on file is still read out. `armedDiff` records which diff
+      // string was on screen when the step was armed: the landing only fires
+      // once a DIFFERENT diff has committed, so the outgoing file's DOM can
+      // never satisfy the target during the swap.
+      const crossToFile = (fileDelta: -1 | 1, place: "first" | "last") => {
+        pendingHunkTargetRef.current = {
+          fileIndex: (currentFileIndex ?? 0) + fileDelta,
+          place,
+          armedDiff: diff,
+        };
+        fileStepAnnouncePendingRef.current = true;
+        onNavigateFile?.(fileDelta);
+      };
+      if (count === 0) {
+        // Hunkless file (binary, image, no changes): keep the flow continuous
+        // instead of dead-ending mid-changeset.
+        if (delta === 1 && hasNextFile) crossToFile(1, "first");
+        else if (delta === -1 && hasPrevFile) crossToFile(-1, "last");
+        return;
+      }
       const current = currentHunkIndexRef.current;
       if (current < 0) {
         // Stepping from the initial sentinel (-1) lands on the first hunk so
@@ -564,33 +617,21 @@ export function FileViewerModal({
         scrollToHunkIndex(0);
         return;
       }
-      const next = current + delta;
-      const count =
-        diffViewerRef.current?.querySelectorAll<HTMLElement>("tbody.diff-hunk").length ?? 0;
-      // Past either end of the file, the step flows into the neighboring file
-      // of the changeset (Kaleidoscope-style continuous change navigation).
-      // `onNavigateFile` is called directly (not via the `navigateFile`
-      // effect event — those are effect-only) with the announce ref set so
-      // the landed-on file is still read out.
+      // Clamp before stepping: collapse/reveal can shrink the live hunk count
+      // under a stale ref, and an unclamped `p` would otherwise read as "past
+      // the end" and step forward.
+      const next = Math.min(current, count - 1) + delta;
       if (next < 0) {
-        if (hasPrevFile) {
-          pendingHunkTargetRef.current = { fileIndex: (currentFileIndex ?? 0) - 1, place: "last" };
-          fileStepAnnouncePendingRef.current = true;
-          onNavigateFile?.(-1);
-        }
+        if (hasPrevFile) crossToFile(-1, "last");
         return;
       }
       if (next >= count) {
-        if (hasNextFile) {
-          pendingHunkTargetRef.current = { fileIndex: (currentFileIndex ?? 0) + 1, place: "first" };
-          fileStepAnnouncePendingRef.current = true;
-          onNavigateFile?.(1);
-        }
+        if (hasNextFile) crossToFile(1, "first");
         return;
       }
       scrollToHunkIndex(next);
     },
-    [scrollToHunkIndex, hasPrevFile, hasNextFile, currentFileIndex, onNavigateFile]
+    [scrollToHunkIndex, hasPrevFile, hasNextFile, currentFileIndex, onNavigateFile, diff]
   );
 
   useEffect(() => {
@@ -663,12 +704,16 @@ export function FileViewerModal({
   }, [isOpen, canStepFiles]);
 
   // `v` — mark the open file viewed and advance to the next unviewed file
-  // (wrapping), the GitHub-review muscle memory. Workspace mode only.
+  // (wrapping), the GitHub-review muscle memory. Requires a matching
+  // changeSet entry; only the footer button unmarks.
   const markViewedAndAdvance = useEffectEvent(() => {
     if (!workspaceEntry || !changeSet || currentFileIndex === undefined) return;
+    const viewedSet = selectViewedSet(useDiffViewedStore.getState(), rootPath);
     const alreadyViewed = viewedSet.has(workspaceEntry.viewedKey);
-    if (!alreadyViewed) setViewed(rootPath, workspaceEntry.viewedKey, true);
-    useAnnouncerStore.getState().announce("Marked viewed");
+    if (!alreadyViewed) {
+      setViewed(rootPath, workspaceEntry.viewedKey, true);
+      useAnnouncerStore.getState().announce("Marked viewed");
+    }
     if (!onSelectFile) return;
     for (let step = 1; step < changeSet.length; step++) {
       const index = (currentFileIndex + step) % changeSet.length;
@@ -683,7 +728,9 @@ export function FileViewerModal({
   });
 
   useEffect(() => {
-    if (!isOpen || !isWorkspace) return;
+    // Gated on the entry (not multi-file workspace mode) so `v` also works
+    // for a single-file changeset, where it marks the file and stays put.
+    if (!isOpen || !workspaceEntry) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "v") return;
@@ -706,7 +753,7 @@ export function FileViewerModal({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen, isWorkspace]);
+  }, [isOpen, workspaceEntry]);
 
   // IntersectionObserver tracks the most-visible hunk during free scrolling.
   // Observes tr:first-child (not tbody — table-row-group collapses to 0 height
@@ -714,6 +761,13 @@ export function FileViewerModal({
   // so split/unified toggles re-observe the new DOM.
   useEffect(() => {
     if (!isOpen || mode !== "diff" || !diff) {
+      // Destination diff observed loading: drop the armed-diff identity check
+      // so a destination whose diff STRING happens to equal the source's
+      // (sentinel pairs) can still land once it commits.
+      const pendingWhileLoading = pendingHunkTargetRef.current;
+      if (pendingWhileLoading && pendingWhileLoading.fileIndex === (currentFileIndex ?? -1)) {
+        pendingWhileLoading.armedDiff = undefined;
+      }
       setActiveHunkIndex(-1);
       setHunkCount(0);
       setHunkMarkers([]);
@@ -743,12 +797,15 @@ export function FileViewerModal({
     setHunkCount(count);
 
     // Land a cross-file hunk step once the destination file's hunks exist.
-    // A stale target (user jumped elsewhere meanwhile) is dropped instead.
+    // A stale target (user jumped elsewhere meanwhile) is dropped instead,
+    // and the outgoing file's still-rendered diff never satisfies the target
+    // (`armedDiff` identity check) — the swap can commit the new index a
+    // frame before the new diff arrives.
     const pending = pendingHunkTargetRef.current;
     if (pending) {
       if (pending.fileIndex !== (currentFileIndex ?? -1)) {
         pendingHunkTargetRef.current = null;
-      } else if (count > 0) {
+      } else if (count > 0 && diff !== pending.armedDiff) {
         pendingHunkTargetRef.current = null;
         const landingIndex = pending.place === "last" ? count - 1 : 0;
         requestAnimationFrame(() => scrollToHunkIndex(landingIndex));
@@ -1001,7 +1058,10 @@ export function FileViewerModal({
             ? "7xl"
             : "6xl"
       }
-      maxHeight={isWorkspace ? "max-h-[92vh]" : "max-h-[90vh]"}
+      /* Workspace mode holds a fixed frame (h-, not just max-h-): a short
+         diff must not shrink-wrap the dialog mid-review — stepping files
+         would otherwise resize the whole surface on every jump. */
+      maxHeight={isWorkspace ? "h-[92vh] max-h-[92vh]" : "max-h-[90vh]"}
       restoreFocusTo={restoreFocusTo}
       data-testid="file-viewer-dialog"
     >
@@ -1150,6 +1210,7 @@ export function FileViewerModal({
             currentIndex={currentFileIndex ?? -1}
             worktreePath={rootPath}
             onSelect={(index) => {
+              if (index === currentFileIndex) return;
               fileStepAnnouncePendingRef.current = true;
               onSelectFile(index);
             }}
@@ -1413,7 +1474,10 @@ export function FileViewerModal({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
-                      onClick={() => onNavigateFile?.(-1)}
+                      onClick={() => {
+                        fileStepAnnouncePendingRef.current = true;
+                        onNavigateFile?.(-1);
+                      }}
                       disabled={!hasPrevFile}
                       aria-label="Previous file"
                       className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
@@ -1433,7 +1497,10 @@ export function FileViewerModal({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
-                      onClick={() => onNavigateFile?.(1)}
+                      onClick={() => {
+                        fileStepAnnouncePendingRef.current = true;
+                        onNavigateFile?.(1);
+                      }}
                       disabled={!hasNextFile}
                       aria-label="Next file"
                       className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
@@ -1451,12 +1518,12 @@ export function FileViewerModal({
                   <button
                     type="button"
                     onClick={() => toggleViewed(rootPath, workspaceEntry.viewedKey)}
-                    aria-pressed={viewedSet.has(workspaceEntry.viewedKey)}
+                    aria-pressed={currentViewed}
                     aria-label="Viewed"
                     data-testid="diff-viewed-button"
                     className={cn(
                       "ml-1 flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors",
-                      viewedSet.has(workspaceEntry.viewedKey)
+                      currentViewed
                         ? "bg-status-success/15 text-status-success"
                         : "text-muted-foreground hover:text-daintree-text hover:bg-daintree-border"
                     )}

--- a/src/components/FileViewer/ImageDiffViewer.tsx
+++ b/src/components/FileViewer/ImageDiffViewer.tsx
@@ -1,0 +1,396 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { GripVertical, ImageOff } from "lucide-react";
+import type { DiffMediaFileVersions, DiffMediaSide, GitStatus } from "@shared/types";
+import { diffMediaClient } from "@/clients/diffMediaClient";
+import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/button";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
+import { formatBytes } from "@/lib/formatBytes";
+import { cn } from "@/lib/utils";
+
+export interface ImageDiffViewerProps {
+  /** Repo-relative path of the changed image */
+  relPath: string;
+  /** Worktree root (IPC cwd) */
+  worktreePath: string;
+  status: GitStatus;
+}
+
+const IMAGE_DIFF_EXTENSION_RE = /\.(png|jpe?g|gif|webp|bmp|ico|svg)$/i;
+
+export function isImageDiffCandidate(path: string): boolean {
+  return IMAGE_DIFF_EXTENSION_RE.test(path);
+}
+
+type ImageDiffMode = "two-up" | "swipe" | "onion";
+
+const MODE_OPTIONS: Array<{ value: ImageDiffMode; label: string }> = [
+  { value: "two-up", label: "Two-up" },
+  { value: "swipe", label: "Swipe" },
+  { value: "onion", label: "Onion skin" },
+];
+
+const SWIPE_KEYBOARD_STEP = 2;
+
+// Neutral checkerboard so transparency reads correctly on both themes — the
+// border token tracks theme polarity, and the low-alpha mix keeps it quiet.
+const CHECKERBOARD_STYLE: CSSProperties = {
+  backgroundImage:
+    "repeating-conic-gradient(color-mix(in oklab, var(--color-daintree-border) 45%, transparent) 0% 25%, transparent 0% 50%)",
+  backgroundSize: "16px 16px",
+};
+
+function sideErrorMessage(error: Extract<DiffMediaSide, { ok: false }>["error"]): string {
+  switch (error) {
+    case "TOO_LARGE":
+      return "Image too large to compare (over 8 MB)";
+    case "UNSUPPORTED":
+      return "This file format can't be previewed as an image";
+    case "NOT_FOUND":
+      return "No version to show";
+    case "ERROR":
+      return "Couldn't load this version";
+  }
+}
+
+function SideChip({ label, floating }: { label: string; floating?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "rounded bg-daintree-sidebar px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground",
+        floating && "bg-daintree-sidebar/90"
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface ImagePaneProps {
+  label: string;
+  side: DiffMediaSide;
+  relPath: string;
+  caption?: string;
+}
+
+function ImagePane({ label, side, relPath, caption }: ImagePaneProps) {
+  const [dims, setDims] = useState<{ width: number; height: number } | null>(null);
+  const src = side.ok ? side.dataUrl : null;
+
+  useEffect(() => {
+    setDims(null);
+  }, [src]);
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <SideChip label={label} />
+        {caption ? <span className="text-xs text-muted-foreground">{caption}</span> : null}
+      </div>
+      <div
+        className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-daintree-border"
+        style={side.ok ? CHECKERBOARD_STYLE : undefined}
+      >
+        {side.ok ? (
+          <img
+            src={side.dataUrl}
+            alt={`${label} version of ${relPath}`}
+            draggable={false}
+            className="max-h-full max-w-full object-contain"
+            onLoad={(event) =>
+              setDims({
+                width: event.currentTarget.naturalWidth,
+                height: event.currentTarget.naturalHeight,
+              })
+            }
+          />
+        ) : (
+          <p className="px-4 text-center text-xs text-muted-foreground">
+            {sideErrorMessage(side.error)}
+          </p>
+        )}
+      </div>
+      {side.ok ? (
+        <p className="text-[11px] tabular-nums text-muted-foreground">
+          {dims ? `${dims.width}×${dims.height} px · ` : ""}
+          {formatBytes(side.byteSize)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface OkSides {
+  head: Extract<DiffMediaSide, { ok: true }>;
+  working: Extract<DiffMediaSide, { ok: true }>;
+}
+
+// Both layers render into the same full-container box with object-contain, so
+// they superimpose in an identical fitted rect and pixel comparison lines up.
+function OverlayLayers({
+  sides,
+  relPath,
+  topStyle,
+}: {
+  sides: OkSides;
+  relPath: string;
+  topStyle: CSSProperties;
+}) {
+  return (
+    <>
+      <img
+        src={sides.working.dataUrl}
+        alt={`Working tree version of ${relPath}`}
+        draggable={false}
+        className="absolute inset-0 h-full w-full object-contain"
+      />
+      <img
+        src={sides.head.dataUrl}
+        alt={`HEAD version of ${relPath}`}
+        draggable={false}
+        className="absolute inset-0 h-full w-full object-contain"
+        style={topStyle}
+      />
+    </>
+  );
+}
+
+function OverlayChips() {
+  return (
+    <>
+      <div className="pointer-events-none absolute left-2 top-2 z-10">
+        <SideChip label="HEAD" floating />
+      </div>
+      <div className="pointer-events-none absolute right-2 top-2 z-10">
+        <SideChip label="Working tree" floating />
+      </div>
+    </>
+  );
+}
+
+function SwipeCompare({ sides, relPath }: { sides: OkSides; relPath: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState(50);
+  const draggingRef = useRef(false);
+
+  const updateFromClientX = useCallback((clientX: number) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return;
+    const next = ((clientX - rect.left) / rect.width) * 100;
+    setPosition(Math.min(100, Math.max(0, next)));
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative min-h-0 flex-1 touch-none overflow-hidden rounded-md border border-daintree-border"
+      style={CHECKERBOARD_STYLE}
+      onPointerDown={(event) => {
+        draggingRef.current = true;
+        event.currentTarget.setPointerCapture(event.pointerId);
+        updateFromClientX(event.clientX);
+      }}
+      onPointerMove={(event) => {
+        if (draggingRef.current) updateFromClientX(event.clientX);
+      }}
+      onPointerUp={() => {
+        draggingRef.current = false;
+      }}
+      onPointerCancel={() => {
+        draggingRef.current = false;
+      }}
+    >
+      <OverlayLayers
+        sides={sides}
+        relPath={relPath}
+        // HEAD on top, clipped to the left of the divider — old on the left,
+        // new on the right.
+        topStyle={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}
+      />
+      <OverlayChips />
+      <div
+        role="slider"
+        tabIndex={0}
+        aria-label="Swipe divider"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(position)}
+        className="absolute inset-y-0 z-10 flex w-4 -translate-x-1/2 cursor-ew-resize items-center justify-center"
+        style={{ left: `${position}%` }}
+        onKeyDown={(event) => {
+          if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+          event.preventDefault();
+          const delta = event.key === "ArrowLeft" ? -SWIPE_KEYBOARD_STEP : SWIPE_KEYBOARD_STEP;
+          setPosition((prev) => Math.min(100, Math.max(0, prev + delta)));
+        }}
+      >
+        <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-daintree-text/60 shadow-[0_0_0_1px_var(--color-daintree-bg)]" />
+        <div className="relative flex h-6 w-3.5 items-center justify-center rounded border border-daintree-border bg-daintree-sidebar">
+          <GripVertical className="h-3 w-3 text-muted-foreground" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OnionCompare({
+  sides,
+  relPath,
+  opacity,
+}: {
+  sides: OkSides;
+  relPath: string;
+  opacity: number;
+}) {
+  return (
+    <div
+      className="relative min-h-0 flex-1 overflow-hidden rounded-md border border-daintree-border"
+      style={CHECKERBOARD_STYLE}
+    >
+      {/* HEAD as the base layer; the working-tree layer fades in on top. */}
+      <img
+        src={sides.head.dataUrl}
+        alt={`HEAD version of ${relPath}`}
+        draggable={false}
+        className="absolute inset-0 h-full w-full object-contain"
+      />
+      <img
+        src={sides.working.dataUrl}
+        alt={`Working tree version of ${relPath}`}
+        draggable={false}
+        className="absolute inset-0 h-full w-full object-contain"
+        style={{ opacity: opacity / 100 }}
+      />
+      <OverlayChips />
+    </div>
+  );
+}
+
+export function ImageDiffViewer({ relPath, worktreePath, status }: ImageDiffViewerProps) {
+  const [versions, setVersions] = useState<DiffMediaFileVersions | null>(null);
+  const [loadState, setLoadState] = useState<"loading" | "loaded" | "error">("loading");
+  const [fetchNonce, setFetchNonce] = useState(0);
+  const [mode, setMode] = useState<ImageDiffMode>("two-up");
+  const [onionOpacity, setOnionOpacity] = useState(50);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadState("loading");
+    setVersions(null);
+    diffMediaClient
+      .readFileVersions({ cwd: worktreePath, filePath: relPath })
+      .then((result) => {
+        if (cancelled) return;
+        setVersions(result);
+        setLoadState("loaded");
+      })
+      .catch(() => {
+        if (!cancelled) setLoadState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [worktreePath, relPath, fetchNonce]);
+
+  const retry = useCallback(() => setFetchNonce((nonce) => nonce + 1), []);
+
+  const singleSide: "head" | "working" | null =
+    status === "added" || status === "untracked" ? "working" : status === "deleted" ? "head" : null;
+
+  if (loadState === "loading") {
+    return (
+      <Skeleton
+        label="Loading image versions"
+        className="flex h-full min-h-0 w-full flex-col gap-3 p-3"
+      >
+        <SkeletonBone className="h-6 w-44" />
+        <div className="flex min-h-0 flex-1 gap-3">
+          <SkeletonBone className="min-h-0 flex-1 rounded-md" />
+          {singleSide === null ? <SkeletonBone className="min-h-0 flex-1 rounded-md" /> : null}
+        </div>
+      </Skeleton>
+    );
+  }
+
+  if (loadState === "error" || (versions !== null && !versions.head.ok && !versions.working.ok)) {
+    return (
+      <div className="flex h-full min-h-0 w-full flex-col items-center justify-center">
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          icon={<ImageOff />}
+          title="Couldn't load image versions"
+          description="Neither version of this image could be read"
+          action={
+            <Button variant="outline" size="sm" onClick={retry}>
+              Retry
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (versions === null) return null;
+
+  if (singleSide !== null) {
+    const caption =
+      singleSide === "working" ? "Added — no previous version" : "Deleted — no working version";
+    return (
+      <div className="flex h-full min-h-0 w-full flex-col p-3">
+        <ImagePane
+          label={singleSide === "working" ? "Working tree" : "HEAD"}
+          side={versions[singleSide]}
+          relPath={relPath}
+          caption={caption}
+        />
+      </div>
+    );
+  }
+
+  const okSides: OkSides | null =
+    versions.head.ok && versions.working.ok
+      ? { head: versions.head, working: versions.working }
+      : null;
+  const bothOk = okSides !== null;
+  const effectiveMode: ImageDiffMode = bothOk ? mode : "two-up";
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col">
+      {bothOk ? (
+        <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3">
+          <SegmentedToggle options={MODE_OPTIONS} value={effectiveMode} onChange={setMode} />
+          {effectiveMode === "onion" ? (
+            <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+              Working tree opacity
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={onionOpacity}
+                aria-label="Working tree opacity"
+                onChange={(event) => setOnionOpacity(Number(event.currentTarget.value))}
+                className="w-36 cursor-pointer"
+                style={{ accentColor: "var(--color-daintree-text)" }}
+              />
+            </label>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex min-h-0 flex-1 flex-col p-3">
+        {effectiveMode === "two-up" || okSides === null ? (
+          <div className="flex min-h-0 flex-1 gap-3">
+            <ImagePane label="HEAD" side={versions.head} relPath={relPath} />
+            <ImagePane label="Working tree" side={versions.working} relPath={relPath} />
+          </div>
+        ) : effectiveMode === "swipe" ? (
+          <SwipeCompare sides={okSides} relPath={relPath} />
+        ) : (
+          <OnionCompare sides={okSides} relPath={relPath} opacity={onionOpacity} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileViewer/ImageDiffViewer.tsx
+++ b/src/components/FileViewer/ImageDiffViewer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { GripVertical, ImageOff } from "lucide-react";
 import type { DiffMediaFileVersions, DiffMediaSide, GitStatus } from "@shared/types";
+import { getDiffMediaImageMime } from "@shared/types/ipc/diffMedia";
 import { diffMediaClient } from "@/clients/diffMediaClient";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -17,10 +18,8 @@ export interface ImageDiffViewerProps {
   status: GitStatus;
 }
 
-const IMAGE_DIFF_EXTENSION_RE = /\.(png|jpe?g|gif|webp|bmp|ico|svg)$/i;
-
 export function isImageDiffCandidate(path: string): boolean {
-  return IMAGE_DIFF_EXTENSION_RE.test(path);
+  return getDiffMediaImageMime(path) !== null;
 }
 
 type ImageDiffMode = "two-up" | "swipe" | "onion";
@@ -76,10 +75,12 @@ interface ImagePaneProps {
 
 function ImagePane({ label, side, relPath, caption }: ImagePaneProps) {
   const [dims, setDims] = useState<{ width: number; height: number } | null>(null);
+  const [decodeFailed, setDecodeFailed] = useState(false);
   const src = side.ok ? side.dataUrl : null;
 
   useEffect(() => {
     setDims(null);
+    setDecodeFailed(false);
   }, [src]);
 
   return (
@@ -90,9 +91,9 @@ function ImagePane({ label, side, relPath, caption }: ImagePaneProps) {
       </div>
       <div
         className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-daintree-border"
-        style={side.ok ? CHECKERBOARD_STYLE : undefined}
+        style={side.ok && !decodeFailed ? CHECKERBOARD_STYLE : undefined}
       >
-        {side.ok ? (
+        {side.ok && !decodeFailed ? (
           <img
             src={side.dataUrl}
             alt={`${label} version of ${relPath}`}
@@ -104,14 +105,15 @@ function ImagePane({ label, side, relPath, caption }: ImagePaneProps) {
                 height: event.currentTarget.naturalHeight,
               })
             }
+            onError={() => setDecodeFailed(true)}
           />
         ) : (
           <p className="px-4 text-center text-xs text-muted-foreground">
-            {sideErrorMessage(side.error)}
+            {side.ok ? "Couldn't display this version" : sideErrorMessage(side.error)}
           </p>
         )}
       </div>
-      {side.ok ? (
+      {side.ok && !decodeFailed ? (
         <p className="text-[11px] tabular-nums text-muted-foreground">
           {dims ? `${dims.width}×${dims.height} px · ` : ""}
           {formatBytes(side.byteSize)}

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -46,6 +46,7 @@ vi.mock("@/lib/trustedTypesPolicy", () => ({
 }));
 
 import { FileViewerModal } from "../FileViewerModal";
+import { useDiffViewedStore } from "@/store/diffViewedStore";
 
 const { capturedDialogProps } = vi.hoisted(() => ({
   capturedDialogProps: { restoreFocusTo: undefined as unknown },
@@ -163,10 +164,16 @@ vi.mock("@/components/Worktree/DiffViewer", () => ({
 }));
 
 const setDiffViewTypeMock = vi.fn();
+const setDiffShowFileListMock = vi.fn();
+const setDiffFontSizeMock = vi.fn();
 const usePreferencesStoreMock = vi.fn((selector?: (s: Record<string, unknown>) => unknown) => {
   const state = {
     diffViewType: "split" as const,
     setDiffViewType: setDiffViewTypeMock,
+    diffShowFileList: true,
+    setDiffShowFileList: setDiffShowFileListMock,
+    diffFontSize: "m" as const,
+    setDiffFontSize: setDiffFontSizeMock,
   };
   return selector ? selector(state) : state;
 });
@@ -224,6 +231,10 @@ beforeEach(() => {
       const state = {
         diffViewType: "split" as const,
         setDiffViewType: setDiffViewTypeMock,
+        diffShowFileList: true,
+        setDiffShowFileList: setDiffShowFileListMock,
+        diffFontSize: "m" as const,
+        setDiffFontSize: setDiffFontSizeMock,
       };
       return selector ? selector(state) : state;
     }
@@ -638,8 +649,6 @@ describe("FileViewerModal", () => {
         expect(screen.getByTestId("diff-viewer")).toBeTruthy();
       });
 
-      const hunk1 = screen.getByTestId("hunk-1");
-
       // Walk forward to the last hunk, then press past the end.
       fireEvent.keyDown(window, { key: "n" }); // hunk 0
       fireEvent.keyDown(window, { key: "n" }); // hunk 1 (last)
@@ -647,11 +656,9 @@ describe("FileViewerModal", () => {
       fireEvent.keyDown(window, { key: "n" });
       fireEvent.keyDown(window, { key: "n" });
 
-      // Clamping past the end must keep landing on hunk 1, never wrap to hunk 0.
-      expect(scrollIntoViewCalls.length).toBeGreaterThan(0);
-      for (const target of scrollIntoViewCalls) {
-        expect(target).toBe(hunk1);
-      }
+      // Past the end with no next file in the changeset the step is a no-op:
+      // no wrap to hunk 0 and no redundant re-scroll of the last hunk.
+      expect(scrollIntoViewCalls.length).toBe(0);
     });
 
     it("scrolls to the previous hunk on `p`", async () => {
@@ -1416,6 +1423,182 @@ describe("FileViewerModal", () => {
       });
 
       expect(capturedDialogProps.restoreFocusTo).toBe(ref);
+    });
+  });
+
+  describe("review workspace (changeSet)", () => {
+    const diff = "diff --git a/file.ts b/file.ts\n@@ -1 +1 @@\n-a\n+b\n";
+    const changeSet = [
+      {
+        path: "src/a.ts",
+        status: "modified" as const,
+        insertions: 3,
+        deletions: 1,
+        viewedKey: "modified:src/a.ts",
+      },
+      {
+        path: "src/b.ts",
+        status: "added" as const,
+        insertions: 10,
+        deletions: 0,
+        viewedKey: "added:src/b.ts",
+      },
+      {
+        path: "docs/c.md",
+        status: "deleted" as const,
+        insertions: 0,
+        deletions: 5,
+        viewedKey: "deleted:docs/c.md",
+      },
+    ];
+
+    beforeEach(() => {
+      useDiffViewedStore.setState({ viewedByWorktree: {} });
+    });
+
+    function renderWorkspace(overrides: Record<string, unknown> = {}) {
+      const onSelectFile = vi.fn();
+      const onNavigateFile = vi.fn();
+      render(
+        <FileViewerModal
+          {...defaultProps}
+          filePath="/project/src/a.ts"
+          diff={diff}
+          defaultMode="diff"
+          changeSet={changeSet}
+          onSelectFile={onSelectFile}
+          onNavigateFile={onNavigateFile}
+          currentFileIndex={0}
+          totalFileCount={changeSet.length}
+          {...overrides}
+        />
+      );
+      return { onSelectFile, onNavigateFile };
+    }
+
+    it("renders the changed-files sidebar with all changeset entries", async () => {
+      renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-file-sidebar")).toBeTruthy();
+      });
+      expect(screen.getAllByTestId("diff-sidebar-file")).toHaveLength(3);
+      expect(screen.getByTestId("diff-sidebar-progress").textContent).toContain("0 of 3 viewed");
+    });
+
+    it("does not render the sidebar for single-file openers", async () => {
+      render(<FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+      expect(screen.queryByTestId("diff-file-sidebar")).toBeNull();
+    });
+
+    it("jumps to a file when its sidebar row is clicked", async () => {
+      const { onSelectFile } = renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-file-sidebar")).toBeTruthy();
+      });
+      // Rows are directory-grouped, so target by label rather than position;
+      // the callback still receives the file's index in the flat changeset.
+      fireEvent.click(screen.getByLabelText("Open docs/c.md"));
+      expect(onSelectFile).toHaveBeenCalledWith(2);
+    });
+
+    it("`v` marks the open file viewed and advances to the next unviewed file", async () => {
+      const { onSelectFile } = renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-file-sidebar")).toBeTruthy();
+      });
+      fireEvent.keyDown(window, { key: "v" });
+
+      expect(
+        useDiffViewedStore.getState().viewedByWorktree["/project"]?.has("modified:src/a.ts")
+      ).toBe(true);
+      expect(onSelectFile).toHaveBeenCalledWith(1);
+    });
+
+    it("`v` skips already-viewed files when advancing", async () => {
+      useDiffViewedStore.getState().setViewed("/project", "added:src/b.ts", true);
+      const { onSelectFile } = renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-file-sidebar")).toBeTruthy();
+      });
+      fireEvent.keyDown(window, { key: "v" });
+
+      expect(onSelectFile).toHaveBeenCalledWith(2);
+    });
+
+    it("the footer Viewed button toggles without advancing", async () => {
+      const { onSelectFile } = renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewed-button")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByTestId("diff-viewed-button"));
+
+      expect(
+        useDiffViewedStore.getState().viewedByWorktree["/project"]?.has("modified:src/a.ts")
+      ).toBe(true);
+      expect(onSelectFile).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTestId("diff-viewed-button"));
+      expect(
+        useDiffViewedStore.getState().viewedByWorktree["/project"]?.has("modified:src/a.ts")
+      ).toBe(false);
+    });
+
+    it("`n` past the last hunk steps to the next file", async () => {
+      const { onNavigateFile } = renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+      fireEvent.keyDown(window, { key: "n" }); // hunk 0
+      fireEvent.keyDown(window, { key: "n" }); // hunk 1 (last)
+      fireEvent.keyDown(window, { key: "n" }); // crosses into the next file
+
+      expect(onNavigateFile).toHaveBeenCalledWith(1);
+    });
+
+    it("`p` before the first hunk steps to the previous file", async () => {
+      const { onNavigateFile } = renderWorkspace({ currentFileIndex: 1 });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+      fireEvent.keyDown(window, { key: "n" }); // hunk 0
+      fireEvent.keyDown(window, { key: "p" }); // crosses into the previous file
+
+      expect(onNavigateFile).toHaveBeenCalledWith(-1);
+    });
+
+    it("`n` at the end of the last file stays put", async () => {
+      const { onNavigateFile } = renderWorkspace({ currentFileIndex: 2 });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+      fireEvent.keyDown(window, { key: "n" }); // hunk 0
+      fireEvent.keyDown(window, { key: "n" }); // hunk 1 (last)
+      fireEvent.keyDown(window, { key: "n" });
+
+      expect(onNavigateFile).not.toHaveBeenCalled();
+    });
+
+    it("sidebar filter narrows the list without touching the open file", async () => {
+      renderWorkspace();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-file-sidebar")).toBeTruthy();
+      });
+      fireEvent.change(screen.getByTestId("diff-sidebar-filter"), { target: { value: "docs" } });
+
+      expect(screen.getAllByTestId("diff-sidebar-file")).toHaveLength(1);
     });
   });
 });

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -1600,5 +1600,48 @@ describe("FileViewerModal", () => {
 
       expect(screen.getAllByTestId("diff-sidebar-file")).toHaveLength(1);
     });
+
+    it("Escape in the filter clears it instead of closing the workspace", async () => {
+      const onClose = vi.fn();
+      renderWorkspace({ onClose });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-file-sidebar")).toBeTruthy();
+      });
+      const filter = screen.getByTestId("diff-sidebar-filter");
+      fireEvent.change(filter, { target: { value: "docs" } });
+      expect(screen.getAllByTestId("diff-sidebar-file")).toHaveLength(1);
+
+      fireEvent.keyDown(filter, { key: "Escape" });
+
+      expect((filter as HTMLInputElement).value).toBe("");
+      expect(screen.getAllByTestId("diff-sidebar-file")).toHaveLength(3);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("`n` on a hunkless file continues to the next file instead of dead-ending", async () => {
+      // Collapsed mock = no tbody.diff-hunk rows, standing in for a binary
+      // or image file mid-changeset.
+      mockDiffViewerControl.startCollapsed = true;
+      const { onNavigateFile } = renderWorkspace({ currentFileIndex: 1 });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+      fireEvent.keyDown(window, { key: "n" });
+
+      expect(onNavigateFile).toHaveBeenCalledWith(1);
+    });
+
+    it("hides viewed controls when the changeset entry does not match the open file", async () => {
+      // Index/list drift: currentFileIndex points at src/b.ts while the open
+      // file is src/a.ts — the guard must refuse to mark the wrong viewedKey.
+      renderWorkspace({ currentFileIndex: 1 });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+      });
+      expect(screen.queryByTestId("diff-viewed-button")).toBeNull();
+    });
   });
 });

--- a/src/components/FileViewer/__tests__/ImageDiffViewer.test.tsx
+++ b/src/components/FileViewer/__tests__/ImageDiffViewer.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiffMediaFileVersions } from "@shared/types";
+import { ImageDiffViewer, isImageDiffCandidate } from "../ImageDiffViewer";
+
+const mockReadFileVersions = vi.fn();
+vi.mock("@/clients/diffMediaClient", () => ({
+  diffMediaClient: {
+    readFileVersions: (...args: unknown[]) => mockReadFileVersions(...args),
+  },
+}));
+
+const HEAD_URL = "data:image/png;base64,aGVhZA==";
+const WORKING_URL = "data:image/png;base64,d29ya2luZw==";
+
+function bothOk(): DiffMediaFileVersions {
+  return {
+    head: { ok: true, dataUrl: HEAD_URL, byteSize: 4 },
+    working: { ok: true, dataUrl: WORKING_URL, byteSize: 7 },
+  };
+}
+
+describe("ImageDiffViewer", () => {
+  beforeEach(() => {
+    mockReadFileVersions.mockReset();
+  });
+
+  it("renders both sides in two-up with the mode toggle", async () => {
+    mockReadFileVersions.mockResolvedValue(bothOk());
+
+    render(<ImageDiffViewer relPath="assets/logo.png" worktreePath="/repo" status="modified" />);
+
+    const headImg = await screen.findByAltText("HEAD version of assets/logo.png");
+    const workingImg = screen.getByAltText("Working tree version of assets/logo.png");
+    expect(headImg.getAttribute("src")).toBe(HEAD_URL);
+    expect(workingImg.getAttribute("src")).toBe(WORKING_URL);
+
+    expect(screen.getByRole("button", { name: "Two-up" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Swipe" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Onion skin" })).toBeDefined();
+
+    expect(mockReadFileVersions).toHaveBeenCalledWith({
+      cwd: "/repo",
+      filePath: "assets/logo.png",
+    });
+  });
+
+  it("switches to swipe mode with a keyboard-adjustable divider", async () => {
+    mockReadFileVersions.mockResolvedValue(bothOk());
+
+    render(<ImageDiffViewer relPath="logo.png" worktreePath="/repo" status="modified" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Swipe" }));
+
+    const divider = screen.getByRole("slider", { name: "Swipe divider" });
+    expect(divider.getAttribute("aria-valuenow")).toBe("50");
+
+    fireEvent.keyDown(divider, { key: "ArrowRight" });
+    expect(divider.getAttribute("aria-valuenow")).toBe("52");
+    fireEvent.keyDown(divider, { key: "ArrowLeft" });
+    fireEvent.keyDown(divider, { key: "ArrowLeft" });
+    expect(divider.getAttribute("aria-valuenow")).toBe("48");
+  });
+
+  it("shows a single working-tree pane for an added file and hides compare modes", async () => {
+    mockReadFileVersions.mockResolvedValue({
+      head: { ok: false, error: "NOT_FOUND" },
+      working: { ok: true, dataUrl: WORKING_URL, byteSize: 7 },
+    } satisfies DiffMediaFileVersions);
+
+    render(<ImageDiffViewer relPath="new.png" worktreePath="/repo" status="added" />);
+
+    await screen.findByAltText("Working tree version of new.png");
+    expect(screen.queryByAltText("HEAD version of new.png")).toBeNull();
+    expect(screen.getByText("Added — no previous version")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Swipe" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Onion skin" })).toBeNull();
+  });
+
+  it("shows a single HEAD pane for a deleted file", async () => {
+    mockReadFileVersions.mockResolvedValue({
+      head: { ok: true, dataUrl: HEAD_URL, byteSize: 4 },
+      working: { ok: false, error: "NOT_FOUND" },
+    } satisfies DiffMediaFileVersions);
+
+    render(<ImageDiffViewer relPath="gone.png" worktreePath="/repo" status="deleted" />);
+
+    await screen.findByAltText("HEAD version of gone.png");
+    expect(screen.getByText("Deleted — no working version")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Swipe" })).toBeNull();
+  });
+
+  it("shows a per-side message and hides compare modes when one side is too large", async () => {
+    mockReadFileVersions.mockResolvedValue({
+      head: { ok: false, error: "TOO_LARGE" },
+      working: { ok: true, dataUrl: WORKING_URL, byteSize: 7 },
+    } satisfies DiffMediaFileVersions);
+
+    render(<ImageDiffViewer relPath="huge.png" worktreePath="/repo" status="modified" />);
+
+    expect(await screen.findByText("Image too large to compare (over 8 MB)")).toBeDefined();
+    expect(screen.getByAltText("Working tree version of huge.png")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Swipe" })).toBeNull();
+  });
+
+  it("recovers via Retry after a failed fetch", async () => {
+    mockReadFileVersions.mockRejectedValueOnce(new Error("ipc down"));
+    mockReadFileVersions.mockResolvedValueOnce(bothOk());
+
+    render(<ImageDiffViewer relPath="logo.png" worktreePath="/repo" status="modified" />);
+
+    const retryButton = await screen.findByRole("button", { name: "Retry" });
+    fireEvent.click(retryButton);
+
+    await screen.findByAltText("HEAD version of logo.png");
+    expect(mockReadFileVersions).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a double-sided failure like a fetch failure", async () => {
+    mockReadFileVersions.mockResolvedValue({
+      head: { ok: false, error: "ERROR" },
+      working: { ok: false, error: "ERROR" },
+    } satisfies DiffMediaFileVersions);
+
+    render(<ImageDiffViewer relPath="logo.png" worktreePath="/repo" status="modified" />);
+
+    expect(await screen.findByRole("button", { name: "Retry" })).toBeDefined();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("shows the loading skeleton while the fetch is pending", () => {
+    mockReadFileVersions.mockReturnValue(new Promise(() => {}));
+
+    render(<ImageDiffViewer relPath="logo.png" worktreePath="/repo" status="modified" />);
+
+    expect(screen.getByRole("status", { name: "Loading image versions" })).toBeDefined();
+  });
+
+  describe("isImageDiffCandidate", () => {
+    it("accepts every supported image extension case-insensitively", () => {
+      for (const path of [
+        "a.png",
+        "b.jpg",
+        "c.JPEG",
+        "d.gif",
+        "e.webp",
+        "f.bmp",
+        "g.ico",
+        "nested/dir/h.SVG",
+      ]) {
+        expect(isImageDiffCandidate(path)).toBe(true);
+      }
+    });
+
+    it("rejects non-image paths and lookalikes", () => {
+      for (const path of ["a.ts", "png", "archive.png.zip", "no-extension", "svg/readme.md"]) {
+        expect(isImageDiffCandidate(path)).toBe(false);
+      }
+    });
+  });
+
+  it("waits for the two-up mode toggle before allowing onion skin", async () => {
+    mockReadFileVersions.mockResolvedValue(bothOk());
+
+    render(<ImageDiffViewer relPath="logo.png" worktreePath="/repo" status="modified" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Onion skin" }));
+
+    const slider = screen.getByRole("slider", { name: "Working tree opacity" });
+    fireEvent.change(slider, { target: { value: "25" } });
+
+    const workingImg = screen.getByAltText("Working tree version of logo.png");
+    expect(workingImg.style.opacity).toBe("0.25");
+  });
+});

--- a/src/components/FileViewer/diffChangeSet.ts
+++ b/src/components/FileViewer/diffChangeSet.ts
@@ -1,0 +1,45 @@
+import type { GitStatus } from "@shared/types";
+
+/**
+ * One file of the changeset a diff modal was opened from. Leaf module (no
+ * component imports) so the sidebar, the modal, and its openers can all share
+ * the shape without creating an import cycle through FileDiffModal.
+ */
+export interface DiffChangeSetEntry {
+  /** Repo-relative path */
+  path: string;
+  status: GitStatus;
+  insertions?: number | null;
+  deletions?: number | null;
+  /**
+   * Caller-owned key for the viewed-marker store (scoped per worktree).
+   * Callers keep their existing conventions: `staged:{path}` /
+   * `unstaged:{path}` (Review Hub), `{status}:{path}` (change list),
+   * `base:{path}` (base-branch review).
+   */
+  viewedKey: string;
+}
+
+export const DIFF_STATUS_CONFIG: Record<GitStatus, { label: string; color: string }> = {
+  modified: { label: "M", color: "text-status-warning" },
+  added: { label: "A", color: "text-status-success" },
+  deleted: { label: "D", color: "text-status-error" },
+  untracked: { label: "?", color: "text-status-success" },
+  renamed: { label: "R", color: "text-status-info" },
+  copied: { label: "C", color: "text-status-info" },
+  ignored: { label: "I", color: "text-daintree-text/40" },
+  conflicted: { label: "!", color: "text-status-error" },
+};
+
+export function summarizeChangeSet(files: DiffChangeSetEntry[]): {
+  insertions: number;
+  deletions: number;
+} {
+  let insertions = 0;
+  let deletions = 0;
+  for (const file of files) {
+    insertions += file.insertions ?? 0;
+    deletions += file.deletions ?? 0;
+  }
+  return { insertions, deletions };
+}

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -716,6 +716,12 @@
   .diff-viewer .diff-gutter {
     border-right: 1px solid CanvasText;
   }
+  /* Split-view void cells: the hatch background is stripped to Canvas, so the
+     "nothing exists on this side" cue rides a dotted system-color edge. */
+  .diff-viewer .diff-code-omit {
+    background-image: none;
+    border-left: 1px dotted GrayText;
+  }
   /* Moved lines: the tinted fill and inset bar are stripped, so the cue rides
      a pattern change — dash the side edge the rules above draw solid. */
   .diff-viewer tr.diff-line-moved-old td.diff-code-delete,

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -13,7 +13,8 @@
 /* React-Diff-View Tokyo Night Theme Overrides */
 .diff-viewer {
   font-family: var(--font-mono);
-  font-size: 12px;
+  /* Set per-surface by the diff workspace's text-size control (S/M/L). */
+  font-size: var(--diff-font-size, 12px);
   line-height: 1.5;
 }
 
@@ -163,11 +164,21 @@
   color: var(--color-status-danger);
 }
 
-/* Split-view empty-side placeholders: dim the void so "nothing exists here"
-   reads differently from an unchanged blank line. */
+/* Split-view empty-side placeholders: a faint diagonal hatch (the classic
+   comparison-tool void pattern) so "nothing exists here" reads differently
+   from an unchanged blank line, in any theme and under grayscale. */
 .diff-viewer .diff-code-omit,
 .diff-viewer .diff-gutter-omit {
-  background: color-mix(in oklab, var(--color-daintree-sidebar) 45%, var(--color-daintree-bg));
+  background-color: color-mix(
+    in oklab,
+    var(--color-daintree-sidebar) 45%,
+    var(--color-daintree-bg)
+  );
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0 5px,
+    color-mix(in oklab, var(--color-daintree-border) 55%, transparent) 5px 6px
+  );
 }
 
 .diff-viewer .diff-gutter-omit::before {
@@ -238,7 +249,7 @@
 
 .light .diff-viewer .diff-code-omit,
 .light .diff-viewer .diff-gutter-omit {
-  background: color-mix(in oklab, var(--color-daintree-sidebar) 45%, var(--color-surface));
+  background-color: color-mix(in oklab, var(--color-daintree-sidebar) 45%, var(--color-surface));
 }
 
 /* Light edit pills consume the per-palette tokens (theme-engine owned, D1b

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -965,7 +965,20 @@ function FileDiff({
       {relPath && (
         <div className="sticky top-0 z-10 flex items-center justify-between px-3 py-1.5 bg-daintree-sidebar border-b border-daintree-border text-xs font-mono">
           <TruncatedTooltip content={relPath}>
-            <span className="truncate text-daintree-text/80">{relPath}</span>
+            <span className="truncate text-daintree-text/80">
+              {relPath.includes("/") ? (
+                <>
+                  <span className="text-daintree-text/45">
+                    {relPath.slice(0, relPath.lastIndexOf("/") + 1)}
+                  </span>
+                  <span className="text-daintree-text">
+                    {relPath.slice(relPath.lastIndexOf("/") + 1)}
+                  </span>
+                </>
+              ) : (
+                relPath
+              )}
+            </span>
           </TruncatedTooltip>
           {langLoadFailed && (
             <span

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FileChangeDetail, GitStatus } from "../../types";
+import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { cn } from "../../lib/utils";
 import { FileDiffModal } from "./FileDiffModal";
 import { Folder } from "lucide-react";
@@ -185,6 +186,30 @@ export function FileChangeList({
       return change ? { path: change.relativePath, status: change.status } : null;
     },
     [selectedIndex, sortedChanges]
+  );
+
+  // Changeset handed to the diff modal so it can render the review-workspace
+  // sidebar. Indexed identically to `selectedIndex`/`navigateFile`.
+  const diffChangeSet = useMemo(
+    (): DiffChangeSetEntry[] =>
+      sortedChanges.map((change) => ({
+        path: change.relativePath,
+        status: change.status,
+        insertions: change.insertions,
+        deletions: change.deletions,
+        viewedKey: `${change.status}:${change.relativePath}`,
+      })),
+    [sortedChanges]
+  );
+
+  const selectFileAt = useCallback(
+    (index: number) => {
+      const change = sortedChanges[index];
+      if (!change) return;
+      setSelectedFile({ path: change.relativePath, status: change.status });
+      setSelectedIndex(index);
+    },
+    [sortedChanges]
   );
 
   const groupedChanges = useMemo((): FolderGroup[] => {
@@ -377,6 +402,8 @@ export function FileChangeList({
           totalFileCount={sortedChanges.length}
           onNavigateFile={navigateFile}
           getAdjacentFile={getAdjacentFile}
+          changeSet={diffChangeSet}
+          onSelectFile={selectFileAt}
         />
       </>
     );
@@ -417,6 +444,8 @@ export function FileChangeList({
         totalFileCount={sortedChanges.length}
         onNavigateFile={navigateFile}
         getAdjacentFile={getAdjacentFile}
+        changeSet={diffChangeSet}
+        onSelectFile={selectFileAt}
       />
     </>
   );

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -51,6 +51,8 @@ interface FileChangeListProps {
   rootPath: string;
   groupByFolder?: boolean;
   isStale?: boolean;
+  /** Extra classes for the scroll container (surface, radius, padding). */
+  className?: string;
 }
 
 function splitPath(filePath: string): { dir: string; base: string } {
@@ -91,9 +93,9 @@ export function FileChangeList({
   rootPath,
   groupByFolder = false,
   isStale = false,
+  className,
 }: FileChangeListProps) {
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   // Plugin-contributed `file` context-menu items. Pulled once for the list; a
   // row is only wrapped in a ContextMenu when there are items, so a zero-plugin
   // file list keeps its existing flat-row DOM (no per-row trigger overhead).
@@ -179,6 +181,26 @@ export function FileChangeList({
     [sortedChanges, maxVisible]
   );
 
+  // Position of the open file, re-derived from the live list every render so
+  // a background refresh that re-sorts (churn ordering) can't strand the
+  // index on a different file. Falls back to path-only when the status
+  // changed under the open modal (e.g. untracked → added).
+  const selectedIndex = useMemo(() => {
+    if (!selectedFile) return null;
+    const exact = sortedChanges.findIndex(
+      (change) => change.relativePath === selectedFile.path && change.status === selectedFile.status
+    );
+    if (exact !== -1) return exact;
+    const byPath = sortedChanges.findIndex((change) => change.relativePath === selectedFile.path);
+    return byPath === -1 ? null : byPath;
+  }, [selectedFile, sortedChanges]);
+
+  // The modal's fetch subject follows the LIVE entry, not the open-time
+  // snapshot: a file whose status flips under the open modal (untracked →
+  // added, added → modified after an agent commit) must be re-fetched under
+  // its current status, or the diff renders in the wrong mode.
+  const liveSelected = selectedIndex !== null ? (sortedChanges[selectedIndex] ?? null) : null;
+
   const getAdjacentFile = useCallback(
     (delta: -1 | 1) => {
       if (selectedIndex === null) return null;
@@ -189,7 +211,10 @@ export function FileChangeList({
   );
 
   // Changeset handed to the diff modal so it can render the review-workspace
-  // sidebar. Indexed identically to `selectedIndex`/`navigateFile`.
+  // sidebar. Indexed identically to `selectedIndex`/`navigateFile`. Viewed
+  // keys are status-scoped (this list mixes staged and unstaged changes, so
+  // it can't use the Review Hub's `section:path` namespace); markers are
+  // invalidated wholesale when the hub commits (diffViewedStore.clearWorktree).
   const diffChangeSet = useMemo(
     (): DiffChangeSetEntry[] =>
       sortedChanges.map((change) => ({
@@ -207,7 +232,6 @@ export function FileChangeList({
       const change = sortedChanges[index];
       if (!change) return;
       setSelectedFile({ path: change.relativePath, status: change.status });
-      setSelectedIndex(index);
     },
     [sortedChanges]
   );
@@ -248,27 +272,22 @@ export function FileChangeList({
     if (!change) return;
     triggerElementRef.current = triggerEl;
     setSelectedFile({ path: change.relativePath, status: change.status });
-    setSelectedIndex(index);
   };
 
   const closeModal = () => {
     setSelectedFile(null);
-    setSelectedIndex(null);
   };
 
   const navigateFile = (delta: -1 | 1) => {
-    setSelectedIndex((current) => {
-      if (current === null) return current;
-      // Clamp against the live length first — a worktree refresh can shrink the
-      // set while the modal is open, leaving the index stale.
-      const safeCurrent = Math.min(current, sortedChanges.length - 1);
-      const next = Math.min(Math.max(safeCurrent + delta, 0), sortedChanges.length - 1);
-      const change = sortedChanges[next];
-      if (change) {
-        setSelectedFile({ path: change.relativePath, status: change.status });
-      }
-      return next;
-    });
+    // Clamp against the live length first — a worktree refresh can shrink the
+    // set while the modal is open, leaving the derived index stale.
+    if (selectedIndex === null) return;
+    const safeCurrent = Math.min(selectedIndex, sortedChanges.length - 1);
+    const next = Math.min(Math.max(safeCurrent + delta, 0), sortedChanges.length - 1);
+    const change = sortedChanges[next];
+    if (change) {
+      setSelectedFile({ path: change.relativePath, status: change.status });
+    }
   };
 
   const renderFileItem = (change: FileChangeWithRelativePath, showDir: boolean) => {
@@ -361,7 +380,13 @@ export function FileChangeList({
       <>
         <div
           className={cn(
-            "space-y-3 w-full max-h-64 overflow-y-auto overscroll-contain",
+            "space-y-3 w-full max-h-64 overscroll-contain",
+            className,
+            // After `className` so no caller can undo it: the rows' -mx-1.5
+            // hover bleed overflows the container, and with overflow-y set,
+            // `visible` on x computes to `auto` — a horizontal scrollbar. The
+            // container's padding absorbs the bleed; anything longer truncates.
+            "overflow-y-auto overflow-x-hidden",
             isStale && "surface-stale"
           )}
           aria-busy={isStale || undefined}
@@ -369,9 +394,9 @@ export function FileChangeList({
           {groupedChanges.map((group) => (
             <div key={group.dir}>
               <div className="flex items-center gap-1.5 text-[11px] text-daintree-text/40 mb-1">
-                <Folder className="w-3 h-3" />
-                <span className="font-mono">{group.displayDir}</span>
-                <span className="text-daintree-text/30">({group.files.length})</span>
+                <Folder className="w-3 h-3 shrink-0" />
+                <span className="min-w-0 truncate font-mono">{group.displayDir}</span>
+                <span className="shrink-0 text-daintree-text/30">({group.files.length})</span>
               </div>
               <div className="pl-4 flex flex-col gap-0.5">
                 {group.files.map((file) => renderFileItem(file, false))}
@@ -393,8 +418,8 @@ export function FileChangeList({
 
         <FileDiffModal
           isOpen={selectedFile !== null}
-          filePath={selectedFile?.path ?? ""}
-          status={selectedFile?.status ?? "modified"}
+          filePath={liveSelected?.relativePath ?? selectedFile?.path ?? ""}
+          status={liveSelected?.status ?? selectedFile?.status ?? "modified"}
           worktreePath={rootPath}
           onClose={closeModal}
           restoreFocusTo={triggerElementRef}
@@ -413,7 +438,10 @@ export function FileChangeList({
     <>
       <div
         className={cn(
-          "flex flex-col gap-0.5 w-full max-h-64 overflow-y-auto overscroll-contain",
+          "flex flex-col gap-0.5 w-full max-h-64 overscroll-contain",
+          className,
+          // Same post-className overflow guarantee as the grouped container.
+          "overflow-y-auto overflow-x-hidden",
           isStale && "surface-stale"
         )}
         aria-busy={isStale || undefined}
@@ -435,8 +463,8 @@ export function FileChangeList({
 
       <FileDiffModal
         isOpen={selectedFile !== null}
-        filePath={selectedFile?.path ?? ""}
-        status={selectedFile?.status ?? "modified"}
+        filePath={liveSelected?.relativePath ?? selectedFile?.path ?? ""}
+        status={liveSelected?.status ?? selectedFile?.status ?? "modified"}
         worktreePath={rootPath}
         onClose={closeModal}
         restoreFocusTo={triggerElementRef}

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, useEffect, useCallback, useState, useRef } from "react";
 import type { GitStatus } from "@shared/types";
+import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import type { RestoreFocusTarget } from "@/components/ui/AppDialog";
 import { actionService } from "@/services/ActionService";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
@@ -121,6 +122,10 @@ export interface FileDiffModalProps {
   onNavigateFile?: (delta: -1 | 1) => void;
   /** Resolve the neighboring file in the set, for prefetching its diff. */
   getAdjacentFile?: (delta: -1 | 1) => { path: string; status: GitStatus } | null;
+  /** Full changeset (indexed like `currentFileIndex`) — enables the review workspace. */
+  changeSet?: DiffChangeSetEntry[];
+  /** Jump directly to a file in `changeSet`. */
+  onSelectFile?: (index: number) => void;
 }
 
 export function FileDiffModal({
@@ -134,6 +139,8 @@ export function FileDiffModal({
   totalFileCount,
   onNavigateFile,
   getAdjacentFile,
+  changeSet,
+  onSelectFile,
 }: FileDiffModalProps) {
   const [diff, setDiff] = useState<string | undefined>(undefined);
   const requestRef = useRef(0);
@@ -232,6 +239,9 @@ export function FileDiffModal({
         currentFileIndex={currentFileIndex}
         totalFileCount={totalFileCount}
         onNavigateFile={onNavigateFile}
+        changeSet={changeSet}
+        onSelectFile={onSelectFile}
+        fileStatus={status}
       />
     </Suspense>
   );

--- a/src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx
+++ b/src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useState, useRef } from "react";
 import type { RestoreFocusTarget } from "@/components/ui/AppDialog";
 import { FileViewerModal } from "@/components/FileViewer/FileViewerModal";
+import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { useBranchForPath } from "@/hooks/useBranchForPath";
 import { usePreferencesStore } from "@/store/preferencesStore";
 
@@ -19,6 +20,10 @@ interface BaseBranchDiffModalProps {
   totalFileCount?: number;
   /** Step to the previous (-1) or next (1) file in the set. */
   onNavigateFile?: (delta: -1 | 1) => void;
+  /** Full changeset (indexed like `currentFileIndex`) — enables the review workspace. */
+  changeSet?: DiffChangeSetEntry[];
+  /** Jump directly to a file in `changeSet`. */
+  onSelectFile?: (index: number) => void;
 }
 
 export function BaseBranchDiffModal({
@@ -32,6 +37,8 @@ export function BaseBranchDiffModal({
   currentFileIndex,
   totalFileCount,
   onNavigateFile,
+  changeSet,
+  onSelectFile,
 }: BaseBranchDiffModalProps) {
   const [diff, setDiff] = useState<string | undefined>(undefined);
   const requestRef = useRef(0);
@@ -89,6 +96,8 @@ export function BaseBranchDiffModal({
       currentFileIndex={currentFileIndex}
       totalFileCount={totalFileCount}
       onNavigateFile={onNavigateFile}
+      changeSet={changeSet}
+      onSelectFile={onSelectFile}
     />
   );
 }

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -58,7 +58,7 @@ interface FileSectionProps {
     e: React.MouseEvent
   ) => void;
   onBulkAction: () => void;
-  viewedFiles: Set<string>;
+  viewedFiles: ReadonlySet<string>;
   onViewedChange: (viewedKey: string, viewed: boolean) => void;
   sectionRef?: Ref<HTMLDivElement>;
 }

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -826,6 +826,9 @@ export function ReviewHubContent({
       debouncedBgRefreshRef.current?.cancel();
       try {
         await window.electron.git.commit(worktreePath, message);
+        // A commit resets the review: anything still (or newly) changed after
+        // it is a new change, so stale viewed markers must not stick to it.
+        useDiffViewedStore.getState().clearWorktree(worktreePath);
         await refresh();
       } catch (err) {
         setActionError(formatErrorMessage(err, "Failed to commit changes"));
@@ -976,6 +979,8 @@ export function ReviewHubContent({
         setActionError(formatErrorMessage(err, "Failed to commit changes"));
         throw err;
       }
+      // Same review reset as handleCommit — the changeset starts over.
+      useDiffViewedStore.getState().clearWorktree(worktreePath);
       await refresh();
       await runPush();
     },
@@ -1782,7 +1787,16 @@ export function ReviewHubContent({
           <LazyFileDiffModal
             isOpen={selectedFile !== null}
             filePath={selectedFile?.path ?? ""}
-            status={selectedFile?.status ?? "modified"}
+            // Status follows the LIVE entry — a file whose status flips under
+            // the open modal (stage/unstage, agent commit) must be re-fetched
+            // under its current status, not the open-time snapshot.
+            status={
+              (selectedFileIndex !== null
+                ? navigableItems[selectedFileIndex]?.file.status
+                : undefined) ??
+              selectedFile?.status ??
+              "modified"
+            }
             worktreePath={worktreePath}
             onClose={() => setSelectedFile(null)}
             restoreFocusTo={diffTriggerRef}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -22,6 +22,8 @@ import { isProtectedBranch } from "@shared/utils/gitConstants";
 import { useUIStore } from "@/store/uiStore";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
+import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
+import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
@@ -151,11 +153,16 @@ export function ReviewHubContent({
     status: GitStatus;
     section: FileStageRowSection;
   } | null>(null);
-  // Session-scoped per-file Viewed indicator. Keys are `staged:{path}` or
+  // Session-scoped per-file Viewed indicator, shared with the diff
+  // workspace's sidebar through diffViewedStore so a file checked off in
+  // either surface reads as reviewed in both. Keys are `staged:{path}` or
   // `unstaged:{path}` so that the same path appearing in both sections (valid
-  // during partial staging) tracks Viewed independently. Resets on close and
-  // on ReviewHub unmount — intentional, this is not persisted.
-  const [viewedFiles, setViewedFiles] = useState<Set<string>>(() => new Set());
+  // during partial staging) tracks Viewed independently. Survives close and
+  // reopen within an app session; not persisted.
+  const viewedFiles = useDiffViewedStore(
+    useCallback((state) => selectViewedSet(state, worktreePath), [worktreePath])
+  );
+  const setStoreViewed = useDiffViewedStore((state) => state.setViewed);
   const [diffMode, setDiffMode] = useState<DiffMode>("working-tree");
   const [forcePushDialogOpen, setForcePushDialogOpen] = useState(false);
   const [pullRebaseConfirmOpen, setPullRebaseConfirmOpen] = useState(false);
@@ -325,6 +332,58 @@ export function ReviewHubContent({
     const byPath = navigableItems.findIndex((item) => item.file.path === selectedFile.path);
     return byPath === -1 ? null : byPath;
   }, [selectedFile, navigableItems]);
+
+  // Changesets handed to the diff modals so they can render the
+  // review-workspace sidebar. Indexed identically to the modal's
+  // `currentFileIndex`, and viewed keys match the hub's own conventions so
+  // markers stay in sync across both surfaces.
+  const workingTreeChangeSet = useMemo(
+    (): DiffChangeSetEntry[] =>
+      navigableItems.map((item) => ({
+        path: item.file.path,
+        status: item.file.status,
+        insertions: item.file.insertions,
+        deletions: item.file.deletions,
+        viewedKey: `${item.section}:${item.file.path}`,
+      })),
+    [navigableItems]
+  );
+
+  const selectWorkingTreeFileAt = useCallback(
+    (index: number) => {
+      const item = navigableItems[index];
+      if (!item) return;
+      setSelectedFile({ path: item.file.path, status: item.file.status, section: item.section });
+    },
+    [navigableItems]
+  );
+
+  const baseBranchChangeSet = useMemo((): DiffChangeSetEntry[] | undefined => {
+    if (!sortedBaseBranchFiles) return undefined;
+    const statusMap: Record<string, GitStatus> = {
+      A: "added",
+      D: "deleted",
+      M: "modified",
+      R: "renamed",
+      C: "copied",
+      U: "conflicted",
+    };
+    return sortedBaseBranchFiles.map((file) => ({
+      path: file.path,
+      status: statusMap[file.status] ?? "modified",
+      insertions: file.insertions,
+      deletions: file.deletions,
+      viewedKey: `base:${file.path}`,
+    }));
+  }, [sortedBaseBranchFiles]);
+
+  const selectBaseBranchFileAt = useCallback(
+    (index: number) => {
+      const file = sortedBaseBranchFiles?.[index];
+      if (file) setSelectedBaseBranchFile(file);
+    },
+    [sortedBaseBranchFiles]
+  );
 
   const lastSelectedFileIndexRef = useRef(0);
   useEffect(() => {
@@ -619,7 +678,7 @@ export function ReviewHubContent({
       setForcePushDialogOpen(false);
       setPullRebasing(false);
       isPullRebasingRef.current = false;
-      setViewedFiles(new Set());
+      // Viewed markers deliberately survive close/reopen (diffViewedStore).
       setSelectedPaths(new Set());
       setSelectionSection(null);
       selectionAnchorRef.current = null;
@@ -1091,14 +1150,12 @@ export function ReviewHubContent({
     [status, selectionSection]
   );
 
-  const handleViewedChange = useCallback((viewedKey: string, viewed: boolean) => {
-    setViewedFiles((prev) => {
-      const next = new Set(prev);
-      if (viewed) next.add(viewedKey);
-      else next.delete(viewedKey);
-      return next;
-    });
-  }, []);
+  const handleViewedChange = useCallback(
+    (viewedKey: string, viewed: boolean) => {
+      setStoreViewed(worktreePath, viewedKey, viewed);
+    },
+    [setStoreViewed, worktreePath]
+  );
 
   const handleDiffModeChange = useCallback(
     (mode: DiffMode) => {
@@ -1733,6 +1790,8 @@ export function ReviewHubContent({
             totalFileCount={navigableItems.length}
             onNavigateFile={navigateWorkingTreeFile}
             getAdjacentFile={getAdjacentWorkingTreeFile}
+            changeSet={workingTreeChangeSet}
+            onSelectFile={selectWorkingTreeFileAt}
           />
         </Suspense>
       )}
@@ -1751,6 +1810,8 @@ export function ReviewHubContent({
             currentFileIndex={selectedBaseBranchIndex ?? undefined}
             totalFileCount={sortedBaseBranchFiles?.length ?? 0}
             onNavigateFile={navigateBaseBranchFile}
+            changeSet={baseBranchChangeSet}
+            onSelectFile={selectBaseBranchFileAt}
           />
         </Suspense>
       )}

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.commitHistoryAndFileSelection.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.commitHistoryAndFileSelection.test.tsx
@@ -333,6 +333,7 @@ vi.mock("@/components/ui/EmptyState", () => ({
 import { ReviewHub } from "../ReviewHub";
 import { useUIStore } from "@/store/uiStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
+import { useDiffViewedStore } from "@/store/diffViewedStore";
 
 const WORKTREE_PATH = "/home/user/project";
 
@@ -390,6 +391,10 @@ describe("ReviewHub", () => {
     // #8025: reset the per-worktree push-confirm opt-out so a previous test
     // that pre-set it can't leak into the next one.
     usePreferencesStore.getState().setSkipPushConfirmForWorktree(WORKTREE_PATH, false);
+
+    // Viewed markers live in the shared diffViewedStore (they deliberately
+    // survive hub close/reopen), so tests must reset them explicitly.
+    useDiffViewedStore.setState({ viewedByWorktree: {} });
 
     worktreeStoreData.current = new Map([
       [
@@ -851,7 +856,10 @@ describe("ReviewHub", () => {
       expect(viewedCount).toBe(1);
     });
 
-    it("resets Viewed state when the modal closes and reopens", async () => {
+    it("keeps Viewed state when the modal closes and reopens", async () => {
+      // Viewed markers live in the shared diffViewedStore so an in-progress
+      // review survives closing the hub (and shows in the diff workspace's
+      // sidebar); only an app restart clears them.
       const { rerender } = render(
         <ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />
       );
@@ -866,9 +874,9 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByText("index.ts"));
 
       const reopened = screen.getByRole("checkbox", {
-        name: "Mark src/index.ts as viewed",
+        name: "Mark src/index.ts as not viewed",
       }) as HTMLInputElement;
-      expect(reopened.checked).toBe(false);
+      expect(reopened.checked).toBe(true);
     });
   });
 

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -181,16 +181,20 @@ export function WorktreeDetails({
             </div>
           )}
 
-          {/* Block 3: Artifacts (grouped file changes + system path) */}
+          {/* Block 3: Artifacts (grouped file changes + system path). The list
+              sits in a well painted the selected-worktree-card color
+              (`.sidebar-active-well`, sidebar.css) — a hairline carries the
+              shape on themes where that fill lands close to the panel's. */}
           {hasChanges && worktree.worktreeChanges && (
-            <div className="space-y-2">
-              <div className="text-xs font-medium text-text-secondary">Changed Files</div>
+            <div className="space-y-2.5">
+              <div className="px-2 text-xs font-medium text-text-secondary">Changed Files</div>
               <FileChangeList
                 changes={worktree.worktreeChanges.changes}
                 rootPath={worktree.worktreeChanges.rootPath}
                 maxVisible={MAX_VISIBLE_FILES}
                 groupByFolder={worktree.worktreeChanges.changedFileCount > 5}
                 isStale={isStale}
+                className="sidebar-active-well rounded-[var(--radius-md)] border border-border-subtle p-2"
               />
             </div>
           )}

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -33,7 +33,7 @@ import {
 import { X } from "lucide-react";
 import { Button } from "./button";
 
-type DialogSize = "sm" | "md" | "lg" | "4xl" | "5xl" | "6xl" | "7xl";
+type DialogSize = "sm" | "md" | "lg" | "4xl" | "5xl" | "6xl" | "7xl" | "workspace";
 type DialogVariant = "default" | "destructive" | "info";
 type DialogZIndex = "modal" | "nested";
 type DialogInitialFocus = "first" | "cancel" | "confirm" | "none";
@@ -102,6 +102,8 @@ const sizeClasses: Record<DialogSize, string> = {
   "5xl": "max-w-5xl",
   "6xl": "max-w-6xl",
   "7xl": "max-w-[min(96rem,92vw)]",
+  // App-scale surfaces (diff review workspace): near-full-window canvas.
+  workspace: "max-w-[min(110rem,95vw)]",
 };
 
 export function AppDialog({

--- a/src/components/ui/SegmentedToggle.tsx
+++ b/src/components/ui/SegmentedToggle.tsx
@@ -4,6 +4,8 @@ export interface SegmentedToggleOption<T extends string> {
   value: T;
   label: string;
   disabled?: boolean;
+  /** Screen-reader name when the visible label is an abbreviation (S/M/L). */
+  ariaLabel?: string;
 }
 
 /**
@@ -28,6 +30,7 @@ export function SegmentedToggle<T extends string>({
           type="button"
           onClick={() => onChange(option.value)}
           disabled={option.disabled}
+          aria-label={option.ariaLabel}
           aria-pressed={value === option.value}
           className={cn(
             "px-2.5 py-1 text-xs font-medium rounded transition-colors",

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -354,6 +354,13 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
       "Parent shows focus: the diff search bar wrapper has `focus-within:border-daintree-accent focus-within:ring-1`",
   },
   {
+    file: "src/components/FileViewer/DiffFileSidebar.tsx",
+    fragment:
+      "w-full bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
+    reason:
+      "Parent shows focus: the sidebar filter wrapper has `focus-within:border-daintree-accent focus-within:ring-1`",
+  },
+  {
     file: "src/panels/file/FilePane.tsx",
     fragment:
       "w-full bg-transparent text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",

--- a/src/store/__tests__/diffViewedStore.test.ts
+++ b/src/store/__tests__/diffViewedStore.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { useDiffViewedStore, selectViewedSet } from "../diffViewedStore";
+
+describe("diffViewedStore", () => {
+  beforeEach(() => {
+    useDiffViewedStore.setState({ viewedByWorktree: {} });
+  });
+
+  it("marks and unmarks keys per worktree", () => {
+    const { setViewed } = useDiffViewedStore.getState();
+    setViewed("/wt-a", "staged:src/a.ts", true);
+    setViewed("/wt-b", "staged:src/a.ts", true);
+
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt-a").has("staged:src/a.ts")).toBe(
+      true
+    );
+    setViewed("/wt-a", "staged:src/a.ts", false);
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt-a").has("staged:src/a.ts")).toBe(
+      false
+    );
+    // The other worktree's marker is untouched.
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt-b").has("staged:src/a.ts")).toBe(
+      true
+    );
+  });
+
+  it("toggleViewed flips membership", () => {
+    const { toggleViewed } = useDiffViewedStore.getState();
+    toggleViewed("/wt", "k");
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt").has("k")).toBe(true);
+    toggleViewed("/wt", "k");
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt").has("k")).toBe(false);
+  });
+
+  it("setViewed is a no-op state update when the value is unchanged", () => {
+    const { setViewed } = useDiffViewedStore.getState();
+    setViewed("/wt", "k", true);
+    const before = useDiffViewedStore.getState().viewedByWorktree;
+    setViewed("/wt", "k", true);
+    expect(useDiffViewedStore.getState().viewedByWorktree).toBe(before);
+  });
+
+  it("returns a stable empty set for unknown worktrees", () => {
+    const a = selectViewedSet(useDiffViewedStore.getState(), "/unknown-1");
+    const b = selectViewedSet(useDiffViewedStore.getState(), "/unknown-2");
+    expect(a.size).toBe(0);
+    expect(a).toBe(b);
+  });
+
+  it("clearWorktree drops only that worktree", () => {
+    const { setViewed, clearWorktree } = useDiffViewedStore.getState();
+    setViewed("/wt-a", "k", true);
+    setViewed("/wt-b", "k", true);
+    clearWorktree("/wt-a");
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt-a").size).toBe(0);
+    expect(selectViewedSet(useDiffViewedStore.getState(), "/wt-b").has("k")).toBe(true);
+  });
+});

--- a/src/store/diffViewedStore.ts
+++ b/src/store/diffViewedStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+
+/**
+ * Session-scoped "viewed" markers for changeset review, shared by the diff
+ * workspace sidebar and the Review Hub file list so a file checked off in one
+ * surface reads as reviewed in the other. Keys are caller-owned strings
+ * (Review Hub uses `staged:{path}` / `unstaged:{path}`; the worktree change
+ * list uses `{status}:{path}`; base-branch review uses `base:{path}`), scoped
+ * per worktree path. Deliberately not persisted: a fresh app session starts a
+ * fresh review.
+ */
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+interface DiffViewedState {
+  viewedByWorktree: Record<string, ReadonlySet<string>>;
+  setViewed: (worktreePath: string, key: string, viewed: boolean) => void;
+  toggleViewed: (worktreePath: string, key: string) => void;
+  clearWorktree: (worktreePath: string) => void;
+}
+
+export const useDiffViewedStore = create<DiffViewedState>((set) => ({
+  viewedByWorktree: {},
+  setViewed: (worktreePath, key, viewed) =>
+    set((state) => {
+      const current = state.viewedByWorktree[worktreePath] ?? EMPTY_SET;
+      if (current.has(key) === viewed) return state;
+      const next = new Set(current);
+      if (viewed) next.add(key);
+      else next.delete(key);
+      return { viewedByWorktree: { ...state.viewedByWorktree, [worktreePath]: next } };
+    }),
+  toggleViewed: (worktreePath, key) =>
+    set((state) => {
+      const current = state.viewedByWorktree[worktreePath] ?? EMPTY_SET;
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return { viewedByWorktree: { ...state.viewedByWorktree, [worktreePath]: next } };
+    }),
+  clearWorktree: (worktreePath) =>
+    set((state) => {
+      if (!(worktreePath in state.viewedByWorktree)) return state;
+      const { [worktreePath]: _removed, ...rest } = state.viewedByWorktree;
+      return { viewedByWorktree: rest };
+    }),
+}));
+
+/** Stable empty-set selector helper so components don't allocate per render. */
+export function selectViewedSet(state: DiffViewedState, worktreePath: string): ReadonlySet<string> {
+  return state.viewedByWorktree[worktreePath] ?? EMPTY_SET;
+}

--- a/src/store/diffViewedStore.ts
+++ b/src/store/diffViewedStore.ts
@@ -38,6 +38,10 @@ export const useDiffViewedStore = create<DiffViewedState>((set) => ({
       else next.add(key);
       return { viewedByWorktree: { ...state.viewedByWorktree, [worktreePath]: next } };
     }),
+  // Called on commit success (Review Hub) — a commit starts a new review, so
+  // stale markers must not stick to files that change again afterwards. Not
+  // wired to worktree deletion; leftover markers there are a few strings
+  // until app restart.
   clearWorktree: (worktreePath) =>
     set((state) => {
       if (!(worktreePath in state.viewedByWorktree)) return state;

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -9,6 +9,8 @@ export type DockDensity = "compact" | "normal" | "comfortable";
 // from the UI library.
 export type DiffViewType = "split" | "unified";
 
+export type DiffFontSize = "s" | "m" | "l";
+
 interface PreferencesState {
   showProjectPulse: boolean;
   setShowProjectPulse: (show: boolean) => void;
@@ -33,6 +35,11 @@ interface PreferencesState {
   setDiffWrapLines: (value: boolean) => void;
   diffIgnoreWhitespace: boolean;
   setDiffIgnoreWhitespace: (value: boolean) => void;
+  /** Show the changed-files sidebar in the diff workspace (multi-file review). */
+  diffShowFileList: boolean;
+  setDiffShowFileList: (value: boolean) => void;
+  diffFontSize: DiffFontSize;
+  setDiffFontSize: (value: DiffFontSize) => void;
   /** Soft-wrap long lines in markdown Source view (panel + file viewer). */
   markdownWrapLines: boolean;
   setMarkdownWrapLines: (value: boolean) => void;
@@ -51,6 +58,10 @@ function isDockDensity(value: unknown): value is DockDensity {
 
 function isDiffViewType(value: unknown): value is DiffViewType {
   return value === "split" || value === "unified";
+}
+
+function isDiffFontSize(value: unknown): value is DiffFontSize {
+  return value === "s" || value === "m" || value === "l";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -75,6 +86,8 @@ function sanitizePersistedPreferences(
   if (!isDiffViewType(sanitized.diffViewType)) sanitized.diffViewType = "split";
   if (typeof sanitized.diffWrapLines !== "boolean") sanitized.diffWrapLines = false;
   if (typeof sanitized.diffIgnoreWhitespace !== "boolean") sanitized.diffIgnoreWhitespace = false;
+  if (typeof sanitized.diffShowFileList !== "boolean") sanitized.diffShowFileList = true;
+  if (!isDiffFontSize(sanitized.diffFontSize)) sanitized.diffFontSize = "m";
   if (typeof sanitized.markdownWrapLines !== "boolean") sanitized.markdownWrapLines = true;
   if (typeof sanitized.showAgentTaskTitles !== "boolean") sanitized.showAgentTaskTitles = true;
 
@@ -116,6 +129,10 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDiffWrapLines: (value) => set({ diffWrapLines: value }),
       diffIgnoreWhitespace: false,
       setDiffIgnoreWhitespace: (value) => set({ diffIgnoreWhitespace: value }),
+      diffShowFileList: true,
+      setDiffShowFileList: (value) => set({ diffShowFileList: value }),
+      diffFontSize: "m",
+      setDiffFontSize: (value) => set({ diffFontSize: value }),
       markdownWrapLines: true,
       setMarkdownWrapLines: (value) => set({ markdownWrapLines: value }),
       lastSelectedWorktreeRecipeIdByProject: {},
@@ -149,7 +166,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     {
       name: "daintree-preferences",
       storage: createSafeJSONStorage(),
-      version: 11,
+      version: 12,
       // Runs on every hydration (unlike `migrate`, which Zustand skips when the
       // persisted version matches). Closed-set normalisation lives here so a
       // corrupt-but-parseable value is clamped even at the current version.
@@ -248,6 +265,10 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.showAgentTaskTitles = true;
           }
         }
+        if (version < 12 && isRecord(persisted)) {
+          if (typeof persisted.diffShowFileList !== "boolean") persisted.diffShowFileList = true;
+          if (!isDiffFontSize(persisted.diffFontSize)) persisted.diffFontSize = "m";
+        }
         return persisted as PreferencesState;
       },
     }
@@ -258,5 +279,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean> }",
 });

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -47,6 +47,18 @@
   background: var(--sidebar-hover-bg, rgba(255, 255, 255, 0.03));
 }
 
+/* The selected-card fill as a standalone opaque plane (the details panel's
+   Changed Files well). `--sidebar-active-bg` is a translucent lift on dark
+   themes, so it must composite over the sidebar surface — the same stack a
+   selected card renders on — or the color shifts with whatever's beneath. */
+.sidebar-active-well {
+  background-color: var(--theme-surface-sidebar);
+  background-image: linear-gradient(
+    var(--sidebar-active-bg, rgba(255, 255, 255, 0.05)),
+    var(--sidebar-active-bg, rgba(255, 255, 255, 0.05))
+  );
+}
+
 html[data-dragging="true"]
   .sidebar-worktree-card[data-hoverable="true"]:not([data-drop-target="true"]):hover,
 html[data-dragging="true"]


### PR DESCRIPTION
This is a fairly big change that turns our single-file diff modal into a multi-file review workspace. The design inspiration here is [Kaleidoscope](https://kaleidoscope.app/): reviewing a changeset should feel like working in a dedicated app, not peeking at one file at a time.

Single-file openers keep the classic modal. The workspace only kicks in when the opener hands over a full changeset.

## Multi-file changesets

When a user opens a diff from a multi-file changeset, they now get a sidebar with all the changed files:

- Total files changed and lines added/removed.
- Review progress, with a bar once the first file is marked viewed.
- A filter input (Escape clears the filter instead of closing the workspace).
- Files grouped by directory.
- Per-file viewed markers.

The workspace holds a fixed frame, so stepping between short and tall files doesn't resize the whole surface.

## Continuous change navigation

`n` and `p` step through changes, and they now flow past file boundaries. Pressing `n` on the last hunk of a file takes you to the first hunk of the next file, and hunkless files (binary, images) don't break the stream. `v` marks the current file viewed and advances to the next unviewed one. `[` and `]` still step files directly.

There was some genuinely fiddly work here around landing targets: the outgoing file's DOM can't satisfy a cross-file jump, and a stale index from a list reorder can't mark the wrong file as viewed.

## Viewed markers

Viewed state lives in a shared session store, so the workspace sidebar and the Review Hub file list stay in sync. Committing from the Review Hub clears the worktree's markers, since a commit starts a new review.

## Image compare

Changed images get a real compare view with Two-up, Swipe, and Onion skin modes, comparing `HEAD` against the working tree. This comes through a new `diffMedia` IPC namespace with the full hardening treatment: zod payload validation, path traversal and containment checks, `O_NOFOLLOW` plus an fd stat to close the FIFO race, LFS pointer detection, an 8 MB per-side cap, and its own rate budget.

## Other bits

- S/M/L text size preference for diffs, persisted.
- Breadcrumb file titles (muted directory, strong basename).
- Hatched void cells in split view, with a forced-colors substitute cue.

## Known gaps, out of scope on purpose

- Base-branch image review stays a static preview. Reusing the `HEAD` vs working tree compare there would be the wrong semantics, so it needs its own ref-aware path.
- Renamed images only show one side, since the changeset entries don't carry the old path yet.
- Commits made from a terminal don't clear viewed markers; only Review Hub commits do.
- The sidebar isn't virtualized. Fine up to a few hundred files, worth revisiting for monorepo-sized changesets.
- `FileViewerModal` is getting big and deserves a split into a workspace shell plus content body. That fits the existing oversized-file cleanup work.

## Testing

The full unit suite passes, including new suites for the `diffMedia` handler, the image viewer, `GitService.readFileAtHead`, and the workspace navigation. The covered E2E specs pass against the built app, and I drove the whole flow in the real app with screenshots to check the design.
