### PR TITLE
feat(scratch): give fresh Scratch workspaces a proper first-run experience

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,6 @@ import { useAppBootstrap } from "./hooks/app/useAppBootstrap";
 import { usePaletteWiring } from "./hooks/app/usePaletteWiring";
 
 import {
-  LazyWelcomeScreen,
   LazyModalHostLayer,
   preloadSettingsDialog,
   LazyDiagnosticsReviewDialogHost,
@@ -82,11 +81,7 @@ import {
   usePreferencesStore,
   usePluginManagerStore,
 } from "./store";
-// Leaf path, never the "@/store" barrel — the barrel-mocking suites hand-list
-// their hook factories and crash on an undefined destructure.
-import { useScratchStore } from "./store/scratchStore";
-import { ContentGridEmptyState } from "./components/Terminal/ContentGridEmptyState";
-import { resolveEmptyCanvas } from "./components/Terminal/emptyCanvas";
+import { useEmptyCanvasContent } from "./hooks/app/useEmptyCanvasContent";
 // Eager side-effect import: auto-discovers every built-in plugin renderer and
 // registers its builtin view slots at module-eval time, before first render.
 // Must stay static — a deferred/idle import races the user, so getBuiltinView
@@ -177,7 +172,6 @@ function AppInner() {
     shouldMountActionPalette,
   } = usePaletteWiring();
   const currentProject = useProjectStore((state) => state.currentProject);
-  const currentScratch = useScratchStore((state) => state.currentScratch);
   const gitInitDialogOpen = useProjectStore((state) => state.gitInitDialogOpen);
   const gitInitDirectoryPath = useProjectStore((state) => state.gitInitDirectoryPath);
   const closeGitInitDialog = useProjectStore((state) => state.closeGitInitDialog);
@@ -211,7 +205,6 @@ function AppInner() {
   );
 
   const { activeWorktree, defaultTerminalCwd } = useActiveWorktreeSync();
-  const emptyCanvas = resolveEmptyCanvas(currentProject, currentScratch);
   useAgentActivityBroadcast();
   const resumeSession = useResumeAgentSession();
 
@@ -270,6 +263,8 @@ function AppInner() {
     pluginDeepLink,
     gettingStarted,
   } = useAppBootstrap();
+
+  const { emptyContent, workspaceId } = useEmptyCanvasContent(gettingStarted);
 
   const {
     gitPushResetKey,
@@ -495,41 +490,14 @@ function AppInner() {
                   <ErrorBoundary
                     variant="section"
                     componentName="ContentGrid"
-                    resetKeys={[currentProject?.id ?? currentScratch?.id].filter(
-                      (k): k is string => k != null
-                    )}
+                    resetKeys={[workspaceId].filter((k): k is string => k != null)}
                   >
                     <Profiler id="content-grid" onRender={onContentGridRender}>
                       <ContentGrid
                         className="h-full w-full"
                         agentAvailability={availability}
                         defaultCwd={defaultTerminalCwd}
-                        emptyContent={
-                          // A scratch is a workspace, so its empty canvas gets
-                          // the launcher — not WelcomeScreen, whose CTAs all
-                          // acquire a workspace the user already has (#11076).
-                          // It has no worktree, branch, recipes or project
-                          // settings, so those affordances stay off. `project`
-                          // falls through to the grid's own context-driven
-                          // empty state.
-                          emptyCanvas.kind === "project" ? undefined : emptyCanvas.kind ===
-                            "scratch" ? (
-                            <ContentGridEmptyState
-                              hasLaunchTarget
-                              hasProjectContext={false}
-                              hasWorktrees={false}
-                              isWorktreeInitialized={false}
-                              workspaceName={emptyCanvas.scratch.name}
-                              activeWorktreePath={emptyCanvas.scratch.path}
-                              showProjectPulse={false}
-                              defaultCwd={emptyCanvas.scratch.path}
-                            />
-                          ) : (
-                            <Suspense fallback={null}>
-                              <LazyWelcomeScreen gettingStarted={gettingStarted} />
-                            </Suspense>
-                          )
-                        }
+                        emptyContent={emptyContent}
                       />
                     </Profiler>
                   </ErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,11 @@ import {
   usePreferencesStore,
   usePluginManagerStore,
 } from "./store";
+// Leaf path, never the "@/store" barrel — the barrel-mocking suites hand-list
+// their hook factories and crash on an undefined destructure.
+import { useScratchStore } from "./store/scratchStore";
+import { ContentGridEmptyState } from "./components/Terminal/ContentGridEmptyState";
+import { resolveEmptyCanvas } from "./components/Terminal/emptyCanvas";
 // Eager side-effect import: auto-discovers every built-in plugin renderer and
 // registers its builtin view slots at module-eval time, before first render.
 // Must stay static — a deferred/idle import races the user, so getBuiltinView
@@ -172,6 +177,7 @@ function AppInner() {
     shouldMountActionPalette,
   } = usePaletteWiring();
   const currentProject = useProjectStore((state) => state.currentProject);
+  const currentScratch = useScratchStore((state) => state.currentScratch);
   const gitInitDialogOpen = useProjectStore((state) => state.gitInitDialogOpen);
   const gitInitDirectoryPath = useProjectStore((state) => state.gitInitDirectoryPath);
   const closeGitInitDialog = useProjectStore((state) => state.closeGitInitDialog);
@@ -205,6 +211,7 @@ function AppInner() {
   );
 
   const { activeWorktree, defaultTerminalCwd } = useActiveWorktreeSync();
+  const emptyCanvas = resolveEmptyCanvas(currentProject, currentScratch);
   useAgentActivityBroadcast();
   const resumeSession = useResumeAgentSession();
 
@@ -488,7 +495,9 @@ function AppInner() {
                   <ErrorBoundary
                     variant="section"
                     componentName="ContentGrid"
-                    resetKeys={[currentProject?.id].filter((k): k is string => k != null)}
+                    resetKeys={[currentProject?.id ?? currentScratch?.id].filter(
+                      (k): k is string => k != null
+                    )}
                   >
                     <Profiler id="content-grid" onRender={onContentGridRender}>
                       <ContentGrid
@@ -496,11 +505,30 @@ function AppInner() {
                         agentAvailability={availability}
                         defaultCwd={defaultTerminalCwd}
                         emptyContent={
-                          currentProject === null ? (
+                          // A scratch is a workspace, so its empty canvas gets
+                          // the launcher — not WelcomeScreen, whose CTAs all
+                          // acquire a workspace the user already has (#11076).
+                          // It has no worktree, branch, recipes or project
+                          // settings, so those affordances stay off. `project`
+                          // falls through to the grid's own context-driven
+                          // empty state.
+                          emptyCanvas.kind === "project" ? undefined : emptyCanvas.kind ===
+                            "scratch" ? (
+                            <ContentGridEmptyState
+                              hasLaunchTarget
+                              hasProjectContext={false}
+                              hasWorktrees={false}
+                              isWorktreeInitialized={false}
+                              workspaceName={emptyCanvas.scratch.name}
+                              activeWorktreePath={emptyCanvas.scratch.path}
+                              showProjectPulse={false}
+                              defaultCwd={emptyCanvas.scratch.path}
+                            />
+                          ) : (
                             <Suspense fallback={null}>
                               <LazyWelcomeScreen gettingStarted={gettingStarted} />
                             </Suspense>
-                          ) : undefined
+                          )
                         }
                       />
                     </Profiler>

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelStore, useProjectStore, useWorktreeSelectionStore } from "@/store";
+import { useScratchStore } from "@/store/scratchStore";
 import {
   isDockPanel,
   isFilePanel,
@@ -121,6 +122,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const getTabGroups = usePanelStore((state) => state.getTabGroups);
   const getTabGroupPanels = usePanelStore((state) => state.getTabGroupPanels);
   const currentProject = useProjectStore((s) => s.currentProject);
+  const currentScratch = useScratchStore((s) => s.currentScratch);
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const agentAvailability = useCliAvailabilityStore((s) => s.availability);
@@ -234,7 +236,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const { worktrees } = useWorktrees();
 
   const activeWorktree = activeWorktreeId ? worktrees.find((w) => w.id === activeWorktreeId) : null;
-  const cwd = activeWorktree?.path ?? currentProject?.path ?? "";
+  // Include the scratch (#11076): this cwd is passed down as an explicit launch
+  // option, and `""` is not nullish — an empty string would win over
+  // `useAgentLauncher`'s own scratch fallback and strand dock launches in the
+  // home dir.
+  const cwd = activeWorktree?.path ?? currentProject?.path ?? currentScratch?.path ?? "";
 
   const { sorted: launchAgents, pinnedCount } = useMemo(() => {
     const baseIds = getAgentIds();

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelStore, useProjectStore, useWorktreeSelectionStore } from "@/store";
 import { useScratchStore } from "@/store/scratchStore";
+import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
 import {
   isDockPanel,
   isFilePanel,
@@ -236,11 +237,14 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const { worktrees } = useWorktrees();
 
   const activeWorktree = activeWorktreeId ? worktrees.find((w) => w.id === activeWorktreeId) : null;
-  // Include the scratch (#11076): this cwd is passed down as an explicit launch
-  // option, and `""` is not nullish — an empty string would win over
-  // `useAgentLauncher`'s own scratch fallback and strand dock launches in the
-  // home dir.
-  const cwd = activeWorktree?.path ?? currentProject?.path ?? currentScratch?.path ?? "";
+  // This cwd rides down as an explicit launch option, and `""` is not nullish —
+  // it would win over any fallback further down the chain, so it has to resolve
+  // the whole workspace here (#11076).
+  const cwd = resolveWorkspaceCwd({
+    worktreePath: activeWorktree?.path,
+    projectPath: currentProject?.path,
+    scratchPath: currentScratch?.path,
+  });
 
   const { sorted: launchAgents, pinnedCount } = useMemo(() => {
     const baseIds = getAgentIds();

--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -145,7 +145,8 @@ export function ContentGridDefault({
                   <div className="col-span-full row-span-full">
                     {ctx.emptyContent ?? (
                       <ContentGridEmptyState
-                        hasActiveWorktree={ctx.hasActiveWorktree}
+                        hasLaunchTarget={ctx.hasActiveWorktree}
+                        hasProjectContext={ctx.projectName !== null}
                         hasWorktrees={ctx.worktreeMap.size > 0}
                         isWorktreeInitialized={ctx.isWorktreeInitialized}
                         activeWorktreeName={ctx.activeWorktreeName}
@@ -154,7 +155,7 @@ export function ContentGridDefault({
                         activeWorktreeIsDetached={ctx.activeWorktreeIsDetached}
                         activeWorktreeHead={ctx.activeWorktreeHead}
                         activeWorktreePath={ctx.activeWorktreePath}
-                        projectName={ctx.projectName}
+                        workspaceName={ctx.projectName}
                         projectEmoji={ctx.projectEmoji}
                         showProjectPulse={ctx.showProjectPulse}
                         projectIconSvg={ctx.projectIconSvg}

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -17,8 +17,15 @@ import { LauncherQuickActions } from "./LauncherQuickActions";
 
 const PATH_TRUNCATE_LENGTH = 52;
 
+// The active workspace is a project OR a scratch (#11076). `hasLaunchTarget`
+// gates the launcher column on having somewhere to launch INTO — a scratch has
+// no worktree but is a perfectly good target. `hasProjectContext` gates the
+// affordances only a real project can honour: the settings gear (there is no
+// scratch settings tab) and the tip catalog (it talks about worktrees and the
+// project file tree).
 export function ContentGridEmptyState({
-  hasActiveWorktree,
+  hasLaunchTarget,
+  hasProjectContext,
   hasWorktrees,
   isWorktreeInitialized,
   activeWorktreeName,
@@ -27,13 +34,14 @@ export function ContentGridEmptyState({
   activeWorktreeIsDetached,
   activeWorktreeHead,
   activeWorktreePath,
-  projectName,
+  workspaceName,
   projectEmoji,
   showProjectPulse,
   projectIconSvg,
   defaultCwd,
 }: {
-  hasActiveWorktree: boolean;
+  hasLaunchTarget: boolean;
+  hasProjectContext: boolean;
   hasWorktrees: boolean;
   isWorktreeInitialized: boolean;
   activeWorktreeName?: string | null;
@@ -42,7 +50,7 @@ export function ContentGridEmptyState({
   activeWorktreeIsDetached?: boolean;
   activeWorktreeHead?: string | null;
   activeWorktreePath?: string | null;
-  projectName?: string | null;
+  workspaceName?: string | null;
   projectEmoji?: string | null;
   showProjectPulse: boolean;
   projectIconSvg?: string;
@@ -73,7 +81,7 @@ export function ContentGridEmptyState({
   const pathLabel = activeWorktreePath
     ? middleTruncate(formatPath(activeWorktreePath, homeDir), PATH_TRUNCATE_LENGTH)
     : null;
-  const hasProjectIdentity = Boolean(projectName);
+  const hasWorkspaceIdentity = Boolean(workspaceName);
 
   const handleOpenProjectSettings = () => {
     window.dispatchEvent(
@@ -109,10 +117,10 @@ export function ContentGridEmptyState({
       <div className="relative h-full w-full overflow-y-auto">
         <div className="flex min-h-full flex-col items-center justify-center p-8">
           <div className="max-w-3xl w-full flex flex-col items-center">
-            {hasActiveWorktree && (
+            {hasLaunchTarget && (
               <div className="mb-6 flex flex-col items-center text-center">
                 <div className="mb-4">{identityMark}</div>
-                {hasProjectIdentity ? (
+                {hasWorkspaceIdentity ? (
                   <div className="flex flex-col items-center gap-1.5 min-w-0 max-w-full">
                     {/* The name stays centered under the mark; the gear is
                         pulled out of flow (absolute, just past the name) so its
@@ -126,16 +134,18 @@ export function ContentGridEmptyState({
                             {projectEmoji}
                           </span>
                         ) : null}
-                        {projectName}
+                        {workspaceName}
                       </h3>
-                      <button
-                        type="button"
-                        onClick={handleOpenProjectSettings}
-                        className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 shrink-0 rounded-full p-1 text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-subtle hover:text-daintree-text group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
-                        aria-label="Project settings"
-                      >
-                        <Settings className="h-3.5 w-3.5" />
-                      </button>
+                      {hasProjectContext && (
+                        <button
+                          type="button"
+                          onClick={handleOpenProjectSettings}
+                          className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 shrink-0 rounded-full p-1 text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-subtle hover:text-daintree-text group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                          aria-label="Project settings"
+                        >
+                          <Settings className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                     </div>
                     {(branchLabel || pathLabel) && (
                       <div className="flex flex-col items-center gap-0.5 text-daintree-text/60 max-w-full min-w-0 font-mono">
@@ -164,8 +174,8 @@ export function ContentGridEmptyState({
               </div>
             )}
 
-            {!hasActiveWorktree && !isWorktreeInitialized && null}
-            {!hasActiveWorktree && isWorktreeInitialized && hasWorktrees && (
+            {!hasLaunchTarget && !isWorktreeInitialized && null}
+            {!hasLaunchTarget && isWorktreeInitialized && hasWorktrees && (
               <EmptyState
                 variant="zero-data"
                 scale="canvas"
@@ -174,7 +184,7 @@ export function ContentGridEmptyState({
                 description="Choose a worktree from the sidebar to open it in the canvas"
               />
             )}
-            {!hasActiveWorktree && isWorktreeInitialized && !hasWorktrees && (
+            {!hasLaunchTarget && isWorktreeInitialized && !hasWorktrees && (
               <EmptyState
                 variant="zero-data"
                 scale="canvas"
@@ -195,31 +205,31 @@ export function ContentGridEmptyState({
               />
             )}
 
-            {hasActiveWorktree && recipesProjectId !== null && !recipesLoading && (
+            {hasLaunchTarget && recipesProjectId !== null && !recipesLoading && (
               <div className="mb-3 w-full flex justify-center">
                 <RecipeRunner activeWorktreeId={activeWorktreeId} defaultCwd={defaultCwd} />
               </div>
             )}
 
-            {hasActiveWorktree && (
+            {hasLaunchTarget && (
               <div className="mb-3 w-full flex justify-center">
                 <ResumeSessionLine />
               </div>
             )}
 
-            {hasActiveWorktree && (
+            {hasLaunchTarget && (
               <div className="mb-6 w-full flex justify-center">
                 <LauncherQuickActions />
               </div>
             )}
 
-            {showProjectPulse && hasActiveWorktree && activeWorktreeId && (
+            {showProjectPulse && hasLaunchTarget && activeWorktreeId && (
               <div className="w-full flex justify-center">
                 <ProjectPulseStrip worktreeId={activeWorktreeId} />
               </div>
             )}
 
-            {hasActiveWorktree && hasEverLaunchedAgent && (
+            {hasLaunchTarget && hasProjectContext && hasEverLaunchedAgent && (
               <div className="flex flex-col items-center gap-4 mt-6">
                 <RotatingTip />
               </div>

--- a/src/components/Terminal/ContentGridFleetScope.tsx
+++ b/src/components/Terminal/ContentGridFleetScope.tsx
@@ -73,7 +73,8 @@ export function ContentGridFleetScope({
           {ctx.fleetPanels.length === 0 ? (
             <div className="col-span-full row-span-full">
               <ContentGridEmptyState
-                hasActiveWorktree={ctx.hasActiveWorktree}
+                hasLaunchTarget={ctx.hasActiveWorktree}
+                hasProjectContext={ctx.projectName !== null}
                 hasWorktrees={ctx.worktreeMap.size > 0}
                 isWorktreeInitialized={ctx.isWorktreeInitialized}
                 activeWorktreeName={ctx.activeWorktreeName}
@@ -82,7 +83,7 @@ export function ContentGridFleetScope({
                 activeWorktreeIsDetached={ctx.activeWorktreeIsDetached}
                 activeWorktreeHead={ctx.activeWorktreeHead}
                 activeWorktreePath={ctx.activeWorktreePath}
-                projectName={ctx.projectName}
+                workspaceName={ctx.projectName}
                 projectEmoji={ctx.projectEmoji}
                 showProjectPulse={ctx.showProjectPulse}
                 projectIconSvg={ctx.projectIconSvg}

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Hoisted mutable state so each mock reads its slice at call time and a test can
+// reshape the stores before rendering.
+const h = vi.hoisted(() => ({
+  panelIds: [] as string[],
+  panelsById: {} as Record<string, unknown>,
+  recipes: { currentProjectId: null as string | null, isLoading: false },
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (sel: (s: typeof h) => unknown) => sel(h),
+}));
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: (sel: (s: typeof h.recipes) => unknown) => sel(h.recipes),
+}));
+vi.mock("@/hooks/app/useHomeDir", () => ({
+  useHomeDir: () => ({ homeDir: "/home/user" }),
+}));
+
+// The launcher column and the project-only strips are covered by their own
+// suites; here they only need to be identifiable in the tree.
+vi.mock("../LauncherQuickActions", () => ({
+  LauncherQuickActions: () => <div data-testid="launcher-quick-actions" />,
+}));
+vi.mock("../RecipeRunner/RecipeRunner", () => ({
+  RecipeRunner: () => <div data-testid="recipe-runner" />,
+}));
+vi.mock("../ResumeSessionLine", () => ({
+  ResumeSessionLine: () => <div data-testid="resume-session-line" />,
+}));
+vi.mock("../contentGridTips", () => ({
+  RotatingTip: () => <div data-testid="rotating-tip" />,
+}));
+vi.mock("@/components/Pulse", () => ({
+  ProjectPulseStrip: () => <div data-testid="project-pulse" />,
+}));
+
+import { ContentGridEmptyState } from "../ContentGridEmptyState";
+
+const PROJECT_PROPS = {
+  hasLaunchTarget: true,
+  hasProjectContext: true,
+  hasWorktrees: true,
+  isWorktreeInitialized: true,
+  activeWorktreeId: "wt-1",
+  activeWorktreeName: "feature",
+  activeWorktreeBranch: "feature/x",
+  activeWorktreePath: "/repo-worktrees/feature",
+  workspaceName: "My project",
+  showProjectPulse: true,
+} as const;
+
+// A scratch is an active workspace with no worktree, branch, recipes or project
+// settings — the launcher must still be reachable (#11076).
+const SCRATCH_PROPS = {
+  hasLaunchTarget: true,
+  hasProjectContext: false,
+  hasWorktrees: false,
+  isWorktreeInitialized: false,
+  workspaceName: "Scratch 2026-07-12 09:30",
+  activeWorktreePath: "/scratches/abc-123",
+  showProjectPulse: false,
+  defaultCwd: "/scratches/abc-123",
+} as const;
+
+// `isPtyPanel` treats a missing kind as "terminal"; hasEverLaunchedAgent then
+// keys off the launch/detected agent fields.
+const markLaunchedAnAgent = () => {
+  h.panelIds = ["p1"];
+  h.panelsById = { p1: { kind: "terminal", launchAgentId: "claude" } };
+};
+
+describe("ContentGridEmptyState — workspace capabilities", () => {
+  beforeEach(() => {
+    h.panelIds = [];
+    h.panelsById = {};
+    h.recipes.currentProjectId = null;
+    h.recipes.isLoading = false;
+  });
+
+  describe("an active scratch", () => {
+    it("offers the launcher instead of leaving the canvas empty", () => {
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.getByTestId("launcher-quick-actions")).toBeTruthy();
+    });
+
+    it("shows the scratch's own name and path", () => {
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.getByText(SCRATCH_PROPS.workspaceName)).toBeTruthy();
+      expect(screen.getByTitle(SCRATCH_PROPS.activeWorktreePath)).toBeTruthy();
+    });
+
+    it("hides project settings — a scratch has no settings tab to open", () => {
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.queryByLabelText("Project settings")).toBeNull();
+    });
+
+    it("withholds the tip catalog, which only speaks of worktrees and project files", () => {
+      markLaunchedAnAgent();
+
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.queryByTestId("rotating-tip")).toBeNull();
+    });
+
+    it("suppresses the project pulse", () => {
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.queryByTestId("project-pulse")).toBeNull();
+    });
+
+    it("does not offer to open a folder — the user already has a workspace", () => {
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.queryByRole("button", { name: /open folder/i })).toBeNull();
+    });
+
+    it("suppresses recipes, which are project-scoped", () => {
+      render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+
+      expect(screen.queryByTestId("recipe-runner")).toBeNull();
+    });
+  });
+
+  describe("an active project", () => {
+    it("keeps its settings affordance", () => {
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.getByLabelText("Project settings")).toBeTruthy();
+    });
+
+    it("keeps its tips once an agent has been launched", () => {
+      markLaunchedAnAgent();
+
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.getByTestId("rotating-tip")).toBeTruthy();
+    });
+
+    // Issue #6752 — first-run users shouldn't get shortcut-carousel teaching
+    // content before they've launched anything.
+    it("withholds tips until the first agent launch", () => {
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.queryByTestId("rotating-tip")).toBeNull();
+    });
+
+    it("shows recipes once the recipe store has settled on the project", () => {
+      h.recipes.currentProjectId = "project-1";
+
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.getByTestId("recipe-runner")).toBeTruthy();
+    });
+
+    // The CLAUDE.md recipe-gating gotcha: `loadRecipes()` sets currentProjectId
+    // synchronously before the IPC resolves, so an unsettled store must stay
+    // quiet rather than flash the "create your first recipe" empty state.
+    it("withholds recipes while the recipe store is still loading", () => {
+      h.recipes.currentProjectId = "project-1";
+      h.recipes.isLoading = true;
+
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.queryByTestId("recipe-runner")).toBeNull();
+    });
+
+    it("shows the project pulse", () => {
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.getByTestId("project-pulse")).toBeTruthy();
+    });
+
+    it("honours the user's pulse hide toggle", () => {
+      render(<ContentGridEmptyState {...PROJECT_PROPS} showProjectPulse={false} />);
+
+      expect(screen.queryByTestId("project-pulse")).toBeNull();
+    });
+  });
+
+  describe("no launch target", () => {
+    it("withholds the launcher and the identity hero when there is nowhere to launch into", () => {
+      render(
+        <ContentGridEmptyState
+          hasLaunchTarget={false}
+          hasProjectContext
+          hasWorktrees
+          isWorktreeInitialized
+          workspaceName="My project"
+          showProjectPulse={false}
+        />
+      );
+
+      expect(screen.queryByTestId("launcher-quick-actions")).toBeNull();
+      expect(screen.queryByText("My project")).toBeNull();
+      expect(screen.getByText("Select a worktree")).toBeTruthy();
+    });
+
+    it("offers to open a folder when the project has no worktrees at all", () => {
+      render(
+        <ContentGridEmptyState
+          hasLaunchTarget={false}
+          hasProjectContext
+          hasWorktrees={false}
+          isWorktreeInitialized
+          showProjectPulse={false}
+        />
+      );
+
+      expect(screen.getByText("Open a project folder")).toBeTruthy();
+    });
+
+    // Issue #8645 — before the worktree snapshot lands, both copy variants would
+    // be a guess, so the canvas stays silent rather than flashing the wrong one.
+    it("stays silent until the worktree snapshot has initialized", () => {
+      render(
+        <ContentGridEmptyState
+          hasLaunchTarget={false}
+          hasProjectContext
+          hasWorktrees={false}
+          isWorktreeInitialized={false}
+          showProjectPulse={false}
+        />
+      );
+
+      expect(screen.queryByText("Open a project folder")).toBeNull();
+      expect(screen.queryByText("Select a worktree")).toBeNull();
+    });
+  });
+});

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -202,6 +202,21 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
   });
 
   describe("no launch target", () => {
+    // Every launcher-column element hangs off `hasLaunchTarget`. Without this,
+    // the fixtures correlate the conjuncts and dropping that gate from any one
+    // of them would go unnoticed.
+    it("withholds recipes, tips and the pulse even when their own conditions are met", () => {
+      markLaunchedAnAgent();
+      h.recipes.currentProjectId = "project-1";
+
+      render(<ContentGridEmptyState {...PROJECT_PROPS} hasLaunchTarget={false} />);
+
+      expect(screen.queryByTestId("recipe-runner")).toBeNull();
+      expect(screen.queryByTestId("rotating-tip")).toBeNull();
+      expect(screen.queryByTestId("project-pulse")).toBeNull();
+      expect(screen.queryByTestId("resume-session-line")).toBeNull();
+    });
+
     it("withholds the launcher and the identity hero when there is nowhere to launch into", () => {
       render(
         <ContentGridEmptyState

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 // Hoisted mutable state so each mock reads its slice at call time and a test can
 // reshape the stores before rendering.
@@ -8,8 +8,12 @@ const h = vi.hoisted(() => ({
   panelIds: [] as string[],
   panelsById: {} as Record<string, unknown>,
   recipes: { currentProjectId: null as string | null, isLoading: false },
+  dispatch: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: h.dispatch },
+}));
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (sel: (s: typeof h) => unknown) => sel(h),
 }));
@@ -79,6 +83,7 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
     h.panelsById = {};
     h.recipes.currentProjectId = null;
     h.recipes.isLoading = false;
+    h.dispatch.mockClear();
   });
 
   describe("an active scratch", () => {
@@ -171,6 +176,18 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
       expect(screen.queryByTestId("recipe-runner")).toBeNull();
     });
 
+    // Isolates the project-binding conjunct: a settled store that hasn't bound a
+    // project yet must stay quiet even in full project context, or the cold-start
+    // flash returns.
+    it("withholds recipes until the store has bound a project", () => {
+      h.recipes.currentProjectId = null;
+      h.recipes.isLoading = false;
+
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+      expect(screen.queryByTestId("recipe-runner")).toBeNull();
+    });
+
     it("shows the project pulse", () => {
       render(<ContentGridEmptyState {...PROJECT_PROPS} />);
 
@@ -214,23 +231,44 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
       );
 
       expect(screen.getByText("Open a project folder")).toBeTruthy();
+      expect(screen.queryByText("Select a worktree")).toBeNull();
     });
 
-    // Issue #8645 — before the worktree snapshot lands, both copy variants would
-    // be a guess, so the canvas stays silent rather than flashing the wrong one.
-    it("stays silent until the worktree snapshot has initialized", () => {
+    it("dispatches the add-project action from the open-folder button", () => {
       render(
         <ContentGridEmptyState
           hasLaunchTarget={false}
           hasProjectContext
           hasWorktrees={false}
-          isWorktreeInitialized={false}
+          isWorktreeInitialized
           showProjectPulse={false}
         />
       );
 
-      expect(screen.queryByText("Open a project folder")).toBeNull();
-      expect(screen.queryByText("Select a worktree")).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: /open folder/i }));
+
+      expect(h.dispatch).toHaveBeenCalledWith("project.add", undefined, { source: "user" });
     });
+
+    // Issue #8645 — before the worktree snapshot lands, either copy variant would
+    // be a guess, so the canvas stays silent rather than flashing the wrong one.
+    // Both branches are checked: `hasWorktrees` alone must not decide it.
+    it.each([true, false])(
+      "stays silent until the worktree snapshot has initialized (hasWorktrees=%s)",
+      (hasWorktrees) => {
+        render(
+          <ContentGridEmptyState
+            hasLaunchTarget={false}
+            hasProjectContext
+            hasWorktrees={hasWorktrees}
+            isWorktreeInitialized={false}
+            showProjectPulse={false}
+          />
+        );
+
+        expect(screen.queryByText("Open a project folder")).toBeNull();
+        expect(screen.queryByText("Select a worktree")).toBeNull();
+      }
+    );
   });
 });

--- a/src/components/Terminal/__tests__/contentGridEmptyContent.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyContent.test.ts
@@ -47,7 +47,7 @@ describe("ContentGrid richer project identity (issue #7472)", () => {
 
   it("ContentGridDefault threads project identity props to empty state", async () => {
     const content = await readFile(DEFAULT_PATH, "utf-8");
-    expect(content).toContain("projectName={ctx.projectName}");
+    expect(content).toContain("workspaceName={ctx.projectName}");
     expect(content).toContain("projectEmoji={ctx.projectEmoji}");
     expect(content).toContain("activeWorktreeBranch={ctx.activeWorktreeBranch}");
     expect(content).toContain("activeWorktreePath={ctx.activeWorktreePath}");
@@ -55,7 +55,7 @@ describe("ContentGrid richer project identity (issue #7472)", () => {
 
   it("ContentGridFleetScope threads project identity props to empty state", async () => {
     const content = await readFile(FLEET_PATH, "utf-8");
-    expect(content).toContain("projectName={ctx.projectName}");
+    expect(content).toContain("workspaceName={ctx.projectName}");
     expect(content).toContain("activeWorktreeBranch={ctx.activeWorktreeBranch}");
     expect(content).toContain("activeWorktreePath={ctx.activeWorktreePath}");
   });
@@ -81,22 +81,11 @@ describe("ContentGrid richer project identity (issue #7472)", () => {
 describe("ContentGridEmptyState surfaces recipes pre-agent-launch (issue #8086)", () => {
   it("RecipeRunner is gated on the recipe store binding, not hasEverLaunchedAgent", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    // The gate must allow first-run discovery: visible whenever there's an
-    // active worktree, recipes are bound to a project, and the load has
-    // settled (avoiding the in-flight empty-state flash).
-    expect(content).toContain("hasActiveWorktree && recipesProjectId !== null && !recipesLoading");
     // The previous double-gate that hid RecipeRunner until an agent had launched
-    // must no longer apply to RecipeRunner.
-    expect(content).not.toMatch(
-      /hasActiveWorktree && hasEverLaunchedAgent && \(\s*<div[^>]*>\s*<RecipeRunner /
-    );
-  });
-
-  it("RotatingTip stays gated on hasEverLaunchedAgent (teaching content)", async () => {
-    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toMatch(
-      /hasActiveWorktree && hasEverLaunchedAgent && \(\s*<div[^>]*>\s*<RotatingTip /
-    );
+    // must no longer apply to RecipeRunner. (That recipes appear on first run,
+    // and wait for the store to settle, is asserted by rendering in
+    // ContentGridEmptyState.workspace.test.tsx.)
+    expect(content).not.toMatch(/hasEverLaunchedAgent && \(\s*<div[^>]*>\s*<RecipeRunner /);
   });
 
   it("subscribes to the recipe store for both projectId and loading state", async () => {

--- a/src/components/Terminal/__tests__/contentGridEmptyContent.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyContent.test.ts
@@ -5,7 +5,6 @@ import { resolve } from "path";
 const GRID_PATH = resolve(__dirname, "../ContentGrid.tsx");
 const CONTEXT_PATH = resolve(__dirname, "../useContentGridContext.tsx");
 const DEFAULT_PATH = resolve(__dirname, "../ContentGridDefault.tsx");
-const FLEET_PATH = resolve(__dirname, "../ContentGridFleetScope.tsx");
 const EMPTY_STATE_PATH = resolve(__dirname, "../ContentGridEmptyState.tsx");
 
 describe("ContentGrid emptyContent prop (issue #4254)", () => {
@@ -45,20 +44,10 @@ describe("ContentGrid richer project identity (issue #7472)", () => {
     expect(content).toContain("activeWorktreePath: activeWorktree?.path ?? null");
   });
 
-  it("ContentGridDefault threads project identity props to empty state", async () => {
-    const content = await readFile(DEFAULT_PATH, "utf-8");
-    expect(content).toContain("workspaceName={ctx.projectName}");
-    expect(content).toContain("projectEmoji={ctx.projectEmoji}");
-    expect(content).toContain("activeWorktreeBranch={ctx.activeWorktreeBranch}");
-    expect(content).toContain("activeWorktreePath={ctx.activeWorktreePath}");
-  });
-
-  it("ContentGridFleetScope threads project identity props to empty state", async () => {
-    const content = await readFile(FLEET_PATH, "utf-8");
-    expect(content).toContain("workspaceName={ctx.projectName}");
-    expect(content).toContain("activeWorktreeBranch={ctx.activeWorktreeBranch}");
-    expect(content).toContain("activeWorktreePath={ctx.activeWorktreePath}");
-  });
+  // Both grids thread the workspace identity into the empty state; that the
+  // empty state then renders name, branch and path is asserted by rendering in
+  // ContentGridEmptyState.workspace.test.tsx rather than by matching prop
+  // spelling here (a rename would otherwise force a tautological edit).
 
   it("ContentGridEmptyState formats path via shared utilities and useHomeDir", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
@@ -79,14 +68,9 @@ describe("ContentGrid richer project identity (issue #7472)", () => {
 });
 
 describe("ContentGridEmptyState surfaces recipes pre-agent-launch (issue #8086)", () => {
-  it("RecipeRunner is gated on the recipe store binding, not hasEverLaunchedAgent", async () => {
-    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    // The previous double-gate that hid RecipeRunner until an agent had launched
-    // must no longer apply to RecipeRunner. (That recipes appear on first run,
-    // and wait for the store to settle, is asserted by rendering in
-    // ContentGridEmptyState.workspace.test.tsx.)
-    expect(content).not.toMatch(/hasEverLaunchedAgent && \(\s*<div[^>]*>\s*<RecipeRunner /);
-  });
+  // That RecipeRunner appears on first run (not gated on hasEverLaunchedAgent),
+  // waits for the store to settle, and waits for a bound project is asserted by
+  // rendering in ContentGridEmptyState.workspace.test.tsx.
 
   it("subscribes to the recipe store for both projectId and loading state", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -37,17 +37,11 @@ describe("ContentGrid EmptyState — RecipeRunner integration", () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("hasEverLaunchedAgent");
     expect(content).toContain("usePanelStore");
-    expect(content).toContain("hasActiveWorktree && hasEverLaunchedAgent");
   });
 
-  it("gates RotatingTip on hasEverLaunchedAgent — teaching content waits until after first launch", async () => {
-    // Issue #6752 — first-run users (no agent ever launched) shouldn't see
-    // shortcut-carousel teaching content. Returning users still see the
-    // count-biased rotation polished by issue #6756.
-    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toContain("<RotatingTip />");
-    expect(content).toMatch(/hasActiveWorktree && hasEverLaunchedAgent &&[\s\S]*?<RotatingTip \/>/);
-  });
+  // The gating behaviour these once asserted against the source text now lives in
+  // ContentGridEmptyState.workspace.test.tsx, which renders the component: tips
+  // wait for the first launch (#6752) and are withheld from scratches entirely.
 });
 
 describe("ContentGrid EmptyState — recipe-forward launcher composition", () => {
@@ -64,8 +58,6 @@ describe("ContentGrid EmptyState — recipe-forward launcher composition", () =>
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("<ProjectPulseStrip");
     expect(content).not.toContain("<ProjectPulseCard");
-    // Still honors the user's Settings hide toggle.
-    expect(content).toContain("showProjectPulse && hasActiveWorktree && activeWorktreeId");
   });
 
   it("drops the three-row ResumeSessionsCard entirely", async () => {
@@ -75,7 +67,7 @@ describe("ContentGrid EmptyState — recipe-forward launcher composition", () =>
 });
 
 describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", () => {
-  it("accepts a hasWorktrees prop alongside hasActiveWorktree", async () => {
+  it("accepts a hasWorktrees prop alongside the launch-target gate", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("hasWorktrees: boolean");
     expect(content).toMatch(/hasWorktrees,\s*\n/);
@@ -106,12 +98,8 @@ describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", 
     expect(content).toContain('"project.add"');
   });
 
-  it("gates the project-icon hero on hasActiveWorktree so empty states stay silent", async () => {
-    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toMatch(
-      /\{hasActiveWorktree && \(\s*\n\s*<div className="mb-6 flex flex-col items-center text-center"/
-    );
-  });
+  // The identity hero is gated on having a launch target — asserted by rendering
+  // in ContentGridEmptyState.workspace.test.tsx rather than by matching source.
 });
 
 describe("ContentGrid EmptyState — initialization gate (issue #8645)", () => {
@@ -120,19 +108,15 @@ describe("ContentGrid EmptyState — initialization gate (issue #8645)", () => {
     expect(content).toContain("isWorktreeInitialized: boolean");
   });
 
-  it("guards no-worktree branch on isWorktreeInitialized to prevent cold-start copy flash", async () => {
-    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toContain("!hasActiveWorktree && !isWorktreeInitialized");
-    expect(content).toContain("!hasActiveWorktree && isWorktreeInitialized && hasWorktrees");
-    expect(content).toContain("!hasActiveWorktree && isWorktreeInitialized && !hasWorktrees");
-  });
+  // The cold-start flash guard (silent until initialized, then the right copy
+  // variant) is asserted by rendering in ContentGridEmptyState.workspace.test.tsx.
 
   it("does not render bare <p> with text-daintree-text/60 in the no-worktree branch", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     // The old bare <p> with diluted text color is gone — replaced by EmptyState
     const lines = content.split("\n");
     const noWorktreeSection = lines.filter(
-      (line) => !line.includes("hasActiveWorktree") || line.includes("!hasActiveWorktree")
+      (line) => !line.includes("hasLaunchTarget") || line.includes("!hasLaunchTarget")
     );
     const hasOldPattern = noWorktreeSection.some(
       (line) =>

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -113,15 +113,13 @@ describe("ContentGrid EmptyState — initialization gate (issue #8645)", () => {
 
   it("does not render bare <p> with text-daintree-text/60 in the no-worktree branch", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    // The old bare <p> with diluted text color is gone — replaced by EmptyState
-    const lines = content.split("\n");
-    const noWorktreeSection = lines.filter(
-      (line) => !line.includes("hasLaunchTarget") || line.includes("!hasLaunchTarget")
-    );
-    const hasOldPattern = noWorktreeSection.some(
-      (line) =>
-        line.includes("<p") && line.includes("text-daintree-text/60") && line.includes("max-w-md")
-    );
+    // The old bare <p> with diluted text color is gone — replaced by EmptyState.
+    const hasOldPattern = content
+      .split("\n")
+      .some(
+        (line) =>
+          line.includes("<p") && line.includes("text-daintree-text/60") && line.includes("max-w-md")
+      );
     expect(hasOldPattern).toBe(false);
   });
 });

--- a/src/components/Terminal/__tests__/emptyCanvas.test.ts
+++ b/src/components/Terminal/__tests__/emptyCanvas.test.ts
@@ -16,10 +16,7 @@ describe("resolveEmptyCanvas", () => {
   it("hands an empty scratch the launcher, not the welcome screen", () => {
     // #11076: switching to a scratch nulls the project pointer, which used to
     // read as "no workspace" and offer to open a folder the user already had.
-    const canvas = resolveEmptyCanvas(null, scratch);
-
-    expect(canvas.kind).toBe("scratch");
-    expect(canvas).toEqual({ kind: "scratch", scratch });
+    expect(resolveEmptyCanvas(null, scratch)).toEqual({ kind: "scratch", scratch });
   });
 
   it("leaves a project's empty canvas to the grid's own context", () => {

--- a/src/components/Terminal/__tests__/emptyCanvas.test.ts
+++ b/src/components/Terminal/__tests__/emptyCanvas.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import type { Scratch } from "@shared/types/scratch";
+import { resolveEmptyCanvas } from "../emptyCanvas";
+
+const scratch: Scratch = {
+  id: "scratch-1",
+  path: "/scratches/scratch-1",
+  name: "Scratch 2026-07-12 09:30",
+  createdAt: 0,
+  lastOpened: 0,
+};
+
+const project = { id: "project-1" };
+
+describe("resolveEmptyCanvas", () => {
+  it("hands an empty scratch the launcher, not the welcome screen", () => {
+    // #11076: switching to a scratch nulls the project pointer, which used to
+    // read as "no workspace" and offer to open a folder the user already had.
+    const canvas = resolveEmptyCanvas(null, scratch);
+
+    expect(canvas.kind).toBe("scratch");
+    expect(canvas).toEqual({ kind: "scratch", scratch });
+  });
+
+  it("leaves a project's empty canvas to the grid's own context", () => {
+    expect(resolveEmptyCanvas(project, null)).toEqual({ kind: "project" });
+  });
+
+  it("welcomes a user with no workspace at all", () => {
+    expect(resolveEmptyCanvas(null, null)).toEqual({ kind: "welcome" });
+  });
+
+  it("prefers the project when both pointers are transiently set", () => {
+    expect(resolveEmptyCanvas(project, scratch)).toEqual({ kind: "project" });
+  });
+});

--- a/src/components/Terminal/emptyCanvas.ts
+++ b/src/components/Terminal/emptyCanvas.ts
@@ -1,0 +1,28 @@
+import type { Scratch } from "@shared/types/scratch";
+
+/**
+ * What an empty canvas should offer, given the active workspace (#11076).
+ *
+ * `project` defers to the grid's own context-driven empty state; `scratch`
+ * needs the launcher built from scratch-derived props (it has no worktree, so
+ * the grid context can't supply them); `welcome` is the only true
+ * no-workspace case.
+ */
+export type EmptyCanvas =
+  | { kind: "project" }
+  | { kind: "scratch"; scratch: Scratch }
+  | { kind: "welcome" };
+
+/**
+ * The two workspace pointers are mutually exclusive — switching to a scratch
+ * clears the project and vice versa. Project-first only guards the transient
+ * state where both are briefly set.
+ */
+export function resolveEmptyCanvas(
+  currentProject: { id: string } | null,
+  currentScratch: Scratch | null
+): EmptyCanvas {
+  if (currentProject !== null) return { kind: "project" };
+  if (currentScratch !== null) return { kind: "scratch", scratch: currentScratch };
+  return { kind: "welcome" };
+}

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
@@ -12,7 +12,10 @@ const mocks = vi.hoisted(() => ({
     selectWorktree: vi.fn(),
   },
   projectState: {
-    currentProject: { id: "project-1", path: "/repo" },
+    currentProject: { id: "project-1", path: "/repo" } as { id: string; path: string } | null,
+  },
+  scratchState: {
+    currentScratch: null as { id: string; path: string } | null,
   },
 }));
 
@@ -28,6 +31,11 @@ vi.mock("@/store/worktreeStore", () => ({
 vi.mock("@/store", () => ({
   useProjectStore: (selector: (state: typeof mocks.projectState) => unknown): unknown =>
     selector(mocks.projectState),
+}));
+
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: (selector: (state: typeof mocks.scratchState) => unknown): unknown =>
+    selector(mocks.scratchState),
 }));
 
 vi.mock("@/hooks/app/useHomeDir", () => ({
@@ -53,6 +61,8 @@ describe("useActiveWorktreeSync initialization", () => {
     mocks.selectionState.activeWorktreeId = null;
     mocks.selectionState.selectWorktree.mockReset();
     mocks.useWorktrees.mockReset();
+    mocks.projectState.currentProject = { id: "project-1", path: "/repo" };
+    mocks.scratchState.currentScratch = null;
   });
 
   it("waits for the authoritative snapshot before selecting a fallback worktree", () => {

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -1,36 +1,128 @@
-import { describe, it, expect } from "vitest";
-import { readFile } from "fs/promises";
-import { resolve } from "path";
+// @vitest-environment jsdom
 
-const HOOK_PATH = resolve(__dirname, "../useActiveWorktreeSync.ts");
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useActiveWorktreeSync } from "../useActiveWorktreeSync";
 
-describe("useActiveWorktreeSync homeDir fallback (issue #4254)", () => {
-  it("imports useHomeDir", async () => {
-    const content = await readFile(HOOK_PATH, "utf-8");
-    expect(content).toContain('import { useHomeDir } from "@/hooks/app/useHomeDir"');
+const mocks = vi.hoisted(() => ({
+  useWorktrees: vi.fn(),
+  selectionState: {
+    activeWorktreeId: null as string | null,
+    selectWorktree: vi.fn(),
+  },
+  projectState: {
+    currentProject: null as { id: string; path: string } | null,
+  },
+  scratchState: {
+    currentScratch: null as { id: string; path: string } | null,
+  },
+  homeDir: { homeDir: "/home/user" as string | null },
+}));
+
+vi.mock("@/hooks", () => ({
+  useWorktrees: () => mocks.useWorktrees(),
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (state: typeof mocks.selectionState) => unknown): unknown =>
+    selector(mocks.selectionState),
+}));
+
+vi.mock("@/store", () => ({
+  useProjectStore: (selector: (state: typeof mocks.projectState) => unknown): unknown =>
+    selector(mocks.projectState),
+}));
+
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: (selector: (state: typeof mocks.scratchState) => unknown): unknown =>
+    selector(mocks.scratchState),
+}));
+
+vi.mock("@/hooks/app/useHomeDir", () => ({
+  useHomeDir: () => mocks.homeDir,
+}));
+
+// The active-worktree sync effect pushes the selection over the worktree port
+// whenever a project and a worktree are both set. jsdom aliases globalThis to
+// window, so stubbing the global satisfies the hook's `window.electron` read
+// without an unsafe cast.
+vi.stubGlobal("electron", {
+  worktreePort: { request: vi.fn(() => Promise.resolve()) },
+});
+
+// `useWorktrees` is mocked, so the hook reads this shape straight through — no
+// cast to the full WorktreeState is needed for the fields under test.
+const worktree = {
+  id: "wt-1",
+  name: "feature",
+  path: "/repo-worktrees/feature",
+  isMainWorktree: false,
+};
+
+const cwdOf = () => renderHook(() => useActiveWorktreeSync()).result.current.defaultTerminalCwd;
+
+/**
+ * The workspace is a project OR a scratch (#11076), and `terminal.new` spawns
+ * into whatever this resolves to — a missed branch strands the terminal in the
+ * home dir rather than the workspace the user is looking at.
+ */
+describe("useActiveWorktreeSync defaultTerminalCwd", () => {
+  beforeEach(() => {
+    mocks.selectionState.activeWorktreeId = worktree.id;
+    mocks.projectState.currentProject = null;
+    mocks.scratchState.currentScratch = null;
+    mocks.homeDir.homeDir = "/home/user";
+    mocks.useWorktrees.mockReturnValue({ worktrees: [worktree], isInitialized: true });
   });
 
-  it("calls useHomeDir inside the hook", async () => {
-    const content = await readFile(HOOK_PATH, "utf-8");
-    expect(content).toContain("const { homeDir } = useHomeDir()");
+  it("prefers the active worktree over every other workspace path", () => {
+    mocks.projectState.currentProject = { id: "p1", path: "/repo" };
+    mocks.scratchState.currentScratch = { id: "s1", path: "/scratches/s1" };
+
+    expect(cwdOf()).toBe(worktree.path);
   });
 
-  it("uses homeDir as fallback before empty string in defaultTerminalCwd", async () => {
-    const content = await readFile(HOOK_PATH, "utf-8");
-    // When initialized: worktree path → project path → homeDir → ""
-    expect(content).toContain('activeWorktree?.path ?? currentProject?.path ?? homeDir ?? ""');
-    // When not initialized: project path → homeDir → "" (skips worktree which hasn't loaded)
-    expect(content).toContain('currentProject?.path ?? homeDir ?? ""');
+  it("falls back to the project when no worktree is selected", () => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.projectState.currentProject = { id: "p1", path: "/repo" };
+
+    expect(cwdOf()).toBe("/repo");
   });
 
-  it("gates defaultTerminalCwd on isInitialized to prevent race condition", async () => {
-    const content = await readFile(HOOK_PATH, "utf-8");
-    expect(content).toContain("isInitialized");
-    expect(content).toContain("const { worktrees, isInitialized } = useWorktrees()");
+  it("resolves to the scratch when it is the only active workspace", () => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.scratchState.currentScratch = { id: "s1", path: "/scratches/s1" };
+
+    expect(cwdOf()).toBe("/scratches/s1");
   });
 
-  it("includes homeDir and isInitialized in useMemo dependency array", async () => {
-    const content = await readFile(HOOK_PATH, "utf-8");
-    expect(content).toContain("[activeWorktree, currentProject, homeDir, isInitialized]");
+  it("resolves to the scratch before the worktree snapshot has initialized", () => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.scratchState.currentScratch = { id: "s1", path: "/scratches/s1" };
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: false });
+
+    expect(cwdOf()).toBe("/scratches/s1");
+  });
+
+  it("prefers the project over the scratch in a transient both-set state", () => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.projectState.currentProject = { id: "p1", path: "/repo" };
+    mocks.scratchState.currentScratch = { id: "s1", path: "/scratches/s1" };
+
+    expect(cwdOf()).toBe("/repo");
+  });
+
+  it("falls back to the home dir when no workspace is active", () => {
+    mocks.selectionState.activeWorktreeId = null;
+
+    expect(cwdOf()).toBe("/home/user");
+  });
+
+  it("never yields an empty cwd while a scratch is active but the home dir is unknown", () => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.scratchState.currentScratch = { id: "s1", path: "/scratches/s1" };
+    mocks.homeDir.homeDir = null;
+
+    expect(cwdOf()).toBe("/scratches/s1");
   });
 });

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -125,4 +125,60 @@ describe("useActiveWorktreeSync defaultTerminalCwd", () => {
 
     expect(cwdOf()).toBe("/scratches/s1");
   });
+
+  // Issue #4254 — a selection that predates the authoritative snapshot must not
+  // decide the cwd, or terminals spawn in a worktree that may not be current.
+  it("withholds a matching worktree until the snapshot is authoritative", () => {
+    mocks.projectState.currentProject = { id: "p1", path: "/repo" };
+    mocks.useWorktrees.mockReturnValue({ worktrees: [worktree], isInitialized: false });
+
+    expect(cwdOf()).toBe("/repo");
+  });
+
+  it("falls back to the home dir before initialization when no workspace is active", () => {
+    mocks.selectionState.activeWorktreeId = null;
+    mocks.useWorktrees.mockReturnValue({ worktrees: [], isInitialized: false });
+
+    expect(cwdOf()).toBe("/home/user");
+  });
+
+  describe("recomputes when its inputs change", () => {
+    it("adopts the worktree once the snapshot becomes authoritative", () => {
+      mocks.projectState.currentProject = { id: "p1", path: "/repo" };
+      mocks.useWorktrees.mockReturnValue({ worktrees: [worktree], isInitialized: false });
+
+      const { result, rerender } = renderHook(() => useActiveWorktreeSync());
+      expect(result.current.defaultTerminalCwd).toBe("/repo");
+
+      mocks.useWorktrees.mockReturnValue({ worktrees: [worktree], isInitialized: true });
+      rerender();
+
+      expect(result.current.defaultTerminalCwd).toBe(worktree.path);
+    });
+
+    it("adopts the home dir once it resolves", () => {
+      mocks.selectionState.activeWorktreeId = null;
+      mocks.homeDir.homeDir = null;
+
+      const { result, rerender } = renderHook(() => useActiveWorktreeSync());
+      expect(result.current.defaultTerminalCwd).toBe("");
+
+      mocks.homeDir.homeDir = "/home/user";
+      rerender();
+
+      expect(result.current.defaultTerminalCwd).toBe("/home/user");
+    });
+
+    it("adopts a scratch the moment one becomes active", () => {
+      mocks.selectionState.activeWorktreeId = null;
+
+      const { result, rerender } = renderHook(() => useActiveWorktreeSync());
+      expect(result.current.defaultTerminalCwd).toBe("/home/user");
+
+      mocks.scratchState.currentScratch = { id: "s1", path: "/scratches/s1" };
+      rerender();
+
+      expect(result.current.defaultTerminalCwd).toBe("/scratches/s1");
+    });
+  });
 });

--- a/src/hooks/app/__tests__/useEmptyCanvasContent.test.tsx
+++ b/src/hooks/app/__tests__/useEmptyCanvasContent.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, renderHook } from "@testing-library/react";
+
+const h = vi.hoisted(() => ({
+  projectState: { currentProject: null as { id: string; name: string; path: string } | null },
+  scratchState: {
+    currentScratch: null as { id: string; name: string; path: string } | null,
+  },
+}));
+
+vi.mock("@/store", () => ({
+  useProjectStore: (sel: (s: typeof h.projectState) => unknown) => sel(h.projectState),
+}));
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: (sel: (s: typeof h.scratchState) => unknown) => sel(h.scratchState),
+}));
+vi.mock("@/lazyPanels", () => ({
+  LazyWelcomeScreen: () => <div data-testid="welcome-screen" />,
+}));
+vi.mock("@/components/Terminal/ContentGridEmptyState", () => ({
+  // Reflect the props back out so the wiring itself is under test, not the
+  // component's rendering (which has its own suite).
+  ContentGridEmptyState: (props: Record<string, unknown>) => (
+    <div data-testid="empty-state" data-props={JSON.stringify(props)} />
+  ),
+}));
+
+import { useEmptyCanvasContent } from "../useEmptyCanvasContent";
+import type { GettingStartedChecklistState } from "../useGettingStartedChecklist";
+
+const gettingStarted: GettingStartedChecklistState = {
+  visible: false,
+  collapsed: false,
+  checklist: null,
+  showCelebration: false,
+  dismiss: () => {},
+  toggleCollapse: () => {},
+  notifyOnboardingComplete: () => {},
+  markItem: () => {},
+};
+
+const scratch = { id: "scratch-1", name: "Scratch 2026-07-12 09:30", path: "/scratches/scratch-1" };
+const project = { id: "project-1", name: "My project", path: "/repo" };
+
+const renderContent = () => renderHook(() => useEmptyCanvasContent(gettingStarted)).result;
+
+const emptyStateProps = (): Record<string, unknown> => {
+  const raw = screen.getByTestId("empty-state").getAttribute("data-props");
+  return JSON.parse(raw ?? "{}");
+};
+
+describe("useEmptyCanvasContent", () => {
+  beforeEach(() => {
+    h.projectState.currentProject = null;
+    h.scratchState.currentScratch = null;
+  });
+
+  describe("with an active scratch", () => {
+    beforeEach(() => {
+      h.scratchState.currentScratch = scratch;
+    });
+
+    // The bug: a scratch nulls currentProject, which used to read as "no
+    // workspace" and hand the user an acquire-a-workspace screen.
+    it("gives the canvas the launcher, not the welcome screen", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+      expect(screen.queryByTestId("welcome-screen")).toBeNull();
+    });
+
+    it("hands the empty state the scratch's identity and cwd", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      const props = emptyStateProps();
+      expect(props.workspaceName).toBe(scratch.name);
+      expect(props.activeWorktreePath).toBe(scratch.path);
+      expect(props.defaultCwd).toBe(scratch.path);
+    });
+
+    it("marks the scratch as a launch target with no project affordances", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      const props = emptyStateProps();
+      expect(props.hasLaunchTarget).toBe(true);
+      expect(props.hasProjectContext).toBe(false);
+      expect(props.hasWorktrees).toBe(false);
+      expect(props.showProjectPulse).toBe(false);
+    });
+
+    it("keys the canvas on the scratch so switching scratches resets it", () => {
+      expect(renderContent().current.workspaceId).toBe(scratch.id);
+    });
+  });
+
+  describe("with an active project", () => {
+    beforeEach(() => {
+      h.projectState.currentProject = project;
+    });
+
+    // undefined, not null — the grid falls back to its own context-driven empty
+    // state via `emptyContent ?? <ContentGridEmptyState/>`.
+    it("defers to the grid's own empty state", () => {
+      expect(renderContent().current.emptyContent).toBeUndefined();
+    });
+
+    it("keys the canvas on the project", () => {
+      expect(renderContent().current.workspaceId).toBe(project.id);
+    });
+
+    it("still defers when a stale scratch pointer lingers", () => {
+      h.scratchState.currentScratch = scratch;
+
+      const result = renderContent().current;
+
+      expect(result.emptyContent).toBeUndefined();
+      expect(result.workspaceId).toBe(project.id);
+    });
+  });
+
+  describe("with no workspace at all", () => {
+    it("welcomes the user", () => {
+      render(<>{renderContent().current.emptyContent}</>);
+
+      expect(screen.getByTestId("welcome-screen")).toBeTruthy();
+      expect(screen.queryByTestId("empty-state")).toBeNull();
+    });
+
+    it("has no workspace to key the canvas on", () => {
+      expect(renderContent().current.workspaceId).toBeNull();
+    });
+  });
+});

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -4,6 +4,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useProjectStore } from "@/store";
 import { useScratchStore } from "@/store/scratchStore";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
+import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
 
 export function useActiveWorktreeSync() {
   const { worktrees, isInitialized } = useWorktrees();
@@ -67,13 +68,16 @@ export function useActiveWorktreeSync() {
       });
   }, [activeWorktreeId, currentProject?.id, worktrees]);
 
-  // A scratch is an active workspace with no worktree (#11076) — without it in
-  // the chain, `terminal.new` lands in the home dir instead of the scratch.
+  // Before the snapshot is authoritative the worktree is withheld from the
+  // chain — a stale selection would spawn terminals in the wrong tree.
   const defaultTerminalCwd = useMemo(
     () =>
-      isInitialized
-        ? (activeWorktree?.path ?? currentProject?.path ?? currentScratch?.path ?? homeDir ?? "")
-        : (currentProject?.path ?? currentScratch?.path ?? homeDir ?? ""),
+      resolveWorkspaceCwd({
+        worktreePath: isInitialized ? activeWorktree?.path : null,
+        projectPath: currentProject?.path,
+        scratchPath: currentScratch?.path,
+        homeDir,
+      }),
     [activeWorktree, currentProject, currentScratch, homeDir, isInitialized]
   );
 

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useWorktrees } from "@/hooks";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useProjectStore } from "@/store";
+import { useScratchStore } from "@/store/scratchStore";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 
 export function useActiveWorktreeSync() {
@@ -9,6 +10,7 @@ export function useActiveWorktreeSync() {
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
   const currentProject = useProjectStore((s) => s.currentProject);
+  const currentScratch = useScratchStore((s) => s.currentScratch);
   const { homeDir } = useHomeDir();
 
   const lastSyncedActiveRef = useRef<{ projectId: string | null; worktreeId: string | null }>({
@@ -65,12 +67,14 @@ export function useActiveWorktreeSync() {
       });
   }, [activeWorktreeId, currentProject?.id, worktrees]);
 
+  // A scratch is an active workspace with no worktree (#11076) — without it in
+  // the chain, `terminal.new` lands in the home dir instead of the scratch.
   const defaultTerminalCwd = useMemo(
     () =>
       isInitialized
-        ? (activeWorktree?.path ?? currentProject?.path ?? homeDir ?? "")
-        : (currentProject?.path ?? homeDir ?? ""),
-    [activeWorktree, currentProject, homeDir, isInitialized]
+        ? (activeWorktree?.path ?? currentProject?.path ?? currentScratch?.path ?? homeDir ?? "")
+        : (currentProject?.path ?? currentScratch?.path ?? homeDir ?? ""),
+    [activeWorktree, currentProject, currentScratch, homeDir, isInitialized]
   );
 
   return { activeWorktree, defaultTerminalCwd };

--- a/src/hooks/app/useEmptyCanvasContent.tsx
+++ b/src/hooks/app/useEmptyCanvasContent.tsx
@@ -1,0 +1,58 @@
+import { Suspense } from "react";
+import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
+import { useProjectStore } from "@/store";
+import { useScratchStore } from "@/store/scratchStore";
+import { ContentGridEmptyState } from "@/components/Terminal/ContentGridEmptyState";
+import { resolveEmptyCanvas } from "@/components/Terminal/emptyCanvas";
+import { LazyWelcomeScreen } from "@/lazyPanels";
+
+/**
+ * What the content grid shows when it has no panels, and the id of the
+ * workspace that content belongs to (#11076).
+ *
+ * A scratch is a workspace, so its empty canvas gets the agent launcher — not
+ * WelcomeScreen, whose CTAs all acquire a workspace the user already has. It
+ * has no worktree, branch, recipes or project settings, so those affordances
+ * stay off. A project returns `undefined`, deferring to the grid's own
+ * context-driven empty state.
+ */
+export function useEmptyCanvasContent(gettingStarted: GettingStartedChecklistState): {
+  emptyContent: React.ReactNode | undefined;
+  workspaceId: string | null;
+} {
+  const currentProject = useProjectStore((state) => state.currentProject);
+  const currentScratch = useScratchStore((state) => state.currentScratch);
+
+  const canvas = resolveEmptyCanvas(currentProject, currentScratch);
+
+  if (canvas.kind === "project") {
+    return { emptyContent: undefined, workspaceId: currentProject?.id ?? null };
+  }
+
+  if (canvas.kind === "scratch") {
+    return {
+      emptyContent: (
+        <ContentGridEmptyState
+          hasLaunchTarget
+          hasProjectContext={false}
+          hasWorktrees={false}
+          isWorktreeInitialized={false}
+          workspaceName={canvas.scratch.name}
+          activeWorktreePath={canvas.scratch.path}
+          showProjectPulse={false}
+          defaultCwd={canvas.scratch.path}
+        />
+      ),
+      workspaceId: canvas.scratch.id,
+    };
+  }
+
+  return {
+    emptyContent: (
+      <Suspense fallback={null}>
+        <LazyWelcomeScreen gettingStarted={gettingStarted} />
+      </Suspense>
+    ),
+    workspaceId: null,
+  };
+}

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -13,6 +13,7 @@ import { systemClient } from "@/clients";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { logError, logWarn } from "@/utils/logger";
 import { markRendererPerformance } from "@/utils/performance";
+import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -320,11 +321,12 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
 
         const cwd =
           launchOptions?.cwd ??
-          targetWorktree?.path ??
-          currentScratch?.path ??
-          currentProject?.path ??
-          homeDir ??
-          "";
+          resolveWorkspaceCwd({
+            worktreePath: targetWorktree?.path,
+            projectPath: currentProject?.path,
+            scratchPath: currentScratch?.path,
+            homeDir,
+          });
 
         // Handle browser pane specially
         if (agentId === "browser") {

--- a/src/utils/__tests__/workspaceCwd.test.ts
+++ b/src/utils/__tests__/workspaceCwd.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { resolveWorkspaceCwd } from "../workspaceCwd";
+
+describe("resolveWorkspaceCwd", () => {
+  it("prefers the worktree over every other workspace path", () => {
+    expect(
+      resolveWorkspaceCwd({
+        worktreePath: "/repo-worktrees/feature",
+        projectPath: "/repo",
+        scratchPath: "/scratches/s1",
+        homeDir: "/home/user",
+      })
+    ).toBe("/repo-worktrees/feature");
+  });
+
+  it("falls back to the project when there is no worktree", () => {
+    expect(
+      resolveWorkspaceCwd({ projectPath: "/repo", scratchPath: "/scratches/s1", homeDir: "/home" })
+    ).toBe("/repo");
+  });
+
+  // #11076: a scratch is an active workspace with no worktree. Skipping it here
+  // is what stranded `terminal.new` and dock launches in the home dir.
+  it("resolves to the scratch when it is the only active workspace", () => {
+    expect(resolveWorkspaceCwd({ scratchPath: "/scratches/s1", homeDir: "/home" })).toBe(
+      "/scratches/s1"
+    );
+  });
+
+  it("falls back to the home dir when no workspace is active", () => {
+    expect(resolveWorkspaceCwd({ homeDir: "/home/user" })).toBe("/home/user");
+  });
+
+  it("yields an empty string only when nothing resolves", () => {
+    expect(resolveWorkspaceCwd({})).toBe("");
+  });
+
+  it("treats absent paths as absent rather than skipping the rest of the chain", () => {
+    expect(
+      resolveWorkspaceCwd({ worktreePath: null, projectPath: undefined, scratchPath: "/scratches" })
+    ).toBe("/scratches");
+  });
+});

--- a/src/utils/workspaceCwd.ts
+++ b/src/utils/workspaceCwd.ts
@@ -1,0 +1,22 @@
+/**
+ * The one place the workspace cwd chain lives (#11076).
+ *
+ * The active workspace is a project OR a scratch — switching to a scratch
+ * clears the project pointer and vice versa. A scratch has no worktree, so any
+ * chain that stops at the project silently strands its terminals in the home
+ * dir. Project-first only guards the transient state where both pointers are
+ * briefly set (a cached view that hasn't processed the switch broadcast yet);
+ * callers that hand-rolled this disagreed on that order, which is why it now
+ * lives here.
+ *
+ * Returns "" only when nothing at all resolves — main treats a falsy cwd as
+ * "use the home dir".
+ */
+export function resolveWorkspaceCwd(paths: {
+  worktreePath?: string | null;
+  projectPath?: string | null;
+  scratchPath?: string | null;
+  homeDir?: string | null;
+}): string {
+  return paths.worktreePath ?? paths.projectPath ?? paths.scratchPath ?? paths.homeDir ?? "";
+}


### PR DESCRIPTION
## The bug

Switching to a Scratch clears `currentProject`. Main enforces the two workspace pointers, `currentProject` and `currentScratch`, as mutually exclusive. `App.tsx` routed the empty canvas on `currentProject === null`, so a Scratch always rendered `WelcomeScreen`, an onboarding screen for acquiring a workspace ("Open folder", "Clone repository", "Recent projects") shown to someone who already has one. The agent-launching `ContentGridEmptyState` and `LauncherQuickActions` were unreachable from a Scratch. Same bug class as #11068, where the assistant couldn't launch in a Scratch, fixed the same way.

## The fix

- `resolveEmptyCanvas()` routes the empty canvas three ways, project, scratch, or welcome, off the two mutually exclusive pointers. Project wins in the rare transient state where both are set.
- `useEmptyCanvasContent()` owns that routing so it's testable in isolation. `App.tsx` just consumes `{ emptyContent, workspaceId }`.
- `ContentGridEmptyState` now gates on `hasLaunchTarget` (true for a Scratch even though it has no worktree) and `hasProjectContext` (false for a Scratch: there's no settings tab to open, and the tip catalog talks about worktrees, branches, and the project file tree, none of which apply). `projectName` became `workspaceName`, since a Scratch has a name too.
- `ContentGrid`'s `ErrorBoundary` now keys on the active workspace id, so switching between Scratches resets a previously failed canvas instead of carrying it over.

## Two cwd bugs found along the way

Building the new launcher's "New terminal" button surfaced two more bugs in workspace cwd resolution. Both are in scope and fixed here:

- `useActiveWorktreeSync` never consulted the Scratch at all, so `terminal.new` inside a Scratch spawned in the home directory.
- `ContentDock` ended its fallback chain with `?? ""`. An empty string isn't nullish, so it silently beat `useAgentLauncher`'s own Scratch fallback and stranded dock launches in the home directory too.

Root cause: the same cwd chain was hand-rolled in three places that disagreed with each other (`useAgentLauncher` checked the Scratch before the project, the other two checked it after). Consolidated into one `resolveWorkspaceCwd()` utility, project-first everywhere.

## Testing

469 tests pass across the affected suites, plus a full typecheck.

Replaced two source-string-grepping suites with behavioural ones. The old `useActiveWorktreeSync` suite asserted the literal text of the cwd expression as a string, so a rename would have forced a tautological edit for no reason. The empty-state gating assertions moved off source-regex matching onto an actual rendering suite, preserving the guarantees they used to encode: #6752 (tips wait for first launch), #8645 (cold-start silence), #8086 (recipe settle gate), and the pulse-hide toggle.

## Out of scope, worth a follow-up

- Durable panel restore for Scratch workspaces is still project-only, persistence and hydration key off `currentProjectId`. Fixing that needs main-process work that would break this PR's renderer-only property.
- `scratchStore` is globally broadcast rather than scoped per view, so a cached view can briefly show stale scratch state across a switch. Pre-existing, and this PR doesn't make it worse: a Scratch previously showed the wrong screen every time.
- No E2E spec. `ProjectViewManager`'s view swap makes the Playwright `Page` reference go stale mid-spec, which is a flake generator, and E2E gates releases here. Covered by unit and component tests instead.
- #11076 said it depends on #11075 (Scratch naming), still open. This landed independently because the naming plumbing (the `name` field, `renameScratch`) already exists in the store.

Resolves #11076
