### PR TITLE
fix(forge): backfill legacy GitHub token into forge credentials

### DIFF
--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { getCurrentDiskSpaceStatus } from "./DiskSpaceMonitor.js";
 
-export const LATEST_SCHEMA_VERSION = 23;
+export const LATEST_SCHEMA_VERSION = 24;
 
 export interface Migration {
   version: number;

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 
 // The migrations barrel transitively imports modules that touch `electron.app`
 // at module load (ProjectStore in migration003). Mock it before the barrel
@@ -909,6 +910,23 @@ describe("MigrationRunner", () => {
     const plugins = store.data.plugins as Record<string, unknown>;
     expect(plugins.disabled).toEqual(["daintree.github"]);
     expect("disabledBuiltins" in plugins).toBe(false);
+  });
+
+  it("runs migration024 from v23 under the full barrel, backfilling the GitHub token (#11033)", async () => {
+    const store = createMockStore(storePath, {
+      _schemaVersion: 23,
+      "userConfig.githubToken": "ghp_pre_cutover",
+    });
+    const runner = new MigrationRunner(store as never);
+
+    await runner.runMigrations(migrations);
+
+    expect(store.data._schemaVersion).toBe(LATEST_SCHEMA_VERSION);
+    expect("userConfig.githubToken" in store.data).toBe(false);
+    const credentials = store.data.forgeCredentials as Record<string, string>;
+    expect(JSON.parse(credentials[BUILTIN_GITHUB_PROVIDER_ID])).toEqual({
+      token: "ghp_pre_cutover",
+    });
   });
 
   it("does nothing when there are no pending migrations", async () => {

--- a/electron/services/migrations/024-backfill-github-forge-credential.ts
+++ b/electron/services/migrations/024-backfill-github-forge-credential.ts
@@ -1,0 +1,98 @@
+import type { Migration } from "../StoreMigrations.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
+
+const LEGACY_TOKEN_KEY = "userConfig.githubToken";
+
+/**
+ * Carry a pre-cutover GitHub token from the legacy `userConfig.githubToken`
+ * key into the provider-keyed `forgeCredentials` map (#11033).
+ *
+ * The forge-neutral refactor (#10347) moved the connection gate to
+ * `forgeCredentials`, but the token save/read path kept writing the legacy key.
+ * Users who saved a token before the cutover ended up authenticated (the
+ * toolbar issue/PR counts read the legacy key via `GitHubAuth.getToken()`) yet
+ * shown a "GitHub not connected" empty state in every panel, because that gate
+ * reads `forgeCredentials` and found nothing.
+ *
+ * `forgeCredentials` is not just a UI flag — `PluginHostFactory` replays it into
+ * freshly bound provider impls (and utility-process hosts, which cannot reach
+ * secure storage at all), so the fix has to persist rather than paper over the
+ * read.
+ *
+ * The legacy key is always removed once a token is found there, even when the
+ * destination already holds a credential. `forge:clear-credential` only deletes
+ * the `forgeCredentials` entry, so a surviving legacy key would resurrect the
+ * token on the next boot via the plugin's `initializeTokenStorage()`.
+ */
+
+/**
+ * Deliberately duplicated from `forgeSettings.ts` rather than imported: a
+ * migration is a snapshot of the schema as it was, and must not drift when the
+ * live reader changes. Importing the handler module would also drag the IPC
+ * registry into the boot path.
+ */
+function recordHasCredential(raw: unknown): boolean {
+  if (typeof raw !== "string" || raw.length === 0) return false;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return false;
+    return Object.values(parsed as Record<string, unknown>).some(
+      (v) => typeof v === "string" && v.trim().length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+export const migration024: Migration = {
+  version: 24,
+  description: "Backfill the legacy GitHub token into the forge credentials map",
+  up: (store) => {
+    const get = store.get.bind(store) as (key: string) => unknown;
+    const set = store.set.bind(store) as (key: string, value: unknown) => void;
+    const del = store.delete.bind(store) as (key: string) => void;
+
+    const rawToken = get(LEGACY_TOKEN_KEY);
+    if (rawToken === undefined || rawToken === null) return;
+
+    if (typeof rawToken !== "string") {
+      // Mirrors `SecureStorage.get`, which clears a corrupt non-string entry
+      // rather than handing it to a caller that expects a token.
+      console.warn(`[Migrations] Dropping corrupt non-string ${LEGACY_TOKEN_KEY}`);
+      del(LEGACY_TOKEN_KEY);
+      return;
+    }
+
+    const token = rawToken.trim();
+    if (token.length === 0) {
+      // Readers treat a blank credential as absent, so copying it would only
+      // leave a phantom entry behind. Drop the key and stop.
+      del(LEGACY_TOKEN_KEY);
+      return;
+    }
+
+    const rawMap = get("forgeCredentials");
+    let map: Record<string, unknown> = {};
+    if (rawMap !== undefined && rawMap !== null) {
+      if (typeof rawMap === "object" && !Array.isArray(rawMap)) {
+        map = rawMap as Record<string, unknown>;
+      } else {
+        // Repair rather than throw: a corrupt sibling key shouldn't trip the
+        // runner's restore-from-backup path for the whole migration chain.
+        console.warn("[Migrations] Replacing corrupt non-object forgeCredentials");
+      }
+    }
+
+    // Guard the destination, not the source: a token saved after the cutover
+    // wins over the stale legacy copy, and a replay after a partial failure
+    // cannot clobber it.
+    if (!recordHasCredential(map[BUILTIN_GITHUB_PROVIDER_ID])) {
+      set("forgeCredentials", {
+        ...map,
+        [BUILTIN_GITHUB_PROVIDER_ID]: JSON.stringify({ token }),
+      });
+    }
+
+    del(LEGACY_TOKEN_KEY);
+  },
+};

--- a/electron/services/migrations/__tests__/024-backfill-github-forge-credential.test.ts
+++ b/electron/services/migrations/__tests__/024-backfill-github-forge-credential.test.ts
@@ -166,6 +166,38 @@ describe("migration024 — backfill legacy GitHub token into forgeCredentials", 
     warnSpy.mockRestore();
   });
 
+  it("replaces an array-shaped forgeCredentials rather than spreading its indices", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_legacytoken",
+      forgeCredentials: [],
+    };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(Array.isArray(data.forgeCredentials)).toBe(false);
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+    warnSpy.mockRestore();
+  });
+
+  it("writes the canonical provider id alongside a legacy-keyed alias", () => {
+    // Nothing writes `github`/`builtin.github` into forgeCredentials today, and
+    // no reader normalizes these keys — both index by the canonical id. Left
+    // untouched so a hand-edited config keeps whatever it had.
+    const alias = JSON.stringify({ token: "ghp_alias" });
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_legacytoken",
+      forgeCredentials: { github: alias },
+    };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+    expect(credentialsOf(data).github).toBe(alias);
+  });
+
   it("trims surrounding whitespace off the migrated token", () => {
     const data: Record<string, unknown> = { [LEGACY_KEY]: "  ghp_legacytoken\n" };
     const store = makeStoreMock(data);

--- a/electron/services/migrations/__tests__/024-backfill-github-forge-credential.test.ts
+++ b/electron/services/migrations/__tests__/024-backfill-github-forge-credential.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { migration024 } from "../024-backfill-github-forge-credential.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
+
+const LEGACY_KEY = "userConfig.githubToken";
+
+/**
+ * Flat key map — matches the dot-notated keys electron-store resolves for
+ * `userConfig.githubToken`, mirroring `SecureStorage.test.ts`.
+ */
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    delete: vi.fn((key: string) => {
+      delete data[key];
+    }),
+  } as unknown as Parameters<typeof migration024.up>[0];
+}
+
+function credentialsOf(data: Record<string, unknown>): Record<string, string> {
+  return (data.forgeCredentials ?? {}) as Record<string, string>;
+}
+
+/** The token a reader would recover from the stored credential record. */
+function storedToken(data: Record<string, unknown>): string | undefined {
+  const raw = credentialsOf(data)[BUILTIN_GITHUB_PROVIDER_ID];
+  if (typeof raw !== "string") return undefined;
+  return (JSON.parse(raw) as { token?: string }).token;
+}
+
+describe("migration024 — backfill legacy GitHub token into forgeCredentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("backfills the legacy token and removes the legacy key", () => {
+    const data: Record<string, unknown> = { [LEGACY_KEY]: "ghp_legacytoken" };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+    expect(LEGACY_KEY in data).toBe(false);
+  });
+
+  it("merges into forgeCredentials without disturbing other providers", () => {
+    const otherEntry = JSON.stringify({ token: "glpat_other" });
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_legacytoken",
+      forgeCredentials: { "acme.gitlab": otherEntry },
+    };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(credentialsOf(data)["acme.gitlab"]).toBe(otherEntry);
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+  });
+
+  it("keeps a post-cutover credential and still drops the stale legacy key", () => {
+    // Closes the clear-token resurrection path: `forge:clear-credential` never
+    // touched the legacy key, so leaving it would restore the old token on boot.
+    const current = JSON.stringify({ token: "ghp_current" });
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_stale",
+      forgeCredentials: { [BUILTIN_GITHUB_PROVIDER_ID]: current },
+    };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(storedToken(data)).toBe("ghp_current");
+    expect(LEGACY_KEY in data).toBe(false);
+  });
+
+  it("overwrites a destination entry that readers treat as absent", () => {
+    // `recordHasCredential` rejects a blank value, so the panel gate would still
+    // report "not connected" if the backfill deferred to this entry.
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_legacytoken",
+      forgeCredentials: { [BUILTIN_GITHUB_PROVIDER_ID]: JSON.stringify({ token: "   " }) },
+    };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+  });
+
+  it("overwrites a destination entry that is not parseable JSON", () => {
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_legacytoken",
+      forgeCredentials: { [BUILTIN_GITHUB_PROVIDER_ID]: "not-json" },
+    };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+  });
+
+  it("is replay-safe: a second run leaves the migrated state untouched", () => {
+    const data: Record<string, unknown> = { [LEGACY_KEY]: "ghp_legacytoken" };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+    const afterFirst = { ...credentialsOf(data) };
+    migration024.up(store);
+
+    expect(credentialsOf(data)).toEqual(afterFirst);
+    expect(LEGACY_KEY in data).toBe(false);
+  });
+
+  it("does nothing when there is no legacy token", () => {
+    const data: Record<string, unknown> = { forgeCredentials: {} };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    const { set, delete: del } = store as unknown as {
+      set: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    };
+    expect(set).not.toHaveBeenCalled();
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it("drops a blank legacy token without writing a phantom credential", () => {
+    const data: Record<string, unknown> = { [LEGACY_KEY]: "   " };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(data.forgeCredentials).toBeUndefined();
+    expect(LEGACY_KEY in data).toBe(false);
+  });
+
+  it("warns and drops a corrupt non-string legacy token", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const data: Record<string, unknown> = { [LEGACY_KEY]: { nested: "object" } };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(data.forgeCredentials).toBeUndefined();
+    expect(LEGACY_KEY in data).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(LEGACY_KEY));
+    warnSpy.mockRestore();
+  });
+
+  it("replaces a corrupt non-object forgeCredentials rather than throwing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const data: Record<string, unknown> = {
+      [LEGACY_KEY]: "ghp_legacytoken",
+      forgeCredentials: "corrupt-string",
+    };
+    const store = makeStoreMock(data);
+
+    expect(() => migration024.up(store)).not.toThrow();
+
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("forgeCredentials"));
+    warnSpy.mockRestore();
+  });
+
+  it("trims surrounding whitespace off the migrated token", () => {
+    const data: Record<string, unknown> = { [LEGACY_KEY]: "  ghp_legacytoken\n" };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    expect(storedToken(data)).toBe("ghp_legacytoken");
+  });
+
+  it("clears the legacy key with delete, never set(key, undefined)", () => {
+    // electron-store v11 throws on `set(key, undefined)` (#2727).
+    const data: Record<string, unknown> = { [LEGACY_KEY]: "ghp_legacytoken" };
+    const store = makeStoreMock(data);
+
+    migration024.up(store);
+
+    const { set, delete: del } = store as unknown as {
+      set: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    };
+    expect(del).toHaveBeenCalledWith(LEGACY_KEY);
+    expect(set).not.toHaveBeenCalledWith(LEGACY_KEY, undefined);
+  });
+});

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -20,6 +20,7 @@ import { migration020 } from "./020-window-states-store.js";
 import { migration021 } from "./021-merge-disabled-plugins.js";
 import { migration022 } from "./022-audit-logs-store.js";
 import { migration023 } from "./023-audit-rings-to-audit-logs-store.js";
+import { migration024 } from "./024-backfill-github-forge-credential.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -44,4 +45,5 @@ export const migrations: Migration[] = [
   migration021,
   migration022,
   migration023,
+  migration024,
 ];


### PR DESCRIPTION
## Summary

Users who saved a GitHub token before the forge-neutral refactor (#10347) see accurate issue and PR counts in the toolbar pills, but every GitHub panel shows a "GitHub not connected" empty state asking them to add a token they already have.

There are two independent sources of truth for whether a token exists:

- **Stats/count path** — `GitHubAuth.getToken()` reads `secureStorage.get("userConfig.githubToken")`, the legacy key. It holds the real token, so authenticated fetches succeed and counts are correct.
- **Panel connection gate** — `forge.getCredentialStatus(BUILTIN_GITHUB_PROVIDER_ID)` reads `store.get("forgeCredentials")[providerId]`. Empty for pre-cutover users, so `hasCredential: false` and the panel shows "not connected."

The #10347 cutover moved the gate to the provider-keyed `forgeCredentials` store, but the token save/read path everything else uses stayed on the legacy key, and existing tokens were never surfaced to the new gate.

Resolves #11033

## Fix

A boot-time store migration (`migration024`) copies the legacy token into `forgeCredentials[daintree.github.github]` and deletes the legacy key. No renderer, IPC, or runtime changes.

### Why a migration, not a read-time fallback

`forgeCredentials` isn't just a UI flag — `PluginHostFactory` replays it into freshly bound provider implementations via `setCredentials()`, and utility-process hosts (`workspace-host`) can't reach `secureStorage` at all. Patching the read in `forgeSettings.ts` would silence the panel but leave that replay path empty. The fix has to persist the token, not just paper over one read site.

### Also closes a latent second-order bug

`forge:clear-credential` only deletes the `forgeCredentials` entry — it never touches the legacy key. Once the read gap is fixed and these users can finally see and click "Clear token," the legacy token would resurrect on the next boot via the plugin's `initializeTokenStorage()`. The migration deletes the legacy key even when the destination already holds a credential, closing this permanently.

### Safety / replay

- Guards the destination rather than the source — a token saved after the cutover always wins over the stale legacy copy, so a replay after a partial failure can't clobber it.
- `_schemaVersion` bumps only after `up()` returns, so a crash mid-migration replays the whole thing idempotently.
- A corrupt non-object `forgeCredentials` is warned-and-repaired rather than thrown, matching `migration023`'s precedent — throwing would trip `MigrationRunner`'s restore-from-backup for the entire chain.
- Uses `store.delete()` since electron-store v11 throws on `set(key, undefined)`.

## Testing

- 14 unit test cases on the migration: backfill, merge without disturbing other providers, post-cutover token preserved, entries readers treat as absent overwritten, replay safety, blank/corrupt token handling, delete-not-set-undefined.
- A full-barrel integration test drives `migration024` through the real `MigrationRunner` from v23 with a seeded legacy token.
- `npm run check` passes all 11 checks.

## Follow-up (not in this PR)

`GitHubTokenOrchestrator.ts` (`setTokenAndSync`/`clearTokenAndSync`) is dead code with zero callers — it predates the cutover and only writes to `secureStorage`. Worth a separate cleanup issue.
