### PR TITLE
fix(updater): route update install through the graceful shutdown coordinator

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -236,6 +236,7 @@ const deferredInitQueueMock = vi.hoisted(() => ({
 vi.mock("../../window/deferredInitQueue.js", () => deferredInitQueueMock);
 
 import type { ShutdownDeps } from "../shutdown.js";
+import { CLEANUP_TIMEOUT_MS } from "../shutdownConfig.js";
 
 function makeDeps(overrides?: Partial<ShutdownDeps>): ShutdownDeps {
   return {
@@ -380,7 +381,13 @@ describe("registerShutdownHandler", () => {
     const event = makeEvent();
     await beforeQuitCb(event);
 
+    // haltDeferredQueue runs in the chain's synchronous prefix; the drain sits
+    // behind the chain's dynamic import of ipc/utils, so wait for it rather than
+    // counting microtasks. The invariant under test is the ORDER, not the timing.
     expect(deferredInitQueueMock.haltDeferredQueue).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(drainRateLimitQueues).toHaveBeenCalled();
+    });
     const haltOrder = deferredInitQueueMock.haltDeferredQueue.mock.invocationCallOrder[0];
     const drainOrder = vi.mocked(drainRateLimitQueues).mock.invocationCallOrder[0];
     expect(haltOrder).toBeLessThan(drainOrder);
@@ -1179,6 +1186,183 @@ describe("registerShutdownHandler", () => {
       const record = persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>;
       expect(record.sessionId).toBe("sess-1");
       expect(record.branch).toBeUndefined();
+    });
+  });
+
+  // Issue #11104. On macOS, quitAndInstall() reaches native Squirrel.Mac, which
+  // closes every window before Electron emits `before-quit` — so the update path
+  // could never reach this chain and silently skipped journaling, the DB
+  // checkpoint, audit flushes and subprocess teardown, hand-copying three
+  // clean-exit markers instead. The chain is now reachable without `before-quit`.
+  describe("update-install shutdown (issue #11104)", () => {
+    beforeEach(() => {
+      // clearAllMocks() resets call records, NOT implementations — a mcpServer.stop
+      // wedged by an earlier test would otherwise hang every test after it.
+      mcpServerMock.stop.mockReturnValue(Promise.resolve());
+    });
+
+    async function setupCoordinated(overrides?: Partial<ShutdownDeps>) {
+      const { registerShutdownHandler } = await import("../shutdown.js");
+      const coordinator = await import("../shutdownCoordinator.js");
+      const deps = makeDeps(overrides);
+      registerShutdownHandler(deps);
+      const beforeQuitCb = appMock.on.mock.calls.find(
+        (args: string[]) => args[0] === "before-quit"
+      )![1] as (event: { preventDefault: () => void }) => Promise<void>;
+      return { deps, beforeQuitCb, coordinator };
+    }
+
+    it("runs the full cleanup chain for an update install without any before-quit", async () => {
+      const { coordinator } = await setupCoordinated();
+      const onReadyToInstall = vi.fn();
+
+      const status = coordinator.requestGracefulShutdownForUpdate(onReadyToInstall);
+      expect(status).toBe("started");
+
+      await vi.waitFor(() => expect(onReadyToInstall).toHaveBeenCalled());
+
+      // The work the update path used to lose entirely.
+      expect(closeSharedDbMock.closeSharedDb).toHaveBeenCalled();
+      expect(dbMaintenanceMock.dispose).toHaveBeenCalled();
+      expect(mcpServerMock.stop).toHaveBeenCalled();
+      expect(closeTelemetryMock).toHaveBeenCalled();
+      // The install decides how the process ends — the chain must not exit itself.
+      expect(appMock.exit).not.toHaveBeenCalled();
+    });
+
+    it("hands off with a clean outcome and writes the markers the update path used to hand-copy", async () => {
+      const { coordinator } = await setupCoordinated();
+      const onReadyToInstall = vi.fn();
+
+      coordinator.requestGracefulShutdownForUpdate(onReadyToInstall);
+      await vi.waitFor(() => expect(onReadyToInstall).toHaveBeenCalled());
+
+      expect(onReadyToInstall).toHaveBeenCalledWith("clean");
+      expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+      expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not install before the cleanup chain settles", async () => {
+      let releaseCleanup: () => void = () => {};
+      mcpServerMock.stop.mockReturnValue(
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        })
+      );
+
+      const { coordinator } = await setupCoordinated();
+      const onReadyToInstall = vi.fn();
+      coordinator.requestGracefulShutdownForUpdate(onReadyToInstall);
+
+      // Chain is wedged mid-cleanup: nothing may be installed or marked clean yet.
+      await vi.waitFor(() => expect(mcpServerMock.stop).toHaveBeenCalled());
+      expect(onReadyToInstall).not.toHaveBeenCalled();
+      expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+
+      releaseCleanup();
+      await vi.waitFor(() => expect(onReadyToInstall).toHaveBeenCalled());
+      expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+      // Markers must land before the installer takes the process (lesson #7158).
+      expect(crashRecoveryMock.cleanupOnExit.mock.invocationCallOrder[0]).toBeLessThan(
+        onReadyToInstall.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("still installs on a dirty outcome but leaves the crash marker intact", async () => {
+      vi.useFakeTimers();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mcpServerMock.stop.mockReturnValue(new Promise(() => {}));
+
+      try {
+        const { coordinator } = await setupCoordinated();
+        const onReadyToInstall = vi.fn();
+        coordinator.requestGracefulShutdownForUpdate(onReadyToInstall);
+
+        await vi.advanceTimersByTimeAsync(CLEANUP_TIMEOUT_MS);
+        await vi.runAllTimersAsync();
+
+        // The user asked to update — a timed-out cleanup must not swallow that.
+        expect(onReadyToInstall).toHaveBeenCalledWith("dirty");
+        // But it must not claim a clean exit it never achieved.
+        expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+        expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+      } finally {
+        consoleSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    it("prevents a quit that lands while the update cleanup is still running", async () => {
+      let releaseCleanup: () => void = () => {};
+      mcpServerMock.stop.mockReturnValue(
+        new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        })
+      );
+
+      const { beforeQuitCb, coordinator } = await setupCoordinated();
+      coordinator.requestGracefulShutdownForUpdate(vi.fn());
+      await vi.waitFor(() => expect(mcpServerMock.stop).toHaveBeenCalled());
+
+      // A Cmd+Q here would otherwise close the windows and kill the process out
+      // from under the in-flight chain — losing the very work it is doing.
+      const event = makeEvent();
+      await beforeQuitCb(event);
+      expect(event.preventDefault).toHaveBeenCalled();
+
+      releaseCleanup();
+    });
+
+    it("allows the quit that Squirrel issues once the install has been handed off", async () => {
+      const { beforeQuitCb, coordinator } = await setupCoordinated();
+      const onReadyToInstall = vi.fn();
+      coordinator.requestGracefulShutdownForUpdate(onReadyToInstall);
+      await vi.waitFor(() => expect(onReadyToInstall).toHaveBeenCalled());
+
+      // quitAndInstall() closes the windows and calls app.quit() behind our back.
+      // Blocking that quit would strand every install behind the force-exit watchdog.
+      const event = makeEvent();
+      await beforeQuitCb(event);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("refuses an update install once a normal quit already owns the shutdown", async () => {
+      const { beforeQuitCb, coordinator } = await setupCoordinated();
+      await beforeQuitCb(makeEvent());
+
+      // Attaching a second terminal action here would race quitAndInstall()
+      // against the app.exit() the quit path already owns.
+      const onReadyToInstall = vi.fn();
+      expect(coordinator.requestGracefulShutdownForUpdate(onReadyToInstall)).toBe(
+        "already-shutting-down"
+      );
+
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalledWith(0));
+      expect(onReadyToInstall).not.toHaveBeenCalled();
+    });
+
+    it("runs the cleanup chain once when a second install request races the first", async () => {
+      const { coordinator } = await setupCoordinated();
+      const first = vi.fn();
+      const second = vi.fn();
+
+      expect(coordinator.requestGracefulShutdownForUpdate(first)).toBe("started");
+      expect(coordinator.requestGracefulShutdownForUpdate(second)).toBe("already-shutting-down");
+
+      await vi.waitFor(() => expect(first).toHaveBeenCalled());
+      expect(second).not.toHaveBeenCalled();
+      expect(closeSharedDbMock.closeSharedDb).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports unavailable — and cleans up nothing — when no shutdown handler is registered", async () => {
+      const coordinator = await import("../shutdownCoordinator.js");
+
+      const onReadyToInstall = vi.fn();
+      expect(coordinator.requestGracefulShutdownForUpdate(onReadyToInstall)).toBe("unavailable");
+
+      expect(onReadyToInstall).not.toHaveBeenCalled();
+      expect(closeSharedDbMock.closeSharedDb).not.toHaveBeenCalled();
+      expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -235,8 +235,20 @@ const deferredInitQueueMock = vi.hoisted(() => ({
 
 vi.mock("../../window/deferredInitQueue.js", () => deferredInitQueueMock);
 
+// Runs in the post-cleanup tail, outside the hard-timeout race. Mocked so a test
+// can wedge it and prove the run still settles (issue #11104).
+const performanceTraceMock = vi.hoisted(() => ({
+  stopPerformanceTraceIfActive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../utils/performanceTrace.js", () => performanceTraceMock);
+
 import type { ShutdownDeps } from "../shutdown.js";
-import { CLEANUP_TIMEOUT_MS } from "../shutdownConfig.js";
+import {
+  CLEANUP_TIMEOUT_MS,
+  SHUTDOWN_DEADLINE_MS,
+  SHUTDOWN_TAIL_TIMEOUT_MS,
+} from "../shutdownConfig.js";
 
 function makeDeps(overrides?: Partial<ShutdownDeps>): ShutdownDeps {
   return {
@@ -1196,9 +1208,10 @@ describe("registerShutdownHandler", () => {
   // clean-exit markers instead. The chain is now reachable without `before-quit`.
   describe("update-install shutdown (issue #11104)", () => {
     beforeEach(() => {
-      // clearAllMocks() resets call records, NOT implementations — a mcpServer.stop
-      // wedged by an earlier test would otherwise hang every test after it.
+      // clearAllMocks() resets call records, NOT implementations — anything an
+      // earlier test wedged would otherwise hang every test after it.
       mcpServerMock.stop.mockReturnValue(Promise.resolve());
+      performanceTraceMock.stopPerformanceTraceIfActive.mockReturnValue(Promise.resolve());
     });
 
     async function setupCoordinated(overrides?: Partial<ShutdownDeps>) {
@@ -1352,6 +1365,56 @@ describe("registerShutdownHandler", () => {
       await vi.waitFor(() => expect(first).toHaveBeenCalled());
       expect(second).not.toHaveBeenCalled();
       expect(closeSharedDbMock.closeSharedDb).toHaveBeenCalledTimes(1);
+    });
+
+    // The before-quit listener holds off every quit while a chain is cleaning, so a
+    // chain that never settles would leave the app impossible to quit at all. The
+    // perf-trace flush is the live risk: it runs after the cleanup race (so the
+    // hard timeout doesn't cover it) and contentTracing.stopRecording() has no cap.
+    it("abandons a wedged trace flush at the tail budget and still hands off", async () => {
+      vi.useFakeTimers();
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      performanceTraceMock.stopPerformanceTraceIfActive.mockReturnValue(new Promise(() => {}));
+
+      try {
+        const { coordinator } = await setupCoordinated();
+        const onReadyToInstall = vi.fn();
+        coordinator.requestGracefulShutdownForUpdate(onReadyToInstall);
+
+        // Advance ONLY the tail budget — deliberately short of the coordinator's
+        // absolute deadline, so this proves the tail bound itself and can't pass
+        // on the strength of the outer backstop.
+        await vi.advanceTimersByTimeAsync(SHUTDOWN_TAIL_TIMEOUT_MS);
+
+        expect(onReadyToInstall).toHaveBeenCalled();
+      } finally {
+        performanceTraceMock.stopPerformanceTraceIfActive.mockReturnValue(Promise.resolve());
+        consoleSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    // The backstop behind every other budget. Once a chain is cleaning, the
+    // before-quit listener holds off every quit — so a chain that never settles at
+    // all would leave an app that literally cannot be quit.
+    it("forces the terminal action when the chain never settles at all", async () => {
+      vi.useFakeTimers();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const coordinator = await import("../shutdownCoordinator.js");
+        coordinator.setShutdownRunner(() => new Promise(() => {}));
+
+        const onSettled = vi.fn();
+        expect(coordinator.startShutdown("app-quit", onSettled)).toBe("started");
+
+        await vi.advanceTimersByTimeAsync(SHUTDOWN_DEADLINE_MS);
+
+        expect(onSettled).toHaveBeenCalledWith("dirty");
+      } finally {
+        consoleSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
 
     it("reports unavailable — and cleans up nothing — when no shutdown handler is registered", async () => {

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -1411,6 +1411,11 @@ describe("registerShutdownHandler", () => {
         await vi.advanceTimersByTimeAsync(SHUTDOWN_DEADLINE_MS);
 
         expect(onSettled).toHaveBeenCalledWith("dirty");
+        // A deadline-forced handoff never reaches the chain's own
+        // clearSafetyBeltTimer(), so the coordinator must defuse the belt itself —
+        // otherwise it fires seconds later and app.exit(1)s straight through the
+        // updater's install window.
+        expect(signalShutdownMock.clearSafetyBeltTimer).toHaveBeenCalled();
       } finally {
         consoleSpy.mockRestore();
         vi.useRealTimers();

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -55,6 +55,12 @@ import { isSmokeTest } from "../setup/environment.js";
 import { stopPerformanceTraceIfActive } from "../utils/performanceTrace.js";
 import { isSignalShutdown, clearSafetyBeltTimer } from "./signalShutdownState.js";
 import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
+import {
+  getActiveShutdown,
+  setShutdownRunner,
+  startShutdown,
+  type ShutdownOutcome,
+} from "./shutdownCoordinator.js";
 
 export { CLEANUP_TIMEOUT_MS };
 
@@ -77,12 +83,35 @@ export interface ShutdownDeps {
   windowRegistry?: import("../window/WindowRegistry.js").WindowRegistry;
 }
 
-let isQuitting = false;
 let isConfirmingQuit = false;
 
 export function registerShutdownHandler(deps: ShutdownDeps): void {
+  // Publish the cleanup chain to the coordinator so the update-install path
+  // (AutoUpdaterService) can run the exact same shutdown work. On macOS,
+  // quitAndInstall() reaches native Squirrel.Mac, which closes every window
+  // before Electron emits `before-quit` — so this listener never usefully fires
+  // for an update and the chain has to be reachable without it (issue #11104).
+  setShutdownRunner(() => runShutdownChain(deps));
+
   app.on("before-quit", async (event) => {
-    if (isQuitting || isSmokeTest) {
+    if (isSmokeTest) {
+      return;
+    }
+
+    const active = getActiveShutdown();
+    if (active) {
+      // A shutdown already owns the process. While its chain is still running,
+      // this quit must not tear the process down under it — Electron would close
+      // the windows and exit, losing exactly the journaling/checkpoint work the
+      // chain is doing. The owner's own terminal action ends the process.
+      //
+      // Once the chain has handed off, do NOT prevent: on the update path this
+      // quit IS the terminal action landing (Squirrel calls app.quit() behind
+      // quitAndInstall()), and blocking it would strand every install behind the
+      // force-exit watchdog.
+      if (active.phase === "cleaning") {
+        event.preventDefault();
+      }
       return;
     }
 
@@ -118,552 +147,562 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
       event.preventDefault();
     }
 
-    isQuitting = true;
+    // The quit is committed. Claim the coordinator and own the terminal action:
+    // app.exit() with the code the chain's outcome dictates.
+    startShutdown("app-quit", (outcome) => {
+      app.exit(outcome === "clean" ? 0 : 1);
+    });
+  });
+}
 
-    // Halt the deferred init queue before anything yields to the event loop —
-    // a pending setImmediate drain step could otherwise re-initialize services
-    // the cleanup chain below is about to tear down (issue #9881). Placed
-    // after the quit-confirmation dialog deliberately: halting is permanent,
-    // so a cancelled quit must never reach it (an abandoned drain chain cannot
-    // be resumed). Tasks that start during the dialog run against a fully live
-    // app and are torn down by the cleanup chain like any other service.
-    haltDeferredQueue();
+// The graceful-shutdown chain, shared by every path that ends the process: the
+// `before-quit` listener above and AutoUpdaterService's update install. It runs
+// the cleanup work and reports whether it settled clean or dirty — it never ends
+// the process itself, because who does that (and how) belongs to the caller.
+async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
+  // Halt the deferred init queue before anything yields to the event loop —
+  // a pending setImmediate drain step could otherwise re-initialize services
+  // the cleanup chain below is about to tear down (issue #9881). Placed
+  // after the quit-confirmation dialog deliberately: halting is permanent,
+  // so a cancelled quit must never reach it (an abandoned drain chain cannot
+  // be resumed). Tasks that start during the dialog run against a fully live
+  // app and are torn down by the cleanup chain like any other service.
+  haltDeferredQueue();
 
-    // Eager snapshot at quit-intent so the next launch has a post-quit-intent
-    // backup regardless of which branch of the cleanup race wins. Without this,
-    // a hard-timeout dirty exit skips cleanupOnExit() entirely and leaves the
-    // user with whatever the 60s backup timer last captured. takeBackup() is
-    // synchronous and best-effort (swallows its own errors), so it cannot
-    // block or fail the shutdown chain.
-    try {
-      getCrashRecoveryService().takeBackup();
-    } catch (err) {
-      console.warn("[MAIN] Eager takeBackup at quit-intent failed:", err);
+  // Eager snapshot at quit-intent so the next launch has a post-quit-intent
+  // backup regardless of which branch of the cleanup race wins. Without this,
+  // a hard-timeout dirty exit skips cleanupOnExit() entirely and leaves the
+  // user with whatever the 60s backup timer last captured. takeBackup() is
+  // synchronous and best-effort (swallows its own errors), so it cannot
+  // block or fail the shutdown chain.
+  try {
+    getCrashRecoveryService().takeBackup();
+  } catch (err) {
+    console.warn("[MAIN] Eager takeBackup at quit-intent failed:", err);
+  }
+
+  // Persist compile-cache entries on clean quit. Synchronous and cheap (one
+  // fs write), placed here before the async graceful-shutdown chain so it
+  // can't race the cleanup timeout. We've already committed to quitting
+  // (isQuitting = true), so this never fires on a cancelled quit dialog.
+  try {
+    if (typeof flushCompileCache === "function") {
+      flushCompileCache();
     }
+  } catch (err) {
+    console.warn("[MAIN] flushCompileCache at quit failed:", err);
+  }
 
-    // Persist compile-cache entries on clean quit. Synchronous and cheap (one
-    // fs write), placed here before the async graceful-shutdown chain so it
-    // can't race the cleanup timeout. We've already committed to quitting
-    // (isQuitting = true), so this never fires on a cancelled quit dialog.
+  console.log("[MAIN] Starting graceful shutdown...");
+  const { drainRateLimitQueues } = await import("../ipc/utils.js");
+  drainRateLimitQueues();
+
+  const ptyClient = deps.getPtyClient();
+  const workspaceClient = deps.getWorkspaceClient();
+  const gracefulShutdownPromise = (async () => {
+    if (!ptyClient) return;
     try {
-      if (typeof flushCompileCache === "function") {
-        flushCompileCache();
-      }
-    } catch (err) {
-      console.warn("[MAIN] flushCompileCache at quit failed:", err);
-    }
-
-    console.log("[MAIN] Starting graceful shutdown...");
-    const { drainRateLimitQueues } = await import("../ipc/utils.js");
-    drainRateLimitQueues();
-
-    const ptyClient = deps.getPtyClient();
-    const workspaceClient = deps.getWorkspaceClient();
-    const gracefulShutdownPromise = (async () => {
-      if (!ptyClient) return;
+      // Snapshot terminal infos before the kills — info is gone once the PTY
+      // exits — so each captured agent session can be journaled below. Outside
+      // the 4s kill race; a failed snapshot just no-ops the journal step.
+      let terminalInfoById = new Map<
+        string,
+        Awaited<ReturnType<PtyClient["getAllTerminalsAsync"]>>[number]
+      >();
       try {
-        // Snapshot terminal infos before the kills — info is gone once the PTY
-        // exits — so each captured agent session can be journaled below. Outside
-        // the 4s kill race; a failed snapshot just no-ops the journal step.
-        let terminalInfoById = new Map<
-          string,
-          Awaited<ReturnType<PtyClient["getAllTerminalsAsync"]>>[number]
-        >();
-        try {
-          const allTerminals = await ptyClient.getAllTerminalsAsync();
-          terminalInfoById = new Map(allTerminals.map((t) => [t.id, t]));
-        } catch {
-          // Snapshot is best-effort; journaling below skips when info is absent.
-        }
-        // Freeze each terminal's launch generation alongside the info snapshot,
-        // before any kill — the journal write below must stay attributed to the
-        // incarnation being shut down.
-        const ledger = getLifecycleLedger();
-        const generationById = new Map<string, number | undefined>(
-          [...terminalInfoById.keys()].map((id) => [id, ledger.currentGeneration(id)])
+        const allTerminals = await ptyClient.getAllTerminalsAsync();
+        terminalInfoById = new Map(allTerminals.map((t) => [t.id, t]));
+      } catch {
+        // Snapshot is best-effort; journaling below skips when info is absent.
+      }
+      // Freeze each terminal's launch generation alongside the info snapshot,
+      // before any kill — the journal write below must stay attributed to the
+      // incarnation being shut down.
+      const ledger = getLifecycleLedger();
+      const generationById = new Map<string, number | undefined>(
+        [...terminalInfoById.keys()].map((id) => [id, ledger.currentGeneration(id)])
+      );
+
+      const allProjects = projectStore.getAllProjects();
+      const projectIds = allProjects.map((p) => p.id);
+      // Cap each project's graceful kill independently (in parallel) rather
+      // than racing the whole batch against one 4s deadline: a single slow
+      // project must not discard the captured sessions of projects that did
+      // finish in time — both the projectStore write and the resume journal
+      // below depend on those partial results. Wall-clock stays ~4s (parallel).
+      const allResults = await Promise.all(
+        projectIds.map((pid) => {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          return Promise.race([
+            ptyClient.gracefulKillByProject(pid),
+            new Promise<Array<{ id: string; agentSessionId: string | null }>>((resolve) => {
+              timer = setTimeout(() => resolve([]), 4000);
+            }),
+          ]).finally(() => {
+            if (timer) clearTimeout(timer);
+          });
+        })
+      );
+
+      for (let i = 0; i < projectIds.length; i++) {
+        const results = allResults[i];
+        const captured = results.filter((r) => r.agentSessionId);
+        if (captured.length === 0) continue;
+
+        await projectStore.enqueueProjectStateUpdate(projectIds[i], (state) => {
+          if (!state?.terminals) return null;
+          for (const result of captured) {
+            const snapshot = state.terminals.find((t: { id: string }) => t.id === result.id);
+            if (snapshot) {
+              snapshot.agentSessionId = result.agentSessionId ?? undefined;
+            }
+          }
+          return state;
+        });
+      }
+
+      // Journal a resume record per captured agent session, matching the
+      // trash-expiry / kill / gracefulKill close paths. Non-agent terminals
+      // and sessions with no resumable id are skipped. Branch lookups are
+      // time-boxed (200ms each, parallel over unique worktrees) so a stalled
+      // workspace-host can't push the chain past the cleanup budget (#7151).
+      const capturedAgents = allResults
+        .flat()
+        .filter((r) => r.agentSessionId)
+        .map((r) => ({ result: r, info: terminalInfoById.get(r.id) }))
+        .filter((c): c is { result: typeof c.result; info: NonNullable<typeof c.info> } =>
+          Boolean(c.info?.launchAgentId)
         );
 
-        const allProjects = projectStore.getAllProjects();
-        const projectIds = allProjects.map((p) => p.id);
-        // Cap each project's graceful kill independently (in parallel) rather
-        // than racing the whole batch against one 4s deadline: a single slow
-        // project must not discard the captured sessions of projects that did
-        // finish in time — both the projectStore write and the resume journal
-        // below depend on those partial results. Wall-clock stays ~4s (parallel).
-        const allResults = await Promise.all(
-          projectIds.map((pid) => {
+      if (capturedAgents.length > 0) {
+        const uniqueWorktreeIds = [
+          ...new Set(
+            capturedAgents
+              .map((c) => c.info.worktreeId)
+              .filter((w): w is string => typeof w === "string" && w.length > 0)
+          ),
+        ];
+        const branchByWorktree = new Map<string, string>();
+        await Promise.all(
+          uniqueWorktreeIds.map(async (wid) => {
             let timer: ReturnType<typeof setTimeout> | undefined;
-            return Promise.race([
-              ptyClient.gracefulKillByProject(pid),
-              new Promise<Array<{ id: string; agentSessionId: string | null }>>((resolve) => {
-                timer = setTimeout(() => resolve([]), 4000);
-              }),
-            ]).finally(() => {
+            try {
+              const snapshot = await Promise.race([
+                workspaceClient ? workspaceClient.getMonitorAsync(wid) : Promise.resolve(null),
+                new Promise<null>((resolve) => {
+                  timer = setTimeout(() => resolve(null), 200);
+                }),
+              ]);
+              const branch = snapshot?.branch;
+              if (branch && branch !== "HEAD") branchByWorktree.set(wid, branch);
+            } catch {
+              // best-effort
+            } finally {
               if (timer) clearTimeout(timer);
-            });
+            }
           })
         );
 
-        for (let i = 0; i < projectIds.length; i++) {
-          const results = allResults[i];
-          const captured = results.filter((r) => r.agentSessionId);
-          if (captured.length === 0) continue;
-
-          await projectStore.enqueueProjectStateUpdate(projectIds[i], (state) => {
-            if (!state?.terminals) return null;
-            for (const result of captured) {
-              const snapshot = state.terminals.find((t: { id: string }) => t.id === result.id);
-              if (snapshot) {
-                snapshot.agentSessionId = result.agentSessionId ?? undefined;
-              }
-            }
-            return state;
-          });
-        }
-
-        // Journal a resume record per captured agent session, matching the
-        // trash-expiry / kill / gracefulKill close paths. Non-agent terminals
-        // and sessions with no resumable id are skipped. Branch lookups are
-        // time-boxed (200ms each, parallel over unique worktrees) so a stalled
-        // workspace-host can't push the chain past the cleanup budget (#7151).
-        const capturedAgents = allResults
-          .flat()
-          .filter((r) => r.agentSessionId)
-          .map((r) => ({ result: r, info: terminalInfoById.get(r.id) }))
-          .filter((c): c is { result: typeof c.result; info: NonNullable<typeof c.info> } =>
-            Boolean(c.info?.launchAgentId)
-          );
-
-        if (capturedAgents.length > 0) {
-          const uniqueWorktreeIds = [
-            ...new Set(
-              capturedAgents
-                .map((c) => c.info.worktreeId)
-                .filter((w): w is string => typeof w === "string" && w.length > 0)
-            ),
-          ];
-          const branchByWorktree = new Map<string, string>();
-          await Promise.all(
-            uniqueWorktreeIds.map(async (wid) => {
-              let timer: ReturnType<typeof setTimeout> | undefined;
-              try {
-                const snapshot = await Promise.race([
-                  workspaceClient ? workspaceClient.getMonitorAsync(wid) : Promise.resolve(null),
-                  new Promise<null>((resolve) => {
-                    timer = setTimeout(() => resolve(null), 200);
-                  }),
-                ]);
-                const branch = snapshot?.branch;
-                if (branch && branch !== "HEAD") branchByWorktree.set(wid, branch);
-              } catch {
-                // best-effort
-              } finally {
-                if (timer) clearTimeout(timer);
-              }
-            })
-          );
-
-          for (const { result, info } of capturedAgents) {
-            try {
-              // Exactly-once funnel: the ledger key (terminalId, generation)
-              // drops a record another close path (e.g. a user kill landing
-              // mid-shutdown) already journaled for this incarnation.
-              await journalAgentSession(
-                {
-                  sessionId: result.agentSessionId as string,
-                  agentId: info.launchAgentId as string,
-                  worktreeId: info.worktreeId ?? null,
-                  // Prefer the observed task title, matching the trash-expiry
-                  // and kill close paths — except under a user lock, where the
-                  // record should read the same as the frozen live tab.
-                  title:
-                    (info.titleMode === "user"
-                      ? info.title
-                      : (info.lastObservedTitle ?? info.title)) ?? null,
-                  projectId: info.projectId ?? null,
-                  agentLaunchFlags: info.agentLaunchFlags,
-                  agentModelId: info.agentModelId,
-                  cwd: info.cwd ?? undefined,
-                  branch: info.worktreeId ? branchByWorktree.get(info.worktreeId) : undefined,
-                },
-                { terminalId: result.id, generation: generationById.get(result.id) }
-              );
-            } catch (err) {
-              console.warn("[MAIN] Failed to journal agent session on shutdown:", err);
-            }
+        for (const { result, info } of capturedAgents) {
+          try {
+            // Exactly-once funnel: the ledger key (terminalId, generation)
+            // drops a record another close path (e.g. a user kill landing
+            // mid-shutdown) already journaled for this incarnation.
+            await journalAgentSession(
+              {
+                sessionId: result.agentSessionId as string,
+                agentId: info.launchAgentId as string,
+                worktreeId: info.worktreeId ?? null,
+                // Prefer the observed task title, matching the trash-expiry
+                // and kill close paths — except under a user lock, where the
+                // record should read the same as the frozen live tab.
+                title:
+                  (info.titleMode === "user"
+                    ? info.title
+                    : (info.lastObservedTitle ?? info.title)) ?? null,
+                projectId: info.projectId ?? null,
+                agentLaunchFlags: info.agentLaunchFlags,
+                agentModelId: info.agentModelId,
+                cwd: info.cwd ?? undefined,
+                branch: info.worktreeId ? branchByWorktree.get(info.worktreeId) : undefined,
+              },
+              { terminalId: result.id, generation: generationById.get(result.id) }
+            );
+          } catch (err) {
+            console.warn("[MAIN] Failed to journal agent session on shutdown:", err);
           }
         }
-      } catch (error) {
-        console.warn("[MAIN] Graceful agent shutdown incomplete:", error);
       }
-    })();
+    } catch (error) {
+      console.warn("[MAIN] Graceful agent shutdown incomplete:", error);
+    }
+  })();
 
-    let currentPhase = "service-disposal";
-    let exitCalled = false;
-    let hardTimer: ReturnType<typeof setTimeout> | undefined;
+  let currentPhase = "service-disposal";
+  let hardTimer: ReturnType<typeof setTimeout> | undefined;
 
-    // Stop the CCR config watcher and unwire PluginService's WorkspaceClient
-    // reference before the Promise.all that disposes the WorkspaceClient.
-    // Running these sequentially guarantees no file-change callback can fire
-    // into a half-disposed WorkspaceClient during the await. Both wrap their
-    // own failures so a single throw can't strand the rest of shutdown.
-    const preDisposePromise = gracefulShutdownPromise.then(async () => {
-      const ccr = getCcrConfigService();
-      if (ccr) {
-        try {
-          await ccr.stopWatching();
-        } catch (err) {
-          console.warn("[MAIN] CcrConfigService.stopWatching failed:", err);
-        }
-        setCcrConfigService(null);
-      }
+  // Stop the CCR config watcher and unwire PluginService's WorkspaceClient
+  // reference before the Promise.all that disposes the WorkspaceClient.
+  // Running these sequentially guarantees no file-change callback can fire
+  // into a half-disposed WorkspaceClient during the await. Both wrap their
+  // own failures so a single throw can't strand the rest of shutdown.
+  const preDisposePromise = gracefulShutdownPromise.then(async () => {
+    const ccr = getCcrConfigService();
+    if (ccr) {
       try {
-        const { pluginService } = await import("../services/PluginService.js");
-        pluginService.setWorkspaceClient(null);
-      } catch {
-        // Module load errors during teardown are non-fatal (PluginService may
-        // never have been loaded if shutdown fired before first-interactive).
-      }
-      // Stop the DB maintenance worker BEFORE the audit flushNow() calls
-      // below. The drain wait is capped (a wedged worker must not eat the
-      // shutdown budget), so it is best-effort — shutdownDbWorker() advances
-      // the write fence afterwards, making any ring write a slow worker
-      // commits later in the shutdown window a no-op. Post-shutdown, every
-      // ring write executes synchronously on main, so the final flushNow()
-      // snapshots are durable and cannot be clobbered.
-      try {
-        const { shutdownDbWorker } = await import("../services/persistence/dbWorkerClient.js");
-        await shutdownDbWorker();
+        await ccr.stopWatching();
       } catch (err) {
-        console.warn("[MAIN] DB worker shutdown failed:", err);
+        console.warn("[MAIN] CcrConfigService.stopWatching failed:", err);
+      }
+      setCcrConfigService(null);
+    }
+    try {
+      const { pluginService } = await import("../services/PluginService.js");
+      pluginService.setWorkspaceClient(null);
+    } catch {
+      // Module load errors during teardown are non-fatal (PluginService may
+      // never have been loaded if shutdown fired before first-interactive).
+    }
+    // Stop the DB maintenance worker BEFORE the audit flushNow() calls
+    // below. The drain wait is capped (a wedged worker must not eat the
+    // shutdown budget), so it is best-effort — shutdownDbWorker() advances
+    // the write fence afterwards, making any ring write a slow worker
+    // commits later in the shutdown window a no-op. Post-shutdown, every
+    // ring write executes synchronously on main, so the final flushNow()
+    // snapshots are durable and cannot be clobbered.
+    try {
+      const { shutdownDbWorker } = await import("../services/persistence/dbWorkerClient.js");
+      await shutdownDbWorker();
+    } catch (err) {
+      console.warn("[MAIN] DB worker shutdown failed:", err);
+    }
+  });
+
+  const cleanupPromise = preDisposePromise
+    .then(() =>
+      Promise.all([
+        workspaceClient ? workspaceClient.dispose() : Promise.resolve(),
+        // McpServerService is dynamically imported only after first-interactive.
+        // If the deferred task never ran (early shutdown), the module never loaded
+        // and there is nothing to stop — skip silently.
+        import("../services/McpServerService.js")
+          .then(({ mcpServerService }) => mcpServerService.stop())
+          .catch(() => {}),
+        // Flush any debounced plugin-audit records before exit — the flush
+        // timer is unref'd, so the tail of a session would otherwise be lost.
+        // Lazy-import guarded like MCP: skip silently if init never ran.
+        import("../services/PluginActionAuditService.js")
+          .then(({ getPluginActionAuditService }) => getPluginActionAuditService().flushNow())
+          .catch(() => {}),
+        // Flush any forge audit records still inside the 2s debounce window.
+        // The flush timer is unref()'d so Node won't keep the process alive
+        // for it — without this drain, the last few records are lost on quit.
+        // Lazy-imported: the module only loads if a forge handler ran.
+        import("../services/forge/forgeAuditService.js")
+          .then(({ forgeAuditService }) => forgeAuditService.flushNow())
+          .catch(() => {}),
+        // Mirror for the durable run-history ring (#9949). Same unref'd 2s
+        // debounce, same loss-on-quit if not drained explicitly.
+        import("../services/runHistory/runHistoryService.js")
+          .then(({ runHistoryLog }) => runHistoryLog.flushNow())
+          .catch(() => {}),
+        // Mirror for the plugin-MCP inbound audit ring (#9234). Same unref'd
+        // 2s debounce, same loss-on-quit if not drained explicitly.
+        import("../services/plugin-mcp/instances.js")
+          .then(({ getPluginMcpAuditService }) => getPluginMcpAuditService().flushNow())
+          .catch(() => {}),
+        // Revoke and remove any in-flight help-session dirs. Same lazy-import
+        // guard as MCP — the module only loads if a help session was provisioned.
+        import("../services/HelpSessionService.js")
+          .then(({ helpSessionService }) => helpSessionService.revokeAll())
+          .catch(() => {}),
+        // Tear down every supervised plugin MCP subprocess (#9233). Same
+        // lazy-import guard — if no plugin ever activated an MCP server, the
+        // supervisor module never loaded and there is nothing to stop.
+        import("../services/PluginMcpSupervisor.js")
+          .then(({ getPluginMcpSupervisor }) => getPluginMcpSupervisor().shutdownAll())
+          .catch(() => {}),
+        // Close the CLI control socket and unlink the socket file (F32). Same
+        // lazy-import guard — the module only loaded if the deferred task ran.
+        import("../services/PluginCliServer.js")
+          .then(({ stopPluginCliServer }) => stopPluginCliServer())
+          .catch(() => {}),
+        new Promise<void>((resolve) => {
+          // Global singletons that previously tore down on last-window-close
+          // (electron/window/windowServices.ts) live here now so they cover
+          // the macOS dock-reactivate path without racing a new window's
+          // re-init. Every dispose() wraps in try/catch so one failure can't
+          // strand later cleanup (PTY/workspace/watchdog/DB) — matching the
+          // pattern already used for closeSharedDb downstream.
+          // Order: stop monitors and timers, then connectivity, then
+          // notifiers, then port broker (before WorkspaceClient is killed),
+          // then PTY/workspace/watchdog.
+          try {
+            getResourceProfileService()?.stop();
+          } catch (err) {
+            console.warn("[MAIN] ResourceProfileService.stop failed:", err);
+          }
+          setResourceProfileService(null);
+
+          try {
+            getHibernationService().stop();
+          } catch (err) {
+            console.warn("[MAIN] HibernationService.stop failed:", err);
+          }
+          try {
+            getIdleTerminalNotificationService().stop();
+          } catch (err) {
+            console.warn("[MAIN] IdleTerminalNotificationService.stop failed:", err);
+          }
+          try {
+            getIdleBackgroundAutoCloseService().stop();
+          } catch (err) {
+            console.warn("[MAIN] IdleBackgroundAutoCloseService.stop failed:", err);
+          }
+          try {
+            getSystemSleepService().dispose();
+          } catch (err) {
+            console.warn("[MAIN] SystemSleepService.dispose failed:", err);
+          }
+          try {
+            getOsDndService().dispose();
+          } catch (err) {
+            console.warn("[MAIN] OsDndService.dispose failed:", err);
+          }
+
+          try {
+            agentConnectivityService.dispose();
+          } catch (err) {
+            console.warn("[MAIN] agentConnectivityService.dispose failed:", err);
+          }
+          try {
+            getServiceConnectivityRegistry().dispose();
+          } catch (err) {
+            console.warn("[MAIN] ServiceConnectivityRegistry.dispose failed:", err);
+          }
+
+          try {
+            notificationService.dispose();
+          } catch (err) {
+            console.warn("[MAIN] notificationService.dispose failed:", err);
+          }
+          try {
+            getAgentNotificationServiceRef()?.dispose();
+          } catch (err) {
+            console.warn("[MAIN] AgentNotificationService.dispose failed:", err);
+          }
+          setAgentNotificationServiceRef(null);
+          try {
+            getAutoUpdaterServiceRef()?.dispose();
+          } catch (err) {
+            console.warn("[MAIN] AutoUpdaterService.dispose failed:", err);
+          }
+          setAutoUpdaterServiceRef(null);
+          try {
+            getWindowsStoreNotifierServiceRef()?.dispose();
+          } catch (err) {
+            console.warn("[MAIN] WindowsStoreNotifierService.dispose failed:", err);
+          }
+          setWindowsStoreNotifierServiceRef(null);
+
+          try {
+            getWorktreePortBrokerRef()?.dispose();
+          } catch (err) {
+            console.warn("[MAIN] WorktreePortBroker.dispose failed:", err);
+          }
+          setWorktreePortBrokerRef(null);
+
+          try {
+            disposePowerSaveBlockerService();
+          } catch (err) {
+            console.warn("[MAIN] disposePowerSaveBlockerService failed:", err);
+          }
+          try {
+            disposeAgentAvailabilityStore();
+          } catch (err) {
+            console.warn("[MAIN] disposeAgentAvailabilityStore failed:", err);
+          }
+          if (ptyClient) {
+            try {
+              ptyClient.dispose();
+            } catch (err) {
+              console.warn("[MAIN] PtyClient.dispose failed:", err);
+            }
+            deps.setPtyClient(null);
+          }
+          try {
+            disposePtyClient();
+          } catch (err) {
+            console.warn("[MAIN] disposePtyClient failed:", err);
+          }
+          // Disarm the POSIX crash-safe supervisor only after PTY teardown.
+          // DISARM tells the supervisor this is a clean quit and it should not
+          // SIGKILL on pipe close — but if we disarmed before the PTYs were
+          // actually gone (e.g. the graceful-kill above timed out), a crash in
+          // the intervening window would leave them orphaned. Disarming last
+          // guarantees the cooperative kill has run first. No-op on Windows /
+          // when no supervisor was started.
+          try {
+            helpSessionJobService.dispose();
+          } catch (err) {
+            console.warn("[MAIN] helpSessionJobService.dispose failed:", err);
+          }
+          try {
+            disposeWorkspaceClient();
+          } catch (err) {
+            console.warn("[MAIN] disposeWorkspaceClient failed:", err);
+          }
+          setWorkspaceClientRef(null);
+          try {
+            getMainProcessWatchdogClientRef()?.dispose();
+          } catch (err) {
+            console.warn("[MAIN] MainProcessWatchdogClient.dispose failed:", err);
+          }
+          setMainProcessWatchdogClientRef(null);
+          try {
+            disposeMainProcessWatchdog();
+          } catch (err) {
+            console.warn("[MAIN] disposeMainProcessWatchdog failed:", err);
+          }
+          resolve();
+        }),
+      ])
+    )
+    .then(async () => {
+      currentPhase = "ipc-cleanup";
+      const cleanupIpc = deps.getCleanupIpcHandlers();
+      if (cleanupIpc) {
+        cleanupIpc();
+        deps.setCleanupIpcHandlers(null);
+      }
+      const cleanupErr = deps.getCleanupErrorHandlers();
+      if (cleanupErr) {
+        cleanupErr();
+        deps.setCleanupErrorHandlers(null);
+      }
+      const stopLag = deps.getStopEventLoopLagMonitor();
+      if (stopLag) {
+        stopLag();
+        deps.setStopEventLoopLagMonitor(null);
+      }
+      const stopMem = deps.getStopProcessMemoryMonitor();
+      if (stopMem) {
+        stopMem();
+        deps.setStopProcessMemoryMonitor(null);
+      }
+      const stopMetrics = deps.getStopAppMetricsMonitor();
+      if (stopMetrics) {
+        stopMetrics();
+        deps.setStopAppMetricsMonitor(null);
+      }
+      const stopDisk = deps.getStopDiskSpaceMonitor();
+      if (stopDisk) {
+        stopDisk();
+        deps.setStopDiskSpaceMonitor(null);
+      }
+
+      // Stop the periodic cleanup timer and drain any in-flight sweep before
+      // DB maintenance, so no tick races the final WAL checkpoint (#9537).
+      try {
+        await getPeriodicCleanupService().dispose();
+      } catch (error) {
+        console.warn("[MAIN] Periodic cleanup dispose failed:", error);
+      }
+
+      // Stop the opt-in plugin update checker and drain any in-flight pass
+      // (#10893) — its timers/wake listeners must not survive teardown.
+      try {
+        const { getPluginUpdateCheckService } =
+          await import("../services/PluginUpdateCheckService.js");
+        await getPluginUpdateCheckService().dispose();
+      } catch (error) {
+        console.warn("[MAIN] Plugin update check dispose failed:", error);
+      }
+
+      try {
+        await getDatabaseMaintenanceService().dispose();
+      } catch (error) {
+        console.warn("[MAIN] Database maintenance dispose failed:", error);
+      }
+
+      try {
+        closeSharedDb();
+      } catch (error) {
+        console.warn("[MAIN] Failed to close SQLite connection:", error);
       }
     });
 
-    const cleanupPromise = preDisposePromise
-      .then(() =>
-        Promise.all([
-          workspaceClient ? workspaceClient.dispose() : Promise.resolve(),
-          // McpServerService is dynamically imported only after first-interactive.
-          // If the deferred task never ran (early shutdown), the module never loaded
-          // and there is nothing to stop — skip silently.
-          import("../services/McpServerService.js")
-            .then(({ mcpServerService }) => mcpServerService.stop())
-            .catch(() => {}),
-          // Flush any debounced plugin-audit records before exit — the flush
-          // timer is unref'd, so the tail of a session would otherwise be lost.
-          // Lazy-import guarded like MCP: skip silently if init never ran.
-          import("../services/PluginActionAuditService.js")
-            .then(({ getPluginActionAuditService }) => getPluginActionAuditService().flushNow())
-            .catch(() => {}),
-          // Flush any forge audit records still inside the 2s debounce window.
-          // The flush timer is unref()'d so Node won't keep the process alive
-          // for it — without this drain, the last few records are lost on quit.
-          // Lazy-imported: the module only loads if a forge handler ran.
-          import("../services/forge/forgeAuditService.js")
-            .then(({ forgeAuditService }) => forgeAuditService.flushNow())
-            .catch(() => {}),
-          // Mirror for the durable run-history ring (#9949). Same unref'd 2s
-          // debounce, same loss-on-quit if not drained explicitly.
-          import("../services/runHistory/runHistoryService.js")
-            .then(({ runHistoryLog }) => runHistoryLog.flushNow())
-            .catch(() => {}),
-          // Mirror for the plugin-MCP inbound audit ring (#9234). Same unref'd
-          // 2s debounce, same loss-on-quit if not drained explicitly.
-          import("../services/plugin-mcp/instances.js")
-            .then(({ getPluginMcpAuditService }) => getPluginMcpAuditService().flushNow())
-            .catch(() => {}),
-          // Revoke and remove any in-flight help-session dirs. Same lazy-import
-          // guard as MCP — the module only loads if a help session was provisioned.
-          import("../services/HelpSessionService.js")
-            .then(({ helpSessionService }) => helpSessionService.revokeAll())
-            .catch(() => {}),
-          // Tear down every supervised plugin MCP subprocess (#9233). Same
-          // lazy-import guard — if no plugin ever activated an MCP server, the
-          // supervisor module never loaded and there is nothing to stop.
-          import("../services/PluginMcpSupervisor.js")
-            .then(({ getPluginMcpSupervisor }) => getPluginMcpSupervisor().shutdownAll())
-            .catch(() => {}),
-          // Close the CLI control socket and unlink the socket file (F32). Same
-          // lazy-import guard — the module only loaded if the deferred task ran.
-          import("../services/PluginCliServer.js")
-            .then(({ stopPluginCliServer }) => stopPluginCliServer())
-            .catch(() => {}),
-          new Promise<void>((resolve) => {
-            // Global singletons that previously tore down on last-window-close
-            // (electron/window/windowServices.ts) live here now so they cover
-            // the macOS dock-reactivate path without racing a new window's
-            // re-init. Every dispose() wraps in try/catch so one failure can't
-            // strand later cleanup (PTY/workspace/watchdog/DB) — matching the
-            // pattern already used for closeSharedDb downstream.
-            // Order: stop monitors and timers, then connectivity, then
-            // notifiers, then port broker (before WorkspaceClient is killed),
-            // then PTY/workspace/watchdog.
-            try {
-              getResourceProfileService()?.stop();
-            } catch (err) {
-              console.warn("[MAIN] ResourceProfileService.stop failed:", err);
-            }
-            setResourceProfileService(null);
-
-            try {
-              getHibernationService().stop();
-            } catch (err) {
-              console.warn("[MAIN] HibernationService.stop failed:", err);
-            }
-            try {
-              getIdleTerminalNotificationService().stop();
-            } catch (err) {
-              console.warn("[MAIN] IdleTerminalNotificationService.stop failed:", err);
-            }
-            try {
-              getIdleBackgroundAutoCloseService().stop();
-            } catch (err) {
-              console.warn("[MAIN] IdleBackgroundAutoCloseService.stop failed:", err);
-            }
-            try {
-              getSystemSleepService().dispose();
-            } catch (err) {
-              console.warn("[MAIN] SystemSleepService.dispose failed:", err);
-            }
-            try {
-              getOsDndService().dispose();
-            } catch (err) {
-              console.warn("[MAIN] OsDndService.dispose failed:", err);
-            }
-
-            try {
-              agentConnectivityService.dispose();
-            } catch (err) {
-              console.warn("[MAIN] agentConnectivityService.dispose failed:", err);
-            }
-            try {
-              getServiceConnectivityRegistry().dispose();
-            } catch (err) {
-              console.warn("[MAIN] ServiceConnectivityRegistry.dispose failed:", err);
-            }
-
-            try {
-              notificationService.dispose();
-            } catch (err) {
-              console.warn("[MAIN] notificationService.dispose failed:", err);
-            }
-            try {
-              getAgentNotificationServiceRef()?.dispose();
-            } catch (err) {
-              console.warn("[MAIN] AgentNotificationService.dispose failed:", err);
-            }
-            setAgentNotificationServiceRef(null);
-            try {
-              getAutoUpdaterServiceRef()?.dispose();
-            } catch (err) {
-              console.warn("[MAIN] AutoUpdaterService.dispose failed:", err);
-            }
-            setAutoUpdaterServiceRef(null);
-            try {
-              getWindowsStoreNotifierServiceRef()?.dispose();
-            } catch (err) {
-              console.warn("[MAIN] WindowsStoreNotifierService.dispose failed:", err);
-            }
-            setWindowsStoreNotifierServiceRef(null);
-
-            try {
-              getWorktreePortBrokerRef()?.dispose();
-            } catch (err) {
-              console.warn("[MAIN] WorktreePortBroker.dispose failed:", err);
-            }
-            setWorktreePortBrokerRef(null);
-
-            try {
-              disposePowerSaveBlockerService();
-            } catch (err) {
-              console.warn("[MAIN] disposePowerSaveBlockerService failed:", err);
-            }
-            try {
-              disposeAgentAvailabilityStore();
-            } catch (err) {
-              console.warn("[MAIN] disposeAgentAvailabilityStore failed:", err);
-            }
-            if (ptyClient) {
-              try {
-                ptyClient.dispose();
-              } catch (err) {
-                console.warn("[MAIN] PtyClient.dispose failed:", err);
-              }
-              deps.setPtyClient(null);
-            }
-            try {
-              disposePtyClient();
-            } catch (err) {
-              console.warn("[MAIN] disposePtyClient failed:", err);
-            }
-            // Disarm the POSIX crash-safe supervisor only after PTY teardown.
-            // DISARM tells the supervisor this is a clean quit and it should not
-            // SIGKILL on pipe close — but if we disarmed before the PTYs were
-            // actually gone (e.g. the graceful-kill above timed out), a crash in
-            // the intervening window would leave them orphaned. Disarming last
-            // guarantees the cooperative kill has run first. No-op on Windows /
-            // when no supervisor was started.
-            try {
-              helpSessionJobService.dispose();
-            } catch (err) {
-              console.warn("[MAIN] helpSessionJobService.dispose failed:", err);
-            }
-            try {
-              disposeWorkspaceClient();
-            } catch (err) {
-              console.warn("[MAIN] disposeWorkspaceClient failed:", err);
-            }
-            setWorkspaceClientRef(null);
-            try {
-              getMainProcessWatchdogClientRef()?.dispose();
-            } catch (err) {
-              console.warn("[MAIN] MainProcessWatchdogClient.dispose failed:", err);
-            }
-            setMainProcessWatchdogClientRef(null);
-            try {
-              disposeMainProcessWatchdog();
-            } catch (err) {
-              console.warn("[MAIN] disposeMainProcessWatchdog failed:", err);
-            }
-            resolve();
-          }),
-        ])
-      )
-      .then(async () => {
-        currentPhase = "ipc-cleanup";
-        const cleanupIpc = deps.getCleanupIpcHandlers();
-        if (cleanupIpc) {
-          cleanupIpc();
-          deps.setCleanupIpcHandlers(null);
-        }
-        const cleanupErr = deps.getCleanupErrorHandlers();
-        if (cleanupErr) {
-          cleanupErr();
-          deps.setCleanupErrorHandlers(null);
-        }
-        const stopLag = deps.getStopEventLoopLagMonitor();
-        if (stopLag) {
-          stopLag();
-          deps.setStopEventLoopLagMonitor(null);
-        }
-        const stopMem = deps.getStopProcessMemoryMonitor();
-        if (stopMem) {
-          stopMem();
-          deps.setStopProcessMemoryMonitor(null);
-        }
-        const stopMetrics = deps.getStopAppMetricsMonitor();
-        if (stopMetrics) {
-          stopMetrics();
-          deps.setStopAppMetricsMonitor(null);
-        }
-        const stopDisk = deps.getStopDiskSpaceMonitor();
-        if (stopDisk) {
-          stopDisk();
-          deps.setStopDiskSpaceMonitor(null);
-        }
-
-        // Stop the periodic cleanup timer and drain any in-flight sweep before
-        // DB maintenance, so no tick races the final WAL checkpoint (#9537).
-        try {
-          await getPeriodicCleanupService().dispose();
-        } catch (error) {
-          console.warn("[MAIN] Periodic cleanup dispose failed:", error);
-        }
-
-        // Stop the opt-in plugin update checker and drain any in-flight pass
-        // (#10893) — its timers/wake listeners must not survive teardown.
-        try {
-          const { getPluginUpdateCheckService } =
-            await import("../services/PluginUpdateCheckService.js");
-          await getPluginUpdateCheckService().dispose();
-        } catch (error) {
-          console.warn("[MAIN] Plugin update check dispose failed:", error);
-        }
-
-        try {
-          await getDatabaseMaintenanceService().dispose();
-        } catch (error) {
-          console.warn("[MAIN] Database maintenance dispose failed:", error);
-        }
-
-        try {
-          closeSharedDb();
-        } catch (error) {
-          console.warn("[MAIN] Failed to close SQLite connection:", error);
-        }
-      });
-
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      hardTimer = setTimeout(() => {
-        reject(
-          new Error(
-            `Hard shutdown timeout after ${CLEANUP_TIMEOUT_MS}ms — stuck at phase: ${currentPhase}`
-          )
-        );
-      }, CLEANUP_TIMEOUT_MS);
-    });
-
-    Promise.race([cleanupPromise, timeoutPromise])
-      .then(async () => {
-        if (exitCalled) return;
-        exitCalled = true;
-        clearTimeout(hardTimer);
-        console.log("[MAIN] Graceful shutdown complete");
-        // Mark the exit clean BEFORE telemetry — telemetry is best-effort and
-        // a closeTelemetry failure must never make the next launch think we crashed.
-        // Independent try blocks so a failure in one marker write doesn't skip the other.
-        try {
-          getCrashRecoveryService().cleanupOnExit();
-        } catch (err) {
-          console.warn("[MAIN] CrashRecoveryService.cleanupOnExit failed:", err);
-        }
-        try {
-          getCrashLoopGuard().markCleanExit();
-        } catch (err) {
-          console.warn("[MAIN] CrashLoopGuard.markCleanExit failed:", err);
-        }
-        try {
-          getPanelSuspectLedger().markCleanLaunch();
-        } catch (err) {
-          console.warn("[MAIN] PanelSuspectLedger.markCleanLaunch failed:", err);
-        }
-        // Defuse the signal-handler safety-belt the moment we've committed to a
-        // clean exit. closeTelemetry below has a 2500ms internal cap, but
-        // clearing first eliminates the dependency on that cap holding — if a
-        // future refactor extends the telemetry budget, the belt won't be able
-        // to fire after app.exit(0) and clobber the exit code with exit(1).
-        clearSafetyBeltTimer();
-        try {
-          await closeTelemetry();
-        } catch (err) {
-          console.warn("[MAIN] closeTelemetry failed:", err);
-        }
-        // Flush the perf trace (if --trace was active) while the GPU/renderer
-        // child processes are still alive. app.exit() bypasses will-quit, so
-        // this is the only reliable point to stop tracing before exit; no-op
-        // for normal runs. Awaited so the trace file isn't truncated.
-        await stopPerformanceTraceIfActive();
-        app.exit(0);
-      })
-      .catch(async (error) => {
-        if (exitCalled) return;
-        exitCalled = true;
-        clearTimeout(hardTimer);
-        console.error("[MAIN] Error during cleanup:", error);
-        // Intentionally do NOT clean up the marker on the error/timeout path —
-        // leaving running.lock on disk is the dirty-exit signal for next launch.
-        // Defuse the belt before telemetry flush for the same reason as the
-        // clean branch above.
-        clearSafetyBeltTimer();
-        try {
-          await closeTelemetry();
-        } catch (err) {
-          console.warn("[MAIN] closeTelemetry failed:", err);
-        }
-        // Best-effort trace flush on the error path too — a partial trace is
-        // still useful, and the call is a no-op when tracing is off.
-        await stopPerformanceTraceIfActive();
-        app.exit(1);
-      });
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    hardTimer = setTimeout(() => {
+      reject(
+        new Error(
+          `Hard shutdown timeout after ${CLEANUP_TIMEOUT_MS}ms — stuck at phase: ${currentPhase}`
+        )
+      );
+    }, CLEANUP_TIMEOUT_MS);
   });
+
+  let outcome: ShutdownOutcome;
+  try {
+    await Promise.race([cleanupPromise, timeoutPromise]);
+    clearTimeout(hardTimer);
+    outcome = "clean";
+    console.log("[MAIN] Graceful shutdown complete");
+    // Mark the exit clean BEFORE telemetry — telemetry is best-effort and
+    // a closeTelemetry failure must never make the next launch think we crashed.
+    // Independent try blocks so a failure in one marker write doesn't skip the other.
+    //
+    // These three markers are the ONLY thing the update-install path used to
+    // write (hand-copied into AutoUpdaterService, issue #9638). They live here
+    // now, and only here: a marker written before the chain settles is a lie
+    // about state that was never actually persisted (lesson #7158).
+    try {
+      getCrashRecoveryService().cleanupOnExit();
+    } catch (err) {
+      console.warn("[MAIN] CrashRecoveryService.cleanupOnExit failed:", err);
+    }
+    try {
+      getCrashLoopGuard().markCleanExit();
+    } catch (err) {
+      console.warn("[MAIN] CrashLoopGuard.markCleanExit failed:", err);
+    }
+    try {
+      getPanelSuspectLedger().markCleanLaunch();
+    } catch (err) {
+      console.warn("[MAIN] PanelSuspectLedger.markCleanLaunch failed:", err);
+    }
+  } catch (error) {
+    clearTimeout(hardTimer);
+    outcome = "dirty";
+    console.error("[MAIN] Error during cleanup:", error);
+    // Intentionally do NOT write the markers on the error/timeout path —
+    // leaving running.lock on disk is the dirty-exit signal for next launch.
+    // This holds for an update install too: a timed-out cleanup still installs,
+    // but the next boot gets a truthful dirty marker and its recovery flow
+    // rather than a false "everything was saved".
+  }
+
+  // Defuse the signal-handler safety-belt the moment the outcome is decided.
+  // closeTelemetry below has a 2500ms internal cap, but clearing first
+  // eliminates the dependency on that cap holding — if a future refactor
+  // extends the telemetry budget, the belt won't be able to fire after the
+  // terminal action and clobber it.
+  clearSafetyBeltTimer();
+  try {
+    await closeTelemetry();
+  } catch (err) {
+    console.warn("[MAIN] closeTelemetry failed:", err);
+  }
+  // Flush the perf trace (if --trace was active) while the GPU/renderer child
+  // processes are still alive. app.exit() bypasses will-quit, so this is the
+  // only reliable point to stop tracing before exit; no-op for normal runs.
+  // Awaited so the trace file isn't truncated, but wrapped: a rejection here
+  // must not strand the caller's terminal action and leave the process hung.
+  try {
+    await stopPerformanceTraceIfActive();
+  } catch (err) {
+    console.warn("[MAIN] stopPerformanceTraceIfActive failed:", err);
+  }
+
+  return outcome;
 }

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -54,7 +54,7 @@ import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
 import { stopPerformanceTraceIfActive } from "../utils/performanceTrace.js";
 import { isSignalShutdown, clearSafetyBeltTimer } from "./signalShutdownState.js";
-import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
+import { CLEANUP_TIMEOUT_MS, SHUTDOWN_TAIL_TIMEOUT_MS } from "./shutdownConfig.js";
 import {
   getActiveShutdown,
   setShutdownRunner,
@@ -682,27 +682,55 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
     // rather than a false "everything was saved".
   }
 
-  // Defuse the signal-handler safety-belt the moment the outcome is decided.
-  // closeTelemetry below has a 2500ms internal cap, but clearing first
-  // eliminates the dependency on that cap holding — if a future refactor
-  // extends the telemetry budget, the belt won't be able to fire after the
-  // terminal action and clobber it.
+  // Defuse the signal-handler safety-belt the moment the outcome is decided, so
+  // it can't fire during the tail below and clobber the terminal action.
   clearSafetyBeltTimer();
-  try {
-    await closeTelemetry();
-  } catch (err) {
-    console.warn("[MAIN] closeTelemetry failed:", err);
-  }
-  // Flush the perf trace (if --trace was active) while the GPU/renderer child
-  // processes are still alive. app.exit() bypasses will-quit, so this is the
-  // only reliable point to stop tracing before exit; no-op for normal runs.
-  // Awaited so the trace file isn't truncated, but wrapped: a rejection here
-  // must not strand the caller's terminal action and leave the process hung.
-  try {
-    await stopPerformanceTraceIfActive();
-  } catch (err) {
-    console.warn("[MAIN] stopPerformanceTraceIfActive failed:", err);
-  }
+
+  // The tail runs AFTER the cleanup race, so CLEANUP_TIMEOUT_MS does not cover
+  // it. Bound it: a rejection here is caught, but a promise that simply never
+  // settles would hang this function forever — and a shutdown run that never
+  // settles blocks every subsequent quit (the before-quit listener holds them off
+  // while a chain is cleaning), leaving an app that cannot be quit at all.
+  // `stopPerformanceTraceIfActive` is the live risk: contentTracing.stopRecording()
+  // has no internal cap, so a wedged tracing service would do exactly that.
+  await settleWithin(
+    (async () => {
+      try {
+        await closeTelemetry();
+      } catch (err) {
+        console.warn("[MAIN] closeTelemetry failed:", err);
+      }
+      // Flush the perf trace (if --trace was active) while the GPU/renderer child
+      // processes are still alive. app.exit() bypasses will-quit, so this is the
+      // only reliable point to stop tracing before exit; no-op for normal runs.
+      try {
+        await stopPerformanceTraceIfActive();
+      } catch (err) {
+        console.warn("[MAIN] stopPerformanceTraceIfActive failed:", err);
+      }
+    })(),
+    SHUTDOWN_TAIL_TIMEOUT_MS,
+    "shutdown tail (telemetry + trace flush)"
+  );
 
   return outcome;
+}
+
+// Waits for `work`, abandoning it if it outlives `budgetMs`. Resolves either way —
+// it exists to bound a hang, so it must never introduce one of its own.
+async function settleWithin(work: Promise<void>, budgetMs: number, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      work,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          console.warn(`[MAIN] ${label} exceeded ${budgetMs}ms — abandoning it and exiting`);
+          resolve();
+        }, budgetMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/electron/lifecycle/shutdownConfig.ts
+++ b/electron/lifecycle/shutdownConfig.ts
@@ -3,9 +3,23 @@
 // in the full shutdown.ts service graph (ProjectStore, TelemetryService, etc).
 export const CLEANUP_TIMEOUT_MS = 10_000;
 
-// Safety-belt timer for the signal handler. Must outlast the full cleanup chain:
-// CLEANUP_TIMEOUT_MS (graceful cleanup race) + 3000ms historical buffer + 2500ms
-// worst-case closeTelemetry() (Sentry init-wait cap 500ms + close timeout 2000ms,
-// see TelemetryService.ts). Without the telemetry budget the belt could fire
-// mid-`await closeTelemetry()` and clobber the intended app.exit(1) on the dirty path.
-export const SAFETY_BELT_TIMEOUT_MS = CLEANUP_TIMEOUT_MS + 3_000 + 2_500;
+// Bounds the post-cleanup tail — the telemetry flush and perf-trace flush that run
+// AFTER the cleanup race resolves and are therefore NOT covered by
+// CLEANUP_TIMEOUT_MS. Sized for the worst-case closeTelemetry(): the Sentry
+// init-wait cap (500ms) followed by Sentry.close(2000), whose client-drain and
+// transport-flush waits each get that timeout in sequence — plus slack for
+// contentTracing.stopRecording(), which has no internal cap at all.
+export const SHUTDOWN_TAIL_TIMEOUT_MS = 5_000;
+
+// Absolute deadline for an entire shutdown run, backstopping every budget above.
+// A run that never settles is not merely slow: once a chain is cleaning, the
+// before-quit listener holds off every subsequent quit so nothing can tear the
+// process down mid-cleanup. A single unbounded await anywhere in that ~540-line
+// chain would therefore leave the app impossible to quit at all. This guarantees
+// the terminal action — app.exit(), or the update install — always fires.
+export const SHUTDOWN_DEADLINE_MS = CLEANUP_TIMEOUT_MS + SHUTDOWN_TAIL_TIMEOUT_MS + 2_000;
+
+// Safety-belt timer for the signal handler. Must strictly outlast every budget it
+// backstops (lesson #7151) — otherwise it fires mid-cleanup and clobbers the exit
+// code the chain was about to set.
+export const SAFETY_BELT_TIMEOUT_MS = SHUTDOWN_DEADLINE_MS + 3_000;

--- a/electron/lifecycle/shutdownCoordinator.ts
+++ b/electron/lifecycle/shutdownCoordinator.ts
@@ -11,6 +11,9 @@
 // importing it directly would be an import cycle. shutdown.ts registers its
 // chain here as the runner instead.
 
+import { app } from "electron";
+import { SHUTDOWN_DEADLINE_MS } from "./shutdownConfig.js";
+
 export type ShutdownOutcome = "clean" | "dirty";
 export type ShutdownInitiator = "app-quit" | "update-install";
 
@@ -62,18 +65,55 @@ export function startShutdown(
   const run: ActiveShutdown = { initiator, phase: "cleaning" };
   active = run;
 
-  void runner()
-    .catch((err: unknown) => {
-      // The chain handles its own failures and resolves "dirty"; a rejection here
-      // means the chain itself broke. Treat it as dirty rather than stranding the
-      // process with no terminal action.
-      console.error("[MAIN] Shutdown chain rejected unexpectedly:", err);
-      return "dirty" as ShutdownOutcome;
-    })
-    .then((outcome) => {
-      run.phase = "handoff";
+  // Start the chain. `runner` is an async function, so a throw in its synchronous
+  // prefix surfaces as a rejection — but wrap it anyway: a synchronous throw here
+  // would leave `active` stuck in "cleaning" forever, and a shutdown stuck in
+  // "cleaning" is an app that can never be quit (see the before-quit listener).
+  let chain: Promise<ShutdownOutcome>;
+  try {
+    chain = runner();
+  } catch (err) {
+    console.error("[MAIN] Shutdown runner threw synchronously:", err);
+    chain = Promise.resolve("dirty");
+  }
+
+  // The chain reports its own failures as "dirty"; a rejection means the chain
+  // itself broke.
+  const settled = chain.catch((err: unknown) => {
+    console.error("[MAIN] Shutdown chain rejected unexpectedly:", err);
+    return "dirty" as ShutdownOutcome;
+  });
+
+  // Absolute deadline. Every budget inside the chain is bounded, but this is the
+  // structural guarantee that the terminal action ALWAYS runs: without it, one
+  // unbounded await anywhere in the chain would hang the run in "cleaning" and
+  // make the app unquittable. Resolves (never rejects) so it cannot itself strand
+  // the handoff.
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<ShutdownOutcome>((resolve) => {
+    deadlineTimer = setTimeout(() => {
+      console.error(
+        `[MAIN] Shutdown exceeded its ${SHUTDOWN_DEADLINE_MS}ms deadline — forcing the terminal action`
+      );
+      resolve("dirty");
+    }, SHUTDOWN_DEADLINE_MS);
+  });
+
+  void Promise.race([settled, deadline]).then((outcome) => {
+    clearTimeout(deadlineTimer);
+    // Flip to "handoff" BEFORE invoking the terminal action, in the same
+    // synchronous turn: onSettled issues quitAndInstall(), and Squirrel's
+    // app.quit() behind it must be allowed through the before-quit listener.
+    run.phase = "handoff";
+    try {
       onSettled(outcome);
-    });
+    } catch (err) {
+      // A terminal action that throws would leave a torn-down process alive with
+      // nothing left to end it. Nothing sane to do but exit.
+      console.error("[MAIN] Shutdown terminal action threw:", err);
+      app.exit(1);
+    }
+  });
 
   return "started";
 }

--- a/electron/lifecycle/shutdownCoordinator.ts
+++ b/electron/lifecycle/shutdownCoordinator.ts
@@ -1,0 +1,92 @@
+// Ownership registry for the one graceful-shutdown chain (issue #11104).
+//
+// Two callers can decide the process must die: the `before-quit` listener in
+// shutdown.ts (user quit, signal, session-end) and AutoUpdaterService when the
+// user installs an update. Both must run the SAME cleanup chain, and exactly
+// one of them must own the terminal action that ends the process — otherwise a
+// normal quit's `app.exit()` races the update path's `quitAndInstall()`.
+//
+// Kept as a leaf module (no heavy imports), mirroring signalShutdownState.ts:
+// shutdown.ts eagerly imports half the service layer, so AutoUpdaterService
+// importing it directly would be an import cycle. shutdown.ts registers its
+// chain here as the runner instead.
+
+export type ShutdownOutcome = "clean" | "dirty";
+export type ShutdownInitiator = "app-quit" | "update-install";
+
+// "cleaning" — the chain is running; the process must not be torn down under it.
+// "handoff"  — the chain settled and the owner's terminal action is running
+//              (app.exit, or quitAndInstall and the app.quit Squirrel issues
+//              behind it). A quit arriving now is the terminal action landing,
+//              not an interruption.
+type ShutdownPhase = "cleaning" | "handoff";
+
+export type ShutdownRequestResult = "started" | "already-shutting-down" | "unavailable";
+
+interface ActiveShutdown {
+  initiator: ShutdownInitiator;
+  phase: ShutdownPhase;
+}
+
+type ShutdownRunner = () => Promise<ShutdownOutcome>;
+
+let runner: ShutdownRunner | null = null;
+let active: ActiveShutdown | null = null;
+
+export const setShutdownRunner = (fn: ShutdownRunner | null): void => {
+  runner = fn;
+};
+
+export const getActiveShutdown = (): Readonly<ActiveShutdown> | null => active;
+
+// True while the cleanup chain is still running. A `before-quit` landing in this
+// window must be preventDefault()'d — Electron would otherwise close the windows
+// and terminate the process out from under an in-flight chain, losing exactly the
+// journaling/checkpoint work this coordinator exists to guarantee.
+export const isCleaningUp = (): boolean => active?.phase === "cleaning";
+
+// Claims ownership of the shutdown and starts (or joins) the cleanup chain.
+// `onSettled` runs the caller's terminal action once the chain resolves — phase
+// flips to "handoff" in the same synchronous turn, so there is no window where
+// the chain has settled but the terminal action hasn't been issued.
+//
+// The first caller wins. A second, differently-intentioned request is refused
+// rather than queued: the losing caller must not attach a second terminal action.
+export function startShutdown(
+  initiator: ShutdownInitiator,
+  onSettled: (outcome: ShutdownOutcome) => void
+): ShutdownRequestResult {
+  if (!runner) return "unavailable";
+  if (active) return "already-shutting-down";
+
+  const run: ActiveShutdown = { initiator, phase: "cleaning" };
+  active = run;
+
+  void runner()
+    .catch((err: unknown) => {
+      // The chain handles its own failures and resolves "dirty"; a rejection here
+      // means the chain itself broke. Treat it as dirty rather than stranding the
+      // process with no terminal action.
+      console.error("[MAIN] Shutdown chain rejected unexpectedly:", err);
+      return "dirty" as ShutdownOutcome;
+    })
+    .then((outcome) => {
+      run.phase = "handoff";
+      onSettled(outcome);
+    });
+
+  return "started";
+}
+
+// AutoUpdaterService's entry point. `onReadyToInstall` must invoke the updater
+// synchronously — the phase is already "handoff" when it runs, so any deferral
+// reopens the window where a quit could slip past and skip the install.
+export const requestGracefulShutdownForUpdate = (
+  onReadyToInstall: (outcome: ShutdownOutcome) => void
+): ShutdownRequestResult => startShutdown("update-install", onReadyToInstall);
+
+// Test-only: the module singleton persists across tests that don't reset modules.
+export const resetShutdownCoordinatorForTests = (): void => {
+  runner = null;
+  active = null;
+};

--- a/electron/lifecycle/shutdownCoordinator.ts
+++ b/electron/lifecycle/shutdownCoordinator.ts
@@ -13,6 +13,7 @@
 
 import { app } from "electron";
 import { SHUTDOWN_DEADLINE_MS } from "./shutdownConfig.js";
+import { clearSafetyBeltTimer } from "./signalShutdownState.js";
 
 export type ShutdownOutcome = "clean" | "dirty";
 export type ShutdownInitiator = "app-quit" | "update-install";
@@ -65,6 +66,26 @@ export function startShutdown(
   const run: ActiveShutdown = { initiator, phase: "cleaning" };
   active = run;
 
+  // Absolute deadline. Every budget inside the chain is bounded, but this is the
+  // structural guarantee that the terminal action ALWAYS runs: without it, one
+  // unbounded await anywhere in the chain would hang the run in "cleaning" and
+  // make the app unquittable. Resolves (never rejects) so it cannot itself strand
+  // the handoff.
+  //
+  // Armed BEFORE the runner starts: the chain does synchronous work (the eager
+  // backup snapshot, the compile-cache flush) before its first await, and a
+  // deadline armed after that would start late — eating into the margin the signal
+  // safety-belt is sized against.
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<ShutdownOutcome>((resolve) => {
+    deadlineTimer = setTimeout(() => {
+      console.error(
+        `[MAIN] Shutdown exceeded its ${SHUTDOWN_DEADLINE_MS}ms deadline — forcing the terminal action`
+      );
+      resolve("dirty");
+    }, SHUTDOWN_DEADLINE_MS);
+  });
+
   // Start the chain. `runner` is an async function, so a throw in its synchronous
   // prefix surfaces as a rejection — but wrap it anyway: a synchronous throw here
   // would leave `active` stuck in "cleaning" forever, and a shutdown stuck in
@@ -84,23 +105,14 @@ export function startShutdown(
     return "dirty" as ShutdownOutcome;
   });
 
-  // Absolute deadline. Every budget inside the chain is bounded, but this is the
-  // structural guarantee that the terminal action ALWAYS runs: without it, one
-  // unbounded await anywhere in the chain would hang the run in "cleaning" and
-  // make the app unquittable. Resolves (never rejects) so it cannot itself strand
-  // the handoff.
-  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<ShutdownOutcome>((resolve) => {
-    deadlineTimer = setTimeout(() => {
-      console.error(
-        `[MAIN] Shutdown exceeded its ${SHUTDOWN_DEADLINE_MS}ms deadline — forcing the terminal action`
-      );
-      resolve("dirty");
-    }, SHUTDOWN_DEADLINE_MS);
-  });
-
   void Promise.race([settled, deadline]).then((outcome) => {
     clearTimeout(deadlineTimer);
+    // Defuse the signal safety-belt at handoff. The chain clears it on its own
+    // way out, but a DEADLINE-forced handoff means the chain is still wedged and
+    // never reached that line — leaving an armed belt that would app.exit(1) a few
+    // seconds later, straight through the updater's install window and killing the
+    // very update we just spent the whole cleanup preparing for.
+    clearSafetyBeltTimer();
     // Flip to "handoff" BEFORE invoking the terminal action, in the same
     // synchronous turn: onSettled issues quitAndInstall(), and Squirrel's
     // app.quit() behind it must be allowed through the before-quit listener.

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -7,9 +7,7 @@ import type { UpdateInfo, ProgressInfo } from "electron-updater";
 import * as semver from "semver";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
-import { getCrashRecoveryService } from "./CrashRecoveryService.js";
-import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
-import { getPanelSuspectLedger } from "./PanelSuspectLedgerService.js";
+import { requestGracefulShutdownForUpdate } from "../lifecycle/shutdownCoordinator.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { trackEvent } from "./TelemetryService.js";
 import { store } from "../store.js";
@@ -91,13 +89,22 @@ const { autoUpdater } = electronUpdater;
 
 const RESUME_CHECK_DELAY_MS = 7_000;
 
-// macOS-only watchdog after `autoUpdater.quitAndInstall()`: if the process is
-// still alive after 5s, Squirrel.Mac's ShipIt likely failed to acquire its
-// staging lock (electron-builder #8997) and the in-flight `app.quit()` will
-// never fire. `app.exit(0)` force-terminates so ShipIt has a clean shot on the
+// Watchdog after `autoUpdater.quitAndInstall()`: if the process is still alive
+// after 5s, the install handoff failed to end it and nothing else will.
+//
+// On macOS that means Squirrel.Mac's ShipIt likely failed to acquire its staging
+// lock (electron-builder #8997) and the in-flight `app.quit()` will never fire.
+// On Windows/Linux, `BaseUpdater.quitAndInstall()` only schedules its `app.quit()`
+// when `install()` SUCCEEDS — a failed install simply returns. That used to be
+// survivable (the app stayed live and showed an "Update failed" toast), but the
+// install is now preceded by the full graceful-shutdown chain: by this point the
+// DB is closed and the PTYs and IPC handlers are torn down, so a non-quitting
+// process is a zombie. Hence the watchdog arms on every platform (issue #11104).
+//
+// `app.exit(0)` force-terminates, which also gives ShipIt a clean shot on the
 // next launch. 5s is the community-recommended floor — 3s is too tight under
-// memory pressure or slow disk. Windows/Linux keep the original setImmediate
-// timing (no force-exit) because their installer paths don't share this mode.
+// memory pressure or slow disk. It only ever fires if the install path failed to
+// quit on its own, so a healthy install never reaches it.
 const QUIT_AND_INSTALL_WATCHDOG_MS = 5_000;
 
 // 400ms Doherty threshold gates the "Checking…" menu label so a fast CDN
@@ -118,6 +125,11 @@ class AutoUpdaterService {
   private initialized = false;
   private channelHandlersRegistered = false;
   private updateDownloaded = false;
+  // Spans the whole install window — from the moment the shutdown coordinator
+  // accepts, through the multi-second cleanup chain, to the updater handoff.
+  // Guards re-entry, and tells dispose() (which the cleanup chain itself invokes)
+  // not to tear down the state the pending handoff still depends on.
+  private installInFlight = false;
   private isManualCheck = false;
   private lastBroadcastVersion: string | null = null;
   private menuState: UpdateMenuState = "idle";
@@ -182,32 +194,79 @@ class AutoUpdaterService {
     };
   }
 
-  // Shared install-trigger for `quitAndInstallIfReady()` and the
-  // UPDATE_QUIT_AND_INSTALL IPC handler. Both call sites need identical
-  // behavior: defer past the menu-close frame via `setImmediate` (Windows
-  // animation timing), then arm a macOS-only watchdog that force-exits if
-  // ShipIt fails to land its `app.quit()`. `quitAndInstall()` is wrapped so
-  // a thrown exception still arms the watchdog (force-exit is still the
-  // right move — ShipIt has its best chance on the next launch), and the
-  // `app.exit(0)` inside the watchdog is wrapped so a shutdown-time throw
-  // doesn't become an unhandled rejection.
+  // The install handoff. Runs ONLY once the graceful-shutdown chain has settled
+  // (see `startQuitAndInstall`), so everything the chain owns — agent session
+  // journaling, the DB checkpoint, audit flushes, subprocess teardown — is
+  // already durable before the updater takes the process.
+  //
+  // Deliberately synchronous. The old `setImmediate` wrapper (which existed to
+  // clear the menu-close frame) would now reopen the very gap this fix closes:
+  // the shutdown coordinator is in its `handoff` phase the moment this is called,
+  // so a `before-quit` arriving in a deferred tick would be let through and quit
+  // the app WITHOUT installing. The multi-tick cleanup chain already provides far
+  // more deferral than a `setImmediate` ever did, and `BaseUpdater.quitAndInstall()`
+  // keeps its own internal `setImmediate` before `app.quit()` on Windows/Linux.
+  //
+  // `quitAndInstall()` is wrapped so a throw still arms the watchdog — force-exit
+  // remains the right move, and it's the only thing standing between a failed
+  // install and a torn-down zombie process. The `app.exit(0)` inside the watchdog
+  // is wrapped so a shutdown-time throw doesn't become an unhandled rejection.
   private executeQuitAndInstall(): void {
-    setImmediate(() => {
+    try {
+      autoUpdater.quitAndInstall();
+    } catch (err) {
+      console.error("[MAIN] autoUpdater.quitAndInstall() threw:", err);
+    }
+    this.watchdogTimeout = setTimeout(() => {
+      this.watchdogTimeout = null;
       try {
-        autoUpdater.quitAndInstall();
+        app.exit(0);
       } catch (err) {
-        console.error("[MAIN] autoUpdater.quitAndInstall() threw:", err);
+        console.error("[MAIN] Quit-and-install watchdog app.exit(0) failed:", err);
       }
-      if (process.platform !== "darwin") return;
-      this.watchdogTimeout = setTimeout(() => {
-        this.watchdogTimeout = null;
-        try {
-          app.exit(0);
-        } catch (err) {
-          console.error("[MAIN] Quit-and-install watchdog app.exit(0) failed:", err);
-        }
-      }, QUIT_AND_INSTALL_WATCHDOG_MS);
-    });
+    }, QUIT_AND_INSTALL_WATCHDOG_MS);
+  }
+
+  // Shared entry point for `quitAndInstallIfReady()` (native menu) and the
+  // UPDATE_QUIT_AND_INSTALL IPC handler (renderer toast).
+  //
+  // Before #11104 both call sites hand-copied three clean-exit markers and then
+  // installed immediately, because on macOS `quitAndInstall()` reaches native
+  // Squirrel.Mac — which closes every window before Electron emits `before-quit`,
+  // so the graceful-shutdown chain never ran. Everything else it does (session
+  // journaling, DB checkpoint, audit flushes) was simply lost on an update.
+  //
+  // Now the install waits for that chain. The markers are gone from here: the
+  // chain writes them itself, and only once it has actually settled clean.
+  private startQuitAndInstall(): boolean {
+    if (this.installInFlight) return false;
+
+    const previousAutoInstall = autoUpdater.autoInstallOnAppQuit;
+    this.installInFlight = true;
+    // Disarm the auto-install-on-quit path for the WHOLE cleanup window, not just
+    // the instant before installing. Cleanup is now multi-second, and a Cmd+Q
+    // landing inside it would otherwise be a second, concurrent install trigger
+    // racing the installer subprocess.
+    autoUpdater.autoInstallOnAppQuit = false;
+
+    const status = requestGracefulShutdownForUpdate(() => this.executeQuitAndInstall());
+    if (status !== "started") {
+      // Either a quit already owns the shutdown (its terminal action will end the
+      // process — attaching ours too would race `app.exit()` against the installer)
+      // or the coordinator has no chain registered. Roll back so the staged update
+      // stays installable rather than being silently consumed.
+      console.warn(`[MAIN] Quit-and-install declined by the shutdown coordinator: ${status}`);
+      this.installInFlight = false;
+      autoUpdater.autoInstallOnAppQuit = previousAutoInstall;
+      return false;
+    }
+
+    // Consume the staged update only once the coordinator has accepted, so a
+    // declined request leaves the menu item and toast still actionable. Flipping
+    // both guards here also means a rapid double-click reads idle and bails.
+    this.updateDownloaded = false;
+    this.setMenuState("idle");
+    return true;
   }
 
   private checkPendingUpdateInstallVersion(): void {
@@ -239,42 +298,7 @@ class AutoUpdaterService {
   quitAndInstallIfReady(): boolean {
     if (isWindowsStoreBuild()) return false;
     if (this.menuState !== "ready" || !this.updateDownloaded) return false;
-    // Flip both guards synchronously so a rapid double-click can't queue two
-    // setImmediate(quitAndInstall) calls — the second invocation reads idle
-    // and bails. Resetting menuState back to idle also gives instant visual
-    // feedback that the click registered.
-    this.updateDownloaded = false;
-    this.setMenuState("idle");
-    try {
-      getCrashRecoveryService().cleanupOnExit();
-    } catch (err) {
-      console.error("[MAIN] Crash recovery cleanup before quit-and-install failed:", err);
-    }
-    // An update relaunch is a clean exit, but quitAndInstall() bypasses the
-    // before-quit cleanup chain (issue #9638), so the two clean-exit markers the
-    // normal shutdown path writes are skipped — leaving cleanExit:false and
-    // firing a false crash-recovery prompt on the post-update boot. Mirror
-    // shutdown.ts: each marker in its own try/catch so one failure can't skip
-    // the next (lesson #7158). markCleanExit/markCleanLaunch are synchronous
-    // writeFileSync, so they commit before the setImmediate-deferred install.
-    try {
-      getCrashLoopGuard().markCleanExit();
-    } catch (err) {
-      console.error("[MAIN] CrashLoopGuard.markCleanExit before quit-and-install failed:", err);
-    }
-    try {
-      getPanelSuspectLedger().markCleanLaunch();
-    } catch (err) {
-      console.error(
-        "[MAIN] PanelSuspectLedger.markCleanLaunch before quit-and-install failed:",
-        err
-      );
-    }
-    // Disarm the before-quit listener so the explicit quitAndInstall() path
-    // and the autoInstallOnAppQuit path don't race the installer subprocess.
-    autoUpdater.autoInstallOnAppQuit = false;
-    this.executeQuitAndInstall();
-    return true;
+    return this.startQuitAndInstall();
   }
 
   // electron-updater 6.3.x doesn't surface a categorized error type, so classify
@@ -660,6 +684,10 @@ class AutoUpdaterService {
 
       this.errorHandler = (err: Error) => {
         console.error("[MAIN] Auto-updater error:", err);
+        // Once the install is underway the service is being torn down around us:
+        // scheduling a retry would arm a timer against a disposed service, and a
+        // toast would target a renderer that is going away. Log and stop.
+        if (this.installInFlight) return;
         const wasManual = this.isManualCheck;
         this.isManualCheck = false;
         this.clearCheckingMenuTimeout();
@@ -737,9 +765,9 @@ class AutoUpdaterService {
       };
       autoUpdater.on("update-downloaded", this.downloadedHandler);
 
-      // Handle quit-and-install request from renderer. Mirrors the guard +
-      // cleanup pattern from quitAndInstallIfReady() and validates the sender
-      // origin synchronously (matches UPDATE_DISMISS_TOAST pattern).
+      // Handle quit-and-install request from renderer. Validates the sender origin
+      // synchronously (matches the UPDATE_DISMISS_TOAST pattern), then delegates to
+      // the same coordinated install path the native menu uses.
       ipcMain.handle(CHANNELS.UPDATE_QUIT_AND_INSTALL, (event) => {
         const senderUrl = event.senderFrame?.url;
         if (!senderUrl || !isTrustedRendererUrl(senderUrl)) return;
@@ -747,31 +775,7 @@ class AutoUpdaterService {
           console.warn("[MAIN] Quit-and-install called before download completed");
           return;
         }
-        this.updateDownloaded = false;
-        this.setMenuState("idle");
-        try {
-          getCrashRecoveryService().cleanupOnExit();
-        } catch (err) {
-          console.error("[MAIN] Crash recovery cleanup before quit-and-install failed:", err);
-        }
-        // Issue #9638: write the clean-exit markers the before-quit chain would
-        // otherwise skip on an update relaunch. Independent try/catch per marker
-        // (lesson #7158); both are synchronous so they commit before the install.
-        try {
-          getCrashLoopGuard().markCleanExit();
-        } catch (err) {
-          console.error("[MAIN] CrashLoopGuard.markCleanExit before quit-and-install failed:", err);
-        }
-        try {
-          getPanelSuspectLedger().markCleanLaunch();
-        } catch (err) {
-          console.error(
-            "[MAIN] PanelSuspectLedger.markCleanLaunch before quit-and-install failed:",
-            err
-          );
-        }
-        autoUpdater.autoInstallOnAppQuit = false;
-        this.executeQuitAndInstall();
+        this.startQuitAndInstall();
       });
 
       // Handle manual check-for-updates request from renderer
@@ -849,7 +853,13 @@ class AutoUpdaterService {
       clearTimeout(this.resumeTimeout);
       this.resumeTimeout = null;
     }
-    if (this.watchdogTimeout) {
+    // The graceful-shutdown chain disposes this service as part of its normal
+    // teardown — which, on the update path, happens WHILE an install is pending.
+    // Never clear the force-exit watchdog in that case: a cleanup chain that hit
+    // its hard timeout keeps running in the background and can reach this line
+    // AFTER the handoff already armed it, disarming the one thing that guarantees
+    // a failed install can't leave a torn-down zombie process (issue #11104).
+    if (this.watchdogTimeout && !this.installInFlight) {
       clearTimeout(this.watchdogTimeout);
       this.watchdogTimeout = null;
     }
@@ -876,7 +886,13 @@ class AutoUpdaterService {
       autoUpdater.off("update-not-available", this.notAvailableHandler);
       this.notAvailableHandler = null;
     }
-    if (this.errorHandler) {
+    // Keep the error listener attached across an in-flight install. This disposal
+    // runs INSIDE the cleanup chain, i.e. before quitAndInstall() is called — and
+    // electron-updater dispatches failures through `emit("error", ...)` on a bare
+    // EventEmitter, which THROWS when nothing is listening. Detaching here would
+    // turn a routine "install failed" into an uncaught exception. The handler
+    // short-circuits to a log while installInFlight, so it stays inert.
+    if (this.errorHandler && !this.installInFlight) {
       autoUpdater.off("error", this.errorHandler);
       this.errorHandler = null;
     }
@@ -926,6 +942,10 @@ class AutoUpdaterService {
     }
 
     this.updateDownloaded = false;
+    // Reset last: every guard above reads it to decide what an in-flight install
+    // still needs. By this point those decisions are made, and the flag must not
+    // survive a full teardown.
+    this.installInFlight = false;
     this.isManualCheck = false;
     this.lastBroadcastVersion = null;
     this.channelHandlersRegistered = false;

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -886,13 +886,13 @@ class AutoUpdaterService {
       autoUpdater.off("update-not-available", this.notAvailableHandler);
       this.notAvailableHandler = null;
     }
-    // Keep the error listener attached across an in-flight install. This disposal
-    // runs INSIDE the cleanup chain, i.e. before quitAndInstall() is called — and
-    // electron-updater dispatches failures through `emit("error", ...)` on a bare
-    // EventEmitter, which THROWS when nothing is listening. Detaching here would
-    // turn a routine "install failed" into an uncaught exception. The handler
-    // short-circuits to a log while installInFlight, so it stays inert.
-    if (this.errorHandler && !this.installInFlight) {
+    // Detach unconditionally, including during an in-flight install. It's safe:
+    // AppUpdater's own constructor attaches a permanent "error" listener of its
+    // own (it logs), so the emitter is never left listener-less and
+    // `emit("error")` cannot throw for want of a handler. Detaching ours is in
+    // fact the stronger guarantee — it makes it impossible for a late install
+    // error to schedule a retry timer against this now-disposed service.
+    if (this.errorHandler) {
       autoUpdater.off("error", this.errorHandler);
       this.errorHandler = null;
     }

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -60,9 +60,36 @@ const storeMock = vi.hoisted(() => ({
   delete: vi.fn(),
 }));
 
+// Issue #11104: AutoUpdaterService no longer writes the clean-exit markers itself
+// — the shared shutdown chain does, and only once it has actually settled clean.
+// These stay mocked so the tests below can prove the duplicated writes are GONE.
 const cleanupOnExitMock = vi.hoisted(() => vi.fn());
 const markCleanExitMock = vi.hoisted(() => vi.fn());
 const markCleanLaunchMock = vi.hoisted(() => vi.fn());
+
+// The shutdown coordinator (issue #11104). The install path now runs the full
+// graceful-shutdown chain BEFORE handing off to the updater, so these tests drive
+// the handoff explicitly: `requestGracefulShutdownForUpdate` captures the
+// continuation, and `settleShutdown(outcome)` plays it back as the real chain would.
+const shutdownCoordinatorMock = vi.hoisted(() => {
+  type Outcome = "clean" | "dirty";
+  const requestGracefulShutdownForUpdate = vi.fn<
+    (cb: (outcome: Outcome) => void) => "started" | "already-shutting-down" | "unavailable"
+  >(() => "started");
+  return {
+    requestGracefulShutdownForUpdate,
+    settleShutdown: (outcome: Outcome = "clean") => {
+      const calls = requestGracefulShutdownForUpdate.mock.calls;
+      const last = calls[calls.length - 1];
+      if (!last) throw new Error("No coordinated shutdown was requested");
+      last[0](outcome);
+    },
+  };
+});
+
+vi.mock("../../lifecycle/shutdownCoordinator.js", () => ({
+  requestGracefulShutdownForUpdate: shutdownCoordinatorMock.requestGracefulShutdownForUpdate,
+}));
 
 const fsMock = vi.hoisted(() => ({
   existsSync: vi.fn((_p: unknown) => false),
@@ -362,53 +389,81 @@ describe("AutoUpdaterService", () => {
       )![1];
     });
 
-    it("calls cleanupOnExit before quitAndInstall when update is downloaded", () => {
+    it("requests a coordinated shutdown instead of installing immediately", () => {
       downloadedHandler({ version: "2.0.0" });
 
       quitAndInstallHandler(TRUSTED_SENDER);
 
-      expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
-      expect(cleanupOnExitMock.mock.invocationCallOrder[0]).toBeLessThan(
-        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0] || Infinity
-      );
+      // The whole point of #11104: the graceful chain runs FIRST. Nothing may
+      // reach the updater until the coordinator says the chain has settled.
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).toHaveBeenCalledTimes(1);
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
 
-    it("defers quitAndInstall via setImmediate", () => {
+    it("installs once the coordinated shutdown settles clean", () => {
       downloadedHandler({ version: "2.0.0" });
 
       quitAndInstallHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
-      vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
 
-    it("disarms autoInstallOnAppQuit before quitAndInstall", () => {
+    it("still installs when the cleanup chain settles dirty", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("dirty");
+
+      // A timed-out or failed cleanup must not swallow the update the user asked
+      // for — the dirty marker it leaves behind is what protects their data.
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("never writes the clean-exit markers itself — the shutdown chain owns them", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      quitAndInstallHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("clean");
+
+      // Before #11104 these three were hand-copied here (and in the menu path),
+      // written eagerly at click time for work that hadn't happened yet.
+      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+      expect(markCleanExitMock).not.toHaveBeenCalled();
+      expect(markCleanLaunchMock).not.toHaveBeenCalled();
+    });
+
+    it("disarms autoInstallOnAppQuit for the whole cleanup window, not just the install", () => {
       downloadedHandler({ version: "2.0.0" });
       autoUpdaterMock.autoInstallOnAppQuit = true;
 
       quitAndInstallHandler(TRUSTED_SENDER);
 
+      // Cleanup is now multi-second. A Cmd+Q landing inside that window would
+      // otherwise be a second, concurrent install trigger.
       expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false);
     });
 
-    it("does not call cleanupOnExit or quitAndInstall when no update is downloaded", () => {
+    it("restores autoInstallOnAppQuit and keeps the update staged when the coordinator declines", () => {
+      downloadedHandler({ version: "2.0.0" });
+      autoUpdaterMock.autoInstallOnAppQuit = true;
+      shutdownCoordinatorMock.requestGracefulShutdownForUpdate.mockReturnValueOnce(
+        "already-shutting-down"
+      );
+
       quitAndInstallHandler(TRUSTED_SENDER);
 
-      expect(cleanupOnExitMock).not.toHaveBeenCalled();
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
+      // The staged update must stay installable rather than be silently consumed.
+      expect(autoUpdaterService.getMenuState()).not.toBe("idle");
     });
 
-    it("still schedules quitAndInstall when cleanupOnExit throws", () => {
-      downloadedHandler({ version: "2.0.0" });
-      cleanupOnExitMock.mockImplementationOnce(() => {
-        throw new Error("cleanup failed");
-      });
-
+    it("does not request a shutdown when no update is downloaded", () => {
       quitAndInstallHandler(TRUSTED_SENDER);
 
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
 
     it("rejects untrusted sender frame", () => {
@@ -416,7 +471,7 @@ describe("AutoUpdaterService", () => {
 
       quitAndInstallHandler({ senderFrame: { url: "https://evil.example.com/x.html" } });
 
-      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).not.toHaveBeenCalled();
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
 
@@ -425,102 +480,18 @@ describe("AutoUpdaterService", () => {
 
       quitAndInstallHandler({});
 
-      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).not.toHaveBeenCalled();
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
 
-    it("resets updateDownloaded flag to prevent double-IPC", () => {
+    it("coordinates one shutdown and one install on a rapid double-IPC", () => {
       downloadedHandler({ version: "2.0.0" });
 
       quitAndInstallHandler(TRUSTED_SENDER);
       quitAndInstallHandler(TRUSTED_SENDER);
 
-      expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-    });
-
-    // Issue #9638: the update relaunch must write the same clean-exit markers
-    // the normal shutdown chain does, so the post-update boot isn't treated as
-    // a crash.
-    it("writes clean-exit markers before the deferred quitAndInstall", () => {
-      downloadedHandler({ version: "2.0.0" });
-
-      quitAndInstallHandler(TRUSTED_SENDER);
-
-      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-      vi.advanceTimersToNextTimer();
-      expect(markCleanExitMock.mock.invocationCallOrder[0]).toBeLessThan(
-        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
-      );
-      expect(markCleanLaunchMock.mock.invocationCallOrder[0]).toBeLessThan(
-        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
-      );
-    });
-
-    it("does not write clean-exit markers when no update is downloaded", () => {
-      quitAndInstallHandler(TRUSTED_SENDER);
-
-      expect(markCleanExitMock).not.toHaveBeenCalled();
-      expect(markCleanLaunchMock).not.toHaveBeenCalled();
-    });
-
-    it("does not write clean-exit markers for an untrusted sender", () => {
-      downloadedHandler({ version: "2.0.0" });
-
-      quitAndInstallHandler({ senderFrame: { url: "https://evil.example.com/x.html" } });
-
-      expect(markCleanExitMock).not.toHaveBeenCalled();
-      expect(markCleanLaunchMock).not.toHaveBeenCalled();
-    });
-
-    it("writes the markers only once on a rapid double-IPC", () => {
-      downloadedHandler({ version: "2.0.0" });
-
-      quitAndInstallHandler(TRUSTED_SENDER);
-      quitAndInstallHandler(TRUSTED_SENDER);
-
-      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-    });
-
-    it("still writes markCleanLaunch and installs when cleanupOnExit throws", () => {
-      downloadedHandler({ version: "2.0.0" });
-      cleanupOnExitMock.mockImplementationOnce(() => {
-        throw new Error("cleanup failed");
-      });
-
-      quitAndInstallHandler(TRUSTED_SENDER);
-
-      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-    });
-
-    it("still writes markCleanLaunch and installs when markCleanExit throws", () => {
-      downloadedHandler({ version: "2.0.0" });
-      markCleanExitMock.mockImplementationOnce(() => {
-        throw new Error("markCleanExit failed");
-      });
-
-      quitAndInstallHandler(TRUSTED_SENDER);
-
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-    });
-
-    it("still installs when markCleanLaunch throws", () => {
-      downloadedHandler({ version: "2.0.0" });
-      markCleanLaunchMock.mockImplementationOnce(() => {
-        throw new Error("markCleanLaunch failed");
-      });
-
-      quitAndInstallHandler(TRUSTED_SENDER);
-
-      vi.advanceTimersToNextTimer();
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).toHaveBeenCalledTimes(1);
+      shutdownCoordinatorMock.settleShutdown("clean");
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
   });
@@ -1576,8 +1547,8 @@ describe("AutoUpdaterService", () => {
         (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
       )![1];
       quitHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
 
@@ -1953,7 +1924,7 @@ describe("AutoUpdaterService", () => {
       vi.advanceTimersByTime(0);
 
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
-      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).not.toHaveBeenCalled();
     });
 
     it("returns false when state is checking (no install staged)", () => {
@@ -1965,131 +1936,81 @@ describe("AutoUpdaterService", () => {
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
 
-    it("calls cleanupOnExit then quitAndInstall when ready, deferred via setImmediate", () => {
+    it("coordinates the shutdown when ready, and installs only once it settles", () => {
       downloadedHandler({ version: "2.0.0" });
 
       const result = autoUpdaterService.quitAndInstallIfReady();
 
       expect(result).toBe(true);
-      expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
-      // setImmediate is faked by vi.useFakeTimers — it hasn't fired yet.
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).toHaveBeenCalledTimes(1);
+      // The chain is still running — the updater must not be touched yet.
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
 
-      // advanceTimersToNextTimer fires only the queued setImmediate; using
-      // runAllTimers would also drain the 4h periodic interval and recurse.
-      vi.advanceTimersToNextTimer();
+      shutdownCoordinatorMock.settleShutdown("clean");
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
 
-    it("still schedules quitAndInstall when cleanupOnExit throws", () => {
+    it("installs on a dirty outcome too", () => {
       downloadedHandler({ version: "2.0.0" });
-      cleanupOnExitMock.mockImplementationOnce(() => {
-        throw new Error("cleanup failed");
-      });
 
       expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
-      vi.advanceTimersToNextTimer();
+      shutdownCoordinatorMock.settleShutdown("dirty");
 
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
 
-    it("still writes both markers when cleanupOnExit throws", () => {
+    it("never writes the clean-exit markers itself — the shutdown chain owns them", () => {
       downloadedHandler({ version: "2.0.0" });
-      cleanupOnExitMock.mockImplementationOnce(() => {
-        throw new Error("cleanup failed");
-      });
 
       expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
+      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+      expect(markCleanExitMock).not.toHaveBeenCalled();
+      expect(markCleanLaunchMock).not.toHaveBeenCalled();
     });
 
-    it("a rapid double-call only schedules a single quitAndInstall (idempotency)", () => {
+    it("a rapid double-call coordinates one shutdown and one install (idempotency)", () => {
       downloadedHandler({ version: "2.0.0" });
 
-      // Two calls back-to-back — the second must read idle and bail before
-      // queuing a second setImmediate. Otherwise cleanupOnExit + quitAndInstall
-      // would fire twice on a double-click.
+      // The second call must read idle and bail. Otherwise a double-click would
+      // start two cleanup chains and hand two installs to a non-reentrant updater
+      // (MacUpdater.quitAndInstall has no guard of its own).
       const first = autoUpdaterService.quitAndInstallIfReady();
       const second = autoUpdaterService.quitAndInstallIfReady();
 
       expect(first).toBe(true);
       expect(second).toBe(false);
-      expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersToNextTimer();
+      shutdownCoordinatorMock.settleShutdown("clean");
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
 
-    it("disarms autoInstallOnAppQuit before calling quitAndInstall", () => {
+    it("disarms autoInstallOnAppQuit for the whole cleanup window", () => {
       downloadedHandler({ version: "2.0.0" });
       autoUpdaterMock.autoInstallOnAppQuit = true;
 
       autoUpdaterService.quitAndInstallIfReady();
 
+      // Disarmed at the START of the window, before the chain runs — not just in
+      // the instant before installing.
       expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false);
-    });
-
-    // Issue #9638: mirror the shutdown chain's clean-exit markers so an update
-    // relaunch isn't counted as a crash on the next boot.
-    it("writes clean-exit markers before the deferred quitAndInstall when ready", () => {
-      downloadedHandler({ version: "2.0.0" });
-
-      autoUpdaterService.quitAndInstallIfReady();
-
-      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-      // Markers must commit before the install runs.
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
-      vi.advanceTimersToNextTimer();
-      expect(markCleanExitMock.mock.invocationCallOrder[0]).toBeLessThan(
-        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
-      );
-      expect(markCleanLaunchMock.mock.invocationCallOrder[0]).toBeLessThan(
-        autoUpdaterMock.quitAndInstall.mock.invocationCallOrder[0]
-      );
     });
 
-    it("does not write clean-exit markers when state is idle", () => {
-      autoUpdaterService.quitAndInstallIfReady();
-
-      expect(markCleanExitMock).not.toHaveBeenCalled();
-      expect(markCleanLaunchMock).not.toHaveBeenCalled();
-    });
-
-    it("writes the markers only once on a rapid double-call", () => {
+    it("rolls back and keeps the update staged when the coordinator is unavailable", () => {
       downloadedHandler({ version: "2.0.0" });
+      autoUpdaterMock.autoInstallOnAppQuit = true;
+      shutdownCoordinatorMock.requestGracefulShutdownForUpdate.mockReturnValueOnce("unavailable");
 
-      autoUpdaterService.quitAndInstallIfReady();
-      autoUpdaterService.quitAndInstallIfReady();
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(false);
 
-      expect(markCleanExitMock).toHaveBeenCalledTimes(1);
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-    });
-
-    it("still writes markCleanLaunch and installs when markCleanExit throws", () => {
-      downloadedHandler({ version: "2.0.0" });
-      markCleanExitMock.mockImplementationOnce(() => {
-        throw new Error("markCleanExit failed");
-      });
-
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
+      // Still installable — a declined request must not consume the staged update.
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
       expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
-
-      expect(markCleanLaunchMock).toHaveBeenCalledTimes(1);
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-    });
-
-    it("still installs when markCleanLaunch throws", () => {
-      downloadedHandler({ version: "2.0.0" });
-      markCleanLaunchMock.mockImplementationOnce(() => {
-        throw new Error("markCleanLaunch failed");
-      });
-
-      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -2197,7 +2118,7 @@ describe("AutoUpdaterService", () => {
       // IPC handler must reject — updateDownloaded was reset synchronously
       // before the await.
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
-      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+      expect(shutdownCoordinatorMock.requestGracefulShutdownForUpdate).not.toHaveBeenCalled();
 
       clearResolve();
       return channelPromise;
@@ -2384,11 +2305,11 @@ describe("AutoUpdaterService", () => {
       )![1];
     });
 
-    it("arms a 5s app.exit(0) watchdog on darwin after quitAndInstall fires", () => {
+    it("arms a 5s app.exit(0) watchdog after quitAndInstall fires", () => {
       downloadedHandler({ version: "2.0.0" });
       quitAndInstallHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
       expect(appMock.exit).not.toHaveBeenCalled();
 
@@ -2400,28 +2321,34 @@ describe("AutoUpdaterService", () => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
 
-    it("does not arm the watchdog on win32", () => {
-      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    // Issue #11104 widened this from macOS-only. BaseUpdater (win32/linux) only
+    // schedules its app.quit() when install() SUCCEEDS — and the install is now
+    // preceded by the full teardown, so a failed one would leave a process with
+    // no DB, no PTYs and no IPC that never quits. The watchdog is the only thing
+    // between that and a zombie.
+    it.each(["win32", "linux"])("arms the watchdog on %s too", (platform) => {
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
       downloadedHandler({ version: "2.0.0" });
       quitAndInstallHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(60_000);
       expect(appMock.exit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5_000);
+      expect(appMock.exit).toHaveBeenCalledWith(0);
     });
 
-    it("does not arm the watchdog on linux", () => {
-      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    it("does not arm the watchdog while the cleanup chain is still running", () => {
       downloadedHandler({ version: "2.0.0" });
       quitAndInstallHandler(TRUSTED_SENDER);
 
-      vi.advanceTimersToNextTimer();
-      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
-
+      // The chain has NOT settled. The two budgets must run strictly in sequence:
+      // arming the 5s force-exit now would kill a cleanup that is still allowed
+      // up to CLEANUP_TIMEOUT_MS to finish.
       vi.advanceTimersByTime(60_000);
       expect(appMock.exit).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
 
     it("swallows a thrown app.exit so the watchdog callback never escapes", () => {
@@ -2430,18 +2357,17 @@ describe("AutoUpdaterService", () => {
       });
       downloadedHandler({ version: "2.0.0" });
       quitAndInstallHandler(TRUSTED_SENDER);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      vi.advanceTimersToNextTimer();
       expect(() => vi.advanceTimersByTime(5_000)).not.toThrow();
       expect(appMock.exit).toHaveBeenCalledTimes(1);
     });
 
-    it("quitAndInstallIfReady also arms the macOS watchdog", () => {
+    it("quitAndInstallIfReady also arms the watchdog", () => {
       downloadedHandler({ version: "2.0.0" });
-      const triggered = autoUpdaterService.quitAndInstallIfReady();
-      expect(triggered).toBe(true);
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
+      shutdownCoordinatorMock.settleShutdown("clean");
 
-      vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
       expect(appMock.exit).not.toHaveBeenCalled();
 
@@ -2449,15 +2375,32 @@ describe("AutoUpdaterService", () => {
       expect(appMock.exit).toHaveBeenCalledTimes(1);
     });
 
-    it("dispose() cancels a pending watchdog so app.exit never fires", () => {
+    // The cleanup chain disposes this service as part of its own teardown. On a
+    // chain that hit its hard timeout, that disposal can land AFTER the handoff
+    // already armed the watchdog — disarming the one guarantee against a zombie.
+    it("dispose() during an in-flight install does not disarm the armed watchdog", () => {
       downloadedHandler({ version: "2.0.0" });
       quitAndInstallHandler(TRUSTED_SENDER);
-      vi.advanceTimersToNextTimer();
+      shutdownCoordinatorMock.settleShutdown("dirty");
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
 
       autoUpdaterService.dispose();
-      vi.advanceTimersByTime(60_000);
-      expect(appMock.exit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5_000);
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+
+    it("keeps the error listener attached through an in-flight install", () => {
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      // The chain disposes this service BEFORE quitAndInstall() runs. Detaching
+      // the "error" listener there would turn a routine install failure into an
+      // uncaught throw — electron-updater dispatches errors through a bare
+      // EventEmitter.emit("error"), which throws when nothing is listening.
+      autoUpdaterService.dispose();
+
+      expect(autoUpdaterMock.off).not.toHaveBeenCalledWith("error", expect.any(Function));
     });
 
     it("still arms the watchdog when autoUpdater.quitAndInstall throws", () => {
@@ -2467,7 +2410,7 @@ describe("AutoUpdaterService", () => {
       downloadedHandler({ version: "2.0.0" });
       quitAndInstallHandler(TRUSTED_SENDER);
 
-      expect(() => vi.advanceTimersToNextTimer()).not.toThrow();
+      expect(() => shutdownCoordinatorMock.settleShutdown("clean")).not.toThrow();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
 
       vi.advanceTimersByTime(5_000);

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -2390,17 +2390,23 @@ describe("AutoUpdaterService", () => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
 
-    it("keeps the error listener attached through an in-flight install", () => {
+    it("does not schedule a retry when the updater errors during an in-flight install", () => {
       downloadedHandler({ version: "2.0.0" });
+      const errorHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "error"
+      )![1];
+      // Flush the jittered launch check first, so the advance below can only
+      // surface a retry — not the startup check that was already pending.
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
       quitAndInstallHandler(TRUSTED_SENDER);
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
 
-      // The chain disposes this service BEFORE quitAndInstall() runs. Detaching
-      // the "error" listener there would turn a routine install failure into an
-      // uncaught throw — electron-updater dispatches errors through a bare
-      // EventEmitter.emit("error"), which throws when nothing is listening.
-      autoUpdaterService.dispose();
+      // Teardown is already underway. A retry timer armed now would fire against a
+      // service the cleanup chain is in the middle of disposing.
+      errorHandler(new Error("net::ERR_CONNECTION_RESET"));
+      vi.advanceTimersByTime(60_000);
 
-      expect(autoUpdaterMock.off).not.toHaveBeenCalledWith("error", expect.any(Function));
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
 
     it("still arms the watchdog when autoUpdater.quitAndInstall throws", () => {


### PR DESCRIPTION
## The bug

The graceful-shutdown chain — agent session journaling, the DB WAL checkpoint, audit-ring flushes, subprocess teardown, telemetry close — was wired exclusively to `app.on("before-quit")`.

On macOS that event never usefully fires for an update install. `autoUpdater.quitAndInstall()` reaches native Squirrel.Mac, which **closes every window first** and only then calls `app.quit()`. Electron's own docs say as much: "the `before-quit` event is not emitted before all windows are closed." So installing an update skipped the entire chain. `AutoUpdaterService` papered over it by hand-copying three clean-exit markers in two separate places (#9638) — everything else was simply lost.

`before-quit-for-update` can't fix this. Its listener signature is `() => void`: no event object, so no `preventDefault()`, nothing to gate on. The only option is to gate the call to `quitAndInstall()` itself.

## The fix

New leaf module `electron/lifecycle/shutdownCoordinator.ts` owns the single shutdown run — who initiated it, and whether it's `cleaning` or has `handoff`ed. The chain is extracted out of the `before-quit` listener into `runShutdownChain()`, which reports `clean`/`dirty` and never ends the process; the caller owns that. Both paths now share it.

- `before-quit` `preventDefault()`s while a chain is **cleaning** (a Cmd+Q would otherwise tear the process down mid-cleanup), and lets the quit through after **handoff** — that quit *is* Squirrel's post-install `app.quit()` landing, and blocking it would strand every install behind the watchdog.
- The install waits for the chain, then proceeds on both outcomes. A timed-out cleanup still installs — but leaves the dirty marker, so the next boot gets a truthful signal and its recovery flow instead of a false "everything was saved".
- The three hand-copied marker blocks are deleted. Markers are written by the chain, and only once it settles clean (lesson #7158).
- `autoInstallOnAppQuit` is disarmed for the whole cleanup window, not just the instant before installing — cleanup is now multi-second, and a quit landing inside it would be a second, concurrent install trigger.
- Dropped the `setImmediate` around `quitAndInstall()`: it would reopen the gap where the phase is `handoff` but no install has been issued. `BaseUpdater` keeps its own internal `setImmediate` on Windows/Linux, so their timing is unchanged.

## Two things that fell out of review

**The watchdog now arms on every platform, not just macOS.** `BaseUpdater.quitAndInstall()` only schedules its `app.quit()` when `install()` *succeeds*. A failed install used to be survivable — the app stayed live and showed an "Update failed" toast. Now the install is preceded by full teardown, so a failure would leave a process with no DB, no PTYs and no IPC that never quits. The force-exit watchdog is the only thing between that and a zombie.

**A wedged shutdown could have made the app unquittable.** Because `before-quit` now holds off quits while a chain is cleaning, a chain that never settles blocks *every* subsequent quit. Two awaits were unbounded: `closeTelemetry()` and `stopPerformanceTraceIfActive()` run *after* the cleanup race, so `CLEANUP_TIMEOUT_MS` never covered them, and `contentTracing.stopRecording()` has no cap of its own. The tail is now bounded, with an absolute `SHUTDOWN_DEADLINE_MS` in the coordinator as the structural backstop so the terminal action always fires. The safety belt is re-sized to strictly outlast both budgets (lesson #7151) and is defused at handoff — a deadline-forced handoff never reaches the chain's own `clearSafetyBeltTimer()`, and an armed belt would `app.exit(1)` straight through the updater's install window.

## Testing

333 tests green across `shutdown`, `shutdownCoordinator`, `AutoUpdaterService`, `AutoUpdaterEndpoint`, `signalShutdownState` and `menu`. The new guards are mutation-verified — each fails independently when its guard is removed.

Not unit-testable, and worth a manual pass before release: a real signed macOS build, staged N→N+1, installed with an agent session live, verifying the resume journal, DB integrity and markers after relaunch.

## Known limitation (follow-up, not a regression)

`.deb` installs go through `LinuxUpdater` → `spawnSyncLog` → `child_process.spawnSync`, which **blocks the main thread**. If a `pkexec`/`sudo` prompt stalls, the event loop is blocked and the watchdog can't arm. This is pre-existing electron-updater behavior and no JS timer can preempt a blocking `spawnSync`; force-killing `dpkg`/`apt` mid-install would be unsafe. Worth its own issue.

Resolves #11104