### PR TITLE
feat(worktree): add dedicated button to open diff from Changed Files

### DIFF
--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { FileChangeDetail, GitStatus } from "../../types";
 import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { cn } from "../../lib/utils";
@@ -55,6 +63,11 @@ interface FileChangeListProps {
   className?: string;
 }
 
+export interface FileChangeListHandle {
+  /** Open the diff viewer on the first (highest-churn) changed file. */
+  openFirstFile(triggerEl: HTMLElement | null): void;
+}
+
 function splitPath(filePath: string): { dir: string; base: string } {
   const dir = dirname(filePath);
   const base = basename(filePath);
@@ -87,328 +100,385 @@ function rowKey(change: { path: string; status: GitStatus }): string {
   return `${change.path}-${change.status}`;
 }
 
-export function FileChangeList({
-  changes,
-  maxVisible = 8,
-  rootPath,
-  groupByFolder = false,
-  isStale = false,
-  className,
-}: FileChangeListProps) {
-  const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
-  // Plugin-contributed `file` context-menu items. Pulled once for the list; a
-  // row is only wrapped in a ContextMenu when there are items, so a zero-plugin
-  // file list keeps its existing flat-row DOM (no per-row trigger overhead).
-  const filePluginItems = usePluginContextMenuItems("file");
-  // Holds the row element that opened the modal so focus can return to it on
-  // close. Identity-stable across renders so AppDialog's restore logic doesn't
-  // spuriously re-fire (the ref is the fallback for an unmounted trigger).
-  const triggerElementRef = useRef<HTMLElement | null>(null);
+export const FileChangeList = forwardRef<FileChangeListHandle, FileChangeListProps>(
+  function FileChangeList(
+    { changes, maxVisible = 8, rootPath, groupByFolder = false, isStale = false, className },
+    ref
+  ) {
+    const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
+    // Plugin-contributed `file` context-menu items. Pulled once for the list; a
+    // row is only wrapped in a ContextMenu when there are items, so a zero-plugin
+    // file list keeps its existing flat-row DOM (no per-row trigger overhead).
+    const filePluginItems = usePluginContextMenuItems("file");
+    // Holds the row element that opened the modal so focus can return to it on
+    // close. Identity-stable across renders so AppDialog's restore logic doesn't
+    // spuriously re-fire (the ref is the fallback for an unmounted trigger).
+    const triggerElementRef = useRef<HTMLElement | null>(null);
 
-  const sortedChanges = useMemo(() => {
-    return [...changes]
-      .map((change) => ({
-        ...change,
-        relativePath: isAbsolute(change.path)
-          ? getRelativePath(rootPath, change.path)
-          : change.path,
-      }))
-      .sort((a, b) => {
-        const churnA = (a.insertions ?? 0) + (a.deletions ?? 0);
-        const churnB = (b.insertions ?? 0) + (b.deletions ?? 0);
-        if (churnA !== churnB) {
-          return churnB - churnA;
+    const sortedChanges = useMemo(() => {
+      return [...changes]
+        .map((change) => ({
+          ...change,
+          relativePath: isAbsolute(change.path)
+            ? getRelativePath(rootPath, change.path)
+            : change.path,
+        }))
+        .sort((a, b) => {
+          const churnA = (a.insertions ?? 0) + (a.deletions ?? 0);
+          const churnB = (b.insertions ?? 0) + (b.deletions ?? 0);
+          if (churnA !== churnB) {
+            return churnB - churnA;
+          }
+
+          const priorityA = STATUS_PRIORITY[a.status] ?? 99;
+          const priorityB = STATUS_PRIORITY[b.status] ?? 99;
+          if (priorityA !== priorityB) {
+            return priorityA - priorityB;
+          }
+
+          return a.path.localeCompare(b.path);
+        });
+    }, [changes, rootPath]);
+
+    // Plugin-contributed file decorations for the local worktree file list. Pulled
+    // once for the whole list under a `worktree-files:<root>` scope — distinct from
+    // the Review Hub's `worktree-diff:` scope so a PR-review provider's badges don't
+    // leak onto the local change list. Keyed by the same `change.path` strings that
+    // were sent to the host, so `decorations[change.path]` resolves per row. The
+    // hook early-outs (stable empty map) when no plugin registers the scope, so this
+    // costs nothing on a zero-plugin file list.
+    const decorationPaths = useMemo(() => sortedChanges.map((c) => c.path), [sortedChanges]);
+    const decorations = useFileTreeDecorations(`worktree-files:${rootPath}`, decorationPaths);
+
+    // Map each row key to its position in `sortedChanges` so file stepping spans
+    // the whole change set (not just the visible cap) and grouped rows resolve to
+    // the same deterministic order as the flat list.
+    const indexByKey = useMemo(() => {
+      const map = new Map<string, number>();
+      sortedChanges.forEach((change, index) => map.set(rowKey(change), index));
+      return map;
+    }, [sortedChanges]);
+
+    const visibleChanges = useMemo(
+      () => sortedChanges.slice(0, maxVisible),
+      [sortedChanges, maxVisible]
+    );
+    const remainingCount = Math.max(0, sortedChanges.length - maxVisible);
+
+    // Track which row keys arrived since the previous render. Empty on mount because
+    // prevKeysRef is seeded with the initial keys — the first paint must NOT flash
+    // every existing row. The decay IS the recency signal (semantic exception, ~2s).
+    const prevKeysRef = useRef<Set<string> | null>(null);
+    const [newRowKeys, setNewRowKeys] = useState<Set<string>>(() => new Set());
+
+    useLayoutEffect(() => {
+      const currentKeys = sortedChanges.map(rowKey);
+      if (prevKeysRef.current === null) {
+        prevKeysRef.current = new Set(currentKeys);
+        return;
+      }
+      const added = new Set<string>();
+      for (const key of currentKeys) {
+        if (!prevKeysRef.current.has(key)) {
+          added.add(key);
         }
-
-        const priorityA = STATUS_PRIORITY[a.status] ?? 99;
-        const priorityB = STATUS_PRIORITY[b.status] ?? 99;
-        if (priorityA !== priorityB) {
-          return priorityA - priorityB;
-        }
-
-        return a.path.localeCompare(b.path);
-      });
-  }, [changes, rootPath]);
-
-  // Plugin-contributed file decorations for the local worktree file list. Pulled
-  // once for the whole list under a `worktree-files:<root>` scope — distinct from
-  // the Review Hub's `worktree-diff:` scope so a PR-review provider's badges don't
-  // leak onto the local change list. Keyed by the same `change.path` strings that
-  // were sent to the host, so `decorations[change.path]` resolves per row. The
-  // hook early-outs (stable empty map) when no plugin registers the scope, so this
-  // costs nothing on a zero-plugin file list.
-  const decorationPaths = useMemo(() => sortedChanges.map((c) => c.path), [sortedChanges]);
-  const decorations = useFileTreeDecorations(`worktree-files:${rootPath}`, decorationPaths);
-
-  // Map each row key to its position in `sortedChanges` so file stepping spans
-  // the whole change set (not just the visible cap) and grouped rows resolve to
-  // the same deterministic order as the flat list.
-  const indexByKey = useMemo(() => {
-    const map = new Map<string, number>();
-    sortedChanges.forEach((change, index) => map.set(rowKey(change), index));
-    return map;
-  }, [sortedChanges]);
-
-  const visibleChanges = useMemo(
-    () => sortedChanges.slice(0, maxVisible),
-    [sortedChanges, maxVisible]
-  );
-  const remainingCount = Math.max(0, sortedChanges.length - maxVisible);
-
-  // Track which row keys arrived since the previous render. Empty on mount because
-  // prevKeysRef is seeded with the initial keys — the first paint must NOT flash
-  // every existing row. The decay IS the recency signal (semantic exception, ~2s).
-  const prevKeysRef = useRef<Set<string> | null>(null);
-  const [newRowKeys, setNewRowKeys] = useState<Set<string>>(() => new Set());
-
-  useLayoutEffect(() => {
-    const currentKeys = sortedChanges.map(rowKey);
-    if (prevKeysRef.current === null) {
+      }
       prevKeysRef.current = new Set(currentKeys);
-      return;
-    }
-    const added = new Set<string>();
-    for (const key of currentKeys) {
-      if (!prevKeysRef.current.has(key)) {
-        added.add(key);
-      }
-    }
-    prevKeysRef.current = new Set(currentKeys);
-    setNewRowKeys((prev) => (added.size === 0 && prev.size === 0 ? prev : added));
-  }, [sortedChanges]);
-  const remainingFiles = useMemo(
-    () => sortedChanges.slice(maxVisible, maxVisible + 2),
-    [sortedChanges, maxVisible]
-  );
-
-  // Position of the open file, re-derived from the live list every render so
-  // a background refresh that re-sorts (churn ordering) can't strand the
-  // index on a different file. Falls back to path-only when the status
-  // changed under the open modal (e.g. untracked → added).
-  const selectedIndex = useMemo(() => {
-    if (!selectedFile) return null;
-    const exact = sortedChanges.findIndex(
-      (change) => change.relativePath === selectedFile.path && change.status === selectedFile.status
+      setNewRowKeys((prev) => (added.size === 0 && prev.size === 0 ? prev : added));
+    }, [sortedChanges]);
+    const remainingFiles = useMemo(
+      () => sortedChanges.slice(maxVisible, maxVisible + 2),
+      [sortedChanges, maxVisible]
     );
-    if (exact !== -1) return exact;
-    const byPath = sortedChanges.findIndex((change) => change.relativePath === selectedFile.path);
-    return byPath === -1 ? null : byPath;
-  }, [selectedFile, sortedChanges]);
 
-  // The modal's fetch subject follows the LIVE entry, not the open-time
-  // snapshot: a file whose status flips under the open modal (untracked →
-  // added, added → modified after an agent commit) must be re-fetched under
-  // its current status, or the diff renders in the wrong mode.
-  const liveSelected = selectedIndex !== null ? (sortedChanges[selectedIndex] ?? null) : null;
+    // Position of the open file, re-derived from the live list every render so
+    // a background refresh that re-sorts (churn ordering) can't strand the
+    // index on a different file. Falls back to path-only when the status
+    // changed under the open modal (e.g. untracked → added).
+    const selectedIndex = useMemo(() => {
+      if (!selectedFile) return null;
+      const exact = sortedChanges.findIndex(
+        (change) =>
+          change.relativePath === selectedFile.path && change.status === selectedFile.status
+      );
+      if (exact !== -1) return exact;
+      const byPath = sortedChanges.findIndex((change) => change.relativePath === selectedFile.path);
+      return byPath === -1 ? null : byPath;
+    }, [selectedFile, sortedChanges]);
 
-  const getAdjacentFile = useCallback(
-    (delta: -1 | 1) => {
-      if (selectedIndex === null) return null;
-      const change = sortedChanges[selectedIndex + delta];
-      return change ? { path: change.relativePath, status: change.status } : null;
-    },
-    [selectedIndex, sortedChanges]
-  );
+    // The modal's fetch subject follows the LIVE entry, not the open-time
+    // snapshot: a file whose status flips under the open modal (untracked →
+    // added, added → modified after an agent commit) must be re-fetched under
+    // its current status, or the diff renders in the wrong mode.
+    const liveSelected = selectedIndex !== null ? (sortedChanges[selectedIndex] ?? null) : null;
 
-  // Changeset handed to the diff modal so it can render the review-workspace
-  // sidebar. Indexed identically to `selectedIndex`/`navigateFile`. Viewed
-  // keys are status-scoped (this list mixes staged and unstaged changes, so
-  // it can't use the Review Hub's `section:path` namespace); markers are
-  // invalidated wholesale when the hub commits (diffViewedStore.clearWorktree).
-  const diffChangeSet = useMemo(
-    (): DiffChangeSetEntry[] =>
-      sortedChanges.map((change) => ({
-        path: change.relativePath,
-        status: change.status,
-        insertions: change.insertions,
-        deletions: change.deletions,
-        viewedKey: `${change.status}:${change.relativePath}`,
-      })),
-    [sortedChanges]
-  );
+    const getAdjacentFile = useCallback(
+      (delta: -1 | 1) => {
+        if (selectedIndex === null) return null;
+        const change = sortedChanges[selectedIndex + delta];
+        return change ? { path: change.relativePath, status: change.status } : null;
+      },
+      [selectedIndex, sortedChanges]
+    );
 
-  const selectFileAt = useCallback(
-    (index: number) => {
-      const change = sortedChanges[index];
-      if (!change) return;
-      setSelectedFile({ path: change.relativePath, status: change.status });
-    },
-    [sortedChanges]
-  );
+    // Changeset handed to the diff modal so it can render the review-workspace
+    // sidebar. Indexed identically to `selectedIndex`/`navigateFile`. Viewed
+    // keys are status-scoped (this list mixes staged and unstaged changes, so
+    // it can't use the Review Hub's `section:path` namespace); markers are
+    // invalidated wholesale when the hub commits (diffViewedStore.clearWorktree).
+    const diffChangeSet = useMemo(
+      (): DiffChangeSetEntry[] =>
+        sortedChanges.map((change) => ({
+          path: change.relativePath,
+          status: change.status,
+          insertions: change.insertions,
+          deletions: change.deletions,
+          viewedKey: `${change.status}:${change.relativePath}`,
+        })),
+      [sortedChanges]
+    );
 
-  const groupedChanges = useMemo((): FolderGroup[] => {
-    if (!groupByFolder) return [];
+    const selectFileAt = useCallback(
+      (index: number) => {
+        const change = sortedChanges[index];
+        if (!change) return;
+        setSelectedFile({ path: change.relativePath, status: change.status });
+      },
+      [sortedChanges]
+    );
 
-    const groups = new Map<string, FileChangeWithRelativePath[]>();
+    const groupedChanges = useMemo((): FolderGroup[] => {
+      if (!groupByFolder) return [];
 
-    visibleChanges.forEach((change) => {
-      const { dir } = splitPath(change.relativePath);
-      const groupKey = dir || "(root)";
-      if (!groups.has(groupKey)) {
-        groups.set(groupKey, []);
-      }
-      groups.get(groupKey)!.push(change);
-    });
+      const groups = new Map<string, FileChangeWithRelativePath[]>();
 
-    return Array.from(groups.entries())
-      .map(([dir, files]) => ({
-        dir,
-        displayDir: dir === "(root)" ? "(root)" : formatDirForDisplay(dir, 3),
-        files,
-      }))
-      .sort((a, b) => {
-        if (a.dir === "(root)") return -1;
-        if (b.dir === "(root)") return 1;
-        return a.dir.localeCompare(b.dir);
+      visibleChanges.forEach((change) => {
+        const { dir } = splitPath(change.relativePath);
+        const groupKey = dir || "(root)";
+        if (!groups.has(groupKey)) {
+          groups.set(groupKey, []);
+        }
+        groups.get(groupKey)!.push(change);
       });
-  }, [visibleChanges, groupByFolder]);
 
-  if (changes.length === 0) {
-    return null;
-  }
+      return Array.from(groups.entries())
+        .map(([dir, files]) => ({
+          dir,
+          displayDir: dir === "(root)" ? "(root)" : formatDirForDisplay(dir, 3),
+          files,
+        }))
+        .sort((a, b) => {
+          if (a.dir === "(root)") return -1;
+          if (b.dir === "(root)") return 1;
+          return a.dir.localeCompare(b.dir);
+        });
+    }, [visibleChanges, groupByFolder]);
 
-  const openFileAt = (index: number, triggerEl: HTMLElement | null) => {
-    const change = sortedChanges[index];
-    if (!change) return;
-    triggerElementRef.current = triggerEl;
-    setSelectedFile({ path: change.relativePath, status: change.status });
-  };
+    const openFileAt = useCallback(
+      (index: number, triggerEl: HTMLElement | null) => {
+        const change = sortedChanges[index];
+        if (!change) return;
+        triggerElementRef.current = triggerEl;
+        setSelectedFile({ path: change.relativePath, status: change.status });
+      },
+      [sortedChanges]
+    );
 
-  const closeModal = () => {
-    setSelectedFile(null);
-  };
+    // Imperative entry point for the "Open changes" button in WorktreeDetails.
+    // Registered before the empty-list early return so the handle stays stable
+    // even with no files present (a safe no-op then, via openFileAt's bounds check).
+    useImperativeHandle(
+      ref,
+      () => ({
+        openFirstFile: (triggerEl: HTMLElement | null) => openFileAt(0, triggerEl),
+      }),
+      [openFileAt]
+    );
 
-  const navigateFile = (delta: -1 | 1) => {
-    // Clamp against the live length first — a worktree refresh can shrink the
-    // set while the modal is open, leaving the derived index stale.
-    if (selectedIndex === null) return;
-    const safeCurrent = Math.min(selectedIndex, sortedChanges.length - 1);
-    const next = Math.min(Math.max(safeCurrent + delta, 0), sortedChanges.length - 1);
-    const change = sortedChanges[next];
-    if (change) {
-      setSelectedFile({ path: change.relativePath, status: change.status });
+    if (changes.length === 0) {
+      return null;
     }
-  };
 
-  const renderFileItem = (change: FileChangeWithRelativePath, showDir: boolean) => {
-    const config = STATUS_CONFIG[change.status] || STATUS_CONFIG.untracked;
-    const { dir, base } = splitPath(change.relativePath);
-    const displayDir = formatDirForDisplay(dir);
-    const key = rowKey(change);
-    const isNew = newRowKeys.has(key);
-    const index = indexByKey.get(key) ?? 0;
+    const closeModal = () => {
+      setSelectedFile(null);
+    };
 
-    const row = (
-      <Tooltip key={key} autoDismiss={false}>
-        <TooltipTrigger asChild>
-          <div
-            data-recency-new={isNew ? "true" : undefined}
-            role="button"
-            tabIndex={0}
-            aria-label={`Open ${change.relativePath}`}
-            className={cn(
-              "group/filerow flex items-center text-xs font-mono hover:bg-tint/5 rounded px-1.5 py-0.5 -mx-1.5 cursor-pointer transition-colors",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-daintree-accent",
-              isNew && "file-change-row-new"
-            )}
-            onClick={(e) => openFileAt(index, e.currentTarget)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                openFileAt(index, e.currentTarget);
-              }
-            }}
-          >
-            <span className={cn("w-4 font-bold shrink-0", config.color)}>{config.label}</span>
+    const navigateFile = (delta: -1 | 1) => {
+      // Clamp against the live length first — a worktree refresh can shrink the
+      // set while the modal is open, leaving the derived index stale.
+      if (selectedIndex === null) return;
+      const safeCurrent = Math.min(selectedIndex, sortedChanges.length - 1);
+      const next = Math.min(Math.max(safeCurrent + delta, 0), sortedChanges.length - 1);
+      const change = sortedChanges[next];
+      if (change) {
+        setSelectedFile({ path: change.relativePath, status: change.status });
+      }
+    };
 
-            <div className="flex-1 min-w-0 flex items-center mr-2">
-              {showDir && displayDir && (
-                <span className="truncate min-w-0 text-daintree-text/60 opacity-60 group-hover/filerow:opacity-80">
-                  {displayDir}/
+    const renderFileItem = (change: FileChangeWithRelativePath, showDir: boolean) => {
+      const config = STATUS_CONFIG[change.status] || STATUS_CONFIG.untracked;
+      const { dir, base } = splitPath(change.relativePath);
+      const displayDir = formatDirForDisplay(dir);
+      const key = rowKey(change);
+      const isNew = newRowKeys.has(key);
+      const index = indexByKey.get(key) ?? 0;
+
+      const row = (
+        <Tooltip key={key} autoDismiss={false}>
+          <TooltipTrigger asChild>
+            <div
+              data-recency-new={isNew ? "true" : undefined}
+              role="button"
+              tabIndex={0}
+              aria-label={`Open ${change.relativePath}`}
+              className={cn(
+                "group/filerow flex items-center text-xs font-mono hover:bg-tint/5 rounded px-1.5 py-0.5 -mx-1.5 cursor-pointer transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-daintree-accent",
+                isNew && "file-change-row-new"
+              )}
+              onClick={(e) => openFileAt(index, e.currentTarget)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openFileAt(index, e.currentTarget);
+                }
+              }}
+            >
+              <span className={cn("w-4 font-bold shrink-0", config.color)}>{config.label}</span>
+
+              <div className="flex-1 min-w-0 flex items-center mr-2">
+                {showDir && displayDir && (
+                  <span className="truncate min-w-0 text-daintree-text/60 opacity-60 group-hover/filerow:opacity-80">
+                    {displayDir}/
+                  </span>
+                )}
+                <span className="text-daintree-text group-hover/filerow:text-daintree-text font-medium truncate min-w-0">
+                  {base}
                 </span>
-              )}
-              <span className="text-daintree-text group-hover/filerow:text-daintree-text font-medium truncate min-w-0">
-                {base}
-              </span>
-            </div>
+              </div>
 
-            <div className="flex items-center gap-2 shrink-0 text-[11px]">
-              {(change.insertions ?? 0) > 0 && (
-                <span className="text-status-success/80">+{change.insertions}</span>
-              )}
-              {(change.deletions ?? 0) > 0 && (
-                <span className="text-status-error/80">-{change.deletions}</span>
-              )}
-              <FileDecorationBadge decoration={decorations[change.path]} />
+              <div className="flex items-center gap-2 shrink-0 text-[11px]">
+                {(change.insertions ?? 0) > 0 && (
+                  <span className="text-status-success/80">+{change.insertions}</span>
+                )}
+                {(change.deletions ?? 0) > 0 && (
+                  <span className="text-status-error/80">-{change.deletions}</span>
+                )}
+                <FileDecorationBadge decoration={decorations[change.path]} />
+              </div>
             </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{change.relativePath}</TooltipContent>
+        </Tooltip>
+      );
+
+      // Wrap in a `file` context menu only when a plugin contributes file items —
+      // a zero-plugin list keeps its plain-row DOM. The dispatched args carry the
+      // real clicked file (absolute path, worktree root, status) so a plugin's
+      // item — or a built-in like `file.openDiff` — receives the subject instead
+      // of `undefined`.
+      if (filePluginItems.length === 0) return row;
+
+      const absolutePath = isAbsolute(change.path)
+        ? change.path
+        : join(rootPath, change.relativePath);
+      return (
+        <ContextMenu key={key}>
+          <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+          <ContextMenuContent>
+            <PluginContextMenuSection
+              items={filePluginItems}
+              leadingSeparator={false}
+              dispatchArgs={{
+                path: absolutePath,
+                worktreePath: rootPath,
+                status: change.status,
+              }}
+            />
+          </ContextMenuContent>
+        </ContextMenu>
+      );
+    };
+
+    if (groupByFolder && groupedChanges.length > 0) {
+      return (
+        <>
+          <div
+            className={cn(
+              "space-y-3 w-full max-h-64 overscroll-contain",
+              className,
+              // After `className` so no caller can undo it: the rows' -mx-1.5
+              // hover bleed overflows the container, and with overflow-y set,
+              // `visible` on x computes to `auto` — a horizontal scrollbar. The
+              // container's padding absorbs the bleed; anything longer truncates.
+              "overflow-y-auto overflow-x-hidden",
+              isStale && "surface-stale"
+            )}
+            aria-busy={isStale || undefined}
+          >
+            {groupedChanges.map((group) => (
+              <div key={group.dir}>
+                <div className="flex items-center gap-1.5 text-[11px] text-daintree-text/40 mb-1">
+                  <Folder className="w-3 h-3 shrink-0" />
+                  <span className="min-w-0 truncate font-mono">{group.displayDir}</span>
+                  <span className="shrink-0 text-daintree-text/30">({group.files.length})</span>
+                </div>
+                <div className="pl-4 flex flex-col gap-0.5">
+                  {group.files.map((file) => renderFileItem(file, false))}
+                </div>
+              </div>
+            ))}
+            {remainingCount > 0 && (
+              <div className="text-[11px] text-daintree-text/60 pl-4 pt-1">
+                ...and {remainingCount} more
+                {remainingFiles.length > 0 && (
+                  <span className="ml-1 opacity-75">
+                    ({remainingFiles.map((f) => basename(f.relativePath)).join(", ")}
+                    {sortedChanges.length > maxVisible + 2 && ", ..."})
+                  </span>
+                )}
+              </div>
+            )}
           </div>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{change.relativePath}</TooltipContent>
-      </Tooltip>
-    );
 
-    // Wrap in a `file` context menu only when a plugin contributes file items —
-    // a zero-plugin list keeps its plain-row DOM. The dispatched args carry the
-    // real clicked file (absolute path, worktree root, status) so a plugin's
-    // item — or a built-in like `file.openDiff` — receives the subject instead
-    // of `undefined`.
-    if (filePluginItems.length === 0) return row;
-
-    const absolutePath = isAbsolute(change.path)
-      ? change.path
-      : join(rootPath, change.relativePath);
-    return (
-      <ContextMenu key={key}>
-        <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
-        <ContextMenuContent>
-          <PluginContextMenuSection
-            items={filePluginItems}
-            leadingSeparator={false}
-            dispatchArgs={{
-              path: absolutePath,
-              worktreePath: rootPath,
-              status: change.status,
-            }}
+          <FileDiffModal
+            isOpen={selectedFile !== null}
+            filePath={liveSelected?.relativePath ?? selectedFile?.path ?? ""}
+            status={liveSelected?.status ?? selectedFile?.status ?? "modified"}
+            worktreePath={rootPath}
+            onClose={closeModal}
+            restoreFocusTo={triggerElementRef}
+            currentFileIndex={selectedIndex ?? undefined}
+            totalFileCount={sortedChanges.length}
+            onNavigateFile={navigateFile}
+            getAdjacentFile={getAdjacentFile}
+            changeSet={diffChangeSet}
+            onSelectFile={selectFileAt}
           />
-        </ContextMenuContent>
-      </ContextMenu>
-    );
-  };
+        </>
+      );
+    }
 
-  if (groupByFolder && groupedChanges.length > 0) {
     return (
       <>
         <div
           className={cn(
-            "space-y-3 w-full max-h-64 overscroll-contain",
+            "flex flex-col gap-0.5 w-full max-h-64 overscroll-contain",
             className,
-            // After `className` so no caller can undo it: the rows' -mx-1.5
-            // hover bleed overflows the container, and with overflow-y set,
-            // `visible` on x computes to `auto` — a horizontal scrollbar. The
-            // container's padding absorbs the bleed; anything longer truncates.
+            // Same post-className overflow guarantee as the grouped container.
             "overflow-y-auto overflow-x-hidden",
             isStale && "surface-stale"
           )}
           aria-busy={isStale || undefined}
         >
-          {groupedChanges.map((group) => (
-            <div key={group.dir}>
-              <div className="flex items-center gap-1.5 text-[11px] text-daintree-text/40 mb-1">
-                <Folder className="w-3 h-3 shrink-0" />
-                <span className="min-w-0 truncate font-mono">{group.displayDir}</span>
-                <span className="shrink-0 text-daintree-text/30">({group.files.length})</span>
-              </div>
-              <div className="pl-4 flex flex-col gap-0.5">
-                {group.files.map((file) => renderFileItem(file, false))}
-              </div>
-            </div>
-          ))}
+          {visibleChanges.map((change) => renderFileItem(change, true))}
+
           {remainingCount > 0 && (
-            <div className="text-[11px] text-daintree-text/60 pl-4 pt-1">
+            <div className="text-[11px] text-daintree-text/60 pl-5 pt-1">
               ...and {remainingCount} more
               {remainingFiles.length > 0 && (
                 <span className="ml-1 opacity-75">
-                  ({remainingFiles.map((f) => basename(f.relativePath)).join(", ")}
+                  ({remainingFiles.map((f) => basename(f.path)).join(", ")}
                   {sortedChanges.length > maxVisible + 2 && ", ..."})
                 </span>
               )}
@@ -433,48 +503,4 @@ export function FileChangeList({
       </>
     );
   }
-
-  return (
-    <>
-      <div
-        className={cn(
-          "flex flex-col gap-0.5 w-full max-h-64 overscroll-contain",
-          className,
-          // Same post-className overflow guarantee as the grouped container.
-          "overflow-y-auto overflow-x-hidden",
-          isStale && "surface-stale"
-        )}
-        aria-busy={isStale || undefined}
-      >
-        {visibleChanges.map((change) => renderFileItem(change, true))}
-
-        {remainingCount > 0 && (
-          <div className="text-[11px] text-daintree-text/60 pl-5 pt-1">
-            ...and {remainingCount} more
-            {remainingFiles.length > 0 && (
-              <span className="ml-1 opacity-75">
-                ({remainingFiles.map((f) => basename(f.path)).join(", ")}
-                {sortedChanges.length > maxVisible + 2 && ", ..."})
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-
-      <FileDiffModal
-        isOpen={selectedFile !== null}
-        filePath={liveSelected?.relativePath ?? selectedFile?.path ?? ""}
-        status={liveSelected?.status ?? selectedFile?.status ?? "modified"}
-        worktreePath={rootPath}
-        onClose={closeModal}
-        restoreFocusTo={triggerElementRef}
-        currentFileIndex={selectedIndex ?? undefined}
-        totalFileCount={sortedChanges.length}
-        onNavigateFile={navigateFile}
-        getAdjacentFile={getAdjacentFile}
-        changeSet={diffChangeSet}
-        onSelectFile={selectFileAt}
-      />
-    </>
-  );
-}
+);

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -1,13 +1,13 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import type { WorktreeState } from "../../types";
 import type { ErrorRecord, RetryAction } from "../../store/errorStore";
 import { ErrorBanner } from "../Errors/ErrorBanner";
-import { FileChangeList } from "./FileChangeList";
+import { FileChangeList, type FileChangeListHandle } from "./FileChangeList";
 import { LiveTimeAgo } from "./LiveTimeAgo";
 import { CommitAuthorAvatar } from "./WorktreeCard/CommitAuthorAvatar";
 import { CommitInfoTooltip } from "./WorktreeCard/CommitInfoTooltip";
 import { cn } from "../../lib/utils";
-import { GitCommit, Copy, Check, ExternalLink } from "lucide-react";
+import { GitCommit, Copy, Check, ExternalLink, FileDiff } from "lucide-react";
 import { parseNoteWithLinks, formatPath, type TextSegment } from "../../utils/textParsing";
 import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
@@ -57,6 +57,7 @@ export function WorktreeDetails({
   const displayPath = formatPath(worktree.path, homeDir);
   const rawLastCommitMsg = worktree.worktreeChanges?.lastCommitMessage;
   const { copied: pathCopied, copy: copyPath } = useCopyWithFeedback();
+  const fileChangeListRef = useRef<FileChangeListHandle>(null);
 
   // "Last active" footer line. Prefers the worktree's activity timestamp, but
   // falls back to the last-commit time so a worktree with no in-session
@@ -187,8 +188,26 @@ export function WorktreeDetails({
               shape on themes where that fill lands close to the panel's. */}
           {hasChanges && worktree.worktreeChanges && (
             <div className="space-y-2.5">
-              <div className="px-2 text-xs font-medium text-text-secondary">Changed Files</div>
+              <div className="flex items-center justify-between gap-2 px-2">
+                <span className="text-xs font-medium text-text-secondary">Changed Files</span>
+                {worktree.worktreeChanges.changes.length > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={(e) => fileChangeListRef.current?.openFirstFile(e.currentTarget)}
+                        className="shrink-0 rounded p-1 text-text-muted transition-colors hover:bg-overlay-soft hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                        aria-label="Open changes"
+                      >
+                        <FileDiff className="w-3.5 h-3.5" aria-hidden="true" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Open changes</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
               <FileChangeList
+                ref={fileChangeListRef}
                 changes={worktree.worktreeChanges.changes}
                 rootPath={worktree.worktreeChanges.rootPath}
                 maxVisible={MAX_VISIBLE_FILES}

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -195,7 +195,13 @@ export function WorktreeDetails({
                     <TooltipTrigger asChild>
                       <button
                         type="button"
-                        onClick={(e) => fileChangeListRef.current?.openFirstFile(e.currentTarget)}
+                        onClick={(e) => {
+                          // Stop the click reaching WorktreeCard's onSelect — in the
+                          // overview modal that closes the card and unmounts this list
+                          // before the diff can open (matches the sibling path buttons).
+                          e.stopPropagation();
+                          fileChangeListRef.current?.openFirstFile(e.currentTarget);
+                        }}
                         className="shrink-0 rounded p-1 text-text-muted transition-colors hover:bg-overlay-soft hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                         aria-label="Open changes"
                       >

--- a/src/components/Worktree/__tests__/FileChangeList.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.test.tsx
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { act, render, cleanup, fireEvent } from "@testing-library/react";
+import { createRef } from "react";
 import type { FileChangeDetail } from "../../../types";
 
 const { capturedModalProps } = vi.hoisted(() => ({
@@ -45,7 +46,7 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-import { FileChangeList } from "../FileChangeList";
+import { FileChangeList, type FileChangeListHandle } from "../FileChangeList";
 
 const ROOT = "/repo";
 
@@ -396,5 +397,61 @@ describe("FileChangeList — focus restore & file stepping (#9217)", () => {
     act(() => capturedModalProps.onClose!());
     expect(capturedModalProps.isOpen).toBe(false);
     expect(capturedModalProps.currentFileIndex).toBeUndefined();
+  });
+});
+
+describe("FileChangeList — openFirstFile imperative handle (#11041)", () => {
+  beforeEach(() => {
+    capturedModalProps.isOpen = false;
+    capturedModalProps.filePath = "";
+    capturedModalProps.restoreFocusTo = undefined;
+    capturedModalProps.currentFileIndex = undefined;
+    capturedModalProps.totalFileCount = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each([false, true])(
+    "opens the highest-churn file first and seeds the given trigger (groupByFolder=%s)",
+    (groupByFolder) => {
+      const ref = createRef<FileChangeListHandle>();
+      // Raw order lists b.ts first, but a.ts has more churn, so it sorts to index 0.
+      const changes = [
+        { ...file("b.ts"), insertions: 1 },
+        { ...file("a.ts"), insertions: 100 },
+      ];
+      render(
+        <FileChangeList ref={ref} changes={changes} rootPath={ROOT} groupByFolder={groupByFolder} />
+      );
+
+      const trigger = document.createElement("button");
+      act(() => ref.current!.openFirstFile(trigger));
+
+      expect(capturedModalProps.isOpen).toBe(true);
+      expect(capturedModalProps.filePath).toBe("a.ts");
+      expect(capturedModalProps.currentFileIndex).toBe(0);
+      const restore = capturedModalProps.restoreFocusTo as { current: HTMLElement | null };
+      expect(restore.current).toBe(trigger);
+    }
+  );
+
+  it("keeps the handle stable across an empty→populated transition and no-ops while empty", () => {
+    const ref = createRef<FileChangeListHandle>();
+    const { rerender } = render(<FileChangeList ref={ref} changes={[]} rootPath={ROOT} />);
+
+    // The hook is registered above the empty-list early return, so the handle
+    // exists even though nothing rendered; calling it is a safe no-op.
+    expect(ref.current).not.toBeNull();
+    act(() => ref.current!.openFirstFile(document.createElement("button")));
+    expect(capturedModalProps.isOpen).toBe(false);
+
+    act(() => {
+      rerender(<FileChangeList ref={ref} changes={[file("a.ts")]} rootPath={ROOT} />);
+    });
+    act(() => ref.current!.openFirstFile(document.createElement("button")));
+    expect(capturedModalProps.isOpen).toBe(true);
+    expect(capturedModalProps.filePath).toBe("a.ts");
   });
 });

--- a/src/components/Worktree/__tests__/FileChangeList.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.test.tsx
@@ -437,7 +437,7 @@ describe("FileChangeList — openFirstFile imperative handle (#11041)", () => {
     }
   );
 
-  it("keeps the handle stable across an empty→populated transition and no-ops while empty", () => {
+  it("keeps the handle available across an empty→populated transition and no-ops while empty", () => {
     const ref = createRef<FileChangeListHandle>();
     const { rerender } = render(<FileChangeList ref={ref} changes={[]} rootPath={ROOT} />);
 
@@ -450,6 +450,10 @@ describe("FileChangeList — openFirstFile imperative handle (#11041)", () => {
     act(() => {
       rerender(<FileChangeList ref={ref} changes={[file("a.ts")]} rootPath={ROOT} />);
     });
+    // The modal renders now that a file exists but stays closed until the handle
+    // is invoked, so the open below is a real effect of the call, not a leftover.
+    expect(capturedModalProps.isOpen).toBe(false);
+
     act(() => ref.current!.openFirstFile(document.createElement("button")));
     expect(capturedModalProps.isOpen).toBe(true);
     expect(capturedModalProps.filePath).toBe("a.ts");

--- a/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import type { WorktreeState } from "@/types";
 import type { WorktreeChanges } from "@shared/types/git";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,6 +10,23 @@ import { WorktreeDetails, type WorktreeDetailsProps } from "../WorktreeDetails";
 
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: vi.fn() },
+}));
+
+const { capturedModalProps } = vi.hoisted(() => ({
+  capturedModalProps: {
+    isOpen: false as boolean,
+    filePath: "" as string,
+    restoreFocusTo: undefined as unknown,
+  },
+}));
+
+vi.mock("../FileDiffModal", () => ({
+  FileDiffModal: (props: { isOpen: boolean; filePath: string; restoreFocusTo?: unknown }) => {
+    capturedModalProps.isOpen = props.isOpen;
+    capturedModalProps.filePath = props.filePath;
+    capturedModalProps.restoreFocusTo = props.restoreFocusTo;
+    return null;
+  },
 }));
 
 const noop = () => {};
@@ -96,5 +113,45 @@ describe("WorktreeDetails last-active line", () => {
     const { container } = renderDetails({ worktree });
     expect(screen.getByText("Last active")).toBeDefined();
     expect(container.querySelector("img")).toBeNull();
+  });
+});
+
+describe("WorktreeDetails — open changes button (#11041)", () => {
+  const worktreeWithChanges: WorktreeState = {
+    ...baseWorktree,
+    worktreeChanges: {
+      ...baseWorktree.worktreeChanges,
+      changedFileCount: 2,
+      changes: [
+        { path: "a.ts", status: "modified", insertions: 5, deletions: 1 },
+        { path: "b.ts", status: "added", insertions: 2, deletions: 0 },
+      ],
+      rootPath: "/tmp/wt",
+    } as WorktreeChanges,
+  };
+
+  beforeEach(() => {
+    capturedModalProps.isOpen = false;
+    capturedModalProps.filePath = "";
+    capturedModalProps.restoreFocusTo = undefined;
+  });
+
+  it("shows the button when there are changes and opens the first file's diff from it", () => {
+    renderDetails({ worktree: worktreeWithChanges, hasChanges: true });
+    const button = screen.getByLabelText("Open changes");
+
+    fireEvent.click(button);
+
+    expect(capturedModalProps.isOpen).toBe(true);
+    // a.ts has the higher churn (6 vs 2), so it sorts to the first slot.
+    expect(capturedModalProps.filePath).toBe("a.ts");
+    // Focus restores to the header button that opened the modal, not a row.
+    const restore = capturedModalProps.restoreFocusTo as { current: HTMLElement | null };
+    expect(restore.current).toBe(button);
+  });
+
+  it("hides the button when the change list is empty", () => {
+    renderDetails({ worktree: baseWorktree, hasChanges: true });
+    expect(screen.queryByLabelText("Open changes")).toBeNull();
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDetails.test.tsx
@@ -122,9 +122,11 @@ describe("WorktreeDetails — open changes button (#11041)", () => {
     worktreeChanges: {
       ...baseWorktree.worktreeChanges,
       changedFileCount: 2,
+      // b.ts is listed first but has lower churn (2 vs 6), so a discriminating
+      // test proves the button opens the *sorted* first file, not raw index 0.
       changes: [
-        { path: "a.ts", status: "modified", insertions: 5, deletions: 1 },
         { path: "b.ts", status: "added", insertions: 2, deletions: 0 },
+        { path: "a.ts", status: "modified", insertions: 5, deletions: 1 },
       ],
       rootPath: "/tmp/wt",
     } as WorktreeChanges,
@@ -138,20 +140,39 @@ describe("WorktreeDetails — open changes button (#11041)", () => {
 
   it("shows the button when there are changes and opens the first file's diff from it", () => {
     renderDetails({ worktree: worktreeWithChanges, hasChanges: true });
-    const button = screen.getByLabelText("Open changes");
+    const button = screen.getByRole("button", { name: "Open changes" });
 
     fireEvent.click(button);
 
     expect(capturedModalProps.isOpen).toBe(true);
-    // a.ts has the higher churn (6 vs 2), so it sorts to the first slot.
+    // a.ts has the higher churn (6 vs 2), so it sorts ahead of the raw-first b.ts.
     expect(capturedModalProps.filePath).toBe("a.ts");
     // Focus restores to the header button that opened the modal, not a row.
     const restore = capturedModalProps.restoreFocusTo as { current: HTMLElement | null };
     expect(restore.current).toBe(button);
   });
 
+  it("does not bubble the click to the surrounding card (stops propagation)", () => {
+    // In the overview modal, a click reaching WorktreeCard's onSelect closes the
+    // card and unmounts the list before the diff can open — so the button must
+    // not let its click bubble.
+    const onParentClick = vi.fn();
+    render(
+      <TooltipProvider>
+        <div onClick={onParentClick}>
+          <WorktreeDetails {...baseProps} worktree={worktreeWithChanges} hasChanges />
+        </div>
+      </TooltipProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open changes" }));
+
+    expect(capturedModalProps.isOpen).toBe(true);
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
   it("hides the button when the change list is empty", () => {
     renderDetails({ worktree: baseWorktree, hasChanges: true });
-    expect(screen.queryByLabelText("Open changes")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open changes" })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a dedicated icon button next to the `Changed Files` heading in the worktree details panel that opens the diff viewer directly on the first changed file, so there's no need to click an individual file row first.
- Matches the affordance VS Code calls Open Changes and JetBrains calls Show Diff.
- The button stops click propagation so it can't bubble into `WorktreeCard`'s `onSelect`, which in the overview modal would close the card and unmount the file list before the diff opens.

Resolves #11041

## Changes
- `FileChangeList` exposes an `openFirstFile(triggerEl)` imperative handle via `forwardRef` and `useImperativeHandle`, reusing the existing `openFileAt(0)` path (hoisted above the empty-list early return).
- `WorktreeDetails` holds the ref and renders the button, gated on a non-empty change list, restoring focus to the button on modal close via the existing `triggerElementRef`.
- Button click handler calls `stopPropagation` to prevent the click reaching `WorktreeCard`'s `onSelect` in the overview modal.

## Testing
- 5 new unit tests: imperative handle across flat and grouped branches and the empty-to-populated transition; button visibility, first-file selection, focus target, and a propagation regression.
- Full covering test set green: 88 tests across 7 files.
- Known, pre-existing, out-of-scope follow-up: the individual file-row click handler in `FileChangeList` has the same latent overview-modal bubbling behavior (no `stopPropagation`); not introduced or worsened here.