### PR TITLE
fix(forge): refresh the issues dropdown as soon as a self-assign lands

### DIFF
--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -258,6 +258,21 @@ export function invalidateRepoListCachesForCountChange(
   repo: string,
   changed: { issues: boolean; prs: boolean }
 ): void {
+  invalidateRepoListCaches(owner, repo, changed);
+}
+
+/**
+ * The invalidation core shared by the count-as-cache-buster above and by issue
+ * mutations. Any caller that can prove a repo's cached pages for a type are out
+ * of date drops them, bumps the type's epoch so an in-flight query can't write
+ * a pre-change page back, and drops the combined stats-and-page snapshot (it
+ * embeds both first pages, so a change to either invalidates it).
+ */
+function invalidateRepoListCaches(
+  owner: string,
+  repo: string,
+  changed: { issues: boolean; prs: boolean }
+): void {
   if (!changed.issues && !changed.prs) return;
   if (changed.issues) {
     const prefix = `issue:${owner}/${repo}:`;
@@ -272,6 +287,30 @@ export function invalidateRepoListCachesForCountChange(
     bumpRepoListEpoch("pr", owner, repo);
   }
   repoStatsAndPageSnapshotCache.invalidate(`${owner}/${repo}`);
+}
+
+/**
+ * An assign/unassign changes an issue's assignees without moving the open
+ * count, so the count poll's fingerprint can't detect it (#11087) and every
+ * cached issue page for the repo now carries a stale assignee list. Drop them
+ * so the renderer's next read — including a revalidate the count fingerprint
+ * downgraded to a cached one — cannot be served the pre-mutation page, and so
+ * the next stats poll can't broadcast the stale snapshot back over the
+ * renderer's optimistic patch. The tooltip renders assignees too, so the
+ * mutated issue's entry goes with them (matching the legacy assign path).
+ *
+ * Issue-scoped on purpose: an assignment tells us nothing about PR pages, and
+ * evicting them would double the refetch volume on active repos. Deliberately
+ * narrower than `clearGitHubCaches()`, which also drops unrelated repos, the
+ * repo/health caches, and the persistent caches.
+ */
+export function invalidateRepoIssueCachesForAssignment(
+  owner: string,
+  repo: string,
+  issueNumber: number
+): void {
+  invalidateRepoListCaches(owner, repo, { issues: true, prs: false });
+  issueTooltipCache.invalidate(`${owner}/${repo}:${issueNumber}`);
 }
 
 export interface PRRequiredStatusEntry {

--- a/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
@@ -17,6 +17,8 @@ import {
   prListCache,
   getRepoListEpoch,
   invalidateRepoListCachesForCountChange,
+  invalidateRepoIssueCachesForAssignment,
+  issueTooltipCache,
   MAX_REVIEW_THREAD_PAGES,
   REVIEW_THREADS_PER_PAGE,
 } from "../GitHubCaches.js";
@@ -277,6 +279,79 @@ describe("invalidateRepoListCachesForCountChange (count-as-cache-buster)", () =>
     const before = getRepoListEpoch("issue", "unrelated", "repo");
     invalidateRepoListCachesForCountChange("owner", "repo", { issues: true, prs: true });
     expect(getRepoListEpoch("issue", "unrelated", "repo")).toBe(before);
+  });
+
+  describe("invalidateRepoIssueCachesForAssignment (#11087)", () => {
+    // An assignment changes an issue's assignees without moving the open count,
+    // so the count fingerprint can't detect it and every cached issue page for
+    // the repo now carries a stale assignee list.
+    it("drops every cached issue variant for the repo so no read can serve the pre-assignment page", () => {
+      seedLists();
+
+      invalidateRepoIssueCachesForAssignment("owner", "repo", 42);
+
+      expect(forgeIssueListCache.get("issue:owner/repo:open::created:")).toBeUndefined();
+      expect(forgeIssueListCache.get("issue:owner/repo:closed::updated:cursor123")).toBeUndefined();
+      expect(issueListCache.get("issue:owner/repo:open::created:")).toBeUndefined();
+      expect(issueListCache.get("issue:owner/repo:all:search-term:created:")).toBeUndefined();
+    });
+
+    it("drops the stats-and-page snapshot so the next poll cannot broadcast stale rows over the renderer's patch", () => {
+      seedLists();
+
+      invalidateRepoIssueCachesForAssignment("owner", "repo", 42);
+
+      expect(repoStatsAndPageSnapshotCache.get("owner/repo")).toBeUndefined();
+    });
+
+    it("bumps the issue epoch so a list query already in flight cannot write its pre-assignment page back", () => {
+      const issueBefore = getRepoListEpoch("issue", "owner", "repo");
+
+      invalidateRepoIssueCachesForAssignment("owner", "repo", 42);
+
+      expect(getRepoListEpoch("issue", "owner", "repo")).toBe(issueBefore + 1);
+    });
+
+    it("leaves PR pages and their epoch alone — an assignment says nothing about PRs", () => {
+      seedLists();
+      const prBefore = getRepoListEpoch("pr", "owner", "repo");
+
+      invalidateRepoIssueCachesForAssignment("owner", "repo", 42);
+
+      expect(forgePRListCache.get("pr:owner/repo:open::created:")).toBe(forgePage);
+      expect(prListCache.get("pr:owner/repo:open::created:")).toBe(legacyPage);
+      expect(getRepoListEpoch("pr", "owner", "repo")).toBe(prBefore);
+    });
+
+    it("leaves other repos untouched", () => {
+      seedLists();
+
+      invalidateRepoIssueCachesForAssignment("owner", "repo", 42);
+
+      expect(forgeIssueListCache.get("issue:other/repo:open::created:")).toBe(forgePage);
+      expect(issueListCache.get("issue:other/repo:open::created:")).toBe(legacyPage);
+      expect(repoStatsAndPageSnapshotCache.get("other/repo")).toBeDefined();
+    });
+
+    it("drops the mutated issue's tooltip — it renders assignees too — but not a sibling's", () => {
+      issueTooltipCache.clear();
+      const tooltip = {
+        number: 42,
+        title: "t",
+        body: "",
+        state: "open",
+        url: "u",
+        assignees: [],
+        labels: [],
+      } as unknown as Parameters<typeof issueTooltipCache.set>[1];
+      issueTooltipCache.set("owner/repo:42", tooltip);
+      issueTooltipCache.set("owner/repo:99", tooltip);
+
+      invalidateRepoIssueCachesForAssignment("owner", "repo", 42);
+
+      expect(issueTooltipCache.get("owner/repo:42")).toBeUndefined();
+      expect(issueTooltipCache.get("owner/repo:99")).toBe(tooltip);
+    });
   });
 });
 

--- a/plugins/builtin/github/main/mutations.ts
+++ b/plugins/builtin/github/main/mutations.ts
@@ -18,7 +18,12 @@ import {
   CONVERT_PR_TO_DRAFT_MUTATION,
   MARK_PR_READY_FOR_REVIEW_MUTATION,
 } from "./GitHubQueries.js";
-import { clearGitHubCaches, clearPRCaches, issueTooltipCache } from "./GitHubCaches.js";
+import {
+  clearGitHubCaches,
+  clearPRCaches,
+  invalidateRepoIssueCachesForAssignment,
+  issueTooltipCache,
+} from "./GitHubCaches.js";
 import {
   isoToMs,
   restToForgeIssue,
@@ -292,6 +297,7 @@ export async function assignIssueImpl(
       `Failed to assign issue #${issueNumber} to ${username}: HTTP ${response.status}${text ? ` — ${text.slice(0, 200)}` : ""}`
     );
   }
+  invalidateRepoIssueCachesForAssignment(repo.owner, repo.repo, issueNumber);
 }
 
 export async function unassignIssueImpl(
@@ -321,6 +327,7 @@ export async function unassignIssueImpl(
       `Failed to unassign issue #${issueNumber} from ${username}: HTTP ${response.status}${text ? ` — ${text.slice(0, 200)}` : ""}`
     );
   }
+  invalidateRepoIssueCachesForAssignment(repo.owner, repo.repo, issueNumber);
 }
 
 export async function createPRImpl(repo: RepoRef, input: CreatePRInput): Promise<PR> {

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { cn } from "@/lib/utils";
 import { worktreeClient, forgeClient, agentSettingsClient, systemClient } from "@/clients";
-import { mutateCacheEntries } from "@/lib/forgeResourceCache";
+import { patchIssueAssigneeCache } from "@/lib/forgeResourceCache";
 import { logError } from "@/utils/logger";
 import { resolveIssuePrequeries } from "./bulkCreatePrequery";
 import { notify } from "@/lib/notify";
@@ -706,27 +706,15 @@ export function BulkCreateWorktreeDialog({
                       // open issues dropdown reflects the assignment immediately
                       // instead of waiting for the next SWR revalidate (#10667).
                       // Mirrors the single-create flow (#10529). The dedup guard
-                      // inside the transform makes a re-assign a no-op, and the
+                      // inside the helper makes a re-assign a no-op, and the
                       // forge refresh remains the correctness backstop.
                       try {
-                        mutateCacheEntries(rootPath, "issue", (entry) => {
-                          let changed = false;
-                          const items = entry.items.map((item) => {
-                            // `assignees` exists only on Issue, so this `in` check
-                            // narrows the Issue|PR union and skips non-issue slots.
-                            if (!("assignees" in item) || item.number !== itemNumber) return item;
-                            if (item.assignees.some((a) => a.login === username)) return item;
-                            changed = true;
-                            return {
-                              ...item,
-                              assignees: [
-                                ...item.assignees,
-                                { login: username, avatarUrl: assignAvatarUrl, rawData: null },
-                              ],
-                            };
-                          });
-                          return changed ? { ...entry, items } : null;
-                        });
+                        patchIssueAssigneeCache(
+                          rootPath,
+                          itemNumber,
+                          { login: username, avatarUrl: assignAvatarUrl },
+                          true
+                        );
                       } catch (cacheErr) {
                         // A cache-layer throw must not masquerade as an assignment
                         // failure: the server-side assign already succeeded here.

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -602,7 +602,12 @@ export const ForgeStatsToolbarButton = memo(
         const cacheKey = buildCacheKey(currentProject.path, type, "open", "created");
 
         const cached = getCache(cacheKey);
-        if (cached && Date.now() - cached.timestamp < PREFETCH_FRESHNESS_MS) return;
+        // A `stale` entry is the one case a recent timestamp doesn't vouch for:
+        // an optimistic assignee patch restamps it (#11087) and the count poll
+        // marks diverged rows — both need the warm-up the freshness shortcut
+        // would skip, leaving the fetch on the click path.
+        if (cached && !cached.stale && Date.now() - cached.timestamp < PREFETCH_FRESHNESS_MS)
+          return;
 
         // Hover prefetch primes the list cache silently. The count badge stays
         // fresh via the 30s background poll and the click-time refresh —

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -618,11 +618,20 @@ export const ForgeStatsToolbarButton = memo(
         // hover with zero GraphQL; only a cold slot spends a query — the same
         // query the click would have made anyway. This is what makes firing on
         // every hover quota-safe. `bypassCache: true` stays reserved for
-        // explicit intent (dropdown open / manual refresh).
+        // explicit intent (dropdown open / manual refresh) — and for a `stale`
+        // entry, which needs it for correctness, not freshness: a cache-first
+        // read joins any list query already in flight (the main-process
+        // singleflight only skips the join when bypassing), so a hover landing
+        // right after an assign could be handed the page that request fetched
+        // BEFORE the assign — and the write below, being newer than the
+        // optimistic patch, would commit those rows and clear `stale`. The
+        // extra query is not extra spend: an assign invalidates the backend's
+        // issue pages, so a cache-first read would have missed and queried too.
+        const bypassCache = cached?.stale === true;
         const fetchOptions = {
           state: "open" as const,
           sort: "created",
-          bypassCache: false,
+          bypassCache,
         };
         const request =
           type === "issue"

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
@@ -291,6 +291,62 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     expect(refreshStatsMock).not.toHaveBeenCalled();
   });
 
+  it("prefetches a `stale` entry even when its timestamp is fresh", async () => {
+    // An optimistic assignee patch restamps `timestamp` (#11087), so freshness
+    // alone would skip the warm-up on exactly the entry that needs it.
+    setCache(buildCacheKey("/test/proj", "issue", "open", "created"), {
+      items: [makeIssue(99)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      stale: true,
+    });
+    const { container } = renderToolbar();
+
+    await act(async () => {
+      pointerEnter(getIssuesButton(container));
+    });
+
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("bypasses the cache when prefetching a `stale` entry so it cannot join a pre-mutation query", async () => {
+    // The main-process singleflight only skips joining an in-flight request when
+    // bypassing. A cache-first hover right after an assign could otherwise be
+    // handed the page that request fetched BEFORE the assign, and its write
+    // would clear `stale` and drop the optimistic assignee.
+    setCache(buildCacheKey("/test/proj", "issue", "open", "created"), {
+      items: [makeIssue(99)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      stale: true,
+    });
+    const { container } = renderToolbar();
+
+    await act(async () => {
+      pointerEnter(getIssuesButton(container));
+    });
+
+    expect(mockListIssues.mock.calls[0]?.[1]).toMatchObject({ bypassCache: true });
+  });
+
+  it("keeps the cache-first prefetch for a non-stale entry — that is what makes hovering quota-safe", async () => {
+    setCache(buildCacheKey("/test/proj", "issue", "open", "created"), {
+      items: [makeIssue(99)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 11_000,
+    });
+    const { container } = renderToolbar();
+
+    await act(async () => {
+      pointerEnter(getIssuesButton(container));
+    });
+
+    expect(mockListIssues.mock.calls[0]?.[1]).toMatchObject({ bypassCache: false });
+  });
+
   it("does fire the prefetch when the cache entry is stale (>10s)", async () => {
     setCache(buildCacheKey("/test/proj", "issue", "open", "created"), {
       items: [makeIssue(99)],

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -630,12 +630,20 @@ export function NewWorktreeDialog({
         // Skip when the selected issue already lists the current user as an
         // assignee: the assign call would be a no-op and the resulting Undo
         // would strip a pre-existing assignment this flow never created.
+        // Compared case-insensitively — forge logins are, so an "Ada" row would
+        // otherwise slip past this guard and hand the user an Undo that removes
+        // an assignment they already had.
+        const alreadyAssignedToViewer =
+          snapCurrentUser != null &&
+          snapIssue?.assignees.some(
+            (a) => a.login.trim().toLowerCase() === snapCurrentUser.trim().toLowerCase()
+          );
         if (
           !snapUseExisting &&
           snapIssue &&
           snapAssignToSelf &&
           snapCurrentUser &&
-          !snapIssue.assignees.some((a) => a.login === snapCurrentUser)
+          !alreadyAssignedToViewer
         ) {
           try {
             await forgeClient.assignIssue(rootPath, snapIssue.number, snapCurrentUser);

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -11,7 +11,7 @@ import { worktreeClient, forgeClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { notify } from "@/lib/notify";
-import { mutateCacheEntries } from "@/lib/forgeResourceCache";
+import { patchIssueAssigneeCache } from "@/lib/forgeResourceCache";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
@@ -643,37 +643,16 @@ export function NewWorktreeDialog({
             const assignUsername = snapCurrentUser;
             // Optimistically patch every cached issue-list slot so the open
             // issues dropdown reflects the assignment immediately instead of
-            // waiting ~30s for the next SWR revalidate (#10529). Provider-
-            // agnostic: only touches the renderer cache through the forge
-            // abstraction. The forge refresh remains the correctness backstop.
+            // waiting out the renderer TTL (#10529). Provider-agnostic: only
+            // touches the renderer cache through the forge abstraction. The
+            // forge refresh remains the correctness backstop.
             const patchAssigneeCache = (assigned: boolean): void => {
-              mutateCacheEntries(rootPath, "issue", (entry) => {
-                let changed = false;
-                const items = entry.items.map((item) => {
-                  // `assignees` exists only on Issue, so this `in` check narrows
-                  // the Issue|PR union safely and skips any non-issue slot.
-                  if (!("assignees" in item) || item.number !== assignIssueNumber) return item;
-                  const hasUser = item.assignees.some((a) => a.login === assignUsername);
-                  if (assigned) {
-                    if (hasUser) return item;
-                    changed = true;
-                    return {
-                      ...item,
-                      assignees: [
-                        ...item.assignees,
-                        { login: assignUsername, avatarUrl: snapCurrentUserAvatar, rawData: null },
-                      ],
-                    };
-                  }
-                  if (!hasUser) return item;
-                  changed = true;
-                  return {
-                    ...item,
-                    assignees: item.assignees.filter((a) => a.login !== assignUsername),
-                  };
-                });
-                return changed ? { ...entry, items } : null;
-              });
+              patchIssueAssigneeCache(
+                rootPath,
+                assignIssueNumber,
+                { login: assignUsername, avatarUrl: snapCurrentUserAvatar },
+                assigned
+              );
             };
             // A cache-layer throw must not masquerade as an assignment failure:
             // the server-side assign already succeeded by this point.
@@ -689,7 +668,13 @@ export function NewWorktreeDialog({
               void forgeClient
                 .unassignIssue(rootPath, assignIssueNumber, assignUsername)
                 .then(() => {
-                  patchAssigneeCache(false);
+                  // Same isolation as the forward patch — the unassign already
+                  // succeeded, so a cache throw must not report a failed undo.
+                  try {
+                    patchAssigneeCache(false);
+                  } catch (cacheErr) {
+                    logError("Failed to patch issue cache after undo", cacheErr);
+                  }
                 })
                 .catch((err: unknown) => {
                   // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -1263,7 +1263,7 @@ describe("useRepositoryStats", () => {
       });
 
       const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
-      const patchedIssue = {
+      const patchedIssue: Issue = {
         number: 7,
         title: "Patched",
         body: "",
@@ -1330,22 +1330,21 @@ describe("useRepositoryStats", () => {
       });
 
       const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
+      const oldRow: Issue = {
+        number: 7,
+        title: "Old",
+        body: "",
+        state: "open",
+        rawState: "open",
+        url: "u",
+        assignees: [],
+        labels: [],
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      };
       setCache(issuesKey, {
-        items: [
-          {
-            number: 7,
-            title: "Old",
-            body: "",
-            state: "open",
-            rawState: "open",
-            url: "u",
-            assignees: [],
-            labels: [],
-            createdAt: 0,
-            updatedAt: 0,
-            rawData: null,
-          },
-        ],
+        items: [oldRow],
         nextCursor: null,
         hasMore: false,
         timestamp: 1,

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -1238,6 +1238,142 @@ describe("useRepositoryStats", () => {
       });
     });
 
+    it("does not seed over an optimistically-patched (stale) cache entry, even with a newer fetchedAt", async () => {
+      // `fetchedAt` is stamped when the push is BUILT, not when its pages left
+      // the forge — so a stats query already in flight when a self-assign lands
+      // broadcasts pre-assignment rows under a newer timestamp. Seeding that
+      // would drop the optimistic assignee and clear the `stale` mark that
+      // forces the next dropdown open to revalidate fresh (#11087).
+      const project = { id: "p", path: "/repo/optimistic" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 1,
+        issueCount: 1,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoStatsAndPageUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
+      const patchedIssue = {
+        number: 7,
+        title: "Patched",
+        body: "",
+        state: "open",
+        rawState: "open",
+        url: "u",
+        assignees: [{ login: "ada", avatarUrl: undefined, rawData: null }],
+        labels: [],
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      };
+      setCache(issuesKey, {
+        items: [patchedIssue],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: 1,
+        stale: true,
+      });
+
+      renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(getCurrentMock).toHaveBeenCalled();
+      });
+
+      const pushedStats: ForgeRepositoryStats = {
+        commitCount: 2,
+        issueCount: 1,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: 2000,
+      };
+      await act(async () => {
+        // A far-newer fetchedAt carrying the pre-assignment page (no assignees).
+        pushHandler?.(makePushPayload(project.path, pushedStats, Date.now() + 10_000));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const cached = getCache(issuesKey);
+      expect(cached?.stale).toBe(true);
+      expect(cached?.items).toHaveLength(1);
+      expect(cached?.items[0]).toMatchObject({ number: 7 });
+    });
+
+    it("still seeds a non-stale entry when the push is newer", async () => {
+      const project = { id: "p", path: "/repo/seedable" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 1,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoStatsAndPageUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
+      setCache(issuesKey, {
+        items: [
+          {
+            number: 7,
+            title: "Old",
+            body: "",
+            state: "open",
+            rawState: "open",
+            url: "u",
+            assignees: [],
+            labels: [],
+            createdAt: 0,
+            updatedAt: 0,
+            rawData: null,
+          },
+        ],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: 1,
+      });
+
+      renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(getCurrentMock).toHaveBeenCalled();
+      });
+
+      const pushedStats: ForgeRepositoryStats = {
+        commitCount: 2,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: 2000,
+      };
+      await act(async () => {
+        pushHandler?.(makePushPayload(project.path, pushedStats, Date.now() + 10_000));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The push carries an empty page — a non-stale entry is replaced by it.
+      expect(getCache(issuesKey)?.items).toEqual([]);
+    });
+
     it("ignores a push payload whose fetchedAt is older than the last applied result", async () => {
       const project = { id: "p", path: "/repo/stale" };
       getCurrentMock.mockResolvedValue(project);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -841,7 +841,20 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           // stamped — this payload can carry a re-stamped main-process
           // snapshot (probe-unchanged path), so it must never satisfy the
           // "just fetched from GitHub, skip the open revalidate" gate.
-          if (!existingIssues || existingIssues.timestamp < payload.fetchedAt) {
+          //
+          // A `stale` entry is never seeded over. `fetchedAt` is stamped when
+          // the push is built, not when its pages left the forge, so it does
+          // NOT prove the payload's content is newer than what the entry holds
+          // — and a stale entry holds exactly the content the push can't know
+          // about: an optimistic assignee patch (#11087) or a row set the count
+          // poll already disproved. Seeding here would drop the rows and clear
+          // the `stale` mark that forces the next open to revalidate fresh.
+          // The entry keeps rendering its rows either way; the next open-time
+          // bypass is what refreshes it.
+          if (
+            !existingIssues ||
+            (!existingIssues.stale && existingIssues.timestamp < payload.fetchedAt)
+          ) {
             setCache(issuesKey, {
               items: payload.issues.items,
               nextCursor: payload.issues.endCursor,
@@ -850,7 +863,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
               countAtWrite: payload.issues.totalCount,
             });
           }
-          if (!existingPRs || existingPRs.timestamp < payload.fetchedAt) {
+          if (!existingPRs || (!existingPRs.stale && existingPRs.timestamp < payload.fetchedAt)) {
             setCache(prsKey, {
               items: payload.prs.items,
               nextCursor: payload.prs.endCursor,

--- a/src/lib/__tests__/forgeResourceCache.test.ts
+++ b/src/lib/__tests__/forgeResourceCache.test.ts
@@ -365,7 +365,7 @@ describe("forgeResourceCache", () => {
       const withAvatar = seedSlot("open", "created", [makeIssue(1)]);
       patchIssueAssigneeCache("/proj", 1, viewer, true);
       const added = getCache(withAvatar)?.items[0];
-      expect(added && "assignees" in added ? added.assignees[0].avatarUrl : null).toBe(
+      expect(added && "assignees" in added ? added.assignees[0]?.avatarUrl : null).toBe(
         viewer.avatarUrl
       );
 

--- a/src/lib/__tests__/forgeResourceCache.test.ts
+++ b/src/lib/__tests__/forgeResourceCache.test.ts
@@ -492,6 +492,34 @@ describe("forgeResourceCache", () => {
       expect(loginsOn(key, 1)).toEqual([]);
       expect(getGeneration(key)).toBe(genBefore);
     });
+
+    it("matches the cached assignee case-insensitively — forge logins are", () => {
+      // The server would unassign "ada" when handed "Ada"; the cache must not
+      // keep a row the forge already dropped.
+      const key = seedSlot("open", "created", [withAssignee(1, "ada")]);
+
+      patchIssueAssigneeCache("/proj", 1, { login: "Ada" }, false);
+
+      expect(loginsOn(key, 1)).toEqual([]);
+    });
+
+    it("does not double-add a user whose cached login differs only by case", () => {
+      const key = seedSlot("open", "created", [withAssignee(1, "Ada")]);
+      const genBefore = getGeneration(key);
+
+      patchIssueAssigneeCache("/proj", 1, { login: "ada" }, true);
+
+      expect(loginsOn(key, 1)).toEqual(["Ada"]);
+      expect(getGeneration(key)).toBe(genBefore);
+    });
+
+    it("stores the trimmed login — main trims before it reaches the forge", () => {
+      const key = seedSlot("open", "created", [makeIssue(1)]);
+
+      patchIssueAssigneeCache("/proj", 1, { login: "  ada  " }, true);
+
+      expect(loginsOn(key, 1)).toEqual(["ada"]);
+    });
   });
 
   describe("_resetForTests", () => {

--- a/src/lib/__tests__/forgeResourceCache.test.ts
+++ b/src/lib/__tests__/forgeResourceCache.test.ts
@@ -7,8 +7,10 @@ import {
   getGeneration,
   markCountStale,
   mutateCacheEntries,
+  patchIssueAssigneeCache,
   _resetForTests,
 } from "../forgeResourceCache";
+import type { ForgeResourceCacheEntry } from "../forgeResourceCache";
 import type { Issue } from "@shared/types/forge";
 
 const makeIssue = (n: number): Issue => ({
@@ -320,6 +322,175 @@ describe("forgeResourceCache", () => {
       expect(getCache(issueKey)?.stale).toBe(true);
       expect(getCache(prKey)?.stale).toBeUndefined();
       expect(getCache(otherProjectKey)?.stale).toBeUndefined();
+    });
+  });
+
+  describe("patchIssueAssigneeCache (optimistic assign/unassign)", () => {
+    const viewer = { login: "octocat", avatarUrl: "https://fake.test/octocat.png" };
+
+    const seedSlot = (
+      filter: string,
+      sort: string,
+      items: Issue[],
+      overrides: Partial<ForgeResourceCacheEntry> = {}
+    ): string => {
+      const key = buildCacheKey("/proj", "issue", filter, sort);
+      setCache(key, { ...entry(items), ...overrides });
+      return key;
+    };
+
+    const withAssignee = (n: number, login: string): Issue => ({
+      ...makeIssue(n),
+      assignees: [{ login, avatarUrl: undefined, rawData: null }],
+    });
+
+    const loginsOn = (key: string, issueNumber: number): string[] | undefined => {
+      const item = getCache(key)?.items.find((i) => i.number === issueNumber);
+      return item && "assignees" in item ? item.assignees.map((a) => a.login) : undefined;
+    };
+
+    it("adds the user to the target issue across every filter/sort slot", () => {
+      const openCreated = seedSlot("open", "created", [makeIssue(1), makeIssue(2)]);
+      const openUpdated = seedSlot("open", "updated", [makeIssue(1)]);
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(loginsOn(openCreated, 1)).toEqual([viewer.login]);
+      expect(loginsOn(openUpdated, 1)).toEqual([viewer.login]);
+      // Sibling rows in the same slot are untouched.
+      expect(loginsOn(openCreated, 2)).toEqual([]);
+    });
+
+    it("carries the avatar onto the optimistic assignee, and tolerates not having one", () => {
+      const withAvatar = seedSlot("open", "created", [makeIssue(1)]);
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+      const added = getCache(withAvatar)?.items[0];
+      expect(added && "assignees" in added ? added.assignees[0].avatarUrl : null).toBe(
+        viewer.avatarUrl
+      );
+
+      _resetForTests();
+      const noAvatar = seedSlot("open", "created", [makeIssue(1)]);
+      patchIssueAssigneeCache("/proj", 1, { login: "someone-else" }, true);
+      const addedBare = getCache(noAvatar)?.items[0];
+      expect(addedBare && "assignees" in addedBare ? addedBare.assignees[0] : null).toMatchObject({
+        login: "someone-else",
+        avatarUrl: undefined,
+      });
+    });
+
+    it("removes the user on unassign, leaving co-assignees in place", () => {
+      const key = seedSlot("open", "created", [
+        {
+          ...makeIssue(1),
+          assignees: [
+            { login: "someone-else", avatarUrl: undefined, rawData: null },
+            { login: viewer.login, avatarUrl: undefined, rawData: null },
+          ],
+        },
+      ]);
+
+      patchIssueAssigneeCache("/proj", 1, viewer, false);
+
+      expect(loginsOn(key, 1)).toEqual(["someone-else"]);
+    });
+
+    it("marks the patched entry stale so the next revalidate cannot be downgraded to a cached read", () => {
+      // An assignment never moves the open count, so `countAtWrite` still
+      // matches and `planWarmRevalidate` would otherwise honor the backend's
+      // own list cache and serve the pre-assignment page straight back.
+      const key = seedSlot("open", "created", [makeIssue(1)], { countAtWrite: 5 });
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(getCache(key)?.stale).toBe(true);
+      expect(getCache(key)?.countAtWrite).toBe(5);
+    });
+
+    it("advances the entry timestamp so an older stats broadcast cannot seed over the patch", () => {
+      const key = seedSlot("open", "created", [makeIssue(1)], { timestamp: 1 });
+      const before = getCache(key)?.timestamp ?? 0;
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(getCache(key)?.timestamp).toBeGreaterThan(before);
+    });
+
+    it("does not claim a fresh bypass — the rows are optimistic, not forge-fetched", () => {
+      const key = seedSlot("open", "created", [makeIssue(1)]);
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(getCache(key)?.freshBypassAt).toBeUndefined();
+    });
+
+    it("preserves the entry's pagination metadata", () => {
+      const key = buildCacheKey("/proj", "issue", "open", "created");
+      setCache(key, {
+        items: [makeIssue(1)],
+        nextCursor: "cursor-abc",
+        hasMore: true,
+        timestamp: 1,
+      });
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(getCache(key)).toMatchObject({ nextCursor: "cursor-abc", hasMore: true });
+    });
+
+    it("re-assigning an already-assigned user is a no-op that does not bump the generation", () => {
+      const key = seedSlot("open", "created", [withAssignee(1, viewer.login)]);
+      const genBefore = getGeneration(key);
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(loginsOn(key, 1)).toEqual([viewer.login]);
+      expect(getGeneration(key)).toBe(genBefore);
+      expect(getCache(key)?.stale).toBeUndefined();
+    });
+
+    it("unassigning a user who is not assigned is a no-op that does not bump the generation", () => {
+      const key = seedSlot("open", "created", [makeIssue(1)]);
+      const genBefore = getGeneration(key);
+
+      patchIssueAssigneeCache("/proj", 1, viewer, false);
+
+      expect(getGeneration(key)).toBe(genBefore);
+      expect(getCache(key)?.stale).toBeUndefined();
+    });
+
+    it("bumps the generation of a changed slot so an in-flight fetch cannot commit over it", () => {
+      const key = seedSlot("open", "created", [makeIssue(1)]);
+      const genBefore = getGeneration(key);
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(getGeneration(key)).toBe(genBefore + 1);
+    });
+
+    it("leaves other projects, other resource types, and other issues untouched", () => {
+      const target = seedSlot("open", "created", [makeIssue(1)]);
+      const otherIssueSlot = buildCacheKey("/other", "issue", "open", "created");
+      const prSlot = buildCacheKey("/proj", "pr", "open", "created");
+      setCache(otherIssueSlot, entry([makeIssue(1)]));
+      setCache(prSlot, entry([makeIssue(1)]));
+
+      patchIssueAssigneeCache("/proj", 1, viewer, true);
+
+      expect(loginsOn(target, 1)).toEqual([viewer.login]);
+      expect(loginsOn(otherIssueSlot, 1)).toEqual([]);
+      expect(loginsOn(prSlot, 1)).toEqual([]);
+      expect(getCache(prSlot)?.stale).toBeUndefined();
+    });
+
+    it("is a no-op when the issue is not in any cached page", () => {
+      const key = seedSlot("open", "created", [makeIssue(1)]);
+      const genBefore = getGeneration(key);
+
+      patchIssueAssigneeCache("/proj", 999, viewer, true);
+
+      expect(loginsOn(key, 1)).toEqual([]);
+      expect(getGeneration(key)).toBe(genBefore);
     });
   });
 

--- a/src/lib/forgeResourceCache.ts
+++ b/src/lib/forgeResourceCache.ts
@@ -156,29 +156,34 @@ export function patchIssueAssigneeCache(
   user: Pick<ForgeUser, "login" | "avatarUrl">,
   assigned: boolean
 ): void {
+  // Forge logins are case-insensitive, and the main process trims the username
+  // before it reaches the provider — so match the identity the server actually
+  // acted on rather than the raw string, or an "Ada" unassign would leave a
+  // cached "ada" behind. The row is still added under the caller's spelling.
+  const login = user.login.trim();
+  const matchLogin = login.toLowerCase();
+  const isUser = (a: ForgeUser): boolean => a.login.trim().toLowerCase() === matchLogin;
+
   mutateCacheEntries(projectPath, "issue", (entry) => {
     let changed = false;
     const items = entry.items.map((item) => {
       // `assignees` exists only on Issue, so this `in` check narrows the
       // Issue|PR union safely and skips any non-issue slot.
       if (!("assignees" in item) || item.number !== issueNumber) return item;
-      const hasUser = item.assignees.some((a) => a.login === user.login);
+      const hasUser = item.assignees.some(isUser);
       if (assigned) {
         if (hasUser) return item;
         changed = true;
         return {
           ...item,
-          assignees: [
-            ...item.assignees,
-            { login: user.login, avatarUrl: user.avatarUrl, rawData: null },
-          ],
+          assignees: [...item.assignees, { login, avatarUrl: user.avatarUrl, rawData: null }],
         };
       }
       if (!hasUser) return item;
       changed = true;
       return {
         ...item,
-        assignees: item.assignees.filter((a) => a.login !== user.login),
+        assignees: item.assignees.filter((a) => !isUser(a)),
       };
     });
     return changed ? { ...entry, items, timestamp: Date.now(), stale: true } : null;

--- a/src/lib/forgeResourceCache.ts
+++ b/src/lib/forgeResourceCache.ts
@@ -1,4 +1,4 @@
-import type { Issue, PR } from "@shared/types/forge";
+import type { ForgeUser, Issue, PR } from "@shared/types/forge";
 import { TtlCache } from "@/utils/ttlCache";
 
 /**
@@ -132,6 +132,56 @@ export function markCountStale(projectPath: string, type: "issue" | "pr", openCo
     if (!keyRemainder.startsWith("open:")) return null;
     if (entry.stale || entry.countAtWrite == null || entry.countAtWrite === openCount) return null;
     return { ...entry, stale: true };
+  });
+}
+
+/**
+ * Optimistically add or remove an assignee on every cached issue slot for a
+ * project, so the toolbar dropdown reflects an assignment the moment it lands
+ * instead of waiting out the 45s TTL (#11087). Call it after the forge mutation
+ * succeeds — the forge refresh remains the correctness backstop.
+ *
+ * Marks touched entries `stale` rather than trusting the patched rows: an
+ * assignment never moves the open count, so `planWarmRevalidate` would
+ * otherwise downgrade the next open-time revalidate to a cached read and let
+ * the backend's own 60s list cache serve the pre-assignment page straight back
+ * over this patch. `stale` forces that revalidate to bypass. `timestamp` is
+ * restamped for the same reason — a stats page broadcast only seeds over an
+ * entry it is newer than. `freshBypassAt` is deliberately NOT stamped: this
+ * content is optimistic, not something the forge just handed us.
+ */
+export function patchIssueAssigneeCache(
+  projectPath: string,
+  issueNumber: number,
+  user: Pick<ForgeUser, "login" | "avatarUrl">,
+  assigned: boolean
+): void {
+  mutateCacheEntries(projectPath, "issue", (entry) => {
+    let changed = false;
+    const items = entry.items.map((item) => {
+      // `assignees` exists only on Issue, so this `in` check narrows the
+      // Issue|PR union safely and skips any non-issue slot.
+      if (!("assignees" in item) || item.number !== issueNumber) return item;
+      const hasUser = item.assignees.some((a) => a.login === user.login);
+      if (assigned) {
+        if (hasUser) return item;
+        changed = true;
+        return {
+          ...item,
+          assignees: [
+            ...item.assignees,
+            { login: user.login, avatarUrl: user.avatarUrl, rawData: null },
+          ],
+        };
+      }
+      if (!hasUser) return item;
+      changed = true;
+      return {
+        ...item,
+        assignees: item.assignees.filter((a) => a.login !== user.login),
+      };
+    });
+    return changed ? { ...entry, items, timestamp: Date.now(), stale: true } : null;
   });
 }
 

--- a/src/services/actions/definitions/__tests__/forgeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/forgeActions.adversarial.test.ts
@@ -29,6 +29,27 @@ vi.mock("@/clients", () => ({ forgeClient: forgeClientMock }));
 vi.mock("@/store/projectStore", () => ({ useProjectStore: projectStoreMock }));
 
 import { registerForgeActions } from "../forgeActions";
+import {
+  buildCacheKey,
+  getCache,
+  setCache,
+  _resetForTests as resetForgeResourceCache,
+} from "@/lib/forgeResourceCache";
+import type { Issue } from "@shared/types/forge";
+
+const makeIssue = (n: number, assignees: string[]): Issue => ({
+  number: n,
+  title: `Issue #${n}`,
+  body: "",
+  state: "open",
+  rawState: "open",
+  url: `https://fake.test/${n}`,
+  assignees: assignees.map((login) => ({ login, avatarUrl: undefined, rawData: null })),
+  labels: [],
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
 
 function setupActions() {
   const actions: ActionRegistry = new Map();
@@ -157,6 +178,92 @@ describe("forge.* navigation adversarial", () => {
     await expect(
       runAction("forge.assignIssue", { issueNumber: 7, username: "bob" })
     ).rejects.toThrow("No active worktree");
+  });
+
+  describe("optimistic issue-cache patching (#11087)", () => {
+    const seedIssueSlot = (projectPath: string, issue: Issue): string => {
+      const key = buildCacheKey(projectPath, "issue", "open", "created");
+      setCache(key, { items: [issue], nextCursor: null, hasMore: false, timestamp: 1 });
+      return key;
+    };
+
+    const assigneesOn = (key: string, issueNumber: number): string[] | undefined => {
+      const item = getCache(key)?.items.find((i) => i.number === issueNumber);
+      return item && "assignees" in item ? item.assignees.map((a) => a.login) : undefined;
+    };
+
+    beforeEach(() => {
+      resetForgeResourceCache();
+    });
+
+    it("assignIssue adds the username to the cached issue so the dropdown reflects it at once", async () => {
+      const key = seedIssueSlot("/repo", makeIssue(42, []));
+
+      await runAction("forge.assignIssue", { cwd: "/repo", issueNumber: 42, username: "bob" });
+
+      expect(assigneesOn(key, 42)).toEqual(["bob"]);
+    });
+
+    it("unassignIssue removes the username — the Quick Create Undo path", async () => {
+      const key = seedIssueSlot("/repo", makeIssue(42, ["bob"]));
+
+      await runAction("forge.unassignIssue", { cwd: "/repo", issueNumber: 42, username: "bob" });
+
+      expect(assigneesOn(key, 42)).toEqual([]);
+    });
+
+    it("leaves the cache untouched when the forge rejects the assign", async () => {
+      const key = seedIssueSlot("/repo", makeIssue(42, []));
+      forgeClientMock.assignIssue.mockRejectedValueOnce(new Error("HTTP 403"));
+
+      await expect(
+        runAction("forge.assignIssue", { cwd: "/repo", issueNumber: 42, username: "bob" })
+      ).rejects.toThrow("HTTP 403");
+
+      expect(assigneesOn(key, 42)).toEqual([]);
+    });
+
+    it("leaves the cache untouched when the forge rejects the unassign", async () => {
+      const key = seedIssueSlot("/repo", makeIssue(42, ["bob"]));
+      forgeClientMock.unassignIssue.mockRejectedValueOnce(new Error("HTTP 500"));
+
+      await expect(
+        runAction("forge.unassignIssue", { cwd: "/repo", issueNumber: 42, username: "bob" })
+      ).rejects.toThrow("HTTP 500");
+
+      expect(assigneesOn(key, 42)).toEqual(["bob"]);
+    });
+
+    it("patches the project the caller named, not some other cached project", async () => {
+      const target = seedIssueSlot("/repo", makeIssue(42, []));
+      const other = seedIssueSlot("/other-repo", makeIssue(42, []));
+
+      await runAction("forge.assignIssue", { cwd: "/repo", issueNumber: 42, username: "bob" });
+
+      expect(assigneesOn(target, 42)).toEqual(["bob"]);
+      expect(assigneesOn(other, 42)).toEqual([]);
+    });
+
+    it("still completes the forge mutation when the cwd matches no cached slot", async () => {
+      // `cwd` defaulted to a worktree path: the cache keys on the project root,
+      // so the patch no-ops. That must not fail the action.
+      const key = seedIssueSlot("/repo", makeIssue(42, []));
+
+      await expect(
+        runAction(
+          "forge.assignIssue",
+          { issueNumber: 42, username: "bob" },
+          { activeWorktreePath: "/repo/.worktrees/feature" }
+        )
+      ).resolves.not.toThrow();
+
+      expect(forgeClientMock.assignIssue).toHaveBeenCalledWith(
+        "/repo/.worktrees/feature",
+        42,
+        "bob"
+      );
+      expect(assigneesOn(key, 42)).toEqual([]);
+    });
   });
 
   it("approvePR forwards cwd, prNumber, and optional body positionally", async () => {

--- a/src/services/actions/definitions/__tests__/forgeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/forgeActions.adversarial.test.ts
@@ -244,10 +244,28 @@ describe("forge.* navigation adversarial", () => {
       expect(assigneesOn(other, 42)).toEqual([]);
     });
 
-    it("still completes the forge mutation when the cwd matches no cached slot", async () => {
-      // `cwd` defaulted to a worktree path: the cache keys on the project root,
-      // so the patch no-ops. That must not fail the action.
+    it("patches the project root when cwd defaults to a linked worktree path", async () => {
+      // The forge call targets the worktree, but the cache keys on the project
+      // root — patching the worktree path would silently match no slot.
+      setCurrentProject({ path: "/repo" });
       const key = seedIssueSlot("/repo", makeIssue(42, []));
+
+      await runAction(
+        "forge.assignIssue",
+        { issueNumber: 42, username: "bob" },
+        { activeWorktreePath: "/repo/.worktrees/feature" }
+      );
+
+      expect(forgeClientMock.assignIssue).toHaveBeenCalledWith(
+        "/repo/.worktrees/feature",
+        42,
+        "bob"
+      );
+      expect(assigneesOn(key, 42)).toEqual(["bob"]);
+    });
+
+    it("completes the mutation even when no project is open to patch", async () => {
+      setCurrentProject(null);
 
       await expect(
         runAction(
@@ -257,12 +275,7 @@ describe("forge.* navigation adversarial", () => {
         )
       ).resolves.not.toThrow();
 
-      expect(forgeClientMock.assignIssue).toHaveBeenCalledWith(
-        "/repo/.worktrees/feature",
-        42,
-        "bob"
-      );
-      expect(assigneesOn(key, 42)).toEqual([]);
+      expect(forgeClientMock.assignIssue).toHaveBeenCalled();
     });
   });
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -56,6 +56,28 @@ vi.mock("@/store/slices/panelRegistry", () => selectorMock);
   { electron: { git: { getStagingStatus: gitGetStagingStatusMock } } };
 
 import { registerWorkflowActions } from "../workflowActions";
+import {
+  buildCacheKey,
+  getCache,
+  getGeneration,
+  setCache,
+  _resetForTests as resetForgeResourceCache,
+} from "@/lib/forgeResourceCache";
+import type { Issue } from "@shared/types/forge";
+
+const makeCacheIssue = (n: number, assignees: string[]): Issue => ({
+  number: n,
+  title: `Issue #${n}`,
+  body: "",
+  state: "open",
+  rawState: "open",
+  url: `https://fake.test/${n}`,
+  assignees: assignees.map((login) => ({ login, avatarUrl: undefined, rawData: null })),
+  labels: [],
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
 
 interface MockCallbacks {
   onLaunchAgent: ReturnType<typeof vi.fn>;
@@ -1131,6 +1153,141 @@ describe("worktree.createWithRecipe — issue assignment", () => {
     expect(result.worktreeId).toBe("wt-new");
     expect(result.assignedToSelf).toBe(false);
     expect(result.assignmentError).toBe("IPC unavailable");
+  });
+});
+
+describe("self-assign patches the issues dropdown cache (#11087)", () => {
+  const seedIssueSlot = (issue: Issue, filter = "open", sort = "created"): string => {
+    const key = buildCacheKey("/repo", "issue", filter, sort);
+    setCache(key, { items: [issue], nextCursor: null, hasMore: false, timestamp: 1 });
+    return key;
+  };
+
+  const assigneesOn = (key: string, issueNumber: number) => {
+    const item = getCache(key)?.items.find((i) => i.number === issueNumber);
+    return item && "assignees" in item ? item.assignees : undefined;
+  };
+
+  beforeEach(() => {
+    resetForgeResourceCache();
+    forgeClientMock.getIssue.mockResolvedValue({ number: 6609, title: "t", url: "u" });
+  });
+
+  it("worktree.createWithRecipe — the palette path — adds the viewer to every cached slot", async () => {
+    setGithubUser("ada");
+    const openSlot = seedIssueSlot(makeCacheIssue(6625, []));
+    const updatedSlot = seedIssueSlot(makeCacheIssue(6625, []), "open", "updated");
+
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await def.run(
+      { branchName: "feature/foo", issueNumber: 6625, assignToSelf: true },
+      {} as never
+    );
+
+    expect(assigneesOn(openSlot, 6625)?.map((a) => a.login)).toEqual(["ada"]);
+    expect(assigneesOn(updatedSlot, 6625)?.map((a) => a.login)).toEqual(["ada"]);
+  });
+
+  it("workflow.startWorkOnIssue adds the viewer to the cached issue", async () => {
+    setGithubUser("ada");
+    const key = seedIssueSlot(makeCacheIssue(6609, []));
+
+    const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
+    await def.run({ issueNumber: 6609, agentId: "claude", assignToSelf: true }, {} as never);
+
+    expect(assigneesOn(key, 6609)?.map((a) => a.login)).toEqual(["ada"]);
+  });
+
+  it("the optimistic assignee carries the avatar the forge reported for the viewer", async () => {
+    forgeClientMock.getCurrentUser.mockResolvedValue({
+      login: "ada",
+      avatarUrl: "https://fake.test/ada.png",
+    });
+    const key = seedIssueSlot(makeCacheIssue(6625, []));
+
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await def.run(
+      { branchName: "feature/foo", issueNumber: 6625, assignToSelf: true },
+      {} as never
+    );
+
+    expect(assigneesOn(key, 6625)?.[0]?.avatarUrl).toBe("https://fake.test/ada.png");
+  });
+
+  it("marks the slot stale so the next revalidate refetches instead of trusting the backend's cached page", async () => {
+    setGithubUser("ada");
+    const key = buildCacheKey("/repo", "issue", "open", "created");
+    setCache(key, {
+      items: [makeCacheIssue(6625, [])],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: 1,
+      countAtWrite: 3,
+    });
+
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await def.run(
+      { branchName: "feature/foo", issueNumber: 6625, assignToSelf: true },
+      {} as never
+    );
+
+    expect(getCache(key)?.stale).toBe(true);
+  });
+
+  it("a failed assign leaves the cache untouched", async () => {
+    setGithubUser("ada");
+    forgeClientMock.assignIssue.mockRejectedValue(new Error("403 Forbidden"));
+    const key = seedIssueSlot(makeCacheIssue(6625, []));
+
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    const result = (await def.run(
+      { branchName: "feature/foo", issueNumber: 6625, assignToSelf: true },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(result.assignedToSelf).toBe(false);
+    expect(assigneesOn(key, 6625)).toEqual([]);
+  });
+
+  it("does not touch an issue that is already assigned to the viewer", async () => {
+    setGithubUser("ada");
+    const key = seedIssueSlot(makeCacheIssue(6625, ["ada"]));
+    const genBefore = getGeneration(key);
+
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await def.run(
+      { branchName: "feature/foo", issueNumber: 6625, assignToSelf: true },
+      {} as never
+    );
+
+    expect(assigneesOn(key, 6625)?.map((a) => a.login)).toEqual(["ada"]);
+    expect(getGeneration(key)).toBe(genBefore);
+  });
+
+  it("a cache-layer throw does not turn a successful assign into an assignmentError", async () => {
+    setGithubUser("ada");
+    // Simulate a corrupt cached row: reading `assignees` blows up inside the
+    // patch. The server-side assign has already succeeded by then, so the
+    // action must still report success.
+    const corrupt = makeCacheIssue(6625, []);
+    Object.defineProperty(corrupt, "assignees", {
+      enumerable: true,
+      get() {
+        throw new Error("corrupt cache entry");
+      },
+    });
+    seedIssueSlot(corrupt);
+
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    const result = (await def.run(
+      { branchName: "feature/foo", issueNumber: 6625, assignToSelf: true },
+      {} as never
+    )) as Record<string, unknown>;
+
+    expect(forgeClientMock.assignIssue).toHaveBeenCalledWith("/repo", 6625, "ada");
+    expect(result.assignedToSelf).toBe(true);
+    expect(result.assignedUsername).toBe("ada");
+    expect(result.assignmentError).toBeNull();
   });
 });
 

--- a/src/services/actions/definitions/forgeActions.ts
+++ b/src/services/actions/definitions/forgeActions.ts
@@ -8,25 +8,34 @@ import { patchIssueAssigneeCache } from "@/lib/forgeResourceCache";
 import { logError } from "@/utils/logger";
 
 /**
+ * The cache keys on the PROJECT ROOT, but these actions resolve their forge
+ * target to `cwd ?? ctx.activeWorktreePath` — and a linked worktree path
+ * matches no cache slot. So when the caller named no `cwd`, the mutation went
+ * to the active worktree's repo, which is the active project: patch that root.
+ * An explicit `cwd` is honored as given, since it may name another repo
+ * entirely; if it isn't a project root the patch simply finds nothing.
+ */
+function assigneeCachePath(cwd: string | undefined): string | null {
+  if (cwd) return cwd;
+  return useProjectStore.getState().currentProject?.path ?? null;
+}
+
+/**
  * Optimistically reflect an assign/unassign in the cached issue lists so the
  * toolbar dropdown updates immediately (#11087). Best-effort by design: the
  * forge mutation has already succeeded by the time this runs, so a cache-layer
  * throw must never surface as a failed action.
  *
- * Keyed on the resolved `cwd`. The cache keys on the project root, so this
- * no-ops when the caller let `cwd` default to a worktree path — never wrong,
- * just ineffective. The Quick Create Undo path (the one that matters here)
- * passes the project root explicitly.
- *
  * No avatar is available: these actions take an arbitrary username, not the
  * viewer. A login-only assignee is valid — the next forge refresh fills it in.
  */
 function patchAssigneeCache(
-  projectPath: string,
+  projectPath: string | null,
   issueNumber: number,
   username: string,
   assigned: boolean
 ): void {
+  if (!projectPath) return;
   try {
     patchIssueAssigneeCache(projectPath, issueNumber, { login: username }, assigned);
   } catch (err) {
@@ -268,7 +277,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
         const resolvedCwd = cwd ?? ctx.activeWorktreePath;
         if (!resolvedCwd) throw new Error("No active worktree");
         await forgeClient.assignIssue(resolvedCwd, issueNumber, username);
-        patchAssigneeCache(resolvedCwd, issueNumber, username, true);
+        patchAssigneeCache(assigneeCachePath(cwd), issueNumber, username, true);
       },
     })
   );
@@ -294,7 +303,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
         const resolvedCwd = cwd ?? ctx.activeWorktreePath;
         if (!resolvedCwd) throw new Error("No active worktree");
         await forgeClient.unassignIssue(resolvedCwd, issueNumber, username);
-        patchAssigneeCache(resolvedCwd, issueNumber, username, false);
+        patchAssigneeCache(assigneeCachePath(cwd), issueNumber, username, false);
       },
     })
   );

--- a/src/services/actions/definitions/forgeActions.ts
+++ b/src/services/actions/definitions/forgeActions.ts
@@ -4,6 +4,35 @@ import { defineAction } from "../defineAction";
 import { z } from "zod";
 import { forgeClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
+import { patchIssueAssigneeCache } from "@/lib/forgeResourceCache";
+import { logError } from "@/utils/logger";
+
+/**
+ * Optimistically reflect an assign/unassign in the cached issue lists so the
+ * toolbar dropdown updates immediately (#11087). Best-effort by design: the
+ * forge mutation has already succeeded by the time this runs, so a cache-layer
+ * throw must never surface as a failed action.
+ *
+ * Keyed on the resolved `cwd`. The cache keys on the project root, so this
+ * no-ops when the caller let `cwd` default to a worktree path — never wrong,
+ * just ineffective. The Quick Create Undo path (the one that matters here)
+ * passes the project root explicitly.
+ *
+ * No avatar is available: these actions take an arbitrary username, not the
+ * viewer. A login-only assignee is valid — the next forge refresh fills it in.
+ */
+function patchAssigneeCache(
+  projectPath: string,
+  issueNumber: number,
+  username: string,
+  assigned: boolean
+): void {
+  try {
+    patchIssueAssigneeCache(projectPath, issueNumber, { login: username }, assigned);
+  } catch (err) {
+    logError("Failed to patch issue cache after assignment change", err);
+  }
+}
 
 const ForgeListOptionsSchema = z.object({
   cwd: z
@@ -239,6 +268,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
         const resolvedCwd = cwd ?? ctx.activeWorktreePath;
         if (!resolvedCwd) throw new Error("No active worktree");
         await forgeClient.assignIssue(resolvedCwd, issueNumber, username);
+        patchAssigneeCache(resolvedCwd, issueNumber, username, true);
       },
     })
   );
@@ -264,6 +294,7 @@ export function registerForgeActions(actions: ActionRegistry, _callbacks: Action
         const resolvedCwd = cwd ?? ctx.activeWorktreePath;
         if (!resolvedCwd) throw new Error("No active worktree");
         await forgeClient.unassignIssue(resolvedCwd, issueNumber, username);
+        patchAssigneeCache(resolvedCwd, issueNumber, username, false);
       },
     })
   );

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -11,6 +11,8 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
+import { patchIssueAssigneeCache } from "@/lib/forgeResourceCache";
+import { logError } from "@/utils/logger";
 import { partialSuccessError, slugifyForBranch } from "./workflowHelpers";
 
 export function registerWorkflowCreationActions(
@@ -267,6 +269,18 @@ export function registerWorkflowCreationActions(
                 assignedUsername = user.login;
               } catch (err) {
                 assignmentError = formatErrorMessage(err, "Failed to assign issue");
+              }
+              if (assignedToSelf) {
+                // Optimistically patch the cached issue lists so the toolbar
+                // dropdown shows the assignment immediately (#11087). Sits
+                // outside the assign try/catch: the server-side assign already
+                // succeeded, so a cache-layer throw must not masquerade as an
+                // assignment failure.
+                try {
+                  patchIssueAssigneeCache(rootPath, issueNumber, user, true);
+                } catch (cacheErr) {
+                  logError("Failed to patch issue cache after self-assign", cacheErr);
+                }
               }
             } else {
               assignmentError = "No forge viewer available";
@@ -588,6 +602,16 @@ export function registerWorkflowCreationActions(
                 assignedUsername = user.login;
               } catch (err) {
                 assignmentError = formatErrorMessage(err, "Failed to assign issue");
+              }
+              if (assignedToSelf) {
+                // See worktree.createWithRecipe: optimistic dropdown patch
+                // (#11087), isolated so a cache throw can't be reported as an
+                // assignment failure.
+                try {
+                  patchIssueAssigneeCache(rootPath, issue.number, user, true);
+                } catch (cacheErr) {
+                  logError("Failed to patch issue cache after self-assign", cacheErr);
+                }
               }
             } else {
               assignmentError = "No forge viewer available";


### PR DESCRIPTION
## Summary

The Quick Create Palette dispatches `worktree.createWithRecipe`, which self-assigns the issue but never patched the renderer's issue-list cache (`src/lib/forgeResourceCache.ts`, 45s TTL). The dialog paths (`NewWorktreeDialog`, `BulkCreateWorktreeDialog`) already patched it after an assign; the action paths didn't. So the most common self-assign flow, creating a worktree from the palette, left the toolbar Issues dropdown showing the issue as unassigned until the TTL expired.

Resolves #11087

## Changes

The fix has four parts, in order:

1. **Shared cache patch helper.** New `patchIssueAssigneeCache` helper in `forgeResourceCache.ts`, sitting alongside `markCountStale`. All four call sites now route through it: `worktree.createWithRecipe`, `workflow.startWorkOnIssue`, `forge.assignIssue`, and `forge.unassignIssue`. Replaces three near-identical inline copies of the same transform that used to live in the dialogs.
2. **Patch `forge.unassignIssue` too.** Not scope creep, it's required for the fix to be correct: once the forward patch exists, the palette's Undo action would strip the assignment on the forge but leave the optimistic row behind in the cache, a new inverse staleness bug that didn't exist before.
3. **The patch alone wasn't enough.** An assignment never moves the open-issue count, so `planWarmRevalidate` would downgrade the next dropdown revalidate to a cached read and let the backend's own 60s list cache serve the pre-assignment page straight back over the patch. The patched entry is now marked `stale` (forcing a bypass) and its timestamp is restamped. Two further clobber paths are closed too: a stats page broadcast could wholesale-replace the entry, since its `fetchedAt` is stamped when the push is built rather than when its pages left the forge, so it can't prove its content is newer, broadcasts no longer seed over a `stale` entry. And a cache-first hover prefetch was joining an in-flight list query (the main-process singleflight only skips the join when bypassing), so a hover right after an assign could get handed a page fetched before it, stale entries now prefetch with `bypassCache`.
4. **Main process invalidation.** `assignIssueImpl`/`unassignIssueImpl` now invalidate the repo's issue list caches, the combined stats-and-page snapshot, and the mutated issue's tooltip, matching what the legacy assign path already did. Previously an assign invalidated nothing there, so a later stats poll could broadcast a stale page back.

Also fixed along the way:

- Assignee logins are now compared case-insensitively and trimmed. Main trims the username before it reaches the provider, so an "Ada" unassign would otherwise strip nothing and leave a cached "ada" row behind.
- `forge.assignIssue`/`forge.unassignIssue` now patch the project root when `cwd` defaults to a linked worktree path, which previously matched no cache slot.
- `NewWorktreeDialog`'s already-assigned guard no longer lets a case-variant row slip past and hand the user an Undo that removes an assignment they already had.

## Testing

836 tests pass across the 19 suites covering every changed module. New coverage for the helper's invariants (add/remove across slots, stale marking, generation bumps, no-op idempotency, case/whitespace identity), both action paths, the palette Undo path, the broadcast-vs-stale guard, and the stale-entry prefetch bypass. Red-checked: disabling the helper turns exactly the patch-asserting tests red (20) while the negative controls stay green. `npm run typecheck` clean.

## Known follow-ups (pre-existing, not fixed here)

- `GitHubFirstPageCache` (the durable disk cache) is written before the epoch check and isn't repo-invalidated on assign, so a cold start within its 10 minute window could re-hydrate pre-assignment assignee data. Self-heals on the first revalidate.
- `inFlightIssueTooltips` isn't generation-guarded, so a tooltip request in flight at the assign instant can repopulate a stale 5 minute entry. This change is still a strict improvement over the status quo, where the tooltip was never invalidated on assign at all.
