### PR TITLE
feat(completions): insertText item model, app/plugin badges, trigger-neutral ranking

### DIFF
--- a/shared/types/completionSources.ts
+++ b/shared/types/completionSources.ts
@@ -18,12 +18,12 @@ import type { SlashCommandScope } from "./slashCommands.js";
 export type CompletionTrigger = "/" | "$" | "@";
 
 /**
- * Semantic category of a completion. Only `command` and `skill` are produced
- * today; `app`/`plugin` are a deliberate follow-up (Codex Apps/Plugins have no
- * verified local manifest yet — see #11043) and extend this union
- * non-breakingly when they land.
+ * Semantic category of a completion. `command` and `skill` are produced today;
+ * `app`/`plugin` are modelled ahead of their discovery backends (Codex
+ * Apps/Plugins have no verified local manifest yet — see #11043) so the item
+ * model, badges, and ranking can carry them the moment a source populates them.
  */
-export type CompletionKind = "command" | "skill";
+export type CompletionKind = "command" | "skill" | "app" | "plugin";
 
 /**
  * Closed allow-list of directory parsers implemented in `electron/`. The

--- a/shared/types/slashCommands.ts
+++ b/shared/types/slashCommands.ts
@@ -1,16 +1,28 @@
 import type { BuiltInAgentId } from "../config/agentIds.js";
-import type { CompletionTrigger } from "./completionSources.js";
+import type { CompletionKind, CompletionTrigger } from "./completionSources.js";
 
 export type SlashCommandScope = "built-in" | "global" | "user" | "project";
 
 export interface SlashCommand {
   id: string;
-  label: string; // e.g. "/compact"
+  label: string; // display token, e.g. "/compact" or "Plugin Creator"
   description: string;
   scope: SlashCommandScope;
   agentId: BuiltInAgentId;
   sourcePath?: string;
-  kind?: "command" | "skill";
+  kind?: CompletionKind;
+  /**
+   * The canonical token inserted when the command is chosen (e.g. `/compact`,
+   * `$plugin-creator`). Distinct from `label` (display) so a capability whose
+   * name differs from its token can be expressed. Optional: absent when the
+   * label *is* the token (built-ins), where consumers fall back to `label`.
+   */
+  insertText?: string;
+  /**
+   * Extra search-only tokens matched during ranking but never displayed or
+   * inserted. Mirrors `searchAliases` on the panel-kind registry.
+   */
+  aliases?: readonly string[];
   /**
    * Which trigger opens this completion (`/`, `$`, `@`). Stamped by the
    * discovery engine; absent on the renderer's built-in fallback, where it is

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -21,16 +21,20 @@ function getDescriptionSnippet(description: string, maxLength = 60): string {
 /**
  * Visible badge text per category. `command` is intentionally absent — plain
  * commands render without a badge (a `[Command]` on every slash token is noise),
- * so only the notable kinds (skills, and later apps/plugins) are called out.
+ * so only the notable kinds (skills, apps, plugins) are called out.
  */
 const CATEGORY_LABEL: Partial<Record<CompletionKind, string>> = {
   skill: "Skill",
+  app: "App",
+  plugin: "Plugin",
 };
 
 export interface AutocompleteItem {
   key: string;
+  /** Display text shown in the menu. May differ from what gets inserted. */
   label: string;
-  value: string;
+  /** Canonical token inserted on selection (e.g. `/diff`, `$plugin-creator`). */
+  insertText: string;
   description?: string;
   /** Semantic category; drives the neutral badge. Undefined for file/context items. */
   category?: CompletionKind;

--- a/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
+++ b/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
@@ -203,7 +203,8 @@ describe("AutocompleteMenu", () => {
 
     const option = screen.getByRole("option");
     expect(within(option).getByText("Plugin Creator")).toBeTruthy();
-    expect(within(option).queryByText("$plugin-creator")).toBeNull();
+    // The raw insert token must never surface in the row — the label is shown, not the token.
+    expect(option.textContent).not.toContain("$plugin-creator");
   });
 
   it("scrolls the keyboard-selected option into view as selection moves", () => {

--- a/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
+++ b/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
@@ -68,8 +68,8 @@ describe("AutocompleteMenu", () => {
 
   it("renders listbox with options when items are present", () => {
     const items: AutocompleteItem[] = [
-      { key: "a", label: "alpha", value: "alpha" },
-      { key: "b", label: "beta", value: "beta" },
+      { key: "a", label: "alpha", insertText: "alpha" },
+      { key: "b", label: "beta", insertText: "beta" },
     ];
 
     render(
@@ -91,7 +91,7 @@ describe("AutocompleteMenu", () => {
     render(
       <AutocompleteMenu
         isOpen={true}
-        items={[{ key: "a", label: "alpha", value: "alpha" }]}
+        items={[{ key: "a", label: "alpha", insertText: "alpha" }]}
         selectedIndex={0}
         onSelect={noop}
         title="Commands"
@@ -105,7 +105,7 @@ describe("AutocompleteMenu", () => {
   });
 
   it("marks the listbox busy while results are stale or loading", () => {
-    const items: AutocompleteItem[] = [{ key: "a", label: "alpha", value: "alpha" }];
+    const items: AutocompleteItem[] = [{ key: "a", label: "alpha", insertText: "alpha" }];
 
     const { rerender } = render(
       <AutocompleteMenu
@@ -146,10 +146,12 @@ describe("AutocompleteMenu", () => {
     expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
   });
 
-  it("renders a neutral, screen-reader-labeled badge for skill items only", () => {
+  it("renders a neutral, screen-reader-labeled badge for skill, app, and plugin items", () => {
     const items: AutocompleteItem[] = [
-      { key: "s", label: "/commit", value: "/commit", category: "skill" },
-      { key: "c", label: "/help", value: "/help", category: "command" },
+      { key: "s", label: "/commit", insertText: "/commit", category: "skill" },
+      { key: "a", label: "/connect", insertText: "/connect", category: "app" },
+      { key: "p", label: "/gh", insertText: "/gh", category: "plugin" },
+      { key: "c", label: "/help", insertText: "/help", category: "command" },
     ];
 
     render(
@@ -163,18 +165,45 @@ describe("AutocompleteMenu", () => {
     );
 
     const options = screen.getAllByRole("option");
-    const skillRow = options.find((o) => within(o).queryByText("/commit"))!;
-    const commandRow = options.find((o) => within(o).queryByText("/help"))!;
+    const rowFor = (text: string) => options.find((o) => within(o).queryByText(text))!;
 
-    // Skill row: visible badge is hidden from AT, paired with an sr-only label.
-    expect(within(skillRow).getByText("Skill", { selector: "[aria-hidden='true']" })).toBeTruthy();
-    expect(within(skillRow).getByText("Category: Skill")).toBeTruthy();
+    // Each notable kind: visible badge hidden from AT, paired with an sr-only label.
+    for (const [text, badge] of [
+      ["/commit", "Skill"],
+      ["/connect", "App"],
+      ["/gh", "Plugin"],
+    ] as const) {
+      const row = rowFor(text);
+      expect(within(row).getByText(badge, { selector: "[aria-hidden='true']" })).toBeTruthy();
+      expect(within(row).getByText(`Category: ${badge}`)).toBeTruthy();
+    }
 
     // Command row carries no badge — plain by design.
+    const commandRow = rowFor("/help");
     expect(
       within(commandRow).queryByText("Skill", { selector: "[aria-hidden='true']" })
     ).toBeNull();
     expect(within(commandRow).queryByText(/Category:/)).toBeNull();
+  });
+
+  it("displays the label, not the insert token, when they differ", () => {
+    const items: AutocompleteItem[] = [
+      { key: "p", label: "Plugin Creator", insertText: "$plugin-creator", category: "plugin" },
+    ];
+
+    render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={items}
+        selectedIndex={0}
+        onSelect={noop}
+        emptyMessage="No matches"
+      />
+    );
+
+    const option = screen.getByRole("option");
+    expect(within(option).getByText("Plugin Creator")).toBeTruthy();
+    expect(within(option).queryByText("$plugin-creator")).toBeNull();
   });
 
   it("scrolls the keyboard-selected option into view as selection moves", () => {
@@ -183,9 +212,9 @@ describe("AutocompleteMenu", () => {
     Element.prototype.scrollIntoView = scrollSpy;
     try {
       const items: AutocompleteItem[] = [
-        { key: "a", label: "alpha", value: "alpha" },
-        { key: "b", label: "beta", value: "beta" },
-        { key: "c", label: "gamma", value: "gamma" },
+        { key: "a", label: "alpha", insertText: "alpha" },
+        { key: "b", label: "beta", insertText: "beta" },
+        { key: "c", label: "gamma", insertText: "gamma" },
       ];
 
       const { rerender } = render(

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
@@ -9,14 +9,10 @@ import { useAutocompleteApply } from "../useAutocompleteApply";
 type Params = Parameters<typeof useAutocompleteApply>[0];
 type Latest = NonNullable<Params["latestRef"]["current"]>;
 
-function makeView(doc: string, caret = doc.length) {
-  return new EditorView({
-    state: EditorState.create({ doc, selection: { anchor: caret } }),
-  });
-}
-
 function setup(doc: string, item: AutocompleteItem) {
-  const view = makeView(doc);
+  const view = new EditorView({
+    state: EditorState.create({ doc, selection: { anchor: doc.length } }),
+  });
   const applyEditorValue = vi.fn<Params["applyEditorValue"]>();
   const sendText = vi.fn<Params["sendText"]>();
   const latest: Latest = {
@@ -45,7 +41,7 @@ function setup(doc: string, item: AutocompleteItem) {
   };
 
   const { result } = renderHook(() => useAutocompleteApply(params));
-  return { ...result.current, applyEditorValue, sendText };
+  return { ...result.current, applyEditorValue, sendText, view };
 }
 
 describe("useAutocompleteApply", () => {
@@ -57,24 +53,29 @@ describe("useAutocompleteApply", () => {
   };
 
   it("inserts the canonical token, never the display label", () => {
-    const { handleAutocompleteSelect, applyEditorValue } = setup("/plug", item);
+    const { handleAutocompleteSelect, applyEditorValue, sendText, view } = setup("/plug", item);
+    try {
+      handleAutocompleteSelect(item);
 
-    handleAutocompleteSelect(item);
-
-    expect(applyEditorValue).toHaveBeenCalledTimes(1);
-    const inserted = applyEditorValue.mock.calls[0]![0];
-    expect(inserted).toContain("$plugin-creator");
-    expect(inserted).not.toContain("Plugin Creator");
+      expect(applyEditorValue).toHaveBeenCalledTimes(1);
+      // Replaces the whole "/plug" slash token with the canonical insert token.
+      expect(applyEditorValue.mock.calls[0]![0]).toBe("$plugin-creator ");
+      expect(sendText).not.toHaveBeenCalled();
+    } finally {
+      view.destroy();
+    }
   });
 
   it("executes with the canonical token, never the display label", () => {
-    const { applyAutocompleteSelection, sendText } = setup("/plug", item);
+    const { applyAutocompleteSelection, applyEditorValue, sendText, view } = setup("/plug", item);
+    try {
+      expect(applyAutocompleteSelection("execute")).toBe(true);
 
-    expect(applyAutocompleteSelection("execute")).toBe(true);
-
-    expect(sendText).toHaveBeenCalledTimes(1);
-    const sent = sendText.mock.calls[0]![0];
-    expect(sent).toContain("$plugin-creator");
-    expect(sent).not.toContain("Plugin Creator");
+      expect(sendText).toHaveBeenCalledTimes(1);
+      expect(sendText.mock.calls[0]![0]).toBe("$plugin-creator");
+      expect(applyEditorValue).not.toHaveBeenCalled();
+    } finally {
+      view.destroy();
+    }
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import type { AutocompleteItem } from "../../AutocompleteMenu";
+import { useAutocompleteApply } from "../useAutocompleteApply";
+
+type Params = Parameters<typeof useAutocompleteApply>[0];
+type Latest = NonNullable<Params["latestRef"]["current"]>;
+
+function makeView(doc: string, caret = doc.length) {
+  return new EditorView({
+    state: EditorState.create({ doc, selection: { anchor: caret } }),
+  });
+}
+
+function setup(doc: string, item: AutocompleteItem) {
+  const view = makeView(doc);
+  const applyEditorValue = vi.fn<Params["applyEditorValue"]>();
+  const sendText = vi.fn<Params["sendText"]>();
+  const latest: Latest = {
+    activeMode: "command",
+    autocompleteItems: [item],
+    selectedIndex: 0,
+    slashContext: null,
+    atContext: null,
+    diffContext: null,
+    terminalContext: null,
+    selectionContext: null,
+  };
+
+  const params: Params = {
+    editorViewRef: { current: view },
+    latestRef: { current: latest },
+    lastQueryRef: { current: "" },
+    applyEditorValue,
+    sendText,
+    setAtContext: vi.fn(),
+    setSlashContext: vi.fn(),
+    setDiffContext: vi.fn(),
+    setTerminalContext: vi.fn(),
+    setSelectionContext: vi.fn(),
+    setSelectedIndex: vi.fn(),
+  };
+
+  const { result } = renderHook(() => useAutocompleteApply(params));
+  return { ...result.current, applyEditorValue, sendText };
+}
+
+describe("useAutocompleteApply", () => {
+  const item: AutocompleteItem = {
+    key: "plugin-creator",
+    label: "Plugin Creator",
+    insertText: "$plugin-creator",
+    category: "plugin",
+  };
+
+  it("inserts the canonical token, never the display label", () => {
+    const { handleAutocompleteSelect, applyEditorValue } = setup("/plug", item);
+
+    handleAutocompleteSelect(item);
+
+    expect(applyEditorValue).toHaveBeenCalledTimes(1);
+    const inserted = applyEditorValue.mock.calls[0]![0];
+    expect(inserted).toContain("$plugin-creator");
+    expect(inserted).not.toContain("Plugin Creator");
+  });
+
+  it("executes with the canonical token, never the display label", () => {
+    const { applyAutocompleteSelection, sendText } = setup("/plug", item);
+
+    expect(applyAutocompleteSelection("execute")).toBe(true);
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    const sent = sendText.mock.calls[0]![0];
+    expect(sent).toContain("$plugin-creator");
+    expect(sent).not.toContain("Plugin Creator");
+  });
+});

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
@@ -47,10 +47,10 @@ describe("useAutocompleteItems", () => {
     const [nested, root] = result.current.autocompleteItems;
     expect(nested!.label).toBe("Button.tsx");
     expect(nested!.description).toBe("src/components");
-    expect(nested!.value).toBe("src/components/Button.tsx");
+    expect(nested!.insertText).toBe("src/components/Button.tsx");
     expect(root!.label).toBe("README.md");
     expect(root!.description).toBeUndefined();
-    expect(root!.value).toBe("README.md");
+    expect(root!.insertText).toBe("README.md");
   });
 
   it("disambiguates duplicate basenames via directory descriptions", () => {
@@ -82,7 +82,7 @@ describe("useAutocompleteItems", () => {
     expect(win!.description).toBe("src\\utils");
     // Trailing separator yields an empty basename — falls back to the full path.
     expect(trailing!.label).toBe("src/dir/");
-    expect(trailing!.value).toBe("src/dir/");
+    expect(trailing!.insertText).toBe("src/dir/");
   });
 
   it("returns diff items filtered by partial", () => {
@@ -125,8 +125,8 @@ describe("useAutocompleteItems", () => {
 
   it("returns command items when activeMode is command", () => {
     const commands = [
-      { key: "/help", label: "/help", value: "/help" },
-      { key: "/clear", label: "/clear", value: "/clear" },
+      { key: "/help", label: "/help", insertText: "/help" },
+      { key: "/clear", label: "/clear", insertText: "/clear" },
     ];
     const { result } = renderHook(() =>
       useAutocompleteItems({

--- a/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
@@ -25,7 +25,7 @@ function makeLatest(overrides: Partial<LatestShape> = {}): LatestShape {
     isInHistoryMode: false,
     activeMode: "file",
     isAutocompleteOpen: true,
-    autocompleteItems: [{ key: "src/a.ts", label: "a.ts", value: "src/a.ts" }],
+    autocompleteItems: [{ key: "src/a.ts", label: "a.ts", insertText: "src/a.ts" }],
     isResultsStale: false,
     selectedIndex: 0,
     value: "@a",
@@ -107,7 +107,7 @@ describe("useEditorKeymap", () => {
       const { handlers } = renderKeymap(
         makeLatest({
           activeMode: "command",
-          autocompleteItems: [{ key: "/help", label: "/help", value: "/help" }],
+          autocompleteItems: [{ key: "/help", label: "/help", insertText: "/help" }],
           value: "/he",
         })
       );

--- a/src/components/Terminal/hooks/useAutocompleteApply.ts
+++ b/src/components/Terminal/hooks/useAutocompleteApply.ts
@@ -66,7 +66,7 @@ function applyAutocompleteItem(
   if (latest.activeMode === "terminal") {
     const ctx = getTerminalContext(currentValue, caret) ?? latest.terminalContext;
     if (!ctx) return;
-    const token = `${item.value} `;
+    const token = `${item.insertText} `;
     const before = currentValue.slice(0, ctx.atStart);
     const after = currentValue.slice(ctx.tokenEnd);
     const nextValue = `${before}${token}${after}`;
@@ -84,7 +84,7 @@ function applyAutocompleteItem(
   if (latest.activeMode === "selection") {
     const ctx = getSelectionContext(currentValue, caret) ?? latest.selectionContext;
     if (!ctx) return;
-    const token = `${item.value} `;
+    const token = `${item.insertText} `;
     const before = currentValue.slice(0, ctx.atStart);
     const after = currentValue.slice(ctx.tokenEnd);
     const nextValue = `${before}${token}${after}`;
@@ -102,7 +102,7 @@ function applyAutocompleteItem(
   if (latest.activeMode === "diff") {
     const ctx = getDiffContext(currentValue, caret) ?? latest.diffContext;
     if (!ctx) return;
-    const token = `${item.value} `;
+    const token = `${item.insertText} `;
     const before = currentValue.slice(0, ctx.atStart);
     const after = currentValue.slice(ctx.tokenEnd);
     const nextValue = `${before}${token}${after}`;
@@ -131,7 +131,7 @@ function applyAutocompleteItem(
   if (latest.activeMode === "file") {
     const ctx = getAtFileContext(currentValue, caret);
     if (!ctx) return;
-    const token = `${formatAtFileToken(item.value)} `;
+    const token = `${formatAtFileToken(item.insertText)} `;
     const before = currentValue.slice(0, ctx.atStart);
     const after = currentValue.slice(ctx.tokenEnd);
     const nextValue = `${before}${token}${after}`;
@@ -162,7 +162,7 @@ function applyAutocompleteItem(
     const after = currentValue.slice(slashCtx.tokenEnd);
     const hasLeadingSpace = after.startsWith(" ");
     const shouldAppendSpace = action === "insert" && !hasLeadingSpace;
-    const token = shouldAppendSpace ? `${item.value} ` : item.value;
+    const token = shouldAppendSpace ? `${item.insertText} ` : item.insertText;
     const nextValue = `${before}${token}${after}`;
     const nextCaret =
       before.length + token.length + (action === "insert" && hasLeadingSpace ? 1 : 0);

--- a/src/components/Terminal/hooks/useAutocompleteItems.ts
+++ b/src/components/Terminal/hooks/useAutocompleteItems.ts
@@ -28,26 +28,28 @@ export function useAutocompleteItems({
   const autocompleteDiffItems = useMemo((): AutocompleteItem[] => {
     if (!diffContext) return [];
     const items: AutocompleteItem[] = [
-      { key: "diff", label: "Working tree diff (@diff)", value: "@diff" },
-      { key: "diff:staged", label: "Staged diff (@diff:staged)", value: "@diff:staged" },
-      { key: "diff:head", label: "HEAD diff (@diff:head)", value: "@diff:head" },
+      { key: "diff", label: "Working tree diff (@diff)", insertText: "@diff" },
+      { key: "diff:staged", label: "Staged diff (@diff:staged)", insertText: "@diff:staged" },
+      { key: "diff:head", label: "HEAD diff (@diff:head)", insertText: "@diff:head" },
     ];
     const partial =
       diffContext.tokenEnd > diffContext.atStart + 1
         ? value.slice(diffContext.atStart + 1, diffContext.tokenEnd)
         : "";
     if (!partial) return items;
-    return items.filter((item) => item.value.slice(1).startsWith(partial));
+    return items.filter((item) => item.insertText.slice(1).startsWith(partial));
   }, [diffContext, value]);
 
   const autocompleteTerminalItems = useMemo((): AutocompleteItem[] => {
     if (!terminalContext) return [];
-    return [{ key: "terminal", label: "Terminal output (@terminal)", value: "@terminal" }];
+    return [{ key: "terminal", label: "Terminal output (@terminal)", insertText: "@terminal" }];
   }, [terminalContext]);
 
   const autocompleteSelectionItems = useMemo((): AutocompleteItem[] => {
     if (!selectionContext) return [];
-    return [{ key: "selection", label: "Terminal selection (@selection)", value: "@selection" }];
+    return [
+      { key: "selection", label: "Terminal selection (@selection)", insertText: "@selection" },
+    ];
   }, [selectionContext]);
 
   const autocompleteItems = useMemo((): AutocompleteItem[] => {
@@ -70,7 +72,7 @@ export function useAutocompleteItems({
         return {
           key: file,
           label: base || file,
-          value: file,
+          insertText: file,
           description: dir || undefined,
         };
       });

--- a/src/hooks/__tests__/slashAutocompleteItems.test.ts
+++ b/src/hooks/__tests__/slashAutocompleteItems.test.ts
@@ -27,17 +27,21 @@ describe("toSlashAutocompleteItems", () => {
     expect(labels).not.toContain("$imagegen");
   });
 
-  it("carries kind through as category (skill badged, command default)", () => {
+  it("carries kind through as category (skill/app/plugin badged, command default)", () => {
     const items = toSlashAutocompleteItems(
       [
         make({ label: "/commit", trigger: "/", kind: "skill" }),
         make({ label: "/help", trigger: "/", kind: "command" }),
+        make({ label: "/connect", trigger: "/", kind: "app" }),
+        make({ label: "/gh", trigger: "/", kind: "plugin" }),
       ],
       ""
     );
 
     expect(items.find((i) => i.label === "/commit")?.category).toBe("skill");
     expect(items.find((i) => i.label === "/help")?.category).toBe("command");
+    expect(items.find((i) => i.label === "/connect")?.category).toBe("app");
+    expect(items.find((i) => i.label === "/gh")?.category).toBe("plugin");
   });
 
   it("treats a triggerless built-in fallback as a slash command", () => {
@@ -47,8 +51,27 @@ describe("toSlashAutocompleteItems", () => {
     expect(items[0]?.category).toBe("command");
   });
 
-  it("uses the canonical label as the inserted value", () => {
+  it("falls back to the label for insert text when no distinct token is supplied", () => {
     const items = toSlashAutocompleteItems([make({ label: "/diff", trigger: "/" })], "");
-    expect(items[0]).toMatchObject({ label: "/diff", value: "/diff", key: "/diff" });
+    expect(items[0]).toMatchObject({ label: "/diff", insertText: "/diff", key: "/diff" });
+  });
+
+  it("keeps a distinct insertText separate from the display label (never derives from it)", () => {
+    const items = toSlashAutocompleteItems(
+      [
+        make({
+          label: "Plugin Creator",
+          insertText: "$plugin-creator",
+          trigger: "/",
+          kind: "plugin",
+        }),
+      ],
+      ""
+    );
+    expect(items[0]).toMatchObject({
+      label: "Plugin Creator",
+      insertText: "$plugin-creator",
+      category: "plugin",
+    });
   });
 });

--- a/src/hooks/slashAutocompleteItems.ts
+++ b/src/hooks/slashAutocompleteItems.ts
@@ -17,7 +17,10 @@ export function toSlashAutocompleteItems(
   return rankSlashCommands(slashCommands, query).map((cmd) => ({
     key: cmd.id,
     label: cmd.label,
-    value: cmd.label,
+    // Carry the canonical token through; fall back to the label only when the
+    // source didn't supply a distinct one (built-ins, where label *is* the
+    // token) — never derive a display-only label into inserted text.
+    insertText: cmd.insertText ?? cmd.label,
     description: cmd.description,
     category: cmd.kind ?? "command",
   }));

--- a/src/hooks/useSlashCommandList.ts
+++ b/src/hooks/useSlashCommandList.ts
@@ -59,7 +59,10 @@ export function useSlashCommandList({ agentId, projectPath }: UseSlashCommandLis
       // The slash-chip validation only resolves `/` tokens; keep `$`/`@`
       // completions out of the map so they can't mark a `/token` valid.
       if ((cmd.trigger ?? "/") !== "/") continue;
-      map.set(cmd.label, cmd);
+      // Key by the inserted token (what the chip parser resolves), not the
+      // display label — they diverge once a source supplies a distinct
+      // `insertText`, and the label alone would fail the `/token` lookup.
+      map.set(cmd.insertText ?? cmd.label, cmd);
     }
     return map;
   }, [agentCommands]);

--- a/src/lib/__tests__/slashCommandMatch.test.ts
+++ b/src/lib/__tests__/slashCommandMatch.test.ts
@@ -12,6 +12,16 @@ function cmd(label: string): SlashCommand {
   };
 }
 
+function make(partial: Partial<SlashCommand> & { label: string }): SlashCommand {
+  return {
+    id: partial.label,
+    description: "",
+    scope: "built-in",
+    agentId: "claude",
+    ...partial,
+  };
+}
+
 describe("rankSlashCommands", () => {
   it("prioritizes command-start matches over other matches", () => {
     const ranked = rankSlashCommands([cmd("/git:work-issue"), cmd("/workbench")], "/wo");
@@ -36,5 +46,54 @@ describe("rankSlashCommands", () => {
   it("matches deeper colon namespaces and prefers earlier colon segments", () => {
     const ranked = rankSlashCommands([cmd("/git:branch:list"), cmd("/tool:list")], "/list");
     expect(ranked.map((c) => c.label)).toEqual(["/tool:list", "/git:branch:list"]);
+  });
+
+  it("matches a hyphenated label by each subword and by the whole token", () => {
+    const item = make({ label: "neo-issue" });
+    for (const query of ["neo", "issue", "neo-issue"]) {
+      expect(rankSlashCommands([item], query).map((c) => c.label)).toEqual(["neo-issue"]);
+    }
+  });
+
+  it("matches a space-separated label by each word", () => {
+    const item = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
+    for (const query of ["plugin", "creator"]) {
+      expect(rankSlashCommands([item], query).map((c) => c.label)).toEqual(["Plugin Creator"]);
+    }
+  });
+
+  it("matches against the triggerless insert text", () => {
+    const item = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
+    expect(rankSlashCommands([item], "plugin-creator").map((c) => c.label)).toEqual([
+      "Plugin Creator",
+    ]);
+  });
+
+  it("matches against aliases but never against badge/kind text", () => {
+    const aliased = make({ label: "/deploy", aliases: ["ship", "release"] });
+    expect(rankSlashCommands([aliased], "ship").map((c) => c.label)).toEqual(["/deploy"]);
+
+    // `kind: "plugin"` must not make the command matchable by "plugin".
+    const kinded = make({ label: "/deploy", kind: "plugin" });
+    expect(rankSlashCommands([kinded], "plugin")).toEqual([]);
+  });
+
+  it("ranks identically regardless of the trigger prefix on the query", () => {
+    const commands = [
+      make({ label: "Plugin Creator", insertText: "$plugin-creator" }),
+      cmd("/help"),
+    ];
+    const baseline = rankSlashCommands(commands, "plugin").map((c) => c.label);
+    for (const query of ["/plugin", "$plugin", "@plugin"]) {
+      expect(rankSlashCommands(commands, query).map((c) => c.label)).toEqual(baseline);
+    }
+    expect(baseline).toEqual(["Plugin Creator"]);
+  });
+
+  it("strips only one leading trigger — repeated prefixes are not normalized twice", () => {
+    const item = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
+    // A single `$` matches; a doubled `$$` leaves a literal `$` that cannot match.
+    expect(rankSlashCommands([item], "$plugin").map((c) => c.label)).toEqual(["Plugin Creator"]);
+    expect(rankSlashCommands([item], "$$plugin")).toEqual([]);
   });
 });

--- a/src/lib/__tests__/slashCommandMatch.test.ts
+++ b/src/lib/__tests__/slashCommandMatch.test.ts
@@ -55,45 +55,66 @@ describe("rankSlashCommands", () => {
     }
   });
 
-  it("matches a space-separated label by each word", () => {
-    const item = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
-    for (const query of ["plugin", "creator"]) {
-      expect(rankSlashCommands([item], query).map((c) => c.label)).toEqual(["Plugin Creator"]);
-    }
+  it("tokenizes a space-separated label so each word matches at token tier", () => {
+    // Without splitting on whitespace, "creator" matches "Plugin Creator" only as a
+    // substring (rank 3) and would lose to the prefix match on "creatorx" (rank 1);
+    // token-tier matching (rank 0) requires the whitespace split, so order proves it.
+    const commands = [make({ label: "creatorx" }), make({ label: "Plugin Creator" })];
+    expect(rankSlashCommands(commands, "creator").map((c) => c.label)).toEqual([
+      "Plugin Creator",
+      "creatorx",
+    ]);
+    expect(
+      rankSlashCommands([make({ label: "Plugin Creator" })], "plugin").map((c) => c.label)
+    ).toEqual(["Plugin Creator"]);
   });
 
-  it("matches against the triggerless insert text", () => {
-    const item = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
-    expect(rankSlashCommands([item], "plugin-creator").map((c) => c.label)).toEqual([
+  it("matches against the triggerless insert text when the label alone would not", () => {
+    // Label "Ship It" shares nothing with "deploy" — only a distinct insertText matches.
+    const deployItem = make({ label: "Ship It", insertText: "$deploy" });
+    expect(rankSlashCommands([deployItem], "deploy").map((c) => c.label)).toEqual(["Ship It"]);
+
+    const pluginCreator = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
+    expect(rankSlashCommands([pluginCreator], "plugin-creator").map((c) => c.label)).toEqual([
       "Plugin Creator",
     ]);
   });
 
-  it("matches against aliases but never against badge/kind text", () => {
+  it("matches against every alias but never against kind/badge text", () => {
     const aliased = make({ label: "/deploy", aliases: ["ship", "release"] });
-    expect(rankSlashCommands([aliased], "ship").map((c) => c.label)).toEqual(["/deploy"]);
+    for (const query of ["ship", "release"]) {
+      expect(rankSlashCommands([aliased], query).map((c) => c.label)).toEqual(["/deploy"]);
+    }
 
     // `kind: "plugin"` must not make the command matchable by "plugin".
     const kinded = make({ label: "/deploy", kind: "plugin" });
     expect(rankSlashCommands([kinded], "plugin")).toEqual([]);
   });
 
-  it("ranks identically regardless of the trigger prefix on the query", () => {
-    const commands = [
-      make({ label: "Plugin Creator", insertText: "$plugin-creator" }),
-      cmd("/help"),
-    ];
-    const baseline = rankSlashCommands(commands, "plugin").map((c) => c.label);
-    for (const query of ["/plugin", "$plugin", "@plugin"]) {
-      expect(rankSlashCommands(commands, query).map((c) => c.label)).toEqual(baseline);
+  it("strips a leading trigger from the query so ranking is trigger-neutral", () => {
+    // Unprefixed candidate: only stripping the query's trigger can make it match,
+    // so a pass proves each of /, $, @ is normalized off the query.
+    const item = make({ label: "plugin" });
+    for (const query of ["plugin", "/plugin", "$plugin", "@plugin"]) {
+      expect(rankSlashCommands([item], query).map((c) => c.label)).toEqual(["plugin"]);
     }
-    expect(baseline).toEqual(["Plugin Creator"]);
   });
 
-  it("strips only one leading trigger — repeated prefixes are not normalized twice", () => {
-    const item = make({ label: "Plugin Creator", insertText: "$plugin-creator" });
-    // A single `$` matches; a doubled `$$` leaves a literal `$` that cannot match.
-    expect(rankSlashCommands([item], "$plugin").map((c) => c.label)).toEqual(["Plugin Creator"]);
+  it("strips only one leading trigger — a doubled prefix is not normalized twice", () => {
+    const item = make({ label: "plugin" });
+    expect(rankSlashCommands([item], "$plugin").map((c) => c.label)).toEqual(["plugin"]);
+    // "$$plugin" normalizes to "$plugin" (one strip), which cannot match "plugin".
     expect(rankSlashCommands([item], "$$plugin")).toEqual([]);
+  });
+
+  it("returns commands in original order for an empty or trigger-only query", () => {
+    const commands = [cmd("/zebra"), cmd("/alpha"), cmd("/mango")];
+    for (const query of ["", "   ", "/", "$", "@"]) {
+      expect(rankSlashCommands(commands, query).map((c) => c.label)).toEqual([
+        "/zebra",
+        "/alpha",
+        "/mango",
+      ]);
+    }
   });
 });

--- a/src/lib/slashCommandMatch.ts
+++ b/src/lib/slashCommandMatch.ts
@@ -5,46 +5,87 @@ type MatchScore = {
   detail: number;
 };
 
+/** Trigger characters stripped from the front of a token before matching. */
+const TRIGGER_PREFIXES = ["/", "$", "@"] as const;
+
+/**
+ * Trim/lowercase a token and strip a single leading trigger (`/`, `$`, `@`) so
+ * ranking is trigger-neutral. Only the first character is inspected, exactly
+ * once — `$$plugin` normalizes to `$plugin`, never `plugin` — and triggers that
+ * appear mid-token are left intact.
+ */
 function normalizeToken(value: string): string {
   const trimmed = value.trim().toLowerCase();
-  return trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  return (TRIGGER_PREFIXES as readonly string[]).includes(trimmed[0] ?? "")
+    ? trimmed.slice(1)
+    : trimmed;
 }
 
-function extractOrderedTokens(label: string): string[] {
-  const normalizedLabel = normalizeToken(label);
-  const colonParts = normalizedLabel.split(":");
+/**
+ * Split an already-normalized candidate into ordered subword tokens on
+ * whitespace, colon, then hyphen (order preserved) so `neo-issue`,
+ * `git:work-issue`, and `Plugin Creator` all yield their component words.
+ * Callers must pass a value that has already been through {@link normalizeToken}.
+ */
+function extractOrderedTokens(normalized: string): string[] {
   const tokens: string[] = [];
-
-  for (const part of colonParts) {
-    for (const segment of part.split("-")) {
-      if (!segment) continue;
-      tokens.push(segment);
+  for (const spacePart of normalized.split(/\s+/)) {
+    for (const colonPart of spacePart.split(":")) {
+      for (const segment of colonPart.split("-")) {
+        if (!segment) continue;
+        tokens.push(segment);
+      }
     }
   }
-
   return tokens;
 }
 
-function getMatchScore(label: string, query: string): MatchScore | null {
-  const normalizedLabel = normalizeToken(label);
-  const normalizedQuery = normalizeToken(query);
-  if (!normalizedQuery) return { rank: 0, detail: 0 };
-
-  const tokens = extractOrderedTokens(normalizedLabel);
+/**
+ * Score a single already-normalized candidate against an already-normalized
+ * query across four tiers: exact token → label prefix → token prefix →
+ * substring. Lower `rank`/`detail` is better. Returns null on no match.
+ */
+function scoreCandidate(normalizedCandidate: string, normalizedQuery: string): MatchScore | null {
+  const tokens = extractOrderedTokens(normalizedCandidate);
   for (let index = 0; index < tokens.length; index++) {
     if (tokens[index] === normalizedQuery) return { rank: 0, detail: index };
   }
 
-  if (normalizedLabel.startsWith(normalizedQuery)) return { rank: 1, detail: 0 };
+  if (normalizedCandidate.startsWith(normalizedQuery)) return { rank: 1, detail: 0 };
 
   for (let index = 0; index < tokens.length; index++) {
     if (tokens[index]?.startsWith(normalizedQuery)) return { rank: 2, detail: index };
   }
 
-  const withinIndex = normalizedLabel.indexOf(normalizedQuery);
+  const withinIndex = normalizedCandidate.indexOf(normalizedQuery);
   if (withinIndex !== -1) return { rank: 3, detail: withinIndex };
 
   return null;
+}
+
+/**
+ * Best score for a command across every searchable string — its label, the
+ * triggerless insert text, and any aliases — normalizing each exactly once.
+ * Kind, badge text, and description are deliberately excluded.
+ */
+function getMatchScore(command: SlashCommand, normalizedQuery: string): MatchScore | null {
+  const candidates = [command.label];
+  if (command.insertText) candidates.push(command.insertText);
+  if (command.aliases) candidates.push(...command.aliases);
+
+  let best: MatchScore | null = null;
+  for (const candidate of candidates) {
+    const score = scoreCandidate(normalizeToken(candidate), normalizedQuery);
+    if (
+      score &&
+      (best === null ||
+        score.rank < best.rank ||
+        (score.rank === best.rank && score.detail < best.detail))
+    ) {
+      best = score;
+    }
+  }
+  return best;
 }
 
 export function rankSlashCommands(commands: SlashCommand[], query: string): SlashCommand[] {
@@ -53,7 +94,7 @@ export function rankSlashCommands(commands: SlashCommand[], query: string): Slas
 
   return commands
     .map((command, index) => {
-      const score = getMatchScore(command.label, normalizedQuery);
+      const score = getMatchScore(command, normalizedQuery);
       return score ? { command, score, index } : null;
     })
     .filter(


### PR DESCRIPTION
## Summary

- `AutocompleteItem` now carries a required `insertText` field, separate from the display `label`. This replaces the old `value` field, which conflated the two.
- `CompletionKind` gets two new categories, `app` and `plugin`, rendered as neutral `[App]` / `[Plugin]` badges. They reuse the same `aria-hidden` plus screen-reader-only pattern already in place for `[Skill]`.
- `rankSlashCommands` is now trigger-neutral: it strips a single leading `/`, `$`, or `@` instead of assuming a slash, tokenizes on space, colon, or hyphen, and scores matches across the label, the triggerless `insertText`, and any aliases. It never scores against kind or badge text.

Resolves #11047. Part of #11043, following on from #11046.

## Changes

- `AutocompleteItem`: added required `insertText`, dropped `value`. Insertion (`useAutocompleteApply.ts`) reads `insertText` throughout.
- `CompletionKind` extended with `app` / `plugin`; `CATEGORY_LABEL` and the badge rendering in `AutocompleteMenu.tsx` cover both with the existing a11y treatment.
- `SlashCommand` gained optional `insertText` and `aliases`, and its `kind` widened to `CompletionKind`. This is additive forward-plumbing. There's no live app or plugin data yet.
- `rankSlashCommands` normalizes the trigger once (no double-strip), tokenizes on space/colon/hyphen, and matches label + triggerless `insertText` + aliases through the same tiered scoring (exact, prefix, token-prefix, substring).
- The slash-chip `commandMap` is now keyed by the inserted token, so a command whose `insertText` diverges from its label still resolves the right chip.

This is additive only. It doesn't touch the `$` picker's input-bar trigger parsing, which is a separate issue.

## Testing

185 targeted tests pass across ranking, the item model, insert/execute behavior, badges, and the `inputEditorExtensions` consumer suite. Own files pass eslint and prettier.