### PR TITLE
fix(scratch): kill and clear a deleted scratch's terminals

### DIFF
--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -335,6 +335,13 @@ class ErrorService {
               cwd: args.cwd,
               cols: normalizeTerminalDimension(args.cols, 80),
               rows: normalizeTerminalDimension(args.rows, 30),
+              // Carry the original workspace owner through the retry. Dropping it
+              // makes PtyClient.spawn fall back to its global active-workspace id,
+              // which can hand the respawned terminal to whichever workspace another
+              // window switched to last — and let that workspace's delete kill it.
+              ...(typeof args.projectId === "string" && args.projectId
+                ? { projectId: args.projectId }
+                : {}),
             },
             signal
           );

--- a/electron/ipc/handlers/scratch/__tests__/remove.test.ts
+++ b/electron/ipc/handlers/scratch/__tests__/remove.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue(os.tmpdir()),
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+const scratchStoreMock = vi.hoisted(() => ({
+  getAllScratches: vi.fn(() => []),
+  getCurrentScratch: vi.fn(() => null),
+  getScratchById: vi.fn(),
+  createScratch: vi.fn(),
+  updateScratch: vi.fn(),
+  removeScratch: vi.fn<(scratchId: string) => Promise<void>>(),
+  setCurrentScratch: vi.fn(),
+}));
+
+vi.mock("../../../../services/ScratchStore.js", () => ({
+  scratchStore: scratchStoreMock,
+}));
+
+vi.mock("../../../../services/ProjectStore.js", () => ({
+  projectStore: {
+    clearCurrentProject: vi.fn(),
+  },
+}));
+
+const broadcastMock = vi.hoisted(() => ({ broadcastToRenderer: vi.fn() }));
+vi.mock("../../../utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../utils.js")>();
+  return { ...actual, broadcastToRenderer: broadcastMock.broadcastToRenderer };
+});
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../../channels.js";
+import { registerScratchHandlers } from "../index.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+function getHandler(channel: string) {
+  const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+    .calls;
+  return calls.find((c) => c[0] === channel)?.[1] as (
+    event: unknown,
+    ...args: unknown[]
+  ) => Promise<unknown>;
+}
+
+function makeDeps(ptyClient: unknown): HandlerDependencies {
+  return { mainWindow: {} as unknown, ptyClient } as unknown as HandlerDependencies;
+}
+
+const fakeEvent = { senderFrame: { url: "http://localhost:5173" } };
+
+describe("scratch:remove handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scratchStoreMock.removeScratch.mockResolvedValue(undefined);
+  });
+
+  it("kills the scratch's terminals before deleting it", async () => {
+    const ptyClient = { killByProject: vi.fn(async () => 2) };
+    registerScratchHandlers(makeDeps(ptyClient));
+
+    await getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-1");
+
+    expect(ptyClient.killByProject).toHaveBeenCalledWith("scratch-1");
+    expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-1");
+
+    // Killing after deletion would race the folder removal against live PTYs.
+    const killOrder = ptyClient.killByProject.mock.invocationCallOrder[0];
+    const removeOrder = scratchStoreMock.removeScratch.mock.invocationCallOrder[0];
+    expect(killOrder).toBeLessThan(removeOrder);
+  });
+
+  it("still deletes the scratch and notifies renderers when the kill fails", async () => {
+    const ptyClient = {
+      killByProject: vi.fn(async () => {
+        throw new Error("PTY host disconnected");
+      }),
+    };
+    registerScratchHandlers(makeDeps(ptyClient));
+
+    await expect(
+      getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-2")
+    ).resolves.toBeUndefined();
+
+    expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-2");
+    expect(broadcastMock.broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.SCRATCH_REMOVED,
+      "scratch-2"
+    );
+  });
+
+  it("deletes the scratch when no pty client is available", async () => {
+    registerScratchHandlers(makeDeps(undefined));
+
+    await getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-3");
+
+    expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-3");
+  });
+
+  it("rejects a blank scratch id without touching the store", async () => {
+    const ptyClient = { killByProject: vi.fn(async () => 0) };
+    registerScratchHandlers(makeDeps(ptyClient));
+
+    await expect(getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "")).rejects.toThrow();
+
+    expect(ptyClient.killByProject).not.toHaveBeenCalled();
+    expect(scratchStoreMock.removeScratch).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -342,25 +342,51 @@ describe("terminal spawn handler - projectId resolution", () => {
     expect(spawnArgs.projectId).toBe("project-b-id");
   });
 
-  it("falls back to current project when explicit projectId references deleted project", async () => {
+  // A scratch id is a legitimate owner that resolves to no Project. Retargeting it to
+  // whatever is globally current would hand the terminal to the wrong workspace — and
+  // let that workspace's delete kill it — so an explicit id is preserved as-is (#11079).
+  it("preserves an explicit workspace id that resolves to no project, without retargeting", async () => {
     mockGetProjectById.mockReturnValue(null);
+    mockGetCurrentProject.mockReturnValue(projectB);
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
 
     const handler = getSpawnHandler();
     await handler({} as Electron.IpcMainInvokeEvent, {
-      projectId: "deleted-project-id",
+      projectId: "scratch-uuid",
+      cwd: "/tmp/scratches/scratch-uuid",
       cols: 80,
       rows: 24,
     });
 
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.projectId).toBe("project-b-id");
+    expect(spawnArgs.projectId).toBe("scratch-uuid");
+    // and must not inherit the current project's identity or working directory
+    expect(spawnArgs.projectId).not.toBe(projectB.id);
+    expect(spawnArgs.cwd).not.toBe(projectB.path);
   });
 
-  it("handles deleted projectId with no current project gracefully", async () => {
+  it("does not fetch project settings for an explicit id that is not a registered project", async () => {
+    mockGetProjectById.mockReturnValue(null);
+    mockGetCurrentProject.mockReturnValue(projectB);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      projectId: "scratch-uuid",
+      cwd: "/tmp/scratches/scratch-uuid",
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(mockGetProjectSettings).not.toHaveBeenCalled();
+  });
+
+  it("keeps the explicit workspace id when there is no current project either", async () => {
     mockGetProjectById.mockReturnValue(null);
     mockGetCurrentProject.mockReturnValue(null);
 
@@ -369,14 +395,14 @@ describe("terminal spawn handler - projectId resolution", () => {
 
     const handler = getSpawnHandler();
     await handler({} as Electron.IpcMainInvokeEvent, {
-      projectId: "deleted-project-id",
+      projectId: "scratch-uuid",
       cols: 80,
       rows: 24,
     });
 
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.projectId).toBeUndefined();
+    expect(spawnArgs.projectId).toBe("scratch-uuid");
   });
 
   it("uses explicit projectId even when current project differs", async () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -187,20 +187,21 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
     const id = validatedOptions.id || crypto.randomUUID();
 
-    // Prefer explicit projectId from renderer (captured at action time) over global state.
-    // Falls back to global state for backward compatibility (e.g., agent/workflow spawns).
-    let resolvedProject = validatedOptions.projectId
-      ? projectStore.getProjectById(validatedOptions.projectId)
-      : null;
-    if (!resolvedProject) {
-      if (validatedOptions.projectId) {
-        console.warn(
-          `[TerminalSpawn] Explicit projectId ${validatedOptions.projectId.slice(0, 8)} not found, falling back to current project`
-        );
-      }
-      resolvedProject = projectStore.getCurrentProject();
-    }
-    const projectId = resolvedProject?.id;
+    // The renderer's explicit id identifies the terminal's owning *workspace*, which
+    // is not always a registered project — a scratch id is opaque here and resolves to
+    // no Project. Keep it as the ownership stamp anyway: retargeting an unresolvable id
+    // to whatever is globally current would hand the terminal to the wrong workspace,
+    // and leaving it unset made ownership fall back to PtyClient's global
+    // `activeProjectId`, so deleting a scratch never killed its terminals (#11079).
+    // Only a caller that sent no id at all falls back to the current project.
+    const explicitWorkspaceId = validatedOptions.projectId;
+    const resolvedProject = explicitWorkspaceId
+      ? projectStore.getProjectById(explicitWorkspaceId)
+      : projectStore.getCurrentProject();
+
+    // Ownership is the explicit id; project-only enrichment below (settings, shell
+    // overrides, project-path cwd fallback) stays gated on a resolved Project.
+    const projectId = explicitWorkspaceId ?? resolvedProject?.id;
     const projectPath = resolvedProject?.path;
 
     // Fetch project-level terminal overrides when there's no agent launch
@@ -210,8 +211,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     let projectShell: string | undefined;
     let projectArgs: string[] | undefined;
     let projectCwd: string | undefined;
-    if (projectId && !launchAgentId) {
-      const projSettings = await projectStore.getProjectSettings(projectId);
+    if (resolvedProject && !launchAgentId) {
+      const projSettings = await projectStore.getProjectSettings(resolvedProject.id);
       const ts = projSettings.terminalSettings;
       if (ts) {
         if (!validatedOptions.shell && ts.shell) {
@@ -454,13 +455,13 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
         );
       }
-    } else if (launchAgentId === "claude" && safeCommand.length > 0 && projectId) {
+    } else if (launchAgentId === "claude" && safeCommand.length > 0 && resolvedProject) {
       // Daintree MCP injection for normal Claude Code agent launches.
       // Mints a per-pane bearer token, writes a managed --mcp-config JSON under
       // userData, and injects the flag into the command + the token into env.
       // Token is revoked and the file deleted on PTY exit (see registerTerminalEventHandlers).
       try {
-        const projSettings = await projectStore.getProjectSettings(projectId);
+        const projSettings = await projectStore.getProjectSettings(resolvedProject.id);
         const tier = resolveDaintreeMcpTier(projSettings);
         if (tier !== "off") {
           const mcpServerService = await getMcpServerService();
@@ -487,7 +488,11 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           mcpErr
         );
       }
-    } else if (launchAgentId === "daintree-assistant" && safeCommand.length > 0 && projectId) {
+    } else if (
+      launchAgentId === "daintree-assistant" &&
+      safeCommand.length > 0 &&
+      resolvedProject
+    ) {
       // Daintree Assistant reads its MCP connection details straight from PTY
       // env (`mcpInjection: "env-only"`) — no .mcp.json, no CLI flags. Mint a
       // per-pane bearer via the same `preparePaneConfig` path Claude uses so
@@ -498,7 +503,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       // DAINTREE_PROJECT_ID is injected downstream by `injectDaintreeMetadata`
       // in the pty-host, so it is intentionally not set here.
       try {
-        const projSettings = await projectStore.getProjectSettings(projectId);
+        const projSettings = await projectStore.getProjectSettings(resolvedProject.id);
         const tier = resolveDaintreeMcpTier(projSettings);
         if (tier !== "off") {
           const mcpServerService = await getMcpServerService();

--- a/src/store/__tests__/scratchStore.removeTeardown.test.ts
+++ b/src/store/__tests__/scratchStore.removeTeardown.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/clients/scratchClient", () => ({
+  scratchClient: {
+    getAll: vi.fn(async () => []),
+    getCurrent: vi.fn(async () => null),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(async () => undefined),
+    switch: vi.fn(),
+  },
+}));
+
+const panelStoreMock = vi.hoisted(() => ({
+  panelIds: [] as string[],
+  removePanel: vi.fn<(id: string) => void>(),
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => panelStoreMock },
+}));
+
+type RemovedListener = (scratchId: string) => void;
+
+let onRemoved: RemovedListener | undefined;
+
+/**
+ * Load scratchStore fresh with a seeded view identity. The module registers its
+ * IPC listeners at import time behind a `globalThis` once-guard, so each case
+ * resets modules and the guard to capture its own `onRemoved`.
+ */
+async function loadStoreForView(viewWorkspaceId: string | undefined): Promise<void> {
+  vi.resetModules();
+  globalThis.__scratchStoreListeners__ = undefined;
+  onRemoved = undefined;
+
+  // The suite runs in the node environment (vitest.config.ts), so stand up the
+  // window surface the store reads: main seeds the view's workspace id here.
+  (globalThis as { window?: unknown }).window = {
+    __DAINTREE_INITIAL_PROJECT__: viewWorkspaceId ? { id: viewWorkspaceId } : undefined,
+    electron: {
+      scratch: {
+        onUpdated: vi.fn(),
+        onRemoved: vi.fn((cb: RemovedListener) => {
+          onRemoved = cb;
+        }),
+        onSwitch: vi.fn(),
+      },
+    },
+  };
+
+  await import("../scratchStore");
+}
+
+describe("scratchStore — panel teardown on scratch removal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    panelStoreMock.panelIds = [];
+  });
+
+  it("removes every panel in the view that owns the deleted scratch", async () => {
+    await loadStoreForView("scratch-1");
+    panelStoreMock.panelIds = ["term-a", "term-b", "term-c"];
+
+    onRemoved?.("scratch-1");
+    await vi.waitFor(() => expect(panelStoreMock.removePanel).toHaveBeenCalledTimes(3));
+
+    expect(panelStoreMock.removePanel.mock.calls.map((c) => c[0])).toEqual([
+      "term-a",
+      "term-b",
+      "term-c",
+    ]);
+  });
+
+  it("leaves a sibling view's panels untouched when a different scratch is deleted", async () => {
+    // The removal is broadcast to EVERY view, so a project view must ignore it —
+    // keying the teardown on the globally-replicated `currentScratch` would wipe
+    // this view's live panels.
+    await loadStoreForView("project-abc");
+    panelStoreMock.panelIds = ["term-a", "term-b"];
+
+    onRemoved?.("scratch-1");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(panelStoreMock.removePanel).not.toHaveBeenCalled();
+  });
+
+  it("ignores the removal in a view with no workspace identity", async () => {
+    await loadStoreForView(undefined);
+    panelStoreMock.panelIds = ["term-a"];
+
+    onRemoved?.("scratch-1");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(panelStoreMock.removePanel).not.toHaveBeenCalled();
+  });
+
+  it("clears the current scratch pointer regardless of which view received the removal", async () => {
+    await loadStoreForView("project-abc");
+    const { useScratchStore } = await import("../scratchStore");
+    useScratchStore.setState({
+      currentScratch: { id: "scratch-1", name: "s", path: "/tmp/s" } as never,
+      scratches: [{ id: "scratch-1", name: "s", path: "/tmp/s" } as never],
+    });
+
+    onRemoved?.("scratch-1");
+
+    expect(useScratchStore.getState().currentScratch).toBeNull();
+    expect(useScratchStore.getState().scratches).toHaveLength(0);
+  });
+});

--- a/src/store/__tests__/scratchStore.removeTeardown.test.ts
+++ b/src/store/__tests__/scratchStore.removeTeardown.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Scratch } from "@shared/types";
 
 vi.mock("@/clients/scratchClient", () => ({
   scratchClient: {
@@ -100,10 +101,14 @@ describe("scratchStore — panel teardown on scratch removal", () => {
   it("clears the current scratch pointer regardless of which view received the removal", async () => {
     await loadStoreForView("project-abc");
     const { useScratchStore } = await import("../scratchStore");
-    useScratchStore.setState({
-      currentScratch: { id: "scratch-1", name: "s", path: "/tmp/s" } as never,
-      scratches: [{ id: "scratch-1", name: "s", path: "/tmp/s" } as never],
-    });
+    const scratch: Scratch = {
+      id: "scratch-1",
+      name: "s",
+      path: "/tmp/s",
+      createdAt: 0,
+      lastOpened: 0,
+    };
+    useScratchStore.setState({ currentScratch: scratch, scratches: [scratch] });
 
     onRemoved?.("scratch-1");
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -15,6 +15,7 @@ import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isClientAppError } from "@/utils/clientAppError";
+import { getViewWorkspaceId } from "./viewWorkspaceId";
 import {
   clearPanelStoreForSwitchThroughAccessor,
   clearFleetArmingThroughAccessor,
@@ -217,20 +218,7 @@ function cancelProjectReadRequests(): void {
 }
 
 function getLocationProjectId(): string | null {
-  if (typeof window === "undefined") return null;
-
-  // Prefer the id seeded by preload via additionalArguments (#9162). The
-  // `?projectId=` query string fallback covers the initial-window load
-  // (createWindow.ts still passes it) and any test/shell view without the
-  // bootstrap global.
-  const seeded = window.__DAINTREE_INITIAL_PROJECT__?.id;
-  if (seeded) return seeded;
-
-  try {
-    return new URL(window.location.href).searchParams.get("projectId");
-  } catch {
-    return null;
-  }
+  return getViewWorkspaceId();
 }
 
 function getProjectForCurrentLocation(projects: Project[]): Project | null {

--- a/src/store/scratchStore.ts
+++ b/src/store/scratchStore.ts
@@ -6,6 +6,7 @@ import type { Scratch } from "@shared/types";
 // keeps this store decoupled from those mocks.
 import { scratchClient } from "@/clients/scratchClient";
 import { getViewWorkspaceId } from "./viewWorkspaceId";
+import { logError } from "@/utils/logger";
 
 /**
  * Renderer-side Zustand store for Scratch (one-off agent workspace) state.
@@ -144,7 +145,9 @@ if (typeof window !== "undefined" && window.electron?.scratch) {
     });
     window.electron.scratch.onRemoved((scratchId) => {
       useScratchStore.getState().removeScratchLocal(scratchId);
-      void closePanelsForRemovedScratch(scratchId);
+      void closePanelsForRemovedScratch(scratchId).catch((error: unknown) => {
+        logError("[ScratchStore] Failed to close panels for removed scratch", error);
+      });
     });
     window.electron.scratch.onSwitch((payload) => {
       if (!payload) return;

--- a/src/store/scratchStore.ts
+++ b/src/store/scratchStore.ts
@@ -5,6 +5,7 @@ import type { Scratch } from "@shared/types";
 // The barrel is mocked in many test setups; importing from the leaf module
 // keeps this store decoupled from those mocks.
 import { scratchClient } from "@/clients/scratchClient";
+import { getViewWorkspaceId } from "./viewWorkspaceId";
 
 /**
  * Renderer-side Zustand store for Scratch (one-off agent workspace) state.
@@ -101,6 +102,29 @@ export const useScratchStore = create<ScratchStoreState>((set, get) => ({
     })),
 }));
 
+/**
+ * Deleting a scratch must leave the app in an empty state, not a grid of dead
+ * agent panels: the exit listener deliberately *preserves* agent terminals after
+ * their PTY exits (so a finished agent stays reviewable), so killing the PTYs is
+ * not enough — nothing else ever removes the panels (#11079). `removePanel` also
+ * kills each PTY by id, which backstops any terminal the workspace-scoped kill in
+ * `scratch:remove` missed.
+ *
+ * Keyed on the view's own workspace id, never on `currentScratch`: the removal is
+ * broadcast to *every* view (cached ones included) and `currentScratch` is
+ * replicated into all of them, so matching on it would wipe a sibling project
+ * view's live panels.
+ */
+async function closePanelsForRemovedScratch(scratchId: string): Promise<void> {
+  if (!scratchId || getViewWorkspaceId() !== scratchId) return;
+
+  const { usePanelStore } = await import("@/store/panelStore");
+  const state = usePanelStore.getState();
+  for (const panelId of [...state.panelIds]) {
+    state.removePanel(panelId);
+  }
+}
+
 // HMR-safe: register push-event listeners exactly once. Subsequent module
 // reloads in dev hit the early-return so we don't accumulate listeners.
 type ListenerState = { registered: boolean };
@@ -120,6 +144,7 @@ if (typeof window !== "undefined" && window.electron?.scratch) {
     });
     window.electron.scratch.onRemoved((scratchId) => {
       useScratchStore.getState().removeScratchLocal(scratchId);
+      void closePanelsForRemovedScratch(scratchId);
     });
     window.electron.scratch.onSwitch((payload) => {
       if (!payload) return;

--- a/src/store/slices/panelRegistry/__tests__/addPanelWorkspaceId.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelWorkspaceId.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { terminalClient, projectClient } from "@/clients";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -75,22 +76,20 @@ beforeEach(() => {
 
 const { usePanelStore } = await import("../../../panelStore");
 
+const spawnMock = vi.mocked(terminalClient.spawn);
+const getSettingsMock = vi.mocked(projectClient.getSettings);
+
 /** Seed the view identity main stamps onto every WebContentsView at creation. */
 function setViewWorkspaceId(id: string | undefined): void {
-  (
-    window as unknown as { __DAINTREE_INITIAL_PROJECT__?: { id: string } }
-  ).__DAINTREE_INITIAL_PROJECT__ = id ? { id } : undefined;
+  window.__DAINTREE_INITIAL_PROJECT__ = id ? { id } : undefined;
 }
 
 async function drainMicrotasks(iterations = 100): Promise<void> {
   for (let i = 0; i < iterations; i++) await Promise.resolve();
 }
 
-async function getSpawnArgs(): Promise<Record<string, unknown> | undefined> {
-  const { terminalClient } = (await import("@/clients")) as unknown as {
-    terminalClient: { spawn: ReturnType<typeof vi.fn> };
-  };
-  return terminalClient.spawn.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+function spawnedProjectId(): string | undefined {
+  return spawnMock.mock.calls[0]?.[0]?.projectId;
 }
 
 describe("addPanel workspace ownership (#11079)", () => {
@@ -99,13 +98,9 @@ describe("addPanel workspace ownership (#11079)", () => {
     const { reset } = usePanelStore.getState();
     await reset();
 
-    const { terminalClient, projectClient } = (await import("@/clients")) as unknown as {
-      terminalClient: { spawn: ReturnType<typeof vi.fn> };
-      projectClient: { getSettings: ReturnType<typeof vi.fn> };
-    };
-    terminalClient.spawn.mockReset();
-    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
-    projectClient.getSettings.mockClear();
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(async ({ id }) => id ?? "spawn-id");
+    getSettingsMock.mockClear();
   });
 
   it("stamps the scratch id on a terminal spawned in a scratch view", async () => {
@@ -115,7 +110,7 @@ describe("addPanel workspace ownership (#11079)", () => {
     await usePanelStore.getState().addPanel({ requestedId: "term-1", bypassLimits: true });
     await drainMicrotasks();
 
-    expect((await getSpawnArgs())?.projectId).toBe("scratch-uuid");
+    expect(spawnedProjectId()).toBe("scratch-uuid");
   });
 
   it("does not fetch project settings for a scratch workspace", async () => {
@@ -125,10 +120,7 @@ describe("addPanel workspace ownership (#11079)", () => {
     await usePanelStore.getState().addPanel({ requestedId: "term-2", bypassLimits: true });
     await drainMicrotasks();
 
-    const { projectClient } = (await import("@/clients")) as unknown as {
-      projectClient: { getSettings: ReturnType<typeof vi.fn> };
-    };
-    expect(projectClient.getSettings).not.toHaveBeenCalled();
+    expect(getSettingsMock).not.toHaveBeenCalled();
   });
 
   it("prefers the current project over the view id when a project is active", async () => {
@@ -140,12 +132,8 @@ describe("addPanel workspace ownership (#11079)", () => {
     await usePanelStore.getState().addPanel({ requestedId: "term-3", bypassLimits: true });
     await drainMicrotasks();
 
-    expect((await getSpawnArgs())?.projectId).toBe("project-abc");
-
-    const { projectClient } = (await import("@/clients")) as unknown as {
-      projectClient: { getSettings: ReturnType<typeof vi.fn> };
-    };
-    expect(projectClient.getSettings).toHaveBeenCalledWith("project-abc");
+    expect(spawnedProjectId()).toBe("project-abc");
+    expect(getSettingsMock).toHaveBeenCalledWith("project-abc");
   });
 
   it("leaves the terminal unowned when the view has no workspace identity", async () => {
@@ -155,6 +143,6 @@ describe("addPanel workspace ownership (#11079)", () => {
     await usePanelStore.getState().addPanel({ requestedId: "term-4", bypassLimits: true });
     await drainMicrotasks();
 
-    expect((await getSpawnArgs())?.projectId).toBeUndefined();
+    expect(spawnedProjectId()).toBeUndefined();
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/addPanelWorkspaceId.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelWorkspaceId.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #11079: a terminal spawned in a scratch workspace must be stamped with the
+ * scratch's id, so `killByProject(scratchId)` reaches it when the scratch is
+ * deleted. Capturing only `currentProject` (null in a scratch) left ownership to
+ * PtyClient's global `activeProjectId` back-fill — null after a restore into a
+ * scratch, and last-write-wins across windows.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return { ...actual, saveNormalized: vi.fn() };
+});
+
+// addPanel lazily imports the project store; drive `currentProject` per test.
+let currentProject: { id: string; path: string } | null = null;
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: { getState: () => ({ currentProject }) },
+}));
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: { globalEnv: { get: vi.fn().mockResolvedValue({}) } },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+
+/** Seed the view identity main stamps onto every WebContentsView at creation. */
+function setViewWorkspaceId(id: string | undefined): void {
+  (
+    window as unknown as { __DAINTREE_INITIAL_PROJECT__?: { id: string } }
+  ).__DAINTREE_INITIAL_PROJECT__ = id ? { id } : undefined;
+}
+
+async function drainMicrotasks(iterations = 100): Promise<void> {
+  for (let i = 0; i < iterations; i++) await Promise.resolve();
+}
+
+async function getSpawnArgs(): Promise<Record<string, unknown> | undefined> {
+  const { terminalClient } = (await import("@/clients")) as unknown as {
+    terminalClient: { spawn: ReturnType<typeof vi.fn> };
+  };
+  return terminalClient.spawn.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+describe("addPanel workspace ownership (#11079)", () => {
+  beforeEach(async () => {
+    currentProject = null;
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient, projectClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+      projectClient: { getSettings: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockReset();
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+    projectClient.getSettings.mockClear();
+  });
+
+  it("stamps the scratch id on a terminal spawned in a scratch view", async () => {
+    currentProject = null; // switching to a scratch clears the project pointer
+    setViewWorkspaceId("scratch-uuid");
+
+    await usePanelStore.getState().addPanel({ requestedId: "term-1", bypassLimits: true });
+    await drainMicrotasks();
+
+    expect((await getSpawnArgs())?.projectId).toBe("scratch-uuid");
+  });
+
+  it("does not fetch project settings for a scratch workspace", async () => {
+    currentProject = null;
+    setViewWorkspaceId("scratch-uuid");
+
+    await usePanelStore.getState().addPanel({ requestedId: "term-2", bypassLimits: true });
+    await drainMicrotasks();
+
+    const { projectClient } = (await import("@/clients")) as unknown as {
+      projectClient: { getSettings: ReturnType<typeof vi.fn> };
+    };
+    expect(projectClient.getSettings).not.toHaveBeenCalled();
+  });
+
+  it("prefers the current project over the view id when a project is active", async () => {
+    // The view id and the project agree in practice; assert precedence explicitly so
+    // a project view can never adopt some other workspace's id.
+    currentProject = { id: "project-abc", path: "/repo" };
+    setViewWorkspaceId("project-abc");
+
+    await usePanelStore.getState().addPanel({ requestedId: "term-3", bypassLimits: true });
+    await drainMicrotasks();
+
+    expect((await getSpawnArgs())?.projectId).toBe("project-abc");
+
+    const { projectClient } = (await import("@/clients")) as unknown as {
+      projectClient: { getSettings: ReturnType<typeof vi.fn> };
+    };
+    expect(projectClient.getSettings).toHaveBeenCalledWith("project-abc");
+  });
+
+  it("leaves the terminal unowned when the view has no workspace identity", async () => {
+    currentProject = null;
+    setViewWorkspaceId(undefined);
+
+    await usePanelStore.getState().addPanel({ requestedId: "term-4", bypassLimits: true });
+    await drainMicrotasks();
+
+    expect((await getSpawnArgs())?.projectId).toBeUndefined();
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -37,6 +37,7 @@ import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch
 import { addToWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 
 // Lazy accessor to break circular dependency: addPanel -> projectStore -> panelPersistence -> addPanel.
 // Resolved on first call (after app init), then cached.
@@ -369,11 +370,20 @@ export const createAddPanelActions = (
     const shouldBackground = location === "dock" || (location === "grid" && !isInActiveWorktree);
     const runtimeStatus: TerminalRuntimeStatus = shouldBackground ? "background" : "running";
 
-    // Capture project ID synchronously before any async work to avoid race conditions
-    // if the user switches projects during async operations (issue #3690).
+    // Capture the owning workspace synchronously before any async work to avoid race
+    // conditions if the user switches during async operations (issue #3690).
     // resolveProjectStore() is cached after first call, so subsequent calls resolve immediately.
+    //
+    // Two ids, deliberately: `capturedProjectId` is a *registered project* (it keys
+    // project settings, which a scratch has none of), while `capturedWorkspaceId` is
+    // whichever workspace owns this view — project or scratch. The PTY is stamped with
+    // the workspace id so `killByProject(scratchId)` reaches scratch terminals on
+    // delete (#11079); leaving it unset made ownership fall back to PtyClient's global
+    // `activeProjectId`, which is null after a restore into a scratch and last-write-wins
+    // across windows.
     const projectStore = await resolveProjectStore();
     const capturedProjectId = projectStore.getState().currentProject?.id;
+    const capturedWorkspaceId = capturedProjectId ?? getViewWorkspaceId() ?? undefined;
 
     const isReconnect = !!options.existingId;
     const isAgent = Boolean(launchAgentId);
@@ -675,7 +685,7 @@ export const createAddPanelActions = (
     const launchGeneration = agentLifecycleLedger.recordLaunch(id, {
       launchAgentId,
       cwd: options.cwd,
-      projectId: capturedProjectId,
+      projectId: capturedWorkspaceId,
       worktreeId: options.worktreeId,
       worktreeSource:
         options.worktreeId !== undefined ? (options.worktreeIdSource ?? "explicit") : undefined,
@@ -906,7 +916,7 @@ export const createAddPanelActions = (
           const spawnRows = attachedDims?.rows ?? overlayDims?.rows ?? 24;
           await terminalClient.spawn({
             id,
-            projectId: capturedProjectId,
+            projectId: capturedWorkspaceId,
             cwd: options.cwd,
             shell: options.shell,
             cols: spawnCols,

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -44,6 +44,7 @@ import {
 } from "@/utils/agentRuntimeSettings";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 
 // Lazy accessor to break circular dependency: restart -> projectStore -> panelPersistence -> core.
 let _cachedProjectStore: typeof import("@/store/projectStore").useProjectStore | null = null;
@@ -555,8 +556,12 @@ export const createRestartActions = (
       terminalInstanceService.suppressNextExit(id, 10000);
 
       // Capture project ID before async work to avoid race conditions (issue #3690).
+      // The respawn keeps the panel's workspace ownership (project or scratch) so a
+      // restarted scratch terminal is still killed with its scratch (#11079); project
+      // settings stay keyed on the registered project id.
       const projectStore = await resolveProjectStore();
       const capturedProjectId = projectStore.getState().currentProject?.id;
+      const capturedWorkspaceId = capturedProjectId ?? getViewWorkspaceId() ?? undefined;
 
       // Agent terminals kill via gracefulKill: Main already routes every
       // agent kill through the graceful-shutdown quit-and-capture flow, but
@@ -695,7 +700,7 @@ export const createRestartActions = (
       agentLifecycleLedger.recordLaunch(id, {
         launchAgentId: isAgent ? currentTerminal.launchAgentId : undefined,
         cwd: currentTerminal.cwd,
-        projectId: capturedProjectId,
+        projectId: capturedWorkspaceId,
         worktreeId: currentTerminal.worktreeId,
         worktreeSource: currentTerminal.worktreeId !== undefined ? "explicit" : undefined,
         agentModelId: isAgent ? currentTerminal.agentModelId : undefined,
@@ -709,7 +714,7 @@ export const createRestartActions = (
 
       await terminalClient.spawn({
         id,
-        projectId: capturedProjectId,
+        projectId: capturedWorkspaceId,
         cwd: currentTerminal.cwd,
         cols: spawnCols,
         rows: spawnRows,
@@ -1210,6 +1215,7 @@ export const createRestartActions = (
 
       const projectStore = await resolveProjectStore();
       const capturedProjectId = projectStore.getState().currentProject?.id;
+      const capturedWorkspaceId = capturedProjectId ?? getViewWorkspaceId() ?? undefined;
 
       const restartEnv = await buildRestartEnv(capturedProjectId, runtimeSettings.env, "fallback");
 
@@ -1218,7 +1224,7 @@ export const createRestartActions = (
       agentLifecycleLedger.recordLaunch(id, {
         launchAgentId: terminal.launchAgentId,
         cwd: terminal.cwd,
-        projectId: capturedProjectId,
+        projectId: capturedWorkspaceId,
         worktreeId: terminal.worktreeId,
         worktreeSource: terminal.worktreeId !== undefined ? "explicit" : undefined,
         agentModelId: terminal.agentModelId,
@@ -1232,7 +1238,7 @@ export const createRestartActions = (
 
       await terminalClient.spawn({
         id,
-        projectId: capturedProjectId,
+        projectId: capturedWorkspaceId,
         cwd: terminal.cwd,
         cols: spawnCols,
         rows: spawnRows,

--- a/src/store/viewWorkspaceId.ts
+++ b/src/store/viewWorkspaceId.ts
@@ -1,0 +1,26 @@
+/**
+ * The workspace this renderer view was created for — a project id or a scratch
+ * id (ProjectViewManager is keyed on opaque ids and seeds either kind).
+ *
+ * This is the only view-local workspace identity in the renderer, and it is
+ * immutable for the life of the WebContents: main seeds it at view creation and
+ * verifies the handshake on load. `useScratchStore`'s `currentScratch`, by
+ * contrast, is broadcast to *every* view (including cached ones), so it says
+ * what the user is looking at globally — never which workspace *this* view owns.
+ * Anything that must not act on a sibling view's state has to key off this.
+ */
+export function getViewWorkspaceId(): string | null {
+  if (typeof window === "undefined") return null;
+
+  // Seeded by preload via additionalArguments (#9162). The `?projectId=` query
+  // fallback covers the initial-window load (createWindow.ts still passes it)
+  // and any test/shell view without the bootstrap global.
+  const seeded = window.__DAINTREE_INITIAL_PROJECT__?.id;
+  if (seeded) return seeded;
+
+  try {
+    return new URL(window.location.href).searchParams.get("projectId");
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #11079. The issue's own root-cause analysis was wrong, so this description covers what's actually going on before getting into the fix.

The issue claimed scratch terminals ship `projectId: undefined`, so `killByProject(scratchId)` matches nothing when the scratch is deleted. That's not what happens. `scratch:switch` sets `PtyClient.activeProjectId` to the scratch id, and `PtyClient.spawn` backfills an absent `projectId` from that value (there's an existing test, `defaults spawn() projectId to activeProjectId when omitted`). So in the reported repro, the PTYs are already getting killed.

What the user actually sees is two separate things:

1. Agent panels are deliberately preserved after their PTY exits (`src/store/listeners/panel/lifecycle.ts` returns early for agent terminals, so a finished agent stays reviewable). Nothing ever removes them on scratch delete: `removeScratch` only clears the scratch pointer, and no view switch happens. So dead agent panels linger on screen and read as "still running." The Daintree Assistant disappears only because it's `removeOnExit: true`. That asymmetry in the issue is a red herring, not evidence its kill worked.
2. The kill itself rides on `activeProjectId`, a global last-write-wins pointer. It's null when a window restores into a scratch, because `windowServices` calls `setActiveProject(win.id, null)` since a scratch id doesn't resolve as a project, and it gets clobbered across windows. Those are the genuine orphans.

## Changes

- Stamps terminals with the view's own workspace id (project or scratch) at spawn time, in `addPanel` and both the restart and respawn code paths, instead of only capturing `currentProject`. Ownership no longer depends on a mutable global. Adds a small new leaf helper, `src/store/viewWorkspaceId.ts`, that reads the view's immutable seeded id (main seeds it per `WebContentsView` and verifies the handshake); `projectStore`'s existing private resolver now delegates to it.
- The terminal spawn handler no longer discards an explicit id just because it isn't a registered project, it now preserves it as ownership. Previously it retargeted the terminal to whatever workspace was globally current, which handed it to the wrong workspace and let that workspace's delete kill it. Project-only enrichment (project settings, shell overrides, MCP injection, the project-path cwd fallback) is now gated on an actually resolved `Project`, which preserves today's behavior exactly, since `projectId` was previously only ever truthy when a project resolved.
- On scratch removal, the view that owns that scratch removes its own panels, so the app returns to an empty state. `removePanel` also kills each PTY by id, which backstops any terminal the workspace-scoped kill missed. The guard is keyed on the view's immutable workspace id, not `currentScratch`, because `currentScratch` broadcasts to every view while the panel store is per-view; matching on it would wipe a sibling project view's live panels.
- Also fixes the terminal retry path in `electron/ipc/errorHandlers.ts`, which was dropping `projectId` on respawn. Same underlying bug: a retried spawn in one window could get adopted, and later killed, by whatever workspace another window had switched to most recently.

## Testing

New coverage for spawn-time workspace ownership, `scratch:remove` kill-before-delete ordering, and view-scoped panel teardown (including the sibling-view safety case). Two existing tests in `lifecycle.spawn.test.ts` that pinned the old retargeting behavior were intentionally rewritten.

Known follow-ups, pre-existing and not regressions (checked against the old behavior): Claude launched in a scratch gets no Daintree MCP injection, since there's no project settings to read a tier from; scratch agent sessions don't show up in the resume palette; idle-notification and auto-close policies skip scratch terminals. All three behaved this way before this change.

Local: branch test suite (128 tests) green, full project typecheck green, changed files clean on prettier and eslint.