### PR TITLE
fix(dock): enforce panel-kind dockability at every dock entry point (#11054)

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -106,8 +106,11 @@ import {
   resolveGroupPlacementIndex,
   resolveGridInsertionIndexFromRects,
   findGroupIndex,
+  isNonDockableDockDrop,
+  filterOutDockDroppables,
   type OverDropData,
 } from "./dropResolution";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import {
   DURATION_100,
   DURATION_300,
@@ -1290,6 +1293,22 @@ export function DndProvider({ children }: DndProviderProps) {
         return true;
       }
 
+      // A panel whose kind the dock can't render must never commit into the
+      // dock — it would strand invisibly (#11054). Reject the drop so it snaps
+      // back to its origin. `cursor-no-drop` already signals this during hover
+      // (ContentDock), and `collisionDetection` keeps the dock out of the hover
+      // candidates, so this is the defensive final gate on the same capability
+      // predicate the launch menu and move-to-dock use.
+      const targetContainer =
+        overData?.container ??
+        (overData?.sortable?.containerId
+          ? resolveContainerId(overData.sortable.containerId)
+          : null);
+      if (isNonDockableDockDrop(targetContainer, activeDataRaw.terminal.kind)) {
+        setIsCancelDrop(true);
+        return true;
+      }
+
       // Scrollable panel grid (#8805) — dock→grid drops are never rejected on
       // capacity grounds; the grid scrolls vertically to absorb new panels.
 
@@ -1342,19 +1361,35 @@ export function DndProvider({ children }: DndProviderProps) {
         return closestCenter(args);
       }
 
+      // A drag whose panel kind can't live in the dock (#11054) must never
+      // resolve the dock as a collision target — otherwise the dock's
+      // SortableContext reflows during hover before `cancelDrop` snaps it back.
+      // Filter the dock droppable (and its chip sortables) out of the candidate
+      // set and skip the dock-specific closestCenter branch, so the dock is
+      // invisible to collision detection for this drag. Read the kind
+      // synchronously from the drag data (no ref) to keep this callback stable.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- dnd-kit data.current is loosely typed
+      const activeDragData = args.active.data.current as DragData | undefined;
+      const rejectsDock = !panelKindIsDockable(activeDragData?.terminal?.kind ?? "terminal");
+      const effectiveArgs = rejectsDock
+        ? { ...args, droppableContainers: filterOutDockDroppables(args.droppableContainers) }
+        : args;
+
       // First check if we're directly over any droppable
-      const pointerCollisions = pointerWithin(args);
+      const pointerCollisions = pointerWithin(effectiveArgs);
       if (pointerCollisions.length > 0) {
         return pointerCollisions;
       }
 
       // For dock, use closest center (better for 1D); otherwise rect intersection
       // Using rectIntersection as default prevents oscillation when cursor is
-      // outside all containers (e.g., over disabled worktree drop target)
-      if (overContainerRef.current === "dock") {
-        return closestCenter(args);
+      // outside all containers (e.g., over disabled worktree drop target). A
+      // non-dockable drag never takes the dock branch — its stale
+      // `overContainerRef` could otherwise make closestCenter reorder the grid.
+      if (!rejectsDock && overContainerRef.current === "dock") {
+        return closestCenter(effectiveArgs);
       }
-      return rectIntersection(args);
+      return rectIntersection(effectiveArgs);
     },
     [] // Empty deps - function must be stable to prevent dnd-kit measurement loops
   );

--- a/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
@@ -177,10 +177,10 @@ describe("cancelDrop predicates", () => {
   });
 
   describe("non-dockable dock drop (#11054)", () => {
-    it("cancels a browser panel dropped on the dock (direct container)", () => {
+    it("cancels a review panel dropped on the dock (direct container)", () => {
       const result = runCancelDrop({
         overData: { container: "dock" },
-        activeData: makeDragDataOfKind("browser"),
+        activeData: makeDragDataOfKind("review"),
         sourceLocation: "grid",
         targetContainer: "dock",
         gridIsFull: false,
@@ -213,10 +213,10 @@ describe("cancelDrop predicates", () => {
       expect(result).toEqual({ cancel: false });
     });
 
-    it("does not cancel a browser panel dropped on the grid (dock guard is target-scoped)", () => {
+    it("does not cancel a dev-preview panel dropped on the grid (dock guard is target-scoped)", () => {
       const result = runCancelDrop({
         overData: { container: "grid" },
-        activeData: makeDragDataOfKind("browser"),
+        activeData: makeDragDataOfKind("dev-preview"),
         sourceLocation: "grid",
         targetContainer: "grid",
         gridIsFull: false,

--- a/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { DragData } from "../DndProvider";
-import type { OverDropData } from "../dropResolution";
+import { isNonDockableDockDrop, type OverDropData } from "../dropResolution";
 
 // ── Helpers ──────────────────────────────────────────────
 
@@ -78,7 +78,13 @@ function runCancelDrop(params: {
     return { cancel: true };
   }
 
-  // Predicate 3: Dock-to-grid when grid is full
+  // Predicate 3: Dock drop of a kind the dock can't render (#11054). Calls the
+  // real helper so this stays a genuine test of production logic, not a copy.
+  if (isNonDockableDockDrop(targetContainer, activeData.terminal.kind)) {
+    return { cancel: true };
+  }
+
+  // Predicate 4: Dock-to-grid when grid is full
   if (isDockToGridFull(sourceLocation, targetContainer, gridIsFull)) {
     return { cancel: true };
   }
@@ -107,6 +113,12 @@ function makeDragData(overrides: Partial<ActiveDragData> = {}): ActiveDragData {
     sourceIndex: 0,
     ...overrides,
   };
+}
+
+/** Drag data for a panel of a specific kind (for the #11054 dockability guard). */
+function makeDragDataOfKind(kind: string, overrides: Partial<ActiveDragData> = {}): ActiveDragData {
+  const base = makeDragData(overrides);
+  return { ...base, terminal: { ...base.terminal, kind } as DragData["terminal"] };
 }
 
 // ── Tests ────────────────────────────────────────────────
@@ -157,6 +169,56 @@ describe("cancelDrop predicates", () => {
         activeData: makeDragData({ sourceLocation: "dock" }),
         sourceLocation: "dock",
         targetContainer: "dock",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+  });
+
+  describe("non-dockable dock drop (#11054)", () => {
+    it("cancels a browser panel dropped on the dock (direct container)", () => {
+      const result = runCancelDrop({
+        overData: { container: "dock" },
+        activeData: makeDragDataOfKind("browser"),
+        sourceLocation: "grid",
+        targetContainer: "dock",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+
+    it("cancels a dev-preview panel dropped on a dock chip (sortable container)", () => {
+      const result = runCancelDrop({
+        overData: { sortable: { containerId: "dock-container", index: 0 } },
+        activeData: makeDragDataOfKind("dev-preview"),
+        sourceLocation: "grid",
+        targetContainer: "dock",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+
+    it("does not cancel a dockable non-PTY (file) panel dropped on the dock", () => {
+      const result = runCancelDrop({
+        overData: { container: "dock" },
+        activeData: makeDragDataOfKind("file"),
+        sourceLocation: "grid",
+        targetContainer: "dock",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+
+    it("does not cancel a browser panel dropped on the grid (dock guard is target-scoped)", () => {
+      const result = runCancelDrop({
+        overData: { container: "grid" },
+        activeData: makeDragDataOfKind("browser"),
+        sourceLocation: "grid",
+        targetContainer: "grid",
         gridIsFull: false,
         isWorktreeSort: false,
       });

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -7,6 +7,8 @@ import {
   resolveGroupPlacementIndex,
   resolveGridInsertionIndexFromRects,
   findGroupIndex,
+  isNonDockableDockDrop,
+  filterOutDockDroppables,
   type ClientRectLike,
 } from "../dropResolution";
 import type { PanelInstance } from "@shared/types/panel";
@@ -54,6 +56,62 @@ describe("resolveContainerId", () => {
     expect(resolveContainerId("worktree-foo-accordion")).toBeNull();
     expect(resolveContainerId("")).toBeNull();
     expect(resolveContainerId("random")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isNonDockableDockDrop (#11054)
+// ---------------------------------------------------------------------------
+describe("isNonDockableDockDrop", () => {
+  it("rejects a dock drop of a non-dockable kind", () => {
+    expect(isNonDockableDockDrop("dock", "browser")).toBe(true);
+    expect(isNonDockableDockDrop("dock", "dev-preview")).toBe(true);
+  });
+
+  it("allows a dock drop of a dockable kind", () => {
+    // `file` opts into the dock via `dockable: true`; `terminal` is a PTY kind.
+    expect(isNonDockableDockDrop("dock", "file")).toBe(false);
+    expect(isNonDockableDockDrop("dock", "terminal")).toBe(false);
+  });
+
+  it("treats an undefined kind as a legacy PTY panel (dockable)", () => {
+    expect(isNonDockableDockDrop("dock", undefined)).toBe(false);
+  });
+
+  it("never rejects when the target is not the dock", () => {
+    expect(isNonDockableDockDrop("grid", "browser")).toBe(false);
+    expect(isNonDockableDockDrop(null, "browser")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterOutDockDroppables (#11054)
+// ---------------------------------------------------------------------------
+describe("filterOutDockDroppables", () => {
+  const grid = { id: "grid-container", data: { current: { container: "grid" } } };
+  const dock = { id: "dock-container", data: { current: { container: "dock" } } };
+  const dockChip = {
+    id: "chip-1",
+    data: { current: { sortable: { containerId: "dock-container" } } },
+  };
+  const gridChip = {
+    id: "chip-2",
+    data: { current: { sortable: { containerId: "grid-container" } } },
+  };
+
+  it("drops the dock droppable and its chip sortables", () => {
+    const result = filterOutDockDroppables([grid, dock, dockChip, gridChip]);
+    expect(result).toEqual([grid, gridChip]);
+  });
+
+  it("preserves candidate order for the survivors", () => {
+    const result = filterOutDockDroppables([gridChip, dock, grid]);
+    expect(result.map((c) => c.id)).toEqual(["chip-2", "grid-container"]);
+  });
+
+  it("keeps candidates with no data (e.g. plain droppables)", () => {
+    const bare = { id: "bare", data: { current: null } };
+    expect(filterOutDockDroppables([bare, dock])).toEqual([bare]);
   });
 });
 

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -64,13 +64,14 @@ describe("resolveContainerId", () => {
 // ---------------------------------------------------------------------------
 describe("isNonDockableDockDrop", () => {
   it("rejects a dock drop of a non-dockable kind", () => {
-    expect(isNonDockableDockDrop("dock", "browser")).toBe(true);
+    expect(isNonDockableDockDrop("dock", "review")).toBe(true);
     expect(isNonDockableDockDrop("dock", "dev-preview")).toBe(true);
   });
 
   it("allows a dock drop of a dockable kind", () => {
-    // `file` opts into the dock via `dockable: true`; `terminal` is a PTY kind.
+    // `file` and `browser` opt into the dock via `dockable: true`; `terminal` is a PTY kind.
     expect(isNonDockableDockDrop("dock", "file")).toBe(false);
+    expect(isNonDockableDockDrop("dock", "browser")).toBe(false);
     expect(isNonDockableDockDrop("dock", "terminal")).toBe(false);
   });
 
@@ -79,8 +80,8 @@ describe("isNonDockableDockDrop", () => {
   });
 
   it("never rejects when the target is not the dock", () => {
-    expect(isNonDockableDockDrop("grid", "browser")).toBe(false);
-    expect(isNonDockableDockDrop(null, "browser")).toBe(false);
+    expect(isNonDockableDockDrop("grid", "dev-preview")).toBe(false);
+    expect(isNonDockableDockDrop(null, "dev-preview")).toBe(false);
   });
 });
 

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -1,4 +1,6 @@
 import type { TabGroup } from "@shared/types";
+import type { PanelKind } from "@shared/types/panel";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
@@ -93,6 +95,41 @@ export function resolveContainerId(containerId: string): "grid" | "dock" | null 
   if (containerId === "grid-container") return "grid";
   if (containerId === "dock-container") return "dock";
   return null;
+}
+
+/**
+ * True when a drop targets the dock but the dragged panel's kind can't be
+ * rendered there (#11054). The dock filters its contents by `isDockPanel`, so a
+ * non-dockable kind committed into the dock strands invisibly. Callers reject
+ * the drop and let it snap back. An undefined kind is a legacy PTY panel, which
+ * is always dockable — matches the `kind ?? "terminal"` convention used across
+ * the dockability guards.
+ */
+export function isNonDockableDockDrop(
+  targetContainer: "grid" | "dock" | null,
+  kind: PanelKind | undefined
+): boolean {
+  return targetContainer === "dock" && !panelKindIsDockable(kind ?? "terminal");
+}
+
+/** Minimal dnd-kit droppable shape the dock collision filter reads. */
+interface DockCollisionCandidate {
+  data: { current?: { container?: string; sortable?: { containerId?: string } } | null };
+}
+
+/**
+ * Drop the dock droppable and its chip sortables from a collision-detection
+ * candidate set, so a drag whose kind can't live in the dock never resolves the
+ * dock as a hover/drop target — otherwise the dock's `SortableContext` reflows
+ * during hover before the drop is rejected (#11054). Preserves the order of the
+ * remaining candidates.
+ */
+export function filterOutDockDroppables<T extends DockCollisionCandidate>(containers: T[]): T[] {
+  return containers.filter(
+    (c) =>
+      c.data.current?.container !== "dock" &&
+      c.data.current?.sortable?.containerId !== "dock-container"
+  );
 }
 
 /** Filter terminals to those in a given container and worktree, preserving panelIds order. */

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -37,7 +37,9 @@ import {
   SortableDockPlaceholder,
   DOCK_PLACEHOLDER_ID,
   useIsWorktreeSortDragging,
+  useDndPlaceholder,
 } from "@/components/DragDrop";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useHorizontalScrollControls } from "@/hooks";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
@@ -383,6 +385,15 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // Worktree-card sort drags cannot drop here — signal rejection with cursor-no-drop.
   const isWorktreeSortDragging = useIsWorktreeSortDragging();
 
+  // A panel whose kind the dock can't render can't drop here either (#11054).
+  // Read the active drag from the placeholder context and gate on the same
+  // dockability predicate the store guards use, so the reject cue matches what
+  // `cancelDrop`/`collisionDetection` actually enforce.
+  const { activeTerminal } = useDndPlaceholder();
+  const isDraggingNonDockable =
+    activeTerminal !== null && !panelKindIsDockable(activeTerminal.kind ?? "terminal");
+  const isDockDropRejected = isWorktreeSortDragging || isDraggingNonDockable;
+
   // Sync droppable ref with scroll container ref using stable callback
   // This prevents ResizeObserver thrashing that causes infinite update loops
   const combinedRef = useCallback(
@@ -508,9 +519,9 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
               onFocusCapture={handleDockFocusCapture}
               className={cn(
                 "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth scroll-px-4 px-1 transition-[color,background-color,box-shadow]",
-                isWorktreeSortDragging && "cursor-no-drop",
+                isDockDropRejected && "cursor-no-drop",
                 isOver &&
-                  !isWorktreeSortDragging &&
+                  !isDockDropRejected &&
                   "cursor-copy bg-overlay-soft ring-2 ring-border-default ring-inset rounded-[var(--radius-md)]"
               )}
             >

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -10,6 +10,7 @@ import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import type { ActionSource, AgentAvailabilityState } from "@shared/types";
 import { isAgentBlocked, isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 
 // Cap the "Recently launched" band so it stays a quick-reach shortcut rather
 // than a second full agent list above the fixed Pinned/Other groups.
@@ -173,16 +174,24 @@ export function DockLaunchMenuItems({
         </>
       )}
 
+      {/* The dock launcher creates panels directly in the dock, so it must only
+          offer kinds the dock can render (#11054) — otherwise the panel is
+          redirected to the grid on create (`addPanel`) and the menu item lies
+          about where it lands. Gate on the same `panelKindIsDockable` predicate
+          the store guards use, so #11053 (making browser dockable) flips this
+          on without touching a second allowlist. Terminal is always dockable. */}
       <C.Label>Launch panel</C.Label>
       <C.Item onSelect={() => onLaunchAgent("terminal")}>
         <SquareTerminal className="w-3.5 h-3.5 mr-2" />
         Terminal
       </C.Item>
-      <C.Item onSelect={() => onLaunchAgent("browser")}>
-        <Globe className="w-3.5 h-3.5 mr-2 text-status-info" />
-        Browser
-      </C.Item>
-      {hasDevPreview && (
+      {panelKindIsDockable("browser") && (
+        <C.Item onSelect={() => onLaunchAgent("browser")}>
+          <Globe className="w-3.5 h-3.5 mr-2 text-status-info" />
+          Browser
+        </C.Item>
+      )}
+      {hasDevPreview && panelKindIsDockable("dev-preview") && (
         <C.Item onSelect={() => onLaunchAgent("dev-preview")}>
           <MonitorPlay className="w-3.5 h-3.5 mr-2 text-status-success" />
           Dev preview

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -55,14 +55,20 @@ describe("ContentDock regression test", () => {
   });
 
   // Issue #8162 — drop the ambient in-flight rail tint; the only drag-state cue
-  // is the armed isOver treatment, plus a cursor-no-drop rejection signal for
-  // worktree-card sort drags that can't drop on the dock.
-  it("removes ambient panel-drag tint and adds worktree-sort cursor feedback", () => {
+  // is the armed isOver treatment, plus a cursor-no-drop rejection signal.
+  // Issue #11054 — the rejection cue now also fires for a drag whose panel kind
+  // the dock can't render, not just worktree-card sort drags, via the shared
+  // `isDockDropRejected` gate. Both cases suppress the armed isOver treatment.
+  it("removes ambient panel-drag tint and rejects non-dockable drags with cursor feedback", () => {
     const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
 
     expect(content).not.toContain("useIsDragging");
     expect(content).not.toContain('isPanelDragging && "bg-overlay-subtle"');
-    expect(content).toContain('isWorktreeSortDragging && "cursor-no-drop"');
+    expect(content).toContain('isDockDropRejected && "cursor-no-drop"');
+    // The reject gate folds in a non-dockable-kind check on the active drag.
+    expect(content).toContain("isDraggingNonDockable");
+    expect(content).toMatch(/panelKindIsDockable\(activeTerminal\.kind/);
+    expect(content).toMatch(/isDockDropRejected\s*=\s*isWorktreeSortDragging\s*\|\|/);
     expect(content).toMatch(/isOver\s*&&\s*[^]*?cursor-copy/);
   });
 

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -319,29 +319,15 @@ describe("DockLaunchButton", () => {
     expect(getByText("Gemini").hasAttribute("disabled")).toBe(false);
   });
 
-  it("always exposes Terminal and Browser, gates Dev preview on hasDevPreview", () => {
+  it("offers Terminal but gates non-dockable kinds (browser, dev preview) out of the dock launcher (#11054)", () => {
+    // The dock launcher creates panels directly in the dock, so it must only
+    // offer kinds the dock can render. Terminal is a PTY kind — always dockable,
+    // always offered and launchable. Browser and dev preview can't render in the
+    // dock, so — even with hasDevPreview — they must be hidden here, matching the
+    // `addPanel` redirect. (When #11053 makes browser dockable, its shared
+    // `panelKindIsDockable` flag flips this on without touching this menu.)
     const onLaunchAgent = vi.fn();
-    const { getByText, queryByText, rerender } = render(
-      <DockLaunchButton
-        agents={[]}
-        hasDevPreview={false}
-        onLaunchAgent={onLaunchAgent}
-        activeWorktreeId={null}
-        cwd="/tmp"
-      />
-    );
-
-    expect(getByText("Terminal")).toBeTruthy();
-    expect(getByText("Browser")).toBeTruthy();
-    expect(queryByText("Dev preview")).toBeNull();
-
-    fireEvent.click(getByText("Terminal"));
-    expect(onLaunchAgent).toHaveBeenLastCalledWith("terminal");
-
-    fireEvent.click(getByText("Browser"));
-    expect(onLaunchAgent).toHaveBeenLastCalledWith("browser");
-
-    rerender(
+    const { getByText, queryByText } = render(
       <DockLaunchButton
         agents={[]}
         hasDevPreview
@@ -351,8 +337,12 @@ describe("DockLaunchButton", () => {
       />
     );
 
-    fireEvent.click(getByText("Dev preview"));
-    expect(onLaunchAgent).toHaveBeenLastCalledWith("dev-preview");
+    expect(getByText("Terminal")).toBeTruthy();
+    fireEvent.click(getByText("Terminal"));
+    expect(onLaunchAgent).toHaveBeenLastCalledWith("terminal");
+
+    expect(queryByText("Browser")).toBeNull();
+    expect(queryByText("Dev preview")).toBeNull();
   });
 
   it("shows a No recipes yet discovery cue when no recipes match the active worktree", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -319,13 +319,13 @@ describe("DockLaunchButton", () => {
     expect(getByText("Gemini").hasAttribute("disabled")).toBe(false);
   });
 
-  it("offers Terminal but gates non-dockable kinds (browser, dev preview) out of the dock launcher (#11054)", () => {
+  it("offers Terminal and browser but gates non-dockable kinds (dev preview) out of the dock launcher (#11054)", () => {
     // The dock launcher creates panels directly in the dock, so it must only
-    // offer kinds the dock can render. Terminal is a PTY kind — always dockable,
-    // always offered and launchable. Browser and dev preview can't render in the
-    // dock, so — even with hasDevPreview — they must be hidden here, matching the
-    // `addPanel` redirect. (When #11053 makes browser dockable, its shared
-    // `panelKindIsDockable` flag flips this on without touching this menu.)
+    // offer kinds the dock can render, gating on the shared `panelKindIsDockable`
+    // predicate. Terminal is a PTY kind — always dockable, always offered. Browser
+    // is dockable since #11058, so it appears here. Dev preview can't render in the
+    // dock, so — even with hasDevPreview — it stays hidden, matching the `addPanel`
+    // redirect.
     const onLaunchAgent = vi.fn();
     const { getByText, queryByText } = render(
       <DockLaunchButton
@@ -341,7 +341,7 @@ describe("DockLaunchButton", () => {
     fireEvent.click(getByText("Terminal"));
     expect(onLaunchAgent).toHaveBeenLastCalledWith("terminal");
 
-    expect(queryByText("Browser")).toBeNull();
+    expect(getByText("Browser")).toBeTruthy();
     expect(queryByText("Dev preview")).toBeNull();
   });
 

--- a/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
+++ b/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
@@ -275,9 +275,15 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
       expect(state.panelsById[newId!]?.location).toBe("dock");
     });
 
-    it("focus-preserve spawn of a non-PTY (browser) panel into the dock does not steal focus", async () => {
+    it("focus-preserve spawn of a non-PTY (file) panel into the dock does not steal focus", async () => {
+      // Uses `file` (a dockable non-PTY kind) rather than `browser`: since
+      // #11054, `addPanel` redirects a dock request for a non-dockable kind to
+      // the grid, so `browser` would no longer land in the dock. `file` keeps
+      // this test exercising the non-PTY dock-spawn focus path it was written
+      // for.
       const newId = await usePanelStore.getState().addPanel({
-        kind: "browser",
+        kind: "file",
+        filePath: "/test/readme.md",
         location: "dock",
         activateDockOnCreate: true,
         focusPolicy: "preserve",

--- a/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
+++ b/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
@@ -276,11 +276,10 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
     });
 
     it("focus-preserve spawn of a non-PTY (file) panel into the dock does not steal focus", async () => {
-      // Uses `file` (a dockable non-PTY kind) rather than `browser`: since
-      // #11054, `addPanel` redirects a dock request for a non-dockable kind to
-      // the grid, so `browser` would no longer land in the dock. `file` keeps
-      // this test exercising the non-PTY dock-spawn focus path it was written
-      // for.
+      // Uses `file` (a dockable non-PTY kind) so the panel actually lands in
+      // the dock: since #11054, `addPanel` redirects a dock request for a
+      // non-dockable kind (e.g. dev-preview) to the grid, which would bypass the
+      // non-PTY dock-spawn focus path this test exercises.
       const newId = await usePanelStore.getState().addPanel({
         kind: "file",
         filePath: "/test/readme.md",

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -61,19 +61,23 @@ vi.mock("@/store/terminalInputStore", () => ({
   },
 }));
 
-(globalThis as Record<string, unknown>).window = globalThis.window ?? {};
-(window as unknown as Record<string, unknown>).electron = {
-  ...((window as unknown as Record<string, unknown>).electron ?? {}),
-  terminal: {
-    spawn: vi.fn().mockResolvedValue(undefined),
-    trash: vi.fn().mockResolvedValue(undefined),
-    kill: vi.fn().mockResolvedValue(undefined),
-    restore: vi.fn().mockResolvedValue(undefined),
+// jsdom provides `window`; define a partial `electron` bridge via
+// defineProperty (its descriptor value is untyped) so the store's clients can
+// resolve without an unsafe cast on the typed global shim.
+Object.defineProperty(window, "electron", {
+  configurable: true,
+  value: {
+    terminal: {
+      spawn: vi.fn().mockResolvedValue(undefined),
+      trash: vi.fn().mockResolvedValue(undefined),
+      kill: vi.fn().mockResolvedValue(undefined),
+      restore: vi.fn().mockResolvedValue(undefined),
+    },
+    globalEnv: {
+      get: vi.fn().mockResolvedValue({}),
+    },
   },
-  globalEnv: {
-    get: vi.fn().mockResolvedValue({}),
-  },
-};
+});
 
 import { usePanelStore } from "../panelStore";
 

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -148,16 +148,31 @@ describe("panelStore.addPanel dockability guard (#11054)", () => {
     expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
   });
 
+  it("does not activate the dock for a redirected (non-dockable) dock request", async () => {
+    // The create-focus wrapper keys on the COMMITTED location: a browser
+    // requested into the dock is redirected to the grid, so it must NOT take
+    // the dock-activation path — otherwise activeDockTerminalId would point at a
+    // panel that isn't actually in the dock.
+    const id = await usePanelStore
+      .getState()
+      .addPanel({ kind: "browser", location: "dock", activateDockOnCreate: true });
+
+    expect(id).toBeTruthy();
+    const state = usePanelStore.getState();
+    expect(state.panelsById[id!]?.location).toBe("grid");
+    expect(state.activeDockTerminalId).toBeNull();
+  });
+
   it("redirects a restore-shaped dock request (preserved id + saved dock location) to the grid", async () => {
     // This is the addPanel-contract half of the hydration rescue, not a full
     // restart. On restart, `buildArgsForNonPtyRecreation` (statePatcher.ts)
-    // forwards a persisted non-PTY panel's saved `location: "dock"` and
-    // preserves its id, then `restorePanelsPhase` calls `addPanel` with those
-    // args — both verified by the mocked-addPanel hydration tests in
-    // stateHydration.panelRehydration. Here we prove the other half: addPanel
-    // redirects that request to the grid while preserving the id, so a
-    // previously stranded panel comes back instead of carrying invisible dock
-    // state forever.
+    // forwards a persisted non-PTY panel's saved `location`, and
+    // `restorePanelsPhase` calls `addPanel` with the restored id/config (the
+    // latter covered by the mocked-addPanel hydration tests in
+    // stateHydration.panelRehydration). Here we prove the other half: given a
+    // restore-shaped dock request, addPanel redirects it to the grid while
+    // preserving the id — so a previously stranded panel comes back instead of
+    // carrying invisible dock state forever.
     const id = await usePanelStore.getState().addPanel({
       kind: "browser",
       location: "dock",

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+/**
+ * #11054 — the dock only renders kinds it can host (`isDockPanel`). A dock
+ * request for a non-dockable kind must be redirected to the grid by
+ * `addPanel`, not honored, or the panel strands invisibly (still persisted,
+ * still counted, unreachable). Because state hydration funnels persisted
+ * non-PTY panels through this same `addPanel` path
+ * (`buildArgsForNonPtyRecreation` → `addPanel`), the redirect also rescues
+ * already-stranded panels on restart.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(null),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    get: vi.fn(() => null),
+    cleanup: vi.fn(),
+    destroy: vi.fn(),
+    detachForProjectSwitch: vi.fn(),
+    suppressResizesDuringProjectSwitch: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    sendPtyResize: vi.fn(),
+    setInputLocked: vi.fn(),
+    wake: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(() => "mock-notification-id"),
+}));
+
+vi.mock("@/store/terminalInputStore", () => ({
+  useTerminalInputStore: {
+    getState: () => ({ clearAllDraftInputs: vi.fn() }),
+  },
+}));
+
+(globalThis as Record<string, unknown>).window = globalThis.window ?? {};
+(window as unknown as Record<string, unknown>).electron = {
+  ...((window as unknown as Record<string, unknown>).electron ?? {}),
+  terminal: {
+    spawn: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+  },
+  globalEnv: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+};
+
+import { usePanelStore } from "../panelStore";
+
+function resetState() {
+  usePanelStore.setState((s) => ({
+    ...s,
+    panelsById: {},
+    panelIds: [],
+    trashedTerminals: new Map(),
+    backgroundedTerminals: new Map(),
+    tabGroups: new Map(),
+    focusedId: null,
+    previousFocusedId: null,
+    maximizedId: null,
+    activeDockTerminalId: null,
+    pingedId: null,
+    commandQueue: [],
+    commandQueueCountById: {},
+    mruList: [],
+  }));
+}
+
+describe("panelStore.addPanel dockability guard (#11054)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  afterEach(() => {
+    resetState();
+  });
+
+  it("redirects a dock request for a non-dockable kind (browser) to the grid", async () => {
+    const id = await usePanelStore.getState().addPanel({ kind: "browser", location: "dock" });
+
+    expect(id).toBeTruthy();
+    const panel = usePanelStore.getState().panelsById[id!];
+    expect(panel?.location).toBe("grid");
+    // Rescued to a visible grid slot, not left with dock-flavored hidden state.
+    expect(panel?.isVisible).toBe(true);
+  });
+
+  it("redirects a dock request for dev-preview to the grid", async () => {
+    const id = await usePanelStore.getState().addPanel({ kind: "dev-preview", location: "dock" });
+
+    expect(id).toBeTruthy();
+    expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
+  });
+
+  it("honors a dock request for a dockable non-PTY kind (file)", async () => {
+    const id = await usePanelStore
+      .getState()
+      .addPanel({ kind: "file", filePath: "/test/readme.md", location: "dock" });
+
+    expect(id).toBeTruthy();
+    expect(usePanelStore.getState().panelsById[id!]?.location).toBe("dock");
+  });
+
+  it("honors a dock request for a PTY kind (terminal)", async () => {
+    const id = await usePanelStore
+      .getState()
+      .addPanel({ kind: "terminal", cwd: "/test", location: "dock" });
+
+    expect(id).toBeTruthy();
+    expect(usePanelStore.getState().panelsById[id!]?.location).toBe("dock");
+  });
+
+  it("leaves an explicit grid request for a non-dockable kind untouched", async () => {
+    const id = await usePanelStore.getState().addPanel({ kind: "browser", location: "grid" });
+
+    expect(id).toBeTruthy();
+    expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
+  });
+
+  it("rescues an already-stranded persisted dock panel back to the grid on restore", async () => {
+    // Mirrors what `buildArgsForNonPtyRecreation` passes into `addPanel` when
+    // rehydrating a persisted non-PTY panel: a preserved id plus the saved
+    // `location: "dock"`. The guard redirects it to the grid so the user gets
+    // the panel back instead of carrying invisible state forever.
+    const id = await usePanelStore.getState().addPanel({
+      kind: "browser",
+      location: "dock",
+      requestedId: "stranded-browser-1",
+    });
+
+    expect(id).toBe("stranded-browser-1");
+    expect(usePanelStore.getState().panelsById["stranded-browser-1"]?.location).toBe("grid");
+  });
+});

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -148,11 +148,16 @@ describe("panelStore.addPanel dockability guard (#11054)", () => {
     expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
   });
 
-  it("rescues an already-stranded persisted dock panel back to the grid on restore", async () => {
-    // Mirrors what `buildArgsForNonPtyRecreation` passes into `addPanel` when
-    // rehydrating a persisted non-PTY panel: a preserved id plus the saved
-    // `location: "dock"`. The guard redirects it to the grid so the user gets
-    // the panel back instead of carrying invisible state forever.
+  it("redirects a restore-shaped dock request (preserved id + saved dock location) to the grid", async () => {
+    // This is the addPanel-contract half of the hydration rescue, not a full
+    // restart. On restart, `buildArgsForNonPtyRecreation` (statePatcher.ts)
+    // forwards a persisted non-PTY panel's saved `location: "dock"` and
+    // preserves its id, then `restorePanelsPhase` calls `addPanel` with those
+    // args — both verified by the mocked-addPanel hydration tests in
+    // stateHydration.panelRehydration. Here we prove the other half: addPanel
+    // redirects that request to the grid while preserving the id, so a
+    // previously stranded panel comes back instead of carrying invisible dock
+    // state forever.
     const id = await usePanelStore.getState().addPanel({
       kind: "browser",
       location: "dock",

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -110,8 +110,8 @@ describe("panelStore.addPanel dockability guard (#11054)", () => {
     resetState();
   });
 
-  it("redirects a dock request for a non-dockable kind (browser) to the grid", async () => {
-    const id = await usePanelStore.getState().addPanel({ kind: "browser", location: "dock" });
+  it("redirects a dock request for a non-dockable kind (review) to the grid", async () => {
+    const id = await usePanelStore.getState().addPanel({ kind: "review", location: "dock" });
 
     expect(id).toBeTruthy();
     const panel = usePanelStore.getState().panelsById[id!];
@@ -146,20 +146,20 @@ describe("panelStore.addPanel dockability guard (#11054)", () => {
   });
 
   it("leaves an explicit grid request for a non-dockable kind untouched", async () => {
-    const id = await usePanelStore.getState().addPanel({ kind: "browser", location: "grid" });
+    const id = await usePanelStore.getState().addPanel({ kind: "dev-preview", location: "grid" });
 
     expect(id).toBeTruthy();
     expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
   });
 
   it("does not activate the dock for a redirected (non-dockable) dock request", async () => {
-    // The create-focus wrapper keys on the COMMITTED location: a browser
+    // The create-focus wrapper keys on the COMMITTED location: a dev-preview
     // requested into the dock is redirected to the grid, so it must NOT take
     // the dock-activation path — otherwise activeDockTerminalId would point at a
     // panel that isn't actually in the dock.
     const id = await usePanelStore
       .getState()
-      .addPanel({ kind: "browser", location: "dock", activateDockOnCreate: true });
+      .addPanel({ kind: "dev-preview", location: "dock", activateDockOnCreate: true });
 
     expect(id).toBeTruthy();
     const state = usePanelStore.getState();
@@ -178,12 +178,12 @@ describe("panelStore.addPanel dockability guard (#11054)", () => {
     // preserving the id — so a previously stranded panel comes back instead of
     // carrying invisible dock state forever.
     const id = await usePanelStore.getState().addPanel({
-      kind: "browser",
+      kind: "dev-preview",
       location: "dock",
-      requestedId: "stranded-browser-1",
+      requestedId: "stranded-devpreview-1",
     });
 
-    expect(id).toBe("stranded-browser-1");
-    expect(usePanelStore.getState().panelsById["stranded-browser-1"]?.location).toBe("grid");
+    expect(id).toBe("stranded-devpreview-1");
+    expect(usePanelStore.getState().panelsById["stranded-devpreview-1"]?.location).toBe("grid");
   });
 });

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -361,9 +361,15 @@ export const usePanelStore = create<PanelGridState>()(
         // rescued grid panel would skip grid focus AND falsely take the dock-
         // activation path below — which the registry's atomic commit never ran
         // for it, since that path requires the panel to actually land in the dock.
-        const committedLocation = get().panelsById[id]?.location;
-        const committedToGrid = committedLocation === "grid" || committedLocation === undefined;
-        const committedToDock = committedLocation === "dock";
+        // If the panel was removed during addPanel's async tail (a PTY prewarm
+        // await, a project switch, or an explicit removePanel), the lookup is
+        // undefined — there is nothing to focus, so fall through to neither
+        // branch rather than treating a missing panel as a grid panel.
+        const committedPanel = get().panelsById[id];
+        const committedToGrid =
+          committedPanel !== undefined &&
+          (committedPanel.location === "grid" || committedPanel.location === undefined);
+        const committedToDock = committedPanel?.location === "dock";
         // Skip the per-panel focus mutation while a hydration batch is collecting panels:
         // firing `set({ focusedId })` here would schedule one extra render per panel and
         // defeat the batch's single-render guarantee. The arbitrary "last panel added"

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -392,11 +392,7 @@ export const usePanelStore = create<PanelGridState>()(
           } else {
             set({ focusedId: id });
           }
-        } else if (
-          options.activateDockOnCreate &&
-          committedToDock &&
-          !isHydrationBatchActive()
-        ) {
+        } else if (options.activateDockOnCreate && committedToDock && !isHydrationBatchActive()) {
           // The registry slice atomically advances `focusedId` to the new id
           // inside its commit for normal dock activations (#6590). When the
           // assistant currently owns input we issue a corrective set() to roll

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -355,12 +355,21 @@ export const usePanelStore = create<PanelGridState>()(
             : { ...options, focusPolicy: resolvedFocusPolicy };
         const id = await registrySlice.addPanel(panelOptions);
         if (id === null) return null;
+        // A non-dockable kind requested into the dock is redirected to the grid
+        // by the registry (#11054), so the focus / dock-activation decision must
+        // key off the COMMITTED location, not the requested one. Otherwise a
+        // rescued grid panel would skip grid focus AND falsely take the dock-
+        // activation path below — which the registry's atomic commit never ran
+        // for it, since that path requires the panel to actually land in the dock.
+        const committedLocation = get().panelsById[id]?.location;
+        const committedToGrid = committedLocation === "grid" || committedLocation === undefined;
+        const committedToDock = committedLocation === "dock";
         // Skip the per-panel focus mutation while a hydration batch is collecting panels:
         // firing `set({ focusedId })` here would schedule one extra render per panel and
         // defeat the batch's single-render guarantee. The arbitrary "last panel added"
         // focus also isn't meaningful during restore — focus is resolved elsewhere once
         // the active worktree is set.
-        if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
+        if (committedToGrid && !isHydrationBatchActive()) {
           // Suppress focus capture for preserve-policy spawns or when the
           // Daintree Assistant currently owns keyboard focus. The new panel
           // still lands in the grid; the user keeps typing where they were.
@@ -379,7 +388,7 @@ export const usePanelStore = create<PanelGridState>()(
           }
         } else if (
           options.activateDockOnCreate &&
-          options.location === "dock" &&
+          committedToDock &&
           !isHydrationBatchActive()
         ) {
           // The registry slice atomically advances `focusedId` to the new id

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -94,20 +94,20 @@ describe("Worktree-scoped bulk actions", () => {
   });
 
   it("bulkMoveToDockByWorktree skips a non-dockable kind — it would strand invisibly (#11054)", () => {
-    // A browser panel can't render in the dock (`isDockPanel` filters it out),
+    // A dev-preview panel can't render in the dock (`isDockPanel` filters it out),
     // so bulk-docking a worktree must leave it on the grid, matching the guard
     // on `bulkMoveToDock`.
     setTerminals([
       createMockTerminal("wt1-grid-1", "wt1", "grid"),
-      createMockTerminal("wt1-browser-1", "wt1", "grid", "browser"),
+      createMockTerminal("wt1-devpreview-1", "wt1", "grid", "dev-preview"),
     ]);
 
     usePanelStore.getState().bulkMoveToDockByWorktree("wt1");
 
     const state = usePanelStore.getState();
     expect(state.panelsById["wt1-grid-1"]?.location).toBe("dock");
-    // The non-dockable browser panel stays on the grid.
-    expect(state.panelsById["wt1-browser-1"]?.location).toBe("grid");
+    // The non-dockable dev-preview panel stays on the grid.
+    expect(state.panelsById["wt1-devpreview-1"]?.location).toBe("grid");
   });
 
   it("bulkMoveToGridByWorktree respects grid capacity and only moves that worktree's docked terminals", () => {

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -49,11 +49,13 @@ function setTerminals(terminals: PtyPanelData[]) {
 function createMockTerminal(
   id: string,
   worktreeId: string,
-  location: "grid" | "dock" | "trash" = "grid"
+  location: "grid" | "dock" | "trash" = "grid",
+  kind?: string
 ): PtyPanelData {
   return {
     id,
     type: "terminal",
+    ...(kind !== undefined && { kind }),
     title: `Terminal ${id}`,
     cwd: "/test",
     cols: 80,
@@ -95,16 +97,10 @@ describe("Worktree-scoped bulk actions", () => {
     // A browser panel can't render in the dock (`isDockPanel` filters it out),
     // so bulk-docking a worktree must leave it on the grid, matching the guard
     // on `bulkMoveToDock`.
-    const browserPanel = {
-      id: "wt1-browser-1",
-      type: "browser",
-      kind: "browser",
-      title: "Browser",
-      worktreeId: "wt1",
-      location: "grid",
-    } as unknown as PtyPanelData;
-
-    setTerminals([createMockTerminal("wt1-grid-1", "wt1", "grid"), browserPanel]);
+    setTerminals([
+      createMockTerminal("wt1-grid-1", "wt1", "grid"),
+      createMockTerminal("wt1-browser-1", "wt1", "grid", "browser"),
+    ]);
 
     usePanelStore.getState().bulkMoveToDockByWorktree("wt1");
 

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -91,6 +91,29 @@ describe("Worktree-scoped bulk actions", () => {
     expect(state.panelsById["wt2-grid-1"]?.location).toBe("grid");
   });
 
+  it("bulkMoveToDockByWorktree skips a non-dockable kind — it would strand invisibly (#11054)", () => {
+    // A browser panel can't render in the dock (`isDockPanel` filters it out),
+    // so bulk-docking a worktree must leave it on the grid, matching the guard
+    // on `bulkMoveToDock`.
+    const browserPanel = {
+      id: "wt1-browser-1",
+      type: "browser",
+      kind: "browser",
+      title: "Browser",
+      worktreeId: "wt1",
+      location: "grid",
+    } as unknown as PtyPanelData;
+
+    setTerminals([createMockTerminal("wt1-grid-1", "wt1", "grid"), browserPanel]);
+
+    usePanelStore.getState().bulkMoveToDockByWorktree("wt1");
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["wt1-grid-1"]?.location).toBe("dock");
+    // The non-dockable browser panel stays on the grid.
+    expect(state.panelsById["wt1-browser-1"]?.location).toBe("grid");
+  });
+
   it("bulkMoveToGridByWorktree respects grid capacity and only moves that worktree's docked terminals", () => {
     const otherGrid = Array.from({ length: 15 }, (_, i) =>
       createMockTerminal(`wt2-grid-${i}`, "wt2", "grid")

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -393,8 +393,11 @@ describe("atomic dock activation on create (#6590)", () => {
     expect(wake).not.toHaveBeenCalled();
   });
 
-  it("activates a non-PTY (browser) panel in the dock atomically", async () => {
-    const targetId = "browser-dock-1";
+  it("activates a non-PTY (file) panel in the dock atomically", async () => {
+    // `file` is a dockable non-PTY kind. `browser` is no longer usable here:
+    // since #11054, addPanel redirects a dock request for a non-dockable kind
+    // to the grid, so it would never reach the dock-activation path.
+    const targetId = "file-dock-1";
     const snapshotsWithPanel: Array<{
       hasPanelInById: boolean;
       activeDockTerminalId: string | null;
@@ -412,7 +415,8 @@ describe("atomic dock activation on create (#6590)", () => {
     try {
       const { addPanel } = usePanelStore.getState();
       await addPanel({
-        kind: "browser",
+        kind: "file",
+        filePath: "/readme.md",
         requestedId: targetId,
         cwd: "/",
         location: "dock",
@@ -443,6 +447,9 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
       iconId: "test",
       color: "#000",
       hasPty: false,
+      // Must be dockable, or the #11054 guard redirects the dock request to the
+      // grid and the popover assertion below becomes vacuous.
+      dockable: true,
       canRestart: false,
       canConvert: false,
       usesTerminalUi: false,
@@ -488,6 +495,9 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
       iconId: "test",
       color: "#000",
       hasPty: false,
+      // Must be dockable, or the #11054 guard redirects the dock request to the
+      // grid and the suppression assertion below becomes vacuous.
+      dockable: true,
       canRestart: false,
       canConvert: false,
       usesTerminalUi: false,
@@ -522,7 +532,8 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
   it("kind without a dockPopoverOnSpawn override (default true) still opens the popover", async () => {
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
-      // browser only overrides dockFallbackTarget — dockPopoverOnSpawn stays the default true.
+      // browser only overrides dockFallbackTarget — dockPopoverOnSpawn stays the
+      // default true. It is dockable (#11058), so the popover path runs.
       kind: "browser",
       requestedId: "browser-default-popover",
       cwd: "/",

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -394,9 +394,9 @@ describe("atomic dock activation on create (#6590)", () => {
   });
 
   it("activates a non-PTY (file) panel in the dock atomically", async () => {
-    // `file` is a dockable non-PTY kind. `browser` is no longer usable here:
-    // since #11054, addPanel redirects a dock request for a non-dockable kind
-    // to the grid, so it would never reach the dock-activation path.
+    // `file` is a dockable non-PTY kind, so it reaches the dock-activation path.
+    // A non-dockable kind (e.g. dev-preview) would be redirected to the grid by
+    // addPanel since #11054 and never activate the dock.
     const targetId = "file-dock-1";
     const snapshotsWithPanel: Array<{
       hasPanelInById: boolean;

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -9,6 +9,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import {
   panelKindUsesTerminalUi,
+  panelKindIsDockable,
   getPanelKindConfig,
   getExtensionFallbackDefaults,
   resolvePanelKindPolicy,
@@ -203,7 +204,20 @@ export const createAddPanelActions = (
       // The scrollable grid (#8805) accepts every panel — there's no
       // screen-fit cap any more. Honor the requested location directly; the
       // hard ceiling has already been enforced upstream by `panelLimitStore`.
-      const location = options.location || "grid";
+      const requestedLocation = options.location || "grid";
+      // The dock only renders kinds it can host (`isDockPanel`). A dock request
+      // for a non-dockable kind would strand the panel invisibly — still
+      // persisted, still counted, unreachable from any UI (#11054). Redirect it
+      // to the grid instead. This also rescues already-stranded panels on
+      // restart: hydration funnels non-PTY panels through this same branch
+      // (`buildArgsForNonPtyRecreation` → `addPanel`), so a persisted dock panel
+      // of a non-dockable kind is returned to the grid on next load. Must run
+      // before the `shouldBackground`/`runtimeStatus` derivation below, or a
+      // redirected-to-grid panel would still get dock-flavored background state.
+      const location =
+        requestedLocation === "dock" && !panelKindIsDockable(requestedKind)
+          ? "grid"
+          : requestedLocation;
       const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
       // When activeWorktreeId is null (worktree store not yet hydrated — common
       // during a project switch), treat the panel as being in the active worktree

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -187,7 +187,12 @@ export const createTerminalBulkActionsSlice = (
     bulkMoveToDockByWorktree: (worktreeId) => {
       const terminals = getTerminals();
       const gridTerminals = terminals.filter(
-        (t) => t.worktreeId === worktreeId && (t.location === "grid" || t.location === undefined)
+        (t) =>
+          t.worktreeId === worktreeId &&
+          (t.location === "grid" || t.location === undefined) &&
+          // Never bulk-move a kind the dock can't render (#11054) — it would
+          // strand invisibly. Matches the guard already on `bulkMoveToDock`.
+          panelKindIsDockable(t.kind ?? "terminal")
       );
       gridTerminals.forEach((t) => moveTerminalToDock(t.id));
     },


### PR DESCRIPTION
## Summary

- The dock only renders panel kinds it can host, via the `isDockPanel` predicate (PTY kinds plus anything marked `dockable`, currently just `file`). Two creation/drag-and-drop entry points and the dock launch menu accepted `location: "dock"` for any kind, so non-dockable panels like browser and dev preview could get stranded there: invisible, still persisted across restarts, still counted against panel limits, unreachable from any UI.
- This enforces the existing `panelKindIsDockable` predicate at every entry point that can route a panel to the dock.
- Independent of #11053, which makes browser panels dockable. That issue changes which kinds qualify; this one makes the predicate actually enforced.

Resolves #11054.

## Changes

- `addPanel` (non-PTY branch): redirects a `location: "dock"` request to `grid` for a non-dockable kind, before background/runtime-status derivation runs. This doubles as the hydration rescue: persisted stranded dock panels rehydrate through the same `addPanel` and land back on the grid on next load.
- Drag and drop (`DndProvider`): `cancelDrop` rejects a non-dockable drop onto the dock; collision detection filters the dock out of hover candidates during a non-dockable drag (no jitter) and never takes the dock's `closestCenter` branch. New pure helpers `isNonDockableDockDrop` and `filterOutDockDroppables` in `dropResolution.ts`.
- `ContentDock`: shows a cursor-no-drop affordance for a non-dockable active drag via a shared `isDockDropRejected` gate.
- Dock launch menu: hides Browser/Dev preview when they aren't dockable, driven by the predicate rather than a second hardcoded allowlist, so it stays correct if the dockable set changes later.
- `bulkMoveToDockByWorktree`: skips non-dockable kinds, matching the existing behavior of `bulkMoveToDock`.
- `addPanel` create-focus wrapper in `panelStore`: bases the grid-focus vs. dock-activation decision on the committed location (guarding for panel existence) rather than the requested one, so a redirected panel is focused as a grid panel instead of being treated as a dock activation.

Out of scope, noted for a follow-up: the canonical move sinks (`moveTerminalToDock`, `moveTerminalToPosition`, `moveTabGroupToLocation`) and the mixed-tab-group drag-and-drop case aren't guarded yet. The codebase currently moves non-dockable review panels to the dock intentionally, as a fallback policy, so guarding the mutation layer is a separate behavioral call. Mixed terminal+browser tab groups also aren't normally constructible today (no cross-kind tab merge).

## Testing

390 targeted tests pass across 67 files, covering the `addPanel` redirect and hydration-rescue behavior, the drag-and-drop reject and collision helpers, launch menu filtering, the bulk-action skip, and the focus wrapper. New test file: `panelStore.dockability.test.ts`. Zero net-new lint warnings, prettier clean on all changed files.
