### PR TITLE
feat(scratch): name a scratch and show it in the switcher

### DIFF
--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -9,6 +9,7 @@ import {
   type ScratchRow,
 } from "./persistence/schema.js";
 import { getScratchDir, getScratchesRoot, isValidScratchId } from "./scratchStorePaths.js";
+import { defaultScratchName } from "../../shared/utils/scratchName.js";
 import { logError } from "../utils/logger.js";
 
 const CURRENT_SCRATCH_KEY = "currentScratchId";
@@ -21,11 +22,6 @@ function rowToScratch(row: ScratchRow): Scratch {
     createdAt: row.createdAt,
     lastOpened: row.lastOpened,
   };
-}
-
-function defaultScratchName(date = new Date()): string {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `Scratch ${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
 export class ScratchStore {
@@ -256,7 +252,3 @@ export class ScratchStore {
 }
 
 export const scratchStore = new ScratchStore();
-
-// Test-only helper for asserting the auto-name format. Not part of the public
-// surface but exported for unit tests.
-export const __test = { defaultScratchName };

--- a/shared/utils/__tests__/scratchName.test.ts
+++ b/shared/utils/__tests__/scratchName.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { defaultScratchName } from "../scratchName";
+
+describe("defaultScratchName", () => {
+  it("renders the date's own local fields, not UTC", () => {
+    const date = new Date(2026, 0, 5, 9, 7);
+    const name = defaultScratchName(date);
+    const match = /^Scratch (\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/.exec(name);
+
+    expect(match).not.toBeNull();
+    const [, year, month, day, hours, minutes] = match!;
+    expect(Number(year)).toBe(date.getFullYear());
+    // getMonth() is zero-based; the rendered month must not be.
+    expect(Number(month)).toBe(date.getMonth() + 1);
+    expect(Number(day)).toBe(date.getDate());
+    expect(Number(hours)).toBe(date.getHours());
+    expect(Number(minutes)).toBe(date.getMinutes());
+  });
+
+  it("zero-pads single-digit fields to a fixed width", () => {
+    const name = defaultScratchName(new Date(2026, 8, 3, 4, 5));
+    expect(name).toMatch(/^Scratch \d{4}-09-03 04:05$/);
+  });
+
+  it("keeps two-digit fields unpadded", () => {
+    const name = defaultScratchName(new Date(2026, 10, 23, 14, 38));
+    expect(name).toMatch(/^Scratch \d{4}-11-23 14:38$/);
+  });
+
+  it("uses a 24-hour clock", () => {
+    const evening = defaultScratchName(new Date(2026, 0, 1, 23, 0));
+    expect(evening).toContain(" 23:00");
+  });
+
+  it("produces distinct names for dates a minute apart", () => {
+    const a = defaultScratchName(new Date(2026, 0, 1, 10, 30));
+    const b = defaultScratchName(new Date(2026, 0, 1, 10, 31));
+    expect(a).not.toBe(b);
+  });
+});

--- a/shared/utils/__tests__/scratchName.test.ts
+++ b/shared/utils/__tests__/scratchName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { defaultScratchName } from "../scratchName";
+import { defaultScratchName } from "../scratchName.js";
 
 describe("defaultScratchName", () => {
   // Named for what it can actually prove: on a UTC CI runner a getUTC* implementation

--- a/shared/utils/__tests__/scratchName.test.ts
+++ b/shared/utils/__tests__/scratchName.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { defaultScratchName } from "../scratchName";
 
 describe("defaultScratchName", () => {
-  it("renders the date's own local fields, not UTC", () => {
+  // Named for what it can actually prove: on a UTC CI runner a getUTC* implementation
+  // would be indistinguishable from a local-time one, so this asserts field mapping.
+  it("maps each rendered field to the date's corresponding getter", () => {
     const date = new Date(2026, 0, 5, 9, 7);
     const name = defaultScratchName(date);
     const match = /^Scratch (\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/.exec(name);

--- a/shared/utils/scratchName.ts
+++ b/shared/utils/scratchName.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared so the renderer can prefill a create-scratch input with exactly the
+ * name the main process would otherwise persist. Any drift between the two
+ * would silently rename a scratch the user never edited.
+ */
+export function defaultScratchName(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `Scratch ${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -460,10 +460,13 @@ export function ModalHostLayer({
                 );
               }}
               scratchResults={projectSwitcherPalette.scratchResults}
-              onCreateScratch={() => void projectSwitcherPalette.createScratch()}
+              onCreateScratch={(name) => void projectSwitcherPalette.createScratch(name)}
               onSelectScratch={(scratch) => void projectSwitcherPalette.selectScratch(scratch)}
               onRemoveScratch={(scratchId) =>
                 void projectSwitcherPalette.removeScratchAction(scratchId)
+              }
+              onRenameScratch={(scratchId, name) =>
+                void projectSwitcherPalette.renameScratch(scratchId, name)
               }
               onSaveAsProject={(scratchId) => void projectSwitcherPalette.saveAsProject(scratchId)}
               saveAsProjectConfirm={projectSwitcherPalette.saveAsProjectConfirm}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -20,6 +20,7 @@ import {
   MonitorPlay,
   Ellipsis,
   GitBranch,
+  FileText,
   Pin,
   PinOff,
   Clipboard,
@@ -68,6 +69,8 @@ import {
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 import { useProjectStore } from "@/store/projectStore";
+import { useScratchStore } from "@/store/scratchStore";
+import { activeWorkspaceIdentity } from "@/lib/workspaceIdentity";
 import { usePreferencesStore, useToolbarPreferencesStore, useVoiceRecordingStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -486,6 +489,8 @@ export function Toolbar({
   projectSwitcherPalette,
 }: ToolbarProps) {
   const currentProject = useProjectStore((state) => state.currentProject);
+  const currentScratch = useScratchStore((state) => state.currentScratch);
+  const workspaceIdentity = activeWorkspaceIdentity(currentProject, currentScratch);
   const loadProjects = useProjectStore((state) => state.loadProjects);
   const getCurrentProject = useProjectStore((state) => state.getCurrentProject);
   const { entry: forgeProviderEntry } = useResolvedForgeProvider(currentProject?.id ?? null);
@@ -1435,29 +1440,34 @@ export function Toolbar({
           data-toolbar-item=""
           className="toolbar-project-pill app-no-drag pointer-events-auto flex h-9 min-w-0 max-w-full items-center justify-center gap-2 overflow-hidden border px-3 outline-hidden focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
           data-testid="project-switcher-trigger"
-          aria-label={
-            currentProject ? `Open project switcher for ${currentProject.name}` : "Open project"
-          }
-          role={currentProject ? "combobox" : undefined}
-          aria-haspopup={currentProject ? "listbox" : undefined}
-          aria-expanded={currentProject ? isDropdownOpen : undefined}
+          aria-label={workspaceIdentity.ariaLabel}
+          role={workspaceIdentity.kind !== "none" ? "combobox" : undefined}
+          aria-haspopup={workspaceIdentity.kind !== "none" ? "listbox" : undefined}
+          aria-expanded={workspaceIdentity.kind !== "none" ? isDropdownOpen : undefined}
           onClick={() => projectSwitcher.open("dropdown")}
           onPointerEnter={clearPillTooltipFocusSuppression}
         >
-          <span
-            className={cn("text-base leading-none shrink-0", !currentProject && "opacity-0")}
-            aria-label={currentProject ? "Project emoji" : undefined}
-            aria-hidden={currentProject ? undefined : true}
-          >
-            {currentProject?.emoji ?? "•"}
-          </span>
+          {workspaceIdentity.kind === "scratch" ? (
+            <FileText
+              className="h-4 w-4 leading-none shrink-0 text-text-secondary"
+              aria-hidden="true"
+            />
+          ) : (
+            <span
+              className={cn("text-base leading-none shrink-0", !currentProject && "opacity-0")}
+              aria-label={currentProject ? "Project emoji" : undefined}
+              aria-hidden={currentProject ? undefined : true}
+            >
+              {currentProject?.emoji ?? "•"}
+            </span>
+          )}
           <span
             className={cn(
               "min-w-0 truncate text-xs tracking-wide text-daintree-text",
-              currentProject ? "font-semibold" : "font-medium"
+              workspaceIdentity.kind !== "none" ? "font-semibold" : "font-medium"
             )}
           >
-            {currentProject?.name ?? "Open project"}
+            {workspaceIdentity.name}
           </span>
           <span
             className={cn(
@@ -1525,8 +1535,10 @@ export function Toolbar({
           className="app-no-drag flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
         >
           <Tooltip
-            open={currentProject ? pillTooltipOpen : false}
-            onOpenChange={currentProject ? handlePillTooltipOpenChange : undefined}
+            open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
+            onOpenChange={
+              workspaceIdentity.kind !== "none" ? handlePillTooltipOpenChange : undefined
+            }
           >
             <ContextMenu>
               {shouldMountProjectSwitcherDropdown ? (
@@ -1567,10 +1579,13 @@ export function Toolbar({
                     onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
                     isFreeingMemory={projectSwitcher.isFreeingMemory}
                     scratchResults={projectSwitcher.scratchResults}
-                    onCreateScratch={() => void projectSwitcher.createScratch()}
+                    onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
                     onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
                     onRemoveScratch={(scratchId) =>
                       void projectSwitcher.removeScratchAction(scratchId)
+                    }
+                    onRenameScratch={(scratchId, name) =>
+                      void projectSwitcher.renameScratch(scratchId, name)
                     }
                     onSaveAsProject={(scratchId) => void projectSwitcher.saveAsProject(scratchId)}
                     saveAsProjectConfirm={projectSwitcher.saveAsProjectConfirm}
@@ -1641,6 +1656,14 @@ export function Toolbar({
                   <div className="text-text-muted font-mono text-[11px] truncate">
                     {currentProject.path}
                   </div>
+                </div>
+              </TooltipContent>
+            )}
+            {!currentProject && currentScratch && (
+              <TooltipContent side="bottom" className="max-w-[28rem]">
+                <div className="flex flex-col gap-0.5">
+                  <div className="text-xs font-medium">{currentScratch.name}</div>
+                  <div className="text-text-muted text-[11px]">Scratch workspace</div>
                 </div>
               </TooltipContent>
             )}

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -124,7 +124,9 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
 
     it("project name span has truncate class", () => {
       expect(source).toContain("min-w-0 truncate text-xs tracking-wide text-daintree-text");
-      expect(source).toContain('currentProject ? "font-semibold" : "font-medium"');
+      // Weight tracks whether a workspace (project or scratch) is open, not the
+      // project pointer alone — an active scratch is a named workspace too.
+      expect(source).toMatch(/workspaceIdentity\.kind !== "none"\s*\?\s*"font-semibold"/);
     });
 
     it("emoji span has shrink-0 so it is not squeezed before name truncates", () => {
@@ -143,8 +145,10 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(chevronMatches).not.toBeNull();
     });
 
-    it("empty-state pill displays action-verb label, not brand text", () => {
-      expect(source).toContain("Open project");
+    it("pill label comes from the active workspace, never brand text", () => {
+      // The label strings themselves now live in `activeWorkspaceIdentity`; the
+      // empty-state wording is asserted in its own suite.
+      expect(source).toContain("{workspaceIdentity.name}");
       expect(source).not.toContain("Daintree");
     });
 
@@ -152,10 +156,8 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).not.toMatch(/>Beta</);
     });
 
-    it("project switcher button has an accessible aria-label", () => {
-      expect(source).toMatch(
-        /aria-label=\{[\s\S]*currentProject[\s\S]*Open project switcher for \$\{currentProject\.name\}[\s\S]*"Open project"[\s\S]*\}/
-      );
+    it("project switcher button takes its accessible label from the active workspace", () => {
+      expect(source).toContain("aria-label={workspaceIdentity.ariaLabel}");
     });
   });
 

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -124,9 +124,6 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
 
     it("project name span has truncate class", () => {
       expect(source).toContain("min-w-0 truncate text-xs tracking-wide text-daintree-text");
-      // Weight tracks whether a workspace (project or scratch) is open, not the
-      // project pointer alone — an active scratch is a named workspace too.
-      expect(source).toMatch(/workspaceIdentity\.kind !== "none"\s*\?\s*"font-semibold"/);
     });
 
     it("emoji span has shrink-0 so it is not squeezed before name truncates", () => {

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { ChevronsUpDown, Plus } from "lucide-react";
+import { ChevronsUpDown, FileText, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { useProjectStore } from "@/store/projectStore";
+import { useScratchStore } from "@/store/scratchStore";
+import { activeWorkspaceIdentity } from "@/lib/workspaceIdentity";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
@@ -33,6 +35,8 @@ const renderIcon = (emoji: string, color?: string, sizeClass = "h-9 w-9 text-lg"
 export function ProjectSwitcher() {
   const projects = useProjectStore((state) => state.projects);
   const currentProject = useProjectStore((state) => state.currentProject);
+  const currentScratch = useScratchStore((state) => state.currentScratch);
+  const workspaceIdentity = activeWorkspaceIdentity(currentProject, currentScratch);
   const isLoading = useProjectStore((state) => state.isLoading);
   const showLoadingSpinner = useDohertyGate(isLoading);
   const projectSwitcher = useProjectSwitcherPalette();
@@ -163,7 +167,7 @@ export function ProjectSwitcher() {
     />
   );
 
-  if (!currentProject) {
+  if (!currentProject && !currentScratch) {
     if (projects.length > 0) {
       return (
         <>
@@ -200,9 +204,12 @@ export function ProjectSwitcher() {
             onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
             isFreeingMemory={projectSwitcher.isFreeingMemory}
             scratchResults={projectSwitcher.scratchResults}
-            onCreateScratch={() => void projectSwitcher.createScratch()}
+            onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
             onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
             onRemoveScratch={(scratchId) => void projectSwitcher.removeScratchAction(scratchId)}
+            onRenameScratch={(scratchId, name) =>
+              void projectSwitcher.renameScratch(scratchId, name)
+            }
           >
             <Button
               variant="outline"
@@ -260,7 +267,7 @@ export function ProjectSwitcher() {
         onFreeMemoryProject={handleFreeMemoryProject}
         onLocateProject={handleLocateProject}
         onTogglePinProject={handleTogglePinProject}
-        onOpenProjectSettings={handleOpenSettings}
+        onOpenProjectSettings={currentProject ? handleOpenSettings : undefined}
         onCopyPath={projectSwitcher.copyPath}
         onHoverProject={projectSwitcher.onHoverProject}
         onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
@@ -272,6 +279,11 @@ export function ProjectSwitcher() {
         onFreeMemoryConfirmClose={() => projectSwitcher.setFreeMemoryConfirmProject(null)}
         onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
         isFreeingMemory={projectSwitcher.isFreeingMemory}
+        scratchResults={projectSwitcher.scratchResults}
+        onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
+        onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
+        onRemoveScratch={(scratchId) => void projectSwitcher.removeScratchAction(scratchId)}
+        onRenameScratch={(scratchId, name) => void projectSwitcher.renameScratch(scratchId, name)}
         onDropdownCloseAutoFocus={suppressTooltipDuringFocusRestore}
       >
         <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
@@ -287,20 +299,34 @@ export function ProjectSwitcher() {
                 "active:scale-100"
               )}
               disabled={showLoadingSpinner}
+              aria-label={workspaceIdentity.ariaLabel}
               onClick={handleOpenDropdown}
               onPointerEnter={() => {
                 isRestoringFocusRef.current = false;
               }}
             >
               <div className="flex items-center gap-3 text-left min-w-0">
-                {renderIcon(currentProject.emoji || "🌲", currentProject.color, "h-9 w-9 text-xl")}
+                {currentProject ? (
+                  renderIcon(currentProject.emoji || "🌲", currentProject.color, "h-9 w-9 text-xl")
+                ) : (
+                  <div className="flex h-9 w-9 items-center justify-center rounded-[var(--radius-xl)] bg-tint/[0.04] text-muted-foreground shrink-0">
+                    <FileText className="h-4 w-4" />
+                  </div>
+                )}
 
                 <div className="flex flex-col min-w-0 gap-0.5">
                   <span className="truncate font-semibold text-daintree-text text-sm leading-none">
-                    {currentProject.name}
+                    {workspaceIdentity.name}
                   </span>
-                  <span className="truncate font-mono text-xs text-text-secondary">
-                    {currentProject.path.split(/[/\\]/).pop()}
+                  <span
+                    className={cn(
+                      "truncate text-xs text-text-secondary",
+                      currentProject && "font-mono"
+                    )}
+                  >
+                    {currentProject
+                      ? currentProject.path.split(/[/\\]/).pop()
+                      : "Scratch workspace"}
                   </span>
                 </div>
               </div>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -751,13 +751,17 @@ function ScratchSection({
               {scratches.map((scratch) => {
                 const isRenaming = editor?.kind === "rename" && editor.scratchId === scratch.id;
                 if (isRenaming) {
+                  // Both the seed and the no-op comparison use the name frozen when
+                  // editing began. Against the live name, an untouched editor would
+                  // resubmit the old name and undo a rename that landed by push.
+                  const originalName = editor.name;
                   return (
                     <ScratchNameEditor
                       key={scratch.id}
-                      initialValue={scratch.name}
+                      initialValue={originalName}
                       ariaLabel="Scratch name"
                       testId="scratch-rename-input"
-                      onCommit={(name) => handleRenameCommit(scratch.id, scratch.name, name)}
+                      onCommit={(name) => handleRenameCommit(scratch.id, originalName, name)}
                       onCancel={closeEditor}
                     />
                   );

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -10,6 +10,7 @@ import {
   FolderOpen,
   FolderPlus,
   FolderUp,
+  Pencil,
   Pin,
   PinOff,
   Plus,
@@ -35,6 +36,10 @@ import { formatTimeAgo } from "@/utils/timeAgo";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useModifierKeys } from "@/hooks/useModifierKeys";
 import { useOverlayClaim } from "@/hooks";
+// Leaf import, not the `@/hooks` barrel: several palette suites mock that barrel
+// and would throw on an export they don't list.
+import { useEscapeStack } from "@/hooks/useEscapeStack";
+import { defaultScratchName } from "@shared/utils/scratchName";
 import type {
   ProjectSwitcherMode,
   SearchableProject,
@@ -95,12 +100,14 @@ export interface ProjectSwitcherPaletteProps {
   isFreeingMemory?: boolean;
   /** Scratch (one-off agent workspace) results — rendered in their own collapsible section. */
   scratchResults?: SearchableScratch[];
-  /** Callback to create and switch to a new scratch. */
-  onCreateScratch?: () => void;
+  /** Callback to create and switch to a new scratch. A blank name takes the default. */
+  onCreateScratch?: (name?: string) => void;
   /** Callback to switch to an existing scratch. */
   onSelectScratch?: (scratch: SearchableScratch) => void;
   /** Callback to remove a scratch. */
   onRemoveScratch?: (scratchId: string) => void;
+  /** Callback to rename a scratch in place. */
+  onRenameScratch?: (scratchId: string, name: string) => void;
   /** Callback to save a scratch as a regular project (copy + register). */
   onSaveAsProject?: (scratchId: string) => void;
   /**
@@ -544,11 +551,101 @@ export function formatScratchCleanupCountdown(lastOpened: number, now: number): 
   return `Auto-cleanup in ${daysLeft} days`;
 }
 
+interface ScratchNameEditorProps {
+  initialValue: string;
+  ariaLabel: string;
+  onCommit: (name: string) => void;
+  onCancel: () => void;
+  testId: string;
+}
+
+/**
+ * Inline name field for creating or renaming a scratch. Lives inside
+ * `AppPaletteDialog`, whose document-level Escape backstop would otherwise close
+ * the whole switcher — so Escape is both consumed here and claimed on the escape
+ * stack. Enter is stopped for the same reason: the palette's own Enter handler
+ * lives on the search input, but the backstop listens on document.
+ */
+function ScratchNameEditor({
+  initialValue,
+  ariaLabel,
+  onCommit,
+  onCancel,
+  testId,
+}: ScratchNameEditorProps) {
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Committing on blur would fire on Escape's focus restore too, resurrecting the
+  // cancelled edit; explicit Enter is the only commit path.
+  const committedRef = useRef(false);
+
+  useEscapeStack(true, () => {
+    if (committedRef.current) return;
+    onCancel();
+  });
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, []);
+
+  const commit = useCallback(() => {
+    committedRef.current = true;
+    onCommit(value);
+  }, [onCommit, value]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.nativeEvent.isComposing) return;
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        commit();
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+      }
+    },
+    [commit, onCancel]
+  );
+
+  return (
+    <div className="w-full flex items-center gap-3 px-3 py-2 mt-1 rounded-[var(--radius-md)]">
+      <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
+        <FileText className="h-4 w-4" />
+      </div>
+      <input
+        ref={inputRef}
+        data-scratch-name-input=""
+        data-testid={testId}
+        type="text"
+        value={value}
+        aria-label={ariaLabel}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={onCancel}
+        className="flex-1 min-w-0 bg-overlay-soft border border-[var(--border-overlay)] rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text outline-hidden focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+      />
+    </div>
+  );
+}
+
+type ScratchEditorState =
+  | { kind: "create" }
+  | { kind: "rename"; scratchId: string; name: string }
+  | null;
+
 interface ScratchSectionProps {
   scratches: SearchableScratch[];
-  onCreate?: () => void;
+  onCreate?: (name?: string) => void;
   onSelect?: (scratch: SearchableScratch) => void;
   onRemove?: (scratchId: string) => void;
+  onRename?: (scratchId: string, name: string) => void;
   onSaveAsProject?: (scratchId: string) => void;
 }
 
@@ -565,9 +662,15 @@ function ScratchSection({
   onCreate,
   onSelect,
   onRemove,
+  onRename,
   onSaveAsProject,
 }: ScratchSectionProps) {
   const [collapsed, setCollapsed] = useState<boolean>(scratches.length === 0);
+  const [editor, setEditor] = useState<ScratchEditorState>(null);
+  // Radix restores focus to the context-menu trigger on close, but for a rename
+  // that trigger has been swapped out for the editor — the restore would steal
+  // focus from the input and blur-cancel the edit before it began.
+  const suppressMenuFocusRestoreRef = useRef(false);
   const previousScratchCountRef = useRef(scratches.length);
   // `now` is captured per-render so the countdown updates whenever the
   // surrounding component re-renders. Refresh is naturally driven by store
@@ -585,6 +688,36 @@ function ScratchSection({
       setCollapsed(false);
     }
   }, [scratches.length]);
+
+  // A rename target can vanish under the editor via a scratch:removed push.
+  useEffect(() => {
+    if (editor?.kind !== "rename") return;
+    if (!scratches.some((s) => s.id === editor.scratchId)) {
+      setEditor(null);
+    }
+  }, [editor, scratches]);
+
+  const closeEditor = useCallback(() => setEditor(null), []);
+
+  const handleCreateCommit = useCallback(
+    (name: string) => {
+      setEditor(null);
+      onCreate?.(name);
+    },
+    [onCreate]
+  );
+
+  const handleRenameCommit = useCallback(
+    (scratchId: string, previousName: string, name: string) => {
+      setEditor(null);
+      const trimmed = name.trim();
+      if (!trimmed || trimmed === previousName) return;
+      onRename?.(scratchId, trimmed);
+    },
+    [onRename]
+  );
+
+  const isCreating = editor?.kind === "create";
 
   return (
     <div className="px-2 py-1.5">
@@ -616,8 +749,22 @@ function ScratchSection({
           ) : (
             <div role="listbox" aria-label="Scratch workspaces">
               {scratches.map((scratch) => {
+                const isRenaming = editor?.kind === "rename" && editor.scratchId === scratch.id;
+                if (isRenaming) {
+                  return (
+                    <ScratchNameEditor
+                      key={scratch.id}
+                      initialValue={scratch.name}
+                      ariaLabel="Scratch name"
+                      testId="scratch-rename-input"
+                      onCommit={(name) => handleRenameCommit(scratch.id, scratch.name, name)}
+                      onCancel={closeEditor}
+                    />
+                  );
+                }
+
                 const countdown = formatScratchCleanupCountdown(scratch.lastOpened, now);
-                const hasContextActions = Boolean(onRemove || onSaveAsProject);
+                const hasContextActions = Boolean(onRemove || onSaveAsProject || onRename);
                 return (
                   <ContextMenu key={scratch.id}>
                     <ContextMenuTrigger asChild>
@@ -651,14 +798,35 @@ function ScratchSection({
                       </button>
                     </ContextMenuTrigger>
                     {hasContextActions && (
-                      <ContextMenuContent>
+                      <ContextMenuContent
+                        onCloseAutoFocus={(e) => {
+                          if (!suppressMenuFocusRestoreRef.current) return;
+                          suppressMenuFocusRestoreRef.current = false;
+                          e.preventDefault();
+                        }}
+                      >
+                        {onRename && (
+                          <ContextMenuItem
+                            onSelect={() => {
+                              suppressMenuFocusRestoreRef.current = true;
+                              setEditor({
+                                kind: "rename",
+                                scratchId: scratch.id,
+                                name: scratch.name,
+                              });
+                            }}
+                          >
+                            <Pencil className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                            Rename scratch
+                          </ContextMenuItem>
+                        )}
                         {onSaveAsProject && (
                           <ContextMenuItem onSelect={() => onSaveAsProject(scratch.id)}>
                             <FolderUp className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                             Save as project…
                           </ContextMenuItem>
                         )}
-                        {onSaveAsProject && onRemove && <ContextMenuSeparator />}
+                        {(onSaveAsProject || onRename) && onRemove && <ContextMenuSeparator />}
                         {onRemove && (
                           <ContextMenuItem destructive onSelect={() => onRemove(scratch.id)}>
                             <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
@@ -672,21 +840,30 @@ function ScratchSection({
               })}
             </div>
           )}
-          {onCreate && (
-            <button
-              type="button"
-              onClick={onCreate}
-              className="w-full flex items-center gap-3 px-3 py-2 mt-1 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
-              data-testid="scratch-create-button"
-            >
-              <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
-                <Plus className="h-4 w-4" />
-              </div>
-              <span className="font-medium text-sm text-muted-foreground">
-                New scratch workspace
-              </span>
-            </button>
-          )}
+          {onCreate &&
+            (isCreating ? (
+              <ScratchNameEditor
+                initialValue={defaultScratchName(new Date())}
+                ariaLabel="Name for the new scratch workspace"
+                testId="scratch-create-input"
+                onCommit={handleCreateCommit}
+                onCancel={closeEditor}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditor({ kind: "create" })}
+                className="w-full flex items-center gap-3 px-3 py-2 mt-1 rounded-[var(--radius-md)] text-left transition-colors hover:bg-overlay-subtle"
+                data-testid="scratch-create-button"
+              >
+                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
+                  <Plus className="h-4 w-4" />
+                </div>
+                <span className="font-medium text-sm text-muted-foreground">
+                  New scratch workspace
+                </span>
+              </button>
+            ))}
         </div>
       )}
     </div>
@@ -750,9 +927,10 @@ interface ProjectPaletteInnerProps {
   onHoverProject?: (projectId: string, pointerType: string) => void;
   onHoverProjectEnd?: (pointerType: string) => void;
   scratchResults?: SearchableScratch[];
-  onCreateScratch?: () => void;
+  onCreateScratch?: (name?: string) => void;
   onSelectScratch?: (scratch: SearchableScratch) => void;
   onRemoveScratch?: (scratchId: string) => void;
+  onRenameScratch?: (scratchId: string, name: string) => void;
   onSaveAsProject?: (scratchId: string) => void;
 }
 
@@ -785,6 +963,7 @@ function ProjectPaletteInner({
   onCreateScratch,
   onSelectScratch,
   onRemoveScratch,
+  onRenameScratch,
   onSaveAsProject,
 }: ProjectPaletteInnerProps) {
   const projectSwitcherShortcut = useEffectiveCombo("project.switcherPalette");
@@ -913,6 +1092,7 @@ function ProjectPaletteInner({
               onCreate={onCreateScratch}
               onSelect={onSelectScratch}
               onRemove={onRemoveScratch}
+              onRename={onRenameScratch}
               onSaveAsProject={onSaveAsProject}
             />
           </>
@@ -1032,6 +1212,7 @@ function ModalContent({
         onCreateScratch={innerProps.onCreateScratch}
         onSelectScratch={innerProps.onSelectScratch}
         onRemoveScratch={innerProps.onRemoveScratch}
+        onRenameScratch={innerProps.onRenameScratch}
         onSaveAsProject={innerProps.onSaveAsProject}
       />
     </AppPaletteDialog>
@@ -1091,6 +1272,15 @@ function DropdownContent({
           inputRef.current?.focus();
         }}
         onCloseAutoFocus={() => onDropdownCloseAutoFocus?.()}
+        onEscapeKeyDown={(event) => {
+          // Radix dismisses on a document-capture listener, which beats the
+          // scratch-name input's own handler. While that input owns focus,
+          // Escape means "cancel the edit", not "close the switcher".
+          const active = document.activeElement;
+          if (active instanceof HTMLElement && active.hasAttribute("data-scratch-name-input")) {
+            event.preventDefault();
+          }
+        }}
         onInteractOutside={(event) => {
           const target = event.target;
           if (target instanceof HTMLElement && target.closest('[role="menu"]')) {
@@ -1127,6 +1317,7 @@ function DropdownContent({
           onCreateScratch={innerProps.onCreateScratch}
           onSelectScratch={innerProps.onSelectScratch}
           onRemoveScratch={innerProps.onRemoveScratch}
+          onRenameScratch={innerProps.onRenameScratch}
           onSaveAsProject={innerProps.onSaveAsProject}
         />
       </PopoverContent>
@@ -1173,6 +1364,7 @@ export function ProjectSwitcherPalette({
   onCreateScratch,
   onSelectScratch,
   onRemoveScratch,
+  onRenameScratch,
   onSaveAsProject,
   saveAsProjectConfirm,
   onDismissSaveAsProjectConfirm,
@@ -1217,6 +1409,7 @@ export function ProjectSwitcherPalette({
         onCreateScratch={onCreateScratch}
         onSelectScratch={onSelectScratch}
         onRemoveScratch={onRemoveScratch}
+        onRenameScratch={onRenameScratch}
         onSaveAsProject={onSaveAsProject}
       >
         {children}
@@ -1250,6 +1443,7 @@ export function ProjectSwitcherPalette({
         onCreateScratch={onCreateScratch}
         onSelectScratch={onSelectScratch}
         onRemoveScratch={onRemoveScratch}
+        onRenameScratch={onRenameScratch}
         onSaveAsProject={onSaveAsProject}
       />
     );

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -93,6 +93,13 @@ vi.mock("@/store/projectStore", () => ({
   useProjectStore: <T,>(selector: (s: ProjectStoreState) => T) => selector(projectStoreState),
 }));
 
+// No active scratch: these cases cover the no-workspace empty states, which only
+// render when both pointers are null.
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: <T,>(selector: (s: { currentScratch: null }) => T) =>
+    selector({ currentScratch: null }),
+}));
+
 vi.mock("@/components/ui/ConfirmDialog", () => ({
   ConfirmDialog: () => null,
 }));

--- a/src/components/Project/__tests__/ProjectSwitcher.scratch.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.scratch.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Project, Scratch } from "@shared/types";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: React.ReactNode) => children };
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/lib/colorUtils", () => ({
+  getProjectGradient: () => "linear-gradient(red, blue)",
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useKeybindingDisplay: () => "⌘P",
+}));
+
+const openDropdown = vi.fn();
+
+vi.mock("@/hooks", async () => {
+  const deferred = await vi.importActual<typeof import("@/hooks/useDeferredLoading")>(
+    "@/hooks/useDeferredLoading"
+  );
+  return {
+    useDohertyGate: deferred.useDohertyGate,
+    useProjectSwitcherPalette: () => ({
+      isOpen: false,
+      mode: "dropdown",
+      query: "",
+      results: [],
+      selectedIndex: 0,
+      open: openDropdown,
+      close: vi.fn(),
+      toggle: vi.fn(),
+      setQuery: vi.fn(),
+      selectPrevious: vi.fn(),
+      selectNext: vi.fn(),
+      selectProject: vi.fn(),
+      confirmSelection: vi.fn(),
+      addProject: vi.fn(),
+      cloneRepo: vi.fn(),
+      stopProject: vi.fn(),
+      removeProject: vi.fn(),
+      locateProject: vi.fn(),
+      togglePinProject: vi.fn(),
+      stopConfirmProjectId: null,
+      setStopConfirmProjectId: vi.fn(),
+      confirmStopProject: vi.fn(),
+      isStoppingProject: false,
+      removeConfirmProject: null,
+      setRemoveConfirmProject: vi.fn(),
+      confirmRemoveProject: vi.fn(),
+      isRemovingProject: false,
+      backgroundWaitingCount: 0,
+      scratchResults: [],
+      createScratch: vi.fn(),
+      selectScratch: vi.fn(),
+      removeScratchAction: vi.fn(),
+      renameScratch: vi.fn(),
+    }),
+  };
+});
+
+type ProjectStoreState = {
+  projects: Project[];
+  currentProject: Project | null;
+  isLoading: boolean;
+  openCreateFolderDialog: () => void;
+};
+
+const projectStoreState: ProjectStoreState = {
+  projects: [],
+  currentProject: null,
+  isLoading: false,
+  openCreateFolderDialog: vi.fn(),
+};
+
+const scratchStoreState: { currentScratch: Scratch | null } = { currentScratch: null };
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: <T,>(selector: (s: ProjectStoreState) => T) => selector(projectStoreState),
+}));
+
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: <T,>(selector: (s: typeof scratchStoreState) => T) =>
+    selector(scratchStoreState),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
+
+vi.mock("@/components/Project/ProjectSwitcherPalette", () => ({
+  ProjectSwitcherPalette: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const { ProjectSwitcher } = await import("../ProjectSwitcher");
+
+function makeScratch(name: string): Scratch {
+  return {
+    id: "scratch-1",
+    path: "/tmp/scratches/scratch-1",
+    name,
+    createdAt: Date.now(),
+    lastOpened: Date.now(),
+  };
+}
+
+// The card also renders the path's basename, so keep it distinct from the name —
+// otherwise a getByText(name) would match two nodes.
+function makeProject(name: string): Project {
+  return {
+    id: "project-1",
+    path: "/repo/checkout",
+    name,
+    emoji: "🌲",
+    lastOpened: Date.now(),
+  };
+}
+
+// Names are generated, not hardcoded, so an assertion can't pass against a literal
+// that happens to live in the component.
+let nameCounter = 0;
+const uniqueName = (prefix: string) => `${prefix} ${++nameCounter}`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  projectStoreState.projects = [];
+  projectStoreState.currentProject = null;
+  scratchStoreState.currentScratch = null;
+});
+
+describe("ProjectSwitcher with an active scratch", () => {
+  it("shows the scratch's name instead of the pick-a-project prompt", () => {
+    const name = uniqueName("Spike");
+    scratchStoreState.currentScratch = makeScratch(name);
+
+    render(<ProjectSwitcher />);
+
+    expect(screen.getByText(name)).toBeTruthy();
+    expect(screen.queryByText("Select Project...")).toBeNull();
+    expect(screen.queryByText("Open Project...")).toBeNull();
+  });
+
+  it("labels the trigger as a scratch, not a project", () => {
+    const name = uniqueName("Throwaway");
+    scratchStoreState.currentScratch = makeScratch(name);
+
+    render(<ProjectSwitcher />);
+
+    const trigger = screen.getByRole("button", { name: /scratch/i });
+    expect(trigger.getAttribute("aria-label")).toContain(name);
+  });
+
+  it("still surfaces the scratch when projects exist but none is open", () => {
+    const name = uniqueName("Active scratch");
+    projectStoreState.projects = [makeProject("Some project")];
+    scratchStoreState.currentScratch = makeScratch(name);
+
+    render(<ProjectSwitcher />);
+
+    // The "projects exist, none open" fallback must not win over an active scratch.
+    expect(screen.queryByText("Select Project...")).toBeNull();
+    expect(screen.getByText(name)).toBeTruthy();
+  });
+
+  it("opens the switcher when the scratch card is clicked", () => {
+    scratchStoreState.currentScratch = makeScratch("Clickable");
+
+    render(<ProjectSwitcher />);
+    screen.getByRole("button", { name: /scratch/i }).click();
+
+    expect(openDropdown).toHaveBeenCalled();
+  });
+
+  it("keeps the empty state when no workspace is active at all", () => {
+    render(<ProjectSwitcher />);
+
+    expect(screen.getByText("Open Project...")).toBeTruthy();
+  });
+
+  it("prefers an open project over a lingering scratch pointer", () => {
+    const projectName = uniqueName("Real project");
+    const scratchName = uniqueName("Should not show");
+    projectStoreState.currentProject = makeProject(projectName);
+    scratchStoreState.currentScratch = makeScratch(scratchName);
+
+    render(<ProjectSwitcher />);
+
+    expect(screen.getByText(projectName)).toBeTruthy();
+    expect(screen.queryByText(scratchName)).toBeNull();
+  });
+});

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    value: vi.fn(),
+    configurable: true,
+  });
+});
+afterAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    value: originalScrollIntoView,
+    configurable: true,
+  });
+});
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: React.ReactNode) => children };
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/lib/colorUtils", () => ({
+  getProjectGradient: () => "linear-gradient(red, blue)",
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useKeybindingDisplay: () => "⌘P",
+  useEffectiveCombo: () => undefined,
+}));
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: () => {},
+  useOverlayClaim: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+vi.mock("@/store/uiStore", () => ({
+  useUIStore: () => 0,
+}));
+
+vi.mock("@/components/ui/AppPaletteDialog", () => {
+  const Header = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="palette-header">{children}</div>
+  );
+  const Input = ({
+    inputRef,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    inputRef?: React.Ref<HTMLInputElement>;
+  }) => <input ref={inputRef} data-testid="palette-input" {...props} />;
+  const Body = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="palette-body">{children}</div>
+  );
+  const Footer = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="palette-footer">{children}</div>
+  );
+
+  const Dialog = ({
+    isOpen,
+    children,
+    ariaLabel,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    ariaLabel: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-modal="true" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null;
+  Dialog.Header = Header;
+  Dialog.Input = Input;
+  Dialog.Body = Body;
+  Dialog.Footer = Footer;
+
+  return { AppPaletteDialog: Dialog, KBD_CLASS: "kbd" };
+});
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+// Renders context-menu items inline as buttons so `onSelect` is reachable without
+// driving Radix's pointer/focus machinery.
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => null,
+}));
+
+vi.mock("@/hooks/useModifierKeys", () => ({
+  useModifierKeys: () => ({ meta: false, alt: false }),
+}));
+
+vi.mock("@/utils/timeAgo", () => ({
+  formatTimeAgo: () => "1h ago",
+}));
+
+import type { SearchableScratch } from "@/hooks/useProjectSwitcherPalette";
+import { defaultScratchName } from "@shared/utils/scratchName";
+
+const { ProjectSwitcherPalette } = await import("../ProjectSwitcherPalette");
+
+function makeScratch(overrides: Partial<SearchableScratch> = {}): SearchableScratch {
+  return {
+    id: "scratch-1",
+    name: "Scratch 2026-01-01 09:00",
+    path: "/tmp/scratches/scratch-1",
+    createdAt: Date.now(),
+    lastOpened: Date.now(),
+    isActive: false,
+    ...overrides,
+  };
+}
+
+function renderPalette(overrides: Record<string, unknown> = {}) {
+  const props = {
+    isOpen: true,
+    mode: "modal" as const,
+    query: "",
+    results: [],
+    selectedIndex: 0,
+    onQueryChange: vi.fn(),
+    onSelectPrevious: vi.fn(),
+    onSelectNext: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    scratchResults: [] as SearchableScratch[],
+    onCreateScratch: vi.fn(),
+    onRenameScratch: vi.fn(),
+    onSelectScratch: vi.fn(),
+    onRemoveScratch: vi.fn(),
+    ...overrides,
+  };
+  render(<ProjectSwitcherPalette {...props} />);
+  expandScratchSection();
+  return props;
+}
+
+/**
+ * The section auto-collapses when there are no scratches yet, hiding its contents.
+ * Matched by aria-controls: the header's accessible name absorbs the count badge.
+ */
+function expandScratchSection() {
+  const header = document.querySelector('[aria-controls="scratch-section-list"]');
+  if (header instanceof HTMLElement && header.getAttribute("aria-expanded") === "false") {
+    fireEvent.click(header);
+  }
+}
+
+describe("scratch create naming", () => {
+  it("swaps the create button for a focused, fully-selected input", () => {
+    renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId<HTMLInputElement>("scratch-create-input");
+    expect(screen.queryByTestId("scratch-create-button")).toBeNull();
+    expect(document.activeElement).toBe(input);
+    // Fully selected, so typing replaces the prefill outright.
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it("prefills the name main would otherwise assign", () => {
+    renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId<HTMLInputElement>("scratch-create-input");
+    expect(input.value).toBe(defaultScratchName(new Date()));
+  });
+
+  it("creates with the typed name on Enter", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId("scratch-create-input");
+    fireEvent.change(input, { target: { value: "Retry queue spike" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onCreateScratch).toHaveBeenCalledWith("Retry queue spike");
+  });
+
+  it("forwards the untouched prefill when the user just hits Enter", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId<HTMLInputElement>("scratch-create-input");
+    const prefill = input.value;
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onCreateScratch).toHaveBeenCalledWith(prefill);
+  });
+
+  it("still creates when the name is cleared — main owns the empty-name fallback", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId("scratch-create-input");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onCreateScratch).toHaveBeenCalledTimes(1);
+    expect(props.onCreateScratch).toHaveBeenCalledWith("   ");
+  });
+
+  it("cancels on Escape without creating, and restores the create button", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId("scratch-create-input");
+    fireEvent.change(input, { target: { value: "Abandoned" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(props.onCreateScratch).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("scratch-create-input")).toBeNull();
+    expect(screen.getByTestId("scratch-create-button")).toBeTruthy();
+  });
+
+  it("does not close the palette when Escape cancels the edit", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+    fireEvent.keyDown(screen.getByTestId("scratch-create-input"), { key: "Escape" });
+
+    // The palette's own Escape backstop must not see this keystroke.
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it("cancels on blur rather than creating something the user clicked away from", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId("scratch-create-input");
+    fireEvent.change(input, { target: { value: "Half typed" } });
+    fireEvent.blur(input);
+
+    expect(props.onCreateScratch).not.toHaveBeenCalled();
+    expect(screen.getByTestId("scratch-create-button")).toBeTruthy();
+  });
+
+  it("ignores Enter while an IME composition is active", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId("scratch-create-input");
+    fireEvent.change(input, { target: { value: "にほんご" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(props.onCreateScratch).not.toHaveBeenCalled();
+  });
+
+  it("leaves project navigation alone while the editor owns focus", () => {
+    const props = renderPalette();
+    fireEvent.click(screen.getByTestId("scratch-create-button"));
+
+    const input = screen.getByTestId("scratch-create-input");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+
+    expect(props.onSelectNext).not.toHaveBeenCalled();
+    expect(props.onSelectPrevious).not.toHaveBeenCalled();
+  });
+});
+
+describe("scratch rename", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("replaces only the targeted row with an editor", () => {
+    const scratches = [
+      makeScratch({ id: "a", name: "Alpha" }),
+      makeScratch({ id: "b", name: "Beta" }),
+    ];
+    renderPalette({ scratchResults: scratches });
+
+    const renameButtons = screen.getAllByText("Rename scratch");
+    act(() => {
+      fireEvent.click(renameButtons[0]!);
+    });
+
+    const inputs = screen.getAllByTestId<HTMLInputElement>("scratch-rename-input");
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]!.value).toBe("Alpha");
+    // The untouched row keeps rendering normally.
+    expect(screen.getByText("Beta")).toBeTruthy();
+  });
+
+  it("renames with the trimmed value on Enter", () => {
+    const props = renderPalette({ scratchResults: [makeScratch({ id: "a", name: "Alpha" })] });
+    act(() => {
+      fireEvent.click(screen.getByText("Rename scratch"));
+    });
+
+    const input = screen.getByTestId("scratch-rename-input");
+    fireEvent.change(input, { target: { value: "  Renamed  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onRenameScratch).toHaveBeenCalledWith("a", "Renamed");
+  });
+
+  it("does not hit IPC when the name is unchanged", () => {
+    const props = renderPalette({ scratchResults: [makeScratch({ id: "a", name: "Alpha" })] });
+    act(() => {
+      fireEvent.click(screen.getByText("Rename scratch"));
+    });
+
+    fireEvent.keyDown(screen.getByTestId("scratch-rename-input"), { key: "Enter" });
+
+    expect(props.onRenameScratch).not.toHaveBeenCalled();
+  });
+
+  it("does not hit IPC when the name is cleared", () => {
+    const props = renderPalette({ scratchResults: [makeScratch({ id: "a", name: "Alpha" })] });
+    act(() => {
+      fireEvent.click(screen.getByText("Rename scratch"));
+    });
+
+    const input = screen.getByTestId("scratch-rename-input");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(props.onRenameScratch).not.toHaveBeenCalled();
+  });
+
+  it("reverts on Escape and restores the row", () => {
+    const props = renderPalette({ scratchResults: [makeScratch({ id: "a", name: "Alpha" })] });
+    act(() => {
+      fireEvent.click(screen.getByText("Rename scratch"));
+    });
+
+    const input = screen.getByTestId("scratch-rename-input");
+    fireEvent.change(input, { target: { value: "Discarded" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(props.onRenameScratch).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Alpha")).toBeTruthy();
+  });
+
+  it("selecting a row is not triggered by opening its rename editor", () => {
+    const props = renderPalette({ scratchResults: [makeScratch({ id: "a", name: "Alpha" })] });
+    act(() => {
+      fireEvent.click(screen.getByText("Rename scratch"));
+    });
+
+    expect(props.onSelectScratch).not.toHaveBeenCalled();
+  });
+
+  it("offers no rename affordance when the host wires no handler", () => {
+    renderPalette({
+      scratchResults: [makeScratch({ id: "a", name: "Alpha" })],
+      onRenameScratch: undefined,
+    });
+
+    expect(screen.queryByText("Rename scratch")).toBeNull();
+  });
+});

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx
@@ -49,7 +49,14 @@ vi.mock("@/store/uiStore", () => ({
   useUIStore: () => 0,
 }));
 
-vi.mock("@/components/ui/AppPaletteDialog", () => {
+// Faithful on one point that matters here: the real AppPaletteDialog closes the
+// palette from a DOCUMENT-level Escape backstop. Reproducing that listener is what
+// makes the "Escape cancels the edit without closing the palette" test meaningful —
+// with a passive container mock it would pass even if the editor stopped guarding
+// Escape at all.
+vi.mock("@/components/ui/AppPaletteDialog", async () => {
+  const { useEffect } = await vi.importActual<typeof import("react")>("react");
+
   const Header = ({ children }: { children: React.ReactNode }) => (
     <div data-testid="palette-header">{children}</div>
   );
@@ -70,16 +77,28 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
     isOpen,
     children,
     ariaLabel,
+    onClose,
   }: {
     isOpen: boolean;
     children: React.ReactNode;
     ariaLabel: string;
-  }) =>
-    isOpen ? (
+    onClose?: () => void;
+  }) => {
+    useEffect(() => {
+      if (!isOpen) return;
+      const backstop = (e: KeyboardEvent) => {
+        if (e.key === "Escape") onClose?.();
+      };
+      document.addEventListener("keydown", backstop);
+      return () => document.removeEventListener("keydown", backstop);
+    }, [isOpen, onClose]);
+
+    return isOpen ? (
       <div role="dialog" aria-modal="true" aria-label={ariaLabel}>
         {children}
       </div>
     ) : null;
+  };
   Dialog.Header = Header;
   Dialog.Input = Input;
   Dialog.Body = Body;
@@ -147,8 +166,8 @@ function makeScratch(overrides: Partial<SearchableScratch> = {}): SearchableScra
   };
 }
 
-function renderPalette(overrides: Record<string, unknown> = {}) {
-  const props = {
+function baseProps() {
+  return {
     isOpen: true,
     mode: "modal" as const,
     query: "",
@@ -164,8 +183,11 @@ function renderPalette(overrides: Record<string, unknown> = {}) {
     onRenameScratch: vi.fn(),
     onSelectScratch: vi.fn(),
     onRemoveScratch: vi.fn(),
-    ...overrides,
   };
+}
+
+function renderPalette(overrides: Record<string, unknown> = {}) {
+  const props = { ...baseProps(), ...overrides };
   render(<ProjectSwitcherPalette {...props} />);
   expandScratchSection();
   return props;
@@ -196,11 +218,19 @@ describe("scratch create naming", () => {
   });
 
   it("prefills the name main would otherwise assign", () => {
-    renderPalette();
-    fireEvent.click(screen.getByTestId("scratch-create-button"));
+    // Frozen: computing the expected value from a second `new Date()` would flake
+    // whenever the click straddled a minute boundary.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 17, 8, 5));
+    try {
+      renderPalette();
+      fireEvent.click(screen.getByTestId("scratch-create-button"));
 
-    const input = screen.getByTestId<HTMLInputElement>("scratch-create-input");
-    expect(input.value).toBe(defaultScratchName(new Date()));
+      const input = screen.getByTestId<HTMLInputElement>("scratch-create-input");
+      expect(input.value).toBe(defaultScratchName(new Date()));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates with the typed name on Enter", () => {
@@ -387,5 +417,49 @@ describe("scratch rename", () => {
     });
 
     expect(screen.queryByText("Rename scratch")).toBeNull();
+  });
+
+  it("drops the editor when the scratch being renamed is deleted underneath it", () => {
+    const scratches = [
+      makeScratch({ id: "a", name: "Alpha" }),
+      makeScratch({ id: "b", name: "Beta" }),
+    ];
+    const props = { ...baseProps(), scratchResults: scratches };
+    const { rerender } = render(<ProjectSwitcherPalette {...props} />);
+    expandScratchSection();
+
+    act(() => {
+      fireEvent.click(screen.getAllByText("Rename scratch")[0]!);
+    });
+    expect(screen.getByTestId("scratch-rename-input")).toBeTruthy();
+
+    // A scratch:removed push drops the row out from under the open editor.
+    rerender(<ProjectSwitcherPalette {...props} scratchResults={[scratches[1]!]} />);
+
+    expect(screen.queryByTestId("scratch-rename-input")).toBeNull();
+    expect(props.onRenameScratch).not.toHaveBeenCalled();
+  });
+
+  it("keeps an untouched editor from undoing a rename that landed by push", () => {
+    const scratch = makeScratch({ id: "a", name: "Original" });
+    const props = { ...baseProps(), scratchResults: [scratch] };
+    const { rerender } = render(<ProjectSwitcherPalette {...props} />);
+    expandScratchSection();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Rename scratch"));
+    });
+
+    // Another window renames it while this editor sits open and untouched.
+    rerender(
+      <ProjectSwitcherPalette
+        {...props}
+        scratchResults={[{ ...scratch, name: "Renamed elsewhere" }]}
+      />
+    );
+    fireEvent.keyDown(screen.getByTestId("scratch-rename-input"), { key: "Enter" });
+
+    // Committing the stale value would resurrect "Original".
+    expect(props.onRenameScratch).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/__tests__/useProjectSwitcherPalette.hoverPrefetch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.hoverPrefetch.test.tsx
@@ -113,19 +113,24 @@ vi.mock("@/store/projectSettingsStore", () => ({
   ),
 }));
 
-vi.mock("@/store/scratchStore", () => ({
-  useScratchStore: vi.fn((selector?: (state: unknown) => unknown) => {
-    const state = {
-      scratches: [],
-      currentScratch: null,
-      loadScratches: vi.fn().mockResolvedValue(undefined),
-      createScratch: vi.fn().mockResolvedValue({ id: "s1" }),
-      switchScratch: vi.fn().mockResolvedValue(undefined),
-      removeScratch: vi.fn().mockResolvedValue(undefined),
-    };
-    return selector ? selector(state) : state;
-  }),
-}));
+// Hoisted so every selector call returns stable action identities. A fresh state
+// object per call would churn the hook's effect deps on every render.
+vi.mock("@/store/scratchStore", () => {
+  const state = {
+    scratches: [],
+    currentScratch: null,
+    loadScratches: vi.fn().mockResolvedValue(undefined),
+    createScratch: vi.fn().mockResolvedValue({ id: "s1" }),
+    switchScratch: vi.fn().mockResolvedValue(undefined),
+    removeScratch: vi.fn().mockResolvedValue(undefined),
+    renameScratch: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    useScratchStore: vi.fn((selector?: (s: unknown) => unknown) =>
+      selector ? selector(state) : state
+    ),
+  };
+});
 
 vi.mock("@/lib/notify", () => ({
   notify: notifyMock,

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -9,51 +9,49 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useProjectStoreMock, notifyMock, projectState, projectStatsState, scratchState } =
-  vi.hoisted(() => {
-    const projectStatsState = {
-      stats: {} as Record<
-        string,
-        { activeAgentCount: number; waitingAgentCount: number; processCount: number }
-      >,
-    };
+const { useProjectStoreMock, notifyMock, projectStatsState, scratchState } = vi.hoisted(() => {
+  const projectStatsState = {
+    stats: {} as Record<
+      string,
+      { activeAgentCount: number; waitingAgentCount: number; processCount: number }
+    >,
+  };
 
-    const projectState = {
-      projects: [],
-      currentProject: null as { id: string } | null,
-      switchProject: vi.fn().mockResolvedValue(undefined),
-      reopenProject: vi.fn().mockResolvedValue(undefined),
-      loadProjects: vi.fn().mockResolvedValue(undefined),
-      addProject: vi.fn().mockResolvedValue(undefined),
-      closeProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
-      closeActiveProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
-      removeProject: vi.fn().mockResolvedValue(undefined),
-      locateProject: vi.fn().mockResolvedValue(undefined),
-    };
+  const projectState = {
+    projects: [],
+    currentProject: null as { id: string } | null,
+    switchProject: vi.fn().mockResolvedValue(undefined),
+    reopenProject: vi.fn().mockResolvedValue(undefined),
+    loadProjects: vi.fn().mockResolvedValue(undefined),
+    addProject: vi.fn().mockResolvedValue(undefined),
+    closeProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+    closeActiveProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+    removeProject: vi.fn().mockResolvedValue(undefined),
+    locateProject: vi.fn().mockResolvedValue(undefined),
+  };
 
-    const useProjectStoreMock = Object.assign(
-      vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
-      { getState: () => projectState }
-    );
+  const useProjectStoreMock = Object.assign(
+    vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
+    { getState: () => projectState }
+  );
 
-    const scratchState = {
-      scratches: [],
-      currentScratch: null,
-      loadScratches: vi.fn().mockResolvedValue(undefined),
-      createScratch: vi.fn(),
-      switchScratch: vi.fn(),
-      removeScratch: vi.fn().mockResolvedValue(undefined),
-      renameScratch: vi.fn(),
-    };
+  const scratchState = {
+    scratches: [],
+    currentScratch: null,
+    loadScratches: vi.fn().mockResolvedValue(undefined),
+    createScratch: vi.fn(),
+    switchScratch: vi.fn(),
+    removeScratch: vi.fn().mockResolvedValue(undefined),
+    renameScratch: vi.fn(),
+  };
 
-    return {
-      useProjectStoreMock,
-      notifyMock: vi.fn().mockReturnValue(""),
-      projectState,
-      projectStatsState,
-      scratchState,
-    };
-  });
+  return {
+    useProjectStoreMock,
+    notifyMock: vi.fn().mockReturnValue(""),
+    projectStatsState,
+    scratchState,
+  };
+});
 
 vi.mock("@/clients", () => ({
   projectClient: {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+/**
+ * useProjectSwitcherPalette — scratch create/rename actions (issue #11075).
+ *
+ * Create threads an optional name through to the store and switches to the new
+ * scratch. The retry path is the interesting part: a failure AFTER the scratch
+ * exists must resume at the switch, never create a second workspace.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useProjectStoreMock, notifyMock, projectState, projectStatsState, scratchState } =
+  vi.hoisted(() => {
+    const projectStatsState = {
+      stats: {} as Record<
+        string,
+        { activeAgentCount: number; waitingAgentCount: number; processCount: number }
+      >,
+    };
+
+    const projectState = {
+      projects: [],
+      currentProject: null as { id: string } | null,
+      switchProject: vi.fn().mockResolvedValue(undefined),
+      reopenProject: vi.fn().mockResolvedValue(undefined),
+      loadProjects: vi.fn().mockResolvedValue(undefined),
+      addProject: vi.fn().mockResolvedValue(undefined),
+      closeProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+      closeActiveProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+      removeProject: vi.fn().mockResolvedValue(undefined),
+      locateProject: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const useProjectStoreMock = Object.assign(
+      vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
+      { getState: () => projectState }
+    );
+
+    const scratchState = {
+      scratches: [],
+      currentScratch: null,
+      loadScratches: vi.fn().mockResolvedValue(undefined),
+      createScratch: vi.fn(),
+      switchScratch: vi.fn(),
+      removeScratch: vi.fn().mockResolvedValue(undefined),
+      renameScratch: vi.fn(),
+    };
+
+    return {
+      useProjectStoreMock,
+      notifyMock: vi.fn().mockReturnValue(""),
+      projectState,
+      projectStatsState,
+      scratchState,
+    };
+  });
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    prefetchHydrate: vi.fn().mockResolvedValue(undefined),
+    getBulkStats: vi.fn().mockResolvedValue({}),
+  },
+  scratchClient: {
+    saveAsProject: vi.fn().mockResolvedValue({ status: "cancelled" }),
+  },
+}));
+
+vi.mock("@/store/projectStore", () => ({ useProjectStore: useProjectStoreMock }));
+
+vi.mock("@/store/projectStatsStore", () => ({
+  useProjectStatsStore: Object.assign(
+    vi.fn((selector: (state: typeof projectStatsState) => unknown) => selector(projectStatsState)),
+    {
+      getState: () => ({
+        stats: projectStatsState.stats,
+        setStats: (stats: typeof projectStatsState.stats) => {
+          projectStatsState.stats = stats;
+        },
+      }),
+    }
+  ),
+}));
+
+vi.mock("@/store/projectSettingsStore", () => ({
+  useProjectSettingsStore: Object.assign(
+    vi.fn((selector?: (state: unknown) => unknown) =>
+      selector ? selector({ loadNotificationOverridesForProjects: vi.fn() }) : undefined
+    ),
+    { getState: () => ({ loadNotificationOverridesForProjects: vi.fn() }) }
+  ),
+}));
+
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: vi.fn((selector?: (s: typeof scratchState) => unknown) =>
+    selector ? selector(scratchState) : scratchState
+  ),
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+import { useProjectSwitcherPalette } from "../useProjectSwitcherPalette";
+
+/** Pulls the "Try again" handler out of the last error notification. */
+function lastRetryAction(): () => Promise<void> {
+  const call = notifyMock.mock.calls.at(-1)?.[0] as
+    | { actions?: { label: string; onClick: () => Promise<void> }[] }
+    | undefined;
+  const action = call?.actions?.find((a) => a.label === "Try again");
+  if (!action) throw new Error("expected a Try again action on the error notification");
+  return action.onClick;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  scratchState.createScratch.mockResolvedValue({ id: "scratch-1" });
+  scratchState.switchScratch.mockResolvedValue(undefined);
+  scratchState.renameScratch.mockResolvedValue(undefined);
+});
+
+describe("createScratch", () => {
+  it("forwards a trimmed name and switches to the new scratch", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch("  Retry queue spike  ");
+    });
+
+    expect(scratchState.createScratch).toHaveBeenCalledWith("Retry queue spike");
+    expect(scratchState.switchScratch).toHaveBeenCalledWith("scratch-1");
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards undefined for a blank name so main applies its own default", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch("   ");
+    });
+
+    expect(scratchState.createScratch).toHaveBeenCalledWith(undefined);
+  });
+
+  it("forwards undefined when no name is supplied at all", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch();
+    });
+
+    expect(scratchState.createScratch).toHaveBeenCalledWith(undefined);
+  });
+
+  it("retries creation with the same name when creation itself failed", async () => {
+    scratchState.createScratch.mockRejectedValueOnce(new Error("disk full"));
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch("Named");
+    });
+    expect(scratchState.switchScratch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await lastRetryAction()();
+    });
+
+    expect(scratchState.createScratch).toHaveBeenCalledTimes(2);
+    expect(scratchState.createScratch).toHaveBeenLastCalledWith("Named");
+    expect(scratchState.switchScratch).toHaveBeenCalledWith("scratch-1");
+  });
+
+  it("does not create a second scratch when only the switch failed", async () => {
+    scratchState.switchScratch.mockRejectedValueOnce(new Error("view busy"));
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch("Named");
+    });
+
+    await act(async () => {
+      await lastRetryAction()();
+    });
+
+    // The scratch already exists; retrying must resume at the switch, or the
+    // first workspace is orphaned on disk.
+    expect(scratchState.createScratch).toHaveBeenCalledTimes(1);
+    expect(scratchState.switchScratch).toHaveBeenCalledTimes(2);
+    expect(scratchState.switchScratch).toHaveBeenLastCalledWith("scratch-1");
+  });
+
+  it("says the scratch was created when only the switch failed", async () => {
+    scratchState.switchScratch.mockRejectedValueOnce(new Error("view busy"));
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch("Named");
+    });
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] as { title: string };
+    expect(payload.title).not.toMatch(/couldn't create/i);
+  });
+
+  it("surfaces create failures as an actionable error, not a passive one", async () => {
+    scratchState.createScratch.mockRejectedValueOnce(new Error("nope"));
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.createScratch();
+    });
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] as {
+      type: string;
+      priority?: string;
+      actions?: unknown[];
+    };
+    expect(payload.type).toBe("error");
+    // An inbox-only error would hide the recovery action behind the notification
+    // centre, where a closure-backed onClick can't be reached.
+    expect(payload.priority).not.toBe("low");
+    expect(payload.actions).toHaveLength(1);
+  });
+});
+
+describe("renameScratch", () => {
+  it("renames with the trimmed value", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.renameScratch("scratch-1", "  New name  ");
+    });
+
+    expect(scratchState.renameScratch).toHaveBeenCalledWith("scratch-1", "New name");
+  });
+
+  it("ignores a blank name instead of clearing it", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.renameScratch("scratch-1", "   ");
+    });
+
+    expect(scratchState.renameScratch).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("retries the same id and name after a failure", async () => {
+    scratchState.renameScratch.mockRejectedValueOnce(new Error("locked"));
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    await act(async () => {
+      await result.current.renameScratch("scratch-1", " New name ");
+    });
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalled());
+
+    await act(async () => {
+      await lastRetryAction()();
+    });
+
+    expect(scratchState.renameScratch).toHaveBeenCalledTimes(2);
+    expect(scratchState.renameScratch).toHaveBeenLastCalledWith("scratch-1", "New name");
+  });
+});

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -774,31 +774,41 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       // An empty name is forwarded as undefined so main applies its own
       // `defaultScratchName` — same behavior as before the naming affordance.
       const requestedName = name?.trim() ? name.trim() : undefined;
-      const create = async () => {
-        const created = await createScratchAction(requestedName);
-        await switchScratchAction(created.id);
+      // Resume at the step that failed. Retrying the whole thing after the
+      // scratch already exists would create a second one and orphan its folder.
+      let createdId: string | null = null;
+      const run = async () => {
+        if (!createdId) {
+          createdId = (await createScratchAction(requestedName)).id;
+        }
+        await switchScratchAction(createdId);
+      };
+      const fail = (error: unknown, retry: () => Promise<void>) => {
+        const created = createdId !== null;
+        notify({
+          type: "error",
+          title: created ? "Couldn't open scratch" : "Couldn't create scratch",
+          message: formatErrorMessage(
+            error,
+            created
+              ? "Created the scratch workspace but couldn't switch to it"
+              : "Couldn't create scratch workspace"
+          ),
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+          context: { eventKind: "recovery" },
+        });
       };
       try {
-        await create();
+        await run();
       } catch (error) {
         const retry = async () => {
           try {
-            await create();
+            await run();
           } catch (retryError) {
-            notify({
-              type: "error",
-              title: "Couldn't create scratch",
-              message: formatErrorMessage(retryError, "Couldn't create scratch workspace"),
-              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
-            });
+            fail(retryError, retry);
           }
         };
-        notify({
-          type: "error",
-          title: "Couldn't create scratch",
-          message: formatErrorMessage(error, "Couldn't create scratch workspace"),
-          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
-        });
+        fail(error, retry);
       }
     },
     [close, createScratchAction, switchScratchAction]
@@ -823,7 +833,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
               title: "Couldn't rename scratch",
               message: formatErrorMessage(retryError, "Couldn't rename scratch workspace"),
               actions: [{ label: "Try again", variant: "primary", onClick: retry }],
-              context: { eventKind: "uiFeedback" },
+              context: { eventKind: "recovery" },
             });
           }
         };
@@ -832,7 +842,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           title: "Couldn't rename scratch",
           message: formatErrorMessage(error, "Couldn't rename scratch workspace"),
           actions: [{ label: "Try again", variant: "primary", onClick: retry }],
-          context: { eventKind: "uiFeedback" },
+          // Not `uiFeedback`: its passive policy routes to the inbox, where this
+          // closure-backed "Try again" can never be clicked.
+          context: { eventKind: "recovery" },
         });
       }
     },

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -136,12 +136,17 @@ export interface UseProjectSwitcherPaletteReturn {
   nonActiveAgentCounts: { activeAgentCount: number; waitingAgentCount: number };
   /** Scratch (one-off agent workspace) view-models, sorted by lastOpened desc. */
   scratchResults: SearchableScratch[];
-  /** Create and immediately switch to a new scratch. Closes the palette on success. */
-  createScratch: () => Promise<void>;
+  /**
+   * Create and immediately switch to a new scratch. Closes the palette on success.
+   * An empty or omitted name falls back to the main-process default.
+   */
+  createScratch: (name?: string) => Promise<void>;
   /** Switch to an existing scratch. Closes the palette on success. */
   selectScratch: (scratch: SearchableScratch) => Promise<void>;
   /** Remove a scratch (deletes folder + DB row). Used by context menu. */
   removeScratchAction: (scratchId: string) => Promise<void>;
+  /** Rename a scratch in place. Leaves the palette open. A blank name is a no-op. */
+  renameScratch: (scratchId: string, name: string) => Promise<void>;
   /**
    * Open the directory picker and save the scratch as a project. On success
    * exposes a follow-up confirmation via {@link saveAsProjectConfirm} so the
@@ -257,6 +262,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const createScratchAction = useScratchStore((state) => state.createScratch);
   const switchScratchAction = useScratchStore((state) => state.switchScratch);
   const removeScratchActionStore = useScratchStore((state) => state.removeScratch);
+  const renameScratchActionStore = useScratchStore((state) => state.renameScratch);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -762,33 +768,76 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     return list;
   }, [scratches, currentScratch?.id]);
 
-  const createScratch = useCallback(async () => {
-    close();
-    try {
-      const created = await createScratchAction();
-      await switchScratchAction(created.id);
-    } catch (error) {
-      const retry = async () => {
-        try {
-          const created = await createScratchAction();
-          await switchScratchAction(created.id);
-        } catch (retryError) {
-          notify({
-            type: "error",
-            title: "Couldn't create scratch",
-            message: formatErrorMessage(retryError, "Couldn't create scratch workspace"),
-            actions: [{ label: "Try again", variant: "primary", onClick: retry }],
-          });
-        }
+  const createScratch = useCallback(
+    async (name?: string) => {
+      close();
+      // An empty name is forwarded as undefined so main applies its own
+      // `defaultScratchName` — same behavior as before the naming affordance.
+      const requestedName = name?.trim() ? name.trim() : undefined;
+      const create = async () => {
+        const created = await createScratchAction(requestedName);
+        await switchScratchAction(created.id);
       };
-      notify({
-        type: "error",
-        title: "Couldn't create scratch",
-        message: formatErrorMessage(error, "Couldn't create scratch workspace"),
-        actions: [{ label: "Try again", variant: "primary", onClick: retry }],
-      });
-    }
-  }, [close, createScratchAction, switchScratchAction]);
+      try {
+        await create();
+      } catch (error) {
+        const retry = async () => {
+          try {
+            await create();
+          } catch (retryError) {
+            notify({
+              type: "error",
+              title: "Couldn't create scratch",
+              message: formatErrorMessage(retryError, "Couldn't create scratch workspace"),
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+            });
+          }
+        };
+        notify({
+          type: "error",
+          title: "Couldn't create scratch",
+          message: formatErrorMessage(error, "Couldn't create scratch workspace"),
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+        });
+      }
+    },
+    [close, createScratchAction, switchScratchAction]
+  );
+
+  const renameScratch = useCallback(
+    async (scratchId: string, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const rename = async () => {
+        await renameScratchActionStore(scratchId, trimmed);
+      };
+      try {
+        await rename();
+      } catch (error) {
+        const retry = async () => {
+          try {
+            await rename();
+          } catch (retryError) {
+            notify({
+              type: "error",
+              title: "Couldn't rename scratch",
+              message: formatErrorMessage(retryError, "Couldn't rename scratch workspace"),
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+              context: { eventKind: "uiFeedback" },
+            });
+          }
+        };
+        notify({
+          type: "error",
+          title: "Couldn't rename scratch",
+          message: formatErrorMessage(error, "Couldn't rename scratch workspace"),
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+          context: { eventKind: "uiFeedback" },
+        });
+      }
+    },
+    [renameScratchActionStore]
+  );
 
   const selectScratch = useCallback(
     async (scratch: SearchableScratch) => {
@@ -964,6 +1013,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     createScratch,
     selectScratch,
     removeScratchAction,
+    renameScratch,
     saveAsProject,
     saveAsProjectConfirm,
     dismissSaveAsProjectConfirm,

--- a/src/lib/__tests__/workspaceIdentity.test.ts
+++ b/src/lib/__tests__/workspaceIdentity.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { activeWorkspaceIdentity } from "../workspaceIdentity";
+
+const project = { name: "daintree" };
+const scratch = { name: "Spike: retry queue" };
+
+describe("activeWorkspaceIdentity", () => {
+  it("reports the project when one is open", () => {
+    const identity = activeWorkspaceIdentity(project, null);
+    expect(identity.kind).toBe("project");
+    expect(identity.name).toBe(project.name);
+    expect(identity.ariaLabel).toContain(project.name);
+  });
+
+  it("falls back to the scratch when no project is open", () => {
+    const identity = activeWorkspaceIdentity(null, scratch);
+    expect(identity.kind).toBe("scratch");
+    expect(identity.name).toBe(scratch.name);
+    expect(identity.ariaLabel).toContain(scratch.name);
+  });
+
+  it("distinguishes a scratch from a project in the accessible label", () => {
+    const projectLabel = activeWorkspaceIdentity({ name: "shared" }, null).ariaLabel;
+    const scratchLabel = activeWorkspaceIdentity(null, { name: "shared" }).ariaLabel;
+    expect(scratchLabel).not.toBe(projectLabel);
+    expect(scratchLabel).toMatch(/scratch/i);
+    expect(projectLabel).not.toMatch(/scratch/i);
+  });
+
+  it("lets a project win over a stale scratch pointer", () => {
+    const identity = activeWorkspaceIdentity(project, scratch);
+    expect(identity.kind).toBe("project");
+    expect(identity.name).toBe(project.name);
+  });
+
+  it("reports no workspace when both pointers are empty", () => {
+    const identity = activeWorkspaceIdentity(null, null);
+    expect(identity.kind).toBe("none");
+    // The empty state must still label the pill with an action, not a blank.
+    expect(identity.name.length).toBeGreaterThan(0);
+    expect(identity.ariaLabel.length).toBeGreaterThan(0);
+  });
+
+  it("labels the empty state with an action verb, not brand text", () => {
+    const identity = activeWorkspaceIdentity(null, null);
+    expect(identity.name).toMatch(/^Open\b/);
+    expect(identity.name).not.toMatch(/daintree/i);
+  });
+
+  it("treats undefined like null", () => {
+    expect(activeWorkspaceIdentity(undefined, undefined).kind).toBe("none");
+    expect(activeWorkspaceIdentity(undefined, scratch).kind).toBe("scratch");
+  });
+});

--- a/src/lib/workspaceIdentity.ts
+++ b/src/lib/workspaceIdentity.ts
@@ -1,0 +1,32 @@
+import type { Project, Scratch } from "@shared/types";
+
+export type ActiveWorkspaceIdentity =
+  | { kind: "project"; name: string; ariaLabel: string }
+  | { kind: "scratch"; name: string; ariaLabel: string }
+  | { kind: "none"; name: string; ariaLabel: string };
+
+/**
+ * Resolves what the toolbar pill and sidebar switcher should show. `currentProject`
+ * and `currentScratch` are mutually exclusive pointers in practice; project still
+ * wins here so a stale scratch pointer can never mask an open project.
+ */
+export function activeWorkspaceIdentity(
+  currentProject: Pick<Project, "name"> | null | undefined,
+  currentScratch: Pick<Scratch, "name"> | null | undefined
+): ActiveWorkspaceIdentity {
+  if (currentProject) {
+    return {
+      kind: "project",
+      name: currentProject.name,
+      ariaLabel: `Open project switcher for ${currentProject.name}`,
+    };
+  }
+  if (currentScratch) {
+    return {
+      kind: "scratch",
+      name: currentScratch.name,
+      ariaLabel: `Open project switcher for scratch ${currentScratch.name}`,
+    };
+  }
+  return { kind: "none", name: "Open project", ariaLabel: "Open project" };
+}

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -1,6 +1,7 @@
 import { appClient, terminalClient, worktreeClient, projectClient, systemClient } from "@/clients";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useProjectStore } from "@/store/projectStore";
+import { useScratchStore } from "@/store/scratchStore";
 import { suppressMruRecording } from "@/store/worktreeStore";
 import { useLayoutConfigStore } from "@/store";
 import type {
@@ -213,6 +214,16 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         : [...baseProjects, currentProject];
       return { projects, currentProject, isBootstrapped: bootstrapped };
     });
+
+    // The active scratch persists in main but doesn't ride the hydrate payload,
+    // so without this the toolbar and sidebar show "Open project" after a relaunch
+    // into a scratch. Fire-and-forget: nothing on the boot path blocks on it.
+    void useScratchStore
+      .getState()
+      .loadScratches()
+      .catch(() => {
+        // The switcher reloads scratches whenever it opens; a boot miss self-heals.
+      });
 
     terminalInstanceService.setGPUHardwareAvailable(gpuWebGLHardware ?? true);
 


### PR DESCRIPTION
## Summary

- Users can now name a Scratch workspace instead of always getting the default `Scratch YYYY-MM-DD HH:MM` name, and the active scratch's name now shows in the app chrome (toolbar pill and sidebar switcher).
- Previously, both fell back to the generic `Open project` / `Select Project...` placeholders whenever a scratch was active, since switching to a scratch clears `currentProject`.
- The name plumbing (`scratch:create` IPC to store to main) already existed end to end. Only the UI entry point was missing, and the renderer store's `renameScratch` action had zero callers.

Resolves #11075

## Changes

- Added an inline name editor to the project-switcher palette's Scratch section. The `New scratch workspace` row now reveals a prefilled, select-all input. Enter creates with the typed name, Escape cancels the edit without closing the palette, and blur cancels. A blank name still falls through to the existing main-process default.
- Wired the previously orphaned `renameScratch` store action to a new `Rename scratch` row context-menu action, reusing the same editor.
- Extracted `defaultScratchName` into `shared/utils/scratchName.ts` so the renderer prefills exactly what main would persist, avoiding drift if the user submits the default name unedited.
- Toolbar pill and sidebar switcher now show the active scratch's name (Lucide `FileText` icon, scratch-specific aria-label) via a new pure `activeWorkspaceIdentity` helper. A project always wins over a stale scratch pointer.
- Hydrated the scratch store at boot. The active scratch was persisted in main but never rode the boot hydrate payload, so relaunching into a scratch still showed `Open project` until the palette was first opened.
- Fixed a latent create-retry bug: if a scratch was created but the switch to it failed, clicking `Try again` re-ran both steps, creating a duplicate workspace and orphaning the first one on disk. The retry now resumes at the step that actually failed.
- Routed the create/rename error toasts through the `recovery` event kind instead of `uiFeedback`. `uiFeedback` is passive and routes to the inbox, where a closure-backed `Try again` action can never be clicked.
- Fixed the sidebar's active-workspace branch, which was passing no scratch props at all. With a scratch active it rendered a palette with no Scratch section, so there was no way to switch, rename, or create.

## Testing

368 targeted tests pass locally, covering the branch tests and all suites touching the changed modules. New test files:

- `shared/utils/__tests__/scratchName.test.ts`
- `src/lib/__tests__/workspaceIdentity.test.ts`
- `src/hooks/__tests__/useProjectSwitcherPalette.scratch.test.tsx`
- `src/components/Project/__tests__/ProjectSwitcherPalette.scratchNaming.test.tsx`
- `src/components/Project/__tests__/ProjectSwitcher.scratch.test.tsx`

The Escape-guard behavior and the no-duplicate-retry fix were both mutation-validated with a red-before-green check. Typecheck, lint ratchet, and prettier are all clean.