### PR TITLE
fix(ui): clear all tooltips on every dialog open and close

### DIFF
--- a/src/components/Layout/ResumeSessionsToolbarButton.tsx
+++ b/src/components/Layout/ResumeSessionsToolbarButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback } from "react";
 import { History } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -7,7 +7,6 @@ import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { actionService } from "@/services/ActionService";
-import { shortcutHintStore } from "@/store/shortcutHintStore";
 
 const RESUME_ACTION_ID = "terminal.resumeSessions" as const;
 const RESUME_LABEL = "Resume session";
@@ -24,52 +23,23 @@ export function ResumeSessionsToolbarButton({
   const ariaShortcut = useAriaKeyshortcuts(RESUME_ACTION_ID);
   const hover = useShortcutHintHover(RESUME_ACTION_ID);
 
-  // The launcher opens via dispatch and AppPaletteDialog imperatively restores
-  // focus to this button on close. Mirror ToolbarCommandPaletteButton: a
-  // controlled tooltip gated on the focus restore so it doesn't re-fire.
-  const [tooltipOpen, setTooltipOpen] = useState(false);
-  const isRestoringFocusRef = useRef(false);
-
-  const handleTooltipOpenChange = useCallback((open: boolean) => {
-    if (open && isRestoringFocusRef.current) return;
-    setTooltipOpen(open);
-  }, []);
-
-  const handlePointerEnter = useCallback(
-    (e: React.PointerEvent<HTMLButtonElement>) => {
-      isRestoringFocusRef.current = false;
-      hover.onPointerEnter(e);
-    },
-    [hover]
-  );
-
-  const handleFocus = useCallback(
-    (e: React.FocusEvent<HTMLButtonElement>) => {
-      if (isRestoringFocusRef.current) return;
-      hover.onFocus(e);
-    },
-    [hover]
-  );
-
+  // Tooltip and shortcut-hint teardown around the launcher's open/close is
+  // handled globally by AppPaletteDialog's overlay clearing and the shared
+  // focus-open suppression window (issue #11030) — no local suppression.
   const handleClick = useCallback(() => {
-    isRestoringFocusRef.current = true;
-    setTooltipOpen(false);
-    shortcutHintStore.getState().hide();
-    void actionService.dispatch(RESUME_ACTION_ID, undefined, { source: "user" }).finally(() => {
-      shortcutHintStore.getState().hide();
-    });
+    void actionService.dispatch(RESUME_ACTION_ID, undefined, { source: "user" });
   }, []);
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+        <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              onPointerEnter={handlePointerEnter}
+              onPointerEnter={hover.onPointerEnter}
               onPointerLeave={hover.onPointerLeave}
               onPointerDown={hover.onPointerDown}
-              onFocus={handleFocus}
+              onFocus={hover.onFocus}
               onBlur={hover.onBlur}
               variant="ghost"
               size="icon"

--- a/src/components/Layout/ToolbarCommandPaletteButton.tsx
+++ b/src/components/Layout/ToolbarCommandPaletteButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback } from "react";
 import { SquareMenu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -7,7 +7,6 @@ import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { actionService } from "@/services/ActionService";
-import { shortcutHintStore } from "@/store/shortcutHintStore";
 
 const PALETTE_ACTION_ID = "action.palette.open" as const;
 const PALETTE_LABEL = "Command palette";
@@ -24,66 +23,23 @@ export function ToolbarCommandPaletteButton({
   const ariaShortcut = useAriaKeyshortcuts(PALETTE_ACTION_ID);
   const hover = useShortcutHintHover(PALETTE_ACTION_ID);
 
-  // The action palette opens via dispatch and AppPaletteDialog imperatively
-  // restores focus to this button on close (see AppPaletteDialog.tsx:55-68).
-  // Without suppression the focus restore re-fires the Radix tooltip AND the
-  // shortcut hint's focus handler. Mirror the AgentButton / DockLaunchButton
-  // pattern: controlled tooltip, ref-gated open, cleared on the next genuine
-  // pointer hover.
-  const [tooltipOpen, setTooltipOpen] = useState(false);
-  const isRestoringFocusRef = useRef(false);
-
-  const handleTooltipOpenChange = useCallback((open: boolean) => {
-    if (open && isRestoringFocusRef.current) return;
-    setTooltipOpen(open);
-  }, []);
-
-  const handlePointerEnter = useCallback(
-    (e: React.PointerEvent<HTMLButtonElement>) => {
-      isRestoringFocusRef.current = false;
-      hover.onPointerEnter(e);
-    },
-    [hover]
-  );
-
-  const handleFocus = useCallback(
-    (e: React.FocusEvent<HTMLButtonElement>) => {
-      if (isRestoringFocusRef.current) return;
-      hover.onFocus(e);
-    },
-    [hover]
-  );
-
+  // Tooltip and shortcut-hint teardown around the palette's open/close is
+  // handled globally by AppPaletteDialog's overlay clearing and the shared
+  // focus-open suppression window (issue #11030) — no local suppression.
   const handleClick = useCallback(() => {
-    // Set suppression BEFORE dispatch so the focus restore that follows the
-    // palette's close (which targets this button via AppPaletteDialog's
-    // previousFocusRef) is rejected by handleTooltipOpenChange. Also tear
-    // down any in-flight tooltip / shortcut hint from hover dwell so they
-    // don't briefly reappear during the palette's enter animation.
-    isRestoringFocusRef.current = true;
-    setTooltipOpen(false);
-    shortcutHintStore.getState().hide();
-    // ActionService.emitShortcutHint fires after the action's run() and
-    // re-shows the shortcut hint at the recorded pointer (i.e. on top of
-    // the just-opened palette, because ShortcutHint sits at z-toast above
-    // z-modal). The user already saw the shortcut in this button's
-    // tooltip, so the post-dispatch hint is redundant — clear it once the
-    // dispatch chain settles.
-    void actionService.dispatch(PALETTE_ACTION_ID, undefined, { source: "user" }).finally(() => {
-      shortcutHintStore.getState().hide();
-    });
+    void actionService.dispatch(PALETTE_ACTION_ID, undefined, { source: "user" });
   }, []);
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+        <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              onPointerEnter={handlePointerEnter}
+              onPointerEnter={hover.onPointerEnter}
               onPointerLeave={hover.onPointerLeave}
               onPointerDown={hover.onPointerDown}
-              onFocus={handleFocus}
+              onFocus={hover.onFocus}
               onBlur={hover.onBlur}
               variant="ghost"
               size="icon"

--- a/src/components/Layout/__tests__/ToolbarCommandPaletteButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarCommandPaletteButton.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, render, fireEvent } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { ToolbarCommandPaletteButton } from "../ToolbarCommandPaletteButton";
 
 const dispatchMock = vi.fn<(...args: unknown[]) => Promise<{ ok: true; result: undefined }>>(() =>
@@ -12,13 +12,6 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
-const hideMock = vi.fn();
-vi.mock("@/store/shortcutHintStore", () => ({
-  shortcutHintStore: {
-    getState: () => ({ hide: hideMock }),
-  },
-}));
-
 const toggleButtonVisibilityMock = vi.fn();
 vi.mock("@/store/toolbarPreferencesStore", () => ({
   useToolbarPreferencesStore: (
@@ -26,22 +19,8 @@ vi.mock("@/store/toolbarPreferencesStore", () => ({
   ) => selector({ toggleButtonVisibility: toggleButtonVisibilityMock }),
 }));
 
-const tooltipOpenChangeSpy = vi.fn<(open: boolean) => void>();
-let lastTooltipOpen: boolean | undefined;
 vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({
-    children,
-    open,
-    onOpenChange,
-  }: {
-    children: React.ReactNode;
-    open?: boolean;
-    onOpenChange?: (open: boolean) => void;
-  }) => {
-    lastTooltipOpen = open;
-    if (onOpenChange) tooltipOpenChangeSpy.mockImplementation(onOpenChange);
-    return <>{children}</>;
-  },
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipContent: () => null,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -137,11 +116,8 @@ describe("ToolbarCommandPaletteButton", () => {
     dispatchMock.mockClear();
     dispatchMock.mockImplementation(() => Promise.resolve({ ok: true, result: undefined }));
     toggleButtonVisibilityMock.mockClear();
-    hideMock.mockClear();
     hoverFocusSpy.mockClear();
     hoverPointerEnterSpy.mockClear();
-    tooltipOpenChangeSpy.mockClear();
-    lastTooltipOpen = undefined;
   });
 
   it("renders with the command-palette aria-label and keyboard hint", () => {
@@ -168,75 +144,11 @@ describe("ToolbarCommandPaletteButton", () => {
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("command-palette", "right");
   });
 
-  it("tears down any active shortcut hint on click so the open palette doesn't sit beneath it", async () => {
-    const { container } = render(<ToolbarCommandPaletteButton />);
-    const button = container.querySelector(
-      'button[aria-label="Command palette"]'
-    ) as HTMLButtonElement;
-    await act(async () => {
-      fireEvent.click(button);
-    });
-    // Hide is called twice: once eagerly to clear any hover-dwell hint, and
-    // once after dispatch to clear the educational hint emitted by
-    // ActionService.emitShortcutHint (which would otherwise sit above the
-    // just-opened palette on z-toast).
-    expect(hideMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("closes an already-open tooltip on click before opening the palette", () => {
-    const { container } = render(<ToolbarCommandPaletteButton />);
-    const button = container.querySelector(
-      'button[aria-label="Command palette"]'
-    ) as HTMLButtonElement;
-
-    // Pointer-hover opens the tooltip via Radix's onOpenChange path.
-    fireEvent.pointerEnter(button);
-    act(() => {
-      tooltipOpenChangeSpy(true);
-    });
-    expect(lastTooltipOpen).toBe(true);
-
-    // Click should close the tooltip and dispatch the action — without this
-    // the tooltip lingers on top of the opening palette.
-    fireEvent.click(button);
-    expect(lastTooltipOpen).toBe(false);
-    expect(dispatchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("suppresses tooltip reopen during the AppPaletteDialog focus restore that follows a click", () => {
-    const { container } = render(<ToolbarCommandPaletteButton />);
-    const button = container.querySelector(
-      'button[aria-label="Command palette"]'
-    ) as HTMLButtonElement;
-
-    // Simulate the click that opens the palette. AppPaletteDialog will later
-    // restore focus to this button, which triggers Radix's open path.
-    fireEvent.click(button);
-    expect(lastTooltipOpen).toBe(false);
-
-    // The restored focus event hits the button before Radix reaches into
-    // onOpenChange. The shortcut hint's onFocus must be gated.
-    fireEvent.focus(button);
-    expect(hoverFocusSpy).not.toHaveBeenCalled();
-
-    // Radix attempts to open the tooltip when focus lands back on the button.
-    act(() => {
-      tooltipOpenChangeSpy(true);
-    });
-    // Suppression is engaged — Radix's open request is rejected.
-    expect(lastTooltipOpen).toBe(false);
-
-    // A genuine pointer enter clears suppression and lets the next open
-    // request through.
-    fireEvent.pointerEnter(button);
-    expect(hoverPointerEnterSpy).toHaveBeenCalledTimes(1);
-    act(() => {
-      tooltipOpenChangeSpy(true);
-    });
-    expect(lastTooltipOpen).toBe(true);
-  });
-
-  it("forwards focus and pointer-enter to the shortcut-hint hook in the normal (un-suppressed) path", () => {
+  // Tooltip and shortcut-hint teardown around the palette's open/close is
+  // now global (AppPaletteDialog overlay clearing + the shared focus-open
+  // suppression window, issue #11030) — covered by dialogOverlayClearing
+  // and Tooltip tests, so this component only forwards the hint handlers.
+  it("forwards focus and pointer-enter to the shortcut-hint hook", () => {
     const { container } = render(<ToolbarCommandPaletteButton />);
     const button = container.querySelector(
       'button[aria-label="Command palette"]'
@@ -247,9 +159,5 @@ describe("ToolbarCommandPaletteButton", () => {
 
     fireEvent.focus(button);
     expect(hoverFocusSpy).toHaveBeenCalledTimes(1);
-
-    // No dispatch occurred, so the store's hide() must not be called by
-    // hover alone — the hint store stays untouched.
-    expect(hideMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/LauncherQuickActions.tsx
+++ b/src/components/Terminal/LauncherQuickActions.tsx
@@ -3,7 +3,6 @@ import { SquareTerminal, Search } from "lucide-react";
 import { KbdChord } from "@/components/ui/Kbd";
 import { useEffectiveCombo, useAriaKeyshortcuts } from "@/hooks/useKeybinding";
 import { actionService } from "@/services/ActionService";
-import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { getLaunchOptions, type LaunchOption } from "@/components/TerminalPalette/launchOptions";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -56,15 +55,9 @@ function PaletteSearchButton() {
   const combo = useEffectiveCombo("panel.palette");
   const ariaKeyshortcuts = useAriaKeyshortcuts("panel.palette");
   const handleClick = () => {
-    // panel.palette opens a modal palette. Its post-dispatch shortcut hint
-    // (ShortcutHint sits at z-toast, above z-modal) would otherwise land on
-    // top of the just-opened palette and linger until its 2.5s auto-dismiss.
-    // Mirror the toolbar's palette/resume buttons and tear the hint down once
-    // the dispatch chain settles.
-    shortcutHintStore.getState().hide();
-    void actionService
-      .dispatch("panel.palette", undefined, { source: "user" })
-      .finally(() => shortcutHintStore.getState().hide());
+    // The palette's open transition clears the shortcut hint globally
+    // (AppPaletteDialog overlay clearing, issue #11030).
+    void actionService.dispatch("panel.palette", undefined, { source: "user" });
   };
   return (
     <button

--- a/src/components/Terminal/ResumeSessionLine.tsx
+++ b/src/components/Terminal/ResumeSessionLine.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { History } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import { actionService } from "@/services/ActionService";
-import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useAgentSessionRecords } from "@/hooks/useAgentSessionRecords";
@@ -37,13 +36,9 @@ export function ResumeSessionLine() {
   if (!hasLoaded || !primary) return null;
 
   const openLauncher = () => {
-    // Same as the toolbar resume button: terminal.resumeSessions opens a modal
-    // launcher, and the post-dispatch shortcut hint (z-toast, above z-modal)
-    // would otherwise sit on top of it. Clear it once the dispatch settles.
-    shortcutHintStore.getState().hide();
-    void actionService
-      .dispatch("terminal.resumeSessions", undefined, { source: "user" })
-      .finally(() => shortcutHintStore.getState().hide());
+    // The launcher's open transition clears the shortcut hint globally
+    // (AppPaletteDialog overlay clearing, issue #11030).
+    void actionService.dispatch("terminal.resumeSessions", undefined, { source: "user" });
   };
 
   return (

--- a/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
+++ b/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
@@ -7,10 +7,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 // (layout, which ids are built-in agents, and which buttons are visible) before
 // rendering.
 const h = vi.hoisted(() => ({
-  // dispatch returns a Promise so `.finally()` (the palette button's shortcut-
-  // hint teardown) has something to chain onto, matching the real signature.
+  // dispatch returns a Promise, matching the real signature.
   dispatch: vi.fn(() => Promise.resolve()),
-  hide: vi.fn(),
   avail: { availability: {} as Record<string, unknown> },
   options: [] as Array<{
     id: string;
@@ -62,9 +60,6 @@ vi.mock("@/hooks/useKeybinding", () => ({
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: h.dispatch },
 }));
-vi.mock("@/store/shortcutHintStore", () => ({
-  shortcutHintStore: { getState: () => ({ hide: h.hide }) },
-}));
 vi.mock("@/components/ui/Kbd", () => ({
   KbdChord: ({ shortcut }: { shortcut: string }) => <span data-testid="kbd">{shortcut}</span>,
 }));
@@ -73,7 +68,6 @@ import { LauncherQuickActions } from "../LauncherQuickActions";
 
 beforeEach(() => {
   h.dispatch.mockClear();
-  h.hide.mockClear();
   h.avail.availability = {};
   h.options = [
     { id: "claude", launchAgentId: "claude", label: "Claude", description: "", icon: null },
@@ -185,28 +179,10 @@ describe("LauncherQuickActions", () => {
     expect(h.dispatch).toHaveBeenCalledWith("panel.palette", undefined, { source: "user" });
   });
 
-  it("leaves the shortcut hint alone for a plain agent launch (no modal opens over it)", () => {
-    render(<LauncherQuickActions />);
-    fireEvent.click(screen.getByRole("button", { name: /Claude/i }));
-    expect(h.hide).not.toHaveBeenCalled();
-  });
-
-  it("clears the shortcut hint once the palette dispatch settles so it can't strand over the modal", async () => {
-    // Hold the dispatch open so the assertion proves the load-bearing teardown:
-    // the `.finally()` that runs AFTER dispatch (and thus after the shortcut
-    // hint is emitted) settles. The pre-dispatch clear alone would pass and mask
-    // a regression, so assert a hide fires only once the promise resolves.
-    let resolveDispatch: (() => void) | undefined;
-    h.dispatch.mockImplementationOnce(
-      () => new Promise<void>((resolve) => (resolveDispatch = () => resolve()))
-    );
-    render(<LauncherQuickActions />);
-    fireEvent.click(screen.getByRole("button", { name: /Search agents & panels/i }));
-    const hidesBeforeSettle = h.hide.mock.calls.length;
-    resolveDispatch?.();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(h.hide.mock.calls.length).toBeGreaterThan(hidesBeforeSettle);
-  });
+  // Shortcut-hint teardown around the palette open is now global — the
+  // palette's own open transition clears it (AppPaletteDialog overlay
+  // clearing, issue #11030) — so the palette button dispatches plainly,
+  // asserted above.
 
   it("exposes an agent's binding via aria-keyshortcuts, not its accessible name", () => {
     render(<LauncherQuickActions />);

--- a/src/components/Terminal/__tests__/ResumeSessionLine.test.tsx
+++ b/src/components/Terminal/__tests__/ResumeSessionLine.test.tsx
@@ -7,10 +7,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 const h = vi.hoisted(() => ({
   records: { sessions: [] as unknown[], hasLoaded: true },
   resumeFn: vi.fn(),
-  // dispatch returns a Promise so `.finally()` (the '+N more' button's
-  // shortcut-hint teardown) has something to chain onto, as it does for real.
+  // dispatch returns a Promise, matching the real signature.
   dispatch: vi.fn(() => Promise.resolve()),
-  hide: vi.fn(),
   items: { list: [] as Array<Record<string, unknown>> },
 }));
 
@@ -33,9 +31,6 @@ vi.mock("@/services/resumeSessionItems", () => ({
 }));
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: h.dispatch },
-}));
-vi.mock("@/store/shortcutHintStore", () => ({
-  shortcutHintStore: { getState: () => ({ hide: h.hide }) },
 }));
 vi.mock("@/components/PanelPalette/PanelKindIcon", () => ({
   PanelKindIcon: () => <span data-testid="panel-icon" />,
@@ -61,7 +56,6 @@ beforeEach(() => {
   h.items.list = [];
   h.resumeFn.mockClear();
   h.dispatch.mockClear();
-  h.hide.mockClear();
 });
 
 describe("ResumeSessionLine", () => {
@@ -91,28 +85,17 @@ describe("ResumeSessionLine", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("offers a '+N more' browse entry into the resume launcher", async () => {
+  it("offers a '+N more' browse entry into the resume launcher", () => {
     h.items.list = [makeItem("s1", "Resume Claude"), makeItem("s2", "Resume Codex")];
-    // Hold the dispatch open so the hide assertion proves the load-bearing
-    // `.finally()` teardown (fired after the shortcut hint is emitted), not just
-    // the pre-dispatch clear.
-    let resolveDispatch: (() => void) | undefined;
-    h.dispatch.mockImplementationOnce(
-      () => new Promise<void>((resolve) => (resolveDispatch = () => resolve()))
-    );
     render(<ResumeSessionLine />);
     const more = screen.getByRole("button", { name: /browse 1 more resumable session/i });
     fireEvent.click(more);
+    // Shortcut-hint teardown around the launcher open is now global — the
+    // launcher's own open transition clears it (AppPaletteDialog overlay
+    // clearing, issue #11030) — so the button dispatches plainly.
     expect(h.dispatch).toHaveBeenCalledWith("terminal.resumeSessions", undefined, {
       source: "user",
     });
-    // The launcher opens as a modal; the teaching shortcut hint sits above it,
-    // so opening it must tear the hint down once dispatch settles (mirrors the
-    // toolbar resume button).
-    const hidesBeforeSettle = h.hide.mock.calls.length;
-    resolveDispatch?.();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(h.hide.mock.calls.length).toBeGreaterThan(hidesBeforeSettle);
   });
 
   it("does not show '+N more' when there is only one session", () => {

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -63,7 +63,15 @@ export function IssueBadge({
   const showPausedGlyph = freshnessCause === "rate-limit" && !missingCredential;
 
   return (
-    <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300} autoDismiss={false}>
+    <Tooltip
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      delayDuration={300}
+      autoDismiss={false}
+      // Rich hover card whose body IS the content — exempt from the global
+      // dialog-transition dismissal (issue #11030).
+      dismissOnDialogTransition={false}
+    >
       <TooltipTrigger asChild>
         <button
           type="button"

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -111,7 +111,15 @@ export function PRBadge({
   const freshness: TooltipFreshness = { cause: freshnessCause, now, rateLimitResetAt };
 
   return (
-    <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300} autoDismiss={false}>
+    <Tooltip
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      delayDuration={300}
+      autoDismiss={false}
+      // Rich hover card whose body IS the content — exempt from the global
+      // dialog-transition dismissal (issue #11030).
+      dismissOnDialogTransition={false}
+    >
       <TooltipTrigger asChild>
         <button
           type="button"

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -21,6 +21,7 @@ import {
   markBackstopConsumedEscape,
 } from "@/lib/dialogEscapeBackstop";
 import { usePortalStore } from "@/store";
+import { clearDialogOverlays } from "@/lib/dialogOverlayDismissal";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import {
@@ -149,6 +150,11 @@ export function AppDialog({
     const el = previousActiveElement.current;
     previousActiveElement.current = null;
     if (!el) return;
+    // Re-arm the tooltip focus-open suppression right before the focus
+    // move: focusing a tooltip trigger re-opens its tooltip synchronously
+    // through Radix's focus path, and this runs an exit animation after
+    // the close-transition clear already fired (issue #11030).
+    clearDialogOverlays();
     if (document.contains(el)) {
       el.focus();
       return;
@@ -175,6 +181,18 @@ export function AppDialog({
   });
 
   useOverlayState(isOpen || shouldRender);
+
+  // Clear stranded tooltips and shortcut hints on every open and close
+  // transition (issue #11030): on open before the RAF-deferred autofocus
+  // below fires, on close before the exit animation finishes. Transition-
+  // guarded because most dialogs stay mounted with isOpen=false — a bare
+  // effect would dismiss unrelated tooltips whenever one mounts.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (isOpen === wasOpenRef.current) return;
+    wasOpenRef.current = isOpen;
+    clearDialogOverlays();
+  }, [isOpen]);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -57,14 +57,15 @@ export function AppPaletteDialog({
     const el = previousFocusRef.current;
     previousFocusRef.current = null;
     if (!el) return;
+    // Palette-to-palette handoff: the next palette will install its
+    // own focus, so skip restore entirely — and skip the overlay clear
+    // below, which would wipe overlays the incoming palette owns.
+    if (usePaletteStore.getState().activePaletteId) return;
     // Re-arm the tooltip focus-open suppression right before the focus
     // move: focusing a tooltip trigger re-opens its tooltip synchronously
     // through Radix's focus path, and this runs an exit animation after
     // the close-transition clear already fired (issue #11030).
     clearDialogOverlays();
-    // Palette-to-palette handoff: the next palette will install its
-    // own focus, so skip restore entirely.
-    if (usePaletteStore.getState().activePaletteId) return;
     if (document.contains(el)) {
       el.focus();
       return;

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -21,6 +21,7 @@ import {
   markBackstopConsumedEscape,
 } from "@/lib/dialogEscapeBackstop";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
+import { clearDialogOverlays } from "@/lib/dialogOverlayDismissal";
 import { usePaletteStore } from "@/store/paletteStore";
 import {
   UI_PALETTE_ENTER_DURATION,
@@ -56,6 +57,11 @@ export function AppPaletteDialog({
     const el = previousFocusRef.current;
     previousFocusRef.current = null;
     if (!el) return;
+    // Re-arm the tooltip focus-open suppression right before the focus
+    // move: focusing a tooltip trigger re-opens its tooltip synchronously
+    // through Radix's focus path, and this runs an exit animation after
+    // the close-transition clear already fired (issue #11030).
+    clearDialogOverlays();
     // Palette-to-palette handoff: the next palette will install its
     // own focus, so skip restore entirely.
     if (usePaletteStore.getState().activePaletteId) return;
@@ -74,6 +80,18 @@ export function AppPaletteDialog({
   });
 
   useOverlayState(isOpen || shouldRender);
+
+  // Clear stranded tooltips and shortcut hints on every open and close
+  // transition (issue #11030): on open before the RAF-deferred autofocus
+  // below fires, on close before the exit animation finishes. Transition-
+  // guarded because palettes stay mounted with isOpen=false — a bare
+  // effect would dismiss unrelated tooltips whenever one mounts.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (isOpen === wasOpenRef.current) return;
+    wasOpenRef.current = isOpen;
+    clearDialogOverlays();
+  }, [isOpen]);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/src/components/ui/__tests__/Tooltip.test.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FixedDropdownVisibleContext } from "../fixed-dropdown";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../tooltip";
+import { _resetForTests, dismissAllTooltips } from "@/lib/tooltipDismissRegistry";
 
 const { rootSpy, mountSpy, primeOnEventSpy, contentSpy } = vi.hoisted(() => ({
   rootSpy: vi.fn<(props: { open?: boolean; onOpenChange?: (open: boolean) => void }) => void>(),
@@ -301,6 +302,171 @@ describe("Tooltip wrapper — auto-dismiss window", () => {
 
     void act(() => vi.runAllTimers());
     expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+});
+
+describe("Tooltip wrapper — dialog-transition dismissal (issue #11030)", () => {
+  beforeEach(() => {
+    rootSpy.mockClear();
+    _resetForTests();
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  function openLastRoot() {
+    const call = rootSpy.mock.calls.at(-1)?.[0];
+    void act(() => call!.onOpenChange!(true));
+  }
+
+  it("force-closes an open uncontrolled tooltip on dismissAllTooltips", () => {
+    render(
+      <Tooltip>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+
+    void act(() => dismissAllTooltips());
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+
+  it("force-closes an autoDismiss={false} tooltip (the FileChangeList row case)", () => {
+    // The offending file-row tooltip opts out of the timed auto-dismiss so
+    // long paths get full read time — the dialog-transition dismissal must
+    // still close it, or nothing ever does.
+    render(
+      <Tooltip autoDismiss={false}>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+
+    void act(() => dismissAllTooltips());
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+
+  it("notifies a controlled consumer through onOpenChange", () => {
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <Tooltip open={open} onOpenChange={setOpen}>
+          <TooltipTrigger>trigger</TooltipTrigger>
+          <TooltipContent>content</TooltipContent>
+        </Tooltip>
+      );
+    }
+    render(<Harness />);
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+
+    void act(() => dismissAllTooltips());
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+
+  it("leaves a pinned `open` without an onOpenChange handler alone (escape hatch)", () => {
+    render(
+      <Tooltip open={true}>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    void act(() => dismissAllTooltips());
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+  });
+
+  it("does not close a dismissOnDialogTransition={false} rich hover card", () => {
+    render(
+      <Tooltip autoDismiss={false} dismissOnDialogTransition={false}>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    openLastRoot();
+    void act(() => dismissAllTooltips());
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+  });
+
+  it("ignores opens during the post-dismissal suppression window", () => {
+    // Focus restoration after a dialog closes re-opens tooltips through
+    // Radix's focus path — the open request lands right after the dismiss
+    // and must be dropped.
+    render(
+      <Tooltip>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    void act(() => dismissAllTooltips());
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+
+  it("lets a genuine pointer entry end suppression and open again", () => {
+    const { getByTestId } = render(
+      <Tooltip>
+        <TooltipTrigger data-testid="trigger">trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    void act(() => dismissAllTooltips());
+    fireEvent.pointerEnter(getByTestId("trigger"));
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+  });
+
+  it("exempt tooltips ignore the suppression window entirely", () => {
+    render(
+      <Tooltip dismissOnDialogTransition={false}>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    void act(() => dismissAllTooltips());
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+  });
+
+  it("still dismisses after a StrictMode double-mount cycle", () => {
+    // StrictMode's dev mount→unmount→mount must leave exactly one live
+    // registration whose callback reads current state through refs.
+    render(
+      <React.StrictMode>
+        <Tooltip>
+          <TooltipTrigger>trigger</TooltipTrigger>
+          <TooltipContent>content</TooltipContent>
+        </Tooltip>
+      </React.StrictMode>
+    );
+
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+
+    void act(() => dismissAllTooltips());
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+
+  it("unregisters on unmount", () => {
+    const { unmount } = render(
+      <Tooltip>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    unmount();
+    expect(() => dismissAllTooltips()).not.toThrow();
   });
 });
 

--- a/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/src/components/ui/__tests__/Tooltip.test.tsx
@@ -425,6 +425,39 @@ describe("Tooltip wrapper — dialog-transition dismissal (issue #11030)", () =>
     expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
   });
 
+  it("lets a pointer move on the trigger end suppression (pointer resting through the transition)", () => {
+    // Radix opens from pointermove, so a pointer already resting on the
+    // trigger re-earns tooltips on its next micro-move without needing a
+    // fresh pointerenter.
+    const { getByTestId } = render(
+      <Tooltip>
+        <TooltipTrigger data-testid="trigger">trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    void act(() => dismissAllTooltips());
+    fireEvent.pointerMove(getByTestId("trigger"), { pointerType: "mouse" });
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(true);
+  });
+
+  it("ignores touch pointer moves for suppression clearing", () => {
+    // Touch moves never open Radix tooltips — they must not count as hover
+    // intent that re-enables focus opens.
+    const { getByTestId } = render(
+      <Tooltip>
+        <TooltipTrigger data-testid="trigger">trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+
+    void act(() => dismissAllTooltips());
+    fireEvent.pointerMove(getByTestId("trigger"), { pointerType: "touch" });
+    openLastRoot();
+    expect(rootSpy.mock.calls.at(-1)?.[0]?.open).toBe(false);
+  });
+
   it("exempt tooltips ignore the suppression window entirely", () => {
     render(
       <Tooltip dismissOnDialogTransition={false}>

--- a/src/components/ui/__tests__/dialogOverlayClearing.test.tsx
+++ b/src/components/ui/__tests__/dialogOverlayClearing.test.tsx
@@ -3,7 +3,7 @@
 // tooltips and the ShortcutHint teaching overlay — on every open and close
 // transition, and arm the tooltip focus-open suppression window so the
 // focus moves they perform can't re-open a tooltip (issue #11030).
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppDialog } from "../AppDialog";
 import { AppPaletteDialog } from "../AppPaletteDialog";
@@ -30,6 +30,13 @@ vi.mock("@/hooks", async (importOriginal) => {
   };
 });
 
+// Capture onAnimateOut instead of invoking it, so the close-transition
+// tests observe the transition effect in isolation and the restore-focus
+// test drives the (real-world: exit-animation-deferred) path explicitly.
+const captured = vi.hoisted(() => ({
+  onAnimateOut: undefined as (() => void) | undefined,
+}));
+
 vi.mock("@/hooks/useAnimatedPresence", () => ({
   useAnimatedPresence: ({
     isOpen,
@@ -38,9 +45,7 @@ vi.mock("@/hooks/useAnimatedPresence", () => ({
     isOpen: boolean;
     onAnimateOut?: () => void;
   }) => {
-    // The exit path runs onAnimateOut synchronously when isOpen is false —
-    // close enough to the real timing for the restore-focus clearing path.
-    if (!isOpen && onAnimateOut) onAnimateOut();
+    captured.onAnimateOut = onAnimateOut;
     return { isVisible: isOpen, shouldRender: isOpen };
   },
 }));
@@ -150,6 +155,23 @@ describe.each(harnesses)("$name overlay clearing (issue #11030)", ({ node }) => 
     expect(shortcutHintStore.getState().activeHint).toBeNull();
     // The suppression window must be armed so the focus restore that
     // follows can't re-open a tooltip through Radix's focus path.
+    expect(isTooltipFocusOpenSuppressed()).toBe(true);
+  });
+
+  it("re-arms suppression from the restore-focus path after the exit animation", () => {
+    const { rerender } = render(node(true));
+    rerender(node(false));
+    // Drop the state the transitions armed so the assertions isolate the
+    // restore-focus clear, which runs a full exit animation later.
+    resetTooltipRegistry();
+    const dismissSpy = vi.fn();
+    registerTooltipDismiss(dismissSpy);
+    showHint();
+
+    act(() => captured.onAnimateOut?.());
+
+    expect(dismissSpy).toHaveBeenCalled();
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
     expect(isTooltipFocusOpenSuppressed()).toBe(true);
   });
 });

--- a/src/components/ui/__tests__/dialogOverlayClearing.test.tsx
+++ b/src/components/ui/__tests__/dialogOverlayClearing.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+// Both dialog primitives clear stranded overlays — registered Radix
+// tooltips and the ShortcutHint teaching overlay — on every open and close
+// transition, and arm the tooltip focus-open suppression window so the
+// focus moves they perform can't re-open a tooltip (issue #11030).
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppDialog } from "../AppDialog";
+import { AppPaletteDialog } from "../AppPaletteDialog";
+import {
+  _resetForTests as resetTooltipRegistry,
+  isTooltipFocusOpenSuppressed,
+  registerTooltipDismiss,
+} from "@/lib/tooltipDismissRegistry";
+import { shortcutHintStore } from "@/store/shortcutHintStore";
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useOverlayState: () => {},
+  };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({
+    isOpen,
+    onAnimateOut,
+  }: {
+    isOpen: boolean;
+    onAnimateOut?: () => void;
+  }) => {
+    // The exit path runs onAnimateOut synchronously when isOpen is false —
+    // close enough to the real timing for the restore-focus clearing path.
+    if (!isOpen && onAnimateOut) onAnimateOut();
+    return { isVisible: isOpen, shouldRender: isOpen };
+  },
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function showHint() {
+  shortcutHintStore.getState().show("test.action", "Cmd+K", { x: 10, y: 20 });
+}
+
+const harnesses = [
+  {
+    name: "AppDialog",
+    node: (isOpen: boolean) => (
+      <AppDialog isOpen={isOpen} onClose={() => {}}>
+        <AppDialog.Body>
+          <button type="button">inside</button>
+        </AppDialog.Body>
+      </AppDialog>
+    ),
+  },
+  {
+    name: "AppPaletteDialog",
+    node: (isOpen: boolean) => (
+      <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel="Test palette">
+        <input type="text" placeholder="Palette input" />
+      </AppPaletteDialog>
+    ),
+  },
+];
+
+describe.each(harnesses)("$name overlay clearing (issue #11030)", ({ node }) => {
+  beforeEach(() => {
+    resetTooltipRegistry();
+    shortcutHintStore.getState().hide();
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener() {},
+        removeEventListener() {},
+      })
+    );
+  });
+
+  afterEach(() => {
+    resetTooltipRegistry();
+    shortcutHintStore.getState().hide();
+  });
+
+  it("does not clear overlays when mounted closed", () => {
+    // Most dialogs stay mounted with isOpen=false — mounting one must not
+    // dismiss unrelated tooltips or hints elsewhere in the app.
+    const dismissSpy = vi.fn();
+    registerTooltipDismiss(dismissSpy);
+    showHint();
+
+    render(node(false));
+
+    expect(dismissSpy).not.toHaveBeenCalled();
+    expect(shortcutHintStore.getState().activeHint).not.toBeNull();
+  });
+
+  it("clears tooltips and the shortcut hint on the open transition", () => {
+    const dismissSpy = vi.fn();
+    registerTooltipDismiss(dismissSpy);
+    showHint();
+    const { rerender } = render(node(false));
+    expect(dismissSpy).not.toHaveBeenCalled();
+
+    rerender(node(true));
+
+    expect(dismissSpy).toHaveBeenCalled();
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("clears overlays when mounted already open", () => {
+    const dismissSpy = vi.fn();
+    registerTooltipDismiss(dismissSpy);
+    showHint();
+
+    render(node(true));
+
+    expect(dismissSpy).toHaveBeenCalled();
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("clears overlays again on the close transition and arms focus-open suppression", () => {
+    const { rerender } = render(node(true));
+    // Drop the suppression the open transition armed so the assertion below
+    // observes the close transition's own arming.
+    resetTooltipRegistry();
+    const dismissSpy = vi.fn();
+    registerTooltipDismiss(dismissSpy);
+    showHint();
+
+    rerender(node(false));
+
+    expect(dismissSpy).toHaveBeenCalled();
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+    // The suppression window must be armed so the focus restore that
+    // follows can't re-open a tooltip through Radix's focus path.
+    expect(isTooltipFocusOpenSuppressed()).toBe(true);
+  });
+});

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -167,7 +167,16 @@ const TooltipTrigger = React.forwardRef<
   TooltipTriggerProps
 >(
   (
-    { asChild, children, onPointerEnter, onPointerDown, onPointerUp, onFocusCapture, ...props },
+    {
+      asChild,
+      children,
+      onPointerEnter,
+      onPointerMove,
+      onPointerDown,
+      onPointerUp,
+      onFocusCapture,
+      ...props
+    },
     ref
   ) => {
     const radix = useRadixPrimitives();
@@ -188,6 +197,14 @@ const TooltipTrigger = React.forwardRef<
       notifyTooltipPointerActivity();
       primeOnEvent();
       onPointerEnter?.(event);
+    };
+    const handlePointerMove: React.PointerEventHandler<HTMLButtonElement> = (event) => {
+      // Radix opens tooltips from pointermove (not pointerenter), so clear
+      // suppression here too — covers a pointer already resting on the
+      // trigger whose next micro-move should open normally. Touch moves
+      // never open Radix tooltips, so they don't count as hover intent.
+      if (event.pointerType !== "touch") notifyTooltipPointerActivity();
+      onPointerMove?.(event);
     };
     const handlePointerDown: React.PointerEventHandler<HTMLButtonElement> = (event) => {
       pointerActiveRef.current = true;
@@ -215,6 +232,7 @@ const TooltipTrigger = React.forwardRef<
           <Slot
             ref={ref}
             onPointerEnter={handlePointerEnter}
+            onPointerMove={handlePointerMove}
             onPointerDown={handlePointerDown}
             onPointerUp={handlePointerUp}
             onFocusCapture={handleFocusCapture}
@@ -229,6 +247,7 @@ const TooltipTrigger = React.forwardRef<
           type="button"
           ref={ref as React.Ref<HTMLButtonElement>}
           onPointerEnter={handlePointerEnter}
+          onPointerMove={handlePointerMove}
           onPointerDown={handlePointerDown}
           onPointerUp={handlePointerUp}
           onFocusCapture={handleFocusCapture}
@@ -245,6 +264,7 @@ const TooltipTrigger = React.forwardRef<
         ref={ref}
         asChild={asChild}
         onPointerEnter={handlePointerEnter}
+        onPointerMove={handlePointerMove}
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
         onFocusCapture={handleFocusCapture}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -5,6 +5,11 @@ import { cn } from "@/lib/utils";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { FixedDropdownVisibleContext } from "./fixed-dropdown";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
+import {
+  isTooltipFocusOpenSuppressed,
+  notifyTooltipPointerActivity,
+  registerTooltipDismiss,
+} from "@/lib/tooltipDismissRegistry";
 
 type TooltipProviderProps = React.ComponentProps<typeof TooltipPrimitiveType.Provider>;
 
@@ -34,6 +39,14 @@ const TOOLTIP_AUTO_DISMISS_MS = 2500;
 
 type TooltipProps = TooltipRootProps & {
   autoDismiss?: boolean;
+  /**
+   * When true (default), this tooltip closes on every dialog open/close
+   * transition (issue #11030) and honors the brief focus-open suppression
+   * window that follows. Rich hover cards whose body IS the content
+   * (IssueBadge, PRBadge) opt out with `false` — they are fully exempt
+   * from both the forced close and the suppression.
+   */
+  dismissOnDialogTransition?: boolean;
 };
 
 const Tooltip = ({
@@ -42,6 +55,7 @@ const Tooltip = ({
   defaultOpen,
   onOpenChange,
   autoDismiss = true,
+  dismissOnDialogTransition = true,
   ...props
 }: TooltipProps) => {
   const radix = useRadixPrimitives();
@@ -70,10 +84,38 @@ const Tooltip = ({
     onOpenChangeRef.current = onOpenChange;
   });
 
-  const handleOpenChange = React.useCallback((next: boolean) => {
-    setManagedOpen(next);
-    onOpenChangeRef.current?.(next);
-  }, []);
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      // Focus restoration after a dialog transition re-opens tooltips
+      // through Radix's focus path with nothing hovered. Ignore opens
+      // during the post-dismiss suppression window; genuine hovers are
+      // unaffected because pointerenter on any trigger clears it first.
+      if (next && dismissOnDialogTransition && isTooltipFocusOpenSuppressed()) return;
+      setManagedOpen(next);
+      onOpenChangeRef.current?.(next);
+    },
+    [dismissOnDialogTransition]
+  );
+
+  // Mirror of the rendered open state for the dismiss callback, which must
+  // read it post-commit without re-registering on every open/close.
+  const effectiveOpenRef = React.useRef(false);
+  React.useEffect(() => {
+    effectiveOpenRef.current = effectiveOpen;
+  });
+
+  // Register with the global dismiss registry so dialog transitions can
+  // force-close this tooltip (issue #11030). The callback is a stable
+  // closure over refs, so StrictMode's mount→unmount→mount cycle
+  // registers and unregisters cleanly without stale state.
+  React.useEffect(() => {
+    if (!dismissOnDialogTransition) return;
+    return registerTooltipDismiss(() => {
+      if (!effectiveOpenRef.current) return;
+      setManagedOpen(false);
+      onOpenChangeRef.current?.(false);
+    });
+  }, [dismissOnDialogTransition]);
 
   // Fixed display window: each open transition arms the dismiss timer; a
   // close (pointer leave, Escape, click) clears it via the effect cleanup.
@@ -141,6 +183,9 @@ const TooltipTrigger = React.forwardRef<
     const pointerActiveRef = React.useRef(false);
 
     const handlePointerEnter: React.PointerEventHandler<HTMLButtonElement> = (event) => {
+      // A real hover ends the post-dialog-transition focus-open
+      // suppression — the user is pointing, so tooltips are wanted again.
+      notifyTooltipPointerActivity();
       primeOnEvent();
       onPointerEnter?.(event);
     };

--- a/src/hooks/__tests__/useShortcutHintHover.test.ts
+++ b/src/hooks/__tests__/useShortcutHintHover.test.ts
@@ -3,6 +3,11 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useShortcutHintHover } from "../useShortcutHintHover";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
+import {
+  _resetForTests as resetTooltipRegistry,
+  dismissAllTooltips,
+  TOOLTIP_FOCUS_SUPPRESS_MS,
+} from "@/lib/tooltipDismissRegistry";
 
 const { getDisplayComboMock, subscribeMock } = vi.hoisted(() => ({
   getDisplayComboMock: vi.fn(() => "⌘B"),
@@ -62,6 +67,7 @@ describe("useShortcutHintHover", () => {
   });
 
   afterEach(() => {
+    resetTooltipRegistry();
     vi.useRealTimers();
   });
 
@@ -403,6 +409,35 @@ describe("useShortcutHintHover", () => {
     });
 
     expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("suppresses focus hint during the post-dialog-transition window (issue #11030)", () => {
+    // A dialog's focus restoration lands on the trigger with nothing
+    // hovered — the teaching hint must not fire, mirroring the tooltip
+    // focus-open suppression.
+    getDisplayComboMock.mockReturnValue("⌘B");
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    dismissAllTooltips();
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 1, top: 2 })));
+    });
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+
+    // Once the window expires, focus hints behave normally again.
+    act(() => {
+      vi.advanceTimersByTime(TOOLTIP_FOCUS_SUPPRESS_MS + 1);
+    });
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 1, top: 2 })));
+    });
+    expect(shortcutHintStore.getState().activeHint).not.toBeNull();
   });
 
   it("hides the hint on blur", () => {

--- a/src/hooks/useShortcutHintHover.ts
+++ b/src/hooks/useShortcutHintHover.ts
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from "react";
 import type React from "react";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
+import { isTooltipFocusOpenSuppressed } from "@/lib/tooltipDismissRegistry";
 import { keybindingService } from "./useKeybinding";
 
 const HOVER_DWELL_MS = 1500;
@@ -99,6 +100,11 @@ export function useShortcutHintHover(actionId: string) {
   const onFocus = (e: React.FocusEvent) => {
     // Cancel any racing pointer dwell so it can't double-show after focus did.
     clearTimer();
+
+    // Focus restoration after a dialog transition lands here with nothing
+    // hovered — showing a teaching hint then reads as a stray overlay.
+    // Same window that gates tooltip focus-opens (issue #11030).
+    if (isTooltipFocusOpenSuppressed()) return;
 
     const displayCombo = displayComboRef.current;
     if (!displayCombo) return;

--- a/src/lib/__tests__/tooltipDismissRegistry.test.ts
+++ b/src/lib/__tests__/tooltipDismissRegistry.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetForTests,
+  dismissAllTooltips,
+  isTooltipFocusOpenSuppressed,
+  notifyTooltipPointerActivity,
+  registerTooltipDismiss,
+  TOOLTIP_FOCUS_SUPPRESS_MS,
+} from "../tooltipDismissRegistry";
+
+describe("tooltipDismissRegistry", () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    _resetForTests();
+    vi.useRealTimers();
+  });
+
+  it("invokes every registered handler on dismissAllTooltips", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    registerTooltipDismiss(a);
+    registerTooltipDismiss(b);
+
+    dismissAllTooltips();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops invoking a handler after its unregister closure runs", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const unregisterA = registerTooltipDismiss(a);
+    registerTooltipDismiss(b);
+
+    unregisterA();
+    dismissAllTooltips();
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("unregisters exactly one entry when the same handler registered twice", () => {
+    const handler = vi.fn();
+    registerTooltipDismiss(handler);
+    const unregisterSecond = registerTooltipDismiss(handler);
+
+    unregisterSecond();
+    dismissAllTooltips();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates double-unregister without touching other entries", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const unregisterA = registerTooltipDismiss(a);
+    registerTooltipDismiss(b);
+
+    unregisterA();
+    unregisterA();
+    dismissAllTooltips();
+
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("walks a snapshot so a handler unregistering another mid-dismiss cannot skip entries", () => {
+    // A dismiss can re-render controlled consumers and unmount sibling
+    // tooltips mid-walk; iteration must not skip the handlers that were
+    // registered when the dismissal started.
+    const c = vi.fn();
+    const b = vi.fn();
+    let unregisterB: () => void = () => {};
+    registerTooltipDismiss(() => unregisterB());
+    unregisterB = registerTooltipDismiss(b);
+    registerTooltipDismiss(c);
+
+    dismissAllTooltips();
+
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(c).toHaveBeenCalledTimes(1);
+  });
+
+  it("arms the focus-open suppression window on dismissAllTooltips", () => {
+    expect(isTooltipFocusOpenSuppressed()).toBe(false);
+
+    dismissAllTooltips();
+
+    expect(isTooltipFocusOpenSuppressed()).toBe(true);
+  });
+
+  it("lets the suppression window expire", () => {
+    dismissAllTooltips();
+
+    vi.advanceTimersByTime(TOOLTIP_FOCUS_SUPPRESS_MS + 1);
+
+    expect(isTooltipFocusOpenSuppressed()).toBe(false);
+  });
+
+  it("clears suppression immediately on genuine pointer activity", () => {
+    dismissAllTooltips();
+    expect(isTooltipFocusOpenSuppressed()).toBe(true);
+
+    notifyTooltipPointerActivity();
+
+    expect(isTooltipFocusOpenSuppressed()).toBe(false);
+  });
+
+  it("re-arms a fresh window on each dismissal", () => {
+    dismissAllTooltips();
+    vi.advanceTimersByTime(TOOLTIP_FOCUS_SUPPRESS_MS - 50);
+
+    dismissAllTooltips();
+    vi.advanceTimersByTime(100);
+
+    expect(isTooltipFocusOpenSuppressed()).toBe(true);
+  });
+
+  it("_resetForTests clears handlers and suppression", () => {
+    const handler = vi.fn();
+    registerTooltipDismiss(handler);
+    dismissAllTooltips();
+    handler.mockClear();
+
+    _resetForTests();
+
+    expect(isTooltipFocusOpenSuppressed()).toBe(false);
+    dismissAllTooltips();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/dialogOverlayDismissal.ts
+++ b/src/lib/dialogOverlayDismissal.ts
@@ -1,0 +1,13 @@
+import { dismissAllTooltips } from "@/lib/tooltipDismissRegistry";
+import { shortcutHintStore } from "@/store/shortcutHintStore";
+
+/**
+ * Clear every transient overlay a dialog transition can strand: Radix
+ * tooltips (via the dismiss registry) and the ShortcutHint teaching
+ * overlay (z-toast, above z-modal). Called by AppDialog and
+ * AppPaletteDialog on every open and close transition (issue #11030).
+ */
+export function clearDialogOverlays(): void {
+  dismissAllTooltips();
+  shortcutHintStore.getState().hide();
+}

--- a/src/lib/tooltipDismissRegistry.ts
+++ b/src/lib/tooltipDismissRegistry.ts
@@ -1,0 +1,64 @@
+// Global dismiss registry for Radix tooltips (issue #11030).
+//
+// Radix opens tooltips on focus as well as hover, and dialogs move focus
+// around (autofocus into the dialog on open, focus restoration to the
+// trigger on close), so tooltips strand open or appear hover-less around
+// every dialog transition. Radix ships no provider-level "close all" API,
+// so each mounted Tooltip registers a dismiss callback here and the dialog
+// primitives (AppDialog / AppPaletteDialog) invoke `dismissAllTooltips()`
+// on every open and close.
+//
+// Dismissing alone isn't enough: the focus move the dialog performs AFTER
+// the dismiss re-opens a tooltip through Radix's focus path. Each dismiss
+// therefore arms a short suppression window during which focus-driven
+// opens are ignored. Genuine pointer interaction clears the window
+// immediately (a hover open is always preceded by pointerenter on a
+// trigger), so only the hover-less focus-restoration opens are blocked.
+
+// Long enough to cover the dialog's RAF-deferred autofocus (~1 frame) and
+// the exit-animation-deferred focus restore, which both re-arm right
+// before focusing anyway; short enough that a keyboard user tabbing after
+// a dialog closes gets focus tooltips back almost immediately.
+export const TOOLTIP_FOCUS_SUPPRESS_MS = 250;
+
+const dismissHandlers: Array<() => void> = [];
+
+let suppressedUntil = 0;
+
+export function registerTooltipDismiss(handler: () => void): () => void {
+  dismissHandlers.push(handler);
+  return () => {
+    const idx = dismissHandlers.lastIndexOf(handler);
+    if (idx !== -1) dismissHandlers.splice(idx, 1);
+  };
+}
+
+/**
+ * Close every registered tooltip and arm the focus-open suppression
+ * window. Idempotent and cheap — nested dialogs may each fire it.
+ */
+export function dismissAllTooltips(): void {
+  suppressedUntil = Date.now() + TOOLTIP_FOCUS_SUPPRESS_MS;
+  // Iterate over a snapshot: a dismiss can unmount tooltips (controlled
+  // consumers re-rendering), which unregisters mid-walk.
+  for (const handler of [...dismissHandlers]) {
+    handler();
+  }
+}
+
+export function isTooltipFocusOpenSuppressed(): boolean {
+  return Date.now() < suppressedUntil;
+}
+
+/**
+ * A genuine pointer interaction ends suppression early — the user is
+ * actually hovering, so tooltip opens are wanted again.
+ */
+export function notifyTooltipPointerActivity(): void {
+  suppressedUntil = 0;
+}
+
+export function _resetForTests(): void {
+  dismissHandlers.length = 0;
+  suppressedUntil = 0;
+}

--- a/src/services/actions/definitions/navigationActions.ts
+++ b/src/services/actions/definitions/navigationActions.ts
@@ -27,6 +27,9 @@ export function registerNavigationActions(
     danger: "safe",
     scope: "renderer",
     nonRepeatable: true,
+    // Opens a modal palette — a post-dispatch hint would land on top of it
+    // (ShortcutHint sits at z-toast, above z-modal). Issue #11030.
+    suppressShortcutHint: true,
     run: async () => {
       callbacks.onOpenActionPalette();
     },

--- a/src/services/actions/definitions/panelCoreActions.ts
+++ b/src/services/actions/definitions/panelCoreActions.ts
@@ -194,6 +194,9 @@ export function registerPanelCoreActions(
     scope: "renderer",
     keywords: ["create", "add", "launcher", "picker"],
     nonRepeatable: true,
+    // Opens a modal palette — a post-dispatch hint would land on top of it
+    // (ShortcutHint sits at z-toast, above z-modal). Issue #11030.
+    suppressShortcutHint: true,
     run: async () => {
       callbacks.onOpenPanelPalette();
     },

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -62,6 +62,9 @@ export function registerTerminalSpawnActions(
     scope: "renderer",
     keywords: ["resume", "reopen", "closed", "history", "session", "restore"],
     nonRepeatable: true,
+    // Opens a modal palette — a post-dispatch hint would land on top of it
+    // (ShortcutHint sits at z-toast, above z-modal). Issue #11030.
+    suppressShortcutHint: true,
     run: async () => {
       callbacks.onOpenResumeSessionsPalette();
     },


### PR DESCRIPTION
## Summary

- Radix tooltips open on focus as well as hover, and our dialog primitives (`AppDialog`, `AppPaletteDialog`) move focus on open (autofocus) and close (`restoreFocus`), which strands tooltips: `FileChangeList`'s row path tooltip stays open after closing the diff viewer, and `FileViewerModal`'s header tooltip appears on open with nothing hovered.
- Adds a module-level tooltip dismiss registry so every dialog transition clears all tooltips, and removes the pile of scattered per-component workarounds that had grown up around this instead.

Resolves #11030

## Changes

- New `src/lib/tooltipDismissRegistry.ts` (modeled on the existing `src/lib/dialogEscapeBackstop.ts`). Every `Tooltip` registers a dismiss callback. `dismissAllTooltips()` closes everything and arms a 250ms focus-open suppression window; genuine pointer activity (`pointerenter`, or a non-touch `pointermove`, on any `TooltipTrigger`) clears that window early.
- New `clearDialogOverlays()` helper (clears the registry, calls `shortcutHintStore.hide()`) wired into both `AppDialog` and `AppPaletteDialog` on every open/close transition, guarded so mounting an already-closed dialog doesn't clear anything, and re-armed inside `restoreFocus` right before focus actually moves.
- `useShortcutHintHover`'s `onFocus` now honors the same suppression window.
- Rich hover cards where the content is the whole point (`IssueBadge`, `PRBadge`) opt out entirely via a new `dismissOnDialogTransition={false}` prop, exempt from both dismissal and suppression.
- Removed now-redundant workarounds: `ToolbarCommandPaletteButton` and `ResumeSessionsToolbarButton` drop their controlled-tooltip + `isRestoringFocusRef` + hint-hide dance; `LauncherQuickActions` and `ResumeSessionLine` drop their `.finally(hide)` calls.
- The underlying race (a shortcut hint appearing after a palette has already opened) is now prevented at the source instead of papered over: `suppressShortcutHint: true` on the `action.palette.open`, `panel.palette`, and `terminal.resumeSessions` action definitions. The flag already existed and was already honored by `ActionService`, so this also covers the lazy first-open case the old workarounds couldn't handle cleanly.
- Deliberately left alone: `AgentButton`, `DockLaunchButton`, `DockedTerminalItem`, `DockedTabGroup`, and the `useDismissableTooltip` hook. Their overlays are dropdown menus, context menus, popovers, or drag interactions, outside the dialog lifecycle this fix targets.

Two tradeoffs were reviewed and accepted rather than engineered around:

- Tabbing onto a tooltip trigger by keyboard within 250ms of a dialog transition drops that one tooltip open until refocus. That matches the issue's explicit ask to be aggressive about clearing, and focus itself is never touched, so WCAG 2.4.3 is preserved.
- `suppressShortcutHint` also stops hint-count increments for those three actions, which the rotating terminal tips feature uses for ranking. Small, flagged as a possible follow-up.

## Testing

- New: `src/lib/__tests__/tooltipDismissRegistry.test.ts`, `src/components/ui/__tests__/dialogOverlayClearing.test.tsx` (both dialog types across open/close/mount/restore-focus paths), a dismissal/suppression block in the `Tooltip` suite, and a suppression test for `useShortcutHintHover`.
- Updated the existing workaround-assertion tests to match the removals.
- 289 targeted tests across 16 files pass locally, including the `ActionService` and action definition suites.
- Went through two adversarial Codex review passes plus a verification pass, all landing on ship; the fixes from that review are in the second commit.