### PR TITLE
fix(dock): clamp drag placeholder to dock item height

### DIFF
--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -27,7 +27,7 @@ export function DockPlaceholder({ className }: DockPlaceholderProps) {
   return (
     <div
       className={cn(
-        "flex flex-col gap-1 px-3 py-2 min-w-[120px] h-full",
+        "flex flex-col gap-1 px-3 py-2 min-w-[120px] h-[var(--dock-item-height)] overflow-hidden",
         "rounded border border-border-strong bg-overlay-subtle",
         className
       )}

--- a/src/components/DragDrop/PlaceholderContent.tsx
+++ b/src/components/DragDrop/PlaceholderContent.tsx
@@ -151,48 +151,49 @@ function BrowserPlaceholder({ color, compact }: PlaceholderProps) {
           borderRadius: "var(--radius-sm)",
         }}
       />
-      {/* Page content area */}
-      <div
-        style={{
-          flex: 1,
-          minHeight: compact ? 0 : 30,
-          padding: compact ? 4 : 6,
-          backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
-          borderRadius: "var(--radius-sm)",
-          display: "flex",
-          flexDirection: "column",
-          gap: compact ? 3 : 4,
-        }}
-      >
-        {/* Page elements row */}
-        <div style={{ display: "flex", gap: compact ? 3 : 4 }}>
-          <div
-            style={{
-              width: compact ? 8 : 10,
-              height: compact ? 8 : 10,
-              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-          <div
-            style={{
-              width: compact ? 8 : 10,
-              height: compact ? 8 : 10,
-              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-          <div
-            style={{
-              width: compact ? 8 : 10,
-              height: compact ? 8 : 10,
-              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-        </div>
-        {/* Content line */}
-        {!compact && (
+      {/* Page content area — omitted in compact so the dock ghost stays within --dock-item-height */}
+      {!compact && (
+        <div
+          data-placeholder-body
+          style={{
+            flex: 1,
+            minHeight: 30,
+            padding: 6,
+            backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+          }}
+        >
+          {/* Page elements row */}
+          <div style={{ display: "flex", gap: 4 }}>
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+          </div>
+          {/* Content line */}
           <div
             style={{
               height: 5,
@@ -201,8 +202,8 @@ function BrowserPlaceholder({ color, compact }: PlaceholderProps) {
               borderRadius: "var(--radius-sm)",
             }}
           />
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -324,76 +325,77 @@ function DevPreviewPlaceholder({ color, compact }: PlaceholderProps) {
           }}
         />
       </div>
-      {/* Split preview content */}
-      <div
-        style={{
-          flex: 1,
-          minHeight: compact ? 0 : 30,
-          display: "flex",
-          gap: compact ? 3 : 4,
-        }}
-      >
-        {/* Code/terminal side (narrower) */}
+      {/* Split preview content — omitted in compact so the dock ghost stays within --dock-item-height */}
+      {!compact && (
         <div
-          style={{
-            width: "30%",
-            backgroundColor: `color-mix(in srgb, ${color} 6%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-            padding: compact ? 3 : 4,
-            display: "flex",
-            flexDirection: "column",
-            gap: 2,
-          }}
-        >
-          <div
-            style={{
-              height: 3,
-              width: "80%",
-              backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-          <div
-            style={{
-              height: 3,
-              width: "60%",
-              backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-        </div>
-        {/* Preview side (wider) */}
-        <div
+          data-placeholder-body
           style={{
             flex: 1,
-            backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-            padding: compact ? 3 : 4,
+            minHeight: 30,
             display: "flex",
-            flexDirection: "column",
-            gap: compact ? 2 : 3,
+            gap: 4,
           }}
         >
-          {/* Preview content elements */}
-          <div style={{ display: "flex", gap: compact ? 2 : 3 }}>
+          {/* Code/terminal side (narrower) */}
+          <div
+            style={{
+              width: "30%",
+              backgroundColor: `color-mix(in srgb, ${color} 6%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+              padding: 4,
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
             <div
               style={{
-                width: compact ? 6 : 8,
-                height: compact ? 6 : 8,
-                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                height: 3,
+                width: "80%",
+                backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
                 borderRadius: "var(--radius-sm)",
               }}
             />
             <div
               style={{
-                width: compact ? 6 : 8,
-                height: compact ? 6 : 8,
-                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                height: 3,
+                width: "60%",
+                backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
                 borderRadius: "var(--radius-sm)",
               }}
             />
           </div>
-          {!compact && (
+          {/* Preview side (wider) */}
+          <div
+            style={{
+              flex: 1,
+              backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+              padding: 4,
+              display: "flex",
+              flexDirection: "column",
+              gap: 3,
+            }}
+          >
+            {/* Preview content elements */}
+            <div style={{ display: "flex", gap: 3 }}>
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                  borderRadius: "var(--radius-sm)",
+                }}
+              />
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                  borderRadius: "var(--radius-sm)",
+                }}
+              />
+            </div>
             <div
               style={{
                 height: 4,
@@ -402,9 +404,9 @@ function DevPreviewPlaceholder({ color, compact }: PlaceholderProps) {
                 borderRadius: "var(--radius-sm)",
               }}
             />
-          )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
@@ -41,6 +41,9 @@ describe("DockPlaceholder height containment (#11055)", () => {
     });
     const { container } = render(<DockPlaceholder />);
     const root = container.querySelector("[aria-hidden='true']");
+    // Guard against a false pass on an empty render: the ghost must exist before
+    // the class/body assertions below are meaningful.
+    expect(root).not.toBeNull();
     // The #11055 bug was `h-full` resolving to auto height that grew with the
     // ghost content. The box must be pinned to a definite height instead.
     expect(root?.className ?? "").not.toContain("h-full");
@@ -54,6 +57,7 @@ describe("DockPlaceholder height containment (#11055)", () => {
       isDragging: true,
     });
     const { container } = render(<DockPlaceholder />);
+    expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
     expect(container.querySelector("[data-placeholder-body]")).toBeNull();
   });
 });

--- a/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+const mockUseDndPlaceholder = vi.fn();
+vi.mock("../DndProvider", () => ({
+  useDndPlaceholder: () => mockUseDndPlaceholder(),
+}));
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ agentId: null }),
+}));
+
+import { DockPlaceholder } from "../DockPlaceholder";
+
+// The mock's return value is untyped (any), so a plain literal stands in for the
+// active panel without an unsafe cast — DockPlaceholder only reads `kind`.
+function ghostPanel(kind: string) {
+  return { id: "p1", kind, title: "Ghost", location: "dock", isVisible: true };
+}
+
+/**
+ * Regression coverage for #11055. The dock renders the placeholder in compact
+ * mode; browser/dev-preview panels used to overflow --dock-item-height and grow
+ * the whole dock bar during a drag. jsdom can't measure heights, so we assert
+ * the two structural properties that produce the fix: the box is no longer
+ * content-height-driven, and the overflowing body is dropped on the dock path.
+ */
+describe("DockPlaceholder height containment (#11055)", () => {
+  it("renders an invisible spacer with no ghost art when not dragging", () => {
+    mockUseDndPlaceholder.mockReturnValue({ activeTerminal: null, isDragging: false });
+    const { container } = render(<DockPlaceholder />);
+    const root = container.querySelector("[aria-hidden='true']");
+    expect(root).not.toBeNull();
+    expect(container.querySelector("[data-placeholder-body]")).toBeNull();
+  });
+
+  it("clamps the ghost to a definite height and drops the browser body while dragging", () => {
+    mockUseDndPlaceholder.mockReturnValue({
+      activeTerminal: ghostPanel("browser"),
+      isDragging: true,
+    });
+    const { container } = render(<DockPlaceholder />);
+    const root = container.querySelector("[aria-hidden='true']");
+    // The #11055 bug was `h-full` resolving to auto height that grew with the
+    // ghost content. The box must be pinned to a definite height instead.
+    expect(root?.className ?? "").not.toContain("h-full");
+    // And the tall browser body must be absent on the compact dock path.
+    expect(container.querySelector("[data-placeholder-body]")).toBeNull();
+  });
+
+  it("drops the dev-preview split body while dragging", () => {
+    mockUseDndPlaceholder.mockReturnValue({
+      activeTerminal: ghostPanel("dev-preview"),
+      isDragging: true,
+    });
+    const { container } = render(<DockPlaceholder />);
+    expect(container.querySelector("[data-placeholder-body]")).toBeNull();
+  });
+});

--- a/src/components/DragDrop/__tests__/PlaceholderContent.test.tsx
+++ b/src/components/DragDrop/__tests__/PlaceholderContent.test.tsx
@@ -32,12 +32,13 @@ describe("PlaceholderContent compact body gating (#11055)", () => {
 
   it("keeps compact browser/dev-preview placeholders non-empty (address bar survives)", () => {
     // Dropping the body must not blank the ghost — the address-bar row still
-    // renders so the drop target stays visually distinct as a browser panel.
+    // renders so the drop target stays visually distinct. Assert the placeholder
+    // root actually has rendered art, not just that some element exists.
     const browser = render(<PlaceholderContent kind="browser" compact />);
-    expect(browser.container.querySelector("div")).not.toBeNull();
+    expect(browser.container.firstElementChild?.children.length ?? 0).toBeGreaterThan(0);
 
     const devPreview = render(<PlaceholderContent kind="dev-preview" compact />);
-    expect(devPreview.container.querySelector("div")).not.toBeNull();
+    expect(devPreview.container.firstElementChild?.children.length ?? 0).toBeGreaterThan(0);
   });
 
   it("does not introduce a content body for kinds that never had one (terminal)", () => {

--- a/src/components/DragDrop/__tests__/PlaceholderContent.test.tsx
+++ b/src/components/DragDrop/__tests__/PlaceholderContent.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { PlaceholderContent } from "../PlaceholderContent";
+
+/**
+ * Regression coverage for #11055: the dock drag placeholder grew taller than the
+ * dock chips because BrowserPlaceholder / DevPreviewPlaceholder rendered their
+ * padded content body even in compact mode — the only mode the dock uses. The
+ * fix drops that body in compact so the ghost fits within --dock-item-height.
+ *
+ * jsdom has no layout engine, so instead of measuring pixels we assert the
+ * conditional structure that drives the height: the tall body is marked with
+ * [data-placeholder-body] and must be absent in compact mode.
+ */
+describe("PlaceholderContent compact body gating (#11055)", () => {
+  it("renders the browser content body only in full mode, not compact", () => {
+    const full = render(<PlaceholderContent kind="browser" />);
+    expect(full.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(1);
+
+    const compact = render(<PlaceholderContent kind="browser" compact />);
+    expect(compact.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(0);
+  });
+
+  it("renders the dev-preview split body only in full mode, not compact", () => {
+    const full = render(<PlaceholderContent kind="dev-preview" />);
+    expect(full.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(1);
+
+    const compact = render(<PlaceholderContent kind="dev-preview" compact />);
+    expect(compact.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(0);
+  });
+
+  it("keeps compact browser/dev-preview placeholders non-empty (address bar survives)", () => {
+    // Dropping the body must not blank the ghost — the address-bar row still
+    // renders so the drop target stays visually distinct as a browser panel.
+    const browser = render(<PlaceholderContent kind="browser" compact />);
+    expect(browser.container.querySelector("div")).not.toBeNull();
+
+    const devPreview = render(<PlaceholderContent kind="dev-preview" compact />);
+    expect(devPreview.container.querySelector("div")).not.toBeNull();
+  });
+
+  it("does not introduce a content body for kinds that never had one (terminal)", () => {
+    const full = render(<PlaceholderContent kind="terminal" />);
+    const compact = render(<PlaceholderContent kind="terminal" compact />);
+    expect(full.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(0);
+    expect(compact.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Dragging a browser or dev-preview panel over an empty dock rendered the drag-ghost placeholder taller than the real dock chips, so the whole dock bar grew during the drag and snapped back on drop. Terminal and agent drags never showed this.
- Root cause was two-fold: `DockPlaceholder`'s ghost box used `h-full`, which resolves to auto height (the dock row only sets min-height floors), so ghost content drove the row height. On top of that, `BrowserPlaceholder` and `DevPreviewPlaceholder` rendered a padded content body even in compact mode, the only mode the dock uses, overflowing the `--dock-item-height` budget.
- Fix pins the ghost box to `h-[var(--dock-item-height)] overflow-hidden`, matching every real dock chip, and drops the padded body of `BrowserPlaceholder`/`DevPreviewPlaceholder` in compact mode, mirroring the existing pattern in `TerminalPlaceholder`/`AgentPlaceholder`.

Resolves #11055

## Changes
- `src/components/DragDrop/DockPlaceholder.tsx`: clamp the ghost box height instead of `h-full`.
- `src/components/DragDrop/PlaceholderContent.tsx`: skip the padded content body for browser/dev-preview placeholders in compact mode.
- Scoped to the dock: `GridPlaceholder` and `TerminalDragPreview` render `PlaceholderContent` in full mode and are unaffected.

## Testing
- Added regression tests for `PlaceholderContent` and `DockPlaceholder` covering a structural `data-placeholder-body` invariant (no tautological class assertions).
- 56 targeted tests pass; touched files are lint and format clean.