### PR TITLE
fix(project-switcher): keep modal-browse selection on a row that's actually rendered

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -131,15 +131,20 @@ export function ProjectSwitcher() {
     [projectSwitcher]
   );
 
+  // Reads the uncapped, unscoped agent totals rather than `results` — that
+  // array is scoped for presentation (modal browse drops projects whose
+  // process count hasn't landed yet), which would blink the badge off.
   const badgeStatus = useMemo(() => {
-    const bgProjects = projectSwitcher.results.filter((p) => !p.isActive);
-    const totalWaiting = bgProjects.reduce((sum, p) => sum + p.waitingAgentCount, 0);
-    const totalActive = bgProjects.reduce((sum, p) => sum + p.activeAgentCount, 0);
+    const { activeAgentCount, waitingAgentCount } = projectSwitcher.nonActiveAgentCounts;
 
-    if (totalWaiting > 0) return { color: "bg-state-waiting", pulse: false, count: totalWaiting };
-    if (totalActive > 0) return { color: "bg-activity-active", pulse: true, count: totalActive };
+    if (waitingAgentCount > 0) {
+      return { color: "bg-state-waiting", pulse: false, count: waitingAgentCount };
+    }
+    if (activeAgentCount > 0) {
+      return { color: "bg-activity-active", pulse: true, count: activeAgentCount };
+    }
     return null;
-  }, [projectSwitcher.results]);
+  }, [projectSwitcher.nonActiveAgentCounts]);
 
   const stopDialog = (
     <ConfirmDialog

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -451,26 +451,18 @@ function ProjectListContent({
     ].filter((s): s is TemporalSection => s !== null);
   }, [results, isSearching, mode]);
 
-  const displayResults = useMemo(() => {
-    if (mode === "modal" && !isSearching) {
-      return results.filter((p) => p.isActive || p.isBackground || p.processCount > 0);
-    }
-    return results;
-  }, [results, mode, isSearching]);
-
-  const resultIndexMap = useMemo(() => {
-    const map = new Map<string, number>();
-    results.forEach((p, i) => map.set(p.id, i));
-    return map;
-  }, [results]);
+  // `results` is already scoped by the hook to exactly the rows this mode
+  // renders, so it doubles as the arrow-key domain. Never re-filter it here:
+  // a second, narrower array is what stranded the highlight and let Enter
+  // commit an off-screen project (#11071).
+  const selectedProjectId = results[selectedIndex]?.id;
 
   const renderItem = (project: SearchableProject) => {
-    const index = resultIndexMap.get(project.id) ?? 0;
     return (
       <div key={project.id} role="presentation">
         <ProjectListItem
           project={project}
-          isSelected={index === selectedIndex}
+          isSelected={project.id === selectedProjectId}
           onSelect={onSelect}
           onStopProject={onStopProject}
           onCloseProject={onCloseProject}
@@ -489,7 +481,7 @@ function ProjectListContent({
   return (
     <>
       <div ref={listRef} id="project-list" role="listbox" aria-label="Projects">
-        {displayResults.length === 0 ? (
+        {results.length === 0 ? (
           <div className="p-2">
             <div className="px-3 py-8 text-center text-daintree-text/50 text-sm">
               {query.trim() ? (
@@ -528,7 +520,7 @@ function ProjectListContent({
             );
           })
         ) : (
-          <div className="p-2">{displayResults.map((project) => renderItem(project))}</div>
+          <div className="p-2">{results.map((project) => renderItem(project))}</div>
         )}
       </div>
     </>

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -30,6 +30,10 @@ vi.mock("@/hooks/useKeybinding", () => ({
   useKeybindingDisplay: () => "⌘P",
 }));
 
+const paletteState = vi.hoisted(() => ({
+  nonActiveAgentCounts: { activeAgentCount: 0, waitingAgentCount: 0 },
+}));
+
 vi.mock("@/hooks", async () => {
   const deferred = await vi.importActual<typeof import("@/hooks/useDeferredLoading")>(
     "@/hooks/useDeferredLoading"
@@ -40,6 +44,7 @@ vi.mock("@/hooks", async () => {
       isOpen: false,
       mode: "dropdown",
       query: "",
+      // Presentation-scoped and deliberately empty: the badge must not read it.
       results: [],
       selectedIndex: 0,
       open: vi.fn(),
@@ -65,7 +70,7 @@ vi.mock("@/hooks", async () => {
       confirmRemoveProject: vi.fn(),
       isRemovingProject: false,
       backgroundWaitingCount: 0,
-      nonActiveAgentCounts: { activeAgentCount: 0, waitingAgentCount: 0 },
+      nonActiveAgentCounts: paletteState.nonActiveAgentCounts,
     }),
   };
 });
@@ -330,5 +335,50 @@ describe("ProjectSwitcher loading affordance", () => {
     const trigger = getByRole("button");
     expect(trigger.querySelector(".animate-spin")).toBeNull();
     expect(trigger.querySelector(".lucide-chevrons-up-down")).not.toBeNull();
+  });
+});
+
+// The badge counts agents on OTHER projects, so it must read the hook's
+// uncapped totals — not `results`, which modal browse scopes for presentation
+// and can legitimately drop a project whose process count hasn't landed yet
+// (agent counts and process counts arrive from separate stats calls).
+describe("ProjectSwitcher background-agent badge", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setStore({
+      projects: [makeProject()],
+      currentProject: makeProject(),
+      isLoading: false,
+    });
+    paletteState.nonActiveAgentCounts = { activeAgentCount: 0, waitingAgentCount: 0 };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("counts agents on projects that are absent from results", () => {
+    paletteState.nonActiveAgentCounts = { activeAgentCount: 0, waitingAgentCount: 2 };
+    const { getByRole } = render(<ProjectSwitcher />);
+    expect(getByRole("status").getAttribute("aria-label")).toContain("2 background agents waiting");
+  });
+
+  it("prefers waiting agents over working ones", () => {
+    paletteState.nonActiveAgentCounts = { activeAgentCount: 5, waitingAgentCount: 1 };
+    const { getByRole } = render(<ProjectSwitcher />);
+    const label = getByRole("status").getAttribute("aria-label");
+    expect(label).toContain("1 background agent waiting");
+    expect(label).not.toContain("working");
+  });
+
+  it("falls back to working agents when none are waiting", () => {
+    paletteState.nonActiveAgentCounts = { activeAgentCount: 3, waitingAgentCount: 0 };
+    const { getByRole } = render(<ProjectSwitcher />);
+    expect(getByRole("status").getAttribute("aria-label")).toContain("3 background agents working");
+  });
+
+  it("renders no badge when no other project has agents", () => {
+    const { queryByRole } = render(<ProjectSwitcher />);
+    expect(queryByRole("status")).toBeNull();
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -65,6 +65,7 @@ vi.mock("@/hooks", async () => {
       confirmRemoveProject: vi.fn(),
       isRemovingProject: false,
       backgroundWaitingCount: 0,
+      nonActiveAgentCounts: { activeAgentCount: 0, waitingAgentCount: 0 },
     }),
   };
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -270,3 +270,72 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(footer.textContent).toContain("Switch");
   });
 });
+
+// #11071: the palette used to render a narrower list than the one selectedIndex
+// walked, so arrowing onto a row the modal had filtered out left
+// aria-activedescendant pointing at an id with no DOM node — no highlight, and
+// Enter committed an off-screen project. `results` is now the single array the
+// hook scopes, renders, and indexes.
+describe("ProjectSwitcherPalette active descendant", () => {
+  // Deliberately mixed: under the old component-side filter, "closed" would be
+  // dropped from the DOM while still occupying index 1 of `results`.
+  const mixedResults = [
+    makeProject({ id: "active", name: "Active", isActive: true }),
+    makeProject({ id: "closed", name: "Closed" }),
+    makeProject({ id: "background", name: "Background", isBackground: true }),
+  ];
+
+  const mixedProps = {
+    isOpen: true,
+    query: "",
+    results: mixedResults,
+    selectedIndex: 0,
+    onQueryChange: vi.fn(),
+    onSelectPrevious: vi.fn(),
+    onSelectNext: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    mode: "modal" as const,
+  };
+
+  it.each(mixedResults.map((project, index) => [index, project.id] as const))(
+    "resolves aria-activedescendant to the selected option at index %i",
+    (selectedIndex, expectedId) => {
+      render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={selectedIndex} />);
+
+      const input = screen.getByTestId("palette-input");
+      const activeDescendantId = input.getAttribute("aria-activedescendant");
+      expect(activeDescendantId).toBe(`project-option-${expectedId}`);
+
+      const activeOption = document.getElementById(activeDescendantId!);
+      expect(activeOption).not.toBeNull();
+      expect(activeOption!.getAttribute("role")).toBe("option");
+      expect(activeOption!.getAttribute("aria-selected")).toBe("true");
+    }
+  );
+
+  it("marks exactly one option selected for every index", () => {
+    for (const [index] of mixedResults.entries()) {
+      const { unmount } = render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={index} />);
+      const selected = screen
+        .getAllByRole("option")
+        .filter((option) => option.getAttribute("aria-selected") === "true");
+      expect(selected).toHaveLength(1);
+      unmount();
+    }
+  });
+
+  it("Enter selects the project the active descendant points at", () => {
+    const onSelect = vi.fn();
+    render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={1} onSelect={onSelect} />);
+
+    const input = screen.getByTestId("palette-input");
+    const activeDescendantId = input.getAttribute("aria-activedescendant");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const selectedProject = onSelect.mock.calls[0]![0] as SearchableProject;
+    expect(`project-option-${selectedProject.id}`).toBe(activeDescendantId);
+    expect(document.getElementById(activeDescendantId!)).not.toBeNull();
+  });
+});

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -298,19 +298,22 @@ describe("ProjectSwitcherPalette active descendant", () => {
     mode: "modal" as const,
   };
 
-  it.each(mixedResults.map((project, index) => [index, project.id] as const))(
+  it.each(mixedResults.map((project, index) => [index, project.name] as const))(
     "resolves aria-activedescendant to the selected option at index %i",
-    (selectedIndex, expectedId) => {
+    (selectedIndex, expectedName) => {
       render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={selectedIndex} />);
 
       const input = screen.getByTestId("palette-input");
       const activeDescendantId = input.getAttribute("aria-activedescendant");
-      expect(activeDescendantId).toBe(`project-option-${expectedId}`);
+      expect(activeDescendantId).toBeTruthy();
 
+      // The id must resolve to a real option — under the old two-array split it
+      // named a row that had been filtered out of the DOM.
       const activeOption = document.getElementById(activeDescendantId!);
       expect(activeOption).not.toBeNull();
       expect(activeOption!.getAttribute("role")).toBe("option");
       expect(activeOption!.getAttribute("aria-selected")).toBe("true");
+      expect(activeOption!.textContent).toContain(expectedName);
     }
   );
 
@@ -330,12 +333,15 @@ describe("ProjectSwitcherPalette active descendant", () => {
     render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={1} onSelect={onSelect} />);
 
     const input = screen.getByTestId("palette-input");
-    const activeDescendantId = input.getAttribute("aria-activedescendant");
+    const activeOption = document.getElementById(input.getAttribute("aria-activedescendant")!);
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(onSelect).toHaveBeenCalledTimes(1);
     const selectedProject = onSelect.mock.calls[0]![0] as SearchableProject;
-    expect(`project-option-${selectedProject.id}`).toBe(activeDescendantId);
-    expect(document.getElementById(activeDescendantId!)).not.toBeNull();
+    // Enter must commit the row the user can actually see highlighted. Old code
+    // pointed ARIA and Enter at the same *hidden* project — consistently wrong —
+    // so this only holds if the highlighted option is really in the DOM.
+    expect(activeOption).not.toBeNull();
+    expect(activeOption!.textContent).toContain(selectedProject.name);
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -329,7 +329,7 @@ describe("ProjectSwitcherPalette active descendant", () => {
   });
 
   it("Enter selects the project the active descendant points at", () => {
-    const onSelect = vi.fn();
+    const onSelect = vi.fn<(project: SearchableProject) => void>();
     render(<ProjectSwitcherPalette {...mixedProps} selectedIndex={1} onSelect={onSelect} />);
 
     const input = screen.getByTestId("palette-input");
@@ -337,7 +337,7 @@ describe("ProjectSwitcherPalette active descendant", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(onSelect).toHaveBeenCalledTimes(1);
-    const selectedProject = onSelect.mock.calls[0]![0] as SearchableProject;
+    const selectedProject = onSelect.mock.calls[0]![0];
     // Enter must commit the row the user can actually see highlighted. Old code
     // pointed ARIA and Enter at the same *hidden* project — consistently wrong —
     // so this only holds if the highlighted option is really in the DOM.

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -351,10 +351,12 @@ describe("ProjectSwitcherPalette modal mode", () => {
   it("renders every supplied result as an option in modal mode", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
     const list = screen.getByRole("listbox", { name: "Projects" });
-    const optionIds = within(list)
-      .getAllByRole("option")
-      .map((option) => option.id);
-    expect(optionIds).toEqual(multiProjects.map((p) => `project-option-${p.id}`));
+    const options = within(list).getAllByRole("option");
+
+    expect(options).toHaveLength(multiProjects.length);
+    multiProjects.forEach((project, index) => {
+      expect(options[index]!.textContent).toContain(project.name);
+    });
   });
 
   it("renders a flat list with no temporal section labels in modal mode", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 const originalScrollIntoView = Element.prototype.scrollIntoView;
 beforeAll(() => {
@@ -344,29 +344,30 @@ describe("ProjectSwitcherPalette modal mode", () => {
     }),
   ];
 
-  it("shows only active/open projects in modal mode (no closed projects)", () => {
+  // Scoping modal browse to switchable projects is the hook's job
+  // (useProjectSwitcherPalette's `results` memo). The component renders what
+  // it is handed, verbatim — re-filtering here is what stranded the keyboard
+  // selection on a row that was never in the DOM (#11071).
+  it("renders every supplied result as an option in modal mode", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
-    expect(screen.getByText("Active Project")).toBeTruthy();
-    expect(screen.getByText("Background Project")).toBeTruthy();
-    expect(screen.queryByText("Pinned Project")).toBeNull();
-    expect(screen.queryByText("Recent Project")).toBeNull();
-    expect(screen.queryByText("Old Project")).toBeNull();
+    const list = screen.getByRole("listbox", { name: "Projects" });
+    const optionIds = within(list)
+      .getAllByRole("option")
+      .map((option) => option.id);
+    expect(optionIds).toEqual(multiProjects.map((p) => `project-option-${p.id}`));
   });
 
   it("renders a flat list with no temporal section labels in modal mode", () => {
-    render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
+    const scopedModalResults = multiProjects.filter((p) => p.isActive || p.isBackground);
+    render(<ProjectSwitcherPalette {...modalProps} results={scopedModalResults} />);
     expect(screen.queryByText("Pinned")).toBeNull();
     expect(screen.queryByText("Today")).toBeNull();
     expect(screen.queryByText("This Week")).toBeNull();
     expect(screen.queryByText("Older")).toBeNull();
   });
 
-  it("shows 'No active projects' when no projects are active/open in modal mode", () => {
-    const closedProjects = [
-      makeProject({ id: "closed1", name: "Closed 1" }),
-      makeProject({ id: "closed2", name: "Closed 2" }),
-    ];
-    render(<ProjectSwitcherPalette {...modalProps} results={closedProjects} />);
+  it("shows 'No active projects' when modal mode has no results", () => {
+    render(<ProjectSwitcherPalette {...modalProps} results={[]} />);
     expect(screen.getByText("No active projects")).toBeTruthy();
   });
 

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1419,25 +1419,111 @@ describe("useProjectSwitcherPalette", () => {
       expect(projectState.reopenProject).not.toHaveBeenCalledWith("closed");
     });
 
-    it("preselects row 2 of the destination list when reopening in a different mode", async () => {
+    it("preselects against the destination list, not the mode being left", async () => {
+      // Only the current project survives modal scope here, so the row-2 rule
+      // MUST resolve against the destination list: counting all projects (or
+      // the outgoing mode's list) would preselect a row modal doesn't have.
+      projectState.projects = [interleaved[0]!, interleaved[1]!];
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(["current", "closed"]));
+
       const { result } = renderHook(() => useProjectSwitcherPalette());
 
       act(() => {
         result.current.open("dropdown");
       });
       await waitFor(() => {
-        expect(result.current.results).toHaveLength(interleaved.length);
+        expect(result.current.results).toHaveLength(2);
       });
-      expect(result.current.results[result.current.selectedIndex]!.id).toBe("closed");
+      // Dropdown lists both, so row 2 is the closed project.
+      expect(result.current.selectedIndex).toBe(1);
+      expect(result.current.results[1]!.id).toBe("closed");
 
       act(() => {
         result.current.open("modal");
       });
       await waitFor(() => {
-        expect(result.current.results).toHaveLength(2);
+        expect(result.current.results).toHaveLength(1);
       });
-      // Same row-2 rule, but resolved against the scoped list this time.
-      expect(result.current.results[result.current.selectedIndex]!.id).toBe("background");
+      // Modal has a single row — the only valid selection is it.
+      expect(result.current.selectedIndex).toBe(0);
+      expect(result.current.results[0]!.id).toBe("current");
+    });
+
+    it("keeps a switchable project past the unscoped window inside modal browse", async () => {
+      // Enough recent idle projects to fill the results cap on their own. The
+      // background project is the stalest of all, so scoping BEFORE the cap is
+      // the only way it survives — capping first would slice it away.
+      const idle = Array.from({ length: 20 }, (_, i) => ({
+        id: `idle-${i}`,
+        name: `Idle ${i}`,
+        path: `/repo/idle-${i}`,
+        emoji: "🌿",
+        lastOpened: 1000 - i,
+        frecencyScore: 1.0,
+        status: "closed" as const,
+      }));
+      const stale = {
+        id: "stale-background",
+        name: "Stale Background",
+        path: "/repo/stale",
+        emoji: "🌴",
+        lastOpened: 1,
+        frecencyScore: 1.0,
+        status: "background" as const,
+      };
+
+      projectState.projects = [...idle, stale];
+      projectState.currentProject = null;
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats([...idle.map((p) => p.id), stale.id]));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open("modal");
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.map((p) => p.id)).toEqual(["stale-background"]);
+      });
+    });
+
+    it("keeps the highlight on the selected project when a row above it disappears", async () => {
+      const withThreeVisible = [
+        interleaved[0]!,
+        { ...interleaved[2]!, id: "bg-a", name: "Background A", lastOpened: 250 },
+        { ...interleaved[2]!, id: "bg-b", name: "Background B", lastOpened: 150 },
+        { ...interleaved[2]!, id: "bg-c", name: "Background C", lastOpened: 50 },
+      ];
+      projectState.projects = withThreeVisible;
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(withThreeVisible.map((p) => p.id)));
+
+      const { result, rerender } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(4);
+      });
+
+      // Land on a MIDDLE row: bg-b at index 2.
+      act(() => {
+        result.current.selectNext();
+      });
+      expect(result.current.results[result.current.selectedIndex]!.id).toBe("bg-b");
+
+      // A row ABOVE the selection goes away — every later row shifts up one.
+      act(() => {
+        projectState.projects = withThreeVisible.filter((p) => p.id !== "bg-a");
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      // The highlight tracks the project, not the slot it used to occupy.
+      expect(result.current.results[result.current.selectedIndex]!.id).toBe("bg-b");
+      expect(result.current.selectedIndex).toBeLessThan(result.current.results.length);
     });
 
     it("still finds a scoped-out project by search", async () => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1,6 +1,24 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectStatus } from "@shared/types";
+
+/**
+ * `status` is widened to the full union so a describe can pin a fixture to any
+ * lifecycle state — inferring it from the default fixture would freeze the
+ * shared array at that one literal.
+ */
+type ProjectFixture = {
+  id: string;
+  name: string;
+  path: string;
+  emoji: string;
+  lastOpened: number;
+  status: ProjectStatus;
+  color?: string;
+  frecencyScore?: number;
+  pinned?: boolean;
+};
 
 const {
   getBulkStatsMock,
@@ -28,19 +46,25 @@ const {
     projectStatsState.stats = stats;
   });
 
+  // Modal browse lists only projects the user can switch to right now, so a
+  // fixture that is not `currentProject` needs a reason to be listed —
+  // "background" is the realistic one. A "closed"/idle non-current project is
+  // correctly absent from `results` (#11071).
+  const defaultProjects: ProjectFixture[] = [
+    {
+      id: "project-1",
+      name: "Project One",
+      path: "/repo/one",
+      emoji: "🌲",
+      color: "#00aa00",
+      lastOpened: 123,
+      frecencyScore: 3.0,
+      status: "background",
+    },
+  ];
+
   const projectState = {
-    projects: [
-      {
-        id: "project-1",
-        name: "Project One",
-        path: "/repo/one",
-        emoji: "🌲",
-        color: "#00aa00",
-        lastOpened: 123,
-        frecencyScore: 3.0,
-        status: "active" as const,
-      },
-    ],
+    projects: defaultProjects,
     currentProject: null as { id: string } | null,
     switchProject: vi.fn().mockResolvedValue(undefined),
     reopenProject: vi.fn().mockResolvedValue(undefined),
@@ -222,7 +246,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00bb00",
         lastOpened: 200,
         frecencyScore: 7.0,
-        status: "active" as const,
+        status: "background" as const,
       },
       {
         id: "project-3",
@@ -232,7 +256,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00cc00",
         lastOpened: 100,
         frecencyScore: 3.0,
-        status: "active" as const,
+        status: "background" as const,
       },
     ];
 
@@ -324,7 +348,7 @@ describe("useProjectSwitcherPalette", () => {
           color: "#00aa00",
           lastOpened: 100,
           frecencyScore: 50.0,
-          status: "active" as const,
+          status: "background" as const,
         },
         {
           id: "project-b",
@@ -334,7 +358,7 @@ describe("useProjectSwitcherPalette", () => {
           color: "#00bb00",
           lastOpened: 300,
           frecencyScore: 1.0,
-          status: "active" as const,
+          status: "background" as const,
         },
       ];
 
@@ -379,7 +403,7 @@ describe("useProjectSwitcherPalette", () => {
       color: "#00bb00",
       lastOpened: 200,
       frecencyScore: 5.0,
-      status: "active" as const,
+      status: "background" as const,
     };
 
     beforeEach(() => {
@@ -596,7 +620,7 @@ describe("useProjectSwitcherPalette", () => {
           color: "#00aa00",
           lastOpened: 123,
           frecencyScore: 3.0,
-          status: "active" as const,
+          status: "background" as const,
         },
       ];
       projectState.currentProject = null;
@@ -727,7 +751,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00aa00",
         lastOpened: 1000 - i,
         frecencyScore: 1.0,
-        status: "active" as const,
+        status: "background" as const,
       };
     }
 
@@ -836,7 +860,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00aa00",
         lastOpened: 300,
         frecencyScore: 10.0,
-        status: "active" as const,
+        status: "background" as const,
       },
       {
         id: "project-2",
@@ -846,7 +870,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00bb00",
         lastOpened: 200,
         frecencyScore: 7.0,
-        status: "active" as const,
+        status: "background" as const,
       },
       {
         id: "project-3",
@@ -856,7 +880,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00cc00",
         lastOpened: 100,
         frecencyScore: 3.0,
-        status: "active" as const,
+        status: "background" as const,
       },
     ];
 
@@ -953,7 +977,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00bb00",
         lastOpened: 200,
         frecencyScore: 7.0,
-        status: "active" as const,
+        status: "background" as const,
       },
       {
         id: "project-3",
@@ -963,7 +987,7 @@ describe("useProjectSwitcherPalette", () => {
         color: "#00cc00",
         lastOpened: 100,
         frecencyScore: 3.0,
-        status: "active" as const,
+        status: "background" as const,
       },
     ];
 
@@ -1074,7 +1098,7 @@ describe("useProjectSwitcherPalette", () => {
           color: "#00cc00",
           lastOpened: 100,
           frecencyScore: 3.0,
-          status: "active" as const,
+          status: "background" as const,
         },
         {
           id: "project-2",
@@ -1094,7 +1118,7 @@ describe("useProjectSwitcherPalette", () => {
           color: "#00bb00",
           lastOpened: 200,
           frecencyScore: 7.0,
-          status: "active" as const,
+          status: "background" as const,
         },
       ];
 
@@ -1279,6 +1303,182 @@ describe("useProjectSwitcherPalette", () => {
       } finally {
         window.removeEventListener("unhandledrejection", unhandled);
       }
+    });
+  });
+
+  // #11071: modal browse used to render a narrower list than the one
+  // selectedIndex walked, so arrowing could land on a project that was never
+  // on screen — no highlight, and Enter switched to an off-screen project.
+  // `results` is now the single array the palette scopes, renders and indexes.
+  describe("modal browse scope — issue #11071", () => {
+    // MRU order interleaves a closed project between the two the modal shows,
+    // which is exactly the arrangement that stranded the selection.
+    const interleaved = [
+      {
+        id: "current",
+        name: "Current Project",
+        path: "/repo/current",
+        emoji: "🌲",
+        color: "#00aa00",
+        lastOpened: 300,
+        frecencyScore: 10.0,
+        status: "active" as const,
+      },
+      {
+        id: "closed",
+        name: "Closed Project",
+        path: "/repo/closed",
+        emoji: "🌿",
+        color: "#00bb00",
+        lastOpened: 200,
+        frecencyScore: 7.0,
+        status: "closed" as const,
+      },
+      {
+        id: "background",
+        name: "Background Project",
+        path: "/repo/background",
+        emoji: "🌴",
+        color: "#00cc00",
+        lastOpened: 100,
+        frecencyScore: 3.0,
+        status: "background" as const,
+      },
+    ];
+
+    beforeEach(() => {
+      projectState.projects = interleaved;
+      projectState.currentProject = { id: "current" };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(interleaved.map((p) => p.id)));
+    });
+
+    async function openModal() {
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.isOpen).toBe(true);
+      });
+      return result;
+    }
+
+    it("omits an idle project from modal browse even when it is more recent", async () => {
+      const result = await openModal();
+
+      await waitFor(() => {
+        expect(result.current.results.map((p) => p.id)).toEqual(["current", "background"]);
+      });
+    });
+
+    it("lands every arrow step on a project that is actually in results", async () => {
+      const result = await openModal();
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+
+      // One full cycle in each direction: every stop must be a rendered row.
+      const visited: string[] = [];
+      for (let step = 0; step < result.current.results.length * 2; step++) {
+        const selected = result.current.results[result.current.selectedIndex];
+        expect(selected).toBeDefined();
+        visited.push(selected!.id);
+        act(() => {
+          result.current.selectNext();
+        });
+      }
+      for (let step = 0; step < result.current.results.length; step++) {
+        act(() => {
+          result.current.selectPrevious();
+        });
+        expect(result.current.results[result.current.selectedIndex]).toBeDefined();
+      }
+
+      expect(visited).not.toContain("closed");
+    });
+
+    it("confirmSelection switches to the highlighted project, never a scoped-out one", async () => {
+      const result = await openModal();
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+
+      // Row 2 is the MRU switch target — under the old unscoped index this was
+      // the closed project sitting at results[1].
+      const highlighted = result.current.results[result.current.selectedIndex]!;
+      expect(highlighted.id).toBe("background");
+
+      act(() => {
+        result.current.confirmSelection();
+      });
+
+      await waitFor(() => {
+        expect(projectState.reopenProject).toHaveBeenCalledWith("background");
+      });
+      expect(projectState.switchProject).not.toHaveBeenCalledWith("closed");
+      expect(projectState.reopenProject).not.toHaveBeenCalledWith("closed");
+    });
+
+    it("preselects row 2 of the destination list when reopening in a different mode", async () => {
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open("dropdown");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(interleaved.length);
+      });
+      expect(result.current.results[result.current.selectedIndex]!.id).toBe("closed");
+
+      act(() => {
+        result.current.open("modal");
+      });
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+      // Same row-2 rule, but resolved against the scoped list this time.
+      expect(result.current.results[result.current.selectedIndex]!.id).toBe("background");
+    });
+
+    it("still finds a scoped-out project by search", async () => {
+      const result = await openModal();
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(2);
+      });
+
+      act(() => {
+        result.current.setQuery("Closed");
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.map((p) => p.id)).toContain("closed");
+      });
+    });
+
+    it("keeps a scoped-out project's agents in the badge totals", async () => {
+      // Agent counts and process counts arrive from separate ProjectStatsService
+      // calls, so a waiting agent can land before its process count does. The
+      // badge reads uncapped, unscoped totals so it can't blink off just
+      // because modal browse drops that project for a beat.
+      getBulkStatsMock.mockResolvedValue({
+        ...emptyBulkStats(interleaved.map((p) => p.id)),
+        closed: {
+          processCount: 0,
+          terminalCount: 0,
+          estimatedMemoryMB: 0,
+          terminalTypes: {},
+          processIds: [],
+          activeAgentCount: 0,
+          waitingAgentCount: 2,
+        },
+      });
+
+      const result = await openModal();
+
+      await waitFor(() => {
+        expect(result.current.nonActiveAgentCounts.waitingAgentCount).toBe(2);
+      });
+      expect(result.current.results.map((p) => p.id)).not.toContain("closed");
     });
   });
 });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -175,15 +175,20 @@ function isVisibleInModalBrowse(project: SearchableProject): boolean {
  * arrow keys walk. Rank (when searching), then scope, then cap: the cap
  * belongs to the eligible set, so a background project sitting past the first
  * 15 unscoped rows still surfaces in modal browse.
+ *
+ * `isSearching` tracks the live query while `rankQuery` is the deferred one:
+ * the moment the user types, browse scope lifts, even though the ranking is
+ * still catching up. Deriving both from the deferred query would flash
+ * "No projects match" over a scoped-empty list on the first keystroke.
  */
 function buildResults(
   sortedProjects: SearchableProject[],
   mode: ProjectSwitcherMode,
-  query: string
+  rankQuery: string,
+  isSearching: boolean
 ): SearchableProject[] {
-  const trimmed = query.trim();
-  const ranked = trimmed ? rankProjectMatches(query, sortedProjects) : sortedProjects;
-  const scoped = mode === "modal" && !trimmed ? ranked.filter(isVisibleInModalBrowse) : ranked;
+  const ranked = rankQuery.trim() ? rankProjectMatches(rankQuery, sortedProjects) : sortedProjects;
+  const scoped = mode === "modal" && !isSearching ? ranked.filter(isVisibleInModalBrowse) : ranked;
   return scoped.slice(0, MAX_RESULTS);
 }
 
@@ -211,8 +216,11 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const isOpen = mode === "modal" ? modalIsOpen : dropdownIsOpen;
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
-  const isFiltering = query !== deferredQuery;
-  const [selectedIndexState, setSelectedIndex] = useState(0);
+  const isSearching = query.trim().length > 0;
+  // Only stale while a search is still catching up. Clearing the box restores
+  // browse in the same commit, so that transition is never "filtering".
+  const isFiltering = isSearching && query !== deferredQuery;
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [stopConfirmProjectId, setStopConfirmProjectId] = useState<string | null>(null);
   const [isStoppingProject, setIsStoppingProject] = useState(false);
   const [removeConfirmProject, setRemoveConfirmProject] = useState<SearchableProject | null>(null);
@@ -225,8 +233,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     project: Project;
   } | null>(null);
   const [isDeletingOriginalScratch, setIsDeletingOriginalScratch] = useState(false);
-  const selectedProjectIdRef = useRef<string | null>(null);
-
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prefetchInFlightRef = useRef<Set<string>>(new Set());
   const prefetchLastAtRef = useRef<Map<string, number>>(new Map());
@@ -345,21 +351,28 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   }, [searchableProjects]);
 
   // Clearing the box reverts to browse immediately rather than holding the
-  // deferred search for a commit — otherwise modal browse would flash the
-  // unscoped search results on the way back to an empty query.
-  const resultsQuery = query.trim() ? deferredQuery : "";
+  // deferred ranking for a commit — otherwise browse would flash the stale
+  // search ranking on the way back to an empty query.
+  const resultsQuery = isSearching ? deferredQuery : "";
 
   const results = useMemo<SearchableProject[]>(
-    () => buildResults(sortedProjects, mode, resultsQuery),
-    [sortedProjects, mode, resultsQuery]
+    () => buildResults(sortedProjects, mode, resultsQuery, isSearching),
+    [sortedProjects, mode, resultsQuery, isSearching]
   );
 
-  // `selectedIndex` state can outrun `results` for a commit when a stats push
-  // shrinks the list, and the resync effect below only lands after paint.
-  // Clamping on read keeps every consumer — highlight, aria-activedescendant,
-  // Enter — pointed at a row that is actually on screen.
-  const selectedIndex =
-    results.length === 0 ? 0 : Math.min(Math.max(selectedIndexState, 0), results.length - 1);
+  // The selected PROJECT is the state; its index is derived. Tracking an index
+  // instead would let it outlive the row it pointed at — a list that shrinks
+  // under an open palette (a project closing, a stats push) would leave the
+  // index addressing a different project than the user selected, and Enter
+  // would commit that one (#11071). Deriving means the highlight follows the
+  // project across reorders and never addresses a row that isn't rendered.
+  const selectedIndex = useMemo(() => {
+    if (results.length === 0) return 0;
+    const index = selectedProjectId
+      ? results.findIndex((project) => project.id === selectedProjectId)
+      : -1;
+    return index >= 0 ? index : 0;
+  }, [results, selectedProjectId]);
 
   // Decoupled from `results` so the toolbar pill keeps the active project's
   // pin/process state even when search filters exclude it or it sits outside
@@ -369,34 +382,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     [searchableProjects]
   );
 
-  useEffect(() => {
-    if (results.length === 0) {
-      selectedProjectIdRef.current = null;
-      setSelectedIndex(0);
-      return;
-    }
-
-    const selectedId = selectedProjectIdRef.current;
-    if (selectedId) {
-      const nextIndex = results.findIndex((project) => project.id === selectedId);
-      if (nextIndex >= 0) {
-        setSelectedIndex((prev) => (prev === nextIndex ? prev : nextIndex));
-        return;
-      }
-    }
-
-    setSelectedIndex((prev) => Math.min(prev, results.length - 1));
-  }, [results]);
-
-  useEffect(() => {
-    if (results.length === 0) return;
-    selectedProjectIdRef.current = results[selectedIndex]!.id;
-  }, [results, selectedIndex]);
-
+  // A new query re-ranks the list, so fall back to the top match.
   useEffect(() => {
     if (query) {
-      selectedProjectIdRef.current = null;
-      setSelectedIndex(0);
+      setSelectedProjectId(null);
     }
   }, [query]);
 
@@ -425,12 +414,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         setDropdownIsOpen(true);
       }
       setQuery("");
-      selectedProjectIdRef.current = null;
       // Preselect row 2 (the MRU switch target) against the list the palette is
       // about to render. `mode` state hasn't committed yet, so `results` still
       // describes the mode we're leaving — build the destination list instead.
-      const initialResults = buildResults(sortedProjects, nextMode, "");
-      setSelectedIndex(initialResults.length >= 2 ? 1 : 0);
+      const initialResults = buildResults(sortedProjects, nextMode, "", false);
+      const initial = initialResults[initialResults.length >= 2 ? 1 : 0];
+      setSelectedProjectId(initial?.id ?? null);
     },
     [sortedProjects]
   );
@@ -442,32 +431,40 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       setDropdownIsOpen(false);
     }
     setQuery("");
-    setSelectedIndex(0);
+    setSelectedProjectId(null);
   }, [mode]);
+
+  // Steps the selection by `delta` rows, wrapping. Resolves the current row
+  // from the id inside the updater so two calls batched into one tick compose
+  // (the second sees where the first landed) instead of collapsing into one.
+  const step = useCallback(
+    (delta: number) => {
+      if (results.length === 0) return;
+      setSelectedProjectId((previousId) => {
+        const current = previousId ? results.findIndex((project) => project.id === previousId) : -1;
+        const from = current >= 0 ? current : 0;
+        const next = (from + delta + results.length) % results.length;
+        return results[next]!.id;
+      });
+    },
+    [results]
+  );
 
   const toggle = useCallback(
     (nextMode: ProjectSwitcherMode = "modal") => {
       const currentlyOpen = nextMode === "modal" ? modalIsOpen : dropdownIsOpen;
       if (currentlyOpen) {
-        if (results.length <= 1) return;
-        const next = selectedIndex + 1;
-        setSelectedIndex(next >= results.length ? 0 : next);
+        step(1);
       } else {
         open(nextMode);
       }
     },
-    [modalIsOpen, dropdownIsOpen, open, results.length, selectedIndex]
+    [modalIsOpen, dropdownIsOpen, open, step]
   );
 
-  const selectPrevious = useCallback(() => {
-    if (results.length === 0) return;
-    setSelectedIndex(selectedIndex <= 0 ? results.length - 1 : selectedIndex - 1);
-  }, [results.length, selectedIndex]);
+  const selectPrevious = useCallback(() => step(-1), [step]);
 
-  const selectNext = useCallback(() => {
-    if (results.length === 0) return;
-    setSelectedIndex(selectedIndex >= results.length - 1 ? 0 : selectedIndex + 1);
-  }, [results.length, selectedIndex]);
+  const selectNext = useCallback(() => step(1), [step]);
 
   const selectProject = useCallback(
     async (project: SearchableProject) => {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -49,6 +49,12 @@ export interface UseProjectSwitcherPaletteReturn {
   isOpen: boolean;
   mode: ProjectSwitcherMode;
   query: string;
+  /**
+   * The projects the palette renders, in render order — and the only array
+   * `selectedIndex` may be read against. In modal browse this is scoped to the
+   * projects the user can switch between right now; the dropdown and every
+   * search list the full set.
+   */
   results: SearchableProject[];
   /** True while `deferredQuery` has not yet caught up to `query` — the results shown are from the previous query. */
   isFiltering: boolean;
@@ -60,6 +66,10 @@ export interface UseProjectSwitcherPaletteReturn {
    * by the current `query`.
    */
   activeProject: SearchableProject | null;
+  /**
+   * Index into {@link results}. Always in range whenever `results` is
+   * non-empty, so `results[selectedIndex]` is guaranteed to be a rendered row.
+   */
   selectedIndex: number;
   open: (mode?: ProjectSwitcherMode) => void;
   close: () => void;
@@ -116,6 +126,14 @@ export interface UseProjectSwitcherPaletteReturn {
   confirmFreeMemory: () => Promise<void>;
   isFreeingMemory: boolean;
   backgroundWaitingCount: number;
+  /**
+   * Agent totals across every non-active project, uncapped and independent of
+   * `mode`/`query`. Kept off `results` on purpose: that array is scoped for
+   * presentation, and a project whose agent counts have landed before its
+   * process count (the two arrive from separate `ProjectStatsService` calls)
+   * would otherwise drop out of the toolbar badge for a beat.
+   */
+  nonActiveAgentCounts: { activeAgentCount: number; waitingAgentCount: number };
   /** Scratch (one-off agent workspace) view-models, sorted by lastOpened desc. */
   scratchResults: SearchableScratch[];
   /** Create and immediately switch to a new scratch. Closes the palette on success. */
@@ -144,6 +162,32 @@ export interface UseProjectSwitcherPaletteReturn {
 const MAX_RESULTS = 15;
 
 /**
+ * Modal browse lists only the projects the user can switch between right now.
+ * Deliberately not named "switchable": the active project matches too, and
+ * `selectProject` is a no-op for it.
+ */
+function isVisibleInModalBrowse(project: SearchableProject): boolean {
+  return project.isActive || project.isBackground || project.processCount > 0;
+}
+
+/**
+ * Builds the palette's one array — the rows that render AND the rows the
+ * arrow keys walk. Rank (when searching), then scope, then cap: the cap
+ * belongs to the eligible set, so a background project sitting past the first
+ * 15 unscoped rows still surfaces in modal browse.
+ */
+function buildResults(
+  sortedProjects: SearchableProject[],
+  mode: ProjectSwitcherMode,
+  query: string
+): SearchableProject[] {
+  const trimmed = query.trim();
+  const ranked = trimmed ? rankProjectMatches(query, sortedProjects) : sortedProjects;
+  const scoped = mode === "modal" && !trimmed ? ranked.filter(isVisibleInModalBrowse) : ranked;
+  return scoped.slice(0, MAX_RESULTS);
+}
+
+/**
  * Trailing-edge debounce window for the project hover prefetch. Matches the
  * GitHub-stats toolbar pattern (#6282) — long enough to filter cursor
  * traversal across the list, short enough to feel "instant" on intentional
@@ -168,7 +212,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const isFiltering = query !== deferredQuery;
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedIndexState, setSelectedIndex] = useState(0);
   const [stopConfirmProjectId, setStopConfirmProjectId] = useState<string | null>(null);
   const [isStoppingProject, setIsStoppingProject] = useState(false);
   const [removeConfirmProject, setRemoveConfirmProject] = useState<SearchableProject | null>(null);
@@ -280,6 +324,17 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     [searchableProjects]
   );
 
+  const nonActiveAgentCounts = useMemo(() => {
+    let activeAgentCount = 0;
+    let waitingAgentCount = 0;
+    for (const project of searchableProjects) {
+      if (project.isActive) continue;
+      activeAgentCount += project.activeAgentCount;
+      waitingAgentCount += project.waitingAgentCount;
+    }
+    return { activeAgentCount, waitingAgentCount };
+  }, [searchableProjects]);
+
   const sortedProjects = useMemo<SearchableProject[]>(() => {
     return [...searchableProjects].sort((a, b) => {
       if (a.lastOpened !== b.lastOpened) {
@@ -289,13 +344,22 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     });
   }, [searchableProjects]);
 
-  const results = useMemo<SearchableProject[]>(() => {
-    if (!deferredQuery.trim()) {
-      return sortedProjects.slice(0, MAX_RESULTS);
-    }
+  // Clearing the box reverts to browse immediately rather than holding the
+  // deferred search for a commit — otherwise modal browse would flash the
+  // unscoped search results on the way back to an empty query.
+  const resultsQuery = query.trim() ? deferredQuery : "";
 
-    return rankProjectMatches(deferredQuery, sortedProjects).slice(0, MAX_RESULTS);
-  }, [deferredQuery, sortedProjects]);
+  const results = useMemo<SearchableProject[]>(
+    () => buildResults(sortedProjects, mode, resultsQuery),
+    [sortedProjects, mode, resultsQuery]
+  );
+
+  // `selectedIndex` state can outrun `results` for a commit when a stats push
+  // shrinks the list, and the resync effect below only lands after paint.
+  // Clamping on read keeps every consumer — highlight, aria-activedescendant,
+  // Enter — pointed at a row that is actually on screen.
+  const selectedIndex =
+    results.length === 0 ? 0 : Math.min(Math.max(selectedIndexState, 0), results.length - 1);
 
   // Decoupled from `results` so the toolbar pill keeps the active project's
   // pin/process state even when search filters exclude it or it sits outside
@@ -326,7 +390,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
 
   useEffect(() => {
     if (results.length === 0) return;
-    if (selectedIndex < 0 || selectedIndex >= results.length) return;
     selectedProjectIdRef.current = results[selectedIndex]!.id;
   }, [results, selectedIndex]);
 
@@ -363,9 +426,13 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       }
       setQuery("");
       selectedProjectIdRef.current = null;
-      setSelectedIndex(searchableProjects.length >= 2 ? 1 : 0);
+      // Preselect row 2 (the MRU switch target) against the list the palette is
+      // about to render. `mode` state hasn't committed yet, so `results` still
+      // describes the mode we're leaving — build the destination list instead.
+      const initialResults = buildResults(sortedProjects, nextMode, "");
+      setSelectedIndex(initialResults.length >= 2 ? 1 : 0);
     },
-    [searchableProjects.length]
+    [sortedProjects]
   );
 
   const close = useCallback(() => {
@@ -382,27 +449,25 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     (nextMode: ProjectSwitcherMode = "modal") => {
       const currentlyOpen = nextMode === "modal" ? modalIsOpen : dropdownIsOpen;
       if (currentlyOpen) {
-        setSelectedIndex((prev) => {
-          if (results.length <= 1) return prev;
-          const next = prev + 1;
-          return next >= results.length ? 0 : next;
-        });
+        if (results.length <= 1) return;
+        const next = selectedIndex + 1;
+        setSelectedIndex(next >= results.length ? 0 : next);
       } else {
         open(nextMode);
       }
     },
-    [modalIsOpen, dropdownIsOpen, open, results]
+    [modalIsOpen, dropdownIsOpen, open, results.length, selectedIndex]
   );
 
   const selectPrevious = useCallback(() => {
     if (results.length === 0) return;
-    setSelectedIndex((prev) => (prev <= 0 ? results.length - 1 : prev - 1));
-  }, [results.length]);
+    setSelectedIndex(selectedIndex <= 0 ? results.length - 1 : selectedIndex - 1);
+  }, [results.length, selectedIndex]);
 
   const selectNext = useCallback(() => {
     if (results.length === 0) return;
-    setSelectedIndex((prev) => (prev >= results.length - 1 ? 0 : prev + 1));
-  }, [results.length]);
+    setSelectedIndex(selectedIndex >= results.length - 1 ? 0 : selectedIndex + 1);
+  }, [results.length, selectedIndex]);
 
   const selectProject = useCallback(
     async (project: SearchableProject) => {
@@ -483,9 +548,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   useEffect(() => () => clearPendingPrefetchTimer(), [clearPendingPrefetchTimer]);
 
   const confirmSelection = useCallback(() => {
-    if (results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length) {
-      selectProject(results[selectedIndex]!);
-    }
+    if (results.length === 0) return;
+    selectProject(results[selectedIndex]!);
   }, [results, selectedIndex, selectProject]);
 
   const addProject = useCallback(async () => {
@@ -898,6 +962,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     confirmFreeMemory,
     isFreeingMemory,
     backgroundWaitingCount,
+    nonActiveAgentCounts,
     scratchResults,
     createScratch,
     selectScratch,


### PR DESCRIPTION
## The bug

Modal browse in the project switcher renders a filtered subset of the hook's `results` array (only projects that are active, background, or holding processes), but every selection consumer indexed the unfiltered array: `selectedIndex`, `selectNext`/`selectPrevious`, `confirmSelection`, `aria-activedescendant`, the scroll-into-view effect, Enter, and Cmd+Backspace.

Arrowing onto a project that modal browse had filtered out left `aria-activedescendant` naming an id with no DOM node: nothing highlighted for that step, and Enter switched to a project that wasn't on screen. A non-resolving `aria-activedescendant` isn't just a visual glitch, it's a WAI-ARIA violation: screen readers drop or repeat stale announcements.

Resolves #11071

## The fix

`results` is now the single array the palette scopes, renders, indexes, and walks (`useProjectSwitcherPalette.ts`). The component renders it verbatim: `displayResults` and `resultIndexMap` are gone, and rows get `isSelected` by id at the map site.

- Modal-browse scope moved into the hook's `results` memo, applied before the 15-item cap, so a background project sitting past the first 15 unscoped rows still surfaces (the old order capped first, then filtered).
- The selected project is now the state, its index is derived. Tracking an index instead let it outlive the row it pointed at: a list that shrinks under an open palette would leave the index addressing a different project than the one picked. Both selection-resync effects and the id ref are gone.
- Arrow steps resolve the current row inside the state updater, so two calls batched into one tick compose instead of collapsing.
- `open()` computes its row-2 (MRU switch target) preselect against the list the destination mode will actually render, not the mode being left.
- Browse scope lifts on the live query while ranking follows the deferred query. Deriving both from the deferred query flashed "No projects match" over a scoped-empty list on the first keystroke.
- The toolbar's background-agent badge now reads uncapped, unscoped agent totals instead of `results`. Agent counts and process counts arrive from separate `ProjectStatsService` calls, so a project whose agent count landed first would fail the modal predicate and blink the badge off. Caught this in review, having wrongly assumed agents imply a non-zero process count.

## Tests

191 tests green across the touched modules. New regression coverage that fails against the old code: `aria-activedescendant` resolves to a rendered `role="option"` at every index, Enter commits the highlighted row, modal browse omits an idle project even when it's more recent, a switchable project past the unscoped window survives the cap, selection tracks its project when a row above it disappears, and the badge counts agents on projects absent from `results`.

## Out of scope (pre-existing, found while reviewing)

- The Scratch section sits outside the arrow-key sequence. The issue itself calls this a non-blocking follow-on.
- `ActionPalette`'s "/" route calls `openPalette("project-switcher")` directly instead of the hook's `open()`, so if a dropdown was opened earlier in the session the hook's `mode` is still `"dropdown"` and the modal never mounts (Cmd+Alt+P can't recover). Separate mode-routing bug, worth its own issue.
- In dropdown mode the temporal sections (current/pinned/today/etc.) reorder rows relative to the MRU array the arrows walk, so the highlight moves non-monotonically. All ids resolve, so it's a UX wart rather than the ARIA violation, and this fix scoped to modal only.
