### PR TITLE
Coordinate agent terminal resizing

### DIFF
--- a/e2e/full/terminal/core-terminal-divider-resize.spec.ts
+++ b/e2e/full/terminal/core-terminal-divider-resize.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { getGridPanelIds } from "../../helpers/panels";
+import { T_LONG, T_SHORT } from "../../helpers/timeouts";
+import { spawnTerminalAndVerify } from "../../helpers/workflows";
+
+type TerminalGeometry = {
+  cols: number;
+  rows: number;
+  proposedCols: number;
+  proposedRows: number;
+  ptyCols: number | null;
+  ptyRows: number | null;
+};
+
+let ctx: AppContext;
+let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
+
+async function getTerminalGeometry(page: Page, panelId: string): Promise<TerminalGeometry | null> {
+  return page.evaluate(async (id) => {
+    const target = window as unknown as {
+      __daintreeProposeTerminalDimensions?: (terminalId: string) => {
+        cols: number;
+        rows: number;
+        proposedCols: number;
+        proposedRows: number;
+      } | null;
+      electron?: {
+        terminal?: {
+          getInfo?: (terminalId: string) => Promise<{ ptyCols?: number; ptyRows?: number } | null>;
+        };
+      };
+    };
+    const renderer = target.__daintreeProposeTerminalDimensions?.(id) ?? null;
+    const pty = (await target.electron?.terminal?.getInfo?.(id)) ?? null;
+    if (!renderer || !pty) return null;
+    return {
+      ...renderer,
+      ptyCols: pty.ptyCols ?? null,
+      ptyRows: pty.ptyRows ?? null,
+    };
+  }, panelId);
+}
+
+function isConverged(geometry: TerminalGeometry | null): boolean {
+  return (
+    geometry !== null &&
+    geometry.cols > 1 &&
+    geometry.rows > 1 &&
+    geometry.cols === geometry.proposedCols &&
+    geometry.rows === geometry.proposedRows &&
+    geometry.cols === geometry.ptyCols &&
+    geometry.rows === geometry.ptyRows
+  );
+}
+
+async function waitForConvergence(page: Page, panelIds: string[]): Promise<TerminalGeometry[]> {
+  await expect
+    .poll(
+      async () => {
+        const geometries = await Promise.all(
+          panelIds.map((panelId) => getTerminalGeometry(page, panelId))
+        );
+        return geometries.every(isConverged);
+      },
+      { timeout: T_LONG, intervals: [100, 250, 500] }
+    )
+    .toBe(true);
+
+  const geometries = await Promise.all(
+    panelIds.map((panelId) => getTerminalGeometry(page, panelId))
+  );
+  expect(geometries.every(isConverged)).toBe(true);
+  return geometries as TerminalGeometry[];
+}
+
+test.describe.serial("Terminal divider resize coordination", () => {
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({ name: "divider-resize" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Divider Resize");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("holds both grids past the lock TTL and watchdog tick, then converges", async () => {
+    test.setTimeout(6 * T_LONG);
+    const { window } = ctx;
+
+    await spawnTerminalAndVerify(window);
+    await spawnTerminalAndVerify(window);
+
+    const panelIds = await getGridPanelIds(window);
+    expect(panelIds).toHaveLength(2);
+
+    const divider = window.getByRole("separator", { name: "Resize panels" });
+    await expect(divider).toBeVisible({ timeout: T_LONG });
+
+    const baseline = await waitForConvergence(window, panelIds);
+    const gridBox = await window.locator('[data-grid-container="true"]').boundingBox();
+    const dividerBox = await divider.boundingBox();
+    expect(gridBox).not.toBeNull();
+    expect(dividerBox).not.toBeNull();
+
+    const startX = dividerBox!.x + dividerBox!.width / 2;
+    const y = dividerBox!.y + dividerBox!.height / 2;
+    const targetX = gridBox!.x + gridBox!.width * 0.66;
+    const baselineGrids = baseline.map(({ cols, rows, ptyCols, ptyRows }) => ({
+      cols,
+      rows,
+      ptyCols,
+      ptyRows,
+    }));
+
+    await window.mouse.move(startX, y);
+    await window.mouse.down();
+    let released = false;
+    try {
+      await window.mouse.move(targetX, y, { steps: 8 });
+
+      await expect
+        .poll(
+          async () => {
+            const geometries = await Promise.all(
+              panelIds.map((panelId) => getTerminalGeometry(window, panelId))
+            );
+            return geometries.every(
+              (geometry, index) =>
+                geometry !== null &&
+                geometry.cols === baselineGrids[index]!.cols &&
+                geometry.rows === baselineGrids[index]!.rows &&
+                geometry.ptyCols === baselineGrids[index]!.ptyCols &&
+                geometry.ptyRows === baselineGrids[index]!.ptyRows &&
+                geometry.proposedCols !== geometry.cols
+            );
+          },
+          { timeout: T_SHORT, intervals: [50, 100, 250] }
+        )
+        .toBe(true);
+
+      // The controller's dead-man lock expires after 5s and the watchdog ticks
+      // every 3s. Holding for more than their sum proves the gesture re-arm owns
+      // the grid throughout, regardless of the watchdog's interval phase.
+      await window.waitForTimeout(8_250);
+
+      const held = await Promise.all(
+        panelIds.map((panelId) => getTerminalGeometry(window, panelId))
+      );
+      expect(
+        held.map((geometry) =>
+          geometry
+            ? {
+                cols: geometry.cols,
+                rows: geometry.rows,
+                ptyCols: geometry.ptyCols,
+                ptyRows: geometry.ptyRows,
+              }
+            : null
+        )
+      ).toEqual(baselineGrids);
+      expect(held.every((geometry) => geometry && geometry.proposedCols !== geometry.cols)).toBe(
+        true
+      );
+      const heldProposals = held.map((geometry) => ({
+        cols: geometry!.proposedCols,
+        rows: geometry!.proposedRows,
+      }));
+
+      await window.mouse.up();
+      released = true;
+
+      const final = await waitForConvergence(window, panelIds);
+      expect(final.map(({ cols, rows }) => ({ cols, rows }))).toEqual(heldProposals);
+    } finally {
+      if (!released) await window.mouse.up().catch(() => undefined);
+    }
+  });
+});

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -74,6 +74,21 @@ describe("agentRegistry", () => {
       }
     });
 
+    it("requires every built-in agent to declare its resize policy", () => {
+      for (const id of BUILT_IN_AGENT_IDS) {
+        expect(
+          getAgentConfig(id)?.capabilities?.resizeStrategy,
+          `${id} must choose a resize strategy explicitly`
+        ).toBeDefined();
+      }
+    });
+
+    it("settles sticky inline assistants before changing their terminal grid", () => {
+      for (const id of ["codex", "daintree-assistant"]) {
+        expect(getAgentConfig(id)?.capabilities?.resizeStrategy).toBe("settled");
+      }
+    });
+
     it("returns agent config for built-in agents", () => {
       const claude = getAgentConfig("claude");
       expect(claude).toBeDefined();

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -397,6 +397,7 @@ export interface AgentConfig {
     scrollback?: number;
     blockAltScreen?: boolean;
     blockMouseReporting?: boolean;
+    /** Use `settled` for sticky cursor-relative TUIs that should receive one stable final grid. */
     resizeStrategy?: "default" | "settled";
     /** CLI flag to disable alt-screen and use inline rendering (e.g., "--no-alt-screen") */
     inlineModeFlag?: string;

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -75,6 +75,7 @@ export const config: AgentConfig = {
   contextWindow: 200_000,
   capabilities: {
     scrollback: 10000,
+    resizeStrategy: "default",
     supportsBracketedPaste: true,
     softNewlineSequence: "\x1b\r",
     ignoredInputSequences: ["\x1b\r"],

--- a/shared/config/agents/daintree-assistant.ts
+++ b/shared/config/agents/daintree-assistant.ts
@@ -19,6 +19,9 @@ export const config: AgentConfig = {
     args: ["--version"],
     npmPackage: "@daintreehq/daintree-assistant",
   },
+  capabilities: {
+    resizeStrategy: "settled",
+  },
   supports: {
     // The assistant connects over MCP via env vars it reads itself
     // (`DAINTREE_MCP_URL`, `DAINTREE_MCP_TOKEN`, `DAINTREE_PROJECT_ID`,

--- a/shared/config/agents/goose.ts
+++ b/shared/config/agents/goose.ts
@@ -74,6 +74,7 @@ export const config: AgentConfig = {
   capabilities: {
     scrollback: 10000,
     blockAltScreen: false,
+    resizeStrategy: "default",
     supportsBracketedPaste: true,
     softNewlineSequence: "\n",
     ignoredInputSequences: ["\n", "\x1b\r"],

--- a/shared/config/agents/grok.ts
+++ b/shared/config/agents/grok.ts
@@ -72,6 +72,7 @@ export const config: AgentConfig = {
   contextWindow: 200_000,
   capabilities: {
     scrollback: 10000,
+    resizeStrategy: "default",
     // Rust TUI that takes over the alternate screen. We keep it ON the alt
     // screen by default: forcing it inline (--no-alt-screen) renders every frame
     // into the normal-buffer scrollback, so scrolling up shows garbled overdrawn

--- a/shared/config/agents/kiro.ts
+++ b/shared/config/agents/kiro.ts
@@ -41,6 +41,7 @@ export const config: AgentConfig = {
   },
   capabilities: {
     scrollback: 10000,
+    resizeStrategy: "default",
     supportsBracketedPaste: true,
     softNewlineSequence: "\x1b\r",
     ignoredInputSequences: ["\x1b\r"],

--- a/shared/config/agents/opencode.ts
+++ b/shared/config/agents/opencode.ts
@@ -86,6 +86,7 @@ export const config: AgentConfig = {
   capabilities: {
     scrollback: 10000,
     blockAltScreen: false,
+    resizeStrategy: "default",
     supportsBracketedPaste: true,
     softNewlineSequence: "\n",
     ignoredInputSequences: ["\n", "\x1b\r"],

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -39,6 +39,7 @@ export function TwoPaneSplitLayout({
   const [localRatio, setLocalRatio] = useState<number | null>(null);
   const [isDraggingDivider, setIsDraggingDivider] = useState(false);
   const isDraggingDividerRef = useRef(false);
+  const dragLockedIdsRef = useRef<string[]>([]);
   useEffect(() => {
     isDraggingDividerRef.current = isDraggingDivider;
   }, [isDraggingDivider]);
@@ -238,13 +239,40 @@ export function TwoPaneSplitLayout({
     (dragging: boolean) => {
       setIsDraggingDivider(dragging);
 
-      // Lock/unlock terminal resizing to prevent xterm from reacting to size changes during drag
-      for (const terminal of terminals) {
-        terminalInstanceService.lockResize(terminal.id, dragging);
+      if (dragging) {
+        const ids = terminals.map((terminal) => terminal.id);
+        dragLockedIdsRef.current = ids;
+        for (const id of ids) {
+          terminalInstanceService.lockResize(id, true);
+        }
+      } else {
+        const ids = dragLockedIdsRef.current;
+        // Clear gesture ownership before unlocking so an already-queued re-arm
+        // frame cannot restore the lock after drag end.
+        dragLockedIdsRef.current = [];
+        for (const id of ids) {
+          terminalInstanceService.lockResize(id, false);
+        }
+        if (ids.length > 0) {
+          terminalInstanceService.runResizePass(ids);
+        }
       }
     },
     [terminals]
   );
+
+  useEffect(() => {
+    if (!isDraggingDivider) return;
+    let rafId = 0;
+    const rearm = () => {
+      for (const id of dragLockedIdsRef.current) {
+        terminalInstanceService.lockResize(id, true);
+      }
+      rafId = requestAnimationFrame(rearm);
+    };
+    rafId = requestAnimationFrame(rearm);
+    return () => cancelAnimationFrame(rafId);
+  }, [isDraggingDivider]);
 
   // Cleanup: unlock resize and flush pending ratio on unmount only
   useEffect(() => {
@@ -253,9 +281,10 @@ export function TwoPaneSplitLayout({
       const pendingRatio = localRatioRef.current;
       const worktreeId = activeWorktreeIdRef.current;
 
-      // Unlock resize for all terminals
-      for (const terminal of terminalsRef.current) {
-        terminalInstanceService.lockResize(terminal.id, false);
+      const lockedIds = dragLockedIdsRef.current;
+      dragLockedIdsRef.current = [];
+      for (const id of lockedIds) {
+        terminalInstanceService.lockResize(id, false);
       }
 
       // Flush pending ratio if present
@@ -298,32 +327,22 @@ export function TwoPaneSplitLayout({
   // Track previous drag state to detect drag end
   const wasDraggingRef = useRef(false);
 
-  // Fit terminals after resize, but skip during drag to avoid feedback loops
+  // Resize terminals after non-drag layout changes. Drag end owns its final
+  // pass in handleDragStateChange so pending ownership starts synchronously
+  // with the unlock and the watchdog cannot race the settled geometry.
   useEffect(() => {
     const wasDragging = wasDraggingRef.current;
     wasDraggingRef.current = isDraggingDivider;
 
-    // Don't fit during drag - wait for drag to end
-    if (isDraggingDivider) return;
+    if (isDraggingDivider || wasDragging) return;
 
-    // Use longer delay after drag ends to let layout fully stabilize
-    const delay = wasDragging ? 100 : 50;
-
-    const timeoutId = window.setTimeout(() => {
-      for (const terminal of terminals) {
-        const managed = terminalInstanceService.get(terminal.id);
-        if (managed?.hostElement.isConnected) {
-          terminalInstanceService.fit(terminal.id);
-        }
-      }
-    }, delay);
-
-    return () => clearTimeout(timeoutId);
+    terminalInstanceService.scheduleBatchResize(panelIds);
+    return undefined;
     // `leftWidth`/`rightWidth` are now ratio-derived calc() strings, so they no
     // longer change on container resize — depend on `clampedRatio` (ratio drags,
     // double-click reset) and `containerWidth` (container/sidebar reflow) so
     // terminals still re-fit on both.
-  }, [clampedRatio, containerWidth, terminals, isDraggingDivider]);
+  }, [clampedRatio, containerWidth, panelIds, isDraggingDivider]);
 
   return (
     <>

--- a/src/components/Terminal/__tests__/twoPaneSplitLayout.sidebar.test.ts
+++ b/src/components/Terminal/__tests__/twoPaneSplitLayout.sidebar.test.ts
@@ -81,3 +81,41 @@ describe("TwoPaneSplitLayout hydration lock gating (issue #10827)", () => {
     expect(content).toContain("subscribeSidebarHydrationUnlock(");
   });
 });
+
+describe("TwoPaneSplitLayout coordinated terminal resize", () => {
+  it("unlocks into one tracked final resize pass without calling raw fit", async () => {
+    const content = await readFile(LAYOUT_PATH, "utf-8");
+
+    expect(content).not.toContain("terminalInstanceService.fit(");
+    expect(content).toMatch(
+      /dragLockedIdsRef\.current = \[\][\s\S]{0,220}lockResize\(id, false\)[\s\S]{0,180}runResizePass\(ids\)/
+    );
+  });
+
+  it("re-arms gesture-owned locks and clears ownership before drag-end unlock", async () => {
+    const content = await readFile(LAYOUT_PATH, "utf-8");
+
+    expect(content).toContain("dragLockedIdsRef");
+    expect(content).toMatch(
+      /const rearm = \(\) => \{[\s\S]{0,220}lockResize\(id, true\)[\s\S]{0,120}requestAnimationFrame\(rearm\)/
+    );
+    expect(content).toMatch(/dragLockedIdsRef\.current = \[\][\s\S]{0,220}lockResize\(id, false\)/);
+  });
+
+  it("registers non-drag layout work with the batch scheduler immediately", async () => {
+    const content = await readFile(LAYOUT_PATH, "utf-8");
+
+    expect(content).toContain("terminalInstanceService.scheduleBatchResize(panelIds)");
+  });
+
+  it("unmount cleanup releases only gesture-owned terminal locks", async () => {
+    const content = await readFile(LAYOUT_PATH, "utf-8");
+    const cleanupStart = content.indexOf("// Cleanup: unlock resize");
+    const cleanupEnd = content.indexOf("const minRatio", cleanupStart);
+    const cleanup = content.slice(cleanupStart, cleanupEnd);
+
+    expect(cleanup).toContain("const lockedIds = dragLockedIdsRef.current");
+    expect(cleanup).toMatch(/for \(const id of lockedIds\)[\s\S]*lockResize\(id, false\)/);
+    expect(cleanup).not.toContain("terminalsRef.current.map");
+  });
+});

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -43,7 +43,6 @@ import {
 } from "./TerminalListenerInstaller";
 import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackController";
 import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
-import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { isPtyPanel } from "@shared/types/panel";
 import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
@@ -311,6 +310,10 @@ class TerminalInstanceService {
       // stalled-byte flush guard is therefore never blocked by one.
       hasInFlightWake: () => false,
       hasPendingWake: () => false,
+      isResizeTransitioning: (id) =>
+        this.resizeController.isResizeLocked(id) ||
+        this.resizeController.hasPendingResize(id) ||
+        this.resizePassScheduler.isResizePending(id),
       isWebGLActive: (id) => this.webGLManager.isActive(id),
       shouldHaveWebGL: (managed) => this.webGLPolicy.shouldHaveActiveWebGL(managed),
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
@@ -906,7 +909,6 @@ class TerminalInstanceService {
     const terminalOptions = {
       ...options,
       rescaleOverlappingGlyphs: true,
-      reflowCursorLine: true,
       linkHandler: {
         activate: (event: MouseEvent, text: string) => openLink(text, event),
         hover: (_event: MouseEvent, text: string, range: IBufferRange) => {
@@ -1667,15 +1669,13 @@ class TerminalInstanceService {
   }
 
   /**
-   * Cancel a panel's pending resize job and debounce timer *without* applying
-   * it. Used on optimistic close: `flushResize` would force-drain queued
-   * output and reflow scrollback synchronously inside the close click, but the
-   * pending job still has to be cleared so no stale resize fires after the
-   * panel is detached or restored from trash.
+   * Cancel all pending panel resize work *without* applying it. Used on
+   * optimistic close: `flushResize` would force-drain queued output and reflow
+   * scrollback synchronously inside the close click, but stale debounce, idle,
+   * or settled work must not fire after detach or trash restore.
    */
   cancelPendingResize(id: string): void {
-    const managed = this.instances.get(id);
-    if (managed) this.resizeController.clearResizeJob(managed);
+    this.resizeController.cancelPendingResize(id);
   }
 
   sendPtyResize(id: string, cols: number, rows: number): void {
@@ -1916,24 +1916,6 @@ class TerminalInstanceService {
     // are handled by the ResizeObserver-driven applyResize path.
     if (managed.isAltBuffer) return;
 
-    // Settled-strategy agents require atomic xterm+PTY resize (deferred 500ms).
-    // fit() would immediately resize xterm.js while PTY lags, breaking atomicity.
-    // Skip fit() for settled agents and use sendPtyResize which preserves the contract.
-    if (this.getResizeStrategyForTerminal(managed) === "settled") {
-      const cols = managed.latestCols;
-      const rows = managed.latestRows;
-      if (Number.isInteger(cols) && Number.isInteger(rows) && cols > 0 && rows > 0) {
-        this.resizeController.sendPtyResize(id, cols, rows);
-      }
-      // Clear throttle so the next write — or the 3s heartbeat — triggers an
-      // immediate reflow. We don't call maybeReflowTerminal() inline here
-      // because the deferred PTY resize above hasn't landed yet; reflowing
-      // mid-resize would jitter against the pending dimension change. The
-      // heartbeat and focus paths cover any IO unpause within 3s.
-      managed.lastReflowAt = 0;
-      return;
-    }
-
     // Re-measure container dimensions after wake so latestCols/latestRows
     // reflect the current window size rather than pre-hibernation cache.
     // fit() already guards against offscreen/small terminals (returns null).
@@ -1944,18 +1926,22 @@ class TerminalInstanceService {
     // CLI mid-paint — the assistant's boot splash is the canonical victim.
     // Defer to the reconciliation watchdog via the reveal-pending obligation;
     // a no-drift fit falls through (its resize is a no-op and the PTY
-    // re-assert is dedupe-safe). Alt-buffer and settled-strategy panes never
-    // reach here (early returns above).
+    // re-assert is dedupe-safe). Alt-buffer panes never reach here.
     if (this.deferGridChangeForStream(managed, this.proposalDivergesFromGrid(managed))) {
       // Deferred to the watchdog — skip the fit.
     } else {
       const fitResult = this.resizeController.fit(id);
       if (!fitResult) {
-        // Fallback: fit() returned null (terminal offscreen or container too
-        // small). PTY-only — it never re-wraps the xterm buffer, so it stays
-        // safe for a streaming pane too.
+        // Fallback: fit() returned null (terminal offscreen, too small, or
+        // resize-locked). PTY-only and lock-aware — it never re-wraps xterm or
+        // bypasses an in-flight layout transition.
         this.resizeController.forceImmediateResize(id);
       }
+    }
+
+    if (this.resizeController.hasPendingResize(id)) {
+      managed.lastReflowAt = 0;
+      return;
     }
 
     // Kick the IO unpause path for standard terminals that just woke up —
@@ -1964,12 +1950,6 @@ class TerminalInstanceService {
     // first so this runs unconditionally.
     managed.lastReflowAt = 0;
     this.maybeReflowTerminal(managed);
-  }
-
-  private getResizeStrategyForTerminal(managed: ManagedTerminal): "default" | "settled" {
-    if (!managed.runtimeAgentId) return "default";
-    const config = getEffectiveAgentConfig(managed.runtimeAgentId);
-    return config?.capabilities?.resizeStrategy ?? "default";
   }
 
   private handleBufferModeChange(id: string, isAltBuffer: boolean): void {
@@ -2298,8 +2278,6 @@ class TerminalInstanceService {
         managed.terminal.write("\x1b[!p");
 
         this.resetRenderer(id);
-
-        managed.fitAddon?.fit();
 
         const timestamp = new Date().toLocaleTimeString();
         managed.terminal.write(

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -70,6 +70,8 @@ export interface ReconciliationWatchdogDeps {
   hasInFlightWake: (id: string) => boolean;
   /** Wake requested but not started yet (retry-scheduled or rate-limit coalesced). */
   hasPendingWake: (id: string) => boolean;
+  /** Layout or queued resize work owns this terminal's grid until the final resize lands. */
+  isResizeTransitioning: (id: string) => boolean;
   isWebGLActive: (id: string) => boolean;
   shouldHaveWebGL: (managed: ManagedTerminal) => boolean;
   ensureWebGL: (id: string, managed: ManagedTerminal) => void;
@@ -197,9 +199,10 @@ export class TerminalReconciliationWatchdog {
     let heavyBudget = WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK;
     const now = Date.now();
     for (const { id, managed } of onScreen) {
-      this.diagnoseGeometryDivergence(id, managed);
+      const resizeTransitioning = this.deps.isResizeTransitioning(id);
+      if (!resizeTransitioning) this.diagnoseGeometryDivergence(id, managed);
       if (now - (managed.lastWatchdogRepairAt ?? 0) < WATCHDOG_REPAIR_COOLDOWN_MS) continue;
-      heavyBudget -= this.reconcile(id, managed, now, heavyBudget);
+      heavyBudget -= this.reconcile(id, managed, now, heavyBudget, resizeTransitioning);
     }
   }
 
@@ -250,7 +253,8 @@ export class TerminalReconciliationWatchdog {
     id: string,
     managed: ManagedTerminal,
     now: number,
-    heavyBudget: number
+    heavyBudget: number,
+    resizeTransitioning: boolean
   ): number {
     if (!managed.isVisible) {
       if (heavyBudget <= 0) return 0;
@@ -371,7 +375,7 @@ export class TerminalReconciliationWatchdog {
     // A streaming-deferred tick keeps the obligation armed WITHOUT issuing the
     // repair (no cooldown stamp, no heavy budget) and falls through to the
     // cheaper layers below.
-    if (managed.revealPendingRepair && !inSynchronizedBlock) {
+    if (managed.revealPendingRepair && !inSynchronizedBlock && !resizeTransitioning) {
       if (
         managed.revealPendingGeneration !== undefined &&
         managed.revealPendingGeneration > managed.attachGeneration
@@ -415,7 +419,7 @@ export class TerminalReconciliationWatchdog {
     // IS the proof the pane converged wrong, and the watchdog ticks until it
     // matches. Bounded by the heavy-repair budget (== REVEAL_CONCURRENCY) so a
     // grid that all diverges at once never lands as a single long task.
-    if (!inSynchronizedBlock) {
+    if (!inSynchronizedBlock && !resizeTransitioning) {
       const proposal = managed.fitAddon.proposeDimensions?.();
       if (proposal && proposal.cols > 1 && proposal.rows > 1) {
         const diverged =

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -37,7 +37,7 @@ interface XtermCoreRenderDimensions {
  *
  * Uses a narrow structural type instead of `any` and rejects non-finite,
  * zero, or negative values. Returns `null` on any failure so callers can
- * fall back to fitAddon.fit().
+ * fall back to FitAddon's proposed dimensions.
  *
  * Upstream tracking: xtermjs/xterm.js#702 (no public API in 6.0).
  * Replace with a public API when one becomes available.
@@ -159,9 +159,16 @@ export function hasStreamingWrites(managed: ManagedTerminal, now: number): boole
   );
 }
 
+interface SettledResizeRequest {
+  timer: number;
+  cols: number;
+  rows: number;
+  resizeXterm: boolean;
+}
+
 export class TerminalResizeController {
   private resizeLocks = new Map<string, number>();
-  private settledResizeTimers = new Map<string, number>();
+  private settledResizeRequests = new Map<string, SettledResizeRequest>();
   private deps: ResizeControllerDeps;
 
   constructor(deps: ResizeControllerDeps) {
@@ -172,6 +179,11 @@ export class TerminalResizeController {
     if (locked) {
       const ttl = customTtlMs ?? RESIZE_LOCK_TTL_MS;
       this.resizeLocks.set(id, Date.now() + ttl);
+      this.clearSettledTimer(id);
+      const managed = this.deps.getInstance(id);
+      if (managed) {
+        this.clearResizeJob(managed);
+      }
     } else {
       this.resizeLocks.delete(id);
       const managed = this.deps.getInstance(id);
@@ -209,11 +221,22 @@ export class TerminalResizeController {
     }
 
     try {
-      managed.fitAddon.fit();
-      const { cols, rows } = managed.terminal;
+      const proposal = managed.fitAddon.proposeDimensions();
+      if (!proposal || proposal.cols <= 1 || proposal.rows <= 1) {
+        return null;
+      }
+
+      const { cols, rows } = proposal;
+      const buffer = managed.terminal.buffer.active;
+      const wasAtBottom = buffer.viewportY >= buffer.baseY;
+      managed.lastWidth = rect.width;
+      managed.lastHeight = rect.height;
       managed.latestCols = cols;
       managed.latestRows = rows;
-      this.sendPtyResize(id, cols, rows);
+      managed.latestWasAtBottom = wasAtBottom;
+      this.clearResizeJob(managed);
+      this.clearSettledTimer(id);
+      this.applyResize(id, cols, rows);
       return { cols, rows };
     } catch (error) {
       console.warn("Terminal fit failed:", error);
@@ -224,11 +247,23 @@ export class TerminalResizeController {
   flushResize(id: string): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
+    if (this.isResizeLocked(id)) return;
 
     if (managed.resizeJob !== undefined || managed.resizeDebounceTimer !== undefined) {
       this.clearResizeJob(managed);
       this.applyResize(id, managed.latestCols, managed.latestRows);
     }
+
+    const pending = this.takeSettledResize(id);
+    if (pending) {
+      this.commitSettledResize(id, pending);
+    }
+  }
+
+  cancelPendingResize(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (managed) this.clearResizeJob(managed);
+    this.clearSettledTimer(id);
   }
 
   resize(
@@ -275,11 +310,11 @@ export class TerminalResizeController {
       // Background-tier path: a ResizeObserver fired while the host element
       // is inside a content-visibility:hidden container. fitAddon.fit() would
       // read 0x0 from the DOM, so we compute cols/rows from cached cell
-      // metrics instead. sendPtyResize() keeps the settled-strategy timer —
-      // the renderer is live here, so coalescing drag bursts still applies.
+      // metrics instead. Settled agents still coalesce the PTY notification,
+      // but the hidden xterm grid remains untouched until wake reconciliation.
       const dims = this.resizePtyFromCachedCellMetrics(managed, width, height, wasAtBottom);
       if (dims) {
-        this.sendPtyResize(id, dims.cols, dims.rows);
+        this.sendPtyOnlyResize(id, dims.cols, dims.rows);
       }
       return dims;
     }
@@ -302,18 +337,15 @@ export class TerminalResizeController {
           return null;
         }
 
-        managed.fitAddon.fit();
-        const cols = managed.terminal.cols;
-        const rows = managed.terminal.rows;
+        const { cols, rows } = proposal;
         managed.lastWidth = width;
         managed.lastHeight = height;
         managed.latestCols = cols;
         managed.latestRows = rows;
         managed.latestWasAtBottom = wasAtBottom;
-        this.sendPtyResize(id, cols, rows);
-        if (wasAtBottom && !managed.isUserScrolledBack) {
-          managed.terminal.scrollToBottom();
-        }
+        this.clearResizeJob(managed);
+        this.clearSettledTimer(id);
+        this.applyResize(id, cols, rows);
         return { cols, rows };
       }
 
@@ -334,7 +366,7 @@ export class TerminalResizeController {
         // target at the truth, and supersede the stale job.
         managed.latestCols = cols;
         managed.latestRows = rows;
-        if (this.hasPendingResize(id, managed)) {
+        if (this.hasPendingResize(id)) {
           this.clearResizeJob(managed);
           this.sendPtyResize(id, cols, rows);
         }
@@ -346,6 +378,10 @@ export class TerminalResizeController {
       managed.latestCols = cols;
       managed.latestRows = rows;
       managed.latestWasAtBottom = wasAtBottom;
+      // A newer measured target owns geometry immediately, even when its own
+      // debounce/idle work has not fired yet. Do not let an older settled timer
+      // mutate xterm and the PTY in that gap.
+      this.clearSettledTimer(id);
 
       const bufferLineCount = this.getBufferLineCount(id);
 
@@ -391,7 +427,23 @@ export class TerminalResizeController {
       managed.pendingBackgroundResize = { width, height };
       return null;
     }
+    const hadPendingResize = this.hasPendingResize(id);
+    this.cancelPendingResize(id);
     if (isRedundantResize(managed, width, height)) {
+      // A foreground debounce/settled request updates the pixel and grid
+      // caches before it commits. If backgrounding then supplies that same
+      // box, cancelling the queued xterm work must not also discard the PTY
+      // half of the resize. Reassert the cached target directly; this entry
+      // point deliberately never reflows a hidden xterm.
+      if (
+        hadPendingResize &&
+        Number.isInteger(managed.latestCols) &&
+        Number.isInteger(managed.latestRows) &&
+        managed.latestCols > 0 &&
+        managed.latestRows > 0
+      ) {
+        terminalClient.resize(id, managed.latestCols, managed.latestRows);
+      }
       return null;
     }
     const buffer = managed.terminal.buffer.active;
@@ -474,7 +526,7 @@ export class TerminalResizeController {
     // one-shot correction, splitting it across 500ms would leave xterm sized
     // for the new container while the PTY (and any in-flight agent output)
     // still wraps at the pre-background geometry.
-    this.clearSettledTimer(id);
+    this.cancelPendingResize(id);
     this.resizeTerminal(managed, targetCols, targetRows);
     terminalClient.resize(id, targetCols, targetRows);
   }
@@ -559,10 +611,10 @@ export class TerminalResizeController {
     managed.latestCols = cols;
     managed.latestRows = rows;
 
-    // Cancel any pending settled (500ms) resize so this one-shot is the final
-    // word, then apply atomically: resize xterm only when its grid actually
-    // drifted, and always (re)assert the PTY size so the two agree.
-    this.clearSettledTimer(id);
+    // Cancel older queued geometry so this one-shot is the final word, then
+    // apply atomically: resize xterm only when its grid actually drifted, and
+    // always (re)assert the PTY size so the two agree.
+    this.cancelPendingResize(id);
     if (managed.terminal.cols !== cols || managed.terminal.rows !== rows) {
       this.resizeTerminal(managed, cols, rows);
     }
@@ -577,26 +629,36 @@ export class TerminalResizeController {
     if (this.isResizeLocked(id)) {
       return;
     }
-
-    const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
+    this.cancelPendingResize(id);
 
     if (this.getResizeStrategy(managed) === "settled") {
-      // For settled agents, defer xterm.js resize to fire atomically
-      // with the PTY resize inside the settled timer callback.
-      // This avoids a 500ms mismatch where xterm.js shows new dimensions
-      // while the agent is still rendering at old dimensions.
+      const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
+      if (!flushedHeldBytes) {
+        // Keep ingest moving at the still-consistent outgoing grid while the
+        // stable target coalesces. commitResize re-checks the queue immediately
+        // before the paired xterm/PTY change.
+        this.deps.dataBuffer.resumeFlush(id);
+      }
       managed.latestCols = cols;
       managed.latestRows = rows;
       this.sendPtyResize(id, cols, rows);
     } else {
-      this.resizeTerminal(managed, cols, rows);
-      this.sendPtyResize(id, cols, rows);
+      this.clearSettledTimer(id);
+      this.commitResize(id, cols, rows);
     }
+  }
+
+  private commitResize(id: string, cols: number, rows: number): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed || this.isResizeLocked(id)) return;
+
+    const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
+    this.resizeTerminal(managed, cols, rows);
+    terminalClient.resize(id, cols, rows);
 
     if (!flushedHeldBytes) {
       this.deps.dataBuffer.resumeFlush(id);
     }
-
     if (managed.latestWasAtBottom && !managed.isUserScrolledBack) {
       managed.terminal.scrollToBottom();
     }
@@ -607,15 +669,15 @@ export class TerminalResizeController {
    * flushed into xterm (they parse at the outgoing grid inside `resize()`'s
    * flushSync); false when the backlog exceeded
    * {@link RESIZE_FLUSH_SYNC_BUDGET_BYTES} and was left queued — the caller
-   * must `resumeFlush` after the resize so the backlog drains watermarked at
-   * the new grid. The reset only runs on the flush path: `resetForTerminal`
-   * deletes the queue, so resetting a held backlog would drop output.
+   * chooses whether to resume it before or after the geometry commit. The reset
+   * only runs on the flush path: `resetForTerminal` deletes the queue, so
+   * resetting a held backlog would drop output.
    */
   private flushHeldBytesBeforeResize(id: string): boolean {
     const queuedBytes = this.deps.dataBuffer.getQueuedBytes(id);
     if (exceedsResizeFlushSyncBudget(queuedBytes)) {
       logWarn(
-        `[TerminalResizeController] ${id}: ${queuedBytes} held ingest bytes exceed the pre-resize flush budget — draining watermarked at the new grid instead`
+        `[TerminalResizeController] ${id}: ${queuedBytes} held ingest bytes exceed the pre-resize flush budget — leaving the backlog queued for watermarked draining`
       );
       return false;
     }
@@ -630,11 +692,12 @@ export class TerminalResizeController {
    * of the box that armed it, so a later resize that supersedes them must know
    * they exist.
    */
-  private hasPendingResize(id: string, managed: ManagedTerminal): boolean {
+  hasPendingResize(id: string): boolean {
+    const managed = this.deps.getInstance(id);
     return (
-      managed.resizeJob !== undefined ||
-      managed.resizeDebounceTimer !== undefined ||
-      this.settledResizeTimers.has(id)
+      managed?.resizeJob !== undefined ||
+      managed?.resizeDebounceTimer !== undefined ||
+      this.settledResizeRequests.has(id)
     );
   }
 
@@ -659,31 +722,68 @@ export class TerminalResizeController {
       terminalClient.resize(id, cols, rows);
       return;
     }
+    if (this.isResizeLocked(id)) return;
+    this.cancelPendingResize(id);
+    managed.latestCols = cols;
+    managed.latestRows = rows;
 
     if (this.getResizeStrategy(managed) === "settled") {
-      const existing = this.settledResizeTimers.get(id);
-      if (existing !== undefined) clearTimeout(existing);
-
-      const timer = globalThis.setTimeout(() => {
-        this.settledResizeTimers.delete(id);
-
-        const current = this.deps.getInstance(id);
-        if (!current) {
-          return;
-        }
-
-        this.resizeTerminal(current, cols, rows);
-        terminalClient.resize(id, cols, rows);
-      }, SETTLED_RESIZE_DELAY_MS) as unknown as number;
-      this.settledResizeTimers.set(id, timer);
+      this.scheduleSettledResize(id, cols, rows, true);
     } else {
+      this.clearSettledTimer(id);
       terminalClient.resize(id, cols, rows);
     }
+  }
+
+  private sendPtyOnlyResize(id: string, cols: number, rows: number): void {
+    const managed = this.deps.getInstance(id);
+    this.cancelPendingResize(id);
+    if (managed && this.getResizeStrategy(managed) === "settled") {
+      this.scheduleSettledResize(id, cols, rows, false);
+      return;
+    }
+    this.clearSettledTimer(id);
+    terminalClient.resize(id, cols, rows);
+  }
+
+  private scheduleSettledResize(
+    id: string,
+    cols: number,
+    rows: number,
+    resizeXterm: boolean
+  ): void {
+    this.clearSettledTimer(id);
+    const pending: SettledResizeRequest = { timer: 0, cols, rows, resizeXterm };
+    const timer = globalThis.setTimeout(() => {
+      if (this.settledResizeRequests.get(id) !== pending) return;
+      this.settledResizeRequests.delete(id);
+      this.commitSettledResize(id, pending);
+    }, SETTLED_RESIZE_DELAY_MS) as unknown as number;
+    pending.timer = timer;
+    this.settledResizeRequests.set(id, pending);
+  }
+
+  private commitSettledResize(id: string, pending: SettledResizeRequest): void {
+    if (this.isResizeLocked(id)) return;
+    if (pending.resizeXterm) {
+      this.commitResize(id, pending.cols, pending.rows);
+    } else if (this.deps.getInstance(id)) {
+      terminalClient.resize(id, pending.cols, pending.rows);
+    }
+  }
+
+  private takeSettledResize(id: string): SettledResizeRequest | undefined {
+    const pending = this.settledResizeRequests.get(id);
+    if (!pending) return undefined;
+    clearTimeout(pending.timer);
+    this.settledResizeRequests.delete(id);
+    return pending;
   }
 
   forceImmediateResize(id: string): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
+    if (this.isResizeLocked(id)) return;
 
     const cols = managed.latestCols;
     const rows = managed.latestRows;
@@ -691,16 +791,12 @@ export class TerminalResizeController {
       return;
     }
 
-    this.clearSettledTimer(id);
+    this.cancelPendingResize(id);
     terminalClient.resize(id, cols, rows);
   }
 
   clearSettledTimer(id: string): void {
-    const timer = this.settledResizeTimers.get(id);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      this.settledResizeTimers.delete(id);
-    }
+    this.takeSettledResize(id);
   }
 
   private getResizeStrategy(managed: ManagedTerminal): "default" | "settled" {
@@ -721,12 +817,7 @@ export class TerminalResizeController {
             const current = this.deps.getInstance(id);
             if (current) {
               current.resizeJob = undefined;
-              const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
-              this.resizeTerminal(current, current.latestCols, current.latestRows);
-              this.sendPtyResize(id, current.latestCols, current.latestRows);
-              if (!flushedHeldBytes) {
-                this.deps.dataBuffer.resumeFlush(id);
-              }
+              this.applyResize(id, current.latestCols, current.latestRows);
             }
           },
           { priority: "background", signal: controller.signal }
@@ -740,12 +831,7 @@ export class TerminalResizeController {
         const current = this.deps.getInstance(id);
         if (current) {
           current.resizeDebounceTimer = undefined;
-          const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
-          this.resizeTerminal(current, current.latestCols, current.latestRows);
-          this.sendPtyResize(id, current.latestCols, current.latestRows);
-          if (!flushedHeldBytes) {
-            this.deps.dataBuffer.resumeFlush(id);
-          }
+          this.applyResize(id, current.latestCols, current.latestRows);
         }
       }, 0) as unknown as number;
       managed.resizeDebounceTimer = timerId;
@@ -764,12 +850,7 @@ export class TerminalResizeController {
         // and we must not write mid-transition. The lock release path will
         // requeue via batchResize when it ends.
         if (this.isResizeLocked(id)) return;
-        const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
-        this.resizeTerminal(current, cols, rows);
-        this.sendPtyResize(id, cols, rows);
-        if (!flushedHeldBytes) {
-          this.deps.dataBuffer.resumeFlush(id);
-        }
+        this.applyResize(id, cols, rows);
       }
     }, RESIZE_DEBOUNCE_MS) as unknown as number;
     managed.resizeDebounceTimer = timeoutId;

--- a/src/services/terminal/TerminalResizePassScheduler.ts
+++ b/src/services/terminal/TerminalResizePassScheduler.ts
@@ -26,7 +26,8 @@ export interface TerminalResizePassSchedulerDeps {
 export class TerminalResizePassScheduler {
   private gridResizeTimer: number | undefined;
   private readonly gridResizePendingIds = new Set<string>();
-  private resizePassAbort: AbortController | undefined;
+  private readonly frameResizePendingPasses = new Map<number, ReadonlySet<string>>();
+  private activeResizePass: { controller: AbortController; pendingIds: Set<string> } | undefined;
 
   constructor(private deps: TerminalResizePassSchedulerDeps) {}
 
@@ -83,8 +84,26 @@ export class TerminalResizePassScheduler {
       this.gridResizeTimer = undefined;
       const pendingIds = [...this.gridResizePendingIds];
       this.gridResizePendingIds.clear();
-      requestAnimationFrame(() => this.runResizePass(pendingIds));
+      const framePendingIds = new Set(pendingIds);
+      const frameId = requestAnimationFrame(() => {
+        // Establish active-pass ownership before dropping the frame marker so
+        // observers never see a gap where geometry looks stable.
+        try {
+          this.runResizePass(pendingIds);
+        } finally {
+          this.frameResizePendingPasses.delete(frameId);
+        }
+      });
+      this.frameResizePendingPasses.set(frameId, framePendingIds);
     }, GRID_RESIZE_COALESCE_MS);
+  }
+
+  isResizePending(id: string): boolean {
+    if (this.gridResizePendingIds.has(id)) return true;
+    for (const pendingIds of this.frameResizePendingPasses.values()) {
+      if (pendingIds.has(id)) return true;
+    }
+    return this.activeResizePass?.pendingIds.has(id) ?? false;
   }
 
   /**
@@ -101,28 +120,36 @@ export class TerminalResizePassScheduler {
    * panel resizes first so the pane the user is looking at settles in the
    * first frame; far corners of a large grid settle a beat later, unnoticed.
    *
-   * Each new pass aborts any in-flight one: once a newer pass starts, the
-   * survivor set the old one was resizing is already stale, so its remaining
-   * reflows are cancelled. The trailing-edge debounce in
-   * {@link scheduleBatchResize} coalesces a close/open burst before a pass
-   * starts; this abort handles the case where a burst arrives once a pass is
-   * already running. Fire-and-forget — callers never await it.
+   * Each new pass aborts any in-flight one and carries its unprocessed ids
+   * forward. A pending id is an obligation to re-read that terminal's current
+   * host geometry, not a stale pixel target, so a narrower pass must not strand
+   * survivors from an earlier broader pass. {@link cancelActiveResizePass} is
+   * the explicit path for callers that know the old surface work is invalid.
+   * Fire-and-forget — callers never await it.
    */
   runResizePass(ids: string[]): void {
     if (ids.length === 0) return;
-    // A newer pass supersedes any in-flight one — its survivor set is stale.
-    this.resizePassAbort?.abort();
+    const supersededPass = this.activeResizePass;
+    const pendingIds = [...new Set([...ids, ...(supersededPass?.pendingIds ?? [])])];
+    supersededPass?.controller.abort();
     const controller = new AbortController();
-    this.resizePassAbort = controller;
-    const run = () => this.executeResizePass(ids, controller);
+    const pass = { controller, pendingIds: new Set(pendingIds) };
+    this.activeResizePass = pass;
+    const run = () => this.executeResizePass(pendingIds, pass);
     const task =
       typeof scheduler !== "undefined" && typeof scheduler.postTask === "function"
         ? scheduler.postTask(run, { priority: "user-visible", signal: controller.signal })
         : run();
-    void task.catch((error) => {
-      if (error instanceof Error && error.name === "AbortError") return;
-      logError("terminal resize pass failed", error);
-    });
+    void task
+      .catch((error) => {
+        if (error instanceof Error && error.name === "AbortError") return;
+        logError("terminal resize pass failed", error);
+      })
+      .finally(() => {
+        if (this.activeResizePass === pass) {
+          this.activeResizePass = undefined;
+        }
+      });
   }
 
   /**
@@ -134,12 +161,15 @@ export class TerminalResizePassScheduler {
    * a survivor set that is already stale).
    */
   cancelActiveResizePass(): void {
-    this.resizePassAbort?.abort();
-    this.resizePassAbort = undefined;
+    this.activeResizePass?.controller.abort();
+    this.activeResizePass = undefined;
   }
 
-  private async executeResizePass(ids: string[], controller: AbortController): Promise<void> {
-    const { signal } = controller;
+  private async executeResizePass(
+    ids: string[],
+    pass: { controller: AbortController; pendingIds: Set<string> }
+  ): Promise<void> {
+    const { signal } = pass.controller;
     try {
       const ordered = this.orderFocusedFirst([...new Set(ids)]);
       for (let i = 0; i < ordered.length; i += RESIZE_PASS_CHUNK_SIZE) {
@@ -147,14 +177,18 @@ export class TerminalResizePassScheduler {
         // batchResize re-applies every eligibility guard (instance exists,
         // connected, visible, not resize-locked) and reads fresh geometry —
         // correct here because layout has settled across the yields.
-        this.batchResize(ordered.slice(i, i + RESIZE_PASS_CHUNK_SIZE));
+        const chunk = ordered.slice(i, i + RESIZE_PASS_CHUNK_SIZE);
+        this.batchResize(chunk);
+        if (this.activeResizePass === pass) {
+          for (const id of chunk) pass.pendingIds.delete(id);
+        }
         if (i + RESIZE_PASS_CHUNK_SIZE < ordered.length) {
           await yieldToScheduler();
         }
       }
     } finally {
-      if (this.resizePassAbort === controller) {
-        this.resizePassAbort = undefined;
+      if (this.activeResizePass === pass) {
+        this.activeResizePass = undefined;
       }
     }
   }
@@ -174,7 +208,16 @@ export class TerminalResizePassScheduler {
   // doesn't resume against a torn-down service. Called from
   // `TerminalInstanceService.dispose()`.
   dispose(): void {
-    this.resizePassAbort?.abort();
-    this.resizePassAbort = undefined;
+    if (this.gridResizeTimer !== undefined) {
+      clearTimeout(this.gridResizeTimer);
+      this.gridResizeTimer = undefined;
+    }
+    this.gridResizePendingIds.clear();
+    for (const frameId of this.frameResizePendingPasses.keys()) {
+      cancelAnimationFrame(frameId);
+    }
+    this.frameResizePendingPasses.clear();
+    this.activeResizePass?.controller.abort();
+    this.activeResizePass = undefined;
   }
 }

--- a/src/services/terminal/__tests__/TerminalCursorLineResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalCursorLineResize.test.ts
@@ -1,0 +1,23 @@
+import { Terminal } from "@xterm/headless";
+import { describe, expect, it } from "vitest";
+
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve));
+}
+
+describe("xterm cursor-line resize ownership", () => {
+  it("leaves an unfinished cursor line for the foreground application to repaint", async () => {
+    const terminal = new Terminal({ cols: 20, rows: 4, scrollback: 20 });
+    try {
+      await write(terminal, "123456789012345678");
+
+      terminal.resize(10, 4);
+
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe("1234567890");
+      expect(terminal.buffer.active.getLine(1)?.translateToString(true)).toBe("");
+      expect(terminal.buffer.active.cursorY).toBe(0);
+    } finally {
+      terminal.dispose();
+    }
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
@@ -52,7 +52,10 @@ vi.mock("@/clients", () => ({
 
 vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
-    fitAddon: { fit: vi.fn() },
+    fitAddon: {
+      fit: vi.fn(),
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 24 })),
+    },
     serializeAddon: { serialize: vi.fn() },
     imageAddon: { dispose: vi.fn() },
     searchAddon: {},
@@ -101,7 +104,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     expect(typeof registeredLateArrivalCallback).toBe("function");
   });
 
-  it("calls fit on every non-hibernated instance", async () => {
+  it("remeasures every non-hibernated instance", async () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
@@ -120,8 +123,8 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
       undefined
     );
 
-    const f1 = vi.spyOn(m1.fitAddon, "fit");
-    const f2 = vi.spyOn(m2.fitAddon, "fit");
+    const f1 = vi.spyOn(m1.fitAddon, "proposeDimensions");
+    const f2 = vi.spyOn(m2.fitAddon, "proposeDimensions");
 
     terminalInstanceService.repairFontGrid();
 
@@ -201,7 +204,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     terminalInstanceService.destroy("repair-default");
   });
 
-  it("resets lastWidth/lastHeight so the next resize is not deduped", async () => {
+  it("refreshes the cached host dimensions while repairing the grid", async () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
@@ -217,8 +220,8 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
 
     terminalInstanceService.repairFontGrid();
 
-    expect(managed.lastWidth).toBe(0);
-    expect(managed.lastHeight).toBe(0);
+    expect(managed.lastWidth).toBe(800);
+    expect(managed.lastHeight).toBe(600);
 
     terminalInstanceService.destroy("repair-dims");
   });
@@ -236,7 +239,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
       () => TerminalRefreshTier.FOCUSED,
       undefined
     );
-    const fit = vi.spyOn(managed.fitAddon, "fit");
+    const fit = vi.spyOn(managed.fitAddon, "proposeDimensions");
 
     registeredLateArrivalCallback?.();
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -35,7 +35,10 @@ vi.mock("@/clients", () => ({
 
 vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
-    fitAddon: { fit: vi.fn() },
+    fitAddon: {
+      fit: vi.fn(),
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 24 })),
+    },
     serializeAddon: { serialize: vi.fn() },
     imageAddon: { dispose: vi.fn() },
     searchAddon: {},
@@ -91,7 +94,7 @@ describe("TerminalInstanceService - options", () => {
     expect(managed.terminal.options).toEqual(
       expect.objectContaining({
         rescaleOverlappingGlyphs: true,
-        reflowCursorLine: true,
+        reflowCursorLine: false,
       })
     );
 
@@ -121,7 +124,7 @@ describe("TerminalInstanceService - options", () => {
       expect.objectContaining({
         cursorBlink: false,
         rescaleOverlappingGlyphs: true,
-        reflowCursorLine: true,
+        reflowCursorLine: false,
       })
     );
 
@@ -216,7 +219,7 @@ describe("TerminalInstanceService - options", () => {
     );
 
     const refreshSpy = vi.spyOn(managed.terminal, "refresh");
-    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+    const fitSpy = vi.spyOn(managed.fitAddon, "proposeDimensions");
 
     terminalInstanceService.updateOptions("test-options-theme", {
       theme: { foreground: "#ffffff", background: "#000000" },
@@ -248,7 +251,7 @@ describe("TerminalInstanceService - options", () => {
     );
 
     const refreshSpy = vi.spyOn(managed.terminal, "refresh");
-    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+    const fitSpy = vi.spyOn(managed.fitAddon, "proposeDimensions");
 
     terminalInstanceService.updateOptions("test-options-font", { fontSize: 16 });
 
@@ -278,7 +281,7 @@ describe("TerminalInstanceService - options", () => {
     );
 
     const refreshSpy = vi.spyOn(managed.terminal, "refresh");
-    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+    const fitSpy = vi.spyOn(managed.fitAddon, "proposeDimensions");
 
     terminalInstanceService.updateOptions("test-options-both", {
       theme: { foreground: "#ffffff", background: "#000000" },
@@ -357,8 +360,8 @@ describe("TerminalInstanceService - options", () => {
       undefined
     );
 
-    const f1 = vi.spyOn(m1.fitAddon, "fit");
-    const f2 = vi.spyOn(m2.fitAddon, "fit");
+    const f1 = vi.spyOn(m1.fitAddon, "proposeDimensions");
+    const f2 = vi.spyOn(m2.fitAddon, "proposeDimensions");
 
     terminalInstanceService.applyGlobalOptions({ fontSize: 18 });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
@@ -63,14 +63,26 @@ interface PostWakeInstance {
     isConnected: boolean;
     checkVisibility: ReturnType<typeof vi.fn>;
   };
-  fitAddon: { fit: ReturnType<typeof vi.fn> };
-  terminal: { cols: number; rows: number };
-  agentId?: string;
+  fitAddon: {
+    fit: ReturnType<typeof vi.fn>;
+    proposeDimensions: ReturnType<typeof vi.fn>;
+  };
+  terminal: {
+    cols: number;
+    rows: number;
+    buffer: { active: { viewportY: number; baseY: number } };
+    resize: ReturnType<typeof vi.fn>;
+    scrollToBottom: ReturnType<typeof vi.fn>;
+  };
+  runtimeAgentId?: string;
+  isUserScrolledBack: boolean;
 }
 
 type PostWakeTestService = {
   instances: Map<string, PostWakeInstance>;
   handlePostWake: (id: string) => void;
+  maybeReflowTerminal: (managed: PostWakeInstance) => void;
+  resizeController: { lockResize: (id: string, locked: boolean) => void };
 };
 
 function makeInstance(overrides: Partial<PostWakeInstance> = {}): PostWakeInstance {
@@ -83,8 +95,21 @@ function makeInstance(overrides: Partial<PostWakeInstance> = {}): PostWakeInstan
       isConnected: true,
       checkVisibility: vi.fn(() => true),
     },
-    fitAddon: { fit: vi.fn() },
-    terminal: { cols: 120, rows: 30 },
+    fitAddon: {
+      fit: vi.fn(),
+      proposeDimensions: vi.fn(() => ({ cols: 120, rows: 30 })),
+    },
+    terminal: {
+      cols: 80,
+      rows: 24,
+      buffer: { active: { viewportY: 0, baseY: 0 } },
+      resize: vi.fn(function (this: { cols: number; rows: number }, cols: number, rows: number) {
+        this.cols = cols;
+        this.rows = rows;
+      }),
+      scrollToBottom: vi.fn(),
+    },
+    isUserScrolledBack: false,
     ...overrides,
   };
 }
@@ -113,25 +138,50 @@ describe("TerminalInstanceService post-wake handling", () => {
     }
   });
 
-  it("calls fit() first and returns early when fit succeeds", () => {
+  it("applies a fresh fit proposal immediately for a default terminal", () => {
     const id = "term-post-wake";
     if (!service) throw new Error("Service not initialized");
 
-    const instance = makeInstance({ terminal: { cols: 120, rows: 30 } });
+    const instance = makeInstance();
     service.instances.set(id, instance);
 
     service.handlePostWake(id);
 
-    // fit() was called on the addon
-    expect(instance.fitAddon.fit).toHaveBeenCalledTimes(1);
-
-    // fit() succeeded so sendPtyResize was called with the terminal's current dimensions
+    expect(instance.fitAddon.proposeDimensions).toHaveBeenCalledTimes(2);
+    expect(instance.fitAddon.fit).not.toHaveBeenCalled();
+    expect(instance.terminal.resize).toHaveBeenCalledWith(120, 30);
     expect(mockTerminalClient.resize).toHaveBeenCalledTimes(1);
     expect(mockTerminalClient.resize).toHaveBeenCalledWith(id, 120, 30);
 
     // No delayed timers
     vi.advanceTimersByTime(600);
     expect(mockTerminalClient.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it("fresh-measures a settled terminal and delays both xterm and PTY until commit", () => {
+    const id = "term-post-wake-settled";
+    if (!service) throw new Error("Service not initialized");
+    const instance = makeInstance({ runtimeAgentId: "codex" });
+    service.instances.set(id, instance);
+    const reflow = vi.spyOn(service, "maybeReflowTerminal");
+
+    service.handlePostWake(id);
+
+    expect(instance.fitAddon.proposeDimensions).toHaveBeenCalledTimes(2);
+    expect(instance.fitAddon.fit).not.toHaveBeenCalled();
+    expect(instance.terminal.resize).not.toHaveBeenCalled();
+    expect(mockTerminalClient.resize).not.toHaveBeenCalled();
+    expect(reflow).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(499);
+    expect(instance.terminal.resize).not.toHaveBeenCalled();
+    expect(mockTerminalClient.resize).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(instance.terminal.resize).toHaveBeenCalledTimes(1);
+    expect(instance.terminal.resize).toHaveBeenCalledWith(120, 30);
+    expect(mockTerminalClient.resize).toHaveBeenCalledTimes(1);
+    expect(mockTerminalClient.resize).toHaveBeenCalledWith(id, 120, 30);
   });
 
   it("falls back to forceImmediateResize when fit() returns null (offscreen)", () => {
@@ -179,6 +229,19 @@ describe("TerminalInstanceService post-wake handling", () => {
     service.handlePostWake(id);
     vi.advanceTimersByTime(200);
 
+    expect(mockTerminalClient.resize).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate xterm or the PTY when post-wake runs under a resize lock", () => {
+    const id = "term-post-wake-locked";
+    if (!service) throw new Error("Service not initialized");
+    const instance = makeInstance();
+    service.instances.set(id, instance);
+    service.resizeController.lockResize(id, true);
+
+    service.handlePostWake(id);
+
+    expect(instance.terminal.resize).not.toHaveBeenCalled();
     expect(mockTerminalClient.resize).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -53,6 +53,7 @@ type ReflowTestService = {
   instances: Map<string, ManagedTerminal>;
   maybeReflowTerminal: (managed: ManagedTerminal) => void;
   resetRenderer: (id: string) => void;
+  handleBackendRecovery: () => void;
   resizeController: { fit: (id: string) => unknown };
   getSynchronizedOutputMode: (id: string) => boolean | null;
   webGLManager: { repairAtlasForReactivation: (id: string) => boolean };
@@ -418,6 +419,25 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(siblingTerm.refresh).not.toHaveBeenCalled();
     expect(paddingHistory(sibling).length).toBe(0);
     expect(sibling.lastReflowAt).toBe(0);
+  });
+
+  it("routes backend recovery redraws through the resize controller", () => {
+    const write = vi.fn();
+    const managed = makeManaged({
+      terminal: {
+        element: document.createElement("div"),
+        modes: { synchronizedOutputMode: false },
+        write,
+      } as unknown as ManagedTerminal["terminal"],
+    });
+    service.instances.set("t1", managed);
+    const resetRenderer = vi.spyOn(service, "resetRenderer").mockImplementation(() => undefined);
+
+    service.handleBackendRecovery();
+
+    expect(resetRenderer).toHaveBeenCalledWith("t1");
+    expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -206,7 +206,7 @@ describe("TerminalInstanceService runResizePass", () => {
     expect(resizedIds(spy)).toEqual(["c", "a", "b"]);
   });
 
-  it("aborts an in-flight pass when a newer pass supersedes it", async () => {
+  it("restarts an in-flight pass without losing unprocessed resize obligations", async () => {
     for (const id of ["a", "b", "c", "d", "e"]) {
       service.instances.set(id, makeManaged());
     }
@@ -216,15 +216,16 @@ describe("TerminalInstanceService runResizePass", () => {
     service.runResizePass(["a", "b", "c"]);
     expect(resizedIds(spy)).toEqual(["a"]);
 
-    // A new close arrives mid-pass: pass 2 supersedes pass 1.
+    // A new close arrives mid-pass: pass 2 supersedes pass 1 but carries its
+    // unprocessed ids because they still need fresh host measurements.
     service.runResizePass(["d", "e"]);
     expect(resizedIds(spy)).toEqual(["a", "d"]);
 
     await vi.advanceTimersByTimeAsync(50);
 
-    // Pass 1's remaining survivors ("b", "c") are cancelled; only pass 2
-    // finishes ("e"). The stale reflows never run.
-    expect(resizedIds(spy)).toEqual(["a", "d", "e"]);
+    // The new ids run first, then the old pass's remaining survivors are
+    // measured against current geometry instead of being stranded.
+    expect(resizedIds(spy)).toEqual(["a", "d", "e", "b", "c"]);
   });
 
   it("skips ineligible panels (delegates to batchResize guards)", async () => {

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -129,6 +129,7 @@ function makeDeps(
     resumeFlush: vi.fn(),
     hasInFlightWake: vi.fn(() => false),
     hasPendingWake: vi.fn(() => false),
+    isResizeTransitioning: vi.fn(() => false),
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
@@ -557,6 +558,81 @@ describe("TerminalReconciliationWatchdog", () => {
   });
 
   describe("geometry convergence (#10632)", () => {
+    it("defers geometry diagnosis and repair during a coordinated resize, then repairs once stable", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      setRenderPaused(managed, false);
+      (managed.terminal as unknown as { cols: number; rows: number }).cols = 137;
+      (managed.terminal as unknown as { cols: number; rows: number }).rows = 40;
+      const proposeDimensions = vi.fn(() => ({ cols: 100, rows: 40 }));
+      (
+        managed.fitAddon as unknown as {
+          proposeDimensions: () => { cols: number; rows: number };
+        }
+      ).proposeDimensions = proposeDimensions;
+      managed.geometryRepairAttempts = 1;
+      managed.geometryRepairGeneration = managed.attachGeneration;
+      instances.set("t1", managed);
+      let resizeTransitioning = true;
+      const deps = makeDeps(instances, {
+        isResizeTransitioning: vi.fn(() => resizeTransitioning),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(proposeDimensions).not.toHaveBeenCalled();
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.geometryRepairAttempts).toBe(1);
+      expect(managed.lastWatchdogRepairAt).toBeUndefined();
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.some((call) => String(call[0]).includes("geometry divergence"))
+      ).toBe(false);
+
+      resizeTransitioning = false;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
+      expect(managed.geometryRepairAttempts).toBe(2);
+    });
+
+    it("keeps a reveal repair pending while resize coordination owns the grid", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
+      setGrid(managed, { cols: 100, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      let resizeTransitioning = true;
+      const deps = makeDeps(instances, {
+        isResizeTransitioning: vi.fn(() => resizeTransitioning),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.revealPendingRepair).toBe(true);
+      expect(managed.lastWatchdogRepairAt).toBeUndefined();
+
+      resizeTransitioning = false;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
+      expect(managed.revealPendingRepair).toBe(false);
+    });
+
+    it("still runs non-geometry recovery during a coordinated resize", () => {
+      const managed = makeManaged({ isAltBuffer: false });
+      setRenderPaused(managed, true);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, {
+        isResizeTransitioning: vi.fn(() => true),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+    });
+
     it("reconciles an on-screen agent TUI whose grid disagrees with the container (garbled wrapping)", () => {
       // The exact switch-back failure: while backgrounded the container narrowed
       // (137 → 100 cols) but the alt-buffer agent's xterm grid stayed at the old

--- a/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.fitParity.test.ts
@@ -202,6 +202,7 @@ function makeWatchdogDeps(instances: Map<string, ManagedTerminal>): Reconciliati
     resumeFlush: vi.fn(),
     hasInFlightWake: vi.fn(() => false),
     hasPendingWake: vi.fn(() => false),
+    isResizeTransitioning: vi.fn(() => false),
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),
@@ -279,6 +280,30 @@ describe("TerminalResizeController ↔ FitAddon column parity (#11095)", () => {
 
     expect(managed.geometryRepairAttempts).toBe(0);
     expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(managed.lastWatchdogRepairAt).toBeUndefined();
+  });
+
+  it("keeps the watchdog out of geometry while a controller resize is pending", () => {
+    const { managed, terminal, fitAddon } = buildPane();
+    managed.isFocused = false;
+    terminal.buffer.active.length = 500;
+    const controller = makeController(managed);
+
+    controller.resize("t1", CONTAINER.width, CONTAINER.height);
+    expect(controller.hasPendingResize("t1")).toBe(true);
+
+    const instances = new Map<string, ManagedTerminal>([["t1", managed]]);
+    const deps = makeWatchdogDeps(instances);
+    deps.isResizeTransitioning = (id) =>
+      controller.isResizeLocked(id) || controller.hasPendingResize(id);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+    const proposeDimensions = vi.spyOn(fitAddon, "proposeDimensions");
+
+    watchdog.tick();
+
+    expect(proposeDimensions).not.toHaveBeenCalled();
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(managed.geometryRepairAttempts).toBeUndefined();
     expect(managed.lastWatchdogRepairAt).toBeUndefined();
   });
 

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -275,6 +275,7 @@ describe("TerminalResizeController", () => {
     vi.advanceTimersByTime(500);
     expect(resizeMock).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1700), 40);
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
   });
 
   it("background-tier resize reflows xterm when the terminal is visible", () => {
@@ -391,12 +392,15 @@ describe("TerminalResizeController", () => {
 
       controller.applyResize("term-1", 132, 41);
 
-      // The settled timer owns the xterm+PTY resize, but the held backlog must
-      // not wait 500ms to start draining.
+      // Oversized ingest keeps draining at the still-consistent outgoing grid.
       expect(dataBuffer.flushForTerminal).not.toHaveBeenCalled();
       expect(dataBuffer.resumeFlush).toHaveBeenCalledWith("term-1");
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
       vi.advanceTimersByTime(500);
       expect(managed.terminal.resize).toHaveBeenCalledWith(132, 41);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 132, 41);
+      expect(dataBuffer.resumeFlush).toHaveBeenCalledTimes(2);
     });
 
     it("applies the budget on the debounced resize path", () => {
@@ -421,6 +425,46 @@ describe("TerminalResizeController", () => {
       expect(dataBuffer.resetForTerminal).not.toHaveBeenCalled();
       expect(managed.terminal.resize).toHaveBeenCalled();
       expect(dataBuffer.resumeFlush).toHaveBeenCalledWith("term-1");
+    });
+
+    it("commits a debounced settled resize in flush, xterm, PTY order", () => {
+      const managed = createManagedTerminal();
+      managed.runtimeAgentId = "codex";
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 5000;
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: CELL } } } },
+      });
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const sequence: string[] = [];
+      managed.terminal.resize.mockImplementation(function (
+        this: { cols: number; rows: number },
+        cols: number,
+        rows: number
+      ) {
+        sequence.push("xterm");
+        this.cols = cols;
+        this.rows = rows;
+      });
+      resizeMock.mockImplementation(() => sequence.push("pty"));
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: {
+          flushForTerminal: vi.fn(() => sequence.push("flush")),
+          resetForTerminal: vi.fn(() => sequence.push("reset")),
+          getQueuedBytes: vi.fn(() => 0),
+          resumeFlush: vi.fn(() => sequence.push("resume")),
+        } as unknown as ResizeControllerDeps["dataBuffer"],
+      });
+
+      controller.resize("term-1", 1600, 800);
+      vi.advanceTimersByTime(599);
+      expect(sequence).toEqual(["flush", "reset"]);
+
+      vi.advanceTimersByTime(1);
+      expect(sequence).toEqual(["flush", "reset", "flush", "reset", "xterm", "pty"]);
     });
   });
 
@@ -721,10 +765,75 @@ describe("TerminalResizeController", () => {
     });
 
     const result = controller.fit("term-1");
-    expect(result).not.toBeNull();
+    expect(result).toEqual({ cols: 100, rows: 30 });
     expect(managed.hostElement.checkVisibility).toHaveBeenCalled();
-    expect(managed.fitAddon.fit).toHaveBeenCalled();
-    expect(resizeMock).toHaveBeenCalledWith("term-1", managed.terminal.cols, managed.terminal.rows);
+    expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+    expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+  });
+
+  it("fit() defers a settled xterm and PTY pair until the same commit", () => {
+    const managed = createManagedTerminal();
+    managed.runtimeAgentId = "codex";
+    getEffectiveAgentConfigMock.mockReturnValue({
+      capabilities: { resizeStrategy: "settled" },
+    });
+    const dataBuffer = {
+      flushForTerminal: vi.fn(),
+      resetForTerminal: vi.fn(),
+      getQueuedBytes: vi.fn(() => 0),
+      resumeFlush: vi.fn(),
+    } as unknown as ResizeControllerDeps["dataBuffer"];
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer,
+    });
+
+    expect(controller.fit("term-1")).toEqual({ cols: 100, rows: 30 });
+    expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(resizeMock).not.toHaveBeenCalled();
+    expect(dataBuffer.flushForTerminal).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(500);
+
+    expect(dataBuffer.flushForTerminal).toHaveBeenCalledTimes(2);
+    expect(dataBuffer.flushForTerminal).toHaveBeenCalledWith("term-1");
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+    expect(resizeMock).toHaveBeenCalledTimes(1);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+  });
+
+  it("rapid settled fit requests apply only the newest proposal", () => {
+    const managed = createManagedTerminal();
+    managed.runtimeAgentId = "codex";
+    getEffectiveAgentConfigMock.mockReturnValue({
+      capabilities: { resizeStrategy: "settled" },
+    });
+    managed.fitAddon.proposeDimensions
+      .mockReturnValueOnce({ cols: 90, rows: 28 })
+      .mockReturnValueOnce({ cols: 95, rows: 29 })
+      .mockReturnValueOnce({ cols: 105, rows: 31 });
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as unknown as ResizeControllerDeps["dataBuffer"],
+    });
+
+    controller.fit("term-1");
+    controller.fit("term-1");
+    controller.fit("term-1");
+    vi.advanceTimersByTime(500);
+
+    expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+    expect(managed.terminal.resize).toHaveBeenCalledWith(105, 31);
+    expect(resizeMock).toHaveBeenCalledTimes(1);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", 105, 31);
   });
 
   it("settled strategy batches rapid resizes into a single PTY resize", () => {
@@ -751,6 +860,8 @@ describe("TerminalResizeController", () => {
     controller.sendPtyResize("term-1", 120, 40);
 
     expect(resizeMock).not.toHaveBeenCalled();
+    expect(managed.latestCols).toBe(120);
+    expect(managed.latestRows).toBe(40);
 
     vi.advanceTimersByTime(500);
 
@@ -812,6 +923,32 @@ describe("TerminalResizeController", () => {
     expect(resizeMock).not.toHaveBeenCalled();
   });
 
+  it("a resize lock cancels a pending settled xterm and PTY commit", () => {
+    const managed = createManagedTerminal();
+    managed.runtimeAgentId = "codex";
+    getEffectiveAgentConfigMock.mockReturnValue({
+      capabilities: { resizeStrategy: "settled" },
+    });
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as unknown as ResizeControllerDeps["dataBuffer"],
+    });
+
+    controller.applyResize("term-1", 120, 40);
+    expect(controller.hasPendingResize("term-1")).toBe(true);
+    controller.lockResize("term-1", true);
+    expect(controller.hasPendingResize("term-1")).toBe(false);
+    vi.advanceTimersByTime(500);
+
+    expect(managed.terminal.resize).not.toHaveBeenCalled();
+    expect(resizeMock).not.toHaveBeenCalled();
+  });
+
   it("forceImmediateResize sends an immediate resize and cancels pending settled timer", () => {
     const managed = createManagedTerminal();
     managed.launchAgentId = "codex";
@@ -836,6 +973,8 @@ describe("TerminalResizeController", () => {
 
     controller.sendPtyResize("term-1", 100, 30);
     expect(resizeMock).not.toHaveBeenCalled();
+    managed.latestCols = 132;
+    managed.latestRows = 41;
 
     controller.forceImmediateResize("term-1");
     expect(resizeMock).toHaveBeenCalledTimes(1);
@@ -861,6 +1000,27 @@ describe("TerminalResizeController", () => {
       dataBuffer,
     });
 
+    controller.forceImmediateResize("term-1");
+
+    expect(resizeMock).not.toHaveBeenCalled();
+  });
+
+  it("public PTY resize helpers do not bypass an active resize lock", () => {
+    const managed = createManagedTerminal();
+    managed.latestCols = 120;
+    managed.latestRows = 40;
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as unknown as ResizeControllerDeps["dataBuffer"],
+    });
+
+    controller.lockResize("term-1", true);
+    controller.sendPtyResize("term-1", 120, 40);
     controller.forceImmediateResize("term-1");
 
     expect(resizeMock).not.toHaveBeenCalled();
@@ -1086,6 +1246,169 @@ describe("TerminalResizeController", () => {
       expect(dataBuffer.flushForTerminal).toHaveBeenCalled();
     });
 
+    it("flushResize immediately commits a pending settled xterm and PTY pair", () => {
+      const managed = createManagedTerminal();
+      managed.runtimeAgentId = "codex";
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.applyResize("term-1", 120, 40);
+      expect(controller.hasPendingResize("term-1")).toBe(true);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+
+      controller.flushResize("term-1");
+
+      expect(controller.hasPendingResize("term-1")).toBe(false);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(120, 40);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 120, 40);
+      vi.advanceTimersByTime(500);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("flushResize preserves a pending settled PTY-only resize intent", () => {
+      const managed = createManagedTerminal();
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      managed.isFocused = false;
+      managed.isVisible = false;
+      managed.runtimeAgentId = "codex";
+      attachCellDims(managed);
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.resize("term-1", 1200, 800);
+      expect(controller.hasPendingResize("term-1")).toBe(true);
+      controller.flushResize("term-1");
+
+      expect(controller.hasPendingResize("term-1")).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1200), 40);
+      vi.advanceTimersByTime(500);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancelPendingResize drops a pending settled commit", () => {
+      const managed = createManagedTerminal();
+      managed.runtimeAgentId = "codex";
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.applyResize("term-1", 120, 40);
+      controller.cancelPendingResize("term-1");
+      vi.advanceTimersByTime(500);
+
+      expect(controller.hasPendingResize("term-1")).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("a direct default PTY target supersedes an older debounce job", () => {
+      const managed = createManagedTerminal();
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 300;
+      attachCellDims(managed);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.resize("term-1", 1200, 800);
+      expect(managed.resizeDebounceTimer).toBeDefined();
+      controller.sendPtyResize("term-1", 140, 45);
+      vi.advanceTimersByTime(100);
+
+      expect(managed.resizeDebounceTimer).toBeUndefined();
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 140, 45);
+    });
+
+    it("a direct settled target supersedes an older debounce job", () => {
+      const managed = createManagedTerminal();
+      managed.runtimeAgentId = "codex";
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 300;
+      attachCellDims(managed);
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.resize("term-1", 1200, 800);
+      controller.sendPtyResize("term-1", 140, 45);
+      vi.advanceTimersByTime(499);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(140, 45);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 140, 45);
+    });
+
+    it("a PTY-only target supersedes an older debounce job without reflowing xterm", () => {
+      const managed = createManagedTerminal();
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 300;
+      attachCellDims(managed);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.resize("term-1", 1200, 800);
+      controller.resizePtyOnly("term-1", 1500, 800);
+      vi.advanceTimersByTime(100);
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1500), 40);
+    });
+
+    it("forceImmediateResize supersedes an older debounce job", () => {
+      const managed = createManagedTerminal();
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 300;
+      attachCellDims(managed);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: mockDataBuffer(),
+      });
+
+      controller.resize("term-1", 1200, 800);
+      managed.latestCols = 140;
+      managed.latestRows = 45;
+      controller.forceImmediateResize("term-1");
+      vi.advanceTimersByTime(100);
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 140, 45);
+    });
+
     it("debounceResize stores timer in resizeDebounceTimer, not resizeJob", () => {
       const managed = createManagedTerminal();
       attachCellDims(managed);
@@ -1211,7 +1534,7 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1000), 25);
     });
 
-    it("falls back to fitAddon.fit() when cell dims are null", () => {
+    it("uses FitAddon's proposal when cell dims are null", () => {
       const managed = createManagedTerminal();
 
       const controller = new TerminalResizeController({
@@ -1221,16 +1544,13 @@ describe("TerminalResizeController", () => {
 
       const result = controller.resize("term-1", 1200, 900);
 
-      expect(result).not.toBeNull();
-      expect(managed.fitAddon.fit).toHaveBeenCalled();
-      expect(resizeMock).toHaveBeenCalledWith(
-        "term-1",
-        managed.terminal.cols,
-        managed.terminal.rows
-      );
+      expect(result).toEqual({ cols: 100, rows: 30 });
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
     });
 
-    it("falls back to fitAddon.fit() when cell dims are zero", () => {
+    it("uses FitAddon's proposal when cell dims are zero", () => {
       const managed = createManagedTerminal();
       attachCellDims(managed, { width: 0, height: 0 });
 
@@ -1241,13 +1561,10 @@ describe("TerminalResizeController", () => {
 
       const result = controller.resize("term-1", 1200, 900);
 
-      expect(result).not.toBeNull();
-      expect(managed.fitAddon.fit).toHaveBeenCalled();
-      expect(resizeMock).toHaveBeenCalledWith(
-        "term-1",
-        managed.terminal.cols,
-        managed.terminal.rows
-      );
+      expect(result).toEqual({ cols: 100, rows: 30 });
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
     });
 
     it("returns null without mutating cache when proposeDimensions returns undefined", () => {
@@ -1289,12 +1606,9 @@ describe("TerminalResizeController", () => {
 
       // Should NOT be suppressed by dedup guard since lastWidth was never updated
       expect(result2).not.toBeNull();
-      expect(managed.fitAddon.fit).toHaveBeenCalled();
-      expect(resizeMock).toHaveBeenCalledWith(
-        "term-1",
-        managed.terminal.cols,
-        managed.terminal.rows
-      );
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(120, 45);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 120, 45);
     });
 
     it("returns null when proposeDimensions returns degenerate 1x1", () => {
@@ -1378,6 +1692,32 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).toHaveBeenCalledTimes(1);
 
       expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reasserts a pending settled target when the PTY-only box is redundant", () => {
+      const managed = createManagedTerminal();
+      managed.launchAgentId = "codex";
+      managed.runtimeAgentId = "codex";
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const controller = makeController(managed);
+
+      controller.resize("term-1", 1600, 800);
+      expect(controller.hasPendingResize("term-1")).toBe(true);
+      expect(resizeMock).not.toHaveBeenCalled();
+
+      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+
+      expect(controller.hasPendingResize("term-1")).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledWith("term-1", colsFor(1600), 40);
+
+      vi.advanceTimersByTime(500);
       expect(resizeMock).toHaveBeenCalledTimes(1);
     });
 

--- a/src/services/terminal/__tests__/TerminalResizePassScheduler.pending.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizePassScheduler.pending.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ focusedId: null }) },
+}));
+
+import { TerminalResizePassScheduler } from "../TerminalResizePassScheduler";
+import { GRID_RESIZE_COALESCE_MS } from "../types";
+
+describe("TerminalResizePassScheduler pending ownership", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function createScheduler() {
+    return new TerminalResizePassScheduler({
+      getInstance: vi.fn(() => undefined),
+      isResizeLocked: vi.fn(() => false),
+      resize: vi.fn(),
+    });
+  }
+
+  it("retains ownership across coalescing, frame handoff, and a deferred active pass", async () => {
+    let frameCallback: FrameRequestCallback | undefined;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallback = callback;
+        return 1;
+      })
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    let runTask: (() => Promise<void>) | undefined;
+    vi.stubGlobal("scheduler", {
+      postTask: vi.fn(
+        (callback: () => unknown) =>
+          new Promise<void>((resolve, reject) => {
+            runTask = async () => {
+              try {
+                await callback();
+                resolve();
+              } catch (error) {
+                reject(error);
+              }
+            };
+          })
+      ),
+    });
+    const resizeScheduler = createScheduler();
+
+    resizeScheduler.scheduleBatchResize(["term-1"]);
+    expect(resizeScheduler.isResizePending("term-1")).toBe(true);
+
+    vi.advanceTimersByTime(GRID_RESIZE_COALESCE_MS);
+    expect(frameCallback).toBeDefined();
+    expect(resizeScheduler.isResizePending("term-1")).toBe(true);
+
+    frameCallback!(0);
+    expect(resizeScheduler.isResizePending("term-1")).toBe(true);
+
+    await runTask!();
+    await vi.runAllTicks();
+    expect(resizeScheduler.isResizePending("term-1")).toBe(false);
+  });
+
+  it("carries superseded pass obligations into the replacement", () => {
+    vi.stubGlobal("scheduler", undefined);
+    const resizeScheduler = createScheduler();
+
+    resizeScheduler.runResizePass(["old-first", "old-pending"]);
+    expect(resizeScheduler.isResizePending("old-first")).toBe(false);
+    expect(resizeScheduler.isResizePending("old-pending")).toBe(true);
+
+    resizeScheduler.runResizePass(["replacement"]);
+
+    expect(resizeScheduler.isResizePending("old-pending")).toBe(true);
+    expect(resizeScheduler.isResizePending("replacement")).toBe(false);
+  });
+
+  it("clears active and scheduled ownership when cancelled or disposed", () => {
+    vi.stubGlobal("scheduler", undefined);
+    const resizeScheduler = createScheduler();
+
+    resizeScheduler.runResizePass(["first", "pending"]);
+    expect(resizeScheduler.isResizePending("pending")).toBe(true);
+    resizeScheduler.cancelActiveResizePass();
+    expect(resizeScheduler.isResizePending("pending")).toBe(false);
+
+    resizeScheduler.scheduleBatchResize(["scheduled"]);
+    expect(resizeScheduler.isResizePending("scheduled")).toBe(true);
+    resizeScheduler.dispose();
+    expect(resizeScheduler.isResizePending("scheduled")).toBe(false);
+  });
+});

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -181,6 +181,7 @@ function buildDeps(
     resumeFlush: vi.fn(),
     hasInFlightWake: vi.fn(() => false),
     hasPendingWake: vi.fn(() => false),
+    isResizeTransitioning: vi.fn(() => false),
     isWebGLActive: vi.fn(() => true),
     shouldHaveWebGL: vi.fn(() => false),
     ensureWebGL: vi.fn(),

--- a/src/services/terminal/paintFabric/PaintFabricCompositor.ts
+++ b/src/services/terminal/paintFabric/PaintFabricCompositor.ts
@@ -844,21 +844,15 @@ export class PaintFabricCompositor implements TerminalPaintPlane {
     }, GRID_RESIZE_COALESCE_MS);
   }
 
-  // One logical pass spans every surface: surfaces receiving ids supersede
-  // their own in-flight pass (the service's per-instance abort), and surfaces
-  // with no ids in this pass get an explicit cancel so their stale chunked
-  // work cannot keep reflowing a survivor set the fabric has already moved
-  // past. Shards of the same logical pass are dispatched together and never
-  // cancel each other.
+  // One logical pass may span several surfaces, but callers are allowed to
+  // request a scoped subset (for example a two-pane divider). Dispatch each
+  // shard without cancelling absent surfaces: their pending ids are still
+  // fresh-measurement obligations and must survive an unrelated narrower
+  // pass. Call cancelActiveResizePass() explicitly when all active surface
+  // work is genuinely invalid.
   runResizePass(ids: string[]): void {
     if (ids.length === 0) return;
     const groups = this.groupBySurface(ids);
-    if (this.registry.surfaceCount() > 1) {
-      const inPass = new Set(groups.map((group) => group.plane));
-      for (const plane of this.planes()) {
-        if (!inPass.has(plane)) plane.cancelActiveResizePass();
-      }
-    }
     groups.forEach(({ plane, ids: group }) => plane.runResizePass(group));
   }
 

--- a/src/services/terminal/paintFabric/__tests__/PaintFabricCompositor.resize.test.ts
+++ b/src/services/terminal/paintFabric/__tests__/PaintFabricCompositor.resize.test.ts
@@ -4,9 +4,8 @@ import { GRID_RESIZE_COALESCE_MS } from "../../types";
 import { makeSurface } from "./fakePaintPlane";
 
 // Phase 1 watch-list: "cross-surface resize-pass coordination". One logical
-// pass spans every surface: shards of the same pass never cancel each other,
-// while a NEW pass cancels stale chunked work on every surface — including
-// surfaces that have no ids in the new pass.
+// pass can span every surface, while scoped passes must not discard pending
+// fresh-measurement obligations on surfaces outside their id set.
 function makeCompositor() {
   const a = makeSurface("a");
   const b = makeSurface("b");
@@ -48,7 +47,7 @@ describe("PaintFabricCompositor resize coordination", () => {
     expect(b.cancelActiveResizePass).not.toHaveBeenCalled();
   });
 
-  it("a new pass cancels stale chunked work on surfaces outside the pass", async () => {
+  it("a scoped pass preserves active work on surfaces outside the pass", async () => {
     const { compositor, a, b } = makeCompositor();
     await compositor.getOrCreate("t1-b", undefined, {});
     await compositor.getOrCreate("t2-a", undefined, {});
@@ -56,13 +55,14 @@ describe("PaintFabricCompositor resize coordination", () => {
     // Pass 1 hits only surface b; its chunked work is now in flight.
     compositor.runResizePass(["t1-b"]);
     expect(b.runResizePass).toHaveBeenCalledWith(["t1-b"]);
-    expect(a.cancelActiveResizePass).toHaveBeenCalledTimes(1);
+    expect(a.cancelActiveResizePass).not.toHaveBeenCalled();
 
-    // Pass 2 hits only surface a → surface b's stale pass must be cancelled
-    // even though b has no ids in the new pass.
+    // Pass 2 is independently scoped to surface a. Surface b's pending work is
+    // still valid and remains owned until it completes or is explicitly
+    // cancelled.
     compositor.runResizePass(["t2-a"]);
     expect(a.runResizePass).toHaveBeenCalledWith(["t2-a"]);
-    expect(b.cancelActiveResizePass).toHaveBeenCalledTimes(1);
+    expect(b.cancelActiveResizePass).not.toHaveBeenCalled();
   });
 
   it("an empty pass is a no-op and cancels nothing", () => {


### PR DESCRIPTION
## Summary

- Make the reconciliation watchdog treat per-terminal locks, queued controller work, and scheduled resize passes as transitional geometry instead of repairing through them
- Route public fit and final layout resize requests through one strategy-aware coordinator so settled agents change xterm and PTY geometry together, newer targets supersede stale jobs, and output remains safely flushed or watermarked
- Replace the two-pane drag-end raw fit with a tracked final resize pass, keep long drag locks alive, and retain unfinished batch obligations across scoped or cross-surface passes
- Restore xterm's foreground-application ownership of the cursor line, make every built-in agent resize policy explicit, and set Daintree Assistant to `settled`
- Add exact-version xterm, controller, watchdog, scheduler, PaintFabric, wake/recovery, and real Electron divider regressions

## Root cause

The watchdog could invoke its privileged geometry reconciliation while a two-pane divider held only per-terminal resize locks. Separately, the generic `fit()` path mutated xterm immediately before applying the selected PTY strategy, creating a 500 ms split for settled agents. Global cursor-line reflow then let xterm independently rearrange a live main-buffer footer that the foreground application expected to own.

The coordinator also had stale-job edges where an older debounce, idle task, or settled timer could land after a newer explicit resize, and the batch scheduler could drop unprocessed terminal IDs when a narrower pass replaced a broader one.

## Validation

- `npm run check`
- `npm test` — 1,929 files passed; 38,873 tests passed, 2 skipped, 1 todo
- `npm run build`
- `npm run build:e2e`
- `npx playwright test e2e/full/terminal/core-terminal-divider-resize.spec.ts --project=full-terminal --workers=1`
- `npx playwright test e2e/full/resilience/background-terminal-bulk-output.spec.ts --project=full-resilience --grep "resize observed while BACKGROUND propagates to xterm on restore" --workers=1`
