### PR TITLE
fix(help): launch the Daintree Assistant in a scratch workspace

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -44,6 +44,10 @@ import {
   useTerminalInputStore,
 } from "@/store";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
+// Leaf import, not the `@/store` barrel: the barrel is mocked wholesale (with a
+// hand-listed hook set) across the HelpPanel/controller suites, so pulling a new
+// hook through it would crash every one of them on an undefined destructure.
+import { useScratchStore } from "@/store/scratchStore";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { buildResumeLatestCommand } from "@shared/types/agentSettings";
 import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
@@ -225,7 +229,28 @@ export function HelpPanel({
   const cliAvailability = useCliAvailabilityStore((s) => s.availability);
   const cliHasRealData = useCliAvailabilityStore((s) => s.hasRealData);
   const currentProject = useProjectStore((s) => s.currentProject);
+  const currentScratch = useScratchStore((s) => s.currentScratch);
   const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
+
+  // The assistant launches into the active *workspace*, which is a project OR a
+  // scratch (#11068). The two pointers are mutually exclusive by design — a
+  // scratch switch clears `currentProject`, a project switch clears
+  // `currentScratch` — so the fallback never has to disambiguate a both-set
+  // state; project-first only guards against a transient inconsistency.
+  // Everything downstream (provisioning, hibernation, `ctx.projectId` in main)
+  // treats this id as an opaque workspace key, so a scratch id flows through
+  // unchanged. Memoized on the primitive id/path so the identity is stable
+  // across renders — `syncInputs` below patches controller state, which can
+  // re-render this component, and an inline object would churn the effect.
+  const activeWorkspaceId = currentProject?.id ?? currentScratch?.id ?? null;
+  const activeWorkspacePath = currentProject?.path ?? currentScratch?.path ?? null;
+  const activeWorkspace = useMemo(
+    () =>
+      activeWorkspaceId && activeWorkspacePath
+        ? { id: activeWorkspaceId, path: activeWorkspacePath }
+        : null,
+    [activeWorkspaceId, activeWorkspacePath]
+  );
 
   // The ActionContext pinned to this session at launch (#8772). Fetched once
   // per session id — the binding is fixed at provision time and only changes
@@ -310,29 +335,28 @@ export function HelpPanel({
   }, [cliHasRealData, cliAvailability]);
   const supportedInstalledAgentIdsKey = supportedInstalledAgentIds.join(",");
 
-  // A conversation the eviction/crash path captured for this project but never
+  // A conversation the eviction/crash path captured for this workspace but never
   // resumed. On LRU eviction (or renderer crash) main kills the assistant PTY
   // via HelpSessionService.revokeByWebContentsId — grid PTYs survive in the
   // pty-host, the assistant doesn't — and stashes a resume token in its
   // pending-hibernation store. When the idle empty state is about to show, peek
   // that store so we can offer "Resume assistant" instead of a fresh "Start
-  // assistant", making a project switch-back read as a recoverable pause rather
+  // assistant", making a workspace switch-back read as a recoverable pause rather
   // than a crash. The peek is non-consuming: the launch flow still consumes the
-  // entry via takePendingHibernation. We stamp the entry with its projectId so a
-  // mid-flight A→B switch can't show project A's Resume CTA over project B.
+  // entry via takePendingHibernation. We stamp the entry with its workspace id so
+  // a mid-flight A→B switch can't show workspace A's Resume CTA over workspace B.
   const [resumablePending, setResumablePending] = useState<{
-    projectId: string;
+    workspaceId: string;
     agentId: string;
   } | null>(null);
-  const currentProjectId = currentProject?.id ?? null;
   useEffect(() => {
-    if (!isOpen || terminalId || !currentProjectId) {
+    if (!isOpen || terminalId || !activeWorkspaceId) {
       setResumablePending(null);
       return;
     }
     // Optional-chained like the `onViewRevealed` subscription below: a missing
     // binding degrades to the normal "Start assistant" CTA rather than throwing.
-    const peek = window.electron.help.peekPendingHibernation?.(currentProjectId);
+    const peek = window.electron.help.peekPendingHibernation?.(activeWorkspaceId);
     if (!peek) {
       setResumablePending(null);
       return;
@@ -353,7 +377,7 @@ export function HelpPanel({
           supportedInstalledAgentIds.includes(pendingAgentId) &&
           buildResumeLatestCommand(pendingAgentId) !== undefined;
         setResumablePending(
-          canResume ? { projectId: currentProjectId, agentId: pendingAgentId } : null
+          canResume ? { workspaceId: activeWorkspaceId, agentId: pendingAgentId } : null
         );
       })
       .catch((err) => {
@@ -366,27 +390,27 @@ export function HelpPanel({
   }, [
     isOpen,
     terminalId,
-    currentProjectId,
+    activeWorkspaceId,
     supportedInstalledAgentIdsKey,
     supportedInstalledAgentIds,
   ]);
 
-  // Cross-project bleed guard: an A→B switch re-runs the peek effect, but B's
-  // peek resolves asynchronously, so only trust a pending entry whose projectId
-  // matches the project currently in view.
+  // Cross-workspace bleed guard: an A→B switch re-runs the peek effect, but B's
+  // peek resolves asynchronously, so only trust a pending entry whose workspace
+  // id matches the workspace currently in view.
   const resumableAgentId =
-    resumablePending && resumablePending.projectId === currentProjectId
+    resumablePending && resumablePending.workspaceId === activeWorkspaceId
       ? resumablePending.agentId
       : null;
 
-  // #10815: report this project's panel open-state to main on every change so
+  // #10815: report this workspace's panel open-state to main on every change so
   // an LRU eviction / crash capture can stamp `panelWasOpen` onto the resume
   // token. Fire-and-forget — a slow or missing binding must never block the UI.
   useEffect(() => {
-    if (!currentProjectId) return;
-    const reported = window.electron.help.reportPanelOpen?.(currentProjectId, isOpen);
+    if (!activeWorkspaceId) return;
+    const reported = window.electron.help.reportPanelOpen?.(activeWorkspaceId, isOpen);
     if (reported) safeFireAndForget(reported, { context: "HelpPanel.reportPanelOpen" });
-  }, [isOpen, currentProjectId]);
+  }, [isOpen, activeWorkspaceId]);
 
   // #10815: cold switch-back auto-resume — driven by the reliable pull-on-mount
   // peek, NOT a racy main→renderer push. The lazy HelpPanel mounts behind
@@ -405,7 +429,7 @@ export function HelpPanel({
   //
   // Gated on `isReadyToLaunch` so we don't arm — or even peek — until the
   // controller can actually accept the launch (#10815). A true cold restore
-  // renders with project state still hydrating (`isReadyToLaunch === false`);
+  // renders with workspace state still hydrating (`isReadyToLaunch === false`);
   // arming then would set `autoResumeAgentId`, and the fire-effect would call
   // `launch()` against a not-ready controller, which rejects and burns the
   // one-shot intent — silently losing the resume in exactly the target scenario.
@@ -416,16 +440,16 @@ export function HelpPanel({
   const [autoResumeAgentId, setAutoResumeAgentId] = useState<string | null>(null);
   const coldResumeArmedRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!currentProjectId || terminalId || !isReadyToLaunch) return;
-    if (coldResumeArmedRef.current === currentProjectId) return;
-    const peek = window.electron.help.peekPendingHibernation?.(currentProjectId);
+    if (!activeWorkspaceId || terminalId || !isReadyToLaunch) return;
+    if (coldResumeArmedRef.current === activeWorkspaceId) return;
+    const peek = window.electron.help.peekPendingHibernation?.(activeWorkspaceId);
     if (!peek) return;
     let cancelled = false;
     void peek
       .then((pending) => {
-        if (cancelled || coldResumeArmedRef.current === currentProjectId) return;
+        if (cancelled || coldResumeArmedRef.current === activeWorkspaceId) return;
         if (!pending?.panelWasOpen || !pending.agentId) return;
-        coldResumeArmedRef.current = currentProjectId;
+        coldResumeArmedRef.current = activeWorkspaceId;
         setOpen(true);
         setAutoResumeAgentId(pending.agentId);
       })
@@ -435,7 +459,7 @@ export function HelpPanel({
     return () => {
       cancelled = true;
     };
-  }, [currentProjectId, terminalId, isReadyToLaunch, setOpen]);
+  }, [activeWorkspaceId, terminalId, isReadyToLaunch, setOpen]);
 
   // Fire the captured resume once the panel has opened. The `!terminalId` guard
   // covers two cases: a DevTools reload that still holds a live session, and the
@@ -474,7 +498,8 @@ export function HelpPanel({
     controller.syncInputs({
       isOpen,
       isReadyToLaunch,
-      currentProject: currentProject ? { id: currentProject.id, path: currentProject.path } : null,
+      // Legacy field name — carries the active workspace, project or scratch.
+      currentProject: activeWorkspace,
       terminalId,
       preferredAgentId,
       supportedInstalledAgentIds,
@@ -485,7 +510,7 @@ export function HelpPanel({
     controller,
     isOpen,
     isReadyToLaunch,
-    currentProject,
+    activeWorkspace,
     terminalId,
     preferredAgentId,
     supportedInstalledAgentIdsKey,

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -23,6 +23,7 @@ const {
   cliAvailabilityState,
   agentSettingsState,
   projectStoreState,
+  scratchStoreState,
   preferencesState,
   terminalInputState,
   worktreeSelectionState,
@@ -114,6 +115,9 @@ const {
   },
   projectStoreState: {
     currentProject: { id: "proj-default", path: "/repo" } as { id: string; path: string } | null,
+  },
+  scratchStoreState: {
+    currentScratch: null as { id: string; path: string } | null,
   },
   preferencesState: { reduceAnimations: false },
   terminalInputState: { hybridInputEnabled: true } as { hybridInputEnabled: boolean },
@@ -333,6 +337,15 @@ vi.mock("@/store", () => {
   };
 });
 
+// Leaf-path mock, mirroring the component's import (#11068) — kept out of the
+// `@/store` barrel above so barrel-mocking suites don't have to list it.
+vi.mock("@/store/scratchStore", () => {
+  const store = (selector?: (state: typeof scratchStoreState) => unknown) =>
+    selector ? selector(scratchStoreState) : scratchStoreState;
+  store.getState = () => scratchStoreState;
+  return { useScratchStore: store };
+});
+
 vi.mock("@/store/macroFocusStore", () => {
   const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
@@ -446,6 +459,7 @@ function resetState() {
   agentSettingsState.settings = { agents: {} };
 
   projectStoreState.currentProject = { id: "proj-default", path: "/repo" };
+  scratchStoreState.currentScratch = null;
   preferencesState.reduceAnimations = false;
   terminalInputState.hybridInputEnabled = true;
   worktreeSelectionState.activeWorktreeId = null;
@@ -748,6 +762,36 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       expect.objectContaining({ agentId: "claude" }),
       { source: "user" }
     );
+  });
+
+  // #11068: the headline regression. A scratch is a valid workspace (same
+  // ProjectViewManager, same PTY host), but switching to one clears
+  // `currentProject`, so the assistant used to bail with "Project state is still
+  // loading" and never launch.
+  it("launches into an active scratch workspace when no project is active", async () => {
+    projectStoreState.currentProject = null;
+    scratchStoreState.currentScratch = { id: "scratch-1", path: "/scratches/scratch-1" };
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockProvisionSession).toHaveBeenCalledWith({
+      projectId: "scratch-1",
+      projectPath: "/scratches/scratch-1",
+      agentId: "claude",
+      context: {},
+    });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+    // The bug's signature: a "still loading" toast instead of a launch.
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it("does not launch the terminal when session provisioning returns null", async () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -27,6 +27,7 @@ const {
   cliAvailabilityState,
   agentSettingsState,
   projectStoreState,
+  scratchStoreState,
   preferencesState,
   terminalInputState,
   mockTerminalSubmit,
@@ -112,6 +113,9 @@ const {
   },
   projectStoreState: {
     currentProject: null as { id: string; path: string } | null,
+  },
+  scratchStoreState: {
+    currentScratch: null as { id: string; path: string } | null,
   },
   preferencesState: { reduceAnimations: false },
   terminalInputState: { hybridInputEnabled: true } as { hybridInputEnabled: boolean },
@@ -291,6 +295,16 @@ vi.mock("@/store", () => {
   };
 });
 
+// Mocked at its leaf path, mirroring the component's import (#11068). The panel
+// pulls `useScratchStore` from `@/store/scratchStore` rather than the `@/store`
+// barrel precisely so barrel-mocking suites like this one don't have to list it.
+vi.mock("@/store/scratchStore", () => {
+  const store = (selector?: (state: typeof scratchStoreState) => unknown) =>
+    selector ? selector(scratchStoreState) : scratchStoreState;
+  store.getState = () => scratchStoreState;
+  return { useScratchStore: store };
+});
+
 vi.mock("@/store/macroFocusStore", () => {
   const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
   const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
@@ -399,6 +413,7 @@ function resetState() {
   agentSettingsState.settings = { agents: {} };
 
   projectStoreState.currentProject = null;
+  scratchStoreState.currentScratch = null;
   preferencesState.reduceAnimations = false;
   terminalInputState.hybridInputEnabled = true;
   mockTerminalSubmit.mockReset();
@@ -1092,6 +1107,66 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     );
   });
 
+  // #11068: the same cold-resume handoff, but the active workspace is a scratch
+  // (so `currentProject` is null). Every hop — peek, panel-open report, atomic
+  // take — must key on the scratch id; before the fix they all keyed on null and
+  // the assistant refused to launch at all.
+  it("peeks, reports, and takes under the scratch id when a scratch is the active workspace", async () => {
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.terminalId = null;
+    helpPanelState.hibernateSessions = {};
+    helpPanelState.setHibernateSession = vi.fn(
+      (workspaceId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[workspaceId] = entry;
+      }
+    );
+    helpPanelState.clearHibernateSession = vi.fn((workspaceId: string) => {
+      delete helpPanelState.hibernateSessions[workspaceId];
+    });
+    projectStoreState.currentProject = null;
+    scratchStoreState.currentScratch = { id: "scratch-1", path: "/scratches/scratch-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/scratch-1",
+      token: "tok",
+      mcpUrl: "http://localhost:1234",
+      windowId: 1,
+    });
+    mockBuildResumeLatestCommand.mockReturnValue("claude resume --last");
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("resumed-term-1");
+    mockPeekPendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/scratches/scratch-1",
+      panelWasOpen: true,
+    });
+    mockTakePendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/scratches/scratch-1",
+    });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    await flushAsyncWork();
+
+    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("scratch-1");
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith("scratch-1");
+    expect(mockReportPanelOpen).toHaveBeenCalledWith("scratch-1", expect.any(Boolean));
+    // Provisioning treats the scratch as the workspace — same opaque id/path.
+    expect(mockProvisionSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "scratch-1",
+        projectPath: "/scratches/scratch-1",
+      })
+    );
+    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "claude --resume abc-123", launchAgentId: "claude" })
+    );
+  });
+
   it("does NOT auto-resume on app restart (panelWasOpen:false)", async () => {
     // A prior-session token reloaded from disk lacks the in-memory open flag, so
     // main reports panelWasOpen:false. App restart must never silently spin up a
@@ -1414,6 +1489,52 @@ describe("HelpPanel — idle hibernation timer", () => {
       });
       expect(panelStoreState.removePanel).toHaveBeenCalledWith("t1");
       expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #11068: a scratch workspace clears `currentProject`, so before the fix the
+  // hibernate slot was keyed on `null` and the captured session was silently
+  // dropped — the conversation could never be resumed.
+  it("keys the hibernate slot on the scratch id when a scratch is the active workspace", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      helpPanelState.sessionId = "live-session";
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/scratches/scratch-1",
+          agentState: "idle",
+        },
+      };
+      projectStoreState.currentProject = null;
+      scratchStoreState.currentScratch = { id: "scratch-1", path: "/scratches/scratch-1" };
+      mockGracefulKill.mockResolvedValue("resume-token-scratch");
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      expect(mockGracefulKill).toHaveBeenCalledWith("t1");
+      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("scratch-1", {
+        sessionId: "resume-token-scratch",
+        cwd: "/scratches/scratch-1",
+        agentId: "claude",
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -1540,6 +1540,68 @@ describe("HelpPanel — idle hibernation timer", () => {
     }
   });
 
+  // #11068 follow-up: arming with a null workspace used to be possible (the
+  // armed-identity tuple is only terminal+agent, so a later arm with the SAME
+  // tuple early-returns). The timer would then fire, tear the PTY down, and skip
+  // every `if (projectId)` persistence branch — destroying the conversation
+  // instead of hibernating it. Now we refuse to arm until a workspace is known.
+  it("does not arm — and so cannot destroy the session — while the active workspace is null", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      helpPanelState.sessionId = "live-session";
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/scratches/scratch-1",
+          agentState: "idle",
+        },
+      };
+      // Panel closed with a live terminal, but no workspace pointer yet.
+      projectStoreState.currentProject = null;
+      scratchStoreState.currentScratch = null;
+      mockGracefulKill.mockResolvedValue("resume-token-scratch");
+
+      let view: ReturnType<typeof render> | undefined;
+      await act(async () => {
+        view = render(<HelpPanel width={380} />);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      // Nothing armed: the session is left intact rather than killed unsaved.
+      expect(mockGracefulKill).not.toHaveBeenCalled();
+      expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+
+      // The workspace resolves (same terminal + agent — the tuple that used to
+      // early-return past a sticky null arm). Hibernation must now key on it.
+      scratchStoreState.currentScratch = { id: "scratch-1", path: "/scratches/scratch-1" };
+      await act(async () => {
+        view!.rerender(<HelpPanel width={380} />);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      expect(mockGracefulKill).toHaveBeenCalledWith("t1");
+      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("scratch-1", {
+        sessionId: "resume-token-scratch",
+        cwd: "/scratches/scratch-1",
+        agentId: "claude",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not call gracefulKill while the agent is working — defers via the busy re-check", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -8,7 +8,7 @@
 import { getAgentConfig } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
-import { usePanelStore, useProjectStore } from "@/store";
+import { usePanelStore } from "@/store";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type { ActionContext } from "@shared/types/actions";
@@ -23,7 +23,12 @@ import {
   asStringRecord,
 } from "./HelpSessionProvisioner";
 import { HelpVersionGate, checkAssistantVersion } from "./HelpVersionGate";
-import { LaunchNotifications, notifyLaunchFailed } from "./LaunchNotifications";
+import {
+  LaunchNotifications,
+  notifyLaunchFailed,
+  LAUNCH_BLOCKED_LOADING,
+  LAUNCH_BLOCKED_NO_WORKSPACE,
+} from "./LaunchNotifications";
 import { McpActivityTracker } from "./McpActivityTracker";
 import { HibernationManager } from "./HibernationManager";
 
@@ -202,6 +207,17 @@ export interface HelpSessionSnapshot {
   outcomeAlert: import("@shared/types/ipc/mcpServer").TurnOutcomeAlertClass | null;
 }
 
+/**
+ * The workspace the assistant launches into — an opaque `{ id, path }` pair,
+ * NOT necessarily a `Project` (#11068). A scratch workspace is a valid
+ * assistant workspace: `ProjectViewManager` keys its WebContents map on the
+ * scratch id exactly as it does a project id, so main's `ctx.projectId` is the
+ * scratch id while a scratch is active, and provisioning/hibernation validate
+ * the id as an opaque string rather than a projects-table key. Nothing
+ * downstream of acquisition branches on which kind it is, so the flattened
+ * shape is deliberate — the legacy `currentProject` field name is kept to avoid
+ * a rename with no behavior change.
+ */
 export interface HelpProjectRef {
   id: string;
   path: string;
@@ -210,6 +226,7 @@ export interface HelpProjectRef {
 export interface HelpSessionInputs {
   isOpen: boolean;
   isReadyToLaunch: boolean;
+  /** Active workspace (project OR scratch) — see `HelpProjectRef`. */
   currentProject: HelpProjectRef | null;
   terminalId: string | null;
   preferredAgentId: string | null;
@@ -664,8 +681,11 @@ export class HelpSessionController {
    * path (`handleTerminalPanelMissing`).
    */
   private _applyStopSuppression(): void {
-    const projectId = useProjectStore.getState().currentProject?.id ?? null;
-    this._hibernationManager.clearAndSuppress(projectId);
+    // Read the workspace from the synced inputs, not the project store: in a
+    // scratch workspace `currentProject` is null by design, and a live-store
+    // read would leave the scratch's hibernate entry behind (#11068).
+    const workspaceId = this._lastInputs?.currentProject?.id ?? null;
+    this._hibernationManager.clearAndSuppress(workspaceId);
     this._hasAutoLaunched = true;
     this._patch({
       phase: "idle",
@@ -708,12 +728,17 @@ export class HelpSessionController {
   launch(options: HelpLaunchOptions): void {
     const inputs = this._lastInputs;
     const launchAgentId = options.agentId;
-    if (!inputs?.isReadyToLaunch || !inputs?.currentProject) {
+    if (!inputs?.isReadyToLaunch || !inputs.currentProject) {
       // A resume-only auto-resume is silent best-effort recovery — the renderer
       // re-fires once state is ready (#10815), so dropping it here must not raise
       // a scary "still loading" error. Every other caller surfaces it.
       if (!options.resumeOnly) {
-        notifyLaunchFailed(launchAgentId, "Project state is still loading. Try again.");
+        // Only say "loading" when state really is still hydrating. Ready-but-no-
+        // workspace is a different condition and used to lie about it (#11068).
+        notifyLaunchFailed(
+          launchAgentId,
+          inputs?.isReadyToLaunch ? LAUNCH_BLOCKED_NO_WORKSPACE : LAUNCH_BLOCKED_LOADING
+        );
       }
       return;
     }
@@ -759,13 +784,12 @@ export class HelpSessionController {
         });
       }
       // Discarding the current conversation invalidates any persisted
-      // hibernate entry for this project — leaving it would resume the
-      // just-discarded chat on next open.
+      // hibernate entry for this workspace — leaving it would resume the
+      // just-discarded chat on next open. Use the workspace already captured
+      // for this launch: in a scratch the project store is null by design, and
+      // a live read would strand the scratch's entry (#11068).
       if (reservedId) {
-        const projectIdForReset = useProjectStore.getState().currentProject?.id ?? null;
-        if (projectIdForReset) {
-          useHelpPanelStore.getState().clearHibernateSession(projectIdForReset);
-        }
+        useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
         this._patch({ showResumeBanner: false });
       }
     }

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -106,6 +106,18 @@ export class HibernationManager {
     ) {
       return;
     }
+    // Never arm without a workspace to key the entry on. `_fireHibernate` would
+    // tear the session down (kill the PTY, revoke, clear the terminal) and then
+    // skip every `if (projectId)` persistence branch — destroying the
+    // conversation instead of hibernating it. Bailing here keeps the session
+    // alive until a workspace is known; because we return BEFORE touching
+    // `_hibernateArmedFor`, an arm already captured against a real workspace
+    // survives a transient null and keeps its own countdown (the anti-bleed
+    // capture below). Reachable when the active workspace pointer is
+    // transiently null — e.g. the scratch pointer being cleared out from under
+    // a closed panel (#11068).
+    const workspaceId = inputs.currentProject?.id ?? null;
+    if (!workspaceId) return;
     this.clearTimer();
     // Capture the workspace at arm time so a workspace switch between panel
     // close and hibernate fire doesn't write workspace A's session into
@@ -116,7 +128,7 @@ export class HibernationManager {
     this._hibernateArmedFor = {
       terminalId,
       agentId: useHelpPanelStore.getState().agentId,
-      projectId: inputs.currentProject?.id ?? null,
+      projectId: workspaceId,
     };
     const initialTerminalId = terminalId;
     const initialAgentId = this._hibernateArmedFor.agentId;

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -4,7 +4,7 @@
 // their handlers are unchanged, just relocated.
 
 import { useHelpPanelStore } from "@/store/helpPanelStore";
-import { usePanelStore, useProjectStore } from "@/store";
+import { usePanelStore } from "@/store";
 import { isPtyPanel } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -107,14 +107,16 @@ export class HibernationManager {
       return;
     }
     this.clearTimer();
-    // Capture the project at arm time so a project switch between panel
-    // close and hibernate fire doesn't write project A's session into
-    // project B's slot. The fire path reads this captured value, never
-    // the live currentProject.
+    // Capture the workspace at arm time so a workspace switch between panel
+    // close and hibernate fire doesn't write workspace A's session into
+    // workspace B's slot. The fire path reads this captured value, never live
+    // store state. Sourced from the synced inputs rather than the project
+    // store: the active workspace may be a scratch, which leaves
+    // `currentProject` null by design (#11068).
     this._hibernateArmedFor = {
       terminalId,
       agentId: useHelpPanelStore.getState().agentId,
-      projectId: useProjectStore.getState().currentProject?.id ?? null,
+      projectId: inputs.currentProject?.id ?? null,
     };
     const initialTerminalId = terminalId;
     const initialAgentId = this._hibernateArmedFor.agentId;

--- a/src/controllers/LaunchNotifications.ts
+++ b/src/controllers/LaunchNotifications.ts
@@ -9,9 +9,25 @@ import type { HelpSessionSnapshot, LaunchErrorKind } from "./HelpSessionControll
 
 const RESUME_BANNER_AUTO_DISMISS_MS = 4_000;
 
+/**
+ * Workspace state hasn't hydrated yet — retrying really does help.
+ * Says "workspace", not "project": a scratch is an equally valid assistant
+ * workspace (#11068).
+ */
+export const LAUNCH_BLOCKED_LOADING = "Workspace state is still loading. Try again.";
+
+/**
+ * Hydrated, but nothing is open. Both assistant launch paths used to report
+ * this as "Project state is still loading", which was a lie in a scratch
+ * workspace and unhelpful everywhere else (#11068).
+ */
+export const LAUNCH_BLOCKED_NO_WORKSPACE =
+  "No project or scratch workspace is active. Open one, then try again.";
+
 // Exported directly: the launch FSM also calls this before a launch reaches
-// the version gate (e.g. project state still loading), not just from
-// `surfaceLaunchError`.
+// the version gate (e.g. workspace state still loading), not just from
+// `surfaceLaunchError`. The `help.launchAgent` action shares it too, so both
+// launch entry points fail with identical copy.
 export function notifyLaunchFailed(agentId: string, reason: string): void {
   const cfg = getAgentConfig(agentId);
   const name = cfg?.name ?? agentId;

--- a/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
@@ -126,6 +126,32 @@ vi.mock("@/utils/safeFireAndForget", () => ({
 }));
 
 import { HelpSessionController } from "../HelpSessionController";
+import type { HelpSessionInputs } from "../HelpSessionController";
+
+/**
+ * Prime the controller's synced inputs with an active workspace. The controller
+ * reads the workspace it acts on from these inputs — never the live project
+ * store — because a scratch workspace leaves `currentProject` null by design
+ * (#11068). Tests that expect workspace-scoped side effects (clearing the
+ * hibernate slot, etc.) must therefore push inputs, not just seed the store.
+ */
+function syncWorkspaceInputs(
+  ctrl: HelpSessionController,
+  workspace: { id: string; path: string },
+  overrides: Partial<HelpSessionInputs> = {}
+): void {
+  ctrl.syncInputs({
+    isOpen: true,
+    isReadyToLaunch: true,
+    currentProject: workspace,
+    terminalId: "term-1",
+    preferredAgentId: null,
+    supportedInstalledAgentIds: ["claude"],
+    autoLaunchEnabled: false,
+    visibilityEpoch: 0,
+    ...overrides,
+  });
+}
 
 function resetState() {
   helpPanelState.isOpen = false;
@@ -523,20 +549,25 @@ describe("HelpSessionController — syncInputs", () => {
 });
 
 describe("HelpSessionController — endSession (Stop assistant, #10989)", () => {
-  function bindLiveSession() {
+  function bindLiveSession(
+    ctrl: HelpSessionController,
+    workspace = { id: "proj-1", path: "/repo" }
+  ) {
     helpPanelState.terminalId = "term-1";
     helpPanelState.agentId = "claude";
     helpPanelState.sessionId = "sess-bound";
-    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
     panelStoreState.panelsById = {
       "term-1": { id: "term-1", kind: "terminal", cwd: "/help" },
     };
+    // Deliberately leaves `projectStoreState.currentProject` null: the workspace
+    // reaches the controller through synced inputs only (#11068).
+    syncWorkspaceInputs(ctrl, workspace);
   }
 
   it("tears the bound session down without relaunching", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.endSession();
 
@@ -555,9 +586,23 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     expect(ctrl.getSnapshot().phase).toBe("idle");
   });
 
+  // #11068: in a scratch workspace `currentProject` is null by design. Stop must
+  // still drop the hibernate slot — keyed on the scratch id — or the discarded
+  // conversation resurrects on the next open.
+  it("drops the hibernate slot under the scratch id when a scratch is the active workspace", () => {
+    const ctrl = new HelpSessionController();
+    ctrl["_patch"]({ phase: "live" });
+    bindLiveSession(ctrl, { id: "scratch-1", path: "/scratches/scratch-1" });
+    expect(projectStoreState.currentProject).toBeNull();
+
+    ctrl.endSession();
+
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("scratch-1");
+  });
+
   it("revokes the bearer before killing the PTY (revoke-before-kill, #7522)", () => {
     const ctrl = new HelpSessionController();
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.endSession();
 
@@ -610,7 +655,7 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
   it("suppresses an immediate consented auto-relaunch in the same open cycle", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.endSession();
     expect(ctrl["_hasAutoLaunched"]).toBe(true);
@@ -637,7 +682,7 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
   it("re-arms auto-launch after the panel closes and reopens", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
-    bindLiveSession();
+    bindLiveSession(ctrl);
     ctrl.endSession();
     expect(ctrl["_hasAutoLaunched"]).toBe(true);
     helpPanelState.terminalId = null;
@@ -660,18 +705,22 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
 });
 
 describe("HelpSessionController — terminal PTY exit slides the sidebar out (#10989)", () => {
-  function bindLiveSession() {
+  function bindLiveSession(
+    ctrl: HelpSessionController,
+    workspace = { id: "proj-1", path: "/repo" }
+  ) {
     helpPanelState.isOpen = true;
     helpPanelState.terminalId = "term-1";
     helpPanelState.agentId = "claude";
     helpPanelState.sessionId = "sess-bound";
-    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    // Workspace reaches the controller via synced inputs, not the project store.
+    syncWorkspaceInputs(ctrl, workspace);
   }
 
   it("tears the session down and slides the sidebar out when the PTY exits on its own", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     // removeOnExit already removed the panel; the renderer reports the bound
     // terminal as no longer existing.
@@ -689,7 +738,7 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });
     // The stop consumes this open cycle's auto-launch budget so the assistant
@@ -703,7 +752,7 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
     // `_fireHibernate` sets this phase before its gracefulKill; the PTY onExit
     // then removes the panel and fires this handler mid-teardown.
     ctrl["_patch"]({ phase: "hibernating" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });
 
@@ -717,7 +766,7 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
   it("is a no-op while a +New-session terminal is reserved but not yet committed", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
     ctrl["_pendingNewTerminalId"] = "term-1";
 
     ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });
@@ -729,7 +778,7 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
   it("does not close the panel when the missing terminal is a stale, unbound id", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     // A different terminal than the one currently bound in the store.
     ctrl.handleTerminalPanelMissing({ terminalId: "term-stale", terminalExists: false });
@@ -740,21 +789,25 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
 });
 
 describe("HelpSessionController — handleAgentExited (agent /exit inside a live shell, #10989)", () => {
-  function bindLiveSession() {
+  function bindLiveSession(
+    ctrl: HelpSessionController,
+    workspace = { id: "proj-1", path: "/repo" }
+  ) {
     helpPanelState.isOpen = true;
     helpPanelState.terminalId = "term-1";
     helpPanelState.agentId = "claude";
     helpPanelState.sessionId = "sess-bound";
-    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
     panelStoreState.panelsById = {
       "term-1": { id: "term-1", kind: "terminal", cwd: "/help" },
     };
+    // Workspace reaches the controller via synced inputs, not the project store.
+    syncWorkspaceInputs(ctrl, workspace);
   }
 
   it("kills the shell PTY, revokes, and slides the sidebar out on a settled agent exit", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.handleAgentExited("term-1");
 
@@ -772,7 +825,7 @@ describe("HelpSessionController — handleAgentExited (agent /exit inside a live
   it("revokes the bearer before killing the shell PTY (revoke-before-kill, #7522)", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.handleAgentExited("term-1");
 
@@ -788,7 +841,7 @@ describe("HelpSessionController — handleAgentExited (agent /exit inside a live
   it("ignores an exit signal for a terminal that is no longer the bound one", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "live" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     // A +New session / replace already moved the store on to a different id.
     ctrl.handleAgentExited("term-stale");
@@ -801,7 +854,7 @@ describe("HelpSessionController — handleAgentExited (agent /exit inside a live
   it("defers to an in-flight hibernate rather than double-driving the teardown", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "hibernating" });
-    bindLiveSession();
+    bindLiveSession(ctrl);
 
     ctrl.handleAgentExited("term-1");
 

--- a/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
@@ -652,6 +652,101 @@ describe("HelpSessionController — launch error routing", () => {
     ctrl.stop();
   });
 
+  // #11068: the guard used to say "Project state is still loading" for BOTH the
+  // genuinely-hydrating case and the no-workspace case. In a scratch it was
+  // simply false — and it's the reason the assistant couldn't launch there at all.
+  it("blocks with no-workspace copy — not 'still loading' — when ready but no workspace is active", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_lastInputs"] = {
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: null,
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    };
+
+    ctrl.launch({ agentId: "claude" });
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("No project or scratch workspace is active"),
+      })
+    );
+    expect(provisionMock()).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("blocks with loading copy while inputs are still hydrating", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_lastInputs"] = {
+      isOpen: true,
+      isReadyToLaunch: false,
+      currentProject: null,
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    };
+
+    ctrl.launch({ agentId: "claude" });
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("still loading"),
+      })
+    );
+    expect(provisionMock()).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  // A scratch's `{ id, path }` is an opaque workspace ref — it must provision
+  // exactly like a project's, with no branching on workspace kind (#11068).
+  it("launches into an active scratch workspace, provisioning with the scratch id and path", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_lastInputs"] = {
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "scratch-1", path: "/scratches/scratch-1" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    };
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = vi.fn().mockResolvedValue(null);
+    provisionMock().mockResolvedValueOnce({
+      sessionId: "sess-s1",
+      sessionPath: "/s/s1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+
+    ctrl.launch({ agentId: "claude" });
+
+    await vi.waitFor(() => {
+      expect(provisionMock()).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "scratch-1",
+          projectPath: "/scratches/scratch-1",
+        })
+      );
+    });
+    expect(notify).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
   it("revokes the session and surfaces an error when auto-launch throws after provisioning", async () => {
     const ctrl = new HelpSessionController();
     ctrl.start();

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -9,6 +9,7 @@ const {
   mockGetCliAvailabilityState,
   mockGetAgentSettingsState,
   mockGetProjectState,
+  mockGetScratchState,
   mockLogError,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn().mockResolvedValue({ ok: true }),
@@ -18,6 +19,7 @@ const {
   mockGetCliAvailabilityState: vi.fn(),
   mockGetAgentSettingsState: vi.fn(),
   mockGetProjectState: vi.fn(),
+  mockGetScratchState: vi.fn(),
   mockLogError: vi.fn(),
 }));
 
@@ -43,6 +45,12 @@ vi.mock("@/store/agentSettingsStore", () => ({
 
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: { getState: () => mockGetProjectState() },
+}));
+
+// Leaf-path mock, mirroring the projectStore one — the action reads the scratch
+// pointer as its workspace fallback (#11068).
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: { getState: () => mockGetScratchState() },
 }));
 
 vi.mock("@/utils/logger", () => ({
@@ -115,7 +123,9 @@ describe("help.launchAgent", () => {
     });
     mockGetProjectState.mockReturnValue({
       currentProject: { id: "proj-default", path: "/repo" },
+      isBootstrapped: true,
     });
+    mockGetScratchState.mockReturnValue({ currentScratch: null });
     action = extractHelpLaunchAgent();
   });
 
@@ -380,11 +390,92 @@ describe("help.launchAgent", () => {
     );
   });
 
-  it("does not launch until a current project is active", async () => {
+  // #11068: switching to a scratch clears `currentProject` by design, so the
+  // action must fall back to the scratch pointer instead of reporting that
+  // project state is "still loading" and refusing to launch.
+  it("provisions against the active scratch when no project is active", async () => {
     (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
       "/mock/help"
     );
-    mockGetProjectState.mockReturnValue({ currentProject: null });
+    mockGetProjectState.mockReturnValue({ currentProject: null, isBootstrapped: true });
+    mockGetScratchState.mockReturnValue({
+      currentScratch: { id: "scratch-1", path: "/scratches/scratch-1" },
+    });
+    (window.electron.help.provisionSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: "sess-s1",
+      sessionPath: "/sessions/sess-s1",
+      token: "tok-s1",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 3,
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+
+    await action.run(undefined, stubCtx);
+
+    expect(window.electron.help.provisionSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "scratch-1",
+        projectPath: "/scratches/scratch-1",
+        agentId: "claude",
+      })
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({
+        env: expect.objectContaining({ DAINTREE_PROJECT_ID: "scratch-1" }),
+      }),
+      { source: "user" }
+    );
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("runs the assistant in the scratch root when a scratch is the active workspace", async () => {
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "/mock/help"
+    );
+    mockGetProjectState.mockReturnValue({ currentProject: null, isBootstrapped: true });
+    mockGetScratchState.mockReturnValue({
+      currentScratch: { id: "scratch-1", path: "/scratches/scratch-1" },
+    });
+
+    await action.run({ agentId: "daintree-assistant" }, stubCtx);
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({
+        agentId: "daintree-assistant",
+        cwd: "/scratches/scratch-1",
+      }),
+      { source: "user" }
+    );
+  });
+
+  it("prefers the project over a stale scratch pointer when both are somehow set", async () => {
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "/mock/help"
+    );
+    mockGetProjectState.mockReturnValue({
+      currentProject: { id: "proj-1", path: "/repo" },
+      isBootstrapped: true,
+    });
+    mockGetScratchState.mockReturnValue({
+      currentScratch: { id: "scratch-1", path: "/scratches/scratch-1" },
+    });
+
+    await action.run(undefined, stubCtx);
+
+    expect(window.electron.help.provisionSession).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "proj-1", projectPath: "/repo" })
+    );
+  });
+
+  it("reports no active workspace — not 'still loading' — when project state has settled empty", async () => {
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "/mock/help"
+    );
+    mockGetProjectState.mockReturnValue({ currentProject: null, isBootstrapped: true });
+    mockGetScratchState.mockReturnValue({ currentScratch: null });
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
 
     await action.run(undefined, stubCtx);
@@ -394,7 +485,25 @@ describe("help.launchAgent", () => {
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "error",
-        title: "Daintree Assistant",
+        message: expect.stringContaining("No project or scratch workspace is active"),
+      })
+    );
+  });
+
+  it("still reports loading when project state has not bootstrapped yet", async () => {
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "/mock/help"
+    );
+    mockGetProjectState.mockReturnValue({ currentProject: null, isBootstrapped: false });
+    mockGetScratchState.mockReturnValue({ currentScratch: null });
+
+    await action.run(undefined, stubCtx);
+
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining("still loading"),
       })
     );
   });

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -9,7 +9,13 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useFocusStore } from "@/store/focusStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { useProjectStore } from "@/store/projectStore";
+import { useScratchStore } from "@/store/scratchStore";
 import { isAssistantFocused } from "@/store/macroFocusStore";
+import {
+  notifyLaunchFailed,
+  LAUNCH_BLOCKED_LOADING,
+  LAUNCH_BLOCKED_NO_WORKSPACE,
+} from "@/controllers/LaunchNotifications";
 import { logError } from "@/utils/logger";
 import { getDefaultAgentId } from "@/lib/resolveAgentId";
 import { isAssistantOnlyAgentId } from "@shared/config/agentIds";
@@ -122,12 +128,21 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
       // during the model's turn can't retarget actions onto the wrong
       // worktree/terminal (#8317). Capturing after an await would
       // reintroduce the exact stale-read race this fixes (lesson #5087).
-      // `currentProject` is captured in the same synchronous block so the
-      // session is provisioned with a project identity and context snapshot
-      // that are guaranteed consistent — a project switch during the
+      // The workspace is captured in the same synchronous block so the
+      // session is provisioned with a workspace identity and context snapshot
+      // that are guaranteed consistent — a workspace switch during the
       // `getFolderPath()` await can't split them (#8317).
+      //
+      // The active workspace is a project OR a scratch (#11068): switching to a
+      // scratch clears `currentProject` by design, and main keys the assistant's
+      // session on an opaque workspace id (`ctx.projectId` resolves through
+      // ProjectViewManager, which maps scratch ids the same as project ids), so
+      // a scratch's `{ id, path }` provisions unchanged. The two pointers are
+      // mutually exclusive; project-first only guards a transient inconsistency.
       const capturedContext = actionService.getContext();
-      const project = useProjectStore.getState().currentProject;
+      const projectState = useProjectStore.getState();
+      const workspace = projectState.currentProject ?? useScratchStore.getState().currentScratch;
+      const isProjectStateSettled = projectState.isBootstrapped;
       const folderPath = await window.electron.help.getFolderPath();
       if (!folderPath) {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
@@ -156,20 +171,21 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
         "I need help with Daintree, an Electron-based IDE for orchestrating AI coding agents. Please briefly tell me how you can help.";
 
       let session: Awaited<ReturnType<typeof window.electron.help.provisionSession>> | null = null;
-      if (!project) {
-        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-        notify({
-          type: "error",
-          title: "Daintree Assistant",
-          message: "Project state is still loading.",
-        });
+      if (!workspace) {
+        // Shares the panel controller's copy so both launch entry points fail
+        // identically, and only claims "loading" when state really is still
+        // hydrating — the old message said so unconditionally (#11068).
+        notifyLaunchFailed(
+          agentId,
+          isProjectStateSettled ? LAUNCH_BLOCKED_NO_WORKSPACE : LAUNCH_BLOCKED_LOADING
+        );
         return;
       }
 
       try {
         session = await window.electron.help.provisionSession({
-          projectId: project.id,
-          projectPath: project.path,
+          projectId: workspace.id,
+          projectPath: workspace.path,
           agentId,
           context: capturedContext,
         });
@@ -208,16 +224,16 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
 
       // The Daintree Assistant is env-only (MCP via DAINTREE_MCP_* env vars)
       // and ships its own skills, so it reads nothing from cwd. Run it in the
-      // project root so its file tools (read/list/grep/edit) and the terminal's
-      // file-link resolution operate on the actual project; other help agents
+      // workspace root so its file tools (read/list/grep/edit) and the terminal's
+      // file-link resolution operate on the actual workspace; other help agents
       // stay in the session dir that owns their .mcp.json / settings. The
-      // session token still scopes the assistant's MCP surface to this project.
-      const cwd = isAssistantOnlyAgentId(agentId) ? project.path : session.sessionPath;
+      // session token still scopes the assistant's MCP surface to this workspace.
+      const cwd = isAssistantOnlyAgentId(agentId) ? workspace.path : session.sessionPath;
       const env: Record<string, string> = {
         DAINTREE_MCP_TOKEN: session.token,
         DAINTREE_WINDOW_ID: String(session.windowId),
         ...(session.mcpUrl ? { DAINTREE_MCP_URL: session.mcpUrl } : {}),
-        DAINTREE_PROJECT_ID: project.id,
+        DAINTREE_PROJECT_ID: workspace.id,
       };
 
       const result = await actionService.dispatch<{ terminalId: string | null }>(


### PR DESCRIPTION
## Summary

The Daintree Assistant couldn't be launched while a scratch workspace was active. It failed with `Couldn't start Daintree Assistant. Project state is still loading. Try again.` The state wasn't actually loading. Switching to a scratch calls `clearCurrentProject()` by design, since `scratch` and `project` are mutually-exclusive pointers, and both assistant launch entry points hard-required a non-null `currentProject`.

**Why this is renderer-only.** The main process already treats the assistant's `projectId` as an opaque workspace id, not a key into the projects table. `HelpSessionService.validateProvisionInput` only checks non-empty-string plus absolute path, and `ctx.projectId` resolves via `ProjectViewManager.getProjectIdForWebContents()`, whose map gets populated for scratches too via `pvm.switchTo(scratchId, scratch.path)`. So while a scratch is active, main's `ctx.projectId` already equals the scratch UUID. Only the renderer's guards were wrong. No main-process, IPC, or shared-type changes needed.

Resolves #11068

## Changes

- `HelpPanel.tsx` now derives the active workspace as `currentProject` falling back to `currentScratch`, memoized on the primitive id and path for referential stability, and threads it through four gates: the resumable-pending peek, `reportPanelOpen`, the cold-resume auto-arm, and `controller.syncInputs`.
- `HelpSessionController` and `HibernationManager` now read the workspace from the synced inputs instead of live `useProjectStore` reads. Without this, stop-suppression and hibernate keying silently no-op in a scratch workspace.
- `help.launchAgent`, the second and independent launch entry point used by the action/MCP path, gets the same fallback, captured synchronously before the first `await` so the #8317 context/workspace consistency guarantee still holds.
- The misleading "Project state is still loading" bail is split into two accurate messages, shared by both entry points so they can't drift: `Workspace state is still loading. Try again.` when hydrating, versus `No project or scratch workspace is active. Open one, then try again.` when there genuinely is no workspace.

**Follow-up fix found in review.** `HibernationManager.maybeArm` could arm with a null workspace. Since the armed-identity tuple is only `(terminalId, agentId)`, a later arm call with the same tuple would early-return, leaving the timer stuck pointing at null. When that timer fired, it killed the PTY, revoked it, and cleared the terminal, then skipped every `if (projectId)` persistence branch, destroying the conversation instead of hibernating it. It now refuses to arm until a workspace is known, bailing out before touching `_hibernateArmedFor`, so an arm already captured against a real workspace survives a transient null (the deliberate anti-bleed capture stays intact).

**Note for reviewers.** `useScratchStore` is imported from its leaf path `@/store/scratchStore`, not the `@/store` barrel, on purpose. About 20 HelpPanel and controller test files mock that barrel wholesale with hand-listed hook factories, and would crash on an undefined destructure if it were added there. `scratchStore.ts`'s own header comment documents the convention.

**Deliberately out of scope (worth its own issue).** `SCRATCH_ON_SWITCH` is a global `broadcastToRenderer` event, and `scratchStore.onSwitch` blindly overwrites `currentScratch`, so in a multi-window setup a second window switching scratches can retarget another view's scratch pointer. That's a pre-existing store-level scoping gap, not something this PR introduces. `useAgentLauncher` reads `currentScratch` the exact same way for terminal cwd and has the same exposure. The real fix is making `scratchStore` view-scoped the way `projectStore` already is, off the per-view `__DAINTREE_INITIAL_PROJECT__` seed from #9162, but that changes terminal-launch behavior and doesn't belong in a bugfix PR. Also worth flagging: `McpActivityTracker` still reads `useProjectStore` on purpose, since its `projectId` feeds `projectClient.saveSettings`, a real projects-table key, so MCP "Always allow" is a no-op in a scratch workspace while "Approve once" still works.

## Testing

428 tests pass across `src/components/HelpPanel/__tests__`, `src/controllers/__tests__`, and `helpLaunchAgent.test.ts`. New coverage: launching into a scratch from both entry points, assistant cwd equal to the scratch root, peek/take/`reportPanelOpen` keyed on the scratch UUID, hibernate slot keyed on the scratch id, stop-suppression clearing the scratch slot, the null-arm regression, and both new error strings. `npm run typecheck`, `check:help`, and `check:api-surface` are all clean. Lint ratchet is down 6 warnings.
