### PR TITLE
Harden memory-pressure recovery and renderer responsiveness

### DIFF
--- a/docs/architecture/resource-governance.md
+++ b/docs/architecture/resource-governance.md
@@ -34,7 +34,7 @@ The profile is intentionally **coarse**. There are only three states, so every c
 
 ## Signal inputs
 
-`computeTargetProfile()` (`ResourceProfileService.ts:601`) sums a `pressureScore` from these signals. All thresholds that compare against physical RAM are expressed as **fractions of `os.totalmem()`** so an 8 GB and a 64 GB machine behave sensibly without per-device tuning.
+`computeTargetProfile()` (`ResourceProfileService.ts:601`) sums a `pressureScore` from these signals. App, terminal-workload, and fleet thresholds scale with physical RAM. System-available memory uses RAM-relative thresholds capped at 1 GB critical / 2 GB warning so a high-memory macOS machine's normal file-cache occupancy cannot manufacture a multi-gigabyte "critical" floor.
 
 | Signal | Source | Contribution to `pressureScore` |
 | --- | --- | --- |
@@ -43,7 +43,7 @@ The profile is intentionally **coarse**. There are only three states, so every c
 | Thermal (macOS only) | `powerMonitor` `thermal-state-change` + `getCurrentThermalState()` | `+2` critical, `+1` serious |
 | CPU speed limit (macOS & Windows) | `powerMonitor` `speed-limit-change` | `+2` below 50, `+1` below 100 |
 | Active-agent fleet size | cached count from `PtyClient.getAllTerminalsAsync()`, filtered | `+3` ≥ 24, `+2` ≥ 16, `+1` ≥ 8 |
-| System-available memory | `process.getSystemMemoryInfo()` (free + purgeable on macOS, free elsewhere) | `+2` below 0.1 × RAM, `+1` below 0.2 × RAM |
+| System-available memory | `process.getSystemMemoryInfo()` (free + purgeable on macOS, free elsewhere) | `+3` below `min(0.1 × RAM, 1024 MB)`, `+1` below `min(0.2 × RAM, 2048 MB)` |
 | Terminal-workload memory | cached `PtyClient.getMemoryRollup()` (descendant RSS from the pty-host `ProcessTreeCache`, PID-deduplicated, via `electron/services/memoryAccounting.ts`) | `+2` above 0.4 × RAM, `+1` above 0.25 × RAM — only from a fresh (≤ 60 s), successful process-table sweep; stale/unavailable data contributes 0. Per-tier 10% exit band. Bounded at +2 so terminal workloads alone can never latch `efficiency`. |
 
 Mapping (`ResourceProfileService.ts:669`): `score >= 3 → efficiency`, `score === 0 → performance`, otherwise `balanced`.
@@ -125,6 +125,8 @@ Every per-profile knob lives in `RESOURCE_PROFILE_CONFIGS` (`shared/types/resour
 
 - **Scheduled idle** — `inactiveThresholdHours` (default 24 h), user-configurable, profile-independent.
 - **Memory-pressure** — `hibernateUnderMemoryPressure()` (`:267`), invoked by `ProcessMemoryMonitor`'s tier-2 mitigation (`ProcessMemoryMonitor.ts:581`, wired through `globalServicesInit.ts:550`). It hibernates non-current projects idle longer than `memoryPressureInactiveMs`, skipping any project with an active agent (`ACTIVE_AGENT_STATES`) or an in-flight git operation. The profile makes this threshold stricter under pressure (15 min on `efficiency` vs 60 min on `performance`).
+
+`ProcessMemoryMonitor` applies tier 1 once at the start of a pressure episode, then at most once per five minutes while the same episode persists. Tier 1 trims PTY-host state and hidden browser/dev-preview webviews; it never clears caches or forces GC in the visible renderer. Tier 2 requires three consecutive pressure samples, rechecks the originating system-memory signal after tier 1, and is limited to once per ten minutes. It destroys hidden webviews, evicts cached project renderers down to the active view, and runs memory-pressure hibernation. A clean sample resets the episode so a later independent event can react immediately.
 
 ### PtyClient → ResourceGovernor (cross-process)
 

--- a/e2e/full/resilience/memory-pressure-responsiveness-perf.spec.ts
+++ b/e2e/full/resilience/memory-pressure-responsiveness-perf.spec.ts
@@ -1,0 +1,258 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- perf instrumentation crosses Playwright's process boundary */
+import { expect, test } from "@playwright/test";
+import { mkdirSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { closeApp, launchApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { getGridPanelIds, getPanelById, openTerminal } from "../../helpers/panels";
+import {
+  runTerminalCommand,
+  waitForTerminalPty,
+  waitForTerminalText,
+} from "../../helpers/terminal";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const DEFAULT_OUTPUT = path.join(
+  REPO_ROOT,
+  ".tmp",
+  "perf-results",
+  "memory-pressure-responsiveness.json"
+);
+const TERMINAL_COUNT = Number(process.env.PERF_MEMORY_PRESSURE_TERMINALS ?? 5);
+const SCROLLBACK_LINES = Number(process.env.PERF_MEMORY_PRESSURE_SCROLLBACK_LINES ?? 1500);
+const SAMPLE_MS = Number(process.env.PERF_MEMORY_PRESSURE_SAMPLE_MS ?? 12_000);
+const POLL_INTERVAL_MS = Number(process.env.PERF_MEMORY_PRESSURE_POLL_INTERVAL_MS ?? 1000);
+const AVAILABLE_MEMORY_MB = Number(process.env.PERF_MEMORY_PRESSURE_AVAILABLE_MB ?? 512);
+const OUTPUT_PATH = path.resolve(
+  REPO_ROOT,
+  process.env.PERF_MEMORY_PRESSURE_OUTPUT?.trim() || DEFAULT_OUTPUT
+);
+const LABEL = process.env.PERF_MEMORY_PRESSURE_LABEL ?? "run";
+
+interface ResponsivenessMetrics {
+  frameGapP95Ms: number;
+  maximumFrameGapMs: number;
+  timerGapP95Ms: number;
+  maximumTimerGapMs: number;
+  longAnimationFrameCount: number;
+  maximumLongAnimationFrameMs: number;
+  reclaimCount: number;
+  rendererWorkingSetKb: number;
+  rendererJsHeapKb: number;
+}
+
+function percentile(values: number[], percent: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((percent / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, index)]!;
+}
+
+async function startResponsivenessProbe(ctx: AppContext): Promise<void> {
+  await ctx.window.evaluate(() => {
+    const state = {
+      frameGaps: [] as number[],
+      timerGaps: [] as number[],
+      longAnimationFrames: [] as number[],
+      lastFrameAt: performance.now(),
+      lastTimerAt: performance.now(),
+      frameRequestId: 0,
+      timerId: 0,
+      observer: null as PerformanceObserver | null,
+    };
+    const frameTick = (now: number) => {
+      state.frameGaps.push(now - state.lastFrameAt);
+      state.lastFrameAt = now;
+      state.frameRequestId = requestAnimationFrame(frameTick);
+    };
+    state.frameRequestId = requestAnimationFrame(frameTick);
+    state.timerId = window.setInterval(() => {
+      const now = performance.now();
+      state.timerGaps.push(now - state.lastTimerAt);
+      state.lastTimerAt = now;
+    }, 50);
+    try {
+      state.observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) state.longAnimationFrames.push(entry.duration);
+      });
+      state.observer.observe({ type: "long-animation-frame", buffered: false });
+    } catch {
+      state.observer = null;
+    }
+    (window as any).__memoryPressureResponsivenessProbe = state;
+  });
+}
+
+async function stopResponsivenessProbe(
+  ctx: AppContext
+): Promise<Omit<ResponsivenessMetrics, "rendererWorkingSetKb" | "rendererJsHeapKb">> {
+  return await ctx.window.evaluate(() => {
+    const state = (window as any).__memoryPressureResponsivenessProbe as {
+      frameGaps: number[];
+      timerGaps: number[];
+      longAnimationFrames: number[];
+      frameRequestId: number;
+      timerId: number;
+      observer: PerformanceObserver | null;
+    };
+    cancelAnimationFrame(state.frameRequestId);
+    clearInterval(state.timerId);
+    state.observer?.disconnect();
+    delete (window as any).__memoryPressureResponsivenessProbe;
+    const p95 = (values: number[]) => {
+      if (values.length === 0) return 0;
+      const sorted = [...values].sort((a, b) => a - b);
+      return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
+    };
+    const reclaimCount = performance.getEntriesByName("daintree-e2e-reclaim-memory").length;
+    return {
+      frameGapP95Ms: p95(state.frameGaps),
+      maximumFrameGapMs: Math.max(0, ...state.frameGaps),
+      timerGapP95Ms: p95(state.timerGaps),
+      maximumTimerGapMs: Math.max(0, ...state.timerGaps),
+      longAnimationFrameCount: state.longAnimationFrames.length,
+      maximumLongAnimationFrameMs: Math.max(0, ...state.longAnimationFrames),
+      reclaimCount,
+    };
+  });
+}
+
+async function sampleRendererMemory(
+  ctx: AppContext
+): Promise<{ workingSetKb: number; jsHeapKb: number }> {
+  return await ctx.app.evaluate(async ({ app, BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    const views = (win?.contentView?.children ?? []) as Electron.WebContentsView[];
+    for (let index = views.length - 1; index >= 0; index--) {
+      const wc = views[index]?.webContents;
+      if (!wc || wc.isDestroyed()) continue;
+      const isProjectView = await wc
+        .executeJavaScript("!!window.__DAINTREE_INITIAL_PROJECT__", true)
+        .catch(() => false);
+      if (!isProjectView) continue;
+      const pid = wc.getOSProcessId();
+      const metric = app.getAppMetrics().find((item) => item.pid === pid);
+      const jsHeapBytes = await wc
+        .executeJavaScript("performance.memory?.usedJSHeapSize ?? 0", true)
+        .catch(() => 0);
+      return {
+        workingSetKb: metric?.memory.workingSetSize ?? 0,
+        jsHeapKb: Math.round(Number(jsHeapBytes) / 1024),
+      };
+    }
+    return { workingSetKb: 0, jsHeapKb: 0 };
+  });
+}
+
+function persistResult(metrics: ResponsivenessMetrics): void {
+  const result = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    label: LABEL,
+    config: {
+      terminalCount: TERMINAL_COUNT,
+      scrollbackLines: SCROLLBACK_LINES,
+      sampleMs: SAMPLE_MS,
+      pollIntervalMs: POLL_INTERVAL_MS,
+      availableMemoryMb: AVAILABLE_MEMORY_MB,
+    },
+    environment: { platform: process.platform, arch: process.arch, node: process.version },
+    metrics,
+  };
+  mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  const temporaryPath = `${OUTPUT_PATH}.${process.pid}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(result, null, 2)}\n`);
+  try {
+    renameSync(temporaryPath, OUTPUT_PATH);
+  } catch (error) {
+    if (process.platform !== "win32") throw error;
+    try {
+      unlinkSync(OUTPUT_PATH);
+    } catch {
+      // First write has no destination to remove.
+    }
+    renameSync(temporaryPath, OUTPUT_PATH);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+  console.log("──────── memory-pressure responsiveness results ────────");
+  console.table(metrics);
+  console.log(`results written to ${OUTPUT_PATH}`);
+  console.log("─────────────────────────────────────────────────────────");
+}
+
+const perfDescribe = process.env.RUN_PERF_MEMORY_PRESSURE
+  ? test.describe.serial
+  : test.describe.skip;
+
+perfDescribe("Resilience: memory-pressure responsiveness benchmark", () => {
+  test("busy renderer remains responsive across sustained pressure polls", async () => {
+    test.setTimeout(180_000);
+    const fixture = createFixtureRepo({ name: "memory-pressure-responsiveness" });
+    let ctx: AppContext | null = null;
+    try {
+      ctx = await launchApp({
+        enableWebgl: process.env.CI !== "true",
+        env: {
+          DAINTREE_E2E_FAULT_MODE: "1",
+          DAINTREE_E2E_SYSTEM_AVAILABLE_MEMORY_MB: String(AVAILABLE_MEMORY_MB),
+          DAINTREE_E2E_APP_METRICS_POLL_INTERVAL_MS: String(POLL_INTERVAL_MS),
+        },
+      });
+      ctx.window = await openAndOnboardProject(
+        ctx.app,
+        ctx.window,
+        fixture.dir,
+        "Memory pressure responsiveness"
+      );
+      for (let index = 0; index < TERMINAL_COUNT; index++) {
+        await openTerminal(ctx.window);
+        await ctx.window.waitForTimeout(150);
+      }
+      const panels = [];
+      for (const panelId of await getGridPanelIds(ctx.window)) {
+        const panel = getPanelById(ctx.window, panelId);
+        try {
+          await waitForTerminalPty(ctx.window, panel, 15_000);
+          panels.push(panel);
+        } catch {
+          // Ignore non-terminal panels in the grid.
+        }
+      }
+      expect(panels.length).toBeGreaterThanOrEqual(TERMINAL_COUNT);
+
+      for (const [index, panel] of panels.slice(0, TERMINAL_COUNT).entries()) {
+        await runTerminalCommand(
+          ctx.window,
+          panel,
+          `awk 'BEGIN{for(i=0;i<${SCROLLBACK_LINES};i++)printf("pressure-${index} %06d abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ\\n",i)}'; printf 'PRESSURE_READY_${index}\\n'`
+        );
+        await waitForTerminalText(panel, `PRESSURE_READY_${index}`, 30_000);
+        await runTerminalCommand(
+          ctx.window,
+          panel,
+          `node -e 'let i=0;setInterval(()=>console.log("pressure-stream-${index} "+i++),100)'`
+        );
+        await waitForTerminalText(panel, `pressure-stream-${index} 0`, 15_000);
+      }
+
+      await ctx.window.evaluate(() => performance.clearMarks("daintree-e2e-reclaim-memory"));
+      await startResponsivenessProbe(ctx);
+      await ctx.window.waitForTimeout(SAMPLE_MS);
+      const responsiveness = await stopResponsivenessProbe(ctx);
+      const memory = await sampleRendererMemory(ctx);
+      const metrics: ResponsivenessMetrics = {
+        ...responsiveness,
+        rendererWorkingSetKb: memory.workingSetKb,
+        rendererJsHeapKb: memory.jsHeapKb,
+      };
+      expect(metrics.maximumFrameGapMs).toBeGreaterThan(0);
+      expect(metrics.rendererWorkingSetKb).toBeGreaterThan(0);
+      persistResult(metrics);
+    } finally {
+      if (ctx) await closeApp(ctx.app);
+      fixture.cleanup();
+    }
+  });
+});

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -3,6 +3,7 @@ import { app, dialog, shell } from "electron";
 import os from "node:os";
 import v8 from "node:v8";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
+import { readSystemMemorySnapshot } from "../../utils/systemMemory.js";
 import { promises as fs, createWriteStream } from "node:fs";
 import { existsSync } from "node:fs";
 import path from "node:path";
@@ -207,18 +208,8 @@ function readSystemMemoryMB(): { systemTotalMB?: number; systemAvailableMB?: num
     if (Number.isFinite(totalBytes) && totalBytes > 0) {
       out.systemTotalMB = Math.round(totalBytes / 1024 / 1024);
     }
-    const getInfo = (
-      process as {
-        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
-      }
-    ).getSystemMemoryInfo;
-    if (typeof getInfo === "function") {
-      const info = getInfo.call(process);
-      const freeKb = typeof info.free === "number" ? info.free : 0;
-      const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
-      const availableKb = freeKb + purgeableKb;
-      if (availableKb > 0) out.systemAvailableMB = Math.round(availableKb / 1024);
-    }
+    const memory = readSystemMemorySnapshot();
+    if (memory) out.systemAvailableMB = Math.round(memory.availableMb);
     return out;
   } catch {
     return {};

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -3157,8 +3157,16 @@ if (window.top === window && isTrustedRendererUrl(rendererUrl)) {
 // Subscribed through the shared events:push dispatcher so the underlying
 // ipcRenderer listener is ref-counted alongside user-facing subscribers.
 _eventBusOn("window:reclaim-memory", () => {
-  webFrame.clearCache();
-  (globalThis as unknown as { gc?: () => void }).gc?.();
+  if (isE2EFaultMode) {
+    performance.mark("daintree-e2e-reclaim-memory");
+  }
+  if (document.visibilityState !== "hidden") return;
+  const reclaim = () => (globalThis as unknown as { gc?: () => void }).gc?.();
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(reclaim, { timeout: 5_000 });
+  } else {
+    setTimeout(reclaim, 0);
+  }
 });
 
 // Private listener: report Blink (DOM/CSS/cross-frame) memory back to

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -9,6 +9,8 @@ import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import { refreshAppMetricsSnapshot } from "../utils/appMetricsSnapshot.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
+import { getIsE2EFaultMode } from "../setup/runtimeFlags.js";
+import { getSystemMemoryThresholds, readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 
 const POLL_INTERVAL_MS = 30_000;
 const SNAPSHOT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -29,12 +31,6 @@ const UTILITY_MEMORY_FRACTION = 500 / 8192;
 // where several processes individually stay below their own limits.
 const AGGREGATE_MEMORY_FRACTION = 0.25;
 
-// System-wide available-memory floor. Triggers pressure when free + purgeable
-// drops below this fraction of total RAM regardless of how Daintree's own
-// processes are doing — catches the case where the OS is starved by non-
-// Daintree workloads, swap exhaustion, or shrinking purgeable caches on macOS.
-const SYSTEM_LOW_MEMORY_FRACTION = 0.1;
-
 const SNAPSHOT_THRESHOLD_MB = 600;
 
 const MONITORED_TYPES = new Set(["Browser", "Tab", "Utility"]);
@@ -48,6 +44,7 @@ const TREND_WARN_MB_PER_HOUR = 5;
 export const WARMUP_INTERVALS = 5;
 export const PRESSURE_COUNT_TIER2 = 3;
 export const MITIGATION_COOLDOWN_MS = 10 * 60 * 1000;
+export const TIER1_MITIGATION_COOLDOWN_MS = 5 * 60 * 1000;
 
 /**
  * Settle window between applying a tier 1 mitigation step and re-sampling
@@ -279,9 +276,9 @@ export function getEluHighStreaks(): ReadonlyMap<number, number> {
 }
 
 export interface MemoryPressureActions {
-  clearCaches: () => Promise<void>;
   destroyHiddenWebviews: (tier: 1 | 2) => Promise<void>;
   hibernateIdleProjects: () => Promise<void>;
+  evictCachedProjectViews?: () => Promise<void> | void;
   trimPtyHostState?: () => void;
   /**
    * Optional Blink memory sampler. If wired, called once per poll BEFORE
@@ -318,26 +315,13 @@ function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
  * ProjectViewManager.getAvailableMemoryMb so the two memory floors stay in
  * sync.
  */
-function readAvailableMemoryMb(): number | null {
-  try {
-    const getInfo = (
-      process as {
-        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
-      }
-    ).getSystemMemoryInfo;
-    if (typeof getInfo !== "function") return null;
-    const info = getInfo.call(process);
-    const freeKb = typeof info.free === "number" ? info.free : 0;
-    const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
-    const availableKb = freeKb + purgeableKb;
-    if (availableKb <= 0) return null;
-    return availableKb / 1024;
-  } catch {
-    return null;
-  }
-}
-
-let currentAppMetricsPollIntervalMs = POLL_INTERVAL_MS;
+const e2ePollIntervalMs = getIsE2EFaultMode()
+  ? Number(process.env.DAINTREE_E2E_APP_METRICS_POLL_INTERVAL_MS)
+  : Number.NaN;
+let currentAppMetricsPollIntervalMs =
+  Number.isFinite(e2ePollIntervalMs) && e2ePollIntervalMs >= 250
+    ? e2ePollIntervalMs
+    : POLL_INTERVAL_MS;
 let rearmAppMetricsTimer: (() => void) | null = null;
 let appMetricsPollFn: (() => void) | null = null;
 
@@ -362,7 +346,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
     Utility: totalMemMb * UTILITY_MEMORY_FRACTION,
   };
   const aggregateWarnThresholdMb = totalMemMb * AGGREGATE_MEMORY_FRACTION;
-  const systemLowMemoryThresholdMb = totalMemMb * SYSTEM_LOW_MEMORY_FRACTION;
+  const systemLowMemoryThresholdMb = getSystemMemoryThresholds(totalMemMb).criticalMb;
 
   const snapshotCooldowns = new Map<number, number>();
   // trendState is module-level (see getTrendSnapshot) so diagnostics can read
@@ -373,6 +357,8 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
   let removeWakeListener: (() => void) | null = null;
   let pollCount = 0;
   let consecutivePressureCount = 0;
+  let lastTier1At = 0;
+  let lastTier1ReclaimMb = 0;
   let lastTier2At = 0;
   let mitigationInFlight = false;
   const thresholdExceededPids = new Set<number>();
@@ -505,14 +491,13 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
         hasPressure = true;
       }
 
-      // System-wide signal: trigger pressure when free + purgeable drops below
-      // SYSTEM_LOW_MEMORY_FRACTION of total RAM. Catches OS-level starvation
-      // (heavy non-Daintree workloads, swap exhaustion, shrinking purgeable
-      // caches) that the per-process and aggregate checks cannot see. Null
-      // return means the Chromium API is unavailable (tests / sandboxed forks)
-      // and the signal is skipped.
-      const availableMb = readAvailableMemoryMb();
-      if (availableMb !== null && availableMb < systemLowMemoryThresholdMb) {
+      // System-wide signal uses a RAM-relative floor capped at 1 GB. The cap
+      // avoids treating the large natural file-cache footprint of 64–128 GB
+      // macOS machines as critical pressure while retaining proportional
+      // thresholds on constrained machines.
+      const availableMb = readAvailableSystemMemoryMb();
+      const systemPressureActive = availableMb !== null && availableMb < systemLowMemoryThresholdMb;
+      if (systemPressureActive) {
         hasPressure = true;
       }
 
@@ -538,10 +523,19 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
         consecutivePressureCount++;
       } else {
         consecutivePressureCount = 0;
+        lastTier1At = 0;
+        lastTier1ReclaimMb = 0;
         return;
       }
 
       if (mitigationInFlight) return;
+
+      const now = Date.now();
+      const shouldRunTier1 = lastTier1At === 0 || now - lastTier1At >= TIER1_MITIGATION_COOLDOWN_MS;
+      const shouldCheckTier2 =
+        consecutivePressureCount >= PRESSURE_COUNT_TIER2 &&
+        now - lastTier2At >= MITIGATION_COOLDOWN_MS;
+      if (!shouldRunTier1 && !shouldCheckTier2) return;
 
       mitigationInFlight = true;
       void (async () => {
@@ -560,25 +554,28 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             // err on the side of escalating if pressure persists.
           }
 
-          logInfo("memory-pressure-tier1-mitigation", {
-            pollCount,
-            consecutivePressureCount,
-            beforeMb: Math.round(beforeMb),
-          });
+          if (shouldRunTier1) {
+            lastTier1At = Date.now();
+            logInfo("memory-pressure-tier1-mitigation", {
+              pollCount,
+              consecutivePressureCount,
+              beforeMb: Math.round(beforeMb),
+            });
 
-          await actions.clearCaches();
-          await actions.destroyHiddenWebviews(1);
+            await actions.destroyHiddenWebviews(1);
 
-          try {
-            actions.trimPtyHostState?.();
-          } catch {
-            /* non-critical */
+            try {
+              actions.trimPtyHostState?.();
+            } catch {
+              /* non-critical */
+            }
+
+            await new Promise<void>((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS));
           }
-
-          await new Promise<void>((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS));
 
           let afterMb = 0;
           let pressureRemains = false;
+          let systemPressureRemains = false;
           let resampleFailed = false;
           try {
             for (const proc of refreshAppMetricsSnapshot()) {
@@ -599,6 +596,11 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             if (afterMb > aggregateWarnThresholdMb) {
               pressureRemains = true;
             }
+            const availableAfterMb = readAvailableSystemMemoryMb();
+            if (availableAfterMb !== null && availableAfterMb < systemLowMemoryThresholdMb) {
+              pressureRemains = true;
+              systemPressureRemains = true;
+            }
           } catch {
             // Re-sample failed — assume pressure persists and treat reclaim
             // as zero so the gate falls through to escalation. Without
@@ -607,22 +609,27 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             // *suppressing* escalation, which is the opposite of the
             // safe-side intent.
             pressureRemains = true;
+            systemPressureRemains = systemPressureActive;
             resampleFailed = true;
             afterMb = beforeMb;
           }
 
           const deltaMb = resampleFailed ? 0 : Math.max(0, beforeMb - afterMb);
-          logInfo("memory-pressure-tier1-reclaim", {
-            beforeMb: Math.round(beforeMb),
-            afterMb: Math.round(afterMb),
-            deltaMb: Math.round(deltaMb),
-            pressureRemains,
-            resampleFailed,
-          });
+          if (shouldRunTier1) {
+            lastTier1ReclaimMb = deltaMb;
+            logInfo("memory-pressure-tier1-reclaim", {
+              beforeMb: Math.round(beforeMb),
+              afterMb: Math.round(afterMb),
+              deltaMb: Math.round(deltaMb),
+              pressureRemains,
+              resampleFailed,
+            });
+          }
 
           if (
+            shouldCheckTier2 &&
             pressureRemains &&
-            deltaMb < MIN_RECLAIMED_MB &&
+            (systemPressureRemains || lastTier1ReclaimMb < MIN_RECLAIMED_MB) &&
             Date.now() - lastTier2At >= MITIGATION_COOLDOWN_MS
           ) {
             // Stamp the cooldown BEFORE the tier-2 actions so a thrown
@@ -636,6 +643,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               deltaMb: Math.round(deltaMb),
             });
             await actions.destroyHiddenWebviews(2);
+            await actions.evictCachedProjectViews?.();
             await actions.hibernateIdleProjects();
           }
         } catch (err) {
@@ -668,6 +676,8 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       thresholdExceededPids.clear();
       trendWarnedPids.clear();
       consecutivePressureCount = 0;
+      lastTier1At = 0;
+      lastTier1ReclaimMb = 0;
       lastTier2At = 0;
       mitigationInFlight = false;
     });

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -26,6 +26,7 @@ import {
 } from "../../shared/types/resourceProfile.js";
 import type { WhySlowResourceReason, WhySlowResourceSnapshot } from "../../shared/types/whySlow.js";
 import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.js";
+import { getSystemMemoryThresholds, readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 
 /** Map an additive pressure score to a profile. Efficiency latches at ≥ 3; a
  *  zero score (no pressure signals) unlocks performance; anything else is
@@ -123,14 +124,6 @@ const FLEET_COUNT_CRITICAL = 24;
 const FLEET_AGENTS_PER_GB_HIGH = FLEET_COUNT_HIGH / 16;
 const FLEET_AGENTS_PER_GB_VERY_HIGH = FLEET_COUNT_VERY_HIGH / 16;
 const FLEET_AGENTS_PER_GB_CRITICAL = FLEET_COUNT_CRITICAL / 16;
-
-// System-available memory thresholds expressed as fractions of total RAM so
-// devices with very different physical memory behave consistently. On macOS
-// "available" = free + purgeable; elsewhere it's free alone. The score scales
-// alongside the app-private signal to catch the case where the OS as a whole
-// is starved by other processes even when this app's footprint is modest.
-const SYS_AVAILABLE_HIGH_FRACTION = 0.2;
-const SYS_AVAILABLE_LOW_FRACTION = 0.1;
 
 // Terminal-workload signal: summed RSS of every live terminal's descendant
 // tree (agent CLIs, dev servers, language servers, test runners) from the
@@ -233,8 +226,9 @@ export class ResourceProfileService {
     const totalRamMb = os.totalmem() / 1024 / 1024;
     this.memoryThresholdHighMb = totalRamMb * HIGH_FRACTION;
     this.memoryThresholdLowMb = totalRamMb * LOW_FRACTION;
-    this.sysMemThresholdHighMb = totalRamMb * SYS_AVAILABLE_HIGH_FRACTION;
-    this.sysMemThresholdLowMb = totalRamMb * SYS_AVAILABLE_LOW_FRACTION;
+    const systemMemoryThresholds = getSystemMemoryThresholds(totalRamMb);
+    this.sysMemThresholdHighMb = systemMemoryThresholds.warningMb;
+    this.sysMemThresholdLowMb = systemMemoryThresholds.criticalMb;
     this.terminalWorkloadHighMb = totalRamMb * TERMINAL_WORKLOAD_HIGH_FRACTION;
     this.terminalWorkloadLowMb = totalRamMb * TERMINAL_WORKLOAD_LOW_FRACTION;
     const totalRamGb = totalRamMb / 1024;
@@ -765,22 +759,7 @@ export class ResourceProfileService {
    * null when the Chromium API is unavailable (e.g., under test mocks).
    */
   private getAvailableSystemMemoryMb(): number | null {
-    try {
-      const getInfo = (
-        process as {
-          getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
-        }
-      ).getSystemMemoryInfo;
-      if (typeof getInfo !== "function") return null;
-      const info = getInfo.call(process);
-      const freeKb = typeof info.free === "number" ? info.free : 0;
-      const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
-      const availableKb = freeKb + purgeableKb;
-      if (availableKb <= 0) return null;
-      return availableKb / 1024;
-    } catch {
-      return null;
-    }
+    return readAvailableSystemMemoryMb();
   }
 
   stop(): void {
@@ -980,7 +959,7 @@ export class ResourceProfileService {
     if (sysAvailMb !== null) {
       let sysScore = 0;
       if (sysAvailMb < this.sysMemThresholdLowMb) {
-        sysScore = 2;
+        sysScore = 3;
       } else if (sysAvailMb < this.sysMemThresholdHighMb) {
         sysScore = 1;
       }

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -497,17 +497,17 @@ describe("ProcessMemoryMonitor", () => {
 
     beforeEach(() => {
       mockActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        evictCachedProjectViews: vi.fn().mockResolvedValue(undefined),
       };
     });
 
     async function advancePolls(n: number): Promise<void> {
       for (let i = 0; i < n; i++) {
-        vi.advanceTimersByTime(30_000);
+        await vi.advanceTimersByTimeAsync(30_000);
       }
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
     }
 
     it("triggers mitigation when sum exceeds 25% of RAM even though no process alone exceeds its threshold", async () => {
@@ -525,7 +525,7 @@ describe("ProcessMemoryMonitor", () => {
 
       await advancePolls(WARMUP_INTERVALS + 1);
 
-      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
       // No per-process threshold warnings should have fired (each Tab is below 768 MB).
       expect(logWarn).not.toHaveBeenCalledWith(
         "process-memory-threshold-exceeded",
@@ -545,7 +545,7 @@ describe("ProcessMemoryMonitor", () => {
 
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
 
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
 
@@ -561,7 +561,7 @@ describe("ProcessMemoryMonitor", () => {
 
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
 
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
     });
 
     it("escalates aggregate-only pressure to tier 2 after sustained polls", async () => {
@@ -620,9 +620,9 @@ describe("ProcessMemoryMonitor", () => {
 
     beforeEach(() => {
       mockActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        evictCachedProjectViews: vi.fn().mockResolvedValue(undefined),
       };
       originalGetSystemMemoryInfo = (process as { getSystemMemoryInfo?: unknown })
         .getSystemMemoryInfo;
@@ -639,9 +639,8 @@ describe("ProcessMemoryMonitor", () => {
 
     async function advancePolls(n: number): Promise<void> {
       for (let i = 0; i < n; i++) {
-        vi.advanceTimersByTime(30_000);
+        await vi.advanceTimersByTimeAsync(30_000);
       }
-      await vi.advanceTimersByTimeAsync(0);
     }
 
     function stubSystemMemoryInfo(freeKb: number, purgeableKb = 0): void {
@@ -665,7 +664,7 @@ describe("ProcessMemoryMonitor", () => {
       stop = startAppMetricsMonitor(mockActions);
       await advancePolls(WARMUP_INTERVALS + 1);
 
-      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
     });
 
     it("does NOT trigger mitigation when free + purgeable stays above threshold", async () => {
@@ -676,7 +675,7 @@ describe("ProcessMemoryMonitor", () => {
       stop = startAppMetricsMonitor(mockActions);
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
 
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
     });
 
     it("counts purgeable toward available on macOS — free alone below threshold but purgeable rescues", async () => {
@@ -688,7 +687,7 @@ describe("ProcessMemoryMonitor", () => {
       stop = startAppMetricsMonitor(mockActions);
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
 
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
     });
 
     it("skips the signal when getSystemMemoryInfo is unavailable", async () => {
@@ -700,7 +699,38 @@ describe("ProcessMemoryMonitor", () => {
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
 
       // No throw, no mitigation triggered.
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
+    });
+
+    it("does not treat 1116 MB available as critical on a 64 GB machine", async () => {
+      vi.spyOn(os, "totalmem").mockReturnValue(64 * 1024 * 1024 * 1024);
+      stubSystemMemoryInfo(1116 * 1024);
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+    });
+
+    it("escalates sustained system-only pressure and evicts cached views", async () => {
+      stubSystemMemoryInfo(500 * 1024);
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+      vi.mocked(mockActions.destroyHiddenWebviews).mockImplementation(async (tier) => {
+        if (tier === 1) {
+          mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 10 * 1024, 100)]);
+        }
+      });
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
+
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
+      expect(mockActions.evictCachedProjectViews).toHaveBeenCalledTimes(1);
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -709,13 +739,12 @@ describe("ProcessMemoryMonitor", () => {
 
     beforeEach(() => {
       mockActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
       };
     });
 
-    // Helper that mocks getAppMetrics to return `beforeMb` until clearCaches
+    // Helper that mocks getAppMetrics to return `beforeMb` until tier 1
     // is called, then returns `afterMb`. Lets each test express the
     // closed-loop reclamation delta directly.
     function arrangeClosedLoopMetrics(opts: {
@@ -729,8 +758,8 @@ describe("ProcessMemoryMonitor", () => {
         const mb = postMitigation ? afterMb : beforeMb;
         return [makeMetric("Browser", mb * 1024, pid, mb * 1024)];
       });
-      mockActions.clearCaches = vi.fn().mockImplementation(async () => {
-        postMitigation = true;
+      mockActions.destroyHiddenWebviews = vi.fn().mockImplementation(async (tier) => {
+        if (tier === 1) postMitigation = true;
       });
     }
 
@@ -739,10 +768,8 @@ describe("ProcessMemoryMonitor", () => {
     // decision run before assertions.
     async function advancePolls(n: number): Promise<void> {
       for (let i = 0; i < n; i++) {
-        vi.advanceTimersByTime(30_000);
+        await vi.advanceTimersByTimeAsync(30_000);
       }
-      // Flush microtasks so the IIFE starts and reaches the settle await,
-      // then advance through the settle delay (also flushes microtasks).
       await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
     }
 
@@ -753,23 +780,23 @@ describe("ProcessMemoryMonitor", () => {
       // No crash, no mitigation called
     });
 
-    it("does not call clearCaches during warmup period", async () => {
+    it("does not reclaim hidden views during warmup period", async () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
 
       await advancePolls(WARMUP_INTERVALS);
 
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
     });
 
-    it("calls clearCaches on first pressure poll after warmup", async () => {
+    it("reclaims hidden views on first pressure poll after warmup", async () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
 
       // Advance past warmup
       await advancePolls(WARMUP_INTERVALS + 1);
 
-      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
     });
 
     it("does not escalate to tier 2 when tier 1 reclaims above the minimum", async () => {
@@ -781,7 +808,7 @@ describe("ProcessMemoryMonitor", () => {
 
       await advancePolls(WARMUP_INTERVALS + 1);
 
-      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
       expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalledWith(2);
     });
@@ -791,7 +818,7 @@ describe("ProcessMemoryMonitor", () => {
       arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 340 });
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
@@ -854,8 +881,8 @@ describe("ProcessMemoryMonitor", () => {
       arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 345 });
       stop = startAppMetricsMonitor(mockActions);
 
-      // Trigger tier 2 on the first post-warmup pressure poll.
-      await advancePolls(WARMUP_INTERVALS + 1);
+      // Trigger tier 2 after sustained post-warmup pressure.
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
 
       // Continue pressure — should not trigger again within cooldown.
@@ -868,7 +895,7 @@ describe("ProcessMemoryMonitor", () => {
       stop = startAppMetricsMonitor(mockActions);
 
       // Trigger tier 2.
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
 
       // Advance past cooldown (pressure remains, delta remains insufficient).
@@ -882,7 +909,7 @@ describe("ProcessMemoryMonitor", () => {
       arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 345 });
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier1-mitigation", expect.any(Object));
       expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier2-mitigation", expect.any(Object));
@@ -897,7 +924,7 @@ describe("ProcessMemoryMonitor", () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(actionsWithTrim);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       expect(trimPtyHostState).toHaveBeenCalledTimes(1);
     });
@@ -910,7 +937,7 @@ describe("ProcessMemoryMonitor", () => {
         ...mockActions,
         trimPtyHostState,
       };
-      // Default mockActions has clearCaches as a no-op resolver; reclaim
+      // Default mockActions leaves the metrics unchanged; reclaim
       // delta stays at 0 so tier 2 should still fire here.
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(actionsWithTrim);
@@ -918,7 +945,7 @@ describe("ProcessMemoryMonitor", () => {
       await advancePolls(WARMUP_INTERVALS + 1);
 
       expect(trimPtyHostState).toHaveBeenCalled();
-      expect(actionsWithTrim.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+      expect(actionsWithTrim.destroyHiddenWebviews).toHaveBeenCalledWith(1);
     });
 
     it("calls destroyHiddenWebviews(1) on tier 1 mitigation", async () => {
@@ -930,12 +957,24 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(1);
     });
 
-    it("calls destroyHiddenWebviews(2) on tier 2 mitigation", async () => {
-      // Zero reclamation + pressure remains → tier 2 fires immediately.
+    it("does not repeat tier 1 on every poll during one pressure episode", async () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + 6);
+
+      const tier1Calls = vi
+        .mocked(mockActions.destroyHiddenWebviews)
+        .mock.calls.filter(([tier]) => tier === 1);
+      expect(tier1Calls).toHaveLength(1);
+    });
+
+    it("calls destroyHiddenWebviews(2) on tier 2 mitigation", async () => {
+      // Zero reclamation + sustained pressure → tier 2 fires.
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
     });
@@ -952,7 +991,7 @@ describe("ProcessMemoryMonitor", () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       const destroyIdx = callOrder.lastIndexOf("destroyHiddenWebviews");
       const hibernateIdx = callOrder.indexOf("hibernateIdleProjects");
@@ -965,7 +1004,7 @@ describe("ProcessMemoryMonitor", () => {
 
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 5);
 
-      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
 
@@ -976,7 +1015,7 @@ describe("ProcessMemoryMonitor", () => {
       arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 400 - MIN_RECLAIMED_MB });
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
@@ -986,19 +1025,20 @@ describe("ProcessMemoryMonitor", () => {
       // not deltaMb=beforeMb, so the AND gate falls through to escalation.
       // Without `afterMb = beforeMb` inside the catch, the large derived
       // delta would suppress tier 2 even with pressureRemains=true.
-      let cleared = false;
+      let throwNextSample = false;
       mockGetAppMetrics.mockImplementation(() => {
-        if (cleared) {
+        if (throwNextSample) {
+          throwNextSample = false;
           throw new Error("getAppMetrics unavailable");
         }
         return [makeMetric("Browser", 350 * 1024, 100)];
       });
-      mockActions.clearCaches = vi.fn().mockImplementation(async () => {
-        cleared = true;
+      mockActions.destroyHiddenWebviews = vi.fn().mockImplementation(async (tier) => {
+        if (tier === 1) throwNextSample = true;
       });
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
 
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
       expect(logInfo).toHaveBeenCalledWith(
@@ -1024,7 +1064,7 @@ describe("ProcessMemoryMonitor", () => {
 
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + 1);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
       // First cycle: tier-2 attempted, destroyHiddenWebviews(2) called,
       // hibernate throws. Cooldown should still be consumed.
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
@@ -1097,7 +1137,6 @@ describe("ProcessMemoryMonitor", () => {
     it("startAppMetricsMonitor invokes actions.sampleBlinkMemory once per poll", () => {
       const sampleBlinkMemory = vi.fn();
       const actions: MemoryPressureActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleBlinkMemory,
@@ -1120,7 +1159,6 @@ describe("ProcessMemoryMonitor", () => {
         throw new Error("renderer port closed");
       });
       const actions: MemoryPressureActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleBlinkMemory,
@@ -1140,7 +1178,6 @@ describe("ProcessMemoryMonitor", () => {
 
     it("works without sampleBlinkMemory (optional field, backwards compat)", () => {
       const actions: MemoryPressureActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
       };
@@ -1336,7 +1373,6 @@ describe("ProcessMemoryMonitor", () => {
     it("startAppMetricsMonitor invokes actions.sampleRendererElu once per poll", () => {
       const sampleRendererElu = vi.fn();
       const actions: MemoryPressureActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleRendererElu,
@@ -1356,7 +1392,6 @@ describe("ProcessMemoryMonitor", () => {
         throw new Error("renderer port closed");
       });
       const actions: MemoryPressureActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleRendererElu,
@@ -1687,7 +1722,6 @@ describe("ProcessMemoryMonitor", () => {
 
     it("works without sampleRendererElu (optional, backwards compat)", () => {
       const actions: MemoryPressureActions = {
-        clearCaches: vi.fn().mockResolvedValue(undefined),
         destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
       };

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -1567,17 +1567,17 @@ describe("ResourceProfileService", () => {
       }));
     }
 
-    it("system available memory below 10% of total adds +2 to pressure", () => {
+    it("system available memory below the critical floor enters efficiency by itself", () => {
       // 8 GB total. 10% = 819 MB. Stub free+purgeable = 500 MB (well below LOW threshold).
       // Free 300 MB + purgeable 200 MB = 500 MB available.
       stubSystemMemory(300 * 1024, 200 * 1024, EIGHT_GB / 1024);
 
       const deps = createDeps();
       const service = new ResourceProfileService(deps);
-      mockIsOnBatteryPower.mockReturnValue(true);
+      mockIsOnBatteryPower.mockReturnValue(false);
       service.start();
 
-      // Low app memory (0) + battery (+1) + sys mem <10% (+2) = 3 => efficiency
+      // Critical system memory is sufficient to enter efficiency without a corroborating signal.
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
 
       vi.advanceTimersByTime(60_000 + 30_000 + 30_000);

--- a/electron/utils/__tests__/systemMemory.test.ts
+++ b/electron/utils/__tests__/systemMemory.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getSystemMemoryThresholds } from "../systemMemory.js";
+
+describe("systemMemory thresholds", () => {
+  it("preserves proportional thresholds on an 8 GB machine", () => {
+    expect(getSystemMemoryThresholds(8 * 1024)).toEqual({
+      criticalMb: 8 * 1024 * 0.1,
+      warningMb: 8 * 1024 * 0.2,
+    });
+  });
+
+  it("caps thresholds on high-memory machines", () => {
+    expect(getSystemMemoryThresholds(64 * 1024)).toEqual({
+      criticalMb: 1024,
+      warningMb: 2048,
+    });
+  });
+});

--- a/electron/utils/systemMemory.ts
+++ b/electron/utils/systemMemory.ts
@@ -1,0 +1,59 @@
+import os from "node:os";
+import { getIsE2EFaultMode } from "../setup/runtimeFlags.js";
+
+const CRITICAL_FRACTION = 0.1;
+const WARNING_FRACTION = 0.2;
+const CRITICAL_MAX_MB = 1024;
+const WARNING_MAX_MB = 2048;
+
+export interface SystemMemorySnapshot {
+  totalMb: number;
+  freeMb: number;
+  purgeableMb: number;
+  availableMb: number;
+}
+
+export interface SystemMemoryThresholds {
+  criticalMb: number;
+  warningMb: number;
+}
+
+export function getSystemMemoryThresholds(totalMb: number): SystemMemoryThresholds {
+  return {
+    criticalMb: Math.min(totalMb * CRITICAL_FRACTION, CRITICAL_MAX_MB),
+    warningMb: Math.min(totalMb * WARNING_FRACTION, WARNING_MAX_MB),
+  };
+}
+
+export function readSystemMemorySnapshot(): SystemMemorySnapshot | null {
+  const totalMb = os.totalmem() / 1024 / 1024;
+  if (!Number.isFinite(totalMb) || totalMb <= 0) return null;
+
+  if (getIsE2EFaultMode()) {
+    const availableMb = Number(process.env.DAINTREE_E2E_SYSTEM_AVAILABLE_MEMORY_MB);
+    if (Number.isFinite(availableMb) && availableMb > 0) {
+      return { totalMb, freeMb: availableMb, purgeableMb: 0, availableMb };
+    }
+  }
+
+  try {
+    const getInfo = (
+      process as {
+        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+      }
+    ).getSystemMemoryInfo;
+    if (typeof getInfo !== "function") return null;
+    const info = getInfo.call(process);
+    const freeMb = typeof info.free === "number" ? info.free / 1024 : 0;
+    const purgeableMb = typeof info.purgeable === "number" ? info.purgeable / 1024 : 0;
+    const availableMb = freeMb + purgeableMb;
+    if (!Number.isFinite(availableMb) || availableMb <= 0) return null;
+    return { totalMb, freeMb, purgeableMb, availableMb };
+  } catch {
+    return null;
+  }
+}
+
+export function readAvailableSystemMemoryMb(): number | null {
+  return readSystemMemorySnapshot()?.availableMb ?? null;
+}

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -11,6 +11,7 @@ import { cleanupEntry, sumGuestMemoryKb } from "./ProjectViewLifecycleController
 import { hasActiveAgent } from "./ProjectViewAgentStateCache.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import type { EvictionReason, ViewEntry } from "./ProjectViewManagerTypes.js";
+import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 
 /**
  * Evict a cached view whose renderer is already gone (OS memory eviction or
@@ -44,7 +45,11 @@ export function evictDeadView(
   });
 }
 
-export function evictStaleViews(host: ProjectViewManager, reason: EvictionReason): void {
+export function evictStaleViews(
+  host: ProjectViewManager,
+  reason: EvictionReason,
+  forcePressure = false
+): void {
   // Override the user-configured cap when system memory is low so we can
   // reclaim Chromium renderers (~100–500 MB each) before the OS hits
   // compressed-RAM throttling. The override is per-pass — `maxCachedViews`
@@ -52,9 +57,10 @@ export function evictStaleViews(host: ProjectViewManager, reason: EvictionReason
   // effect on the next eviction.
   const availableMb = getAvailableMemoryMb();
   const lowMemoryOverride =
-    host.lowMemoryFreeThresholdMb != null &&
-    availableMb != null &&
-    availableMb < host.lowMemoryFreeThresholdMb;
+    forcePressure ||
+    (host.lowMemoryFreeThresholdMb != null &&
+      availableMb != null &&
+      availableMb < host.lowMemoryFreeThresholdMb);
   const effectiveMax = lowMemoryOverride ? 1 : host.maxCachedViews;
   const effectiveReason: EvictionReason = lowMemoryOverride ? "pressure" : reason;
 
@@ -239,20 +245,5 @@ export function maybeEvictUnderPressure(host: ProjectViewManager): void {
  * when the Chromium API is unavailable (e.g., under test mocks).
  */
 export function getAvailableMemoryMb(): number | null {
-  try {
-    const getInfo = (
-      process as {
-        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
-      }
-    ).getSystemMemoryInfo;
-    if (typeof getInfo !== "function") return null;
-    const info = getInfo.call(process);
-    const freeKb = typeof info.free === "number" ? info.free : 0;
-    const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
-    const availableKb = freeKb + purgeableKb;
-    if (availableKb <= 0) return null;
-    return availableKb / 1024;
-  } catch {
-    return null;
-  }
+  return readAvailableSystemMemoryMb();
 }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -505,6 +505,10 @@ export class ProjectViewManager {
     EvictionController.maybeEvictUnderPressure(this);
   }
 
+  reclaimCachedViewsUnderPressure(): void {
+    EvictionController.evictStaleViews(this, "pressure", true);
+  }
+
   /**
    * Set the soft paint-gate timeout (ms). Does NOT retime an in-flight
    * gate — the value is captured at gate creation. Called by

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -2180,6 +2180,23 @@ describe("ProjectViewManager — low-memory eviction", () => {
     expect(wcA.close).toHaveBeenCalled();
   });
 
+  it("explicit pressure reclaim clamps to the active view without waiting for the sampler", async () => {
+    stubSystemMemoryInfo({ free: 2 * 1024 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+    await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
+    await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
+
+    manager.reclaimCachedViewsUnderPressure();
+
+    expect(manager.getAllViews().map((view) => view.projectId)).toEqual(["proj-c"]);
+    expect(wcA.close).toHaveBeenCalled();
+  });
+
   it("periodic pressure check evicts cached views while idle — no project switch needed", async () => {
     // Healthy at switch time so the switch-driven eviction pass does nothing.
     let freeKb = 2 * 1024 * 1024;

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -50,27 +50,13 @@ import {
   endWindowRecreating,
   isWindowRecreating,
 } from "../lifecycle/windowRecreationState.js";
+import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 
 const CRASH_LOOP_WINDOW_MS = 60_000;
 const CRASH_LOOP_THRESHOLD = 3;
 
 function getAvailableMemoryMb(): number | null {
-  try {
-    const getInfo = (
-      process as {
-        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
-      }
-    ).getSystemMemoryInfo;
-    if (typeof getInfo !== "function") return null;
-    const info = getInfo.call(process);
-    const freeKb = typeof info.free === "number" ? info.free : 0;
-    const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
-    const availableKb = freeKb + purgeableKb;
-    if (availableKb <= 0) return null;
-    return availableKb / 1024;
-  } catch {
-    return null;
-  }
+  return readAvailableSystemMemoryMb();
 }
 
 let windowIpcHandlersRegistered = false;

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -1,5 +1,5 @@
 // eager-import-allow: reads boot config via store.get synchronously while wiring global services
-import { app, dialog, session } from "electron";
+import { app, dialog } from "electron";
 import {
   LATEST_SCHEMA_VERSION,
   MigrationRunner,
@@ -378,34 +378,6 @@ export async function initGlobalServices(
       if (getStopAppMetricsMonitor()) return;
       setStopAppMetricsMonitor(
         startAppMetricsMonitor({
-          clearCaches: async () => {
-            try {
-              await session.defaultSession.clearCache();
-            } catch {
-              /* non-critical */
-            }
-            try {
-              await session.defaultSession.clearStorageData({
-                storages: ["shadercache", "cachestorage"],
-              });
-            } catch {
-              /* non-critical */
-            }
-            if (windowRegistry) {
-              for (const wCtx of windowRegistry.all()) {
-                if (!wCtx.browserWindow.isDestroyed()) {
-                  try {
-                    sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
-                      name: "window:reclaim-memory",
-                      payload: { reason: "memory-pressure" },
-                    });
-                  } catch {
-                    /* non-critical */
-                  }
-                }
-              }
-            }
-          },
           destroyHiddenWebviews: async (tier) => {
             if (windowRegistry) {
               for (const wCtx of windowRegistry.all()) {
@@ -435,6 +407,12 @@ export async function initGlobalServices(
           },
           hibernateIdleProjects: async () => {
             await getHibernationService().hibernateUnderMemoryPressure();
+          },
+          evictCachedProjectViews: () => {
+            if (!windowRegistry) return;
+            for (const wCtx of windowRegistry.all()) {
+              wCtx.services.projectViewManager?.reclaimCachedViewsUnderPressure();
+            }
           },
           trimPtyHostState: () => {
             getPtyClient()?.trimState(SCROLLBACK_BACKGROUND);

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -105,6 +105,17 @@ PERF_BULK_ISSUE_OUTPUT=.tmp/perf-results/bulk-issue-worktrees-before.json npm ru
 
 Controls: `PERF_BULK_ISSUE_SCALES` (default `1,6,10`, maximum 20), `PERF_BULK_ISSUE_ROUNDS` (default `3`), `PERF_BULK_ISSUE_WARMUPS` (default `1`), and `PERF_BULK_ISSUE_OUTPUT`.
 
+## Memory-pressure responsiveness (`perf memory-pressure`)
+
+`npm run perf memory-pressure` builds the E2E benchmark bundle, launches five real PTYs/xterms with seeded scrollback and continuous output, injects a hermetic critical system-memory reading, and measures renderer frame gaps, timer gaps, Long Animation Frames, active-renderer reclaim events, and renderer memory. It is observational rather than CI-gated; use identical controls for before/after comparisons and write each arm to a separate output path.
+
+```bash
+PERF_MEMORY_PRESSURE_LABEL=before PERF_MEMORY_PRESSURE_OUTPUT=.tmp/perf-results/memory-pressure-before.json npm run perf memory-pressure
+PERF_MEMORY_PRESSURE_LABEL=after PERF_MEMORY_PRESSURE_OUTPUT=.tmp/perf-results/memory-pressure-after.json npm run perf memory-pressure
+```
+
+Controls: `PERF_MEMORY_PRESSURE_TERMINALS` (default `5`), `PERF_MEMORY_PRESSURE_SCROLLBACK_LINES` (default `1500`), `PERF_MEMORY_PRESSURE_SAMPLE_MS` (default `12000`), `PERF_MEMORY_PRESSURE_POLL_INTERVAL_MS` (default `1000`, fault-mode only), `PERF_MEMORY_PRESSURE_AVAILABLE_MB` (default `512`, fault-mode only), `PERF_MEMORY_PRESSURE_LABEL`, and `PERF_MEMORY_PRESSURE_OUTPUT`.
+
 ## GPU/compositor traces (`--trace`)
 
 `--trace` makes the packaged app self-start Electron's `contentTracing` (categories `viz,gpu,cc,blink,toplevel,startup`) for the full startup-to-quit window, writing one trace per run to `.tmp/perf-results/trace-run-N.json`. This is the way to see why the compositor takes time between `main_window_shown` and the first painted frame.

--- a/scripts/perf/index.ts
+++ b/scripts/perf/index.ts
@@ -154,6 +154,27 @@ function playwrightBulkIssueWorktrees(): Runner {
   };
 }
 
+function playwrightMemoryPressureResponsiveness(): Runner {
+  return async (rest) => {
+    const buildExitCode = await npmScript("build:e2e:bench");
+    if (buildExitCode !== 0) return buildExitCode;
+    return spawnNode(
+      [
+        resolveBin(
+          ["node_modules/@playwright/test/cli.js", "node_modules/playwright/cli.js"],
+          "playwright"
+        ),
+        "test",
+        "--project=full-resilience",
+        "--workers=1",
+        "e2e/full/resilience/memory-pressure-responsiveness-perf.spec.ts",
+        ...rest,
+      ],
+      { RUN_PERF_MEMORY_PRESSURE: "1" }
+    );
+  };
+}
+
 const REGISTRY: Record<string, Command> = {
   smoke: { summary: "Fast local smoke matrix (run on demand)", runner: harness("smoke") },
   ci: { summary: "CI validation matrix (scheduled + manual dispatch)", runner: harness("ci") },
@@ -182,6 +203,10 @@ const REGISTRY: Record<string, Command> = {
   "memory-compare": {
     summary: "Diff two memory-bench result files into a delta table",
     runner: tsxScript("memory-bench-compare.ts"),
+  },
+  "memory-pressure": {
+    summary: "Renderer responsiveness during sustained synthetic memory pressure",
+    runner: playwrightMemoryPressureResponsiveness(),
   },
   analyze: {
     summary: "Bundle-size visualizer build (ANALYZE=true vite build)",


### PR DESCRIPTION
## Summary

- stop memory-pressure mitigation from clearing Chromium caches or forcing GC in the visible renderer
- centralize free-plus-purgeable system-memory thresholds and correct high-memory-machine classification
- add tier cooldowns, persistent-pressure resampling, cached project-view eviction, and idle-project hibernation
- add a hermetic `npm run perf memory-pressure` benchmark using five streaming PTYs/xterms

## Root cause

The incident was amplified by Daintree's mitigation loop. On a 64 GB Mac, 1.1 GB available memory was treated as critical, tier 1 fired every 30 seconds, and the visible project renderer synchronously cleared Chromium caches and forced GC. The post-mitigation resample omitted system memory, so persistent pressure did not reach tier 2 and cached project views were never shed.

The PTY data plane remained healthy. The increasingly unresponsive UI was consistent with the renderer repeatedly being interrupted while the machine was already under pressure.

## Benchmark

The new benchmark seeds five real xterms with 1,500 lines each, streams output continuously, injects a hermetic 512 MB available-memory reading, and measures renderer responsiveness across sustained pressure polls.

| Metric | Before | After |
| --- | ---: | ---: |
| Active-renderer reclaim/GC events | 3 | 0 |
| Frame-gap p95 | 18.40 ms | 18.53 ms |
| Maximum frame gap | 18.67 ms | 18.66 ms |
| Timer-gap p95 | 51.06 ms | 51.50 ms |
| Long Animation Frames | 0 | 0 |

Frame and timer values are effectively flat within single-run variance. The causal regression metric is the active-renderer reclaim count, which falls to zero while persistent pressure still escalates to tier 2.

## Validation

- `npm run check`
- `npm test` — 1,923 files and 38,723 tests passed
- `npm run build`
- `npm run perf memory-pressure`
- focused memory-pressure suite — 315 tests passed
