### PR TITLE
fix(panels): return to the grid when a new panel takes the grid while maximized

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -156,6 +156,7 @@ const mockAddPanel = vi.fn();
 const mockBeginSpawnBatch = vi.fn(() => Symbol("test-spawn-batch"));
 const mockFlushSpawnBatch = vi.fn();
 const mockSetFocused = vi.fn();
+const mockExitMaximize = vi.fn();
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: () => ({
@@ -165,6 +166,7 @@ vi.mock("@/store/panelStore", () => ({
       beginSpawnBatch: () => mockBeginSpawnBatch(),
       flushSpawnBatch: (token: unknown) => mockFlushSpawnBatch(token),
       setFocused: (id: string) => mockSetFocused(id),
+      exitMaximize: () => mockExitMaximize(),
     }),
   },
 }));

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -85,6 +85,18 @@ export interface AddPanelOptionsBase {
    * Ignored during hydration batches.
    */
   activateDockOnCreate?: boolean;
+  /**
+   * Keep the current fullscreen view when this panel lands in the grid and takes
+   * focus. Only for callers that immediately fold the new panel into the group
+   * that is *already* maximized — the tab-strip "+" adds the panel first and
+   * groups it second, so at commit time it isn't a member yet and would
+   * otherwise look like a plain new grid cell (#11060).
+   *
+   * Not a background-spawn switch: a caller that simply doesn't want to disturb
+   * the user wants `focusPolicy: "preserve"`, which suppresses focus and leaves
+   * maximize untouched on its own.
+   */
+  preserveMaximize?: boolean;
   // --- PTY-related fields (optional on all types, only used by PTY panel kinds) ---
   shell?: string;
   command?: string;

--- a/src/components/Terminal/__tests__/addTabForPanel.test.ts
+++ b/src/components/Terminal/__tests__/addTabForPanel.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PanelInstance } from "@shared/types/panel";
+
+const addPanelMock = vi.fn();
+const getPanelGroupMock = vi.fn();
+const createTabGroupMock = vi.fn();
+const addPanelToGroupMock = vi.fn();
+const deleteTabGroupMock = vi.fn();
+const trashPanelMock = vi.fn();
+const setActiveTabMock = vi.fn();
+const setFocusedMock = vi.fn();
+const buildPanelDuplicateOptionsMock = vi.fn();
+
+vi.mock("@/store/panelStore", () => ({
+  panelStoreApi: {
+    getState: () => ({
+      getPanelGroup: getPanelGroupMock,
+      createTabGroup: createTabGroupMock,
+      addPanelToGroup: addPanelToGroupMock,
+      deleteTabGroup: deleteTabGroupMock,
+      addPanel: addPanelMock,
+      trashPanel: trashPanelMock,
+      setActiveTab: setActiveTabMock,
+      setFocused: setFocusedMock,
+    }),
+  },
+  usePanelStore: Object.assign(vi.fn(), { getState: () => ({}) }),
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: buildPanelDuplicateOptionsMock,
+}));
+
+const { addTabForPanel } = await import("../useContentGridContext");
+
+function makePanel(overrides: Partial<PanelInstance> = {}): PanelInstance {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return {
+    id: "p1",
+    title: "Panel 1",
+    kind: "terminal",
+    location: "grid",
+    worktreeId: "wt-1",
+    ...overrides,
+  } as PanelInstance;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildPanelDuplicateOptionsMock.mockResolvedValue({ kind: "terminal", title: "Panel 1" });
+  addPanelMock.mockResolvedValue("new-tab");
+  addPanelToGroupMock.mockReturnValue(true);
+  getPanelGroupMock.mockReturnValue({ id: "g1", panelIds: ["p1"], activeTabId: "p1" });
+});
+
+describe("addTabForPanel", () => {
+  it("keeps the group fullscreen while adding a tab to it (#11060)", async () => {
+    // The new tab joins the group only after addPanel commits, so without this
+    // flag the store would read it as a plain new grid cell and drop the user out
+    // of the fullscreen group they are adding the tab to.
+    await addTabForPanel(makePanel());
+
+    expect(addPanelMock).toHaveBeenCalledTimes(1);
+    const options = addPanelMock.mock.calls[0]?.[0] as { preserveMaximize?: boolean };
+    expect(options.preserveMaximize).toBe(true);
+  });
+
+  it("folds the new tab into the group and activates it", async () => {
+    await addTabForPanel(makePanel());
+
+    expect(addPanelToGroupMock).toHaveBeenCalledWith("g1", "new-tab");
+    expect(setActiveTabMock).toHaveBeenCalledWith("g1", "new-tab");
+    expect(setFocusedMock).toHaveBeenCalledWith("new-tab");
+  });
+});

--- a/src/components/Terminal/__tests__/addTabForPanel.test.ts
+++ b/src/components/Terminal/__tests__/addTabForPanel.test.ts
@@ -64,8 +64,7 @@ describe("addTabForPanel", () => {
     await addTabForPanel(makePanel());
 
     expect(addPanelMock).toHaveBeenCalledTimes(1);
-    const options = addPanelMock.mock.calls[0]?.[0] as { preserveMaximize?: boolean };
-    expect(options.preserveMaximize).toBe(true);
+    expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ preserveMaximize: true }));
   });
 
   it("folds the new tab into the group and activates it", async () => {

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -128,8 +128,11 @@ export async function addTabForPanel(panel: PanelInstance): Promise<void> {
       createdNewGroup = true;
     }
 
+    // The new tab joins `groupId` below, but only after `addPanel` commits — so
+    // at commit time it looks like a plain new grid cell and would otherwise
+    // drop the user out of a fullscreen group they're adding a tab to (#11060).
     const options = await buildPanelDuplicateOptions(panel, "grid");
-    newPanelId = await addPanel(options);
+    newPanelId = await addPanel({ ...options, preserveMaximize: true });
     if (!newPanelId) {
       if (createdNewGroup && groupId) deleteTabGroup(groupId);
       return;

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -479,7 +479,7 @@ describe("spawnPanelsFromRecipe", () => {
     expect(mockSetFocused).toHaveBeenCalledWith("panel-grid");
   });
 
-  it("leaves fullscreen before focusing the spawned grid panel (#11060)", async () => {
+  it("leaves fullscreen when the spawned grid panel takes focus (#11060)", async () => {
     mockAddPanel.mockResolvedValueOnce("panel-grid");
     mockPanelsById["panel-grid"] = { location: "grid" };
 
@@ -490,18 +490,12 @@ describe("spawnPanelsFromRecipe", () => {
     });
 
     expect(mockExitMaximize).toHaveBeenCalledTimes(1);
-    // Ordering is the whole point: focusing first would promote the panel's
-    // worktree while a stale global maximize target still gated the grid.
-    expect(mockExitMaximize.mock.invocationCallOrder[0]!).toBeLessThan(
-      mockSetFocused.mock.invocationCallOrder[0]!
-    );
+    expect(mockSetFocused).toHaveBeenCalledWith("panel-grid");
   });
 
-  it("stays fullscreen when the spawned panel auto-docks at capacity (#11060)", async () => {
-    // Requested for the grid, but committed to the dock — the fullscreen grid
-    // view is not what the user is being shown, so it must not be disturbed.
-    mockAddPanel.mockResolvedValueOnce("panel-autodocked");
-    mockPanelsById["panel-autodocked"] = { location: "dock" };
+  it("stays fullscreen when the spawned panel committed to the dock (#11060)", async () => {
+    mockAddPanel.mockResolvedValueOnce("panel-docked");
+    mockPanelsById["panel-docked"] = { location: "dock" };
 
     await spawnPanelsFromRecipe({
       terminals: [makeTerminal()],
@@ -510,7 +504,21 @@ describe("spawnPanelsFromRecipe", () => {
     });
 
     expect(mockExitMaximize).not.toHaveBeenCalled();
-    expect(mockSetFocused).toHaveBeenCalledWith("panel-autodocked");
+  });
+
+  it("stays fullscreen when the spawned panel is gone by the time focus is restored (#11060)", async () => {
+    // addPanel resolves an id, but the panel is removed during its async tail (a
+    // PTY prewarm await, a project switch, an explicit removePanel). A panel that
+    // no longer exists must not drag the user out of fullscreen.
+    mockAddPanel.mockResolvedValueOnce("panel-vanished");
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockExitMaximize).not.toHaveBeenCalled();
   });
 
   it("leaves fullscreen alone for a background MCP spawn (#11060)", async () => {

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -29,20 +29,31 @@ vi.mock("@shared/types", async (importActual) => {
 });
 
 const mockSetFocused = vi.fn();
+const mockExitMaximize = vi.fn();
 const mockBeginSpawnBatch = vi.fn(() => Symbol("spawn-batch"));
 const mockFlushSpawnBatch = vi.fn();
+/** Committed panels, keyed by id — the post-batch focus path reads this back to
+ * tell a grid landing from an auto-docked one. Mutable so tests can stage it. */
+const mockPanelsById: Record<string, { location?: string }> = {};
 
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: () => ({
       addPanel: (...args: unknown[]) => mockAddPanel(...args),
       panelIds: [],
-      panelsById: {},
+      panelsById: mockPanelsById,
       beginSpawnBatch: mockBeginSpawnBatch,
       flushSpawnBatch: mockFlushSpawnBatch,
       setFocused: mockSetFocused,
+      exitMaximize: mockExitMaximize,
     }),
   },
+}));
+
+const mockIsMcpSpawnFocusSuppressed = vi.fn(() => false);
+
+vi.mock("@/store/mcpSpawnFocusGuard", () => ({
+  isMcpSpawnFocusSuppressed: () => mockIsMcpSpawnFocusSuppressed(),
 }));
 
 function makeTerminal(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
@@ -79,6 +90,10 @@ function makeAgent(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  for (const key of Object.keys(mockPanelsById)) delete mockPanelsById[key];
+  // clearAllMocks leaves mockReturnValue overrides in place — pin the default
+  // back so the MCP-suppressed case can't leak into the tests after it.
+  mockIsMcpSpawnFocusSuppressed.mockReturnValue(false);
   mockAddPanel.mockResolvedValue("panel-id-123");
   mockAgentSettingsGet.mockResolvedValue({ agents: { claude: { modelId: "sonnet" } } });
   mockSystemGetTmpDir.mockResolvedValue("/tmp/daintree");
@@ -462,6 +477,57 @@ describe("spawnPanelsFromRecipe", () => {
 
     expect(mockSetFocused).toHaveBeenCalledTimes(1);
     expect(mockSetFocused).toHaveBeenCalledWith("panel-grid");
+  });
+
+  it("leaves fullscreen before focusing the spawned grid panel (#11060)", async () => {
+    mockAddPanel.mockResolvedValueOnce("panel-grid");
+    mockPanelsById["panel-grid"] = { location: "grid" };
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockExitMaximize).toHaveBeenCalledTimes(1);
+    // Ordering is the whole point: focusing first would promote the panel's
+    // worktree while a stale global maximize target still gated the grid.
+    expect(mockExitMaximize.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockSetFocused.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("stays fullscreen when the spawned panel auto-docks at capacity (#11060)", async () => {
+    // Requested for the grid, but committed to the dock — the fullscreen grid
+    // view is not what the user is being shown, so it must not be disturbed.
+    mockAddPanel.mockResolvedValueOnce("panel-autodocked");
+    mockPanelsById["panel-autodocked"] = { location: "dock" };
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockExitMaximize).not.toHaveBeenCalled();
+    expect(mockSetFocused).toHaveBeenCalledWith("panel-autodocked");
+  });
+
+  it("leaves fullscreen alone for a background MCP spawn (#11060)", async () => {
+    // A suppressed spawn never takes focus, so there is nothing to reveal —
+    // yanking the user out of fullscreen would be focus-steal-adjacent (#6959).
+    mockIsMcpSpawnFocusSuppressed.mockReturnValue(true);
+    mockAddPanel.mockResolvedValueOnce("panel-grid");
+    mockPanelsById["panel-grid"] = { location: "grid" };
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockSetFocused).not.toHaveBeenCalled();
+    expect(mockExitMaximize).not.toHaveBeenCalled();
   });
 
   it("focuses the last grid panel in a mixed dock/grid interleaving (#9764)", async () => {

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -206,10 +206,12 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
   if (!suppressFocus && lastSpawnedId !== null) {
     // The batch suppressed addPanel's maximize exit along with its focus set, so
     // apply it here too — a spawned grid panel that takes focus has to be
-    // visible, not stranded behind a fullscreen cell (#11060). Read the
-    // committed location fresh: `store` is a pre-spawn snapshot, and a panel
-    // requested for the grid can still auto-dock at capacity.
-    if (usePanelStore.getState().panelsById[lastSpawnedId]?.location !== "dock") {
+    // visible, not stranded behind a fullscreen cell (#11060). Read the panel
+    // back fresh (`store` is a pre-spawn snapshot) and require it to still be a
+    // live grid panel: it can be removed during addPanel's async tail, and a
+    // missing panel must not drop the user out of fullscreen.
+    const committed = usePanelStore.getState().panelsById[lastSpawnedId];
+    if (committed !== undefined && committed.location !== "dock") {
       store.exitMaximize();
     }
     store.setFocused(lastSpawnedId);

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -204,6 +204,14 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
   // Restore the per-panel focus the batch suppressed: focus the last spawned
   // grid panel, matching the prior serial behaviour.
   if (!suppressFocus && lastSpawnedId !== null) {
+    // The batch suppressed addPanel's maximize exit along with its focus set, so
+    // apply it here too — a spawned grid panel that takes focus has to be
+    // visible, not stranded behind a fullscreen cell (#11060). Read the
+    // committed location fresh: `store` is a pre-spawn snapshot, and a panel
+    // requested for the grid can still auto-dock at capacity.
+    if (usePanelStore.getState().panelsById[lastSpawnedId]?.location !== "dock") {
+      store.exitMaximize();
+    }
     store.setFocused(lastSpawnedId);
   }
 

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -555,9 +555,9 @@ describe("panelStore adversarial", () => {
           },
           panelIds: ["p1", "p3", "p4"],
           panelIdsByWorktreeId: { "wt-1": ["p1", "p3", "p4"] },
-          tabGroups: new Map([
-            ["g2", { id: "g2", location: "grid", activeTabId: "p3", panelIds: ["p3", "p4"] }],
-          ]) as never,
+        });
+        usePanelStore.getState().createTabGroup("grid", "wt-1", ["p3", "p4"], "p3");
+        usePanelStore.setState({
           maximizedId: "p1",
           maximizeTarget: { type: "panel", id: "p1" },
         });
@@ -620,14 +620,15 @@ describe("panelStore adversarial", () => {
           },
           panelIds: ["p1", "d1", "d2"],
           panelIdsByWorktreeId: { "wt-1": ["p1", "d1", "d2"] },
-          tabGroups: new Map([
-            ["gd", { id: "gd", location: "dock", activeTabId: "d1", panelIds: ["d1", "d2"] }],
-          ]) as never,
+        });
+        const groupId = usePanelStore.getState().createTabGroup("dock", "wt-1", ["d1", "d2"], "d1");
+        expect(groupId).toBeDefined();
+        usePanelStore.setState({
           maximizedId: "p1",
           maximizeTarget: { type: "panel", id: "p1" },
         });
 
-        usePanelStore.getState().moveTabGroupToLocation("gd", "grid");
+        usePanelStore.getState().moveTabGroupToLocation(groupId!, "grid");
 
         const s = usePanelStore.getState();
         expect(s.maximizedId).toBeNull();

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -420,5 +420,129 @@ describe("panelStore adversarial", () => {
       expect(s.maximizedId).toBe("p1");
       expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
     });
+
+    describe("addPanel leaves fullscreen so the new panel is visible (#11060)", () => {
+      // `review` has no PTY and is not dockable, so it always commits to the
+      // grid without touching the terminal client. `browser` is the non-PTY
+      // kind that IS dockable — the dock branch below needs it.
+      const gridAdd = { kind: "review", worktreeId: "wt-1" } as const;
+
+      it("exits fullscreen and focuses the new panel, keeping the layout snapshot", async () => {
+        seedMaximizedPanel();
+        const snapshot = usePanelStore.getState().preMaximizeLayout;
+
+        const id = await usePanelStore.getState().addPanel(gridAdd);
+
+        const s = usePanelStore.getState();
+        expect(id).not.toBeNull();
+        expect(s.focusedId).toBe(id);
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+        // The distinction from clearMaximize: the user is returning to the grid,
+        // not destroying the panel, so the column count still restores.
+        expect(s.preMaximizeLayout).toBe(snapshot);
+      });
+
+      it("exits a group target whose group has dissolved instead of re-maximizing", async () => {
+        // maximizeTarget points at g1, but no such group exists. toggleMaximize
+        // cannot resolve it, treats the call as a fresh maximize, and would
+        // re-maximize p1 — the exact misfire exitMaximize exists to avoid.
+        usePanelStore.setState({
+          panelsById: { p1: makePanel("p1") },
+          panelIds: ["p1"],
+          panelIdsByWorktreeId: { "wt-1": ["p1"] },
+          tabGroups: new Map(),
+          maximizedId: "p1",
+          maximizeTarget: { type: "group", id: "g1" },
+        });
+
+        await usePanelStore.getState().addPanel(gridAdd);
+
+        const s = usePanelStore.getState();
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+      });
+
+      it("stays fullscreen for a preserve-policy spawn, which never takes focus", async () => {
+        seedMaximizedPanel();
+        usePanelStore.setState({ focusedId: "p1" });
+
+        const id = await usePanelStore.getState().addPanel({
+          ...gridAdd,
+          focusPolicy: "preserve",
+        });
+
+        const s = usePanelStore.getState();
+        expect(id).not.toBeNull();
+        expect(s.focusedId).toBe("p1");
+        expect(s.maximizedId).toBe("p1");
+        expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
+      });
+
+      it("stays fullscreen when preserveMaximize opts the tab-strip add out", async () => {
+        // The tab-strip "+" adds the panel first and groups it second, so at
+        // commit time it looks like a plain new grid cell. It still takes focus.
+        seedMaximizedGroup();
+
+        const id = await usePanelStore.getState().addPanel({
+          ...gridAdd,
+          preserveMaximize: true,
+        });
+
+        const s = usePanelStore.getState();
+        expect(s.focusedId).toBe(id);
+        expect(s.maximizedId).toBe("p1");
+        expect(s.maximizeTarget).toEqual({ type: "group", id: "g1" });
+      });
+
+      it("leaves the grid's fullscreen view alone for a panel committed to the dock", async () => {
+        seedMaximizedPanel();
+
+        await usePanelStore
+          .getState()
+          .addPanel({ kind: "browser", worktreeId: "wt-1", location: "dock" });
+
+        const s = usePanelStore.getState();
+        expect(s.maximizedId).toBe("p1");
+        expect(s.maximizeTarget).toEqual({ type: "panel", id: "p1" });
+      });
+    });
+
+    describe("restore leaves fullscreen so the restored panel is visible (#11060)", () => {
+      it("exits fullscreen when a trashed panel is restored to the grid", () => {
+        seedMaximizedPanel();
+        usePanelStore.getState().trashPanel("p2");
+        // Trashing p2 (unrelated to the maximized p1) must not have cleared it.
+        expect(usePanelStore.getState().maximizedId).toBe("p1");
+
+        usePanelStore.getState().restoreTerminal("p2");
+
+        const s = usePanelStore.getState();
+        expect(s.focusedId).toBe("p2");
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+      });
+
+      it("stays fullscreen when the restored panel lands back in the dock", () => {
+        usePanelStore.setState({
+          panelsById: {
+            p1: makePanel("p1"),
+            d1: makePanel("d1", { location: "dock", kind: "terminal" }),
+          },
+          panelIds: ["p1", "d1"],
+          panelIdsByWorktreeId: { "wt-1": ["p1", "d1"] },
+          maximizedId: "p1",
+          maximizeTarget: { type: "panel", id: "p1" },
+        });
+        usePanelStore.getState().trashPanel("d1");
+
+        usePanelStore.getState().restoreTerminal("d1");
+
+        const s = usePanelStore.getState();
+        // The dock popover reveals it; the grid's fullscreen view is untouched.
+        expect(s.activeDockTerminalId).toBe("d1");
+        expect(s.maximizedId).toBe("p1");
+      });
+    });
   });
 });

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -543,6 +543,96 @@ describe("panelStore adversarial", () => {
         expect(s.activeDockTerminalId).toBe("d1");
         expect(s.maximizedId).toBe("p1");
       });
+
+      it("exits fullscreen when a trashed group is restored to the grid", () => {
+        // p3/p4 are a group unrelated to the maximized p1; trashing them must not
+        // clear maximize, but restoring them to the grid must.
+        usePanelStore.setState({
+          panelsById: {
+            p1: makePanel("p1"),
+            p3: makePanel("p3"),
+            p4: makePanel("p4"),
+          },
+          panelIds: ["p1", "p3", "p4"],
+          panelIdsByWorktreeId: { "wt-1": ["p1", "p3", "p4"] },
+          tabGroups: new Map([
+            ["g2", { id: "g2", location: "grid", activeTabId: "p3", panelIds: ["p3", "p4"] }],
+          ]) as never,
+          maximizedId: "p1",
+          maximizeTarget: { type: "panel", id: "p1" },
+        });
+        // Takes a member panel id, not the group id.
+        usePanelStore.getState().trashPanelGroup("p3");
+        expect(usePanelStore.getState().maximizedId).toBe("p1");
+
+        const groupRestoreId = Array.from(usePanelStore.getState().trashedTerminals.values())[0]
+          ?.groupRestoreId;
+        expect(groupRestoreId).toBeDefined();
+        usePanelStore.getState().restoreTrashedGroup(groupRestoreId!);
+
+        const s = usePanelStore.getState();
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+      });
+
+      it("exits fullscreen when a backgrounded panel is restored to the grid", () => {
+        seedMaximizedPanel();
+        usePanelStore.getState().backgroundTerminal("p2");
+        // p2 is unrelated to the maximized p1, so backgrounding it left maximize
+        // alone — restoring it to the grid is what has to clear it.
+        expect(usePanelStore.getState().maximizedId).toBe("p1");
+
+        usePanelStore.getState().restoreBackgroundTerminal("p2");
+
+        const s = usePanelStore.getState();
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+      });
+    });
+
+    describe("dock to grid moves leave fullscreen (#11060)", () => {
+      it("exits fullscreen when a docked panel is moved to the grid", () => {
+        usePanelStore.setState({
+          panelsById: {
+            p1: makePanel("p1"),
+            d1: makePanel("d1", { location: "dock", kind: "terminal" }),
+          },
+          panelIds: ["p1", "d1"],
+          panelIdsByWorktreeId: { "wt-1": ["p1", "d1"] },
+          maximizedId: "p1",
+          maximizeTarget: { type: "panel", id: "p1" },
+        });
+
+        expect(usePanelStore.getState().moveTerminalToGrid("d1")).toBe(true);
+
+        const s = usePanelStore.getState();
+        expect(s.focusedId).toBe("d1");
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+      });
+
+      it("exits fullscreen when a docked tab group is moved to the grid", () => {
+        usePanelStore.setState({
+          panelsById: {
+            p1: makePanel("p1"),
+            d1: makePanel("d1", { location: "dock", kind: "terminal" }),
+            d2: makePanel("d2", { location: "dock", kind: "terminal" }),
+          },
+          panelIds: ["p1", "d1", "d2"],
+          panelIdsByWorktreeId: { "wt-1": ["p1", "d1", "d2"] },
+          tabGroups: new Map([
+            ["gd", { id: "gd", location: "dock", activeTabId: "d1", panelIds: ["d1", "d2"] }],
+          ]) as never,
+          maximizedId: "p1",
+          maximizeTarget: { type: "panel", id: "p1" },
+        });
+
+        usePanelStore.getState().moveTabGroupToLocation("gd", "grid");
+
+        const s = usePanelStore.getState();
+        expect(s.maximizedId).toBeNull();
+        expect(s.maximizeTarget).toBeNull();
+      });
     });
   });
 });

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -69,6 +69,7 @@ vi.mock("@/clients", () => ({
 const beginSpawnBatchMock = vi.fn(() => Symbol("spawn-batch"));
 const flushSpawnBatchMock = vi.fn();
 const setFocusedMock = vi.fn();
+const exitMaximizeMock = vi.fn();
 
 const panelStoreState: {
   panelIds: string[];
@@ -77,6 +78,7 @@ const panelStoreState: {
   beginSpawnBatch: typeof beginSpawnBatchMock;
   flushSpawnBatch: typeof flushSpawnBatchMock;
   setFocused: typeof setFocusedMock;
+  exitMaximize: typeof exitMaximizeMock;
 } = {
   panelIds: [],
   panelsById: {},
@@ -84,6 +86,7 @@ const panelStoreState: {
   beginSpawnBatch: beginSpawnBatchMock,
   flushSpawnBatch: flushSpawnBatchMock,
   setFocused: setFocusedMock,
+  exitMaximize: exitMaximizeMock,
 };
 
 vi.mock("../panelStore", () => ({
@@ -851,6 +854,63 @@ describe("recipeStore", () => {
 
       expect(setFocusedMock).toHaveBeenCalledTimes(1);
       expect(setFocusedMock).toHaveBeenCalledWith("terminal-2");
+    });
+
+    it("leaves fullscreen before focusing the last spawned grid panel (#11060)", async () => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+      panelStoreState.panelsById = { "terminal-1": { location: "grid" } };
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [{ type: "terminal", title: "Shell 1", command: "a", env: {} }],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+      expect(exitMaximizeMock).toHaveBeenCalledTimes(1);
+      // Must precede the focus set: focusing promotes the panel's worktree to
+      // active, and a stale global maximize target would blank that grid.
+      expect(exitMaximizeMock.mock.invocationCallOrder[0]!).toBeLessThan(
+        setFocusedMock.mock.invocationCallOrder[0]!
+      );
+    });
+
+    it("stays fullscreen when the spawned panel auto-docks at capacity (#11060)", async () => {
+      addTerminalMock.mockResolvedValue("terminal-docked");
+      panelStoreState.panelsById = { "terminal-docked": { location: "dock" } };
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [{ type: "terminal", title: "Shell 1", command: "a", env: {} }],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+      expect(setFocusedMock).toHaveBeenCalledWith("terminal-docked");
+      expect(exitMaximizeMock).not.toHaveBeenCalled();
     });
 
     it("does not steal focus when focusPolicy is preserve", async () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -856,11 +856,7 @@ describe("recipeStore", () => {
       expect(setFocusedMock).toHaveBeenCalledWith("terminal-2");
     });
 
-    it("leaves fullscreen before focusing the last spawned grid panel (#11060)", async () => {
-      let callIndex = 0;
-      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
-      panelStoreState.panelsById = { "terminal-1": { location: "grid" } };
-
+    function seedSingleTerminalRecipe() {
       useRecipeStore.setState({
         recipes: [
           {
@@ -874,42 +870,44 @@ describe("recipeStore", () => {
         isLoading: false,
         currentProjectId: "project-1",
       });
+    }
+
+    it("leaves fullscreen when the spawned grid panel takes focus (#11060)", async () => {
+      addTerminalMock.mockResolvedValue("terminal-1");
+      panelStoreState.panelsById = { "terminal-1": { location: "grid" } };
+      seedSingleTerminalRecipe();
 
       await useRecipeStore
         .getState()
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
 
       expect(exitMaximizeMock).toHaveBeenCalledTimes(1);
-      // Must precede the focus set: focusing promotes the panel's worktree to
-      // active, and a stale global maximize target would blank that grid.
-      expect(exitMaximizeMock.mock.invocationCallOrder[0]!).toBeLessThan(
-        setFocusedMock.mock.invocationCallOrder[0]!
-      );
+      expect(setFocusedMock).toHaveBeenCalledWith("terminal-1");
     });
 
-    it("stays fullscreen when the spawned panel auto-docks at capacity (#11060)", async () => {
+    it("stays fullscreen when the spawned panel committed to the dock (#11060)", async () => {
       addTerminalMock.mockResolvedValue("terminal-docked");
       panelStoreState.panelsById = { "terminal-docked": { location: "dock" } };
-
-      useRecipeStore.setState({
-        recipes: [
-          {
-            id: "recipe-1",
-            name: "Test Recipe",
-            projectId: "project-1",
-            terminals: [{ type: "terminal", title: "Shell 1", command: "a", env: {} }],
-            createdAt: Date.now(),
-          },
-        ],
-        isLoading: false,
-        currentProjectId: "project-1",
-      });
+      seedSingleTerminalRecipe();
 
       await useRecipeStore
         .getState()
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
 
-      expect(setFocusedMock).toHaveBeenCalledWith("terminal-docked");
+      expect(exitMaximizeMock).not.toHaveBeenCalled();
+    });
+
+    it("stays fullscreen when the spawned panel is gone by the time focus is restored (#11060)", async () => {
+      // addPanel resolved an id, but the panel was removed during its async tail.
+      // A panel that no longer exists must not drag the user out of fullscreen.
+      addTerminalMock.mockResolvedValue("terminal-vanished");
+      panelStoreState.panelsById = {};
+      seedSingleTerminalRecipe();
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
       expect(exitMaximizeMock).not.toHaveBeenCalled();
     });
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -387,6 +387,18 @@ export const usePanelStore = create<PanelGridState>()(
           ) {
             return id;
           }
+          // The new panel is about to take focus, but a fullscreen panel/group
+          // would keep rendering over the grid — so the panel the user just
+          // asked for lands focused and invisible (#11060). Leave fullscreen
+          // first. This must precede the focus set: `focusedId` promotes the
+          // panel's worktree to active, and `maximizedId` is global, so a
+          // cross-worktree spawn would otherwise render the newly active grid
+          // against a maximize target that isn't in it. `preserveMaximize`
+          // opts out the caller that is folding this panel into the group that
+          // is already maximized.
+          if (!options.preserveMaximize) {
+            get().exitMaximize();
+          }
           if (focusedBeforeCreate !== id) {
             set({ focusedId: id, previousFocusedId: focusedBeforeCreate });
           } else {
@@ -778,6 +790,15 @@ export const usePanelStore = create<PanelGridState>()(
         if (!restoredPanel) return;
         const previousFocusedId = get().focusedId;
         const landsInDock = restoredPanel.location === "dock" && isDockPanel(restoredPanel);
+        // A grid restore takes focus, so it must be visible: leave fullscreen
+        // rather than focus the panel behind the maximized cell (#11060). The
+        // registry restore only rewrites location/worktree — it never rejoins a
+        // tab group — so the restored panel is always its own grid cell and can
+        // never be a member of the group being maximized. A dock restore opens
+        // the popover instead and leaves the grid's fullscreen view alone.
+        if (!landsInDock) {
+          get().exitMaximize();
+        }
         set({
           focusedId: id,
           // Open the dock popover when the panel landed back in the dock so
@@ -826,6 +847,12 @@ export const usePanelStore = create<PanelGridState>()(
         const restoredPanel = get().panelsById[focusId]!;
         const previousFocusedId = get().focusedId;
         const landsInDock = restoredPanel.location === "dock" && isDockPanel(restoredPanel);
+        // Same as `restoreTerminal`: a grid restore must be visible, so leave
+        // fullscreen (#11060). The restored group was trashed, so it can never
+        // be the group currently maximized.
+        if (!landsInDock) {
+          get().exitMaximize();
+        }
         set({
           focusedId: focusId,
           // Match the restored panel's location so a docked group reopens the

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -388,14 +388,13 @@ export const usePanelStore = create<PanelGridState>()(
             return id;
           }
           // The new panel is about to take focus, but a fullscreen panel/group
-          // would keep rendering over the grid — so the panel the user just
-          // asked for lands focused and invisible (#11060). Leave fullscreen
-          // first. This must precede the focus set: `focusedId` promotes the
-          // panel's worktree to active, and `maximizedId` is global, so a
-          // cross-worktree spawn would otherwise render the newly active grid
-          // against a maximize target that isn't in it. `preserveMaximize`
-          // opts out the caller that is folding this panel into the group that
-          // is already maximized.
+          // keeps rendering over the grid — so the panel the user just asked for
+          // would land focused and invisible (#11060). Leave fullscreen. Both
+          // sets land before React reads the store, so the order between them
+          // isn't observable; exiting first just keeps a synchronous store
+          // subscriber from seeing a focused-but-hidden panel. `preserveMaximize`
+          // opts out the caller that folds this panel into the group that is
+          // already maximized.
           if (!options.preserveMaximize) {
             get().exitMaximize();
           }
@@ -473,6 +472,10 @@ export const usePanelStore = create<PanelGridState>()(
         const moveSucceeded = registrySlice.moveTerminalToGrid(id);
         if (moveSucceeded) {
           const previousFocusedId = get().focusedId;
+          // The panel arrives from the dock and takes focus, so it has to be
+          // visible rather than parked behind a fullscreen cell (#11060). It came
+          // from the dock, so it can never be the panel/group being maximized.
+          get().exitMaximize();
           set({
             focusedId: id,
             activeDockTerminalId: null,
@@ -497,6 +500,10 @@ export const usePanelStore = create<PanelGridState>()(
             activeDockTerminalId !== null &&
             groupBeforeMove.panelIds.includes(activeDockTerminalId);
 
+          // The group arrives from the dock and takes focus, so it has to be
+          // visible rather than parked behind a fullscreen cell (#11060). It came
+          // from the dock, so it can never be the panel/group being maximized.
+          get().exitMaximize();
           set({
             focusedId: nextFocusedId,
             ...(shouldClearDock && { activeDockTerminalId: null }),
@@ -870,6 +877,37 @@ export const usePanelStore = create<PanelGridState>()(
         const group = get().getPanelGroup(focusId);
         if (group) {
           get().setActiveTab(group.id, focusId);
+        }
+      },
+
+      // Un-backgrounding doesn't focus in the registry — every caller activates
+      // the panel right after (BackgroundContainer, useQuickSwitcher). So a grid
+      // landing still has to leave fullscreen, or the panel the user just asked
+      // to see stays hidden behind the maximized cell (#11060). A dock landing is
+      // revealed by the popover and leaves the grid's fullscreen view alone.
+      restoreBackgroundTerminal: (id: string, targetWorktreeId?: string) => {
+        registrySlice.restoreBackgroundTerminal(id, targetWorktreeId);
+        const restored = get().panelsById[id];
+        if (restored !== undefined && restored.location !== "dock") {
+          get().exitMaximize();
+        }
+      },
+
+      restoreBackgroundGroup: (groupRestoreId: string, targetWorktreeId?: string) => {
+        // Snapshot membership before the restore — it clears `backgroundedTerminals`.
+        const memberIds: string[] = [];
+        for (const [id, backgrounded] of get().backgroundedTerminals.entries()) {
+          if (backgrounded.groupRestoreId === groupRestoreId) memberIds.push(id);
+        }
+
+        registrySlice.restoreBackgroundGroup(groupRestoreId, targetWorktreeId);
+
+        const landedInGrid = memberIds.some((id) => {
+          const restored = get().panelsById[id];
+          return restored !== undefined && restored.location !== "dock";
+        });
+        if (landedInGrid) {
+          get().exitMaximize();
         }
       },
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -985,10 +985,12 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       const focusId = results.spawned[results.spawned.length - 1]!.terminalId;
       // The batch suppressed addPanel's maximize exit along with its focus set,
       // so apply it here too — the agents the user just launched have to be
-      // visible, not stranded behind a fullscreen cell (#11060). Read the
-      // committed location fresh: `terminalStore` is a pre-spawn snapshot, and a
-      // panel requested for the grid can still auto-dock at capacity.
-      if (usePanelStore.getState().panelsById[focusId]?.location !== "dock") {
+      // visible, not stranded behind a fullscreen cell (#11060). Read the panel
+      // back fresh (`terminalStore` is a pre-spawn snapshot) and require it to
+      // still be a live grid panel: it can be removed during addPanel's async
+      // tail, and a missing panel must not drop the user out of fullscreen.
+      const committed = usePanelStore.getState().panelsById[focusId];
+      if (committed !== undefined && committed.location !== "dock") {
         terminalStore.exitMaximize();
       }
       terminalStore.setFocused(focusId);

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -982,7 +982,16 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     // Restore the per-panel focus the batch suppressed: focus the last spawned
     // grid panel, matching the prior serial behaviour (last `addPanel` won).
     if (!suppressFocus && results.spawned.length > 0) {
-      terminalStore.setFocused(results.spawned[results.spawned.length - 1]!.terminalId);
+      const focusId = results.spawned[results.spawned.length - 1]!.terminalId;
+      // The batch suppressed addPanel's maximize exit along with its focus set,
+      // so apply it here too — the agents the user just launched have to be
+      // visible, not stranded behind a fullscreen cell (#11060). Read the
+      // committed location fresh: `terminalStore` is a pre-spawn snapshot, and a
+      // panel requested for the grid can still auto-dock at capacity.
+      if (usePanelStore.getState().panelsById[focusId]?.location !== "dock") {
+        terminalStore.exitMaximize();
+      }
+      terminalStore.setFocused(focusId);
     }
 
     // Record this run in the durable history (#9949). Fire-and-forget AFTER the

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -118,6 +118,52 @@ describe("TerminalFocusSlice - Layout Snapshot", () => {
     expect(state.preMaximizeLayout).toBe(null);
   });
 
+  it("exitMaximize leaves fullscreen but keeps the layout snapshot (#11060)", () => {
+    const snapshot = { gridCols: 2, gridItemCount: 4, worktreeId: "worktree-1" };
+    state.maximizedId = "term-1";
+    state.maximizeTarget = { type: "panel", id: "term-1" };
+    state.preMaximizeLayout = snapshot;
+
+    state.exitMaximize();
+
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+    // The whole difference from clearMaximize: the grid still restores its
+    // column count, because the panel isn't going away — the user is.
+    expect(state.preMaximizeLayout).toBe(snapshot);
+  });
+
+  it("exitMaximize leaves fullscreen even when the group target no longer resolves (#11060)", () => {
+    // A group target whose group has dissolved. toggleMaximize can't resolve it,
+    // so it falls through to its maximize branch and re-maximizes term-1 —
+    // exitMaximize must not care about the target at all.
+    state.maximizedId = "term-1";
+    state.maximizeTarget = { type: "group", id: "group-gone" };
+
+    state.exitMaximize();
+
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+  });
+
+  it("toggleMaximize re-maximizes a dissolved group target, which is why exitMaximize exists (#11060)", () => {
+    // Pins the hazard this change routes around: the same seed, through the
+    // conditional toggle, ends up maximized rather than back in the grid.
+    state.maximizedId = "term-1";
+    state.maximizeTarget = { type: "group", id: "group-gone" };
+
+    state.toggleMaximize("term-1", undefined, undefined, mockGetPanelGroup);
+
+    expect(state.maximizedId).toBe("term-1");
+    expect(state.maximizeTarget).toEqual({ type: "panel", id: "term-1" });
+  });
+
+  it("exitMaximize is a no-op when nothing is fullscreen (#11060)", () => {
+    state.exitMaximize();
+
+    expect(setState).not.toHaveBeenCalled();
+  });
+
   it("clearMaximize is a no-op when the trio is already null (#9935)", () => {
     expect(state.maximizedId).toBe(null);
     expect(state.maximizeTarget).toBe(null);

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -158,6 +158,19 @@ describe("TerminalFocusSlice - Layout Snapshot", () => {
     expect(state.maximizeTarget).toEqual({ type: "panel", id: "term-1" });
   });
 
+  it("focusOrMaximizeByIndex restores the grid even when the maximized group has dissolved (#11060)", () => {
+    // The index hotkey routes its force-exit through exitMaximize, so it can't
+    // fall into toggleMaximize's re-maximize branch (pinned by the test above).
+    state.maximizedId = "term-1";
+    state.maximizeTarget = { type: "group", id: "group-gone" };
+
+    state.focusOrMaximizeByIndex(1, () => "term-2", mockGetPanelGroup);
+
+    expect(state.maximizedId).toBe(null);
+    expect(state.maximizeTarget).toBe(null);
+    expect(state.focusedId).toBe("term-2");
+  });
+
   it("exitMaximize is a no-op when nothing is fullscreen (#11060)", () => {
     state.exitMaximize();
 

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -134,6 +134,20 @@ export interface TerminalFocusSlice {
    * `preMaximizeLayout` so the next maximize can reuse the snapshot.
    */
   clearMaximize: () => void;
+  /**
+   * Leave fullscreen and return to the grid, unconditionally. Preserves
+   * `preMaximizeLayout` so the column count restores exactly as a manual
+   * unmaximize would — the sibling of `clearMaximize`: the user is going back to
+   * the grid, not losing the panel.
+   *
+   * Prefer this over `toggleMaximize` wherever the exit is not a user toggle of a
+   * known target. `toggleMaximize` only unmaximizes when it can resolve the
+   * target (a group target needs `getPanelGroup(maximizedId)` to still return
+   * that group); if the group has dissolved it falls through and *maximizes*
+   * instead. That misfire is harmless for a hotkey but not for the panel-creation
+   * paths, which must always end up in the grid (#11060).
+   */
+  exitMaximize: () => void;
   clearPreMaximizeLayout: () => void;
   focusNext: () => void;
   focusPrevious: () => void;
@@ -440,6 +454,14 @@ export const createTerminalFocusSlice =
           preMaximizeLayout: null,
         }),
 
+      exitMaximize: () => {
+        if (!get().maximizedId && !get().maximizeTarget) return;
+        set({
+          maximizedId: null,
+          maximizeTarget: null,
+        });
+      },
+
       focusNext: () => {
         const terminals = getTerminals();
         const activeWorktreeId = getActiveWorktreeId();
@@ -497,24 +519,26 @@ export const createTerminalFocusSlice =
       focusOrMaximizeByIndex: (index, findByIndex, getPanelGroup) => {
         const targetId = findByIndex(index);
         if (!targetId) return;
-        const { focusedId, maximizedId, maximizeTarget, toggleMaximize, activateTerminal } = get();
+        const {
+          focusedId,
+          maximizedId,
+          maximizeTarget,
+          toggleMaximize,
+          exitMaximize,
+          activateTerminal,
+        } = get();
 
         if (maximizedId) {
           // A panel/group is fullscreen. The cell actually *shown* is the
-          // maximized one — which may differ from focusedId, since a panel
-          // opened while fullscreen becomes focused in the background without
-          // ever being displayed. Anchor on the maximized cell (not focus) so
-          // that background panel is revealed in the grid on first press and
-          // only goes fullscreen on a second press.
+          // maximized one — which may differ from focusedId when a panel was
+          // focused in the background without being displayed. Anchor on the
+          // maximized cell (not focus) so re-pressing the shown cell just
+          // restores the grid, while any other index also focuses that panel.
           const targetIsMaximizedCell =
             maximizedId === targetId ||
             (maximizeTarget?.type === "group" &&
               getPanelGroup?.(targetId)?.id === maximizeTarget.id);
-          // Exit fullscreen. Unmaximize via toggleMaximize (not clearMaximize)
-          // to preserve preMaximizeLayout, so the column count restores exactly
-          // as a manual unmaximize would. Re-pressing the shown cell just
-          // restores; any other index also focuses that panel in the grid.
-          toggleMaximize(maximizedId, undefined, undefined, getPanelGroup);
+          exitMaximize();
           if (!targetIsMaximizedCell) {
             activateTerminal(targetId);
           }


### PR DESCRIPTION
## Summary

- While a panel or tab group was maximized, opening a new terminal created and focused it, but the panel stayed hidden behind the maximized cell. The user asked for a terminal and appeared to get nothing.
- This establishes the invariant: a newly created or restored panel that lands in the grid and takes focus must leave fullscreen first.
- Covers every path that lands a panel in the grid and focuses it, not just `terminal.new`, including recipe/fleet spawns, trash restores, and dock to grid moves.

Resolves #11060

## Changes

- New `exitMaximize()` on `terminalFocusSlice` (`src/store/slices/terminalFocusSlice.ts`): unconditionally clears `maximizedId` and `maximizeTarget` while preserving `preMaximizeLayout`, so the grid's column count restores exactly as a manual unmaximize would. It's the documented sibling of `clearMaximize`, which also drops the snapshot and is reserved for panel teardown (trash/reset/project switch). It's needed because `toggleMaximize`'s unmaximize detection is conditional: with a group target it only unmaximizes if `getPanelGroup(maximizedId)` still resolves to that group, and falls through to the maximize branch and re-maximizes if the group has dissolved. `focusOrMaximizeByIndex`'s force-exit was migrated onto the new action too, closing that latent misfire on the index hotkeys.
- `panelStore.addPanel` wrapper that exits maximize when a panel commits to the grid and is allowed to take focus, placed after the existing preserve-policy/assistant-focus early return so background and MCP spawns (`focusPolicy: "preserve"`) and hydration/spawn batches are untouched.
- The remaining paths that land a panel in the grid and focus it, which `addPanel` can't see: grid restores from trash (`restoreTerminal`, `restoreTrashedGroup`), background restores (new `panelStore` wrappers, since the registry doesn't focus but the callers activate), dock-to-grid moves (`moveTerminalToGrid`, `moveTabGroupToLocation`), and the post-batch focus of recipe/worktree spawns (`recipeStore`, `panelSpawning`). A spawn batch suppresses `addPanel`'s focus set, so those two re-apply focus after the flush and have to exit maximize themselves. Launching a recipe or a fleet of agents while maximized was the most visible instance of this bug.
- New transient `preserveMaximize` option on `AddPanelOptionsBase` (`shared/types/addPanelOptions.ts`), set only by the tab-strip "+" (`addTabForPanel`): it adds the panel first and folds it into the group second, so at commit time the new tab isn't a group member yet and would otherwise look like a plain new grid cell and drop the user out of the fullscreen group they're adding a tab to.

Two things worth flagging for review:

- The post-batch paths require a live, committed grid panel. A panel removed during `addPanel`'s async tail would otherwise read as "not dock" and exit fullscreen while focusing a ghost id.
- Exit-before-focus ordering is defensive only, not load-bearing. Both sets land before React reads the store.

Known adjacent issue, deliberately not fixed here: `maximizedId` is a single global field, but `selectWorktree` doesn't validate it on an active-worktree change, so a maximize in worktree A can still gate worktree B's grid. Pre-existing and out of scope for this PR.

## Testing

- Full `npm run typecheck` clean.
- 1481 unit tests green across every suite covering the changed modules: `terminalFocusSlice`, `panelStore.adversarial`, `recipeStore`, `panelSpawning`, `addTabForPanel`, `panelRegistry`, `Terminal`.
- eslint/prettier clean on all changed files, zero new warnings (per-rule lint ratchet safe).
