### PR TITLE
fix(copytree): resolve project settings from the sender's window

### DIFF
--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -11,24 +11,49 @@ const clipboardMock = vi.hoisted(() => ({
 }));
 
 const projectStoreMock = vi.hoisted(() => ({
-  getCurrentProjectId: vi.fn(() => null),
-  getProjectSettings: vi.fn(),
+  getCurrentProjectId: vi.fn<() => string | null>(() => null),
+  getProjectById: vi.fn<(projectId: string) => { id: string; status: string } | null>(() => null),
+  getProjectSettings: vi.fn<(projectId: string) => Promise<unknown>>(),
+}));
+
+/** Structural stand-in for ProjectViewManager — only the binding lookup is read. */
+interface TestProjectViewManager {
+  getProjectIdForWebContents: (webContentsId: number) => string | null;
+}
+
+const browserWindowMock = vi.hoisted(() => ({
+  fromWebContents: vi.fn<() => { id: number; isDestroyed: () => boolean } | null>(() => null),
+  getAllWindows: vi.fn(() => []),
+}));
+
+// windowRef holds the process-global ProjectViewManager that typedHandleWithContext
+// reads to populate ctx.projectId. Mocked so a test can point it at the WRONG
+// project and prove the handlers resolve settings from the sender's window instead.
+const windowRefMock = vi.hoisted(() => ({
+  getProjectViewManager: vi.fn<() => TestProjectViewManager | null>(() => null),
 }));
 
 vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
   clipboard: clipboardMock,
-  BrowserWindow: {
-    fromWebContents: vi.fn(() => null),
-    getAllWindows: vi.fn(() => []),
-  },
+  BrowserWindow: browserWindowMock,
 }));
 
 vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,
 }));
 
+vi.mock("../../../window/windowRef.js", () => ({
+  getProjectViewManager: windowRefMock.getProjectViewManager,
+  setProjectViewManager: vi.fn(),
+  getWindowRegistry: vi.fn(() => null),
+  setWindowRegistry: vi.fn(),
+  getMainWindow: vi.fn(() => null),
+  setMainWindow: vi.fn(),
+}));
+
 import { CHANNELS } from "../../channels.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
 import {
   registerCopyTreeHandlers,
   mergeCopyTreeOptions,
@@ -50,6 +75,13 @@ function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unkn
 describe("copyTree handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but keeps implementations/return values,
+    // so restore the no-window / no-PVM baseline each test.
+    browserWindowMock.fromWebContents.mockReturnValue(null);
+    windowRefMock.getProjectViewManager.mockReturnValue(null);
+    projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    projectStoreMock.getProjectSettings.mockReset();
     registerCopyTreeHandlers({
       mainWindow: {
         isDestroyed: () => false,
@@ -225,6 +257,143 @@ describe("copyTree handlers", () => {
         projectSettingsFixture.copyTreeSettings.maxContextSize
       );
       expect(mergedOptions.always).toEqual(projectSettingsFixture.copyTreeSettings.alwaysInclude);
+    });
+  });
+
+  describe("project-scoped settings resolution", () => {
+    const SENDER_WINDOW_ID = 42;
+    const SENDER_PROJECT = "proj-sender";
+    const GLOBAL_PROJECT = "proj-global";
+
+    // copyTree channels share one rate-limit bucket, and earlier tests in this
+    // file exhaust it. Clear the bucket instead of advancing fake timers: each
+    // vi.useFakeTimers() re-seeds from the real clock, so a fixed advance keeps
+    // landing every call in the same window rather than moving past it.
+    beforeEach(() => {
+      _resetRateLimitQueuesForTest();
+    });
+
+    const senderSettings = {
+      excludedPaths: ["sender-only/**"],
+      copyTreeSettings: { maxContextSize: 1111, alwaysInclude: ["SENDER.md"] },
+    };
+    const globalSettings = {
+      excludedPaths: ["global-only/**"],
+      copyTreeSettings: { maxContextSize: 2222, alwaysInclude: ["GLOBAL.md"] },
+    };
+
+    function makePvm(boundProjectId: string | null): TestProjectViewManager {
+      return { getProjectIdForWebContents: vi.fn(() => boundProjectId) };
+    }
+
+    // Aim every process-global "current project" source at GLOBAL_PROJECT, so a
+    // handler that reads any of them (the #11103 bug, or a naive ctx.projectId
+    // fix — ctx.projectId is derived from the windowRef global) resolves the
+    // wrong project and fails the assertions.
+    function aimGlobalSourcesAtGlobalProject() {
+      windowRefMock.getProjectViewManager.mockReturnValue(makePvm(GLOBAL_PROJECT));
+      projectStoreMock.getCurrentProjectId.mockReturnValue(GLOBAL_PROJECT);
+    }
+
+    function registerWithScope(options: {
+      windowScopedPvm?: TestProjectViewManager;
+      depsPvm?: TestProjectViewManager;
+      withSenderWindow?: boolean;
+    }) {
+      const testConfig = vi.fn().mockResolvedValue({
+        includedFiles: 1,
+        includedSize: 1,
+        excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
+      });
+
+      if (options.withSenderWindow !== false) {
+        browserWindowMock.fromWebContents.mockReturnValue({
+          id: SENDER_WINDOW_ID,
+          isDestroyed: () => false,
+        });
+      }
+
+      projectStoreMock.getProjectById.mockImplementation((projectId) => ({
+        id: projectId,
+        status: "active",
+      }));
+      projectStoreMock.getProjectSettings.mockImplementation(async (projectId) =>
+        projectId === SENDER_PROJECT ? senderSettings : globalSettings
+      );
+
+      ipcMainMock.handle.mockClear();
+      registerCopyTreeHandlers({
+        mainWindow: {
+          isDestroyed: () => false,
+          webContents: { isDestroyed: () => false, send: vi.fn() },
+        },
+        ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
+        worktreeService: {
+          getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
+          testConfig,
+        },
+        windowRegistry: options.windowScopedPvm
+          ? {
+              getByWindowId: (windowId: number) =>
+                windowId === SENDER_WINDOW_ID
+                  ? { services: { projectViewManager: options.windowScopedPvm } }
+                  : undefined,
+            }
+          : undefined,
+        projectViewManager: options.depsPvm,
+      } as never);
+
+      return testConfig;
+    }
+
+    async function invokeTestConfig() {
+      const handler = getInvokeHandler(CHANNELS.COPYTREE_TEST_CONFIG);
+      await handler(mockEvent, { worktreeId: "wt-1", options: {} });
+    }
+
+    it("merges the sender window's project settings, not the globally current project's", async () => {
+      aimGlobalSourcesAtGlobalProject();
+      const testConfig = registerWithScope({
+        windowScopedPvm: makePvm(SENDER_PROJECT),
+        depsPvm: makePvm(GLOBAL_PROJECT),
+      });
+
+      await invokeTestConfig();
+
+      const [, mergedOptions] = testConfig.mock.calls[0];
+      expect(mergedOptions.maxTotalSize).toBe(senderSettings.copyTreeSettings.maxContextSize);
+      expect(mergedOptions.maxTotalSize).not.toBe(globalSettings.copyTreeSettings.maxContextSize);
+      expect(mergedOptions.always).toEqual(senderSettings.copyTreeSettings.alwaysInclude);
+      expect(mergedOptions.exclude).toEqual(senderSettings.excludedPaths);
+      expect(mergedOptions.exclude).not.toContain(globalSettings.excludedPaths[0]);
+      expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(SENDER_PROJECT);
+      expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
+    });
+
+    it("applies no project settings when the sender's view is unbound", async () => {
+      aimGlobalSourcesAtGlobalProject();
+      const testConfig = registerWithScope({ windowScopedPvm: makePvm(null) });
+
+      await invokeTestConfig();
+
+      // An unbound view must not inherit the global current project's settings,
+      // so nothing back-fills the empty runtime options.
+      const [, mergedOptions] = testConfig.mock.calls[0];
+      expect(mergedOptions).toEqual({});
+      expect(projectStoreMock.getProjectSettings).not.toHaveBeenCalled();
+      expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the current project when no project-scoped view manager exists", async () => {
+      projectStoreMock.getCurrentProjectId.mockReturnValue(GLOBAL_PROJECT);
+      const testConfig = registerWithScope({ withSenderWindow: false });
+
+      await invokeTestConfig();
+
+      const [, mergedOptions] = testConfig.mock.calls[0];
+      expect(mergedOptions.maxTotalSize).toBe(globalSettings.copyTreeSettings.maxContextSize);
+      expect(mergedOptions.always).toEqual(globalSettings.copyTreeSettings.alwaysInclude);
+      expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(GLOBAL_PROJECT);
     });
   });
 });

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -299,12 +299,15 @@ describe("copyTree handlers", () => {
       windowScopedPvm?: TestProjectViewManager;
       depsPvm?: TestProjectViewManager;
       withSenderWindow?: boolean;
+      /** Runs when the handler awaits the workspace, i.e. mid-request. */
+      onWorkspaceCall?: () => void;
     }) {
       const testConfig = vi.fn().mockResolvedValue({
         includedFiles: 1,
         includedSize: 1,
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
       });
+      const generateContext = vi.fn().mockResolvedValue({ content: "", fileCount: 1 });
 
       if (options.withSenderWindow !== false) {
         browserWindowMock.fromWebContents.mockReturnValue({
@@ -327,10 +330,14 @@ describe("copyTree handlers", () => {
           isDestroyed: () => false,
           webContents: { isDestroyed: () => false, send: vi.fn() },
         },
-        ptyClient: { hasTerminal: vi.fn(() => false), write: vi.fn() },
+        ptyClient: { hasTerminal: vi.fn(() => true), write: vi.fn() },
         worktreeService: {
-          getAllStatesAsync: vi.fn().mockResolvedValue([{ id: "wt-1", path: "/wt-1" }]),
+          getAllStatesAsync: vi.fn(async () => {
+            options.onWorkspaceCall?.();
+            return [{ id: "wt-1", path: "/wt-1" }];
+          }),
           testConfig,
+          generateContext,
         },
         windowRegistry: options.windowScopedPvm
           ? {
@@ -343,57 +350,103 @@ describe("copyTree handlers", () => {
         projectViewManager: options.depsPvm,
       } as never);
 
-      return testConfig;
+      return { testConfig, generateContext };
     }
 
-    async function invokeTestConfig() {
-      const handler = getInvokeHandler(CHANNELS.COPYTREE_TEST_CONFIG);
-      await handler(mockEvent, { worktreeId: "wt-1", options: {} });
+    /**
+     * The four handlers that merge project settings, with the seam each one hands
+     * the merged options to. Every case runs against all four so a regression in
+     * one call site can't hide behind the others.
+     */
+    const MERGE_CALL_SITES = [
+      { channel: CHANNELS.COPYTREE_TEST_CONFIG, seam: "testConfig" as const, payload: {} },
+      { channel: CHANNELS.COPYTREE_GENERATE, seam: "generateContext" as const, payload: {} },
+      {
+        channel: CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE,
+        seam: "generateContext" as const,
+        payload: {},
+      },
+      {
+        channel: CHANNELS.COPYTREE_INJECT,
+        seam: "generateContext" as const,
+        payload: { terminalId: "term-1" },
+      },
+    ];
+
+    async function invoke(channel: string, extraPayload: Record<string, unknown>) {
+      const handler = getInvokeHandler(channel);
+      await handler(mockEvent, { worktreeId: "wt-1", options: {}, ...extraPayload });
     }
 
-    it("merges the sender window's project settings, not the globally current project's", async () => {
-      aimGlobalSourcesAtGlobalProject();
-      const testConfig = registerWithScope({
-        windowScopedPvm: makePvm(SENDER_PROJECT),
-        depsPvm: makePvm(GLOBAL_PROJECT),
+    describe.each(MERGE_CALL_SITES)("$channel", ({ channel, seam, payload }) => {
+      it("merges the sender window's project settings, not the globally current project's", async () => {
+        aimGlobalSourcesAtGlobalProject();
+        const seams = registerWithScope({
+          windowScopedPvm: makePvm(SENDER_PROJECT),
+          depsPvm: makePvm(GLOBAL_PROJECT),
+        });
+
+        await invoke(channel, payload);
+
+        const [, mergedOptions] = seams[seam].mock.calls[0];
+        expect(mergedOptions.maxTotalSize).toBe(senderSettings.copyTreeSettings.maxContextSize);
+        expect(mergedOptions.maxTotalSize).not.toBe(globalSettings.copyTreeSettings.maxContextSize);
+        expect(mergedOptions.always).toEqual(senderSettings.copyTreeSettings.alwaysInclude);
+        expect(mergedOptions.exclude).toEqual(senderSettings.excludedPaths);
+        expect(mergedOptions.exclude).not.toContain(globalSettings.excludedPaths[0]);
+        expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(SENDER_PROJECT);
+        expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
       });
 
-      await invokeTestConfig();
+      it("applies no project settings when the sender's view is unbound", async () => {
+        aimGlobalSourcesAtGlobalProject();
+        const depsPvm = makePvm(GLOBAL_PROJECT);
+        const seams = registerWithScope({ windowScopedPvm: makePvm(null), depsPvm });
 
-      const [, mergedOptions] = testConfig.mock.calls[0];
-      expect(mergedOptions.maxTotalSize).toBe(senderSettings.copyTreeSettings.maxContextSize);
-      expect(mergedOptions.maxTotalSize).not.toBe(globalSettings.copyTreeSettings.maxContextSize);
-      expect(mergedOptions.always).toEqual(senderSettings.copyTreeSettings.alwaysInclude);
-      expect(mergedOptions.exclude).toEqual(senderSettings.excludedPaths);
-      expect(mergedOptions.exclude).not.toContain(globalSettings.excludedPaths[0]);
-      expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(SENDER_PROJECT);
-      expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
-    });
+        await invoke(channel, payload);
 
-    it("applies no project settings when the sender's view is unbound", async () => {
-      aimGlobalSourcesAtGlobalProject();
-      const testConfig = registerWithScope({ windowScopedPvm: makePvm(null) });
+        // An unbound view must not inherit the global current project's settings
+        // from ANY source, so nothing back-fills the empty runtime options.
+        expect(seams[seam]).toHaveBeenCalledTimes(1);
+        const [, mergedOptions] = seams[seam].mock.calls[0];
+        expect(mergedOptions).toEqual({});
+        expect(depsPvm.getProjectIdForWebContents).not.toHaveBeenCalled();
+        expect(projectStoreMock.getProjectSettings).not.toHaveBeenCalled();
+        expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
+      });
 
-      await invokeTestConfig();
+      it("keeps the sender's project settings when the view is evicted mid-request", async () => {
+        aimGlobalSourcesAtGlobalProject();
+        // The view's binding survives until the handler awaits the workspace,
+        // then eviction drops it — the settings must already be pinned by then.
+        let boundProject: string | null = SENDER_PROJECT;
+        const seams = registerWithScope({
+          windowScopedPvm: { getProjectIdForWebContents: vi.fn(() => boundProject) },
+          depsPvm: makePvm(GLOBAL_PROJECT),
+          onWorkspaceCall: () => {
+            boundProject = null;
+          },
+        });
 
-      // An unbound view must not inherit the global current project's settings,
-      // so nothing back-fills the empty runtime options.
-      const [, mergedOptions] = testConfig.mock.calls[0];
-      expect(mergedOptions).toEqual({});
-      expect(projectStoreMock.getProjectSettings).not.toHaveBeenCalled();
-      expect(projectStoreMock.getCurrentProjectId).not.toHaveBeenCalled();
-    });
+        await invoke(channel, payload);
 
-    it("falls back to the current project when no project-scoped view manager exists", async () => {
-      projectStoreMock.getCurrentProjectId.mockReturnValue(GLOBAL_PROJECT);
-      const testConfig = registerWithScope({ withSenderWindow: false });
+        const [, mergedOptions] = seams[seam].mock.calls[0];
+        expect(mergedOptions.exclude).toEqual(senderSettings.excludedPaths);
+        expect(mergedOptions.maxTotalSize).toBe(senderSettings.copyTreeSettings.maxContextSize);
+        expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(SENDER_PROJECT);
+      });
 
-      await invokeTestConfig();
+      it("falls back to the current project when no project-scoped view manager exists", async () => {
+        projectStoreMock.getCurrentProjectId.mockReturnValue(GLOBAL_PROJECT);
+        const seams = registerWithScope({ withSenderWindow: false });
 
-      const [, mergedOptions] = testConfig.mock.calls[0];
-      expect(mergedOptions.maxTotalSize).toBe(globalSettings.copyTreeSettings.maxContextSize);
-      expect(mergedOptions.always).toEqual(globalSettings.copyTreeSettings.alwaysInclude);
-      expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(GLOBAL_PROJECT);
+        await invoke(channel, payload);
+
+        const [, mergedOptions] = seams[seam].mock.calls[0];
+        expect(mergedOptions.maxTotalSize).toBe(globalSettings.copyTreeSettings.maxContextSize);
+        expect(mergedOptions.always).toEqual(globalSettings.copyTreeSettings.alwaysInclude);
+        expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith(GLOBAL_PROJECT);
+      });
     });
   });
 });

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -15,7 +15,8 @@ import {
   typedHandle,
   typedHandleWithContext,
 } from "../utils.js";
-import type { HandlerDependencies } from "../types.js";
+import { resolveScopedProjectForIpcContext } from "../projectContext.js";
+import type { HandlerDependencies, IpcContext } from "../types.js";
 import type {
   CopyTreeGeneratePayload,
   CopyTreeGenerateAndCopyFilePayload,
@@ -210,18 +211,29 @@ export function mergeCopyTreeOptions(
 }
 
 /**
- * Get the current project's settings for CopyTree operations.
- * Returns undefined if no project is active.
+ * Get CopyTree settings for the project bound to the IPC sender's view.
+ *
+ * The sender's own window-scoped ProjectViewManager is authoritative: reading
+ * the global current project here made a generate in window A inherit window
+ * B's exclusions whenever B was focused most recently (#11103).
+ *
+ * A view that resolves to no project gets `undefined` (runtime options only) —
+ * it must never inherit the global pointer (#6015). The global is consulted
+ * only when project-scoped resolution is unavailable altogether.
  */
-async function getCurrentProjectSettings(): Promise<
-  Pick<ProjectSettings, "excludedPaths" | "copyTreeSettings"> | undefined
-> {
-  const currentProjectId = projectStore.getCurrentProjectId();
-  if (!currentProjectId) {
+async function getCopyTreeProjectSettingsForIpcContext(
+  ctx: IpcContext,
+  deps: HandlerDependencies
+): Promise<Pick<ProjectSettings, "excludedPaths" | "copyTreeSettings"> | undefined> {
+  const scopedProject = resolveScopedProjectForIpcContext(ctx, deps);
+  const projectId =
+    scopedProject === null ? projectStore.getCurrentProjectId() : scopedProject.project?.id;
+
+  if (!projectId) {
     return undefined;
   }
   try {
-    const settings = await projectStore.getProjectSettings(currentProjectId);
+    const settings = await projectStore.getProjectSettings(projectId);
     return {
       excludedPaths: settings.excludedPaths,
       copyTreeSettings: settings.copyTreeSettings,
@@ -290,7 +302,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     };
 
     // Merge project settings with runtime options
-    const projectSettings = await getCurrentProjectSettings();
+    const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     return deps.worktreeService.generateContext(worktree.path, mergedOptions, onProgress);
@@ -353,7 +365,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     };
 
     // Merge project settings with runtime options
-    const projectSettings = await getCurrentProjectSettings();
+    const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     const result = await deps.worktreeService.generateContext(
@@ -527,7 +539,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
 
       // Merge project settings with runtime options
-      const projectSettings = await getCurrentProjectSettings();
+      const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
       const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options || {});
 
       const result = await deps.worktreeService.generateContext(
@@ -705,7 +717,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     }
 
     // Merge project settings with runtime options
-    const projectSettings = await getCurrentProjectSettings();
+    const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     return deps.worktreeService.testConfig(worktree.path, mergedOptions);

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -211,24 +211,31 @@ export function mergeCopyTreeOptions(
 }
 
 /**
- * Get CopyTree settings for the project bound to the IPC sender's view.
+ * Resolve which project's CopyTree settings apply to this request: the one bound
+ * to the IPC sender's view. Reading the global current project here made a
+ * generate in window A inherit window B's exclusions whenever B was focused most
+ * recently (#11103).
  *
- * The sender's own window-scoped ProjectViewManager is authoritative: reading
- * the global current project here made a generate in window A inherit window
- * B's exclusions whenever B was focused most recently (#11103).
+ * A view that resolves to no project yields `null` — it must never inherit the
+ * global pointer (#6015). The global is consulted only when project-scoped
+ * resolution is unavailable altogether.
  *
- * A view that resolves to no project gets `undefined` (runtime options only) —
- * it must never inherit the global pointer (#6015). The global is consulted
- * only when project-scoped resolution is unavailable altogether.
+ * Call this SYNCHRONOUSLY, before the handler's first `await`. The sender's view
+ * can be evicted while a later await is in flight, and a binding that vanishes
+ * mid-request would silently drop the project's exclusions from the context.
  */
-async function getCopyTreeProjectSettingsForIpcContext(
-  ctx: IpcContext,
-  deps: HandlerDependencies
-): Promise<Pick<ProjectSettings, "excludedPaths" | "copyTreeSettings"> | undefined> {
+function resolveCopyTreeProjectId(ctx: IpcContext, deps: HandlerDependencies): string | null {
   const scopedProject = resolveScopedProjectForIpcContext(ctx, deps);
-  const projectId =
-    scopedProject === null ? projectStore.getCurrentProjectId() : scopedProject.project?.id;
+  if (scopedProject === null) {
+    return projectStore.getCurrentProjectId();
+  }
+  return scopedProject.project?.id ?? null;
+}
 
+/** Load the CopyTree-relevant settings for a project resolved by `resolveCopyTreeProjectId`. */
+async function loadCopyTreeProjectSettings(
+  projectId: string | null
+): Promise<Pick<ProjectSettings, "excludedPaths" | "copyTreeSettings"> | undefined> {
   if (!projectId) {
     return undefined;
   }
@@ -281,6 +288,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
+    // Capture the sender's project before awaiting: the view can be evicted
+    // while the workspace call is in flight, taking its binding with it.
+    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+
     const states = await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
@@ -302,7 +313,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     };
 
     // Merge project settings with runtime options
-    const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
+    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     return deps.worktreeService.generateContext(worktree.path, mergedOptions, onProgress);
@@ -344,6 +355,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
+    // Capture the sender's project before awaiting: the view can be evicted
+    // while the workspace call is in flight, taking its binding with it.
+    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+
     const states = await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
@@ -365,7 +380,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     };
 
     // Merge project settings with runtime options
-    const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
+    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     const result = await deps.worktreeService.generateContext(
@@ -507,6 +522,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
+    // Capture the sender's project before awaiting: the view can be evicted
+    // while the workspace call is in flight, taking its binding with it.
+    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+
     contextInjectionTracker.beginInjection(validated.terminalId, injectionId);
 
     try {
@@ -539,7 +558,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
 
       // Merge project settings with runtime options
-      const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
+      const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
       const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options || {});
 
       const result = await deps.worktreeService.generateContext(
@@ -703,6 +722,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
+    // Capture the sender's project before awaiting: the view can be evicted
+    // while the workspace call is in flight, taking its binding with it.
+    const settingsProjectId = resolveCopyTreeProjectId(ctx, deps);
+
     const senderWindowTestConfig = ctx.senderWindow;
     const states = await deps.worktreeService.getAllStatesAsync(senderWindowTestConfig?.id);
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
@@ -717,7 +740,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     }
 
     // Merge project settings with runtime options
-    const projectSettings = await getCopyTreeProjectSettingsForIpcContext(ctx, deps);
+    const projectSettings = await loadCopyTreeProjectSettings(settingsProjectId);
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
     return deps.worktreeService.testConfig(worktree.path, mergedOptions);


### PR DESCRIPTION
## Summary

- The four CopyTree context-generating IPC handlers (`copytree:generate`, `copytree:generate-and-copy-file`, `copytree:inject`, `copytree:test-config`) resolved `excludedPaths` and `copyTreeSettings` from `projectStore.getCurrentProjectId()`, a process-global "current project" pointer, instead of from the sender window's own project.
- With two project windows open, generating context in window A could pick up window B's exclusion rules whenever B was the most recently focused window, meaning files a project explicitly excluded could leak into injected agent context.
- Also fixes a related ordering bug found during review: settings were resolved after an `await`, so a mid-request window eviction could silently drop the project's exclusions entirely.

Resolves #11103

## Changes

- Every handler already resolved its worktree correctly from the sender window; only the settings lookup used the global. Routed that lookup through the existing `resolveScopedProjectForIpcContext(ctx, deps)` helper in `electron/ipc/projectContext.ts`, which resolves the `ProjectViewManager` from the sender window's own `WindowContext.services` rather than the global.
- Threading `ctx.projectId` through would not have fixed this: `ctx.projectId` is itself derived from a process-global, last-window-wins `ProjectViewManager` reference in `electron/window/windowRef.ts`, re-set on every window create/destroy. It reproduces the same misattribution in a real multi-window session while appearing to work in a single-window repro.
- Kept the two-tier fallback deliberately, it's the `#6015` contract: a view that resolves to no project gets no settings (must never inherit the global pointer), and the global is only consulted when project-scoped resolution is unavailable altogether.
- Second fix: all four handlers resolved settings after an `await` on `getAllStatesAsync(...)`. If the sender's view is evicted while that call is in flight, its `ProjectViewManager` binding is gone by the time settings resolve, so the handler silently dropped the project's `excludedPaths`, a worse failure than the original bug since it sweeps in files the project meant to exclude. Split the resolver into a synchronous `resolveCopyTreeProjectId(ctx, deps)` called at handler entry before any `await`, and an async `loadCopyTreeProjectSettings(projectId)`.

## Testing

- Added a parameterized suite in `electron/ipc/handlers/__tests__/copyTree.handlers.test.ts` covering all four merge call sites times four cases: the sender's project wins over the global, an unbound view back-fills nothing, a mid-request eviction keeps the sender's settings, and the no-`ProjectViewManager` legacy path still falls back to the global.
- Validated red before green: reverting the resolver to the global lookup fails the sender-wins and unbound cases, restoring the post-await ordering fails all four eviction cases.
- Locally: 181 tests pass (`copyTree.handlers`, `project.getCurrent`, `app.state`, ipc utils); `npm run typecheck` clean; eslint 0 errors on both changed files (7 pre-existing `typedHandle` warnings, identical count to `develop`, so the lint ratchet baseline is unmoved); prettier clean.