### PR TITLE
fix(dev-preview): keep panel chrome during first load

### DIFF
--- a/src/panels/__tests__/registry.adversarial.test.ts
+++ b/src/panels/__tests__/registry.adversarial.test.ts
@@ -29,6 +29,9 @@ function mockRegistryImports(options?: { throwBrowserDefaults?: boolean }): void
   vi.doMock("@/components/Browser/BrowserPaneSkeleton", () => ({
     BrowserPaneSkeleton: (() => null) as MinimalComponent,
   }));
+  vi.doMock("../dev-preview/DevPreviewPaneFallback", () => ({
+    DevPreviewPaneFallback: (() => null) as MinimalComponent,
+  }));
   vi.doMock("../review/ReviewPaneSkeleton", () => ({
     ReviewPaneSkeleton: (() => null) as MinimalComponent,
   }));

--- a/src/panels/__tests__/registry.fallback.test.tsx
+++ b/src/panels/__tests__/registry.fallback.test.tsx
@@ -24,6 +24,11 @@ function mockWiringImports(): void {
       <div data-testid="browser-skeleton">{label}</div>
     ),
   }));
+  vi.doMock("../dev-preview/DevPreviewPaneFallback", () => ({
+    DevPreviewPaneFallback: ({ title }: { title: string }) => (
+      <div data-testid="dev-preview-panel-fallback">{title}</div>
+    ),
+  }));
   vi.doMock("../review/ReviewPaneSkeleton", () => ({
     ReviewPaneSkeleton: () => <div data-testid="review-skeleton" />,
   }));
@@ -50,10 +55,10 @@ describe("panel registry Suspense fallback wiring", () => {
     expect(screen.getByTestId("browser-skeleton")).toBeTruthy();
   });
 
-  it("dev-preview falls back to the browser skeleton with its own label", async () => {
+  it("dev-preview falls back to real panel chrome instead of the browser ghost", async () => {
     await renderPanelKind("dev-preview");
-    const skeleton = screen.getByTestId("browser-skeleton");
-    expect(skeleton.textContent).toBe("Loading dev preview panel");
+    expect(screen.getByTestId("dev-preview-panel-fallback").textContent).toBe("Panel");
+    expect(screen.queryByTestId("browser-skeleton")).toBeNull();
   });
 
   it("review falls back to the review skeleton, not the browser one", async () => {

--- a/src/panels/dev-preview/DevPreviewPaneFallback.tsx
+++ b/src/panels/dev-preview/DevPreviewPaneFallback.tsx
@@ -1,0 +1,15 @@
+import { ContentPanel, type BasePanelProps } from "@/components/Panel";
+import { Skeleton, SkeletonHint } from "@/components/ui/Skeleton";
+
+const LOADING_LABEL = "Loading dev preview panel";
+
+export function DevPreviewPaneFallback(props: BasePanelProps) {
+  return (
+    <ContentPanel {...props} kind="dev-preview">
+      <div className="relative h-full">
+        <Skeleton label={LOADING_LABEL} className="h-full bg-surface-canvas" />
+        <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+      </div>
+    </ContentPanel>
+  );
+}

--- a/src/panels/dev-preview/__tests__/DevPreviewPaneFallback.test.tsx
+++ b/src/panels/dev-preview/__tests__/DevPreviewPaneFallback.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (state: { worktrees: Map<string, unknown> }) => unknown) =>
+    selector({ worktrees: new Map() }),
+}));
+
+vi.mock("@/hooks/useWorktreeColorMap", () => ({
+  useWorktreeColorMap: () => undefined,
+}));
+
+vi.mock("@/components/DragDrop", () => ({
+  useIsDragging: () => false,
+}));
+
+vi.mock("@/components/Layout/useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({
+    agentId: undefined,
+    iconId: "monitor-play",
+    runtimeKind: "shell",
+    isAgent: false,
+  }),
+}));
+
+vi.mock("@/utils/terminalAgentDisplayState", () => ({
+  getTerminalAgentDisplayState: () => undefined,
+}));
+
+vi.mock("@/components/Terminal/TerminalHeaderContent", () => ({
+  TerminalHeaderContent: () => null,
+}));
+
+vi.mock("@/store", () => ({
+  usePreferencesStore: (
+    selector: (state: { showGridAgentHighlights: boolean; showAgentTaskTitles: boolean }) => unknown
+  ) => selector({ showGridAgentHighlights: false, showAgentTaskTitles: true }),
+  usePanelStore: (selector: (state: { panelsById: Record<string, never> }) => unknown) =>
+    selector({ panelsById: {} }),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+import { DevPreviewPaneFallback } from "../DevPreviewPaneFallback";
+
+describe("DevPreviewPaneFallback", () => {
+  it("keeps the real panel chrome interactive around a quiet loading canvas", () => {
+    const onFocus = vi.fn();
+    const onClose = vi.fn();
+    const onToggleMaximize = vi.fn();
+
+    const { container } = render(
+      <DevPreviewPaneFallback
+        id="preview-1"
+        title="Dev preview"
+        isFocused
+        isMultiPanelGrid
+        onFocus={onFocus}
+        onClose={onClose}
+        onToggleMaximize={onToggleMaximize}
+      />
+    );
+
+    const panel = container.querySelector('[data-panel-id="preview-1"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute("data-panel-location")).toBe("grid");
+    expect(screen.getAllByText("Dev preview").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "More panel actions" })).toBeTruthy();
+
+    const loadingCanvas = screen.getByRole("status", { name: "Loading dev preview panel" });
+    expect(loadingCanvas.getAttribute("aria-busy")).toBe("true");
+    expect(
+      container.querySelectorAll(".animate-pulse-immediate, .animate-pulse-delayed")
+    ).toHaveLength(0);
+
+    fireEvent.click(panel!);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Maximize" }));
+    expect(onToggleMaximize).toHaveBeenCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByTestId("panel-close"));
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -29,6 +29,7 @@ import { serializeBrowser } from "./browser/serializer";
 import { createBrowserDefaults } from "./browser/defaults";
 import { serializeDevPreview } from "./dev-preview/serializer";
 import { createDevPreviewDefaults } from "./dev-preview/defaults";
+import { DevPreviewPaneFallback } from "./dev-preview/DevPreviewPaneFallback";
 import { serializeReview } from "./review/serializer";
 import { createReviewDefaults } from "./review/defaults";
 import { ReviewPaneSkeleton } from "./review/ReviewPaneSkeleton";
@@ -76,10 +77,11 @@ const LazyFilePane = lazy(() => import("./file/FilePane").then((m) => ({ default
 // TerminalPane is intentionally NOT lazy/wrapped: it is the hottest panel kind,
 // open/close must feel instant, and a Suspense skeleton + 150ms fade on every
 // mount is a visible regression for a live text surface.
-// Each fallback mirrors its kind's real chrome (dev-preview shares the browser
-// silhouette because its pane renders the same BrowserToolbar), and all bones
-// pulse immediately — React's ~300ms fallback throttle already serves the
-// anti-flicker gate (#9040 note in useDeferredLoading.ts).
+// Browser/review/file fallbacks mirror their kind's content silhouette and all
+// bones pulse immediately — React's ~300ms fallback throttle already serves the
+// anti-flicker gate (#9040 note in useDeferredLoading.ts). Dev preview uses the
+// real ContentPanel chrome around a quiet canvas so its first-open boundary has
+// the same title, controls, border, and radius as the resolved pane.
 function BrowserPaneWrapper(props: ComponentProps<typeof LazyBrowserPane>) {
   return (
     <ErrorBoundary variant="component" componentName="BrowserPane">
@@ -95,10 +97,8 @@ function BrowserPaneWrapper(props: ComponentProps<typeof LazyBrowserPane>) {
 function DevPreviewPaneWrapper(props: ComponentProps<typeof LazyDevPreviewPane>) {
   return (
     <ErrorBoundary variant="component" componentName="DevPreviewPane">
-      <Suspense fallback={<BrowserPaneSkeleton label="Loading dev preview panel" />}>
-        <ContentFadeIn className="flex flex-col h-full w-full">
-          <LazyDevPreviewPane {...props} />
-        </ContentFadeIn>
+      <Suspense fallback={<DevPreviewPaneFallback {...props} />}>
+        <LazyDevPreviewPane {...props} />
       </Suspense>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary

- Replace the Dev Preview lazy-import browser ghost with the real `ContentPanel` chrome around a quiet blank canvas
- Forward the live panel title, focus, maximize, close, rename, and layout props through the loading boundary
- Remove the whole-panel fade on resolution so the stable chrome does not disappear and fade back in
- Update registry coverage and add an interaction/accessibility regression test for the cold fallback

## Root cause

PR #4735 introduced `BrowserPaneSkeleton` for both browser and Dev Preview, and PR #10987 deliberately retained that pairing because both resolved panes use `BrowserToolbar`. The fallback only hand-drew a header and toolbar silhouette, though, so it did not include the real panel border, radius, focus state, title, or controls. PR #6451 then made the resolved panel fade in as a whole, producing a fake shell → fade → real shell sequence on the first cold import.

Production already module-preloads the Dev Preview chunk through the first-render seed added in PR #9792. Vite development still transforms the lazy module on its first import, which makes the mismatch easiest to see on the first Dev Preview open. The new fallback fixes every timing path without eagerly evaluating the large Dev Preview module in each project view.

## User impact

The first Dev Preview open now starts with standard Daintree panel chrome and working controls. Only the Dev Preview-specific interior waits for the lazy module, using a single solid loading canvas instead of fake toolbar blocks.

Follow-up to #10984.

## Testing

- `npm exec vitest run src/panels/dev-preview/__tests__/DevPreviewPaneFallback.test.tsx src/panels/__tests__/registry.fallback.test.tsx src/panels/__tests__/registry.adversarial.test.ts` — 14 passed
- `npm run check`
- `npm run build`
- `npm exec playwright test e2e/full/panels/core-dev-preview.spec.ts -- --project=full-panels` — 13 passed
