### PR TITLE
feat(toolbar): persist repository counts so switch-back doesn't shift the pills

### DIFF
--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -431,7 +431,14 @@ async function handleForgeGetRepoStats(payload: {
   // is a fallback, not an observation — its forge counts never replace what is
   // stored, though a reliable commit count still may (local git doesn't go
   // stale just because the network did).
-  const cleanForge = fresh && !snapshot.counts.error;
+  //
+  // Deliberately broader than `fresh` (which gates the broadcast on
+  // `source === "network"`): a clean `memory-cache` hit is data the provider
+  // stands behind and the renderer already renders as fresh, and `source` is
+  // optional on the contract — a provider that omits it would otherwise never
+  // persist anything. Only an explicit disk fallback is excluded, since that is
+  // the provider serving its own last-known values back to us.
+  const cleanForge = !snapshot.counts.stale && !snapshot.counts.error && snapshot.source !== "disk";
   await persistRepoStats(cwd, {
     ...(commitReliable ? { commitCount } : {}),
     ...(cleanForge
@@ -488,15 +495,21 @@ async function handleForgeGetFirstPageCache(payload: {
     // count is a local-git fact — so without this the bootstrap payload carried
     // no commit count at all and the renderer seeded a hardcoded 0, leaving the
     // commit pill to shift even when the issue/PR pills hydrated cleanly.
-    // Computed only once a usable snapshot exists, so a cache miss stays free.
-    const { count: commitCount } = await readCommitCount(payload.cwd);
+    //
+    // Only when the snapshot actually carries counts: a first-page entry whose
+    // stats expired has nothing to blend into, and this is the cold-start path
+    // where a needless `rev-list` traversal of a large repo is exactly what we
+    // cannot afford.
+    const stats = snapshot.counts
+      ? { ...snapshot.counts, commitCount: (await readCommitCount(payload.cwd)).count }
+      : undefined;
     return {
       providerId: namespaceId,
       projectPath: path.resolve(payload.cwd),
       issues: snapshot.issues,
       prs: snapshot.prs,
       lastUpdated: snapshot.lastUpdated,
-      stats: snapshot.counts ? { ...snapshot.counts, commitCount } : undefined,
+      stats,
     };
   } catch {
     return null;

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -8,6 +8,7 @@ import { resolveForCwd } from "./forgeResolution.js";
 import { auditForgeCall, summarizeForgeArgs } from "../../services/forge/forgeAuditService.js";
 import { getForgeProviderImpl } from "../../services/forgeProviderRegistry.js";
 import { getCommitCount } from "../../utils/git.js";
+import { logWarn } from "../../utils/logger.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
 import type {
@@ -55,6 +56,65 @@ function requireCwd(value: unknown): string {
     throw new Error("Invalid working directory");
   }
   return value;
+}
+
+/**
+ * The project store is imported lazily: its module-scope singleton reads
+ * `app.getPath()` on construction, so a static import here would drag Electron
+ * into every consumer of this module (and every test that mocks only the pieces
+ * of `electron` it actually uses).
+ */
+type ProjectStoreModule = typeof import("../../services/ProjectStore.js");
+const loadProjectStore = (): Promise<ProjectStoreModule> =>
+  import("../../services/ProjectStore.js");
+
+/**
+ * Read the local commit count, falling back to the project's last-known value
+ * and finally to zero (issue #11078).
+ *
+ * `reliable` marks whether git actually answered. A failed lookup must never be
+ * persisted: it is indistinguishable from an empty repository at the column
+ * level, so writing its fallback would silently overwrite a good count with a
+ * zero and make the commit pill shift on the next switch-back — the exact bug
+ * this is here to fix. The fallback still feeds the *returned* stats so the
+ * toolbar keeps rendering a number through a transient git failure.
+ */
+async function readCommitCount(cwd: string): Promise<{ count: number; reliable: boolean }> {
+  try {
+    return { count: await getCommitCount(cwd), reliable: true };
+  } catch {
+    try {
+      const { projectStore } = await loadProjectStore();
+      const project = await projectStore.getProjectByPath(cwd);
+      return { count: project?.lastKnownStats?.commitCount ?? 0, reliable: false };
+    } catch {
+      return { count: 0, reliable: false };
+    }
+  }
+}
+
+/**
+ * Persist the counts behind a poll so the next switch-back seeds the toolbar
+ * from real numbers (issue #11078). Best-effort: a persistence failure must
+ * never turn a successful forge poll into a renderer-visible error.
+ *
+ * Omitting `forge` preserves the stored issue/PR counts — see
+ * `ProjectStore.saveRepoStats` for why the commit-only path must not null them
+ * out.
+ */
+async function persistRepoStats(
+  cwd: string,
+  update: Parameters<ProjectStoreModule["projectStore"]["saveRepoStats"]>[1]
+): Promise<void> {
+  try {
+    const { projectStore } = await loadProjectStore();
+    projectStore.saveRepoStats(cwd, update);
+  } catch (error) {
+    logWarn("[forgeData] Failed to persist repository stats", {
+      cwd,
+      error: formatErrorMessage(error, "unknown"),
+    });
+  }
 }
 
 /** Blend provider-reported forge counts with the host-computed commit count. */
@@ -334,6 +394,9 @@ async function handleForgeGetRepoStats(payload: {
   // the path is gone; without this guard each poll runs `getCommitCount` ->
   // `createHardenedGit` against the dead path and emits a WARN log. Return a
   // commits-only zero snapshot — the same shape as the no-provider fallback.
+  // Nothing is persisted here: a dead path yields no observation, and writing
+  // this zero would overwrite the counts that let the toolbar hold its pill
+  // widths if the directory comes back (issue #11078).
   if (!existsSync(cwd)) {
     return buildForgeRepositoryStats(0, { issueCount: null, prCount: null });
   }
@@ -345,8 +408,12 @@ async function handleForgeGetRepoStats(payload: {
     // or not yet activated): the toolbar still shows the local commit count,
     // so return a commit-only snapshot instead of failing the whole surface.
     // Forge counts stay null — the renderer renders the commits-only pill.
-    const commitCount = await getCommitCount(cwd).catch(() => 0);
-    return buildForgeRepositoryStats(commitCount, { issueCount: null, prCount: null });
+    const { count, reliable } = await readCommitCount(cwd);
+    // Commit-only update: `forge` is omitted, so the stored issue/PR counts
+    // survive. This branch also covers a provider that is merely mid-activation
+    // — nulling its counts here would discard good data over a blip.
+    if (reliable) await persistRepoStats(cwd, { commitCount: count });
+    return buildForgeRepositoryStats(count, { issueCount: null, prCount: null });
   }
   const { impl, repoRef, namespaceId } = resolved;
   if (!impl.repoStats) {
@@ -355,10 +422,30 @@ async function handleForgeGetRepoStats(payload: {
   const snapshot = await impl.repoStats.getRepoStats(repoRef, {
     bypassCache: payload.bypassCache === true,
   });
-  const commitCount = await getCommitCount(cwd).catch(() => 0);
+  const { count: commitCount, reliable: commitReliable } = await readCommitCount(cwd);
   const stats = buildForgeRepositoryStats(commitCount, snapshot.counts);
 
   const fresh = snapshot.source === "network" && !snapshot.counts.stale;
+
+  // Persist the counts behind this poll (issue #11078). A stale/errored result
+  // is a fallback, not an observation — its forge counts never replace what is
+  // stored, though a reliable commit count still may (local git doesn't go
+  // stale just because the network did).
+  const cleanForge = fresh && !snapshot.counts.error;
+  await persistRepoStats(cwd, {
+    ...(commitReliable ? { commitCount } : {}),
+    ...(cleanForge
+      ? {
+          forge: {
+            issueCount: snapshot.counts.issueCount,
+            prCount: snapshot.counts.prCount,
+            providerId: namespaceId,
+          },
+          lastUpdated: snapshot.counts.lastUpdated ?? Date.now(),
+        }
+      : {}),
+  });
+
   if (snapshot.issues && snapshot.prs && fresh) {
     const push: ForgeRepoStatsAndPagePayload = {
       providerId: namespaceId,
@@ -396,13 +483,20 @@ async function handleForgeGetFirstPageCache(payload: {
     const { impl, repoRef, namespaceId } = await resolveForCwd(payload.cwd);
     const snapshot = await impl.repoStats?.getFirstPageCache?.(repoRef);
     if (!snapshot) return null;
+    // Blend in the host-computed commit count, exactly as the live-poll sibling
+    // does (issue #11078). The provider deliberately doesn't report it — commit
+    // count is a local-git fact — so without this the bootstrap payload carried
+    // no commit count at all and the renderer seeded a hardcoded 0, leaving the
+    // commit pill to shift even when the issue/PR pills hydrated cleanly.
+    // Computed only once a usable snapshot exists, so a cache miss stays free.
+    const { count: commitCount } = await readCommitCount(payload.cwd);
     return {
       providerId: namespaceId,
       projectPath: path.resolve(payload.cwd),
       issues: snapshot.issues,
       prs: snapshot.prs,
       lastUpdated: snapshot.lastUpdated,
-      stats: snapshot.counts,
+      stats: snapshot.counts ? { ...snapshot.counts, commitCount } : undefined,
     };
   } catch {
     return null;

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1,6 +1,7 @@
 // eager-import-allow: reads/writes the project list via sync fs during startup
 import type {
   Project,
+  ProjectRepoStats,
   ProjectState,
   ProjectSettings,
   ProjectStatus,
@@ -45,6 +46,54 @@ import { getWritesSuppressed } from "./diskPressureState.js";
 
 export const DEFAULT_PROJECT_EMOJI = "🌲";
 
+/**
+ * Read a persisted count back, rejecting anything a corrupt row could hold.
+ * `Number.isFinite` alone lets `1.5` and `-1` through; a count is a
+ * non-negative integer or it is unknown.
+ */
+function readPersistedCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+/**
+ * Project the persisted stats columns onto {@link ProjectRepoStats} (issue
+ * #11078). The commit count anchors the snapshot: without it there is nothing
+ * to seed the toolbar with, so the whole field stays absent. Forge counts are
+ * independently optional — a project with no provider persists commits alone.
+ */
+function rowToRepoStats(row: ProjectRow): ProjectRepoStats | null {
+  const commitCount = readPersistedCount(row.statsCommitCount);
+  if (commitCount === null) return null;
+  return {
+    commitCount,
+    issueCount: readPersistedCount(row.statsIssueCount),
+    prCount: readPersistedCount(row.statsPrCount),
+    providerId: typeof row.statsProviderId === "string" ? row.statsProviderId : null,
+    lastUpdated: readPersistedCount(row.statsLastUpdated),
+  };
+}
+
+/**
+ * Inverse of {@link rowToRepoStats}, for the insert paths that rebuild a row
+ * from a `Project` (relocation). Without this the last-known counts would be
+ * dropped on the floor and the toolbar would shift once after every relocate.
+ */
+function repoStatsToColumns(stats: ProjectRepoStats | undefined): {
+  statsCommitCount: number | null;
+  statsIssueCount: number | null;
+  statsPrCount: number | null;
+  statsProviderId: string | null;
+  statsLastUpdated: number | null;
+} {
+  return {
+    statsCommitCount: stats ? readPersistedCount(stats.commitCount) : null,
+    statsIssueCount: stats ? readPersistedCount(stats.issueCount) : null,
+    statsPrCount: stats ? readPersistedCount(stats.prCount) : null,
+    statsProviderId: stats?.providerId ?? null,
+    statsLastUpdated: stats ? readPersistedCount(stats.lastUpdated) : null,
+  };
+}
+
 function rowToProject(row: ProjectRow): Project {
   const project: Project = {
     id: row.id,
@@ -64,6 +113,8 @@ function rowToProject(row: ProjectRow): Project {
     typeof row.frecencyScore === "number" ? row.frecencyScore : FRECENCY_COLD_START;
   project.lastAccessedAt = typeof row.lastAccessedAt === "number" ? row.lastAccessedAt : 0;
   if (typeof row.autoParkedAt === "number") project.autoParkedAt = row.autoParkedAt;
+  const lastKnownStats = rowToRepoStats(row);
+  if (lastKnownStats) project.lastKnownStats = lastKnownStats;
   return project;
 }
 
@@ -435,6 +486,93 @@ export class ProjectStore {
     return rowToProject(row);
   }
 
+  /**
+   * Persist the last-known repository counts for a project (issue #11078), so a
+   * switch-back or a cold start can seed the toolbar from real numbers instead
+   * of em-dashes that resize once a poll lands.
+   *
+   * The two count families have different owners and are updated independently:
+   *
+   * - `commitCount` is a local-git fact. Pass it whenever git actually answered.
+   *   Omit it when the lookup failed — persisting a fallback zero over a good
+   *   count is exactly the corruption this signature exists to prevent.
+   * - `forge` carries the provider-reported counts. Pass it ONLY for a clean
+   *   provider result. Omitting it preserves whatever is already stored; the
+   *   commit-only path fires during transient provider resolution failures
+   *   (plugin activating, temporarily disabled), and nulling the forge columns
+   *   there would throw away good counts over a blip.
+   *
+   * A no-op when nothing material changed — the caller polls every ~30s, and a
+   * provider that re-stamps `lastUpdated` on an unchanged probe must not turn
+   * that into a write per poll.
+   */
+  saveRepoStats(
+    projectPath: string,
+    update: {
+      commitCount?: number;
+      forge?: { issueCount: number | null; prCount: number | null; providerId: string | null };
+      lastUpdated?: number;
+    }
+  ): void {
+    // Honour the same disk-pressure backpressure as every other cache write —
+    // last-known counts are a nicety, never worth a write under pressure.
+    if (getWritesSuppressed()) return;
+
+    const db = getSharedDb();
+    const normalizedPath = path.normalize(projectPath).normalize("NFC");
+    const row = db.select().from(projectsTable).where(eq(projectsTable.path, normalizedPath)).get();
+    // Stats are keyed to a registered project. A worktree path, or a directory
+    // the user never added, has no row to hold them.
+    if (!row) return;
+
+    const set: Partial<{
+      statsCommitCount: number;
+      statsIssueCount: number | null;
+      statsPrCount: number | null;
+      statsProviderId: string | null;
+      statsLastUpdated: number | null;
+    }> = {};
+
+    const nextCommitCount = readPersistedCount(update.commitCount);
+    if (nextCommitCount !== null && nextCommitCount !== row.statsCommitCount) {
+      set.statsCommitCount = nextCommitCount;
+    }
+
+    if (update.forge) {
+      // Discard a result that resolved out of order behind a newer one. Only
+      // guards the forge columns: the commit count above is local git, has no
+      // provider timestamp to compare, and its freshest read always wins.
+      const storedAt = readPersistedCount(row.statsLastUpdated);
+      const incomingAt = readPersistedCount(update.lastUpdated);
+      const outOfOrder =
+        storedAt !== null &&
+        incomingAt !== null &&
+        incomingAt < storedAt &&
+        row.statsProviderId === update.forge.providerId;
+
+      if (!outOfOrder) {
+        const { issueCount, prCount, providerId } = update.forge;
+        const changed =
+          issueCount !== row.statsIssueCount ||
+          prCount !== row.statsPrCount ||
+          providerId !== row.statsProviderId;
+        // Only a genuine count change advances the stored timestamp. Writing on
+        // a re-stamp alone would mean a SQLite UPDATE on every poll of every
+        // open project, forever, for a value nothing reads as fresh — the seed
+        // is always applied as stale and revalidated behind.
+        if (changed) {
+          set.statsIssueCount = issueCount;
+          set.statsPrCount = prCount;
+          set.statsProviderId = providerId;
+          set.statsLastUpdated = incomingAt;
+        }
+      }
+    }
+
+    if (Object.keys(set).length === 0) return;
+    db.update(projectsTable).set(set).where(eq(projectsTable.id, row.id)).run();
+  }
+
   updateProjectStatus(
     projectId: string,
     status: ProjectStatus,
@@ -622,6 +760,7 @@ export class ProjectStore {
           pinned: updatedProject.pinned ? 1 : 0,
           frecencyScore: updatedProject.frecencyScore ?? FRECENCY_COLD_START,
           lastAccessedAt: updatedProject.lastAccessedAt ?? 0,
+          ...repoStatsToColumns(updatedProject.lastKnownStats),
         })
         .run();
       this.settingsManager.migrateEnvForProject(projectId, newProjectId);
@@ -643,6 +782,7 @@ export class ProjectStore {
           pinned: oldProject.pinned ? 1 : 0,
           frecencyScore: oldProject.frecencyScore ?? FRECENCY_COLD_START,
           lastAccessedAt: oldProject.lastAccessedAt ?? 0,
+          ...repoStatsToColumns(oldProject.lastKnownStats),
         })
         .run();
       if (newStateDir && existsSync(newStateDir)) {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -119,6 +119,14 @@ function rowToProject(row: ProjectRow): Project {
 }
 
 export class ProjectStore {
+  /**
+   * Newest forge observation seen per project id this session (issue #11078).
+   * Ordering guard for `saveRepoStats` — see the comment there for why the
+   * persisted timestamp cannot serve as the high-water mark by itself.
+   * Process-local: a restart leaves no in-flight requests to order against.
+   */
+  private readonly repoStatsHighWater = new Map<string, number>();
+
   private projectsConfigDir: string;
   private globalConfigDir: string;
   private userDataDir: string;
@@ -539,19 +547,33 @@ export class ProjectStore {
     }
 
     if (update.forge) {
-      // Discard a result that resolved out of order behind a newer one. Only
-      // guards the forge columns: the commit count above is local git, has no
-      // provider timestamp to compare, and its freshest read always wins.
-      const storedAt = readPersistedCount(row.statsLastUpdated);
+      const { issueCount, prCount, providerId } = update.forge;
       const incomingAt = readPersistedCount(update.lastUpdated);
-      const outOfOrder =
-        storedAt !== null &&
-        incomingAt !== null &&
-        incomingAt < storedAt &&
-        row.statsProviderId === update.forge.providerId;
 
-      if (!outOfOrder) {
-        const { issueCount, prCount, providerId } = update.forge;
+      // Forge counts come from plugin code. A provider returning `-1`, `1.5` or
+      // `NaN` on an otherwise clean result would be written straight through and
+      // then read back as `null`, silently destroying the good counts already
+      // stored. Reject the whole forge snapshot rather than persist part of it.
+      const forgeIsValid =
+        (issueCount === null || readPersistedCount(issueCount) !== null) &&
+        (prCount === null || readPersistedCount(prCount) !== null);
+
+      // Discard a result that resolved out of order behind a newer one. The
+      // stored timestamp can't serve as the high-water mark on its own: the
+      // no-restamp policy below means a poll that merely *confirms* the current
+      // counts leaves it untouched, so a delayed older observation could still
+      // sail past it. Track the newest observation seen this session separately.
+      // Process-local by design — a restart leaves no in-flight requests to
+      // order against. Compared across providers too: a genuine provider change
+      // always arrives on a fresh fetch, so it is never the older one.
+      const highWater = Math.max(
+        this.repoStatsHighWater.get(row.id) ?? 0,
+        readPersistedCount(row.statsLastUpdated) ?? 0
+      );
+      const outOfOrder = incomingAt !== null && incomingAt < highWater;
+
+      if (forgeIsValid && !outOfOrder) {
+        if (incomingAt !== null) this.repoStatsHighWater.set(row.id, incomingAt);
         const changed =
           issueCount !== row.statsIssueCount ||
           prCount !== row.statsPrCount ||

--- a/electron/services/__tests__/ProjectStore.autoParkedAt.test.ts
+++ b/electron/services/__tests__/ProjectStore.autoParkedAt.test.ts
@@ -22,7 +22,12 @@ const CREATE_TABLES_SQL = `
     pinned INTEGER NOT NULL DEFAULT 0,
     frecency_score REAL NOT NULL DEFAULT 3.0,
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
-    auto_parked_at INTEGER
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.diskPressure.test.ts
+++ b/electron/services/__tests__/ProjectStore.diskPressure.test.ts
@@ -21,7 +21,12 @@ const CREATE_TABLES_SQL = `
     pinned INTEGER NOT NULL DEFAULT 0,
     frecency_score REAL NOT NULL DEFAULT 3.0,
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
-    auto_parked_at INTEGER
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.mruSwitch.test.ts
+++ b/electron/services/__tests__/ProjectStore.mruSwitch.test.ts
@@ -21,7 +21,12 @@ const CREATE_TABLES_SQL = `
     pinned INTEGER NOT NULL DEFAULT 0,
     frecency_score REAL NOT NULL DEFAULT 3.0,
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
-    auto_parked_at INTEGER
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/__tests__/ProjectStore.repoStats.test.ts
+++ b/electron/services/__tests__/ProjectStore.repoStats.test.ts
@@ -230,7 +230,7 @@ describe("ProjectStore repository stats (issue #11078)", () => {
       expect(stats?.issueCount).toBe(1);
     });
 
-    it("ignores a same-provider result that resolved out of order behind a newer one", () => {
+    it("ignores a result that resolved out of order behind a newer one", () => {
       store.saveRepoStats(projectPath, {
         commitCount: 412,
         forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
@@ -246,6 +246,71 @@ describe("ProjectStore repository stats (issue #11078)", () => {
       const stats = store.getProjectById(projectId)?.lastKnownStats;
       expect(stats?.issueCount).toBe(7);
       expect(stats?.lastUpdated).toBe(6000);
+    });
+
+    it("orders against the newest observation seen, not just the newest one written", () => {
+      // The no-restamp policy means a poll that merely *confirms* the current
+      // counts writes nothing — so the stored timestamp lags the newest thing
+      // we've actually seen. Without a separate high-water mark, a delayed older
+      // result sails past the stored value and overwrites good counts.
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 100,
+      });
+
+      // A later poll confirms the same counts at t=200 — nothing is written, so
+      // the row's timestamp stays at 100...
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 200,
+      });
+      expect(store.getProjectById(projectId)?.lastKnownStats?.lastUpdated).toBe(100);
+
+      // ...but a straggler that observed different counts back at t=150 must
+      // still lose to the t=200 observation.
+      store.saveRepoStats(projectPath, {
+        forge: { issueCount: 99, prCount: 99, providerId: PROVIDER },
+        lastUpdated: 150,
+      });
+
+      expect(store.getProjectById(projectId)?.lastKnownStats?.issueCount).toBe(7);
+    });
+
+    it("rejects a forge snapshot carrying counts a provider should never emit", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      // Written raw, these would round-trip back as null on read and silently
+      // destroy the good counts above.
+      store.saveRepoStats(projectPath, {
+        forge: { issueCount: -1, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 6000,
+      });
+      store.saveRepoStats(projectPath, {
+        forge: { issueCount: 4, prCount: Number.NaN, providerId: PROVIDER },
+        lastUpdated: 7000,
+      });
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.issueCount).toBe(7);
+      expect(stats?.prCount).toBe(3);
+    });
+
+    it("still accepts a forge snapshot whose counts are legitimately unknown", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: null, prCount: null, providerId: null },
+        lastUpdated: 5000,
+      });
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.issueCount).toBeNull();
+      expect(stats?.providerId).toBeNull();
     });
   });
 

--- a/electron/services/__tests__/ProjectStore.repoStats.test.ts
+++ b/electron/services/__tests__/ProjectStore.repoStats.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as schema from "../persistence/schema.js";
+
+// Mirrors the real `projects` schema including the nullable stats_* columns
+// added by migration 0007 (#11078).
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    last_opened INTEGER NOT NULL,
+    color TEXT,
+    status TEXT,
+    daintree_config_present INTEGER,
+    in_repo_settings INTEGER,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    frecency_score REAL NOT NULL DEFAULT 3.0,
+    last_accessed_at INTEGER NOT NULL DEFAULT 0,
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-repostats-test" },
+}));
+
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    async getRepositoryRoot(p: string): Promise<string> {
+      return p;
+    }
+  },
+}));
+
+vi.mock("../ProjectSettingsManager.js", () => ({
+  ProjectSettingsManager: class {
+    deleteAllEnvForProject() {}
+    migrateEnvForProject() {}
+    getEffectiveNotificationSettings() {
+      return {};
+    }
+  },
+}));
+
+vi.mock("../ProjectStateManager.js", () => ({
+  ProjectStateManager: class {
+    invalidateProjectStateCache() {}
+  },
+}));
+
+vi.mock("../ProjectFileStore.js", () => ({ ProjectFileStore: class {} }));
+vi.mock("../GlobalFileStore.js", () => ({ GlobalFileStore: class {} }));
+vi.mock("../ProjectIdentityFiles.js", () => ({
+  ProjectIdentityFiles: class {
+    async readInRepoProjectIdentity() {
+      return { found: false };
+    }
+  },
+}));
+vi.mock("../projectQuarantineCleanup.js", () => ({
+  cleanupQuarantinedProjectFiles: vi.fn(),
+}));
+
+import { ProjectStore } from "../ProjectStore.js";
+import { setWritesSuppressed, resetWritesSuppressedForTesting } from "../diskPressureState.js";
+
+const PROVIDER = "github.forge.provider";
+
+describe("ProjectStore repository stats (issue #11078)", () => {
+  let store: ProjectStore;
+  let projectDir: string;
+  let projectId: string;
+  let projectPath: string;
+
+  function readRow() {
+    return db.select().from(schema.projects).where(eq(schema.projects.id, projectId)).get();
+  }
+
+  beforeEach(async () => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-stats-"));
+    projectPath = await fs.promises.realpath(projectDir);
+    const { generateProjectId } = await import("../projectStorePaths.js");
+    projectId = generateProjectId(projectPath);
+
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    db.insert(schema.projects)
+      .values({
+        id: projectId,
+        path: projectPath,
+        name: "Stats",
+        emoji: "🌲",
+        lastOpened: Date.now(),
+        status: "active",
+        frecencyScore: 3.0,
+        lastAccessedAt: Date.now(),
+      })
+      .run();
+
+    store = new ProjectStore();
+    resetWritesSuppressedForTesting();
+  });
+
+  afterEach(() => {
+    resetWritesSuppressedForTesting();
+    sqlite.close();
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  describe("round trip", () => {
+    it("exposes a saved snapshot on the project record", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      expect(store.getProjectById(projectId)?.lastKnownStats).toEqual({
+        commitCount: 412,
+        issueCount: 7,
+        prCount: 3,
+        providerId: PROVIDER,
+        lastUpdated: 5000,
+      });
+    });
+
+    it("persists a genuine zero rather than treating it as absent", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 0,
+        forge: { issueCount: 0, prCount: 0, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.commitCount).toBe(0);
+      expect(stats?.issueCount).toBe(0);
+      expect(stats?.prCount).toBe(0);
+    });
+
+    it("omits the snapshot entirely when no commit count was ever stored", () => {
+      expect(store.getProjectById(projectId)?.lastKnownStats).toBeUndefined();
+    });
+
+    it("keeps a corrupt persisted count out of the project record", () => {
+      // A hand-edited or partially-written row must not reach the renderer as a
+      // negative/fractional count that the toolbar would render verbatim.
+      db.update(schema.projects)
+        .set({ statsCommitCount: -1, statsIssueCount: 1.5, statsPrCount: 2 })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+
+      // A bad commit count invalidates the whole snapshot (it is the anchor).
+      expect(store.getProjectById(projectId)?.lastKnownStats).toBeUndefined();
+
+      db.update(schema.projects)
+        .set({ statsCommitCount: 10 })
+        .where(eq(schema.projects.id, projectId))
+        .run();
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.commitCount).toBe(10);
+      // The fractional issue count is dropped; the valid PR count survives.
+      expect(stats?.issueCount).toBeNull();
+      expect(stats?.prCount).toBe(2);
+    });
+  });
+
+  describe("ownership", () => {
+    it("preserves the forge counts when only a commit count is reported", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      // The provider failed to resolve — mid-activation, disabled, offline. The
+      // commit count still moves; the forge counts must not be nulled out.
+      store.saveRepoStats(projectPath, { commitCount: 413 });
+
+      expect(store.getProjectById(projectId)?.lastKnownStats).toEqual({
+        commitCount: 413,
+        issueCount: 7,
+        prCount: 3,
+        providerId: PROVIDER,
+        lastUpdated: 5000,
+      });
+    });
+
+    it("replaces the forge counts when the provider changes", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 1, prCount: 0, providerId: "gitlab.forge.provider" },
+        lastUpdated: 6000,
+      });
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.providerId).toBe("gitlab.forge.provider");
+      expect(stats?.issueCount).toBe(1);
+    });
+
+    it("ignores a same-provider result that resolved out of order behind a newer one", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 6000,
+      });
+
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 99, prCount: 99, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.issueCount).toBe(7);
+      expect(stats?.lastUpdated).toBe(6000);
+    });
+  });
+
+  describe("write cadence", () => {
+    it("does not write when nothing material changed", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      // The provider re-stamps `lastUpdated` whenever its probe confirms nothing
+      // changed. Treating that as a write would mean a SQLite UPDATE on every
+      // poll of every open project, forever.
+      const spy = vi.spyOn(sqlite, "prepare");
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 9999,
+      });
+      const wrote = spy.mock.calls.some(([sql]) => String(sql).startsWith("update"));
+      spy.mockRestore();
+
+      expect(wrote).toBe(false);
+      // The re-stamp is also not recorded — the stored time is when the counts
+      // last actually changed.
+      expect(store.getProjectById(projectId)?.lastKnownStats?.lastUpdated).toBe(5000);
+    });
+
+    it("writes as soon as a count actually changes", () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 8, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 9999,
+      });
+
+      const stats = store.getProjectById(projectId)?.lastKnownStats;
+      expect(stats?.issueCount).toBe(8);
+      expect(stats?.lastUpdated).toBe(9999);
+    });
+  });
+
+  describe("guards", () => {
+    it("skips the write entirely under disk pressure", () => {
+      setWritesSuppressed(true);
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      expect(readRow()?.statsCommitCount).toBeNull();
+    });
+
+    it("is a no-op for a path with no registered project", () => {
+      expect(() =>
+        store.saveRepoStats(path.join(projectPath, "worktrees", "feature"), { commitCount: 9 })
+      ).not.toThrow();
+
+      expect(readRow()?.statsCommitCount).toBeNull();
+    });
+
+    it("ignores a commit count that is not a usable count", () => {
+      store.saveRepoStats(projectPath, { commitCount: 412 });
+      store.saveRepoStats(projectPath, { commitCount: Number.NaN });
+      store.saveRepoStats(projectPath, { commitCount: -5 });
+
+      expect(store.getProjectById(projectId)?.lastKnownStats?.commitCount).toBe(412);
+    });
+  });
+
+  describe("relocation", () => {
+    it("carries the snapshot across a project relocation", async () => {
+      store.saveRepoStats(projectPath, {
+        commitCount: 412,
+        forge: { issueCount: 7, prCount: 3, providerId: PROVIDER },
+        lastUpdated: 5000,
+      });
+
+      const newDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-stats-moved-"));
+      const newPath = await fs.promises.realpath(newDir);
+      try {
+        const relocated = await store.relocateProject(projectId, newPath);
+        expect(relocated.lastKnownStats).toEqual({
+          commitCount: 412,
+          issueCount: 7,
+          prCount: 3,
+          providerId: PROVIDER,
+          lastUpdated: 5000,
+        });
+      } finally {
+        fs.rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/electron/services/__tests__/ProjectStore.test.ts
+++ b/electron/services/__tests__/ProjectStore.test.ts
@@ -581,7 +581,12 @@ const CREATE_TABLES_SQL = `
     pinned INTEGER NOT NULL DEFAULT 0,
     frecency_score REAL NOT NULL DEFAULT 3.0,
     last_accessed_at INTEGER NOT NULL DEFAULT 0,
-    auto_parked_at INTEGER
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER
   );
   CREATE TABLE IF NOT EXISTS app_state (
     key TEXT PRIMARY KEY,

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -342,22 +342,29 @@ describe("openDb (integration)", () => {
     seed.close();
 
     // The final migration's effect must be absent before the upgrade for the test
-    // to mean anything — the seed `projects` table was created without indexes, and
-    // the final migration (0006) adds projects_path_idx + projects_frecency_last_opened_idx.
+    // to mean anything — the seed `projects` table was created without them, and
+    // the final migration (0007) adds the stats_* columns (#11078).
     const preCheck = new Database(dbPath, { readonly: true });
-    const seededIndexes = (
-      preCheck.prepare("PRAGMA index_list(projects)").all() as Array<{ name: string }>
-    ).map((i) => i.name);
+    const seededColumns = (preCheck.prepare("PRAGMA table_info(projects)").all() as ColInfo[]).map(
+      (c) => c.name
+    );
     preCheck.close();
-    expect(seededIndexes).not.toContain("projects_frecency_last_opened_idx");
+    expect(seededColumns).not.toContain("stats_commit_count");
 
     const { sqlite } = openDb(dbPath, migrationsFolder);
     try {
-      const projectIndexes = (
-        sqlite.prepare("PRAGMA index_list(projects)").all() as Array<{ name: string }>
-      ).map((i) => i.name);
-      expect(projectIndexes).toContain("projects_path_idx");
-      expect(projectIndexes).toContain("projects_frecency_last_opened_idx");
+      const projectColumns = (sqlite.pragma("table_info(projects)") as ColInfo[]).map(
+        (c) => c.name
+      );
+      expect(projectColumns).toEqual(
+        expect.arrayContaining([
+          "stats_commit_count",
+          "stats_issue_count",
+          "stats_pr_count",
+          "stats_provider_id",
+          "stats_last_updated",
+        ])
+      );
 
       // The skipped migration is now recorded — total equals the full journal.
       const migrations = sqlite.prepare("SELECT id FROM __drizzle_migrations").all();

--- a/electron/services/persistence/migrations/0007_add_project_stats.sql
+++ b/electron/services/persistence/migrations/0007_add_project_stats.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `projects` ADD `stats_commit_count` integer;--> statement-breakpoint
+ALTER TABLE `projects` ADD `stats_issue_count` integer;--> statement-breakpoint
+ALTER TABLE `projects` ADD `stats_pr_count` integer;--> statement-breakpoint
+ALTER TABLE `projects` ADD `stats_provider_id` text;--> statement-breakpoint
+ALTER TABLE `projects` ADD `stats_last_updated` integer;

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782980261485,
       "tag": "0006_daffy_kid_colt",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1783900000000,
+      "tag": "0007_add_project_stats",
+      "breakpoints": true
     }
   ]
 }

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -20,6 +20,18 @@ export const projects = sqliteTable(
     // "Suspended to free memory" label in the project switcher. Cleared when the
     // project is reopened (`setCurrentProject`).
     autoParkedAt: integer("auto_parked_at"),
+    // Last-known repository counts (issue #11078), so switch-back can seed the
+    // toolbar pills from real numbers instead of em-dashes that resize once a
+    // poll lands. All nullable: absent until the project's first clean stats
+    // poll. `statsCommitCount` is local-git and survives on its own, so a
+    // project with no forge provider still holds its commit pill;
+    // `statsProviderId` scopes the forge counts to the provider that reported
+    // them, and `statsLastUpdated` records when they last changed.
+    statsCommitCount: integer("stats_commit_count"),
+    statsIssueCount: integer("stats_issue_count"),
+    statsPrCount: integer("stats_pr_count"),
+    statsProviderId: text("stats_provider_id"),
+    statsLastUpdated: integer("stats_last_updated"),
   },
   (table) => [
     // Equality lookup for getProjectByPath().

--- a/electron/utils/__tests__/git.commitCount.test.ts
+++ b/electron/utils/__tests__/git.commitCount.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGit = {
+  raw: vi.fn(),
+};
+
+vi.mock("../hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockGit),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { getCommitCount } from "../git.js";
+
+// `getCommitCount` reports a *reliable* count or throws — it deliberately does
+// not report `0` for a failure, because callers persist the result and a
+// fabricated zero would overwrite a good stored count (issue #11078).
+describe("getCommitCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function respond(handler: (args: string[]) => Promise<string>) {
+    mockGit.raw.mockImplementation((args: string[]) => handler(args));
+  }
+
+  it("returns the parsed count on the happy path", async () => {
+    respond(async (args) => (args[0] === "rev-list" ? "1234\n" : ""));
+    await expect(getCommitCount("/repo")).resolves.toBe(1234);
+  });
+
+  it("reports zero for a repository whose HEAD is unborn", async () => {
+    // `git init` with nothing committed: `rev-list HEAD` fails, but the repo is
+    // real and its count is genuinely 0. Throwing here would mean an empty repo
+    // could never persist a count — and so could never seed its toolbar.
+    respond(async (args) => {
+      if (args[0] === "rev-list") throw new Error("fatal: ambiguous argument 'HEAD'");
+      if (args[0] === "rev-parse") return ".git\n";
+      return "";
+    });
+
+    await expect(getCommitCount("/empty-repo")).resolves.toBe(0);
+  });
+
+  it("throws when the directory is not a usable repository", async () => {
+    respond(async () => {
+      throw new Error("fatal: not a git repository");
+    });
+
+    await expect(getCommitCount("/not-a-repo")).rejects.toThrow(/not a git repository/);
+  });
+
+  it("does not report an unparseable answer as a count", async () => {
+    // An empty or garbage `rev-list` answer parses to NaN. Reporting that as a
+    // number would let NaN reach the count columns.
+    respond(async (args) => {
+      if (args[0] === "rev-list") return "\n";
+      throw new Error("fatal: not a git repository");
+    });
+
+    await expect(getCommitCount("/weird")).rejects.toThrow();
+  });
+});

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -211,14 +211,27 @@ export function parseNumstat(diffOutput: string, gitRoot: string): Map<string, D
   return stats;
 }
 
+/**
+ * Commit count on the checked-out branch.
+ *
+ * Throws on failure rather than reporting `0`. A swallowed failure is
+ * indistinguishable from a genuinely empty repository, and callers that persist
+ * the result (issue #11078) would overwrite a good count with a zero after a
+ * transient git error. Every call site already supplies its own fallback.
+ */
 export async function getCommitCount(cwd: string): Promise<number> {
   try {
     const git = await createHardenedGit(cwd);
-    const count = await git.raw(["rev-list", "--count", "HEAD"]);
-    return parseInt(count.trim(), 10);
+    const raw = await git.raw(["rev-list", "--count", "HEAD"]);
+    const count = parseInt(raw.trim(), 10);
+    // An unborn HEAD prints nothing, which `parseInt` reports as NaN.
+    if (!Number.isInteger(count) || count < 0) {
+      throw new Error(`Unparseable commit count: ${JSON.stringify(raw)}`);
+    }
+    return count;
   } catch (error) {
     logWarn("Failed to get commit count", { cwd, error: (error as Error).message });
-    return 0;
+    throw error;
   }
 }
 

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -220,16 +220,26 @@ export function parseNumstat(diffOutput: string, gitRoot: string): Map<string, D
  * transient git error. Every call site already supplies its own fallback.
  */
 export async function getCommitCount(cwd: string): Promise<number> {
+  const git = await createHardenedGit(cwd);
   try {
-    const git = await createHardenedGit(cwd);
     const raw = await git.raw(["rev-list", "--count", "HEAD"]);
     const count = parseInt(raw.trim(), 10);
-    // An unborn HEAD prints nothing, which `parseInt` reports as NaN.
-    if (!Number.isInteger(count) || count < 0) {
-      throw new Error(`Unparseable commit count: ${JSON.stringify(raw)}`);
-    }
-    return count;
+    if (Number.isInteger(count) && count >= 0) return count;
+    throw new Error(`Unparseable commit count: ${JSON.stringify(raw)}`);
   } catch (error) {
+    // `rev-list HEAD` fails on an unborn HEAD — a repository created but not yet
+    // committed to. That is a real, reliable zero, not a failure: report it as
+    // such so callers can persist it (a repo whose count never persists never
+    // seeds its toolbar). If the repo itself doesn't answer, the failure is
+    // genuine and propagates — callers supply their own fallback, and reporting
+    // a fabricated 0 here would let a transient git error overwrite a good
+    // stored count (issue #11078).
+    const isRepo = await git
+      .raw(["rev-parse", "--git-dir"])
+      .then(() => true)
+      .catch(() => false);
+    if (isRepo) return 0;
+
     logWarn("Failed to get commit count", { cwd, error: (error as Error).message });
     throw error;
   }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -85,6 +85,7 @@ export type { BrowserHistory } from "./browser.js";
 export type {
   ProjectStatus,
   Project,
+  ProjectRepoStats,
   TerminalSnapshot,
   PanelSnapshot,
   TerminalLayout,

--- a/shared/types/ipc/forge.ts
+++ b/shared/types/ipc/forge.ts
@@ -174,8 +174,13 @@ export interface ForgeFirstPageCachePayload {
   prs: StatsPage<PR>;
   /** Wall-clock timestamp (ms) when the entry was written. */
   lastUpdated: number;
-  /** Cached counts for cold-start hydration even when page items expired. */
-  stats?: { issueCount: number; prCount: number; lastUpdated: number };
+  /**
+   * Cached counts for cold-start hydration even when page items expired.
+   * `commitCount` is blended in host-side (local git), not reported by the
+   * provider — without it the renderer seeded a hardcoded 0 and the commit pill
+   * shifted even when the issue/PR pills hydrated cleanly (issue #11078).
+   */
+  stats?: { commitCount: number; issueCount: number; prCount: number; lastUpdated: number };
 }
 
 /**

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -22,6 +22,36 @@ import type { NotificationSettings } from "./ipc/api.js";
  */
 export type ProjectStatus = "active" | "background" | "closed" | "missing";
 
+/**
+ * Last-known repository counts persisted on the project row so the toolbar can
+ * render real numbers the instant a project is switched back to, instead of
+ * em-dashes that widen into values once a poll lands (issue #11078).
+ *
+ * Durable facts only — no `loading`/`stale`/`error`/rate-limit/cadence fields.
+ * Those describe a single poll, not the repository, and a resurrected error is
+ * exactly the failure mode the switch-back cache was built to avoid (#10761).
+ *
+ * Written by main on a clean poll only; the renderer treats it as a stale seed
+ * and always revalidates behind it.
+ */
+export interface ProjectRepoStats {
+  /** Commit count on the checked-out branch (host-computed, local git). */
+  commitCount: number;
+  /** Open issues, or `null` when no forge provider reported them. */
+  issueCount: number | null;
+  /** Open pull requests, or `null` when no forge provider reported them. */
+  prCount: number | null;
+  /**
+   * Provider that reported {@link issueCount}/{@link prCount}, or `null` when
+   * only the local commit count is known. Forge counts are reusable only when
+   * this still matches the project's resolved provider — a repo that now
+   * resolves elsewhere must not show the old provider's numbers.
+   */
+  providerId: string | null;
+  /** Epoch ms when these counts were last observed to change. */
+  lastUpdated: number | null;
+}
+
 /** Project (Git repository) managed by Daintree */
 export interface Project {
   /** Unique identifier (UUID or path hash) */
@@ -55,6 +85,12 @@ export interface Project {
    * memory" label. Cleared when the project is reopened.
    */
   autoParkedAt?: number;
+  /**
+   * Last-known repository counts, persisted so switch-back seeds the toolbar
+   * immediately instead of shifting its pill widths (issue #11078). Main owns
+   * the write; absent until the project's first clean stats poll.
+   */
+  lastKnownStats?: ProjectRepoStats;
 }
 
 /** Panel snapshot for state preservation. */

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -42,9 +42,22 @@ vi.mock("@/clients/forgeClient", () => ({
   },
 }));
 
+// Mutable so a test can hand the hook a project row carrying persisted
+// `lastKnownStats` — the pre-paint seed reads it straight off the store (#11078).
+const { currentProjectRef } = vi.hoisted(() => ({
+  currentProjectRef: {
+    current: { id: "test-project", path: "/repo/a" } as {
+      id: string;
+      path: string;
+      lastKnownStats?: import("@shared/types/project").ProjectRepoStats;
+    } | null,
+  },
+}));
+
 vi.mock("@/store/projectStore", () => ({
-  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
-    selector({ currentProject: { id: "test-project" } }),
+  useProjectStore: (
+    selector: (s: { currentProject: typeof currentProjectRef.current }) => unknown
+  ) => selector({ currentProject: currentProjectRef.current }),
 }));
 
 const { resolvedProviderRef, makeResolvedProvider } = vi.hoisted(() => {
@@ -101,6 +114,9 @@ describe("useRepositoryStats", () => {
     // into later tests' cold-start hydration.
     getFirstPageCacheMock.mockResolvedValue(null);
     resolvedProviderRef.current = makeResolvedProvider("test.forge.provider");
+    // No persisted counts by default — a test that seeds them must opt in, or
+    // the seed would suppress the skeleton in every unrelated case.
+    currentProjectRef.current = { id: "test-project", path: "/repo/a" };
     _resetPollingLifecycleForTests();
     _resetSwitchBackCacheForTests();
     useSystemWakeStore.setState({
@@ -2692,6 +2708,247 @@ describe("useRepositoryStats", () => {
 
       expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
       expect(getRepoStatsMock.mock.calls[0]?.[1]).toBe(true);
+    });
+  });
+
+  describe("persisted project-record seed (issue #11078)", () => {
+    const persisted = {
+      commitCount: 412,
+      issueCount: 7,
+      prCount: 3,
+      providerId: PROVIDER_ID,
+      lastUpdated: 1000,
+    };
+
+    beforeEach(() => {
+      currentProjectRef.current = {
+        id: "test-project",
+        path: "/repo/a",
+        lastKnownStats: persisted,
+      };
+      getCurrentMock.mockResolvedValue({
+        id: "test-project",
+        path: "/repo/a",
+        lastKnownStats: persisted,
+      });
+      onSwitchMock.mockReturnValue(() => {});
+    });
+
+    it("renders the persisted counts before the first poll resolves, without a skeleton", async () => {
+      const deferred = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(deferred.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      // The whole point of the issue: real numbers are on screen while the
+      // network poll is still in flight, so the pills never resize from an
+      // em-dash placeholder.
+      await waitFor(() => {
+        expect(result.current.stats?.commitCount).toBe(412);
+      });
+      expect(result.current.stats?.issueCount).toBe(7);
+      expect(result.current.stats?.prCount).toBe(3);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.freshnessLevel).toBe("stale-disk");
+      expect(result.current.error).toBeNull();
+
+      // ...and the refresh behind it still reconciles.
+      await act(async () => {
+        deferred.resolve({
+          commitCount: 413,
+          issueCount: 9,
+          prCount: 4,
+          loading: false,
+          stale: false,
+          lastUpdated: Date.now(),
+        });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(9);
+        expect(result.current.freshnessLevel).toBe("fresh");
+      });
+    });
+
+    it("falls back to the record when the in-memory cache is past its freshness window", async () => {
+      // The module cache is empty here (a fresh V8 context after view eviction,
+      // or a restart) — exactly the case the 90s switch-back cache cannot cover.
+      const deferred = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(deferred.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.commitCount).toBe(412);
+      });
+      // A background revalidation still runs — the seed is not a substitute.
+      expect(getRepoStatsMock).toHaveBeenCalled();
+
+      await act(async () => {
+        deferred.resolve({
+          commitCount: 412,
+          issueCount: 7,
+          prCount: 3,
+          loading: false,
+          stale: false,
+          lastUpdated: Date.now(),
+        });
+        await Promise.resolve();
+      });
+    });
+
+    it("reuses the commit count but not the forge counts when the provider no longer matches", async () => {
+      // The repo now resolves to a different provider: its issue/PR numbers are
+      // not ours to show (#10761). The commit count is local git and survives.
+      currentProjectRef.current = {
+        id: "test-project",
+        path: "/repo/a",
+        lastKnownStats: { ...persisted, providerId: "other.forge.provider" },
+      };
+      const deferred = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(deferred.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.commitCount).toBe(412);
+      });
+      expect(result.current.stats?.issueCount).toBeNull();
+      expect(result.current.stats?.prCount).toBeNull();
+
+      await act(async () => {
+        deferred.resolve({
+          commitCount: 412,
+          issueCount: 1,
+          prCount: 1,
+          loading: false,
+          stale: false,
+          lastUpdated: Date.now(),
+        });
+        await Promise.resolve();
+      });
+    });
+
+    it("never resurrects an error from the seed", async () => {
+      const deferred = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(deferred.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats).not.toBeNull();
+      });
+      expect(result.current.error).toBeNull();
+      expect(result.current.errorSeverity).toBeNull();
+      expect(result.current.isTokenError).toBe(false);
+
+      await act(async () => {
+        deferred.resolve({
+          commitCount: 412,
+          issueCount: 7,
+          prCount: 3,
+          loading: false,
+          stale: false,
+          lastUpdated: Date.now(),
+        });
+        await Promise.resolve();
+      });
+    });
+
+    it("holds the seeded counts through a failed poll instead of flashing dashes", async () => {
+      // `applyStatsResult` only records preserved counts on a *fresh* result, and
+      // the seed is stale by construction — so the seed has to prime the
+      // preservation ref itself, or the first failed poll erases what it painted.
+      const deferred = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(deferred.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(7);
+      });
+
+      await act(async () => {
+        deferred.resolve({
+          commitCount: 412,
+          issueCount: null,
+          prCount: null,
+          loading: false,
+          stale: true,
+          error: "Network unreachable",
+          lastUpdated: 1000,
+        });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.error).toBe("Network unreachable");
+      });
+      expect(result.current.stats?.issueCount).toBe(7);
+      expect(result.current.stats?.prCount).toBe(3);
+    });
+
+    it("does not let a recently-dated seed suppress the reactivation refresh", async () => {
+      // The seed carries the fetch time of the poll that produced it. If that
+      // timestamp is inside the freshness window, the reactivation skip would
+      // strand the toolbar on counts it never reconciles.
+      currentProjectRef.current = {
+        id: "test-project",
+        path: "/repo/a",
+        lastKnownStats: { ...persisted, lastUpdated: Date.now() },
+      };
+      getCurrentMock.mockResolvedValue({
+        id: "test-project",
+        path: "/repo/a",
+        lastKnownStats: { ...persisted, lastUpdated: Date.now() },
+      });
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 412,
+        issueCount: 7,
+        prCount: 3,
+        loading: false,
+        stale: false,
+        lastUpdated: Date.now(),
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.commitCount).toBe(412);
+      });
+      // Seeded from a timestamp that *looks* fresh — the poll must still run.
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalled();
+      });
+    });
+
+    it("prefers a fresh in-memory switch-back entry over the persisted record", async () => {
+      // The module cache is the fresh tier; the record is the stale fallback.
+      // A hit on the former must not be downgraded to `stale-disk`.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 999,
+        issueCount: 42,
+        prCount: 8,
+        loading: false,
+        stale: false,
+        lastUpdated: Date.now(),
+      });
+
+      const { result, unmount } = renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(42);
+      });
+      unmount();
+
+      // Remount against the same project: the switch-back cache still holds the
+      // fresh entry, so the persisted (older) counts must not win.
+      const second = renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(second.result.current.stats?.issueCount).toBe(42);
+      });
+      expect(second.result.current.stats?.commitCount).toBe(999);
+      expect(second.result.current.freshnessLevel).toBe("fresh");
     });
   });
 });

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -42,22 +42,13 @@ vi.mock("@/clients/forgeClient", () => ({
   },
 }));
 
-// Mutable so a test can hand the hook a project row carrying persisted
-// `lastKnownStats` — the pre-paint seed reads it straight off the store (#11078).
-const { currentProjectRef } = vi.hoisted(() => ({
-  currentProjectRef: {
-    current: { id: "test-project", path: "/repo/a" } as {
-      id: string;
-      path: string;
-      lastKnownStats?: import("@shared/types/project").ProjectRepoStats;
-    } | null,
-  },
-}));
-
+// The hook reads only `currentProject.id` from the store — to resolve the forge
+// provider and gate polling. The persisted counts it seeds from (#11078) come
+// off the project returned by `projectClient.getCurrent()`, which is main's
+// authoritative row, so seed tests drive `getCurrentMock` rather than this.
 vi.mock("@/store/projectStore", () => ({
-  useProjectStore: (
-    selector: (s: { currentProject: typeof currentProjectRef.current }) => unknown
-  ) => selector({ currentProject: currentProjectRef.current }),
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({ currentProject: { id: "test-project" } }),
 }));
 
 const { resolvedProviderRef, makeResolvedProvider } = vi.hoisted(() => {
@@ -114,9 +105,6 @@ describe("useRepositoryStats", () => {
     // into later tests' cold-start hydration.
     getFirstPageCacheMock.mockResolvedValue(null);
     resolvedProviderRef.current = makeResolvedProvider("test.forge.provider");
-    // No persisted counts by default — a test that seeds them must opt in, or
-    // the seed would suppress the skeleton in every unrelated case.
-    currentProjectRef.current = { id: "test-project", path: "/repo/a" };
     _resetPollingLifecycleForTests();
     _resetSwitchBackCacheForTests();
     useSystemWakeStore.setState({
@@ -1724,7 +1712,7 @@ describe("useRepositoryStats", () => {
         lastUpdated,
         issues: { items: [], endCursor: null, hasNextPage: false },
         prs: { items: [], endCursor: null, hasNextPage: false },
-        stats: { issueCount: 12, prCount: 7, lastUpdated },
+        stats: { commitCount: 250, issueCount: 12, prCount: 7, lastUpdated },
       });
 
       const { result } = renderHook(() => useRepositoryStats());
@@ -1736,6 +1724,10 @@ describe("useRepositoryStats", () => {
         expect(result.current.stats?.stale).toBe(true);
         expect(result.current.lastUpdated).toBe(lastUpdated);
       });
+      // The host now blends the local-git count into the bootstrap payload. This
+      // used to be hardcoded to 0, so the commit pill shifted on every cold
+      // start even while the issue/PR pills hydrated cleanly (issue #11078).
+      expect(result.current.stats?.commitCount).toBe(250);
     });
 
     it("does not overwrite fresher network stats with bootstrap cache", async () => {
@@ -2721,11 +2713,6 @@ describe("useRepositoryStats", () => {
     };
 
     beforeEach(() => {
-      currentProjectRef.current = {
-        id: "test-project",
-        path: "/repo/a",
-        lastKnownStats: persisted,
-      };
       getCurrentMock.mockResolvedValue({
         id: "test-project",
         path: "/repo/a",
@@ -2771,22 +2758,43 @@ describe("useRepositoryStats", () => {
       });
     });
 
-    it("falls back to the record when the in-memory cache is past its freshness window", async () => {
-      // The module cache is empty here (a fresh V8 context after view eviction,
-      // or a restart) — exactly the case the 90s switch-back cache cannot cover.
-      const deferred = createDeferred<ForgeRepositoryStats>();
-      getRepoStatsMock.mockReturnValue(deferred.promise);
+    it("falls back to the record once the in-memory cache is past its freshness window", async () => {
+      // Land a fresh result whose fetch time is already outside the 90s window,
+      // so the switch-back cache holds an entry that is present but no longer
+      // reusable — the case the module cache alone cannot cover, and the reason
+      // the record exists. Its counts differ from the record's, so whichever
+      // one seeds is unambiguous.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 999,
+        issueCount: 42,
+        prCount: 8,
+        loading: false,
+        stale: false,
+        lastUpdated: Date.now() - FRESH_THRESHOLD_MS - 1_000,
+      });
 
-      const { result } = renderHook(() => useRepositoryStats());
+      const first = renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(first.result.current.stats?.issueCount).toBe(42);
+      });
+      first.unmount();
+
+      // Remount: the cached entry is too old to reuse, so the record must seed.
+      const pending = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(pending.promise);
+
+      const second = renderHook(() => useRepositoryStats());
 
       await waitFor(() => {
-        expect(result.current.stats?.commitCount).toBe(412);
+        expect(second.result.current.stats?.issueCount).toBe(7);
       });
+      expect(second.result.current.stats?.commitCount).toBe(412);
+      expect(second.result.current.freshnessLevel).toBe("stale-disk");
       // A background revalidation still runs — the seed is not a substitute.
-      expect(getRepoStatsMock).toHaveBeenCalled();
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
 
       await act(async () => {
-        deferred.resolve({
+        pending.resolve({
           commitCount: 412,
           issueCount: 7,
           prCount: 3,
@@ -2801,11 +2809,11 @@ describe("useRepositoryStats", () => {
     it("reuses the commit count but not the forge counts when the provider no longer matches", async () => {
       // The repo now resolves to a different provider: its issue/PR numbers are
       // not ours to show (#10761). The commit count is local git and survives.
-      currentProjectRef.current = {
+      getCurrentMock.mockResolvedValue({
         id: "test-project",
         path: "/repo/a",
         lastKnownStats: { ...persisted, providerId: "other.forge.provider" },
-      };
+      });
       const deferred = createDeferred<ForgeRepositoryStats>();
       getRepoStatsMock.mockReturnValue(deferred.promise);
 
@@ -2830,21 +2838,32 @@ describe("useRepositoryStats", () => {
       });
     });
 
-    it("never resurrects an error from the seed", async () => {
-      const deferred = createDeferred<ForgeRepositoryStats>();
-      getRepoStatsMock.mockReturnValue(deferred.promise);
+    it("never resurrects a previous error through the seed", async () => {
+      // Drive a real failure first, so "no error" on the remount is a fact about
+      // the seed rather than a fresh-mount default.
+      getRepoStatsMock.mockRejectedValue(new Error("Bad credentials"));
 
-      const { result } = renderHook(() => useRepositoryStats());
+      const first = renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(first.result.current.error).toBe("Bad credentials");
+      });
+      first.unmount();
+
+      const pending = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(pending.promise);
+
+      const second = renderHook(() => useRepositoryStats());
 
       await waitFor(() => {
-        expect(result.current.stats).not.toBeNull();
+        expect(second.result.current.stats?.issueCount).toBe(7);
       });
-      expect(result.current.error).toBeNull();
-      expect(result.current.errorSeverity).toBeNull();
-      expect(result.current.isTokenError).toBe(false);
+      // The record carries counts, never a failure — the previous error is gone.
+      expect(second.result.current.error).toBeNull();
+      expect(second.result.current.errorSeverity).toBeNull();
+      expect(second.result.current.isTokenError).toBe(false);
 
       await act(async () => {
-        deferred.resolve({
+        pending.resolve({
           commitCount: 412,
           issueCount: 7,
           prCount: 3,
@@ -2889,43 +2908,43 @@ describe("useRepositoryStats", () => {
       expect(result.current.stats?.prCount).toBe(3);
     });
 
-    it("does not let a recently-dated seed suppress the reactivation refresh", async () => {
-      // The seed carries the fetch time of the poll that produced it. If that
-      // timestamp is inside the freshness window, the reactivation skip would
-      // strand the toolbar on counts it never reconciles.
-      currentProjectRef.current = {
-        id: "test-project",
-        path: "/repo/a",
-        lastKnownStats: { ...persisted, lastUpdated: Date.now() },
-      };
-      getCurrentMock.mockResolvedValue({
-        id: "test-project",
-        path: "/repo/a",
-        lastKnownStats: { ...persisted, lastUpdated: Date.now() },
-      });
+    it("does not let a recently-dated stale result suppress the reactivation refresh", async () => {
+      // #10765 skips the network on a reactivation when the last result is still
+      // inside the freshness window. That skip must key off a *genuinely fresh*
+      // result: a stale one (a seed, or a disk fallback like this) carries the
+      // fetch time of the poll that produced it, which can easily look recent —
+      // and skipping on that basis strands the toolbar on counts it never
+      // reconciles.
       getRepoStatsMock.mockResolvedValue({
         commitCount: 412,
         issueCount: 7,
         prCount: 3,
         loading: false,
-        stale: false,
+        stale: true,
         lastUpdated: Date.now(),
       });
 
       const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(result.current.isStale).toBe(true);
+      });
+      const afterFirstPoll = getRepoStatsMock.mock.calls.length;
+
+      // Reactivate (tab focus). Nothing fresh has landed, so the network must run.
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
 
       await waitFor(() => {
-        expect(result.current.stats?.commitCount).toBe(412);
-      });
-      // Seeded from a timestamp that *looks* fresh — the poll must still run.
-      await waitFor(() => {
-        expect(getRepoStatsMock).toHaveBeenCalled();
+        expect(getRepoStatsMock.mock.calls.length).toBeGreaterThan(afterFirstPoll);
       });
     });
 
     it("prefers a fresh in-memory switch-back entry over the persisted record", async () => {
-      // The module cache is the fresh tier; the record is the stale fallback.
-      // A hit on the former must not be downgraded to `stale-disk`.
+      // The module cache is the fresh tier; the record is the stale fallback. A
+      // hit on the former must win outright — not be downgraded to `stale-disk`,
+      // and not be replaced by the record's older numbers.
       getRepoStatsMock.mockResolvedValue({
         commitCount: 999,
         issueCount: 42,
@@ -2935,20 +2954,60 @@ describe("useRepositoryStats", () => {
         lastUpdated: Date.now(),
       });
 
-      const { result, unmount } = renderHook(() => useRepositoryStats());
+      const first = renderHook(() => useRepositoryStats());
       await waitFor(() => {
-        expect(result.current.stats?.issueCount).toBe(42);
+        expect(first.result.current.stats?.issueCount).toBe(42);
       });
-      unmount();
+      first.unmount();
 
-      // Remount against the same project: the switch-back cache still holds the
-      // fresh entry, so the persisted (older) counts must not win.
+      // Remount with the network parked, so only a restore can supply values —
+      // whichever tier wins is the one under test, not the poll.
+      const pending = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockReturnValue(pending.promise);
+
       const second = renderHook(() => useRepositoryStats());
       await waitFor(() => {
-        expect(second.result.current.stats?.issueCount).toBe(42);
+        expect(second.result.current.stats).not.toBeNull();
       });
+
+      expect(second.result.current.stats?.issueCount).toBe(42);
       expect(second.result.current.stats?.commitCount).toBe(999);
       expect(second.result.current.freshnessLevel).toBe("fresh");
+
+      await act(async () => {
+        pending.resolve({
+          commitCount: 999,
+          issueCount: 42,
+          prCount: 8,
+          loading: false,
+          stale: false,
+          lastUpdated: Date.now(),
+        });
+        await Promise.resolve();
+      });
+    });
+
+    it("holds the seeded counts when the provider is still activating in main", async () => {
+      // Main returns a provider-less snapshot (null forge counts, no fetch time)
+      // while its plugin activates, even though this side already resolved a
+      // provider. Applying those nulls verbatim would knock the freshly-seeded
+      // pills straight back to em-dashes — the exact shift this issue is about.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 412,
+        issueCount: null,
+        prCount: null,
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(7);
+      });
+      expect(result.current.stats?.prCount).toBe(3);
     });
   });
 });

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from "react";
 import type { ForgeRateLimitKind, ForgeRepositoryStats } from "@shared/types/ipc/forge";
+import type { ProjectRepoStats } from "@shared/types/project";
 import { projectClient } from "@/clients";
 import { forgeClient } from "@/clients/forgeClient";
 import { isTokenRelatedError } from "@/lib/forgeErrors";
@@ -166,6 +167,14 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // closures (push subscribers). Used to skip stale stat pushes whose
   // `fetchedAt` is older than what we've already applied.
   const lastUpdatedRef = useRef<number | null>(null);
+  // Fetch time of the last *genuinely fresh* result — the subset of
+  // `lastUpdatedRef` that excludes stale seeds (persisted counts, disk
+  // bootstrap). The reactivation skip below reads this rather than
+  // `lastUpdatedRef`: a seed carries the fetch time of the poll that originally
+  // produced it, which can be recent enough to look fresh, and skipping the
+  // revalidation on that basis would leave the toolbar on seeded counts it
+  // never reconciles (issue #11078).
+  const freshLastUpdatedRef = useRef<number | null>(null);
   // Adaptive visible-poll cadence (ms) suggested by the provider's activity
   // probe (issue #9741): ~60s while changes are landing, growing toward ~5min
   // on an idle repo. Read synchronously by `calculateNextInterval` when the
@@ -291,6 +300,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       const nextLastUpdated = repoStats.lastUpdated ?? null;
       lastUpdatedRef.current = nextLastUpdated;
       setLastUpdated(nextLastUpdated);
+      if (!shouldPreserve) freshLastUpdatedRef.current = nextLastUpdated;
 
       // Seed the switch-back reuse cache on genuine fresh success only
       // (issue #10761). `shouldPreserve` covers stale/errored results, and a
@@ -355,6 +365,56 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     [recordPollFailure, resetPollFailures]
   );
 
+  // Seed the toolbar from the counts persisted on the project record
+  // (issue #11078). Applied as `stale: true` so the pills render real numbers —
+  // holding their widths instead of resizing from em-dashes — while the poll
+  // behind this revalidates. Deliberately does NOT write the switch-back cache:
+  // that cache is the fresh tier, and a seed is not an observation.
+  // `resolvedProviderId` is passed rather than read off `providerIdRef`: that
+  // ref is synced in a passive effect, which runs *after* the layout effect
+  // below, so on the render where the provider first resolves the ref still
+  // holds the previous value and every forge count would be discarded as a
+  // mismatch.
+  const seedFromPersistedStats = useCallback(
+    (persisted: ProjectRepoStats, projectPath: string, resolvedProviderId: string | null) => {
+      if (!mountedRef.current || hasAppliedResultRef.current) return;
+
+      // Forge counts belong to the provider that reported them (#10761) — a
+      // project that now resolves elsewhere must not show the old provider's
+      // numbers. The commit count is local git, so it survives a provider
+      // change and seeds regardless.
+      const providerMatches = persisted.providerId === resolvedProviderId;
+      const issueCount = providerMatches ? persisted.issueCount : null;
+      const prCount = providerMatches ? persisted.prCount : null;
+
+      // `applyStatsResult` records `lastKnownCountsRef` only for a fresh result,
+      // and this seed is stale by construction. Seed the preservation ref by
+      // hand: without it the first failed poll behind the seed arrives with null
+      // counts, finds nothing preserved, and erases the numbers just painted.
+      if (issueCount !== null) lastKnownCountsRef.current.issueCount = issueCount;
+      if (prCount !== null) lastKnownCountsRef.current.prCount = prCount;
+
+      applyStatsResult(
+        {
+          commitCount: persisted.commitCount,
+          issueCount,
+          prCount,
+          loading: false,
+          stale: true,
+          // Carry the fetch time only when the forge counts came with it. On a
+          // provider mismatch there is no forge observation behind this seed,
+          // and a dated result would suppress the corrective refetch below,
+          // which is gated on `lastUpdated` still being null.
+          ...(providerMatches && persisted.lastUpdated !== null
+            ? { lastUpdated: persisted.lastUpdated }
+            : {}),
+        },
+        { projectPath }
+      );
+    },
+    [applyStatsResult]
+  );
+
   // Worker instances suppress automatic background polling to conserve the
   // provider's API quota (#10123) — on-demand `refresh()` stays functional.
   const isWorkerInstance = window.__DAINTREE_INSTANCE_ROLE__?.role === "worker";
@@ -372,6 +432,27 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   useEffect(() => {
     providerIdRef.current = providerId;
   }, [providerId]);
+
+  // Pre-paint seed from the project record (issue #11078). The project row is
+  // already resident — main writes the counts on a clean poll and ships them
+  // with boot hydration and the project-switch broadcast — so this needs no IPC
+  // and lands before the browser paints. That matters: `ForgeStatsToolbarButton`
+  // renders nothing at all while the provider is resolving, so its first real
+  // paint is the one that must already carry numbers. The `fetchFn` seed below
+  // is the authoritative fallback (it reads the project through main and is
+  // guarded by the fetch epoch) for the case where the store's project update
+  // and the switch reset land in the other order.
+  //
+  // Gated on the provider being resolved: the seed's forge counts are only
+  // reusable against a known provider, and there is nothing on screen to shift
+  // until resolution completes anyway.
+  const persistedStats = useProjectStore((s) => s.currentProject?.lastKnownStats ?? null);
+  const currentProjectPath = useProjectStore((s) => s.currentProject?.path ?? null);
+  useLayoutEffect(() => {
+    if (providerLoading || !persistedStats || !currentProjectPath) return;
+    if (hasAppliedResultRef.current) return;
+    seedFromPersistedStats(persistedStats, currentProjectPath, providerId);
+  }, [providerLoading, providerId, persistedStats, currentProjectPath, seedFromPersistedStats]);
 
   // Whether the one corrective refetch for the current provider resolution
   // has fired — see the effect below `usePollingLifecycle`. Declared here
@@ -419,6 +500,13 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
             Date.now() - cached.lastUpdated < FRESH_THRESHOLD_MS
           ) {
             applyStatsResult(cached.stats, { projectPath: project.path });
+          } else if (project.lastKnownStats) {
+            // Past the freshness window, or the module cache never had this
+            // project (a fresh V8 context after view eviction, or a restart),
+            // fall back to the counts persisted on the project record
+            // (issue #11078). Seeded as stale, so the poll below still runs and
+            // reconciles — the pills just hold their widths while it does.
+            seedFromPersistedStats(project.lastKnownStats, project.path, providerIdRef.current);
           }
         }
 
@@ -436,11 +524,17 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         // switch-back restore (which repopulates `lastUpdatedRef`) and before
         // `setIsValidating(true)` so a skipped reactivation never flashes a
         // validating affordance.
+        // Reads `freshLastUpdatedRef`, not `lastUpdatedRef`: only a genuinely
+        // fresh result earns the skip. A stale seed (persisted counts, disk
+        // bootstrap) carries the fetch time of the poll that produced it, which
+        // can still fall inside the freshness window — skipping on that basis
+        // would strand the toolbar on seeded counts it never reconciles
+        // (issue #11078).
         if (
           reason === "reactivate" &&
           !force &&
-          lastUpdatedRef.current !== null &&
-          Date.now() - lastUpdatedRef.current < FRESH_THRESHOLD_MS
+          freshLastUpdatedRef.current !== null &&
+          Date.now() - freshLastUpdatedRef.current < FRESH_THRESHOLD_MS
         ) {
           return;
         }
@@ -544,6 +638,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       setStats(null);
       setIsStale(false);
       lastUpdatedRef.current = null;
+      freshLastUpdatedRef.current = null;
       setLastUpdated(null);
       // Drop the previous project's probe cadence so the new project starts at
       // the fixed active interval until its first poll reports one (issue #9741).
@@ -629,7 +724,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         // yet — the network poll will replace these with fresh data.
         if (cached.stats && !hasAppliedResultRef.current) {
           const bootstrapStats: ForgeRepositoryStats = {
-            commitCount: 0,
+            // Host-blended local-git count (issue #11078). This was hardcoded to
+            // 0 because the bootstrap payload never carried one, so the commit
+            // pill shifted on every cold start even when the issue/PR pills
+            // hydrated cleanly.
+            commitCount: cached.stats.commitCount,
             issueCount: cached.stats.issueCount,
             prCount: cached.stats.prCount,
             loading: false,

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import type { ForgeRateLimitKind, ForgeRepositoryStats } from "@shared/types/ipc/forge";
 import type { ProjectRepoStats } from "@shared/types/project";
 import { projectClient } from "@/clients";
@@ -242,8 +242,26 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
       hasAppliedResultRef.current = true;
 
+      // A provider-less snapshot — null forge counts and no fetch time — is what
+      // main returns when it could not resolve a provider for the repo. When
+      // *this* side has a resolved provider, the two disagree only transiently
+      // (main's forge plugin is still activating), so the snapshot carries no
+      // observation: treat it as preserve-worthy rather than letting its nulls
+      // erase counts we are already showing. Without this, a seeded switch-back
+      // paints real numbers and then a single mid-activation poll knocks them
+      // straight back to em-dashes (issue #11078). With no provider resolved
+      // here either, the repo genuinely has none and the commits-only pill is
+      // the correct rendering — so this stays false and the nulls apply.
+      const providerLessWhileResolved =
+        providerIdRef.current !== null &&
+        repoStats.lastUpdated === undefined &&
+        repoStats.error === undefined &&
+        repoStats.issueCount === null &&
+        repoStats.prCount === null;
+
       // Only preserve counts when data is stale or errored (not on successful fresh fetch)
-      const shouldPreserve = repoStats.stale === true || repoStats.error !== undefined;
+      const shouldPreserve =
+        repoStats.stale === true || repoStats.error !== undefined || providerLessWhileResolved;
 
       if (!shouldPreserve) {
         // Fresh successful data — record the confirmed counts so a later
@@ -433,26 +451,18 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     providerIdRef.current = providerId;
   }, [providerId]);
 
-  // Pre-paint seed from the project record (issue #11078). The project row is
-  // already resident — main writes the counts on a clean poll and ships them
-  // with boot hydration and the project-switch broadcast — so this needs no IPC
-  // and lands before the browser paints. That matters: `ForgeStatsToolbarButton`
-  // renders nothing at all while the provider is resolving, so its first real
-  // paint is the one that must already carry numbers. The `fetchFn` seed below
-  // is the authoritative fallback (it reads the project through main and is
-  // guarded by the fetch epoch) for the case where the store's project update
-  // and the switch reset land in the other order.
-  //
-  // Gated on the provider being resolved: the seed's forge counts are only
-  // reusable against a known provider, and there is nothing on screen to shift
-  // until resolution completes anyway.
-  const persistedStats = useProjectStore((s) => s.currentProject?.lastKnownStats ?? null);
-  const currentProjectPath = useProjectStore((s) => s.currentProject?.path ?? null);
-  useLayoutEffect(() => {
-    if (providerLoading || !persistedStats || !currentProjectPath) return;
-    if (hasAppliedResultRef.current) return;
-    seedFromPersistedStats(persistedStats, currentProjectPath, providerId);
-  }, [providerLoading, providerId, persistedStats, currentProjectPath, seedFromPersistedStats]);
+  // The seed deliberately lives in `fetchFn` (below) rather than in a
+  // render-time effect. A layout effect could paint it one IPC round-trip
+  // sooner, but it would have to read the project and the resolved provider off
+  // the renderer's own stores — and neither is trustworthy at that moment:
+  // `useResolvedForgeProvider` resets its state in a passive effect, so on the
+  // render where the project id flips it still reports the *previous* project's
+  // provider, and `onProjectSwitch` fires from an IPC event whose ordering
+  // against the project store's own update is not guaranteed. Both orderings
+  // can seed the outgoing project's counts into the incoming project — exactly
+  // the class of bug #10761 exists to prevent. `fetchFn` reads the project
+  // through main and is guarded by the fetch epoch, so it is the one place that
+  // can seed safely.
 
   // Whether the one corrective refetch for the current provider resolution
   // has fired — see the effect below `usePollingLifecycle`. Declared here

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -937,7 +937,14 @@ export const useProjectStore = create<ProjectState>()(
         name: "project-storage",
         storage: createSafeJSONStorage(),
         partialize: (state) => ({
-          projects: state.projects,
+          // `lastKnownStats` is main-owned (issue #11078): it is written to the
+          // SQLite project row on a clean stats poll and arrives here via boot
+          // hydration and the project-switch broadcast. Persisting it locally
+          // too would make this blob a second durable writer — and a lossy one,
+          // since every `WebContentsView` serializes the whole `projects` array
+          // from its own copy, so a view holding a stale snapshot would clobber
+          // a newer one. Strip it and let main stay authoritative.
+          projects: state.projects.map(({ lastKnownStats: _lastKnownStats, ...rest }) => rest),
         }),
         merge: (persistedState, currentState) => {
           const persisted = persistedState as { projects?: unknown } | undefined;


### PR DESCRIPTION
## Summary

The toolbar's three count pills (open issues, open PRs, commits) reset to placeholder dashes and refetch every time a user switches back to a project, so the pills visibly shift width as the values load in. The existing switch-back cache in `useRepositoryStats.ts` only covers a 90-second window and lives in a single WebContentsView's V8 context, so it's empty after a view eviction or app restart, which is the common case since a user is usually away for minutes.

Resolves #11078

Two root causes here, fixed independently.

### 1. Commit count was hardcoded to 0 on disk bootstrap

Commit count is a host-owned local-git fact, deliberately absent from the provider-reported `ForgeRepoCounts` contract. The live-poll handler `handleForgeGetRepoStats` already computed it correctly, but its disk-bootstrap sibling `handleForgeGetFirstPageCache` never did, and `ForgeFirstPageCachePayload.stats` had no field for it. So the commit pill shifted on every cold start even when the issue/PR pills hydrated cleanly. Fixed at the host boundary; the GitHub plugin isn't involved.

### 2. No durable per-project count store

Last-known counts now persist as five nullable columns on the `projects` SQLite row (migration `0007`), surfaced as `Project.lastKnownStats`. Main is the single writer (`ProjectStore.saveRepoStats`); the renderer seeds from it on switch-back and cold start, applied with a `stale: true` flag so the normal background poll still reconciles behind it. The 90s in-memory cache stays as the fresh tier; the persisted record is the fallback past it and across view eviction or restart.

## Design notes

- Commit count and forge counts have different owners and update independently. `getCommitCount` now throws instead of reporting 0 on failure, because a swallowed failure is indistinguishable from an empty repo and would overwrite a good count. An unborn HEAD (a repo with no commits yet) is still reported as a reliable 0.
- The commit-only write path preserves the stored issue/PR counts rather than nulling them, since that path also fires while a forge plugin is mid-activation, and discarding good counts over a blip is exactly the flicker this fixes. For the same reason, a provider-less snapshot arriving while the renderer does have a provider resolved is treated as preserve-worthy rather than applied as fresh nulls.
- Writes only happen when a count or provider actually changes. The provider re-stamps `lastUpdated` whenever its probe confirms nothing changed, and treating that as a write would mean a SQLite UPDATE roughly every 30s per open project, forever. Forge results are ordered against the newest observation seen this session, since the stored timestamp deliberately lags.
- `lastKnownStats` is stripped from the renderer's localStorage `partialize` so main stays the single source of truth.
- The seed lives in `fetchFn` (guarded by the existing fetch-generation epoch from #10761) rather than a render-time layout effect: a layout effect would have to read the project and provider off renderer stores, and neither is trustworthy mid-switch, since `useResolvedForgeProvider` resets in a passive effect and `onProjectSwitch` fires from an IPC event with no ordering guarantee against the store update.

## Changes

- `electron/services/persistence/migrations/0007_add_project_stats.sql` adds the five nullable stats columns; `schema.ts` and `Project` types updated to match.
- `ProjectStore.saveRepoStats` writes last-known counts with the ownership and ordering rules above.
- `electron/ipc/handlers/forgeData.ts`: disk-bootstrap path now includes commit count.
- `electron/utils/git.ts`: `getCommitCount` throws on hard failure instead of swallowing to 0; unborn HEAD still returns 0.
- `useRepositoryStats.ts`: seeds from `lastKnownStats` in `fetchFn` as a stale fallback behind the 90s fresh cache.
- `projectStore.ts`: `lastKnownStats` excluded from localStorage persistence.

## Testing

373 targeted tests pass, including new `ProjectStore.repoStats.test.ts` (round-trip, corrupt-value rejection, commit-only vs full-forge ownership, write cadence, out-of-order ordering, disk-pressure suppression, relocation), new `git.commitCount.test.ts` (unborn HEAD, hard failure, unparseable output), and a new persisted-seed block in `useRepositoryStats.test.tsx` (seeds before the poll resolves with no skeleton, falls back past the freshness window, provider-mismatch drops forge counts but keeps commits, holds counts through a failed poll and a mid-activation provider, never resurrects an error, doesn't suppress the reactivation refresh). Also updated the four hand-written `ProjectStore` SQL fixtures and the `db.openDb` final-migration assertion. Typecheck clean; no IPC codegen drift.