### PR TITLE
fix(panels): keep the dock popover open while a tab group is maximized

### DIFF
--- a/e2e/full/panels/core-dock-popover-dismissal.spec.ts
+++ b/e2e/full/panels/core-dock-popover-dismissal.spec.ts
@@ -168,21 +168,47 @@ test.describe.serial("Core: Dock popover dismissal guard", () => {
     const { window, app } = ctx;
     await ensureWindowFocused(app);
 
+    // Build the layout this test needs rather than inheriting the previous
+    // test's, so it stays runnable on its own (`--grep`) instead of passing or
+    // failing on whatever the earlier test happened to leave behind.
+    await test.step("Ensure a docked panel and a grid panel to maximize", async () => {
+      if ((await getDockPanelCount(window)) === 0) {
+        // Keep a panel behind in the grid — docking the last one tears the
+        // project view down (#4898).
+        while ((await getGridPanelIds(window)).length < 2) {
+          await openTerminal(window);
+          await window.waitForTimeout(T_SETTLE);
+        }
+        const gridIds = await getGridPanelIds(window);
+        await dispatchAction(window, "terminal.moveToDock", { terminalId: gridIds[0]! });
+        await expect
+          .poll(() => getDockPanelCount(window), { timeout: T_MEDIUM })
+          .toBeGreaterThan(0);
+      }
+
+      while ((await getGridPanelIds(window)).length === 0) {
+        await openTerminal(window);
+        await window.waitForTimeout(T_SETTLE);
+      }
+    });
+
     const dockedId = (await getDockPanelIds(window))[0]!;
     expect(dockedId).toBeTruthy();
 
     const gridPanel = getFirstGridPanel(window);
     await expect(gridPanel).toBeVisible({ timeout: T_MEDIUM });
 
-    await test.step("Turn the remaining grid panel into a tab group", async () => {
-      // The + button is opacity-0 on single panels, so force the click.
-      await gridPanel
-        .locator(SEL.panel.duplicate)
-        .first()
-        .click({ force: true, timeout: T_MEDIUM });
-
+    await test.step("Make the grid panel a tab group — only group maximize enforces focus", async () => {
       const tabs = gridPanel.locator(SEL.panel.tabList).locator(SEL.panel.tab);
-      await expect(tabs).toHaveCount(2, { timeout: T_MEDIUM });
+      if ((await tabs.count()) < 2) {
+        // The + button is opacity-0 on single panels, so force the click.
+        await gridPanel
+          .locator(SEL.panel.duplicate)
+          .first()
+          .click({ force: true, timeout: T_MEDIUM });
+      }
+      await expect(tabs.first()).toBeVisible({ timeout: T_MEDIUM });
+      expect(await tabs.count()).toBeGreaterThanOrEqual(2);
     });
 
     const restoreBtn = window.locator(SEL.panel.restore).first();

--- a/e2e/full/panels/core-dock-popover-dismissal.spec.ts
+++ b/e2e/full/panels/core-dock-popover-dismissal.spec.ts
@@ -3,7 +3,13 @@ import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
 import { openAndOnboardProject } from "../../helpers/project";
 import { ensureWindowFocused } from "../../helpers/focus";
-import { getGridPanelIds, getDockPanelCount, openTerminal } from "../../helpers/panels";
+import {
+  getGridPanelIds,
+  getDockPanelCount,
+  getDockPanelIds,
+  getFirstGridPanel,
+  openTerminal,
+} from "../../helpers/panels";
 import { SEL } from "../../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_SETTLE } from "../../helpers/timeouts";
 
@@ -146,5 +152,68 @@ test.describe.serial("Core: Dock popover dismissal guard", () => {
     await window.locator("#test-radix-popper").click();
     await expect(portalTarget).not.toBeVisible({ timeout: T_MEDIUM });
     await window.evaluate(() => document.getElementById("test-radix-popper")?.remove());
+  });
+
+  // Regression pin for #11065 — the maximized-group focus enforcement in
+  // `useContentGridContext` snapped focus back to the group's active tab
+  // whenever `focusedId` sat outside the group. Focusing a grid panel clears
+  // `activeDockTerminalId`, so opening a dock popover while a tab group was
+  // maximized closed it again instantly. The enforcement now stands down while
+  // the focused terminal is the one whose popover is open.
+  //
+  // A maximized group must COEXIST with the dock popover: the dock is a sibling
+  // of the grid, never covered by the maximize overlay, so the fix must not
+  // exit maximize either. Both halves are asserted below.
+  test("keeps the dock popover open while a grid tab group is maximized", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    const dockedId = (await getDockPanelIds(window))[0]!;
+    expect(dockedId).toBeTruthy();
+
+    const gridPanel = getFirstGridPanel(window);
+    await expect(gridPanel).toBeVisible({ timeout: T_MEDIUM });
+
+    await test.step("Turn the remaining grid panel into a tab group", async () => {
+      // The + button is opacity-0 on single panels, so force the click.
+      await gridPanel
+        .locator(SEL.panel.duplicate)
+        .first()
+        .click({ force: true, timeout: T_MEDIUM });
+
+      const tabs = gridPanel.locator(SEL.panel.tabList).locator(SEL.panel.tab);
+      await expect(tabs).toHaveCount(2, { timeout: T_MEDIUM });
+    });
+
+    const restoreBtn = window.locator(SEL.panel.restore).first();
+
+    await test.step("Maximize the tab group", async () => {
+      await gridPanel.locator(SEL.panel.maximize).first().click();
+      await expect(restoreBtn).toBeVisible({ timeout: T_SHORT });
+    });
+
+    const portalTarget = window.locator(`[data-dock-portal-target="${dockedId}"]`);
+
+    await test.step("Open the dock popover and prove it survives the settle window", async () => {
+      await window
+        .locator(`${SEL.dock.container} [aria-label*="Click to preview"]`)
+        .first()
+        .click();
+      await expect(portalTarget).toBeVisible({ timeout: T_MEDIUM });
+
+      // The pre-fix popover could flash open before enforcement slammed it shut,
+      // so a bare toBeVisible() right after the click would pass on the bug.
+      // Settling first is what makes this a real regression pin.
+      await window.waitForTimeout(T_SETTLE);
+      await expect(portalTarget).toBeVisible({ timeout: T_SHORT });
+
+      // …and the group is still maximized: coexistence, not an exit-maximize.
+      await expect(restoreBtn).toBeVisible({ timeout: T_SHORT });
+    });
+
+    await test.step("Restore the group so later runs start from a clean layout", async () => {
+      await restoreBtn.click();
+      await expect(restoreBtn).not.toBeVisible({ timeout: T_SHORT });
+    });
   });
 });

--- a/src/components/Layout/__tests__/dockPanelVisibility.test.ts
+++ b/src/components/Layout/__tests__/dockPanelVisibility.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { isDockPanelRendered, type DockPanelScope } from "../dockPanelVisibility";
+import type { PtyPanelData, ReviewPanelData } from "@shared/types/panel";
+
+function createDockPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id,
+    title: id,
+    kind: "terminal",
+    cwd: "/project",
+    cols: 80,
+    rows: 24,
+    location: "dock",
+    worktreeId: "wt-a",
+    ...overrides,
+  } as PtyPanelData;
+}
+
+function createScope(overrides: Partial<DockPanelScope> = {}): DockPanelScope {
+  return {
+    // The store keeps trash as a Map; `has` is all the predicate needs.
+    trashedTerminals: new Map<string, unknown>(),
+    helpTerminalId: null,
+    activeWorktreeId: "wt-a",
+    ...overrides,
+  };
+}
+
+describe("isDockPanelRendered", () => {
+  it("renders a docked panel belonging to the active worktree", () => {
+    expect(isDockPanelRendered(createDockPanel("dock-1"), createScope())).toBe(true);
+  });
+
+  it("renders a global panel regardless of the active worktree", () => {
+    const panel = createDockPanel("dock-1", { worktreeId: undefined });
+
+    expect(isDockPanelRendered(panel, createScope({ activeWorktreeId: "wt-b" }))).toBe(true);
+  });
+
+  // #11065 — the dock filters other worktrees' panels out, but the offscreen
+  // watchdog keeps `activeDockTerminalId` pointing at them so the popover can
+  // reopen on the way back. Reading that stale pointer as a live popover strands
+  // focus outside the maximized group.
+  it("does not render a panel owned by a different worktree", () => {
+    const panel = createDockPanel("dock-1", { worktreeId: "wt-a" });
+
+    expect(isDockPanelRendered(panel, createScope({ activeWorktreeId: "wt-b" }))).toBe(false);
+  });
+
+  // Layout undo can restore a panel's location and the dock pointer without
+  // lifting it out of the trash, so the trash check has to be part of "rendered".
+  it("does not render a trashed panel", () => {
+    const scope = createScope({ trashedTerminals: new Map([["dock-1", {}]]) });
+
+    expect(isDockPanelRendered(createDockPanel("dock-1"), scope)).toBe(false);
+  });
+
+  it("does not render the help panel, which owns its own surface", () => {
+    const scope = createScope({ helpTerminalId: "dock-1" });
+
+    expect(isDockPanelRendered(createDockPanel("dock-1"), scope)).toBe(false);
+  });
+
+  it("does not render a panel that has moved back to the grid", () => {
+    const panel = createDockPanel("dock-1", { location: "grid" });
+
+    expect(isDockPanelRendered(panel, createScope())).toBe(false);
+  });
+
+  it("does not render a panel that no longer exists", () => {
+    expect(isDockPanelRendered(undefined, createScope())).toBe(false);
+  });
+
+  it("does not render a panel kind the dock cannot host", () => {
+    const panel: ReviewPanelData = {
+      id: "dock-1",
+      kind: "review",
+      title: "Review",
+      location: "dock",
+      worktreeId: "wt-a",
+    };
+
+    expect(isDockPanelRendered(panel, createScope())).toBe(false);
+  });
+});

--- a/src/components/Layout/dockPanelVisibility.ts
+++ b/src/components/Layout/dockPanelVisibility.ts
@@ -1,0 +1,36 @@
+import { isDockPanel, type PanelInstance } from "@shared/types/panel";
+
+export interface DockPanelScope {
+  /** Structural so both the store's trash `Map` and a plain `Set` satisfy it. */
+  trashedTerminals: { has: (id: string) => boolean };
+  helpTerminalId: string | null;
+  activeWorktreeId: string | null;
+}
+
+/**
+ * Whether the dock currently renders a chip for this panel — and therefore
+ * whether its popover can be on screen at all.
+ *
+ * `activeDockTerminalId` alone does not answer that. The offscreen container's
+ * watchdog deliberately keeps the pointer alive whenever the panel still exists
+ * in `panelsById` (#7278), so it survives a worktree switch that filters the
+ * panel out of the dock — the popover reopens when you switch back. Callers that
+ * need "a popover is really open right now" must intersect the pointer with this
+ * predicate; treating a stale pointer as live focus strands focus on an
+ * unrendered panel (#11065).
+ *
+ * Mirrors the filters in `ContentDock` and `DockPanelOffscreenContainer`, which
+ * inline these conditions across a store selector (panel fields) and a memo
+ * (help/worktree stores a store selector cannot read).
+ */
+export function isDockPanelRendered(
+  panel: PanelInstance | undefined,
+  { trashedTerminals, helpTerminalId, activeWorktreeId }: DockPanelScope
+): boolean {
+  if (!panel || !isDockPanel(panel)) return false;
+  if (panel.location !== "dock") return false;
+  if (trashedTerminals.has(panel.id)) return false;
+  if (panel.id === helpTerminalId) return false;
+  // Global panels (no worktree) ride along with every worktree.
+  return panel.worktreeId == null || panel.worktreeId === activeWorktreeId;
+}

--- a/src/components/Layout/dockPanelVisibility.ts
+++ b/src/components/Layout/dockPanelVisibility.ts
@@ -22,6 +22,11 @@ export interface DockPanelScope {
  * Mirrors the filters in `ContentDock` and `DockPanelOffscreenContainer`, which
  * inline these conditions across a store selector (panel fields) and a memo
  * (help/worktree stores a store selector cannot read).
+ *
+ * One condition stays with the caller: both dock surfaces iterate `panelIds`, so
+ * a panel must also be registered there. That lives on the store state rather
+ * than the panel, so callers resolve `panel` through `panelIds` and pass
+ * `undefined` for an unregistered id.
  */
 export function isDockPanelRendered(
   panel: PanelInstance | undefined,

--- a/src/components/Terminal/__tests__/contentGridFocus.test.ts
+++ b/src/components/Terminal/__tests__/contentGridFocus.test.ts
@@ -23,7 +23,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-1",
-      activeDockTerminalId: null,
+      openDockPopoverId: null,
     });
 
     expect(nextFocus).toBe("term-2");
@@ -35,7 +35,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-2",
-      activeDockTerminalId: null,
+      openDockPopoverId: null,
     });
 
     expect(nextFocus).toBe("term-2");
@@ -47,7 +47,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "missing-panel",
-      activeDockTerminalId: null,
+      openDockPopoverId: null,
     });
 
     expect(nextFocus).toBe("term-1");
@@ -59,7 +59,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-2",
-      activeDockTerminalId: "dock-1",
+      openDockPopoverId: "dock-1",
     });
 
     expect(nextFocus).toBeNull();
@@ -73,10 +73,10 @@ describe("getMaximizedGroupFocusTarget", () => {
       getActiveTabId: () => "term-2",
     };
 
-    expect(getMaximizedGroupFocusTarget({ ...args, activeDockTerminalId: "dock-1" })).toBeNull();
+    expect(getMaximizedGroupFocusTarget({ ...args, openDockPopoverId: "dock-1" })).toBeNull();
     // `closeDockTerminal` clears only `activeDockTerminalId`, leaving focus on
     // the closed dock terminal — enforcement resumes and reclaims the group.
-    expect(getMaximizedGroupFocusTarget({ ...args, activeDockTerminalId: null })).toBe("term-2");
+    expect(getMaximizedGroupFocusTarget({ ...args, openDockPopoverId: null })).toBe("term-2");
   });
 
   it("still rescues stale focus while an unrelated dock popover is open", () => {
@@ -85,7 +85,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-2",
-      activeDockTerminalId: "dock-1",
+      openDockPopoverId: "dock-1",
     });
 
     expect(nextFocus).toBe("term-2");
@@ -97,7 +97,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-2",
-      activeDockTerminalId: null,
+      openDockPopoverId: null,
     });
 
     expect(nextFocus).toBe("term-2");

--- a/src/components/Terminal/__tests__/contentGridFocus.test.ts
+++ b/src/components/Terminal/__tests__/contentGridFocus.test.ts
@@ -23,6 +23,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-1",
+      activeDockTerminalId: null,
     });
 
     expect(nextFocus).toBe("term-2");
@@ -34,6 +35,7 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "term-2",
+      activeDockTerminalId: null,
     });
 
     expect(nextFocus).toBe("term-2");
@@ -45,8 +47,59 @@ describe("getMaximizedGroupFocusTarget", () => {
       groupId: "group-1",
       groupPanels,
       getActiveTabId: () => "missing-panel",
+      activeDockTerminalId: null,
     });
 
     expect(nextFocus).toBe("term-1");
+  });
+
+  it("enforces no target while the focused terminal's dock popover is open", () => {
+    const nextFocus = getMaximizedGroupFocusTarget({
+      focusedId: "dock-1",
+      groupId: "group-1",
+      groupPanels,
+      getActiveTabId: () => "term-2",
+      activeDockTerminalId: "dock-1",
+    });
+
+    expect(nextFocus).toBeNull();
+  });
+
+  it("returns focus to the group once the dock popover closes", () => {
+    const args = {
+      focusedId: "dock-1",
+      groupId: "group-1",
+      groupPanels,
+      getActiveTabId: () => "term-2",
+    };
+
+    expect(getMaximizedGroupFocusTarget({ ...args, activeDockTerminalId: "dock-1" })).toBeNull();
+    // `closeDockTerminal` clears only `activeDockTerminalId`, leaving focus on
+    // the closed dock terminal — enforcement resumes and reclaims the group.
+    expect(getMaximizedGroupFocusTarget({ ...args, activeDockTerminalId: null })).toBe("term-2");
+  });
+
+  it("still rescues stale focus while an unrelated dock popover is open", () => {
+    const nextFocus = getMaximizedGroupFocusTarget({
+      focusedId: "stale-panel",
+      groupId: "group-1",
+      groupPanels,
+      getActiveTabId: () => "term-2",
+      activeDockTerminalId: "dock-1",
+    });
+
+    expect(nextFocus).toBe("term-2");
+  });
+
+  it("rescues absent focus rather than reading it as an open dock popover", () => {
+    const nextFocus = getMaximizedGroupFocusTarget({
+      focusedId: null,
+      groupId: "group-1",
+      groupPanels,
+      getActiveTabId: () => "term-2",
+      activeDockTerminalId: null,
+    });
+
+    expect(nextFocus).toBe("term-2");
   });
 });

--- a/src/components/Terminal/contentGridFocus.ts
+++ b/src/components/Terminal/contentGridFocus.ts
@@ -5,13 +5,20 @@ interface MaximizedGroupFocusArgs {
   groupId: string;
   groupPanels: PanelInstance[];
   getActiveTabId: (groupId: string) => string | null;
+  activeDockTerminalId: string | null;
 }
 
+/**
+ * Resolves which group panel should hold focus while the group is maximized, or
+ * `null` when no enforcement is warranted. Callers treat `null` as "leave focus
+ * alone".
+ */
 export function getMaximizedGroupFocusTarget({
   focusedId,
   groupId,
   groupPanels,
   getActiveTabId,
+  activeDockTerminalId,
 }: MaximizedGroupFocusArgs): string | null {
   if (groupPanels.length === 0) {
     return null;
@@ -19,6 +26,16 @@ export function getMaximizedGroupFocusTarget({
 
   if (focusedId && groupPanels.some((panel) => panel.id === focusedId)) {
     return focusedId;
+  }
+
+  // Focus sits on the terminal whose dock popover is open, so it is live and
+  // deliberate — not the stale persisted focus this fallback exists to rescue.
+  // Enforcing a group panel here would clear `activeDockTerminalId` via
+  // `setFocused` and slam the popover shut (#11065). The truthy `focusedId`
+  // guard matters: both ids are `null` when focus is nowhere and no popover is
+  // open, and that case must still fall through to the rescue below.
+  if (focusedId && focusedId === activeDockTerminalId) {
+    return null;
   }
 
   const activeTabId = getActiveTabId(groupId);

--- a/src/components/Terminal/contentGridFocus.ts
+++ b/src/components/Terminal/contentGridFocus.ts
@@ -5,7 +5,13 @@ interface MaximizedGroupFocusArgs {
   groupId: string;
   groupPanels: PanelInstance[];
   getActiveTabId: (groupId: string) => string | null;
-  activeDockTerminalId: string | null;
+  /**
+   * The dock terminal whose popover is genuinely on screen, or `null`. This is
+   * NOT the raw `activeDockTerminalId` — that pointer outlives the popover it
+   * names (see `isDockPanelRendered`), and trusting it here would strand focus
+   * on a panel the dock no longer renders.
+   */
+  openDockPopoverId: string | null;
 }
 
 /**
@@ -18,7 +24,7 @@ export function getMaximizedGroupFocusTarget({
   groupId,
   groupPanels,
   getActiveTabId,
-  activeDockTerminalId,
+  openDockPopoverId,
 }: MaximizedGroupFocusArgs): string | null {
   if (groupPanels.length === 0) {
     return null;
@@ -31,10 +37,10 @@ export function getMaximizedGroupFocusTarget({
   // Focus sits on the terminal whose dock popover is open, so it is live and
   // deliberate — not the stale persisted focus this fallback exists to rescue.
   // Enforcing a group panel here would clear `activeDockTerminalId` via
-  // `setFocused` and slam the popover shut (#11065). The truthy `focusedId`
-  // guard matters: both ids are `null` when focus is nowhere and no popover is
-  // open, and that case must still fall through to the rescue below.
-  if (focusedId && focusedId === activeDockTerminalId) {
+  // `setFocused` and slam the popover shut (#11065). Compare against `null`
+  // rather than truthiness: both ids are `null` when focus is nowhere and no
+  // popover is open, and that case must still fall through to the rescue below.
+  if (focusedId !== null && focusedId === openDockPopoverId) {
     return null;
   }
 

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -292,6 +292,7 @@ export function useContentGridContext({
     getTerminal,
     getActiveTabId,
     setFocused,
+    activeDockTerminalId,
   } = usePanelStore(
     useShallow((state) => ({
       storeTerminalIds: state.panelIds,
@@ -306,6 +307,7 @@ export function useContentGridContext({
       getTerminal: state.getTerminal,
       getActiveTabId: state.getActiveTabId,
       setFocused: state.setFocused,
+      activeDockTerminalId: state.activeDockTerminalId,
     }))
   );
 
@@ -1093,9 +1095,10 @@ export function useContentGridContext({
             groupId: maximizedGroup.id,
             groupPanels: maximizedGroupPanels,
             getActiveTabId,
+            activeDockTerminalId,
           })
         : null,
-    [focusedId, getActiveTabId, maximizedGroup, maximizedGroupPanels]
+    [activeDockTerminalId, focusedId, getActiveTabId, maximizedGroup, maximizedGroupPanels]
   );
 
   useEffect(() => {

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -294,7 +294,6 @@ export function useContentGridContext({
     getTerminal,
     getActiveTabId,
     setFocused,
-    activeDockTerminalId,
   } = usePanelStore(
     useShallow((state) => ({
       storeTerminalIds: state.panelIds,
@@ -309,7 +308,6 @@ export function useContentGridContext({
       getTerminal: state.getTerminal,
       getActiveTabId: state.getActiveTabId,
       setFocused: state.setFocused,
-      activeDockTerminalId: state.activeDockTerminalId,
     }))
   );
 
@@ -1096,19 +1094,33 @@ export function useContentGridContext({
   // Intersect it with what the dock actually renders, or focus enforcement below
   // would stand down for a popover that isn't on screen and strand focus outside
   // the maximized group (#11065).
-  // `panelsById` is read non-reactively on purpose: subscribing to the panel
-  // object would re-render this hook on every agent-state tick of that terminal
-  // (#8593). The snapshot is safe because every transition that could invalidate
-  // it also moves one of the reactive deps below — a dock panel that is trashed,
-  // removed, or moved to the grid has its pointer cleared or its trash entry set,
-  // and a worktree switch changes `activeWorktreeId`.
-  const openDockPopoverId = useMemo(() => {
-    if (!activeDockTerminalId) return null;
-    const panel = panelStoreApi.getState().panelsById[activeDockTerminalId];
-    return isDockPanelRendered(panel, { trashedTerminals, helpTerminalId, activeWorktreeId })
-      ? activeDockTerminalId
+  // Which dock popover is genuinely on screen, or null. `activeDockTerminalId`
+  // alone can't answer that: the offscreen watchdog keeps the pointer alive for
+  // panels the dock has filtered out (#7278), so focus enforcement below would
+  // stand down for a popover that isn't rendered and strand focus outside the
+  // maximized group (#11065).
+  //
+  // Derived in the selector rather than a useMemo over `panelsById` snapshots:
+  // the panel's structure can change while the pointer holds still (layout undo
+  // rewrites a panel's worktree in place), which a memo keyed on the pointer
+  // would miss. Selecting the id — a primitive — rather than the panel object is
+  // what keeps this free of the per-panel re-render churn of #8593: the selector
+  // re-runs on every store write but returns the same string, so the equality
+  // check short-circuits and the hook doesn't re-render.
+  const openDockPopoverId = usePanelStore((state) => {
+    const id = state.activeDockTerminalId;
+    if (id === null) return null;
+    // Both dock surfaces render from `panelIds`; a panel that lingers in
+    // `panelsById` without being registered there has no chip, hence no popover.
+    const panel = state.panelIds.includes(id) ? state.panelsById[id] : undefined;
+    return isDockPanelRendered(panel, {
+      trashedTerminals: state.trashedTerminals,
+      helpTerminalId,
+      activeWorktreeId,
+    })
+      ? id
       : null;
-  }, [activeDockTerminalId, trashedTerminals, helpTerminalId, activeWorktreeId]);
+  });
 
   const maximizedGroupFocusTarget = useMemo(
     () =>

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -25,6 +25,8 @@ import { getNarrowPanel, getRenderablePanel } from "@/store/slices/panelRegistry
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { isDockPanelRendered } from "@/components/Layout/dockPanelVisibility";
 import { computeGridSelectedAgentIds } from "./contentGridAgentFilter";
 import { buildFleetPanels } from "./contentGridFleetPanels";
 import { useDndPlaceholder, useIsDragging, GRID_PLACEHOLDER_ID } from "@/components/DragDrop";
@@ -322,6 +324,7 @@ export function useContentGridContext({
     rawMaximizedId !== null && closingIds.has(rawMaximizedId) ? null : rawMaximizedId;
 
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
+  const helpTerminalId = useHelpPanelStore((state) => state.terminalId);
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
@@ -1087,6 +1090,26 @@ export function useContentGridContext({
       .map((raw) => getRenderablePanel(byId, raw.id))
       .filter((p): p is PanelInstance => p !== undefined);
   }, [getTabGroupPanels, maximizedGroup]);
+  // `activeDockTerminalId` outlives the popover it names — the offscreen
+  // container's watchdog keeps it pointing at a panel the dock has filtered out
+  // (e.g. after a worktree switch) so the popover can reopen on the way back.
+  // Intersect it with what the dock actually renders, or focus enforcement below
+  // would stand down for a popover that isn't on screen and strand focus outside
+  // the maximized group (#11065).
+  // `panelsById` is read non-reactively on purpose: subscribing to the panel
+  // object would re-render this hook on every agent-state tick of that terminal
+  // (#8593). The snapshot is safe because every transition that could invalidate
+  // it also moves one of the reactive deps below — a dock panel that is trashed,
+  // removed, or moved to the grid has its pointer cleared or its trash entry set,
+  // and a worktree switch changes `activeWorktreeId`.
+  const openDockPopoverId = useMemo(() => {
+    if (!activeDockTerminalId) return null;
+    const panel = panelStoreApi.getState().panelsById[activeDockTerminalId];
+    return isDockPanelRendered(panel, { trashedTerminals, helpTerminalId, activeWorktreeId })
+      ? activeDockTerminalId
+      : null;
+  }, [activeDockTerminalId, trashedTerminals, helpTerminalId, activeWorktreeId]);
+
   const maximizedGroupFocusTarget = useMemo(
     () =>
       maximizedGroup
@@ -1095,10 +1118,10 @@ export function useContentGridContext({
             groupId: maximizedGroup.id,
             groupPanels: maximizedGroupPanels,
             getActiveTabId,
-            activeDockTerminalId,
+            openDockPopoverId,
           })
         : null,
-    [activeDockTerminalId, focusedId, getActiveTabId, maximizedGroup, maximizedGroupPanels]
+    [focusedId, getActiveTabId, maximizedGroup, maximizedGroupPanels, openDockPopoverId]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- While a grid tab group is maximized, the dock is unusable. Launching a panel into the dock, or clicking a dock chip, opens the popover, but the maximized-group focus enforcement in `useContentGridContext` sees focus sitting outside the group and immediately snaps it back to the group's active tab. `setFocused` clears `activeDockTerminalId` for any grid target, so the popover closes instantly, or never visibly opens.
- The enforcement effect exists to rescue stale persisted focus, not to override live dock focus. `getMaximizedGroupFocusTarget` (`contentGridFocus.ts`) now returns `null`, meaning no enforcement, when focus sits on a dock popover that is actually on screen.
- Maximize is never exited by this fix. The dock is a sibling of the grid, never covered by the maximize overlay, so the two coexist by design.

Resolves #11065

## The fix

Returning `null` rather than the dock id keeps the helper's contract honest and needs no change in either consumer. The effect already skips a falsy target, and `ContentGridMaximizedGroup` already falls back to the raw `focusedId`, so the maximized group's tab strip renders as unfocused while the dock has focus, matching the behavior of a non-maximized grid. When the popover closes, `closeDockTerminal` clears only `activeDockTerminalId`, the exception stops matching, and the existing effect snaps focus back to the group on its own.

## Why a rendered-popover check, not just `activeDockTerminalId`

That pointer outlives the popover it names. The offscreen container's watchdog deliberately keeps a panel alive whenever it still exists in `panelsById` (#7278), so it survives a worktree switch that filters the panel out of the dock. Treating the raw pointer as always-live focus would have suppressed enforcement permanently and stranded focus outside the maximized group, a worse bug than the one being fixed.

So the hook derives `openDockPopoverId` by intersecting the pointer with what the dock actually renders, via a new shared predicate, `isDockPanelRendered`: the panel is registered in `panelIds`, is a dockable kind, is docked, is untrashed, is not the help panel, and is in the active worktree or is global. This is derived in the store selector rather than a memo, because layout undo can rewrite a panel's worktree in place while the pointer holds still; selecting the id as a primitive keeps this free of the per-panel re-render churn from #8593.

## Changes

- `contentGridFocus.ts`: `getMaximizedGroupFocusTarget` returns `null` when focus is on a rendered dock popover.
- `useContentGridContext.tsx`: derives `openDockPopoverId` reactively from the store selector and feeds it into the enforcement check.
- `dockPanelVisibility.ts`: new shared `isDockPanelRendered` predicate (registration, dockable kind, docked, untrashed, not the help panel, worktree scope).

## Testing

- `contentGridFocus.test.ts`: 4 new cases (live popover, popover-close sequence, unrelated popover, absent focus) on top of the 3 existing stale-focus rescue cases.
- `dockPanelVisibility.test.ts`: new, covers the worktree-scope, trash, help-panel, location, registration and kind conditions.
- `core-dock-popover-dismissal.spec.ts`: new e2e regression pin asserting the popover survives the settle window and the group stays maximized. Verified as a true pin: reverting the guard fails the test at the popover-visibility assertion, restoring it passes both tests in the spec.
- Locally: 157 unit tests across the 11 files covering the changed modules, 2/2 e2e (full-panels), eslint/prettier/tsc clean on all changed files.

## Note

`ContentDock` and `DockPanelOffscreenContainer` were deliberately not refactored to consume `isDockPanelRendered`, because their existing filters are pinned by literal-source-text assertions in `ContentDock.test.tsx`. The predicate is documented as the shared definition for those two to adopt separately.
