### PR TITLE
Renderer: unify completion contexts into ActiveCompletionContext + Codex $ picker

### DIFF
--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -29,6 +29,23 @@ const CATEGORY_LABEL: Partial<Record<CompletionKind, string>> = {
   plugin: "Plugin",
 };
 
+/** What Enter does on the selected item: complete it, or run it. */
+export type AutocompleteEnterAction = "insert" | "execute";
+
+/** Daintree resolvers that expand a token to content at send time. */
+export type CompletionResolverId = "diff" | "terminal" | "selection";
+
+/**
+ * How the inserted token behaves at send time. `literal` passes through the PTY
+ * verbatim (files, commands, `$` capabilities); a resolver token is expanded by
+ * the matching send-time scanner in `useTokenResolution`. The field is
+ * declarative — the scanners are authoritative, so a manually-typed `@diff`
+ * still resolves.
+ */
+export type AutocompleteInsert =
+  | "literal"
+  | { insert: "resolve"; resolverId: CompletionResolverId };
+
 export interface AutocompleteItem {
   key: string;
   /** Display text shown in the menu. May differ from what gets inserted. */
@@ -38,6 +55,10 @@ export interface AutocompleteItem {
   description?: string;
   /** Semantic category; drives the neutral badge. Undefined for file/context items. */
   category?: CompletionKind;
+  /** Enter behavior; defaults to `insert` when absent. */
+  enterAction?: AutocompleteEnterAction;
+  /** Send-time behavior; defaults to `literal` when absent. */
+  insert?: AutocompleteInsert;
 }
 
 export interface AutocompleteMenuProps {
@@ -45,9 +66,10 @@ export interface AutocompleteMenuProps {
   items: AutocompleteItem[];
   selectedIndex: number;
   isLoading?: boolean;
-  /** Results were produced for an earlier query and a refresh is pending;
-   *  rows render dimmed so they don't read as matches for the current text. */
-  isStale?: boolean;
+  /** Keys of items produced for an earlier query and pending a refresh; those
+   *  rows render dimmed so they don't read as matches for the current text.
+   *  Per-item so a stale async `@file` search can't dim fresh `$`/`@diff`. */
+  staleKeys?: ReadonlySet<string>;
   onSelect: (item: AutocompleteItem) => void;
   style?: React.CSSProperties;
   title?: string;
@@ -64,7 +86,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
       items,
       selectedIndex,
       isLoading = false,
-      isStale = false,
+      staleKeys,
       onSelect,
       style,
       title,
@@ -114,7 +136,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
         }}
         role={isEmpty ? undefined : "listbox"}
         aria-label={ariaLabel ?? title ?? "Autocomplete"}
-        aria-busy={isLoading || isStale || undefined}
+        aria-busy={isLoading || (staleKeys !== undefined && staleKeys.size > 0) || undefined}
       >
         {(title || keyHint) && (
           <div className="flex items-center justify-between gap-2 border-b border-tint/5 px-2 py-1.5">
@@ -144,18 +166,13 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
             </div>
           )}
 
-          <div
-            ref={listRef}
-            className={cn(
-              "transition-opacity duration-150 ease-out",
-              isStale && items.length > 0 && "opacity-50"
-            )}
-          >
+          <div ref={listRef}>
             {items.map((item, idx) => {
               const descriptionSnippet = item.description
                 ? getDescriptionSnippet(item.description)
                 : undefined;
               const badge = item.category ? CATEGORY_LABEL[item.category] : undefined;
+              const isRowStale = staleKeys?.has(item.key) ?? false;
               const tooltipText = [
                 item.label,
                 badge ? `(${badge})` : "",
@@ -172,13 +189,17 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
                       role="option"
                       aria-selected={idx === selectedIndex}
                       className={cn(
-                        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors",
+                        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-[color,background-color,opacity] duration-150 ease-out",
                         idx === selectedIndex
                           ? "bg-overlay-soft text-daintree-text"
-                          : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text"
+                          : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text",
+                        isRowStale && "opacity-50"
                       )}
                       onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => onSelect(item)}
+                      onClick={() => {
+                        if (isRowStale) return;
+                        onSelect(item);
+                      }}
                     >
                       <span className="min-w-0 flex-none max-w-full truncate font-mono text-xs leading-4">
                         {item.label}

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -188,6 +188,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
                       type="button"
                       role="option"
                       aria-selected={idx === selectedIndex}
+                      aria-disabled={isRowStale || undefined}
                       className={cn(
                         "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-[color,background-color,opacity] duration-150 ease-out",
                         idx === selectedIndex

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { EditorView } from "@codemirror/view";
 import { EditorSelection } from "@codemirror/state";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
@@ -12,12 +12,11 @@ import { useSlashCommandList } from "@/hooks/useSlashCommandList";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { AutocompleteMenu, type AutocompleteItem } from "./AutocompleteMenu";
 import {
-  type AtFileContext,
-  type SlashCommandContext,
-  type AtDiffContext,
-  type AtTerminalContext,
-  type AtSelectionContext,
+  getDaintreeAtClaim,
+  fileSearchQuery,
+  type ActiveCompletionContext,
 } from "./hybridInputParsing";
+import type { CompletionTrigger } from "@shared/types";
 import { CommandPickerHost } from "@/components/Commands";
 import { PromptHistoryPalette } from "./PromptHistoryPalette";
 import { useCommandStore } from "@/store/commandStore";
@@ -85,17 +84,12 @@ interface LatestState {
   disabled: boolean;
   isInitializing: boolean;
   isInHistoryMode: boolean;
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
   isAutocompleteOpen: boolean;
   autocompleteItems: AutocompleteItem[];
-  isResultsStale: boolean;
+  staleItemKeys: ReadonlySet<string>;
   selectedIndex: number;
   value: string;
-  atContext: AtFileContext | null;
-  slashContext: SlashCommandContext | null;
-  diffContext: AtDiffContext | null;
-  terminalContext: AtTerminalContext | null;
-  selectionContext: AtSelectionContext | null;
+  activeCompletionContext: ActiveCompletionContext | null;
   onSend: HybridInputBarProps["onSend"];
   onSendKey?: HybridInputBarProps["onSendKey"];
   addToHistory: (terminalId: string, command: string, projectId?: string) => void;
@@ -120,6 +114,8 @@ type ApplyEditorValue = (
   nextValue: string,
   options?: { selection?: EditorSelection; focus?: boolean }
 ) => void;
+
+const EMPTY_STALE_KEYS: ReadonlySet<string> = new Set<string>();
 
 const hybridInputE2EControllers = new Map<string, HybridInputE2EController>();
 
@@ -189,11 +185,8 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const rootRef = useRef<HTMLDivElement | null>(null);
     const lastEmittedValueRef = useRef<string>(value);
     const focusGenerationRef = useRef(0);
-    const [atContext, setAtContext] = useState<AtFileContext | null>(null);
-    const [slashContext, setSlashContext] = useState<SlashCommandContext | null>(null);
-    const [diffContext, setDiffContext] = useState<AtDiffContext | null>(null);
-    const [terminalContext, setTerminalContext] = useState<AtTerminalContext | null>(null);
-    const [selectionContext, setSelectionContext] = useState<AtSelectionContext | null>(null);
+    const [activeCompletionContext, setActiveCompletionContext] =
+      useState<ActiveCompletionContext | null>(null);
 
     const [selectedIndex, setSelectedIndex] = useState(0);
     const lastQueryRef = useRef<string>("");
@@ -274,9 +267,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       const draft = getDraftInput(terminalId, projectId);
       setValue(draft);
       lastEmittedValueRef.current = draft;
-      setAtContext(null);
-      setSlashContext(null);
-      setDiffContext(null);
+      setActiveCompletionContext(null);
       setSelectedIndex(0);
       lastQueryRef.current = "";
       lastEnterKeydownNewlineRef.current = false;
@@ -317,40 +308,41 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       return agentName ? `Ask ${agentName}` : "Ask anything";
     })();
 
-    const activeMode = slashContext
-      ? "command"
-      : terminalContext
-        ? "terminal"
-        : selectionContext
-          ? "selection"
-          : diffContext
-            ? "diff"
-            : atContext
-              ? "file"
-              : null;
-    const isAutocompleteOpen = activeMode !== null && !disabled;
+    // Trigger chars that open a menu, data-driven from the agent's declared
+    // completionSources — `/` and Daintree's `@` are always available; `$`
+    // (Codex capabilities) is added only when the agent declares a `$` source.
+    const activeTriggers = useMemo(() => {
+      const triggers = new Set<CompletionTrigger>(["/", "@"]);
+      for (const source of agentId ? (getAgentConfig(agentId)?.completionSources ?? []) : []) {
+        triggers.add(source.trigger);
+      }
+      return triggers;
+    }, [agentId]);
 
+    const triggerChar = activeCompletionContext?.triggerChar ?? null;
+    // Which Daintree `@` provider claims the query (else `@file` fallback).
+    const atClaim =
+      triggerChar === "@" ? getDaintreeAtClaim(activeCompletionContext?.query ?? "") : null;
+    const isFileMode = triggerChar === "@" && atClaim === null;
+    const isAutocompleteOpen = activeCompletionContext !== null && !disabled;
+
+    const fileQuery = isFileMode ? fileSearchQuery(activeCompletionContext?.query ?? "") : "";
     const {
       files: autocompleteFiles,
       isLoading: isAutocompleteLoading,
       resultsQuery: fileResultsQuery,
     } = useFileAutocomplete({
       cwd,
-      query: atContext?.queryForSearch ?? "",
-      enabled: isAutocompleteOpen && activeMode === "file",
+      query: fileQuery,
+      enabled: isAutocompleteOpen && isFileMode,
       limit: 50,
     });
 
-    // File search is debounced + async; every other mode filters synchronously.
-    // While the visible results belong to an earlier query they are "stale":
-    // rendered dimmed, and never accepted by Enter/Tab (the literal text wins).
-    const isResultsStale =
-      activeMode === "file" && fileResultsQuery !== (atContext?.queryForSearch ?? "");
-
     const { items: autocompleteCommands, isLoading: isCommandsLoading } =
       useSlashCommandAutocomplete({
-        query: slashContext?.query ?? "",
-        enabled: isAutocompleteOpen && activeMode === "command",
+        query: activeCompletionContext?.query ?? "",
+        enabled: isAutocompleteOpen && (triggerChar === "/" || triggerChar === "$"),
+        trigger: triggerChar === "$" ? "$" : "/",
         agentId,
         projectPath: cwd,
       });
@@ -358,16 +350,21 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const { commandMap } = useSlashCommandList({ agentId, projectPath: cwd });
 
     const { autocompleteItems, isLoading } = useAutocompleteItems({
-      activeMode,
-      diffContext,
-      terminalContext,
-      selectionContext,
-      value,
+      activeCompletionContext,
       autocompleteFiles,
       isAutocompleteLoading,
       autocompleteCommands,
       isCommandsLoading,
     });
+
+    // Per-provider staleness: only the debounced async `@file` search can go
+    // stale. Its item keys ARE the file paths, so a stale file search dims only
+    // those rows — never a fresh `$` or static `@diff` list.
+    const isFileStale = isFileMode && fileResultsQuery !== fileQuery;
+    const staleItemKeys = useMemo(
+      () => (isFileStale ? new Set(autocompleteFiles) : EMPTY_STALE_KEYS),
+      [isFileStale, autocompleteFiles]
+    );
 
     useEffect(() => {
       latestRef.current = {
@@ -376,17 +373,12 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         disabled,
         isInitializing,
         isInHistoryMode,
-        activeMode,
         isAutocompleteOpen,
         autocompleteItems,
-        isResultsStale,
+        staleItemKeys,
         selectedIndex,
         value,
-        atContext,
-        slashContext,
-        diffContext,
-        terminalContext,
-        selectionContext,
+        activeCompletionContext,
         onSend,
         onSendKey,
         addToHistory,
@@ -403,33 +395,19 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       inputShellRef,
       menuRef,
       isAutocompleteOpen,
-      activeMode,
-      atContext,
-      slashContext,
-      diffContext,
-      terminalContext,
-      selectionContext,
+      activeCompletionContext,
       setMenuLeftPx,
     });
 
     useAutocompleteState({
       isAutocompleteOpen,
-      activeMode,
-      atContext,
-      slashContext,
-      diffContext,
-      terminalContext,
-      selectionContext,
-      autocompleteItemsLength: autocompleteItems.length,
+      activeCompletionContext,
+      autocompleteItems,
       rootRef,
       selectedIndex,
       setSelectedIndex,
       lastQueryRef,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
     });
 
     const applyEditorValue = (
@@ -484,11 +462,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       latestRef,
       applyEditorValue,
       setIsExpanded,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       terminalId,
       cwd,
       agentId,
@@ -606,11 +580,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       lastQueryRef,
       applyEditorValue,
       sendText,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       setSelectedIndex,
     });
 
@@ -650,6 +620,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
 
     const { handleUpdateRef: contextUpdateRef } = useContextDetection({
       latestRef,
+      activeTriggers,
       applyDocChange: (next) => {
         if (next === lastEmittedValueRef.current) return false;
         lastEmittedValueRef.current = next;
@@ -661,11 +632,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         isApplyingExternalValueRef.current = false;
         return true;
       },
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
     });
 
     const {
@@ -686,11 +653,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       cancelVoiceWaitSubmit,
       stashEditorState,
       popStashedEditorState,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       setIsExpanded,
       setSelectedIndex,
     });
@@ -707,11 +670,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       applyAutocompleteSelection,
       sendFromEditor,
       rootRef,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
     });
 
     useEditorFactory({
@@ -850,39 +809,47 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               items={autocompleteItems}
               selectedIndex={selectedIndex}
               isLoading={isLoading}
-              isStale={isResultsStale}
+              staleKeys={staleItemKeys}
               onSelect={handleAutocompleteSelect}
               style={{ left: `${menuLeftPx}px` }}
               title={
-                activeMode === "command"
+                triggerChar === "/"
                   ? "Commands"
-                  : activeMode === "terminal"
-                    ? "Terminal output"
-                    : activeMode === "selection"
-                      ? "Terminal selection"
-                      : activeMode === "diff"
-                        ? "Diffs"
-                        : "Files"
+                  : triggerChar === "$"
+                    ? "Capabilities"
+                    : atClaim === "terminal"
+                      ? "Terminal output"
+                      : atClaim === "selection"
+                        ? "Terminal selection"
+                        : atClaim === "diff"
+                          ? "Diffs"
+                          : "Files"
               }
-              keyHint={activeMode === "command" ? "↵ run · ⇥ complete" : "↵ insert"}
+              keyHint={
+                autocompleteItems[selectedIndex]?.enterAction === "execute"
+                  ? "↵ run · ⇥ complete"
+                  : "↵ insert"
+              }
               ariaLabel={
-                activeMode === "command"
+                triggerChar === "/"
                   ? "Command autocomplete"
-                  : activeMode === "terminal"
-                    ? "Terminal autocomplete"
-                    : activeMode === "selection"
-                      ? "Selection autocomplete"
-                      : activeMode === "diff"
-                        ? "Diff autocomplete"
-                        : "File autocomplete"
+                  : triggerChar === "$"
+                    ? "Capability autocomplete"
+                    : atClaim === "terminal"
+                      ? "Terminal autocomplete"
+                      : atClaim === "selection"
+                        ? "Selection autocomplete"
+                        : atClaim === "diff"
+                          ? "Diff autocomplete"
+                          : "File autocomplete"
               }
               emptyMessage={
-                activeMode === "command"
+                triggerChar === "/"
                   ? "No commands match"
-                  : activeMode === "file"
-                    ? "No files match"
-                    : activeMode === "terminal"
-                      ? "No terminals match"
+                  : triggerChar === "$"
+                    ? "No capabilities match"
+                    : isFileMode
+                      ? "No files match"
                       : "No matches"
               }
             />

--- a/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
+++ b/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
@@ -104,7 +104,7 @@ describe("AutocompleteMenu", () => {
     expect(screen.getByText("↵ run · ⇥ complete")).toBeTruthy();
   });
 
-  it("marks the listbox busy while results are stale or loading", () => {
+  it("marks the listbox busy while any row is stale or results are loading", () => {
     const items: AutocompleteItem[] = [{ key: "a", label: "alpha", insertText: "alpha" }];
 
     const { rerender } = render(
@@ -112,7 +112,7 @@ describe("AutocompleteMenu", () => {
         isOpen={true}
         items={items}
         selectedIndex={0}
-        isStale={true}
+        staleKeys={new Set(["a"])}
         onSelect={noop}
         emptyMessage="No matches"
       />
@@ -124,7 +124,7 @@ describe("AutocompleteMenu", () => {
         isOpen={true}
         items={items}
         selectedIndex={0}
-        isStale={false}
+        staleKeys={new Set()}
         isLoading={true}
         onSelect={noop}
         emptyMessage="No matches"
@@ -137,13 +137,43 @@ describe("AutocompleteMenu", () => {
         isOpen={true}
         items={items}
         selectedIndex={0}
-        isStale={false}
+        staleKeys={new Set()}
         isLoading={false}
         onSelect={noop}
         emptyMessage="No matches"
       />
     );
     expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
+  });
+
+  it("dims only stale rows and ignores clicks on them", () => {
+    const onSelect = vi.fn();
+    const items: AutocompleteItem[] = [
+      { key: "fresh", label: "fresh", insertText: "fresh" },
+      { key: "stale", label: "stale", insertText: "stale" },
+    ];
+
+    render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={items}
+        selectedIndex={0}
+        staleKeys={new Set(["stale"])}
+        onSelect={onSelect}
+        emptyMessage="No matches"
+      />
+    );
+
+    const options = screen.getAllByRole("option");
+    const freshRow = options.find((o) => within(o).queryByText("fresh"))!;
+    const staleRow = options.find((o) => within(o).queryByText("stale"))!;
+    expect(staleRow.className).toContain("opacity-50");
+    expect(freshRow.className).not.toContain("opacity-50");
+
+    staleRow.click();
+    expect(onSelect).not.toHaveBeenCalled();
+    freshRow.click();
+    expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
   it("renders a neutral, screen-reader-labeled badge for skill, app, and plugin items", () => {

--- a/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
+++ b/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
@@ -146,7 +146,7 @@ describe("AutocompleteMenu", () => {
     expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
   });
 
-  it("dims only stale rows and ignores clicks on them", () => {
+  it("marks only stale rows disabled and ignores clicks on them", () => {
     const onSelect = vi.fn();
     const items: AutocompleteItem[] = [
       { key: "fresh", label: "fresh", insertText: "fresh" },
@@ -167,13 +167,15 @@ describe("AutocompleteMenu", () => {
     const options = screen.getAllByRole("option");
     const freshRow = options.find((o) => within(o).queryByText("fresh"))!;
     const staleRow = options.find((o) => within(o).queryByText("stale"))!;
-    expect(staleRow.className).toContain("opacity-50");
-    expect(freshRow.className).not.toContain("opacity-50");
+    // Only the stale row is flagged disabled to assistive tech.
+    expect(staleRow.getAttribute("aria-disabled")).toBe("true");
+    expect(freshRow.getAttribute("aria-disabled")).toBeNull();
 
+    // A click on a stale row is a no-op; a fresh row selects that exact item.
     staleRow.click();
     expect(onSelect).not.toHaveBeenCalled();
     freshRow.click();
-    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
   });
 
   it("renders a neutral, screen-reader-labeled badge for skill, app, and plugin items", () => {

--- a/src/components/Terminal/__tests__/hybridInputParsing.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputParsing.test.ts
@@ -1,124 +1,135 @@
 import { describe, expect, it } from "vitest";
+import type { CompletionTrigger } from "@shared/types";
 import {
-  getAtFileContext,
-  getSlashCommandContext,
+  getActiveCompletionContext,
+  getDaintreeAtClaim,
+  matchesDiffPrefix,
+  matchesTerminalPrefix,
+  matchesSelectionPrefix,
+  fileSearchQuery,
   getLeadingSlashCommand,
   getAllSlashCommandTokens,
-  getDiffContext,
   getAllAtDiffTokens,
-  getTerminalContext,
   getAllAtTerminalTokens,
-  getSelectionContext,
   getAllAtSelectionTokens,
 } from "../hybridInputParsing";
 
-describe("getAtFileContext", () => {
-  it("detects an @ token at the caret", () => {
+const ALL: ReadonlySet<CompletionTrigger> = new Set(["/", "$", "@"]);
+const SLASH_AT: ReadonlySet<CompletionTrigger> = new Set(["/", "@"]);
+
+describe("getActiveCompletionContext", () => {
+  it("detects an @ file token at the caret", () => {
     const text = "run @src/App.tsx please";
     const caret = "run @src/".length;
-    const ctx = getAtFileContext(text, caret);
+    const ctx = getActiveCompletionContext(text, caret, ALL);
     expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(4);
+    expect(ctx?.triggerChar).toBe("@");
+    expect(ctx?.start).toBe(4);
     expect(ctx?.tokenEnd).toBe("run @src/App.tsx".length);
-    expect(ctx?.queryRaw).toBe("src/");
-    expect(ctx?.queryForSearch).toBe("src/");
+    expect(ctx?.query).toBe("src/");
   });
 
-  it("requires @ to be preceded by whitespace (or start)", () => {
-    const text = "email@test.com";
-    const caret = text.length;
-    expect(getAtFileContext(text, caret)).toBeNull();
+  it("detects a slash command at start of input", () => {
+    const ctx = getActiveCompletionContext("/help", 2, ALL);
+    expect(ctx?.triggerChar).toBe("/");
+    expect(ctx?.start).toBe(0);
+    expect(ctx?.query).toBe("h");
   });
 
-  it("strips a leading quote for queryForSearch", () => {
-    const text = 'open @"My Folder/file name.txt"';
-    const caret = 'open @"My'.length;
-    const ctx = getAtFileContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.queryRaw).toBe('"My');
-    expect(ctx?.queryForSearch).toBe("My");
+  it("detects a $ capability token", () => {
+    const ctx = getActiveCompletionContext("$neo", 4, ALL);
+    expect(ctx?.triggerChar).toBe("$");
+    expect(ctx?.start).toBe(0);
+    expect(ctx?.tokenEnd).toBe(4);
+    expect(ctx?.query).toBe("neo");
+  });
+
+  it("only activates triggers in the active set", () => {
+    expect(getActiveCompletionContext("$neo", 4, SLASH_AT)).toBeNull();
+    expect(getActiveCompletionContext("$neo", 4, ALL)?.triggerChar).toBe("$");
+  });
+
+  it("detects a token mid-text after whitespace / tab / newline", () => {
+    expect(getActiveCompletionContext("echo /help", "echo /h".length, ALL)?.start).toBe(5);
+    expect(getActiveCompletionContext("text\t/compact", "text\t/com".length, ALL)?.query).toBe(
+      "com"
+    );
+    expect(getActiveCompletionContext("line1\n/help", "line1\n/he".length, ALL)?.start).toBe(6);
+  });
+
+  it("rejects a trigger not preceded by whitespace (URLs, emails, paths)", () => {
+    expect(getActiveCompletionContext("email@test.com", "email@test.com".length, ALL)).toBeNull();
+    expect(getActiveCompletionContext("http://example.com", 8, ALL)).toBeNull();
+    expect(getActiveCompletionContext("path/to/file", 6, ALL)).toBeNull();
+  });
+
+  it("rejects doubled triggers (//help, $$foo, @@x)", () => {
+    expect(getActiveCompletionContext("//help", 3, ALL)).toBeNull();
+    expect(getActiveCompletionContext("$$foo", 3, ALL)).toBeNull();
+    expect(getActiveCompletionContext("@@x", 3, ALL)).toBeNull();
+  });
+
+  it("is inactive when the caret is in the token's arguments", () => {
+    expect(getActiveCompletionContext("/open src/App.tsx", "/open src/App.tsx".length, ALL)).toBe(
+      null
+    );
+  });
+
+  it("anchors on the second token when the caret is inside it", () => {
+    const text = "/help /compact";
+    const ctx = getActiveCompletionContext(text, "/help /com".length, ALL);
+    expect(ctx?.start).toBe(6);
+    expect(ctx?.tokenEnd).toBe(14);
+    expect(ctx?.query).toBe("com");
+  });
+
+  it("activates for a bare trigger", () => {
+    expect(getActiveCompletionContext("/", 1, ALL)).toMatchObject({ triggerChar: "/", query: "" });
+    expect(getActiveCompletionContext("echo @", 6, ALL)).toMatchObject({
+      triggerChar: "@",
+      query: "",
+    });
+  });
+
+  it("activates with the caret in the middle of a token", () => {
+    const ctx = getActiveCompletionContext("@diff:staged", "@diff:st".length, ALL);
+    expect(ctx?.triggerChar).toBe("@");
+    expect(ctx?.start).toBe(0);
+    expect(ctx?.query).toBe("diff:st");
+  });
+
+  it("returns null when the caret precedes the trigger or follows the token", () => {
+    expect(getActiveCompletionContext("check @diff", 3, ALL)).toBeNull();
+    expect(getActiveCompletionContext("@diff rest", "@diff r".length, ALL)).toBeNull();
   });
 });
 
-describe("getSlashCommandContext", () => {
-  it("detects a slash command at start of input", () => {
-    expect(getSlashCommandContext("/help", 2)?.query).toBe("/h");
+describe("getDaintreeAtClaim + prefix matchers", () => {
+  it("claims diff for a bare @ and diff prefixes", () => {
+    expect(getDaintreeAtClaim("")).toBe("diff");
+    expect(getDaintreeAtClaim("diff")).toBe("diff");
+    expect(getDaintreeAtClaim("diff:s")).toBe("diff");
+    expect(matchesDiffPrefix("")).toBe(true);
   });
 
-  it("detects a slash command mid-text after whitespace", () => {
-    const ctx = getSlashCommandContext("echo /help", "echo /h".length);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(5);
-    expect(ctx?.tokenEnd).toBe(10);
-    expect(ctx?.query).toBe("/h");
+  it("claims terminal/selection only from four chars in", () => {
+    expect(getDaintreeAtClaim("te")).toBeNull();
+    expect(getDaintreeAtClaim("term")).toBe("terminal");
+    expect(getDaintreeAtClaim("sele")).toBe("selection");
+    expect(matchesTerminalPrefix("ter")).toBe(false);
+    expect(matchesSelectionPrefix("sel")).toBe(false);
   });
 
-  it("detects slash command after tab", () => {
-    const ctx = getSlashCommandContext("text\t/compact", "text\t/com".length);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(5);
-    expect(ctx?.query).toBe("/com");
+  it("falls through to file search for non-provider queries", () => {
+    expect(getDaintreeAtClaim("src/")).toBeNull();
+    expect(getDaintreeAtClaim("ters")).toBeNull();
   });
+});
 
-  it("detects slash command after newline", () => {
-    const ctx = getSlashCommandContext("line1\n/help", "line1\n/he".length);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(6);
-    expect(ctx?.query).toBe("/he");
-  });
-
-  it("rejects slash inside a URL (not preceded by whitespace)", () => {
-    expect(getSlashCommandContext("http://example.com", 8)).toBeNull();
-  });
-
-  it("rejects slash not preceded by whitespace", () => {
-    expect(getSlashCommandContext("path/to/file", 6)).toBeNull();
-  });
-
-  it("is inactive when caret is in arguments", () => {
-    const text = "/open src/App.tsx";
-    const caret = text.length;
-    expect(getSlashCommandContext(text, caret)).toBeNull();
-  });
-
-  it("replaces only the first token", () => {
-    const text = "/cl arg1";
-    const caret = "/cl".length;
-    const ctx = getSlashCommandContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(0);
-    expect(ctx?.tokenEnd).toBe("/cl".length);
-    expect(ctx?.query).toBe("/cl");
-  });
-
-  it("returns correct context for second slash command", () => {
-    const text = "/help /compact";
-    const caret = "/help /com".length;
-    const ctx = getSlashCommandContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(6);
-    expect(ctx?.tokenEnd).toBe(14);
-    expect(ctx?.query).toBe("/com");
-  });
-
-  it("rejects consecutive slashes like //help", () => {
-    expect(getSlashCommandContext("//help", 3)).toBeNull();
-  });
-
-  it("activates for bare slash at start", () => {
-    const ctx = getSlashCommandContext("/", 1);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(0);
-    expect(ctx?.tokenEnd).toBe(1);
-    expect(ctx?.query).toBe("/");
-  });
-
-  it("activates for bare slash mid-text", () => {
-    const ctx = getSlashCommandContext("echo /", 6);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.start).toBe(5);
-    expect(ctx?.tokenEnd).toBe(6);
-    expect(ctx?.query).toBe("/");
+describe("fileSearchQuery", () => {
+  it("strips a single leading quote", () => {
+    expect(fileSearchQuery('"My')).toBe("My");
+    expect(fileSearchQuery("src/")).toBe("src/");
   });
 });
 
@@ -150,11 +161,12 @@ describe("getLeadingSlashCommand", () => {
   it("handles mixed input with @file references", () => {
     const text = "/compact @src/App.tsx some text";
     const slashToken = getLeadingSlashCommand(text);
-    const atContext = getAtFileContext(text, text.indexOf("@") + 1);
+    const atContext = getActiveCompletionContext(text, text.indexOf("@") + 1, ALL);
 
     expect(slashToken?.command).toBe("/compact");
     expect(atContext).not.toBeNull();
-    expect(atContext?.atStart).toBe(9);
+    expect(atContext?.triggerChar).toBe("@");
+    expect(atContext?.start).toBe(9);
   });
 
   it("only treats first slash as command", () => {
@@ -237,89 +249,6 @@ describe("getAllSlashCommandTokens", () => {
   });
 });
 
-describe("getDiffContext", () => {
-  it("detects @diff at the caret", () => {
-    const text = "check @diff please";
-    const caret = "check @diff".length;
-    const ctx = getDiffContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(6);
-    expect(ctx?.tokenEnd).toBe("check @diff".length);
-    expect(ctx?.diffType).toBe("unstaged");
-  });
-
-  it("detects @diff:staged", () => {
-    const text = "show @diff:staged here";
-    const caret = "show @diff:staged".length;
-    const ctx = getDiffContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.diffType).toBe("staged");
-  });
-
-  it("detects @diff:head", () => {
-    const text = "@diff:head";
-    const caret = text.length;
-    const ctx = getDiffContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.diffType).toBe("head");
-  });
-
-  it("returns null diffType for partial typing", () => {
-    const text = "check @dif";
-    const caret = text.length;
-    const ctx = getDiffContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.diffType).toBeNull();
-  });
-
-  it("returns null for non-diff @ tokens", () => {
-    const text = "check @src/file.ts";
-    const caret = "check @src/".length;
-    expect(getDiffContext(text, caret)).toBeNull();
-  });
-
-  it("requires @ to be preceded by whitespace", () => {
-    const text = "nodiff@diff";
-    const caret = text.length;
-    expect(getDiffContext(text, caret)).toBeNull();
-  });
-
-  it("returns null for unknown suffixes like @diff:foo", () => {
-    const text = "@diff:foo";
-    const caret = text.length;
-    expect(getDiffContext(text, caret)).toBeNull();
-  });
-
-  it("activates for partial prefix @diff:", () => {
-    const text = "@diff:s";
-    const caret = text.length;
-    const ctx = getDiffContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.diffType).toBeNull(); // partial, not a full match
-  });
-
-  it("activates with caret in middle of @diff:staged", () => {
-    const text = "@diff:staged";
-    const caret = "@diff:st".length;
-    const ctx = getDiffContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(0);
-    expect(ctx?.diffType).toBe("staged"); // full token is diff:staged
-  });
-
-  it("returns null when caret is before the @", () => {
-    const text = "check @diff";
-    const caret = 3; // before @
-    expect(getDiffContext(text, caret)).toBeNull();
-  });
-
-  it("returns null when caret is after the token with trailing text", () => {
-    const text = "@diff rest";
-    const caret = "@diff r".length; // past the @diff token
-    expect(getDiffContext(text, caret)).toBeNull();
-  });
-});
-
 describe("getAllAtDiffTokens", () => {
   it("finds @diff tokens in text", () => {
     const tokens = getAllAtDiffTokens("check @diff and @diff:staged please");
@@ -369,37 +298,6 @@ describe("getAllAtDiffTokens", () => {
   });
 });
 
-describe("getTerminalContext", () => {
-  it("detects @terminal at the caret", () => {
-    const text = "check @terminal please";
-    const caret = "check @terminal".length;
-    const ctx = getTerminalContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(6);
-    expect(ctx?.tokenEnd).toBe("check @terminal".length);
-  });
-
-  it("returns null for short prefixes like @t or @te", () => {
-    expect(getTerminalContext("@t", 2)).toBeNull();
-    expect(getTerminalContext("@te", 3)).toBeNull();
-    expect(getTerminalContext("@ter", 4)).toBeNull();
-  });
-
-  it("activates for partial prefix @term", () => {
-    const ctx = getTerminalContext("@term", 5);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(0);
-  });
-
-  it("returns null for non-terminal @ tokens", () => {
-    expect(getTerminalContext("@src/file.ts", 5)).toBeNull();
-  });
-
-  it("requires @ to be preceded by whitespace", () => {
-    expect(getTerminalContext("no@terminal", "no@terminal".length)).toBeNull();
-  });
-});
-
 describe("getAllAtTerminalTokens", () => {
   it("finds @terminal tokens in text", () => {
     const tokens = getAllAtTerminalTokens("check @terminal please");
@@ -431,37 +329,6 @@ describe("getAllAtTerminalTokens", () => {
     const tokens = getAllAtTerminalTokens("@terminal @diff @src/file.ts");
     expect(tokens).toHaveLength(1);
     expect(tokens[0]!.start).toBe(0);
-  });
-});
-
-describe("getSelectionContext", () => {
-  it("detects @selection at the caret", () => {
-    const text = "check @selection please";
-    const caret = "check @selection".length;
-    const ctx = getSelectionContext(text, caret);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(6);
-    expect(ctx?.tokenEnd).toBe("check @selection".length);
-  });
-
-  it("returns null for short prefixes like @s or @se", () => {
-    expect(getSelectionContext("@s", 2)).toBeNull();
-    expect(getSelectionContext("@se", 3)).toBeNull();
-    expect(getSelectionContext("@sel", 4)).toBeNull();
-  });
-
-  it("activates for partial prefix @sele", () => {
-    const ctx = getSelectionContext("@sele", 5);
-    expect(ctx).not.toBeNull();
-    expect(ctx?.atStart).toBe(0);
-  });
-
-  it("returns null for non-selection @ tokens", () => {
-    expect(getSelectionContext("@src/file.ts", 5)).toBeNull();
-  });
-
-  it("requires @ to be preceded by whitespace", () => {
-    expect(getSelectionContext("no@selection", "no@selection".length)).toBeNull();
   });
 });
 

--- a/src/components/Terminal/__tests__/hybridInputParsing.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputParsing.test.ts
@@ -69,6 +69,34 @@ describe("getActiveCompletionContext", () => {
     expect(getActiveCompletionContext("@@x", 3, ALL)).toBeNull();
   });
 
+  it("rejects a repeated same-trigger later in the token (/usr/bin, @foo@bar)", () => {
+    // A second `/` in a `/` token is a path, not a command session.
+    expect(getActiveCompletionContext("/usr/bin", "/usr/bin".length, ALL)).toBeNull();
+    // ...but a bare `/usr` (no inner slash yet) is still a command session.
+    expect(getActiveCompletionContext("/usr", 4, ALL)?.query).toBe("usr");
+    // A second `@` in an `@` token is rejected (matches the old last-@ parser).
+    expect(getActiveCompletionContext("@foo@bar", "@foo@bar".length, ALL)).toBeNull();
+    // The `/` inside an `@` file token is NOT a repeat — it stays open.
+    expect(getActiveCompletionContext("@src/App.tsx", "@src/App.tsx".length, ALL)?.query).toBe(
+      "src/App.tsx"
+    );
+  });
+
+  it("handles caret exactly at boundaries and after CRLF", () => {
+    // Caret on the trigger itself (start === caret) — nothing typed yet.
+    expect(getActiveCompletionContext("echo @", 5, ALL)).toBeNull();
+    // Caret at token end just before whitespace — active.
+    expect(getActiveCompletionContext("@diff here", 5, ALL)).toMatchObject({
+      triggerChar: "@",
+      tokenEnd: 5,
+      query: "diff",
+    });
+    // Caret immediately after a delimiter (before a trigger not yet typed past).
+    expect(getActiveCompletionContext("a @", 2, ALL)).toBeNull();
+    // Active token after CRLF.
+    expect(getActiveCompletionContext("x\r\n/help", "x\r\n/he".length, ALL)?.triggerChar).toBe("/");
+  });
+
   it("is inactive when the caret is in the token's arguments", () => {
     expect(getActiveCompletionContext("/open src/App.tsx", "/open src/App.tsx".length, ALL)).toBe(
       null

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
@@ -4,26 +4,22 @@ import { renderHook } from "@testing-library/react";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import type { AutocompleteItem } from "../../AutocompleteMenu";
+import type { ActiveCompletionContext } from "../../hybridInputParsing";
 import { useAutocompleteApply } from "../useAutocompleteApply";
 
 type Params = Parameters<typeof useAutocompleteApply>[0];
 type Latest = NonNullable<Params["latestRef"]["current"]>;
 
-function setup(doc: string, item: AutocompleteItem) {
+function setup(doc: string, item: AutocompleteItem, context: ActiveCompletionContext) {
   const view = new EditorView({
     state: EditorState.create({ doc, selection: { anchor: doc.length } }),
   });
   const applyEditorValue = vi.fn<Params["applyEditorValue"]>();
   const sendText = vi.fn<Params["sendText"]>();
   const latest: Latest = {
-    activeMode: "command",
     autocompleteItems: [item],
     selectedIndex: 0,
-    slashContext: null,
-    atContext: null,
-    diffContext: null,
-    terminalContext: null,
-    selectionContext: null,
+    activeCompletionContext: context,
   };
 
   const params: Params = {
@@ -32,11 +28,7 @@ function setup(doc: string, item: AutocompleteItem) {
     lastQueryRef: { current: "" },
     applyEditorValue,
     sendText,
-    setAtContext: vi.fn(),
-    setSlashContext: vi.fn(),
-    setDiffContext: vi.fn(),
-    setTerminalContext: vi.fn(),
-    setSelectionContext: vi.fn(),
+    setActiveCompletionContext: vi.fn(),
     setSelectedIndex: vi.fn(),
   };
 
@@ -44,21 +36,46 @@ function setup(doc: string, item: AutocompleteItem) {
   return { ...result.current, applyEditorValue, sendText, view };
 }
 
+const dollarContext: ActiveCompletionContext = {
+  triggerChar: "$",
+  start: 0,
+  tokenEnd: 5,
+  query: "plug",
+};
+const slashContext: ActiveCompletionContext = {
+  triggerChar: "/",
+  start: 0,
+  tokenEnd: 5,
+  query: "plug",
+};
+
 describe("useAutocompleteApply", () => {
-  const item: AutocompleteItem = {
+  const capability: AutocompleteItem = {
     key: "plugin-creator",
     label: "Plugin Creator",
     insertText: "$plugin-creator",
     category: "plugin",
+    enterAction: "insert",
+    insert: "literal",
   };
 
-  it("inserts the canonical token, never the display label", () => {
-    const { handleAutocompleteSelect, applyEditorValue, sendText, view } = setup("/plug", item);
-    try {
-      handleAutocompleteSelect(item);
+  const command: AutocompleteItem = {
+    key: "commit",
+    label: "/commit",
+    insertText: "/commit",
+    enterAction: "execute",
+    insert: "literal",
+  };
 
+  it("inserts the canonical token on click, never the display label", () => {
+    const { handleAutocompleteSelect, applyEditorValue, sendText, view } = setup(
+      "$plug",
+      capability,
+      dollarContext
+    );
+    try {
+      handleAutocompleteSelect(capability);
       expect(applyEditorValue).toHaveBeenCalledTimes(1);
-      // Replaces the whole "/plug" slash token with the canonical insert token.
       expect(applyEditorValue.mock.calls[0]![0]).toBe("$plugin-creator ");
       expect(sendText).not.toHaveBeenCalled();
     } finally {
@@ -66,14 +83,49 @@ describe("useAutocompleteApply", () => {
     }
   });
 
-  it("executes with the canonical token, never the display label", () => {
-    const { applyAutocompleteSelection, applyEditorValue, sendText, view } = setup("/plug", item);
+  it("a $ capability inserts (not executes) on Enter — enterAction is insert", () => {
+    const { applyAutocompleteSelection, applyEditorValue, sendText, view } = setup(
+      "$plug",
+      capability,
+      dollarContext
+    );
     try {
-      expect(applyAutocompleteSelection("execute")).toBe(true);
+      expect(applyAutocompleteSelection("enter")).toBe(true);
+      expect(applyEditorValue).toHaveBeenCalledTimes(1);
+      expect(applyEditorValue.mock.calls[0]![0]).toBe("$plugin-creator ");
+      expect(sendText).not.toHaveBeenCalled();
+    } finally {
+      view.destroy();
+    }
+  });
 
+  it("a / command executes on Enter with the canonical token", () => {
+    const { applyAutocompleteSelection, applyEditorValue, sendText, view } = setup(
+      "/plug",
+      command,
+      slashContext
+    );
+    try {
+      expect(applyAutocompleteSelection("enter")).toBe(true);
       expect(sendText).toHaveBeenCalledTimes(1);
-      expect(sendText.mock.calls[0]![0]).toBe("$plugin-creator");
+      expect(sendText.mock.calls[0]![0]).toBe("/commit");
       expect(applyEditorValue).not.toHaveBeenCalled();
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("Tab/complete always inserts even for an execute item", () => {
+    const { applyAutocompleteSelection, applyEditorValue, sendText, view } = setup(
+      "/plug",
+      command,
+      slashContext
+    );
+    try {
+      expect(applyAutocompleteSelection("complete")).toBe(true);
+      expect(applyEditorValue).toHaveBeenCalledTimes(1);
+      expect(applyEditorValue.mock.calls[0]![0]).toBe("/commit ");
+      expect(sendText).not.toHaveBeenCalled();
     } finally {
       view.destroy();
     }

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteApply.test.ts
@@ -16,6 +16,7 @@ function setup(doc: string, item: AutocompleteItem, context: ActiveCompletionCon
   });
   const applyEditorValue = vi.fn<Params["applyEditorValue"]>();
   const sendText = vi.fn<Params["sendText"]>();
+  const setActiveCompletionContext = vi.fn<Params["setActiveCompletionContext"]>();
   const latest: Latest = {
     autocompleteItems: [item],
     selectedIndex: 0,
@@ -28,12 +29,12 @@ function setup(doc: string, item: AutocompleteItem, context: ActiveCompletionCon
     lastQueryRef: { current: "" },
     applyEditorValue,
     sendText,
-    setActiveCompletionContext: vi.fn(),
+    setActiveCompletionContext,
     setSelectedIndex: vi.fn(),
   };
 
   const { result } = renderHook(() => useAutocompleteApply(params));
-  return { ...result.current, applyEditorValue, sendText, view };
+  return { ...result.current, applyEditorValue, sendText, setActiveCompletionContext, view };
 }
 
 const dollarContext: ActiveCompletionContext = {
@@ -83,17 +84,22 @@ describe("useAutocompleteApply", () => {
     }
   });
 
-  it("a $ capability inserts (not executes) on Enter — enterAction is insert", () => {
-    const { applyAutocompleteSelection, applyEditorValue, sendText, view } = setup(
-      "$plug",
-      capability,
-      dollarContext
-    );
+  it("a $ capability inserts (not executes) on Enter and closes the menu", () => {
+    const {
+      applyAutocompleteSelection,
+      applyEditorValue,
+      sendText,
+      setActiveCompletionContext,
+      view,
+    } = setup("$plug", capability, dollarContext);
     try {
       expect(applyAutocompleteSelection("enter")).toBe(true);
       expect(applyEditorValue).toHaveBeenCalledTimes(1);
       expect(applyEditorValue.mock.calls[0]![0]).toBe("$plugin-creator ");
       expect(sendText).not.toHaveBeenCalled();
+      // Menu closes after the first Enter — so the NEXT Enter has no active
+      // context and falls through to a normal send (the two-Enter $ flow).
+      expect(setActiveCompletionContext).toHaveBeenCalledWith(null);
     } finally {
       view.destroy();
     }

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
@@ -4,6 +4,7 @@ import { renderHook } from "@testing-library/react";
 import { useAutocompleteItems } from "../useAutocompleteItems";
 import type { ActiveCompletionContext } from "../../hybridInputParsing";
 import type { AutocompleteItem } from "../../AutocompleteMenu";
+import type { CompletionTrigger } from "@shared/types";
 
 function atContext(query: string): ActiveCompletionContext {
   return { triggerChar: "@", start: 0, tokenEnd: query.length + 1, query };
@@ -35,7 +36,7 @@ describe("useAutocompleteItems", () => {
     );
     expect(result.current.autocompleteItems).toHaveLength(2);
     expect(result.current.autocompleteItems[0]!.key).toBe("src/index.ts");
-    expect(result.current.autocompleteItems[0]!.insert).toBe("literal");
+    expect(result.current.autocompleteItems[0]!.enterAction).toBe("insert");
     expect(result.current.isLoading).toBe(true);
   });
 
@@ -57,6 +58,25 @@ describe("useAutocompleteItems", () => {
     expect(root!.insertText).toBe("@README.md");
   });
 
+  it("splits Windows-separator paths and keeps a canonical @token", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({
+        ...baseParams,
+        activeCompletionContext: atContext("src"),
+        autocompleteFiles: ["src\\utils\\log.ts", "src/dir/"],
+      })
+    );
+    const [win, trailing] = result.current.autocompleteItems;
+    expect(win!.label).toBe("log.ts");
+    expect(win!.description).toBe("src\\utils");
+    // Key stays the raw path (for staleness); insertText is the canonical @token.
+    expect(win!.key).toBe("src\\utils\\log.ts");
+    expect(win!.insertText).toBe("@src\\utils\\log.ts");
+    // Trailing separator → empty basename → falls back to the full path.
+    expect(trailing!.label).toBe("src/dir/");
+    expect(trailing!.insertText).toBe("@src/dir/");
+  });
+
   it("quotes file insert text when the path contains spaces", () => {
     const { result } = renderHook(() =>
       useAutocompleteItems({
@@ -66,30 +86,31 @@ describe("useAutocompleteItems", () => {
       })
     );
     expect(result.current.autocompleteItems[0]!.insertText).toBe('@"My Folder/a b.txt"');
-    // Key stays the raw path so per-item staleness can key off file paths.
     expect(result.current.autocompleteItems[0]!.key).toBe("My Folder/a b.txt");
   });
 
-  it("returns diff items (resolve) filtered by partial when @ query claims diff", () => {
+  it("routes a bare @ to diff items only — file results never leak in", () => {
     const { result } = renderHook(() =>
       useAutocompleteItems({
         ...baseParams,
-        activeCompletionContext: atContext("diff:s"),
+        activeCompletionContext: atContext(""),
+        autocompleteFiles: ["a.ts", "b.ts"],
       })
+    );
+    const items = result.current.autocompleteItems;
+    expect(items).toHaveLength(3);
+    expect(items.every((i) => i.key.startsWith("diff"))).toBe(true);
+  });
+
+  it("filters diff items by partial and carries the diff resolver + insert action", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({ ...baseParams, activeCompletionContext: atContext("diff:s") })
     );
     const items = result.current.autocompleteItems;
     expect(items.some((i) => i.key === "diff:staged")).toBe(true);
     expect(items.every((i) => i.key.startsWith("diff:s"))).toBe(true);
-    expect(items[0]!.insert).toEqual({ insert: "resolve", resolverId: "diff" });
     expect(items[0]!.enterAction).toBe("insert");
-    expect(result.current.isLoading).toBe(false);
-  });
-
-  it("returns all three diff items for a bare @", () => {
-    const { result } = renderHook(() =>
-      useAutocompleteItems({ ...baseParams, activeCompletionContext: atContext("") })
-    );
-    expect(result.current.autocompleteItems).toHaveLength(3);
+    expect(items[0]!.insert).toEqual({ insert: "resolve", resolverId: "diff" });
   });
 
   it("returns the terminal item when @ query claims terminal", () => {
@@ -112,25 +133,29 @@ describe("useAutocompleteItems", () => {
     expect(result.current.autocompleteItems[0]!.key).toBe("selection");
   });
 
-  it("passes through command/capability items verbatim for / and $", () => {
-    const commands: AutocompleteItem[] = [
-      {
-        key: "/help",
-        label: "/help",
-        insertText: "/help",
-        enterAction: "execute",
-        insert: "literal",
-      },
-    ];
-    const { result } = renderHook(() =>
-      useAutocompleteItems({
-        ...baseParams,
-        activeCompletionContext: { triggerChar: "/", start: 0, tokenEnd: 5, query: "h" },
-        autocompleteCommands: commands,
-        isCommandsLoading: true,
-      })
-    );
-    expect(result.current.autocompleteItems).toEqual(commands);
-    expect(result.current.isLoading).toBe(true);
-  });
+  it.each([["/"], ["$"]] as [CompletionTrigger][])(
+    "passes through pre-mapped %s items verbatim (same array, loading state)",
+    (trigger) => {
+      const commands: AutocompleteItem[] = [
+        {
+          key: "x",
+          label: `${trigger}x`,
+          insertText: `${trigger}x`,
+          enterAction: trigger === "/" ? "execute" : "insert",
+          insert: "literal",
+        },
+      ];
+      const { result } = renderHook(() =>
+        useAutocompleteItems({
+          ...baseParams,
+          activeCompletionContext: { triggerChar: trigger, start: 0, tokenEnd: 2, query: "x" },
+          autocompleteCommands: commands,
+          isCommandsLoading: true,
+        })
+      );
+      // Identity: the discovery items pass straight through, unmodified.
+      expect(result.current.autocompleteItems).toBe(commands);
+      expect(result.current.isLoading).toBe(true);
+    }
+  );
 });

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
@@ -2,37 +2,40 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useAutocompleteItems } from "../useAutocompleteItems";
+import type { ActiveCompletionContext } from "../../hybridInputParsing";
+import type { AutocompleteItem } from "../../AutocompleteMenu";
+
+function atContext(query: string): ActiveCompletionContext {
+  return { triggerChar: "@", start: 0, tokenEnd: query.length + 1, query };
+}
 
 const baseParams = {
-  activeMode: null as "command" | "file" | "diff" | "terminal" | "selection" | null,
-  diffContext: null,
-  terminalContext: null,
-  selectionContext: null,
-  value: "",
+  activeCompletionContext: null as ActiveCompletionContext | null,
   autocompleteFiles: [] as string[],
   isAutocompleteLoading: false,
-  autocompleteCommands: [],
+  autocompleteCommands: [] as AutocompleteItem[],
   isCommandsLoading: false,
 };
 
 describe("useAutocompleteItems", () => {
-  it("returns empty items when activeMode is null", () => {
+  it("returns empty items when there is no active context", () => {
     const { result } = renderHook(() => useAutocompleteItems(baseParams));
     expect(result.current.autocompleteItems).toEqual([]);
     expect(result.current.isLoading).toBe(false);
   });
 
-  it("returns file items when activeMode is file", () => {
+  it("returns file items when @ query claims no Daintree provider", () => {
     const { result } = renderHook(() =>
       useAutocompleteItems({
         ...baseParams,
-        activeMode: "file",
+        activeCompletionContext: atContext("src/"),
         autocompleteFiles: ["src/index.ts", "src/app.ts"],
         isAutocompleteLoading: true,
       })
     );
     expect(result.current.autocompleteItems).toHaveLength(2);
     expect(result.current.autocompleteItems[0]!.key).toBe("src/index.ts");
+    expect(result.current.autocompleteItems[0]!.insert).toBe("literal");
     expect(result.current.isLoading).toBe(true);
   });
 
@@ -40,98 +43,89 @@ describe("useAutocompleteItems", () => {
     const { result } = renderHook(() =>
       useAutocompleteItems({
         ...baseParams,
-        activeMode: "file",
+        activeCompletionContext: atContext("src/"),
         autocompleteFiles: ["src/components/Button.tsx", "README.md"],
       })
     );
     const [nested, root] = result.current.autocompleteItems;
     expect(nested!.label).toBe("Button.tsx");
     expect(nested!.description).toBe("src/components");
-    expect(nested!.insertText).toBe("src/components/Button.tsx");
+    // insertText is the canonical @token (formatted at construction).
+    expect(nested!.insertText).toBe("@src/components/Button.tsx");
     expect(root!.label).toBe("README.md");
     expect(root!.description).toBeUndefined();
-    expect(root!.insertText).toBe("README.md");
+    expect(root!.insertText).toBe("@README.md");
   });
 
-  it("disambiguates duplicate basenames via directory descriptions", () => {
+  it("quotes file insert text when the path contains spaces", () => {
     const { result } = renderHook(() =>
       useAutocompleteItems({
         ...baseParams,
-        activeMode: "file",
-        autocompleteFiles: ["src/a/index.ts", "src/b/index.ts"],
+        activeCompletionContext: atContext("My"),
+        autocompleteFiles: ["My Folder/a b.txt"],
+      })
+    );
+    expect(result.current.autocompleteItems[0]!.insertText).toBe('@"My Folder/a b.txt"');
+    // Key stays the raw path so per-item staleness can key off file paths.
+    expect(result.current.autocompleteItems[0]!.key).toBe("My Folder/a b.txt");
+  });
+
+  it("returns diff items (resolve) filtered by partial when @ query claims diff", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({
+        ...baseParams,
+        activeCompletionContext: atContext("diff:s"),
       })
     );
     const items = result.current.autocompleteItems;
-    expect(items[0]!.label).toBe("index.ts");
-    expect(items[1]!.label).toBe("index.ts");
-    expect(items[0]!.description).toBe("src/a");
-    expect(items[1]!.description).toBe("src/b");
-    expect(items[0]!.key).not.toBe(items[1]!.key);
-  });
-
-  it("handles Windows separators and trailing-separator paths", () => {
-    const { result } = renderHook(() =>
-      useAutocompleteItems({
-        ...baseParams,
-        activeMode: "file",
-        autocompleteFiles: ["src\\utils\\log.ts", "src/dir/"],
-      })
-    );
-    const [win, trailing] = result.current.autocompleteItems;
-    expect(win!.label).toBe("log.ts");
-    expect(win!.description).toBe("src\\utils");
-    // Trailing separator yields an empty basename — falls back to the full path.
-    expect(trailing!.label).toBe("src/dir/");
-    expect(trailing!.insertText).toBe("src/dir/");
-  });
-
-  it("returns diff items filtered by partial", () => {
-    const { result } = renderHook(() =>
-      useAutocompleteItems({
-        ...baseParams,
-        activeMode: "diff",
-        diffContext: { atStart: 0, tokenEnd: 6, diffType: "staged" as const },
-        value: "@diff:s",
-      })
-    );
-    expect(result.current.autocompleteItems.length).toBeGreaterThanOrEqual(1);
-    expect(result.current.autocompleteItems.some((i) => i.key === "diff:staged")).toBe(true);
+    expect(items.some((i) => i.key === "diff:staged")).toBe(true);
+    expect(items.every((i) => i.key.startsWith("diff:s"))).toBe(true);
+    expect(items[0]!.insert).toEqual({ insert: "resolve", resolverId: "diff" });
+    expect(items[0]!.enterAction).toBe("insert");
     expect(result.current.isLoading).toBe(false);
   });
 
-  it("returns terminal item when activeMode is terminal", () => {
+  it("returns all three diff items for a bare @", () => {
     const { result } = renderHook(() =>
-      useAutocompleteItems({
-        ...baseParams,
-        activeMode: "terminal",
-        terminalContext: { atStart: 0, tokenEnd: 9 },
-      })
+      useAutocompleteItems({ ...baseParams, activeCompletionContext: atContext("") })
+    );
+    expect(result.current.autocompleteItems).toHaveLength(3);
+  });
+
+  it("returns the terminal item when @ query claims terminal", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({ ...baseParams, activeCompletionContext: atContext("term") })
     );
     expect(result.current.autocompleteItems).toHaveLength(1);
     expect(result.current.autocompleteItems[0]!.key).toBe("terminal");
+    expect(result.current.autocompleteItems[0]!.insert).toEqual({
+      insert: "resolve",
+      resolverId: "terminal",
+    });
   });
 
-  it("returns selection item when activeMode is selection", () => {
+  it("returns the selection item when @ query claims selection", () => {
     const { result } = renderHook(() =>
-      useAutocompleteItems({
-        ...baseParams,
-        activeMode: "selection",
-        selectionContext: { atStart: 0, tokenEnd: 10 },
-      })
+      useAutocompleteItems({ ...baseParams, activeCompletionContext: atContext("sele") })
     );
     expect(result.current.autocompleteItems).toHaveLength(1);
     expect(result.current.autocompleteItems[0]!.key).toBe("selection");
   });
 
-  it("returns command items when activeMode is command", () => {
-    const commands = [
-      { key: "/help", label: "/help", insertText: "/help" },
-      { key: "/clear", label: "/clear", insertText: "/clear" },
+  it("passes through command/capability items verbatim for / and $", () => {
+    const commands: AutocompleteItem[] = [
+      {
+        key: "/help",
+        label: "/help",
+        insertText: "/help",
+        enterAction: "execute",
+        insert: "literal",
+      },
     ];
     const { result } = renderHook(() =>
       useAutocompleteItems({
         ...baseParams,
-        activeMode: "command",
+        activeCompletionContext: { triggerChar: "/", start: 0, tokenEnd: 5, query: "h" },
         autocompleteCommands: commands,
         isCommandsLoading: true,
       })

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteState.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteState.test.ts
@@ -2,82 +2,100 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useAutocompleteState } from "../useAutocompleteState";
+import type { ActiveCompletionContext } from "../../hybridInputParsing";
+import type { AutocompleteItem } from "../../AutocompleteMenu";
+
+type Props = Parameters<typeof useAutocompleteState>[0];
+
+function item(key: string): AutocompleteItem {
+  return { key, label: key, insertText: key };
+}
+
+function atContext(query: string): ActiveCompletionContext {
+  return { triggerChar: "@", start: 0, tokenEnd: query.length + 1, query };
+}
 
 describe("useAutocompleteState", () => {
-  let setSelectedIndex: ReturnType<typeof vi.fn>;
+  let setSelectedIndex: ReturnType<typeof vi.fn<Props["setSelectedIndex"]>>;
+  let setActiveCompletionContext: ReturnType<typeof vi.fn<Props["setActiveCompletionContext"]>>;
   let lastQueryRef: { current: string };
-  let setAtContext: ReturnType<typeof vi.fn>;
-  let setSlashContext: ReturnType<typeof vi.fn>;
-  let setDiffContext: ReturnType<typeof vi.fn>;
-  let setTerminalContext: ReturnType<typeof vi.fn>;
-  let setSelectionContext: ReturnType<typeof vi.fn>;
   let rootRef: { current: HTMLDivElement | null };
 
   beforeEach(() => {
-    setSelectedIndex = vi.fn();
+    setSelectedIndex = vi.fn<Props["setSelectedIndex"]>();
+    setActiveCompletionContext = vi.fn<Props["setActiveCompletionContext"]>();
     lastQueryRef = { current: "" };
-    setAtContext = vi.fn();
-    setSlashContext = vi.fn();
-    setDiffContext = vi.fn();
-    setTerminalContext = vi.fn();
-    setSelectionContext = vi.fn();
     rootRef = { current: document.createElement("div") };
-    vi.restoreAllMocks();
   });
 
-  function render(overrides: Partial<Parameters<typeof useAutocompleteState>[0]> = {}) {
-    return renderHook(() =>
-      useAutocompleteState({
-        isAutocompleteOpen: false,
-        activeMode: null,
-        atContext: null,
-        slashContext: null,
-        diffContext: null,
-        terminalContext: null,
-        selectionContext: null,
-        autocompleteItemsLength: 0,
-        rootRef: rootRef as any,
-        selectedIndex: 0,
-        setSelectedIndex: setSelectedIndex as any,
-        lastQueryRef: lastQueryRef as any,
-        setAtContext: setAtContext as any,
-        setSlashContext: setSlashContext as any,
-        setDiffContext: setDiffContext as any,
-        setTerminalContext: setTerminalContext as any,
-        setSelectionContext: setSelectionContext as any,
-        ...overrides,
-      })
-    );
+  function base(overrides: Partial<Props> = {}): Props {
+    return {
+      isAutocompleteOpen: false,
+      activeCompletionContext: null,
+      autocompleteItems: [],
+      rootRef: rootRef as Props["rootRef"],
+      selectedIndex: 0,
+      setSelectedIndex,
+      lastQueryRef: lastQueryRef as Props["lastQueryRef"],
+      setActiveCompletionContext,
+      ...overrides,
+    };
   }
 
-  describe("query reset", () => {
-    it("resets selectedIndex when query changes", () => {
-      render({
-        activeMode: "command",
-        slashContext: { start: 0, tokenEnd: 5, query: "hel" } as any,
-      });
+  function render(initial: Props) {
+    return renderHook((props: Props) => useAutocompleteState(props), { initialProps: initial });
+  }
+
+  describe("selection", () => {
+    it("resets to the top on a new completion session", () => {
+      render(
+        base({
+          activeCompletionContext: { triggerChar: "/", start: 0, tokenEnd: 4, query: "hel" },
+          autocompleteItems: [item("/help"), item("/hey")],
+          selectedIndex: 3,
+        })
+      );
       expect(setSelectedIndex).toHaveBeenCalledWith(0);
     });
 
-    it("does not reset selectedIndex when query is same as lastQueryRef", () => {
-      lastQueryRef.current = "command:hel";
-      render({
-        activeMode: "command",
-        slashContext: { start: 0, tokenEnd: 5, query: "hel" } as any,
-      });
-      expect(setSelectedIndex).not.toHaveBeenCalled();
+    it("preserves the selected key when async items merge in for the same query", () => {
+      const { rerender } = render(
+        base({
+          activeCompletionContext: atContext("src"),
+          autocompleteItems: [item("f1")],
+          selectedIndex: 0,
+        })
+      );
+      setSelectedIndex.mockClear();
+
+      // A slower provider inserts an item BEFORE the selected one.
+      rerender(
+        base({
+          activeCompletionContext: atContext("src"),
+          autocompleteItems: [item("f0"), item("f1")],
+          selectedIndex: 0,
+        })
+      );
+      expect(setSelectedIndex).toHaveBeenCalledWith(1);
     });
 
-    it("creates query key for file mode", () => {
-      render({ activeMode: "file", atContext: { atStart: 0, queryForSearch: "src" } as any });
-      expect(setSelectedIndex).toHaveBeenCalledWith(0);
-    });
+    it("clamps into range when the selected key vanishes", () => {
+      const { rerender } = render(
+        base({
+          activeCompletionContext: atContext("src"),
+          autocompleteItems: [item("a"), item("b"), item("c")],
+          selectedIndex: 0,
+        })
+      );
+      setSelectedIndex.mockClear();
 
-    it("creates query key for diff mode", () => {
-      render({
-        activeMode: "diff",
-        diffContext: { atStart: 0, tokenEnd: 5, diffType: "unstaged" } as any,
-      });
+      rerender(
+        base({
+          activeCompletionContext: atContext("src"),
+          autocompleteItems: [item("x")],
+          selectedIndex: 2,
+        })
+      );
       expect(setSelectedIndex).toHaveBeenCalledWith(0);
     });
   });
@@ -87,7 +105,7 @@ describe("useAutocompleteState", () => {
       const addSpy = vi.spyOn(document, "addEventListener");
       const removeSpy = vi.spyOn(document, "removeEventListener");
 
-      const { unmount } = render({ isAutocompleteOpen: true });
+      const { unmount } = render(base({ isAutocompleteOpen: true }));
 
       expect(addSpy).toHaveBeenCalledWith("pointerdown", expect.any(Function), true);
 
@@ -95,14 +113,8 @@ describe("useAutocompleteState", () => {
       expect(removeSpy).toHaveBeenCalledWith("pointerdown", expect.any(Function), true);
     });
 
-    it("does not register listener when autocomplete is closed", () => {
-      const addSpy = vi.spyOn(document, "addEventListener");
-      render({ isAutocompleteOpen: false });
-      expect(addSpy).not.toHaveBeenCalled();
-    });
-
-    it("closes contexts when clicking outside root", () => {
-      render({ isAutocompleteOpen: true });
+    it("ignores an outside pointerdown when autocomplete is closed", () => {
+      render(base({ isAutocompleteOpen: false }));
       const outside = document.createElement("div");
       document.body.appendChild(outside);
 
@@ -110,33 +122,29 @@ describe("useAutocompleteState", () => {
         outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
       });
 
-      expect(setAtContext).toHaveBeenCalledWith(null);
-      expect(setSlashContext).toHaveBeenCalledWith(null);
-      expect(setDiffContext).toHaveBeenCalledWith(null);
-      expect(setTerminalContext).toHaveBeenCalledWith(null);
-      expect(setSelectionContext).toHaveBeenCalledWith(null);
+      expect(setActiveCompletionContext).not.toHaveBeenCalled();
     });
 
-    it("does not close contexts when clicking inside root", () => {
-      render({ isAutocompleteOpen: true });
+    it("clears the context when clicking outside root", () => {
+      render(base({ isAutocompleteOpen: true }));
+      const outside = document.createElement("div");
+      document.body.appendChild(outside);
+
+      act(() => {
+        outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+      });
+
+      expect(setActiveCompletionContext).toHaveBeenCalledWith(null);
+    });
+
+    it("does not clear the context when clicking inside root", () => {
+      render(base({ isAutocompleteOpen: true }));
 
       act(() => {
         rootRef.current!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
       });
 
-      expect(setAtContext).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("selectedIndex clamp", () => {
-    it("sets index to 0 when items become empty", () => {
-      render({
-        isAutocompleteOpen: true,
-        autocompleteItemsLength: 0,
-        selectedIndex: 3,
-      });
-
-      expect(setSelectedIndex).toHaveBeenCalledWith(0);
+      expect(setActiveCompletionContext).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useContextDetectionFocus.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useContextDetectionFocus.test.ts
@@ -33,11 +33,7 @@ function makeUpdate(opts: {
 
 function setupHook() {
   const setIsEditorFocused = vi.fn();
-  const setAtContext = vi.fn();
-  const setSlashContext = vi.fn();
-  const setDiffContext = vi.fn();
-  const setTerminalContext = vi.fn();
-  const setSelectionContext = vi.fn();
+  const setActiveCompletionContext = vi.fn();
   const applyDocChange = vi.fn(() => false);
   const consumeExternalValueFlag = vi.fn(() => false);
 
@@ -49,13 +45,10 @@ function setupHook() {
     });
     return useContextDetection({
       latestRef,
+      activeTriggers: new Set(["/", "$", "@"]),
       applyDocChange,
       consumeExternalValueFlag,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       setIsEditorFocused,
     });
   });

--- a/src/components/Terminal/hooks/__tests__/useContextDetectionFocus.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useContextDetectionFocus.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useRef } from "react";
 import type { ViewUpdate } from "@codemirror/view";
+import type { CompletionTrigger } from "@shared/types";
 import { useContextDetection } from "../useContextDetection";
 
 interface LatestRefShape {
@@ -17,21 +18,24 @@ function makeUpdate(opts: {
   hasFocus: boolean;
   docChanged?: boolean;
   selectionSet?: boolean;
+  text?: string;
+  caret?: number;
 }): ViewUpdate {
+  const text = opts.text ?? "";
   return {
     focusChanged: opts.focusChanged,
     docChanged: opts.docChanged ?? false,
     selectionSet: opts.selectionSet ?? false,
     transactions: [],
     state: {
-      doc: { toString: () => "", length: 0 },
-      selection: { main: { head: 0 } },
+      doc: { toString: () => text, length: text.length },
+      selection: { main: { head: opts.caret ?? 0 } },
     },
     view: { hasFocus: opts.hasFocus },
   } as unknown as ViewUpdate;
 }
 
-function setupHook() {
+function setupHook(activeTriggers: CompletionTrigger[] = ["/", "$", "@"]) {
   const setIsEditorFocused = vi.fn();
   const setActiveCompletionContext = vi.fn();
   const applyDocChange = vi.fn(() => false);
@@ -45,7 +49,7 @@ function setupHook() {
     });
     return useContextDetection({
       latestRef,
-      activeTriggers: new Set(["/", "$", "@"]),
+      activeTriggers: new Set(activeTriggers),
       applyDocChange,
       consumeExternalValueFlag,
       setActiveCompletionContext,
@@ -53,7 +57,7 @@ function setupHook() {
     });
   });
 
-  return { result, setIsEditorFocused };
+  return { result, setIsEditorFocused, setActiveCompletionContext };
 }
 
 describe("useContextDetection focus tracking", () => {
@@ -75,5 +79,28 @@ describe("useContextDetection focus tracking", () => {
       makeUpdate({ focusChanged: false, hasFocus: true, docChanged: true })
     );
     expect(setIsEditorFocused).not.toHaveBeenCalled();
+  });
+});
+
+describe("useContextDetection trigger detection", () => {
+  it("opens a $ context when $ is an active trigger", () => {
+    const { result, setActiveCompletionContext } = setupHook(["/", "$", "@"]);
+    result.current.handleUpdateRef.current(
+      makeUpdate({ focusChanged: false, hasFocus: true, docChanged: true, text: "$neo", caret: 4 })
+    );
+    expect(setActiveCompletionContext).toHaveBeenCalledWith(
+      expect.objectContaining({ triggerChar: "$", start: 0, query: "neo" })
+    );
+  });
+
+  it("does not open a $ context when $ is not an active trigger", () => {
+    const { result, setActiveCompletionContext } = setupHook(["/", "@"]);
+    result.current.handleUpdateRef.current(
+      makeUpdate({ focusChanged: false, hasFocus: true, docChanged: true, text: "$neo", caret: 4 })
+    );
+    // Only the initial null (no context) may be emitted — never a $ context.
+    for (const call of setActiveCompletionContext.mock.calls) {
+      expect(call[0]).toBeNull();
+    }
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
@@ -4,17 +4,20 @@ import { renderHook } from "@testing-library/react";
 import { Compartment } from "@codemirror/state";
 import type { EditorState } from "@codemirror/state";
 import type { Dispatch, SetStateAction } from "react";
-import type {
-  AtFileContext,
-  SlashCommandContext,
-  AtDiffContext,
-  AtTerminalContext,
-  AtSelectionContext,
-} from "../../hybridInputParsing";
+import type { ActiveCompletionContext } from "../../hybridInputParsing";
+import type { AutocompleteItem } from "../../AutocompleteMenu";
 import { useEditorKeymap } from "../useEditorKeymap";
 
 type KeymapParams = Parameters<typeof useEditorKeymap>[0];
 type LatestShape = NonNullable<KeymapParams["latestRef"]["current"]>;
+
+const fileItem: AutocompleteItem = {
+  key: "src/a.ts",
+  label: "a.ts",
+  insertText: "src/a.ts",
+  enterAction: "insert",
+  insert: "literal",
+};
 
 function makeLatest(overrides: Partial<LatestShape> = {}): LatestShape {
   return {
@@ -23,10 +26,9 @@ function makeLatest(overrides: Partial<LatestShape> = {}): LatestShape {
     disabled: false,
     isInitializing: false,
     isInHistoryMode: false,
-    activeMode: "file",
     isAutocompleteOpen: true,
-    autocompleteItems: [{ key: "src/a.ts", label: "a.ts", insertText: "src/a.ts" }],
-    isResultsStale: false,
+    autocompleteItems: [fileItem],
+    staleItemKeys: new Set<string>(),
     selectedIndex: 0,
     value: "@a",
     onSendKey: undefined,
@@ -37,32 +39,18 @@ function makeLatest(overrides: Partial<LatestShape> = {}): LatestShape {
 }
 
 describe("useEditorKeymap", () => {
-  let applyAutocompleteSelection: ReturnType<
-    typeof vi.fn<(action: "insert" | "execute") => boolean>
-  >;
+  let applyAutocompleteSelection: ReturnType<typeof vi.fn<(mode: "enter" | "complete") => boolean>>;
   let sendFromEditor: ReturnType<typeof vi.fn<() => void>>;
   let cancelVoiceWaitSubmit: ReturnType<typeof vi.fn<() => boolean>>;
-  let setAtContext: ReturnType<typeof vi.fn<Dispatch<SetStateAction<AtFileContext | null>>>>;
-  let setSlashContext: ReturnType<
-    typeof vi.fn<Dispatch<SetStateAction<SlashCommandContext | null>>>
-  >;
-  let setDiffContext: ReturnType<typeof vi.fn<Dispatch<SetStateAction<AtDiffContext | null>>>>;
-  let setTerminalContext: ReturnType<
-    typeof vi.fn<Dispatch<SetStateAction<AtTerminalContext | null>>>
-  >;
-  let setSelectionContext: ReturnType<
-    typeof vi.fn<Dispatch<SetStateAction<AtSelectionContext | null>>>
+  let setActiveCompletionContext: ReturnType<
+    typeof vi.fn<Dispatch<SetStateAction<ActiveCompletionContext | null>>>
   >;
 
   beforeEach(() => {
-    applyAutocompleteSelection = vi.fn<(action: "insert" | "execute") => boolean>(() => true);
+    applyAutocompleteSelection = vi.fn<(mode: "enter" | "complete") => boolean>(() => true);
     sendFromEditor = vi.fn<() => void>();
     cancelVoiceWaitSubmit = vi.fn<() => boolean>(() => false);
-    setAtContext = vi.fn<Dispatch<SetStateAction<AtFileContext | null>>>();
-    setSlashContext = vi.fn<Dispatch<SetStateAction<SlashCommandContext | null>>>();
-    setDiffContext = vi.fn<Dispatch<SetStateAction<AtDiffContext | null>>>();
-    setTerminalContext = vi.fn<Dispatch<SetStateAction<AtTerminalContext | null>>>();
-    setSelectionContext = vi.fn<Dispatch<SetStateAction<AtSelectionContext | null>>>();
+    setActiveCompletionContext = vi.fn<Dispatch<SetStateAction<ActiveCompletionContext | null>>>();
   });
 
   function renderKeymap(latest: LatestShape) {
@@ -83,11 +71,7 @@ describe("useEditorKeymap", () => {
       popStashedEditorState: vi.fn<
         (terminalId: string, projectId?: string) => EditorState | undefined
       >(() => undefined),
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       setIsExpanded: vi.fn<Dispatch<SetStateAction<boolean>>>(),
       setSelectedIndex: vi.fn<Dispatch<SetStateAction<number>>>(),
     };
@@ -96,27 +80,28 @@ describe("useEditorKeymap", () => {
   }
 
   describe("Enter", () => {
-    it("accepts the selected item when results are fresh", () => {
+    it("applies the selected item on Enter (item owns insert vs execute)", () => {
       const { handlers } = renderKeymap(makeLatest());
       expect(handlers.onEnter()).toBe(true);
-      expect(applyAutocompleteSelection).toHaveBeenCalledWith("insert");
+      expect(applyAutocompleteSelection).toHaveBeenCalledWith("enter");
       expect(sendFromEditor).not.toHaveBeenCalled();
     });
 
-    it("executes instead of inserting in command mode", () => {
+    it("applies on Enter for a command item too (no mode inference in keymap)", () => {
       const { handlers } = renderKeymap(
         makeLatest({
-          activeMode: "command",
-          autocompleteItems: [{ key: "/help", label: "/help", insertText: "/help" }],
+          autocompleteItems: [
+            { key: "/help", label: "/help", insertText: "/help", enterAction: "execute" },
+          ],
           value: "/he",
         })
       );
       expect(handlers.onEnter()).toBe(true);
-      expect(applyAutocompleteSelection).toHaveBeenCalledWith("execute");
+      expect(applyAutocompleteSelection).toHaveBeenCalledWith("enter");
     });
 
-    it("falls through to the normal send when results are stale", () => {
-      const { handlers } = renderKeymap(makeLatest({ isResultsStale: true }));
+    it("falls through to the normal send when the selected item is stale", () => {
+      const { handlers } = renderKeymap(makeLatest({ staleItemKeys: new Set(["src/a.ts"]) }));
       expect(handlers.onEnter()).toBe(true);
       expect(applyAutocompleteSelection).not.toHaveBeenCalled();
       expect(sendFromEditor).toHaveBeenCalledTimes(1);
@@ -125,7 +110,7 @@ describe("useEditorKeymap", () => {
     it("routes stale-Enter on empty text to onSendKey", () => {
       const onSendKey = vi.fn<(key: string) => void>();
       const { handlers } = renderKeymap(
-        makeLatest({ isResultsStale: true, value: "   ", onSendKey })
+        makeLatest({ staleItemKeys: new Set(["src/a.ts"]), value: "   ", onSendKey })
       );
       expect(handlers.onEnter()).toBe(true);
       expect(sendFromEditor).not.toHaveBeenCalled();
@@ -134,36 +119,31 @@ describe("useEditorKeymap", () => {
   });
 
   describe("Tab", () => {
-    it("inserts the selected item when results are fresh", () => {
+    it("completes the selected item when fresh", () => {
       const { handlers } = renderKeymap(makeLatest());
       expect(handlers.onTab()).toBe(true);
-      expect(applyAutocompleteSelection).toHaveBeenCalledWith("insert");
+      expect(applyAutocompleteSelection).toHaveBeenCalledWith("complete");
     });
 
-    it("swallows Tab without inserting when results are stale", () => {
-      const { handlers } = renderKeymap(makeLatest({ isResultsStale: true }));
+    it("swallows Tab without completing when the selected item is stale", () => {
+      const { handlers } = renderKeymap(makeLatest({ staleItemKeys: new Set(["src/a.ts"]) }));
       expect(handlers.onTab()).toBe(true);
       expect(applyAutocompleteSelection).not.toHaveBeenCalled();
     });
   });
 
   describe("Escape", () => {
-    it("clears every autocomplete context, including terminal and selection", () => {
-      const { handlers } = renderKeymap(makeLatest({ activeMode: "terminal" }));
+    it("clears the active completion context", () => {
+      const { handlers } = renderKeymap(makeLatest());
       expect(handlers.onEscape()).toBe(true);
-      expect(setAtContext).toHaveBeenCalledWith(null);
-      expect(setSlashContext).toHaveBeenCalledWith(null);
-      expect(setDiffContext).toHaveBeenCalledWith(null);
-      expect(setTerminalContext).toHaveBeenCalledWith(null);
-      expect(setSelectionContext).toHaveBeenCalledWith(null);
+      expect(setActiveCompletionContext).toHaveBeenCalledWith(null);
     });
 
     it("cancels a pending voice wait-submit before touching autocomplete", () => {
       cancelVoiceWaitSubmit.mockReturnValue(true);
       const { handlers } = renderKeymap(makeLatest());
       expect(handlers.onEscape()).toBe(true);
-      expect(setAtContext).not.toHaveBeenCalled();
-      expect(setTerminalContext).not.toHaveBeenCalled();
+      expect(setActiveCompletionContext).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useTokenResolution.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTokenResolution } from "../useTokenResolution";
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    get: () => undefined,
+    getCachedSelection: () => null,
+    clearDirectingState: () => {},
+    notifyUserInput: () => {},
+  },
+}));
+
+vi.mock("@/store/commandHistoryStore", () => ({
+  useCommandHistoryStore: { getState: () => ({ recordPrompt: vi.fn() }) },
+}));
+
+// learnFromCorrections=false short-circuits the dictionary-learning side effect.
+vi.mock("@/store/voiceRecordingStore", () => ({
+  useVoiceRecordingStore: {
+    getState: () => ({ learnFromCorrections: false, panelBuffers: {} }),
+  },
+}));
+
+type Params = Parameters<typeof useTokenResolution>[0];
+type Latest = NonNullable<Params["latestRef"]["current"]>;
+
+function setup(overrides: Partial<Latest> = {}) {
+  const onSend = vi.fn<Latest["onSend"]>();
+  const addToHistory = vi.fn<Latest["addToHistory"]>();
+  const latest: Latest = {
+    terminalId: "t1",
+    projectId: undefined,
+    disabled: false,
+    value: "",
+    onSend,
+    addToHistory,
+    resetHistoryIndex: vi.fn(),
+    clearDraftInput: vi.fn(),
+    ...overrides,
+  };
+  const params: Params = {
+    latestRef: { current: latest },
+    applyEditorValue: vi.fn(),
+    setIsExpanded: vi.fn(),
+    setActiveCompletionContext: vi.fn(),
+    terminalId: "t1",
+    cwd: "/repo",
+    agentId: undefined,
+  };
+  const { result } = renderHook(() => useTokenResolution(params));
+  return { sendText: result.current.sendText, onSend, addToHistory };
+}
+
+describe("useTokenResolution.sendText", () => {
+  beforeEach(() => {
+    (window as unknown as { electron: unknown }).electron = {
+      git: { getWorkingDiff: vi.fn().mockResolvedValue("BODY") },
+    };
+  });
+
+  it("resolves @diff to fenced diff content while keeping literals and history token", async () => {
+    const getWorkingDiff = (
+      window as unknown as {
+        electron: { git: { getWorkingDiff: ReturnType<typeof vi.fn> } };
+      }
+    ).electron.git.getWorkingDiff;
+
+    const { sendText, onSend, addToHistory } = setup();
+    const text = 'review @diff and @"My File.txt" and $neo';
+
+    await act(async () => {
+      await sendText(text);
+    });
+
+    // The Git call fires at send time with the working-tree diff type.
+    expect(getWorkingDiff).toHaveBeenCalledWith("/repo", "unstaged");
+
+    const sent = onSend.mock.calls[0]![0].text;
+    // @diff is expanded to fenced diff content...
+    expect(sent).toContain("```diff\nBODY\n```");
+    expect(sent).not.toContain("@diff");
+    // ...while @file and $ capabilities pass through literally.
+    expect(sent).toContain('@"My File.txt"');
+    expect(sent).toContain("$neo");
+
+    // History keeps the original human token, never the expanded content.
+    expect(addToHistory).toHaveBeenCalledWith("t1", text, undefined);
+  });
+
+  it("does not call git when there is no @diff token (pure literal send)", async () => {
+    const getWorkingDiff = (
+      window as unknown as {
+        electron: { git: { getWorkingDiff: ReturnType<typeof vi.fn> } };
+      }
+    ).electron.git.getWorkingDiff;
+
+    const { sendText, onSend } = setup();
+    await act(async () => {
+      await sendText("just $neo and @file.ts");
+    });
+
+    expect(getWorkingDiff).not.toHaveBeenCalled();
+    expect(onSend.mock.calls[0]![0].text).toBe("just $neo and @file.ts");
+  });
+});

--- a/src/components/Terminal/hooks/useAutocompleteApply.ts
+++ b/src/components/Terminal/hooks/useAutocompleteApply.ts
@@ -44,14 +44,15 @@ function applyAutocompleteItem(
 
   const currentValue = view.state.doc.toString();
   const caret = view.state.selection.main.head;
-  // Reparse against the live document to survive edits between render and apply;
-  // fall back to the stored context if the token no longer matches.
-  const ctx =
-    getActiveCompletionContext(
-      currentValue,
-      caret,
-      new Set([latest.activeCompletionContext.triggerChar])
-    ) ?? latest.activeCompletionContext;
+  // Reparse against the live document so we never splice using stale offsets: if
+  // the token the caret sits in no longer matches the open menu's trigger (the
+  // doc changed out from under us), abort rather than corrupt unrelated text.
+  const ctx = getActiveCompletionContext(
+    currentValue,
+    caret,
+    new Set([latest.activeCompletionContext.triggerChar])
+  );
+  if (!ctx) return;
 
   const action = mode === "enter" ? (item.enterAction ?? "insert") : "insert";
 

--- a/src/components/Terminal/hooks/useAutocompleteApply.ts
+++ b/src/components/Terminal/hooks/useAutocompleteApply.ts
@@ -2,24 +2,12 @@ import { useCallback } from "react";
 import { EditorSelection } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
 import type { AutocompleteItem } from "../AutocompleteMenu";
-import {
-  getSlashCommandContext,
-  getAtFileContext,
-  getDiffContext,
-  getTerminalContext,
-  getSelectionContext,
-  formatAtFileToken,
-} from "../hybridInputParsing";
+import { getActiveCompletionContext, type ActiveCompletionContext } from "../hybridInputParsing";
 
 interface LatestRefShape {
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
   autocompleteItems: AutocompleteItem[];
   selectedIndex: number;
-  slashContext: import("../hybridInputParsing").SlashCommandContext | null;
-  atContext: import("../hybridInputParsing").AtFileContext | null;
-  diffContext: import("../hybridInputParsing").AtDiffContext | null;
-  terminalContext: import("../hybridInputParsing").AtTerminalContext | null;
-  selectionContext: import("../hybridInputParsing").AtSelectionContext | null;
+  activeCompletionContext: ActiveCompletionContext | null;
 }
 
 interface UseAutocompleteApplyParams {
@@ -31,160 +19,67 @@ interface UseAutocompleteApplyParams {
     options?: { selection?: EditorSelection; focus?: boolean }
   ) => void;
   sendText: (text: string) => void;
-  setAtContext: (value: import("../hybridInputParsing").AtFileContext | null) => void;
-  setSlashContext: (value: import("../hybridInputParsing").SlashCommandContext | null) => void;
-  setDiffContext: (value: import("../hybridInputParsing").AtDiffContext | null) => void;
-  setTerminalContext: (value: import("../hybridInputParsing").AtTerminalContext | null) => void;
-  setSelectionContext: (value: import("../hybridInputParsing").AtSelectionContext | null) => void;
+  setActiveCompletionContext: (value: ActiveCompletionContext | null) => void;
   setSelectedIndex: (value: number) => void;
 }
 
+/** "enter" honors the item's own enterAction; "complete" (Tab/click) always inserts. */
+type ApplyMode = "enter" | "complete";
+
 function applyAutocompleteItem(
   item: AutocompleteItem,
-  action: "insert" | "execute",
+  mode: ApplyMode,
   editorViewRef: React.RefObject<EditorView | null>,
   latestRef: React.RefObject<LatestRefShape | null>,
   lastQueryRef: React.RefObject<string>,
   applyEditorValue: UseAutocompleteApplyParams["applyEditorValue"],
   sendText: UseAutocompleteApplyParams["sendText"],
-  setAtContext: UseAutocompleteApplyParams["setAtContext"],
-  setSlashContext: UseAutocompleteApplyParams["setSlashContext"],
-  setDiffContext: UseAutocompleteApplyParams["setDiffContext"],
-  setTerminalContext: UseAutocompleteApplyParams["setTerminalContext"],
-  setSelectionContext: UseAutocompleteApplyParams["setSelectionContext"],
+  setActiveCompletionContext: UseAutocompleteApplyParams["setActiveCompletionContext"],
   setSelectedIndex: UseAutocompleteApplyParams["setSelectedIndex"]
 ) {
   const view = editorViewRef.current;
   if (!view) return;
   const latest = latestRef.current;
-  if (!latest) return;
+  if (!latest?.activeCompletionContext) return;
 
   const currentValue = view.state.doc.toString();
   const caret = view.state.selection.main.head;
-  const slashCtx = getSlashCommandContext(currentValue, caret) ?? latest.slashContext;
+  // Reparse against the live document to survive edits between render and apply;
+  // fall back to the stored context if the token no longer matches.
+  const ctx =
+    getActiveCompletionContext(
+      currentValue,
+      caret,
+      new Set([latest.activeCompletionContext.triggerChar])
+    ) ?? latest.activeCompletionContext;
 
-  if (latest.activeMode === "terminal") {
-    const ctx = getTerminalContext(currentValue, caret) ?? latest.terminalContext;
-    if (!ctx) return;
-    const token = `${item.insertText} `;
-    const before = currentValue.slice(0, ctx.atStart);
-    const after = currentValue.slice(ctx.tokenEnd);
-    const nextValue = `${before}${token}${after}`;
-    const nextCaret = before.length + token.length;
-    applyEditorValue(nextValue, {
-      selection: EditorSelection.create([EditorSelection.cursor(nextCaret)]),
-      focus: true,
-    });
-    setTerminalContext(null);
+  const action = mode === "enter" ? (item.enterAction ?? "insert") : "insert";
+
+  const before = currentValue.slice(0, ctx.start);
+  const after = currentValue.slice(ctx.tokenEnd);
+  const hasLeadingSpace = after.startsWith(" ");
+  const shouldAppendSpace = action === "insert" && !hasLeadingSpace;
+  const token = shouldAppendSpace ? `${item.insertText} ` : item.insertText;
+  const nextValue = `${before}${token}${after}`;
+
+  const clear = () => {
+    setActiveCompletionContext(null);
     setSelectedIndex(0);
     lastQueryRef.current = "";
+  };
+
+  if (action === "execute") {
+    sendText(nextValue);
+    clear();
     return;
   }
 
-  if (latest.activeMode === "selection") {
-    const ctx = getSelectionContext(currentValue, caret) ?? latest.selectionContext;
-    if (!ctx) return;
-    const token = `${item.insertText} `;
-    const before = currentValue.slice(0, ctx.atStart);
-    const after = currentValue.slice(ctx.tokenEnd);
-    const nextValue = `${before}${token}${after}`;
-    const nextCaret = before.length + token.length;
-    applyEditorValue(nextValue, {
-      selection: EditorSelection.create([EditorSelection.cursor(nextCaret)]),
-      focus: true,
-    });
-    setSelectionContext(null);
-    setSelectedIndex(0);
-    lastQueryRef.current = "";
-    return;
-  }
-
-  if (latest.activeMode === "diff") {
-    const ctx = getDiffContext(currentValue, caret) ?? latest.diffContext;
-    if (!ctx) return;
-    const token = `${item.insertText} `;
-    const before = currentValue.slice(0, ctx.atStart);
-    const after = currentValue.slice(ctx.tokenEnd);
-    const nextValue = `${before}${token}${after}`;
-    const nextCaret = before.length + token.length;
-    if (action === "execute") {
-      sendText(nextValue);
-      setDiffContext(null);
-      setAtContext(null);
-      setSlashContext(null);
-      setSelectedIndex(0);
-      lastQueryRef.current = "";
-      return;
-    }
-    applyEditorValue(nextValue, {
-      selection: EditorSelection.create([EditorSelection.cursor(nextCaret)]),
-      focus: true,
-    });
-    setDiffContext(null);
-    setAtContext(null);
-    setSlashContext(null);
-    setSelectedIndex(0);
-    lastQueryRef.current = "";
-    return;
-  }
-
-  if (latest.activeMode === "file") {
-    const ctx = getAtFileContext(currentValue, caret);
-    if (!ctx) return;
-    const token = `${formatAtFileToken(item.insertText)} `;
-    const before = currentValue.slice(0, ctx.atStart);
-    const after = currentValue.slice(ctx.tokenEnd);
-    const nextValue = `${before}${token}${after}`;
-    const nextCaret = before.length + token.length;
-    if (action === "execute") {
-      sendText(nextValue);
-      setAtContext(null);
-      setSlashContext(null);
-      setDiffContext(null);
-      setSelectedIndex(0);
-      lastQueryRef.current = "";
-      return;
-    }
-    applyEditorValue(nextValue, {
-      selection: EditorSelection.create([EditorSelection.cursor(nextCaret)]),
-      focus: true,
-    });
-    setAtContext(null);
-    setSlashContext(null);
-    setDiffContext(null);
-    setSelectedIndex(0);
-    lastQueryRef.current = "";
-    return;
-  }
-
-  if (latest.activeMode === "command" && slashCtx) {
-    const before = currentValue.slice(0, slashCtx.start);
-    const after = currentValue.slice(slashCtx.tokenEnd);
-    const hasLeadingSpace = after.startsWith(" ");
-    const shouldAppendSpace = action === "insert" && !hasLeadingSpace;
-    const token = shouldAppendSpace ? `${item.insertText} ` : item.insertText;
-    const nextValue = `${before}${token}${after}`;
-    const nextCaret =
-      before.length + token.length + (action === "insert" && hasLeadingSpace ? 1 : 0);
-    if (action === "execute") {
-      sendText(nextValue);
-      setAtContext(null);
-      setSlashContext(null);
-      setDiffContext(null);
-      setSelectedIndex(0);
-      lastQueryRef.current = "";
-      return;
-    }
-    applyEditorValue(nextValue, {
-      selection: EditorSelection.create([EditorSelection.cursor(nextCaret)]),
-      focus: true,
-    });
-    setAtContext(null);
-    setSlashContext(null);
-    setDiffContext(null);
-    setSelectedIndex(0);
-    lastQueryRef.current = "";
-  }
+  const nextCaret = before.length + token.length + (hasLeadingSpace ? 1 : 0);
+  applyEditorValue(nextValue, {
+    selection: EditorSelection.create([EditorSelection.cursor(nextCaret)]),
+    focus: true,
+  });
+  clear();
 }
 
 export function useAutocompleteApply({
@@ -193,32 +88,24 @@ export function useAutocompleteApply({
   lastQueryRef,
   applyEditorValue,
   sendText,
-  setAtContext,
-  setSlashContext,
-  setDiffContext,
-  setTerminalContext,
-  setSelectionContext,
+  setActiveCompletionContext,
   setSelectedIndex,
 }: UseAutocompleteApplyParams) {
   const applyAutocompleteSelection = useCallback(
-    (action: "insert" | "execute") => {
+    (mode: ApplyMode) => {
       const latest = latestRef.current;
       if (!latest) return false;
       const item = latest.autocompleteItems[latest.selectedIndex];
       if (!item) return false;
       applyAutocompleteItem(
         item,
-        action,
+        mode,
         editorViewRef,
         latestRef,
         lastQueryRef,
         applyEditorValue,
         sendText,
-        setAtContext,
-        setSlashContext,
-        setDiffContext,
-        setTerminalContext,
-        setSelectionContext,
+        setActiveCompletionContext,
         setSelectedIndex
       );
       return true;
@@ -229,11 +116,7 @@ export function useAutocompleteApply({
       lastQueryRef,
       applyEditorValue,
       sendText,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       setSelectedIndex,
     ]
   );
@@ -242,17 +125,13 @@ export function useAutocompleteApply({
     (item: AutocompleteItem) =>
       applyAutocompleteItem(
         item,
-        "insert",
+        "complete",
         editorViewRef,
         latestRef,
         lastQueryRef,
         applyEditorValue,
         sendText,
-        setAtContext,
-        setSlashContext,
-        setDiffContext,
-        setTerminalContext,
-        setSelectionContext,
+        setActiveCompletionContext,
         setSelectedIndex
       ),
     [
@@ -261,11 +140,7 @@ export function useAutocompleteApply({
       lastQueryRef,
       applyEditorValue,
       sendText,
-      setAtContext,
-      setSlashContext,
-      setDiffContext,
-      setTerminalContext,
-      setSelectionContext,
+      setActiveCompletionContext,
       setSelectedIndex,
     ]
   );

--- a/src/components/Terminal/hooks/useAutocompleteItems.ts
+++ b/src/components/Terminal/hooks/useAutocompleteItems.ts
@@ -1,101 +1,124 @@
 import { useMemo } from "react";
 import type { AutocompleteItem } from "../AutocompleteMenu";
-import type { AtDiffContext, AtTerminalContext, AtSelectionContext } from "../hybridInputParsing";
+import {
+  getDaintreeAtClaim,
+  formatAtFileToken,
+  type ActiveCompletionContext,
+} from "../hybridInputParsing";
 
 interface UseAutocompleteItemsParams {
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
-  diffContext: AtDiffContext | null;
-  terminalContext: AtTerminalContext | null;
-  selectionContext: AtSelectionContext | null;
-  value: string;
+  activeCompletionContext: ActiveCompletionContext | null;
   autocompleteFiles: string[];
   isAutocompleteLoading: boolean;
   autocompleteCommands: AutocompleteItem[];
   isCommandsLoading: boolean;
 }
 
+const DIFF_ITEMS: AutocompleteItem[] = [
+  {
+    key: "diff",
+    label: "Working tree diff (@diff)",
+    insertText: "@diff",
+    enterAction: "insert",
+    insert: { insert: "resolve", resolverId: "diff" },
+  },
+  {
+    key: "diff:staged",
+    label: "Staged diff (@diff:staged)",
+    insertText: "@diff:staged",
+    enterAction: "insert",
+    insert: { insert: "resolve", resolverId: "diff" },
+  },
+  {
+    key: "diff:head",
+    label: "HEAD diff (@diff:head)",
+    insertText: "@diff:head",
+    enterAction: "insert",
+    insert: { insert: "resolve", resolverId: "diff" },
+  },
+];
+
+const TERMINAL_ITEM: AutocompleteItem = {
+  key: "terminal",
+  label: "Terminal output (@terminal)",
+  insertText: "@terminal",
+  enterAction: "insert",
+  insert: { insert: "resolve", resolverId: "terminal" },
+};
+
+const SELECTION_ITEM: AutocompleteItem = {
+  key: "selection",
+  label: "Terminal selection (@selection)",
+  insertText: "@selection",
+  enterAction: "insert",
+  insert: { insert: "resolve", resolverId: "selection" },
+};
+
+/**
+ * Merge the active trigger's completion items. `/` and `$` come pre-mapped from
+ * discovery; `@` is served by Daintree's diff/terminal/selection providers
+ * (which claim their prefixes ahead of file search) with `@file` fuzzy search
+ * as the fallback provider.
+ */
 export function useAutocompleteItems({
-  activeMode,
-  diffContext,
-  terminalContext,
-  selectionContext,
-  value,
+  activeCompletionContext,
   autocompleteFiles,
   isAutocompleteLoading,
   autocompleteCommands,
   isCommandsLoading,
 }: UseAutocompleteItemsParams) {
-  const autocompleteDiffItems = useMemo((): AutocompleteItem[] => {
-    if (!diffContext) return [];
-    const items: AutocompleteItem[] = [
-      { key: "diff", label: "Working tree diff (@diff)", insertText: "@diff" },
-      { key: "diff:staged", label: "Staged diff (@diff:staged)", insertText: "@diff:staged" },
-      { key: "diff:head", label: "HEAD diff (@diff:head)", insertText: "@diff:head" },
-    ];
-    const partial =
-      diffContext.tokenEnd > diffContext.atStart + 1
-        ? value.slice(diffContext.atStart + 1, diffContext.tokenEnd)
-        : "";
-    if (!partial) return items;
-    return items.filter((item) => item.insertText.slice(1).startsWith(partial));
-  }, [diffContext, value]);
+  const query = activeCompletionContext?.query ?? "";
 
-  const autocompleteTerminalItems = useMemo((): AutocompleteItem[] => {
-    if (!terminalContext) return [];
-    return [{ key: "terminal", label: "Terminal output (@terminal)", insertText: "@terminal" }];
-  }, [terminalContext]);
-
-  const autocompleteSelectionItems = useMemo((): AutocompleteItem[] => {
-    if (!selectionContext) return [];
-    return [
-      { key: "selection", label: "Terminal selection (@selection)", insertText: "@selection" },
-    ];
-  }, [selectionContext]);
-
-  const autocompleteItems = useMemo((): AutocompleteItem[] => {
-    if (activeMode === "terminal") {
-      return autocompleteTerminalItems;
-    }
-    if (activeMode === "selection") {
-      return autocompleteSelectionItems;
-    }
-    if (activeMode === "diff") {
-      return autocompleteDiffItems;
-    }
-    if (activeMode === "file") {
+  const fileItems = useMemo(
+    (): AutocompleteItem[] =>
       // Basename first, directory as the dimmed description — scannable in a
       // dense list and disambiguates duplicate filenames across directories.
-      return autocompleteFiles.map((file) => {
+      autocompleteFiles.map((file) => {
         const sep = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
         const base = sep >= 0 ? file.slice(sep + 1) : file;
         const dir = sep >= 0 ? file.slice(0, sep) : "";
         return {
           key: file,
           label: base || file,
-          insertText: file,
+          insertText: formatAtFileToken(file),
           description: dir || undefined,
+          enterAction: "insert",
+          insert: "literal",
         };
-      });
-    }
-    if (activeMode === "command") {
-      return autocompleteCommands;
-    }
-    return [];
-  }, [
-    activeMode,
-    autocompleteTerminalItems,
-    autocompleteSelectionItems,
-    autocompleteDiffItems,
-    autocompleteCommands,
-    autocompleteFiles,
-  ]);
+      }),
+    [autocompleteFiles]
+  );
 
-  const isLoading =
-    activeMode === "file"
-      ? isAutocompleteLoading
-      : activeMode === "command"
-        ? isCommandsLoading
-        : false;
+  const diffItems = useMemo((): AutocompleteItem[] => {
+    if (!query) return DIFF_ITEMS;
+    return DIFF_ITEMS.filter((item) => item.insertText.slice(1).startsWith(query));
+  }, [query]);
+
+  const { autocompleteItems, isLoading } = useMemo((): {
+    autocompleteItems: AutocompleteItem[];
+    isLoading: boolean;
+  } => {
+    const ctx = activeCompletionContext;
+    if (!ctx) return { autocompleteItems: [], isLoading: false };
+
+    if (ctx.triggerChar === "/" || ctx.triggerChar === "$") {
+      return { autocompleteItems: autocompleteCommands, isLoading: isCommandsLoading };
+    }
+
+    // ctx.triggerChar === "@": Daintree providers claim their prefix; else file.
+    const claim = getDaintreeAtClaim(ctx.query);
+    if (claim === "terminal") return { autocompleteItems: [TERMINAL_ITEM], isLoading: false };
+    if (claim === "selection") return { autocompleteItems: [SELECTION_ITEM], isLoading: false };
+    if (claim === "diff") return { autocompleteItems: diffItems, isLoading: false };
+    return { autocompleteItems: fileItems, isLoading: isAutocompleteLoading };
+  }, [
+    activeCompletionContext,
+    autocompleteCommands,
+    isCommandsLoading,
+    diffItems,
+    fileItems,
+    isAutocompleteLoading,
+  ]);
 
   return { autocompleteItems, isLoading };
 }

--- a/src/components/Terminal/hooks/useAutocompletePositioning.ts
+++ b/src/components/Terminal/hooks/useAutocompletePositioning.ts
@@ -1,12 +1,6 @@
 import { useCallback, useLayoutEffect, useState, type Dispatch, type SetStateAction } from "react";
 import type { EditorView } from "@codemirror/view";
-import type {
-  AtFileContext,
-  SlashCommandContext,
-  AtDiffContext,
-  AtTerminalContext,
-  AtSelectionContext,
-} from "../hybridInputParsing";
+import type { ActiveCompletionContext } from "../hybridInputParsing";
 import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf";
 
 interface UseAutocompletePositioningParams {
@@ -14,12 +8,7 @@ interface UseAutocompletePositioningParams {
   inputShellRef: React.RefObject<HTMLDivElement | null>;
   menuRef: React.RefObject<HTMLDivElement | null>;
   isAutocompleteOpen: boolean;
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
-  atContext: AtFileContext | null;
-  slashContext: SlashCommandContext | null;
-  diffContext: AtDiffContext | null;
-  terminalContext: AtTerminalContext | null;
-  selectionContext: AtSelectionContext | null;
+  activeCompletionContext: ActiveCompletionContext | null;
   setMenuLeftPx: Dispatch<SetStateAction<number>>;
 }
 
@@ -28,12 +17,7 @@ export function useAutocompletePositioning({
   inputShellRef,
   menuRef,
   isAutocompleteOpen,
-  activeMode,
-  atContext,
-  slashContext,
-  diffContext,
-  terminalContext,
-  selectionContext,
+  activeCompletionContext,
   setMenuLeftPx,
 }: UseAutocompletePositioningParams) {
   const [inputShellEl, setInputShellEl] = useState<HTMLDivElement | null>(null);
@@ -66,19 +50,8 @@ export function useAutocompletePositioning({
     const shell = inputShellRef.current;
     if (!view || !shell || !isAutocompleteOpen) return;
 
-    const anchorIndex =
-      activeMode === "terminal"
-        ? terminalContext?.atStart
-        : activeMode === "selection"
-          ? selectionContext?.atStart
-          : activeMode === "diff"
-            ? diffContext?.atStart
-            : activeMode === "file"
-              ? atContext?.atStart
-              : activeMode === "command"
-                ? (slashContext?.start ?? 0)
-                : null;
-    if (anchorIndex === null || anchorIndex === undefined) return;
+    const anchorIndex = activeCompletionContext?.start;
+    if (anchorIndex === undefined) return;
 
     const shellRect = shell.getBoundingClientRect();
     const coords = view.coordsAtPos(anchorIndex);
@@ -96,13 +69,8 @@ export function useAutocompletePositioning({
     inputShellRef,
     menuRef,
     setMenuLeftPx,
-    activeMode,
-    atContext?.atStart,
-    diffContext?.atStart,
-    terminalContext?.atStart,
-    selectionContext?.atStart,
     isAutocompleteOpen,
-    slashContext?.start,
+    activeCompletionContext?.start,
   ]);
 
   useResizeObserverRaf(inputShellEl, () => compute());

--- a/src/components/Terminal/hooks/useAutocompleteState.ts
+++ b/src/components/Terminal/hooks/useAutocompleteState.ts
@@ -1,78 +1,83 @@
-import { useEffect, type Dispatch, type SetStateAction } from "react";
-import type {
-  AtFileContext,
-  SlashCommandContext,
-  AtDiffContext,
-  AtTerminalContext,
-  AtSelectionContext,
-} from "../hybridInputParsing";
+import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
+import type { AutocompleteItem } from "@/components/Terminal/AutocompleteMenu";
+import type { ActiveCompletionContext } from "../hybridInputParsing";
 
 interface UseAutocompleteStateParams {
   isAutocompleteOpen: boolean;
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
-  atContext: AtFileContext | null;
-  slashContext: SlashCommandContext | null;
-  diffContext: AtDiffContext | null;
-  terminalContext: AtTerminalContext | null;
-  selectionContext: AtSelectionContext | null;
-  autocompleteItemsLength: number;
+  activeCompletionContext: ActiveCompletionContext | null;
+  autocompleteItems: AutocompleteItem[];
   rootRef: React.RefObject<HTMLDivElement | null>;
   selectedIndex: number;
   setSelectedIndex: Dispatch<SetStateAction<number>>;
   lastQueryRef: React.RefObject<string>;
-  setAtContext: Dispatch<SetStateAction<AtFileContext | null>>;
-  setSlashContext: Dispatch<SetStateAction<SlashCommandContext | null>>;
-  setDiffContext: Dispatch<SetStateAction<AtDiffContext | null>>;
-  setTerminalContext: Dispatch<SetStateAction<AtTerminalContext | null>>;
-  setSelectionContext: Dispatch<SetStateAction<AtSelectionContext | null>>;
+  setActiveCompletionContext: Dispatch<SetStateAction<ActiveCompletionContext | null>>;
 }
 
 export function useAutocompleteState({
   isAutocompleteOpen,
-  activeMode,
-  atContext,
-  slashContext,
-  diffContext,
-  terminalContext,
-  selectionContext,
-  autocompleteItemsLength,
+  activeCompletionContext,
+  autocompleteItems,
   rootRef,
   selectedIndex,
   setSelectedIndex,
   lastQueryRef,
-  setAtContext,
-  setSlashContext,
-  setDiffContext,
-  setTerminalContext,
-  setSelectionContext,
+  setActiveCompletionContext,
 }: UseAutocompleteStateParams) {
+  // A new query (user typed) resets selection to the top; items arriving async
+  // for the SAME query preserve the selected item by key so a slow provider
+  // merge doesn't jump the highlight. Tracking the items reference lets user
+  // arrow-navigation (selectedIndex changes, items don't) pass through untouched.
+  const prevRef = useRef<{
+    queryKey: string;
+    items: AutocompleteItem[];
+    selectedKey: string | null;
+  }>({ queryKey: "", items: [], selectedKey: null });
+
+  const queryKey = activeCompletionContext
+    ? `${activeCompletionContext.triggerChar}:${activeCompletionContext.start}:${activeCompletionContext.query}`
+    : "";
+
   useEffect(() => {
-    const activeQuery =
-      activeMode === "terminal"
-        ? `terminal:${terminalContext?.atStart ?? ""}`
-        : activeMode === "selection"
-          ? `selection:${selectionContext?.atStart ?? ""}`
-          : activeMode === "diff"
-            ? `diff:${diffContext?.atStart ?? ""}:${diffContext?.tokenEnd ?? ""}:${diffContext?.diffType ?? ""}`
-            : activeMode === "file"
-              ? `file:${atContext?.queryForSearch ?? ""}`
-              : activeMode === "command"
-                ? `command:${slashContext?.query ?? ""}`
-                : "";
-    if (activeQuery !== lastQueryRef.current) {
-      lastQueryRef.current = activeQuery;
-      setSelectedIndex(0);
+    const prev = prevRef.current;
+
+    if (queryKey !== prev.queryKey) {
+      lastQueryRef.current = queryKey;
+      if (selectedIndex !== 0) setSelectedIndex(0);
+      prevRef.current = {
+        queryKey,
+        items: autocompleteItems,
+        selectedKey: autocompleteItems[0]?.key ?? null,
+      };
+      return;
     }
-  }, [
-    activeMode,
-    atContext?.queryForSearch,
-    diffContext?.atStart,
-    diffContext?.tokenEnd,
-    diffContext?.diffType,
-    terminalContext?.atStart,
-    selectionContext?.atStart,
-    slashContext?.query,
-  ]);
+
+    if (autocompleteItems !== prev.items) {
+      // Items merged/refreshed for the same query: keep the selected key if it
+      // survived, else clamp into range.
+      let nextIndex = selectedIndex;
+      if (prev.selectedKey) {
+        const idx = autocompleteItems.findIndex((item) => item.key === prev.selectedKey);
+        nextIndex =
+          idx >= 0 ? idx : Math.min(selectedIndex, Math.max(0, autocompleteItems.length - 1));
+      } else {
+        nextIndex = Math.min(selectedIndex, Math.max(0, autocompleteItems.length - 1));
+      }
+      if (nextIndex !== selectedIndex) setSelectedIndex(nextIndex);
+      prevRef.current = {
+        queryKey,
+        items: autocompleteItems,
+        selectedKey: autocompleteItems[nextIndex]?.key ?? null,
+      };
+      return;
+    }
+
+    // Only selectedIndex changed (user arrow-nav): record the new selection.
+    prevRef.current = {
+      queryKey,
+      items: autocompleteItems,
+      selectedKey: autocompleteItems[selectedIndex]?.key ?? prev.selectedKey,
+    };
+  }, [queryKey, autocompleteItems, selectedIndex, setSelectedIndex, lastQueryRef]);
 
   useEffect(() => {
     if (!isAutocompleteOpen) return;
@@ -82,24 +87,9 @@ export function useAutocompleteState({
       const target = event.target as Node | null;
       if (!target) return;
       if (root.contains(target)) return;
-      setAtContext(null);
-      setSlashContext(null);
-      setDiffContext(null);
-      setTerminalContext(null);
-      setSelectionContext(null);
+      setActiveCompletionContext(null);
     };
     document.addEventListener("pointerdown", onPointerDown, true);
     return () => document.removeEventListener("pointerdown", onPointerDown, true);
-  }, [isAutocompleteOpen]);
-
-  useEffect(() => {
-    if (!isAutocompleteOpen) return;
-    if (autocompleteItemsLength === 0) {
-      setSelectedIndex(0);
-      return;
-    }
-    if (selectedIndex >= autocompleteItemsLength) {
-      setSelectedIndex((prev) => Math.max(0, Math.min(prev, autocompleteItemsLength - 1)));
-    }
-  }, [autocompleteItemsLength, isAutocompleteOpen]);
+  }, [isAutocompleteOpen, rootRef, setActiveCompletionContext]);
 }

--- a/src/components/Terminal/hooks/useAutocompleteState.ts
+++ b/src/components/Terminal/hooks/useAutocompleteState.ts
@@ -54,14 +54,11 @@ export function useAutocompleteState({
     if (autocompleteItems !== prev.items) {
       // Items merged/refreshed for the same query: keep the selected key if it
       // survived, else clamp into range.
-      let nextIndex = selectedIndex;
-      if (prev.selectedKey) {
-        const idx = autocompleteItems.findIndex((item) => item.key === prev.selectedKey);
-        nextIndex =
-          idx >= 0 ? idx : Math.min(selectedIndex, Math.max(0, autocompleteItems.length - 1));
-      } else {
-        nextIndex = Math.min(selectedIndex, Math.max(0, autocompleteItems.length - 1));
-      }
+      const clamped = Math.min(selectedIndex, Math.max(0, autocompleteItems.length - 1));
+      const survivingIndex = prev.selectedKey
+        ? autocompleteItems.findIndex((item) => item.key === prev.selectedKey)
+        : -1;
+      const nextIndex = survivingIndex >= 0 ? survivingIndex : clamped;
       if (nextIndex !== selectedIndex) setSelectedIndex(nextIndex);
       prevRef.current = {
         queryKey,

--- a/src/components/Terminal/hooks/useContextDetection.ts
+++ b/src/components/Terminal/hooks/useContextDetection.ts
@@ -1,17 +1,7 @@
 import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
 import { type ViewUpdate } from "@codemirror/view";
-import {
-  getSlashCommandContext,
-  getAtFileContext,
-  getDiffContext,
-  getTerminalContext,
-  getSelectionContext,
-  type AtFileContext,
-  type SlashCommandContext,
-  type AtDiffContext,
-  type AtTerminalContext,
-  type AtSelectionContext,
-} from "../hybridInputParsing";
+import type { CompletionTrigger } from "@shared/types";
+import { getActiveCompletionContext, type ActiveCompletionContext } from "../hybridInputParsing";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 interface LatestRefShape {
@@ -23,49 +13,54 @@ interface LatestRefShape {
 
 interface UseContextDetectionParams {
   latestRef: React.RefObject<LatestRefShape | null>;
+  /** Trigger chars that open a menu — derived from the agent's completionSources. */
+  activeTriggers: ReadonlySet<CompletionTrigger>;
   // Owner stores the next document value (typically into a ref + setState pair).
   // Returning true signals the value actually changed (i.e. differed from the last emit).
   applyDocChange: (next: string) => boolean;
   // Reads-and-clears an "external value being applied" flag. Returning true means the
   // change came from our own dispatch and should not be treated as user input.
   consumeExternalValueFlag: () => boolean;
-  setAtContext: Dispatch<SetStateAction<AtFileContext | null>>;
-  setSlashContext: Dispatch<SetStateAction<SlashCommandContext | null>>;
-  setDiffContext: Dispatch<SetStateAction<AtDiffContext | null>>;
-  setTerminalContext: Dispatch<SetStateAction<AtTerminalContext | null>>;
-  setSelectionContext: Dispatch<SetStateAction<AtSelectionContext | null>>;
+  setActiveCompletionContext: Dispatch<SetStateAction<ActiveCompletionContext | null>>;
   setIsEditorFocused?: Dispatch<SetStateAction<boolean>>;
+}
+
+function contextsEqual(
+  a: ActiveCompletionContext | null,
+  b: ActiveCompletionContext | null
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.triggerChar === b.triggerChar &&
+    a.start === b.start &&
+    a.tokenEnd === b.tokenEnd &&
+    a.query === b.query
+  );
 }
 
 export function useContextDetection({
   latestRef,
+  activeTriggers,
   applyDocChange,
   consumeExternalValueFlag,
-  setAtContext,
-  setSlashContext,
-  setDiffContext,
-  setTerminalContext,
-  setSelectionContext,
+  setActiveCompletionContext,
   setIsEditorFocused,
 }: UseContextDetectionParams) {
   // Route the listener body through a ref updated in an effect. The extension is
   // built once with a stable callback that reads handleUpdateRef at invocation
   // time. This keeps the React Compiler happy — the extension itself contains no
   // refs it can trace, and actual ref/closure access happens outside render.
-  const trackersRef = useRef<{
-    slash: SlashCommandContext | null;
-    at: AtFileContext | null;
-    diff: AtDiffContext | null;
-    terminal: AtTerminalContext | null;
-    selection: AtSelectionContext | null;
-  }>({ slash: null, at: null, diff: null, terminal: null, selection: null });
+  const trackerRef = useRef<ActiveCompletionContext | null>(null);
+  const activeTriggersRef = useRef(activeTriggers);
+  useEffect(() => {
+    activeTriggersRef.current = activeTriggers;
+  }, [activeTriggers]);
 
   const handleUpdateRef = useRef<(update: ViewUpdate) => void>(() => {});
 
   useEffect(() => {
     handleUpdateRef.current = (update: ViewUpdate) => {
-      const trackers = trackersRef.current;
-
       if (update.focusChanged && setIsEditorFocused) {
         setIsEditorFocused(update.view.hasFocus);
       }
@@ -100,138 +95,10 @@ export function useContextDetection({
       if (update.docChanged || update.selectionSet) {
         const caret = update.state.selection.main.head;
         const text = update.state.doc.toString();
-
-        const slash = getSlashCommandContext(text, caret);
-        if (slash) {
-          const prev = trackers.slash;
-          if (
-            !prev ||
-            prev.start !== slash.start ||
-            prev.tokenEnd !== slash.tokenEnd ||
-            prev.query !== slash.query
-          ) {
-            trackers.slash = slash;
-            setSlashContext(slash);
-          }
-          if (trackers.at !== null) {
-            trackers.at = null;
-            setAtContext(null);
-          }
-          if (trackers.diff !== null) {
-            trackers.diff = null;
-            setDiffContext(null);
-          }
-          if (trackers.terminal !== null) {
-            trackers.terminal = null;
-            setTerminalContext(null);
-          }
-          if (trackers.selection !== null) {
-            trackers.selection = null;
-            setSelectionContext(null);
-          }
-          return;
-        }
-
-        const termCtx = getTerminalContext(text, caret);
-        if (termCtx) {
-          const prev = trackers.terminal;
-          if (!prev || prev.atStart !== termCtx.atStart || prev.tokenEnd !== termCtx.tokenEnd) {
-            trackers.terminal = termCtx;
-            setTerminalContext(termCtx);
-          }
-          if (trackers.at !== null) {
-            trackers.at = null;
-            setAtContext(null);
-          }
-          if (trackers.slash !== null) {
-            trackers.slash = null;
-            setSlashContext(null);
-          }
-          if (trackers.diff !== null) {
-            trackers.diff = null;
-            setDiffContext(null);
-          }
-          if (trackers.selection !== null) {
-            trackers.selection = null;
-            setSelectionContext(null);
-          }
-          return;
-        }
-        if (trackers.terminal !== null) {
-          trackers.terminal = null;
-          setTerminalContext(null);
-        }
-
-        const selCtx = getSelectionContext(text, caret);
-        if (selCtx) {
-          const prev = trackers.selection;
-          if (!prev || prev.atStart !== selCtx.atStart || prev.tokenEnd !== selCtx.tokenEnd) {
-            trackers.selection = selCtx;
-            setSelectionContext(selCtx);
-          }
-          if (trackers.at !== null) {
-            trackers.at = null;
-            setAtContext(null);
-          }
-          if (trackers.slash !== null) {
-            trackers.slash = null;
-            setSlashContext(null);
-          }
-          if (trackers.diff !== null) {
-            trackers.diff = null;
-            setDiffContext(null);
-          }
-          return;
-        }
-        if (trackers.selection !== null) {
-          trackers.selection = null;
-          setSelectionContext(null);
-        }
-
-        const diffCtx = getDiffContext(text, caret);
-        if (diffCtx) {
-          const prevDiff = trackers.diff;
-          if (
-            !prevDiff ||
-            prevDiff.atStart !== diffCtx.atStart ||
-            prevDiff.tokenEnd !== diffCtx.tokenEnd ||
-            prevDiff.diffType !== diffCtx.diffType
-          ) {
-            trackers.diff = diffCtx;
-            setDiffContext(diffCtx);
-          }
-          if (trackers.at !== null) {
-            trackers.at = null;
-            setAtContext(null);
-          }
-          if (trackers.slash !== null) {
-            trackers.slash = null;
-            setSlashContext(null);
-          }
-          return;
-        }
-
-        if (trackers.diff !== null) {
-          trackers.diff = null;
-          setDiffContext(null);
-        }
-
-        const atCtx = getAtFileContext(text, caret);
-        const prevAt = trackers.at;
-        if (
-          (atCtx &&
-            (!prevAt ||
-              prevAt.atStart !== atCtx.atStart ||
-              prevAt.tokenEnd !== atCtx.tokenEnd ||
-              prevAt.queryRaw !== atCtx.queryRaw)) ||
-          (!atCtx && prevAt)
-        ) {
-          trackers.at = atCtx;
-          setAtContext(atCtx);
-        }
-        if (trackers.slash !== null) {
-          trackers.slash = null;
-          setSlashContext(null);
+        const next = getActiveCompletionContext(text, caret, activeTriggersRef.current);
+        if (!contextsEqual(trackerRef.current, next)) {
+          trackerRef.current = next;
+          setActiveCompletionContext(next);
         }
       }
     };

--- a/src/components/Terminal/hooks/useEditorDomHandlers.ts
+++ b/src/components/Terminal/hooks/useEditorDomHandlers.ts
@@ -9,8 +9,7 @@ interface LatestRefShape {
   disabled: boolean;
   isAutocompleteOpen: boolean;
   autocompleteItems: { key: string }[];
-  isResultsStale: boolean;
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
+  staleItemKeys: ReadonlySet<string>;
   selectedIndex: number;
   value: string;
   terminalId: string;
@@ -25,14 +24,10 @@ interface UseEditorDomHandlersParams {
   handledEnterRef: React.MutableRefObject<boolean>;
   lastEnterKeydownNewlineRef: React.MutableRefObject<boolean>;
   submitAfterCompositionRef: React.MutableRefObject<boolean>;
-  applyAutocompleteSelection: (action: "insert" | "execute") => boolean;
+  applyAutocompleteSelection: (mode: "enter" | "complete") => boolean;
   sendFromEditor: () => void;
   rootRef: React.RefObject<HTMLDivElement | null>;
-  setAtContext: (value: null) => void;
-  setSlashContext: (value: null) => void;
-  setDiffContext: (value: null) => void;
-  setTerminalContext: (value: null) => void;
-  setSelectionContext: (value: null) => void;
+  setActiveCompletionContext: (value: null) => void;
 }
 
 export function useEditorDomHandlers({
@@ -45,11 +40,7 @@ export function useEditorDomHandlers({
   applyAutocompleteSelection,
   sendFromEditor,
   rootRef,
-  setAtContext,
-  setSlashContext,
-  setDiffContext,
-  setTerminalContext,
-  setSelectionContext,
+  setActiveCompletionContext,
 }: UseEditorDomHandlersParams) {
   "use no memo";
   const sendFromEditorRef = useRef(sendFromEditor);
@@ -88,14 +79,12 @@ export function useEditorDomHandlers({
             return true;
           }
           if (lastEnterKeydownNewlineRef.current) return false;
-          if (
-            latest.isAutocompleteOpen &&
-            !latest.isResultsStale &&
-            latest.autocompleteItems[latest.selectedIndex]
-          ) {
+          const enterItem = latest.isAutocompleteOpen
+            ? latest.autocompleteItems[latest.selectedIndex]
+            : undefined;
+          if (enterItem && !latest.staleItemKeys.has(enterItem.key)) {
             event.preventDefault();
-            const action = latest.activeMode === "command" ? "execute" : "insert";
-            applyAutocompleteSelectionRef.current(action);
+            applyAutocompleteSelectionRef.current("enter");
             return true;
           }
           event.preventDefault();
@@ -152,11 +141,7 @@ export function useEditorDomHandlers({
           const root = rootRef.current;
           if (root && nextTarget && root.contains(nextTarget)) return false;
           if (latestRef.current?.isExpanded) return false;
-          setAtContext(null);
-          setSlashContext(null);
-          setDiffContext(null);
-          setTerminalContext(null);
-          setSelectionContext(null);
+          setActiveCompletionContext(null);
           lastEnterKeydownNewlineRef.current = false;
           handledEnterRef.current = false;
           submitAfterCompositionRef.current = false;

--- a/src/components/Terminal/hooks/useEditorKeymap.ts
+++ b/src/components/Terminal/hooks/useEditorKeymap.ts
@@ -3,13 +3,7 @@ import { EditorView } from "@codemirror/view";
 import { EditorSelection } from "@codemirror/state";
 import type { Compartment } from "@codemirror/state";
 import type { AutocompleteItem } from "../AutocompleteMenu";
-import type {
-  AtFileContext,
-  SlashCommandContext,
-  AtDiffContext,
-  AtTerminalContext,
-  AtSelectionContext,
-} from "../hybridInputParsing";
+import type { ActiveCompletionContext } from "../hybridInputParsing";
 
 interface LatestRefShape {
   terminalId: string;
@@ -17,10 +11,9 @@ interface LatestRefShape {
   disabled: boolean;
   isInitializing: boolean;
   isInHistoryMode: boolean;
-  activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
   isAutocompleteOpen: boolean;
   autocompleteItems: AutocompleteItem[];
-  isResultsStale: boolean;
+  staleItemKeys: ReadonlySet<string>;
   selectedIndex: number;
   value: string;
   onSendKey?: (key: string) => void;
@@ -35,7 +28,7 @@ interface UseEditorKeymapParams {
   handledEnterRef: React.MutableRefObject<boolean>;
   editableCompartmentRef: React.RefObject<Compartment>;
   historyPaletteOpenRef: React.RefObject<(() => void) | null>;
-  applyAutocompleteSelection: (action: "insert" | "execute") => boolean;
+  applyAutocompleteSelection: (mode: "enter" | "complete") => boolean;
   handleHistoryNavigation: (direction: "up" | "down") => boolean;
   sendFromEditor: () => void;
   startVoiceWaitSubmit: () => void;
@@ -45,11 +38,7 @@ interface UseEditorKeymapParams {
     terminalId: string,
     projectId?: string
   ) => EditorView["state"] | undefined;
-  setAtContext: Dispatch<SetStateAction<AtFileContext | null>>;
-  setSlashContext: Dispatch<SetStateAction<SlashCommandContext | null>>;
-  setDiffContext: Dispatch<SetStateAction<AtDiffContext | null>>;
-  setTerminalContext: Dispatch<SetStateAction<AtTerminalContext | null>>;
-  setSelectionContext: Dispatch<SetStateAction<AtSelectionContext | null>>;
+  setActiveCompletionContext: Dispatch<SetStateAction<ActiveCompletionContext | null>>;
   setIsExpanded: Dispatch<SetStateAction<boolean>>;
   setSelectedIndex: Dispatch<SetStateAction<number>>;
 }
@@ -83,11 +72,7 @@ export function useEditorKeymap({
   cancelVoiceWaitSubmit,
   stashEditorState,
   popStashedEditorState,
-  setAtContext,
-  setSlashContext,
-  setDiffContext,
-  setTerminalContext,
-  setSelectionContext,
+  setActiveCompletionContext,
   setIsExpanded,
   setSelectedIndex,
 }: UseEditorKeymapParams) {
@@ -106,20 +91,18 @@ export function useEditorKeymap({
 
       // Stale results (query changed since they were produced) must not be
       // accepted by a fast Enter — fall through to the normal send path so
-      // the user's literal text wins over an outdated top match.
-      if (
-        latest.isAutocompleteOpen &&
-        !latest.isResultsStale &&
-        latest.autocompleteItems[latest.selectedIndex]
-      ) {
-        const action = latest.activeMode === "command" ? "execute" : "insert";
-
+      // the user's literal text wins over an outdated top match. Enter behavior
+      // (insert vs execute) is owned by the selected item, not the trigger.
+      const enterItem = latest.isAutocompleteOpen
+        ? latest.autocompleteItems[latest.selectedIndex]
+        : undefined;
+      if (enterItem && !latest.staleItemKeys.has(enterItem.key)) {
         handledEnterRef.current = true;
         setTimeout(() => {
           handledEnterRef.current = false;
         }, 0);
 
-        applyAutocompleteSelection(action);
+        applyAutocompleteSelection("enter");
         return true;
       }
 
@@ -162,11 +145,7 @@ export function useEditorKeymap({
       if (cancelVoiceWaitSubmit()) return true;
 
       if (latest.isAutocompleteOpen) {
-        setAtContext(null);
-        setSlashContext(null);
-        setDiffContext(null);
-        setTerminalContext(null);
-        setSelectionContext(null);
+        setActiveCompletionContext(null);
         return true;
       }
 
@@ -270,11 +249,14 @@ export function useEditorKeymap({
       if (!latest) return false;
       if (isComposingRef.current) return false;
 
-      if (latest.isAutocompleteOpen && latest.autocompleteItems[latest.selectedIndex]) {
-        // Swallow Tab while results are stale — inserting an outdated match
-        // is worse than a no-op, and letting Tab through would move focus.
-        if (latest.isResultsStale) return true;
-        applyAutocompleteSelection("insert");
+      const tabItem = latest.isAutocompleteOpen
+        ? latest.autocompleteItems[latest.selectedIndex]
+        : undefined;
+      if (tabItem) {
+        // Swallow Tab while the selected item is stale — inserting an outdated
+        // match is worse than a no-op, and letting Tab through would move focus.
+        if (latest.staleItemKeys.has(tabItem.key)) return true;
+        applyAutocompleteSelection("complete");
         return true;
       }
 

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -15,13 +15,7 @@ import {
   getAllAtSelectionTokens,
   getAllAtDiffTokens,
   type DiffContextType,
-} from "../hybridInputParsing";
-import type {
-  AtFileContext,
-  SlashCommandContext,
-  AtDiffContext,
-  AtTerminalContext,
-  AtSelectionContext,
+  type ActiveCompletionContext,
 } from "../hybridInputParsing";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
@@ -132,11 +126,7 @@ interface UseTokenResolutionParams {
     options?: { selection?: EditorSelection; focus?: boolean }
   ) => void;
   setIsExpanded: Dispatch<SetStateAction<boolean>>;
-  setAtContext: Dispatch<SetStateAction<AtFileContext | null>>;
-  setSlashContext: Dispatch<SetStateAction<SlashCommandContext | null>>;
-  setDiffContext: Dispatch<SetStateAction<AtDiffContext | null>>;
-  setTerminalContext: Dispatch<SetStateAction<AtTerminalContext | null>>;
-  setSelectionContext: Dispatch<SetStateAction<AtSelectionContext | null>>;
+  setActiveCompletionContext: Dispatch<SetStateAction<ActiveCompletionContext | null>>;
   terminalId: string;
   cwd: string;
   agentId?: BuiltInAgentId;
@@ -146,11 +136,7 @@ export function useTokenResolution({
   latestRef,
   applyEditorValue,
   setIsExpanded,
-  setAtContext,
-  setSlashContext,
-  setDiffContext,
-  setTerminalContext,
-  setSelectionContext,
+  setActiveCompletionContext,
   terminalId,
   cwd,
   agentId,
@@ -248,11 +234,7 @@ export function useTokenResolution({
       setIsExpanded(false);
       applyEditorValue("", { selection: EditorSelection.create([EditorSelection.cursor(0)]) });
       latest.clearDraftInput(latest.terminalId, latest.projectId);
-      setAtContext(null);
-      setSlashContext(null);
-      setDiffContext(null);
-      setTerminalContext(null);
-      setSelectionContext(null);
+      setActiveCompletionContext(null);
     },
     [
       applyEditorValue,
@@ -260,12 +242,8 @@ export function useTokenResolution({
       cwd,
       terminalId,
       latestRef,
-      setAtContext,
-      setDiffContext,
+      setActiveCompletionContext,
       setIsExpanded,
-      setSelectionContext,
-      setSlashContext,
-      setTerminalContext,
     ]
   );
 

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -1,10 +1,73 @@
-export type DiffContextType = "unstaged" | "staged" | "head";
+import type { CompletionTrigger } from "@shared/types";
 
-export interface AtDiffContext {
-  atStart: number;
+/**
+ * One completion menu is open at a time, keyed by the trigger char that opened
+ * it. `query` is the triggerless token text between the trigger and the caret;
+ * `start`/`tokenEnd` bound the whole token in the document.
+ */
+export interface ActiveCompletionContext {
+  triggerChar: CompletionTrigger;
+  start: number;
   tokenEnd: number;
-  diffType: DiffContextType | null;
+  query: string;
 }
+
+/**
+ * Detect the completion token the caret sits in. The token is the
+ * whitespace-delimited run containing the caret; it opens a menu only when its
+ * FIRST char is an active trigger — a start-or-whitespace boundary that rejects
+ * `email@x`, `a/b`, `http://…` while still allowing slashes inside the token
+ * (`@src/App.tsx`). A doubled trigger (`//help`, `$$foo`, `@@x`) is rejected.
+ */
+export function getActiveCompletionContext(
+  text: string,
+  caret: number,
+  activeTriggers: ReadonlySet<CompletionTrigger>
+): ActiveCompletionContext | null {
+  if (caret < 0 || caret > text.length) return null;
+
+  let start = caret;
+  while (start > 0 && !/\s/.test(text[start - 1]!)) start--;
+  // The caret must sit strictly past the trigger char (bare `@`/`/` opens only
+  // once you've typed the trigger itself).
+  if (start >= caret) return null;
+
+  const triggerChar = text[start]!;
+  if (!activeTriggers.has(triggerChar as CompletionTrigger)) return null;
+  if (text[start + 1] === triggerChar) return null;
+
+  let tokenEnd = caret;
+  while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) tokenEnd++;
+
+  return {
+    triggerChar: triggerChar as CompletionTrigger,
+    start,
+    tokenEnd,
+    query: text.slice(start + 1, caret),
+  };
+}
+
+/** Daintree's own `@` providers; each claims its prefix ahead of `@file`. */
+export type DaintreeAtClaim = "terminal" | "selection" | "diff";
+
+/**
+ * Which Daintree `@` provider (if any) claims a query, in priority order
+ * terminal > selection > diff. `@file` fuzzy search is the fallback when no
+ * provider claims. Mirrors the old per-parser prefix gates exactly.
+ */
+export function getDaintreeAtClaim(query: string): DaintreeAtClaim | null {
+  if (matchesTerminalPrefix(query)) return "terminal";
+  if (matchesSelectionPrefix(query)) return "selection";
+  if (matchesDiffPrefix(query)) return "diff";
+  return null;
+}
+
+/** Strip a leading quote so `@"src` searches for `src` (matches old queryForSearch). */
+export function fileSearchQuery(query: string): string {
+  return query.replace(/^['"]/, "");
+}
+
+export type DiffContextType = "unstaged" | "staged" | "head";
 
 const DIFF_TOKEN_MAP: Record<string, DiffContextType> = {
   diff: "unstaged",
@@ -27,28 +90,9 @@ const DIFF_PREFIXES = [
   "diff:head",
 ];
 
-export function getDiffContext(text: string, caret: number): AtDiffContext | null {
-  if (caret < 0 || caret > text.length) return null;
-  const beforeCaret = text.slice(0, caret);
-  const atStart = beforeCaret.lastIndexOf("@");
-  if (atStart === -1) return null;
-  if (atStart > 0 && !/\s/.test(beforeCaret[atStart - 1]!)) return null;
-
-  let tokenEnd = atStart + 1;
-  while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) {
-    tokenEnd++;
-  }
-
-  if (caret < atStart + 1 || caret > tokenEnd) return null;
-
-  const token = text.slice(atStart + 1, tokenEnd);
-
-  // Check if the partial text typed so far matches a diff prefix
-  const partial = text.slice(atStart + 1, caret);
-  if (!DIFF_PREFIXES.some((p) => p.startsWith(partial) || partial === p)) return null;
-
-  const diffType = DIFF_TOKEN_MAP[token] ?? null;
-  return { atStart, tokenEnd, diffType };
+/** A query claims the diff provider when it prefixes any diff token (bare `@` too). */
+export function matchesDiffPrefix(query: string): boolean {
+  return DIFF_PREFIXES.some((p) => p.startsWith(query) || query === p);
 }
 
 export interface AtDiffToken {
@@ -92,32 +136,12 @@ export function getAllAtDiffTokens(text: string): AtDiffToken[] {
 
 // --- @terminal context ---
 
-export interface AtTerminalContext {
-  atStart: number;
-  tokenEnd: number;
-}
-
 const TERMINAL_PREFIXES = ["term", "termi", "termin", "termina", "terminal"];
 
-export function getTerminalContext(text: string, caret: number): AtTerminalContext | null {
-  if (caret < 0 || caret > text.length) return null;
-  const beforeCaret = text.slice(0, caret);
-  const atStart = beforeCaret.lastIndexOf("@");
-  if (atStart === -1) return null;
-  if (atStart > 0 && !/\s/.test(beforeCaret[atStart - 1]!)) return null;
-
-  let tokenEnd = atStart + 1;
-  while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) {
-    tokenEnd++;
-  }
-
-  if (caret < atStart + 1 || caret > tokenEnd) return null;
-
-  const partial = text.slice(atStart + 1, caret);
-  if (partial.length < 4) return null;
-  if (!TERMINAL_PREFIXES.some((p) => p.startsWith(partial) || partial === p)) return null;
-
-  return { atStart, tokenEnd };
+/** `@terminal` claims from four chars in (so `@te` still falls to file search). */
+export function matchesTerminalPrefix(query: string): boolean {
+  if (query.length < 4) return false;
+  return TERMINAL_PREFIXES.some((p) => p.startsWith(query) || query === p);
 }
 
 export interface AtTerminalToken {
@@ -159,32 +183,12 @@ export function getAllAtTerminalTokens(text: string): AtTerminalToken[] {
 
 // --- @selection context ---
 
-export interface AtSelectionContext {
-  atStart: number;
-  tokenEnd: number;
-}
-
 const SELECTION_PREFIXES = ["sele", "selec", "select", "selecti", "selectio", "selection"];
 
-export function getSelectionContext(text: string, caret: number): AtSelectionContext | null {
-  if (caret < 0 || caret > text.length) return null;
-  const beforeCaret = text.slice(0, caret);
-  const atStart = beforeCaret.lastIndexOf("@");
-  if (atStart === -1) return null;
-  if (atStart > 0 && !/\s/.test(beforeCaret[atStart - 1]!)) return null;
-
-  let tokenEnd = atStart + 1;
-  while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) {
-    tokenEnd++;
-  }
-
-  if (caret < atStart + 1 || caret > tokenEnd) return null;
-
-  const partial = text.slice(atStart + 1, caret);
-  if (partial.length < 4) return null;
-  if (!SELECTION_PREFIXES.some((p) => p.startsWith(partial) || partial === p)) return null;
-
-  return { atStart, tokenEnd };
+/** `@selection` claims from four chars in, same as `@terminal`. */
+export function matchesSelectionPrefix(query: string): boolean {
+  if (query.length < 4) return false;
+  return SELECTION_PREFIXES.some((p) => p.startsWith(query) || query === p);
 }
 
 export interface AtSelectionToken {
@@ -224,64 +228,11 @@ export function getAllAtSelectionTokens(text: string): AtSelectionToken[] {
   return tokens;
 }
 
-// --- @file context ---
-
-export interface AtFileContext {
-  atStart: number;
-  tokenEnd: number;
-  queryRaw: string;
-  queryForSearch: string;
-}
-
-export function getAtFileContext(text: string, caret: number): AtFileContext | null {
-  if (caret < 0 || caret > text.length) return null;
-  const beforeCaret = text.slice(0, caret);
-  const atStart = beforeCaret.lastIndexOf("@");
-  if (atStart === -1) return null;
-  if (atStart > 0 && !/\s/.test(beforeCaret[atStart - 1]!)) return null;
-
-  let tokenEnd = atStart + 1;
-  while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) {
-    tokenEnd++;
-  }
-
-  if (caret < atStart + 1 || caret > tokenEnd) return null;
-
-  const token = text.slice(atStart + 1, tokenEnd);
-  if (/\s/.test(token)) return null;
-
-  const queryRaw = text.slice(atStart + 1, caret);
-  const queryForSearch = queryRaw.replace(/^['"]/, "");
-
-  return { atStart, tokenEnd, queryRaw, queryForSearch };
-}
+// --- @file token ---
 
 export function formatAtFileToken(file: string): string {
   const needsQuotes = /\s/.test(file);
   return `@${needsQuotes ? `"${file}"` : file}`;
-}
-
-export interface SlashCommandContext {
-  start: number;
-  tokenEnd: number;
-  query: string;
-}
-
-export function getSlashCommandContext(text: string, caret: number): SlashCommandContext | null {
-  if (caret < 0 || caret > text.length) return null;
-  const beforeCaret = text.slice(0, caret);
-  const slashStart = beforeCaret.lastIndexOf("/");
-  if (slashStart === -1) return null;
-  if (slashStart > 0 && !/\s/.test(beforeCaret[slashStart - 1]!)) return null;
-
-  let tokenEnd = slashStart + 1;
-  while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) {
-    tokenEnd++;
-  }
-
-  if (caret < slashStart + 1 || caret > tokenEnd) return null;
-
-  return { start: slashStart, tokenEnd, query: text.slice(slashStart, caret) };
 }
 
 export interface SlashCommandToken {

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -16,8 +16,9 @@ export interface ActiveCompletionContext {
  * Detect the completion token the caret sits in. The token is the
  * whitespace-delimited run containing the caret; it opens a menu only when its
  * FIRST char is an active trigger — a start-or-whitespace boundary that rejects
- * `email@x`, `a/b`, `http://…` while still allowing slashes inside the token
- * (`@src/App.tsx`). A doubled trigger (`//help`, `$$foo`, `@@x`) is rejected.
+ * `email@x`, `a/b`, `http://…` while still allowing OTHER triggers inside the
+ * token (the `/` in `@src/App.tsx`). A repeated instance of the SAME trigger in
+ * the query rejects it (`//help`, `$$foo`, `@@x`, and slash-path `/usr/bin`).
  */
 export function getActiveCompletionContext(
   text: string,
@@ -34,17 +35,14 @@ export function getActiveCompletionContext(
 
   const triggerChar = text[start]!;
   if (!activeTriggers.has(triggerChar as CompletionTrigger)) return null;
-  if (text[start + 1] === triggerChar) return null;
+
+  const query = text.slice(start + 1, caret);
+  if (query.includes(triggerChar)) return null;
 
   let tokenEnd = caret;
   while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) tokenEnd++;
 
-  return {
-    triggerChar: triggerChar as CompletionTrigger,
-    start,
-    tokenEnd,
-    query: text.slice(start + 1, caret),
-  };
+  return { triggerChar: triggerChar as CompletionTrigger, start, tokenEnd, query };
 }
 
 /** Daintree's own `@` providers; each claims its prefix ahead of `@file`. */

--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -12,6 +12,17 @@ export interface ActiveCompletionContext {
   query: string;
 }
 
+/** Narrow an arbitrary char to a declared trigger without an unsafe assertion. */
+function activeTrigger(
+  ch: string,
+  activeTriggers: ReadonlySet<CompletionTrigger>
+): CompletionTrigger | null {
+  for (const trigger of activeTriggers) {
+    if (trigger === ch) return trigger;
+  }
+  return null;
+}
+
 /**
  * Detect the completion token the caret sits in. The token is the
  * whitespace-delimited run containing the caret; it opens a menu only when its
@@ -33,8 +44,8 @@ export function getActiveCompletionContext(
   // once you've typed the trigger itself).
   if (start >= caret) return null;
 
-  const triggerChar = text[start]!;
-  if (!activeTriggers.has(triggerChar as CompletionTrigger)) return null;
+  const triggerChar = activeTrigger(text[start]!, activeTriggers);
+  if (triggerChar === null) return null;
 
   const query = text.slice(start + 1, caret);
   if (query.includes(triggerChar)) return null;
@@ -42,7 +53,7 @@ export function getActiveCompletionContext(
   let tokenEnd = caret;
   while (tokenEnd < text.length && !/\s/.test(text[tokenEnd]!)) tokenEnd++;
 
-  return { triggerChar: triggerChar as CompletionTrigger, start, tokenEnd, query };
+  return { triggerChar, start, tokenEnd, query };
 }
 
 /** Daintree's own `@` providers; each claims its prefix ahead of `@file`. */

--- a/src/hooks/__tests__/slashAutocompleteItems.test.ts
+++ b/src/hooks/__tests__/slashAutocompleteItems.test.ts
@@ -27,6 +27,28 @@ describe("toSlashAutocompleteItems", () => {
     expect(labels).not.toContain("$imagegen");
   });
 
+  it("filters to the requested trigger, keeping $ and / menus disjoint", () => {
+    const commands = [
+      make({ label: "/help", trigger: "/" }),
+      make({ label: "$imagegen", insertText: "$imagegen", trigger: "$", kind: "skill" }),
+    ];
+
+    const dollarLabels = toSlashAutocompleteItems(commands, "", "$").map((i) => i.label);
+    expect(dollarLabels).toEqual(["$imagegen"]);
+    expect(dollarLabels).not.toContain("/help");
+  });
+
+  it("stamps enterAction from the trigger and marks every item literal", () => {
+    const [slash] = toSlashAutocompleteItems([make({ label: "/help", trigger: "/" })], "", "/");
+    const [dollar] = toSlashAutocompleteItems(
+      [make({ label: "$gen", insertText: "$gen", trigger: "$", kind: "skill" })],
+      "",
+      "$"
+    );
+    expect(slash).toMatchObject({ enterAction: "execute", insert: "literal" });
+    expect(dollar).toMatchObject({ enterAction: "insert", insert: "literal" });
+  });
+
   it("carries kind through as category (skill/app/plugin badged, command default)", () => {
     const items = toSlashAutocompleteItems(
       [

--- a/src/hooks/slashAutocompleteItems.ts
+++ b/src/hooks/slashAutocompleteItems.ts
@@ -1,20 +1,23 @@
 import type { AutocompleteItem } from "@/components/Terminal/AutocompleteMenu";
 import { rankSlashCommands } from "@/lib/slashCommandMatch";
-import type { SlashCommand } from "@shared/types";
+import type { CompletionTrigger, SlashCommand } from "@shared/types";
 
 /**
- * Rank the `/` completions for the slash menu and map them to autocomplete
- * items. Filters out any non-`/` trigger — an agent's `$` capabilities arrive
- * in the same discovery result and must never leak into the slash list — and
+ * Rank the completions for one trigger's menu and map them to autocomplete
+ * items. Filters strictly on the requested trigger — `/` and `$` arrive in the
+ * same discovery result and must never leak into each other's menu — and
  * carries `kind` through as `category` so the menu can badge skills. A
  * triggerless built-in (the renderer's pre-IPC fallback) is treated as `/`.
+ * `/` commands execute on Enter; every other trigger inserts. All are literal —
+ * the agent's own parser interprets the inserted token.
  */
 export function toSlashAutocompleteItems(
   commands: SlashCommand[],
-  query: string
+  query: string,
+  trigger: CompletionTrigger = "/"
 ): AutocompleteItem[] {
-  const slashCommands = commands.filter((cmd) => (cmd.trigger ?? "/") === "/");
-  return rankSlashCommands(slashCommands, query).map((cmd) => ({
+  const filtered = commands.filter((cmd) => (cmd.trigger ?? "/") === trigger);
+  return rankSlashCommands(filtered, query).map((cmd) => ({
     key: cmd.id,
     label: cmd.label,
     // Carry the canonical token through; fall back to the label only when the
@@ -23,5 +26,7 @@ export function toSlashAutocompleteItems(
     insertText: cmd.insertText ?? cmd.label,
     description: cmd.description,
     category: cmd.kind ?? "command",
+    enterAction: trigger === "/" ? "execute" : "insert",
+    insert: "literal",
   }));
 }

--- a/src/hooks/useSlashCommandAutocomplete.ts
+++ b/src/hooks/useSlashCommandAutocomplete.ts
@@ -4,12 +4,15 @@ import { slashCommandsClient } from "@/clients";
 import { toSlashAutocompleteItems } from "@/hooks/slashAutocompleteItems";
 
 import { getBuiltinSlashCommands, type SlashCommand } from "@shared/types";
+import type { CompletionTrigger } from "@shared/types";
 import { getAgentConfig } from "@/config/agents";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 
 export interface UseSlashCommandAutocompleteArgs {
   query: string;
   enabled: boolean;
+  /** Which trigger's completions to surface — `/` commands or `$` capabilities. */
+  trigger: CompletionTrigger;
   agentId?: BuiltInAgentId;
   projectPath?: string;
 }
@@ -17,6 +20,7 @@ export interface UseSlashCommandAutocompleteArgs {
 export function useSlashCommandAutocomplete({
   query,
   enabled,
+  trigger,
   agentId,
   projectPath,
 }: UseSlashCommandAutocompleteArgs): {
@@ -62,8 +66,8 @@ export function useSlashCommandAutocomplete({
   }, [agentId, projectPath]);
 
   const items = useMemo(
-    (): AutocompleteItem[] => (enabled ? toSlashAutocompleteItems(commands, query) : []),
-    [commands, enabled, query]
+    (): AutocompleteItem[] => (enabled ? toSlashAutocompleteItems(commands, query, trigger) : []),
+    [commands, enabled, query, trigger]
   );
 
   return { items, isLoading };


### PR DESCRIPTION
## Summary

This is the deep CodeMirror renderer refactor deferred from #11043, following #11046 (which already made Main-process discovery emit Codex `$` skills/plugins that the renderer was discarding).

- Collapsed the five parallel completion-context `useState` slots in `HybridInputBar` (`atContext`, `slashContext`, `diffContext`, `terminalContext`, `selectionContext`) into a single `ActiveCompletionContext { triggerChar, start, tokenEnd, query }`, with one `getActiveCompletionContext` parser replacing the five per-context caret parsers.
- Made trigger handling data-driven from each agent's `completionSources`, so the Codex `$` picker (skills/plugins) now opens alongside `/` and `@`.
- Moved insert-vs-execute onto the item itself and modeled insertion declaratively, so `$` capabilities insert on the first Enter and send on the second, while Daintree's `@diff`/`@terminal`/`@selection` providers keep resolving at send time.

Resolves #11048

## Changes

- New `getActiveCompletionContext` parser: first-char-anchor with a start-or-whitespace boundary and a repeated-trigger reject, replacing the five per-context caret parsers in `hybridInputParsing.ts`.
- `activeTriggers` is always `/` and `@`, plus `$` when the agent declares it. Generalized `toSlashAutocompleteItems` and `useSlashCommandAutocomplete` to take a trigger param; `/` and `$` stay strictly disjoint.
- New `enterAction` field on completion items removes the `activeMode === "command"` inference from `useEditorKeymap` and the DOM handlers.
- Insertion modeled as `insert: "literal" | { insert: "resolve", resolverId }`. Daintree's `@diff`, `@diff:staged`, `@diff:head`, `@terminal`, and `@selection` remain Daintree-owned providers that claim their prefix ahead of `@file` fuzzy search.
- Swapped the single global staleness flag for per-item `staleKeys`, so a stale async `@file` search no longer dims fresh `$`/`@diff` rows, and selection is preserved by item key across async merges.
- Net -438 lines. Renderer-only, no Main-process discovery changes. Capability chips for `$` are intentionally out of scope.

## Testing

Ran 254 targeted unit tests: rewrote the `hybridInputParsing`, `useAutocompleteItems`/`Apply`/`State`, `useEditorKeymap`, `useContextDetection`, `AutocompleteMenu`, and `slashAutocompleteItems` suites, and added `useTokenResolution.test.ts` covering `@diff` send-time resolution and history-keeps-token behavior. `tsc` compiles clean.
