### PR TITLE
feat(completions): discover Codex plugins as $-trigger completions

### DIFF
--- a/electron/services/completions/__tests__/CompletionDiscoveryEngine.test.ts
+++ b/electron/services/completions/__tests__/CompletionDiscoveryEngine.test.ts
@@ -297,4 +297,88 @@ Body.
       await fsp.rm(projectRoot, { recursive: true, force: true });
     }
   });
+
+  it("surfaces enabled Codex plugins as $-kind:plugin, and a user skill wins a label collision", async () => {
+    const homeRoot = await makeTempDir();
+    const projectRoot = await makeTempDir();
+    const prev = overrideHome(homeRoot);
+    const engine = new CompletionDiscoveryEngine();
+    const codexHome = path.join(homeRoot, ".codex");
+
+    try {
+      await fsp.mkdir(path.join(projectRoot, ".git"));
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          `[plugins."github@openai-curated"]`,
+          `enabled = true`,
+          ``,
+          `[plugins."gmail@openai-curated"]`,
+          `enabled = true`,
+        ].join("\n")
+      );
+      const manifest = (name: string, short: string) =>
+        JSON.stringify({
+          name,
+          description: `${name} top`,
+          interface: { shortDescription: short },
+        });
+      await writeFile(
+        path.join(
+          codexHome,
+          "plugins",
+          "cache",
+          "openai-curated",
+          "github",
+          "v1",
+          ".codex-plugin",
+          "plugin.json"
+        ),
+        manifest("github", "Triage PRs and CI")
+      );
+      await writeFile(
+        path.join(
+          codexHome,
+          "plugins",
+          "cache",
+          "openai-curated",
+          "gmail",
+          "v1",
+          ".codex-plugin",
+          "plugin.json"
+        ),
+        manifest("gmail", "Read and manage Gmail")
+      );
+      // A user skill named `github` collides with the plugin's `$github` token.
+      await writeFile(
+        path.join(codexHome, "skills", "github", "SKILL.md"),
+        `---
+description: "user github skill"
+---
+
+Body.
+`
+      );
+
+      const codex = await engine.list("codex", projectRoot);
+
+      const gmail = codex.find((c) => c.label === "$gmail");
+      expect(gmail).toMatchObject({
+        kind: "plugin",
+        trigger: "$",
+        scope: "user",
+        description: "Read and manage Gmail",
+      });
+
+      // Dedupe by trigger+label: plugin sourcePrecedence (10) < skill (20), so
+      // the user's own skill wins the `$github` label.
+      const github = codex.filter((c) => c.label === "$github");
+      expect(github).toHaveLength(1);
+      expect(github[0]).toMatchObject({ kind: "skill", description: "user github skill" });
+    } finally {
+      restoreHome(prev);
+      await fsp.rm(homeRoot, { recursive: true, force: true });
+      await fsp.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/electron/services/completions/__tests__/completionParsers.test.ts
+++ b/electron/services/completions/__tests__/completionParsers.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { getCompletionParser, type RawCompletionEntry } from "../completionParsers.js";
+
+async function makeCodexHome(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), "daintree-codex-plugins-"));
+}
+
+async function write(filePath: string, contents: string): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, contents, "utf8");
+}
+
+async function writeManifest(
+  codexHome: string,
+  marketplace: string,
+  plugin: string,
+  version: string,
+  manifest: unknown,
+  manifestDir = ".codex-plugin"
+): Promise<void> {
+  await write(
+    path.join(
+      codexHome,
+      "plugins",
+      "cache",
+      marketplace,
+      plugin,
+      version,
+      manifestDir,
+      "plugin.json"
+    ),
+    typeof manifest === "string" ? manifest : JSON.stringify(manifest)
+  );
+}
+
+function ifaceManifest(name: string, shortDescription: string): object {
+  return {
+    name,
+    description: `top-level ${name} description`,
+    interface: { displayName: name.toUpperCase(), shortDescription },
+  };
+}
+
+async function runRegistry(codexHome: string): Promise<RawCompletionEntry[]> {
+  const parser = getCompletionParser("codex-plugin-registry");
+  expect(parser).toBeDefined();
+  return parser!(codexHome);
+}
+
+function byName(entries: RawCompletionEntry[]): Map<string, RawCompletionEntry> {
+  return new Map(entries.map((e) => [e.nameParts.join(":"), e]));
+}
+
+describe("codex-plugin-registry parser", () => {
+  it("surfaces only enabled plugins, keyed by name@marketplace, with manifest descriptions", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [
+          `[plugins."github@openai-curated"]`,
+          `enabled = true`,
+          ``,
+          `[plugins."gmail@openai-curated"]`,
+          `enabled = true`,
+        ].join("\n")
+      );
+      await writeManifest(
+        home,
+        "openai-curated",
+        "github",
+        "3fdeeb49",
+        ifaceManifest("github", "Triage PRs and CI")
+      );
+      await writeManifest(
+        home,
+        "openai-curated",
+        "gmail",
+        "3fdeeb49",
+        ifaceManifest("gmail", "Read and manage Gmail")
+      );
+
+      const entries = await runRegistry(home);
+      const map = byName(entries);
+
+      expect([...map.keys()].sort()).toEqual(["github", "gmail"]);
+      expect(map.get("github")).toMatchObject({
+        nameParts: ["github"],
+        description: "Triage PRs and CI",
+        userInvocable: true,
+      });
+      expect(map.get("github")!.relativeSourcePath).toBe(
+        path.join(
+          "plugins",
+          "cache",
+          "openai-curated",
+          "github",
+          "3fdeeb49",
+          ".codex-plugin",
+          "plugin.json"
+        )
+      );
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes cached-but-not-enabled marketplaces (no duplicate, no stale remote)", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [`[plugins."github@openai-curated"]`, `enabled = true`].join("\n")
+      );
+      // Enabled entry.
+      await writeManifest(
+        home,
+        "openai-curated",
+        "github",
+        "3fdeeb49",
+        ifaceManifest("github", "enabled github")
+      );
+      // Same plugin name in a different, un-enabled marketplace — must be skipped.
+      await writeManifest(
+        home,
+        "openai-curated-remote",
+        "github",
+        "0.1.8",
+        ifaceManifest("github", "remote github")
+      );
+      // A plugin only present in the un-enabled remote marketplace — must be skipped.
+      await writeManifest(
+        home,
+        "openai-curated-remote",
+        "openai-templates",
+        "0.1.0",
+        ifaceManifest("openai-templates", "templates")
+      );
+
+      const entries = await runRegistry(home);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ nameParts: ["github"], description: "enabled github" });
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a table without `enabled = true` as disabled", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [
+          `[plugins."github@openai-curated"]`,
+          `# no enabled key`,
+          ``,
+          `[plugins."gmail@openai-curated"]`,
+          `enabled = false`,
+        ].join("\n")
+      );
+      await writeManifest(home, "openai-curated", "github", "v1", ifaceManifest("github", "gh"));
+      await writeManifest(home, "openai-curated", "gmail", "v1", ifaceManifest("gmail", "gm"));
+
+      const entries = await runRegistry(home);
+      expect(entries).toEqual([]);
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the `local` version and reads its manifest description", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [`[plugins."github@openai-curated"]`, `enabled = true`].join("\n")
+      );
+      await writeManifest(
+        home,
+        "openai-curated",
+        "github",
+        "0.9.9",
+        ifaceManifest("github", "released")
+      );
+      await writeManifest(
+        home,
+        "openai-curated",
+        "github",
+        "local",
+        ifaceManifest("github", "local build")
+      );
+
+      const entries = await runRegistry(home);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.description).toBe("local build");
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to .claude-plugin/plugin.json when .codex-plugin is absent", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [`[plugins."github@openai-curated"]`, `enabled = true`].join("\n")
+      );
+      await writeManifest(
+        home,
+        "openai-curated",
+        "github",
+        "v1",
+        ifaceManifest("github", "claude-compat"),
+        ".claude-plugin"
+      );
+
+      const entries = await runRegistry(home);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ nameParts: ["github"], description: "claude-compat" });
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to top-level description, then null, and fails closed on malformed JSON", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [
+          `[plugins."toplevel@m"]`,
+          `enabled = true`,
+          ``,
+          `[plugins."nodesc@m"]`,
+          `enabled = true`,
+          ``,
+          `[plugins."broken@m"]`,
+          `enabled = true`,
+        ].join("\n")
+      );
+      // No interface.shortDescription → uses top-level description.
+      await writeManifest(home, "m", "toplevel", "v1", {
+        name: "toplevel",
+        description: "from top level",
+      });
+      // Neither description present → null.
+      await writeManifest(home, "m", "nodesc", "v1", { name: "nodesc" });
+      // Invalid JSON → plugin excluded, does not throw.
+      await writeManifest(home, "m", "broken", "v1", "{ not valid json ");
+
+      const entries = await runRegistry(home);
+      const map = byName(entries);
+      expect([...map.keys()].sort()).toEqual(["nodesc", "toplevel"]);
+      expect(map.get("toplevel")!.description).toBe("from top level");
+      expect(map.get("nodesc")!.description).toBeNull();
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty list when config.toml is missing", async () => {
+    const home = await makeCodexHome();
+    try {
+      await writeManifest(home, "openai-curated", "github", "v1", ifaceManifest("github", "gh"));
+      await expect(runRegistry(home)).resolves.toEqual([]);
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not throw when the plugins cache is absent", async () => {
+    const home = await makeCodexHome();
+    try {
+      await write(
+        path.join(home, "config.toml"),
+        [`[plugins."github@openai-curated"]`, `enabled = true`].join("\n")
+      );
+      await expect(runRegistry(home)).resolves.toEqual([]);
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/electron/services/completions/completionParsers.ts
+++ b/electron/services/completions/completionParsers.ts
@@ -5,6 +5,11 @@ import type { CompletionParserName } from "../../../shared/types/completionSourc
 
 const FRONTMATTER_MAX_BYTES = 8 * 1024;
 const TOML_MAX_BYTES = 16 * 1024;
+// config.toml carries per-project/notice/tui tables alongside plugins, so it is
+// read with a larger bound than a skill's inline TOML. A file past this bound
+// fails closed — plugins declared beyond the cut simply do not surface.
+const CODEX_CONFIG_MAX_BYTES = 256 * 1024;
+const PLUGIN_MANIFEST_MAX_BYTES = 64 * 1024;
 
 /**
  * Raw output of a directory parser — deliberately free of `agentId`, trigger,
@@ -204,11 +209,197 @@ function sortByPath(entries: RawCompletionEntry[]): RawCompletionEntry[] {
   );
 }
 
+/** Bounded prefix read of a UTF-8 text file; null when the file is unreadable. */
+async function readBoundedText(filePath: string, maxBytes: number): Promise<string | null> {
+  let handle: FileHandle | null = null;
+  try {
+    handle = await fs.open(filePath, "r");
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+    const text = buffer.subarray(0, bytesRead).toString("utf8");
+    // Strip a leading UTF-8 BOM (U+FEFF) if present.
+    return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+/**
+ * Collect the `name@marketplace` keys of enabled Codex plugins from
+ * `config.toml`. Only a `[plugins."<key>"]` table with an explicit
+ * `enabled = true` counts — a table without the key (or `enabled = false`) is
+ * treated as disabled, matching Codex's fail-safe default and avoiding
+ * surfacing merely-cached-but-off plugins. This is a narrow line scan rather
+ * than a full TOML parse: it recognises the section-header form Codex writes
+ * and fails closed (empty set) on anything it does not understand.
+ */
+async function readEnabledCodexPluginKeys(configPath: string): Promise<Set<string>> {
+  const text = await readBoundedText(configPath, CODEX_CONFIG_MAX_BYTES);
+  const enabled = new Set<string>();
+  if (text === null) return enabled;
+
+  const pluginHeader = /^\s*\[plugins\."([^"]+)"\]\s*$/;
+  const anyHeader = /^\s*\[/;
+  const enabledLine = /^\s*enabled\s*=\s*(true|false)\b/;
+
+  let currentKey: string | null = null;
+  let currentEnabled = false;
+  const flush = () => {
+    if (currentKey !== null && currentEnabled) enabled.add(currentKey);
+  };
+
+  for (const line of text.split(/\r?\n/)) {
+    const header = line.match(pluginHeader);
+    if (header) {
+      flush();
+      currentKey = header[1] ?? null;
+      currentEnabled = false;
+      continue;
+    }
+    // Any other table header (including a `[plugins."x".sub]` subtable) ends the
+    // current plugin table. `enabled` is a direct key, so it is always seen
+    // before a subtable — flushing here loses nothing.
+    if (anyHeader.test(line)) {
+      flush();
+      currentKey = null;
+      currentEnabled = false;
+      continue;
+    }
+    if (currentKey !== null) {
+      const match = line.match(enabledLine);
+      if (match) currentEnabled = match[1] === "true";
+    }
+  }
+  flush();
+  return enabled;
+}
+
+/**
+ * Choose a plugin's active version directory. `"local"` always wins outright
+ * (mirroring Codex); otherwise the highest by code-unit order — a deterministic
+ * best-effort stand-in for Codex's semver sort. Because the completion token is
+ * derived from the enabled config key (not the manifest), the version chosen
+ * only affects which manifest's description is shown.
+ */
+async function pickActivePluginVersion(pluginDir: string): Promise<string | null> {
+  const entries = await fs.readdir(pluginDir, { withFileTypes: true }).catch(() => null);
+  if (entries === null) return null;
+
+  const versions = entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => entry.name);
+  if (versions.length === 0) return null;
+  if (versions.includes("local")) return "local";
+
+  return versions.reduce((best, name) => (name > best ? name : best));
+}
+
+interface PluginManifestEntry {
+  relativeSourcePath: string;
+  description: string | null;
+}
+
+/**
+ * Read a plugin's manifest, trying `.codex-plugin/plugin.json` then the
+ * Claude-plugin-compatible `.claude-plugin/plugin.json`. Bounded read + guarded
+ * `JSON.parse`; returns null (fail closed) on any read/parse error.
+ * `relativeSourcePath` is relative to `codexHome` so the engine can rebuild the
+ * absolute manifest path.
+ */
+async function readCodexPluginManifest(
+  codexHome: string,
+  versionDir: string
+): Promise<PluginManifestEntry | null> {
+  for (const manifestRel of [".codex-plugin", ".claude-plugin"]) {
+    const manifestPath = path.join(versionDir, manifestRel, "plugin.json");
+    const text = await readBoundedText(manifestPath, PLUGIN_MANIFEST_MAX_BYTES);
+    if (text === null) continue;
+
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(text);
+    } catch {
+      continue;
+    }
+    if (typeof manifest !== "object" || manifest === null) continue;
+
+    const record = manifest as Record<string, unknown>;
+    const iface =
+      typeof record.interface === "object" && record.interface !== null
+        ? (record.interface as Record<string, unknown>)
+        : undefined;
+    const pick = (value: unknown): string | null => {
+      if (typeof value !== "string") return null;
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    };
+    const description = pick(iface?.shortDescription) ?? pick(record.description);
+
+    return { relativeSourcePath: path.relative(codexHome, manifestPath), description };
+  }
+  return null;
+}
+
+/**
+ * Registry parser for Codex plugins. Given `$CODEX_HOME`, intersects the
+ * enabled `[plugins."name@market"]` tables in `config.toml` with the manifests
+ * cached under `plugins/cache/<marketplace>/<plugin>/<version>/`, emitting one
+ * entry per enabled plugin. Un-enabled marketplaces (e.g. a stale remote cache)
+ * are skipped, so no duplicate/`disabled` plugin surfaces. Bounded, fail-closed,
+ * no watcher — same contract as the directory parsers.
+ */
+async function scanCodexPluginRegistry(codexHome: string): Promise<RawCompletionEntry[]> {
+  const enabledKeys = await readEnabledCodexPluginKeys(path.join(codexHome, "config.toml"));
+  if (enabledKeys.size === 0) return [];
+
+  const cacheRoot = path.join(codexHome, "plugins", "cache");
+  const marketplaces = await fs.readdir(cacheRoot, { withFileTypes: true }).catch(() => null);
+  if (marketplaces === null) return [];
+
+  const results: RawCompletionEntry[] = [];
+
+  await Promise.all(
+    marketplaces.map(async (marketplace) => {
+      if (marketplace.name.startsWith(".") || !marketplace.isDirectory()) return;
+
+      const marketplaceDir = path.join(cacheRoot, marketplace.name);
+      const plugins = await fs.readdir(marketplaceDir, { withFileTypes: true }).catch(() => null);
+      if (plugins === null) return;
+
+      await Promise.all(
+        plugins.map(async (plugin) => {
+          if (plugin.name.startsWith(".") || !plugin.isDirectory()) return;
+          if (!enabledKeys.has(`${plugin.name}@${marketplace.name}`)) return;
+
+          const pluginDir = path.join(marketplaceDir, plugin.name);
+          const version = await pickActivePluginVersion(pluginDir);
+          if (version === null) return;
+
+          const manifest = await readCodexPluginManifest(codexHome, path.join(pluginDir, version));
+          if (manifest === null) return;
+
+          results.push({
+            nameParts: [plugin.name],
+            relativeSourcePath: manifest.relativeSourcePath,
+            description: manifest.description,
+            userInvocable: true,
+          });
+        })
+      );
+    })
+  );
+
+  return sortByPath(results);
+}
+
 /** The closed allow-list of named parsers, resolved from config strings. */
 export const COMPLETION_PARSERS: Record<CompletionParserName, CompletionParser> = {
   "markdown-frontmatter": (rootDir) => scanRecursiveFiles(rootDir, ".md", readYamlFrontmatter),
   toml: (rootDir) => scanRecursiveFiles(rootDir, ".toml", readTomlDescription),
   "skill-dir": (rootDir) => scanSkillDirectories(rootDir),
+  "codex-plugin-registry": (rootDir) => scanCodexPluginRegistry(rootDir),
 };
 
 export function getCompletionParser(name: CompletionParserName): CompletionParser | undefined {

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -144,9 +144,44 @@ export const config: AgentConfig = {
       discovery: { method: "static", catalog: "builtin-slash-commands" },
     },
     {
+      // Codex Plugins, invoked as `$name` (e.g. `$github`). Discovered from the
+      // local registry: enabled `[plugins."name@market"]` tables in
+      // `config.toml` intersected with the manifests under `plugins/cache/*`.
+      // Lower precedence than `skills` so a user's own `$name` skill wins a
+      // label collision. Plugin-BUNDLED skills (`$github:gh-fix-ci`) and Apps
+      // are out of scope: bundled skills are a separate namespace-qualified
+      // surface, and Apps are resolved server-side with no local manifest.
+      id: "plugins",
+      trigger: "$",
+      sourcePrecedence: 10,
+      discovery: {
+        method: "registry",
+        parser: "codex-plugin-registry",
+        derive: {
+          labelPrefix: "$",
+          kind: "plugin",
+          idNamespace: "plugin",
+          fallbackDescription: "Plugin",
+        },
+        locations: [
+          {
+            id: "user:codex-plugins",
+            scope: "user",
+            base: {
+              type: "env",
+              name: "CODEX_HOME",
+              fallback: { type: "homeRelative", segments: [".codex"] },
+            },
+            segments: [],
+            locationPrecedence: 0,
+          },
+        ],
+      },
+    },
+    {
       // Codex Skills, invoked as `$name`. Custom prompts (`~/.codex/prompts`,
       // `/prompts:`) and `.codex/commands` were retired — neither exists in
-      // current Codex. Apps/Plugins are deferred pending manifest verification.
+      // current Codex.
       id: "skills",
       trigger: "$",
       sourcePrecedence: 20,

--- a/shared/types/completionSources.ts
+++ b/shared/types/completionSources.ts
@@ -18,10 +18,13 @@ import type { SlashCommandScope } from "./slashCommands.js";
 export type CompletionTrigger = "/" | "$" | "@";
 
 /**
- * Semantic category of a completion. `command` and `skill` are produced today;
- * `app`/`plugin` are modelled ahead of their discovery backends (Codex
- * Apps/Plugins have no verified local manifest yet — see #11043) so the item
- * model, badges, and ranking can carry them the moment a source populates them.
+ * Semantic category of a completion. `command`, `skill`, and `plugin` are
+ * produced today — `plugin` covers Codex Plugins surfaced from the local plugin
+ * registry (see the `registry` discovery + `codex-plugin-registry` parser).
+ * `app` is modelled ahead of its discovery backend: Codex Apps/connectors are
+ * resolved server-side (chatgpt.com/backend-api/wham/apps) with no local
+ * manifest to discover, so the item model, badges, and ranking can carry the
+ * kind the moment a source populates it — see #11049 / #11043.
  */
 export type CompletionKind = "command" | "skill" | "app" | "plugin";
 
@@ -36,8 +39,17 @@ export type CompletionKind = "command" | "skill" | "app" | "plugin";
  *    from the TOML `description` key (bounded read).
  *  - `skill-dir`: immediate child directories containing `SKILL.md`, name from
  *    the child directory name, description from the `SKILL.md` frontmatter.
+ *  - `codex-plugin-registry`: a `registry` parser (not a plain directory scan)
+ *    handed `$CODEX_HOME`. It intersects the enabled `[plugins."name@market"]`
+ *    tables in `config.toml` with the manifests under `plugins/cache/*`, picks
+ *    each plugin's active version, and reads `.codex-plugin/plugin.json`
+ *    (fallback `.claude-plugin/plugin.json`) for the name/description.
  */
-export type CompletionParserName = "markdown-frontmatter" | "toml" | "skill-dir";
+export type CompletionParserName =
+  | "markdown-frontmatter"
+  | "toml"
+  | "skill-dir"
+  | "codex-plugin-registry";
 
 /** Platforms a location applies to. Matches `process.platform` values. */
 export type CompletionPlatform = "darwin" | "win32" | "linux";
@@ -113,7 +125,26 @@ export interface CompletionDirectoryDiscovery {
   locations: readonly CompletionLocation[];
 }
 
-export type CompletionDiscovery = CompletionStaticDiscovery | CompletionDirectoryDiscovery;
+/**
+ * A registry-backed source: structurally identical to `directory`, but the
+ * `method` distinguishes a parser that does more than turn one directory into
+ * entries (it cross-references sibling manifests/config and resolves versions —
+ * e.g. `codex-plugin-registry` reads `config.toml` + walks `plugins/cache/*`).
+ * The engine treats it exactly like `directory` (same parser/locations/derive
+ * fields), so no engine branch is needed — the distinct `method` only keeps the
+ * schema honest about what the parser does.
+ */
+export interface CompletionRegistryDiscovery {
+  method: "registry";
+  parser: CompletionParserName;
+  derive: CompletionDerivation;
+  locations: readonly CompletionLocation[];
+}
+
+export type CompletionDiscovery =
+  | CompletionStaticDiscovery
+  | CompletionDirectoryDiscovery
+  | CompletionRegistryDiscovery;
 
 /**
  * One completion source an agent declares. `sourcePrecedence` orders


### PR DESCRIPTION
Resolves #11049

## What
Extends Codex `$`-trigger completion discovery (skills shipped in #11046) to **Plugins**. Enabled Codex plugins now surface in the input-bar picker as `$<name>` (e.g. `$github`, `$gmail`) with the plugin's description.

## Research gate — resolved
The issue was research-gated: confirm the on-disk format before writing code. Confirmed against `codex-rs` tag `rust-v0.144.1` **and** live installed data:
- Codex's own `$` picker lists plugins as top-level tokens (`chat_composer.rs::mention_items`), so plugin-as-entity completions are real and user-invocable — the token is the plugin `config_name` split on `@`.
- **Enabled set**: `$CODEX_HOME/config.toml` → `[plugins."<name>@<marketplace>"]` tables with `enabled = true`.
- **Manifest**: `$CODEX_HOME/plugins/cache/<marketplace>/<plugin>/<version>/.codex-plugin/plugin.json` (fallback `.claude-plugin/plugin.json`); label/description from `name` + `interface.shortDescription`/top-level `description`. The `<version>` segment is non-fixed (content-hash / semver+hash / `local`).

## How
- New `codex-plugin-registry` parser: intersects the enabled `config.toml` tables with the cached manifests, picks each plugin's active version (`local` wins, else highest), reads the manifest — bounded reads, fail-closed, no watcher (same conventions as the existing directory parsers). Keying cache dirs by full `name@marketplace` cleanly excludes stale/un-enabled remote-cache entries and avoids duplicate tokens.
- New `registry` `CompletionDiscovery` variant (structurally identical to `directory`; the engine handles it via existing structural narrowing — zero engine change).
- `plugin` added to `CompletionKind`; `SlashCommand.kind` now reuses `CompletionKind` (single source of truth).
- Codex declares a `plugins` `$` source at `sourcePrecedence: 10` (below skills, so a user's own `$name` skill wins a label collision).

## Apps — research outcome (no code, by design)
Codex **Apps/connectors** are resolved **server-side** (a built-in MCP server queries `chatgpt.com/backend-api/wham/apps` via the user's ChatGPT session). There is **no local Apps manifest** to discover: no `~/.codex/apps` dir, no `codex apps` subcommand, and `.app.json` is metadata-free (`{"apps":{"github":{"id":"connector_…"}}}`). This matches the issue's built-in escape hatch — the format *is* confirmed, and the confirmed answer is that nothing local exists to scan. `CompletionKind` documents this (no `app` member).

## Scope / follow-up
- Renderer changes are out of scope (owned by #11047/#11048): no badge/rendering added; widening `CompletionKind` is non-breaking (`AutocompleteMenu` uses `Partial<Record>`, and `command` already renders badge-less).
- **Deferred**: plugin-*bundled* skills are also `$`-invocable but namespace-qualified (`$github:gh-fix-ci`) — a distinct surface (skill namespace, wildcard traversal) worth its own issue, not folded in here.

## Tests
- New `completionParsers.test.ts`: enabled-only, marketplace exclusion / no-duplicate, `enabled`-default-disabled, `local`-version-wins, `.claude-plugin` fallback, description precedence + null, malformed-JSON fail-closed, absent config/cache.
- `CompletionDiscoveryEngine.test.ts`: end-to-end — `$github`/`$gmail` surface as `kind:"plugin"`, and a user skill wins the `$github` label collision (precedence).
- 5 target test files / 71 tests pass locally; prettier + eslint clean on changed files.