### PR TITLE
fix(assistant): make the post-transition reveal repaint a durable obligation

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -631,7 +631,12 @@ export function AppLayout({
         reduceAnimations || layout.performanceMode || isAssistantResizing || mql?.matches === true;
       if (showAssistant) {
         setAssistantInert(false);
-        if (noTransition) assistantReveal.settleAfterTransition(true);
+        // A drag-resize also strips the transition, but a drag is NOT a reveal:
+        // the reveal repaint's reconcileGeometryFresh is lock-exempt, so settling
+        // here would assert geometry mid-drag — at a width the cursor has already
+        // moved past — against the very lock that keeps the handle tracking 1:1.
+        // The drag owns its own geometry and runs its resize pass on release.
+        if (noTransition && !isAssistantResizing) assistantReveal.settleAfterTransition(true);
       } else if (noTransition) {
         setAssistantInert(true);
       }

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -39,7 +39,7 @@ import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import {
-  repaintAssistantAfterTransition,
+  createAssistantRevealCoordinator,
   suppressSidebarResizes,
   getSidebarAffectedTerminalIds,
 } from "@/lib/sidebarToggle";
@@ -183,6 +183,20 @@ export function AppLayout({
   // already cover the in-flight window.
   const [assistantInert, setAssistantInert] = useState(!showAssistant);
 
+  // #11070: the assistant's post-transition reveal repaint is a durable
+  // obligation, not a one-shot. On a cold first open the slide settles while the
+  // session is still provisioning (no terminalId yet), so the coordinator retains
+  // the repaint and discharges it once the terminal binds and attaches. Owned
+  // here because the obligation's lifetime is exactly this DOM's lifetime; the
+  // factory is pure, so Strict Mode's double-invoke of the initializer is free.
+  const [assistantReveal] = useState(createAssistantRevealCoordinator);
+  useEffect(() => assistantReveal.start(), [assistantReveal]);
+  // Cancel on the visibility STATE change, not at the hide slide's end: a
+  // terminal that binds mid-slide-out must not repaint into a hidden pane.
+  useEffect(() => {
+    assistantReveal.setVisible(showAssistant);
+  }, [assistantReveal, showAssistant]);
+
   // Issue #9864: the sidebar wrapper carries overflowClipMargin: 6px so the
   // resize handle's overhang paints outside the contain boundary. But
   // overflow-clip-margin is a discrete (non-animatable) property — when the
@@ -269,11 +283,11 @@ export function AppLayout({
   const handleAssistantTransitionEnd = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {
       if (event.propertyName === "transform" && event.target === event.currentTarget) {
-        repaintAssistantAfterTransition();
+        assistantReveal.settleAfterTransition(showAssistant);
         if (!showAssistant) setAssistantInert(true);
       }
     },
-    [showAssistant]
+    [showAssistant, assistantReveal]
   );
 
   useEffect(() => {
@@ -617,7 +631,7 @@ export function AppLayout({
         reduceAnimations || layout.performanceMode || isAssistantResizing || mql?.matches === true;
       if (showAssistant) {
         setAssistantInert(false);
-        if (noTransition) repaintAssistantAfterTransition();
+        if (noTransition) assistantReveal.settleAfterTransition(true);
       } else if (noTransition) {
         setAssistantInert(true);
       }
@@ -625,7 +639,13 @@ export function AppLayout({
     settle();
     mql?.addEventListener("change", settle);
     return () => mql?.removeEventListener("change", settle);
-  }, [showAssistant, reduceAnimations, layout.performanceMode, isAssistantResizing]);
+  }, [
+    showAssistant,
+    reduceAnimations,
+    layout.performanceMode,
+    isAssistantResizing,
+    assistantReveal,
+  ]);
 
   // Clear macro focus on mouse interaction. A click inside the currently-
   // focused region must NOT clear the claim — otherwise a click within the

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -148,8 +148,14 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
     expect(settle![1]).toContain("layout.performanceMode");
     expect(settle![1]).toContain("isAssistantResizing");
     expect(settle![1]).toContain("mql?.matches === true");
-    // This path only ever runs on a show, so it settles the obligation as shown.
-    expect(settle![1]).toContain("assistantReveal.settleAfterTransition(true)");
+    // This path only ever runs on a show, so it settles the obligation as shown —
+    // but NOT during a drag-resize. A drag also strips the transition, and the
+    // reveal repaint's reconcileGeometryFresh is lock-exempt, so settling there
+    // would assert geometry mid-drag against the lock that keeps the handle
+    // tracking the cursor 1:1. The drag owns its own geometry.
+    expect(settle![1]).toContain(
+      "if (noTransition && !isAssistantResizing) assistantReveal.settleAfterTransition(true)"
+    );
     // The media query is subscribed so an OS reduced-motion flip mid-slide still
     // parks the wrapper inert (the read alone would not re-run).
     expect(source).toContain('mql?.addEventListener("change", settle)');

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -20,7 +20,7 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
   it("imports both the arm and repaint helpers from sidebarToggle", () => {
     expect(source).toContain('from "@/lib/sidebarToggle"');
     expect(source).toMatch(
-      /import \{[^}]*repaintAssistantAfterTransition[^}]*\} from "@\/lib\/sidebarToggle"/
+      /import \{[^}]*createAssistantRevealCoordinator[^}]*\} from "@\/lib\/sidebarToggle"/
     );
     expect(source).toMatch(
       /import \{[^}]*suppressSidebarResizes[^}]*\} from "@\/lib\/sidebarToggle"/
@@ -45,9 +45,30 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
     // Filters on transform (the property the wrapper now animates), not width.
     expect(handler![1]).toContain('event.propertyName === "transform"');
     expect(handler![1]).toContain("event.target === event.currentTarget");
-    expect(handler![1]).toContain("repaintAssistantAfterTransition()");
+    // #11070: the settle carries the show/hide direction, so a hide-settle cancels
+    // the reveal obligation instead of arming one against a parked pane.
+    expect(handler![1]).toContain("assistantReveal.settleAfterTransition(showAssistant)");
     // Inert is only set on a hide (slide-out), never on reveal.
     expect(handler![1]).toContain("if (!showAssistant) setAssistantInert(true)");
+  });
+
+  // Issue #11070: on a cold first open the slide settles while the assistant
+  // session is still provisioning, so there is no terminalId to repaint. The
+  // repaint must survive as an obligation the coordinator discharges once the
+  // terminal binds — not be dropped on the floor.
+  it("owns a reveal coordinator whose lifetime is the layout's", () => {
+    expect(source).toMatch(
+      /const \[assistantReveal\] = useState\(createAssistantRevealCoordinator\)/
+    );
+    // Subscription installed via effect (never at module scope) and disposed with
+    // the component.
+    expect(source).toContain("useEffect(() => assistantReveal.start(), [assistantReveal])");
+  });
+
+  it("cancels the obligation on the hide STATE change, not at the hide slide's end", () => {
+    // A terminal that binds while the panel is sliding away must not repaint into
+    // a hidden pane, so visibility is tracked as it flips — ahead of transitionend.
+    expect(source).toMatch(/assistantReveal\.setVisible\(showAssistant\)/);
   });
 
   it("tracks the parked-inert state for the off-canvas wrapper", () => {
@@ -127,6 +148,8 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
     expect(settle![1]).toContain("layout.performanceMode");
     expect(settle![1]).toContain("isAssistantResizing");
     expect(settle![1]).toContain("mql?.matches === true");
+    // This path only ever runs on a show, so it settles the obligation as shown.
+    expect(settle![1]).toContain("assistantReveal.settleAfterTransition(true)");
     // The media query is subscribed so an OS reduced-motion flip mid-slide still
     // parks the wrapper inert (the read alone would not re-run).
     expect(source).toContain('mql?.addEventListener("change", settle)');

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -192,6 +192,7 @@ describe("suppressSidebarResizes", () => {
 describe("createAssistantRevealCoordinator — issue #11070", () => {
   let rafQueue: FrameRequestCallback[] = [];
   let dispose: (() => void) | null = null;
+  let onViewCachedHandlers: Array<() => void> = [];
 
   // Frames are queued, never run inline: a synchronous rAF stub collapses the
   // frame separation the confirm-paint pass and the generation guards rely on.
@@ -217,32 +218,49 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     helpPanelStoreMock.reset();
     rafQueue = [];
     dispose = null;
+    onViewCachedHandlers = [];
     repaintForRevealMock.mockReturnValue(true);
     waitForAttachSettledMock.mockResolvedValue(undefined);
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
       rafQueue.push(cb);
       return rafQueue.length;
     });
+    (window as unknown as Record<string, unknown>).electron = {
+      app: {
+        onViewCached: (cb: () => void) => {
+          onViewCachedHandlers.push(cb);
+          return () => {
+            onViewCachedHandlers = onViewCachedHandlers.filter((h) => h !== cb);
+          };
+        },
+      },
+    };
   });
 
   afterEach(() => {
     dispose?.();
+    delete (window as unknown as Record<string, unknown>).electron;
     vi.unstubAllGlobals();
   });
 
-  it("fires one corrective repaint when the terminal is already bound and paintable", () => {
+  it("repaints the warm assistant terminal that is already bound at settle time", async () => {
     helpPanelStoreMock.emit({ terminalId: "assistant-1" });
     const coordinator = start();
 
     coordinator.settleAfterTransition(true);
+    await pump();
 
-    expect(repaintForRevealMock).toHaveBeenCalledTimes(1);
+    // The attach gate is not skipped even on the warm path — it resolves at once
+    // for an already-attached terminal, and going through it keeps a mid-attach
+    // paint from retiring the obligation early.
+    expect(waitForAttachSettledMock).toHaveBeenCalledWith("assistant-1", {
+      timeoutMs: expect.any(Number),
+    });
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(REVEAL_CONFIRM_PAINTS);
     expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
-    // Already paintable — the obligation is discharged inline, no attach wait.
-    expect(waitForAttachSettledMock).not.toHaveBeenCalled();
   });
 
-  it("does not clear the resize lock — the suppression timer owns the unlock", () => {
+  it("does not clear the resize lock — the suppression timer owns the unlock", async () => {
     // reconcileGeometryFresh inside repaintForReveal is lock-exempt, so the
     // corrective resize lands while the lock stays armed. Clearing it here would
     // defeat the dead-man TTL that gates the ResizeObserver debounce tail.
@@ -250,6 +268,7 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     const coordinator = start();
 
     coordinator.settleAfterTransition(true);
+    await pump();
 
     expect(lockResizeMock).not.toHaveBeenCalled();
   });
@@ -336,14 +355,67 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     const coordinator = start();
 
     coordinator.settleAfterTransition(true);
-    expect(repaintForRevealMock).toHaveBeenCalledTimes(1);
-
     await pump();
 
     expect(waitForAttachSettledMock).toHaveBeenCalledWith("assistant-1", {
       timeoutMs: expect.any(Number),
     });
-    expect(repaintForRevealMock.mock.calls.length).toBeGreaterThan(1);
+    // One unpaintable frame, then the confirm paints.
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(1 + REVEAL_CONFIRM_PAINTS);
+  });
+
+  it("re-arms the attach wait when it times out, so a late attach still discharges", async () => {
+    // A timed-out waiter is deregistered — a single wait would silently abandon a
+    // terminal that attaches just after the deadline, with the sidebar still open
+    // and no further store edge coming. That is #11070 with a longer fuse.
+    waitForAttachSettledMock
+      .mockRejectedValueOnce(new Error("attach settle timeout"))
+      .mockResolvedValue(undefined);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    await pump();
+
+    expect(waitForAttachSettledMock.mock.calls.length).toBeGreaterThan(1);
+    expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
+  });
+
+  it("gives up the attach wait after a bounded number of attempts", async () => {
+    waitForAttachSettledMock.mockRejectedValue(new Error("attach settle timeout"));
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    await pump();
+
+    // Bounded — a dead binding must not spin forever.
+    expect(waitForAttachSettledMock.mock.calls.length).toBeLessThan(10);
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("yields the obligation when the project view is cached", async () => {
+    // The switch-back sweep (repaintActiveWorktreeTerminals) already owns the
+    // assistant terminal (#9637). Two geometry reconciles racing one live
+    // terminal is the #10863 corruption — this side yields.
+    let settleAttach: () => void = () => {};
+    waitForAttachSettledMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        settleAttach = resolve;
+      })
+    );
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump(2);
+
+    expect(onViewCachedHandlers.length).toBe(1);
+    onViewCachedHandlers[0]?.();
+    settleAttach();
+    await pump();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
   });
 
   it("cancels the obligation when the assistant is hidden before the terminal binds", async () => {
@@ -389,8 +461,10 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     expect(repaintForRevealMock).not.toHaveBeenCalled();
   });
 
-  it("keeps the obligation armed when the attach wait times out, and retries on the next binding", async () => {
-    waitForAttachSettledMock.mockRejectedValueOnce(new Error("attach settle timeout"));
+  it("keeps the obligation armed when the attach wait is exhausted, and retries on the next binding", async () => {
+    // Every attach attempt times out, so the discharge gives up — but it must
+    // give up WITHOUT retiring the obligation, or the repaint is dropped again.
+    waitForAttachSettledMock.mockRejectedValue(new Error("attach settle timeout"));
     const coordinator = start();
 
     coordinator.settleAfterTransition(true);
@@ -401,6 +475,7 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
 
     // The reserved id is finalized in place once provisioning resolves — the
     // session edge picks the still-armed obligation back up.
+    waitForAttachSettledMock.mockReset();
     waitForAttachSettledMock.mockResolvedValue(undefined);
     helpPanelStoreMock.emit({ terminalId: "assistant-1", sessionId: "s-1" });
     await pump();

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -192,7 +192,6 @@ describe("suppressSidebarResizes", () => {
 describe("createAssistantRevealCoordinator — issue #11070", () => {
   let rafQueue: FrameRequestCallback[] = [];
   let dispose: (() => void) | null = null;
-  let onViewCachedHandlers: Array<() => void> = [];
 
   // Frames are queued, never run inline: a synchronous rAF stub collapses the
   // frame separation the confirm-paint pass and the generation guards rely on.
@@ -218,28 +217,16 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     helpPanelStoreMock.reset();
     rafQueue = [];
     dispose = null;
-    onViewCachedHandlers = [];
     repaintForRevealMock.mockReturnValue(true);
     waitForAttachSettledMock.mockResolvedValue(undefined);
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
       rafQueue.push(cb);
       return rafQueue.length;
     });
-    (window as unknown as Record<string, unknown>).electron = {
-      app: {
-        onViewCached: (cb: () => void) => {
-          onViewCachedHandlers.push(cb);
-          return () => {
-            onViewCachedHandlers = onViewCachedHandlers.filter((h) => h !== cb);
-          };
-        },
-      },
-    };
   });
 
   afterEach(() => {
     dispose?.();
-    delete (window as unknown as Record<string, unknown>).electron;
     vi.unstubAllGlobals();
   });
 
@@ -364,11 +351,14 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     expect(repaintForRevealMock).toHaveBeenCalledTimes(1 + REVEAL_CONFIRM_PAINTS);
   });
 
-  it("re-arms the attach wait when it times out, so a late attach still discharges", async () => {
+  it("re-arms the attach wait across repeated timeouts, so a late attach still discharges", async () => {
     // A timed-out waiter is deregistered — a single wait would silently abandon a
     // terminal that attaches just after the deadline, with the sidebar still open
     // and no further store edge coming. That is #11070 with a longer fuse.
+    // TWO rejections before the success: a one-rejection fixture would also pass
+    // against an implementation that only ever retried once.
     waitForAttachSettledMock
+      .mockRejectedValueOnce(new Error("attach settle timeout"))
       .mockRejectedValueOnce(new Error("attach settle timeout"))
       .mockResolvedValue(undefined);
     helpPanelStoreMock.emit({ terminalId: "assistant-1" });
@@ -377,7 +367,7 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
     coordinator.settleAfterTransition(true);
     await pump();
 
-    expect(waitForAttachSettledMock.mock.calls.length).toBeGreaterThan(1);
+    expect(waitForAttachSettledMock.mock.calls.length).toBeGreaterThan(2);
     expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
   });
 
@@ -391,30 +381,6 @@ describe("createAssistantRevealCoordinator — issue #11070", () => {
 
     // Bounded — a dead binding must not spin forever.
     expect(waitForAttachSettledMock.mock.calls.length).toBeLessThan(10);
-    expect(repaintForRevealMock).not.toHaveBeenCalled();
-  });
-
-  it("yields the obligation when the project view is cached", async () => {
-    // The switch-back sweep (repaintActiveWorktreeTerminals) already owns the
-    // assistant terminal (#9637). Two geometry reconciles racing one live
-    // terminal is the #10863 corruption — this side yields.
-    let settleAttach: () => void = () => {};
-    waitForAttachSettledMock.mockReturnValue(
-      new Promise<void>((resolve) => {
-        settleAttach = resolve;
-      })
-    );
-    const coordinator = start();
-
-    coordinator.settleAfterTransition(true);
-    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
-    await pump(2);
-
-    expect(onViewCachedHandlers.length).toBe(1);
-    onViewCachedHandlers[0]?.();
-    settleAttach();
-    await pump();
-
     expect(repaintForRevealMock).not.toHaveBeenCalled();
   });
 

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -1,21 +1,50 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const suppressMock = vi.hoisted(() => vi.fn());
 const lockResizeMock = vi.hoisted(() => vi.fn());
 const repaintForRevealMock = vi.hoisted(() => vi.fn());
+const revealTerminalMock = vi.hoisted(() => vi.fn());
+const waitForAttachSettledMock = vi.hoisted(() => vi.fn());
 const lockMock = vi.hoisted(() => vi.fn());
 const getPanelStateMock = vi.hoisted(() => vi.fn());
 const getWorktreeSelectionStateMock = vi.hoisted(() => vi.fn());
-const getHelpPanelStateMock = vi.hoisted(() =>
-  vi.fn(() => ({ terminalId: null }) as { terminalId: string | null })
-);
+
+type HelpPanelFixture = { terminalId: string | null; sessionId: string | null };
+type HelpPanelSubscriber = (state: HelpPanelFixture, prev: HelpPanelFixture) => void;
+
+// The help store is the discharge trigger, so the mock needs a real subscriber
+// list — `getState` alone can't express the null→bound edge #11070 turns on.
+const helpPanelStoreMock = vi.hoisted(() => {
+  let state: HelpPanelFixture = { terminalId: null, sessionId: null };
+  const subscribers = new Set<HelpPanelSubscriber>();
+  return {
+    getState: (): HelpPanelFixture => state,
+    subscribe: (fn: HelpPanelSubscriber): (() => void) => {
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+    /** Test-side: publish a new state and notify, exactly as Zustand would. */
+    emit(next: Partial<HelpPanelFixture>): void {
+      const prev = state;
+      state = { ...state, ...next };
+      for (const fn of subscribers) fn(state, prev);
+    },
+    reset(): void {
+      state = { terminalId: null, sessionId: null };
+      subscribers.clear();
+    },
+    subscriberCount: (): number => subscribers.size,
+  };
+});
 
 vi.mock("@/services/terminal/TerminalInstanceService", () => ({
   terminalInstanceService: {
     suppressResizesDuringLayoutTransition: suppressMock,
     lockResize: lockResizeMock,
     repaintForReveal: repaintForRevealMock,
+    revealTerminal: revealTerminalMock,
+    waitForAttachSettled: waitForAttachSettledMock,
   },
 }));
 
@@ -28,14 +57,15 @@ vi.mock("@/store/worktreeStore", () => ({
 }));
 
 vi.mock("@/store/helpPanelStore", () => ({
-  useHelpPanelStore: { getState: getHelpPanelStateMock },
+  useHelpPanelStore: helpPanelStoreMock,
 }));
 
 vi.mock("../layoutTransitionLock", () => ({
   lockSidebarLayoutTransition: lockMock,
 }));
 
-import { repaintAssistantAfterTransition, suppressSidebarResizes } from "../sidebarToggle";
+import { createAssistantRevealCoordinator, suppressSidebarResizes } from "../sidebarToggle";
+import { MAX_REVEAL_FRAMES, REVEAL_CONFIRM_PAINTS } from "@/services/terminal/revealUntilStable";
 import { SIDEBAR_TOGGLE_LOCK_MS } from "../terminalLayout";
 
 type PanelFixture = {
@@ -55,6 +85,7 @@ function setup(panels: PanelFixture[], activeWorktreeId: string | null) {
 describe("suppressSidebarResizes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    helpPanelStoreMock.reset();
   });
 
   it("suppresses resizes for grid panels of the active worktree", () => {
@@ -132,7 +163,7 @@ describe("suppressSidebarResizes", () => {
   });
 
   it("includes the assistant terminal when it is a live panel", () => {
-    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
     setup(
       [
         { id: "p-grid", location: "grid", worktreeId: "wt-a" },
@@ -149,7 +180,7 @@ describe("suppressSidebarResizes", () => {
   });
 
   it("omits the assistant terminal when it is not yet a registered panel", () => {
-    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
     setup([{ id: "p-grid", location: "grid", worktreeId: "wt-a" }], "wt-a");
 
     suppressSidebarResizes();
@@ -158,36 +189,289 @@ describe("suppressSidebarResizes", () => {
   });
 });
 
-describe("repaintAssistantAfterTransition", () => {
+describe("createAssistantRevealCoordinator — issue #11070", () => {
+  let rafQueue: FrameRequestCallback[] = [];
+  let dispose: (() => void) | null = null;
+
+  // Frames are queued, never run inline: a synchronous rAF stub collapses the
+  // frame separation the confirm-paint pass and the generation guards rely on.
+  async function pump(ticks = MAX_REVEAL_FRAMES + 2): Promise<void> {
+    for (let i = 0; i < ticks; i++) {
+      await Promise.resolve();
+      const queued = rafQueue;
+      rafQueue = [];
+      for (const cb of queued) cb(0);
+      await Promise.resolve();
+    }
+  }
+
+  function start() {
+    const coordinator = createAssistantRevealCoordinator();
+    dispose = coordinator.start();
+    coordinator.setVisible(true);
+    return coordinator;
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
-    getHelpPanelStateMock.mockReturnValue({ terminalId: null });
+    helpPanelStoreMock.reset();
+    rafQueue = [];
+    dispose = null;
+    repaintForRevealMock.mockReturnValue(true);
+    waitForAttachSettledMock.mockResolvedValue(undefined);
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
   });
 
-  it("fires one corrective repaint for the assistant terminal", () => {
-    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+  afterEach(() => {
+    dispose?.();
+    vi.unstubAllGlobals();
+  });
 
-    repaintAssistantAfterTransition();
+  it("fires one corrective repaint when the terminal is already bound and paintable", () => {
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
 
     expect(repaintForRevealMock).toHaveBeenCalledTimes(1);
     expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
+    // Already paintable — the obligation is discharged inline, no attach wait.
+    expect(waitForAttachSettledMock).not.toHaveBeenCalled();
   });
 
   it("does not clear the resize lock — the suppression timer owns the unlock", () => {
     // reconcileGeometryFresh inside repaintForReveal is lock-exempt, so the
     // corrective resize lands while the lock stays armed. Clearing it here would
     // defeat the dead-man TTL that gates the ResizeObserver debounce tail.
-    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    const coordinator = start();
 
-    repaintAssistantAfterTransition();
+    coordinator.settleAfterTransition(true);
 
     expect(lockResizeMock).not.toHaveBeenCalled();
   });
 
-  it("is a no-op when no assistant terminal is present", () => {
-    getHelpPanelStateMock.mockReturnValue({ terminalId: null });
+  it("retains the dropped repaint and discharges it once the terminal binds", async () => {
+    // The #11070 regression: the slide settles while the session is still
+    // provisioning, so there is no terminalId to repaint. The old one-shot
+    // returned early and the footer never painted.
+    const coordinator = start();
 
-    expect(() => repaintAssistantAfterTransition()).not.toThrow();
+    coordinator.settleAfterTransition(true);
     expect(repaintForRevealMock).not.toHaveBeenCalled();
+
+    helpPanelStoreMock.emit({ terminalId: "assistant-1", sessionId: "s-1" });
+    await pump();
+
+    expect(waitForAttachSettledMock).toHaveBeenCalledWith("assistant-1", {
+      timeoutMs: expect.any(Number),
+    });
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(REVEAL_CONFIRM_PAINTS);
+    expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
+  });
+
+  it("discharges through repaintForReveal, never revealTerminal (#10671)", async () => {
+    // revealTerminal passes trustDomVisibility, which would let a transform-hidden
+    // assistant pane accumulate a fleet-wide WebGL want — and it reports `true`
+    // for a MISSING instance, which would bank false confirm paints against a
+    // reserved-but-unregistered id and re-drop the repaint.
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+
+    expect(revealTerminalMock).not.toHaveBeenCalled();
+    expect(repaintForRevealMock).toHaveBeenCalled();
+    for (const call of repaintForRevealMock.mock.calls) {
+      // No opts argument — the isVisible gate stays on.
+      expect(call).toEqual(["assistant-1"]);
+    }
+  });
+
+  it("waits for the xterm to attach before repainting a freshly reserved id", async () => {
+    // setTerminal publishes a RESERVED id before addPanel is even awaited, so the
+    // id arriving is not the terminal existing.
+    let settleAttach: () => void = () => {};
+    waitForAttachSettledMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        settleAttach = resolve;
+      })
+    );
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump(3);
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+
+    settleAttach();
+    await pump();
+
+    expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
+  });
+
+  it("retries across frames when the host has no renderable box yet", async () => {
+    repaintForRevealMock.mockImplementation(
+      () => repaintForRevealMock.mock.calls.length > 2 // unpaintable for the first two frames
+    );
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(2 + REVEAL_CONFIRM_PAINTS);
+  });
+
+  it("drives the retry itself when the terminal is bound but unpaintable — no store edge is coming", async () => {
+    // terminalId is already set at settle time, so no null→bound subscription
+    // edge will ever fire. The obligation has to start its own discharge.
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    repaintForRevealMock.mockReturnValueOnce(false).mockReturnValue(true);
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(1);
+
+    await pump();
+
+    expect(waitForAttachSettledMock).toHaveBeenCalledWith("assistant-1", {
+      timeoutMs: expect.any(Number),
+    });
+    expect(repaintForRevealMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("cancels the obligation when the assistant is hidden before the terminal binds", async () => {
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    coordinator.setVisible(false);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+
+    // A terminal that binds while the panel is sliding away must not be
+    // repainted into a hidden pane.
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("abandons an in-flight discharge when the assistant is hidden mid-attach", async () => {
+    let settleAttach: () => void = () => {};
+    waitForAttachSettledMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        settleAttach = resolve;
+      })
+    );
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump(2);
+
+    coordinator.setVisible(false);
+    settleAttach();
+    await pump();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("arms nothing on a hide settle", async () => {
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(false);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the obligation armed when the attach wait times out, and retries on the next binding", async () => {
+    waitForAttachSettledMock.mockRejectedValueOnce(new Error("attach settle timeout"));
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+
+    // The reserved id is finalized in place once provisioning resolves — the
+    // session edge picks the still-armed obligation back up.
+    waitForAttachSettledMock.mockResolvedValue(undefined);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1", sessionId: "s-1" });
+    await pump();
+
+    expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
+  });
+
+  it("stops repainting a terminal superseded by a re-bind", async () => {
+    let settleAttach: () => void = () => {};
+    waitForAttachSettledMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          settleAttach = resolve;
+        })
+    );
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump(2);
+
+    // A relaunch rebinds the panel to a new terminal while the first is still
+    // waiting to attach. The stale wait must not repaint the dead id.
+    helpPanelStoreMock.emit({ terminalId: "assistant-2" });
+    settleAttach();
+    await pump();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalledWith("assistant-1");
+    expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-2");
+  });
+
+  it("does not repaint once disposed, and drops its store subscription", async () => {
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    dispose?.();
+    dispose = null;
+
+    expect(helpPanelStoreMock.subscriberCount()).toBe(0);
+
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores help-store updates that leave the terminal binding untouched", async () => {
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    // An unrelated field changing (figures, width, …) must not spin up a discharge.
+    helpPanelStoreMock.emit({});
+    await pump();
+
+    expect(waitForAttachSettledMock).not.toHaveBeenCalled();
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
+  });
+
+  it("does not re-discharge a completed obligation on a later binding", async () => {
+    const coordinator = start();
+
+    coordinator.settleAfterTransition(true);
+    helpPanelStoreMock.emit({ terminalId: "assistant-1" });
+    await pump();
+    const callsAfterDischarge = repaintForRevealMock.mock.calls.length;
+    expect(callsAfterDischarge).toBe(REVEAL_CONFIRM_PAINTS);
+
+    // The obligation is discharged; a later session update is not a new trigger.
+    helpPanelStoreMock.emit({ sessionId: "s-2" });
+    await pump();
+
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(callsAfterDischarge);
   });
 });

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -1,4 +1,5 @@
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
+import { isDocumentHidden, revealUntilStable } from "@/services/terminal/revealUntilStable";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -52,11 +53,35 @@ export function suppressSidebarResizes(): void {
   lockSidebarLayoutTransition(SIDEBAR_TOGGLE_LOCK_MS);
 }
 
+// Ceiling on the wait for the assistant's xterm to attach after its terminal id
+// binds. `setTerminal` publishes a RESERVED id synchronously, before addPanel is
+// even awaited (#6953), so the id lands well ahead of the panel commit, the
+// TerminalPane mount, and xterm's open() — the wait absorbs that provisioning
+// latency so the bounded frame loop below only has to cover post-attach layout
+// settling. Matches addPanel's own startup attach gate. On timeout the
+// obligation stays ARMED: a later binding (or the next show settle) retries it,
+// which is strictly better than dropping the repaint the way #11070 did.
+const ASSISTANT_ATTACH_SETTLE_TIMEOUT_MS = 2500;
+
 /**
- * Issue one corrective repaint to the Assistant terminal once its width
- * transition has settled. Wired to the wrapper's transitionend in AppLayout so
- * the single authoritative geometry pass fires the instant the animation ends,
- * after the per-frame ResizeObserver storm has been suppressed (#10693).
+ * Owns the Assistant terminal's post-transition reveal repaint as a durable
+ * obligation rather than a one-shot (#11070).
+ *
+ * The repaint has to fire when the sidebar's slide settles, but on a COLD first
+ * open the assistant session is still provisioning at that moment: the help
+ * store has no `terminalId`, so the old one-shot returned early and the single
+ * authoritative geometry pass was dropped for good — the footer stayed unpainted
+ * until some unrelated geometry pass happened to fire (a project switch-back,
+ * which is why the bug looked intermittent). The obligation is now retained and
+ * discharged once the terminal actually binds AND attaches.
+ *
+ * Bounded and singular by construction — this is the sole owner of the
+ * sidebar-transition reveal trigger, and it must stay that way. HelpPanel must
+ * NOT grow a parallel per-frame repaint cascade: a second geometry reconcile
+ * racing this one against live PTY output corrupts xterm's line-wrap metadata
+ * (#10863). The project-view `app:view-revealed` sweep is a separate trigger
+ * domain with its own owner (repaintActiveWorktreeTerminals) — do not call it
+ * from here; it repaints every grid terminal on the active worktree.
  *
  * Deliberately does NOT clear the resize lock: repaintForReveal's
  * reconcileGeometryFresh is lock-exempt (it asserts the final cols/rows whether
@@ -70,9 +95,131 @@ export function suppressSidebarResizes(): void {
  * repainting there would assert a transient wrong column count. The cancel is
  * harmlessly ignored because the suppression timer still owns the unlock and
  * the subsequent show's transitionend issues the correct repaint.
+ *
+ * The factory is pure — it installs no subscriptions and starts no timers, so a
+ * React 19 Strict Mode double-invoke of the lazy initializer is free. Ownership
+ * is AppLayout's: the obligation's lifetime is exactly the lifetime of the DOM
+ * whose transition produces it.
  */
-export function repaintAssistantAfterTransition(): void {
-  const assistantTerminalId = useHelpPanelStore.getState().terminalId;
-  if (!assistantTerminalId) return;
-  terminalInstanceService.repaintForReveal(assistantTerminalId);
+export interface AssistantRevealCoordinator {
+  /** Install the help-store subscription. Returns its disposer. */
+  start: () => () => void;
+  /**
+   * Track assistant visibility. A hide cancels any outstanding obligation at the
+   * STATE change, not at the hide animation's end — a terminal that binds while
+   * the panel is sliding away must not be repainted into a hidden pane.
+   */
+  setVisible: (visible: boolean) => void;
+  /**
+   * The slide settled (or was suppressed entirely). On a show, repaint now if the
+   * terminal is paintable; otherwise retain the obligation. On a hide, cancel.
+   */
+  settleAfterTransition: (isShown: boolean) => void;
+}
+
+export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
+  let visible = false;
+  let pending = false;
+  // Monotonic obligation stamp. Bumped on every hide, every fresh settle, and
+  // every re-bind, so an in-flight attach wait or frame loop belonging to a
+  // superseded obligation can neither repaint nor clear the current one.
+  let generation = 0;
+  let inFlight: { id: string; generation: number } | null = null;
+  let unsubscribe: (() => void) | null = null;
+
+  const cancel = (): void => {
+    pending = false;
+    generation++;
+    inFlight = null;
+  };
+
+  const discharge = (id: string): void => {
+    const stamp = generation;
+    // Already chasing this exact obligation — a second store edge must not stack
+    // a duplicate frame loop on top of it.
+    if (inFlight && inFlight.id === id && inFlight.generation === stamp) return;
+    inFlight = { id, generation: stamp };
+
+    void (async () => {
+      try {
+        try {
+          await terminalInstanceService.waitForAttachSettled(id, {
+            timeoutMs: ASSISTANT_ATTACH_SETTLE_TIMEOUT_MS,
+          });
+        } catch {
+          // Never attached in time. Leave `pending` armed — the next store
+          // binding or show settle picks the obligation back up.
+          return;
+        }
+        if (stamp !== generation || !visible) return;
+
+        // repaintForReveal, NOT revealTerminal: the assistant pane keeps the
+        // `isVisible` gate on the WebGL reattach (a transform-hidden pane must
+        // not accumulate a fleet-wide WebGL want, #10671), and it reports FALSE
+        // for a missing instance — so a still-registering terminal keeps
+        // retrying instead of banking revealTerminal's "gone → settled" true.
+        const painted = await revealUntilStable(
+          id,
+          (target) => terminalInstanceService.repaintForReveal(target),
+          () => stamp !== generation || !visible || isDocumentHidden(),
+          "[assistantReveal]"
+        );
+        if (painted && stamp === generation) pending = false;
+      } finally {
+        if (inFlight && inFlight.id === id && inFlight.generation === stamp) inFlight = null;
+      }
+    })();
+  };
+
+  return {
+    start() {
+      unsubscribe?.();
+      const dispose = useHelpPanelStore.subscribe((state, prev) => {
+        // sessionId as well as terminalId: a reserved id is finalized in place
+        // when provisioning resolves, so the id alone can be edge-less on the
+        // retry path after an attach-wait timeout.
+        if (state.terminalId === prev.terminalId && state.sessionId === prev.sessionId) return;
+        if (!state.terminalId || !pending || !visible) return;
+        // A re-bind supersedes whatever the previous binding was chasing.
+        generation++;
+        discharge(state.terminalId);
+      });
+      unsubscribe = dispose;
+      return () => {
+        if (unsubscribe !== dispose) return;
+        dispose();
+        unsubscribe = null;
+        cancel();
+      };
+    },
+
+    setVisible(next) {
+      visible = next;
+      if (!next) cancel();
+    },
+
+    settleAfterTransition(isShown) {
+      visible = isShown;
+      if (!isShown) {
+        cancel();
+        return;
+      }
+      const assistantTerminalId = useHelpPanelStore.getState().terminalId;
+      // The happy path — the terminal was already bound and paintable when the
+      // slide settled (every open after the first). One pass, obligation over.
+      if (assistantTerminalId && terminalInstanceService.repaintForReveal(assistantTerminalId)) {
+        cancel();
+        return;
+      }
+      // Either no terminal yet, or the host had no renderable box. Retain the
+      // obligation instead of dropping the repaint (#11070).
+      generation++;
+      pending = true;
+      inFlight = null;
+      // Already bound but not yet paintable: no store edge is coming, so drive
+      // the retry from here rather than waiting for a subscription that will
+      // never fire.
+      if (assistantTerminalId) discharge(assistantTerminalId);
+    },
+  };
 }

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -195,7 +195,7 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
   return {
     start() {
       unsubscribe?.();
-      const offStore = useHelpPanelStore.subscribe((state, prev) => {
+      const dispose = useHelpPanelStore.subscribe((state, prev) => {
         // sessionId as well as terminalId: a reserved id is finalized in place
         // when provisioning resolves, so the id alone can be edge-less on the
         // retry path after an attach-wait timeout.
@@ -205,18 +205,15 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
         generation++;
         discharge(state.terminalId);
       });
-      // Hand the obligation off when this project view is cached (backgrounded).
-      // A cached WebContentsView does not reliably fire a DOM visibilitychange,
-      // so isDocumentHidden alone would let the frame loop keep repainting into
-      // an unpresented view — and, worse, still be running when the switch-back
-      // fires repaintActiveWorktreeTerminals, whose sweep already owns the
-      // assistant terminal (#9637). Two geometry reconciles racing one live
-      // terminal is exactly the corruption #10863 fixed, so this side yields.
-      const offViewCached = window.electron?.app?.onViewCached?.(() => cancel());
-      const dispose = (): void => {
-        offStore();
-        offViewCached?.();
-      };
+      // Deliberately NOT cancelled on app:view-cached. Yielding the obligation to
+      // the switch-back sweep looks tempting, but that sweep only covers the
+      // assistant once BOTH its terminalId and its registered panel exist
+      // (collectActiveWorktreeTerminalTargets) — so a view cached while the
+      // session is still provisioning would hand the repaint to an owner that
+      // never takes it, and #11070 returns. A discharge that lands in a
+      // backgrounded view is merely wasted (repaintForReveal still gates on
+      // DOM-truth dims, and with no opts it keeps the isVisible WebGL gate,
+      // #10671), and the switch-back sweep repaints the terminal again anyway.
       unsubscribe = dispose;
       return () => {
         if (unsubscribe !== dispose) return;

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -62,6 +62,11 @@ export function suppressSidebarResizes(): void {
 // obligation stays ARMED: a later binding (or the next show settle) retries it,
 // which is strictly better than dropping the repaint the way #11070 did.
 const ASSISTANT_ATTACH_SETTLE_TIMEOUT_MS = 2500;
+// A timed-out attach waiter is deregistered, so a single wait would silently
+// abandon a terminal that attaches a moment after the deadline. Re-arm the wait
+// a bounded number of times (~7.5s total) — long enough to cover a slow cold
+// agent spawn, short enough that a genuinely dead binding stops costing frames.
+const ASSISTANT_ATTACH_WAIT_ATTEMPTS = 3;
 
 /**
  * Owns the Assistant terminal's post-transition reveal repaint as a durable
@@ -140,18 +145,34 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
     if (inFlight && inFlight.id === id && inFlight.generation === stamp) return;
     inFlight = { id, generation: stamp };
 
+    const isStale = (): boolean => stamp !== generation || !visible;
+
     void (async () => {
       try {
-        try {
-          await terminalInstanceService.waitForAttachSettled(id, {
-            timeoutMs: ASSISTANT_ATTACH_SETTLE_TIMEOUT_MS,
-          });
-        } catch {
-          // Never attached in time. Leave `pending` armed — the next store
-          // binding or show settle picks the obligation back up.
-          return;
+        // waitForAttachSettled resolves IMMEDIATELY when the terminal is already
+        // attached (the warm open, every time after the first) and otherwise
+        // parks on the attach notification. It REJECTS on timeout, and a
+        // timed-out waiter is deregistered — so a terminal that attaches just
+        // after the deadline would never wake us again, and with the sidebar
+        // still open no further settle or store edge is coming. That is #11070
+        // with a longer fuse, so the wait is retried rather than abandoned.
+        let attached = false;
+        for (let attempt = 0; attempt < ASSISTANT_ATTACH_WAIT_ATTEMPTS; attempt++) {
+          if (isStale()) return;
+          try {
+            await terminalInstanceService.waitForAttachSettled(id, {
+              timeoutMs: ASSISTANT_ATTACH_SETTLE_TIMEOUT_MS,
+            });
+            attached = true;
+            break;
+          } catch {
+            // Timed out — fall through and re-arm the wait (it resolves at once
+            // if the attach landed in the gap).
+          }
         }
-        if (stamp !== generation || !visible) return;
+        // Out of patience. Leave `pending` armed so a later re-bind or a fresh
+        // show settle can still pick the obligation up.
+        if (!attached || isStale()) return;
 
         // repaintForReveal, NOT revealTerminal: the assistant pane keeps the
         // `isVisible` gate on the WebGL reattach (a transform-hidden pane must
@@ -161,7 +182,7 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
         const painted = await revealUntilStable(
           id,
           (target) => terminalInstanceService.repaintForReveal(target),
-          () => stamp !== generation || !visible || isDocumentHidden(),
+          () => isStale() || isDocumentHidden(),
           "[assistantReveal]"
         );
         if (painted && stamp === generation) pending = false;
@@ -174,7 +195,7 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
   return {
     start() {
       unsubscribe?.();
-      const dispose = useHelpPanelStore.subscribe((state, prev) => {
+      const offStore = useHelpPanelStore.subscribe((state, prev) => {
         // sessionId as well as terminalId: a reserved id is finalized in place
         // when provisioning resolves, so the id alone can be edge-less on the
         // retry path after an attach-wait timeout.
@@ -184,6 +205,18 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
         generation++;
         discharge(state.terminalId);
       });
+      // Hand the obligation off when this project view is cached (backgrounded).
+      // A cached WebContentsView does not reliably fire a DOM visibilitychange,
+      // so isDocumentHidden alone would let the frame loop keep repainting into
+      // an unpresented view — and, worse, still be running when the switch-back
+      // fires repaintActiveWorktreeTerminals, whose sweep already owns the
+      // assistant terminal (#9637). Two geometry reconciles racing one live
+      // terminal is exactly the corruption #10863 fixed, so this side yields.
+      const offViewCached = window.electron?.app?.onViewCached?.(() => cancel());
+      const dispose = (): void => {
+        offStore();
+        offViewCached?.();
+      };
       unsubscribe = dispose;
       return () => {
         if (unsubscribe !== dispose) return;
@@ -204,22 +237,25 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
         cancel();
         return;
       }
-      const assistantTerminalId = useHelpPanelStore.getState().terminalId;
-      // The happy path — the terminal was already bound and paintable when the
-      // slide settled (every open after the first). One pass, obligation over.
-      if (assistantTerminalId && terminalInstanceService.repaintForReveal(assistantTerminalId)) {
-        cancel();
-        return;
-      }
-      // Either no terminal yet, or the host had no renderable box. Retain the
-      // obligation instead of dropping the repaint (#11070).
+      // Every settle opens a FRESH obligation that supersedes the last.
       generation++;
       pending = true;
       inFlight = null;
-      // Already bound but not yet paintable: no store edge is coming, so drive
-      // the retry from here rather than waiting for a subscription that will
-      // never fire.
-      if (assistantTerminalId) discharge(assistantTerminalId);
+
+      const assistantTerminalId = useHelpPanelStore.getState().terminalId;
+      // No terminal yet (the cold first open — the #11070 case). Hold the
+      // obligation; the help-store subscription discharges it once one binds.
+      if (!assistantTerminalId) return;
+
+      // Bound already: drive the discharge from here, because no null→bound
+      // store edge is coming to trigger it. Everything routes through the same
+      // attach-gated, confirm-painted path — a bare synchronous repaintForReveal
+      // would be a weaker pass than the loop (it has no isAttaching guard, so it
+      // can report a paint that the terminal's own post-attach fit then
+      // supersedes) and banking it would retire the obligation on one unstuck
+      // paint. The warm case costs nothing extra: waitForAttachSettled resolves
+      // immediately for an already-attached terminal.
+      discharge(assistantTerminalId);
     },
   };
 }

--- a/src/services/terminal/__tests__/revealUntilStable.test.ts
+++ b/src/services/terminal/__tests__/revealUntilStable.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const logWarnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: logWarnMock,
+}));
+
+import { MAX_REVEAL_FRAMES, REVEAL_CONFIRM_PAINTS, revealUntilStable } from "../revealUntilStable";
+
+let rafQueue: FrameRequestCallback[] = [];
+
+/**
+ * Drain queued rAF callbacks and microtasks alternately. A SYNCHRONOUS rAF stub
+ * (one that invokes the callback inline) collapses the frame separation the
+ * confirm-paint pass depends on, so frames are queued and flushed explicitly.
+ */
+async function pump(ticks: number): Promise<void> {
+  for (let i = 0; i < ticks; i++) {
+    await Promise.resolve();
+    const queued = rafQueue;
+    rafQueue = [];
+    for (const cb of queued) cb(0);
+    await Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  logWarnMock.mockClear();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("revealUntilStable", () => {
+  it("confirms the reveal only after repeated paints on separate frames", async () => {
+    const attempt = vi.fn(() => true);
+    let settled = false;
+    const result = revealUntilStable("t-1", attempt, () => false, "[test]").then((value) => {
+      settled = true;
+      return value;
+    });
+
+    // The first pass runs eagerly, but a single paint must NOT settle the reveal:
+    // it can land before the compositor presents the frame, so it doesn't stick.
+    // The confirm paint only becomes reachable once a frame has been yielded.
+    await Promise.resolve();
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    await pump(MAX_REVEAL_FRAMES);
+    await expect(result).resolves.toBe(true);
+    expect(attempt).toHaveBeenCalledTimes(REVEAL_CONFIRM_PAINTS);
+    expect(attempt).toHaveBeenCalledWith("t-1");
+  });
+
+  it("retries across frames while the terminal reports itself unpaintable", async () => {
+    const paintable = vi.fn(() => paintable.mock.calls.length > 3);
+    const result = revealUntilStable("t-1", paintable, () => false, "[test]");
+
+    await pump(MAX_REVEAL_FRAMES);
+
+    await expect(result).resolves.toBe(true);
+    // Three not-yet-paintable frames, then the confirm paints.
+    expect(paintable).toHaveBeenCalledTimes(3 + REVEAL_CONFIRM_PAINTS);
+  });
+
+  it("reports the reveal undischarged when the frame budget runs out", async () => {
+    const attempt = vi.fn(() => false);
+    const result = revealUntilStable("t-1", attempt, () => false, "[test]");
+
+    await pump(MAX_REVEAL_FRAMES + 2);
+
+    // A terminal that never becomes paintable must not spin forever, and the
+    // caller must learn the obligation is still outstanding.
+    await expect(result).resolves.toBe(false);
+    expect(attempt).toHaveBeenCalledTimes(MAX_REVEAL_FRAMES);
+  });
+
+  it("stops immediately once the caller aborts", async () => {
+    let aborted = false;
+    // Never paintable, so the loop is still retrying when the abort lands — a
+    // reveal that had already banked its confirm paints would have exited on its
+    // own and proven nothing about the abort.
+    const attempt = vi.fn(() => false);
+    const result = revealUntilStable("t-1", attempt, () => aborted, "[test]");
+
+    await pump(1);
+    const callsBeforeAbort = attempt.mock.calls.length;
+    expect(callsBeforeAbort).toBeGreaterThan(0);
+
+    aborted = true;
+    await pump(MAX_REVEAL_FRAMES);
+
+    await expect(result).resolves.toBe(false);
+    expect(attempt).toHaveBeenCalledTimes(callsBeforeAbort);
+  });
+
+  it("does not abort when the caller stays live", async () => {
+    const isAborted = vi.fn(() => false);
+    const result = revealUntilStable("t-1", () => true, isAborted, "[test]");
+
+    await pump(MAX_REVEAL_FRAMES);
+
+    await expect(result).resolves.toBe(true);
+    expect(isAborted).toHaveBeenCalled();
+  });
+
+  it("isolates a throwing reveal, logging it under the caller's context", async () => {
+    const boom = new Error("renderer gone");
+    const attempt = vi.fn(() => {
+      throw boom;
+    });
+
+    const result = revealUntilStable("t-1", attempt, () => false, "[assistantReveal]");
+    await pump(MAX_REVEAL_FRAMES);
+
+    await expect(result).resolves.toBe(false);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalledWith("[assistantReveal] reveal failed", {
+      id: "t-1",
+      error: boom,
+    });
+  });
+
+  it("awaits an async reveal pass before counting it", async () => {
+    const attempt = vi.fn(() => Promise.resolve(true));
+    const result = revealUntilStable("t-1", attempt, () => false, "[test]");
+
+    await pump(MAX_REVEAL_FRAMES);
+
+    await expect(result).resolves.toBe(true);
+    expect(attempt).toHaveBeenCalledTimes(REVEAL_CONFIRM_PAINTS);
+  });
+});

--- a/src/services/terminal/revealUntilStable.ts
+++ b/src/services/terminal/revealUntilStable.ts
@@ -1,0 +1,101 @@
+import { logWarn } from "@/utils/logger";
+
+// Upper bound on frames a single terminal will keep retrying its reveal before
+// the caller gives up on it. A warm project-view return that's settling its
+// layout needs only a couple of frames; the ceiling just stops a pane that's
+// genuinely offscreen/unmeasurable from spinning forever (~10 frames ≈ 160ms).
+export const MAX_REVEAL_FRAMES = 10;
+// Paint each pane on two SEPARATE frames once it's paintable. The first paint
+// can land in the frame before the compositor swaps the now-foreground project
+// view in — or before xterm's own IntersectionObserver re-fires as the view
+// un-occludes and momentarily re-pauses the renderer — so it doesn't visually
+// stick. The second, a frame later once those observers have settled, is the
+// one the user actually sees. This double pass is what turns the previously
+// intermittent reveal into a reliable one.
+export const REVEAL_CONFIRM_PAINTS = 2;
+
+// rAF is paused for a backgrounded/occluded WebContentsView, so its callback can
+// never fire there. Race it against a timeout so a caller awaiting a frame can't
+// hang forever (and later resume stale to interleave with the next reveal). In
+// the normal foreground case the real frame (~16ms) always wins well before the
+// fallback.
+const NEXT_FRAME_FALLBACK_MS = 250;
+
+export function nextFrame(): Promise<void> {
+  if (typeof requestAnimationFrame !== "function") return Promise.resolve();
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    requestAnimationFrame(done);
+    if (typeof setTimeout === "function") setTimeout(done, NEXT_FRAME_FALLBACK_MS);
+  });
+}
+
+export function isDocumentHidden(): boolean {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
+/**
+ * Attempt one reveal pass. Returns `true` when the terminal was paintable and
+ * the pass landed, `false` when it isn't paintable yet and the caller should
+ * retry on a later frame.
+ *
+ * The two reveal entry points are NOT interchangeable, which is why this is
+ * injected rather than hard-wired:
+ *
+ * - `revealTerminal` — the project-view sweep's pass. Opens hibernated/unopened
+ *   panes and passes `trustDomVisibility` so a stale reactive `isVisible=false`
+ *   on a warm WebContentsView resume doesn't skip the WebGL reattach. It also
+ *   reports `true` for a MISSING instance ("gone — nothing to retry").
+ * - `repaintForReveal` — the assistant sidebar-transition pass. Keeps the
+ *   `isVisible` gate (a transform-hidden pane must not accumulate a fleet-wide
+ *   WebGL want, #10671) and reports `false` for a missing instance, so a
+ *   still-provisioning terminal keeps retrying instead of banking a false paint.
+ */
+export type RevealAttempt = (id: string) => boolean | Promise<boolean>;
+
+/**
+ * Drive a single terminal's reveal to a stable result: retry frame-by-frame
+ * until {@link RevealAttempt} reports paintable, then paint it
+ * {@link REVEAL_CONFIRM_PAINTS} times across separate frames to defeat the
+ * compositor/observer present-race that otherwise leaves the first paint
+ * un-stuck. Bounded by {@link MAX_REVEAL_FRAMES}.
+ *
+ * @returns `true` once every confirm paint landed; `false` when the caller
+ * aborted, the frame budget ran out before the terminal became paintable, or the
+ * attempt threw. A `false` return means the reveal obligation is NOT discharged —
+ * callers that own a durable obligation (the assistant sidebar transition) must
+ * keep it armed for a later retry.
+ */
+export async function revealUntilStable(
+  id: string,
+  attempt: RevealAttempt,
+  isAborted: () => boolean,
+  logContext: string
+): Promise<boolean> {
+  let painted = 0;
+  for (let frame = 0; frame < MAX_REVEAL_FRAMES && painted < REVEAL_CONFIRM_PAINTS; frame++) {
+    // The view may have been switched away (detached → hidden) since the reveal
+    // started, or the assistant re-hidden, during a frame yield. Stop before
+    // touching a hidden surface — the caller owns the retry.
+    if (isAborted()) return false;
+    let paintable: boolean;
+    try {
+      paintable = await attempt(id);
+    } catch (error) {
+      // One broken terminal must not abort the caller's wider sweep — the next
+      // visible terminal still needs its post-reveal repaint.
+      logWarn(`${logContext} reveal failed`, { id, error });
+      return false;
+    }
+    if (paintable) painted++;
+    // Yield a frame between attempts: lets layout/compositor settle before a
+    // retry, and spaces the confirm paint out from the first.
+    await nextFrame();
+  }
+  return painted >= REVEAL_CONFIRM_PAINTS;
+}

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -1,4 +1,5 @@
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { isDocumentHidden, revealUntilStable } from "@/services/terminal/revealUntilStable";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -156,78 +157,9 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
   await Promise.all(workers);
 }
 
-// Upper bound on frames a single terminal will keep retrying its reveal before
-// the sweep gives up on it. A warm project-view return that's settling its
-// layout needs only a couple of frames; the ceiling just stops a pane that's
-// genuinely offscreen/unmeasurable from spinning forever (~10 frames ≈ 160ms).
-const MAX_REVEAL_FRAMES = 10;
 // At most this many terminals repaint on any one frame so a large grid never
 // produces a single long task on the reveal frame.
 const REVEAL_CONCURRENCY = 2;
-// Paint each pane on two SEPARATE frames once it's paintable. The first paint
-// can land in the frame before the compositor swaps the now-foreground project
-// view in — or before xterm's own IntersectionObserver re-fires as the view
-// un-occludes and momentarily re-pauses the renderer — so it doesn't visually
-// stick. The second, a frame later once those observers have settled, is the
-// one the user actually sees. This double pass is what turns the previously
-// intermittent reveal into a reliable one.
-const REVEAL_CONFIRM_PAINTS = 2;
-
-// rAF is paused for a backgrounded/occluded WebContentsView, so its callback can
-// never fire there. Race it against a timeout so a worker awaiting a frame can't
-// hang the reveal sweep forever (and later resume stale to interleave with the
-// next reveal). In the normal foreground case the real frame (~16ms) always wins
-// well before the fallback.
-const NEXT_FRAME_FALLBACK_MS = 250;
-
-function nextFrame(): Promise<void> {
-  if (typeof requestAnimationFrame !== "function") return Promise.resolve();
-  return new Promise((resolve) => {
-    let settled = false;
-    const done = (): void => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    requestAnimationFrame(done);
-    if (typeof setTimeout === "function") setTimeout(done, NEXT_FRAME_FALLBACK_MS);
-  });
-}
-
-function isDocumentHidden(): boolean {
-  return typeof document !== "undefined" && document.visibilityState === "hidden";
-}
-
-/**
- * Drive a single terminal's reveal to a stable result: retry frame-by-frame
- * until it reports paintable, then paint it {@link REVEAL_CONFIRM_PAINTS} times
- * across separate frames to defeat the compositor/observer present-race that
- * otherwise leaves the first paint un-stuck. Bounded by {@link MAX_REVEAL_FRAMES}.
- */
-async function revealUntilStable(id: string, isAborted: () => boolean): Promise<void> {
-  let painted = 0;
-  for (let frame = 0; frame < MAX_REVEAL_FRAMES && painted < REVEAL_CONFIRM_PAINTS; frame++) {
-    // The view may have been switched away (detached → hidden) since the sweep
-    // started or during a frame yield. Stop before touching a hidden view — the
-    // switch-back starts a fresh sweep. The caller latches the same flag for the
-    // worker pool, so a single hidden event abandons the WHOLE sweep, not just
-    // this terminal.
-    if (isAborted()) return;
-    let paintable: boolean;
-    try {
-      paintable = await terminalInstanceService.revealTerminal(id);
-    } catch (error) {
-      // One broken terminal must not abort the sweep — the next visible
-      // terminal still needs its post-reveal reveal/repaint.
-      logWarn("[repaintActiveWorktreeTerminals] reveal failed", { id, error });
-      return;
-    }
-    if (paintable) painted++;
-    // Yield a frame between attempts: lets layout/compositor settle before a
-    // retry, and spaces the confirm paint out from the first.
-    await nextFrame();
-  }
-}
 
 /**
  * Re-run the terminal reveal across every grid agent terminal AFTER the project
@@ -287,7 +219,19 @@ export async function repaintActiveWorktreeTerminals(): Promise<void> {
       while (cursor < targets.length) {
         if (aborted) return;
         const id = targets[cursor++];
-        if (id) await revealUntilStable(id, () => aborted);
+        // revealTerminal (not repaintForReveal): this sweep also has to OPEN
+        // panes the occluded warm wake could not, and it trusts DOM-truth
+        // visibility for the WebGL reattach because the foreground view is
+        // confirmed presented. The assistant sidebar-transition owner
+        // deliberately uses the other pass — see revealUntilStable's RevealAttempt.
+        if (id) {
+          await revealUntilStable(
+            id,
+            (target) => terminalInstanceService.revealTerminal(target),
+            () => aborted,
+            "[repaintActiveWorktreeTerminals]"
+          );
+        }
       }
     };
     const workerCount = Math.min(REVEAL_CONCURRENCY, targets.length);


### PR DESCRIPTION
## The bug

On a cold first open of the Assistant sidebar, the terminal skips painting its footer. Switching to another project and back repairs it, which is what made it look intermittent.

It's a first-show race. When the slide settles, `AppLayout` calls the post-transition reveal repaint — but on a cold open the session is still provisioning, so `useHelpPanelStore` has no `terminalId` yet and the repaint returned early:

```ts
export function repaintAssistantAfterTransition(): void {
  const assistantTerminalId = useHelpPanelStore.getState().terminalId;
  if (!assistantTerminalId) return;   // dropped, with no retry
  terminalInstanceService.repaintForReveal(assistantTerminalId);
}
```

Nothing retried once `terminalId` arrived. The sole authoritative geometry pass was dropped for good. On a project switch-back the id already exists by the time the transition settles, so the repaint runs and restores the missing content — that's why the round-trip "fixes" it.

## The fix

The repaint is now a durable obligation instead of a one-shot, owned by `createAssistantRevealCoordinator` in `src/lib/sidebarToggle.ts` and instantiated by `AppLayout` (its lifetime is exactly the lifetime of the DOM whose transition produces it).

- If the slide settles with no `terminalId`, the obligation is **retained**, and a `useHelpPanelStore` subscription discharges it once a terminal binds.
- `terminalId` is not a paintability signal — `setTerminal` publishes a reserved id synchronously, before `addPanel` is even awaited (#6953) — so the discharge gates on `waitForAttachSettled` and then runs the existing bounded, confirm-painted `revealUntilStable` loop.
- Generation-stamped: a hide, a fresh settle, or a re-bind supersedes any in-flight discharge, so a stale loop can neither repaint a dead terminal nor retire a live obligation.

`revealUntilStable`/`nextFrame` moved out of `wakeActiveWorktreeTerminals.ts` into `src/services/terminal/revealUntilStable.ts`, with the reveal pass injected. That injection is load-bearing, not cosmetic:

- The project-view sweep keeps `revealTerminal` (it must also OPEN unopened panes, and it trusts DOM visibility for the WebGL reattach on a warm resume).
- The assistant passes `repaintForReveal` with **no opts**, which keeps the `isVisible` gate — a transform-hidden pane must not accumulate a fleet-wide WebGL want (#10671) — and which reports `false` for a missing instance. `revealTerminal` reports `true` there ("gone, nothing to retry"), which against a reserved-but-unregistered id would bank two false confirm-paints and silently re-drop the repaint.

The sidebar transition stays the sole owner of its trigger. No repaint logic went into `HelpPanel` — a second cascade reconciling geometry against live PTY output is what corrupted xterm's line-wrap metadata in #10863, and that guard test passes unmodified.

## Caught in review

- **Attach-timeout wedge.** A timed-out attach waiter is deregistered, so a terminal attaching just past the deadline would never wake the coordinator again — sidebar still open, no further store edge coming. That was #11070 with a longer fuse. The wait is now re-armed a bounded number of times.
- **Mid-attach discharge.** `repaintForReveal` has no `isAttaching` guard, so a synchronous fast path could bank a paint the terminal's own post-attach fit then supersedes. The fast path is gone; everything routes through the attach-gated discharge (`waitForAttachSettled` resolves immediately for an already-attached terminal, so the warm path costs nothing).
- **Drag-resize.** `isAssistantResizing` also strips the transition, so the no-transition path was settling on drag start — and `reconcileGeometryFresh` is lock-exempt, so the confirm pass resized xterm and the PTY mid-drag at a width the cursor had already moved past. A drag is not a reveal; it now owns its own geometry.

## On the E2E

The issue asks for one. I wrote it, and then deleted it: it passed with the fix reverted, so it proved nothing. The E2E harness forces the DOM renderer (`DAINTREE_DISABLE_WEBGL=1`), which paints rows on every write regardless of the reveal pass, and the terminal attaches after the resize lock expires so its own fit is already correct. The symptom depends on WebGL atlas state and a paused renderer that the harness doesn't reproduce. An always-green E2E is a false guarantee, so the regression guard is the unit coverage instead, which pins the contract directly.

## Known limitation

If all three attach attempts time out (~7.5s) *and* the terminal attaches after that with no later re-bind or settle, the obligation stays armed but has no wake source. Closing it needs an abortable no-timeout wait plus a paintability scheduler; `repaintForReveal` already names the reconciliation watchdog as the backstop for the not-paintable case, so I left it.

## Tests

78 passing across the touched suites: new `revealUntilStable` spec (retry, confirm-paint, abort, bounded budget, throw isolation), rewritten `sidebarToggle` coordinator spec (cold-bind discharge, attach gating, re-arm on timeout, bounded give-up, hide cancellation, re-bind supersession, disposal), plus the existing wake-sweep, AppLayout-wiring, and `HelpPanel.revealBackstop` (#10863) suites unchanged and green. Typecheck passes.

Resolves #11070