### PR TITLE
fix(workspace-host): stop "Free memory" from blocking the Electron main thread

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -697,7 +697,13 @@ export class WorkspaceHostProcess extends EventEmitter {
 
     this.child.on("exit", (code) => {
       this.flushHostOutputBuffers();
-      logWarn(`[WorkspaceHost:${this.serviceName}] Exited with code ${code}`);
+      // A disposed host exiting is the cooperative path, not a crash — every
+      // eviction ends here, so warning on it would read as a fault.
+      if (this.isDisposed) {
+        logInfo(`[WorkspaceHost:${this.serviceName}] Exited with code ${code} after dispose`);
+      } else {
+        logWarn(`[WorkspaceHost:${this.serviceName}] Exited with code ${code}`);
+      }
 
       if (this.healthCheckInterval) {
         clearInterval(this.healthCheckInterval);

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -490,21 +490,34 @@ export class WorkspaceHostProcess extends EventEmitter {
     if (this.child) {
       this.send({ type: "dispose" });
       // Unref'd so the pending backstop never holds the Electron event loop
-      // alive after app.quit when the host has already cooperated.
+      // alive after app.quit when the host has already cooperated. Cleared by
+      // the `exit` handler, so a host that exits on the dispose message above
+      // never reaches the signal below.
       this.disposeTimer = setTimeout(() => {
         this.disposeTimer = null;
-        if (this.child) {
-          try {
-            this.child.kill();
-          } catch (error) {
+        const pid = this.child?.pid;
+        if (!pid) return;
+        // Deliberately NOT `child.kill()` (#11069): Electron's
+        // `UtilityProcess.kill()` runs `Process::Terminate` +
+        // `base::EnsureProcessTerminated`, which on macOS blocks the calling
+        // thread — main — for up to 2s waiting for the child to die, freezing
+        // window input routing. A raw SIGKILL is non-blocking and cannot be
+        // trapped by the child. Matches the health watchdog's force-kill.
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch (error) {
+          // ESRCH — the child exited between the pid read and the signal.
+          const code =
+            typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+          if (code !== "ESRCH") {
             console.warn(
               `[WorkspaceHost:${this.serviceName}] Failed to kill host during dispose:`,
               error
             );
-          } finally {
-            this.child = null;
           }
         }
+        // `this.child` stays set — the `exit` event is the authority on process
+        // death and nulls it. Clearing it here would strand that handler.
       }, 1000);
       this.disposeTimer.unref?.();
     }
@@ -693,6 +706,12 @@ export class WorkspaceHostProcess extends EventEmitter {
       if (this.handshakeTimeout) {
         clearTimeout(this.handshakeTimeout);
         this.handshakeTimeout = null;
+      }
+      // The host cooperated with `dispose` — retire the force-kill backstop so
+      // it cannot signal a pid the OS may have already recycled.
+      if (this.disposeTimer) {
+        clearTimeout(this.disposeTimer);
+        this.disposeTimer = null;
       }
       this.isWaitingForHandshake = false;
       this.missedHeartbeats = 0;

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -607,6 +607,110 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
     });
   });
 
+  // #11069 — the dispose backstop used to call Electron's `UtilityProcess.kill()`,
+  // whose `base::EnsureProcessTerminated` blocks the calling thread (main) for up
+  // to 2s on macOS while it waits for the child to die. Against a host that traps
+  // SIGTERM without exiting that wait ran to the full timeout, freezing window
+  // input routing and dropping clicks a second after "Free memory".
+  describe("dispose force-kill backstop (#11069)", () => {
+    async function disposeWedgedHost() {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const { WorkspaceHostProcess } = await loadModule();
+      const host = new WorkspaceHostProcess("/tmp/project", {
+        maxRestartAttempts: 3,
+        healthCheckIntervalMs: 30000,
+      } as any);
+      host.waitForReady().catch(() => {});
+
+      const child = mockChildren[0] as MockUtilityChild;
+      child.emit("message", { type: "ready" });
+
+      return { host, child, killSpy };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("signals a wedged host with a non-blocking SIGKILL instead of the main-thread-blocking child.kill()", async () => {
+      const { host, child, killSpy } = await disposeWedgedHost();
+
+      host.dispose();
+      expect(child.postMessage).toHaveBeenCalledWith({ type: "dispose" });
+      // Cooperative window: nothing is signalled while the host still has a
+      // chance to exit on its own.
+      expect(killSpy).not.toHaveBeenCalled();
+
+      // The host never exits — the backstop fires.
+      vi.runOnlyPendingTimers();
+
+      expect(killSpy).toHaveBeenCalledWith(child.pid, "SIGKILL");
+      expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    it("leaves the child reference to the exit event, which alone proves the process died", async () => {
+      const { host, child, killSpy } = await disposeWedgedHost();
+
+      host.dispose();
+      vi.runOnlyPendingTimers();
+      expect(killSpy).toHaveBeenCalledTimes(1);
+
+      // Signalling is a request, not proof of death: the wrapper must still be
+      // holding the child so the `exit` handler can run its teardown.
+      expect((host as any).child).toBe(child);
+      child.emit("exit", 0);
+      expect((host as any).child).toBeNull();
+    });
+
+    it("retires the backstop when the host exits cooperatively, signalling nothing", async () => {
+      const { host, child, killSpy } = await disposeWedgedHost();
+
+      host.dispose();
+      // The host honours the dispose message and exits before the deadline.
+      child.emit("exit", 0);
+      vi.runOnlyPendingTimers();
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(child.kill).not.toHaveBeenCalled();
+      expect((host as any).disposeTimer).toBeNull();
+    });
+
+    it("does not restart a host that exits after dispose", async () => {
+      const { host, child } = await disposeWedgedHost();
+
+      host.dispose();
+      child.emit("exit", 0);
+      vi.runOnlyPendingTimers();
+
+      expect(forkMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows the ESRCH race where the child exits between the pid read and the signal", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const esrch = Object.assign(new Error("kill ESRCH"), { code: "ESRCH" });
+      vi.spyOn(process, "kill").mockImplementation(() => {
+        throw esrch;
+      });
+
+      const { WorkspaceHostProcess } = await loadModule();
+      const host = new WorkspaceHostProcess("/tmp/project", {
+        maxRestartAttempts: 3,
+        healthCheckIntervalMs: 30000,
+      } as any);
+      host.waitForReady().catch(() => {});
+      (mockChildren[0] as MockUtilityChild).emit("message", { type: "ready" });
+
+      host.dispose();
+      expect(() => vi.runOnlyPendingTimers()).not.toThrow();
+
+      const warnings = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnings.some((w) => w.includes("Failed to kill host during dispose"))).toBe(false);
+    });
+  });
+
   it("restart delay has random jitter (full-jitter parity with PtyHostLifecycle)", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setImmediate", "Date"] });
     // Mock Math.random to control jitter

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -393,8 +393,14 @@ let isShuttingDown = false;
  * where Electron's `UtilityProcess.kill()` blocks the main thread for up to 2s
  * on macOS (`base::EnsureProcessTerminated`) and swallows user input.
  *
- * `setImmediate` gives the synchronous abort handlers one turn to settle; the OS
- * reclaims whatever asynchronous cleanup has not finished by then.
+ * Exit is bounded rather than immediate. Closing the port stops new work and
+ * releases the handle that would otherwise keep this process alive forever, so
+ * once the loop drains the process ends on its own. The unref'd deadline does
+ * not hold it open, but still fires if a handle `dispose` cannot reach — the
+ * persistent copytree worker, an in-flight `.daintree` copy — keeps the loop
+ * alive, so exit is guaranteed either way. The budget stays under the parent's
+ * 1s force-kill backstop, and lets a short write tail finish instead of being
+ * truncated the way the old SIGKILL-after-3s teardown truncated it.
  */
 function shutdown(): void {
   if (isShuttingDown) return;
@@ -406,7 +412,13 @@ function shutdown(): void {
   } catch (err) {
     console.warn("[WorkspaceHost] Error during shutdown:", err);
   } finally {
-    setImmediate(() => process.exit(0));
+    try {
+      port.close();
+    } catch {
+      // Already closed — the exit below is what matters.
+    }
+    const deadline = setTimeout(() => process.exit(0), 750);
+    deadline.unref?.();
   }
 }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -378,6 +378,38 @@ const workspaceService = new WorkspaceService(sendEvent);
 // `docs/architecture/forge-provider-abstraction.md` for the rationale.
 const forgeBridge = initForgeBridge(sendEvent);
 
+let isShuttingDown = false;
+
+/**
+ * Idempotent teardown shared by both shutdown triggers — the parent's `dispose`
+ * message and SIGTERM.
+ *
+ * The explicit `process.exit(0)` is load-bearing (#11069). Disposing the
+ * services alone never ends the process: the `port.on("message")` listener, the
+ * persistent copytree worker, and in-flight parcel-watcher unsubscribes all keep
+ * the event loop alive, and merely installing a SIGTERM handler suppresses
+ * Node's default terminate-on-SIGTERM. A host that outlives `dispose` defeats
+ * the point of "free memory" and strands the parent's backstop on a live child,
+ * where Electron's `UtilityProcess.kill()` blocks the main thread for up to 2s
+ * on macOS (`base::EnsureProcessTerminated`) and swallows user input.
+ *
+ * `setImmediate` gives the synchronous abort handlers one turn to settle; the OS
+ * reclaims whatever asynchronous cleanup has not finished by then.
+ */
+function shutdown(): void {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  try {
+    shutdownController.abort();
+    workspaceService.dispose();
+    forgeBridge.dispose();
+  } catch (err) {
+    console.warn("[WorkspaceHost] Error during shutdown:", err);
+  } finally {
+    setImmediate(() => process.exit(0));
+  }
+}
+
 // Handle requests from Main
 port.on("message", async (rawMsg: any) => {
   idleHeapCompactor.noteActivity();
@@ -582,14 +614,10 @@ port.on("message", async (rawMsg: any) => {
         sendEvent({ type: "pong" });
         break;
 
+      // Aborts in-flight git work and rejects pending forge calls (so awaiting
+      // paths fail fast instead of hanging on the 30s timeout), then exits.
       case "dispose":
-        shutdownController.abort();
-        workspaceService.dispose();
-        // Reject any pending forge calls so awaiting code paths fail fast
-        // instead of waiting on the 30s timeout. Late `forge:rpc-result`
-        // messages after this are still safe — `handleResult` drops unknown
-        // ids — but eagerly clearing the pending map prevents shutdown delays.
-        forgeBridge.dispose();
+        shutdown();
         break;
 
       case "set-log-level-overrides": {
@@ -832,9 +860,7 @@ port.on("message", async (rawMsg: any) => {
 // Graceful shutdown on SIGTERM (macOS/Linux; Windows uses TerminateProcess so this won't fire)
 process.on("SIGTERM", () => {
   console.log("[WorkspaceHost] SIGTERM received, shutting down");
-  shutdownController.abort();
-  workspaceService.dispose();
-  forgeBridge.dispose();
+  shutdown();
 });
 
 // Signal ready

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -393,14 +393,17 @@ let isShuttingDown = false;
  * where Electron's `UtilityProcess.kill()` blocks the main thread for up to 2s
  * on macOS (`base::EnsureProcessTerminated`) and swallows user input.
  *
- * Exit is bounded rather than immediate. Closing the port stops new work and
- * releases the handle that would otherwise keep this process alive forever, so
- * once the loop drains the process ends on its own. The unref'd deadline does
- * not hold it open, but still fires if a handle `dispose` cannot reach — the
- * persistent copytree worker, an in-flight `.daintree` copy — keeps the loop
- * alive, so exit is guaranteed either way. The budget stays under the parent's
- * 1s force-kill backstop, and lets a short write tail finish instead of being
- * truncated the way the old SIGKILL-after-3s teardown truncated it.
+ * Exit runs on a short deadline rather than the next turn. Electron's ParentPort
+ * exposes no `close()`, so its listener keeps this event loop alive and the
+ * process never drains on its own — the deadline below IS the exit. It is
+ * unref'd purely so it cannot hold the process open in the case where the loop
+ * does drain; while the port keeps the loop alive it still fires.
+ *
+ * The delay is a best-effort window for a short in-flight write tail (the
+ * `.daintree` copy), NOT a guarantee — the parent force-kills at 1s regardless,
+ * and this clock only starts after IPC delivery plus the synchronous dispose
+ * above, so it is budgeted well under that. Exiting on the very next turn would
+ * truncate tails that the old SIGKILL-after-~3s teardown let finish.
  */
 function shutdown(): void {
   if (isShuttingDown) return;
@@ -412,12 +415,7 @@ function shutdown(): void {
   } catch (err) {
     console.warn("[WorkspaceHost] Error during shutdown:", err);
   } finally {
-    try {
-      port.close();
-    } catch {
-      // Already closed — the exit below is what matters.
-    }
-    const deadline = setTimeout(() => process.exit(0), 750);
+    const deadline = setTimeout(() => process.exit(0), 500);
     deadline.unref?.();
   }
 }


### PR DESCRIPTION
Resolves #11069

The issue guessed that `evictProjectRenderer` and workspace-host teardown were running synchronously and were the likely culprits. That guess was wrong. Neither blocks: `cleanupEntry` is `removeChildView` plus an async `wc.close()`, and `dispose()` just posts a message and arms a timer. The PTY scrollback fsync is heavy, but it runs in the pty-host utility process, not main, so it can't be freezing input routing.

## Actual root cause

`WorkspaceHostProcess.dispose()` posted `{type:"dispose"}` and armed a 1s backstop calling Electron's `UtilityProcess.kill()`. That runs `Process::Terminate` (SIGTERM) plus `base::EnsureProcessTerminated`, and per Chromium's `base/process/kill.h`, "on OS X this method may block for up to 2 seconds" (kqueue `WaitForChildToDie`, then SIGKILL, then a blocking `waitpid` reap).

Meanwhile the child never exited. Its `dispose` handler cleaned up but never called `process.exit()`, and merely installing a `process.on("SIGTERM")` handler suppressed Node's default terminate-on-SIGTERM behavior. So main was blocking on a kqueue wait for a child that had no way to die, which is exactly why the freeze lands ~1s after the click and swallows whatever you click next.

There's a second-order bug hiding in there too: since the child never exited, Free memory leaked the very workspace-host process it existed to reclaim.

## The fix

Two production files.

**`electron/workspace-host.ts`**: one idempotent `shutdown()` shared by the `dispose` message handler and the SIGTERM handler. It aborts in-flight git work, disposes services, then actually exits. The exit runs on a short unref'd deadline rather than the next turn, so a short in-flight write tail (the `.daintree` copy) can finish. Electron's `ParentPort` has no `close()` method, so the loop never drains on its own. That deadline is the exit path.

**`electron/services/WorkspaceHostProcess.ts`**: the dispose backstop now sends a raw non-blocking `process.kill(pid, "SIGKILL")` (matching the existing health-watchdog precedent) instead of the blocking Electron API. The child reference is left to the authoritative `exit` event, and the backstop timer is cleared on exit so a cooperative exit never signals. Disposed exits now log at info rather than warn, since every eviction is now a cooperative exit and would otherwise read as a crash.

## Tests

New `dispose force-kill backstop (#11069)` block in `WorkspaceHostProcess.test.ts`:

- a wedged host gets the non-blocking SIGKILL, never Electron's blocking `child.kill()`
- a cooperative exit retires the backstop and signals nothing
- the child reference survives until the `exit` event
- ESRCH is swallowed

These fail against the old code. 1000 tests across 232 suites pass locally, covering the free-memory handler, all `WorkspaceHostProcess` and `WorkspaceClient` pool suites, idle-eviction, crash-recovery lifecycle, and the workspace-host service suites.

## Known follow-ups

Pre-existing, deliberately out of scope here:

- the same blocking `child.kill()` pattern exists in `PtyHostLifecycle`, `PluginDevWorkerHost`, and `AssistantHostProcess`
- eviction can still truncate an in-flight durable write (pre-existing: the old path SIGKILLed the child too, just ~3s later)
- `WorkspaceHostPool.prewarmProject`'s init-failure path leaves a stale dormant-cleanup timer
