### PR TITLE
fix(mcp): expire stuck focus-suppression leases so dock launches recover

### DIFF
--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -136,18 +136,20 @@ export function useMcpBridge(): void {
           }
 
           const dispatchArgs = tagMcpSpawnSource(actionId, args);
-          const result = await runWithMcpSpawnFocusSuppressed(() =>
-            actionService.dispatch(actionId as ActionId, dispatchArgs, {
-              source: "agent",
-              confirmed: effectiveConfirmed,
-              // Pinned help-session dispatch carries the provision-time
-              // context snapshot; replay it so the action targets the
-              // worktree/terminal focused at launch, not wherever focus
-              // drifted during the model's turn (#8317). Undefined for
-              // unpinned external dispatch — ActionService then falls
-              // back to live renderer context, unchanged behaviour.
-              contextOverride: context,
-            })
+          const result = await runWithMcpSpawnFocusSuppressed(
+            () =>
+              actionService.dispatch(actionId as ActionId, dispatchArgs, {
+                source: "agent",
+                confirmed: effectiveConfirmed,
+                // Pinned help-session dispatch carries the provision-time
+                // context snapshot; replay it so the action targets the
+                // worktree/terminal focused at launch, not wherever focus
+                // drifted during the model's turn (#8317). Undefined for
+                // unpinned external dispatch — ActionService then falls
+                // back to live renderer context, unchanged behaviour.
+                contextOverride: context,
+              }),
+            actionId
           );
           if (disposed) return;
           window.electron.mcpBridge.sendDispatchActionResponse({

--- a/src/store/__tests__/mcpSpawnFocusGuard.test.ts
+++ b/src/store/__tests__/mcpSpawnFocusGuard.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Lease semantics for the MCP spawn focus guard. The critical regression: an
+ * MCP-dispatched action whose handler never settles (confirm dialog torn down,
+ * hung IPC — Main abandons the dispatch after 30s without cancelling the
+ * renderer side) must not force `focusPolicy: "preserve"` on every later panel
+ * creation in the project view forever. Symptom when it did: the dock's +
+ * launch never auto-opened its popover again in that one project.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import { logWarn } from "@/utils/logger";
+import { isMcpSpawnFocusSuppressed, runWithMcpSpawnFocusSuppressed } from "../mcpSpawnFocusGuard";
+
+const LEASE_TTL_MS = 45_000;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("mcpSpawnFocusGuard leases", () => {
+  const pendingSettles: Array<() => void> = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    // Settle every hung dispatch a test created so module-level lease state
+    // can't leak into the next test.
+    for (const settle of pendingSettles.splice(0)) settle();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("suppresses while a dispatch is pending and releases on resolve", async () => {
+    const { promise, resolve } = deferred<void>();
+    const run = runWithMcpSpawnFocusSuppressed(() => promise);
+    expect(isMcpSpawnFocusSuppressed()).toBe(true);
+    resolve();
+    await run;
+    expect(isMcpSpawnFocusSuppressed()).toBe(false);
+  });
+
+  it("releases on rejection", async () => {
+    const { promise, reject } = deferred<void>();
+    const run = runWithMcpSpawnFocusSuppressed(() => promise);
+    expect(isMcpSpawnFocusSuppressed()).toBe(true);
+    reject(new Error("boom"));
+    await expect(run).rejects.toThrow("boom");
+    expect(isMcpSpawnFocusSuppressed()).toBe(false);
+  });
+
+  it("stops suppressing once a hung dispatch outlives the TTL and warns once", async () => {
+    const { promise, resolve } = deferred<void>();
+    const run = runWithMcpSpawnFocusSuppressed(() => promise, "agent.launch");
+    pendingSettles.push(() => {
+      resolve();
+      void run;
+    });
+
+    vi.advanceTimersByTime(LEASE_TTL_MS - 1);
+    expect(isMcpSpawnFocusSuppressed()).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(isMcpSpawnFocusSuppressed()).toBe(false);
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("lease outlived"),
+      expect.objectContaining({ label: "agent.launch" })
+    );
+
+    // Repeated checks don't re-warn for the same lease.
+    expect(isMcpSpawnFocusSuppressed()).toBe(false);
+    expect(logWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("a fresh dispatch still suppresses while an expired lease lingers", async () => {
+    const hung = deferred<void>();
+    const hungRun = runWithMcpSpawnFocusSuppressed(() => hung.promise, "worktree.create");
+    pendingSettles.push(() => {
+      hung.resolve();
+      void hungRun;
+    });
+    vi.advanceTimersByTime(LEASE_TTL_MS);
+    expect(isMcpSpawnFocusSuppressed()).toBe(false);
+
+    const fresh = deferred<void>();
+    const freshRun = runWithMcpSpawnFocusSuppressed(() => fresh.promise);
+    expect(isMcpSpawnFocusSuppressed()).toBe(true);
+    fresh.resolve();
+    await freshRun;
+    expect(isMcpSpawnFocusSuppressed()).toBe(false);
+  });
+
+  it("a late settle of an expired lease releases only itself", async () => {
+    const hung = deferred<void>();
+    const hungRun = runWithMcpSpawnFocusSuppressed(() => hung.promise);
+    vi.advanceTimersByTime(LEASE_TTL_MS);
+
+    const live = deferred<void>();
+    const liveRun = runWithMcpSpawnFocusSuppressed(() => live.promise);
+    pendingSettles.push(() => {
+      live.resolve();
+      void liveRun;
+    });
+
+    hung.resolve();
+    await hungRun;
+    // The live dispatch keeps suppressing — the stale release can't underflow
+    // a shared counter the way the old depth implementation could.
+    expect(isMcpSpawnFocusSuppressed()).toBe(true);
+  });
+});

--- a/src/store/mcpSpawnFocusGuard.ts
+++ b/src/store/mcpSpawnFocusGuard.ts
@@ -1,14 +1,61 @@
-let mcpSpawnFocusSuppressionDepth = 0;
+import { logWarn } from "@/utils/logger";
 
-export function isMcpSpawnFocusSuppressed(): boolean {
-  return mcpSpawnFocusSuppressionDepth > 0;
+/**
+ * Ambient focus-suppression leases for MCP-dispatched actions.
+ *
+ * The bridge wraps every MCP action dispatch in a lease so panels spawned
+ * *indirectly* by the action (handlers that don't thread `focusPolicy`
+ * through their args) still resolve to "preserve" and can't steal focus
+ * (#6959). Direct spawn actions don't depend on this: `tagMcpSpawnSource`
+ * stamps `focusPolicy: "preserve"` on their args explicitly.
+ *
+ * Leases expire. Main's MCP bridge abandons a dispatch after
+ * `MCP_DISPATCH_TIMEOUT_MS` (30s) without cancelling the renderer-side
+ * action, so a handler awaiting something unbounded (a confirm dialog, a
+ * hung IPC) holds its lease forever. Under the old depth counter that
+ * permanently forced "preserve" on every later panel creation in this
+ * project view — the dock's launch popover never auto-opened again until
+ * the view reloaded. An expired lease stops suppressing but stays tracked
+ * until its dispatch settles, so a late settle can only release itself.
+ */
+const LEASE_TTL_MS = 45_000;
+
+interface SuppressionLease {
+  label: string | undefined;
+  startedAt: number;
+  warned: boolean;
 }
 
-export async function runWithMcpSpawnFocusSuppressed<T>(fn: () => Promise<T>): Promise<T> {
-  mcpSpawnFocusSuppressionDepth += 1;
+let nextLeaseId = 0;
+const activeLeases = new Map<number, SuppressionLease>();
+
+export function isMcpSpawnFocusSuppressed(): boolean {
+  if (activeLeases.size === 0) return false;
+  const now = Date.now();
+  let suppressed = false;
+  for (const lease of activeLeases.values()) {
+    if (now - lease.startedAt < LEASE_TTL_MS) {
+      suppressed = true;
+    } else if (!lease.warned) {
+      lease.warned = true;
+      logWarn(
+        "[McpSpawnFocusGuard] Focus-suppression lease outlived the MCP dispatch timeout — the action handler never settled; ignoring the lease",
+        { label: lease.label, heldMs: now - lease.startedAt }
+      );
+    }
+  }
+  return suppressed;
+}
+
+export async function runWithMcpSpawnFocusSuppressed<T>(
+  fn: () => Promise<T>,
+  label?: string
+): Promise<T> {
+  const leaseId = nextLeaseId++;
+  activeLeases.set(leaseId, { label, startedAt: Date.now(), warned: false });
   try {
     return await fn();
   } finally {
-    mcpSpawnFocusSuppressionDepth = Math.max(0, mcpSpawnFocusSuppressionDepth - 1);
+    activeLeases.delete(leaseId);
   }
 }


### PR DESCRIPTION
I ran into a strange bug that only happened in a single project. Clicking the plus button in the dock added the panel chip, but the popover never auto-opened. The same launch in any other project worked fine, and restarting the app cleared it.

After some digging, the problem is a module-level depth counter in `mcpSpawnFocusGuard.ts`. It's incremented around every MCP-dispatched action and decremented when the action settles. If an action handler never settles, the counter stays stuck above zero forever. The main process abandons the dispatch after 30 seconds (`MCP_DISPATCH_TIMEOUT_MS`), but it never cancels the renderer side, so the renderer keeps waiting for a response that will never come. Since each project view is long-lived, the broken state persists in that one project until the view reloads. Every later `addPanel` then resolves `focusPolicy` to `"preserve"`, which is what suppresses the dock popover activation.

The fix replaces the counter with per-dispatch leases with a 45 second TTL (the main process's 30 second timeout plus some grace). An expired lease stops suppressing and logs a one-shot warning naming the hung action id, so if this happens again the log tells us exactly which action wedged. A late settle releases only its own lease, so it can't underflow a newer dispatch the way the old counter could.

Direct MCP spawn actions are unaffected. `tagMcpSpawnSource` already stamps `focusPolicy: "preserve"` onto their args explicitly, so the ambient guard was only ever a net for indirect spawns.

Added unit tests covering the lease semantics.