### PR TITLE
fix(terminal): resume the pane's own session on agent restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - **Deps & native modules:** `npm install` (dev) / `npm ci` (CI); `postinstall` rebuilds `node-pty` for Electron. Native-module errors → `npm run rebuild`.
 - **Code style:** Minimal comments, no decorative headers, high signal-to-noise.
 - **Markdown style:** Never hard-wrap prose — every paragraph/list item/table row is ONE physical line (soft wrap is the renderer's job). Applies to all `.md`. Code blocks and ASCII diagrams keep internal breaks.
-- **Codex MCP:** `mcp__codex__codex` always takes `model: "gpt-5.5"` — the only valid value (ignore the MCP definition's examples). Include file paths so Codex can read the code.
+- **Codex MCP:** `mcp__codex__codex` takes `model: "gpt-5.6-sol"` unless you're aware of a newer model. Include file paths so Codex can read the code.
 - **GitHub:** Public repo `daintreehq/daintree`. Use the `gh` CLI for ALL GitHub ops — HTTP fetches fail on auth.
 - **Branching:** Gitflow. All PRs target `develop`, NEVER `main` (release merges only).
 - **Tracked configs:** `.daintree/recipes/*.json` (recipes = saved parameterized agent-launch configs) are intentionally tracked — never remove or gitignore.

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -43,6 +43,14 @@ vi.mock("@/clients", () => ({
   systemClient: {
     getTmpDir: vi.fn().mockResolvedValue("/tmp"),
   },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  worktreeClient: {
+    getAll: vi.fn().mockResolvedValue([{ id: "wt-new", path: "/new/worktree" }]),
+  },
 }));
 
 vi.mock("@/services/TerminalInstanceService", () => ({
@@ -57,6 +65,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     fit: vi.fn(),
     captureBufferText: mockCaptureBufferText,
     addAgentStateListener: mockAddAgentStateListener,
+    setInputLocked: vi.fn(),
   },
 }));
 
@@ -97,13 +106,17 @@ vi.mock("@/config/agents", () => ({
   sanitizeAgentEnv: (env: Record<string, string> | undefined) => env,
 }));
 
-vi.mock("@shared/types", () => ({
-  generateAgentCommand: vi.fn().mockReturnValue("claude --resume"),
-  buildAgentLaunchFlags: vi.fn().mockReturnValue([]),
-  buildResumeCommand: vi.fn().mockReturnValue(null),
-  buildResumeLatestCommand: vi.fn().mockReturnValue(null),
-  buildLaunchCommandFromFlags: vi.fn().mockReturnValue("claude"),
-}));
+vi.mock("@shared/types", async () => {
+  const actual = await vi.importActual<typeof import("@shared/types")>("@shared/types");
+  return {
+    ...actual,
+    generateAgentCommand: vi.fn().mockReturnValue("claude --fresh"),
+    buildAgentLaunchFlags: vi.fn().mockReturnValue([]),
+    buildResumeCommand: vi.fn().mockReturnValue(null),
+    buildResumeLatestCommand: vi.fn().mockReturnValue(null),
+    buildLaunchCommandFromFlags: vi.fn().mockReturnValue("claude"),
+  };
+});
 
 vi.mock("@/store/ccrPresetsStore", () => ({
   useCcrPresetsStore: {
@@ -186,7 +199,12 @@ describe("moveToNewWorktreeAndTransfer (#4773)", () => {
     expect(mockCaptureBufferText).not.toHaveBeenCalled();
   });
 
-  it("does not call gracefulKill (abandoned session resume path)", async () => {
+  it("discards the session id captured by the restart's graceful kill (fresh session)", async () => {
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    // The restart kills the agent via gracefulKill, which captures the live
+    // session id — but the move flow re-seeds context by injecting the old
+    // buffer, so the capture must be discarded, not resumed.
+    mockGracefulKill.mockResolvedValueOnce("live-session-42");
     mockCaptureBufferText.mockReturnValue("some history");
     usePanelStore.setState({
       panelsById: { [agentTerminal.id]: agentTerminal },
@@ -197,22 +215,15 @@ describe("moveToNewWorktreeAndTransfer (#4773)", () => {
 
     await vi.dynamicImportSettled();
 
-    // Simulate worktree creation callback
-    if (openCreateDialogCallback) {
-      // Mock worktreeClient.getAll inside the callback
-      vi.doMock("@/clients", async (importOriginal) => {
-        const original = (await importOriginal()) as Record<string, unknown>;
-        return {
-          ...original,
-          worktreeClient: {
-            getAll: vi.fn().mockResolvedValue([{ id: "wt-new", path: "/new/worktree" }]),
-          },
-        };
-      });
-    }
+    expect(openCreateDialogCallback).not.toBeNull();
+    await openCreateDialogCallback!("wt-new");
 
-    // gracefulKill should never be called in the new flow
-    expect(mockGracefulKill).not.toHaveBeenCalled();
+    expect(mockGracefulKill).toHaveBeenCalledWith("test-1");
+    expect(buildResumeCommand).not.toHaveBeenCalled();
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+    const restarted = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    expect(restarted?.restartError).toBeUndefined();
+    expect(restarted?.agentSessionId).toBeUndefined();
   });
 
   it("clears agentSessionId in state before restart", async () => {

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -3,6 +3,7 @@ import type { PtyPanelData } from "@shared/types/panel";
 
 const mockSpawn = vi.fn().mockResolvedValue({ id: "test-1" });
 const mockKill = vi.fn().mockResolvedValue(undefined);
+const mockGracefulKill = vi.fn().mockResolvedValue(null);
 const getMergedPresetMock = vi.hoisted(() => vi.fn().mockReturnValue(undefined));
 const buildAgentLaunchFlagsMock = vi.hoisted(() => vi.fn().mockReturnValue([]));
 
@@ -17,7 +18,7 @@ vi.mock("@/clients", () => ({
     onData: vi.fn(),
     onExit: vi.fn(),
     onAgentStateChanged: vi.fn(),
-    gracefulKill: vi.fn().mockResolvedValue(null),
+    gracefulKill: mockGracefulKill,
     submit: vi.fn().mockResolvedValue(undefined),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
@@ -648,11 +649,254 @@ describe("restartTerminal resume-latest fallback (#8787)", () => {
   });
 });
 
+describe("restartTerminal captured live-session resume", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getMergedPresetMock.mockReturnValue(undefined);
+    buildAgentLaunchFlagsMock.mockReturnValue([]);
+    mockGracefulKill.mockResolvedValue(null);
+    const { agentSettingsClient, projectClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  it("resumes the exact session id captured by the graceful kill", async () => {
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("live-123");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --resume live-123");
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: undefined,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockGracefulKill).toHaveBeenCalledWith("test-1");
+    expect(buildResumeCommand).toHaveBeenCalledWith("claude", "live-123", ["--persisted-flag"]);
+    // Exact resume must preempt the resume-latest fallback — resume-latest
+    // resolves to the most recently active session in scope, which with
+    // several terminals of the same agent is often another pane's session.
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --resume live-123");
+    expect(payload.launchAgentId).toBe("claude");
+  });
+
+  it("keeps the pre-restart command durable when resuming a captured id", async () => {
+    const { buildResumeCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("live-123");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --resume live-123");
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    // The resume command is transient: storing it durably would replay the
+    // consumed session id on the next restart.
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    expect(after?.command).toBe(agentPanelBase.command);
+  });
+
+  it("prefers the captured live id over a stale stored one", async () => {
+    const { buildResumeCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("live-123");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockImplementation(
+      (_agentId: string, sessionId: string) => `claude --resume ${sessionId}`
+    );
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: "stale-abc",
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(buildResumeCommand).toHaveBeenCalledWith("claude", "live-123", ["--persisted-flag"]);
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --resume live-123");
+  });
+
+  it("discards the captured id when allowResumeLatest is false (worktree-move)", async () => {
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("live-123");
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: undefined,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1", { allowResumeLatest: false });
+
+    // Fresh-launch intent: resuming would make the move flow's injected
+    // history land in an already-loaded conversation.
+    expect(buildResumeCommand).not.toHaveBeenCalled();
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --flag");
+  });
+
+  it("falls back to bare kill and resume-latest when gracefulKill rejects", async () => {
+    const { buildResumeLatestCommand } = await import("@shared/types");
+    mockGracefulKill.mockRejectedValueOnce(new Error("ipc dead"));
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --continue");
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockKill).toHaveBeenCalledWith("test-1");
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --continue");
+  });
+
+  it("uses bare kill (not gracefulKill) for demoted terminals", async () => {
+    const demoted = { ...agentPanelBase, agentState: "exited" as const, exitCode: 0 };
+    usePanelStore.setState({
+      panelsById: { [demoted.id]: demoted },
+      panelIds: [demoted.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockGracefulKill).not.toHaveBeenCalled();
+    expect(mockKill).toHaveBeenCalledWith("test-1");
+  });
+
+  it("uses bare kill for failed-spawn retries (no live process to quit)", async () => {
+    const failedToStart = {
+      ...agentPanelBase,
+      agentState: "exited" as const,
+      spawnStatus: "failed" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [failedToStart.id]: failedToStart },
+      panelIds: [failedToStart.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockGracefulKill).not.toHaveBeenCalled();
+    expect(mockKill).toHaveBeenCalledWith("test-1");
+    // The retry still relaunches as the agent (#10816).
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.launchAgentId).toBe("claude");
+  });
+
+  it("never degrades an exact candidate to resume-latest when its command is unbuildable", async () => {
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("live-123");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --continue");
+    const active = { ...agentPanelBase, agentState: "working" as const };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    // Resume-latest resolves to "most recent session in scope" — the safe
+    // outcome for a known-but-unbuildable session is a fresh launch.
+    expect(buildResumeCommand).toHaveBeenCalled();
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --flag");
+  });
+
+  it("ignores the captured id when a different agent is live in the pane", async () => {
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("codex-session-9");
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --continue");
+    // Claude-launched pane whose live detected identity is Codex: the
+    // graceful shutdown quit (and captured a session from) Codex, so the id
+    // must not be fed to `claude --resume`.
+    const hijacked = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      detectedAgentId: "codex" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [hijacked.id]: hijacked },
+      panelIds: [hijacked.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(buildResumeCommand).not.toHaveBeenCalled();
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --continue");
+  });
+
+  it("restores the captured session id for retry when the respawn fails", async () => {
+    const { buildResumeCommand } = await import("@shared/types");
+    mockGracefulKill.mockResolvedValue("live-123");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --resume live-123");
+    mockSpawn.mockRejectedValueOnce(new Error("spawn failed"));
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: "stale-abc",
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    expect(after?.restartError).toBeDefined();
+    // The consumed live id — not the stale stored one — must survive for the
+    // retry to resume the same conversation.
+    expect(after?.agentSessionId).toBe("live-123");
+  });
+});
+
 describe("restartTerminal stale flow state cleared (#9899)", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     getMergedPresetMock.mockReturnValue(undefined);
     buildAgentLaunchFlagsMock.mockReturnValue([]);
+    // clearAllMocks keeps implementations — undo any per-test overrides from
+    // earlier suites.
+    mockGracefulKill.mockResolvedValue(null);
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
     const { agentSettingsClient, projectClient } = await import("@/clients");
     (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
     (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -702,6 +946,12 @@ describe("restartTerminal input lock + parallel IPC (#9164)", () => {
     vi.clearAllMocks();
     getMergedPresetMock.mockReturnValue(undefined);
     buildAgentLaunchFlagsMock.mockReturnValue([]);
+    // clearAllMocks keeps implementations — undo any per-test overrides from
+    // earlier suites.
+    mockGracefulKill.mockResolvedValue(null);
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
     const { agentSettingsClient, projectClient } = await import("@/clients");
     (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
     (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
@@ -802,15 +1052,21 @@ describe("restartTerminal input lock + parallel IPC (#9164)", () => {
     expect(after?.isInputLocked).not.toBe(true);
   });
 
-  it("starts terminalClient.kill before awaiting buildRestartEnv IPCs (parallelization)", async () => {
+  it("starts the kill IPC before awaiting buildRestartEnv IPCs (parallelization)", async () => {
     const { projectClient, globalEnvClient } = await import("@/clients");
     const projectSettings = projectClient.getSettings as ReturnType<typeof vi.fn>;
     const globalEnvGet = globalEnvClient.get as ReturnType<typeof vi.fn>;
 
     const order: string[] = [];
-    mockKill.mockImplementation(() => {
+    // Agent restarts kill via gracefulKill (session-id capture). Hold the
+    // kill promise open: if the env IPCs still start, they were launched in
+    // parallel with the kill, not awaited after it.
+    let resolveKill: (value: string | null) => void = () => {};
+    mockGracefulKill.mockImplementationOnce(() => {
       order.push("kill-start");
-      return Promise.resolve();
+      return new Promise<string | null>((resolve) => {
+        resolveKill = resolve;
+      });
     });
     projectSettings.mockImplementation(() => {
       order.push("project-settings-start");
@@ -830,15 +1086,19 @@ describe("restartTerminal input lock + parallel IPC (#9164)", () => {
       panelIds: [active.id],
     });
 
-    await usePanelStore.getState().restartTerminal("test-1");
+    const restartPromise = usePanelStore.getState().restartTerminal("test-1");
 
-    // All three IPC starts should appear before spawn — i.e. they were
-    // launched as part of the Promise.all, not awaited serially.
+    await vi.waitFor(() => {
+      expect(order).toContain("global-env-start");
+    });
     expect(order).toContain("kill-start");
-    expect(order).toContain("global-env-start");
-    // The kill IPC must have been invoked before the spawn IPC.
-    const killOrder = mockKill.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
-    const spawnOrder = mockSpawn.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
-    expect(killOrder).toBeLessThan(spawnOrder);
+    // The kill is still pending, so nothing downstream of the Promise.all —
+    // including spawn — may have run yet.
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    resolveKill(null);
+    await restartPromise;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -351,6 +351,15 @@ export const createRestartActions = (
     let nextAgentPresetId = currentTerminal.agentPresetId;
     let nextAgentPresetColor = currentTerminal.agentPresetColor;
     let nextOriginalPresetId = currentTerminal.originalPresetId;
+    // The resume-vs-fresh command choice is deferred until after the kill:
+    // the graceful shutdown during the kill is what captures the live session
+    // id, so choosing beforehand would always miss it. These carry the
+    // precomputed pieces across the teardown — all are re-synced inside the
+    // `isAgent` block below before the post-kill selection reads them.
+    let resumeFlags = nextAgentLaunchFlags;
+    let consumedSessionId: string | undefined;
+    let freshCommand = commandToRun;
+    let freshLaunchFlags = nextAgentLaunchFlags;
 
     const loadAgentRuntimeSettings = async (): Promise<LoadedAgentRuntimeSettings | undefined> => {
       if (!effectiveAgentId || runtimeSettingsLoaded) return loadedRuntimeSettings;
@@ -421,7 +430,7 @@ export const createRestartActions = (
       // rebuild) reconciles only captured flags; `resumeFlags` additionally
       // injects the tokens into an empty snapshot so a session launched before
       // either feature honours the current resolution.
-      let resumeFlags = nextAgentLaunchFlags;
+      resumeFlags = nextAgentLaunchFlags;
       if (runtimeForEnv) {
         const effectiveBypass = resolveEffectiveBypass(
           runtimeForEnv.settings.effectiveEntry,
@@ -448,34 +457,20 @@ export const createRestartActions = (
           if (injectedFromEmpty.length > 0) resumeFlags = injectedFromEmpty;
         }
       }
-      const sessionId = currentTerminal.agentSessionId;
-      if (sessionId) {
-        const resumeCmd = buildResumeCommand(effectiveAgentId, sessionId, resumeFlags);
-        if (resumeCmd) {
-          commandToRun = resumeCmd;
-        }
-      } else if (allowResumeLatest) {
-        // No captured session ID — graceful-shutdown pattern match missed or
-        // timed out. Try the agent's resume-latest fallback (e.g. claude
-        // --continue, codex resume --last, gemini -r latest) before falling
-        // through to a fresh launch so the user keeps their prior CWD-scoped
-        // conversation. Suppressed by moveToNewWorktreeAndTransfer because the
-        // new CWD would resume a stale or unrelated session.
-        const resumeLatestCmd = buildResumeLatestCommand(effectiveAgentId, resumeFlags);
-        if (resumeLatestCmd) {
-          commandToRun = resumeLatestCmd;
-          usedResumeLatest = true;
-        }
-      }
-
-      if (commandToRun === currentTerminal.command) {
-        const persistedFlags = nextAgentLaunchFlags;
+      // Only the fresh-launch command (the no-resume outcome) can be derived
+      // up front, while the settings IPCs are already loaded. Whether it
+      // actually spawns is decided post-kill, once the graceful shutdown has
+      // had its chance to capture the live session id.
+      freshCommand = commandToRun;
+      freshLaunchFlags = nextAgentLaunchFlags;
+      {
+        const persistedFlags = freshLaunchFlags;
         let hasPersistedFlags = Boolean(persistedFlags && persistedFlags.length > 0);
         const agentConfig = getAgentConfig(effectiveAgentId);
         const baseCommand = agentConfig?.command || effectiveAgentId;
         const runtimeSettings = runtimeForEnv ?? (await loadAgentRuntimeSettings());
         if (!hasPersistedFlags && runtimeSettings) {
-          nextAgentLaunchFlags = buildAgentLaunchFlagsForRuntimeSettings(
+          freshLaunchFlags = buildAgentLaunchFlagsForRuntimeSettings(
             runtimeSettings.settings.effectiveEntry,
             effectiveAgentId,
             runtimeSettings.settings.preset,
@@ -485,16 +480,16 @@ export const createRestartActions = (
               globalUseAltScreen: runtimeSettings.globalUseAltScreen,
             }
           );
-          hasPersistedFlags = nextAgentLaunchFlags.length > 0;
+          hasPersistedFlags = freshLaunchFlags.length > 0;
         }
 
         if (hasPersistedFlags && effectiveAgentId !== "gemini") {
           // Sync fast path: non-Gemini agents have no runtime-dynamic flag
           // injection, so the persisted flags are the complete command.
-          commandToRun = buildLaunchCommandFromFlags(
+          freshCommand = buildLaunchCommandFromFlags(
             baseCommand,
             effectiveAgentId,
-            nextAgentLaunchFlags as string[]
+            freshLaunchFlags as string[]
           );
         } else {
           // Async path: either Gemini (needs clipboard directory re-injection)
@@ -506,14 +501,14 @@ export const createRestartActions = (
             if (hasPersistedFlags) {
               const entry = runtimeSettings?.entry;
               const shareClipboardDirectory = entry?.shareClipboardDirectory as boolean | undefined;
-              commandToRun = buildLaunchCommandFromFlags(
+              freshCommand = buildLaunchCommandFromFlags(
                 baseCommand,
                 effectiveAgentId,
-                nextAgentLaunchFlags as string[],
+                freshLaunchFlags as string[],
                 { clipboardDirectory, shareClipboardDirectory }
               );
             } else if (runtimeSettings) {
-              commandToRun = generateAgentCommand(
+              freshCommand = generateAgentCommand(
                 baseCommand,
                 runtimeSettings.settings.effectiveEntry,
                 effectiveAgentId,
@@ -537,16 +532,6 @@ export const createRestartActions = (
         }
       }
     }
-
-    const spawnCommand = commandToRun;
-    // Track session ID for restore-on-failure; resume command is transient,
-    // so keep the original command as the durable stored command. Same for
-    // the resume-latest fallback (e.g. `claude --continue`) — re-storing that
-    // as durable would re-resume on every subsequent restart instead of
-    // launching fresh.
-    const consumedSessionId = currentTerminal.agentSessionId;
-    const durableCommand =
-      consumedSessionId || usedResumeLatest ? currentTerminal.command : spawnCommand;
 
     try {
       // CAPTURE LIVE DIMENSIONS before destroying the frontend
@@ -573,15 +558,91 @@ export const createRestartActions = (
       const projectStore = await resolveProjectStore();
       const capturedProjectId = projectStore.getState().currentProject?.id;
 
-      // Parallelize the kill IPC with the env-fetch IPCs (#9164): they have
-      // no ordering dependency, so awaiting them serially adds a needless
-      // round-trip to the restart hot path.
-      const [, restartEnv] = await Promise.all([
-        terminalClient.kill(id).catch((error: unknown) => {
-          logWarn("[TerminalStore] kill failed during restart; continuing", { id, error });
-        }),
+      // Agent terminals kill via gracefulKill: Main already routes every
+      // agent kill through the graceful-shutdown quit-and-capture flow, but
+      // only the gracefulKill channel returns the captured session id — the
+      // bare kill channel discards it. Parallelized with the env-fetch IPCs
+      // (#9164): they have no ordering dependency, so awaiting them serially
+      // adds a needless round-trip to the restart hot path.
+      const [capturedSessionId, restartEnv] = await Promise.all([
+        (async (): Promise<string | null> => {
+          // A failed spawn (`wasFailed`) has no live process to quit — bare
+          // kill keeps PtyManager's missing-terminal cleanup (session-file
+          // delete), which the graceful channel skips on a registry miss.
+          if (isAgent && !wasFailed) {
+            try {
+              return await terminalClient.gracefulKill(id);
+            } catch (error) {
+              logWarn("[TerminalStore] gracefulKill failed during restart; falling back to kill", {
+                id,
+                error,
+              });
+            }
+          }
+          await terminalClient.kill(id).catch((error: unknown) => {
+            logWarn("[TerminalStore] kill failed during restart; continuing", { id, error });
+          });
+          return null;
+        })(),
         buildRestartEnv(capturedProjectId, runtimeForEnv?.settings.env, "restart"),
       ]);
+
+      // Choose the spawn command now that the live session id (if any) is in
+      // hand: an exact resume of THIS pane's session wins; the agent's
+      // resume-latest fallback covers a missed capture (#8787); otherwise the
+      // fresh-launch command derived above. Resume-latest alone is what used
+      // to restart panes into the wrong conversation: it resolves to the most
+      // recently active session in scope (`codex resume --last`,
+      // `claude --continue`), which with several terminals of the same agent
+      // is often another pane's session.
+      if (isAgent && effectiveAgentId) {
+        // Captured beats stored: a stored id dates from a resume launch and
+        // goes stale the moment the CLI rotates session ids mid-run. Two
+        // gates on the capture:
+        //   - identity: the graceful shutdown quits whatever agent is LIVE
+        //     (detected), so a pane whose detected identity diverged from its
+        //     launch identity (e.g. a Claude pane hosting a hand-started
+        //     Codex) would otherwise build `claude --resume <codex-id>`.
+        //   - fresh intent: `allowResumeLatest: false` (the worktree-move
+        //     flow) discards the capture too — it re-seeds context by
+        //     injecting the old buffer, and resuming would make that
+        //     injection land in an already-loaded conversation. A stored id
+        //     still resumes in that case (pre-existing contract the
+        //     update-cwd flow relies on).
+        const captureTrusted =
+          allowResumeLatest &&
+          (currentTerminal.detectedAgentId === undefined ||
+            currentTerminal.detectedAgentId === effectiveAgentId);
+        const sessionId =
+          (captureTrusted ? capturedSessionId : null) ?? currentTerminal.agentSessionId;
+        if (sessionId) {
+          // An exact candidate never degrades to resume-latest: if its
+          // command can't be built, the safe outcome is a fresh launch, not
+          // "most recent session in scope".
+          const resumeCmd = buildResumeCommand(effectiveAgentId, sessionId, resumeFlags);
+          if (resumeCmd) {
+            commandToRun = resumeCmd;
+            consumedSessionId = sessionId;
+          }
+        } else if (allowResumeLatest) {
+          const resumeLatestCmd = buildResumeLatestCommand(effectiveAgentId, resumeFlags);
+          if (resumeLatestCmd) {
+            commandToRun = resumeLatestCmd;
+            usedResumeLatest = true;
+          }
+        }
+        if (!consumedSessionId && !usedResumeLatest) {
+          commandToRun = freshCommand;
+          nextAgentLaunchFlags = freshLaunchFlags;
+        }
+      }
+
+      const spawnCommand = commandToRun;
+      // Resume commands are transient: keep the original command as the
+      // durable stored command so a later restart doesn't replay a consumed
+      // session id or re-run resume-latest instead of launching fresh.
+      const durableCommand =
+        consumedSessionId || usedResumeLatest ? currentTerminal.command : spawnCommand;
 
       // Update terminal in store: increment restartKey, reset agent state, update location
       set((state) => {

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -23,13 +23,17 @@ export type { AddPanelOptions };
  */
 export interface RestartTerminalOptions {
   /**
-   * When `false`, suppresses the "resume the most recent session" fallback
-   * even if the agent declares `resumeLatestArgs`. Used by
-   * `moveToNewWorktreeAndTransfer` where the CWD has changed and a fresh
-   * launch with buffer-injected context is intentional — letting the agent
-   * silently resume a stale session in the new CWD would mask the move. See
-   * issue #4781 for the cross-worktree-transfer rationale.
-   * Defaults to `true` (fallback enabled).
+   * When `false`, suppresses session continuity from the kill: the session id
+   * captured by the graceful shutdown is discarded and the "resume the most
+   * recent session" fallback is skipped even if the agent declares
+   * `resumeLatestArgs`. Used by `moveToNewWorktreeAndTransfer` where the CWD
+   * has changed and a fresh launch with buffer-injected context is
+   * intentional — silently resuming a session in the new CWD would mask the
+   * move and double up the injected history. A session id already stored on
+   * the panel still resumes exactly (pre-existing contract; the update-cwd
+   * flow relies on it). See issue #4781 for the cross-worktree-transfer
+   * rationale.
+   * Defaults to `true` (resume enabled).
    */
   allowResumeLatest?: boolean;
 }


### PR DESCRIPTION
Restarting an agent terminal could load a different terminal's conversation into the pane. The restart never had the session id of the pane it was restarting, so it fell back to the agent's resume-latest command (`codex resume --last`, `claude --continue`). That just picks the most recently active session in scope, which with several terminals of the same agent is often another pane's.

The fix was mostly already there. The main process captures the session id during the graceful shutdown it runs on every agent kill, then discards it. Restarts now go through the `gracefulKill` channel instead, get that id back, and resume exactly that session. Resume-latest is demoted to a fallback for missed captures.

A few guards around the captured id:

- Ignored when the detected agent differs from the launch identity. A Claude pane hosting a hand-started Codex would otherwise get `claude --resume <codex-session-id>`.
- Ignored when the caller wants a fresh session, like the worktree move flow, which injects the old buffer as context instead.
- Failed-spawn retries keep the bare kill path, since there's no live process to quit.
- An exact session id that can't be built into a resume command launches fresh instead of degrading to resume-latest.

This applies to every agent with a session-id resume config, not just Codex.

Ten new unit tests cover the different cases, and the worktree-move test that previously never reached the restart now exercises the real flow.