### PR TITLE
fix(db): never let maintenance overwrite a good backup with a corrupt one

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -98,6 +98,12 @@ vi.mock("../../services/TelemetryService.js", () => ({
   closeTelemetry: vi.fn(),
 }));
 
+const consumeDatabaseRecovery = vi.hoisted(() => vi.fn(() => null as unknown));
+
+vi.mock("../../services/DatabaseMaintenanceService.js", () => ({
+  getDatabaseMaintenanceService: () => ({ consumeRecovery: consumeDatabaseRecovery }),
+}));
+
 vi.mock("../../window/deferredInitQueue.js", () => ({
   signalFirstInteractive: vi.fn(),
 }));
@@ -602,6 +608,40 @@ describe("app:boot handler", () => {
     expect(result.terminalConfig).toEqual(cachedResult.terminalConfig);
     expect(result.crashPending).toBeNull();
     expect(result.crashConfig).toEqual({ autoRestoreOnCrash: false });
+  });
+
+  it("surfaces the boot-time database recovery on the slow path", async () => {
+    const recovery = { kind: "reset-to-fresh", quarantinedPath: "/u/daintree.db.corrupt-x" };
+    consumeDatabaseRecovery.mockReturnValueOnce(recovery);
+
+    const result = (await invokeBoot()) as Record<string, unknown>;
+
+    expect(result.databaseRecovery).toEqual(recovery);
+    expect(consumeDatabaseRecovery).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the boot-time database recovery even on the prefetch cache-hit path", async () => {
+    // The prefetch snapshot predates the boot probe and carries no recovery, so
+    // the live one-shot consumer has to run on this path too or the user is
+    // never told their database was rebuilt.
+    const recovery = { kind: "restored-from-backup", quarantinedPath: "/u/daintree.db.corrupt-x" };
+    consumeDatabaseRecovery.mockReturnValueOnce(recovery);
+    vi.mocked(consumePrefetchedHydrateResult).mockReturnValue({
+      appState: { terminals: [], sidebarWidth: 350 },
+      terminalConfig: { scrollbackLines: 3000 },
+      project: null,
+      databaseRecovery: null,
+    } as unknown as ReturnType<typeof consumePrefetchedHydrateResult>);
+    const projectStoreModule = await import("../../services/ProjectStore.js");
+    vi.mocked(projectStoreModule.projectStore.getCurrentProject).mockReturnValue({
+      id: "p1",
+      name: "P",
+      path: "/p",
+    } as unknown as ReturnType<typeof projectStoreModule.projectStore.getCurrentProject>);
+
+    const result = (await invokeBoot()) as Record<string, unknown>;
+
+    expect(result.databaseRecovery).toEqual(recovery);
   });
 
   it("hydrates the project bound to the sending project view instead of the stale global current project", async () => {

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -99,9 +99,13 @@ vi.mock("../../services/TelemetryService.js", () => ({
 }));
 
 const consumeDatabaseRecovery = vi.hoisted(() => vi.fn(() => null as unknown));
+const restoreDatabaseRecovery = vi.hoisted(() => vi.fn());
 
 vi.mock("../../services/DatabaseMaintenanceService.js", () => ({
-  getDatabaseMaintenanceService: () => ({ consumeRecovery: consumeDatabaseRecovery }),
+  getDatabaseMaintenanceService: () => ({
+    consumeRecovery: consumeDatabaseRecovery,
+    restoreRecovery: restoreDatabaseRecovery,
+  }),
 }));
 
 vi.mock("../../window/deferredInitQueue.js", () => ({
@@ -618,6 +622,23 @@ describe("app:boot handler", () => {
 
     expect(result.databaseRecovery).toEqual(recovery);
     expect(consumeDatabaseRecovery).toHaveBeenCalledTimes(1);
+    expect(restoreDatabaseRecovery).not.toHaveBeenCalled();
+  });
+
+  it("hands the database recovery back when a pending crash will discard this payload", async () => {
+    // useAppBootstrap throws the boot payload away and re-runs app:hydrate once
+    // the crash gate resolves. An unclean exit is also exactly how the DB gets
+    // corrupted, so consuming the one-shot here would lose the notification in
+    // the very scenario it exists for.
+    const recovery = { kind: "restored-from-backup", quarantinedPath: "/u/daintree.db.corrupt-x" };
+    consumeDatabaseRecovery.mockReturnValueOnce(recovery);
+    crashService.getPendingCrash.mockReturnValue({ terminals: [], timestamp: 1 });
+
+    const result = (await invokeBoot()) as Record<string, unknown>;
+
+    expect(result.crashPending).not.toBeNull();
+    expect(result.databaseRecovery).toBeNull();
+    expect(restoreDatabaseRecovery).toHaveBeenCalledWith(recovery);
   });
 
   it("surfaces the boot-time database recovery even on the prefetch cache-hit path", async () => {

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -10,6 +10,7 @@ import {
   filterValidTerminalEntries,
 } from "../../../schemas/ipc.js";
 import { getCrashRecoveryService } from "../../../services/CrashRecoveryService.js";
+import { getDatabaseMaintenanceService } from "../../../services/DatabaseMaintenanceService.js";
 import { USAGE_WINDOW_MS, MAX_USES_PER_ENTRY } from "../../../../shared/utils/actionUsage.js";
 
 export const CRASH_CRITICAL_FIELDS = new Set([
@@ -99,6 +100,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
         crashCount: cacheGuard.getCrashCount(),
         lastCrashAt: cacheGuard.getLastCrashTimestamp(),
         settingsRecovery: consumePendingSettingsRecovery(),
+        // Boot-time DB recovery is one-shot and predates the prefetch, so it is
+        // consumed live here — the cached payload always carries a null for it.
+        databaseRecovery: getDatabaseMaintenanceService().consumeRecovery(),
         // Crash-loop quarantine notifications are gated on safe mode; the
         // fast path runs only when safe mode is inactive, so clear the field.
         crashLoopStateRecovery: null,
@@ -440,6 +444,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       crashCount: guard.getCrashCount(),
       lastCrashAt: guard.getLastCrashTimestamp(),
       settingsRecovery: consumePendingSettingsRecovery(),
+      databaseRecovery: getDatabaseMaintenanceService().consumeRecovery(),
       projectStateRecovery: projectStateQuarantinedPath
         ? { quarantinedPath: projectStateQuarantinedPath }
         : null,
@@ -470,7 +475,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
   // Batched cold-start boot payload. Collapses what was three separate renderer
   // round-trips (`crash-recovery:get-pending`, `crash-recovery:get-config`,
   // `app:hydrate`) into one. The destructive one-shot consumers
-  // (`consumePanelFilter`, `consumePendingSettingsRecovery`) and the prefetch
+  // (`consumePanelFilter`, `consumePendingSettingsRecovery`, `consumeRecovery`) and the prefetch
   // fast path remain inside `handleAppHydrate` — boot just appends the crash
   // gate fields onto the same result.
   const handleAppBoot = async (ctx: IpcContext) => {

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -506,8 +506,19 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       typeof (rawAppTheme.customSchemes as unknown) !== "string"
         ? (rawAppTheme as import("../../../../shared/types/appTheme.js").AppThemeConfig)
         : undefined;
+    // `useAppBootstrap` throws this whole payload away and re-runs `app:hydrate`
+    // once the crash gate resolves (`hadPendingCrash ? null : bootResult`), so a
+    // destructive one-shot consumed above would never reach the user. An unclean
+    // exit is also exactly how the database gets corrupted — hand the recovery
+    // back so the live hydrate that follows delivers it.
+    const droppedRecovery = crashPending !== null ? hydrate.databaseRecovery : null;
+    if (droppedRecovery) {
+      getDatabaseMaintenanceService().restoreRecovery(droppedRecovery);
+    }
+
     return {
       ...hydrate,
+      databaseRecovery: droppedRecovery ? null : hydrate.databaseRecovery,
       crashPending,
       crashConfig: crashService.getConfig(),
       appTheme,

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -18,7 +18,8 @@ import { inferKind } from "../../shared/utils/inferPanelKind.js";
  * This is the read-only, non-destructive counterpart to `handleAppHydrate` in
  * the IPC handler. It assembles the same shape but:
  *   - never calls destructive one-shot consumers (consumePendingSettingsRecovery,
- *     consumePanelFilter) — those are startup-only
+ *     consumePanelFilter, DatabaseMaintenanceService.consumeRecovery) — those are
+ *     startup-only
  *   - never runs migration writes (saveProjectState) — migration only applies
  *     on first app load, not on project switches
  *   - always returns safeMode: false — safe mode is a startup-only condition
@@ -112,6 +113,7 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     runningUnderRosetta: isRunningUnderRosetta(),
     rosettaWarningDismissed: store.get("rosettaWarningDismissed") === true,
     settingsRecovery: null,
+    databaseRecovery: null,
     projectStateRecovery: projectStateQuarantinedPath
       ? { quarantinedPath: projectStateQuarantinedPath }
       : null,

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -10,6 +10,7 @@ import {
 } from "./persistence/db.js";
 import { runDbWork } from "./persistence/dbWorkerClient.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
+import type { DatabaseRecovery } from "../../shared/types/ipc/app.js";
 
 const TICK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const IDLE_THRESHOLD_S = 60; // 60 seconds of system idle
@@ -21,6 +22,14 @@ class DatabaseMaintenanceService {
   private disposed = false;
   private initialized = false;
   private deferredQuickCheckPending = false;
+  private deferredQuickCheckInFlight: Promise<boolean> | null = null;
+  private pendingRecovery: DatabaseRecovery | null = null;
+  // Latched once corruption is confirmed — either by the deferred quick_check on
+  // the live DB or by a candidate backup failing its probe. Both mean the source
+  // pages are bad, so every later backup would overwrite the last good one with
+  // garbage. Recovery cannot run mid-session (the DB is open), so the safe move
+  // is to stop backing up and preserve what we have until the next boot's probe.
+  private backupBlockedByCorruption = false;
 
   initialize(wasCleanExit = false): void {
     if (this.initialized) return;
@@ -34,11 +43,20 @@ class DatabaseMaintenanceService {
     // full scan immediately so recovery happens before getSharedDb() opens the file.
     if (!probeDb(dbPath, !wasCleanExit)) {
       console.error("[DatabaseMaintenance] Database corruption detected, attempting recovery");
-      const recovered = attemptRecovery(dbPath);
-      if (recovered) {
-        console.log("[DatabaseMaintenance] Recovery successful — restored from backup");
+      const recovery = attemptRecovery(dbPath);
+      if (recovery === null) {
+        console.error(
+          "[DatabaseMaintenance] Recovery failed — corrupt database may still be in place"
+        );
       } else {
-        console.warn("[DatabaseMaintenance] No backup to restore — fresh database will be created");
+        this.pendingRecovery = recovery;
+        if (recovery.kind === "restored-from-backup") {
+          console.log("[DatabaseMaintenance] Recovery successful — restored from backup");
+        } else {
+          console.warn(
+            "[DatabaseMaintenance] No usable backup to restore — fresh database will be created"
+          );
+        }
       }
     } else if (wasCleanExit) {
       // Clean-exit boots skip the O(size) quick_check; run it once from the
@@ -47,6 +65,17 @@ class DatabaseMaintenanceService {
     }
 
     console.log("[DatabaseMaintenance] Initialized (probe complete)");
+  }
+
+  /**
+   * One-shot read of the boot-time recovery outcome, consumed by the first
+   * `app:hydrate` so the renderer can tell the user exactly once. Mirrors
+   * `consumePendingSettingsRecovery()` in store.ts.
+   */
+  consumeRecovery(): DatabaseRecovery | null {
+    const recovery = this.pendingRecovery;
+    this.pendingRecovery = null;
+    return recovery;
   }
 
   startMaintenance(): void {
@@ -94,8 +123,16 @@ class DatabaseMaintenanceService {
     }
 
     // Final backup + TRUNCATE checkpoint (DB is NOT closed here —
-    // shutdown.ts may still need it for project state saves afterward)
-    await this.runBackup();
+    // shutdown.ts may still need it for project state saves afterward).
+    // A DB already known to be corrupt is never backed up: the existing backup
+    // is the only good copy left and the next boot's probe will restore from it.
+    if (this.backupBlockedByCorruption) {
+      console.warn(
+        "[DatabaseMaintenance] Skipping final backup — database corruption was detected this session"
+      );
+    } else {
+      await this.runBackup();
+    }
     this.optimize();
     this.checkpoint("TRUNCATE");
     console.log("[DatabaseMaintenance] Disposed — optimize + checkpoint complete");
@@ -118,25 +155,73 @@ class DatabaseMaintenanceService {
     // would spin a main-thread write on its busy_timeout. The full TRUNCATE
     // runs once, on main, from dispose() at shutdown.
     void runDbWork({ op: "checkpoint", mode: "PASSIVE" }, () => this.checkpoint("PASSIVE"));
-    this.runDeferredQuickCheck();
+
+    // Confirmed corruption: never overwrite the last good backup with it.
+    if (this.backupBlockedByCorruption) return;
+
+    // Gate the backup on the deferred integrity check, but only while one is
+    // actually outstanding. Once the DB has passed (or on unclean-exit boots,
+    // where initialize() already ran the full scan), the backup fires
+    // synchronously from this tick exactly as before — no added latency.
+    const quickCheck = this.runDeferredQuickCheck();
+    if (quickCheck) {
+      void quickCheck.then((ok) => {
+        if (ok && !this.disposed && !this.backupBlockedByCorruption) {
+          this.backupPromise = this.runBackup();
+        }
+      });
+      return;
+    }
+
     this.backupPromise = this.runBackup();
   }
 
-  private runDeferredQuickCheck(): void {
-    if (!this.deferredQuickCheckPending) return;
-    this.deferredQuickCheckPending = false;
-    // Advisory only, and never on main — when the worker is unavailable the
-    // fallback skips the scan rather than stalling the event loop for it.
-    void runDbWork<string | null>({ op: "quickCheck" }, () => null).then((result) => {
-      if (result === null) {
-        console.warn("[DatabaseMaintenance] Deferred quick_check skipped — DB worker unavailable");
-      } else if (result !== "ok") {
+  /**
+   * Runs the deferred full quick_check, at most one at a time. Resolves to
+   * whether the backup may proceed; returns null when no check is outstanding.
+   *
+   * The pending flag only clears on an exact "ok" — a check that never succeeded
+   * must never look like one that did, so a worker-unavailable result leaves it
+   * set for a later idle tick to retry. That case still allows the backup: the
+   * candidate probe in runBackup() is the real guard against promoting a corrupt
+   * copy, and it catches on main exactly what the worker could not check here.
+   * Only confirmed corruption stops backups, via `backupBlockedByCorruption`.
+   */
+  private runDeferredQuickCheck(): Promise<boolean> | null {
+    if (this.deferredQuickCheckInFlight) return this.deferredQuickCheckInFlight;
+    if (!this.deferredQuickCheckPending) return null;
+
+    // Never on main — when the worker is unavailable the fallback skips the scan
+    // rather than stalling the event loop for it.
+    const inFlight = runDbWork<string | null>({ op: "quickCheck" }, () => null)
+      .then((result) => {
+        if (result === "ok") {
+          this.deferredQuickCheckPending = false;
+          return true;
+        }
+        if (result === null) {
+          console.warn(
+            "[DatabaseMaintenance] Deferred quick_check skipped — DB worker unavailable; will retry next idle tick"
+          );
+          return true;
+        }
+        this.backupBlockedByCorruption = true;
         console.error(
-          `[DatabaseMaintenance] Deferred quick_check reported corruption in ${getDbPath()}:`,
+          `[DatabaseMaintenance] Deferred quick_check reported corruption in ${getDbPath()} — backups suspended to preserve the existing backup:`,
           result
         );
-      }
-    });
+        return false;
+      })
+      .catch((error: unknown) => {
+        console.warn("[DatabaseMaintenance] Deferred quick_check failed; will retry:", error);
+        return true;
+      })
+      .finally(() => {
+        this.deferredQuickCheckInFlight = null;
+      });
+
+    this.deferredQuickCheckInFlight = inFlight;
+    return inFlight;
   }
 
   private checkpoint(mode: "PASSIVE" | "TRUNCATE"): void {
@@ -175,16 +260,39 @@ class DatabaseMaintenanceService {
 
     try {
       await sqlite.backup(tmpPath);
+
+      // sqlite.backup() copies pages verbatim and never validates them, so a
+      // corrupt source yields a corrupt copy with no error. Probe the candidate
+      // before it replaces the last known-good backup. On the shutdown path the
+      // DB worker is already gone, so this runs its fallback on main — the same
+      // tradeoff dispose() already makes for optimize + TRUNCATE.
+      const intact = await runDbWork<boolean>({ op: "probePath", dbPath: tmpPath }, () =>
+        probeDb(tmpPath)
+      );
+
+      if (!intact) {
+        this.backupBlockedByCorruption = true;
+        console.error(
+          `[DatabaseMaintenance] Backup failed its integrity check — discarding it and keeping the existing backup at ${backupPath}`
+        );
+        this.discardTempBackup(tmpPath);
+        return;
+      }
+
       fs.renameSync(tmpPath, backupPath);
     } catch (error) {
       console.warn("[DatabaseMaintenance] Backup failed:", error);
-      try {
-        if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
-      } catch {
-        // ignore cleanup failure
-      }
+      this.discardTempBackup(tmpPath);
     } finally {
       this.backupPromise = null;
+    }
+  }
+
+  private discardTempBackup(tmpPath: string): void {
+    try {
+      if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+    } catch (error) {
+      console.warn(`[DatabaseMaintenance] Failed to remove temp backup ${tmpPath}:`, error);
     }
   }
 }

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -6,10 +6,12 @@ import {
   getBackupPath,
   getSharedSqlite,
   probeDb,
+  probeDbFile,
   attemptRecovery,
 } from "./persistence/db.js";
 import { runDbWork } from "./persistence/dbWorkerClient.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
+import type { DbProbeResult } from "./persistence/dbWorkerProtocol.js";
 import type { DatabaseRecovery } from "../../shared/types/ipc/app.js";
 
 const TICK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -78,6 +80,17 @@ class DatabaseMaintenanceService {
     return recovery;
   }
 
+  /**
+   * Hand a consumed recovery back when its payload is about to be thrown away.
+   * `app:boot` is fired before the crash-recovery gate resolves, and the renderer
+   * discards that payload and re-hydrates whenever a crash was pending — which is
+   * precisely the boot where the database gets corrupted, so without this the
+   * notification would be lost exactly when it matters most.
+   */
+  restoreRecovery(recovery: DatabaseRecovery): void {
+    this.pendingRecovery ??= recovery;
+  }
+
   startMaintenance(): void {
     // Defensive: dispose() may run before startMaintenance() drains from the
     // deferred queue (window closed before first-interactive). The timer/listener
@@ -113,6 +126,16 @@ class DatabaseMaintenanceService {
       this.removeSuspendListener = null;
     }
 
+    // Let an outstanding integrity check finish first — if it is about to report
+    // corruption, the final backup must not run at all.
+    if (this.deferredQuickCheckInFlight) {
+      try {
+        await this.deferredQuickCheckInFlight;
+      } catch {
+        // ignore — quick_check errors already logged
+      }
+    }
+
     // Wait for any in-flight backup from a tick before proceeding
     if (this.backupPromise) {
       try {
@@ -131,7 +154,7 @@ class DatabaseMaintenanceService {
         "[DatabaseMaintenance] Skipping final backup — database corruption was detected this session"
       );
     } else {
-      await this.runBackup();
+      await this.runBackup(true);
     }
     this.optimize();
     this.checkpoint("TRUNCATE");
@@ -246,7 +269,13 @@ class DatabaseMaintenanceService {
     }
   }
 
-  private async runBackup(): Promise<void> {
+  /**
+   * `probeOnMain` is set by dispose(): shutdown.ts drains the DB worker before
+   * it calls us, so going through runDbWork there would spawn a fresh worker
+   * purely to tear it down. Probe directly instead — dispose() already accepts
+   * synchronous optimize + TRUNCATE on main.
+   */
+  private async runBackup(probeOnMain = false): Promise<void> {
     if (this.backupPromise && !this.disposed) {
       // Another backup is already in flight from a tick — skip
       return this.backupPromise;
@@ -262,20 +291,33 @@ class DatabaseMaintenanceService {
       await sqlite.backup(tmpPath);
 
       // sqlite.backup() copies pages verbatim and never validates them, so a
-      // corrupt source yields a corrupt copy with no error. Probe the candidate
-      // before it replaces the last known-good backup. On the shutdown path the
-      // DB worker is already gone, so this runs its fallback on main — the same
-      // tradeoff dispose() already makes for optimize + TRUNCATE.
-      const intact = await runDbWork<boolean>({ op: "probePath", dbPath: tmpPath }, () =>
-        probeDb(tmpPath)
-      );
+      // corrupt source yields a corrupt copy with no error at all. Probe the
+      // candidate before it replaces the last known-good backup. Note this uses
+      // probeDbFile, NOT probeDb: probeDb is fail-open on unreadable files, and
+      // promoting an unverifiable candidate over the only good backup is exactly
+      // the destruction this guards against.
+      const verdict = probeOnMain
+        ? probeDbFile(tmpPath)
+        : await runDbWork<DbProbeResult>({ op: "probePath", dbPath: tmpPath }, () =>
+            probeDbFile(tmpPath)
+          );
 
-      if (!intact) {
-        this.backupBlockedByCorruption = true;
-        console.error(
-          `[DatabaseMaintenance] Backup failed its integrity check — discarding it and keeping the existing backup at ${backupPath}`
-        );
+      if (verdict !== "ok") {
         this.discardTempBackup(tmpPath);
+        if (verdict === "corrupt") {
+          // Proven bad pages — the source DB is damaged, so every later backup
+          // would be too. Keep what we have and let the next boot recover.
+          this.backupBlockedByCorruption = true;
+          console.error(
+            `[DatabaseMaintenance] New backup failed its integrity check — the database is corrupt. Keeping the existing backup at ${backupPath} and suspending backups`
+          );
+        } else {
+          // Could not verify it. No evidence the DB is bad, so don't suspend
+          // backups — just refuse to promote an unverified copy, and retry.
+          console.warn(
+            `[DatabaseMaintenance] Could not verify the new backup — discarding it and keeping the existing backup at ${backupPath}; will retry`
+          );
+        }
         return;
       }
 

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -16,6 +16,16 @@ import type { DatabaseRecovery } from "../../shared/types/ipc/app.js";
 
 const TICK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const IDLE_THRESHOLD_S = 60; // 60 seconds of system idle
+// Shutdown has a 10s hard timeout, but a wedged DB worker only fails its request
+// after 30s (dbWorkerClient's REQUEST_TIMEOUT_MS) — so the wait for an in-flight
+// check has to be bounded well inside both. Timing out is safe: the candidate
+// probe in runBackup() still refuses to promote an unverified copy.
+const QUICK_CHECK_DRAIN_TIMEOUT_MS = 2000;
+// Verification failures are not proof the database is bad (a faulty write can
+// mangle only the copy), so a single one re-checks the live DB rather than
+// latching. Repeated ones mean something is durably wrong — stop rewriting the
+// backup and keep the last good one.
+const MAX_BACKUP_VERIFY_FAILURES = 3;
 
 class DatabaseMaintenanceService {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -26,12 +36,12 @@ class DatabaseMaintenanceService {
   private deferredQuickCheckPending = false;
   private deferredQuickCheckInFlight: Promise<boolean> | null = null;
   private pendingRecovery: DatabaseRecovery | null = null;
-  // Latched once corruption is confirmed — either by the deferred quick_check on
-  // the live DB or by a candidate backup failing its probe. Both mean the source
-  // pages are bad, so every later backup would overwrite the last good one with
-  // garbage. Recovery cannot run mid-session (the DB is open), so the safe move
-  // is to stop backing up and preserve what we have until the next boot's probe.
-  private backupBlockedByCorruption = false;
+  // Latched when the live database is confirmed corrupt, or when candidates keep
+  // failing verification. Recovery cannot run mid-session (the DB is open), so
+  // the safe move is to stop backing up entirely and preserve the last good
+  // backup for the next boot's probe to restore from.
+  private backupsSuspended = false;
+  private consecutiveVerifyFailures = 0;
 
   initialize(wasCleanExit = false): void {
     if (this.initialized) return;
@@ -127,13 +137,18 @@ class DatabaseMaintenanceService {
     }
 
     // Let an outstanding integrity check finish first — if it is about to report
-    // corruption, the final backup must not run at all.
+    // corruption, the final backup must not run at all. Bounded: a wedged worker
+    // would otherwise hold this for the client's 30s request timeout, blowing
+    // past shutdown's own 10s cap. Giving up early is safe — the candidate probe
+    // below still refuses to promote an unverified copy.
     if (this.deferredQuickCheckInFlight) {
-      try {
-        await this.deferredQuickCheckInFlight;
-      } catch {
-        // ignore — quick_check errors already logged
-      }
+      await Promise.race([
+        this.deferredQuickCheckInFlight.catch(() => undefined),
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, QUICK_CHECK_DRAIN_TIMEOUT_MS);
+          timer.unref?.();
+        }),
+      ]);
     }
 
     // Wait for any in-flight backup from a tick before proceeding
@@ -149,7 +164,7 @@ class DatabaseMaintenanceService {
     // shutdown.ts may still need it for project state saves afterward).
     // A DB already known to be corrupt is never backed up: the existing backup
     // is the only good copy left and the next boot's probe will restore from it.
-    if (this.backupBlockedByCorruption) {
+    if (this.backupsSuspended) {
       console.warn(
         "[DatabaseMaintenance] Skipping final backup — database corruption was detected this session"
       );
@@ -180,7 +195,7 @@ class DatabaseMaintenanceService {
     void runDbWork({ op: "checkpoint", mode: "PASSIVE" }, () => this.checkpoint("PASSIVE"));
 
     // Confirmed corruption: never overwrite the last good backup with it.
-    if (this.backupBlockedByCorruption) return;
+    if (this.backupsSuspended) return;
 
     // Gate the backup on the deferred integrity check, but only while one is
     // actually outstanding. Once the DB has passed (or on unclean-exit boots,
@@ -189,7 +204,7 @@ class DatabaseMaintenanceService {
     const quickCheck = this.runDeferredQuickCheck();
     if (quickCheck) {
       void quickCheck.then((ok) => {
-        if (ok && !this.disposed && !this.backupBlockedByCorruption) {
+        if (ok && !this.disposed && !this.backupsSuspended) {
           this.backupPromise = this.runBackup();
         }
       });
@@ -208,7 +223,7 @@ class DatabaseMaintenanceService {
    * set for a later idle tick to retry. That case still allows the backup: the
    * candidate probe in runBackup() is the real guard against promoting a corrupt
    * copy, and it catches on main exactly what the worker could not check here.
-   * Only confirmed corruption stops backups, via `backupBlockedByCorruption`.
+   * Only confirmed corruption stops backups, via `backupsSuspended`.
    */
   private runDeferredQuickCheck(): Promise<boolean> | null {
     if (this.deferredQuickCheckInFlight) return this.deferredQuickCheckInFlight;
@@ -228,7 +243,7 @@ class DatabaseMaintenanceService {
           );
           return true;
         }
-        this.backupBlockedByCorruption = true;
+        this.backupsSuspended = true;
         console.error(
           `[DatabaseMaintenance] Deferred quick_check reported corruption in ${getDbPath()} — backups suspended to preserve the existing backup:`,
           result
@@ -304,29 +319,48 @@ class DatabaseMaintenanceService {
 
       if (verdict !== "ok") {
         this.discardTempBackup(tmpPath);
-        if (verdict === "corrupt") {
-          // Proven bad pages — the source DB is damaged, so every later backup
-          // would be too. Keep what we have and let the next boot recover.
-          this.backupBlockedByCorruption = true;
-          console.error(
-            `[DatabaseMaintenance] New backup failed its integrity check — the database is corrupt. Keeping the existing backup at ${backupPath} and suspending backups`
-          );
-        } else {
-          // Could not verify it. No evidence the DB is bad, so don't suspend
-          // backups — just refuse to promote an unverified copy, and retry.
-          console.warn(
-            `[DatabaseMaintenance] Could not verify the new backup — discarding it and keeping the existing backup at ${backupPath}; will retry`
-          );
-        }
+        this.onBackupVerifyFailed(verdict, backupPath);
         return;
       }
 
       fs.renameSync(tmpPath, backupPath);
+      this.consecutiveVerifyFailures = 0;
     } catch (error) {
       console.warn("[DatabaseMaintenance] Backup failed:", error);
       this.discardTempBackup(tmpPath);
     } finally {
       this.backupPromise = null;
+    }
+  }
+
+  /**
+   * A candidate that failed verification tells us the COPY is unusable — not, on
+   * its own, that the live database is. A faulty write can mangle only the temp
+   * file. So re-run the full check against the live DB and let THAT decide
+   * whether to stop backing up, rather than condemning a healthy database on
+   * indirect evidence. Repeated failures give up regardless: something is
+   * durably wrong, and rewriting the backup from a suspect source is not worth
+   * the risk to the last good copy.
+   */
+  private onBackupVerifyFailed(verdict: DbProbeResult, backupPath: string): void {
+    this.consecutiveVerifyFailures += 1;
+
+    if (verdict === "corrupt") {
+      this.deferredQuickCheckPending = true;
+      console.error(
+        `[DatabaseMaintenance] New backup failed its integrity check — discarding it, keeping the existing backup at ${backupPath}, and re-checking the live database`
+      );
+    } else {
+      console.warn(
+        `[DatabaseMaintenance] Could not verify the new backup — discarding it and keeping the existing backup at ${backupPath}; will retry`
+      );
+    }
+
+    if (this.consecutiveVerifyFailures >= MAX_BACKUP_VERIFY_FAILURES) {
+      this.backupsSuspended = true;
+      console.error(
+        `[DatabaseMaintenance] ${this.consecutiveVerifyFailures} backups in a row failed verification — suspending backups to preserve the existing backup at ${backupPath}`
+      );
     }
   }
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
@@ -201,8 +201,8 @@ describe("DatabaseMaintenanceService adversarial", () => {
   });
 
   it("CORRUPT_CANDIDATE_SURVIVES_FAILED_TEMP_CLEANUP", async () => {
-    // The candidate probes dirty AND the temp file cannot be removed. The latch
-    // must still hold: a failed unlink is not a reason to promote the bad copy.
+    // The candidate probes dirty AND the temp file cannot be removed. A failed
+    // unlink is not a reason to promote the bad copy over the good backup.
     mockDbModule.probeDbFile.mockReturnValue("corrupt");
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.unlinkSync).mockImplementation(() => {
@@ -219,13 +219,13 @@ describe("DatabaseMaintenanceService adversarial", () => {
     expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
 
     await service.dispose();
-    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
     expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
   });
 
   it("CORRUPT_CANDIDATE_NEVER_REPLACES_GOOD_BACKUP", async () => {
-    // The live DB is fine at boot, but the copy sqlite.backup() produces probes
-    // dirty — promoting it would destroy the only good backup we have.
+    // Every candidate sqlite.backup() produces probes dirty. However many ticks
+    // pass and however shutdown lands, the good backup must never be renamed
+    // over — that file is the user's last copy of their data.
     mockDbModule.probeDbFile.mockReturnValue("corrupt");
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
@@ -233,17 +233,15 @@ describe("DatabaseMaintenanceService adversarial", () => {
     service.initialize();
     service.startMaintenance();
 
-    vi.advanceTimersByTime(5 * 60 * 1000);
-    await drainMicrotasks();
+    for (let i = 0; i < 6; i++) {
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      await drainMicrotasks();
+    }
 
-    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
     expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
 
-    // The latch holds through shutdown: the final backup is skipped rather than
-    // given a second chance to clobber the good backup.
     await service.dispose();
-    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
     expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
     expect(mockSqlite.pragma.mock.calls.at(-1)).toEqual(["wal_checkpoint(TRUNCATE)"]);
   });

--- a/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
@@ -21,6 +21,7 @@ const mockDbModule = vi.hoisted(() => ({
   getBackupPath: vi.fn().mockReturnValue("/fake/daintree.db.backup"),
   getSharedSqlite: vi.fn().mockReturnValue(mockSqlite),
   probeDb: vi.fn().mockReturnValue(true),
+  probeDbFile: vi.fn().mockReturnValue("ok"),
   attemptRecovery: vi.fn().mockReturnValue({
     kind: "restored-from-backup",
     quarantinedPath: "/fake/daintree.db.corrupt-2026-01-01",
@@ -99,6 +100,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
     mockDbModule.getBackupPath.mockReturnValue("/fake/daintree.db.backup");
     mockDbModule.getSharedSqlite.mockReturnValue(mockSqlite);
     mockDbModule.probeDb.mockReturnValue(true);
+    mockDbModule.probeDbFile.mockReturnValue("ok");
     mockSqlite.backup.mockResolvedValue(undefined);
     mockSqlite.pragma.mockReset();
     mockPowerMonitor.getSystemIdleTime.mockReturnValue(120);
@@ -198,12 +200,33 @@ describe("DatabaseMaintenanceService adversarial", () => {
     await expect(service.dispose()).resolves.toBeUndefined();
   });
 
+  it("CORRUPT_CANDIDATE_SURVIVES_FAILED_TEMP_CLEANUP", async () => {
+    // The candidate probes dirty AND the temp file cannot be removed. The latch
+    // must still hold: a failed unlink is not a reason to promote the bad copy.
+    mockDbModule.probeDbFile.mockReturnValue("corrupt");
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.unlinkSync).mockImplementation(() => {
+      throw Object.assign(new Error("unlink failed"), { code: "EPERM" });
+    });
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    await drainMicrotasks();
+
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+
+    await service.dispose();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+  });
+
   it("CORRUPT_CANDIDATE_NEVER_REPLACES_GOOD_BACKUP", async () => {
     // The live DB is fine at boot, but the copy sqlite.backup() produces probes
     // dirty — promoting it would destroy the only good backup we have.
-    mockDbModule.probeDb.mockImplementation(
-      (path: string) => path !== "/fake/daintree.db.backup.tmp"
-    );
+    mockDbModule.probeDbFile.mockReturnValue("corrupt");
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
     const service = new DatabaseMaintenanceService();

--- a/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
@@ -21,7 +21,10 @@ const mockDbModule = vi.hoisted(() => ({
   getBackupPath: vi.fn().mockReturnValue("/fake/daintree.db.backup"),
   getSharedSqlite: vi.fn().mockReturnValue(mockSqlite),
   probeDb: vi.fn().mockReturnValue(true),
-  attemptRecovery: vi.fn().mockReturnValue(true),
+  attemptRecovery: vi.fn().mockReturnValue({
+    kind: "restored-from-backup",
+    quarantinedPath: "/fake/daintree.db.corrupt-2026-01-01",
+  }),
 }));
 
 vi.mock("electron", () => ({
@@ -74,6 +77,14 @@ function createDeferred<T>(): DeferredPromise<T> {
 
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
+}
+
+/**
+ * A backup now awaits its candidate integrity probe before the rename, so the
+ * chain spans several microtask turns. Drain generously rather than counting.
+ */
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
 }
 
 describe("DatabaseMaintenanceService adversarial", () => {
@@ -177,12 +188,41 @@ describe("DatabaseMaintenanceService adversarial", () => {
     service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000);
-    await flushMicrotasks();
+    // The candidate probe (probeDb, mocked clean) sits between the backup and
+    // the rename now, so the rename is one extra microtask turn out.
+    await drainMicrotasks();
 
     expect(console.warn).toHaveBeenCalledWith("[DatabaseMaintenance] Backup failed:", renameError);
     expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
 
     await expect(service.dispose()).resolves.toBeUndefined();
+  });
+
+  it("CORRUPT_CANDIDATE_NEVER_REPLACES_GOOD_BACKUP", async () => {
+    // The live DB is fine at boot, but the copy sqlite.backup() produces probes
+    // dirty — promoting it would destroy the only good backup we have.
+    mockDbModule.probeDb.mockImplementation(
+      (path: string) => path !== "/fake/daintree.db.backup.tmp"
+    );
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(5 * 60 * 1000);
+    await drainMicrotasks();
+
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
+
+    // The latch holds through shutdown: the final backup is skipped rather than
+    // given a second chance to clobber the good backup.
+    await service.dispose();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+    expect(mockSqlite.pragma.mock.calls.at(-1)).toEqual(["wal_checkpoint(TRUNCATE)"]);
   });
 
   it("SUSPEND_DURING_INFLIGHT_BACKUP_ONLY_CHECKPOINTS", async () => {

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -26,6 +26,7 @@ const mockDbModule = vi.hoisted(() => ({
   getBackupPath: vi.fn().mockReturnValue("/fake/daintree.db.backup"),
   getSharedSqlite: vi.fn().mockReturnValue(mockSqlite),
   probeDb: vi.fn().mockReturnValue(true),
+  probeDbFile: vi.fn().mockReturnValue("ok"),
   attemptRecovery: vi.fn().mockReturnValue({
     kind: "restored-from-backup",
     quarantinedPath: "/fake/daintree.db.corrupt-2026-01-01",
@@ -107,6 +108,7 @@ describe("DatabaseMaintenanceService", () => {
     mockDbModule.getBackupPath.mockReturnValue("/fake/daintree.db.backup");
     mockDbModule.getSharedSqlite.mockReturnValue(mockSqlite);
     mockDbModule.probeDb.mockReturnValue(true);
+    mockDbModule.probeDbFile.mockReturnValue("ok");
     mockDbModule.attemptRecovery.mockReturnValue(RESTORED_RECOVERY);
     mockSqlite.backup.mockResolvedValue(undefined);
     mockPowerMonitor.getSystemIdleTime.mockReturnValue(120);
@@ -168,6 +170,20 @@ describe("DatabaseMaintenanceService", () => {
     expect(service.consumeRecovery()).toEqual(RESTORED_RECOVERY);
     // One-shot: the notification must not re-fire on a later hydrate.
     expect(service.consumeRecovery()).toBeNull();
+    void service.dispose();
+  });
+
+  it("stashes a reset-to-fresh outcome, not just a restore", () => {
+    const reset = { kind: "reset-to-fresh" as const, quarantinedPath: "/fake/x.corrupt" };
+    mockDbModule.probeDb.mockReturnValue(false);
+    mockDbModule.attemptRecovery.mockReturnValue(reset);
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    // The reset is the branch that actually loses the user's projects — dropping
+    // it while stashing restores would silently swallow the worse outcome.
+    expect(service.consumeRecovery()).toEqual(reset);
     void service.dispose();
   });
 
@@ -470,12 +486,10 @@ describe("DatabaseMaintenanceService", () => {
     expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
   });
 
-  it("discards a candidate backup that fails its integrity probe", async () => {
+  it("discards a candidate backup that probes corrupt, and suspends backups", async () => {
     // The candidate written by sqlite.backup() probes dirty — its source pages
     // are corrupt, so promoting it would destroy the only good backup.
-    mockDbModule.probeDb.mockImplementation(
-      (path: string) => path !== "/fake/daintree.db.backup.tmp"
-    );
+    mockDbModule.probeDbFile.mockReturnValue("corrupt");
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
     const service = new DatabaseMaintenanceService();
@@ -499,7 +513,13 @@ describe("DatabaseMaintenanceService", () => {
     expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
   });
 
-  it("probes the candidate backup on the worker before promoting it", async () => {
+  it("discards an unverifiable candidate without suspending backups", async () => {
+    // "unknown" is not evidence the DB is bad — it only means this copy could not
+    // be checked. Refuse to promote it, but keep trying: treating it as
+    // corruption would strand the user on an increasingly stale backup.
+    mockDbModule.probeDbFile.mockReturnValueOnce("unknown");
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
     const service = new DatabaseMaintenanceService();
     service.initialize();
     service.startMaintenance();
@@ -507,21 +527,95 @@ describe("DatabaseMaintenanceService", () => {
     vi.advanceTimersByTime(TICK);
     await drainMicrotasks();
 
-    expect(mockRunDbWork).toHaveBeenCalledWith(
-      { op: "probePath", dbPath: "/fake/daintree.db.backup.tmp" },
-      expect.any(Function)
-    );
-    // The probe must precede the rename that replaces the last good backup.
-    const probeCall = mockRunDbWork.mock.calls.findIndex(
-      ([op]) => (op as { op: string }).op === "probePath"
-    );
-    expect(probeCall).toBeGreaterThanOrEqual(0);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
+
+    // The next tick probes "ok" and promotes normally — backups are not latched off.
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(2);
     expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
       "/fake/daintree.db.backup.tmp",
       "/fake/daintree.db.backup"
     );
+    await service.dispose();
+  });
+
+  it("does not rename until the candidate probe has actually returned", async () => {
+    const probe = createDeferred<string>();
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "probePath" ? probe.promise : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+
+    // The candidate is written but its verdict is still outstanding. Renaming it
+    // over the good backup now is exactly the bug — the probe must gate it.
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(mockRunDbWork).toHaveBeenCalledWith(
+      { op: "probePath", dbPath: "/fake/daintree.db.backup.tmp" },
+      expect.any(Function)
+    );
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+
+    probe.resolve("ok");
+    await drainMicrotasks();
+
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+      "/fake/daintree.db.backup.tmp",
+      "/fake/daintree.db.backup"
+    );
+    await service.dispose();
+  });
+
+  it("waits for an in-flight quick_check before running the final backup", async () => {
+    const quickCheck = createDeferred<string>();
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "quickCheck" ? quickCheck.promise : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize(true);
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+
+    // Shutdown lands while the check is still running — and it comes back corrupt.
+    const disposePromise = service.dispose();
+    quickCheck.resolve("*** in database main *** Page 4 is never used");
+    await disposePromise;
+
+    // dispose() must not have raced ahead and backed the corrupt database up.
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+    expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+  });
+
+  it("probes the final backup on main rather than spawning a worker at shutdown", async () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
 
     await service.dispose();
+
+    // shutdown.ts drains the DB worker before disposing us, so routing this probe
+    // through runDbWork would spawn a fresh worker purely to tear it down.
+    expect(mockDbModule.probeDbFile).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
+    expect(
+      mockRunDbWork.mock.calls.filter(([op]) => (op as { op: string }).op === "probePath")
+    ).toHaveLength(0);
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+      "/fake/daintree.db.backup.tmp",
+      "/fake/daintree.db.backup"
+    );
   });
 
   it("does not schedule a deferred quick_check when the boot probe already ran the full scan", () => {

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -187,6 +187,24 @@ describe("DatabaseMaintenanceService", () => {
     void service.dispose();
   });
 
+  it("hands a recovery back so a discarded boot payload does not lose it", () => {
+    mockDbModule.probeDb.mockReturnValue(false);
+    mockDbModule.attemptRecovery.mockReturnValue(RESTORED_RECOVERY);
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    // The real round trip app:boot performs when a pending crash means the
+    // renderer will throw its payload away: consume, hand back, consume again.
+    const consumed = service.consumeRecovery();
+    expect(consumed).toEqual(RESTORED_RECOVERY);
+    service.restoreRecovery(consumed!);
+
+    expect(service.consumeRecovery()).toEqual(RESTORED_RECOVERY);
+    expect(service.consumeRecovery()).toBeNull();
+    void service.dispose();
+  });
+
   it("reports no recovery when the boot probe found a healthy database", () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
@@ -486,9 +504,10 @@ describe("DatabaseMaintenanceService", () => {
     expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
   });
 
-  it("discards a candidate backup that probes corrupt, and suspends backups", async () => {
-    // The candidate written by sqlite.backup() probes dirty — its source pages
-    // are corrupt, so promoting it would destroy the only good backup.
+  it("never promotes a candidate that probes corrupt, and re-checks the live DB", async () => {
+    // The candidate written by sqlite.backup() probes dirty. Promoting it would
+    // destroy the only good backup — but a bad COPY is not by itself proof the
+    // live DB is bad, so the service re-checks the source rather than assuming.
     mockDbModule.probeDbFile.mockReturnValue("corrupt");
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
@@ -503,13 +522,76 @@ describe("DatabaseMaintenanceService", () => {
     expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
     expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
 
-    // ...and the corruption latch stops every later backup too.
+    // The bad candidate arms a full check of the live database, which the next
+    // idle tick runs — the source is interrogated directly rather than condemned
+    // on the evidence of one bad copy.
+    expect(quickCheckOps()).toHaveLength(0);
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(quickCheckOps()).toHaveLength(1);
+
+    await service.dispose();
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+  });
+
+  it("suspends backups once the live DB confirms the corruption a bad candidate hinted at", async () => {
+    mockDbModule.probeDbFile.mockReturnValue("corrupt");
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "quickCheck"
+        ? Promise.resolve("*** in database main *** Page 4 is never used")
+        : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    // Tick 1 writes a bad candidate and arms the live re-check.
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+
+    // Tick 2 runs that check; it reports corruption, so backups stop for good.
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+
     vi.advanceTimersByTime(TICK);
     await drainMicrotasks();
     expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
 
     await service.dispose();
     expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+  });
+
+  it("gives up after repeated verification failures even if the live DB looks fine", async () => {
+    // The live check keeps passing but every candidate comes out bad. Something
+    // is durably wrong; stop rewriting the backup from a suspect source rather
+    // than looping forever on a full copy + scan every idle tick.
+    mockDbModule.probeDbFile.mockReturnValue("corrupt");
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "quickCheck"
+        ? Promise.resolve("ok")
+        : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    for (let i = 0; i < 6; i++) {
+      vi.advanceTimersByTime(TICK);
+      await drainMicrotasks();
+    }
+
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+    // Bounded: it stopped trying rather than copying the DB on every tick forever.
+    expect(mockSqlite.backup.mock.calls.length).toBeLessThanOrEqual(3);
+
+    await service.dispose();
     expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
   });
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPowerMonitor = vi.hoisted(() => ({
@@ -15,12 +16,20 @@ const mockSqlite = vi.hoisted(() => ({
   backup: vi.fn().mockResolvedValue(undefined),
 }));
 
+const RESTORED_RECOVERY = {
+  kind: "restored-from-backup" as const,
+  quarantinedPath: "/fake/daintree.db.corrupt-2026-01-01",
+};
+
 const mockDbModule = vi.hoisted(() => ({
   getDbPath: vi.fn().mockReturnValue("/fake/daintree.db"),
   getBackupPath: vi.fn().mockReturnValue("/fake/daintree.db.backup"),
   getSharedSqlite: vi.fn().mockReturnValue(mockSqlite),
   probeDb: vi.fn().mockReturnValue(true),
-  attemptRecovery: vi.fn().mockReturnValue(true),
+  attemptRecovery: vi.fn().mockReturnValue({
+    kind: "restored-from-backup",
+    quarantinedPath: "/fake/daintree.db.corrupt-2026-01-01",
+  }),
   closeSharedDb: vi.fn(),
 }));
 
@@ -60,6 +69,32 @@ vi.mock("node:fs", async () => {
 
 import { DatabaseMaintenanceService } from "../DatabaseMaintenanceService.js";
 
+const TICK = 5 * 60 * 1000 + 100;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * A backup now awaits its candidate integrity probe before the rename, so the
+ * chain spans several microtask turns. Drain generously rather than counting.
+ */
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
+const quickCheckOps = () =>
+  mockRunDbWork.mock.calls.filter(([op]) => (op as { op: string }).op === "quickCheck");
+
 describe("DatabaseMaintenanceService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -72,8 +107,20 @@ describe("DatabaseMaintenanceService", () => {
     mockDbModule.getBackupPath.mockReturnValue("/fake/daintree.db.backup");
     mockDbModule.getSharedSqlite.mockReturnValue(mockSqlite);
     mockDbModule.probeDb.mockReturnValue(true);
+    mockDbModule.attemptRecovery.mockReturnValue(RESTORED_RECOVERY);
     mockSqlite.backup.mockResolvedValue(undefined);
     mockPowerMonitor.getSystemIdleTime.mockReturnValue(120);
+    mockRunDbWork.mockImplementation((_op: unknown, fallback: () => unknown) =>
+      Promise.resolve(fallback())
+    );
+    // restoreAllMocks strips the mock factory's implementations, so re-arm them.
+    vi.mocked(fs.existsSync).mockReset().mockReturnValue(false);
+    vi.mocked(fs.unlinkSync)
+      .mockReset()
+      .mockImplementation(() => undefined);
+    vi.mocked(fs.renameSync)
+      .mockReset()
+      .mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -94,7 +141,6 @@ describe("DatabaseMaintenanceService", () => {
 
   it("attempts recovery when corruption detected", () => {
     mockDbModule.probeDb.mockReturnValue(false);
-    mockDbModule.attemptRecovery.mockReturnValue(true);
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
@@ -105,10 +151,44 @@ describe("DatabaseMaintenanceService", () => {
 
   it("handles failed recovery gracefully", () => {
     mockDbModule.probeDb.mockReturnValue(false);
-    mockDbModule.attemptRecovery.mockReturnValue(false);
+    mockDbModule.attemptRecovery.mockReturnValue(null);
 
     const service = new DatabaseMaintenanceService();
     expect(() => service.initialize()).not.toThrow();
+    void service.dispose();
+  });
+
+  it("stashes the boot recovery outcome for exactly one consumer", () => {
+    mockDbModule.probeDb.mockReturnValue(false);
+    mockDbModule.attemptRecovery.mockReturnValue(RESTORED_RECOVERY);
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    expect(service.consumeRecovery()).toEqual(RESTORED_RECOVERY);
+    // One-shot: the notification must not re-fire on a later hydrate.
+    expect(service.consumeRecovery()).toBeNull();
+    void service.dispose();
+  });
+
+  it("reports no recovery when the boot probe found a healthy database", () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    expect(service.consumeRecovery()).toBeNull();
+    void service.dispose();
+  });
+
+  it("reports no recovery when the recovery attempt itself failed", () => {
+    mockDbModule.probeDb.mockReturnValue(false);
+    mockDbModule.attemptRecovery.mockReturnValue(null);
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    // A rename that threw leaves the corrupt DB in place — claiming a restore
+    // or a reset here would tell the user something that never happened.
+    expect(service.consumeRecovery()).toBeNull();
     void service.dispose();
   });
 
@@ -278,9 +358,6 @@ describe("DatabaseMaintenanceService", () => {
     service.initialize(true);
     service.startMaintenance();
 
-    const quickCheckOps = () =>
-      mockRunDbWork.mock.calls.filter(([op]) => (op as { op: string }).op === "quickCheck");
-
     vi.advanceTimersByTime(5 * 60 * 1000 + 100);
     expect(quickCheckOps()).toHaveLength(1);
 
@@ -290,6 +367,161 @@ describe("DatabaseMaintenanceService", () => {
     // The deferred scan must never run on the main connection.
     expect(mockSqlite.pragma).not.toHaveBeenCalledWith("quick_check", { simple: true });
     void service.dispose();
+  });
+
+  it("holds the first backup until the deferred quick_check passes", async () => {
+    const quickCheck = createDeferred<string>();
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "quickCheck" ? quickCheck.promise : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize(true);
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+
+    // Integrity still unknown — backing up now could copy a corrupt DB.
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+
+    quickCheck.resolve("ok");
+    await drainMicrotasks();
+
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    await service.dispose();
+  });
+
+  it("lifts the backup gate for the rest of the process once the check passes", async () => {
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "quickCheck"
+        ? Promise.resolve("ok")
+        : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize(true);
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+
+    // A passing check clears the pending flag: later ticks back up straight from
+    // the timer callback and never re-run the O(size) scan.
+    vi.advanceTimersByTime(TICK);
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(2);
+    expect(quickCheckOps()).toHaveLength(1);
+
+    await drainMicrotasks();
+    await service.dispose();
+  });
+
+  it("keeps the quick_check pending and retries when the DB worker is unavailable", async () => {
+    // Default mock: the worker is unavailable, so quickCheck's fallback returns
+    // null — the scan never actually ran.
+    const service = new DatabaseMaintenanceService();
+    service.initialize(true);
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(quickCheckOps()).toHaveLength(1);
+
+    // A check that never ran must not look like one that passed.
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(quickCheckOps()).toHaveLength(2);
+
+    // The backup still runs — its own candidate probe is what guards the
+    // existing backup, and it catches on main what the worker could not.
+    expect(mockSqlite.backup).toHaveBeenCalled();
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+      "/fake/daintree.db.backup.tmp",
+      "/fake/daintree.db.backup"
+    );
+    await service.dispose();
+  });
+
+  it("suspends all backups once the deferred quick_check reports corruption", async () => {
+    mockRunDbWork.mockImplementation((op: unknown, fallback: () => unknown) =>
+      (op as { op: string }).op === "quickCheck"
+        ? Promise.resolve("*** in database main *** Page 4 is never used")
+        : Promise.resolve(fallback())
+    );
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize(true);
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+
+    // Every later tick stays suspended — the existing backup is the last good copy.
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+
+    // ...including the final backup at shutdown.
+    await service.dispose();
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+    expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+  });
+
+  it("discards a candidate backup that fails its integrity probe", async () => {
+    // The candidate written by sqlite.backup() probes dirty — its source pages
+    // are corrupt, so promoting it would destroy the only good backup.
+    mockDbModule.probeDb.mockImplementation(
+      (path: string) => path !== "/fake/daintree.db.backup.tmp"
+    );
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalledWith("/fake/daintree.db.backup.tmp");
+
+    // ...and the corruption latch stops every later backup too.
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+
+    await service.dispose();
+    expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.renameSync)).not.toHaveBeenCalled();
+  });
+
+  it("probes the candidate backup on the worker before promoting it", async () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(TICK);
+    await drainMicrotasks();
+
+    expect(mockRunDbWork).toHaveBeenCalledWith(
+      { op: "probePath", dbPath: "/fake/daintree.db.backup.tmp" },
+      expect.any(Function)
+    );
+    // The probe must precede the rename that replaces the last good backup.
+    const probeCall = mockRunDbWork.mock.calls.findIndex(
+      ([op]) => (op as { op: string }).op === "probePath"
+    );
+    expect(probeCall).toBeGreaterThanOrEqual(0);
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+      "/fake/daintree.db.backup.tmp",
+      "/fake/daintree.db.backup"
+    );
+
+    await service.dispose();
   });
 
   it("does not schedule a deferred quick_check when the boot probe already ran the full scan", () => {

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -39,7 +39,14 @@ vi.mock("drizzle-orm/better-sqlite3", () => ({
   drizzle: vi.fn(() => ({})),
 }));
 
-import { openDb, probeDb, attemptRecovery, closeSharedDb, withDiskRecovery } from "../db.js";
+import {
+  openDb,
+  probeDb,
+  probeDbFile,
+  attemptRecovery,
+  closeSharedDb,
+  withDiskRecovery,
+} from "../db.js";
 
 describe("probeDb", () => {
   let tmpDir: string;
@@ -239,6 +246,99 @@ describe("attemptRecovery", () => {
     expect(attemptRecovery(dbPath)).toBeNull();
     expect(fs.existsSync(dbPath)).toBe(true);
     renameSpy.mockRestore();
+  });
+
+  it("still reports a reset when the DB moved but a later quarantine step failed", () => {
+    const dbPath = path.join(tmpDir, "daintree.db");
+    fs.writeFileSync(dbPath, "corrupt");
+    fs.writeFileSync(dbPath + "-wal", "wal");
+
+    // The main DB is quarantined, then the WAL rename fails. The DB is already
+    // gone, so a fresh one WILL be created — staying silent here would lose the
+    // user's data with no notification, which is the whole bug being fixed.
+    const realRename = fs.renameSync.bind(fs);
+    let calls = 0;
+    const renameSpy = vi
+      .spyOn(fs, "renameSync")
+      .mockImplementation((from: fs.PathLike, to: fs.PathLike) => {
+        calls += 1;
+        if (calls === 1) return realRename(from, to);
+        throw Object.assign(new Error("rename failed"), { code: "EPERM" });
+      });
+
+    const result = attemptRecovery(dbPath);
+
+    expect(result).toMatchObject({ kind: "reset-to-fresh" });
+    expect(fs.existsSync(dbPath)).toBe(false);
+    renameSpy.mockRestore();
+  });
+});
+
+describe("probeDbFile", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-db-probe-"));
+    dbPath = path.join(tmpDir, "candidate.db");
+    fs.writeFileSync(dbPath, "dummy");
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockDatabaseConstructor.mockImplementation(() => ({}));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("opens the candidate read-only and refuses to create a missing one", () => {
+    mockPragma.mockReturnValue("ok");
+
+    expect(probeDbFile(dbPath)).toBe("ok");
+    expect(mockDatabaseConstructor).toHaveBeenCalledWith(dbPath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("reports a failed quick_check as corrupt", () => {
+    mockPragma.mockReturnValue("*** in database main ***\nPage 48: btreeInitPage() error");
+
+    expect(probeDbFile(dbPath)).toBe("corrupt");
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("reports SQLITE_CORRUPT and SQLITE_NOTADB as corrupt", () => {
+    for (const code of ["SQLITE_CORRUPT_VTAB", "SQLITE_NOTADB"]) {
+      mockPragma.mockImplementation(() => {
+        throw Object.assign(new Error("bad"), { code });
+      });
+      expect(probeDbFile(dbPath)).toBe("corrupt");
+    }
+  });
+
+  // The whole point of this function. probeDb is fail-open — it returns TRUE for
+  // both of these, which is right at boot (don't quarantine a DB over a transient
+  // EACCES) and catastrophic when promoting a backup (an unverifiable candidate
+  // would overwrite the only good copy). Neither may ever come back "ok".
+  it("reports an unreadable candidate as unknown, never as ok", () => {
+    mockPragma.mockImplementation(() => {
+      throw Object.assign(new Error("permission denied"), { code: "SQLITE_IOERR_SHORT_READ" });
+    });
+
+    expect(probeDbFile(dbPath)).toBe("unknown");
+    expect(probeDb(dbPath)).toBe(true); // ...whereas the fail-open probe says fine
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("reports a missing candidate as unknown, never as ok", () => {
+    const absent = path.join(tmpDir, "absent.db");
+
+    expect(probeDbFile(absent)).toBe("unknown");
+    expect(probeDb(absent)).toBe(true); // ...whereas the fail-open probe says fine
+    expect(mockDatabaseConstructor).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -270,7 +270,36 @@ describe("attemptRecovery", () => {
 
     expect(result).toMatchObject({ kind: "reset-to-fresh" });
     expect(fs.existsSync(dbPath)).toBe(false);
+    // A stale WAL left at its live name can be replayed into the replacement DB.
+    // If it won't move aside it has to go.
+    expect(fs.existsSync(dbPath + "-wal")).toBe(false);
     renameSpy.mockRestore();
+  });
+
+  it("moves a surviving backup aside when it cannot be restored", () => {
+    const dbPath = path.join(tmpDir, "daintree.db");
+    const backupPath = dbPath + ".backup";
+    fs.writeFileSync(dbPath, "corrupt");
+    fs.writeFileSync(backupPath, "the user's real data");
+
+    // The backup can't be read — not proven corrupt, just unverifiable.
+    mockPragma.mockImplementation(() => {
+      throw Object.assign(new Error("io error"), { code: "SQLITE_IOERR_SHORT_READ" });
+    });
+
+    const result = attemptRecovery(dbPath);
+
+    // It must NOT be copied over the DB and announced as a successful restore...
+    expect(result).toMatchObject({ kind: "reset-to-fresh" });
+    // ...and it must not be left sitting at backupPath either: the app now comes
+    // up on an empty database, and the first idle backup would copy that empty
+    // DB straight over the user's last good data. Preserve it, don't destroy it.
+    expect(fs.existsSync(backupPath)).toBe(false);
+    const preserved = fs
+      .readdirSync(tmpDir)
+      .find((f) => f.startsWith("daintree.db.backup.corrupt-"));
+    expect(preserved).toBeDefined();
+    expect(fs.readFileSync(path.join(tmpDir, preserved!), "utf8")).toBe("the user's real data");
   });
 });
 

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -172,7 +172,13 @@ describe("attemptRecovery", () => {
 
     const result = attemptRecovery(dbPath);
 
-    expect(result).toBe(true);
+    expect(result).toEqual({
+      kind: "restored-from-backup",
+      quarantinedPath: expect.stringContaining("daintree.db.corrupt-"),
+    });
+    // The reported path is the quarantined DB itself, and it still holds the
+    // original bytes — a user handed this path must find the damaged file there.
+    expect(fs.readFileSync(result!.quarantinedPath!, "utf8")).toBe("corrupt");
     // Backup was copied to dbPath
     expect(fs.readFileSync(dbPath, "utf8")).toBe("valid backup");
     // Original files quarantined
@@ -182,17 +188,20 @@ describe("attemptRecovery", () => {
     expect(files.filter((f) => f.includes(".corrupt-")).length).toBe(3);
   });
 
-  it("returns false when no backup exists", () => {
+  it("resets to a fresh database when no backup exists", () => {
     const dbPath = path.join(tmpDir, "daintree.db");
     fs.writeFileSync(dbPath, "corrupt");
 
     const result = attemptRecovery(dbPath);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({
+      kind: "reset-to-fresh",
+      quarantinedPath: expect.stringContaining("daintree.db.corrupt-"),
+    });
     expect(fs.existsSync(dbPath)).toBe(false);
   });
 
-  it("returns false when backup is also corrupt", () => {
+  it("resets to a fresh database when the backup is also corrupt", () => {
     const dbPath = path.join(tmpDir, "daintree.db");
     const backupPath = dbPath + ".backup";
 
@@ -208,10 +217,28 @@ describe("attemptRecovery", () => {
 
     const result = attemptRecovery(dbPath);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({
+      kind: "reset-to-fresh",
+      quarantinedPath: expect.stringContaining("daintree.db.corrupt-"),
+    });
     // Both quarantined
     expect(fs.existsSync(dbPath)).toBe(false);
     expect(fs.existsSync(backupPath)).toBe(false);
+  });
+
+  it("reports no recovery when quarantining the corrupt DB fails", () => {
+    const dbPath = path.join(tmpDir, "daintree.db");
+    fs.writeFileSync(dbPath, "corrupt");
+
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation(() => {
+      throw Object.assign(new Error("rename failed"), { code: "EPERM" });
+    });
+
+    // The corrupt DB is still in place, so claiming a restore or a reset here
+    // would tell the user something that never happened.
+    expect(attemptRecovery(dbPath)).toBeNull();
+    expect(fs.existsSync(dbPath)).toBe(true);
+    renameSpy.mockRestore();
   });
 });
 

--- a/electron/services/persistence/__tests__/dbMaintenanceWorker.test.ts
+++ b/electron/services/persistence/__tests__/dbMaintenanceWorker.test.ts
@@ -273,7 +273,7 @@ describe("dbMaintenanceWorker (real worker thread)", () => {
 
     const w = spawn();
     const response = await request(w, { op: "probePath", dbPath: candidatePath });
-    expect(response).toMatchObject({ ok: true, result: true });
+    expect(response).toMatchObject({ ok: true, result: "ok" });
 
     // The probe's handle must be closed — a lingering one would block the
     // rename that promotes this file over the live backup on Windows.
@@ -281,23 +281,36 @@ describe("dbMaintenanceWorker (real worker thread)", () => {
     expect(fs.existsSync(path.join(tmpDir, "promoted.db"))).toBe(true);
   });
 
-  it("reports a non-SQLite candidate as failing its probe", async () => {
+  it("reports a non-SQLite candidate as corrupt", async () => {
     const candidatePath = path.join(tmpDir, "garbage.db");
     fs.writeFileSync(candidatePath, "this is not a sqlite database");
 
     const w = spawn();
     const response = await request(w, { op: "probePath", dbPath: candidatePath });
-    expect(response).toMatchObject({ ok: true, result: false });
+    expect(response).toMatchObject({ ok: true, result: "corrupt" });
   });
 
-  it("rejects a probe of a missing path rather than reporting it clean", async () => {
+  it("reports a missing candidate as unverifiable, never as clean", async () => {
     const w = spawn();
     const response = await request(w, {
       op: "probePath",
       dbPath: path.join(tmpDir, "does-not-exist.db"),
     });
-    // Not a corruption verdict — the client falls back to probing on main.
-    expect(response.ok).toBe(false);
+    // "unknown", not "ok" — an unverifiable file must never be promoted over the
+    // good backup, but it is also not evidence that the live DB is corrupt.
+    expect(response).toMatchObject({ ok: true, result: "unknown" });
+  });
+
+  it("leaves the live database usable after probing an unrelated path", async () => {
+    const candidatePath = path.join(tmpDir, "candidate.db");
+    fs.writeFileSync(candidatePath, "not a database");
+
+    const w = spawn();
+    await request(w, { op: "probePath", dbPath: candidatePath });
+
+    // A corrupt candidate must not poison the worker's own connection.
+    const after = await request(w, { op: "quickCheck" });
+    expect(after).toMatchObject({ ok: true, result: "ok" });
   });
 
   it("responds to close and exits without terminate()", async () => {

--- a/electron/services/persistence/__tests__/dbMaintenanceWorker.test.ts
+++ b/electron/services/persistence/__tests__/dbMaintenanceWorker.test.ts
@@ -265,6 +265,41 @@ describe("dbMaintenanceWorker (real worker thread)", () => {
     expect(response).toMatchObject({ ok: true, result: "ok" });
   });
 
+  it("probes a healthy file at an arbitrary path, not just its own connection", async () => {
+    const candidatePath = path.join(tmpDir, "candidate.db");
+    const candidate = new Database(candidatePath);
+    candidate.exec(AUDIT_RINGS_DDL);
+    candidate.close();
+
+    const w = spawn();
+    const response = await request(w, { op: "probePath", dbPath: candidatePath });
+    expect(response).toMatchObject({ ok: true, result: true });
+
+    // The probe's handle must be closed — a lingering one would block the
+    // rename that promotes this file over the live backup on Windows.
+    fs.renameSync(candidatePath, path.join(tmpDir, "promoted.db"));
+    expect(fs.existsSync(path.join(tmpDir, "promoted.db"))).toBe(true);
+  });
+
+  it("reports a non-SQLite candidate as failing its probe", async () => {
+    const candidatePath = path.join(tmpDir, "garbage.db");
+    fs.writeFileSync(candidatePath, "this is not a sqlite database");
+
+    const w = spawn();
+    const response = await request(w, { op: "probePath", dbPath: candidatePath });
+    expect(response).toMatchObject({ ok: true, result: false });
+  });
+
+  it("rejects a probe of a missing path rather than reporting it clean", async () => {
+    const w = spawn();
+    const response = await request(w, {
+      op: "probePath",
+      dbPath: path.join(tmpDir, "does-not-exist.db"),
+    });
+    // Not a corruption verdict — the client falls back to probing on main.
+    expect(response.ok).toBe(false);
+  });
+
   it("responds to close and exits without terminate()", async () => {
     const w = spawn();
     const exited = new Promise<number>((resolve) => w.once("exit", resolve));

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -8,6 +8,7 @@ import path from "path";
 import { getWritesSuppressed } from "../diskPressureState.js";
 import * as schema from "./schema.js";
 import type { DatabaseRecovery } from "../../../shared/types/ipc/app.js";
+import type { DbProbeResult } from "./dbWorkerProtocol.js";
 
 export type AppDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -165,15 +166,49 @@ export function probeDb(dbPath: string, fullCheck = true): boolean {
  * recovery itself failed (a rename threw) — the corrupt database may still be in
  * place, so callers must not report a successful restore or reset.
  */
+/**
+ * Probe an arbitrary SQLite file, reporting "could not verify" separately from
+ * "proven corrupt". Distinct from `probeDb`, which is fail-open by design: at
+ * boot, a transient EACCES must not quarantine a healthy database. Promoting a
+ * backup is the opposite call — it overwrites the last known-good copy, so
+ * anything short of a proven "ok" must not proceed.
+ *
+ * The DB worker reimplements this verdict table inline (it cannot import this
+ * module — Electron's `app` does not exist in a worker thread); keep them in step.
+ */
+export function probeDbFile(dbPath: string): DbProbeResult {
+  if (!fs.existsSync(dbPath)) return "unknown";
+  let testDb: Database.Database | null = null;
+  try {
+    testDb = new Database(dbPath, { readonly: true, fileMustExist: true });
+    return testDb.pragma("quick_check", { simple: true }) === "ok" ? "ok" : "corrupt";
+  } catch (error: unknown) {
+    const code = (error as { code?: string }).code;
+    if (
+      typeof code === "string" &&
+      (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB")
+    ) {
+      return "corrupt";
+    }
+    return "unknown";
+  } finally {
+    try {
+      testDb?.close();
+    } catch {
+      // ignore close errors
+    }
+  }
+}
+
 export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const corruptSuffix = `.corrupt-${timestamp}`;
   const backupPath = dbPath + ".backup";
 
+  // Quarantine corrupt DB and associated WAL/SHM files. Only the main file's
+  // path is reported — it is the one a user would inspect or hand to support.
+  let quarantinedPath: string | undefined;
   try {
-    // Quarantine corrupt DB and associated WAL/SHM files. Only the main file's
-    // path is reported — it is the one a user would inspect or hand to support.
-    let quarantinedPath: string | undefined;
     for (const suffix of ["", "-wal", "-shm"]) {
       const filePath = dbPath + suffix;
       if (fs.existsSync(filePath)) {
@@ -181,7 +216,16 @@ export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
         if (suffix === "") quarantinedPath = filePath + corruptSuffix;
       }
     }
+  } catch (error) {
+    console.error("[DB] Failed to quarantine the corrupt database:", error);
+    // Nothing moved yet — the corrupt DB is still in place and will be reopened.
+    // Reporting a restore or a reset here would claim something that never
+    // happened, so report nothing. Once the main file HAS moved we are committed
+    // and must fall through: the user ends up on a different database either way.
+    if (!quarantinedPath) return null;
+  }
 
+  try {
     // Restore from backup if available
     if (fs.existsSync(backupPath)) {
       // Verify backup integrity before restoring
@@ -189,19 +233,20 @@ export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
         fs.copyFileSync(backupPath, dbPath);
         console.log("[DB] Restored database from backup");
         return { kind: "restored-from-backup", quarantinedPath };
-      } else {
-        console.error("[DB] Backup is also corrupt, cannot restore");
-        // Quarantine the corrupt backup too
-        fs.renameSync(backupPath, backupPath + corruptSuffix);
-        return { kind: "reset-to-fresh", quarantinedPath };
       }
+      console.error("[DB] Backup is also corrupt, cannot restore");
+      // Quarantine the corrupt backup too
+      fs.renameSync(backupPath, backupPath + corruptSuffix);
+      return { kind: "reset-to-fresh", quarantinedPath };
     }
 
     console.warn("[DB] No backup available for recovery — fresh database will be created");
     return { kind: "reset-to-fresh", quarantinedPath };
   } catch (error) {
-    console.error("[DB] Recovery failed:", error);
-    return null;
+    console.error("[DB] Restore from backup failed:", error);
+    // The corrupt DB is already quarantined, so openDb creates a fresh one. That
+    // is a reset the user lost data to — it must be reported, not swallowed.
+    return { kind: "reset-to-fresh", quarantinedPath };
   }
 }
 

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "path";
 import { getWritesSuppressed } from "../diskPressureState.js";
 import * as schema from "./schema.js";
+import type { DatabaseRecovery } from "../../../shared/types/ipc/app.js";
 
 export type AppDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -156,17 +157,28 @@ export function probeDb(dbPath: string, fullCheck = true): boolean {
   }
 }
 
-export function attemptRecovery(dbPath: string): boolean {
+/**
+ * Quarantine a corrupt database and restore it from the backup when that backup
+ * probes clean, otherwise leave the path empty so `openDb` creates a fresh file.
+ *
+ * Returns what actually happened so callers can tell the user. `null` means the
+ * recovery itself failed (a rename threw) — the corrupt database may still be in
+ * place, so callers must not report a successful restore or reset.
+ */
+export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const corruptSuffix = `.corrupt-${timestamp}`;
   const backupPath = dbPath + ".backup";
 
   try {
-    // Quarantine corrupt DB and associated WAL/SHM files
+    // Quarantine corrupt DB and associated WAL/SHM files. Only the main file's
+    // path is reported — it is the one a user would inspect or hand to support.
+    let quarantinedPath: string | undefined;
     for (const suffix of ["", "-wal", "-shm"]) {
       const filePath = dbPath + suffix;
       if (fs.existsSync(filePath)) {
         fs.renameSync(filePath, filePath + corruptSuffix);
+        if (suffix === "") quarantinedPath = filePath + corruptSuffix;
       }
     }
 
@@ -176,20 +188,20 @@ export function attemptRecovery(dbPath: string): boolean {
       if (probeDb(backupPath)) {
         fs.copyFileSync(backupPath, dbPath);
         console.log("[DB] Restored database from backup");
-        return true;
+        return { kind: "restored-from-backup", quarantinedPath };
       } else {
         console.error("[DB] Backup is also corrupt, cannot restore");
         // Quarantine the corrupt backup too
         fs.renameSync(backupPath, backupPath + corruptSuffix);
-        return false;
+        return { kind: "reset-to-fresh", quarantinedPath };
       }
     }
 
     console.warn("[DB] No backup available for recovery — fresh database will be created");
-    return false;
+    return { kind: "reset-to-fresh", quarantinedPath };
   } catch (error) {
     console.error("[DB] Recovery failed:", error);
-    return false;
+    return null;
   }
 }
 

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -205,48 +205,72 @@ export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
   const corruptSuffix = `.corrupt-${timestamp}`;
   const backupPath = dbPath + ".backup";
 
-  // Quarantine corrupt DB and associated WAL/SHM files. Only the main file's
+  // Quarantine the corrupt DB and its WAL/SHM sidecars. Only the main file's
   // path is reported — it is the one a user would inspect or hand to support.
   let quarantinedPath: string | undefined;
-  try {
-    for (const suffix of ["", "-wal", "-shm"]) {
-      const filePath = dbPath + suffix;
-      if (fs.existsSync(filePath)) {
-        fs.renameSync(filePath, filePath + corruptSuffix);
-        if (suffix === "") quarantinedPath = filePath + corruptSuffix;
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const filePath = dbPath + suffix;
+    if (!fs.existsSync(filePath)) continue;
+    try {
+      fs.renameSync(filePath, filePath + corruptSuffix);
+      if (suffix === "") quarantinedPath = filePath + corruptSuffix;
+    } catch (error) {
+      if (suffix === "") {
+        // Nothing moved — the corrupt DB is still in place and will be reopened.
+        // Claiming a restore or a reset here would report something that never
+        // happened, so report nothing at all.
+        console.error("[DB] Failed to quarantine the corrupt database:", error);
+        return null;
+      }
+      // A stale WAL/SHM left beside the replacement database can be replayed
+      // into it. If it will not move aside, delete it — losing an orphaned
+      // sidecar beats corrupting the database we are about to restore.
+      console.warn(`[DB] Could not quarantine ${filePath}, removing it instead:`, error);
+      try {
+        fs.unlinkSync(filePath);
+      } catch (unlinkError) {
+        console.error(`[DB] Could not remove ${filePath} either:`, unlinkError);
       }
     }
-  } catch (error) {
-    console.error("[DB] Failed to quarantine the corrupt database:", error);
-    // Nothing moved yet — the corrupt DB is still in place and will be reopened.
-    // Reporting a restore or a reset here would claim something that never
-    // happened, so report nothing. Once the main file HAS moved we are committed
-    // and must fall through: the user ends up on a different database either way.
-    if (!quarantinedPath) return null;
   }
 
+  // Past this point the corrupt DB is gone, so the app WILL come up on a
+  // different database — the user has to be told either way.
   try {
-    // Restore from backup if available
     if (fs.existsSync(backupPath)) {
-      // Verify backup integrity before restoring
-      if (probeDb(backupPath)) {
+      // probeDbFile, not probeDb: restoring overwrites the database the app is
+      // about to open, so a backup we merely failed to READ must not be copied
+      // over it and then reported as a successful restore.
+      const verdict = probeDbFile(backupPath);
+      if (verdict === "ok") {
         fs.copyFileSync(backupPath, dbPath);
         console.log("[DB] Restored database from backup");
         return { kind: "restored-from-backup", quarantinedPath };
       }
-      console.error("[DB] Backup is also corrupt, cannot restore");
-      // Quarantine the corrupt backup too
-      fs.renameSync(backupPath, backupPath + corruptSuffix);
-      return { kind: "reset-to-fresh", quarantinedPath };
+      console.error(`[DB] Backup cannot be restored (${verdict}) — starting fresh`);
+    } else {
+      console.warn("[DB] No backup available for recovery — fresh database will be created");
     }
-
-    console.warn("[DB] No backup available for recovery — fresh database will be created");
-    return { kind: "reset-to-fresh", quarantinedPath };
   } catch (error) {
     console.error("[DB] Restore from backup failed:", error);
-    // The corrupt DB is already quarantined, so openDb creates a fresh one. That
-    // is a reset the user lost data to — it must be reported, not swallowed.
-    return { kind: "reset-to-fresh", quarantinedPath };
+  }
+
+  // Starting fresh. DatabaseMaintenanceService will back the new (empty) database
+  // up over `backupPath` on its first idle tick, so any surviving backup has to
+  // move out of the way first — otherwise recovery itself destroys the last copy
+  // of the user's data, which is the very failure this whole change exists to
+  // prevent. Preserve it rather than delete it: it may still be salvageable.
+  preserveStaleBackup(backupPath, corruptSuffix);
+  return { kind: "reset-to-fresh", quarantinedPath };
+}
+
+function preserveStaleBackup(backupPath: string, corruptSuffix: string): void {
+  try {
+    if (fs.existsSync(backupPath)) {
+      fs.renameSync(backupPath, backupPath + corruptSuffix);
+    }
+  } catch (error) {
+    console.error("[DB] Could not move the unusable backup aside:", error);
   }
 }
 

--- a/electron/services/persistence/dbMaintenanceWorker.ts
+++ b/electron/services/persistence/dbMaintenanceWorker.ts
@@ -8,7 +8,12 @@
 import Database from "better-sqlite3";
 import { parentPort, workerData } from "node:worker_threads";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
-import type { DbWorkerData, DbWorkerRequest, DbWorkerResponse } from "./dbWorkerProtocol.js";
+import type {
+  DbProbeResult,
+  DbWorkerData,
+  DbWorkerRequest,
+  DbWorkerResponse,
+} from "./dbWorkerProtocol.js";
 
 const port = parentPort;
 if (!port) {
@@ -58,24 +63,26 @@ function getRingStatements(): RingStatements {
 }
 
 // Full quick_check against an arbitrary file on its own short-lived readonly
-// handle. Deliberately duplicates db.ts's probeDb rather than importing it: that
-// module imports Electron's `app` at module scope, which does not exist inside a
-// worker thread. Corruption resolves false; any other open/IO failure throws so
-// the client falls back to probing on main.
-function probePath(dbPath: string): boolean {
+// handle. Deliberately duplicates db.ts's probeDbFile rather than importing it:
+// that module imports Electron's `app` at module scope, which does not exist
+// inside a worker thread. Keep the two verdict tables in step.
+//
+// "unknown" (could not verify) is distinct from "corrupt" (proven bad): the
+// caller discards the candidate either way, but only "corrupt" stops backups.
+function probePath(dbPath: string): DbProbeResult {
   let candidate: Database.Database | null = null;
   try {
     candidate = new Database(dbPath, { readonly: true, fileMustExist: true });
-    return candidate.pragma("quick_check", { simple: true }) === "ok";
+    return candidate.pragma("quick_check", { simple: true }) === "ok" ? "ok" : "corrupt";
   } catch (error: unknown) {
     const code = (error as { code?: string }).code;
     if (
       typeof code === "string" &&
       (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB")
     ) {
-      return false;
+      return "corrupt";
     }
-    throw error;
+    return "unknown";
   } finally {
     try {
       candidate?.close();

--- a/electron/services/persistence/dbMaintenanceWorker.ts
+++ b/electron/services/persistence/dbMaintenanceWorker.ts
@@ -57,6 +57,34 @@ function getRingStatements(): RingStatements {
   return ringStatements;
 }
 
+// Full quick_check against an arbitrary file on its own short-lived readonly
+// handle. Deliberately duplicates db.ts's probeDb rather than importing it: that
+// module imports Electron's `app` at module scope, which does not exist inside a
+// worker thread. Corruption resolves false; any other open/IO failure throws so
+// the client falls back to probing on main.
+function probePath(dbPath: string): boolean {
+  let candidate: Database.Database | null = null;
+  try {
+    candidate = new Database(dbPath, { readonly: true, fileMustExist: true });
+    return candidate.pragma("quick_check", { simple: true }) === "ok";
+  } catch (error: unknown) {
+    const code = (error as { code?: string }).code;
+    if (
+      typeof code === "string" &&
+      (code.startsWith("SQLITE_CORRUPT") || code === "SQLITE_NOTADB")
+    ) {
+      return false;
+    }
+    throw error;
+  } finally {
+    try {
+      candidate?.close();
+    } catch {
+      // ignore close errors
+    }
+  }
+}
+
 function execute(request: DbWorkerRequest): unknown {
   switch (request.op) {
     case "checkpoint":
@@ -64,6 +92,8 @@ function execute(request: DbWorkerRequest): unknown {
       return null;
     case "quickCheck":
       return sqlite.pragma("quick_check", { simple: true });
+    case "probePath":
+      return probePath(request.dbPath);
     case "ringWriteAll": {
       const { ring, records, maxRecords, fence } = request;
       const { insert, trim, clear } = getRingStatements();

--- a/electron/services/persistence/dbWorkerProtocol.ts
+++ b/electron/services/persistence/dbWorkerProtocol.ts
@@ -2,6 +2,15 @@ export interface DbWorkerData {
   dbPath: string;
 }
 
+/**
+ * Verdict on a SQLite file's integrity. "unknown" (could not be verified — the
+ * file is missing, locked, or unreadable) is deliberately distinct from
+ * "corrupt" (quick_check proved it bad): a caller about to overwrite the last
+ * known-good backup must treat both as "do not promote", but only "corrupt" is
+ * evidence that the source database itself is damaged.
+ */
+export type DbProbeResult = "ok" | "corrupt" | "unknown";
+
 export type DbWorkerOp =
   | { op: "checkpoint"; mode: "PASSIVE" | "TRUNCATE" }
   | { op: "quickCheck" }

--- a/electron/services/persistence/dbWorkerProtocol.ts
+++ b/electron/services/persistence/dbWorkerProtocol.ts
@@ -5,6 +5,10 @@ export interface DbWorkerData {
 export type DbWorkerOp =
   | { op: "checkpoint"; mode: "PASSIVE" | "TRUNCATE" }
   | { op: "quickCheck" }
+  // Full quick_check against an arbitrary SQLite file (not the worker's own
+  // connection) — used to verify a freshly written backup before it replaces
+  // the last known-good one. Resolves true only on an exact "ok".
+  | { op: "probePath"; dbPath: string }
   | { op: "ringWriteAll"; ring: string; records: string[]; maxRecords: number }
   | { op: "close" };
 
@@ -13,7 +17,7 @@ export type DbWorkerOp =
 // user_version inside its immediate write transaction and no-ops any ring
 // write whose epoch no longer matches — this is how main invalidates stale
 // queued snapshots after a degrade or a shutdown-drain timeout. Idempotent ops
-// (checkpoint, quickCheck) ignore it.
+// (checkpoint, quickCheck, probePath) ignore it.
 export type DbWorkerRequest = DbWorkerOp & { id: number; fence: number };
 
 export type DbWorkerResponse =

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -119,6 +119,14 @@ export type SettingsRecovery =
   | { kind: "restored-from-backup"; quarantinedPath?: string }
   | { kind: "reset-to-defaults"; quarantinedPath?: string };
 
+/**
+ * Describes how the SQLite database recovered from corruption at startup.
+ * `quarantinedPath` is absent when the corrupt file could not be preserved.
+ */
+export type DatabaseRecovery =
+  | { kind: "restored-from-backup"; quarantinedPath?: string }
+  | { kind: "reset-to-fresh"; quarantinedPath?: string };
+
 /** Describes a per-project state file that was quarantined due to corruption */
 export interface ProjectStateRecovery {
   quarantinedPath: string;
@@ -205,6 +213,12 @@ export interface HydrateResult {
   lastCrashAt?: number;
   settingsRecovery?: SettingsRecovery | null;
   projectStateRecovery?: ProjectStateRecovery | null;
+  /**
+   * Populated for the first hydrate after a boot where the SQLite database was
+   * found corrupt and either restored from its backup or recreated empty.
+   * One-shot: `DatabaseMaintenanceService.consumeRecovery()` clears it.
+   */
+  databaseRecovery?: DatabaseRecovery | null;
   /**
    * Populated only when the crash-loop state file was corrupt AND the boot
    * also tripped safe mode — the renderer banner gates on `safeMode === true`

--- a/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
+++ b/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { HydrateResult } from "@shared/types/ipc/app";
 
 const notifyMock = vi.hoisted(() => vi.fn());
+const showItemInFolderUnconfined = vi.hoisted(() => vi.fn<(path: string) => Promise<void>>());
 
 vi.mock("@/lib/notify", () => ({
   notify: (args: unknown) => notifyMock(args),
+}));
+
+vi.mock("@/clients/systemClient", () => ({
+  systemClient: { showItemInFolderUnconfined },
 }));
 
 const { dispatchRecoveryNotifications, __resetGpuAccelNotifiedForTests } =
@@ -23,6 +28,7 @@ function makeHydrateResult(overrides: Partial<HydrateResult>): HydrateResult {
     gpuAngleFallbackActive: false,
     safeMode: false,
     settingsRecovery: null,
+    databaseRecovery: null,
     projectStateRecovery: null,
     crashLoopStateRecovery: null,
   };
@@ -31,6 +37,8 @@ function makeHydrateResult(overrides: Partial<HydrateResult>): HydrateResult {
 
 beforeEach(() => {
   notifyMock.mockReset();
+  showItemInFolderUnconfined.mockReset();
+  showItemInFolderUnconfined.mockResolvedValue(undefined);
   __resetGpuAccelNotifiedForTests();
 });
 
@@ -38,6 +46,71 @@ describe("dispatchRecoveryNotifications", () => {
   it("does nothing when no recovery flags are set", () => {
     dispatchRecoveryNotifications(makeHydrateResult({}));
     expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  describe("database recovery", () => {
+    const QUARANTINED = "/u/daintree.db.corrupt-2026-01-01";
+
+    it("warns that the database was restored, and auto-dismisses", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          databaseRecovery: { kind: "restored-from-backup", quarantinedPath: QUARANTINED },
+        })
+      );
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      const arg = notifyMock.mock.calls[0]![0];
+      expect(arg).toMatchObject({
+        type: "warning",
+        title: "Database restored from backup",
+        priority: "high",
+        duration: 8000,
+        context: { eventKind: "recovery" },
+      });
+      expect(arg.message).toContain(QUARANTINED);
+    });
+
+    it("warns that the database was reset, and stays until dismissed", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          databaseRecovery: { kind: "reset-to-fresh", quarantinedPath: QUARANTINED },
+        })
+      );
+
+      const arg = notifyMock.mock.calls[0]![0];
+      expect(arg).toMatchObject({
+        type: "warning",
+        title: "Database reset",
+        priority: "high",
+        // A reset loses the project list — it must not disappear on its own.
+        duration: 0,
+      });
+      expect(arg.message).toContain(QUARANTINED);
+    });
+
+    it("reveals the quarantined file from the recovery action", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          databaseRecovery: { kind: "reset-to-fresh", quarantinedPath: QUARANTINED },
+        })
+      );
+
+      const { action } = notifyMock.mock.calls[0]![0];
+      expect(action.label).toBe("Show damaged file");
+      action.onClick();
+      expect(showItemInFolderUnconfined).toHaveBeenCalledWith(QUARANTINED);
+    });
+
+    it("omits the reveal action when the corrupt file could not be preserved", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({ databaseRecovery: { kind: "reset-to-fresh" } })
+      );
+
+      const arg = notifyMock.mock.calls[0]![0];
+      // Nothing to reveal — offering the action would open an empty folder.
+      expect(arg.action).toBeUndefined();
+      expect(arg.message).not.toContain("preserved at");
+    });
   });
 
   describe("GPU hardware acceleration", () => {

--- a/src/utils/stateHydration/recoveryNotifications.ts
+++ b/src/utils/stateHydration/recoveryNotifications.ts
@@ -1,4 +1,5 @@
 import { notify } from "@/lib/notify";
+import { systemClient } from "@/clients/systemClient";
 import type { HydrateResult } from "@shared/types/ipc/app";
 
 // One-shot guard so the GPU-disabled toast fires at most once per renderer
@@ -56,6 +57,41 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
         priority: "high",
         duration: 0,
         context: { eventKind: "recovery" },
+      });
+    }
+  }
+
+  if (hydrateResult.databaseRecovery) {
+    const { kind, quarantinedPath } = hydrateResult.databaseRecovery;
+    const pathNote = quarantinedPath ? `\nCorrupt file preserved at: ${quarantinedPath}` : "";
+    const revealAction = quarantinedPath
+      ? {
+          label: "Show damaged file",
+          onClick: () => {
+            void systemClient.showItemInFolderUnconfined(quarantinedPath);
+          },
+        }
+      : undefined;
+
+    if (kind === "restored-from-backup") {
+      notify({
+        type: "warning",
+        title: "Database restored from backup",
+        message: `Daintree's database was corrupted and has been restored from a backup. Projects or history added since that backup may be missing.${pathNote}`,
+        priority: "high",
+        duration: 8000,
+        context: { eventKind: "recovery" },
+        action: revealAction,
+      });
+    } else {
+      notify({
+        type: "warning",
+        title: "Database reset",
+        message: `Daintree's database was corrupted and no usable backup was available, so it started fresh. Re-add your projects to continue — your repositories and worktrees on disk are untouched.${pathNote}`,
+        priority: "high",
+        duration: 0,
+        context: { eventKind: "recovery" },
+        action: revealAction,
       });
     }
   }


### PR DESCRIPTION
## Summary

`electron/services/DatabaseMaintenanceService.ts` had four related bugs that together meant latent SQLite corruption could destroy the only good backup, silently, with no way for the user to find out:

1. `tick()` fired the deferred `quick_check` and the backup concurrently, so the first backup after a clean-exit boot could copy a database that had never actually been integrity-checked.
2. `runDeferredQuickCheck()` cleared its pending flag synchronously, before the async result landed. A corruption result, or a result that never ran at all because the DB worker was unavailable, left the check permanently marked done.
3. `runBackup()` renamed the temp file straight over the existing backup with no integrity probe. `sqlite.backup()` copies pages verbatim and never validates them, so a corrupt source produced a corrupt backup with no error at all, destroying the only good copy.
4. Boot-time recovery (restore-from-backup or reset-to-fresh) was `console.log` only. The user was never told their database had been rebuilt.

## Changes

- Every candidate backup is now integrity-probed before the rename promotes it. Added a path-parameterized `probePath` op on the DB worker (the probe logic is written inline there since the worker can't import `db.ts`, which pulls in Electron's `app`), with a main-thread fallback.
- Added `probeDbFile`, returning a strict tri-state (`ok` / `corrupt` / `unknown`). This mattered: the existing `probeDb` is fail-open by design, it returns `true` on non-corruption errors so a transient `EACCES` at boot can't quarantine a healthy database, which makes it exactly the wrong predicate for a destructive promotion. A truncated candidate throwing `SQLITE_IOERR_SHORT_READ` would have been renamed straight over the good backup under the old check. Now only a proven `ok` gets promoted, and only a proven `corrupt` stops backups.
- The deferred check stays pending until it returns exactly `ok`, guarded by an in-flight promise so overlapping ticks fire it once instead of racing. A worker-unavailable result retries on a later tick rather than masquerading as a pass. The backup is gated on the check only while one is actually outstanding, so ticks with nothing pending still back up straight from the timer callback with no added latency.
- A corrupt backup *copy* isn't treated as proof the source is corrupt (a faulty write can mangle just the temp file). It re-runs the full check against the live database and lets that decide. Confirmed live corruption, or repeated verification failures, suspends backups for the rest of the session, preserving the last good backup for the next boot's recovery. Recovery can't run against an open database, so stopping is the safe move.
- Recovery itself no longer destroys the backup. After a reset-to-fresh, the app comes up on an empty database, and the first idle tick would have copied that empty database straight over the user's last real data. A surviving backup is now always moved aside (preserved, not deleted). The restore path also stopped trusting the fail-open probe, and WAL/SHM sidecars are quarantined independently, since a stale WAL left beside the replacement database can be replayed straight into it.
- Boot-time recovery now actually reaches the user. `attemptRecovery` reports what happened and where the corrupt file went, threaded through a new optional `HydrateResult.databaseRecovery` to a warning notification with a "Show damaged file" action. It never claims a restore or reset that didn't happen, and it's also handed back when a pending crash makes the renderer discard the boot payload, since an unclean exit is exactly how a database gets corrupted in the first place, so that's the one scenario the notification exists for and it was being lost there.
- `dispose()`'s wait on an in-flight check is bounded to 2 seconds (the worker's request timeout is 30s, shutdown's hard cap is 10s), and it probes on the main thread rather than spawning a DB worker during teardown.

## Testing

327 tests across 15 suites pass locally, plus a full typecheck. New coverage includes: the backup gate holding until the check passes, a worker-unavailable check retrying instead of clearing, a corrupt candidate never reaching the rename with the good backup surviving every tick and shutdown, the unknown-vs-corrupt distinction, recovery reporting reset-to-fresh even when a later quarantine step fails, and the real worker thread probing arbitrary paths.

## Known limitation

A DB worker can still be spawned in the window between `shutdownDbWorker()` and the maintenance `dispose()` if an idle tick lands there. That's pre-existing (the tick's passive checkpoint already did this) and needs a `shutdown.ts` reordering to fix properly. Out of scope here.

Resolves #11105