### PR TITLE
fix(main): treat every window's foreground project as visible (#11102)

### DIFF
--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import os from "os";
 
 vi.mock("electron", () => ({
@@ -229,6 +229,100 @@ describe("project:close handler", () => {
       await expect(
         handler(EVENT, "project-background", { killTerminals: false })
       ).resolves.toBeTruthy();
+    });
+
+    it("rejects a non-kill close when the project goes visible during the stats await", async () => {
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-focused");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-late",
+        name: "Late",
+        status: "active",
+        path: "/test/project-late",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+
+      // No window shows it when the handler starts...
+      let shownInSecondWindow: string | null = null;
+      const registry = {
+        all: () => [
+          {
+            services: {
+              projectViewManager: {
+                getActiveProjectId: () => shownInSecondWindow,
+                getOutgoingBridgeProjectId: () => null,
+              },
+            },
+          },
+        ],
+      };
+
+      const ptyClient = {
+        // ...but the user switches to it while the stats round-trip is in flight.
+        getProjectStats: vi.fn(async () => {
+          shownInSecondWindow = "project-late";
+          return { terminalCount: 1, processIds: [1], terminalTypes: { terminal: 1 } };
+        }),
+        killByProject: vi.fn(async () => 1),
+        onProjectSwitch: vi.fn(),
+        setActiveProject: vi.fn(),
+      };
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient,
+        worktreeService: { pauseProject: vi.fn() },
+      } as unknown as HandlerDependencies;
+      (deps as unknown as { windowRegistry: unknown }).windowRegistry = registry;
+
+      const handler = getCloseHandler(deps);
+
+      await expect(handler(EVENT, "project-late", { killTerminals: false })).rejects.toThrow(
+        "open in a window"
+      );
+      // The entry guard passed, so only the post-await recheck can have caught
+      // this — and it must have caught it BEFORE backgrounding/pausing.
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      expect(
+        (deps as unknown as { worktreeService: { pauseProject: Mock } }).worktreeService
+          .pauseProject
+      ).not.toHaveBeenCalled();
+    });
+
+    it("does not clear a pointer that moved to another project during the kill", async () => {
+      // Pointer names the project being closed when the handler starts...
+      let pointer: string | null = "project-doomed";
+      projectStoreMock.getCurrentProjectId.mockImplementation(() => pointer);
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-doomed",
+        name: "Doomed",
+        status: "active",
+        path: "/test/project-doomed",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+
+      const ptyClient = {
+        getProjectStats: vi.fn(async () => ({
+          terminalCount: 1,
+          processIds: [1],
+          terminalTypes: { terminal: 1 },
+        })),
+        // ...but another window switches away while the kill is in flight.
+        killByProject: vi.fn(async () => {
+          pointer = "project-other";
+          return 1;
+        }),
+        onProjectSwitch: vi.fn(),
+        setActiveProject: vi.fn(),
+      };
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient,
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+      await handler(EVENT, "project-doomed", { killTerminals: true });
+
+      // Clearing on the stale snapshot would have wiped project-other's pointer.
+      expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
     });
 
     it("still allows an explicit kill-terminals close of a visible project", async () => {

--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -140,7 +140,123 @@ describe("project:close handler", () => {
       handler({ senderFrame: { url: "http://localhost:5173" } }, "project-active", {
         killTerminals: false,
       })
-    ).rejects.toThrow("Cannot close the active project");
+    ).rejects.toThrow("open in a window");
+  });
+
+  describe("multi-window visibility guard (#11102)", () => {
+    /** A WindowRegistry-shaped stub whose windows show the given projects. */
+    function registryShowing(...activeProjectIds: Array<string | null>) {
+      return {
+        all: () =>
+          activeProjectIds.map((id) => ({
+            services: {
+              projectViewManager: {
+                getActiveProjectId: () => id,
+                getOutgoingBridgeProjectId: () => null,
+              },
+            },
+          })),
+      };
+    }
+
+    function makePtyClient() {
+      return {
+        getProjectStats: vi.fn(async () => ({
+          terminalCount: 1,
+          processIds: [1],
+          terminalTypes: { terminal: 1 },
+        })),
+        killByProject: vi.fn(async () => 1),
+        onProjectSwitch: vi.fn(),
+        setActiveProject: vi.fn(),
+      };
+    }
+
+    function getCloseHandler(deps: HandlerDependencies) {
+      registerProjectCrudHandlers(deps);
+      const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } })
+        .mock.calls;
+      const closeCall = calls.find((c) => c[0] === CHANNELS.PROJECT_CLOSE);
+      expect(closeCall).toBeTruthy();
+      return closeCall?.[1] as unknown as (
+        event: unknown,
+        projectId: string,
+        options?: { killTerminals?: boolean }
+      ) => Promise<unknown>;
+    }
+
+    const EVENT = { senderFrame: { url: "http://localhost:5173" } };
+
+    it("rejects closing a project visible in a second, unfocused window", async () => {
+      // The DB pointer names a DIFFERENT project — pre-fix, the guard let this
+      // through and closed a project the user was actively looking at.
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-focused");
+
+      const ptyClient = makePtyClient();
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient,
+        windowRegistry: registryShowing("project-focused", "project-second-window"),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+
+      await expect(
+        handler(EVENT, "project-second-window", { killTerminals: false })
+      ).rejects.toThrow("open in a window");
+      expect(ptyClient.killByProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.clearProjectState).not.toHaveBeenCalled();
+    });
+
+    it("still closes a project no window is showing", async () => {
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-focused");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-background",
+        name: "Background",
+        status: "active",
+        path: "/test/project-background",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient: makePtyClient(),
+        windowRegistry: registryShowing("project-focused", "project-second-window"),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+
+      // The guard must not over-block a genuinely background project.
+      await expect(
+        handler(EVENT, "project-background", { killTerminals: false })
+      ).resolves.toBeTruthy();
+    });
+
+    it("still allows an explicit kill-terminals close of a visible project", async () => {
+      // killTerminals is the deliberate, destructive path — the visibility guard
+      // deliberately does not apply to it.
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-focused");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-second-window",
+        name: "Second",
+        status: "active",
+        path: "/test/project-second-window",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+
+      const ptyClient = makePtyClient();
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient,
+        windowRegistry: registryShowing("project-focused", "project-second-window"),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+      await handler(EVENT, "project-second-window", { killTerminals: true });
+
+      expect(ptyClient.killByProject).toHaveBeenCalledWith("project-second-window");
+      // The DB pointer names a different project, so it must NOT be cleared —
+      // that bookkeeping tracks the pointer, not visibility.
+      expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
+    });
   });
 
   it("backgrounds a non-active project and calls pauseProject", async () => {

--- a/electron/ipc/handlers/__tests__/project.freeMemory.test.ts
+++ b/electron/ipc/handlers/__tests__/project.freeMemory.test.ts
@@ -82,6 +82,21 @@ describe("project:free-memory handler", () => {
     vi.clearAllMocks();
   });
 
+  /** A WindowRegistry-shaped stub whose windows show the given projects. */
+  function registryShowing(...activeProjectIds: Array<string | null>) {
+    return {
+      all: () =>
+        activeProjectIds.map((id) => ({
+          services: {
+            projectViewManager: {
+              getActiveProjectId: () => id,
+              getOutgoingBridgeProjectId: () => null,
+            },
+          },
+        })),
+    };
+  }
+
   it("rejects freeing memory for the active project", async () => {
     projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
 
@@ -95,9 +110,66 @@ describe("project:free-memory handler", () => {
 
     const handler = getFreeMemoryHandler(deps);
 
-    await expect(handler(EVENT, "project-active")).rejects.toThrow("Switch to another project");
+    await expect(handler(EVENT, "project-active")).rejects.toThrow("open in a window");
     expect(ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
     expect(worktreeService.evictProject).not.toHaveBeenCalled();
+  });
+
+  it("rejects freeing memory for a project visible in a second, unfocused window (#11102)", async () => {
+    // The DB pointer names a DIFFERENT project — pre-fix, that alone let the
+    // guard through and tore down a renderer the user was looking at.
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-focused");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "project-second-window",
+      name: "Second",
+      status: "active",
+      path: "/p/second",
+    });
+
+    const ptyClient = { gracefulKillByProject: vi.fn(async () => []) };
+    const worktreeService = { evictProject: vi.fn(() => true) };
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+      worktreeService,
+      windowRegistry: registryShowing("project-focused", "project-second-window"),
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+
+    await expect(handler(EVENT, "project-second-window")).rejects.toThrow("open in a window");
+    // Nothing was reclaimed out from under the visible window.
+    expect(ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(evictProjectRendererMock).not.toHaveBeenCalled();
+    expect(worktreeService.evictProject).not.toHaveBeenCalled();
+    expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+  });
+
+  it("still frees memory for a project no window is showing", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-focused");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "project-background",
+      name: "Background",
+      status: "active",
+      path: "/p/background",
+    });
+    evictProjectRendererMock.mockReturnValue(1);
+
+    const ptyClient = { gracefulKillByProject: vi.fn(async () => [{ id: "t1" }]) };
+    const worktreeService = { evictProject: vi.fn(() => true) };
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+      worktreeService,
+      windowRegistry: registryShowing("project-focused", "project-second-window"),
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+    const result = await handler(EVENT, "project-background");
+
+    // The guard must not over-block: a genuinely background project still frees.
+    expect(result.terminalsKilled).toBe(1);
+    expect(result.rendererEvicted).toBe(true);
   });
 
   it("throws when the project does not exist", async () => {

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -3,6 +3,10 @@ import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import {
+  collectActiveProjectIds,
+  projectViewManagersFrom,
+} from "../../../window/activeProjectIds.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -153,10 +157,26 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     const killTerminals = options?.killTerminals ?? false;
     console.log(`[IPC] project:close: ${projectId} (killTerminals: ${killTerminals})`);
 
+    // Kept separate from the visibility check below: this is the persisted
+    // pointer, only used for the `clearCurrentProject()` bookkeeping further
+    // down. It is NOT a "is this project on-screen" signal.
     const storeActiveProjectId = projectStore.getCurrentProjectId();
 
-    if (projectId === storeActiveProjectId && !killTerminals) {
-      throw new Error("Cannot close the active project. Switch to another project first.");
+    // Check EVERY window's foreground project, not just the DB pointer — that
+    // tracks the last-focused window only, so a project on-screen in a second
+    // window would otherwise be closed out from under the user (#11102).
+    if (!killTerminals) {
+      const activeIds = collectActiveProjectIds(
+        projectViewManagersFrom(deps.windowRegistry),
+        storeActiveProjectId,
+        "project-close"
+      );
+      if (activeIds.has(projectId)) {
+        throw new Error(
+          "Cannot close a project that's open in a window. " +
+            "Switch that window to another project first."
+        );
+      }
     }
 
     const project = projectStore.getProjectById(projectId);

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -16,6 +16,14 @@ import { AppError } from "../../../utils/errorTypes.js";
 import { pruneWindowStateForPath } from "../../../windowState.js";
 
 /**
+ * Rejection copy for a close attempt against a project that is on-screen in
+ * some window. Deliberately doesn't say "another window": the same guard covers
+ * the invoking window, a second window, and the outgoing paint-gate bridge.
+ */
+const PROJECT_VISIBLE_MESSAGE =
+  "Cannot close a project that's open in a window. Switch that window to another project first.";
+
+/**
  * Validate, register, and broadcast a project for the given absolute path.
  * Extracted from `handleProjectAdd` so other handlers (e.g. scratch
  * Save-as-Project) can register a path as a project without going through IPC.
@@ -157,26 +165,20 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     const killTerminals = options?.killTerminals ?? false;
     console.log(`[IPC] project:close: ${projectId} (killTerminals: ${killTerminals})`);
 
-    // Kept separate from the visibility check below: this is the persisted
-    // pointer, only used for the `clearCurrentProject()` bookkeeping further
-    // down. It is NOT a "is this project on-screen" signal.
-    const storeActiveProjectId = projectStore.getCurrentProjectId();
-
-    // Check EVERY window's foreground project, not just the DB pointer — that
-    // tracks the last-focused window only, so a project on-screen in a second
-    // window would otherwise be closed out from under the user (#11102).
-    if (!killTerminals) {
-      const activeIds = collectActiveProjectIds(
+    // Is the project on-screen in ANY window? The DB pointer tracks the
+    // last-focused window only, so a project visible in a second window would
+    // otherwise be closed out from under the user (#11102). Re-evaluated rather
+    // than snapshotted: the checks below straddle awaits the user can switch
+    // projects during.
+    const isVisibleAnywhere = (): boolean =>
+      collectActiveProjectIds(
         projectViewManagersFrom(deps.windowRegistry),
-        storeActiveProjectId,
+        projectStore.getCurrentProjectId(),
         "project-close"
-      );
-      if (activeIds.has(projectId)) {
-        throw new Error(
-          "Cannot close a project that's open in a window. " +
-            "Switch that window to another project first."
-        );
-      }
+      ).has(projectId);
+
+    if (!killTerminals && isVisibleAnywhere()) {
+      throw new Error(PROJECT_VISIBLE_MESSAGE);
     }
 
     const project = projectStore.getProjectById(projectId);
@@ -196,7 +198,12 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
 
         await projectStore.clearProjectState(projectId);
 
-        if (projectId === storeActiveProjectId) {
+        // Read the pointer fresh, not from a snapshot taken before the awaits
+        // above: another window can switch projects while the kill is in
+        // flight, and clearing on a stale read would wipe a DIFFERENT
+        // project's pointer. This is pointer bookkeeping, not a visibility
+        // check — it must stay keyed on the DB pointer.
+        if (projectId === projectStore.getCurrentProjectId()) {
           projectStore.clearCurrentProject();
         }
         projectStore.updateProjectStatus(projectId, "closed");
@@ -211,6 +218,19 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
           terminalsKilled,
         };
       } else {
+        // Re-check after the awaited stats call: the user can bring the project
+        // on-screen in any window while it's in flight, and backgrounding it +
+        // pausing its workspace host would then hit a visible project. Thrown as
+        // an AppError so the catch below rethrows it as-is instead of relabelling
+        // a guard rejection as an INTERNAL failure.
+        if (isVisibleAnywhere()) {
+          throw new AppError({
+            code: "VALIDATION",
+            message: PROJECT_VISIBLE_MESSAGE,
+            context: { projectId },
+          });
+        }
+
         projectStore.updateProjectStatus(projectId, "background");
         if (deps.worktreeService) {
           deps.worktreeService.pauseProject(project.path);
@@ -226,6 +246,10 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
         };
       }
     } catch (error) {
+      // A guard rejection (the project went visible mid-close) is a precondition
+      // failure, not a crash — rethrow it rather than relabelling it INTERNAL.
+      if (error instanceof AppError) throw error;
+
       console.error(`[IPC] project:close: Failed to close project ${projectId}:`, error);
       throw new AppError({
         code: "INTERNAL",

--- a/electron/ipc/handlers/projectFreeMemory.ts
+++ b/electron/ipc/handlers/projectFreeMemory.ts
@@ -1,6 +1,7 @@
 import { CHANNELS } from "../channels.js";
 import { broadcastToRenderer } from "../utils.js";
 import { projectStore } from "../../services/ProjectStore.js";
+import { collectActiveProjectIds, projectViewManagersFrom } from "../../window/activeProjectIds.js";
 import { getHibernationService } from "../../services/HibernationService.js";
 import { writeHibernatedMarker } from "../../services/pty/terminalSessionPersistence.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
@@ -32,12 +33,20 @@ export function registerProjectFreeMemoryHandlers(deps: HandlerDependencies): ()
             throw new Error("Invalid project ID");
           }
 
-          // The active project owns the visible renderer and the live workspace
-          // host for this window — tearing them down would blank the window and
-          // sever the worktree feed. Match project:close's guard: switch away.
-          if (projectId === projectStore.getCurrentProjectId()) {
+          // A visible project owns its window's renderer and live workspace host
+          // — tearing them down would blank that window and sever the worktree
+          // feed. Check EVERY window, not just the DB current-project pointer:
+          // that only tracks the last-focused window, so a project on-screen in
+          // a second window would otherwise look like a background one (#11102).
+          const activeIds = collectActiveProjectIds(
+            projectViewManagersFrom(deps.windowRegistry),
+            projectStore.getCurrentProjectId(),
+            "project-free-memory"
+          );
+          if (activeIds.has(projectId)) {
             throw new Error(
-              "Cannot free memory for the active project. Switch to another project first."
+              "Cannot free memory for a project that's open in a window. " +
+                "Switch that window to another project first."
             );
           }
 

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -11,6 +11,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import { writeHibernatedMarker } from "./pty/terminalSessionPersistence.js";
 import type { PtyClient } from "./PtyClient.js";
 import type { ProjectViewManager } from "../window/ProjectViewManager.js";
+import { collectActiveProjectIds } from "../window/activeProjectIds.js";
 import { getPtyClient } from "../window/serviceRefs.js";
 
 export interface HibernationConfig {
@@ -104,6 +105,20 @@ export class HibernationService {
    */
   setProjectViewManagersProvider(provider: (() => ProjectViewManager[]) | null): void {
     this.projectViewManagersProvider = provider;
+  }
+
+  /**
+   * The set of project IDs on-screen in ANY window. The DB current-project
+   * pointer only tracks the last-focused window, so comparing against it alone
+   * would hibernate a project the user is actively looking at in a second,
+   * unfocused window (#11102).
+   */
+  private collectActiveProjectIds(): Set<string> {
+    return collectActiveProjectIds(
+      this.projectViewManagersProvider,
+      projectStore.getCurrentProjectId(),
+      "hibernation"
+    );
   }
 
   setMemoryPressureThresholdMs(ms: number): void {
@@ -250,7 +265,6 @@ export class HibernationService {
       return;
     }
 
-    const currentProjectId = projectStore.getCurrentProjectId();
     const projects = projectStore.getAllProjects();
     const now = Date.now();
     const thresholdMs = config.inactiveThresholdHours * 60 * 60 * 1000;
@@ -259,9 +273,12 @@ export class HibernationService {
     const ptyClient = this.ptyClient;
     const allTerminals = await ptyClient.getAllTerminalsAsync();
 
+    const activeIds = this.collectActiveProjectIds();
+
     for (const project of projects) {
-      // Never hibernate the active project
-      if (project.id === currentProjectId) continue;
+      // Never hibernate a project that's on-screen in ANY window (#11102) — the
+      // DB pointer alone only tracks the last-focused one.
+      if (activeIds.has(project.id)) continue;
 
       // Skip projects with missing/invalid lastOpened to avoid treating them as infinitely inactive
       if (!project.lastOpened) continue;
@@ -295,6 +312,11 @@ export class HibernationService {
         continue;
       }
 
+      // Re-read visibility immediately before acting: the git probe above is a
+      // filesystem round-trip, and the user can bring the project on-screen in
+      // any window while it runs. Same TOCTOU guard the auto-close sweep uses.
+      if (this.collectActiveProjectIds().has(project.id)) continue;
+
       const hoursInactive = Math.floor(inactiveDuration / 3600000);
       logInfo("scheduled-hibernate-project", {
         project: project.name,
@@ -326,7 +348,6 @@ export class HibernationService {
   }
 
   async hibernateUnderMemoryPressure(): Promise<void> {
-    const currentProjectId = projectStore.getCurrentProjectId();
     const projects = projectStore.getAllProjects();
     const now = Date.now();
 
@@ -334,8 +355,11 @@ export class HibernationService {
     const ptyClient = this.ptyClient;
     const allTerminals = await ptyClient.getAllTerminalsAsync();
 
+    const activeIds = this.collectActiveProjectIds();
+
     for (const project of projects) {
-      if (project.id === currentProjectId) continue;
+      // Never hibernate a project that's on-screen in ANY window (#11102).
+      if (activeIds.has(project.id)) continue;
 
       if (!project.lastOpened) continue;
 
@@ -357,6 +381,10 @@ export class HibernationService {
         });
         continue;
       }
+
+      // Re-read visibility immediately before acting — the git probe above is a
+      // filesystem round-trip the user can bring the project on-screen during.
+      if (this.collectActiveProjectIds().has(project.id)) continue;
 
       logInfo("memory-pressure-hibernate-project", {
         project: project.name,

--- a/electron/services/IdleBackgroundAutoCloseService.ts
+++ b/electron/services/IdleBackgroundAutoCloseService.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../shared/types/ipc/idleBackgroundAutoClose.js";
 import type { PtyClient } from "./PtyClient.js";
 import type { ProjectViewManager } from "../window/ProjectViewManager.js";
+import { collectActiveProjectIds } from "../window/activeProjectIds.js";
 import { getPtyClient, getWorkspaceClientRef } from "../window/serviceRefs.js";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
@@ -246,33 +247,11 @@ export class IdleBackgroundAutoCloseService {
    * the active project.
    */
   private collectActiveProjectIds(): Set<string> {
-    const activeIds = new Set<string>();
-    const provider = this.projectViewManagersProvider;
-    if (provider) {
-      let managers: ProjectViewManager[] = [];
-      try {
-        managers = provider();
-      } catch (error) {
-        // windowRegistry may be tearing down — best-effort; fall through to the
-        // DB pointer below so we never auto-close a project we can't verify.
-        logError("idle-background-auto-close-provider-failed", error);
-      }
-      for (const manager of managers) {
-        try {
-          const id = manager.getActiveProjectId();
-          if (id) activeIds.add(id);
-          const outgoing = manager.getOutgoingBridgeProjectId();
-          if (outgoing) activeIds.add(outgoing);
-        } catch (error) {
-          // A disposing ProjectViewManager can throw — isolate per window so one
-          // failure doesn't drop the rest of the active set (#8607).
-          logError("idle-background-auto-close-active-id-failed", error);
-        }
-      }
-    }
-    const dbCurrent = projectStore.getCurrentProjectId();
-    if (dbCurrent) activeIds.add(dbCurrent);
-    return activeIds;
+    return collectActiveProjectIds(
+      this.projectViewManagersProvider,
+      projectStore.getCurrentProjectId(),
+      "idle-background-auto-close"
+    );
   }
 
   private async checkAndClose(): Promise<void> {

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -368,7 +368,6 @@ export class IdleTerminalNotificationService {
       }
     }
 
-    const activeIds = this.collectActiveProjectIds();
     const projects = projectStore.getAllProjects();
     if (projects.length === 0) {
       if (notifiedChanged) store.set("idleTerminalNotifiedAt", notifiedAt);
@@ -380,6 +379,11 @@ export class IdleTerminalNotificationService {
       return;
     }
     const allTerminals = await this.ptyClient.getAllTerminalsAsync();
+
+    // Collected AFTER the pty-host round-trip, not before: the loop below runs
+    // synchronously from here, so sampling visibility any earlier would let a
+    // project brought on-screen during that await be nudged anyway.
+    const activeIds = this.collectActiveProjectIds();
 
     const clearNotified = (pid: string): void => {
       if (notifiedAt[pid] !== undefined) {

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -6,6 +6,8 @@ import type {
   IdleTerminalProjectEntry,
 } from "../../shared/types/ipc/idleTerminals.js";
 import type { PtyClient } from "./PtyClient.js";
+import type { ProjectViewManagersProvider } from "../window/activeProjectIds.js";
+import { collectActiveProjectIds } from "../window/activeProjectIds.js";
 import { getPtyClient } from "../window/serviceRefs.js";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
@@ -56,6 +58,7 @@ export class IdleTerminalNotificationService {
   private readonly WAKE_QUIET_MS = 30_000;
   private currentCheckIntervalMs = this.CHECK_INTERVAL_MS;
   private ptyClient: PtyClient | null = null;
+  private projectViewManagersProvider: ProjectViewManagersProvider | null = null;
 
   /**
    * Inject the live PtyClient so idle checks read the real terminal registry
@@ -64,6 +67,29 @@ export class IdleTerminalNotificationService {
    */
   setPtyClient(client: PtyClient | null): void {
     this.ptyClient = client;
+  }
+
+  /**
+   * Inject a lazy provider over every window's ProjectViewManager so a project
+   * on-screen in a non-focused window is never nudged about its "idle"
+   * terminals (#11102). Lazy because windows open and close after this wires —
+   * re-read on each check. NOT cleared in stop(): it's a stateless closure over
+   * the window registry (no stale object pinned), so a Settings off→on toggle
+   * doesn't lose multi-window awareness (#8637).
+   */
+  setProjectViewManagersProvider(provider: ProjectViewManagersProvider | null): void {
+    this.projectViewManagersProvider = provider;
+  }
+
+  /**
+   * The set of project IDs on-screen in ANY window — see #11102.
+   */
+  private collectActiveProjectIds(): Set<string> {
+    return collectActiveProjectIds(
+      this.projectViewManagersProvider,
+      projectStore.getCurrentProjectId(),
+      "idle-terminal-notification"
+    );
   }
 
   private normalizeThreshold(value: unknown, fallback: number): number {
@@ -342,7 +368,7 @@ export class IdleTerminalNotificationService {
       }
     }
 
-    const currentProjectId = projectStore.getCurrentProjectId();
+    const activeIds = this.collectActiveProjectIds();
     const projects = projectStore.getAllProjects();
     if (projects.length === 0) {
       if (notifiedChanged) store.set("idleTerminalNotifiedAt", notifiedAt);
@@ -368,13 +394,14 @@ export class IdleTerminalNotificationService {
       if (!project.id) continue;
       const pid = project.id;
 
-      // The active project is never notified, but we deliberately do NOT reset
-      // its throttle here: merely viewing a project isn't engaging with its
-      // terminals, and clearing on focus alone would let a switch-to-then-away
-      // round trip re-notify the same still-idle terminals inside the cooldown.
-      // A genuine reset (typing, agent activity) surfaces as terminal activity
-      // below and clears the throttle through the ineligible path.
-      if (pid === currentProjectId) continue;
+      // A project on-screen in ANY window is never notified (#11102 — the DB
+      // pointer alone only tracks the last-focused one). We deliberately do NOT
+      // reset its throttle here: merely viewing a project isn't engaging with
+      // its terminals, and clearing on focus alone would let a switch-to-then-
+      // away round trip re-notify the same still-idle terminals inside the
+      // cooldown. A genuine reset (typing, agent activity) surfaces as terminal
+      // activity below and clears the throttle through the ineligible path.
+      if (activeIds.has(pid)) continue;
 
       // Any remaining non-qualifying reason (no terminals, active agent, recent
       // activity) means the project has left the idle state, so its notified
@@ -460,9 +487,19 @@ export function getIdleTerminalNotificationService(): IdleTerminalNotificationSe
   return idleTerminalNotificationService;
 }
 
-export function initializeIdleTerminalNotificationService(): IdleTerminalNotificationService {
+/**
+ * `projectViewManagersProvider` is wired BEFORE start() so the first (5s) check
+ * already sees every window's foreground project — taking it here makes that
+ * ordering correct by construction rather than by convention.
+ */
+export function initializeIdleTerminalNotificationService(
+  projectViewManagersProvider?: ProjectViewManagersProvider
+): IdleTerminalNotificationService {
   const service = getIdleTerminalNotificationService();
   service.setPtyClient(getPtyClient());
+  if (projectViewManagersProvider) {
+    service.setProjectViewManagersProvider(projectViewManagersProvider);
+  }
   service.start();
   return service;
 }

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -416,7 +416,10 @@ describe("HibernationService", () => {
       const service = makeService();
       await service.hibernateUnderMemoryPressure();
 
-      expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
+      // Assert on the selection observable, not gracefulKillByProject: the PTY
+      // kill is experiment-guarded off on this path, so it never fires either
+      // way and asserting it would pass even if the guard regressed.
+      expect(hibernatedProjectIds()).toEqual([]);
     });
 
     it("skips projects inactive less than 30 minutes", async () => {
@@ -1334,6 +1337,157 @@ describe("HibernationService", () => {
         "hibernation:project-hibernated",
         expect.objectContaining({ reason: "user-initiated" })
       );
+    });
+  });
+
+  describe("multi-window visibility guard (#11102)", () => {
+    const THIRTY_ONE_MINUTES = 31 * 60 * 1000;
+    const TWENTY_FIVE_HOURS = 25 * 60 * 60 * 1000;
+
+    type PvmMock = {
+      getActiveProjectId: Mock<() => string | null>;
+      getOutgoingBridgeProjectId: Mock<() => string | null>;
+      destroyView: Mock<(projectId: string) => boolean>;
+    };
+
+    function makePvm(
+      activeProjectId: string | null = null,
+      outgoingBridgeProjectId: string | null = null
+    ): PvmMock {
+      return {
+        getActiveProjectId: vi.fn(() => activeProjectId),
+        getOutgoingBridgeProjectId: vi.fn(() => outgoingBridgeProjectId),
+        destroyView: vi.fn(() => true),
+      };
+    }
+
+    function serviceWith(managers: PvmMock[]): HibernationService {
+      const service = makeService();
+      service.setProjectViewManagersProvider(() => managers as unknown as ProjectViewManager[]);
+      return service;
+    }
+
+    /**
+     * Two long-idle projects with live terminals. `focused` is the DB pointer's
+     * project; `second` is the one on-screen in the OTHER, unfocused window.
+     * Both are old enough to be eligible, so any that survives the sweep did so
+     * because of the visibility guard, not the inactivity threshold.
+     */
+    function seedTwoIdleProjects(inactiveFor: number): void {
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+        { id: "t1", projectId: "focused-proj", agentState: "idle" },
+        { id: "t2", projectId: "second-window-proj", agentState: "idle" },
+        { id: "t3", projectId: "truly-background-proj", agentState: "idle" },
+      ]);
+      projectStoreMock.getAllProjects.mockReturnValue([
+        {
+          id: "focused-proj",
+          name: "Focused",
+          path: "/projects/focused",
+          lastOpened: Date.now() - inactiveFor,
+        },
+        {
+          id: "second-window-proj",
+          name: "Second Window",
+          path: "/projects/second",
+          lastOpened: Date.now() - inactiveFor,
+        },
+        {
+          id: "truly-background-proj",
+          name: "Background",
+          path: "/projects/background",
+          lastOpened: Date.now() - inactiveFor,
+        },
+      ]);
+      projectStoreMock.getCurrentProjectId.mockReturnValue("focused-proj");
+    }
+
+    it("does not hibernate a project visible in a second, unfocused window", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      seedTwoIdleProjects(TWENTY_FIVE_HOURS);
+      const service = serviceWith([makePvm("focused-proj"), makePvm("second-window-proj")]);
+
+      await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
+
+      // Only the project no window is showing gets selected.
+      expect(hibernatedProjectIds()).toEqual(["truly-background-proj"]);
+    });
+
+    it("does not hibernate the outgoing paint-gate bridge project", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      seedTwoIdleProjects(TWENTY_FIVE_HOURS);
+      // Second window is mid cold-switch: it already points at a third project,
+      // but second-window-proj is still painted behind the anti-flash bridge.
+      const service = serviceWith([
+        makePvm("focused-proj"),
+        makePvm("truly-background-proj", "second-window-proj"),
+      ]);
+
+      await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
+
+      expect(hibernatedProjectIds()).toEqual([]);
+    });
+
+    it("spares a second-window project under memory pressure too", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      seedTwoIdleProjects(THIRTY_ONE_MINUTES);
+      const service = serviceWith([makePvm("focused-proj"), makePvm("second-window-proj")]);
+
+      await service.hibernateUnderMemoryPressure();
+
+      expect(hibernatedProjectIds()).toEqual(["truly-background-proj"]);
+    });
+
+    it("re-reads visibility after the git probe, sparing a project brought on-screen mid-sweep", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      seedTwoIdleProjects(TWENTY_FIVE_HOURS);
+
+      // The window shows nothing when the sweep starts, then switches to
+      // truly-background-proj while the (awaited) git probe is in flight.
+      const late = makePvm("focused-proj");
+      let collectCount = 0;
+      late.getActiveProjectId.mockImplementation(() => {
+        collectCount++;
+        // First collection (pre-loop) sees the old state; later ones see the switch.
+        return collectCount <= 1 ? "focused-proj" : "truly-background-proj";
+      });
+
+      const service = serviceWith([late]);
+      await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
+
+      // Without the late recheck this would have hibernated a now-visible project.
+      expect(hibernatedProjectIds()).not.toContain("truly-background-proj");
+    });
+
+    it("still hibernates a background project when one window's manager throws (#8607)", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      seedTwoIdleProjects(TWENTY_FIVE_HOURS);
+
+      const disposing = makePvm();
+      disposing.getActiveProjectId.mockImplementation(() => {
+        throw new Error("manager disposed");
+      });
+      const healthy = makePvm("second-window-proj");
+      const service = serviceWith([disposing, healthy]);
+
+      await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
+
+      // The throwing window doesn't abort collection: the healthy window's
+      // project is still protected, and the sweep still does its job.
+      expect(hibernatedProjectIds()).toEqual(["truly-background-proj"]);
+    });
+
+    it("falls back to the DB pointer when no provider is wired (early startup)", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: true, inactiveThresholdHours: 24 });
+      seedTwoIdleProjects(TWENTY_FIVE_HOURS);
+
+      const service = makeService(); // provider never injected
+
+      await (service as unknown as { checkAndHibernate(): Promise<void> }).checkAndHibernate();
+
+      // The pointer still protects the focused project; the rest are fair game.
+      expect(hibernatedProjectIds()).not.toContain("focused-proj");
+      expect(hibernatedProjectIds()).toContain("truly-background-proj");
     });
   });
 });

--- a/electron/services/__tests__/IdleTerminalNotificationService.test.ts
+++ b/electron/services/__tests__/IdleTerminalNotificationService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi, type Mock } from "vitest";
 
 const storeBacking: Record<string, unknown> = {};
 const storeMock = vi.hoisted(() => ({
@@ -56,6 +56,7 @@ vi.mock("../HibernationService.js", () => ({
 
 import { IdleTerminalNotificationService } from "../IdleTerminalNotificationService.js";
 import type { PtyClient } from "../PtyClient.js";
+import type { ProjectViewManager } from "../../window/ProjectViewManager.js";
 
 /** Construct a service with the PtyClient-shaped mock injected (#10054). */
 function makeService(): IdleTerminalNotificationService {
@@ -602,6 +603,114 @@ describe("IdleTerminalNotificationService", () => {
       const service = makeService();
       service.dismissProject("");
       expect(storeBacking.idleTerminalDismissals).toBeUndefined();
+    });
+  });
+
+  describe("multi-window visibility guard (#11102)", () => {
+    type PvmMock = {
+      getActiveProjectId: Mock<() => string | null>;
+      getOutgoingBridgeProjectId: Mock<() => string | null>;
+    };
+
+    function makePvm(
+      activeProjectId: string | null = null,
+      outgoingBridgeProjectId: string | null = null
+    ): PvmMock {
+      return {
+        getActiveProjectId: vi.fn(() => activeProjectId),
+        getOutgoingBridgeProjectId: vi.fn(() => outgoingBridgeProjectId),
+      };
+    }
+
+    function serviceWith(managers: PvmMock[]): IdleTerminalNotificationService {
+      const service = makeService();
+      service.setProjectViewManagersProvider(() => managers as unknown as ProjectViewManager[]);
+      return service;
+    }
+
+    /**
+     * Two projects whose terminals are equally idle. Only the visibility guard
+     * can distinguish them, so whichever survives into the payload did so on
+     * visibility grounds alone.
+     */
+    function seedTwoIdleProjects(): void {
+      storeBacking.idleTerminalNotify = { enabled: true, thresholdMinutes: 60 };
+      projectStoreMock.getCurrentProjectId.mockReturnValue("focused-proj");
+      projectStoreMock.getAllProjects.mockReturnValue([
+        makeProject("second-window-proj", "Second Window"),
+        makeProject("background-proj", "Background"),
+      ]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+        makeTerminal({ id: "t1", projectId: "second-window-proj" }),
+        makeTerminal({ id: "t2", projectId: "background-proj" }),
+      ]);
+    }
+
+    function notifiedProjectIds(): string[] {
+      const call = broadcastToRendererMock.mock.calls[0];
+      if (!call) return [];
+      return (call[1] as { projects: Array<{ projectId: string }> }).projects.map(
+        (p) => p.projectId
+      );
+    }
+
+    it("does not nudge about a project visible in a second, unfocused window", async () => {
+      seedTwoIdleProjects();
+      const service = serviceWith([makePvm("focused-proj"), makePvm("second-window-proj")]);
+
+      await runCheck(service);
+
+      expect(notifiedProjectIds()).toEqual(["background-proj"]);
+    });
+
+    it("does not nudge about the outgoing paint-gate bridge project", async () => {
+      seedTwoIdleProjects();
+      const service = serviceWith([makePvm("background-proj", "second-window-proj")]);
+
+      await runCheck(service);
+
+      // Both projects are on-screen in that window (one active, one still
+      // painted behind the bridge) — nothing left to notify about.
+      expect(broadcastToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it("preserves the notified throttle of a project visible in another window", async () => {
+      seedTwoIdleProjects();
+      const notifiedAt = Date.now() - 1000;
+      storeBacking.idleTerminalNotifiedAt = { "second-window-proj": notifiedAt };
+
+      const service = serviceWith([makePvm("second-window-proj")]);
+      await runCheck(service);
+
+      // Merely being on-screen isn't engaging with the terminals, so the
+      // throttle must survive — otherwise a switch-away would re-nudge instantly.
+      const stored = storeBacking.idleTerminalNotifiedAt as Record<string, number>;
+      expect(stored["second-window-proj"]).toBe(notifiedAt);
+    });
+
+    it("retains the provider across a stop() so a Settings off→on keeps multi-window awareness", async () => {
+      seedTwoIdleProjects();
+      const service = serviceWith([makePvm("second-window-proj")]);
+
+      service.stop();
+      // stop() clears the PtyClient; start() re-acquires it (#10054). Re-inject
+      // so this test isolates provider retention rather than tripping that guard.
+      service.setPtyClient(ptyManagerMock as unknown as PtyClient);
+      await runCheck(service);
+
+      // The provider is a stateless closure over the window registry, so the
+      // second window's project is still protected after the toggle (#8637).
+      expect(notifiedProjectIds()).toEqual(["background-proj"]);
+    });
+
+    it("still nudges when no provider is wired, using the DB pointer alone", async () => {
+      seedTwoIdleProjects();
+      const service = makeService(); // provider never injected
+
+      await runCheck(service);
+
+      // Neither project is the DB pointer's, so both are fair game.
+      expect(notifiedProjectIds().sort()).toEqual(["background-proj", "second-window-proj"]);
     });
   });
 });

--- a/electron/services/__tests__/IdleTerminalNotificationService.test.ts
+++ b/electron/services/__tests__/IdleTerminalNotificationService.test.ts
@@ -703,6 +703,28 @@ describe("IdleTerminalNotificationService", () => {
       expect(notifiedProjectIds()).toEqual(["background-proj"]);
     });
 
+    it("does not nudge about a project brought on-screen during the pty-host await", async () => {
+      seedTwoIdleProjects();
+
+      // Nothing on-screen when the check starts...
+      const pvm = makePvm(null);
+      const service = serviceWith([pvm]);
+
+      // ...but the user switches to it while the terminal snapshot is in flight.
+      ptyManagerMock.getAllTerminalsAsync.mockImplementation(async () => {
+        pvm.getActiveProjectId.mockReturnValue("second-window-proj");
+        return [
+          makeTerminal({ id: "t1", projectId: "second-window-proj" }),
+          makeTerminal({ id: "t2", projectId: "background-proj" }),
+        ];
+      });
+
+      await runCheck(service);
+
+      // Only a post-await collection can see the switch.
+      expect(notifiedProjectIds()).toEqual(["background-proj"]);
+    });
+
     it("still nudges when no provider is wired, using the DB pointer alone", async () => {
       seedTwoIdleProjects();
       const service = makeService(); // provider never injected

--- a/electron/window/__tests__/activeProjectIds.test.ts
+++ b/electron/window/__tests__/activeProjectIds.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+import { collectActiveProjectIds, projectViewManagersFrom } from "../activeProjectIds.js";
+import type { ProjectViewManager } from "../ProjectViewManager.js";
+import type { WindowRegistry } from "../WindowRegistry.js";
+
+type ProjectViewManagerMock = {
+  getActiveProjectId: Mock<() => string | null>;
+  getOutgoingBridgeProjectId: Mock<() => string | null>;
+};
+
+function makePvm(
+  activeProjectId: string | null = null,
+  outgoingBridgeProjectId: string | null = null
+): ProjectViewManagerMock {
+  return {
+    getActiveProjectId: vi.fn(() => activeProjectId),
+    getOutgoingBridgeProjectId: vi.fn(() => outgoingBridgeProjectId),
+  };
+}
+
+function providerOf(managers: ProjectViewManagerMock[]): () => ProjectViewManager[] {
+  return () => managers as unknown as ProjectViewManager[];
+}
+
+describe("collectActiveProjectIds (#11102)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unions the foreground project of every window, not just the focused one", () => {
+    const focused = makePvm("proj-a");
+    const unfocused = makePvm("proj-b");
+
+    const ids = collectActiveProjectIds(providerOf([focused, unfocused]), "proj-a", "test");
+
+    expect(ids.has("proj-b")).toBe(true);
+  });
+
+  it("treats the outgoing paint-gate bridge as visible", () => {
+    // Mid cold-switch: activeProjectId already points at the incoming project,
+    // but the outgoing one is still painted behind the anti-flash bridge.
+    const switching = makePvm("proj-incoming", "proj-outgoing");
+
+    const ids = collectActiveProjectIds(providerOf([switching]), null, "test");
+
+    expect([...ids].sort()).toEqual(["proj-incoming", "proj-outgoing"]);
+  });
+
+  it("deduplicates a project that is foreground in more than one window", () => {
+    const windowOne = makePvm("proj-a");
+    const windowTwo = makePvm("proj-a");
+
+    const ids = collectActiveProjectIds(providerOf([windowOne, windowTwo]), "proj-a", "test");
+
+    expect(ids.size).toBe(1);
+  });
+
+  it("unions the fallback pointer additively rather than using it as the sole source", () => {
+    const window = makePvm("proj-visible");
+
+    const ids = collectActiveProjectIds(providerOf([window]), "proj-db-pointer", "test");
+
+    // Both survive: the DB pointer never displaces what the windows report.
+    expect(ids.has("proj-visible")).toBe(true);
+    expect(ids.has("proj-db-pointer")).toBe(true);
+  });
+
+  it("falls back to the pointer alone when no provider is wired yet (early startup)", () => {
+    const ids = collectActiveProjectIds(null, "proj-db-pointer", "test");
+
+    expect([...ids]).toEqual(["proj-db-pointer"]);
+  });
+
+  it("returns an empty set when nothing is visible and no pointer is set", () => {
+    const ids = collectActiveProjectIds(providerOf([makePvm(null)]), null, "test");
+
+    expect(ids.size).toBe(0);
+  });
+
+  it("still yields the fallback pointer when the provider itself throws", () => {
+    const throwing = (): ProjectViewManager[] => {
+      throw new Error("registry tearing down");
+    };
+
+    const ids = collectActiveProjectIds(throwing, "proj-db-pointer", "test");
+
+    // Never reclaim a project we could not verify — the pointer survives.
+    expect(ids.has("proj-db-pointer")).toBe(true);
+  });
+
+  it("isolates a throwing manager so later windows are still collected (#8607)", () => {
+    const disposing = makePvm();
+    disposing.getActiveProjectId.mockImplementation(() => {
+      throw new Error("manager disposed");
+    });
+    const healthy = makePvm("proj-still-visible");
+
+    const ids = collectActiveProjectIds(providerOf([disposing, healthy]), null, "test");
+
+    expect(ids.has("proj-still-visible")).toBe(true);
+    expect(healthy.getActiveProjectId).toHaveBeenCalled();
+  });
+});
+
+describe("projectViewManagersFrom", () => {
+  it("re-reads the registry on each call so windows opened later are seen", () => {
+    const contexts: Array<{ services: { projectViewManager?: ProjectViewManager } }> = [];
+    const registry = { all: () => contexts } as unknown as WindowRegistry;
+
+    const provider = projectViewManagersFrom(registry);
+    expect(provider()).toHaveLength(0);
+
+    contexts.push({
+      services: { projectViewManager: makePvm("p") as unknown as ProjectViewManager },
+    });
+
+    expect(provider()).toHaveLength(1);
+  });
+
+  it("drops windows that have no ProjectViewManager", () => {
+    const registry = {
+      all: () => [
+        { services: {} },
+        { services: { projectViewManager: makePvm("p") as unknown as ProjectViewManager } },
+      ],
+    } as unknown as WindowRegistry;
+
+    expect(projectViewManagersFrom(registry)()).toHaveLength(1);
+  });
+
+  it("yields an empty list when no registry is available", () => {
+    expect(projectViewManagersFrom(undefined)()).toEqual([]);
+  });
+});

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -153,6 +153,13 @@ vi.mock("../../services/HibernationService.js", () => ({
   getHibernationService: () => ({ stop: vi.fn(), hibernateUnderMemoryPressure: vi.fn() }),
 }));
 
+const initIdleTerminalNotificationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../services/IdleTerminalNotificationService.js", () => ({
+  initializeIdleTerminalNotificationService: initIdleTerminalNotificationMock,
+  getIdleTerminalNotificationService: vi.fn(),
+}));
+
 vi.mock("../../services/pty/terminalSessionPersistence.js", () => ({
   evictSessionFiles: vi.fn(async () => ({ deleted: 0, bytesFreed: 0 })),
   SESSION_EVICTION_TTL_MS: 0,
@@ -409,6 +416,40 @@ describe("initGlobalServices task ordering", () => {
     expect(typeof provider).toBe("function");
     // Lazy: re-reads the registry on each call rather than capturing a snapshot.
     expect(provider()).toEqual([]);
+  });
+
+  it("wires a lazy ProjectViewManager provider into IdleTerminalNotificationService (#11102)", async () => {
+    initIdleTerminalNotificationMock.mockClear();
+
+    const contexts: Array<{ services: { projectViewManager?: unknown } }> = [];
+    const fakeRegistry = {
+      all: () => contexts,
+      get size() {
+        return contexts.length;
+      },
+    } as unknown as WindowRegistry;
+
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("idle-terminal-notification-service");
+    expect(run).toBeDefined();
+    await run!();
+
+    // The provider is passed to the initializer, which wires it BEFORE start()
+    // — so the first check already sees every window's foreground project.
+    expect(initIdleTerminalNotificationMock).toHaveBeenCalledTimes(1);
+    const provider = initIdleTerminalNotificationMock.mock.calls[0][0] as () => unknown[];
+    expect(typeof provider).toBe("function");
+
+    // Lazy: a window that opens after wiring is still seen.
+    expect(provider()).toEqual([]);
+    const pvm = { getActiveProjectId: () => "p1" };
+    contexts.push({ services: { projectViewManager: pvm } });
+    expect(provider()).toEqual([pvm]);
+
+    // Windows without a ProjectViewManager are filtered out.
+    contexts.push({ services: {} });
+    expect(provider()).toEqual([pvm]);
   });
 
   it("registers monitor tasks before resource-profile-service so the profile reads ready data", async () => {

--- a/electron/window/activeProjectIds.ts
+++ b/electron/window/activeProjectIds.ts
@@ -1,0 +1,76 @@
+import type { ProjectViewManager } from "./ProjectViewManager.js";
+import type { WindowRegistry } from "./WindowRegistry.js";
+import { logError } from "../utils/logger.js";
+
+export type ProjectViewManagersProvider = () => ProjectViewManager[];
+
+/**
+ * Adapt a WindowRegistry into the lazy provider shape above. Callers that hold
+ * a registry directly (the IPC handlers, via `HandlerDependencies`) use this
+ * instead of the `setProjectViewManagersProvider` closure the long-lived global
+ * services are wired with. Stays lazy: windows open and close between calls.
+ */
+export function projectViewManagersFrom(
+  registry: WindowRegistry | undefined
+): ProjectViewManagersProvider {
+  return () =>
+    registry
+      ?.all()
+      .map((wCtx) => wCtx.services.projectViewManager)
+      .filter((pvm): pvm is ProjectViewManager => pvm !== undefined) ?? [];
+}
+
+/**
+ * Collect the set of project IDs that are foreground in ANY window.
+ *
+ * The SQLite current-project pointer only tracks the LAST-FOCUSED window, so a
+ * project on-screen in a second, unfocused window looks like a background
+ * project to anything that compares against it alone (#11102). Every decision
+ * that reclaims a project's resources — hibernation, PTY teardown, close,
+ * idle nudges — must consult all windows instead.
+ *
+ * `outgoingBridgeProjectId` counts as visible: during a cold project switch the
+ * outgoing project stays painted behind the anti-flash bridge until the paint
+ * gate settles, even though `activeProjectId` already points at the incoming one.
+ *
+ * `fallbackProjectId` (the DB pointer) is unioned in ADDITIVELY, never used as
+ * the sole check — it covers the early-startup window before the provider is
+ * wired, so a first sweep still skips the active project (#6016).
+ *
+ * @param source Short identifier for the calling site, attached to error logs.
+ */
+export function collectActiveProjectIds(
+  provider: ProjectViewManagersProvider | null,
+  fallbackProjectId: string | null,
+  source: string
+): Set<string> {
+  const activeIds = new Set<string>();
+
+  if (provider) {
+    let managers: ProjectViewManager[] = [];
+    try {
+      managers = provider();
+    } catch (error) {
+      // The window registry may be tearing down — best-effort. Fall through to
+      // the DB pointer so we never reclaim a project we couldn't verify.
+      logError("active-project-ids-provider-failed", error, { source });
+    }
+
+    for (const manager of managers) {
+      try {
+        const activeId = manager.getActiveProjectId();
+        if (activeId) activeIds.add(activeId);
+        const outgoingId = manager.getOutgoingBridgeProjectId();
+        if (outgoingId) activeIds.add(outgoingId);
+      } catch (error) {
+        // A disposing ProjectViewManager can throw — isolate per window so one
+        // failure doesn't drop the rest of the active set (#8607).
+        logError("active-project-ids-manager-failed", error, { source });
+      }
+    }
+  }
+
+  if (fallbackProjectId) activeIds.add(fallbackProjectId);
+
+  return activeIds;
+}

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -627,7 +627,17 @@ export async function initGlobalServices(
     run: async () => {
       const { initializeIdleTerminalNotificationService } =
         await import("../services/IdleTerminalNotificationService.js");
-      initializeIdleTerminalNotificationService();
+      // Multi-window active guard — read every window's ProjectViewManager so a
+      // project visible in a non-focused window is never nudged about its
+      // "idle" terminals (#11102). Lazy lambda: windows open/close after this
+      // wires, so re-read on each check.
+      initializeIdleTerminalNotificationService(
+        () =>
+          windowRegistry
+            ?.all()
+            .map((wCtx) => wCtx.services.projectViewManager)
+            .filter((pvm): pvm is ProjectViewManager => pvm !== undefined) ?? []
+      );
     },
   });
 


### PR DESCRIPTION
## The bug
Four main-process sites decided "is this project in the background?" by comparing against `projectStore.getCurrentProjectId()` — the SQLite pointer, which only tracks the **last-focused** window. Daintree is multi-window and each window has its own `ProjectViewManager` with its own active project, so a project sitting on-screen in a second, unfocused window looked like a background project. It could be hibernated, have its PTYs torn down, be closed, or get nudged about "idle" terminals while the user was looking at it.

Same bug class as #8607, which already fixed this once for `ResourceProfileService` and `IdleBackgroundAutoCloseService`.

## The fix
New shared helper `electron/window/activeProjectIds.ts`:

- `collectActiveProjectIds(provider, fallbackProjectId, source)` — unions every window's `getActiveProjectId()` + `getOutgoingBridgeProjectId()` (the outgoing paint-gate bridge still counts as painted during a cold switch), isolates a throwing manager per window so one disposing window can't drop the rest of the set (#8607), and unions the DB pointer **additively** as a boot-time fallback — never as the sole check (#6016).
- `projectViewManagersFrom(registry)` — adapts a `WindowRegistry` into that lazy provider shape for the IPC handlers, which already carry `windowRegistry` on `HandlerDependencies`.

Applied at all four reported sites:
- `HibernationService.checkAndHibernate()` + `hibernateUnderMemoryPressure()` — the provider was already injected but only `evictProjectRenderer()` consumed it; the two sweeps never did.
- `IdleTerminalNotificationService` — had no provider at all; added, wired before `start()`.
- `project:free-memory` and `project:close` IPC guards.

`IdleBackgroundAutoCloseService` is refactored onto the shared helper so there's exactly one copy of the logic rather than a fifth hand-rolled one. `evictProjectRenderer()` is deliberately left per-window — it skips the window showing the project and evicts the cached view everywhere else, which is the #10668 reclaim; routing it through a global "visible anywhere" set would turn it into "evict nowhere".

## Races fixed along the way
Review turned up three TOCTOU holes around `await` boundaries:

- **`project:close` cleared the wrong project's pointer.** The DB pointer was snapshotted on entry, then compared against after the kill awaits to decide whether to clear it — if another window switched projects mid-kill, this wiped *that* project's pointer. Now read fresh at the point of use.
- **`project:close` checked visibility only on entry**, so a project brought on-screen during the awaited `getProjectStats()` was still backgrounded and had its workspace host paused. Re-checked before the mutation, raised as a `VALIDATION` `AppError` so a precondition failure isn't relabelled `INTERNAL`.
- **`IdleTerminalNotificationService` sampled the active set before awaiting the pty host**, so a project opened during that round-trip was still nudged. Collection moved after the await.

The hibernation sweeps get the same treatment: they re-collect immediately before acting, after the awaited git probe — matching what the auto-close sweep already does.

## Notes / deliberate non-changes
- **No `isMinimized()`/`isOccluded()` filtering.** The issue mentions "non-minimized window", but a minimized window still owns a live project session, and the reference pattern the issue endorses doesn't filter on it. Treating minimized projects as reclaimable would be a separate policy change.
- **`killTerminals: true` still bypasses the visibility guard** — that's the pre-existing "I really mean it" path. Making it sender-aware (reject when the project is visible in *another* window) is a reasonable follow-up but it's a destructive-tier UX decision, not a bugfix.
- **Stale DB pointer can over-protect.** When the window owning the pointer closes while another stays open, the pointer isn't retargeted, so its project stays "protected" even though nothing shows it. Pre-existing (the old `=== currentProjectId` check behaved identically) and the opposite failure direction from this issue, so it's out of scope here — but it's the natural sequel.
- `ProjectStore.checkMissingProjects()` and `relocateProject()` use the same pointer-as-visibility pattern and are worth a follow-up.

## Testing
- New `electron/window/__tests__/activeProjectIds.test.ts` — union across windows, outgoing bridge, dedup, additive fallback, provider failure, per-manager isolation, lazy registry re-read.
- Multi-window regression suites added to `HibernationService`, `IdleTerminalNotificationService`, `project.close`, `project.freeMemory`, plus the provider-wiring contract in `globalServicesInit.order`.
- Each guard test is built so the DB pointer names a *different* project than the one the second window shows, so it fails against the old `=== getCurrentProjectId()` check rather than passing vacuously.
- Strengthened an existing hibernation test that asserted `gracefulKillByProject` wasn't called — that assertion is vacuous under the current experiment flag (it's never called on background paths), so it now asserts the real selection observable.

258 tests pass locally across the affected suites; typecheck and scoped lint/format clean.

Resolves #11102