### PR TITLE
fix(browser): Enter on a webview dialog's Cancel button now cancels

### DIFF
--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -109,10 +109,13 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
   );
 
   // Text inputs have no native Enter action outside a <form>, so the prompt
-  // owns its own submit.
+  // owns its own submit. keyCode 229 is Chromium's "Process" signal on the first
+  // keydown of an IME composition, before isComposing is set — submitting there
+  // would send a half-composed value.
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key !== "Enter") return;
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
       e.preventDefault();
       handleOk();
     },

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -92,21 +92,31 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
     onRespond(false);
   }, [onRespond]);
 
-  const handleKeyDown = useCallback(
+  // Escape only. Enter is deliberately left alone so a focused button runs its
+  // native activation — intercepting it here cancelled the Cancel button's
+  // Enter-to-click and confirmed the guest's dialog instead (issue #11106).
+  const handleEscape = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      if (dialog?.type === "alert") {
         handleOk();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        if (dialog?.type === "alert") {
-          handleOk();
-        } else {
-          handleCancel();
-        }
+      } else {
+        handleCancel();
       }
     },
     [dialog, handleOk, handleCancel]
+  );
+
+  // Text inputs have no native Enter action outside a <form>, so the prompt
+  // owns its own submit.
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "Enter") return;
+      e.preventDefault();
+      handleOk();
+    },
+    [handleOk]
   );
 
   if (!dialog) return null;
@@ -114,7 +124,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
   return (
     <div
       className="absolute inset-0 z-50 flex items-center justify-center bg-scrim-medium"
-      onKeyDown={handleKeyDown}
+      onKeyDown={handleEscape}
     >
       <div
         ref={panelRef}
@@ -137,6 +147,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
             type="text"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleInputKeyDown}
             aria-describedby={messageId}
             className="w-full px-3 py-1.5 text-sm bg-daintree-sidebar border border-daintree-border rounded-md text-daintree-text focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50 mb-4"
           />

--- a/src/components/Browser/__tests__/WebviewDialog.test.tsx
+++ b/src/components/Browser/__tests__/WebviewDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { WebviewDialog, type WebviewDialogRequest } from "../WebviewDialog";
 
@@ -18,6 +18,22 @@ const basePrompt: WebviewDialogRequest = {
   message: "Enter a value",
   defaultValue: "default",
 };
+
+const baseConfirm: WebviewDialogRequest = {
+  dialogId: "dlg-3",
+  panelId: "browser-panel-1",
+  type: "confirm",
+  message: "Are you sure?",
+  defaultValue: "",
+};
+
+function getButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const match = Array.from(container.querySelectorAll("button")).find(
+    (btn) => btn.textContent === label
+  );
+  if (!match) throw new Error(`No "${label}" button rendered`);
+  return match;
+}
 
 describe("WebviewDialog accessibility", () => {
   it("inner panel has dialog role, aria-modal, and is focusable", () => {
@@ -131,5 +147,85 @@ describe("WebviewDialog accessibility", () => {
       const tabindex = region.getAttribute("tabindex");
       expect(tabindex === null || Number(tabindex) < 0).toBe(true);
     }
+  });
+});
+
+// jsdom doesn't implement a button's native Enter-to-click activation, so the
+// assertable contract for the buttons is that the overlay leaves Enter alone —
+// neither cancelling it nor synthesising a response of its own. Chromium then
+// turns that keydown into the click these tests exercise separately.
+describe("WebviewDialog keyboard handling", () => {
+  it("leaves Enter on Cancel to native activation instead of confirming", () => {
+    const onRespond = vi.fn();
+    const { container } = render(<WebviewDialog dialog={baseConfirm} onRespond={onRespond} />);
+    const cancel = getButton(container, "Cancel");
+    cancel.focus();
+
+    const notPrevented = fireEvent.keyDown(cancel, { key: "Enter" });
+
+    // The regression in #11106: the overlay confirmed the guest's dialog here.
+    expect(onRespond).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true);
+
+    fireEvent.click(cancel);
+    expect(onRespond).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("leaves Enter on OK to native activation, which confirms", () => {
+    const onRespond = vi.fn();
+    const { container } = render(<WebviewDialog dialog={baseConfirm} onRespond={onRespond} />);
+    const ok = getButton(container, "OK");
+    ok.focus();
+
+    const notPrevented = fireEvent.keyDown(ok, { key: "Enter" });
+
+    expect(onRespond).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true);
+
+    fireEvent.click(ok);
+    expect(onRespond).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("submits the edited value on Enter in the prompt input", () => {
+    const onRespond = vi.fn();
+    const { container } = render(<WebviewDialog dialog={basePrompt} onRespond={onRespond} />);
+    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+
+    fireEvent.change(input, { target: { value: "edited" } });
+    const notPrevented = fireEvent.keyDown(input, { key: "Enter" });
+
+    // A text input has no native Enter action outside a <form>, so the overlay
+    // must consume this one.
+    expect(notPrevented).toBe(false);
+    expect(onRespond).toHaveBeenCalledExactlyOnceWith(true, "edited");
+  });
+
+  it("cancels a prompt on Escape from the input", () => {
+    const onRespond = vi.fn();
+    const { container } = render(<WebviewDialog dialog={basePrompt} onRespond={onRespond} />);
+    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onRespond).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("cancels a confirm on Escape from the Cancel button", () => {
+    const onRespond = vi.fn();
+    const { container } = render(<WebviewDialog dialog={baseConfirm} onRespond={onRespond} />);
+
+    fireEvent.keyDown(getButton(container, "Cancel"), { key: "Escape" });
+
+    expect(onRespond).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  // An alert has no Cancel — dismissing it is the only response the guest can get.
+  it("acknowledges an alert on Escape", () => {
+    const onRespond = vi.fn();
+    const { container } = render(<WebviewDialog dialog={baseAlert} onRespond={onRespond} />);
+
+    fireEvent.keyDown(getButton(container, "OK"), { key: "Escape" });
+
+    expect(onRespond).toHaveBeenCalledExactlyOnceWith(true);
   });
 });

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -178,7 +178,12 @@ export function FleetArmingRibbon(): ReactElement | null {
         (target.tagName === "INPUT" ||
           target.tagName === "TEXTAREA" ||
           target.isContentEditable ||
-          target.closest(".xterm") !== null)
+          target.closest(".xterm") !== null ||
+          // A modal owns the keyboard while it is open. Without this, Enter on a
+          // webview dialog's Cancel button was swallowed here (capture phase, so
+          // it beats the button's native activation) and confirmed the fleet
+          // action instead of cancelling the dialog (issue #11106).
+          target.closest('[aria-modal="true"]') !== null)
       ) {
         return;
       }

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -168,6 +168,14 @@ export function FleetArmingRibbon(): ReactElement | null {
     if (pending === null) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
+      // A modal owns the keyboard while it is open. This listener is capture-
+      // phase, so without the guard it beat a focused Cancel button to the Enter
+      // and confirmed the fleet action instead of activating that button
+      // (issue #11106). Tested by existence rather than ancestry because modal
+      // content can be portaled outside the dialog's subtree (Radix menus and
+      // selects mount under <body>). The fleet's own confirmation is an inline
+      // role="status" banner, not a modal, so its Enter stays reachable.
+      if (document.querySelector('[role="dialog"][aria-modal="true"]') !== null) return;
       const rawTarget = e.target;
       const target =
         rawTarget && typeof (rawTarget as HTMLElement).closest === "function"
@@ -178,12 +186,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         (target.tagName === "INPUT" ||
           target.tagName === "TEXTAREA" ||
           target.isContentEditable ||
-          target.closest(".xterm") !== null ||
-          // A modal owns the keyboard while it is open. Without this, Enter on a
-          // webview dialog's Cancel button was swallowed here (capture phase, so
-          // it beats the button's native activation) and confirmed the fleet
-          // action instead of cancelling the dialog (issue #11106).
-          target.closest('[aria-modal="true"]') !== null)
+          target.closest(".xterm") !== null)
       ) {
         return;
       }

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -679,32 +679,42 @@ describe("FleetArmingRibbon", () => {
   // This listener is capture-phase, so without a modal guard it beat a focused
   // dialog button to the Enter and confirmed a destructive fleet action instead
   // of activating that button (issue #11106).
-  it("ignores Enter that a modal dialog owns", async () => {
-    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-    useFleetPendingActionStore.setState({
-      pending: { kind: "kill", targetCount: 3, sessionLossCount: 0 },
+  describe.each([
+    // Inside the dialog's own subtree — a webview dialog's Cancel button.
+    { name: "a modal dialog owns", portaled: false },
+    // Outside it — Radix menus and selects portal their content under <body>,
+    // so an ancestry check would miss this one.
+    { name: "portaled content of an open modal owns", portaled: true },
+  ])("ignores Enter that $name", ({ portaled }) => {
+    it("leaves the fleet action undispatched", async () => {
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      useFleetPendingActionStore.setState({
+        pending: { kind: "kill", targetCount: 3, sessionLossCount: 0 },
+      });
+      const actionServiceModule = await import("@/services/ActionService");
+      const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+      render(<FleetArmingRibbon />);
+
+      const modal = document.createElement("div");
+      modal.setAttribute("role", "dialog");
+      modal.setAttribute("aria-modal", "true");
+      document.body.appendChild(modal);
+
+      const target = document.createElement("button");
+      target.textContent = "Cancel";
+      (portaled ? document.body : modal).appendChild(target);
+
+      try {
+        target.focus();
+        fireEvent.keyDown(target, { key: "Enter" });
+
+        expect(dispatchSpy.mock.calls.find((c) => c[0] === "fleet.kill")).toBeUndefined();
+      } finally {
+        target.remove();
+        modal.remove();
+        dispatchSpy.mockRestore();
+      }
     });
-    const actionServiceModule = await import("@/services/ActionService");
-    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
-    render(<FleetArmingRibbon />);
-
-    const modal = document.createElement("div");
-    modal.setAttribute("role", "dialog");
-    modal.setAttribute("aria-modal", "true");
-    const cancel = document.createElement("button");
-    cancel.textContent = "Cancel";
-    modal.appendChild(cancel);
-    document.body.appendChild(modal);
-
-    try {
-      cancel.focus();
-      fireEvent.keyDown(cancel, { key: "Enter" });
-
-      expect(dispatchSpy.mock.calls.find((c) => c[0] === "fleet.kill")).toBeUndefined();
-    } finally {
-      modal.remove();
-      dispatchSpy.mockRestore();
-    }
   });
 
   describe("Selection menu", () => {

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -676,6 +676,37 @@ describe("FleetArmingRibbon", () => {
     dispatchSpy.mockRestore();
   });
 
+  // This listener is capture-phase, so without a modal guard it beat a focused
+  // dialog button to the Enter and confirmed a destructive fleet action instead
+  // of activating that button (issue #11106).
+  it("ignores Enter that a modal dialog owns", async () => {
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "kill", targetCount: 3, sessionLossCount: 0 },
+    });
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+
+    const modal = document.createElement("div");
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
+    const cancel = document.createElement("button");
+    cancel.textContent = "Cancel";
+    modal.appendChild(cancel);
+    document.body.appendChild(modal);
+
+    try {
+      cancel.focus();
+      fireEvent.keyDown(cancel, { key: "Enter" });
+
+      expect(dispatchSpy.mock.calls.find((c) => c[0] === "fleet.kill")).toBeUndefined();
+    } finally {
+      modal.remove();
+      dispatchSpy.mockRestore();
+    }
+  });
+
   describe("Selection menu", () => {
     function findMenuItem(label: RegExp | string): HTMLElement {
       const items = screen.getAllByRole("menuitem");

--- a/src/hooks/__tests__/useWebviewDialog.test.tsx
+++ b/src/hooks/__tests__/useWebviewDialog.test.tsx
@@ -216,6 +216,15 @@ describe("useWebviewDialog focus lifecycle", () => {
     return button;
   }
 
+  // Stands in for the control WebviewDialog autofocuses. Closing the overlay
+  // detaches it, which is what leaves document.activeElement on <body> and tells
+  // the hook the dialog still owned focus — so the tests must detach it too.
+  function focusOverlayControl(label: string): HTMLButtonElement {
+    const control = addButton(label);
+    control.focus();
+    return control;
+  }
+
   beforeEach(() => {
     root = document.createElement("div");
     root.id = "root";
@@ -243,11 +252,10 @@ describe("useWebviewDialog focus lifecycle", () => {
       expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
     });
 
-    // The overlay autofocuses its OK button once it renders.
-    const okButton = addButton("OK");
-    okButton.focus();
+    const ok = focusOverlayControl("OK");
 
     act(() => {
+      ok.remove();
       result.current.handleDialogRespond(true);
     });
     await waitFor(() => {
@@ -271,8 +279,7 @@ describe("useWebviewDialog focus lifecycle", () => {
       expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
     });
 
-    const firstOk = addButton("OK (dialog-1)");
-    firstOk.focus();
+    const firstOk = focusOverlayControl("OK (dialog-1)");
 
     act(() => {
       result.current.handleDialogRespond(true);
@@ -281,14 +288,15 @@ describe("useWebviewDialog focus lifecycle", () => {
       expect(result.current.currentDialog?.dialogId).toBe("dialog-2");
     });
 
-    // Mid-queue: focus stays in the overlay. Restoring here would yank the user
-    // out of a dialog that is still open.
+    // Mid-queue the overlay is still open, so focus stays in it. Restoring here
+    // would yank the user out of a dialog they still have to answer.
     expect(document.activeElement).toBe(firstOk);
 
-    const secondOk = addButton("OK (dialog-2)");
-    secondOk.focus();
+    firstOk.remove();
+    const secondOk = focusOverlayControl("OK (dialog-2)");
 
     act(() => {
+      secondOk.remove();
       result.current.handleDialogRespond(false);
     });
     await waitFor(() => {
@@ -314,9 +322,10 @@ describe("useWebviewDialog focus lifecycle", () => {
       expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
     });
 
-    addButton("OK").focus();
+    const ok = focusOverlayControl("OK");
 
     act(() => {
+      ok.remove();
       emitDismiss("panel-1");
     });
     await waitFor(() => {
@@ -325,6 +334,37 @@ describe("useWebviewDialog focus lifecycle", () => {
 
     expect(document.activeElement).toBe(opener);
     expect(respondToDialog).not.toHaveBeenCalled();
+  });
+
+  // Guest pages fire dialogs on their own schedule, so the user may well have
+  // clicked into another pane before this one's queue drains.
+  it("leaves focus alone when something else took it while the dialog was open", async () => {
+    const opener = addButton("opener");
+    opener.focus();
+
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    const ok = focusOverlayControl("OK");
+    // The user clicks into a different panel, which takes focus out of the overlay.
+    const otherPane = addButton("other pane");
+    otherPane.focus();
+
+    act(() => {
+      ok.remove();
+      emitDismiss("panel-1");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    expect(document.activeElement).toBe(otherPane);
   });
 
   it("falls back to the app shell when the opener is gone by the time the dialog closes", async () => {
@@ -341,10 +381,12 @@ describe("useWebviewDialog focus lifecycle", () => {
       expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
     });
 
+    const ok = focusOverlayControl("OK");
     // The page behind the dialog navigated away and took the opener with it.
     opener.remove();
 
     act(() => {
+      ok.remove();
       result.current.handleDialogRespond(true);
     });
     await waitFor(() => {
@@ -367,10 +409,11 @@ describe("useWebviewDialog focus lifecycle", () => {
       expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
     });
 
-    addButton("OK").focus();
+    const ok = focusOverlayControl("OK");
 
     // Unmounting skips the non-empty -> empty edge entirely, so without the
     // cleanup restore, focus would be stranded on the removed OK button.
+    ok.remove();
     unmount();
 
     expect(document.activeElement).toBe(opener);

--- a/src/hooks/__tests__/useWebviewDialog.test.tsx
+++ b/src/hooks/__tests__/useWebviewDialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/notify", () => ({
   notify: vi.fn(),
@@ -35,7 +35,10 @@ beforeEach(() => {
   dismissCleanup = vi.fn(() => {
     dismissListener = null;
   });
-  respondToDialog = vi.fn();
+  // The hook chains .catch() onto every respond, so the default must be a
+  // Promise. Tests that need a specific outcome still override it with a
+  // *Once mock, which takes precedence.
+  respondToDialog = vi.fn().mockResolvedValue(undefined);
   registerPanel = vi.fn().mockResolvedValue(undefined);
 
   Object.defineProperty(window, "electron", {
@@ -196,5 +199,190 @@ describe("useWebviewDialog", () => {
     unmount();
     expect(dismissCleanup).toHaveBeenCalled();
     expect(dismissListener).toBeNull();
+  });
+});
+
+// A queue of dialogs is one modal session: focus is captured once on the way in
+// and restored once on the way out, never between queued dialogs.
+describe("useWebviewDialog focus lifecycle", () => {
+  let root: HTMLElement;
+  let spawned: HTMLElement[] = [];
+
+  function addButton(label: string, parent: HTMLElement = document.body): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.textContent = label;
+    parent.appendChild(button);
+    spawned.push(button);
+    return button;
+  }
+
+  beforeEach(() => {
+    root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+  });
+
+  // Removed one by one rather than wiping <body>, which would race Testing
+  // Library's own container cleanup.
+  afterEach(() => {
+    for (const element of spawned) element.remove();
+    spawned = [];
+    root.remove();
+  });
+
+  it("returns focus to the element that was focused before the dialog opened", async () => {
+    const opener = addButton("opener");
+    opener.focus();
+
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    // The overlay autofocuses its OK button once it renders.
+    const okButton = addButton("OK");
+    okButton.focus();
+
+    act(() => {
+      result.current.handleDialogRespond(true);
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it("does not restore or recapture focus while advancing through a queue", async () => {
+    const opener = addButton("opener");
+    opener.focus();
+
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+      emitDialog("panel-1", "dialog-2");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    const firstOk = addButton("OK (dialog-1)");
+    firstOk.focus();
+
+    act(() => {
+      result.current.handleDialogRespond(true);
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-2");
+    });
+
+    // Mid-queue: focus stays in the overlay. Restoring here would yank the user
+    // out of a dialog that is still open.
+    expect(document.activeElement).toBe(firstOk);
+
+    const secondOk = addButton("OK (dialog-2)");
+    secondOk.focus();
+
+    act(() => {
+      result.current.handleDialogRespond(false);
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    // The opener — not either dialog's own OK button, which is what a naive
+    // per-dialog recapture would have recorded.
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it("restores focus when the queue is dismissed rather than answered", async () => {
+    const opener = addButton("opener");
+    opener.focus();
+
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+      emitDialog("panel-1", "dialog-2");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    addButton("OK").focus();
+
+    act(() => {
+      emitDismiss("panel-1");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    expect(document.activeElement).toBe(opener);
+    expect(respondToDialog).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the app shell when the opener is gone by the time the dialog closes", async () => {
+    const shellButton = addButton("shell", root);
+    const opener = addButton("opener");
+    opener.focus();
+
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    // The page behind the dialog navigated away and took the opener with it.
+    opener.remove();
+
+    act(() => {
+      result.current.handleDialogRespond(true);
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    expect(document.activeElement).toBe(shellButton);
+  });
+
+  it("restores focus when the panel unmounts with a dialog still open", async () => {
+    const opener = addButton("opener");
+    opener.focus();
+
+    const { result, unmount } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+    });
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    addButton("OK").focus();
+
+    // Unmounting skips the non-empty -> empty edge entirely, so without the
+    // cleanup restore, focus would be stranded on the removed OK button.
+    unmount();
+
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it("does not move focus when a panel with no open dialog unmounts", () => {
+    const elsewhere = addButton("elsewhere");
+    elsewhere.focus();
+
+    const { unmount } = renderHook(() => useWebviewDialog("panel-1", null, false));
+    unmount();
+
+    expect(document.activeElement).toBe(elsewhere);
   });
 });

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -27,6 +27,15 @@ export function useWebviewDialog(
   const restoreFocus = useCallback(() => {
     const previous = previousActiveElementRef.current;
     previousActiveElementRef.current = null;
+
+    // Only restore if this dialog still owned focus. Tearing down the overlay
+    // detaches whatever it had focused, which leaves activeElement on <body> —
+    // that's the signal restoration is needed. Anything else connected means
+    // focus already moved on (another pane, another dialog, a click elsewhere)
+    // and dragging it back to our opener would steal it.
+    const active = document.activeElement;
+    if (active && active !== document.body && document.contains(active)) return;
+
     // Falls back to the webview so the guest page gets keyboard input back when
     // whatever opened the dialog is gone (guest crash, panel teardown).
     restoreFocusTo(previous, webviewElementRef.current);

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from "react";
 import type { WebviewDialogRequest } from "@/components/Browser/WebviewDialog";
+import { restoreFocusTo } from "@/lib/accessibility";
 import { logError, logWarn } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -11,6 +12,55 @@ export function useWebviewDialog(
   kind?: string
 ) {
   const [dialogQueue, setDialogQueue] = useState<WebviewDialogRequest[]>([]);
+
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
+  const hadDialogRef = useRef(false);
+  const webviewElementRef = useRef(webviewElement);
+  const hasDialog = dialogQueue.length > 0;
+
+  // Declared before the queue-transition effect below so a commit that swaps the
+  // webview and drains the queue together restores to the current node.
+  useLayoutEffect(() => {
+    webviewElementRef.current = webviewElement;
+  }, [webviewElement]);
+
+  const restoreFocus = useCallback(() => {
+    const previous = previousActiveElementRef.current;
+    previousActiveElementRef.current = null;
+    // Falls back to the webview so the guest page gets keyboard input back when
+    // whatever opened the dialog is gone (guest crash, panel teardown).
+    restoreFocusTo(previous, webviewElementRef.current);
+  }, []);
+
+  // A queue of dialogs is one modal session: capture on the empty -> non-empty
+  // edge and restore on non-empty -> empty, so advancing between queued dialogs
+  // neither recaptures (which would record the previous dialog's own OK button)
+  // nor restores early. Layout effect so the capture reads document.activeElement
+  // before WebviewDialog's rAF-deferred autofocus moves it into the overlay.
+  useLayoutEffect(() => {
+    if (hasDialog === hadDialogRef.current) return;
+    hadDialogRef.current = hasDialog;
+
+    if (hasDialog) {
+      const active = document.activeElement;
+      previousActiveElementRef.current =
+        active instanceof HTMLElement && active !== document.body ? active : null;
+    } else {
+      restoreFocus();
+    }
+  }, [hasDialog, restoreFocus]);
+
+  // Unmounting while a dialog is open skips the non-empty -> empty edge entirely,
+  // stranding focus on a control that no longer exists. Kept separate from
+  // `hasDialog` (a captured null is legitimate when focus was on <body>, so the
+  // captured element can't double as the "restore armed" flag).
+  useEffect(() => {
+    return () => {
+      if (!hadDialogRef.current) return;
+      hadDialogRef.current = false;
+      restoreFocus();
+    };
+  }, [restoreFocus]);
 
   // Register panel with main process when webview is ready
   useEffect(() => {

--- a/src/lib/__tests__/accessibility.test.ts
+++ b/src/lib/__tests__/accessibility.test.ts
@@ -156,20 +156,13 @@ describe("restoreFocusTo", () => {
     expect(document.activeElement).toBe(shellButton);
   });
 
-  // A focus target may delegate inward — an Electron <webview> hands focus to the
-  // guest page behind its shadow root, and the document reports the host element.
-  it("accepts a candidate that delegates focus to a descendant", () => {
-    const host = document.createElement("div");
-    const inner = document.createElement("button");
-    inner.textContent = "inner";
-    host.appendChild(inner);
-    document.body.appendChild(host);
-    host.focus = () => inner.focus();
+  it("stops at the first accepting candidate without touching later ones", () => {
+    const accepting = addButton("accepting");
+    const successor = addButton("successor");
 
-    restoreFocusTo(host);
+    restoreFocusTo(accepting, successor);
 
-    expect(document.activeElement).toBe(inner);
-    host.remove();
+    expect(document.activeElement).toBe(accepting);
   });
 
   // Focus falling to <body> strands keyboard users with nothing to tab from.

--- a/src/lib/__tests__/accessibility.test.ts
+++ b/src/lib/__tests__/accessibility.test.ts
@@ -134,6 +134,44 @@ describe("restoreFocusTo", () => {
     expect(document.activeElement).toBe(successor);
   });
 
+  // Being connected isn't enough to accept focus — .focus() on a disabled
+  // element is a silent no-op, which would otherwise drop focus to <body>.
+  it("falls through a connected candidate that refuses focus", () => {
+    const disabled = addButton("disabled");
+    disabled.disabled = true;
+    const successor = addButton("successor");
+
+    restoreFocusTo(disabled, successor);
+
+    expect(document.activeElement).toBe(successor);
+  });
+
+  it("falls back to the app shell when every candidate refuses focus", () => {
+    const shellButton = addButton("shell", root);
+    const disabled = addButton("disabled");
+    disabled.disabled = true;
+
+    restoreFocusTo(disabled);
+
+    expect(document.activeElement).toBe(shellButton);
+  });
+
+  // A focus target may delegate inward — an Electron <webview> hands focus to the
+  // guest page behind its shadow root, and the document reports the host element.
+  it("accepts a candidate that delegates focus to a descendant", () => {
+    const host = document.createElement("div");
+    const inner = document.createElement("button");
+    inner.textContent = "inner";
+    host.appendChild(inner);
+    document.body.appendChild(host);
+    host.focus = () => inner.focus();
+
+    restoreFocusTo(host);
+
+    expect(document.activeElement).toBe(inner);
+    host.remove();
+  });
+
   // Focus falling to <body> strands keyboard users with nothing to tab from.
   it("falls back to the app shell's first tabbable element when no candidate survives", () => {
     const shellButton = addButton("shell", root);

--- a/src/lib/__tests__/accessibility.test.ts
+++ b/src/lib/__tests__/accessibility.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { closeAndAnnounce } from "../accessibility";
+import { closeAndAnnounce, restoreFocusTo } from "../accessibility";
 import {
   useAnnouncerStore,
   _resetAnnouncerDeliveryForTests,
@@ -84,5 +84,74 @@ describe("closeAndAnnounce", () => {
     // announcement is only written after the modal closes.
     expect(storeWasEmptyAtCloseTime).toBe(true);
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Terminal killed");
+  });
+});
+
+describe("restoreFocusTo", () => {
+  let root: HTMLElement;
+
+  function addButton(label: string, parent: HTMLElement = document.body): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.textContent = label;
+    parent.appendChild(button);
+    return button;
+  }
+
+  beforeEach(() => {
+    root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("focuses the first candidate when it is still connected", () => {
+    const first = addButton("first");
+    const second = addButton("second");
+
+    restoreFocusTo(first, second);
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("falls through to the next candidate when the first was unmounted", () => {
+    const removed = addButton("removed");
+    const successor = addButton("successor");
+    removed.remove();
+
+    restoreFocusTo(removed, successor);
+
+    expect(document.activeElement).toBe(successor);
+  });
+
+  it("skips null and body candidates without consuming the chain", () => {
+    const successor = addButton("successor");
+
+    restoreFocusTo(null, document.body, undefined, successor);
+
+    expect(document.activeElement).toBe(successor);
+  });
+
+  // Focus falling to <body> strands keyboard users with nothing to tab from.
+  it("falls back to the app shell's first tabbable element when no candidate survives", () => {
+    const shellButton = addButton("shell", root);
+    const removed = addButton("removed");
+    removed.remove();
+
+    restoreFocusTo(removed, null);
+
+    expect(document.activeElement).toBe(shellButton);
+  });
+
+  // Degrades rather than throwing when the app shell isn't mounted.
+  it("does nothing when no candidate survives and nothing is tabbable", () => {
+    const removed = addButton("removed");
+    removed.remove();
+    root.remove();
+
+    expect(() => restoreFocusTo(removed)).not.toThrow();
+    expect(document.activeElement).toBe(document.body);
   });
 });

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -48,9 +48,9 @@ export function getVisibleTabbableElements(root: ParentNode): HTMLElement[] {
  * Being connected is not enough to accept focus: a candidate that is `disabled`,
  * `inert`, or hidden makes `.focus()` a silent no-op, which would drop focus to
  * `<body>` — so each attempt is verified and the chain continues on failure.
- * Containment counts as success because a focus target may delegate inward: an
- * Electron `<webview>` hosts the guest page behind a shadow root, and focus
- * inside a shadow tree is reported as the host element.
+ * Strict equality is the right check even for a candidate that delegates focus
+ * into a shadow tree (an Electron `<webview>` hosts the guest page that way):
+ * focus inside a shadow tree is reported at the document level as the host.
  */
 export function restoreFocusTo(...candidates: (HTMLElement | null | undefined)[]): void {
   for (const candidate of candidates) {
@@ -58,8 +58,7 @@ export function restoreFocusTo(...candidates: (HTMLElement | null | undefined)[]
     if (!document.contains(candidate)) continue;
 
     candidate.focus();
-    const active = document.activeElement;
-    if (active === candidate || candidate.contains(active)) return;
+    if (document.activeElement === candidate) return;
   }
 
   const root = document.getElementById("root");

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -36,6 +36,33 @@ export function getVisibleTabbableElements(root: ParentNode): HTMLElement[] {
 }
 
 /**
+ * Hand focus to the first candidate that is still connected to the document,
+ * falling back to the app shell's first tabbable element so focus never drops
+ * silently to `<body>` (which strands keyboard users).
+ *
+ * Candidates are tried in preference order — typically the element focused
+ * before an overlay opened, then a logical successor for when that element has
+ * since been unmounted. `<body>` never counts as a candidate: it is what
+ * `document.activeElement` reports when nothing is focused at all.
+ *
+ * Deliberately does not verify that `.focus()` actually moved focus. An Electron
+ * `<webview>` is a custom element hosting the guest page behind a shadow root,
+ * so a false-negative check would yank focus into the app shell — worse than
+ * leaving it where it landed.
+ */
+export function restoreFocusTo(...candidates: (HTMLElement | null | undefined)[]): void {
+  for (const candidate of candidates) {
+    if (!candidate || candidate === document.body) continue;
+    if (!document.contains(candidate)) continue;
+    candidate.focus();
+    return;
+  }
+
+  const root = document.getElementById("root");
+  getVisibleTabbableElements(root ?? document.body)[0]?.focus();
+}
+
+/**
  * Close a modal/dialog/popover, then announce a result to assistive tech.
  *
  * macOS VoiceOver drops `aria-live` updates that originate outside the focused

--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -36,26 +36,30 @@ export function getVisibleTabbableElements(root: ParentNode): HTMLElement[] {
 }
 
 /**
- * Hand focus to the first candidate that is still connected to the document,
- * falling back to the app shell's first tabbable element so focus never drops
- * silently to `<body>` (which strands keyboard users).
+ * Hand focus to the first candidate that actually accepts it, falling back to
+ * the app shell's first tabbable element so focus never drops silently to
+ * `<body>` (which strands keyboard users with nothing to tab from).
  *
  * Candidates are tried in preference order — typically the element focused
  * before an overlay opened, then a logical successor for when that element has
  * since been unmounted. `<body>` never counts as a candidate: it is what
  * `document.activeElement` reports when nothing is focused at all.
  *
- * Deliberately does not verify that `.focus()` actually moved focus. An Electron
- * `<webview>` is a custom element hosting the guest page behind a shadow root,
- * so a false-negative check would yank focus into the app shell — worse than
- * leaving it where it landed.
+ * Being connected is not enough to accept focus: a candidate that is `disabled`,
+ * `inert`, or hidden makes `.focus()` a silent no-op, which would drop focus to
+ * `<body>` — so each attempt is verified and the chain continues on failure.
+ * Containment counts as success because a focus target may delegate inward: an
+ * Electron `<webview>` hosts the guest page behind a shadow root, and focus
+ * inside a shadow tree is reported as the host element.
  */
 export function restoreFocusTo(...candidates: (HTMLElement | null | undefined)[]): void {
   for (const candidate of candidates) {
     if (!candidate || candidate === document.body) continue;
     if (!document.contains(candidate)) continue;
+
     candidate.focus();
-    return;
+    const active = document.activeElement;
+    if (active === candidate || candidate.contains(active)) return;
   }
 
   const root = document.getElementById("root");


### PR DESCRIPTION
## Root cause
`WebviewDialog`'s keydown handler was bound to the overlay's wrapping div and ran `e.preventDefault(); handleOk();` on EVERY bubbled Enter. The native keydown fires at the focused button and bubbles to that div before the browser evaluates the button's Enter→click activation, so `preventDefault()` cancelled that activation and `handleOk()` confirmed unconditionally. A user deliberately focused on Cancel was approving the guest page's `confirm()`.

Resolves #11106

## What changed
1. **Enter ownership** (`src/components/Browser/WebviewDialog.tsx`) — the overlay handler is now Escape-only. Enter is left alone so a focused button runs its native activation, which is already wired to `handleOk`/`handleCancel`. This follows `AppDialog`, whose keydown trap handles Tab only and never touches Enter. The prompt `<input>` gets its own Enter-to-submit (a text input has no native Enter action outside a `<form>`), mirroring `TypedNameConfirmInput`, plus an IME-composition guard so an Enter that commits a composition doesn't submit a half-typed value.

2. **Focus capture/restore** (`src/hooks/useWebviewDialog.ts`) — a queue of dialogs is treated as ONE modal session: focus is captured on the queue's empty→non-empty edge and restored on the drain, never between queued dialogs (a naive per-dialog recapture would record the previous dialog's own OK button). Capture runs in a layout effect so it reads `document.activeElement` before the overlay's rAF-deferred autofocus moves it. Covers all three drain paths: respond, guest dismiss, and unmount-while-open. Restore is declined if something else took focus while the dialog was open, so a late guest dismiss can't steal focus from another pane.

3. **`restoreFocusTo`** (`src/lib/accessibility.ts`) — new shared primitive for the candidate chain (previously-focused element → the webview, so the guest page gets keyboard input back → the app shell's first tabbable). Each attempt is verified, because a connected-but-disabled/inert/hidden candidate makes `.focus()` a silent no-op that would drop focus to `<body>`.

4. **Fleet Enter hijack** (`src/components/Fleet/FleetArmingRibbon.tsx`) — found while fixing the above, and the same bug class in a more dangerous form. While a fleet confirmation is pending, the ribbon installs a CAPTURE-phase window keydown listener that consumed Enter and dispatched `fleet.kill`/`fleet.trash` with `{confirmed: true}`. Because it's capture-phase, it beat the dialog's Cancel button to the key — so Enter on Cancel ran a destructive fleet action. It now ignores Enter whenever a modal dialog is open. Guarded by existence (`document.querySelector('[role="dialog"][aria-modal="true"]')`, the pattern already used in `useGlobalKeybindings`) rather than by ancestry, because Radix menus and selects portal their content outside the owning dialog's subtree. The fleet's own confirmation is an inline `role="status"` banner, not a modal, so its Enter stays reachable.

## Testing
- jsdom does NOT implement a button's native Enter→click activation, so the assertable contract for the buttons is that the overlay leaves Enter uncancelled and synthesises no response of its own; the click mapping is asserted separately.
- All three keyboard tests were red-before-green validated against the old handler (Enter on Cancel failed with "expected onRespond to not be called, but was called 1 times"). The Fleet guard test was likewise red-checked — without it, `fleet.kill` IS dispatched — so it isn't passing vacuously.
- 561 tests green across the changed modules and every test covering them.

## Known limitations (deliberately out of scope)
- A user could rebind a global action to bare Enter, or a plugin could bind Enter in an active scope; either would still `preventDefault` the key and defeat native activation. Fixing that means changing global-keybinding semantics for all modals — a broader change that deserves its own issue.
- Clicking a NON-focusable pane header while a dialog is open leaves DOM focus on `<body>`, so a late guest dismiss can still restore focus to the original pane.