### PR TITLE
fix(toolbar): stop reserving blank branch space for scratch workspaces

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -70,7 +70,7 @@ import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
-import { activeWorkspaceIdentity } from "@/lib/workspaceIdentity";
+import { activeWorkspaceIdentity, branchChipState } from "@/lib/workspaceIdentity";
 import { usePreferencesStore, useToolbarPreferencesStore, useVoiceRecordingStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -1423,6 +1423,7 @@ export function Toolbar({
 
   const activeSearchableProject = projectSwitcher.activeProject;
   const truncatedBranchName = branchName ? middleTruncate(branchName, 24) : undefined;
+  const chipState = branchChipState(workspaceIdentity.kind, branchName);
   const { copy: copyPillPath } = useCopyWithFeedback({ announcement: "Path copied" });
   const handleCopyProjectPath = useCallback(() => {
     if (!currentProject) return;
@@ -1469,23 +1470,19 @@ export function Toolbar({
           >
             {workspaceIdentity.name}
           </span>
-          {/* Scratch workspaces have no git repo, so the chip is unmounted outright
-           * rather than faded — a hidden-but-mounted chip reserves blank pill width
-           * (issue #11084). Projects and the pre-hydration "none" state keep the
-           * transparent placeholder below: their branch can arrive late (secondary
-           * windows hydrate over IPC) or never (detached HEAD), and collapsing the
-           * pill mid-hydration is the titlebar shift 88e295a07 fixed. */}
-          {workspaceIdentity.kind !== "scratch" && (
+          {chipState !== "hidden" && (
             <span
               className={cn(
                 "toolbar-project-chip shrink-0 inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 font-mono tabular-nums",
-                !branchName && "opacity-0"
+                chipState === "reserved" && "opacity-0"
               )}
-              aria-label={branchName ? `Current branch ${branchName}` : undefined}
-              aria-hidden={branchName ? undefined : true}
+              aria-label={chipState === "visible" ? `Current branch ${branchName}` : undefined}
+              aria-hidden={chipState === "visible" ? undefined : true}
             >
               <GitBranch className="toolbar-project-chip-icon h-3 w-3 shrink-0" />
-              <span className="toolbar-project-chip-label">{truncatedBranchName ?? "main"}</span>
+              <span className="toolbar-project-chip-label">
+                {chipState === "visible" ? truncatedBranchName : "main"}
+              </span>
             </span>
           )}
           <ChevronsUpDown className="toolbar-project-meta h-3 w-3 shrink-0" />

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1469,17 +1469,25 @@ export function Toolbar({
           >
             {workspaceIdentity.name}
           </span>
-          <span
-            className={cn(
-              "toolbar-project-chip shrink-0 inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 font-mono tabular-nums",
-              !branchName && "opacity-0"
-            )}
-            aria-label={branchName ? `Current branch ${branchName}` : undefined}
-            aria-hidden={branchName ? undefined : true}
-          >
-            <GitBranch className="toolbar-project-chip-icon h-3 w-3 shrink-0" />
-            <span className="toolbar-project-chip-label">{truncatedBranchName ?? "main"}</span>
-          </span>
+          {/* Scratch workspaces have no git repo, so the chip is unmounted outright
+           * rather than faded — a hidden-but-mounted chip reserves blank pill width
+           * (issue #11084). Projects and the pre-hydration "none" state keep the
+           * transparent placeholder below: their branch can arrive late (secondary
+           * windows hydrate over IPC) or never (detached HEAD), and collapsing the
+           * pill mid-hydration is the titlebar shift 88e295a07 fixed. */}
+          {workspaceIdentity.kind !== "scratch" && (
+            <span
+              className={cn(
+                "toolbar-project-chip shrink-0 inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 font-mono tabular-nums",
+                !branchName && "opacity-0"
+              )}
+              aria-label={branchName ? `Current branch ${branchName}` : undefined}
+              aria-hidden={branchName ? undefined : true}
+            >
+              <GitBranch className="toolbar-project-chip-icon h-3 w-3 shrink-0" />
+              <span className="toolbar-project-chip-label">{truncatedBranchName ?? "main"}</span>
+            </span>
+          )}
           <ChevronsUpDown className="toolbar-project-meta h-3 w-3 shrink-0" />
         </button>
       </TooltipTrigger>

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -134,6 +134,28 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).toContain("shrink-0 inline-flex items-center gap-1 rounded-full border");
     });
 
+    it("unmounts the branch chip for scratch workspaces — issue #11084", () => {
+      // A scratch workspace has no git repo, so a hidden-but-mounted chip would
+      // reserve blank width between the name and the caret. The gate must be the
+      // workspace kind, not the branch: `!branchName` alone would also collapse
+      // the chip for a detached-HEAD project (see the reservation test below).
+      const chipIndex = source.indexOf("toolbar-project-chip shrink-0");
+      expect(chipIndex).toBeGreaterThan(-1);
+      const beforeChip = source.slice(Math.max(0, chipIndex - 300), chipIndex);
+      expect(beforeChip).toMatch(/workspaceIdentity\.kind !== "scratch"\s*&&\s*\(/);
+    });
+
+    it("keeps the branchless width reservation outside scratch workspaces", () => {
+      // Regression guard for 88e295a07: a project's branch hydrates asynchronously
+      // in secondary windows and is absent entirely on detached HEAD, so the chip
+      // stays mounted-but-transparent instead of collapsing the pill. A gate that
+      // mounts the chip on `branchName` would reintroduce that titlebar shift.
+      const chipIndex = source.indexOf("toolbar-project-chip shrink-0");
+      const chipBlock = source.slice(chipIndex, chipIndex + 400);
+      expect(chipBlock).toMatch(/!branchName\s*&&\s*"opacity-0"/);
+      expect(source).not.toMatch(/\{branchName\s*&&\s*\(?\s*<span[\s\S]{0,120}toolbar-project-chip/);
+    });
+
     it("chevron icons have shrink-0", () => {
       // The chevron carries shrink-0 so it stays visible during truncation. It
       // no longer carries an ml-0.5 nudge — the pill's uniform gap-2 owns the

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -150,7 +150,9 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(chipBlock).toMatch(/chipState === "reserved"\s*&&\s*"opacity-0"/);
       // The chip must never mount straight off the branch: that collapses the pill
       // for a branchless project too, which is the titlebar shift 88e295a07 fixed.
-      expect(source).not.toMatch(/\{branchName\s*&&\s*\(?\s*<span[\s\S]{0,120}toolbar-project-chip/);
+      expect(source).not.toMatch(
+        /\{branchName\s*&&\s*\(?\s*<span[\s\S]{0,120}toolbar-project-chip/
+      );
     });
 
     it("chevron icons have shrink-0", () => {

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -134,25 +134,22 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).toContain("shrink-0 inline-flex items-center gap-1 rounded-full border");
     });
 
-    it("unmounts the branch chip for scratch workspaces — issue #11084", () => {
-      // A scratch workspace has no git repo, so a hidden-but-mounted chip would
-      // reserve blank width between the name and the caret. The gate must be the
-      // workspace kind, not the branch: `!branchName` alone would also collapse
-      // the chip for a detached-HEAD project (see the reservation test below).
+    it("can drop the branch chip out of the layout entirely — issue #11084", () => {
+      // A scratch workspace has no branch, and a merely-faded chip still reserves
+      // blank width beside the name. So the chip must be conditionally mounted, not
+      // unconditionally rendered and hidden. Which of the three states applies to a
+      // given workspace is `branchChipState`'s contract, unit-tested in
+      // src/lib/__tests__/workspaceIdentity.test.ts — here we only prove the pill is
+      // wired to it and can still reserve width without showing a branch.
       const chipIndex = source.indexOf("toolbar-project-chip shrink-0");
       expect(chipIndex).toBeGreaterThan(-1);
       const beforeChip = source.slice(Math.max(0, chipIndex - 300), chipIndex);
-      expect(beforeChip).toMatch(/workspaceIdentity\.kind !== "scratch"\s*&&\s*\(/);
-    });
+      expect(beforeChip).toMatch(/chipState !== "hidden"\s*&&\s*\(/);
 
-    it("keeps the branchless width reservation outside scratch workspaces", () => {
-      // Regression guard for 88e295a07: a project's branch hydrates asynchronously
-      // in secondary windows and is absent entirely on detached HEAD, so the chip
-      // stays mounted-but-transparent instead of collapsing the pill. A gate that
-      // mounts the chip on `branchName` would reintroduce that titlebar shift.
-      const chipIndex = source.indexOf("toolbar-project-chip shrink-0");
-      const chipBlock = source.slice(chipIndex, chipIndex + 400);
-      expect(chipBlock).toMatch(/!branchName\s*&&\s*"opacity-0"/);
+      const chipBlock = source.slice(chipIndex, chipIndex + 800);
+      expect(chipBlock).toMatch(/chipState === "reserved"\s*&&\s*"opacity-0"/);
+      // The chip must never mount straight off the branch: that collapses the pill
+      // for a branchless project too, which is the titlebar shift 88e295a07 fixed.
       expect(source).not.toMatch(/\{branchName\s*&&\s*\(?\s*<span[\s\S]{0,120}toolbar-project-chip/);
     });
 

--- a/src/lib/__tests__/workspaceIdentity.test.ts
+++ b/src/lib/__tests__/workspaceIdentity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { activeWorkspaceIdentity } from "../workspaceIdentity";
+import { activeWorkspaceIdentity, branchChipState } from "../workspaceIdentity";
 
 const project = { name: "daintree" };
 const scratch = { name: "Spike: retry queue" };
@@ -50,5 +50,44 @@ describe("activeWorkspaceIdentity", () => {
   it("treats undefined like null", () => {
     expect(activeWorkspaceIdentity(undefined, undefined).kind).toBe("none");
     expect(activeWorkspaceIdentity(undefined, scratch).kind).toBe("scratch");
+  });
+});
+
+describe("branchChipState", () => {
+  it("shows the branch for a project on a branch", () => {
+    expect(branchChipState("project", "feature/x")).toBe("visible");
+  });
+
+  it("drops the chip entirely for a scratch workspace — issue #11084", () => {
+    // A scratch is never a git repo, so the chip has nothing to say and must leave
+    // the layout: a merely-faded chip still reserves blank width beside the name.
+    expect(branchChipState("scratch", undefined)).toBe("hidden");
+  });
+
+  it("drops the chip for a scratch even if a stale branch is still selected", () => {
+    // The worktree selection is not scratch-aware, so a branch can linger in the
+    // store after switching to a scratch. The workspace kind, not the branch, decides.
+    expect(branchChipState("scratch", "feature/x")).toBe("hidden");
+  });
+
+  it("reserves the chip's width for a branchless project", () => {
+    // Detached HEAD, or a view that painted before its project bound. The branch may
+    // still arrive, so the width is held rather than collapsed — a late expansion
+    // would shift the titlebar's no-drag region.
+    expect(branchChipState("project", undefined)).toBe("reserved");
+  });
+
+  it("reserves rather than shows in the empty state, even with a stale branch", () => {
+    // Closing a project nulls it without clearing the worktree selection, so the
+    // branch outlives it. It must not linger visibly beside "Open project".
+    expect(branchChipState("none", undefined)).toBe("reserved");
+    expect(branchChipState("none", "feature/x")).toBe("reserved");
+  });
+
+  it("never shows a branch outside a project", () => {
+    const outsideProject = (["scratch", "none"] as const).map((kind) =>
+      branchChipState(kind, "feature/x")
+    );
+    expect(outsideProject).not.toContain("visible");
   });
 });

--- a/src/lib/workspaceIdentity.ts
+++ b/src/lib/workspaceIdentity.ts
@@ -30,3 +30,28 @@ export function activeWorkspaceIdentity(
   }
   return { kind: "none", name: "Open project", ariaLabel: "Open project" };
 }
+
+/**
+ * How the toolbar pill's git-branch chip should render.
+ *
+ * - `hidden` — not mounted at all. A scratch workspace is never a git repo, so a
+ *   faded chip would only reserve blank width beside the name (issue #11084).
+ * - `reserved` — mounted but transparent, holding the chip's width. A project's
+ *   branch can arrive late (a view first-paints before its project binds) or never
+ *   (detached HEAD); collapsing the pill then would shift the titlebar's no-drag
+ *   region, which is why the placeholder exists.
+ * - `visible` — mounted and showing the branch.
+ */
+export type BranchChipState = "hidden" | "reserved" | "visible";
+
+export function branchChipState(
+  kind: ActiveWorkspaceIdentity["kind"],
+  branchName: string | null | undefined
+): BranchChipState {
+  if (kind === "scratch") return "hidden";
+  // `branchName` rides the worktree selection, which closing a project does not
+  // clear — so it can outlive `currentProject`. Requiring a project keeps a closed
+  // project's branch from lingering beside the "Open project" empty state.
+  if (kind !== "project" || !branchName) return "reserved";
+  return "visible";
+}


### PR DESCRIPTION
## Summary

- The project switcher pill's git branch chip was always mounted and just faded out with `opacity-0` when there was no branch name, using a placeholder label of `main` purely to hold width.
- A Scratch workspace is never a git repo, so the chip could never fill in. It just reserved a blank gap between the workspace name and the caret.
- The chip's three states now come from a single pure function, `branchChipState()`, in `src/lib/workspaceIdentity.ts`.

Resolves #11084

## The fix

`branchChipState()` returns one of three states:

- `hidden` - scratch: unmounted entirely, takes no layout space.
- `reserved` - mounted but transparent, holds its width.
- `visible` - shows the branch.

## Why not just gate on `!branchName`

That's the obvious fix, and it's wrong. `git log -S` shows the chip used to be `{branchName && (...)}`, conditionally rendered only when a branch name existed, and was deliberately converted to always-mounted-plus-`opacity-0` by `88e295a07` ("fix(toolbar): stabilize titlebar no-drag regions").

That commit exists because a renderer can first-paint before its project view binds (`windowServices.ts` registers the view after the renderer starts; `Toolbar.tsx` even has a retry path for it), and a project can be permanently branchless on a detached HEAD. Collapsing the pill in those cases shifts the titlebar's no-drag region, which is the exact bug `88e295a07` fixed. So projects and the empty state keep reserving the space. Only Scratch drops out.

## Second bug found in review

Worth calling out separately. `branchName` rides the worktree selection, and `closeActiveProject()` nulls `currentProject` without clearing it (`worktreeStore.reset()` has no caller on that path). The branch name can outlive the project, so a closed project's branch chip could sit visibly next to the "Open project" empty state.

Visibility now requires an actual current project, and the hidden chip always measures the fixed `main` placeholder, so a lingering stale branch name can't vary the reserved width either.

## Out of scope

The empty state (no project open at all) still reserves the chip's width. That's pre-existing and deliberate: the emoji span beside it, and both other project-scoped toolbar placeholders, all reserve on `!currentProject` too. Properly compacting the empty pill means addressing all of those plus the drag-region behavior together, which is separate from this Scratch-specific fix.

## Testing

- `branchChipState` gets a behavioral state-table test in `src/lib/__tests__/workspaceIdentity.test.ts`, covering all five cases including both stale-branch paths.
- The Toolbar layout suite is a source-regex test (the full `Toolbar` component is too IPC-heavy to render in jsdom), and it keeps only a wiring guard.
- 215 tests pass across the seven affected suites. `prettier` and `tsc` are clean.
