### PR TITLE
fix(panels): make browser panels dockable (#11053)

### DIFF
--- a/e2e/full/panels/core-browser-panel.spec.ts
+++ b/e2e/full/panels/core-browser-panel.spec.ts
@@ -305,8 +305,9 @@ test.describe.serial("Core: Browser Panel", () => {
       await expect(gridBrowsers).toHaveCount(0, { timeout: T_MEDIUM });
 
       // A single dock chip appears; clicking opens the popover with the live
-      // browser relocated into it. Its URL survived the move — the webview's
-      // guest is preserved by the offscreen container's moveBefore relocation.
+      // browser relocated into it via the offscreen container's moveBefore, and
+      // its navigation state survives the relocation (address bar still page-a).
+      // (This asserts URL/history survival, not full guest-DOM preservation.)
       const chip = window.locator("[data-dock-item]");
       await expect(chip).toHaveCount(1, { timeout: T_MEDIUM });
       await chip.click();
@@ -321,10 +322,13 @@ test.describe.serial("Core: Browser Panel", () => {
         window.locator('[data-dock-portal-target] [data-testid="panel-move-to-grid"]')
       ).toBeVisible({ timeout: T_SHORT });
 
-      // Double-click restores the panel to the grid.
+      // Double-click restores the panel to the grid with its URL intact.
       await chip.dblclick();
       await expect(gridBrowsers).toHaveCount(1, { timeout: T_MEDIUM });
       await expect(chip).toHaveCount(0, { timeout: T_MEDIUM });
+      await expect(gridBrowsers.locator(SEL.browser.addressBar)).toHaveValue(/page-a/, {
+        timeout: T_MEDIUM,
+      });
     });
   });
 

--- a/e2e/full/panels/core-browser-panel.spec.ts
+++ b/e2e/full/panels/core-browser-panel.spec.ts
@@ -269,6 +269,65 @@ test.describe.serial("Core: Browser Panel", () => {
     });
   });
 
+  test.describe.serial("Dock lifecycle (#11053)", () => {
+    test.beforeAll(async () => {
+      // Start from a clean grid so membership counts are deterministic. No
+      // earlier test docks a panel, so the dock starts empty too.
+      const { window } = ctx;
+      let count = await getGridPanelCount(window);
+      while (count > 0) {
+        const panel = window.locator(SEL.panel.gridPanel).first();
+        await panel.locator(SEL.panel.close).first().click({ force: true });
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(count - 1);
+        count -= 1;
+      }
+    });
+
+    test("browser panel moves to the dock, previews from the chip with state intact, and restores to the grid", async () => {
+      const { window } = ctx;
+      const gridBrowsers = window
+        .locator(SEL.panel.gridPanel)
+        .filter({ has: window.locator(SEL.browser.addressBar) });
+
+      // Open a browser and navigate it to a known page.
+      await openBrowser(window);
+      await expect(gridBrowsers).toHaveCount(1, { timeout: T_LONG });
+      const addressBar = gridBrowsers.locator(SEL.browser.addressBar);
+      await addressBar.click();
+      await addressBar.fill(`http://127.0.0.1:${port}/page-a`);
+      await window.keyboard.press("Enter");
+      await window.waitForTimeout(T_SETTLE);
+      await expect(addressBar).toHaveValue(/page-a/, { timeout: T_LONG });
+
+      // Move it to the dock. The grid browser leaves, but the panel is not lost
+      // — before #11053 it vanished with no dock render path.
+      await gridBrowsers.locator(SEL.panel.minimize).click();
+      await expect(gridBrowsers).toHaveCount(0, { timeout: T_MEDIUM });
+
+      // A single dock chip appears; clicking opens the popover with the live
+      // browser relocated into it. Its URL survived the move — the webview's
+      // guest is preserved by the offscreen container's moveBefore relocation.
+      const chip = window.locator("[data-dock-item]");
+      await expect(chip).toHaveCount(1, { timeout: T_MEDIUM });
+      await chip.click();
+      const dockedAddressBar = window.locator(
+        '[data-dock-portal-target] [data-testid="browser-address-bar"]'
+      );
+      await expect(dockedAddressBar).toBeVisible({ timeout: T_LONG });
+      await expect(dockedAddressBar).toHaveValue(/page-a/, { timeout: T_MEDIUM });
+
+      // A single docked panel exposes the inline "Move to grid" control.
+      await expect(
+        window.locator('[data-dock-portal-target] [data-testid="panel-move-to-grid"]')
+      ).toBeVisible({ timeout: T_SHORT });
+
+      // Double-click restores the panel to the grid.
+      await chip.dblclick();
+      await expect(gridBrowsers).toHaveCount(1, { timeout: T_MEDIUM });
+      await expect(chip).toHaveCount(0, { timeout: T_MEDIUM });
+    });
+  });
+
   // Find-in-page tests skipped: webview crashes in E2E after Console Capture cleanup.
   // The feature works in manual testing — investigate webview lifecycle in E2E context.
   test.describe.skip("Find in Page", () => {

--- a/e2e/full/panels/core-panel-dockability.spec.ts
+++ b/e2e/full/panels/core-panel-dockability.spec.ts
@@ -15,9 +15,9 @@ let ctx: AppContext;
 let fixtureDir: string;
 let fixtureCleanup: (() => void) | undefined;
 
-test.describe.serial("Core: Non-PTY panels reject the dock", () => {
+test.describe.serial("Core: Panel dockability", () => {
   test.beforeAll(async () => {
-    const { dir, cleanup } = createFixtureRepo({ name: "non-pty-dock" });
+    const { dir, cleanup } = createFixtureRepo({ name: "panel-dockability" });
     fixtureDir = dir;
     fixtureCleanup = cleanup;
     ctx = await launchApp();
@@ -29,7 +29,7 @@ test.describe.serial("Core: Non-PTY panels reject the dock", () => {
     fixtureCleanup?.();
   });
 
-  test("terminal panels expose move-to-dock, browser panels do not", async () => {
+  test("terminal and browser panels both expose move-to-dock", async () => {
     const { window } = ctx;
 
     await test.step("A terminal panel shows the move-to-dock control", async () => {
@@ -41,7 +41,7 @@ test.describe.serial("Core: Non-PTY panels reject the dock", () => {
       await expect(terminal.locator(SEL.panel.minimize)).toBeVisible({ timeout: T_SHORT });
     });
 
-    await test.step("A browser panel has no move-to-dock control", async () => {
+    await test.step("A browser panel shows the move-to-dock control (#11053)", async () => {
       await openBrowser(window);
       await expect
         .poll(() => getGridPanelCount(window), { timeout: T_LONG })
@@ -53,9 +53,10 @@ test.describe.serial("Core: Non-PTY panels reject the dock", () => {
         .filter({ has: window.locator(SEL.browser.addressBar) });
       await expect(browserPanel).toHaveCount(1, { timeout: T_MEDIUM });
 
-      // showMoveToDock requires `hasPty` — browser panels render no dock button.
-      // Rendering it would silently strand the panel (ContentDock filters by isPtyPanel).
-      await expect(browserPanel.locator(SEL.panel.minimize)).toHaveCount(0);
+      // browser is now a dockable reading surface (panelKindIsDockable), so the
+      // dock affordance renders — the panel can leave the grid without vanishing.
+      await browserPanel.hover();
+      await expect(browserPanel.locator(SEL.panel.minimize)).toBeVisible({ timeout: T_SHORT });
       // It still has the standard close affordance, confirming this is a real
       // panel header and not a missing-panel false negative.
       await expect(browserPanel.locator(SEL.panel.close)).toHaveCount(1);

--- a/shared/config/__tests__/panelKindPolicy.test.ts
+++ b/shared/config/__tests__/panelKindPolicy.test.ts
@@ -24,17 +24,19 @@ describe("resolvePanelKindPolicy", () => {
 
   it("returns the default policy for a kind that omits the policy block", () => {
     expect(resolvePanelKindPolicy("terminal")).toEqual(DEFAULT_PANEL_KIND_POLICY);
-    expect(resolvePanelKindPolicy("browser")).toEqual(DEFAULT_PANEL_KIND_POLICY);
     expect(resolvePanelKindPolicy("dev-preview")).toEqual(DEFAULT_PANEL_KIND_POLICY);
   });
 
   it("layers a kind's declared policy over the default", () => {
-    const reviewConfig = getPanelKindConfig("review");
-    expect(reviewConfig).toBeDefined();
-    expect(resolvePanelKindPolicy("review")).toEqual({
-      ...DEFAULT_PANEL_KIND_POLICY,
-      dockFallbackTarget: "previous-focused",
-    });
+    // Review and browser are reading surfaces: focus returns to what the user
+    // was last viewing when the panel leaves the grid.
+    for (const kind of ["review", "browser"] as const) {
+      expect(getPanelKindConfig(kind)).toBeDefined();
+      expect(resolvePanelKindPolicy(kind)).toEqual({
+        ...DEFAULT_PANEL_KIND_POLICY,
+        dockFallbackTarget: "previous-focused",
+      });
+    }
   });
 
   it("accepts a PanelKindConfig directly to skip the registry lookup", () => {

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -536,12 +536,12 @@ describe("panelKindIsDockable", () => {
     expect(panelKindIsDockable("terminal")).toBe(true);
   });
 
-  it("file panels opt in via the dockable capability", () => {
+  it("file and browser panels opt in via the dockable capability", () => {
     expect(panelKindIsDockable("file")).toBe(true);
+    expect(panelKindIsDockable("browser")).toBe(true);
   });
 
   it("non-PTY kinds without the capability are not dockable", () => {
-    expect(panelKindIsDockable("browser")).toBe(false);
     expect(panelKindIsDockable("dev-preview")).toBe(false);
     expect(panelKindIsDockable("review")).toBe(false);
   });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -191,11 +191,15 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
+    dockable: true,
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
     searchAliases: ["web", "chrome", "internet", "www"],
     firstRenderRestore: true,
     lazyImportPath: "src/components/Browser/BrowserPane.tsx",
+    // Reading surface like file/review: focus returns to what the user was
+    // last viewing when the panel leaves the grid, not the first grid terminal.
+    policy: { dockFallbackTarget: "previous-focused" },
   },
   "dev-preview": {
     id: "dev-preview",

--- a/shared/types/__tests__/panel.test.ts
+++ b/shared/types/__tests__/panel.test.ts
@@ -3,6 +3,7 @@ import {
   isBuiltInPanelKind,
   isBrowserPanel,
   isDevPreviewPanel,
+  isDockPanel,
   isGridPanelLocation,
   isPtyPanel,
   type PanelInstance,
@@ -96,5 +97,17 @@ describe("panel variant guards", () => {
     expect(isPtyPanel(legacy)).toBe(true);
     expect(isBrowserPanel(legacy)).toBe(false);
     expect(isDevPreviewPanel(legacy)).toBe(false);
+  });
+
+  it("isDockPanel admits PTY, file, and browser panels but not dev-preview/review", () => {
+    // The dock render path only surfaces panels isDockPanel recognizes; browser
+    // must be admitted or it vanishes when moved to the dock (#11053).
+    const filePanel = { id: "p4", kind: "file", title: "t", location: "dock" } as PanelInstance;
+    const reviewPanel = { id: "p5", kind: "review", title: "t", location: "grid" } as PanelInstance;
+    expect(isDockPanel(ptyPanel)).toBe(true);
+    expect(isDockPanel(browserPanel)).toBe(true);
+    expect(isDockPanel(filePanel)).toBe(true);
+    expect(isDockPanel(devPreviewPanel)).toBe(false);
+    expect(isDockPanel(reviewPanel)).toBe(false);
   });
 });

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -634,10 +634,10 @@ export function isFilePanel(panel: PanelInstance | TerminalInstance): panel is F
  * `dockable` capability (`panelKindIsDockable`) — extend both together when a
  * new kind gains dock support, along with a chip branch in `ContentDock`.
  */
-export type DockPanelData = PtyPanelData | FilePanelData;
+export type DockPanelData = PtyPanelData | FilePanelData | BrowserPanelData;
 
 export function isDockPanel(panel: PanelInstance | TerminalInstance): panel is DockPanelData {
-  return isPtyPanel(panel) || isFilePanel(panel);
+  return isPtyPanel(panel) || isFilePanel(panel) || isBrowserPanel(panel);
 }
 
 /**

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -99,11 +99,15 @@ function fileChipTitle(panel: FilePanelData): string {
 }
 
 // Host beats the generic "Browser" title in the chip, mirroring BrowserPane's
-// displayTitle (a page-supplied title still wins).
+// displayTitle (a page-supplied title still wins; a user-locked rename always
+// wins). Falls back to the kind title when there's no host to show (e.g.
+// about:blank, whose URL.host is empty) so the chip is never blank.
 function browserChipTitle(panel: BrowserPanelData): string {
+  if (panel.titleMode === "user") return panel.title;
   if (panel.title && panel.title !== "Browser") return panel.title;
   const currentUrl = panel.browserHistory?.present || panel.browserUrl || "";
-  return currentUrl ? extractHostPort(currentUrl) : panel.title;
+  const host = currentUrl ? extractHostPort(currentUrl) : "";
+  return host || panel.title;
 }
 
 export function ContentDock({ density = "normal" }: ContentDockProps) {

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -107,7 +107,8 @@ function browserChipTitle(panel: BrowserPanelData): string {
   if (panel.title && panel.title !== "Browser") return panel.title;
   const currentUrl = panel.browserHistory?.present || panel.browserUrl || "";
   const host = currentUrl ? extractHostPort(currentUrl) : "";
-  return host || panel.title;
+  // Ultimate fallback so the chip is never blank (e.g. empty title + no URL).
+  return host || panel.title || "Browser";
 }
 
 export function ContentDock({ density = "normal" }: ContentDockProps) {

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -9,14 +9,18 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { usePanelStore, useProjectStore, useWorktreeSelectionStore } from "@/store";
 import {
   isDockPanel,
+  isFilePanel,
   isPtyPanel,
+  type BrowserPanelData,
   type DockPanelData,
+  type FilePanelData,
   type PanelInstance,
 } from "@shared/types/panel";
+import { extractHostPort } from "@/components/Browser/browserUtils";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { TrashedTerminal } from "@/store/slices";
 import { DockedTerminalItem } from "./DockedTerminalItem";
-import { DockedFilePanelItem } from "./DockedFilePanelItem";
+import { DockedNonPtyPanelItem } from "./DockedNonPtyPanelItem";
 import { DockedTabGroup } from "./DockedTabGroup";
 import { TrashContainer } from "./TrashContainer";
 import { WaitingContainer } from "./WaitingContainer";
@@ -85,6 +89,21 @@ const EMPTY_DOCK_TERMINALS: readonly DockPanelData[] = [];
 
 interface ContentDockProps {
   density?: DockDensity;
+}
+
+// File name beats the generic kind title in the chip, mirroring FilePane's own
+// title layering (a user-locked rename still wins).
+function fileChipTitle(panel: FilePanelData): string {
+  const fileName = panel.filePath?.split(/[/\\]/).filter(Boolean).pop();
+  return panel.titleMode === "user" ? panel.title : (fileName ?? panel.title);
+}
+
+// Host beats the generic "Browser" title in the chip, mirroring BrowserPane's
+// displayTitle (a page-supplied title still wins).
+function browserChipTitle(panel: BrowserPanelData): string {
+  if (panel.title && panel.title !== "Browser") return panel.title;
+  const currentUrl = panel.browserHistory?.present || panel.browserUrl || "";
+  return currentUrl ? extractHostPort(currentUrl) : panel.title;
 }
 
 export function ContentDock({ density = "normal" }: ContentDockProps) {
@@ -507,8 +526,16 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                           <SortableDockItem key={group.id} terminal={terminal} sourceIndex={index}>
                             {isPtyPanel(terminal) ? (
                               <DockedTerminalItem terminal={terminal} />
+                            ) : isFilePanel(terminal) ? (
+                              <DockedNonPtyPanelItem
+                                panel={terminal}
+                                displayTitle={fileChipTitle(terminal)}
+                              />
                             ) : (
-                              <DockedFilePanelItem panel={terminal} />
+                              <DockedNonPtyPanelItem
+                                panel={terminal}
+                                displayTitle={browserChipTitle(terminal)}
+                              />
                             )}
                           </SortableDockItem>
                         );

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -3,7 +3,7 @@ import { canDuplicatePanelKind } from "@/services/terminal/panelDuplicationServi
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, useWorktreeSelectionStore } from "@/store";
-import { isDockPanel, type DockPanelData } from "@shared/types/panel";
+import { isDockPanel, isPtyPanel, type DockPanelData } from "@shared/types/panel";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
@@ -337,7 +337,11 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
                   terminal={terminal}
                   onPopoverClose={handlePopoverClose}
                   onAddTab={
-                    isSinglePanel && canDuplicatePanelKind(terminal.kind)
+                    // Dock tab groups are PTY-only (ContentDock resolves groups
+                    // through isPtyPanel), so only PTY panels get the add-tab
+                    // affordance. A duplicable non-PTY kind like browser would
+                    // otherwise spawn a dock group the dock can't render as one.
+                    isSinglePanel && isPtyPanel(terminal) && canDuplicatePanelKind(terminal.kind)
                       ? () => handleAddTabForPanel(terminal)
                       : undefined
                   }

--- a/src/components/Layout/DockedNonPtyPanelItem.tsx
+++ b/src/components/Layout/DockedNonPtyPanelItem.tsx
@@ -5,7 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { cn } from "@/lib/utils";
 import { usePanelStore, useFocusStore } from "@/store";
-import type { FilePanelData } from "@shared/types/panel";
+import type { BrowserPanelData, FilePanelData } from "@shared/types/panel";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
@@ -19,18 +19,21 @@ import {
 } from "./dockPopoverGuard";
 import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
-interface DockedFilePanelItemProps {
-  panel: FilePanelData;
+interface DockedNonPtyPanelItemProps {
+  panel: FilePanelData | BrowserPanelData;
+  /** Chip label, derived per-kind by the caller (file name, browser host). */
+  displayTitle: string;
 }
 
 /**
- * Dock chip for a file viewer panel. Mirrors DockedTerminalItem's popover +
- * stable-wrapper relocation flow, minus everything PTY: no renderer policies,
- * no xterm fit, no agent state. The panel's React subtree lives in
- * DockPanelOffscreenContainer and is moved (not remounted) into this popover,
- * so scroll position and view mode survive open/close.
+ * Dock chip for a non-PTY content panel (file viewer, browser). Mirrors
+ * DockedTerminalItem's popover + stable-wrapper relocation flow, minus
+ * everything PTY: no renderer policies, no xterm fit, no agent state. The
+ * panel's React subtree lives in DockPanelOffscreenContainer and is moved (not
+ * remounted) into this popover — a webview's guest survives the move too — so
+ * scroll position, view mode, and page state survive open/close.
  */
-export function DockedFilePanelItem({ panel }: DockedFilePanelItemProps) {
+export function DockedNonPtyPanelItem({ panel, displayTitle }: DockedNonPtyPanelItemProps) {
   // Pointer/touch drag listeners only — dnd-kit's keyboard handler would
   // preventDefault() this button's activation click (see DockedTerminalItem).
   const dragHandle = useDragHandle();
@@ -104,11 +107,6 @@ export function DockedFilePanelItem({ panel }: DockedFilePanelItemProps) {
   }, [panel.id, moveTerminalToGrid, closeDockTerminal]);
 
   const chrome = useMemo(() => deriveTerminalChrome({ kind: panel.kind }), [panel.kind]);
-
-  // File name beats the generic kind title in the chip, mirroring the pane's
-  // own title layering (a user-locked rename still wins).
-  const fileName = panel.filePath?.split(/[/\\]/).filter(Boolean).pop();
-  const displayTitle = panel.titleMode === "user" ? panel.title : (fileName ?? panel.title);
 
   const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize();
 

--- a/src/components/Layout/__tests__/dockRenderItems.test.ts
+++ b/src/components/Layout/__tests__/dockRenderItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { FilePanelData, PtyPanelData } from "@shared/types/panel";
+import type { BrowserPanelData, FilePanelData, PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 import { buildDockRenderItems } from "../dockRenderItems";
 
@@ -36,6 +36,17 @@ function filePanel(id: string): FilePanelData {
   } as FilePanelData;
 }
 
+function browserPanel(id: string): BrowserPanelData {
+  return {
+    id,
+    title: id,
+    kind: "browser",
+    location: "dock",
+    isVisible: false,
+    browserUrl: `https://example.com/${id}`,
+  } as BrowserPanelData;
+}
+
 describe("buildDockRenderItems", () => {
   it("renders a docked file panel as a standalone chip", () => {
     const items = buildDockRenderItems([], () => [], null, [filePanel("spec")]);
@@ -43,6 +54,32 @@ describe("buildDockRenderItems", () => {
     expect(items).toHaveLength(1);
     expect(items[0]?.panels[0]?.kind).toBe("file");
     expect(items[0]?.group.panelIds).toEqual(["spec"]);
+  });
+
+  it("renders a docked browser panel as a standalone chip", () => {
+    // #11053: browser panels were committable to the dock but had no render
+    // membership, so they vanished. They must surface as standalone chips.
+    const items = buildDockRenderItems([], () => [], null, [browserPanel("docs")]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.panels[0]?.kind).toBe("browser");
+    expect(items[0]?.group.panelIds).toEqual(["docs"]);
+  });
+
+  it("renders a browser panel standalone even when its stored group only resolves PTY panels", () => {
+    // A grid tab group containing a terminal and a browser panel moved to the
+    // dock: groups resolve PTY-only, so the browser panel falls through to the
+    // flat membership list and must not vanish (#11053).
+    const items = buildDockRenderItems(
+      [group(["term-1", "docs"], "term-1")],
+      () => [terminal("term-1")],
+      null,
+      [terminal("term-1"), browserPanel("docs")]
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.group.panelIds).toEqual(["term-1"]);
+    expect(items[1]?.panels[0]?.id).toBe("docs");
   });
 
   it("renders a file panel standalone even when its stored group only resolves PTY panels", () => {

--- a/src/components/Layout/dockRenderItems.ts
+++ b/src/components/Layout/dockRenderItems.ts
@@ -8,7 +8,7 @@ export interface DockRenderItem {
 
 export function buildDockRenderItems(
   tabGroups: TabGroup[],
-  // Tab groups stay PTY-only — file panels dock as standalone chips.
+  // Tab groups stay PTY-only — dockable non-PTY panels (file, browser) dock as standalone chips.
   resolvePanels: (groupId: string) => PtyPanelData[],
   excludedPanelId?: string | null,
   dockTerminals: DockPanelData[] = []

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -174,7 +174,7 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Diagnostics/TelemetryContent.tsx",
     "src/components/Fleet/FleetArmingRibbon.tsx",
     "src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx",
-    "src/components/Layout/DockedFilePanelItem.tsx",
+    "src/components/Layout/DockedNonPtyPanelItem.tsx",
     "src/components/Layout/DockedTabGroup.tsx",
     "src/components/Layout/DockedTerminalItem.tsx",
     "src/components/Layout/Sidebar.tsx",

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -519,7 +519,7 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
     }
   });
 
-  it("kind without policy (default dockPopoverOnSpawn: true) still opens the popover", async () => {
+  it("kind without a dockPopoverOnSpawn override (default true) still opens the popover", async () => {
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
       // browser only overrides dockFallbackTarget — dockPopoverOnSpawn stays the default true.
@@ -639,7 +639,7 @@ describe("defaultFocusOnCreate policy gate (#8946)", () => {
     }
   });
 
-  it("kind without policy (default defaultFocusOnCreate: true) does steal focus on grid spawn", async () => {
+  it("kind without a defaultFocusOnCreate override (default true) does steal focus on grid spawn", async () => {
     const { addPanel } = usePanelStore.getState();
     const firstId = await addPanel({
       kind: "browser",

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -522,7 +522,7 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
   it("kind without policy (default dockPopoverOnSpawn: true) still opens the popover", async () => {
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
-      // browser has no policy — uses default dockPopoverOnSpawn: true.
+      // browser only overrides dockFallbackTarget — dockPopoverOnSpawn stays the default true.
       kind: "browser",
       requestedId: "browser-default-popover",
       cwd: "/",
@@ -652,7 +652,7 @@ describe("defaultFocusOnCreate policy gate (#8946)", () => {
     expect(usePanelStore.getState().focusedId).toBe("anchor-2");
 
     const secondId = await addPanel({
-      // browser has no policy → default defaultFocusOnCreate: true.
+      // browser only overrides dockFallbackTarget → defaultFocusOnCreate stays the default true.
       kind: "browser",
       requestedId: "stealer-2",
       cwd: "/",


### PR DESCRIPTION
## Summary

- Browser panels could be committed to `location: "dock"` (via the dock's `+` launch menu and drag-to-dock, neither kind-guarded), but the dock had no render path for them: `DockPanelData`, `isDockPanel`, and `panelKindIsDockable("browser")` all excluded the browser kind. The panel went invisible while still persisting in the store and still counting against panel limits.
- This fix follows the existing file-panel dockable pattern from `6479b7a18`: the browser kind now gets `dockable: true` and a fallback policy, the dock chip renderer learns a third kind, and the dock's add-tab affordance is scoped to PTY panels so a non-PTY dockable kind can't spawn an unrenderable tab group.

Resolves #11053

## Changes

- Browser panel kind gets `dockable: true` plus `policy: { dockFallbackTarget: "previous-focused" }`, matching file and review panels.
- `BrowserPanelData` added to the `DockPanelData` union and to `isDockPanel`.
- `DockedFilePanelItem` generalized and renamed to `DockedNonPtyPanelItem`, now handling both file and browser panels; the chip title is derived per-kind by `ContentDock` via new `fileChipTitle` / `browserChipTitle` helpers.
- `ContentDock`'s dock chip switch is now three-way: terminal, file, browser.
- Dock add-tab affordance gated to PTY panels only, since browser is the first dockable-and-duplicable non-PTY kind and would otherwise spawn an unrenderable dock group.
- Webview preservation: opening/closing the dock popover relocates the same wrapper element via the offscreen container's connected-path `moveBefore`, so the Electron `<webview>` guest (page state, scroll position, JS state) survives chip open/close with no reload.

**Known limitation (out of scope, matches the file-panel precedent):** the one-time move between grid and dock remounts the panel into a separate render host, so the webview guest reloads once on that transition (URL and history survive). A location-independent webview wrapper spanning grid and dock would be a separate, larger change.

**Explicitly out of scope per the issue:** a generic guard blocking non-dockable kinds (dev-preview, plugin panels) from the dock, and rescuing panels already stranded in persisted state from before this fix.

## Testing

- Registry, policy, type-guard, and dock-render unit tests updated, including a new `isDockPanel(browser)` membership assertion.
- `core-panel-non-pty-rejection.spec.ts` renamed to `core-panel-dockability.spec.ts` (browser now exposes the move-to-dock affordance), plus a new browser dock-lifecycle test in `core-browser-panel.spec.ts`. E2E runs on stabilize/release, not PR CI.
- Locally: 197 targeted unit tests pass, prettier clean, eslint 0 errors on changed files.
