### PR TITLE
perf: throttle PTY output analysis, bound recipe startup, batch bulk-worktree admission

### DIFF
--- a/e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts
+++ b/e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts
@@ -1,0 +1,644 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- perf instrumentation crosses Playwright's process boundary */
+import { expect, test, type ElectronApplication, type Page } from "@playwright/test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { closeApp, launchApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo, removePathSync } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import {
+  connectGitHub,
+  makeFixtureIssue,
+  stubListIssues,
+  stubRepoStats,
+} from "../../helpers/githubHelpers";
+import { SEL } from "../../helpers/selectors";
+import { T_LONG, T_MEDIUM } from "../../helpers/timeouts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const DEFAULT_OUTPUT = path.join(REPO_ROOT, ".tmp", "perf-results", "bulk-issue-worktrees.json");
+const RECIPE_NAME = "Bulk issue benchmark layout";
+const READY_TIMEOUT_MS = 90_000;
+const WHOLE_RUN_TIMEOUT_MS = 30 * 60_000;
+const PAUSE_THRESHOLD_MS = 500;
+
+function parseInteger(
+  name: string,
+  fallback: number,
+  options: { allowZero?: boolean } = {}
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  const minimum = options.allowZero ? 0 : 1;
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer >= ${minimum}, got '${raw}'`);
+  }
+  return value;
+}
+
+function parseScales(): number[] {
+  const raw = process.env.PERF_BULK_ISSUE_SCALES ?? "1,6,10";
+  const scales = raw.split(",").map((part) => Number(part.trim()));
+  if (
+    scales.length === 0 ||
+    scales.some((scale) => !Number.isSafeInteger(scale) || scale < 1 || scale > 20)
+  ) {
+    throw new Error(`PERF_BULK_ISSUE_SCALES must contain integers from 1 to 20, got '${raw}'`);
+  }
+  if (new Set(scales).size !== scales.length) {
+    throw new Error(`PERF_BULK_ISSUE_SCALES must not contain duplicates, got '${raw}'`);
+  }
+  return scales;
+}
+
+const CONFIG = {
+  scales: parseScales(),
+  rounds: parseInteger("PERF_BULK_ISSUE_ROUNDS", 3),
+  warmups: parseInteger("PERF_BULK_ISSUE_WARMUPS", 1, { allowZero: true }),
+  outputPath: path.resolve(REPO_ROOT, process.env.PERF_BULK_ISSUE_OUTPUT?.trim() || DEFAULT_OUTPUT),
+};
+
+interface TimedCall {
+  startedAt: number;
+  resolvedAt: number | null;
+  failed: boolean;
+  id?: string;
+  branch?: string;
+  spawnBatchId?: string;
+  spawnBatchSize?: number;
+}
+
+interface HarnessMetrics {
+  worktrees: TimedCall[];
+  terminals: TimedCall[];
+}
+
+interface SampleMetrics {
+  issueSelectionMs: number;
+  dialogOpenMs: number;
+  recipeSelectionMs: number;
+  firstWorktreeStartedMs: number;
+  allWorktreesResolvedMs: number;
+  dialogDoneMs: number;
+  firstTerminalStartedMs: number;
+  allTerminalsSpawnedMs: number;
+  totalFlowMs: number;
+  maximumRendererFrameGapMs: number;
+  largestTerminalAdmissionGapMs: number;
+  terminalPauseCount: number;
+  terminalsBeforeFirstPause: number;
+}
+
+interface BenchmarkSample {
+  id: "PERF-182";
+  scale: number;
+  round: number;
+  warmup: boolean;
+  ok: boolean;
+  metricsMs: SampleMetrics;
+  counts: {
+    issues: number;
+    worktreesStarted: number;
+    worktreesResolved: number;
+    terminalsStarted: number;
+    terminalsResolved: number;
+    failedCalls: number;
+  };
+  errors: string[];
+}
+
+interface BenchmarkSummary {
+  scale: number;
+  count: number;
+  failures: number;
+  metricsMs: Record<keyof SampleMetrics, { median: number; p95: number }>;
+}
+
+interface ResultDocument {
+  version: 1;
+  generatedAt: string;
+  config: typeof CONFIG;
+  environment: {
+    platform: NodeJS.Platform;
+    arch: string;
+    node: string;
+    fakeForge: true;
+    fakeWorktrees: true;
+    realTerminalPipeline: true;
+  };
+  samples: BenchmarkSample[];
+  summaries: BenchmarkSummary[];
+}
+
+let resultDocument: ResultDocument;
+let fixtureDir = "";
+let fixtureCleanup: (() => void) | undefined;
+let harnessTempDir = "";
+let fakeBinDir = "";
+let emptyZdotdir = "";
+
+function percentile(values: number[], percent: number): number {
+  if (values.length === 0) return Number.NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((percent / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, index)]!;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return Number.NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1]! + sorted[middle]!) / 2 : sorted[middle]!;
+}
+
+function buildSummaries(samples: BenchmarkSample[]): BenchmarkSummary[] {
+  return CONFIG.scales.map((scale) => {
+    const cells = samples.filter((sample) => !sample.warmup && sample.scale === scale);
+    const successful = cells.filter((sample) => sample.ok);
+    const metrics = {} as BenchmarkSummary["metricsMs"];
+    const names = Object.keys(cells[0]?.metricsMs ?? {}) as Array<keyof SampleMetrics>;
+    for (const name of names) {
+      const values = successful.map((sample) => sample.metricsMs[name]);
+      metrics[name] = { median: median(values), p95: percentile(values, 95) };
+    }
+    return {
+      scale,
+      count: successful.length,
+      failures: cells.length - successful.length,
+      metricsMs: metrics,
+    };
+  });
+}
+
+function persistResults(): void {
+  resultDocument.generatedAt = new Date().toISOString();
+  resultDocument.summaries = buildSummaries(resultDocument.samples);
+  mkdirSync(path.dirname(CONFIG.outputPath), { recursive: true });
+  const temporaryPath = `${CONFIG.outputPath}.${process.pid}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(resultDocument, null, 2)}\n`);
+  try {
+    renameSync(temporaryPath, CONFIG.outputPath);
+  } catch (error) {
+    if (process.platform !== "win32") throw error;
+    try {
+      unlinkSync(CONFIG.outputPath);
+    } catch {
+      // First write has no destination to remove.
+    }
+    renameSync(temporaryPath, CONFIG.outputPath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+function prepareFixture(): void {
+  const fixture = createFixtureRepo({ name: "bulk-issue-worktree-perf", withGitHubRemote: true });
+  fixtureDir = fixture.dir;
+  fixtureCleanup = fixture.cleanup;
+  harnessTempDir = mkdtempSync(path.join(os.tmpdir(), "daintree-bulk-issue-perf-"));
+  fakeBinDir = path.join(harnessTempDir, "bin");
+  emptyZdotdir = path.join(harnessTempDir, "zdotdir");
+  mkdirSync(fakeBinDir, { recursive: true });
+  mkdirSync(emptyZdotdir, { recursive: true });
+
+  const executableName =
+    process.platform === "win32" ? "daintree-bulk-perf-agent.js" : "daintree-bulk-perf-agent";
+  const executablePath = path.join(fakeBinDir, executableName);
+  writeFileSync(
+    executablePath,
+    [
+      "#!/usr/bin/env node",
+      "process.stdout.write('bulk-issue-ready\\n');",
+      "process.stdin.resume();",
+      "const keepAlive = setInterval(() => {}, 1000);",
+      "const shutdown = () => { clearInterval(keepAlive); process.exit(0); };",
+      "process.on('SIGINT', shutdown);",
+      "process.on('SIGTERM', shutdown);",
+      "",
+    ].join("\n")
+  );
+  chmodSync(executablePath, 0o755);
+  if (process.platform === "win32") {
+    writeFileSync(
+      path.join(fakeBinDir, "daintree-bulk-perf-agent.cmd"),
+      ["@echo off", 'node "%~dp0daintree-bulk-perf-agent.js" %*', ""].join("\r\n")
+    );
+  }
+
+  const recipesDir = path.join(fixtureDir, ".daintree", "recipes");
+  mkdirSync(recipesDir, { recursive: true });
+  writeFileSync(
+    path.join(recipesDir, "bulk-issue-benchmark.json"),
+    `${JSON.stringify(
+      {
+        id: "bulk-issue-benchmark-layout",
+        name: RECIPE_NAME,
+        terminals: [
+          {
+            type: "terminal",
+            title: "Issue agent",
+            command: "daintree-bulk-perf-agent",
+            env: {},
+          },
+        ],
+        createdAt: 1_700_000_000_000,
+        showInEmptyState: false,
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+async function installHermeticHandlers(app: ElectronApplication): Promise<void> {
+  await app.evaluate(
+    ({ ipcMain }, { cwd }) => {
+      const handlers = (ipcMain as any)._invokeHandlers as Map<
+        string,
+        (event: unknown, payload: any) => Promise<unknown>
+      >;
+      const originalTerminalSpawn = handlers.get("terminal:spawn");
+      if (!originalTerminalSpawn) throw new Error("terminal:spawn handler is unavailable");
+
+      const metrics: HarnessMetrics = { worktrees: [], terminals: [] };
+      (globalThis as any).__bulkIssuePerfMetrics = metrics;
+
+      const replace = (
+        channel: string,
+        handler: (event: unknown, payload: any) => Promise<unknown>
+      ) => {
+        ipcMain.removeHandler(channel);
+        ipcMain.handle(channel, handler);
+      };
+
+      replace("worktree:get-available-branch", async (_event, payload) => payload.branchName);
+      replace("worktree:get-default-path", async () => cwd);
+      replace("worktree:create", async (_event, payload) => {
+        const entry: TimedCall = {
+          startedAt: Date.now(),
+          resolvedAt: null,
+          failed: false,
+          branch: payload.options.newBranch,
+        };
+        metrics.worktrees.push(entry);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        entry.resolvedAt = Date.now();
+        entry.id = `fake-worktree-${metrics.worktrees.length}-${payload.options.newBranch}`;
+        return entry.id;
+      });
+      replace("worktree:set-active", async () => undefined);
+      replace("terminal:spawn", async (event, payload) => {
+        const entry: TimedCall = {
+          startedAt: Date.now(),
+          resolvedAt: null,
+          failed: false,
+          id: payload.id,
+          spawnBatchId: payload.spawnBatchId,
+          spawnBatchSize: payload.spawnBatchSize,
+        };
+        metrics.terminals.push(entry);
+        try {
+          const result = await originalTerminalSpawn(event, payload);
+          entry.resolvedAt = Date.now();
+          return result;
+        } catch (error) {
+          entry.failed = true;
+          entry.resolvedAt = Date.now();
+          throw error;
+        }
+      });
+    },
+    { cwd: fixtureDir }
+  );
+}
+
+async function readHarnessMetrics(app: ElectronApplication): Promise<HarnessMetrics> {
+  return await app.evaluate(() => {
+    const metrics = (globalThis as any).__bulkIssuePerfMetrics as HarnessMetrics | undefined;
+    if (!metrics) throw new Error("bulk issue perf metrics are unavailable");
+    return structuredClone(metrics);
+  });
+}
+
+async function startFrameProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = { gaps: [] as number[], last: performance.now(), requestId: 0 };
+    const tick = (now: number) => {
+      state.gaps.push(now - state.last);
+      state.last = now;
+      state.requestId = requestAnimationFrame(tick);
+    };
+    state.requestId = requestAnimationFrame(tick);
+    (window as any).__bulkIssueFrameProbe = state;
+  });
+}
+
+async function stopFrameProbe(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const state = (window as any).__bulkIssueFrameProbe as
+      | { gaps: number[]; requestId: number }
+      | undefined;
+    if (!state) return 0;
+    cancelAnimationFrame(state.requestId);
+    delete (window as any).__bulkIssueFrameProbe;
+    return state.gaps.length > 0 ? Math.max(...state.gaps) : 0;
+  });
+}
+
+async function openIssuesDropdown(page: Page): Promise<void> {
+  const pill = page.locator(SEL.github.statPillIssues);
+  await expect(pill).toBeVisible({ timeout: T_MEDIUM });
+  await expect(pill).not.toHaveAccessibleName(/Configure/, { timeout: T_MEDIUM });
+  await pill.scrollIntoViewIfNeeded();
+  await pill.click();
+}
+
+function analyzeAdmissionGaps(terminals: TimedCall[]): {
+  largestGap: number;
+  pauseCount: number;
+  beforeFirstPause: number;
+} {
+  const starts = terminals.map((terminal) => terminal.startedAt).sort((a, b) => a - b);
+  const gaps = starts.slice(1).map((startedAt, index) => startedAt - starts[index]!);
+  const pauseIndex = gaps.findIndex((gap) => gap >= PAUSE_THRESHOLD_MS);
+  return {
+    largestGap: gaps.length > 0 ? Math.max(...gaps) : 0,
+    pauseCount: gaps.filter((gap) => gap >= PAUSE_THRESHOLD_MS).length,
+    beforeFirstPause: pauseIndex < 0 ? starts.length : pauseIndex + 1,
+  };
+}
+
+async function runSample(scale: number, round: number, warmup: boolean): Promise<BenchmarkSample> {
+  let ctx: AppContext | null = null;
+  const errors: string[] = [];
+  const pageErrors: string[] = [];
+  const issueBase = round * 1_000 + (warmup ? 50_000 : 10_000);
+  const issues = Array.from({ length: scale }, (_, index) =>
+    makeFixtureIssue(issueBase + index + 1, `Bulk benchmark issue ${index + 1}`)
+  );
+
+  let issueSelectionMs = -1;
+  let dialogOpenMs = -1;
+  let recipeSelectionMs = -1;
+  let dialogDoneMs = -1;
+  let totalFlowMs = -1;
+  let maximumRendererFrameGapMs = 0;
+  let confirmStartedAt = 0;
+  let backendReadyAt = 0;
+  let harnessMetrics: HarnessMetrics = { worktrees: [], terminals: [] };
+
+  try {
+    ctx = await launchApp({
+      env: {
+        DAINTREE_E2E_FAULT_MODE: "1",
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        ZDOTDIR: emptyZdotdir,
+      },
+    });
+    ctx.window = await openAndOnboardProject(
+      ctx.app,
+      ctx.window,
+      fixtureDir,
+      `Bulk issue perf N=${scale} R=${round}`
+    );
+    ctx.window.on("pageerror", (error) => pageErrors.push(error.message));
+
+    await installHermeticHandlers(ctx.app);
+    await connectGitHub(ctx.app, ctx.window);
+    await stubRepoStats(
+      ctx.app,
+      { issueCount: issues.length, prCount: 0, commitCount: 1 },
+      ctx.window
+    );
+    await stubListIssues(ctx.app, issues);
+
+    await startFrameProbe(ctx.window);
+    const flowStartedAt = Date.now();
+    await openIssuesDropdown(ctx.window);
+    await ctx.window.locator(SEL.github.searchIssues).fill("Bulk benchmark");
+    await expect(ctx.window.locator(SEL.github.item(issues[0]!.number))).toBeVisible({
+      timeout: T_LONG,
+    });
+    const selectAll = ctx.window
+      .locator(SEL.github.selectionActions)
+      .getByRole("button", { name: /Select all/ });
+    await expect(selectAll).toBeVisible({ timeout: T_MEDIUM });
+    await selectAll.click();
+    issueSelectionMs = Date.now() - flowStartedAt;
+
+    await expect(ctx.window.locator(SEL.github.bulkActionBar)).toBeVisible({ timeout: T_MEDIUM });
+    await ctx.window.locator(SEL.github.bulkCreateButton).click();
+    const dialog = ctx.window.locator(SEL.github.bulkCreateDialog);
+    await expect(dialog).toBeVisible({ timeout: T_LONG });
+    dialogOpenMs = Date.now() - flowStartedAt;
+
+    const assignmentToggle = dialog.getByRole("checkbox", {
+      name: "Assign issues to me when creating worktrees",
+    });
+    if (await assignmentToggle.isChecked()) await assignmentToggle.uncheck();
+
+    const recipeTrigger = ctx.window.locator("#bulk-recipe-selector-trigger");
+    await expect(recipeTrigger).toBeVisible({ timeout: T_LONG });
+    await recipeTrigger.click();
+    const recipeList = ctx.window.locator("#bulk-recipe-selector");
+    await expect(recipeList).toBeVisible({ timeout: T_MEDIUM });
+    await recipeList.getByRole("option", { name: new RegExp(RECIPE_NAME, "i") }).click();
+    await expect(recipeTrigger).toContainText(RECIPE_NAME, { timeout: T_MEDIUM });
+    recipeSelectionMs = Date.now() - flowStartedAt;
+
+    const confirm = dialog.locator('[data-testid="bulk-create-confirm-button"]');
+    await expect(confirm).toHaveText(`Create ${scale} worktree${scale === 1 ? "" : "s"}`);
+    confirmStartedAt = Date.now();
+    await confirm.click();
+
+    const done = dialog.locator('[data-testid="bulk-create-done-button"]');
+    await expect(done).toBeVisible({ timeout: READY_TIMEOUT_MS });
+    dialogDoneMs = Date.now() - confirmStartedAt;
+    await expect(dialog).toContainText(`${scale} of ${scale} created`, { timeout: T_MEDIUM });
+    await expect(dialog).not.toContainText("failed", { timeout: T_MEDIUM });
+
+    await expect
+      .poll(
+        async () => {
+          const current = await readHarnessMetrics(ctx!.app);
+          return current.terminals.filter((terminal) => terminal.resolvedAt !== null).length;
+        },
+        { timeout: READY_TIMEOUT_MS, intervals: [25, 50, 100, 250] }
+      )
+      .toBe(scale);
+    backendReadyAt = Date.now();
+    totalFlowMs = backendReadyAt - flowStartedAt;
+    harnessMetrics = await readHarnessMetrics(ctx.app);
+    maximumRendererFrameGapMs = await stopFrameProbe(ctx.window);
+  } catch (error) {
+    errors.push(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    if (ctx?.window && !ctx.window.isClosed()) {
+      maximumRendererFrameGapMs = await stopFrameProbe(ctx.window).catch(() => 0);
+    }
+    if (ctx?.app) {
+      harnessMetrics = await readHarnessMetrics(ctx.app).catch(() => harnessMetrics);
+    }
+  } finally {
+    errors.push(...pageErrors.map((message) => `pageerror: ${message}`));
+    if (ctx?.app) await closeApp(ctx.app).catch(() => {});
+  }
+
+  const resolvedWorktrees = harnessMetrics.worktrees.filter(
+    (worktree) => worktree.resolvedAt !== null && !worktree.failed
+  );
+  const resolvedTerminals = harnessMetrics.terminals.filter(
+    (terminal) => terminal.resolvedAt !== null && !terminal.failed
+  );
+  const failedCalls = [...harnessMetrics.worktrees, ...harnessMetrics.terminals].filter(
+    (call) => call.failed
+  ).length;
+  if (harnessMetrics.worktrees.length !== scale) {
+    errors.push(`observed ${harnessMetrics.worktrees.length}/${scale} fake worktree creates`);
+  }
+  if (resolvedWorktrees.length !== scale) {
+    errors.push(`resolved ${resolvedWorktrees.length}/${scale} fake worktree creates`);
+  }
+  if (harnessMetrics.terminals.length !== scale) {
+    errors.push(`observed ${harnessMetrics.terminals.length}/${scale} terminal spawns`);
+  }
+  if (resolvedTerminals.length !== scale) {
+    errors.push(`resolved ${resolvedTerminals.length}/${scale} terminal spawns`);
+  }
+  if (failedCalls > 0) errors.push(`${failedCalls} instrumented calls failed`);
+
+  const firstWorktreeStartedAt = Math.min(
+    ...harnessMetrics.worktrees.map((worktree) => worktree.startedAt)
+  );
+  const lastWorktreeResolvedAt = Math.max(
+    ...resolvedWorktrees.map((worktree) => worktree.resolvedAt!)
+  );
+  const firstTerminalStartedAt = Math.min(
+    ...harnessMetrics.terminals.map((terminal) => terminal.startedAt)
+  );
+  const lastTerminalResolvedAt = Math.max(
+    ...resolvedTerminals.map((terminal) => terminal.resolvedAt!)
+  );
+  const admission = analyzeAdmissionGaps(harnessMetrics.terminals);
+  const fallbackEnd = backendReadyAt || Date.now();
+
+  return {
+    id: "PERF-182",
+    scale,
+    round,
+    warmup,
+    ok: errors.length === 0,
+    metricsMs: {
+      issueSelectionMs,
+      dialogOpenMs,
+      recipeSelectionMs,
+      firstWorktreeStartedMs: Number.isFinite(firstWorktreeStartedAt)
+        ? firstWorktreeStartedAt - confirmStartedAt
+        : -1,
+      allWorktreesResolvedMs: Number.isFinite(lastWorktreeResolvedAt)
+        ? lastWorktreeResolvedAt - confirmStartedAt
+        : -1,
+      dialogDoneMs,
+      firstTerminalStartedMs: Number.isFinite(firstTerminalStartedAt)
+        ? firstTerminalStartedAt - confirmStartedAt
+        : -1,
+      allTerminalsSpawnedMs: Number.isFinite(lastTerminalResolvedAt)
+        ? lastTerminalResolvedAt - confirmStartedAt
+        : fallbackEnd - confirmStartedAt,
+      totalFlowMs,
+      maximumRendererFrameGapMs,
+      largestTerminalAdmissionGapMs: admission.largestGap,
+      terminalPauseCount: admission.pauseCount,
+      terminalsBeforeFirstPause: admission.beforeFirstPause,
+    },
+    counts: {
+      issues: scale,
+      worktreesStarted: harnessMetrics.worktrees.length,
+      worktreesResolved: resolvedWorktrees.length,
+      terminalsStarted: harnessMetrics.terminals.length,
+      terminalsResolved: resolvedTerminals.length,
+      failedCalls,
+    },
+    errors,
+  };
+}
+
+function printSummary(): void {
+  console.table(
+    resultDocument.summaries.map((summary) => ({
+      N: summary.scale,
+      Success: `${summary.count}/${summary.count + summary.failures}`,
+      "Confirm → worktrees median ms": summary.metricsMs.allWorktreesResolvedMs?.median.toFixed(1),
+      "Confirm → dialog done median ms": summary.metricsMs.dialogDoneMs?.median.toFixed(1),
+      "Confirm → terminals median ms": summary.metricsMs.allTerminalsSpawnedMs?.median.toFixed(1),
+      "Whole flow median ms": summary.metricsMs.totalFlowMs?.median.toFixed(1),
+      "Largest admission gap median ms":
+        summary.metricsMs.largestTerminalAdmissionGapMs?.median.toFixed(1),
+      "Pauses median": summary.metricsMs.terminalPauseCount?.median.toFixed(1),
+      "Max frame gap p95 ms": summary.metricsMs.maximumRendererFrameGapMs?.p95.toFixed(1),
+    }))
+  );
+}
+
+const perfDescribe = process.env.RUN_PERF_BULK_ISSUE_WORKTREES ? test.describe : test.describe.skip;
+
+perfDescribe("Bulk issue worktree + recipe performance", () => {
+  test("PERF-182 fake issues → fake worktrees → real recipe terminals", async () => {
+    test.setTimeout(WHOLE_RUN_TIMEOUT_MS);
+    prepareFixture();
+    resultDocument = {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      config: CONFIG,
+      environment: {
+        platform: process.platform,
+        arch: process.arch,
+        node: process.version,
+        fakeForge: true,
+        fakeWorktrees: true,
+        realTerminalPipeline: true,
+      },
+      samples: [],
+      summaries: [],
+    };
+    persistResults();
+
+    try {
+      for (let warmup = 1; warmup <= CONFIG.warmups; warmup++) {
+        const sample = await runSample(Math.min(...CONFIG.scales), warmup, true);
+        resultDocument.samples.push(sample);
+        persistResults();
+        expect(sample.errors, `warmup ${warmup} passed reliability gates`).toEqual([]);
+      }
+
+      for (let round = 1; round <= CONFIG.rounds; round++) {
+        const scales = round % 2 === 0 ? [...CONFIG.scales].reverse() : CONFIG.scales;
+        for (const scale of scales) {
+          const sample = await runSample(scale, round, false);
+          resultDocument.samples.push(sample);
+          persistResults();
+          expect(sample.errors, `PERF-182 N=${scale} round=${round}`).toEqual([]);
+        }
+      }
+    } finally {
+      fixtureCleanup?.();
+      if (harnessTempDir) removePathSync(harnessTempDir);
+      persistResults();
+      printSummary();
+      console.log(`bulk issue worktree results: ${CONFIG.outputPath}`);
+    }
+
+    expect(
+      resultDocument.samples.filter((sample) => !sample.warmup && !sample.ok),
+      "every measured sample passed reliability gates"
+    ).toEqual([]);
+  });
+});

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -753,6 +753,37 @@ describe("terminal spawn rate limiting (#5352)", () => {
     expect(waitForBurstRateLimitSlotMock).toHaveBeenLastCalledWith("terminalSpawn", 1_000, 6);
   });
 
+  it("shares one admission across a multi-worktree recipe batch", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    const batch = {
+      spawnBatchId: "00000000-0000-4000-8000-000000000012",
+      spawnBatchSize: 12,
+    };
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      id: "bulk-terminal-1",
+      cols: 80,
+      rows: 24,
+      ...batch,
+    });
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      id: "bulk-terminal-2",
+      cols: 80,
+      rows: 24,
+      ...batch,
+    });
+
+    expect(waitForBurstRateLimitSlotMock).toHaveBeenCalledTimes(1);
+    expect(waitForBurstRateLimitSlotMock).toHaveBeenCalledWith(
+      "terminalRecipeSpawnBatch",
+      1_000,
+      1
+    );
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects without calling ptyClient.spawn when the rate-limit slot rejects", async () => {
     waitForBurstRateLimitSlotMock.mockRejectedValueOnce(new Error("Spawn queue full"));
 

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -51,7 +51,7 @@ function claimRecipeSpawnBatchAdmission(
 ): Promise<void> | null {
   const batchId = options.spawnBatchId;
   const batchSize = options.spawnBatchSize;
-  if (!batchId || !batchSize || batchSize > MAX_TERMINALS_PER_RECIPE) return null;
+  if (!batchId || !batchSize || batchSize > MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH) return null;
 
   const existing = recipeSpawnBatchAdmissions.get(batchId);
   if (existing) {
@@ -152,7 +152,7 @@ import type { WorkspaceClient } from "../../../services/WorkspaceClient.js";
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { quoteCommandArg } from "../../../../shared/utils/shellEscape.js";
-import { MAX_TERMINALS_PER_RECIPE } from "../../../../shared/utils/recipeSanitizer.js";
+import { MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH } from "../../../../shared/utils/recipeSanitizer.js";
 import { buildCommandLaunchShell } from "./commandLaunch.js";
 
 export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): () => void {

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -17,7 +17,7 @@ import type {
   McpConfirmationDecision,
   TurnOutcomeClass,
 } from "../../shared/types/ipc/mcpServer.js";
-import { MAX_TERMINALS_PER_RECIPE } from "../../shared/utils/recipeSanitizer.js";
+import { MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH } from "../../shared/utils/recipeSanitizer.js";
 
 /** Schema for a launch hint — built-in agent id or plugin-provided string. */
 const LaunchAgentIdSchema = z.union([z.enum(BUILT_IN_AGENT_IDS), z.string().min(1)]);
@@ -354,7 +354,7 @@ export const TerminalSpawnOptionsSchema = z.object({
   titleMode: TitleModeSchema.optional(),
   restore: z.boolean().optional(),
   spawnBatchId: z.string().uuid().optional(),
-  spawnBatchSize: z.number().int().min(2).max(MAX_TERMINALS_PER_RECIPE).optional(),
+  spawnBatchSize: z.number().int().min(2).max(MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH).optional(),
   isEphemeral: z.boolean().optional(),
   agentLaunchFlags: z.array(z.string()).optional(),
   agentModelId: z.string().optional(),

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -59,6 +59,7 @@ const SIMPLE_COMPLETION_MIN_QUIET_MS = 1500;
 // snapshot — long enough for xterm's async parse of the last chunk (and any
 // resize/focus-triggered redraw) to land before a frame is latched.
 const SIMPLE_SNAPSHOT_SETTLE_MS = 1000;
+const SIMPLE_SNAPSHOT_MIN_INTERVAL_MS = 250;
 // Idle-agent polling backoff (#10906). Once a simple-output agent has settled
 // into idle and stayed silent this long, drop the polling cadence to
 // FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS so a prompt sitting idle for an hour
@@ -270,10 +271,13 @@ export class ActivityMonitor {
   private readonly skipInitialStateEmit: boolean;
   private readonly simpleOutputState: boolean;
   private readonly simpleOutputTemperature = new AgentActivityTemperature();
-  // Memoized captureSimpleOutputSnapshot result, valid only while the quiet
-  // clock it was keyed on (`simpleSnapshotCacheKey`) is unchanged.
+  // Memoized captureSimpleOutputSnapshot result. Streaming agents cap full
+  // viewport extraction at 4Hz; quiet agents reuse it until new data arrives.
   private simpleSnapshotCache?: VisibleContentSnapshot;
   private simpleSnapshotCacheKey = 0;
+  private simpleSnapshotCapturedAt = 0;
+  private simpleSnapshotCapturedByteAt = 0;
+  private simpleSnapshotLastByteAt = 0;
   private simpleSnapshotSettleFrom = 0;
 
   // Polling interval configuration.
@@ -587,6 +591,7 @@ export class ActivityMonitor {
         return;
       }
       this.lastDataTimestamp = now;
+      this.simpleSnapshotLastByteAt = now;
       // Wake-on-data: any output means the agent is live again — restore the
       // full polling cadence before the settle timer fires or while backed off.
       this.cancelFsmIdleBackoff(true);
@@ -868,20 +873,25 @@ export class ActivityMonitor {
     // settle window — extracting and hashing the full viewport 20x/sec for an
     // idle terminal is pure waste. New data moves `lastDataTimestamp`; resize,
     // focus, agent swap, and external promotion invalidate explicitly.
+    const now = Date.now();
     const quietSince = Math.max(this.lastDataTimestamp, this.simpleSnapshotSettleFrom);
-    const settled = Date.now() - quietSince >= SIMPLE_SNAPSHOT_SETTLE_MS;
+    const settled = now - quietSince >= SIMPLE_SNAPSHOT_SETTLE_MS;
     if (
-      settled &&
       this.simpleSnapshotCache !== undefined &&
-      this.simpleSnapshotCacheKey === quietSince
+      ((settled && this.simpleSnapshotCacheKey === quietSince) ||
+        (!settled &&
+          this.simpleSnapshotLastByteAt !== this.simpleSnapshotCapturedByteAt &&
+          now - this.simpleSnapshotCapturedAt < SIMPLE_SNAPSHOT_MIN_INTERVAL_MS))
     ) {
       return this.simpleSnapshotCache;
     }
 
     const snapshot = this.computeSimpleOutputSnapshot();
-    if (settled && snapshot !== undefined) {
+    if (snapshot !== undefined) {
       this.simpleSnapshotCache = snapshot;
       this.simpleSnapshotCacheKey = quietSince;
+      this.simpleSnapshotCapturedAt = now;
+      this.simpleSnapshotCapturedByteAt = this.simpleSnapshotLastByteAt;
     } else {
       this.simpleSnapshotCache = undefined;
     }
@@ -905,6 +915,8 @@ export class ActivityMonitor {
   // dropping the cached frame.
   private invalidateSimpleSnapshotCache(): void {
     this.simpleSnapshotCache = undefined;
+    this.simpleSnapshotCapturedAt = 0;
+    this.simpleSnapshotCapturedByteAt = 0;
     this.simpleSnapshotSettleFrom = Date.now();
   }
 
@@ -1008,6 +1020,9 @@ export class ActivityMonitor {
     this.simpleOutputTemperature.reset();
     this.simpleSnapshotCache = undefined;
     this.simpleSnapshotCacheKey = 0;
+    this.simpleSnapshotCapturedAt = 0;
+    this.simpleSnapshotCapturedByteAt = 0;
+    this.simpleSnapshotLastByteAt = 0;
     this.simpleSnapshotSettleFrom = 0;
     this.lineRewriteDetector.reset();
     this.synchronizedFrameAnalyzer.reset();

--- a/electron/services/__tests__/ActivityMonitor.simple-output.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.simple-output.test.ts
@@ -434,6 +434,44 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
+    it("coalesces viewport extraction during a byte stream but still observes redraws", () => {
+      const onStateChange = vi.fn();
+      let visible = "waiting";
+      const getVisibleContentSnapshot = vi.fn(() => createVisibleContentSnapshot(visible));
+      const monitor = new ActivityMonitor(
+        "agent-simple-active-snapshot-cache",
+        1000,
+        onStateChange,
+        {
+          agentId: "claude",
+          getVisibleLines: () => [visible],
+          getVisibleContentSnapshot,
+          initialState: "idle",
+          skipInitialStateEmit: true,
+        }
+      );
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      getVisibleContentSnapshot.mockClear();
+
+      for (let i = 0; i < 10; i += 1) {
+        visible = `stream ${i}`;
+        monitor.onData(visible);
+        vi.advanceTimersByTime(50);
+      }
+
+      const streamCaptures = getVisibleContentSnapshot.mock.calls.length;
+      expect(streamCaptures).toBeGreaterThan(0);
+      expect(streamCaptures).toBeLessThan(10);
+
+      visible = "asynchronous redraw";
+      vi.advanceTimersByTime(50);
+      expect(getVisibleContentSnapshot).toHaveBeenCalledTimes(streamCaptures + 1);
+
+      monitor.dispose();
+    });
+
     it("keeps Enter immediate in simple agent mode", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("agent-simple-enter", 1000, onStateChange, {

--- a/electron/services/pty/SustainedChangeTracker.ts
+++ b/electron/services/pty/SustainedChangeTracker.ts
@@ -22,11 +22,13 @@ export interface ChangeObservation {
 }
 
 export interface VisibleContentSnapshot {
-  text: string;
-  units: readonly string[];
+  text?: string;
+  units: readonly VisibleContentUnit[];
   hash: number;
   length: number;
 }
+
+export type VisibleContentUnit = string | number;
 
 export interface VisibleContentDelta {
   changed: boolean;
@@ -177,17 +179,22 @@ export function measureVisibleContentDelta(
   previous: VisibleContentSnapshot | undefined,
   current: VisibleContentSnapshot
 ): VisibleContentDelta {
+  const previousUnits = previous?.units;
+  const currentUnits = current.units;
   if (
     !previous ||
+    previous === current ||
     (previous.hash === current.hash &&
       previous.length === current.length &&
-      previous.text === current.text)
+      (previousUnits && currentUnits
+        ? unitsEqual(previousUnits, currentUnits)
+        : previous.text === current.text))
   ) {
     return { changed: false, changedChars: 0 };
   }
 
-  const previousChars = previous.units ?? Array.from(previous.text);
-  const currentChars = current.units ?? Array.from(current.text);
+  const previousChars = previousUnits ?? Array.from(previous.text ?? "");
+  const currentChars = currentUnits ?? Array.from(current.text ?? "");
   if (isSuffixOf(previousChars, currentChars) || isSuffixOf(currentChars, previousChars)) {
     return { changed: false, changedChars: 0 };
   }
@@ -217,7 +224,18 @@ export function measureVisibleContentDelta(
   return { changed: changedChars > 0, changedChars };
 }
 
-function isSuffixOf(needle: readonly string[], haystack: readonly string[]): boolean {
+function unitsEqual(a: readonly VisibleContentUnit[], b: readonly VisibleContentUnit[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+}
+
+function isSuffixOf(
+  needle: readonly VisibleContentUnit[],
+  haystack: readonly VisibleContentUnit[]
+): boolean {
   if (needle.length > haystack.length) {
     return false;
   }

--- a/electron/services/pty/__tests__/headlessViewport.snapshot.test.ts
+++ b/electron/services/pty/__tests__/headlessViewport.snapshot.test.ts
@@ -40,6 +40,55 @@ function write(term: HeadlessTerminalType, data: string): Promise<void> {
   return new Promise((resolve) => term.write(data, () => resolve()));
 }
 
+function createDefaultCell(chars: string): IBufferCell {
+  const code = chars.codePointAt(0)!;
+  return {
+    getWidth: () => 1,
+    getChars: () => chars,
+    getCode: () => code,
+    isBold: () => false,
+    isItalic: () => false,
+    isDim: () => false,
+    isUnderline: () => false,
+    isBlink: () => false,
+    isInvisible: () => false,
+    isStrikethrough: () => false,
+    isOverline: () => false,
+    getFgColorMode: () => 0,
+    getFgColor: () => -1,
+  } as unknown as IBufferCell;
+}
+
+function createSingleCellTerminal(chars: string, useRawBuffer: boolean): HeadlessTerminalType {
+  const cell = createDefaultCell(chars);
+  const code = chars.codePointAt(0)!;
+  const line = {
+    translateToString: () => chars,
+    getCell: () => cell,
+    ...(useRawBuffer
+      ? {
+          _line: {
+            _data: new Uint32Array([code | (1 << 22), 0, 0]),
+            _combined: {},
+            _extendedAttrs: {},
+            length: 1,
+          },
+        }
+      : {}),
+  };
+  return {
+    rows: 1,
+    cols: 1,
+    buffer: {
+      active: {
+        baseY: 0,
+        getNullCell: () => cell,
+        getLine: () => line,
+      },
+    },
+  } as unknown as HeadlessTerminalType;
+}
+
 // The pre-fusion pipeline, verbatim: full-viewport cell extraction with the
 // original per-cell blank checks and 9-bit attribute capture, fed through the
 // still-exported createVisibleCellContentSnapshot.
@@ -154,6 +203,20 @@ describe("fused viewport snapshot parity (PERF-035)", () => {
       changedChars: 0,
     });
   });
+
+  it.each(["h", "𝕩", "─"])(
+    "keeps the same unit key for raw and public-cell extraction of %s",
+    (chars) => {
+      const raw = readVisibleActivitySnapshot(createSingleCellTerminal(chars, true), 1)!;
+      const fallback = readVisibleActivitySnapshot(createSingleCellTerminal(chars, false), 1)!;
+
+      expect(fallback.units).toEqual(raw.units);
+      expect(measureVisibleContentDelta(raw, fallback)).toEqual({
+        changed: false,
+        changedChars: 0,
+      });
+    }
+  );
 
   it("masks the inverse attribute like the legacy key scheme (cursor toggles are not changes)", async () => {
     await write(term, "prompt ready > ");

--- a/electron/services/pty/analysis/headlessViewport.ts
+++ b/electron/services/pty/analysis/headlessViewport.ts
@@ -3,6 +3,7 @@ import {
   createVisibleContentSnapshot,
   isCollapsibleFillText,
   type VisibleContentSnapshot,
+  type VisibleContentUnit,
 } from "../SustainedChangeTracker.js";
 
 type CursorBufferLine = {
@@ -132,6 +133,27 @@ function isBlankCellText(chars: string): boolean {
   return /^\s*$/u.test(chars);
 }
 
+function isCollapsibleFillCode(code: number): boolean {
+  return (
+    code === 0x2d ||
+    code === 0x5f ||
+    code === 0x3d ||
+    code === 0x2e ||
+    code === 0x00b7 ||
+    code === 0x2022 ||
+    code === 0x2219 ||
+    code === 0x25cf ||
+    code === 0x2500 ||
+    code === 0x2501 ||
+    code === 0x2550 ||
+    code === 0x254c ||
+    code === 0x254d ||
+    code === 0x23af ||
+    code === 0x2581 ||
+    code === 0x2594
+  );
+}
+
 function rawBufferLine(line: CursorBufferLine, cols: number): RawBufferLine | undefined {
   const raw = line._line;
   return raw?._data instanceof Uint32Array &&
@@ -156,13 +178,10 @@ function rawBufferLine(line: CursorBufferLine, cols: number): RawBufferLine | un
  * object, a NormalizedVisibleUnit object, and a 6-segment template-string key
  * per visible cell, plus a second full pass to hash them):
  *
- *   * default-styled single-width cells — the overwhelming majority of real
- *     terminal content — use their raw chars as the unit key. Styled or wide
- *     cells keep the full 6-segment key. The two forms cannot collide (a
- *     full key always carries 5 "|" separators and is longer than any 1–2
- *     codepoint chars value), and within each form key equality is exactly
- *     the old scheme's, so unit-level deltas (changed/changedChars) are
- *     unchanged.
+ *   * default-styled single-width raw cells — the overwhelming majority of
+ *     real terminal content — use their numeric code point as the unit key,
+ *     avoiding one string allocation per occupied cell. Combined cells keep
+ *     a string key; styled and wide cells keep the full 6-segment key.
  *   * the FNV-1a hash is accumulated while units are built instead of in a
  *     second pass over every key char.
  *   * the inverse attribute (masked out of keys by design — see
@@ -183,9 +202,9 @@ function buildViewportUnitsSnapshot(
   const cols = terminal.cols;
   const reusableCell = buffer.getNullCell();
 
-  const units: string[] = [];
+  const units: VisibleContentUnit[] = [];
   let hash = FNV_SEED;
-  let lastKey: string | undefined;
+  let lastKey: VisibleContentUnit | undefined;
 
   for (let y = start; y < end; y += 1) {
     const line = buffer.getLine(y);
@@ -207,12 +226,13 @@ function buildViewportUnitsSnapshot(
     }
 
     for (let x = 0; x < cellLimit; x += 1) {
-      let chars: string;
+      let chars: string | undefined;
       let code: number;
       let width: number;
       let attributes: number;
       let fgColorMode: number;
       let fgColor: number;
+      let rawCodePoint: number | undefined;
 
       if (raw) {
         const offset = x * CELL_SIZE;
@@ -227,9 +247,8 @@ function buildViewportUnitsSnapshot(
           code = chars.charCodeAt(chars.length - 1);
         } else {
           if (codePoint === 0 || isWhitespaceCode(codePoint)) continue;
-          chars =
-            codePoint <= 0xffff ? String.fromCharCode(codePoint) : String.fromCodePoint(codePoint);
           code = codePoint;
+          rawCodePoint = codePoint;
         }
 
         const fg = raw._data[offset + 1] ?? 0;
@@ -281,16 +300,44 @@ function buildViewportUnitsSnapshot(
         fgColor = cell.getFgColor();
       }
 
-      const key =
-        attributes === 0 && fgColorMode === 0 && fgColor === -1 && width === 1 && chars.length <= 2
-          ? chars
-          : `${chars}|${code}|${width}|${fgColorMode}|${fgColor}|${attributes}`;
+      const defaultSingleWidth =
+        attributes === 0 && fgColorMode === 0 && fgColor === -1 && width === 1;
+      let key: VisibleContentUnit;
+      let collapsible: boolean;
+      if (defaultSingleWidth && rawCodePoint !== undefined) {
+        key = rawCodePoint;
+        collapsible = isCollapsibleFillCode(rawCodePoint);
+      } else {
+        const resolvedChars =
+          chars ??
+          (rawCodePoint! <= 0xffff
+            ? String.fromCharCode(rawCodePoint!)
+            : String.fromCodePoint(rawCodePoint!));
+        key =
+          defaultSingleWidth && resolvedChars.length <= 2
+            ? resolvedChars
+            : `${resolvedChars}|${code}|${width}|${fgColorMode}|${fgColor}|${attributes}`;
+        collapsible = isCollapsibleFillText(resolvedChars);
+      }
 
-      if (lastKey === key && isCollapsibleFillText(chars)) continue;
+      if (lastKey === key && collapsible) continue;
       units.push(key);
-      for (let i = 0; i < key.length; i += 1) {
-        hash ^= key.charCodeAt(i);
-        hash = Math.imul(hash, FNV_PRIME);
+      if (typeof key === "number") {
+        if (key <= 0xffff) {
+          hash ^= key;
+          hash = Math.imul(hash, FNV_PRIME);
+        } else {
+          const astral = key - 0x10000;
+          hash ^= 0xd800 + (astral >> 10);
+          hash = Math.imul(hash, FNV_PRIME);
+          hash ^= 0xdc00 + (astral & 0x3ff);
+          hash = Math.imul(hash, FNV_PRIME);
+        }
+      } else {
+        for (let i = 0; i < key.length; i += 1) {
+          hash ^= key.charCodeAt(i);
+          hash = Math.imul(hash, FNV_PRIME);
+        }
       }
       hash ^= HASH_UNIT_SEPARATOR;
       hash = Math.imul(hash, FNV_PRIME);
@@ -299,7 +346,6 @@ function buildViewportUnitsSnapshot(
   }
 
   return {
-    text: units.join(""),
     units,
     hash: hash >>> 0,
     length: units.length,

--- a/electron/services/pty/analysis/headlessViewport.ts
+++ b/electron/services/pty/analysis/headlessViewport.ts
@@ -133,6 +133,11 @@ function isBlankCellText(chars: string): boolean {
   return /^\s*$/u.test(chars);
 }
 
+function singleCodePoint(chars: string): number | undefined {
+  const code = chars.codePointAt(0);
+  return code !== undefined && String.fromCodePoint(code) === chars ? code : undefined;
+}
+
 function isCollapsibleFillCode(code: number): boolean {
   return (
     code === 0x2d ||
@@ -178,10 +183,11 @@ function rawBufferLine(line: CursorBufferLine, cols: number): RawBufferLine | un
  * object, a NormalizedVisibleUnit object, and a 6-segment template-string key
  * per visible cell, plus a second full pass to hash them):
  *
- *   * default-styled single-width raw cells — the overwhelming majority of
- *     real terminal content — use their numeric code point as the unit key,
- *     avoiding one string allocation per occupied cell. Combined cells keep
- *     a string key; styled and wide cells keep the full 6-segment key.
+ *   * default-styled single-width cells — the overwhelming majority of real
+ *     terminal content — use their numeric code point as the unit key,
+ *     avoiding one string allocation per occupied cell in either extraction
+ *     path. Combined cells keep a string key; styled and wide cells keep the
+ *     full 6-segment key.
  *   * the FNV-1a hash is accumulated while units are built instead of in a
  *     second pass over every key char.
  *   * the inverse attribute (masked out of keys by design — see
@@ -302,11 +308,13 @@ function buildViewportUnitsSnapshot(
 
       const defaultSingleWidth =
         attributes === 0 && fgColorMode === 0 && fgColor === -1 && width === 1;
+      const defaultCodePoint =
+        defaultSingleWidth && chars !== undefined ? singleCodePoint(chars) : rawCodePoint;
       let key: VisibleContentUnit;
       let collapsible: boolean;
-      if (defaultSingleWidth && rawCodePoint !== undefined) {
-        key = rawCodePoint;
-        collapsible = isCollapsibleFillCode(rawCodePoint);
+      if (defaultSingleWidth && defaultCodePoint !== undefined) {
+        key = defaultCodePoint;
+        collapsible = isCollapsibleFillCode(defaultCodePoint);
       } else {
         const resolvedChars =
           chars ??

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -17,7 +17,7 @@ const WATCHER_WORKTREE_MAX_WAIT_MS = 1500;
 // leading timer back onto the trailing ramp, so storm coalescing (and the
 // PERF-104 quiescence profile) is preserved.
 const WATCHER_WORKTREE_LEADING_DEBOUNCE_MS = 25;
-const WATCHER_WORKTREE_QUIET_WINDOW_MS = 2_000;
+const WATCHER_WORKTREE_QUIET_WINDOW_MS = GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS;
 const WATCHER_ELEVATION_DOWNGRADE_DELAY_MS = 3_000;
 
 export type WatcherMode = "none" | "git-only" | "recursive";

--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -954,6 +954,12 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(screen.getByText(/6 of 6 created/)).toBeTruthy();
     expect(screen.queryByText(/0 of/)).toBeNull();
     expect(screen.queryByText(/failed/)).toBeNull();
+    const spawnBatches = mockRunRecipeWithResults.mock.calls.map(
+      (call) => (call[4] as { spawnBatch?: { id: string; size: number } })?.spawnBatch
+    );
+    expect(spawnBatches.every(Boolean)).toBe(true);
+    expect(new Set(spawnBatches.map((batch) => batch?.id)).size).toBe(1);
+    expect(spawnBatches.every((batch) => batch?.size === spawnBatches.length)).toBe(true);
   });
 
   it("done-phase counts match UI after recipe verification with mixed outcomes", async () => {

--- a/plugins/builtin/github/renderer/__tests__/bulkCreateUtils.test.ts
+++ b/plugins/builtin/github/renderer/__tests__/bulkCreateUtils.test.ts
@@ -12,6 +12,7 @@ import {
   BACKOFF_CAP_MS,
   ASSIGNMENT_BACKOFF_CAP_MS,
   MAX_TRANSIENT_RETRY_MS,
+  planBulkRecipeSpawnBatches,
 } from "../components/bulkCreateUtils";
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
@@ -68,6 +69,45 @@ describe("planIssueWorktrees", () => {
     ];
     const result = planIssueWorktrees(issues, new Set());
     expect(result[0]!.branchName).not.toBe(result[1]!.branchName);
+  });
+});
+
+describe("planBulkRecipeSpawnBatches", () => {
+  it("shares one admission across single-terminal recipes for ten worktrees", () => {
+    const batches = planBulkRecipeSpawnBatches(
+      Array.from({ length: 10 }, (_, index) => index + 1),
+      1,
+      () => "batch-a"
+    );
+
+    expect(batches).toHaveLength(10);
+    expect(new Set([...batches.values()].map((batch) => batch.id))).toEqual(new Set(["batch-a"]));
+    expect([...batches.values()].every((batch) => batch.size === batches.size)).toBe(true);
+  });
+
+  it("splits larger operations into bounded groups without splitting a recipe", () => {
+    let nextId = 0;
+    const batches = planBulkRecipeSpawnBatches(
+      Array.from({ length: 7 }, (_, index) => index + 1),
+      5,
+      () => `batch-${++nextId}`
+    );
+
+    const groups = new Map<string, Array<{ id: string; size: number }>>();
+    for (const batch of batches.values()) {
+      const group = groups.get(batch.id) ?? [];
+      group.push(batch);
+      groups.set(batch.id, group);
+    }
+    expect(groups.size).toBe(2);
+    expect(groups.get("batch-1")).toHaveLength(6);
+    expect(groups.get("batch-1")?.every((batch) => batch.size === 30)).toBe(true);
+    expect(groups.get("batch-2")).toHaveLength(1);
+    expect(groups.get("batch-2")?.[0]?.size).toBe(5);
+  });
+
+  it("does not attach batch metadata to one single-terminal launch", () => {
+    expect(planBulkRecipeSpawnBatches([1], 1, () => "unused")).toEqual(new Map());
   });
 });
 

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -44,7 +44,9 @@ import {
   QUEUE_CONCURRENCY,
   BACKOFF_BASE_MS,
   ASSIGNMENT_BACKOFF_CAP_MS,
-  VERIFICATION_SETTLE_MS,
+  VERIFICATION_EXIT_SETTLE_MS,
+  VERIFICATION_SPAWN_WAIT_MS,
+  planBulkRecipeSpawnBatches,
 } from "./bulkCreateUtils";
 import type { PlannedWorktree } from "./bulkCreateUtils";
 import type { ForgeBulkCreateWorktreeDialogProps } from "@/types/forgeSlotProps";
@@ -52,6 +54,35 @@ import type { BranchInfo } from "@shared/types";
 
 /** Conforms to the host's bulk-create slot contract (forge-normalized shapes). */
 export type BulkCreateWorktreeDialogProps = ForgeBulkCreateWorktreeDialogProps;
+
+function waitForPanelSpawns(panelIds: string[], timeoutMs: number): Promise<void> {
+  if (panelIds.length === 0) return Promise.resolve();
+  const allSettled = () => {
+    const { panelsById } = usePanelStore.getState();
+    return panelIds.every((panelId) => {
+      const panel = panelsById[panelId];
+      return !panel || !isPtyPanel(panel) || panel.spawnStatus !== "spawning";
+    });
+  };
+  if (allSettled()) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let unsubscribe = () => {};
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve();
+    };
+    const timeout = setTimeout(finish, timeoutMs);
+    unsubscribe = usePanelStore.subscribe(() => {
+      if (allSettled()) finish();
+    });
+    if (allSettled()) finish();
+  });
+}
 
 export function BulkCreateWorktreeDialog({
   isOpen,
@@ -243,6 +274,13 @@ export function BulkCreateWorktreeDialog({
       });
       queueRef.current = queue;
       const currentRunItems = new Set(toCreate.map((p) => p.item.number));
+      const ptyTerminalsPerRecipe =
+        selectedRecipe?.terminals.filter((terminal) => terminal.type !== "dev-preview").length ?? 0;
+      const recipeSpawnBatches = planBulkRecipeSpawnBatches(
+        [...currentRunItems],
+        ptyTerminalsPerRecipe,
+        () => crypto.randomUUID()
+      );
       const succeededItems = new Set<number>();
       const failedItems = new Set<number>();
       let lastSuccessfulWorktreeId: string | null = null;
@@ -597,6 +635,7 @@ export function BulkCreateWorktreeDialog({
                       recipeContext,
                       {
                         terminalIndices: shouldRetryTerminals,
+                        spawnBatch: recipeSpawnBatches.get(itemNumber),
                       }
                     );
 
@@ -759,7 +798,16 @@ export function BulkCreateWorktreeDialog({
 
       // Post-batch verification: check terminal health for current run items only
       if (selectedRecipeId) {
-        await delay(VERIFICATION_SETTLE_MS);
+        const verificationPanelIds = [...tracking]
+          .filter(
+            ([itemNumber, tracked]) =>
+              currentRunItems.has(itemNumber) &&
+              !failedItems.has(itemNumber) &&
+              tracked.failedTerminalIndices.length === 0
+          )
+          .flatMap(([, tracked]) => tracked.spawnedTerminalIds);
+        await waitForPanelSpawns(verificationPanelIds, VERIFICATION_SPAWN_WAIT_MS);
+        await delay(VERIFICATION_EXIT_SETTLE_MS);
         if (runIdRef.current !== currentRunId) return;
 
         const { panelsById } = usePanelStore.getState();
@@ -799,7 +847,7 @@ export function BulkCreateWorktreeDialog({
 
       dispatchProgress({ type: "DONE" });
     },
-    [selectedRecipeId, assignWorktreeToSelf, currentProject?.path]
+    [selectedRecipeId, selectedRecipe, assignWorktreeToSelf, currentProject?.path]
   );
 
   const handleCreate = useCallback(async () => {

--- a/plugins/builtin/github/renderer/components/bulkCreateUtils.ts
+++ b/plugins/builtin/github/renderer/components/bulkCreateUtils.ts
@@ -1,6 +1,7 @@
 import { detectPrefixFromIssue, buildBranchName } from "@/components/Worktree/branchPrefixUtils";
 import { generateBranchSlug } from "@/utils/textParsing";
 import type { Issue, PR } from "@shared/types/forge";
+import { MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH } from "@shared/utils/recipeSanitizer";
 import type { PlannedWorktree } from "./bulkCreatePrequery";
 
 export type { PlannedWorktree };
@@ -29,7 +30,37 @@ export const BACKOFF_CAP_MS = 30000;
 // wait at least 60s when no Retry-After header is supplied, so the assignment
 // retry loop uses its own cap instead of the shared 30s value.
 export const ASSIGNMENT_BACKOFF_CAP_MS = 60000;
-export const VERIFICATION_SETTLE_MS = 800;
+export const VERIFICATION_SPAWN_WAIT_MS = 700;
+export const VERIFICATION_EXIT_SETTLE_MS = 100;
+
+export interface BulkRecipeSpawnBatch {
+  id: string;
+  size: number;
+}
+
+export function planBulkRecipeSpawnBatches(
+  itemNumbers: number[],
+  ptyTerminalsPerItem: number,
+  createBatchId: () => string
+): Map<number, BulkRecipeSpawnBatch> {
+  const batches = new Map<number, BulkRecipeSpawnBatch>();
+  if (ptyTerminalsPerItem <= 0 || ptyTerminalsPerItem > MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH) {
+    return batches;
+  }
+
+  const itemsPerBatch = Math.max(
+    1,
+    Math.floor(MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH / ptyTerminalsPerItem)
+  );
+  for (let offset = 0; offset < itemNumbers.length; offset += itemsPerBatch) {
+    const itemBatch = itemNumbers.slice(offset, offset + itemsPerBatch);
+    const size = itemBatch.length * ptyTerminalsPerItem;
+    if (size < 2) continue;
+    const batch = { id: createBatchId(), size };
+    for (const itemNumber of itemBatch) batches.set(itemNumber, batch);
+  }
+  return batches;
+}
 
 // IPC strips structured error fields (lesson #3769), so renderer-side classification
 // matches the strings emitted by `parseGitHubError` in the main process — not status codes.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -91,6 +91,20 @@ Controls: `PERF_RECIPE_FANOUT_SIZES` (default `1,5,10`, maximum 10), `PERF_RECIP
 
 The benchmark has reliability gates but no latency budget: every expected panel, cold PTY spawn, xterm attachment, panel-scoped token paint, worktree assignment, and cleanup must succeed, while timing summaries remain observational until platform baselines are reviewed.
 
+## Bulk issue worktrees (`perf bulk-issue-worktrees`)
+
+`npm run perf bulk-issue-worktrees` measures the full bulk workflow represented by PERF-182: open the forge issue list, select every fixture issue, click Create worktrees, choose a starting-layout recipe, confirm, create one fake worktree per issue, and run the recipe in each worktree. Forge responses, branch/path resolution, and worktree creation are hermetic in-memory IPC handlers, so the benchmark never contacts GitHub or executes `git worktree`; terminal startup continues through the production renderer queue, IPC admission limiter, PTY host, and child-process path.
+
+The default matrix runs N=1, 6, and 10 across three fresh-app rounds with one warmup. Results are written atomically to `.tmp/perf-results/bulk-issue-worktrees.json` and include selection/dialog latency, first and last fake-worktree completion, dialog completion, first and last real terminal spawn, whole-flow latency, renderer frame gaps, terminal-admission pauses, and the number of terminals admitted before the first pause.
+
+```bash
+npm run perf bulk-issue-worktrees
+PERF_BULK_ISSUE_SCALES=1,10 PERF_BULK_ISSUE_ROUNDS=1 npm run perf bulk-issue-worktrees
+PERF_BULK_ISSUE_OUTPUT=.tmp/perf-results/bulk-issue-worktrees-before.json npm run perf bulk-issue-worktrees
+```
+
+Controls: `PERF_BULK_ISSUE_SCALES` (default `1,6,10`, maximum 20), `PERF_BULK_ISSUE_ROUNDS` (default `3`), `PERF_BULK_ISSUE_WARMUPS` (default `1`), and `PERF_BULK_ISSUE_OUTPUT`.
+
 ## GPU/compositor traces (`--trace`)
 
 `--trace` makes the packaged app self-start Electron's `contentTracing` (categories `viz,gpu,cc,blink,toplevel,startup`) for the full startup-to-quit window, writing one trace per run to `.tmp/perf-results/trace-run-N.json`. This is the way to see why the compositor takes time between `main_window_shown` and the first painted frame.

--- a/scripts/perf/index.ts
+++ b/scripts/perf/index.ts
@@ -133,6 +133,27 @@ function playwrightRecipeFanout(): Runner {
   };
 }
 
+function playwrightBulkIssueWorktrees(): Runner {
+  return async (rest) => {
+    const buildExitCode = await npmScript("build:e2e:bench");
+    if (buildExitCode !== 0) return buildExitCode;
+    return spawnNode(
+      [
+        resolveBin(
+          ["node_modules/@playwright/test/cli.js", "node_modules/playwright/cli.js"],
+          "playwright"
+        ),
+        "test",
+        "--project=full-panels",
+        "--workers=1",
+        "e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts",
+        ...rest,
+      ],
+      { RUN_PERF_BULK_ISSUE_WORKTREES: "1" }
+    );
+  };
+}
+
 const REGISTRY: Record<string, Command> = {
   smoke: { summary: "Fast local smoke matrix (run on demand)", runner: harness("smoke") },
   ci: { summary: "CI validation matrix (scheduled + manual dispatch)", runner: harness("ci") },
@@ -149,6 +170,10 @@ const REGISTRY: Record<string, Command> = {
   "recipe-fanout": {
     summary: "Cold recipe fanout through worktree, PTY host, and xterm",
     runner: playwrightRecipeFanout(),
+  },
+  "bulk-issue-worktrees": {
+    summary: "Fake issue selection through bulk worktree recipes and real PTYs",
+    runner: playwrightBulkIssueWorktrees(),
   },
   memory: {
     summary: "Memory kitchen-sink soak spec via Playwright",

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -52,9 +52,9 @@ export interface AddPanelOptionsBase {
   focusPolicy?: AddPanelFocusPolicy;
   /** Bypass rate limiter during session restore (consumes main-process quota) */
   restore?: boolean;
-  /** Opaque admission group shared by PTY panels from one bounded recipe run. */
+  /** Opaque admission group shared by PTY panels from one bounded recipe operation. */
   spawnBatchId?: string;
-  /** Number of PTY panels declared by the bounded recipe run. */
+  /** Total PTY panels declared by that recipe operation, potentially across worktrees. */
   spawnBatchSize?: number;
   /** Bypass panel limit checks (used during hydration/state restoration) */
   bypassLimits?: boolean;

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -38,9 +38,9 @@ export interface TerminalSpawnOptions {
   command?: string;
   /** Whether to restore previous session content (default: true). Set to false on restart. */
   restore?: boolean;
-  /** Opaque ID shared by the PTY spawns from one bounded recipe run. */
+  /** Opaque ID shared by PTY spawns from one bounded, user-confirmed recipe operation. */
   spawnBatchId?: string;
-  /** Number of PTY spawns declared by the bounded recipe run. */
+  /** Total PTY spawns declared by that recipe operation, potentially across worktrees. */
   spawnBatchSize?: number;
   /** Whether to kill the PTY when the frontend disconnects (no terminal registry entry) */
   isEphemeral?: boolean;

--- a/shared/utils/recipeSanitizer.ts
+++ b/shared/utils/recipeSanitizer.ts
@@ -20,6 +20,9 @@ import type { RecipeTerminal, RecipeTerminalType } from "../types/project.js";
  */
 export const MAX_TERMINALS_PER_RECIPE = 10;
 
+/** Maximum PTY count admitted as one user-confirmed recipe batch across worktrees. */
+export const MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH = 30;
+
 /**
  * Control characters forbidden in command-like fields (`command`, `args`,
  * `devCommand`, and `env` keys/values). Rejects CR, LF, and all C0 control

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -794,6 +794,36 @@ describe("recipeStore", () => {
       ).toBe(true);
     });
 
+    it("forwards a shared bulk admission to a single-terminal recipe", async () => {
+      addTerminalMock.mockResolvedValue("terminal-1");
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [{ type: "terminal", title: "Shell", command: "a", env: {} }],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          spawnBatch: { id: "00000000-0000-4000-8000-000000000010", size: 10 },
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spawnBatchId: "00000000-0000-4000-8000-000000000010",
+          spawnBatchSize: 10,
+        })
+      );
+    });
+
     it("focuses the last spawned grid panel after the batch flush", async () => {
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -55,6 +55,8 @@ export interface RecipeRunOptions {
   spawnedBy?: TerminalSpawnSource;
   focusPolicy?: AddPanelFocusPolicy;
   terminalIndices?: number[];
+  /** Shared admission batch for one user-confirmed recipe operation spanning worktrees. */
+  spawnBatch?: { id: string; size: number };
   /**
    * The action dispatch source that triggered this run. When `"agent"`, a
    * lower per-run terminal cap ({@link MAX_AGENT_RECIPE_TERMINALS}) is applied
@@ -793,8 +795,18 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     const ptySpawnCount = spawnIndices.filter(
       (index) => recipe.terminals[index]?.type !== "dev-preview"
     ).length;
+    const requestedSpawnBatch = options?.spawnBatch;
     const spawnBatch =
-      ptySpawnCount > 1 ? { spawnBatchId: crypto.randomUUID(), spawnBatchSize: ptySpawnCount } : {};
+      requestedSpawnBatch &&
+      requestedSpawnBatch.size >= ptySpawnCount &&
+      requestedSpawnBatch.size > 1
+        ? {
+            spawnBatchId: requestedSpawnBatch.id,
+            spawnBatchSize: requestedSpawnBatch.size,
+          }
+        : ptySpawnCount > 1
+          ? { spawnBatchId: crypto.randomUUID(), spawnBatchSize: ptySpawnCount }
+          : {};
     try {
       const settled = await Promise.allSettled(
         spawnIndices.map(async (index) => {

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -239,6 +239,65 @@ describe("optimistic panel spawn (#5789)", () => {
     }
   });
 
+  it("realizes a declared recipe batch two terminals at a time", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const waitForAttachSettledMock = vi.mocked(terminalInstanceService.waitForAttachSettled);
+    const releases: Array<() => void> = [];
+    const attachGates = Array.from(
+      { length: 4 },
+      () =>
+        new Promise<void>((resolve) => {
+          releases.push(resolve);
+        })
+    );
+
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "batched");
+    waitForAttachSettledMock.mockImplementation((id: string) => {
+      const index = Number(id.slice("recipe-".length));
+      return attachGates[index]!;
+    });
+
+    const { addPanel } = usePanelStore.getState();
+    const launches = Array.from({ length: 4 }, (_, i) =>
+      addPanel({
+        kind: "terminal",
+        launchAgentId: "claude",
+        command: "claude",
+        requestedId: `recipe-${i}`,
+        cwd: "/",
+        bypassLimits: true,
+        spawnBatchId: "recipe-batch",
+        spawnBatchSize: 4,
+      })
+    );
+
+    await Promise.all(launches);
+    await drainMicrotasks();
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(2);
+
+    releases[0]!();
+    await drainMicrotasks();
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(3);
+
+    releases[1]!();
+    await drainMicrotasks();
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(4);
+
+    releases[2]!();
+    releases[3]!();
+    await drainMicrotasks();
+
+    const state = usePanelStore.getState();
+    for (let i = 0; i < 4; i++) {
+      expect((state.panelsById[`recipe-${i}`] as PtyPanelData | undefined)?.spawnStatus).toBe(
+        "ready"
+      );
+    }
+  });
+
   it("does not stamp eagerAttach on dock launches", async () => {
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -110,13 +110,13 @@ function estimateOverlayGridDims(fontSize: number): { cols: number; rows: number
 }
 
 class TerminalStartupQueue {
-  private readonly tasks: Array<() => Promise<void>> = [];
-  private isDraining = false;
+  private readonly tasks: Array<{ run: () => Promise<void>; concurrency: number }> = [];
+  private activeTasks = 0;
   private reservations = 0;
 
   /** True when an enqueued task would start immediately (single-launch fast path). */
   get isIdle(): boolean {
-    return this.tasks.length === 0 && !this.isDraining && this.reservations === 0;
+    return this.tasks.length === 0 && this.activeTasks === 0 && this.reservations === 0;
   }
 
   /**
@@ -130,37 +130,35 @@ class TerminalStartupQueue {
     this.reservations++;
   }
 
-  enqueue(task: () => Promise<void>): void {
+  enqueue(task: () => Promise<void>, concurrency = 1): void {
     if (this.reservations > 0) this.reservations--;
-    this.tasks.push(task);
-    void this.drain();
+    this.tasks.push({ run: task, concurrency });
+    this.drain();
   }
 
-  private async drain(): Promise<void> {
-    if (this.isDraining) return;
-    this.isDraining = true;
+  private drain(): void {
+    while (this.tasks.length > 0 && this.activeTasks < this.tasks[0]!.concurrency) {
+      const task = this.tasks.shift();
+      if (!task) continue;
+      this.activeTasks++;
+      void this.runTask(task.run);
+    }
+  }
 
+  private async runTask(task: () => Promise<void>): Promise<void> {
     try {
-      while (this.tasks.length > 0) {
-        const task = this.tasks.shift();
-        if (!task) continue;
-
-        try {
-          await task();
-        } catch (error) {
-          logError("[TerminalStore] Terminal startup task failed", error);
-        }
-      }
+      await task();
+    } catch (error) {
+      logError("[TerminalStore] Terminal startup task failed", error);
     } finally {
-      this.isDraining = false;
-      if (this.tasks.length > 0) {
-        void this.drain();
-      }
+      this.activeTasks--;
+      this.drain();
     }
   }
 }
 
 const terminalStartupQueue = new TerminalStartupQueue();
+const RECIPE_TERMINAL_STARTUP_CONCURRENCY = 2;
 
 export const createAddPanelActions = (
   set: Set,
@@ -429,7 +427,7 @@ export const createAddPanelActions = (
     // and the first fit with the env fetch + spawn IPC below. Decided at
     // commit time — the flag must be in the first committed panel record
     // because TerminalPane reads it on first render. Burst spawns (queue
-    // busy) keep the gate so panels realize one at a time (#5789).
+    // busy) keep the gate so panels realize with bounded concurrency (#5789).
     const eagerAttach =
       !isReconnect && location === "grid" && isInActiveWorktree && terminalStartupQueue.isIdle;
     // Every non-reconnect PTY panel reaches the enqueue below (prewarm and
@@ -865,187 +863,192 @@ export const createAddPanelActions = (
     const shouldWaitForVisibleAttach = location === "grid" && isInActiveWorktree;
 
     // The panel chrome is already committed. Realize backend PTY startup and
-    // visible xterm.open() through a single queue so bulk recipes can add many
+    // visible xterm.open() through a bounded queue so bulk recipes can add many
     // panels without making Chromium/xterm settle every terminal in the same
     // frame. spawnStatus remains "spawning" while queued, so TerminalPane shows
     // lightweight chrome instead of mounting XtermAdapter.
-    terminalStartupQueue.enqueue(async () => {
-      const _p0 = get().panelsById[id];
-      if (!_p0 || !isPtyPanel(_p0) || _p0.spawnStatus !== "spawning") return;
-      markRendererPerformance("agentlaunch.task-start", { id });
+    terminalStartupQueue.enqueue(
+      async () => {
+        const _p0 = get().panelsById[id];
+        if (!_p0 || !isPtyPanel(_p0) || _p0.spawnStatus !== "spawning") return;
+        markRendererPerformance("agentlaunch.task-start", { id });
 
-      try {
-        const mergedEnv = await spawnEnvPromise;
+        try {
+          const mergedEnv = await spawnEnvPromise;
 
-        markRendererPerformance("agentlaunch.env-ready", { id });
-        const _p1 = get().panelsById[id];
-        if (!_p1 || !isPtyPanel(_p1) || _p1.spawnStatus !== "spawning") return;
+          markRendererPerformance("agentlaunch.env-ready", { id });
+          const _p1 = get().panelsById[id];
+          if (!_p1 || !isPtyPanel(_p1) || _p1.spawnStatus !== "spawning") return;
 
-        const commandToExecute = options.skipCommandExecution ? undefined : options.command;
-        // Spawn the PTY at the grid the renderer is actually showing. The
-        // overlay XtermAdapter mounts without waiting for spawnStatus, so by
-        // now the xterm may already be attached and fitted — a PTY resize it
-        // sent before this spawn resolved was silently dropped by the
-        // pty-host (no terminal yet), and booting at 80×24 anyway left the
-        // CLI painting a width the renderer wasn't wrapping at (#10863).
-        const attachedDims = getAttachedGridDims(id);
-        const spawnCols = attachedDims?.cols ?? overlayDims?.cols ?? 80;
-        const spawnRows = attachedDims?.rows ?? overlayDims?.rows ?? 24;
-        await terminalClient.spawn({
-          id,
-          projectId: capturedProjectId,
-          cwd: options.cwd,
-          shell: options.shell,
-          cols: spawnCols,
-          rows: spawnRows,
-          command: commandToExecute,
-          kind,
-          launchAgentId,
-          title,
-          titleMode: options.titleMode,
-          env: mergedEnv,
-          restore: options.restore,
-          spawnBatchId: options.spawnBatchId,
-          spawnBatchSize: options.spawnBatchSize,
-          agentLaunchFlags: options.agentLaunchFlags,
-          agentModelId: options.agentModelId,
-          worktreeId: options.worktreeId,
-          agentPresetId: options.agentPresetId,
-          agentPresetColor: options.agentPresetColor,
-          originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
-          // Launch-time context for the daintree-assistant pinned session
-          // (#10647). Threaded straight through; the main-process handler only
-          // consumes it for that agent and ignores it otherwise.
-          actionContext: options.actionContext,
-        });
+          const commandToExecute = options.skipCommandExecution ? undefined : options.command;
+          // Spawn the PTY at the grid the renderer is actually showing. The
+          // overlay XtermAdapter mounts without waiting for spawnStatus, so by
+          // now the xterm may already be attached and fitted — a PTY resize it
+          // sent before this spawn resolved was silently dropped by the
+          // pty-host (no terminal yet), and booting at 80×24 anyway left the
+          // CLI painting a width the renderer wasn't wrapping at (#10863).
+          const attachedDims = getAttachedGridDims(id);
+          const spawnCols = attachedDims?.cols ?? overlayDims?.cols ?? 80;
+          const spawnRows = attachedDims?.rows ?? overlayDims?.rows ?? 24;
+          await terminalClient.spawn({
+            id,
+            projectId: capturedProjectId,
+            cwd: options.cwd,
+            shell: options.shell,
+            cols: spawnCols,
+            rows: spawnRows,
+            command: commandToExecute,
+            kind,
+            launchAgentId,
+            title,
+            titleMode: options.titleMode,
+            env: mergedEnv,
+            restore: options.restore,
+            spawnBatchId: options.spawnBatchId,
+            spawnBatchSize: options.spawnBatchSize,
+            agentLaunchFlags: options.agentLaunchFlags,
+            agentModelId: options.agentModelId,
+            worktreeId: options.worktreeId,
+            agentPresetId: options.agentPresetId,
+            agentPresetColor: options.agentPresetColor,
+            originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
+            // Launch-time context for the daintree-assistant pinned session
+            // (#10647). Threaded straight through; the main-process handler only
+            // consumes it for that agent and ignores it otherwise.
+            actionContext: options.actionContext,
+          });
 
-        markRendererPerformance("agentlaunch.spawn-ipc-resolved", { id });
+          markRendererPerformance("agentlaunch.spawn-ipc-resolved", { id });
 
-        // Reject a spawn resolution that no longer belongs to this incarnation:
-        // if a restart or hydration replay re-launched the id while our IPC was
-        // in flight, the successor owns spawnStatus now and its own resolution
-        // manages it. The ledger records the rejection as an anomaly. One
-        // carve-out: when the successor's panel is ALSO gone, the backend PTY
-        // this resolution just created has no owner at all — kill it, exactly
-        // like the orphan path below (killing the shared id is safe only when
-        // no live panel claims it).
-        if (!agentLifecycleLedger.recordSpawnResolved(id, launchGeneration, true).accepted) {
-          if (!get().panelsById[id]) {
+          // Reject a spawn resolution that no longer belongs to this incarnation:
+          // if a restart or hydration replay re-launched the id while our IPC was
+          // in flight, the successor owns spawnStatus now and its own resolution
+          // manages it. The ledger records the rejection as an anomaly. One
+          // carve-out: when the successor's panel is ALSO gone, the backend PTY
+          // this resolution just created has no owner at all — kill it, exactly
+          // like the orphan path below (killing the shared id is safe only when
+          // no live panel claims it).
+          if (!agentLifecycleLedger.recordSpawnResolved(id, launchGeneration, true).accepted) {
+            if (!get().panelsById[id]) {
+              terminalClient.kill(id).catch((killError) => {
+                logWarn("[TerminalStore] Compensating kill after stale spawn resolution failed", {
+                  id,
+                  error: killError,
+                });
+              });
+            }
+            return;
+          }
+
+          // Promote spawnStatus to "ready" once the PTY is live. If the panel was
+          // removed during the spawn window, issue a compensating kill to avoid
+          // orphaning the freshly-spawned PTY (removePanel's kill IPC was a no-op
+          // at the time because the backend had no terminal yet).
+          let orphaned = false;
+          let mountedPanel = false;
+          set((state) => {
+            const current = state.panelsById[id];
+            if (!current) {
+              orphaned = true;
+              return state;
+            }
+            if (!isPtyPanel(current) || current.spawnStatus !== "spawning") return state;
+            mountedPanel = true;
+            return {
+              panelsById: { ...state.panelsById, [id]: { ...current, spawnStatus: "ready" } },
+            };
+          });
+          if (orphaned) {
             terminalClient.kill(id).catch((killError) => {
-              logWarn("[TerminalStore] Compensating kill after stale spawn resolution failed", {
+              logWarn("[TerminalStore] Compensating kill after orphan spawn failed", {
                 id,
                 error: killError,
               });
             });
+          } else {
+            if (mountedPanel) markRendererPerformance("agentlaunch.ready", { id });
+            // Recover the attach-during-spawn race: a fit that ran while the
+            // spawn IPC was in flight had its PTY resize dropped (no terminal
+            // existed yet), which would strand the CLI at the spawn dims while
+            // xterm renders the fitted grid — the assistant's progressively
+            // garbled prompt (#10863). Re-assert the live grid now that the PTY
+            // exists. PTY-only and direct: xterm already shows these dims, and
+            // sendPtyResize would defer 500ms for a settled-strategy agent —
+            // exactly the window in which the CLI paints its banner at the
+            // stale spawn width. The backend dedupes when nothing drifted.
+            const settledDims = getAttachedGridDims(id);
+            if (settledDims && (settledDims.cols !== spawnCols || settledDims.rows !== spawnRows)) {
+              terminalClient.resize(id, settledDims.cols, settledDims.rows);
+            }
           }
-          return;
-        }
 
-        // Promote spawnStatus to "ready" once the PTY is live. If the panel was
-        // removed during the spawn window, issue a compensating kill to avoid
-        // orphaning the freshly-spawned PTY (removePanel's kill IPC was a no-op
-        // at the time because the backend had no terminal yet).
-        let orphaned = false;
-        let mountedPanel = false;
-        set((state) => {
-          const current = state.panelsById[id];
-          if (!current) {
-            orphaned = true;
-            return state;
+          if (mountedPanel && shouldWaitForVisibleAttach) {
+            try {
+              await terminalInstanceService.waitForAttachSettled(id, {
+                timeoutMs: TERMINAL_STARTUP_ATTACH_TIMEOUT_MS,
+              });
+            } catch (error) {
+              logWarn("[TerminalStore] Terminal did not attach before startup queue advanced", {
+                id,
+                error,
+              });
+            }
           }
-          if (!isPtyPanel(current) || current.spawnStatus !== "spawning") return state;
-          mountedPanel = true;
-          return {
-            panelsById: { ...state.panelsById, [id]: { ...current, spawnStatus: "ready" } },
-          };
-        });
-        if (orphaned) {
-          terminalClient.kill(id).catch((killError) => {
-            logWarn("[TerminalStore] Compensating kill after orphan spawn failed", {
-              id,
-              error: killError,
-            });
-          });
-        } else {
-          if (mountedPanel) markRendererPerformance("agentlaunch.ready", { id });
-          // Recover the attach-during-spawn race: a fit that ran while the
-          // spawn IPC was in flight had its PTY resize dropped (no terminal
-          // existed yet), which would strand the CLI at the spawn dims while
-          // xterm renders the fitted grid — the assistant's progressively
-          // garbled prompt (#10863). Re-assert the live grid now that the PTY
-          // exists. PTY-only and direct: xterm already shows these dims, and
-          // sendPtyResize would defer 500ms for a settled-strategy agent —
-          // exactly the window in which the CLI paints its banner at the
-          // stale spawn width. The backend dedupes when nothing drifted.
-          const settledDims = getAttachedGridDims(id);
-          if (settledDims && (settledDims.cols !== spawnCols || settledDims.rows !== spawnRows)) {
-            terminalClient.resize(id, settledDims.cols, settledDims.rows);
+        } catch (error) {
+          logError("[TerminalStore] Failed to spawn terminal", error);
+          // Same staleness gate as the success path: never stamp a failure onto
+          // a successor incarnation that re-launched this id mid-flight.
+          if (!agentLifecycleLedger.recordSpawnResolved(id, launchGeneration, false).accepted) {
+            return;
           }
-        }
+          const current = get().panelsById[id];
+          if (!current || !isPtyPanel(current) || current.spawnStatus !== "spawning") return;
 
-        if (mountedPanel && shouldWaitForVisibleAttach) {
-          try {
-            await terminalInstanceService.waitForAttachSettled(id, {
-              timeoutMs: TERMINAL_STARTUP_ATTACH_TIMEOUT_MS,
-            });
-          } catch (error) {
-            logWarn("[TerminalStore] Terminal did not attach before startup queue advanced", {
-              id,
-              error,
-            });
-          }
-        }
-      } catch (error) {
-        logError("[TerminalStore] Failed to spawn terminal", error);
-        // Same staleness gate as the success path: never stamp a failure onto
-        // a successor incarnation that re-launched this id mid-flight.
-        if (!agentLifecycleLedger.recordSpawnResolved(id, launchGeneration, false).accepted) {
-          return;
-        }
-        const current = get().panelsById[id];
-        if (!current || !isPtyPanel(current) || current.spawnStatus !== "spawning") return;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- error shape from node-pty spawn rejection
+          const err = error as { code?: string; errno?: number; syscall?: string; path?: string };
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SpawnError construction from caught IPC error
+          const spawnError = {
+            code: err.code ?? "UNKNOWN",
+            message: formatErrorMessage(error, "Failed to start terminal process"),
+            errno: err.errno,
+            syscall: err.syscall,
+            path: err.path,
+          } as import("@shared/types/pty-host").SpawnError;
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- error shape from node-pty spawn rejection
-        const err = error as { code?: string; errno?: number; syscall?: string; path?: string };
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SpawnError construction from caught IPC error
-        const spawnError = {
-          code: err.code ?? "UNKNOWN",
-          message: formatErrorMessage(error, "Failed to start terminal process"),
-          errno: err.errno,
-          syscall: err.syscall,
-          path: err.path,
-        } as import("@shared/types/pty-host").SpawnError;
-
-        set((state) => {
-          const _current = state.panelsById[id];
-          if (!_current || !isPtyPanel(_current) || _current.spawnStatus !== "spawning")
-            return state;
-          // A launched agent that fails to start never produces a PTY exit, so
-          // its optimistic agentState would stay stuck (e.g. "working"). Mark it
-          // "exited" so terminal.list / terminal.getStatus report the crash
-          // instead of a phantom running agent (#10816). Plain shells have no
-          // launchAgentId and keep agentState undefined.
-          const agentPatch = _current.launchAgentId
-            ? { agentState: "exited" as const, lastStateChange: Date.now() }
-            : {};
-          return {
-            panelsById: {
-              ...state.panelsById,
-              [id]: {
-                ..._current,
-                spawnStatus: "failed",
-                spawnError,
-                runtimeStatus: "error",
-                ...agentPatch,
+          set((state) => {
+            const _current = state.panelsById[id];
+            if (!_current || !isPtyPanel(_current) || _current.spawnStatus !== "spawning")
+              return state;
+            // A launched agent that fails to start never produces a PTY exit, so
+            // its optimistic agentState would stay stuck (e.g. "working"). Mark it
+            // "exited" so terminal.list / terminal.getStatus report the crash
+            // instead of a phantom running agent (#10816). Plain shells have no
+            // launchAgentId and keep agentState undefined.
+            const agentPatch = _current.launchAgentId
+              ? { agentState: "exited" as const, lastStateChange: Date.now() }
+              : {};
+            return {
+              panelsById: {
+                ...state.panelsById,
+                [id]: {
+                  ..._current,
+                  spawnStatus: "failed",
+                  spawnError,
+                  runtimeStatus: "error",
+                  ...agentPatch,
+                },
               },
-            },
-          };
-        });
+            };
+          });
 
-        const after = get();
-        saveNormalized(after.panelsById, after.panelIds);
-      }
-    });
+          const after = get();
+          saveNormalized(after.panelsById, after.panelIds);
+        }
+      },
+      options.spawnBatchId && (options.spawnBatchSize ?? 0) > 1
+        ? RECIPE_TERMINAL_STARTUP_CONCURRENCY
+        : 1
+    );
 
     return id;
   },


### PR DESCRIPTION
## Summary

A performance-focused branch cutting background CPU on chatty agent terminals, speeding up recipe fanout, and killing the "spawn a burst, then stall one second at a time" cliff you hit when creating a batch of issue worktrees. Two logically distinct pieces:

**1. PTY output analysis + terminal startup (`7456271f1`)**
- **ActivityMonitor** caps simple-output viewport snapshot capture at 4Hz for streaming agents and reuses the memoized snapshot in between, so chatty output no longer re-extracts and re-hashes the full viewport on every 50ms tick — while still observing async redraws once the stream goes quiet.
- **SustainedChangeTracker / headlessViewport** represent default-styled single-width cells as numeric code points instead of allocating a string per occupied cell, with a matching numeric FNV hash path, and drop the eagerly-joined `text` string in favor of unit-only comparison.
- **WatcherController** reuses the git self-trigger cooldown constant (1s) for the worktree quiet window instead of a separate hardcoded 2s value.
- **addPanel** reworks the terminal startup queue from strictly serial to bounded concurrency (2 for recipe launches), so bulk recipes spawn PTYs faster without settling every xterm in a single frame.

**2. Bulk worktree recipe admission (`e2efa0c04`)**
- The generic terminal burst limiter treated each single-terminal recipe as a separate action, so a batch started ~6 immediately and admitted the rest one per second. Bulk creation now shares **one** user-confirmed admission batch across all created worktrees via `planBulkRecipeSpawnBatches`, capped at 30 PTYs and chunked safely above that. `MAX_TERMINALS_PER_RECIPE` → `MAX_TERMINALS_PER_RECIPE_ADMISSION_BATCH`.
- The unconditional 800ms post-creation verification wait is replaced with an event-driven `waitForPanelSpawns` + short settle.
- New `perf bulk-issue-worktrees` benchmark (PERF-182) exercising the full UI → renderer orchestration → IPC admission limiter → PTY host path (forge + worktree creation faked; no GitHub requests, no real git worktrees, no user repo touched).

## Measured impact

Lower is better; multipliers cover different workloads and shouldn't be multiplied together.

| Area | Before | After | Improvement |
| --- | --- | --- | --- |
| Agent output analysis p50 | 748.9 ms | 295.1 ms | 60.6% · 2.54× |
| Agent output analysis p95 | 756.0 ms | 314.5 ms | 58.4% · 2.40× |
| Sidebar burst coalescing p50 (50 edits) | 827.5 ms | 63.0 ms | 92.4% · 13.14× |
| Existing-worktree recipe, 10 agents ready | 2,367.2 ms | 1,154.5 ms | 51.2% · 2.05× |
| New-worktree recipe, 10 agents ready | 2,905.3 ms | 1,477.7 ms | 49.1% · 1.97× |
| Bulk issue workflow, 10 issues | 8,976 ms | 5,662 ms | 36.9% · 1.59× |
| Bulk confirm → all terminals, 10 issues | 4,547 ms | 1,223 ms | 73.1% · 3.72× |
| Largest terminal-admission gap, 10 issues | 1,002 ms | 75 ms | 92.5% · 13.36× |
| One-second admission pauses, 10 issues | 3 | 0 | Eliminated |

## Testing

- `npm run check` clean
- Full unit suite green (38,404 passed, 2 skipped, 1 todo)
- Production benchmark build + all benchmark samples pass
- New E2E: `e2e/full/panels/bulk-issue-worktree-recipe-perf.spec.ts`

## Review note

In `headlessViewport.ts` the numeric-key optimization means the raw-buffer path emits a **numeric** code point for a default single-width cell while the public-cell fallback path emits a **string** for the same cell. `measureVisibleContentDelta` compares units with `===`, so if a given line's raw-buffer availability differs between two compared frames (identical content), `unitsEqual` returns false even though the hash matches — a spurious full-viewport change. It's low-probability (raw availability is stable per line outside of resize/reflow, which is separately suppressed), but it's a latent regression the old all-string keying didn't have. Worth a follow-up to normalize the fallback path to numeric keys too, or key both consistently.
