### PR TITLE
fix(test): cap vitest workers by core count to stop CI oversubscription

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { availableParallelism } from "os";
 import path from "path";
 
 export default defineConfig({
@@ -24,7 +25,11 @@ export default defineConfig({
     // minWorkers:3 forced 3 workers even on the 2-core CI runners). Cap the
     // upper bound because high-core hosts can otherwise overwhelm Vitest's RPC
     // teardown and turn an all-passing run into an EnvironmentTeardownError.
-    maxWorkers: 8,
+    // Take the min with the core count so this only ever *lowers* the worker
+    // count on big machines — a bare `maxWorkers: 8` would instead force 8
+    // fork processes onto the 4-core CI shards, oversubscribing them 2x and
+    // timing out the import-heavy suites.
+    maxWorkers: Math.min(availableParallelism(), 8),
     maxConcurrency: 10,
     include: [
       "electron/**/*.{test,spec}.{js,ts}",


### PR DESCRIPTION
## Problem

CI on `develop` went red at 5c27ad428 (`fix: stabilize browser restore and test workers`). Parent `2ef713d97` was green. Two shards timed out on the import-heaviest suites:

- `actionDefinitions.test.ts > registers core app actions` — *Test timed out in 15000ms*
- `actionPaletteBehavior.test.ts` `beforeAll` — *Hook timed out in 10000ms*

Both pass locally in ~1.3s — these are contention timeouts, not assertion failures.

## Root cause

That commit added a literal `maxWorkers: 8` to the forks pool to cap RPC teardown on high-core dev hosts. But the GitHub `ubuntu-latest` shards have **4 cores**, where vitest previously tracked CPU count (~4 workers). The literal `8` overrides that and forces **8 fork processes onto 4 cores** — 2× oversubscription. The heaviest imports (the whole action-definition graph) starve under that and blow the 15s/10s timeouts.

## Fix

```ts
maxWorkers: Math.min(availableParallelism(), 8)
```

The cap now only ever *lowers* the worker count on big machines (16-core dev host → 8, keeping the teardown fix) while the 4-core CI shards revert to their previously-green count of 4. Strictly cannot make CI worse than the last green run.

Verified: both previously-failing suites pass locally with the change.