### PR TITLE
fix(toolbar): keep commit count stable on switch-back

### DIFF
--- a/src/hooks/__tests__/usePollingLifecycle.test.tsx
+++ b/src/hooks/__tests__/usePollingLifecycle.test.tsx
@@ -190,7 +190,8 @@ describe("usePollingLifecycle", () => {
     });
 
     it("fans projectClient.onSwitch to all subscribers as onProjectSwitch + refetch", async () => {
-      let captured: (() => void) | undefined;
+      const project = { id: "project-a", path: "/repo/a" };
+      let captured: ((payload?: { project: typeof project; switchId: string }) => void) | undefined;
       onSwitchMock.mockImplementation((cb) => {
         captured = cb;
         return () => {};
@@ -209,13 +210,13 @@ describe("usePollingLifecycle", () => {
       });
 
       await act(async () => {
-        captured?.();
+        captured?.({ project, switchId: "switch-a" });
         await Promise.resolve();
       });
 
       await waitFor(() => {
-        expect(onSwitchA).toHaveBeenCalledTimes(1);
-        expect(onSwitchB).toHaveBeenCalledTimes(1);
+        expect(onSwitchA).toHaveBeenCalledWith(project);
+        expect(onSwitchB).toHaveBeenCalledWith(project);
         expect(fetchA).toHaveBeenCalledTimes(2);
         expect(fetchB).toHaveBeenCalledTimes(2);
       });

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -619,6 +619,46 @@ describe("useRepositoryStats", () => {
       expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
     });
 
+    it("keeps a cached view's unchanged commit count visible while switch-back revalidates", async () => {
+      const project = { id: "a", path: "/repo/a" };
+      const delayedCurrent = createDeferred<typeof project>();
+      getCurrentMock.mockResolvedValueOnce(project);
+      let switchHandler:
+        | ((payload?: { project: typeof project; switchId: string }) => void)
+        | undefined;
+      onSwitchMock.mockImplementation((cb: typeof switchHandler) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const stats = freshStats({
+        commitCount: 19_488,
+        issueCount: 5,
+        prCount: 1,
+        lastUpdated: Date.now(),
+      });
+      getRepoStatsMock.mockResolvedValue(stats);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(19_488));
+
+      getCurrentMock.mockImplementationOnce(() => delayedCurrent.promise);
+      act(() => {
+        switchHandler?.({ project, switchId: "switch-back-a" });
+      });
+
+      expect(result.current.stats?.commitCount).toBe(19_488);
+      expect(result.current.loading).toBe(false);
+
+      await act(async () => {
+        delayedCurrent.resolve(project);
+        await delayedCurrent.promise;
+      });
+
+      expect(result.current.stats?.commitCount).toBe(19_488);
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+    });
+
     it("skips the network even when both project-switch and visibility reactivations fire (#10765)", async () => {
       // Production per-view reality: reactivating a backgrounded WebContentsView
       // fires BOTH onProjectSwitch and visibilitychange, each a reactivation

--- a/src/hooks/usePollingLifecycle.ts
+++ b/src/hooks/usePollingLifecycle.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { projectClient } from "@/clients";
+import type { Project } from "@shared/types";
 
 /**
  * Why a fetch fired. Lets a consumer treat a cheap reactivation (tab focus /
@@ -48,10 +49,10 @@ export interface PollingLifecycleConfig {
    */
   calculateNextInterval: (context: { isVisible: boolean }) => number;
   /**
-   * Fires before the post-switch fetch kicks off. The consumer should reset
-   * any per-project state here so the immediate refetch lands cleanly.
+   * Fires before the post-switch fetch kicks off. The target lets consumers
+   * distinguish a cached-view reactivation from a genuine project change.
    */
-  onProjectSwitch?: () => void;
+  onProjectSwitch?: (project?: Project) => void;
   /**
    * When false, the lifecycle is fully inert: no initial fetch, no timer, and
    * no global-trigger subscription — the consumer never registers in the
@@ -72,7 +73,7 @@ interface Subscriber {
   onVisibilityVisible: () => void;
   onVisibilityHidden: () => void;
   onSidebarRefresh: () => void;
-  onProjectSwitch: () => void;
+  onProjectSwitch: (project?: Project) => void;
 }
 
 // Module-level singleton: every consumer of `usePollingLifecycle` shares one
@@ -85,7 +86,7 @@ let visibilityHandler: (() => void) | null = null;
 let sidebarHandler: (() => void) | null = null;
 let projectSwitchCleanup: (() => void) | null = null;
 
-function fanOut(method: keyof Subscriber) {
+function fanOut(method: Exclude<keyof Subscriber, "onProjectSwitch">) {
   // Snapshot to a copy so subscribers can register/unregister inside their
   // own callbacks (defensive — current consumers don't, but the Set
   // iterator's mutation-during-iteration behaviour is undefined).
@@ -102,6 +103,17 @@ function fanOut(method: keyof Subscriber) {
   }
 }
 
+function fanOutProjectSwitch(project?: Project) {
+  const snapshot = Array.from(subscribers);
+  for (const subscriber of snapshot) {
+    try {
+      subscriber.onProjectSwitch(project);
+    } catch (err) {
+      console.warn("usePollingLifecycle: onProjectSwitch subscriber failed", err);
+    }
+  }
+}
+
 function ensureGlobalListenersInstalled() {
   if (visibilityHandler !== null) return;
 
@@ -112,7 +124,7 @@ function ensureGlobalListenersInstalled() {
   // silently missing for the rest of the process lifetime.
   let cleanup: (() => void) | null;
   try {
-    cleanup = projectClient.onSwitch(() => fanOut("onProjectSwitch"));
+    cleanup = projectClient.onSwitch((payload) => fanOutProjectSwitch(payload?.project));
   } catch (err) {
     console.warn("usePollingLifecycle: failed to subscribe project switch", err);
     return;
@@ -339,12 +351,12 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
       onSidebarRefresh: () => {
         void refresh({ force: true });
       },
-      onProjectSwitch: () => {
+      onProjectSwitch: (project) => {
         if (pollTimerRef.current) {
           clearTimeout(pollTimerRef.current);
           pollTimerRef.current = null;
         }
-        configRef.current.onProjectSwitch?.();
+        configRef.current.onProjectSwitch?.(project);
         void callFetchFn(false, "reactivate").then(() => {
           if (aliveRef.current) scheduleNextPoll();
         });

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -224,6 +224,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // earlier epoch's result through. Captured locally before the first `await`
   // in `fetchFn` and re-checked after each await.
   const fetchGenerationRef = useRef(0);
+  const statsProjectPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -241,6 +242,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       if (!mountedRef.current) return;
 
       hasAppliedResultRef.current = true;
+      statsProjectPathRef.current = opts.projectPath;
 
       // A provider-less snapshot — null forge counts and no fetch time — is what
       // main returns when it could not resolve a provider for the repo. When
@@ -490,6 +492,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
             lastUpdatedRef.current = null;
             setLastUpdated(null);
             lastErrorRef.current = null;
+            statsProjectPathRef.current = null;
             resetPollFailures();
           }
           return;
@@ -634,16 +637,23 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         : 1;
       return IDLE_POLL_INTERVAL * multiplier;
     },
-    onProjectSwitch: () => {
+    onProjectSwitch: (project) => {
       // Advance the fetch epoch unconditionally (even while unmounted) so any
       // in-flight fetch from the previous project is discarded when it resolves
       // instead of applying its stats/error to the newly-switched project
       // (issue #10761). This must precede the mounted-guard early return.
       fetchGenerationRef.current += 1;
       if (!mountedRef.current) return;
+      // PROJECT_ON_SWITCH targets the incoming view. A warm cached view still
+      // owns valid stats for that same project, so keep them visible while the
+      // async revalidation runs instead of shrinking the pills back to dashes.
+      if (project?.path === statsProjectPathRef.current && hasAppliedResultRef.current) {
+        return;
+      }
       // Clear preserved counts on project switch to prevent cross-contamination
       lastKnownCountsRef.current = { issueCount: null, prCount: null };
       hasAppliedResultRef.current = false;
+      statsProjectPathRef.current = null;
 
       setStats(null);
       setIsStale(false);


### PR DESCRIPTION
## Summary

- Keep cached repository counts visible when a project-scoped view is reactivated for the same project
- Forward the authoritative project-switch target through the shared polling lifecycle while preserving the full reset for genuine cross-project switches
- Add regression coverage that pauses the async project read and proves the unchanged `19,488` commit count never becomes a dash

## Root cause

PR #11081 correctly persisted issue, pull-request, and commit counts in SQLite, but `useRepositoryStats` still cleared its visible stats synchronously on every `PROJECT_ON_SWITCH` event. A warm project view is revealed before receiving that targeted event, so the commit pill changed from `19,488` to a dash and back after `projectClient.getCurrent()` resolved. The five-digit count also changed the toolbar width, making an unchanged value unusually noticeable.

The hook now tracks which project owns the applied stats. A targeted reactivation for that same path keeps the existing values visible while normal background reconciliation runs; a different target still clears project-scoped state to prevent cross-project leakage.

## Validation

- `npm test -- --run src/hooks/__tests__/useRepositoryStats.test.tsx src/hooks/__tests__/usePollingLifecycle.test.tsx electron/services/__tests__/ProjectStore.repoStats.test.ts src/components/Layout/__tests__/ForgeStatsToolbarButton.freshFetch.test.tsx` — 160 tests passed
- `npm run check`
- `npx playwright test e2e/full/panels/core-forge-stats-lifecycle.spec.ts` — 4 tests passed
