### PR TITLE
fix(voice): let Windows reach the mic prompt; stop a missing Linux settings binary from killing the app

### DIFF
--- a/electron/ipc/handlers/__tests__/voiceInput.permissions.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.permissions.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn(),
+}));
+
+const systemPreferencesMock = vi.hoisted(() => ({
+  getMediaAccessStatus: vi.fn(() => "not-determined"),
+  askForMediaAccess: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  systemPreferences: systemPreferencesMock,
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn(() => null) },
+}));
+
+/** A stand-in ChildProcess whose "error" event we can fire on demand. */
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+}
+
+const childProcessMock = vi.hoisted(() => ({ spawn: vi.fn() }));
+vi.mock("child_process", () => childProcessMock);
+
+const openExternalUrlMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+vi.mock("../../../utils/openExternal.js", () => ({ openExternalUrl: openExternalUrlMock }));
+
+const logDebugMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../utils/logger.js", () => ({
+  logDebug: logDebugMock,
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: { getCurrentProject: vi.fn(() => null), getCurrentProjectId: vi.fn(() => null) },
+}));
+
+vi.mock("../../../store.js", () => ({
+  store: { get: vi.fn(() => undefined), set: vi.fn() },
+}));
+
+vi.mock("../../channels.js", () => ({
+  CHANNELS: {
+    VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",
+    VOICE_INPUT_SET_SETTINGS: "voice-input:set-settings",
+    VOICE_INPUT_START: "voice-input:start",
+    VOICE_INPUT_STOP: "voice-input:stop",
+    VOICE_INPUT_AUDIO_CHUNK: "voice-input:audio-chunk",
+    VOICE_INPUT_TRANSCRIPTION_DELTA: "voice-input:transcription-delta",
+    VOICE_INPUT_TRANSCRIPTION_COMPLETE: "voice-input:transcription-complete",
+    VOICE_INPUT_ERROR: "voice-input:error",
+    VOICE_INPUT_STATUS: "voice-input:status",
+    VOICE_INPUT_CHECK_MIC_PERMISSION: "voice-input:check-mic-permission",
+    VOICE_INPUT_REQUEST_MIC_PERMISSION: "voice-input:request-mic-permission",
+    VOICE_INPUT_OPEN_MIC_SETTINGS: "voice-input:open-mic-settings",
+    VOICE_INPUT_VALIDATE_API_KEY: "voice-input:validate-api-key",
+    VOICE_INPUT_CORRECT: "voice-input:correct",
+    VOICE_INPUT_FLUSH_PARAGRAPH: "voice-input:flush-paragraph",
+    VOICE_INPUT_PARAGRAPH_BOUNDARY: "voice-input:paragraph-boundary",
+    VOICE_INPUT_FILE_TOKEN_RESOLVED: "voice-input:file-token-resolved",
+  },
+}));
+
+import { registerVoiceInputHandlers } from "../voiceInput.js";
+
+const fakeEvent = {
+  sender: { once: vi.fn(), removeListener: vi.fn(), isDestroyed: () => false },
+} as unknown as Electron.IpcMainInvokeEvent;
+
+function getHandler(channel: string) {
+  const call = ipcMainMock.handle.mock.calls.find(([c]) => c === channel);
+  if (!call) throw new Error(`No handler registered for channel: ${channel}`);
+  return call[1] as (event: unknown, ...args: unknown[]) => unknown;
+}
+
+const requestMicPermission = () =>
+  getHandler("voice-input:request-mic-permission")(fakeEvent) as Promise<boolean>;
+// These two handlers are synchronous — they resolve through IPC, not a promise.
+const checkMicPermission = () => getHandler("voice-input:check-mic-permission")(fakeEvent);
+const openMicSettings = () => getHandler("voice-input:open-mic-settings")(fakeEvent);
+
+describe("voiceInput — microphone permission handlers", () => {
+  const originalPlatform = process.platform;
+  let cleanup: () => void;
+
+  const setPlatform = (value: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    childProcessMock.spawn.mockImplementation(() => new FakeChild());
+    cleanup = registerVoiceInputHandlers({
+      mainWindow: {
+        webContents: { send: vi.fn() },
+        isDestroyed: () => false,
+      } as unknown as Electron.BrowserWindow,
+    } as Parameters<typeof registerVoiceInputHandlers>[0]);
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    setPlatform(originalPlatform);
+  });
+
+  describe("requestMicPermission", () => {
+    it("lets Windows through to getUserMedia instead of reporting a denial", async () => {
+      // The Windows dead-end: this used to resolve false, which the renderer read
+      // as a hard denial and bailed on before ever reaching getUserMedia.
+      setPlatform("win32");
+
+      await expect(requestMicPermission()).resolves.toBe(true);
+      expect(systemPreferencesMock.askForMediaAccess).not.toHaveBeenCalled();
+    });
+
+    it("lets Linux through to getUserMedia without a native request", async () => {
+      setPlatform("linux");
+
+      await expect(requestMicPermission()).resolves.toBe(true);
+      expect(systemPreferencesMock.askForMediaAccess).not.toHaveBeenCalled();
+    });
+
+    it("relays the native macOS verdict in both directions", async () => {
+      // macOS is the only platform that can answer authoritatively, so its
+      // `false` must survive as a real denial rather than being normalized away.
+      setPlatform("darwin");
+
+      systemPreferencesMock.askForMediaAccess.mockResolvedValueOnce(true);
+      await expect(requestMicPermission()).resolves.toBe(true);
+
+      systemPreferencesMock.askForMediaAccess.mockResolvedValueOnce(false);
+      await expect(requestMicPermission()).resolves.toBe(false);
+
+      expect(systemPreferencesMock.askForMediaAccess).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("checkMicPermission", () => {
+    it("forwards the OS-reported status on Windows", () => {
+      setPlatform("win32");
+      systemPreferencesMock.getMediaAccessStatus.mockReturnValueOnce("denied");
+
+      expect(checkMicPermission()).toBe("denied");
+    });
+
+    it("reports unknown on Linux, which has no status API", () => {
+      setPlatform("linux");
+
+      expect(checkMicPermission()).toBe("unknown");
+      expect(systemPreferencesMock.getMediaAccessStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("openMicSettings", () => {
+    it("contains a missing Linux settings binary instead of crashing the app", () => {
+      // A missing binary arrives as an async "error" event, never a throw. With no
+      // listener attached it becomes an uncaughtException and takes the app into
+      // fatal recovery — so the listener must be on the child before we return.
+      setPlatform("linux");
+      const child = new FakeChild();
+      childProcessMock.spawn.mockReturnValueOnce(child);
+
+      openMicSettings();
+
+      expect(child.listenerCount("error")).toBeGreaterThan(0);
+
+      const enoent = Object.assign(new Error("spawn gnome-control-center ENOENT"), {
+        code: "ENOENT",
+      });
+      expect(() => child.emit("error", enoent)).not.toThrow();
+      expect(logDebugMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ error: enoent.message })
+      );
+    });
+
+    it("survives a synchronous spawn failure on Linux", () => {
+      setPlatform("linux");
+      childProcessMock.spawn.mockImplementationOnce(() => {
+        throw new Error("EACCES");
+      });
+
+      expect(() => openMicSettings()).not.toThrow();
+      expect(logDebugMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ error: "EACCES" })
+      );
+    });
+
+    it("uses a settings URL rather than a spawned binary on macOS and Windows", () => {
+      setPlatform("darwin");
+      openMicSettings();
+      setPlatform("win32");
+      openMicSettings();
+
+      expect(childProcessMock.spawn).not.toHaveBeenCalled();
+      expect(openExternalUrlMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("contains a rejected settings-URL open", async () => {
+      setPlatform("win32");
+      openExternalUrlMock.mockRejectedValueOnce(new Error("no handler registered"));
+
+      expect(() => openMicSettings()).not.toThrow();
+      await vi.waitFor(() =>
+        expect(logDebugMock).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ error: "no handler registered" })
+        )
+      );
+    });
+  });
+});

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -175,12 +175,21 @@ function checkMicPermission(): MicPermissionStatus {
   return "unknown";
 }
 
+/**
+ * Native permission preflight. The boolean means "the renderer may proceed to
+ * getUserMedia" — NOT "the OS confirmed access".
+ *
+ * macOS is the only platform with a main-process request API
+ * (askForMediaAccess), so it is the only one that can answer authoritatively;
+ * a `false` there is a real denial. Windows and Linux have no such API —
+ * getUserMedia is the actual gate — so they must return `true` to let the
+ * renderer reach it. Returning `false` here dead-ends voice input on Windows.
+ */
 async function requestMicPermission(): Promise<boolean> {
   if (process.platform === "darwin") {
     return systemPreferences.askForMediaAccess("microphone");
   }
-  // On Windows/Linux, permission is requested via getUserMedia in the renderer
-  return false;
+  return true;
 }
 
 function openMicSettings(): void {
@@ -196,13 +205,18 @@ function openMicSettings(): void {
   } else if (process.platform === "win32") {
     void openExternalUrl("ms-settings:privacy-microphone").catch(logOpenFailure);
   } else {
-    // Linux: try gnome-control-center, fall back silently
+    // Linux: try gnome-control-center, fall back silently. A missing binary
+    // surfaces as an async "error" event, not a throw — without this listener it
+    // becomes an uncaughtException and takes the app into fatal recovery.
     try {
-      spawn("gnome-control-center", ["sound"], { detached: true, stdio: "ignore" }).unref();
-    } catch (err) {
-      logDebug("[VoiceInput] Failed to open mic settings", {
-        error: (err as Error)?.message ?? String(err),
+      const child = spawn("gnome-control-center", ["sound"], {
+        detached: true,
+        stdio: "ignore",
       });
+      child.on("error", logOpenFailure);
+      child.unref();
+    } catch (err) {
+      logOpenFailure(err);
     }
   }
 }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1604,7 +1604,15 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onError(callback: (error: VoiceInputError) => void): () => void;
     onStatus(callback: (status: VoiceInputStatus) => void): () => void;
     checkMicPermission(): Promise<MicPermissionStatus>;
+    /**
+     * Native permission preflight. Resolves to whether the renderer may proceed
+     * to getUserMedia — NOT to whether the OS granted access. Only macOS can
+     * answer authoritatively (a `false` there is a real denial); Windows and
+     * Linux have no main-process request API and always resolve `true`, because
+     * getUserMedia is the real gate on those platforms.
+     */
     requestMicPermission(): Promise<boolean>;
+    /** Best-effort: opens the OS microphone settings. Failures are logged, never surfaced. */
     openMicSettings(): Promise<void>;
     validateApiKey(apiKey: string): Promise<{ valid: boolean; error?: string }>;
     /** Run a whole-passage AI cleanup pass over the dictated text after recording stops. */

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -110,17 +110,28 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
 
 type ApiKeyValidation = "idle" | "testing" | "valid" | "invalid";
 
+type ConclusiveMicStatus = "granted" | "denied" | "restricted";
+
+/** Only these settle the question; not-determined and unknown leave it open. */
+function isConclusive(status: MicPermissionStatus | undefined): status is ConclusiveMicStatus {
+  return status === "granted" || status === "denied" || status === "restricted";
+}
+
 /**
  * Opens the mic just long enough to settle permission, then releases it. This is
  * the only way to request access on platforms without a native request API.
+ *
+ * A refusal is the only outcome that means "denied" — a missing or busy device
+ * fails too, and reporting that as a permission problem would send the user to
+ * the privacy settings for a mic they don't have.
  */
-async function probeMicCapture(): Promise<boolean> {
+async function probeMicCapture(): Promise<"granted" | "denied" | "unavailable"> {
   let stream: MediaStream | undefined;
   try {
     stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
-    return true;
-  } catch {
-    return false;
+    return "granted";
+  } catch (err) {
+    return err instanceof DOMException && err.name === "NotAllowedError" ? "denied" : "unavailable";
   } finally {
     stream?.getTracks().forEach((track) => track.stop());
   }
@@ -178,29 +189,51 @@ export function VoiceInputSettingsTab() {
     });
   };
 
+  // Best-effort: a transient IPC failure is inconclusive, not an answer.
+  const readMicPermission = async (): Promise<MicPermissionStatus | undefined> => {
+    try {
+      return await window.electron?.voiceInput?.checkMicPermission();
+    } catch {
+      return undefined;
+    }
+  };
+
+  // Same: a failed preflight must not block the capture gate behind it.
+  const runNativePreflight = async (): Promise<boolean | undefined> => {
+    try {
+      return await window.electron?.voiceInput?.requestMicPermission();
+    } catch {
+      return undefined;
+    }
+  };
+
   const handleRequestMicPermission = async () => {
     setIsRequestingMic(true);
     try {
       // macOS settles this natively. Windows/Linux have no main-process request
       // API — a `true` there only means "clear to attempt capture", so the OS
-      // status stays not-determined and getUserMedia below is the actual request.
-      const canAttemptCapture = await window.electron?.voiceInput?.requestMicPermission();
-      let status = await window.electron?.voiceInput?.checkMicPermission();
+      // status stays unsettled and the capture probe below is the actual request.
+      const canAttemptCapture = await runNativePreflight();
 
-      if (canAttemptCapture && (!status || status === "not-determined")) {
-        const captured = await probeMicCapture();
-        const rechecked = await window.electron?.voiceInput?.checkMicPermission();
-        // Windows can keep reporting not-determined even after capture succeeds;
-        // trust what the attempt actually proved over an inconclusive status.
-        status =
-          rechecked && rechecked !== "not-determined"
-            ? rechecked
-            : captured
-              ? "granted"
-              : "denied";
+      const status = await readMicPermission();
+      if (isConclusive(status)) {
+        setMicPermission(status);
+        return;
+      }
+      if (canAttemptCapture === false) {
+        // Only macOS answers authoritatively, and it just refused — the OS status
+        // simply hasn't caught up yet.
+        setMicPermission("denied");
+        return;
       }
 
-      if (status) setMicPermission(status);
+      const probed = await probeMicCapture();
+      const rechecked = await readMicPermission();
+      // The OS can keep reporting not-determined (or unknown) even after capture
+      // succeeds; trust what the attempt actually proved over an unsettled status.
+      if (isConclusive(rechecked)) setMicPermission(rechecked);
+      else if (probed !== "unavailable") setMicPermission(probed);
+      else if (rechecked) setMicPermission(rechecked);
     } catch {
       // Non-fatal — the row keeps its last known status.
     } finally {

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -110,6 +110,22 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
 
 type ApiKeyValidation = "idle" | "testing" | "valid" | "invalid";
 
+/**
+ * Opens the mic just long enough to settle permission, then releases it. This is
+ * the only way to request access on platforms without a native request API.
+ */
+async function probeMicCapture(): Promise<boolean> {
+  let stream: MediaStream | undefined;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    stream?.getTracks().forEach((track) => track.stop());
+  }
+}
+
 export function VoiceInputSettingsTab() {
   const [settings, setSettings] = useState<VoiceInputSettings>(DEFAULT_SETTINGS);
   const [micPermission, setMicPermission] = useState<MicPermissionStatus>("unknown");
@@ -165,11 +181,28 @@ export function VoiceInputSettingsTab() {
   const handleRequestMicPermission = async () => {
     setIsRequestingMic(true);
     try {
-      await window.electron?.voiceInput?.requestMicPermission();
-      const status = await window.electron?.voiceInput?.checkMicPermission();
+      // macOS settles this natively. Windows/Linux have no main-process request
+      // API — a `true` there only means "clear to attempt capture", so the OS
+      // status stays not-determined and getUserMedia below is the actual request.
+      const canAttemptCapture = await window.electron?.voiceInput?.requestMicPermission();
+      let status = await window.electron?.voiceInput?.checkMicPermission();
+
+      if (canAttemptCapture && (!status || status === "not-determined")) {
+        const captured = await probeMicCapture();
+        const rechecked = await window.electron?.voiceInput?.checkMicPermission();
+        // Windows can keep reporting not-determined even after capture succeeds;
+        // trust what the attempt actually proved over an inconclusive status.
+        status =
+          rechecked && rechecked !== "not-determined"
+            ? rechecked
+            : captured
+              ? "granted"
+              : "denied";
+      }
+
       if (status) setMicPermission(status);
     } catch {
-      // ignore
+      // Non-fatal — the row keeps its last known status.
     } finally {
       setIsRequestingMic(false);
     }

--- a/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { VoiceInputSettingsTab } from "../VoiceInputSettingsTab";
 
 const mockNotify = vi.fn();
@@ -268,6 +268,106 @@ describe("VoiceInputSettingsTab", () => {
       expect(screen.getByText(/not used for model training/)).toBeTruthy();
       expect(screen.getByText(/abuse-monitoring logs for up to 30 days/)).toBeTruthy();
       expect(screen.queryByText(/stored locally in plain text/)).toBeNull();
+    });
+  });
+
+  describe("microphone permission request on Windows", () => {
+    const originalNavigator = globalThis.navigator;
+
+    const stubWindowsNavigator = (getUserMedia: ReturnType<typeof vi.fn>) => {
+      Object.defineProperty(globalThis, "navigator", {
+        value: {
+          userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+          mediaDevices: { getUserMedia },
+        },
+        writable: true,
+        configurable: true,
+      });
+    };
+
+    const renderWithMic = async (api: Partial<typeof window.electron.voiceInput>) => {
+      window.electron = {
+        voiceInput: createVoiceInputApi({
+          getSettings: vi.fn().mockResolvedValue({
+            enabled: true,
+            openaiApiKey: "sk-test",
+            language: "en",
+            customDictionary: [],
+            transcriptionModel: "gpt-realtime-whisper",
+            correctionEnabled: false,
+            correctionModel: "gpt-5-mini",
+            correctionCustomInstructions: "",
+            paragraphingStrategy: "spoken-command",
+            resolveFileLinks: true,
+            deviceId: "",
+          }),
+          ...api,
+        }),
+      } as unknown as typeof window.electron;
+
+      render(<VoiceInputSettingsTab />);
+      const button = await screen.findByRole("button", { name: /Request/ });
+      fireEvent.click(button);
+    };
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, "navigator", {
+        value: originalNavigator,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("reaches getUserMedia, since Windows has no native request API", async () => {
+      // The preflight only clears the way on Windows — without this capture
+      // attempt the Request button can never actually prompt for the mic.
+      const track = { stop: vi.fn() };
+      const getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [track] });
+      stubWindowsNavigator(getUserMedia);
+
+      const requestMicPermission = vi.fn().mockResolvedValue(true);
+      await renderWithMic({
+        requestMicPermission,
+        checkMicPermission: vi.fn().mockResolvedValue("not-determined"),
+      });
+
+      await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+      expect(requestMicPermission).toHaveBeenCalledTimes(1);
+      // The probe must never hold the mic open past the request.
+      expect(track.stop).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(screen.getByText(/access granted/)).toBeTruthy());
+    });
+
+    it("reports a denial when the capture attempt is refused", async () => {
+      const getUserMedia = vi
+        .fn()
+        .mockRejectedValue(new DOMException("Permission denied", "NotAllowedError"));
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockResolvedValue(true),
+        checkMicPermission: vi.fn().mockResolvedValue("not-determined"),
+      });
+
+      await waitFor(() => expect(screen.getByText(/Microphone denied/)).toBeTruthy());
+    });
+
+    it("skips capture when the native preflight denies, as it does on macOS", async () => {
+      const getUserMedia = vi.fn();
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockResolvedValue(false),
+        // not-determined on mount is what surfaces the Request button at all; the
+        // native prompt settles it to denied by the time the handler re-checks.
+        checkMicPermission: vi
+          .fn()
+          .mockResolvedValueOnce("not-determined")
+          .mockResolvedValue("denied"),
+      });
+
+      await waitFor(() => expect(screen.getByText(/Microphone denied/)).toBeTruthy());
+      expect(getUserMedia).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
@@ -352,6 +352,60 @@ describe("VoiceInputSettingsTab", () => {
       await waitFor(() => expect(screen.getByText(/Microphone denied/)).toBeTruthy());
     });
 
+    it("does not blame permission when the machine simply has no microphone", async () => {
+      // NotFoundError is a device problem, not a refusal — calling it "denied"
+      // would send the user to the privacy settings for a mic they don't have.
+      const getUserMedia = vi
+        .fn()
+        .mockRejectedValue(new DOMException("No device", "NotFoundError"));
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockResolvedValue(true),
+        checkMicPermission: vi.fn().mockResolvedValue("not-determined"),
+      });
+
+      await waitFor(() => expect(getUserMedia).toHaveBeenCalled());
+      // Let the handler settle fully before asserting the absence of a denial.
+      await waitFor(() => expect(screen.getByText(/not yet requested/)).toBeTruthy());
+      expect(screen.queryByText(/Microphone denied/)).toBeNull();
+    });
+
+    it("still probes when the OS reports an unsettled 'unknown' status", async () => {
+      // unknown is as unsettled as not-determined — treating it as an answer
+      // would dead-end the button exactly like the bug being fixed here.
+      const track = { stop: vi.fn() };
+      const getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [track] });
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockResolvedValue(true),
+        checkMicPermission: vi
+          .fn()
+          .mockResolvedValueOnce("not-determined")
+          .mockResolvedValue("unknown"),
+      });
+
+      await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText(/access granted/)).toBeTruthy());
+    });
+
+    it("keeps a successful capture when the status re-check fails transiently", async () => {
+      const track = { stop: vi.fn() };
+      const getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [track] });
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockResolvedValue(true),
+        checkMicPermission: vi
+          .fn()
+          .mockResolvedValueOnce("not-determined")
+          .mockRejectedValue(new Error("IPC dropped")),
+      });
+
+      await waitFor(() => expect(screen.getByText(/access granted/)).toBeTruthy());
+    });
+
     it("skips capture when the native preflight denies, as it does on macOS", async () => {
       const getUserMedia = vi.fn();
       stubWindowsNavigator(getUserMedia);
@@ -368,6 +422,36 @@ describe("VoiceInputSettingsTab", () => {
 
       await waitFor(() => expect(screen.getByText(/Microphone denied/)).toBeTruthy());
       expect(getUserMedia).not.toHaveBeenCalled();
+    });
+
+    it("trusts a native refusal even when the OS status has not caught up", async () => {
+      // Only macOS can return false, and it is authoritative — don't reopen the
+      // mic just because getMediaAccessStatus is still lagging on not-determined.
+      const getUserMedia = vi.fn();
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockResolvedValue(false),
+        checkMicPermission: vi.fn().mockResolvedValue("not-determined"),
+      });
+
+      await waitFor(() => expect(screen.getByText(/Microphone denied/)).toBeTruthy());
+      expect(getUserMedia).not.toHaveBeenCalled();
+    });
+
+    it("falls through to the capture gate when the preflight IPC fails", async () => {
+      // A broken preflight must not block the only real gate on Windows.
+      const track = { stop: vi.fn() };
+      const getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [track] });
+      stubWindowsNavigator(getUserMedia);
+
+      await renderWithMic({
+        requestMicPermission: vi.fn().mockRejectedValue(new Error("IPC dropped")),
+        checkMicPermission: vi.fn().mockResolvedValue("not-determined"),
+      });
+
+      await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText(/access granted/)).toBeTruthy());
     });
   });
 });

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -566,7 +566,7 @@ class VoiceRecordingService {
     }
 
     if (micStatus === "not-determined") {
-      logDebug(`${LOG_PREFIX} Requesting OS microphone permission`);
+      logDebug(`${LOG_PREFIX} Running native microphone permission preflight`);
       // Only macOS can answer this natively; Windows/Linux resolve `true` to mean
       // "clear to attempt capture", so a `false` here is a genuine macOS denial.
       let canAttemptCapture: boolean;
@@ -587,7 +587,7 @@ class VoiceRecordingService {
       if (this.isStartRequestStale(startRequestId)) {
         return;
       }
-      logDebug(`${LOG_PREFIX} OS microphone permission result`, { canAttemptCapture });
+      logDebug(`${LOG_PREFIX} Native microphone preflight result`, { canAttemptCapture });
       if (!canAttemptCapture) {
         const message = "Microphone permission denied. Enable it in System Settings and try again.";
         useVoiceRecordingStore

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -567,9 +567,11 @@ class VoiceRecordingService {
 
     if (micStatus === "not-determined") {
       logDebug(`${LOG_PREFIX} Requesting OS microphone permission`);
-      let granted: boolean;
+      // Only macOS can answer this natively; Windows/Linux resolve `true` to mean
+      // "clear to attempt capture", so a `false` here is a genuine macOS denial.
+      let canAttemptCapture: boolean;
       try {
-        granted = await window.electron.voiceInput.requestMicPermission();
+        canAttemptCapture = await window.electron.voiceInput.requestMicPermission();
       } catch (err) {
         logError(`${LOG_PREFIX} requestMicPermission IPC rejected`, err);
         if (!this.isStartRequestStale(startRequestId)) {
@@ -585,8 +587,8 @@ class VoiceRecordingService {
       if (this.isStartRequestStale(startRequestId)) {
         return;
       }
-      logDebug(`${LOG_PREFIX} OS microphone permission result`, { granted });
-      if (!granted) {
+      logDebug(`${LOG_PREFIX} OS microphone permission result`, { canAttemptCapture });
+      if (!canAttemptCapture) {
         const message = "Microphone permission denied. Enable it in System Settings and try again.";
         useVoiceRecordingStore
           .getState()
@@ -597,7 +599,9 @@ class VoiceRecordingService {
       }
     }
 
-    // Acquire microphone stream — permission should be granted at this point.
+    // Acquire microphone stream. On macOS the preflight above already settled
+    // permission; on Windows/Linux this call IS the permission gate, so a denial
+    // arrives here as NotAllowedError rather than from the preflight.
     logDebug(`${LOG_PREFIX} Requesting microphone access`);
     let stream: MediaStream;
     try {

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -150,7 +150,7 @@ const runtime = vi.hoisted(() => ({
     >(),
     checkMicPermission: vi.fn<() => Promise<string>>(),
     requestMicPermission: vi.fn<() => Promise<boolean>>(),
-    openMicSettings: vi.fn(),
+    openMicSettings: vi.fn<() => Promise<void>>(),
     sendAudioChunk: vi.fn<(chunk: ArrayBuffer) => void>(),
     start: vi.fn<() => Promise<{ ok: boolean; error?: string }>>(),
     stop: vi.fn<() => Promise<void>>(),
@@ -268,6 +268,9 @@ function resetRuntime(): void {
     const next = runtime.requestMicPermissionQueue.shift();
     return next instanceof Promise ? next : (next ?? true);
   });
+  // The real IPC method resolves a promise; the caller hands it to
+  // safeFireAndForget, which would throw on a bare undefined.
+  runtime.voiceInput.openMicSettings.mockImplementation(async () => {});
   runtime.voiceInput.start.mockImplementation(async () => {
     const next = runtime.startQueue.shift();
     if (next instanceof Promise) {
@@ -557,6 +560,79 @@ describe("VoiceRecordingService adversarial", () => {
     expect(runtime.voiceFns.beginSession).not.toHaveBeenCalled();
     expect(runtime.voiceInput.start).not.toHaveBeenCalled();
     expect(runtime.createdWorkletNodes).toHaveLength(0);
+  });
+
+  it("NOT_DETERMINED_PREFLIGHT_REACHES_GET_USER_MEDIA", async () => {
+    // Windows reports not-determined and has no native request API, so the
+    // preflight only clears the way — getUserMedia is the real gate and must be
+    // reached. Regression for the dead-end where a non-grant aborted start().
+    runtime.micPermissionQueue.push("not-determined");
+    runtime.requestMicPermissionQueue.push(true);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    await voiceRecordingService.start({ panelId: "panel-1", panelTitle: "Panel One" });
+
+    expect(runtime.createdStreams).toHaveLength(1);
+    expect(runtime.voiceFns.beginSession).toHaveBeenCalledTimes(1);
+    expect(runtime.voiceInput.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("NATIVE_PREFLIGHT_DENIAL_SKIPS_CAPTURE", async () => {
+    // macOS is the one platform that can deny authoritatively; that false must
+    // still abort before we ever open the mic.
+    runtime.micPermissionQueue.push("not-determined");
+    runtime.requestMicPermissionQueue.push(false);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    await voiceRecordingService.start({ panelId: "panel-1", panelTitle: "Panel One" });
+
+    expect(runtime.createdStreams).toHaveLength(0);
+    expect(runtime.voiceFns.beginSession).not.toHaveBeenCalled();
+    expect(runtime.voiceFns.setLastError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "mic_permission_denied", severity: "fatal" })
+    );
+  });
+
+  it("CAPTURE_DENIAL_IS_FATAL_BUT_RETRYABLE", async () => {
+    // A denial at the getUserMedia gate must report as a permission denial and
+    // leave no cached refusal behind — the next start has to try capture again.
+    const denial = Promise.reject(new DOMException("Permission denied", "NotAllowedError"));
+    denial.catch(() => {}); // Mark handled; the mock still rejects on await.
+    const retryStream = createStream();
+    runtime.micPermissionQueue.push("not-determined", "not-determined");
+    runtime.requestMicPermissionQueue.push(true, true);
+    runtime.getUserMediaQueue.push(denial as unknown as MockStream, retryStream);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    const target: VoiceRecordingTarget = { panelId: "panel-1", panelTitle: "Panel One" };
+
+    await voiceRecordingService.start(target);
+    expect(runtime.voiceFns.setLastError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "mic_permission_denied", severity: "fatal" })
+    );
+    expect(runtime.voiceFns.beginSession).not.toHaveBeenCalled();
+
+    await voiceRecordingService.start(target);
+    expect(runtime.voiceFns.beginSession).toHaveBeenCalledTimes(1);
+    expect(runtime.voiceInput.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("OS_LEVEL_DENIAL_NEVER_REACHES_THE_PREFLIGHT", async () => {
+    // A status of denied/restricted is already authoritative on every platform,
+    // so it must short-circuit ahead of both the preflight and capture.
+    for (const status of ["denied", "restricted"]) {
+      resetRuntime();
+      setupGlobals();
+      runtime.micPermissionQueue.push(status);
+
+      vi.resetModules();
+      const { voiceRecordingService } = await import("../VoiceRecordingService");
+      await voiceRecordingService.start({ panelId: "panel-1", panelTitle: "Panel One" });
+
+      expect(runtime.voiceInput.requestMicPermission).not.toHaveBeenCalled();
+      expect(runtime.createdStreams).toHaveLength(0);
+      expect(runtime.voiceInput.openMicSettings).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("HUGE_AUDIO_BUFFER_BATCHES_LEVEL_PER_FRAME", async () => {


### PR DESCRIPTION
## Summary
- `requestMicPermission()` returned `false` on every platform except macOS, which `VoiceRecordingService` read as a hard denial on `not-determined` and short-circuited before ever calling `getUserMedia`. Fresh Windows users could never reach the permission prompt, so voice input was dead on arrival there.
- The "open sound settings" path on Linux spawned `gnome-control-center` with no `error` listener on the child process. A missing binary (anything non-GNOME) emits an async `ENOENT` that a plain try/catch can't catch, which reached the global `uncaughtException` handler and took the app down.
- Found a third instance of the same dead end during review: the Settings mic Request button.

Resolves #11108

## Changes
- `electron/ipc/handlers/voiceInput.ts`: `requestMicPermission()` now returns `true` on non-macOS instead of `false`. The boolean means "clear to attempt getUserMedia," not "the OS confirmed a grant." `askForMediaAccess` is macOS-only in Electron 42, so there's no main-process request API on Windows or Linux, and `getUserMedia` itself is the gate there. macOS keeps returning its authoritative verdict, and a `false` there still aborts. The contract is documented on the IPC surface (`shared/types/ipc/api.ts`) so it doesn't quietly get "fixed" back to `false`.
- Same file: the sound-settings spawn now gets an `error` listener attached to the child before it's unref'd. A failed settings open is a debug log now, not a crash.
- `src/components/Settings/VoiceInputSettingsTab.tsx`: the Request button's handler used to await the preflight, ignore the result, then re-check the status, which on Windows meant clicking it did nothing. It now performs the capture attempt itself, treats only `NotAllowedError` as a denial (a missing or busy mic is a device problem, not a permission one, and shouldn't send someone to OS privacy settings for a mic they don't have), and treats `unknown` as unsettled rather than as an answer.
- `checkMicPermission()` is deliberately untouched. `getMediaAccessStatus` is meaningful on Windows, so its denied/restricted fatal branch was already correct.

## Testing
- New `electron/ipc/handlers/__tests__/voiceInput.permissions.test.ts`: platform-branched permission handlers, plus the async spawn-error containment (asserts the error listener is attached before control returns, then fires an ENOENT at it).
- Extended the adversarial `VoiceRecordingService` suite and the `VoiceInputSettingsTab` suite.
- 139 tests pass. Red-before-green validated: the 5 tests encoding these bugs all fail against the unfixed source.
- Confirmed `TRUSTED_SESSION_PERMISSIONS` in `electron/setup/security.ts` already allowlists `"media"`, so Electron's own permission layer was never a second cause here.