### PR TITLE
fix(terminal): reserve scrollbar width in column math

### DIFF
--- a/src/config/__tests__/xtermConfig.test.ts
+++ b/src/config/__tests__/xtermConfig.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  TERMINAL_SCROLLBAR_WIDTH,
+  calculateTerminalDimensions,
+  getEffectiveScrollbarWidth,
+  getTerminalMetrics,
+  getXtermOptions,
+} from "@/config/xtermConfig";
+
+const APPEARANCE = {
+  fontSize: 12,
+  fontFamily: "monospace",
+  scrollback: 1000,
+  performanceMode: false,
+};
+
+describe("scrollbar gutter (#11095)", () => {
+  it("hands xterm the same gutter the column math reserves", () => {
+    // The bug: getXtermOptions() configured a 15px scrollbar while
+    // calculateTerminalDimensions() divided the *full* container width. Both
+    // must derive from one constant, or the estimate runs wide and the
+    // reconciliation watchdog re-wraps the grid after the agent has painted.
+    expect(getXtermOptions(APPEARANCE).scrollbar?.width).toBe(TERMINAL_SCROLLBAR_WIDTH);
+  });
+
+  describe("getEffectiveScrollbarWidth", () => {
+    // Mirrors FitAddon.proposeDimensions()'s gating exactly. The parity suite in
+    // TerminalResizeController.fitParity.test.ts checks these same cases against
+    // the real FitAddon; these pin the helper on its own.
+    it("reserves the configured width for a scrollable terminal", () => {
+      expect(getEffectiveScrollbarWidth({ scrollback: 1000, scrollbar: { width: 15 } })).toBe(15);
+    });
+
+    it("reserves nothing when the terminal has no scrollback", () => {
+      expect(getEffectiveScrollbarWidth({ scrollback: 0, scrollbar: { width: 15 } })).toBe(0);
+    });
+
+    it("reserves nothing when the scrollbar is explicitly hidden", () => {
+      expect(
+        getEffectiveScrollbarWidth({
+          scrollback: 1000,
+          scrollbar: { width: 15, showScrollbar: false },
+        })
+      ).toBe(0);
+    });
+
+    it("falls back to xterm's own default when no width is configured", () => {
+      // xterm's documented default is 14px — a contract with the library, not
+      // with us. If an upgrade changes it, the FitAddon parity suite fails too.
+      expect(getEffectiveScrollbarWidth({ scrollback: 1000 })).toBe(14);
+    });
+
+    it("honours an explicit zero width rather than treating it as unset", () => {
+      // Guards the `??` — an `||` here would silently widen a deliberately
+      // gutterless terminal back to the 14px default.
+      expect(getEffectiveScrollbarWidth({ scrollback: 1000, scrollbar: { width: 0 } })).toBe(0);
+    });
+  });
+
+  describe("calculateTerminalDimensions", () => {
+    it("round-trips a container sized to hold an exact column count", () => {
+      const { cellWidth, cellHeight } = getTerminalMetrics(APPEARANCE.fontSize);
+      const desiredCols = 80;
+      const desiredRows = 24;
+
+      // Build the container the way the renderer does: room for the columns the
+      // agent should get, *plus* the gutter xterm will steal back. The estimate
+      // must return exactly those columns — not one extra, which is the spawn
+      // that the watchdog later corrects mid-paint.
+      const widthPx = desiredCols * cellWidth + TERMINAL_SCROLLBAR_WIDTH;
+      const heightPx = desiredRows * cellHeight;
+
+      expect(calculateTerminalDimensions(widthPx, heightPx, APPEARANCE.fontSize)).toEqual({
+        cols: desiredCols,
+        rows: desiredRows,
+      });
+    });
+
+    it("reserves the gutter from width only, never from height", () => {
+      const { cellHeight } = getTerminalMetrics(APPEARANCE.fontSize);
+      const desiredRows = 30;
+
+      // A height sized to exactly `desiredRows` cells must yield exactly that
+      // many rows: xterm never reserves the scrollbar against available height,
+      // so subtracting it there would come back a row short.
+      const dims = calculateTerminalDimensions(1200, desiredRows * cellHeight, APPEARANCE.fontSize);
+
+      expect(dims.rows).toBe(desiredRows);
+    });
+
+    it("clamps rather than going negative when the container is thinner than the gutter", () => {
+      const dims = calculateTerminalDimensions(TERMINAL_SCROLLBAR_WIDTH - 1, 400, 12);
+      expect(dims.cols).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/config/__tests__/xtermConfig.test.ts
+++ b/src/config/__tests__/xtermConfig.test.ts
@@ -44,11 +44,12 @@ describe("scrollbar gutter (#11095)", () => {
       ).toBe(0);
     });
 
-    it("falls back to xterm's own default when no width is configured", () => {
-      // xterm's documented default is 14px — a contract with the library, not
-      // with us. If an upgrade changes it, the FitAddon parity suite fails too.
-      expect(getEffectiveScrollbarWidth({ scrollback: 1000 })).toBe(14);
-    });
+    // The unset-width fallback (xterm's own default) is deliberately NOT asserted
+    // against a literal here — that would just copy the constant back out of the
+    // implementation. The "no configured width" case in
+    // TerminalResizeController.fitParity.test.ts pins it against the real
+    // FitAddon, which is the only oracle that can actually catch us drifting from
+    // xterm's default.
 
     it("honours an explicit zero width rather than treating it as unset", () => {
       // Guards the `??` — an `||` here would silently widen a deliberately

--- a/src/config/xtermConfig.ts
+++ b/src/config/xtermConfig.ts
@@ -52,6 +52,40 @@ export const BASE_TERMINAL_OPTIONS = {
 } satisfies Partial<ITerminalOptions>;
 
 /**
+ * Width of xterm's vertical scrollbar / overview ruler, in CSS pixels.
+ *
+ * This is both the width handed to xterm and the gutter every pixel-to-column
+ * conversion must reserve, because `FitAddon.proposeDimensions()` subtracts it
+ * before dividing by the cell width. Deriving both from one constant is what
+ * keeps the two calculations from drifting apart again (#11095).
+ */
+export const TERMINAL_SCROLLBAR_WIDTH = 15;
+
+/** xterm's own fallback when `scrollbar.width` is unset — see `@xterm/addon-fit`. */
+const XTERM_DEFAULT_SCROLLBAR_WIDTH = 14;
+
+/**
+ * CSS pixels `FitAddon` reserves for the scrollbar on a given terminal.
+ *
+ * Mirrors `FitAddon.proposeDimensions()` exactly, including its gating: the
+ * gutter disappears when the terminal has no scrollback or the scrollbar is
+ * explicitly hidden. Manual pixel-to-column math that skips this lands a couple
+ * of columns wider than xterm's own fit, and `TerminalReconciliationWatchdog`
+ * then re-wraps the grid seconds later — after the agent has already painted
+ * (#11095). Read the live `terminal.options` rather than caching, so a terminal
+ * whose scrollback or scrollbar changes mid-life stays in agreement.
+ *
+ * Width only: xterm never reserves the scrollbar against available height.
+ */
+export function getEffectiveScrollbarWidth(
+  options: Pick<ITerminalOptions, "scrollback" | "scrollbar">
+): number {
+  const showScrollbar = options.scrollbar?.showScrollbar ?? true;
+  if (options.scrollback === 0 || !showScrollbar) return 0;
+  return options.scrollbar?.width ?? XTERM_DEFAULT_SCROLLBAR_WIDTH;
+}
+
+/**
  * Get complete xterm options for a terminal instance.
  * This function returns all options needed to create a consistent terminal.
  *
@@ -72,7 +106,7 @@ export function getXtermOptions(config: TerminalAppearanceConfig): ITerminalOpti
     // xterm 6.1 folds the overview ruler into the scrollbar options: setting
     // `scrollbar.width` enables the ruler (search match markers) at that
     // CSS-pixel width.
-    scrollbar: { width: 15 },
+    scrollbar: { width: TERMINAL_SCROLLBAR_WIDTH },
   };
 }
 
@@ -125,6 +159,17 @@ export function getTerminalMetrics(fontSize: number): {
 
 /**
  * Calculate terminal dimensions in columns/rows from pixel dimensions.
+ *
+ * `widthPx` is the raw container width — every caller passes the terminal host's
+ * own box — so the scrollbar gutter is reserved here, exactly as `FitAddon` does
+ * when it later fits the same container. Skipping it spawns the PTY a couple of
+ * columns too wide and the watchdog re-wraps the grid after the agent has
+ * painted its first frame (#11095).
+ *
+ * This stays an estimate: {@link getTerminalMetrics} approximates the cell width
+ * from the font size rather than measuring it, so it can't match `FitAddon` to
+ * the column. Reserving the gutter removes the one error term that is both
+ * systematic and known.
  */
 export function calculateTerminalDimensions(
   widthPx: number,
@@ -132,8 +177,9 @@ export function calculateTerminalDimensions(
   fontSize: number
 ): { cols: number; rows: number } {
   const metrics = getTerminalMetrics(fontSize);
+  const availableWidth = widthPx - TERMINAL_SCROLLBAR_WIDTH;
   return {
-    cols: Math.max(20, Math.min(500, Math.floor(widthPx / metrics.cellWidth))),
+    cols: Math.max(20, Math.min(500, Math.floor(availableWidth / metrics.cellWidth))),
     rows: Math.max(10, Math.min(200, Math.floor(heightPx / metrics.cellHeight))),
   };
 }

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -2,6 +2,7 @@ import { Terminal } from "@xterm/xterm";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import { getEffectiveScrollbarWidth } from "@/config/xtermConfig";
 import { logError, logWarn } from "@/utils/logger";
 import type { ManagedTerminal } from "./types";
 import type { TerminalOutputIngestService } from "./TerminalOutputIngestService";
@@ -62,6 +63,26 @@ export function getXtermCellDimensions(
     // Fall through to null — terminal may not be fully initialized
   }
   return null;
+}
+
+/**
+ * Columns a container of `widthPx` can hold — the manual twin of
+ * `FitAddon.proposeDimensions()`.
+ *
+ * The paths below deliberately compute cols/rows from cached cell metrics rather
+ * than calling `proposeDimensions()`, which reads a DOM that may not reflect the
+ * ResizeObserver dimensions yet. That is why the scrollbar gutter has to be
+ * reserved by hand here: FitAddon reserves it, so a raw `width / cellWidth`
+ * settles a couple of columns wider than xterm's own fit, and
+ * `TerminalReconciliationWatchdog` repairs the difference ~3s later — after the
+ * pane has painted, which corrupts cursor-relative inline TUIs (#11095).
+ *
+ * `Math.max(2, …)` matches FitAddon's floor and absorbs a container narrower
+ * than the gutter itself.
+ */
+function colsForWidth(terminal: Terminal, widthPx: number, cellWidth: number): number {
+  const availableWidth = widthPx - getEffectiveScrollbarWidth(terminal.options);
+  return Math.max(2, Math.floor(availableWidth / cellWidth));
 }
 
 export interface ResizeControllerDeps {
@@ -247,7 +268,7 @@ export class TerminalResizeController {
         return { cols, rows };
       }
 
-      const cols = Math.max(2, Math.floor(width / cellDims.width));
+      const cols = colsForWidth(managed.terminal, width, cellDims.width);
       const rows = Math.max(1, Math.floor(height / cellDims.height));
 
       if (managed.terminal.cols === cols && managed.terminal.rows === rows) {
@@ -332,7 +353,7 @@ export class TerminalResizeController {
     if (!cellDims) {
       return null;
     }
-    const cols = Math.max(2, Math.floor(width / cellDims.width));
+    const cols = colsForWidth(managed.terminal, width, cellDims.width);
     const rows = Math.max(1, Math.floor(height / cellDims.height));
     if (managed.latestCols === cols && managed.latestRows === rows) {
       managed.lastWidth = width;
@@ -446,7 +467,7 @@ export class TerminalResizeController {
     } else {
       const cellDims = getXtermCellDimensions(managed.terminal);
       if (!cellDims) return false;
-      cols = Math.max(2, Math.floor(rect.width / cellDims.width));
+      cols = colsForWidth(managed.terminal, rect.width, cellDims.width);
       rows = Math.max(1, Math.floor(rect.height / cellDims.height));
     }
 

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -321,6 +321,23 @@ export class TerminalResizeController {
       const rows = rowsForHeight(height, cellDims.height);
 
       if (managed.terminal.cols === cols && managed.terminal.rows === rows) {
+        // The grid this box wants is the one xterm is already on, so there is no
+        // reflow to do — but the caches and any queued job may still describe an
+        // OLDER box. `latestCols`/`latestRows` are the deferred-resize target
+        // (applyDeferredResize, forceImmediateResize and flushResize all read
+        // them), and a debounced/idle job captured the geometry of the box that
+        // armed it. A boundary reversal inside the debounce window
+        // (672.1px → 671.9px → 672.1px) queues a 72-column resize and then lands
+        // here with xterm correctly at 73: letting that job fire would drag xterm
+        // AND the PTY down to 72 for a 73-column container — stranding exactly
+        // the column the watchdog then repairs after paint (#11095). Re-point the
+        // target at the truth, and supersede the stale job.
+        managed.latestCols = cols;
+        managed.latestRows = rows;
+        if (this.hasPendingResize(id, managed)) {
+          this.clearResizeJob(managed);
+          this.sendPtyResize(id, cols, rows);
+        }
         return null;
       }
 
@@ -605,6 +622,20 @@ export class TerminalResizeController {
     this.deps.dataBuffer.flushForTerminal(id);
     this.deps.dataBuffer.resetForTerminal(id);
     return true;
+  }
+
+  /**
+   * True while a resize is queued but not yet applied — a debounce timer, an
+   * idle (postTask) job, or a settled-strategy timer. Each carries the geometry
+   * of the box that armed it, so a later resize that supersedes them must know
+   * they exist.
+   */
+  private hasPendingResize(id: string, managed: ManagedTerminal): boolean {
+    return (
+      managed.resizeJob !== undefined ||
+      managed.resizeDebounceTimer !== undefined ||
+      this.settledResizeTimers.has(id)
+    );
   }
 
   clearResizeJob(managed: ManagedTerminal): void {

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -66,14 +66,30 @@ export function getXtermCellDimensions(
 }
 
 /**
+ * A container dimension as `FitAddon` sees it: whole CSS pixels, clamped at zero.
+ *
+ * FitAddon measures through `Math.max(0, parseInt(getComputedStyle(el).width, 10) || 0)`,
+ * which TRUNCATES the fractional pixel a CSS grid or flex track almost always
+ * produces (846.67px → 846). A ResizeObserver `contentRect` and
+ * `getBoundingClientRect()` both report the un-truncated value, so dividing it
+ * raw lands a column — or a row — past xterm's own fit on exactly the sizes our
+ * layout generates. That is the same post-paint watchdog rewrap this fix exists
+ * to remove, one column further out, so normalize to FitAddon's integer view
+ * before dividing OR deduping (#11095).
+ */
+function toFitPx(px: number): number {
+  return Number.isFinite(px) ? Math.max(0, Math.trunc(px)) : 0;
+}
+
+/**
  * Columns a container of `widthPx` can hold — the manual twin of
  * `FitAddon.proposeDimensions()`.
  *
  * The paths below deliberately compute cols/rows from cached cell metrics rather
  * than calling `proposeDimensions()`, which reads a DOM that may not reflect the
- * ResizeObserver dimensions yet. That is why the scrollbar gutter has to be
- * reserved by hand here: FitAddon reserves it, so a raw `width / cellWidth`
- * settles a couple of columns wider than xterm's own fit, and
+ * ResizeObserver dimensions yet. That is why FitAddon's arithmetic has to be
+ * reproduced by hand: it reserves the scrollbar gutter, so a raw
+ * `width / cellWidth` settles a couple of columns wider than xterm's own fit and
  * `TerminalReconciliationWatchdog` repairs the difference ~3s later — after the
  * pane has painted, which corrupts cursor-relative inline TUIs (#11095).
  *
@@ -81,8 +97,35 @@ export function getXtermCellDimensions(
  * than the gutter itself.
  */
 function colsForWidth(terminal: Terminal, widthPx: number, cellWidth: number): number {
-  const availableWidth = widthPx - getEffectiveScrollbarWidth(terminal.options);
+  const availableWidth = toFitPx(widthPx) - getEffectiveScrollbarWidth(terminal.options);
   return Math.max(2, Math.floor(availableWidth / cellWidth));
+}
+
+/**
+ * Rows a container of `heightPx` can hold. The scrollbar is never reserved
+ * against height — FitAddon subtracts it from width alone.
+ */
+function rowsForHeight(heightPx: number, cellHeight: number): number {
+  return Math.max(1, Math.floor(toFitPx(heightPx) / cellHeight));
+}
+
+/**
+ * True when a new pixel box cannot change the grid, so the resize is redundant.
+ *
+ * Deduping on FitAddon's whole-pixel view rather than a `< 1px` tolerance: a
+ * sub-pixel jitter that stays inside one pixel genuinely cannot move the grid,
+ * but one that CROSSES a pixel boundary can (846.9 → 847.1 shifts FitAddon's
+ * truncated width by a pixel, which may cross a cell boundary). The old
+ * tolerance swallowed exactly those, stranding xterm a column behind its
+ * container until the watchdog repaired it after paint — "redundant" and
+ * "stale" are not the same, and only the former is safe to drop (#7762, #11095).
+ * Letting a boundary-crosser through is cheap: when the grid really is
+ * unchanged, the cols/rows dedup downstream returns before anything mutates.
+ */
+function isRedundantResize(managed: ManagedTerminal, width: number, height: number): boolean {
+  return (
+    toFitPx(managed.lastWidth) === toFitPx(width) && toFitPx(managed.lastHeight) === toFitPx(height)
+  );
 }
 
 export interface ResizeControllerDeps {
@@ -201,6 +244,12 @@ export class TerminalResizeController {
       return null;
     }
 
+    // Mirrors resizePtyOnly's guard: a non-finite box would otherwise poison the
+    // pixel cache and deliver a garbage grid to the PTY.
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+      return null;
+    }
+
     const currentTier =
       managed.lastAppliedTier ?? managed.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED;
     // Defer the xterm reflow only when the terminal is genuinely hidden
@@ -215,7 +264,7 @@ export class TerminalResizeController {
     const isBackgroundUnfocused =
       currentTier === TerminalRefreshTier.BACKGROUND && !managed.isFocused && !managed.isVisible;
 
-    if (Math.abs(managed.lastWidth - width) < 1 && Math.abs(managed.lastHeight - height) < 1) {
+    if (isRedundantResize(managed, width, height)) {
       return null;
     }
 
@@ -269,7 +318,7 @@ export class TerminalResizeController {
       }
 
       const cols = colsForWidth(managed.terminal, width, cellDims.width);
-      const rows = Math.max(1, Math.floor(height / cellDims.height));
+      const rows = rowsForHeight(height, cellDims.height);
 
       if (managed.terminal.cols === cols && managed.terminal.rows === rows) {
         return null;
@@ -325,7 +374,7 @@ export class TerminalResizeController {
       managed.pendingBackgroundResize = { width, height };
       return null;
     }
-    if (Math.abs(managed.lastWidth - width) < 1 && Math.abs(managed.lastHeight - height) < 1) {
+    if (isRedundantResize(managed, width, height)) {
       return null;
     }
     const buffer = managed.terminal.buffer.active;
@@ -354,7 +403,7 @@ export class TerminalResizeController {
       return null;
     }
     const cols = colsForWidth(managed.terminal, width, cellDims.width);
-    const rows = Math.max(1, Math.floor(height / cellDims.height));
+    const rows = rowsForHeight(height, cellDims.height);
     if (managed.latestCols === cols && managed.latestRows === rows) {
       managed.lastWidth = width;
       managed.lastHeight = height;
@@ -468,7 +517,7 @@ export class TerminalResizeController {
       const cellDims = getXtermCellDimensions(managed.terminal);
       if (!cellDims) return false;
       cols = colsForWidth(managed.terminal, rect.width, cellDims.width);
-      rows = Math.max(1, Math.floor(rect.height / cellDims.height));
+      rows = rowsForHeight(rect.height, cellDims.height);
     }
 
     // Never re-wrap a main-buffer pane out from under a CLI that is still

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -329,6 +329,42 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
       expect(terminal.rows).toBe(proposal!.rows);
     });
 
+    it("supersedes a queued resize when the box returns to the grid xterm already has", () => {
+      // Boundary reversal inside the debounce window. The container dips to
+      // 671.9px (queuing a 72-column resize), then comes back to 672.1px before
+      // that job fires — where xterm is still correctly at 73. The stale job must
+      // not be allowed to drag xterm and the PTY down to 72 for a 73-column box.
+      const wide = { width: 672.1, height: 360 };
+      const narrow = { width: 671.9, height: 360 };
+      const cell = { width: 9, height: 18 };
+
+      const { managed, terminal, fitAddon } = buildPane(wide, {}, cell);
+      const controller = makeController(managed);
+
+      // Settle xterm on the wide box first.
+      controller.resize("t1", wide.width, wide.height, { immediate: true });
+      const settled = fitAddon.proposeDimensions();
+      expect(terminal.cols).toBe(settled!.cols);
+
+      // Now take the debounced path (unfocused + a long buffer), so the narrow
+      // box only QUEUES its resize rather than applying it.
+      managed.isFocused = false;
+      terminal.buffer.active.length = 300;
+
+      controller.resize("t1", narrow.width, narrow.height);
+      expect(terminal.cols).toBe(settled!.cols); // still queued, not yet applied
+
+      // Reversal: back to the wide box. The grid is already right, so this
+      // returns null — but it must cancel the queued 72-column job.
+      expect(controller.resize("t1", wide.width, wide.height)).toBeNull();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(terminal.cols).toBe(settled!.cols);
+      expect(managed.latestCols).toBe(settled!.cols);
+      expect(resizeMock).not.toHaveBeenCalledWith("t1", 72, expect.anything());
+    });
+
     it("still dedups a jitter that stays inside the same pixel", () => {
       // The other half of the contract: sub-pixel noise that cannot move
       // FitAddon's truncated box must not churn the PTY.

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -68,7 +68,8 @@ function buildPane(
   optionOverrides: {
     scrollback?: number;
     scrollbar?: { width?: number; showScrollbar?: boolean };
-  } = {}
+  } = {},
+  cell: { width: number; height: number } = CELL
 ): Pane {
   // The container FitAddon measures (terminal.element.parentElement) is the same
   // box the ResizeObserver reports to resize() — that equivalence is the whole
@@ -104,7 +105,7 @@ function buildPane(
     ...optionOverrides,
   };
 
-  const cellDims = { css: { cell: { width: CELL.width, height: CELL.height } } };
+  const cellDims = { css: { cell: { width: cell.width, height: cell.height } } };
 
   const terminal = {
     cols: 80,
@@ -258,15 +259,88 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
 
     controller.resize("t1", CONTAINER.width, CONTAINER.height);
 
+    // Seed a prior repair attempt as a REACH WITNESS. The watchdog zeroes this
+    // only on the converged branch, so observing the reset proves the geometry
+    // check actually ran — without it, this test would still pass if some
+    // unrelated gate (hydration lock, visibility, render-pause) short-circuited
+    // the tick before it ever compared the grids.
+    managed.geometryRepairAttempts = 1;
+
     const instances = new Map<string, ManagedTerminal>([["t1", managed]]);
     const deps = makeWatchdogDeps(instances);
     watchdog = new TerminalReconciliationWatchdog(deps);
 
     vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
 
+    expect(managed.geometryRepairAttempts).toBe(0);
     expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
-    expect(managed.geometryRepairAttempts).toBeFalsy();
     expect(managed.lastWatchdogRepairAt).toBeUndefined();
+  });
+
+  describe("fractional layout boxes", () => {
+    // FitAddon reads the container with parseInt(getComputedStyle(...).width),
+    // truncating to whole pixels — while a ResizeObserver contentRect reports the
+    // fractional value a CSS grid/flex track actually produces. Dividing that raw
+    // is a second, subtler way to land off xterm's grid, on both axes.
+    const FRACTIONAL_CONTAINER = { width: 670.25, height: 380.25 };
+    const FRACTIONAL_CELL = { width: 9.1, height: 18.1 };
+
+    it("matches FitAddon on a fractional container with fractional cells", () => {
+      const { managed, terminal, fitAddon } = buildPane(FRACTIONAL_CONTAINER, {}, FRACTIONAL_CELL);
+      const controller = makeController(managed);
+
+      const proposal = fitAddon.proposeDimensions();
+      expect(proposal).toBeDefined();
+
+      const applied = controller.resize(
+        "t1",
+        FRACTIONAL_CONTAINER.width,
+        FRACTIONAL_CONTAINER.height
+      );
+
+      // Both axes: truncation affects rows too, and the watchdog compares both.
+      expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
+      expect(terminal.cols).toBe(proposal!.cols);
+      expect(terminal.rows).toBe(proposal!.rows);
+    });
+
+    it("does not let a sub-pixel resize that crosses a pixel boundary go unapplied", () => {
+      // The dedup hole: 671.9 → 672.1 is a 0.2px change, but FitAddon's truncated
+      // width moves 671 → 672, which crosses a cell boundary and changes the grid.
+      // A `< 1px` tolerance would swallow it and strand xterm a column behind the
+      // container until the watchdog repaired it after paint.
+      const before = { width: 671.9, height: 359.9 };
+      const after = { width: 672.1, height: 360.1 };
+      const cell = { width: 9, height: 18 };
+
+      const { managed, terminal, fitAddon } = buildPane(before, {}, cell);
+      const controller = makeController(managed);
+
+      controller.resize("t1", before.width, before.height);
+
+      // Re-measure the same pane at the new box, exactly as a ResizeObserver would.
+      managed.hostElement.style.width = `${after.width}px`;
+      managed.hostElement.style.height = `${after.height}px`;
+      controller.resize("t1", after.width, after.height);
+
+      const proposal = fitAddon.proposeDimensions();
+      expect(proposal).toBeDefined();
+      expect(terminal.cols).toBe(proposal!.cols);
+      expect(terminal.rows).toBe(proposal!.rows);
+    });
+
+    it("still dedups a jitter that stays inside the same pixel", () => {
+      // The other half of the contract: sub-pixel noise that cannot move
+      // FitAddon's truncated box must not churn the PTY.
+      const { managed } = buildPane({ width: 670.1, height: 360.1 });
+      const controller = makeController(managed);
+
+      controller.resize("t1", 670.1, 360.1);
+      resizeMock.mockClear();
+
+      expect(controller.resize("t1", 670.4, 360.4)).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
   });
 
   it("keeps the PTY-only (backgrounded) path in agreement with FitAddon", () => {
@@ -337,5 +411,26 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
     // on either side — both floor at 2.
     expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
     expect(applied!.cols).toBeGreaterThanOrEqual(2);
+  });
+
+  it("clamps to FitAddon's floor when the container is shorter than one cell", () => {
+    const short = { width: 665, height: 9 };
+    const { managed, fitAddon } = buildPane(short);
+    const controller = makeController(managed);
+
+    const proposal = fitAddon.proposeDimensions();
+    const applied = controller.resize("t1", short.width, short.height);
+
+    expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
+    expect(applied!.rows).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a non-finite box instead of caching a garbage grid", () => {
+    const { managed } = buildPane();
+    const controller = makeController(managed);
+
+    expect(controller.resize("t1", Number.NaN, CONTAINER.height)).toBeNull();
+    expect(managed.latestCols).toBe(80); // untouched seed value
+    expect(resizeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -1,0 +1,341 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FitAddon } from "@xterm/addon-fit";
+import type { Terminal } from "@xterm/xterm";
+import { TerminalRefreshTier } from "@/types";
+
+const { resizeMock } = vi.hoisted(() => ({ resizeMock: vi.fn() }));
+
+vi.mock("@/clients", () => ({
+  terminalClient: { resize: resizeMock },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { TerminalResizeController, type ResizeControllerDeps } from "../TerminalResizeController";
+import {
+  TerminalReconciliationWatchdog,
+  WATCHDOG_INTERVAL_MS,
+  type ReconciliationWatchdogDeps,
+} from "../TerminalReconciliationWatchdog";
+import {
+  __resetSidebarHydrationLockForTests,
+  __resetSidebarLayoutTransitionLockForTests,
+  unlockSidebarHydration,
+} from "@/lib/layoutTransitionLock";
+import { getXtermOptions } from "@/config/xtermConfig";
+import type { ManagedTerminal } from "../types";
+
+/**
+ * Parity between Daintree's manual pixel-to-column math and xterm's own
+ * `FitAddon` (#11095).
+ *
+ * `TerminalResizeController` deliberately computes cols/rows from cached cell
+ * metrics rather than calling `proposeDimensions()`, which reads a DOM that may
+ * not reflect the ResizeObserver dimensions yet. That hand-rolled math has to
+ * stay bug-for-bug identical to FitAddon's, because `TerminalReconciliationWatchdog`
+ * uses FitAddon as its ground truth: any disagreement is a grid it "repairs"
+ * seconds later, after the pane has painted — which is what corrupts the
+ * cursor-relative inline TUIs (the Assistant sidebar) the issue describes.
+ *
+ * So the oracle here is the REAL FitAddon, driven off the REAL production
+ * options (`getXtermOptions()`). Nothing asserts a hardcoded column count: the
+ * assertions are equalities between the two implementations, which is the
+ * property that actually has to hold. Before the fix, the controller floored the
+ * full container width while FitAddon reserved the scrollbar, so these
+ * equalities fail.
+ */
+
+/** Realistic cell metrics for a ~15px monospace font. */
+const CELL = { width: 9, height: 18 };
+
+/** Fits inside jsdom's default 1024x768 viewport, so the watchdog sees it on-screen. */
+const CONTAINER = { width: 665, height: 360 };
+
+interface Pane {
+  managed: ManagedTerminal;
+  terminal: { cols: number; rows: number; resize: ReturnType<typeof vi.fn> };
+  fitAddon: FitAddon;
+}
+
+function buildPane(
+  container: { width: number; height: number } = CONTAINER,
+  optionOverrides: {
+    scrollback?: number;
+    scrollbar?: { width?: number; showScrollbar?: boolean };
+  } = {}
+): Pane {
+  // The container FitAddon measures (terminal.element.parentElement) is the same
+  // box the ResizeObserver reports to resize() — that equivalence is the whole
+  // point, so model it with one element.
+  const hostElement = document.createElement("div");
+  hostElement.style.width = `${container.width}px`;
+  hostElement.style.height = `${container.height}px`;
+  document.body.appendChild(hostElement);
+
+  const termEl = document.createElement("div");
+  hostElement.appendChild(termEl);
+
+  hostElement.getBoundingClientRect = () =>
+    ({
+      width: container.width,
+      height: container.height,
+      top: 10,
+      left: 10,
+      bottom: 10 + container.height,
+      right: 10 + container.width,
+    }) as DOMRect;
+  hostElement.checkVisibility = () => true;
+
+  // Real production options, so the controller and FitAddon read the same
+  // scrollbar/scrollback config a live terminal would be constructed with.
+  const options = {
+    ...getXtermOptions({
+      fontSize: 15,
+      fontFamily: "monospace",
+      scrollback: 1000,
+      performanceMode: false,
+    }),
+    ...optionOverrides,
+  };
+
+  const cellDims = { css: { cell: { width: CELL.width, height: CELL.height } } };
+
+  const terminal = {
+    cols: 80,
+    rows: 24,
+    element: termEl,
+    options,
+    // Public API FitAddon reads.
+    dimensions: cellDims,
+    // Private path getXtermCellDimensions() reads, plus the watchdog's pause probe.
+    _core: { _renderService: { dimensions: cellDims, _isPaused: false } },
+    modes: { synchronizedOutputMode: false },
+    buffer: { active: { baseY: 0, viewportY: 0, length: 10 } },
+    resize: vi.fn(function (this: { cols: number; rows: number }, cols: number, rows: number) {
+      this.cols = cols;
+      this.rows = rows;
+    }),
+    scrollToBottom: vi.fn(),
+    write: vi.fn(),
+  };
+
+  const fitAddon = new FitAddon();
+  fitAddon.activate(terminal as unknown as Terminal);
+
+  const managed = {
+    terminal,
+    fitAddon,
+    hostElement,
+    kind: "terminal",
+    isOpened: true,
+    isVisible: true,
+    isFocused: true,
+    isAttaching: false,
+    isDetached: false,
+    isResizeSuppressed: false,
+    isUserScrolledBack: false,
+    isAltBuffer: false,
+    lastActiveTime: 0,
+    // Zeroed so the pixel dedup gate never suppresses the first resize.
+    lastWidth: 0,
+    lastHeight: 0,
+    lastAttachAt: 0,
+    lastDetachAt: 0,
+    latestCols: 80,
+    latestRows: 24,
+    latestWasAtBottom: true,
+    listeners: [],
+    exitSubscribers: new Set(),
+    agentStateSubscribers: new Set(),
+    altBufferListeners: new Set(),
+    writeChain: Promise.resolve(),
+    restoreGeneration: 0,
+    isSerializedRestoreInProgress: false,
+    deferredOutput: [],
+    scrollbackRestoreState: "none",
+    attachGeneration: 0,
+    attachRevealToken: 0,
+    keyHandlerInstalled: false,
+    ipcListenerCount: 0,
+    lastAppliedTier: TerminalRefreshTier.FOCUSED,
+    getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+    pendingWrites: 0,
+    lastWriteAt: 0,
+  } as unknown as ManagedTerminal;
+
+  return { managed, terminal, fitAddon };
+}
+
+function makeController(managed: ManagedTerminal): TerminalResizeController {
+  return new TerminalResizeController({
+    getInstance: () => managed,
+    dataBuffer: {
+      getQueuedBytes: vi.fn(() => 0),
+      flushForTerminal: vi.fn(),
+      resetForTerminal: vi.fn(),
+      resumeFlush: vi.fn(),
+    } as unknown as ResizeControllerDeps["dataBuffer"],
+  });
+}
+
+function makeWatchdogDeps(instances: Map<string, ManagedTerminal>): ReconciliationWatchdogDeps {
+  return {
+    getInstances: () => instances.entries(),
+    setVisible: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    reassertActiveBackendTier: vi.fn(),
+    getBackendTier: vi.fn(() => "active" as const),
+    getStalledBytes: vi.fn(() => 0),
+    getQueuedBytes: vi.fn(() => 0),
+    resumeFlush: vi.fn(),
+    hasInFlightWake: vi.fn(() => false),
+    hasPendingWake: vi.fn(() => false),
+    isWebGLActive: vi.fn(() => true),
+    shouldHaveWebGL: vi.fn(() => false),
+    ensureWebGL: vi.fn(),
+    forceReflow: vi.fn(),
+    reconcileRevealGeometry: vi.fn(() => true),
+    isStoreBackgrounded: vi.fn(() => false),
+    isStoreHidden: vi.fn(() => false),
+    repairStoreVisibility: vi.fn(),
+  };
+}
+
+describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
+  let watchdog: TerminalReconciliationWatchdog | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    unlockSidebarHydration();
+  });
+
+  afterEach(() => {
+    watchdog?.dispose();
+    watchdog = undefined;
+    document.body.innerHTML = "";
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("sizes a ResizeObserver-driven resize to exactly what FitAddon would propose", () => {
+    const { managed, terminal, fitAddon } = buildPane();
+    const controller = makeController(managed);
+
+    const proposal = fitAddon.proposeDimensions();
+    expect(proposal).toBeDefined();
+
+    // The dimensions a ResizeObserver would hand us for that same box.
+    const applied = controller.resize("t1", CONTAINER.width, CONTAINER.height);
+
+    expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
+    // ...and the grid xterm actually ends up on agrees too, which is what the
+    // watchdog compares against.
+    expect(terminal.cols).toBe(proposal!.cols);
+    expect(terminal.rows).toBe(proposal!.rows);
+    expect(resizeMock).toHaveBeenCalledWith("t1", proposal!.cols, proposal!.rows);
+  });
+
+  it("leaves the reconciliation watchdog with nothing to repair after paint", () => {
+    // The issue's actual symptom: the grid settles a couple of columns wide, the
+    // pane paints, and ~3s later the watchdog re-wraps it underneath a
+    // cursor-relative TUI. With parity there is no divergence to detect.
+    const { managed } = buildPane();
+    const controller = makeController(managed);
+
+    controller.resize("t1", CONTAINER.width, CONTAINER.height);
+
+    const instances = new Map<string, ManagedTerminal>([["t1", managed]]);
+    const deps = makeWatchdogDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(managed.geometryRepairAttempts).toBeFalsy();
+    expect(managed.lastWatchdogRepairAt).toBeUndefined();
+  });
+
+  it("keeps the PTY-only (backgrounded) path in agreement with FitAddon", () => {
+    const { managed, fitAddon } = buildPane();
+    const controller = makeController(managed);
+
+    const proposal = fitAddon.proposeDimensions();
+    const applied = controller.resizePtyOnly("t1", CONTAINER.width, CONTAINER.height);
+
+    expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
+  });
+
+  it("keeps the reveal reconciler's cell-metric fallback in agreement with FitAddon", () => {
+    const { managed, terminal, fitAddon } = buildPane();
+    const proposal = fitAddon.proposeDimensions();
+    expect(proposal).toBeDefined();
+
+    // Force the fallback branch: the renderer hasn't published proposable
+    // dimensions yet, so reconcileGeometryFresh() computes from cell metrics.
+    // It must still land on the grid FitAddon would have chosen.
+    const controller = makeController(managed);
+    managed.fitAddon = {
+      ...fitAddon,
+      proposeDimensions: () => undefined,
+    } as unknown as ManagedTerminal["fitAddon"];
+
+    expect(controller.reconcileGeometryFresh("t1")).toBe(true);
+    expect(terminal.cols).toBe(proposal!.cols);
+    expect(terminal.rows).toBe(proposal!.rows);
+  });
+
+  describe("mirrors FitAddon's scrollbar gating", () => {
+    // FitAddon only reserves the gutter when the terminal can actually scroll
+    // and the scrollbar is shown. Each case is checked against the real addon
+    // rather than against a value we chose.
+    const cases: Array<{
+      name: string;
+      options: { scrollback?: number; scrollbar?: { width?: number; showScrollbar?: boolean } };
+    }> = [
+      { name: "a normal scrollable terminal", options: {} },
+      { name: "no scrollback (gutter collapses)", options: { scrollback: 0 } },
+      { name: "scrollbar explicitly hidden", options: { scrollbar: { showScrollbar: false } } },
+      { name: "no configured width (xterm's default)", options: { scrollbar: {} } },
+    ];
+
+    for (const { name, options } of cases) {
+      it(name, () => {
+        const { managed, fitAddon } = buildPane(CONTAINER, options);
+        const controller = makeController(managed);
+
+        const proposal = fitAddon.proposeDimensions();
+        const applied = controller.resize("t1", CONTAINER.width, CONTAINER.height);
+
+        expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
+      });
+    }
+  });
+
+  it("clamps to FitAddon's floor when the container is thinner than the gutter", () => {
+    const narrow = { width: 10, height: 360 };
+    const { managed, fitAddon } = buildPane(narrow);
+    const controller = makeController(managed);
+
+    const proposal = fitAddon.proposeDimensions();
+    const applied = controller.resize("t1", narrow.width, narrow.height);
+
+    // Negative available width must not produce a negative or zero column count
+    // on either side — both floor at 2.
+    expect(applied).toEqual({ cols: proposal!.cols, rows: proposal!.rows });
+    expect(applied!.cols).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -59,7 +59,12 @@ const CONTAINER = { width: 665, height: 360 };
 
 interface Pane {
   managed: ManagedTerminal;
-  terminal: { cols: number; rows: number; resize: ReturnType<typeof vi.fn> };
+  terminal: {
+    cols: number;
+    rows: number;
+    resize: ReturnType<typeof vi.fn>;
+    buffer: { active: { baseY: number; viewportY: number; length: number } };
+  };
   fitAddon: FitAddon;
 }
 

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -27,11 +27,41 @@ import {
   RESIZE_FLUSH_SYNC_BUDGET_BYTES,
   type ResizeControllerDeps,
 } from "../TerminalResizeController";
+import { TERMINAL_SCROLLBAR_WIDTH } from "@/config/xtermConfig";
+
+/**
+ * The scrollbar gutter the controller reserves before dividing a container width
+ * into columns, mirroring `FitAddon` (#11095). Sourced from the config rather
+ * than hardcoded so a change to the configured width doesn't silently desync the
+ * mock terminal from the production one.
+ */
+const SCROLLBAR_PX = TERMINAL_SCROLLBAR_WIDTH;
+
+/** Cell metrics these tests attach via `_core` (see `getXtermCellDimensions`). */
+const CELL = { width: 10, height: 20 };
+
+/**
+ * Columns the controller should derive for a container of `widthPx`.
+ *
+ * These suites exercise the resize *control flow* — dedup gates, debounce, lock
+ * replay, PTY delivery — so they take the column formula as given and assert
+ * against it. The formula itself is verified against a genuinely independent
+ * oracle (the real `FitAddon`) in `TerminalResizeController.fitParity.test.ts`.
+ */
+const colsFor = (widthPx: number): number =>
+  Math.max(2, Math.floor((widthPx - SCROLLBAR_PX) / CELL.width));
 
 function createManagedTerminal() {
   const terminal = {
     cols: 80,
     rows: 24,
+    // Mirrors getXtermOptions(): a live terminal always has scrollback and a
+    // visible scrollbar, so the controller reserves SCROLLBAR_PX of every
+    // container width before dividing into columns — same as FitAddon (#11095).
+    options: {
+      scrollback: 1000,
+      scrollbar: { width: SCROLLBAR_PX },
+    },
     buffer: {
       active: {
         baseY: 0,
@@ -48,6 +78,7 @@ function createManagedTerminal() {
   } as unknown as {
     cols: number;
     rows: number;
+    options: { scrollback: number; scrollbar: { width: number } };
     buffer: { active: { baseY: number; viewportY: number; length: number } };
     resize: ReturnType<typeof vi.fn>;
     write: ReturnType<typeof vi.fn>;
@@ -144,13 +175,15 @@ describe("TerminalResizeController", () => {
     });
 
     const result = controller.resize("term-1", 1600, 800);
-    expect(result).toEqual({ cols: 160, rows: 40 });
+    expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
     expect(managed.fitAddon.fit).not.toHaveBeenCalled();
     // Buffer reflow is deferred to wake — xterm.resize() must NOT fire while paint is paused.
     expect(managed.terminal.resize).not.toHaveBeenCalled();
-    expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
-    expect(managed.latestCols).toBe(160);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+    expect(managed.latestCols).toBe(colsFor(1600));
     expect(managed.latestRows).toBe(40);
+    // The pixel dedup cache still tracks the RAW container width — the scrollbar
+    // is reserved when dividing into columns, never folded into this gate.
     expect(managed.lastWidth).toBe(1600);
     expect(managed.lastHeight).toBe(800);
   });
@@ -241,7 +274,7 @@ describe("TerminalResizeController", () => {
 
     vi.advanceTimersByTime(500);
     expect(resizeMock).toHaveBeenCalledTimes(1);
-    expect(resizeMock).toHaveBeenCalledWith("term-1", 170, 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1700), 40);
   });
 
   it("background-tier resize reflows xterm when the terminal is visible", () => {
@@ -270,10 +303,10 @@ describe("TerminalResizeController", () => {
     });
 
     const result = controller.resize("term-1", 1600, 800, { immediate: true });
-    expect(result).toEqual({ cols: 160, rows: 40 });
+    expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
     // Visible terminal: xterm's grid is reflowed, not deferred to wake.
-    expect(managed.terminal.resize).toHaveBeenCalledWith(160, 40);
-    expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1600), 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
   });
 
   it("flushes and resets ingest buffers before applying resize", () => {
@@ -1117,7 +1150,8 @@ describe("TerminalResizeController", () => {
 
     it("postTask callback applies resize and clears resizeJob", async () => {
       const managed = createManagedTerminal();
-      attachCellDims(managed); // width:10, height:20 → 1200/10=120 cols, 900/20=45 rows
+      // width:10, height:20 → (1200-15)/10 = 118 cols (scrollbar reserved), 900/20 = 45 rows
+      attachCellDims(managed);
       managed.isFocused = false;
       managed.isVisible = false;
       managed.terminal.buffer.active.length = 300;
@@ -1135,7 +1169,7 @@ describe("TerminalResizeController", () => {
 
       expect(managed.resizeJob).toBeUndefined();
       expect(dataBuffer.flushForTerminal).toHaveBeenCalledWith("term-1");
-      expect(managed.terminal.resize).toHaveBeenCalledWith(120, 45);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1200), 45);
     });
   });
 
@@ -1171,10 +1205,10 @@ describe("TerminalResizeController", () => {
 
       const result = controller.resize("term-1", 1000, 500);
 
-      expect(result).toEqual({ cols: 100, rows: 25 });
+      expect(result).toEqual({ cols: colsFor(1000), rows: 25 });
       expect(managed.fitAddon.fit).not.toHaveBeenCalled();
-      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 25);
-      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 25);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1000), 25);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1000), 25);
     });
 
     it("falls back to fitAddon.fit() when cell dims are null", () => {
@@ -1305,11 +1339,11 @@ describe("TerminalResizeController", () => {
       const controller = makeController(managed);
       const result = controller.resizePtyOnly("term-1", 1600, 800);
 
-      expect(result).toEqual({ cols: 160, rows: 40 });
+      expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
       expect(managed.terminal.resize).not.toHaveBeenCalled();
       expect(managed.fitAddon.fit).not.toHaveBeenCalled();
-      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
-      expect(managed.latestCols).toBe(160);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+      expect(managed.latestCols).toBe(colsFor(1600));
       expect(managed.latestRows).toBe(40);
       expect(managed.lastWidth).toBe(1600);
       expect(managed.lastHeight).toBe(800);
@@ -1357,12 +1391,19 @@ describe("TerminalResizeController", () => {
       controller.resizePtyOnly("term-1", 1600, 800);
       expect(resizeMock).toHaveBeenCalledTimes(1);
 
-      // +5px is under one 10px cell — same cols/rows, but the cache must
-      // track the new pixels so the next delta computes against them.
-      const second = controller.resizePtyOnly("term-1", 1605, 800);
+      // Grow the container to the widest pixel that still yields the same column
+      // count — under one cell, so cols/rows don't move, but the cache must
+      // track the new pixels so the next delta computes against them. Derived
+      // from the gutter rather than hardcoded: now that the scrollbar is
+      // reserved before the division (#11095), a fixed "+5px" would cross a cell
+      // boundary and silently stop testing the dedup path it was written for.
+      const subCellWidth = 1600 + (CELL.width - 1 - ((1600 - SCROLLBAR_PX) % CELL.width));
+      expect(colsFor(subCellWidth)).toBe(colsFor(1600));
+
+      const second = controller.resizePtyOnly("term-1", subCellWidth, 800);
       expect(second).toBeNull();
       expect(resizeMock).toHaveBeenCalledTimes(1);
-      expect(managed.lastWidth).toBe(1605);
+      expect(managed.lastWidth).toBe(subCellWidth);
     });
 
     it("returns null without poisoning the dedup cache when cell dims are unavailable", () => {
@@ -1405,10 +1446,10 @@ describe("TerminalResizeController", () => {
       const controller = makeController(managed);
       const result = controller.resizePtyOnly("term-1", 1600, 800);
 
-      expect(result).toEqual({ cols: 160, rows: 40 });
+      expect(result).toEqual({ cols: colsFor(1600), rows: 40 });
       // Direct delivery — not deferred behind the settled 500ms timer, which
       // would also reflow xterm in a hidden (possibly frozen) renderer.
-      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
 
       vi.advanceTimersByTime(500);
       expect(managed.terminal.resize).not.toHaveBeenCalled();
@@ -1432,7 +1473,7 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).not.toHaveBeenCalled();
 
       controller.resizePtyOnly("term-1", 1600, 800);
-      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
 
       vi.advanceTimersByTime(500);
       // The stale timer must not fire its 120x30 resize or reflow xterm.
@@ -1648,7 +1689,9 @@ describe("TerminalResizeController", () => {
 
     it("falls back to cell-metric math when no proposable dimensions exist", () => {
       const managed = createManagedTerminal();
-      // host box is 1000x700; cell is 10x20 → 100 cols x 35 rows.
+      // host box is 1000x700; cell is 10x20 → (1000-15)/10 = 98 cols x 35 rows.
+      // The fallback reserves the same scrollbar gutter the primary
+      // proposeDimensions() branch would, so the two agree (#11095).
       managed.fitAddon.proposeDimensions = vi.fn(() => undefined);
       Object.assign(managed.terminal, {
         _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
@@ -1658,8 +1701,8 @@ describe("TerminalResizeController", () => {
       const ok = controller.reconcileGeometryFresh("term-1");
 
       expect(ok).toBe(true);
-      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 35);
-      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 35);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(colsFor(1000), 35);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1000), 35);
     });
 
     it("returns false (retry next frame) when the box is not measurable yet", () => {
@@ -1753,7 +1796,7 @@ describe("TerminalResizeController", () => {
       controller.lockResize("term-1", false);
 
       // The held geometry is delivered to the PTY once on unlock, stash cleared.
-      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
       expect(managed.pendingBackgroundResize).toBeUndefined();
     });
 


### PR DESCRIPTION
## Summary

Daintree's manual pixel-to-column math disagreed with xterm's `FitAddon` on every terminal, because `FitAddon` reserves the configured 15px scrollbar before dividing while our math floored the full container width. `TerminalReconciliationWatchdog` treats `FitAddon` as ground truth, so it corrected the grid about 3 seconds after paint, which visibly corrupted cursor-relative inline TUIs like the Assistant sidebar (they'd render, then re-wrap once the watchdog fired).

This closes three separate divergences between our math and `FitAddon`, all found while chasing the same symptom.

Resolves #11095

## Changes

**1. Scrollbar gutter (the reported bug).** Added `TERMINAL_SCROLLBAR_WIDTH` and `getEffectiveScrollbarWidth()` to `src/config/xtermConfig.ts`, so one source of truth feeds both the width handed to xterm and the width the column math reserves. Root cause: `37ff040e4` introduced the raw division, then `9cd995a9d` set the scrollbar to 15px without touching any of the column sites. The helper mirrors `FitAddon`'s own gating exactly (no gutter when scrollback is 0 or the scrollbar is hidden, xterm's 14px default when unset) and reads live `terminal.options` rather than a cached value. Applied at all four conversion sites: `calculateTerminalDimensions` (prewarm), `resize()`, `resizePtyFromCachedCellMetrics()` (background and PTY-only), and `reconcileGeometryFresh()`'s cell-metric fallback. Width only, rows never reserve the gutter.

**2. Fractional truncation (found in review).** `FitAddon` measures via `parseInt(getComputedStyle(el).width)`, so it works in whole pixels. We were dividing the raw fractional value a `ResizeObserver` `contentRect` reports, and CSS grid tracks are fractional far more often than not, so the grid still landed a column, or a row, past where `FitAddon` itself would fit. Added `toFitPx()` and routed both columns and rows through it.

**3. Sub-pixel dedup hole (found in review).** `resize()` skipped updates when `|Δwidth| < 1px`, but something like 671.9 to 672.1 is only a 0.2px change that can cross a pixel boundary, and it's exactly that boundary `FitAddon`'s truncated width treats as real. The gate was swallowing exactly the changes that mattered. It now dedups on the truncated box instead of the raw one.

Also fixed: a queued debounce/settled job could fire with stale geometry after a boundary value reverses twice in a row (672.1 → 671.9 → 672.1), dragging xterm off a grid that was already correct. The early return now supersedes any such queued job. `resize()` also rejects a non-finite box, mirroring a guard `resizePtyOnly` already had.

## Testing

The headline regression test drives the real `FitAddon` as an independent oracle, no hardcoded column counts, just equality assertions between the two implementations. It then runs a real `TerminalReconciliationWatchdog` tick and asserts it finds nothing to repair, with a seeded repair attempt included as a reach witness proving the geometry-comparison branch actually ran.

Each fix was validated red before green: reverted the production change, confirmed the corresponding test failed (e.g. the controller computing 73 columns against `FitAddon`'s 72, or the watchdog firing `reconcileRevealGeometry` once), then reintroduced the fix.

Files: `src/config/xtermConfig.ts`, `src/services/terminal/TerminalResizeController.ts` (production); `src/config/__tests__/xtermConfig.test.ts` (new), `src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts` (new), `src/services/terminal/__tests__/TerminalResizeController.test.ts` (updated).

Locally: 197 targeted tests pass across `TerminalResizeController`, `fitParity`, `xtermConfig`, `TerminalReconciliationWatchdog`, `addPanelSpawnDims`, and `TerminalInstanceService` `fullWake`/`postWake`. ESLint clean, Prettier clean, `tsc` clean on changed files.

**Known limitation:** a mid-life scrollback → 0 change wouldn't invalidate the cached pixel measurement, since a same-size resize skips re-reading terminal options. Deferring this, it needs a change in `TerminalInstanceService.updateOptions`, and no live code path currently sets scrollback to 0 (`getScrollbackForType` floors at 200/500).