### PR TITLE
fix(dock): snap dock chips into place instead of reflow-animating

### DIFF
--- a/e2e/helpers/dragDrop.ts
+++ b/e2e/helpers/dragDrop.ts
@@ -32,8 +32,7 @@ export async function keyboardReorderElement(
  * Dock chips are sortable through the global `DndProvider`, which — unlike
  * `DockedTabGroup`'s own `DndContext` (PointerSensor/TouchSensor only) —
  * registers a `KeyboardSensor`. A single arrow step avoids the autoscroll-driven
- * source unmount that long keyboard drags can hit (#8478), and keeps the drag
- * short enough for framer-motion's FLIP to settle before assertions (#9029).
+ * source unmount that long keyboard drags can hit (#8478).
  */
 export async function keyboardReorderDockChip(
   page: Page,

--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -51,7 +51,9 @@ export function SortableDockPlaceholder() {
   };
 
   return (
-    <m.div layout="position" className="h-full">
+    // No FLIP on the dock path — the placeholder hands off to the first real
+    // chip without a shuffle, matching SortableDockItem (#11063).
+    <m.div layout={false} className="h-full">
       <div
         ref={setNodeRef}
         style={style}

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -119,8 +119,12 @@ export function SortableDockItem({
   void _tabIndex;
 
   return (
+    // A dropped chip snaps straight into its slot like the macOS dock, so FLIP
+    // stays off here — framer would otherwise slide every non-dragged chip from
+    // its old slot to its new one (#11063). The wrapper itself still carries the
+    // forwarded dnd-kit attributes, so it can't be collapsed away.
     <m.div
-      layout="position"
+      layout={false}
       className="flex-shrink-0"
       {...remainingAttributes}
       aria-roledescription="sortable item"

--- a/src/components/DragDrop/__tests__/DockReflow.test.tsx
+++ b/src/components/DragDrop/__tests__/DockReflow.test.tsx
@@ -19,7 +19,7 @@ import type { PtyPanelData } from "@shared/types/panel";
  */
 
 /** Framer's own layout union; anything truthy here opts the node into FLIP. */
-type MotionLayout = boolean | "position" | "size" | "preserve-aspect" | undefined;
+type MotionLayout = boolean | "position" | "size" | "preserve-aspect" | "x" | "y" | undefined;
 
 interface MotionDivProps extends HTMLAttributes<HTMLDivElement> {
   layout?: MotionLayout;
@@ -190,5 +190,11 @@ describe("empty-dock placeholder snaps too (#11063)", () => {
     const dropTarget = container.querySelector("[data-placeholder-id]");
     expect(dropTarget).not.toBeNull();
     expect(dropTarget).toBe(transformNode);
+
+    // Same split as the chip: the motion wrapper stays wrapped around the
+    // sortable node rather than being merged into it.
+    const motionWrapper = container.firstChild;
+    expect(motionWrapper).not.toBe(dropTarget);
+    expect(motionWrapper?.contains(dropTarget)).toBe(true);
   });
 });

--- a/src/components/DragDrop/__tests__/DockReflow.test.tsx
+++ b/src/components/DragDrop/__tests__/DockReflow.test.tsx
@@ -6,19 +6,20 @@ import type { PtyPanelData } from "@shared/types/panel";
 
 /**
  * Regression coverage for #11063. Dropping a chip into the dock must land it in
- * its slot the way the macOS dock does — no sibling shuffle. Two independent
- * engines can reflow the row, and both have to stay off: framer-motion's FLIP
- * (the `layout` prop on the wrapper) and dnd-kit's own sort transition
- * (`animateLayoutChanges`). jsdom can't observe animation, so these assert the
- * enablement contract each engine reads, not the frames it would paint.
+ * its slot the way the macOS dock does — no sibling shuffle. The reflow came
+ * from framer-motion's FLIP, which a motion node opts into via the raw
+ * `layout`/`layoutId` predicate: truthy either one and framer measures and
+ * animates the node between layouts. jsdom can't observe painted frames, so
+ * these assert that opt-in predicate across every motion node the dock renders,
+ * in both the idle and dragging states.
  *
- * The assertions are deliberately written against framer's own predicate —
- * layout projection is enabled iff `layout` or `layoutId` is truthy — so
- * dropping the prop entirely (behaviorally identical) keeps them green, while
- * restoring `layout="position"` fails them.
+ * Asserting the predicate rather than the literal prop is deliberate: dropping
+ * `layout` entirely is behaviorally identical and stays green, while any truthy
+ * `layout`/`layoutId` — on either wrapper, in either state — fails.
  */
 
-type MotionLayout = boolean | "position" | "size" | undefined;
+/** Framer's own layout union; anything truthy here opts the node into FLIP. */
+type MotionLayout = boolean | "position" | "size" | "preserve-aspect" | undefined;
 
 interface MotionDivProps extends HTMLAttributes<HTMLDivElement> {
   layout?: MotionLayout;
@@ -33,7 +34,6 @@ interface MotionRecord {
   layoutId: string | undefined;
   animate: { opacity?: number } | undefined;
   transition: { duration?: number } | undefined;
-  roleDescription: string | undefined;
 }
 
 const motionRecords: MotionRecord[] = [];
@@ -41,42 +41,31 @@ const motionRecords: MotionRecord[] = [];
 vi.mock("framer-motion", () => ({
   m: {
     div: ({ layout, layoutId, animate, transition, children, ...rest }: MotionDivProps) => {
-      motionRecords.push({
-        layout,
-        layoutId,
-        animate,
-        transition,
-        roleDescription: rest["aria-roledescription"],
-      });
+      motionRecords.push({ layout, layoutId, animate, transition });
       return <div {...rest}>{children}</div>;
     },
   },
 }));
 
-interface SortableOptions {
-  id: string;
-  animateLayoutChanges?: () => boolean;
-}
-
-const sortableCalls: SortableOptions[] = [];
+/** The element dnd-kit puts its drag transform on — must stay a separate node. */
+let transformNode: HTMLElement | null = null;
 let mockIsDragging = false;
 
 vi.mock("@dnd-kit/sortable", () => ({
-  useSortable: (options: SortableOptions) => {
-    sortableCalls.push(options);
-    return {
-      attributes: { role: "button", tabIndex: 0, "aria-describedby": "dnd-describedby" },
-      listeners: { onPointerDown: vi.fn() },
-      setNodeRef: vi.fn(),
-      setActivatorNodeRef: vi.fn(),
-      transform: null,
-      transition: undefined,
-      isDragging: mockIsDragging,
-      isOver: false,
-      active: null,
-      over: null,
-    };
-  },
+  useSortable: () => ({
+    attributes: { role: "button", tabIndex: 0, "aria-describedby": "dnd-describedby" },
+    listeners: { onPointerDown: vi.fn() },
+    setNodeRef: (el: HTMLElement | null) => {
+      if (el) transformNode = el;
+    },
+    setActivatorNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: mockIsDragging,
+    isOver: false,
+    active: null,
+    over: null,
+  }),
 }));
 
 vi.mock("@dnd-kit/utilities", () => ({
@@ -106,9 +95,19 @@ const terminal: PtyPanelData = {
   isVisible: true,
 };
 
-/** Framer enables layout projection iff `layout` or `layoutId` is truthy. */
+/** Framer opts a node into FLIP iff `layout` or `layoutId` is truthy. */
 function projectsLayout(record: MotionRecord): boolean {
   return Boolean(record.layout) || Boolean(record.layoutId);
+}
+
+/**
+ * No motion node the dock rendered may opt into FLIP. Checking every record —
+ * rather than the one wrapper the issue named — is what catches reflow coming
+ * back on a different node, or only in one drag state.
+ */
+function expectNothingProjectsLayout() {
+  expect(motionRecords.length).toBeGreaterThan(0);
+  expect(motionRecords.filter(projectsLayout)).toEqual([]);
 }
 
 function renderDockItem() {
@@ -117,13 +116,6 @@ function renderDockItem() {
       <div data-testid="chip" />
     </SortableDockItem>
   );
-}
-
-/** The wrapper that forwards dnd-kit's ARIA — the one that used to carry FLIP. */
-function chipWrapper(): MotionRecord {
-  const wrapper = motionRecords.find((r) => r.roleDescription === "sortable item");
-  expect(wrapper).toBeDefined();
-  return wrapper!;
 }
 
 /** The inner wrapper that fades the dragged chip — a separate animation. */
@@ -135,34 +127,20 @@ function fadeWrapper(): MotionRecord {
 
 beforeEach(() => {
   motionRecords.length = 0;
-  sortableCalls.length = 0;
+  transformNode = null;
   mockIsDragging = false;
 });
 
 describe("dock chips snap into place on drop (#11063)", () => {
-  it("leaves framer's layout projection off on the chip wrapper", () => {
+  it("opts no chip motion node into FLIP while idle", () => {
     renderDockItem();
-    expect(projectsLayout(chipWrapper())).toBe(false);
+    expectNothingProjectsLayout();
   });
 
-  it("leaves dnd-kit's own reorder transition off on the chip", () => {
+  it("opts no chip motion node into FLIP while dragging", () => {
+    mockIsDragging = true;
     renderDockItem();
-    const options = sortableCalls.find((c) => c.id === terminal.id);
-    expect(options?.animateLayoutChanges).toBeDefined();
-    expect(options!.animateLayoutChanges!()).toBe(false);
-  });
-
-  it("keeps the wrapper — and the dnd-kit attributes it forwards — in the tree", () => {
-    // Guards the tempting follow-up cleanup: with FLIP off the wrapper looks
-    // inert, but it still carries dnd-kit's forwarded attributes, and keeping
-    // it separate from the transform node is the #9029 contract.
-    const { container } = renderDockItem();
-    const wrapper = container.firstChild;
-    expect(wrapper).toBeInstanceOf(HTMLElement);
-    const el = container.querySelector("[aria-roledescription='sortable item']");
-    expect(el).not.toBeNull();
-    expect(el?.getAttribute("aria-describedby")).toBe("dnd-describedby");
-    expect(el?.getAttribute("role")).toBeNull();
+    expectNothingProjectsLayout();
   });
 
   it("still fades the dragged chip, and animates that fade", () => {
@@ -175,31 +153,42 @@ describe("dock chips snap into place on drop (#11063)", () => {
     const dragging = fadeWrapper();
 
     // Relational, not a copy of DRAG_GHOST_OPACITY: the dragged chip must be
-    // more transparent than an idle one, and get there over time rather than
-    // snapping — the fade is the one dock animation this issue preserves.
+    // more transparent than an idle one and get there over time rather than
+    // snapping. This fade is the one dock animation #11063 preserves, so it has
+    // to survive turning FLIP off.
     expect(dragging.animate?.opacity).toBeLessThan(idleOpacity!);
     expect(dragging.transition?.duration).toBeGreaterThan(0);
-    // ...and the fade must not have smuggled FLIP back in on its own wrapper.
-    expect(projectsLayout(dragging)).toBe(false);
+  });
+
+  it("keeps the ARIA wrapper wrapped around — not merged into — the transform node", () => {
+    // With FLIP off the outer wrapper looks inert, and the tempting follow-up is
+    // to delete it. It still forwards dnd-kit's attributes, and collapsing it
+    // into the transform node would put framer's and dnd-kit's transforms on one
+    // element — the exact pairing #9029 separated.
+    const { container } = renderDockItem();
+
+    const ariaWrapper = container.querySelector("[aria-roledescription='sortable item']");
+    expect(ariaWrapper).not.toBeNull();
+    expect(ariaWrapper?.getAttribute("aria-describedby")).toBe("dnd-describedby");
+
+    expect(transformNode).not.toBeNull();
+    expect(ariaWrapper).not.toBe(transformNode);
+    expect(ariaWrapper?.contains(transformNode)).toBe(true);
   });
 });
 
 describe("empty-dock placeholder snaps too (#11063)", () => {
-  it("leaves framer's layout projection off on the placeholder wrapper", () => {
+  it("opts no placeholder motion node into FLIP", () => {
     render(<SortableDockPlaceholder />);
-    expect(motionRecords).toHaveLength(1);
-    expect(projectsLayout(motionRecords[0]!)).toBe(false);
-  });
-
-  it("leaves dnd-kit's own reorder transition off on the placeholder", () => {
-    render(<SortableDockPlaceholder />);
-    const options = sortableCalls[0];
-    expect(options?.animateLayoutChanges).toBeDefined();
-    expect(options!.animateLayoutChanges!()).toBe(false);
+    expectNothingProjectsLayout();
   });
 
   it("keeps the sortable drop target mounted inside the motion wrapper", () => {
+    // Positive control: without it, the negative assertion above would also pass
+    // on a placeholder that rendered nothing at all.
     const { container } = render(<SortableDockPlaceholder />);
-    expect(container.querySelector("[data-placeholder-id]")).not.toBeNull();
+    const dropTarget = container.querySelector("[data-placeholder-id]");
+    expect(dropTarget).not.toBeNull();
+    expect(dropTarget).toBe(transformNode);
   });
 });

--- a/src/components/DragDrop/__tests__/DockReflow.test.tsx
+++ b/src/components/DragDrop/__tests__/DockReflow.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import type { HTMLAttributes, ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { PtyPanelData } from "@shared/types/panel";
+
+/**
+ * Regression coverage for #11063. Dropping a chip into the dock must land it in
+ * its slot the way the macOS dock does — no sibling shuffle. Two independent
+ * engines can reflow the row, and both have to stay off: framer-motion's FLIP
+ * (the `layout` prop on the wrapper) and dnd-kit's own sort transition
+ * (`animateLayoutChanges`). jsdom can't observe animation, so these assert the
+ * enablement contract each engine reads, not the frames it would paint.
+ *
+ * The assertions are deliberately written against framer's own predicate —
+ * layout projection is enabled iff `layout` or `layoutId` is truthy — so
+ * dropping the prop entirely (behaviorally identical) keeps them green, while
+ * restoring `layout="position"` fails them.
+ */
+
+type MotionLayout = boolean | "position" | "size" | undefined;
+
+interface MotionDivProps extends HTMLAttributes<HTMLDivElement> {
+  layout?: MotionLayout;
+  layoutId?: string;
+  animate?: { opacity?: number };
+  transition?: { duration?: number };
+  children?: ReactNode;
+}
+
+interface MotionRecord {
+  layout: MotionLayout;
+  layoutId: string | undefined;
+  animate: { opacity?: number } | undefined;
+  transition: { duration?: number } | undefined;
+  roleDescription: string | undefined;
+}
+
+const motionRecords: MotionRecord[] = [];
+
+vi.mock("framer-motion", () => ({
+  m: {
+    div: ({ layout, layoutId, animate, transition, children, ...rest }: MotionDivProps) => {
+      motionRecords.push({
+        layout,
+        layoutId,
+        animate,
+        transition,
+        roleDescription: rest["aria-roledescription"],
+      });
+      return <div {...rest}>{children}</div>;
+    },
+  },
+}));
+
+interface SortableOptions {
+  id: string;
+  animateLayoutChanges?: () => boolean;
+}
+
+const sortableCalls: SortableOptions[] = [];
+let mockIsDragging = false;
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: (options: SortableOptions) => {
+    sortableCalls.push(options);
+    return {
+      attributes: { role: "button", tabIndex: 0, "aria-describedby": "dnd-describedby" },
+      listeners: { onPointerDown: vi.fn() },
+      setNodeRef: vi.fn(),
+      setActivatorNodeRef: vi.fn(),
+      transform: null,
+      transition: undefined,
+      isDragging: mockIsDragging,
+      isOver: false,
+      active: null,
+      over: null,
+    };
+  },
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+vi.mock("../DndProvider", () => ({
+  useDndPlaceholder: () => ({ activeTerminal: null, isDragging: false }),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ agentId: null }),
+}));
+
+import { SortableDockItem } from "../SortableDockItem";
+import { SortableDockPlaceholder } from "../DockPlaceholder";
+
+const terminal: PtyPanelData = {
+  id: "t1",
+  kind: "terminal",
+  title: "Dock Terminal",
+  cwd: "/test",
+  cols: 80,
+  rows: 24,
+  worktreeId: "wt1",
+  location: "dock",
+  isVisible: true,
+};
+
+/** Framer enables layout projection iff `layout` or `layoutId` is truthy. */
+function projectsLayout(record: MotionRecord): boolean {
+  return Boolean(record.layout) || Boolean(record.layoutId);
+}
+
+function renderDockItem() {
+  return render(
+    <SortableDockItem terminal={terminal} sourceIndex={0}>
+      <div data-testid="chip" />
+    </SortableDockItem>
+  );
+}
+
+/** The wrapper that forwards dnd-kit's ARIA — the one that used to carry FLIP. */
+function chipWrapper(): MotionRecord {
+  const wrapper = motionRecords.find((r) => r.roleDescription === "sortable item");
+  expect(wrapper).toBeDefined();
+  return wrapper!;
+}
+
+/** The inner wrapper that fades the dragged chip — a separate animation. */
+function fadeWrapper(): MotionRecord {
+  const fade = motionRecords.find((r) => r.animate !== undefined);
+  expect(fade).toBeDefined();
+  return fade!;
+}
+
+beforeEach(() => {
+  motionRecords.length = 0;
+  sortableCalls.length = 0;
+  mockIsDragging = false;
+});
+
+describe("dock chips snap into place on drop (#11063)", () => {
+  it("leaves framer's layout projection off on the chip wrapper", () => {
+    renderDockItem();
+    expect(projectsLayout(chipWrapper())).toBe(false);
+  });
+
+  it("leaves dnd-kit's own reorder transition off on the chip", () => {
+    renderDockItem();
+    const options = sortableCalls.find((c) => c.id === terminal.id);
+    expect(options?.animateLayoutChanges).toBeDefined();
+    expect(options!.animateLayoutChanges!()).toBe(false);
+  });
+
+  it("keeps the wrapper — and the dnd-kit attributes it forwards — in the tree", () => {
+    // Guards the tempting follow-up cleanup: with FLIP off the wrapper looks
+    // inert, but it still carries dnd-kit's forwarded attributes, and keeping
+    // it separate from the transform node is the #9029 contract.
+    const { container } = renderDockItem();
+    const wrapper = container.firstChild;
+    expect(wrapper).toBeInstanceOf(HTMLElement);
+    const el = container.querySelector("[aria-roledescription='sortable item']");
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute("aria-describedby")).toBe("dnd-describedby");
+    expect(el?.getAttribute("role")).toBeNull();
+  });
+
+  it("still fades the dragged chip, and animates that fade", () => {
+    renderDockItem();
+    const idleOpacity = fadeWrapper().animate?.opacity;
+
+    motionRecords.length = 0;
+    mockIsDragging = true;
+    renderDockItem();
+    const dragging = fadeWrapper();
+
+    // Relational, not a copy of DRAG_GHOST_OPACITY: the dragged chip must be
+    // more transparent than an idle one, and get there over time rather than
+    // snapping — the fade is the one dock animation this issue preserves.
+    expect(dragging.animate?.opacity).toBeLessThan(idleOpacity!);
+    expect(dragging.transition?.duration).toBeGreaterThan(0);
+    // ...and the fade must not have smuggled FLIP back in on its own wrapper.
+    expect(projectsLayout(dragging)).toBe(false);
+  });
+});
+
+describe("empty-dock placeholder snaps too (#11063)", () => {
+  it("leaves framer's layout projection off on the placeholder wrapper", () => {
+    render(<SortableDockPlaceholder />);
+    expect(motionRecords).toHaveLength(1);
+    expect(projectsLayout(motionRecords[0]!)).toBe(false);
+  });
+
+  it("leaves dnd-kit's own reorder transition off on the placeholder", () => {
+    render(<SortableDockPlaceholder />);
+    const options = sortableCalls[0];
+    expect(options?.animateLayoutChanges).toBeDefined();
+    expect(options!.animateLayoutChanges!()).toBe(false);
+  });
+
+  it("keeps the sortable drop target mounted inside the motion wrapper", () => {
+    const { container } = render(<SortableDockPlaceholder />);
+    expect(container.querySelector("[data-placeholder-id]")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Dropping a panel into the footer terminal dock made every other dock chip FLIP-slide from its old slot to its new one. The macOS dock just snaps items into place, so this fixes the mismatch.
- The reflow came entirely from framer-motion's `layout="position"` on the wrapper `m.div` around each dock chip. `dnd-kit`'s own sort transition was already disabled (`animateLayoutChanges: () => false`), so framer-motion was the sole animator causing the slide.
- Fix is a one-line change in two places: `layout="position"` to `layout={false}` on the outer wrapper. The wrapper itself stays, since it forwards `dnd-kit`'s ARIA attributes, and keeping framer's node separate from `dnd-kit`'s transform node is the contract from #9029.

Resolves #11063

## Changes

- `src/components/DragDrop/SortableDockItem.tsx`: `layout="position"` → `layout={false}` on the outer wrapper.
- `src/components/DragDrop/DockPlaceholder.tsx`: same change on `SortableDockPlaceholder`, the empty-dock placeholder.
- `src/components/DragDrop/__tests__/DockReflow.test.tsx` (new): asserts framer's layout opt-in predicate (a truthy `layout` or `layoutId`) is false across every motion node the dock renders, in both idle and dragging states. Also checks the dragged chip's opacity fade still animates (a relational assertion, not a copied constant), and that the ARIA wrapper still contains, rather than is, `dnd-kit`'s transform node.
- `e2e/helpers/dragDrop.ts`: dropped a comment claiming the helper keeps drags short enough "for framer-motion's FLIP to settle", which this change makes false.

The dragged chip's opacity fade during drag is preserved, since it's a separate animation from the layout reflow. Grid and worktree reflow are untouched on purpose: `SortableTerminal.tsx`, `GridPlaceholder.tsx`, and `SortableWorktreeTerminal.tsx` carry the same `layout="position"` literal, but they're explicitly out of scope per the issue, which states this only happens in the dock.

## Testing

- 102 unit tests green across 8 files, including the grid and worktree suites, proving no behavior leaked into those areas.
- Mutation-checked the new guard: temporarily restoring `layout="position"` fails exactly the 3 no-FLIP test cases, everything else stays green.
- `e2e/full/panels/core-drag-drop.spec.ts` (full-panels bucket): 5/5 passed.
- eslint and prettier clean on all 4 changed files, no new warnings.
- Full `npm run build` (including `tsc`) passed.