### PR TITLE
fix(project): restore previous-project navigation from a scratch

### DIFF
--- a/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
+++ b/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
@@ -394,8 +394,8 @@ describe("useProjectMruSwitcher", () => {
     beforeEach(() => {
       // Switching to a scratch clears `currentProject` but leaves every
       // project's `lastOpened` untouched, so the pre-scratch project is still
-      // the MRU head. Realistic post-switch statuses: the departed project is
-      // reconciled to "background" (#11085).
+      // the MRU head. Statuses here are the post-reconciliation snapshot, once
+      // main has repaired the departed row to "background" (#11085).
       projectState.currentProject = null;
       projectState.projects = [
         {
@@ -424,6 +424,7 @@ describe("useProjectMruSwitcher", () => {
         keyDown("Equal");
       });
 
+      expect(reopenProjectMock).toHaveBeenCalledTimes(1);
       expect(reopenProjectMock).toHaveBeenCalledWith("p-prev");
       expect(switchProjectMock).not.toHaveBeenCalled();
     });
@@ -435,7 +436,41 @@ describe("useProjectMruSwitcher", () => {
         keyDown("Equal", { shiftKey: true });
       });
 
+      expect(reopenProjectMock).toHaveBeenCalledTimes(1);
       expect(reopenProjectMock).toHaveBeenCalledWith("p-older");
+      expect(switchProjectMock).not.toHaveBeenCalled();
+    });
+
+    it("still targets the pre-scratch project before main reconciles its status", () => {
+      // The immediate post-switch snapshot: the departed row is still "active"
+      // because the scratch switch never demoted or broadcast it.
+      projectState.projects = [
+        {
+          id: "p-prev",
+          path: "/p-prev",
+          name: "Previous",
+          emoji: "tree",
+          lastOpened: 500,
+          status: "active",
+        },
+        {
+          id: "p-older",
+          path: "/p-older",
+          name: "Older",
+          emoji: "carrot",
+          lastOpened: 300,
+          status: "background",
+        },
+      ];
+      renderHook(() => useProjectMruSwitcher());
+
+      act(() => {
+        keyDown("Equal");
+      });
+
+      expect(switchProjectMock).toHaveBeenCalledTimes(1);
+      expect(switchProjectMock).toHaveBeenCalledWith("p-prev");
+      expect(reopenProjectMock).not.toHaveBeenCalled();
     });
 
     it("no-ops when no projects exist at all", () => {

--- a/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
+++ b/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
@@ -389,4 +389,65 @@ describe("useProjectMruSwitcher", () => {
     expect(event.defaultPrevented).toBe(false);
     expect(switchProjectMock).not.toHaveBeenCalled();
   });
+
+  describe("with a scratch active (no current project)", () => {
+    beforeEach(() => {
+      // Switching to a scratch clears `currentProject` but leaves every
+      // project's `lastOpened` untouched, so the pre-scratch project is still
+      // the MRU head. Realistic post-switch statuses: the departed project is
+      // reconciled to "background" (#11085).
+      projectState.currentProject = null;
+      projectState.projects = [
+        {
+          id: "p-prev",
+          path: "/p-prev",
+          name: "Previous",
+          emoji: "tree",
+          lastOpened: 500,
+          status: "background",
+        },
+        {
+          id: "p-older",
+          path: "/p-older",
+          name: "Older",
+          emoji: "carrot",
+          lastOpened: 300,
+          status: "background",
+        },
+      ];
+    });
+
+    it("Cmd+Alt+= returns to the project active before the scratch", () => {
+      renderHook(() => useProjectMruSwitcher());
+
+      act(() => {
+        keyDown("Equal");
+      });
+
+      expect(reopenProjectMock).toHaveBeenCalledWith("p-prev");
+      expect(switchProjectMock).not.toHaveBeenCalled();
+    });
+
+    it("Cmd+Shift+Alt+= wraps to the least-recent project", () => {
+      renderHook(() => useProjectMruSwitcher());
+
+      act(() => {
+        keyDown("Equal", { shiftKey: true });
+      });
+
+      expect(reopenProjectMock).toHaveBeenCalledWith("p-older");
+    });
+
+    it("no-ops when no projects exist at all", () => {
+      projectState.projects = [];
+      renderHook(() => useProjectMruSwitcher());
+
+      act(() => {
+        keyDown("Equal");
+      });
+
+      expect(switchProjectMock).not.toHaveBeenCalled();
+      expect(reopenProjectMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -338,6 +338,36 @@ describe("useProjectSwitcherPalette", () => {
       expect(result.current.results[1]!.id).toBe("project-2");
     });
 
+    it("defaults to the MRU head when a scratch is active (no project is active)", async () => {
+      // A scratch clears `currentProject` without touching any project's
+      // `lastOpened`, and the departed project reconciles to "background". The
+      // preselected row must be the pre-scratch project itself, not the row
+      // after it — there is no active row to skip past (#11085).
+      const scratchProjects = multipleProjects.map((project) => ({
+        ...project,
+        status: "background" as const,
+      }));
+      // Supplied out of MRU order so the assertion proves the computed sort,
+      // not the fixture's array position.
+      projectState.projects = [scratchProjects[2]!, scratchProjects[0]!, scratchProjects[1]!];
+      projectState.currentProject = null;
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(multipleProjects.map((p) => p.id)));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+
+      const freshest = [...scratchProjects].sort((a, b) => b.lastOpened - a.lastOpened)[0]!;
+      expect(result.current.results.some((project) => project.isActive)).toBe(false);
+      expect(result.current.results[result.current.selectedIndex]?.id).toBe(freshest.id);
+    });
+
     it("sorts by lastOpened, ignoring frecencyScore", async () => {
       const projectsWithMismatchedScores = [
         {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -338,18 +338,26 @@ describe("useProjectSwitcherPalette", () => {
       expect(result.current.results[1]!.id).toBe("project-2");
     });
 
-    it("defaults to the MRU head when a scratch is active (no project is active)", async () => {
-      // A scratch clears `currentProject` without touching any project's
-      // `lastOpened`, and the departed project reconciles to "background". The
-      // preselected row must be the pre-scratch project itself, not the row
-      // after it — there is no active row to skip past (#11085).
-      const scratchProjects = multipleProjects.map((project) => ({
-        ...project,
-        status: "background" as const,
-      }));
-      // Supplied out of MRU order so the assertion proves the computed sort,
-      // not the fixture's array position.
-      projectState.projects = [scratchProjects[2]!, scratchProjects[0]!, scratchProjects[1]!];
+    /**
+     * The state the renderer actually holds on the first palette open from a
+     * scratch: the scratch switch cleared `currentProject` but never demoted or
+     * broadcast the row it left, so the pre-scratch project is still "active"
+     * with no process of its own. Main repairs that to "background" on its next
+     * read — which lands only after the palette's async reload (#11085).
+     */
+    function scratchWorkspaceProjects() {
+      // Supplied out of MRU order so assertions prove the computed sort, not the
+      // fixture's array position.
+      return [
+        { ...multipleProjects[2]!, status: "background" as const },
+        { ...multipleProjects[0]!, status: "active" as const },
+        { ...multipleProjects[1]!, status: "background" as const },
+      ];
+    }
+
+    it("keeps the pre-scratch project browsable and preselected on the first open", async () => {
+      const scratchProjects = scratchWorkspaceProjects();
+      projectState.projects = scratchProjects;
       projectState.currentProject = null;
       getBulkStatsMock.mockResolvedValue(emptyBulkStats(multipleProjects.map((p) => p.id)));
 
@@ -365,7 +373,58 @@ describe("useProjectSwitcherPalette", () => {
 
       const freshest = [...scratchProjects].sort((a, b) => b.lastOpened - a.lastOpened)[0]!;
       expect(result.current.results.some((project) => project.isActive)).toBe(false);
+      // The stale-"active" row must survive the modal-browse scope filter, not
+      // get dropped for being neither active nor background.
+      expect(result.current.results.map((project) => project.id)).toContain(freshest.id);
       expect(result.current.results[result.current.selectedIndex]?.id).toBe(freshest.id);
+    });
+
+    it("preselects the pre-scratch project in dropdown mode too", async () => {
+      const scratchProjects = scratchWorkspaceProjects();
+      projectState.projects = scratchProjects;
+      projectState.currentProject = null;
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(multipleProjects.map((p) => p.id)));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open("dropdown");
+      });
+
+      await waitFor(() => {
+        expect(result.current.isOpen).toBe(true);
+      });
+
+      const freshest = [...scratchProjects].sort((a, b) => b.lastOpened - a.lastOpened)[0]!;
+      expect(result.current.results[result.current.selectedIndex]?.id).toBe(freshest.id);
+    });
+
+    it("preselects the freshest switchable project when the active one isn't the MRU head", async () => {
+      // Reachable when the active project's `lastOpened` write was suppressed or
+      // another window bumped a different project. The preselect must be the MRU
+      // switch target — the freshest row that isn't the one we're already in —
+      // never the active row itself, which Enter would no-op on.
+      projectState.projects = [
+        { ...multipleProjects[1]!, lastOpened: 300, status: "background" as const },
+        { ...multipleProjects[0]!, lastOpened: 100, status: "active" as const },
+        { ...multipleProjects[2]!, lastOpened: 50, status: "background" as const },
+      ];
+      projectState.currentProject = { id: multipleProjects[0]!.id };
+      getBulkStatsMock.mockResolvedValue(emptyBulkStats(multipleProjects.map((p) => p.id)));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+
+      const selected = result.current.results[result.current.selectedIndex];
+      expect(selected?.isActive).toBe(false);
+      expect(selected?.id).toBe(multipleProjects[1]!.id);
     });
 
     it("sorts by lastOpened, ignoring frecencyScore", async () => {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -330,12 +330,13 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       const isActive = p.id === currentProject?.id;
       const isMissing = p.status === "missing";
       const hasProcesses = (stats?.processCount ?? 0) > 0;
-      // Main repairs a stale "active" row — one that isn't the current project —
-      // down to "background" on its next read, but a scratch switch clears the
-      // project pointer without demoting or broadcasting the row it left. Without
-      // mirroring that repair here, the pre-scratch project is neither active nor
-      // background and `isVisibleInModalBrowse` drops it from the list entirely
-      // until the async reload lands (#11085).
+      // A scratch switch clears the project pointer without demoting or
+      // broadcasting the row it left, so the pre-scratch project reaches us still
+      // marked "active" while nothing is active. Untreated it is neither active
+      // nor background, and `isVisibleInModalBrowse` drops it from the list until
+      // the async reload lands — main makes the same repair on its next read once
+      // the canonical pointer is null (#11085). View-relative by design: a project
+      // another window owns isn't this view's either.
       const isStaleActive = !isActive && p.status === "active";
       const isBackground =
         p.status === "background" || isStaleActive || (!isActive && !isMissing && hasProcesses);

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -452,11 +452,14 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         setDropdownIsOpen(true);
       }
       setQuery("");
-      // Preselect row 2 (the MRU switch target) against the list the palette is
-      // about to render. `mode` state hasn't committed yet, so `results` still
-      // describes the mode we're leaving — build the destination list instead.
+      // Preselect the MRU switch target — the first row that isn't the project
+      // we're already in — against the list the palette is about to render.
+      // `mode` state hasn't committed yet, so `results` still describes the mode
+      // we're leaving; build the destination list instead. From a scratch there
+      // is no active row, so this lands on row 1 (the project used just before
+      // the scratch) rather than skipping past it (#11085).
       const initialResults = buildResults(sortedProjects, nextMode, "", false);
-      const initial = initialResults[initialResults.length >= 2 ? 1 : 0];
+      const initial = initialResults.find((project) => !project.isActive) ?? initialResults[0];
       setSelectedProjectId(initial?.id ?? null);
     },
     [sortedProjects]

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -330,7 +330,15 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       const isActive = p.id === currentProject?.id;
       const isMissing = p.status === "missing";
       const hasProcesses = (stats?.processCount ?? 0) > 0;
-      const isBackground = p.status === "background" || (!isActive && !isMissing && hasProcesses);
+      // Main repairs a stale "active" row — one that isn't the current project —
+      // down to "background" on its next read, but a scratch switch clears the
+      // project pointer without demoting or broadcasting the row it left. Without
+      // mirroring that repair here, the pre-scratch project is neither active nor
+      // background and `isVisibleInModalBrowse` drops it from the list entirely
+      // until the async reload lands (#11085).
+      const isStaleActive = !isActive && p.status === "active";
+      const isBackground =
+        p.status === "background" || isStaleActive || (!isActive && !isMissing && hasProcesses);
 
       return {
         id: p.id,

--- a/src/lib/__tests__/projectMruSwitch.test.ts
+++ b/src/lib/__tests__/projectMruSwitch.test.ts
@@ -14,15 +14,37 @@ function make(id: string, lastOpened: number, name = id): Project {
 }
 
 describe("getProjectMruSwitchTarget", () => {
-  it("returns null when no current project is set", () => {
+  it("targets the MRU head for 'older' when no current project is set (scratch active)", () => {
+    // Supplied out of MRU order: "b" is the freshest, so it's the project that
+    // was active immediately before the scratch took over (#11085).
     const projects = [make("a", 100), make("b", 200)];
-    expect(getProjectMruSwitchTarget(projects, null, "older")).toBeNull();
-    expect(getProjectMruSwitchTarget(projects, undefined, "newer")).toBeNull();
+    expect(getProjectMruSwitchTarget(projects, null, "older")?.id).toBe("b");
+    expect(getProjectMruSwitchTarget(projects, undefined, "older")?.id).toBe("b");
+  });
+
+  it("targets the MRU tail for 'newer' when no current project is set", () => {
+    const projects = [make("a", 100), make("b", 200)];
+    expect(getProjectMruSwitchTarget(projects, null, "newer")?.id).toBe("a");
+    expect(getProjectMruSwitchTarget(projects, undefined, "newer")?.id).toBe("a");
+  });
+
+  it("returns the sole project in both directions when no current project is set", () => {
+    const projects = [make("a", 100)];
+    expect(getProjectMruSwitchTarget(projects, null, "older")?.id).toBe("a");
+    expect(getProjectMruSwitchTarget(projects, null, "newer")?.id).toBe("a");
+  });
+
+  it("returns null when no current project is set and no projects exist", () => {
+    expect(getProjectMruSwitchTarget([], null, "older")).toBeNull();
+    expect(getProjectMruSwitchTarget([], null, "newer")).toBeNull();
   });
 
   it("returns null when the current project is not in the list", () => {
+    // A stale id is inconsistent state, not the deliberate "no anchor" that a
+    // null id means — it must stay a no-op rather than firing a surprise switch.
     const projects = [make("a", 100), make("b", 200)];
     expect(getProjectMruSwitchTarget(projects, "ghost", "older")).toBeNull();
+    expect(getProjectMruSwitchTarget(projects, "ghost", "newer")).toBeNull();
   });
 
   it("returns null when only the current project exists", () => {

--- a/src/lib/projectMruSwitch.ts
+++ b/src/lib/projectMruSwitch.ts
@@ -12,9 +12,16 @@ export function getProjectMruSwitchTarget(
   currentProjectId: string | null | undefined,
   direction: ProjectMruCycleDirection
 ): Project | null {
-  if (!currentProjectId) return null;
-
   const sorted = getMruProjects(projects);
+
+  // A scratch workspace clears `currentProject` without touching any project's
+  // `lastOpened`, so the project used just before the scratch is still the MRU
+  // head. With nothing to excise, the same circular walk over the full list
+  // lands "older" on it and "newer" on the tail.
+  if (!currentProjectId) {
+    return (direction === "older" ? sorted[0] : sorted.at(-1)) ?? null;
+  }
+
   const current = sorted.find((project) => project.id === currentProjectId);
   if (!current) return null;
 

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -101,21 +101,25 @@ describe("projectActions adversarial", () => {
     });
 
     it("project.mruCycleOlder returns to the MRU head when a scratch cleared the current project", async () => {
-      const { switchProject } = mockMruState(null);
+      const { switchProject, reopenProject } = mockMruState(null);
 
       const { run } = setupActions();
       await run("project.mruCycleOlder");
 
+      expect(switchProject).toHaveBeenCalledTimes(1);
       expect(switchProject).toHaveBeenCalledWith("p-current");
+      expect(reopenProject).not.toHaveBeenCalled();
     });
 
     it("project.mruCycleNewer wraps to the MRU tail when a scratch cleared the current project", async () => {
-      const { switchProject } = mockMruState(null);
+      const { switchProject, reopenProject } = mockMruState(null);
 
       const { run } = setupActions();
       await run("project.mruCycleNewer");
 
+      expect(switchProject).toHaveBeenCalledTimes(1);
       expect(switchProject).toHaveBeenCalledWith("p-older");
+      expect(reopenProject).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -60,7 +60,7 @@ beforeEach(() => {
 
 describe("projectActions adversarial", () => {
   describe("MRU cycle fallbacks", () => {
-    function mockMruState() {
+    function mockMruState(currentProject: { id: string } | null = { id: "p-current" }) {
       const switchProject = vi.fn().mockResolvedValue(undefined);
       const reopenProject = vi.fn().mockResolvedValue(undefined);
       const projects: Project[] = [
@@ -70,7 +70,7 @@ describe("projectActions adversarial", () => {
       ];
 
       projectStoreMock.getState.mockReturnValue({
-        currentProject: { id: "p-current" },
+        currentProject,
         projects,
         switchProject,
         reopenProject,
@@ -98,6 +98,24 @@ describe("projectActions adversarial", () => {
 
       expect(switchProject).toHaveBeenCalledWith("p-older");
       expect(reopenProject).not.toHaveBeenCalled();
+    });
+
+    it("project.mruCycleOlder returns to the MRU head when a scratch cleared the current project", async () => {
+      const { switchProject } = mockMruState(null);
+
+      const { run } = setupActions();
+      await run("project.mruCycleOlder");
+
+      expect(switchProject).toHaveBeenCalledWith("p-current");
+    });
+
+    it("project.mruCycleNewer wraps to the MRU tail when a scratch cleared the current project", async () => {
+      const { switchProject } = mockMruState(null);
+
+      const { run } = setupActions();
+      await run("project.mruCycleNewer");
+
+      expect(switchProject).toHaveBeenCalledWith("p-older");
     });
   });
 


### PR DESCRIPTION
## Summary

- When a scratch workspace is active, the renderer's `currentProject` pointer is null (scratch and project are mutually exclusive, and main calls `clearCurrentProject()` on a scratch switch). Two navigation affordances assumed a project is always active and broke: the MRU cycle shortcut (Option+Command+= / Command+Shift+Option+=) went dead, and the switcher palette (Option+Command+P) pre-highlighted the wrong row.
- The fix needs no new state. A scratch switch clears the project pointer but never bumps any project's `lastOpened` (unlike a project to project switch, which bumps the departing project back in the order), so the project that was active right before the scratch is still sitting at the head of the MRU list.
- Found a third bug during review: a scratch switch leaves the pre-scratch project marked `status: "active"` without demoting it, so it was computing as neither active nor background and getting dropped from the palette entirely until the next async reconcile.

Resolves #11085

## Changes

- `getProjectMruSwitchTarget` (`src/lib/projectMruSwitch.ts`): reworked as a circular walk over the MRU-sorted list with the current project excluded. With no current project there's nothing to exclude, so the same walk over an empty exclusion set gives `older` the head of the list and `newer` the tail. One fix covers both entry points: the capture-phase shortcut hook (`useProjectMruSwitcher`) and the `project.mruCycleOlder`/`mruCycleNewer` actions. A ghost `currentProjectId` (non-null but absent from the project list) still returns null. A null pointer is a deliberate "no anchor" state; a stale id is inconsistent state and shouldn't trigger a surprise switch.
- Palette preselect (`src/hooks/useProjectSwitcherPalette.ts`, `open()`): preselects the first row that isn't the active project, instead of hard-selecting index 1. Identical on the normal path. From a scratch it now lands on row 0 instead of skipping past it. This also fixes an edge case where the active project isn't at the MRU head (a suppressed `lastOpened` write, another window bumping a project, a timestamp tie): the old logic preselected the active row itself, which Enter no-ops on.
- Stale-active backstop (same file, `searchableProjects`): treats a non-current `"active"` row as background, mirroring the repair `getAllProjects()` makes on its next read. Without this the other two fixes would have looked correct in tests and still failed in the running app.

Known and accepted: with no workspace open at all (the welcome screen), the shortcut now opens the MRU head instead of no-oping, which is reasonable for a deliberate keypress. And because this is an MRU cycle rather than a back-stack, a project created while a scratch is active (e.g. via "save as project") tops the MRU and becomes the `older` target. That's pre-existing MRU behavior that affects normal project to project cycling identically, not something this change introduces.

## Testing

244 tests pass across the MRU, palette, and switcher suites. New coverage: no-current-project head/tail/single/empty cases in `projectMruSwitch.test.ts` (two assertions that had encoded the old buggy behavior were flipped); both MRU entry points with a null current project in `useProjectMruSwitcher.test.tsx` and `projectActions.adversarial.test.ts`; palette preselect from the real first-open state (the stale-active head case), from dropdown mode, and from the active-not-MRU-head case.

Changed files are lint and format clean with zero errors. Remaining warnings are pre-existing and outside the changed lines.
