### PR TITLE
Resolve IPC project context from sender identity, not the last-created window

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -84,11 +84,24 @@ vi.mock("electron", () => ({
   },
 }));
 
+const projectStoreMock = vi.hoisted(() => ({
+  getAllProjects: vi.fn(() => []),
+  getCurrentProjectId: vi.fn<() => string | null>(() => null),
+  addProject: vi.fn<(path: string) => Promise<{ id: string; path: string }>>(),
+  setCurrentProject: vi.fn<(id: string) => Promise<void>>(async () => {}),
+  getProjectById: vi.fn<(id: string) => { id: string; path: string } | null>(() => null),
+}));
+
 vi.mock("../services/ProjectStore.js", () => ({
-  projectStore: {
-    getAllProjects: vi.fn(() => []),
-    getCurrentProjectId: vi.fn(() => null),
-  },
+  projectStore: projectStoreMock,
+}));
+
+vi.mock("../ipc/projectSwitchBroadcast.js", () => ({
+  broadcastProjectSwitchUpdates: vi.fn(),
+}));
+
+vi.mock("../window/portDistribution.js", () => ({
+  distributePortsToView: vi.fn(),
 }));
 
 vi.mock("../ipc/channels.js", () => ({
@@ -108,10 +121,12 @@ vi.mock("../window/windowServices.js", () => ({
   getWorktreePortBrokerRef: vi.fn(),
 }));
 
-vi.mock("../window/windowRef.js", () => ({
-  getWindowRegistry: vi.fn(() => null),
-  getProjectViewManager: vi.fn(() => null),
+const windowRefMock = vi.hoisted(() => ({
+  getWindowRegistry: vi.fn<() => unknown>(() => null),
+  getProjectViewManager: vi.fn<() => unknown>(() => null),
 }));
+
+vi.mock("../window/windowRef.js", () => windowRefMock);
 
 const autoUpdaterServiceMock = vi.hoisted(() => {
   let menuState: "idle" | "checking" | "ready" = "idle";
@@ -150,7 +165,7 @@ vi.mock("../../shared/config/distribution.js", () => ({
   isWindowsStoreBuild: isWindowsStoreBuildMock,
 }));
 
-import { createApplicationMenu } from "../menu.js";
+import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
 import { webContents, app, Menu } from "electron";
 
 function findMenuItem(
@@ -691,5 +706,48 @@ describe("update menu lifecycle", () => {
 
       expect(() => dispatchUpdate("checking")).not.toThrow();
     });
+  });
+});
+
+// #11100: handleDirectoryOpen reached for the process-global ProjectViewManager,
+// which every new window overwrites. Opening a directory from an older window's
+// menu therefore switched the newest window's view instead of the one the user
+// clicked in.
+describe("handleDirectoryOpen window targeting", () => {
+  const PROJECT = { id: "project-a", path: "/repos/alpha" };
+
+  function createManager() {
+    return {
+      switchTo: vi.fn(async () => ({
+        view: { webContents: { isDestroyed: () => false, send: vi.fn() } },
+        isNew: true,
+      })),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStoreMock.addProject.mockResolvedValue(PROJECT);
+    projectStoreMock.getProjectById.mockReturnValue(PROJECT);
+    projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+  });
+
+  it("switches the view of the window the menu action came from, not the newest window", async () => {
+    const targetManager = createManager();
+    const newestManager = createManager();
+
+    // The user clicked in window 7; window 9 was created most recently, so it
+    // owns the global slot.
+    windowRefMock.getWindowRegistry.mockReturnValue({
+      getByWindowId: (id: number) =>
+        id === 7 ? { services: { projectViewManager: targetManager } } : undefined,
+    });
+    windowRefMock.getProjectViewManager.mockReturnValue(newestManager);
+
+    const targetWindow = { id: 7, isDestroyed: () => false } as unknown as Electron.BrowserWindow;
+    await handleDirectoryOpen(PROJECT.path, targetWindow);
+
+    expect(targetManager.switchTo).toHaveBeenCalledWith(PROJECT.id, PROJECT.path);
+    expect(newestManager.switchTo).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -116,6 +116,7 @@ vi.mock("../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: vi.fn(() => null),
   getAppWebContents: vi.fn(() => null),
   getAllAppWebContents: vi.fn(() => []),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("../../ipc/utils.js", async (importOriginal) => {

--- a/electron/ipc/__tests__/define.test.ts
+++ b/electron/ipc/__tests__/define.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: vi.fn(() => null),
   getAppWebContents: vi.fn(() => ({ send: undefined, isDestroyed: () => true })),
   getAllAppWebContents: vi.fn(() => []),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("../../window/windowRef.js", () => ({

--- a/electron/ipc/__tests__/utils.test.ts
+++ b/electron/ipc/__tests__/utils.test.ts
@@ -10,6 +10,11 @@ const browserWindowGetAllWindowsMock = vi.hoisted(() => vi.fn(() => [] as unknow
 const isCachedViewWebContentsMock = vi.hoisted(() => vi.fn((_id: number) => false));
 const getWebContentsForProjectMock = vi.hoisted(() => vi.fn((_projectId: string) => [] as never[]));
 const hasRegisteredProjectViewsMock = vi.hoisted(() => vi.fn(() => false));
+const getProjectForWebContentsMock = vi.hoisted(() =>
+  vi.fn<(id: number) => string | null>(() => null)
+);
+const getProjectViewManagerMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
+const isPerformanceCaptureEnabledMock = vi.hoisted(() => vi.fn<() => boolean>(() => false));
 
 vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
@@ -40,11 +45,25 @@ vi.mock("../../window/webContentsRegistry.js", () => ({
   isCachedViewWebContents: isCachedViewWebContentsMock,
   getWebContentsForProject: getWebContentsForProjectMock,
   hasRegisteredProjectViews: hasRegisteredProjectViewsMock,
+  getProjectForWebContents: getProjectForWebContentsMock,
 }));
 
+// Kept as an adversarial fixture: the multi-window suite below points this at
+// a manager that only knows the last-created window, so any regression back to
+// resolving `ctx.projectId` through the process-global manager fails loudly.
 vi.mock("../../window/windowRef.js", () => ({
-  getProjectViewManager: vi.fn(() => null),
+  getProjectViewManager: getProjectViewManagerMock,
 }));
+
+vi.mock("../../utils/performance.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils/performance.js")>();
+  return {
+    ...actual,
+    isPerformanceCaptureEnabled: isPerformanceCaptureEnabledMock,
+    markPerformance: vi.fn(),
+    sampleIpcTiming: vi.fn(),
+  };
+});
 
 import {
   sendToRenderer,
@@ -1053,5 +1072,129 @@ describe("restore quota", () => {
     _resetRateLimitQueuesForTest();
 
     expect(consumeRestoreQuota()).toBe(false);
+  });
+});
+
+// #11100: `ctx.projectId` used to be resolved through the process-global
+// ProjectViewManager, which every new window overwrites. Each manager only
+// knows its own window's views, so every window except the last-created one
+// resolved to null. These specs pin sender identity — not global state — as
+// the authority.
+describe("typedHandleWithContext multi-window project resolution", () => {
+  const WINDOW_A = { id: 1 };
+  const WINDOW_B = { id: 2 };
+  const SENDER_A = 101;
+  const SENDER_B = 202;
+
+  // The registry map spans every window; the manager map does not. Model both
+  // so a regression to the manager can be observed rather than assumed.
+  let viewToProject: Map<number, string>;
+
+  function invokeFrom(
+    registered: (...args: unknown[]) => unknown,
+    senderId: number
+  ): Promise<unknown> {
+    return Promise.resolve(registered({ sender: { id: senderId } }));
+  }
+
+  function lastRegisteredHandler(): (...args: unknown[]) => unknown {
+    const calls = ipcMainMock.handle.mock.calls as [string, (...args: unknown[]) => unknown][];
+    return calls[calls.length - 1][1];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetIpcGuardForTesting();
+    markIpcSecurityReady();
+
+    viewToProject = new Map([
+      [SENDER_A, "project-a"],
+      [SENDER_B, "project-b"],
+    ]);
+    getProjectForWebContentsMock.mockImplementation((id) => viewToProject.get(id) ?? null);
+    browserWindowFromWebContentsMock.mockImplementation((wc: { id: number }) =>
+      wc.id === SENDER_A ? WINDOW_A : WINDOW_B
+    );
+
+    // The process-global manager points at window B — the last window created.
+    // It has never heard of window A's view, which is exactly why the old
+    // lookup returned null for it.
+    getProjectViewManagerMock.mockReturnValue({
+      getProjectIdForWebContents: (id: number) => (id === SENDER_B ? "project-b" : null),
+    });
+    isPerformanceCaptureEnabledMock.mockReturnValue(false);
+  });
+
+  it.each([
+    ["capture disabled", false],
+    ["capture enabled", true],
+  ])(
+    "each window resolves its own project while the global manager knows only the newest (%s)",
+    async (_label, captureEnabled) => {
+      isPerformanceCaptureEnabledMock.mockReturnValue(captureEnabled);
+
+      const seen: { projectId: string | null; webContentsId: number }[] = [];
+      const handler = vi.fn((ctx: { projectId: string | null; webContentsId: number }) => {
+        seen.push({ projectId: ctx.projectId, webContentsId: ctx.webContentsId });
+        return { ok: true };
+      });
+      typedHandleWithContext("project:get:all" as never, handler as never);
+      const registered = lastRegisteredHandler();
+
+      await invokeFrom(registered, SENDER_A);
+      await invokeFrom(registered, SENDER_B);
+
+      expect(seen).toEqual([
+        { projectId: "project-a", webContentsId: SENDER_A },
+        { projectId: "project-b", webContentsId: SENDER_B },
+      ]);
+    }
+  );
+
+  it("resolution does not depend on which manager the global slot holds", async () => {
+    const handler = vi.fn((ctx: { projectId: string | null }) => ({ projectId: ctx.projectId }));
+    typedHandleWithContext("project:get:all" as never, handler as never);
+    const registered = lastRegisteredHandler();
+
+    const before = await invokeFrom(registered, SENDER_A);
+
+    // Focus/creation churn flips the global slot; sender A must be unmoved.
+    getProjectViewManagerMock.mockReturnValue({
+      getProjectIdForWebContents: (id: number) => (id === SENDER_A ? "project-a" : null),
+    });
+    const afterFlip = await invokeFrom(registered, SENDER_A);
+
+    getProjectViewManagerMock.mockReturnValue(null);
+    const afterClear = await invokeFrom(registered, SENDER_A);
+
+    expect(before).toEqual({ projectId: "project-a" });
+    expect(afterFlip).toEqual(before);
+    expect(afterClear).toEqual(before);
+  });
+
+  it("closing window B leaves window A's context intact", async () => {
+    const handler = vi.fn((ctx: { projectId: string | null }) => ({ projectId: ctx.projectId }));
+    typedHandleWithContext("project:get:all" as never, handler as never);
+    const registered = lastRegisteredHandler();
+
+    // Window B closes: its view is unregistered (id-scoped) and main.ts nulls
+    // the global manager slot. Window A is untouched by both.
+    viewToProject.delete(SENDER_B);
+    getProjectViewManagerMock.mockReturnValue(null);
+
+    await expect(invokeFrom(registered, SENDER_A)).resolves.toEqual({ projectId: "project-a" });
+    await expect(invokeFrom(registered, SENDER_B)).resolves.toEqual({ projectId: null });
+  });
+
+  it("an unbound window with no registered view resolves a null project", async () => {
+    const handler = vi.fn((ctx: { projectId: string | null }) => ({ projectId: ctx.projectId }));
+    typedHandleWithContext("project:get:all" as never, handler as never);
+    const registered = lastRegisteredHandler();
+
+    // Cmd+N windows sit on the project picker and are deliberately never
+    // registered as project views. Null means "unknown", not "unauthorized" —
+    // handlers that fail closed on it break these windows.
+    const UNBOUND_SENDER = 303;
+    await expect(invokeFrom(registered, UNBOUND_SENDER)).resolves.toEqual({ projectId: null });
   });
 });

--- a/electron/ipc/handlers/__tests__/keybinding.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/keybinding.adversarial.test.ts
@@ -22,6 +22,7 @@ const profileIoMock = vi.hoisted(() => ({
 
 const windowRegistryMock = vi.hoisted(() => ({
   getWindowForWebContents: vi.fn(),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("electron", () => ({

--- a/electron/ipc/handlers/__tests__/portal.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/portal.adversarial.test.ts
@@ -54,6 +54,7 @@ vi.mock("electron", () => ({
 vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: getWindowForWebContentsMock,
   getAppWebContents: getAppWebContentsMock,
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 import { CHANNELS } from "../../channels.js";

--- a/electron/ipc/handlers/__tests__/project.getCurrent.test.ts
+++ b/electron/ipc/handlers/__tests__/project.getCurrent.test.ts
@@ -53,6 +53,7 @@ vi.mock("../../../services/RunCommandDetector.js", () => ({
 const mockGetWindowForWebContents = vi.fn();
 vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: (...args: unknown[]) => mockGetWindowForWebContents(...args),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("../../../window/portDistribution.js", () => ({

--- a/electron/ipc/handlers/__tests__/project.openDialog.test.ts
+++ b/electron/ipc/handlers/__tests__/project.openDialog.test.ts
@@ -50,6 +50,7 @@ vi.mock("../../../services/RunCommandDetector.js", () => ({
 const mockGetWindowForWebContents = vi.fn();
 vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: (...args: unknown[]) => mockGetWindowForWebContents(...args),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("../../../window/portDistribution.js", () => ({

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -74,6 +74,7 @@ vi.mock("../../../window/webContentsRegistry.js", () => ({
   // Returning [] keeps the broadcast a no-op in this suite; PROJECT_UPDATED
   // delivery is covered by projectSwitchBroadcast.test.ts.
   getAllAppWebContents: vi.fn(() => []),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("../../../window/portDistribution.js", () => ({

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: vi.fn(() => null),
   getAppWebContents: vi.fn(),
   getAllAppWebContents: vi.fn(() => []),
+  getProjectForWebContents: vi.fn(() => null),
 }));
 
 vi.mock("../../../window/windowRef.js", () => ({

--- a/electron/ipc/handlers/terminal/__tests__/io.projectIsolation.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/io.projectIsolation.test.ts
@@ -134,16 +134,32 @@ describe("terminal worker ingest port — cross-project ownership", () => {
     expect(distributeTerminalWorkerPortToViewMock).toHaveBeenCalledTimes(2);
   });
 
-  it("allows a terminal with no recorded owner — null means unknown, not unauthorized", async () => {
-    // Terminals spawned by an unbound (Cmd+N) window carry no project id, and
-    // that window's view is deliberately never registered. Both sides of the
-    // gate can be null; only a proven mismatch may be rejected.
+  it("serves an unbound window its own projectless terminal", async () => {
+    // A Cmd+N window sits on the project picker: its view is deliberately never
+    // registered, so its context project is null, and the default terminal it
+    // spawns carries no owner either. Null must match null, or these windows
+    // lose their dedicated port for no reason.
     getProjectForWebContentsMock.mockReturnValue(null);
 
     await expect(requestIngestPort(SENDER_A, "term-unowned")).resolves.toEqual({
       token: "port-token",
     });
     expect(distributeTerminalWorkerPortToViewMock).toHaveBeenCalledOnce();
+  });
+
+  // The two asymmetric cases. Null is an identity, not a wildcard: the pty-host
+  // skips its per-window filter entirely when a window's project is null, so a
+  // port minted for either mismatch would be fed real bytes.
+  it("refuses a null-context sender a project-owned terminal", async () => {
+    getProjectForWebContentsMock.mockReturnValue(null);
+
+    await expect(requestIngestPort(SENDER_A, "term-b")).resolves.toBeNull();
+    expect(distributeTerminalWorkerPortToViewMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a project-bound sender an unowned terminal", async () => {
+    await expect(requestIngestPort(SENDER_A, "term-unowned")).resolves.toBeNull();
+    expect(distributeTerminalWorkerPortToViewMock).not.toHaveBeenCalled();
   });
 
   it("returns null for a terminal that no longer exists", async () => {

--- a/electron/ipc/handlers/terminal/__tests__/io.projectIsolation.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/io.projectIsolation.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #11100: the cross-project ownership gate on the worker ingest port is only
+ * as good as `ctx.projectId`. While that resolved through the process-global
+ * ProjectViewManager, every window except the last-created one resolved null
+ * and the gate failed open — a terminal in project B could be handed a live
+ * ingest port to a window sitting on project A.
+ *
+ * These specs drive the real `defineIpcNamespace` → `typedHandleWithContext`
+ * chain so the context is built by production code, not by the fixture.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  BrowserWindow: { fromWebContents: vi.fn(() => null), getAllWindows: () => [] },
+  webContents: { fromId: vi.fn(() => null) },
+}));
+
+const getWindowForWebContentsMock = vi.hoisted(() =>
+  vi.fn<(wc: { id: number }) => unknown>(() => null)
+);
+const getProjectForWebContentsMock = vi.hoisted(() =>
+  vi.fn<(id: number) => string | null>(() => null)
+);
+
+vi.mock("../../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: getWindowForWebContentsMock,
+  getProjectForWebContents: getProjectForWebContentsMock,
+  getAppWebContents: vi.fn(() => null),
+  getAllAppWebContents: vi.fn(() => []),
+  getWebContentsForProject: vi.fn(() => []),
+  hasRegisteredProjectViews: vi.fn(() => true),
+  isCachedViewWebContents: vi.fn(() => false),
+}));
+
+const distributeTerminalWorkerPortToViewMock = vi.hoisted(() =>
+  vi.fn(() => ({ token: "port-token" }))
+);
+
+vi.mock("../../../../window/portDistribution.js", () => ({
+  distributeTerminalWorkerPortToView: distributeTerminalWorkerPortToViewMock,
+  releaseTerminalWorkerPort: vi.fn(),
+}));
+
+import { CHANNELS } from "../../../channels.js";
+import { registerTerminalIOHandlers } from "../io.js";
+import { _resetIpcGuardForTesting, markIpcSecurityReady } from "../../../ipcGuard.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+const WINDOW_A = 1;
+const WINDOW_B = 2;
+const SENDER_A = 101;
+const SENDER_B = 202;
+
+/** Window A is on project A; window B — created later — is on project B. */
+const VIEW_TO_PROJECT = new Map([
+  [SENDER_A, "project-a"],
+  [SENDER_B, "project-b"],
+]);
+
+/** Terminal "term-b" belongs to project B, i.e. to window B. */
+const TERMINALS = new Map([
+  ["term-a", { id: "term-a", projectId: "project-a" }],
+  ["term-b", { id: "term-b", projectId: "project-b" }],
+  ["term-unowned", { id: "term-unowned", projectId: null }],
+]);
+
+function buildDeps(): HandlerDependencies {
+  const windowContexts = new Map([
+    [WINDOW_A, { windowId: WINDOW_A, services: {} }],
+    [WINDOW_B, { windowId: WINDOW_B, services: {} }],
+  ]);
+
+  return {
+    ptyClient: {
+      getTerminalAsync: vi.fn((id: string) => Promise.resolve(TERMINALS.get(id) ?? null)),
+    },
+    windowRegistry: {
+      getByWindowId: (id: number) => windowContexts.get(id),
+    },
+  } as unknown as HandlerDependencies;
+}
+
+/** Invoke the registered ingest-port handler as the given renderer. */
+function requestIngestPort(senderId: number, terminalId: string): Promise<unknown> {
+  const call = ipcMainMock.handle.mock.calls.find(
+    ([channel]) => channel === CHANNELS.TERMINAL_REQUEST_WORKER_INGEST_PORT
+  );
+  if (!call) throw new Error("ingest-port handler was never registered");
+  const registered = call[1] as (...args: unknown[]) => Promise<unknown>;
+  return registered({ sender: { id: senderId } }, terminalId);
+}
+
+describe("terminal worker ingest port — cross-project ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetIpcGuardForTesting();
+    markIpcSecurityReady();
+
+    getProjectForWebContentsMock.mockImplementation((id) => VIEW_TO_PROJECT.get(id) ?? null);
+    getWindowForWebContentsMock.mockImplementation((wc) =>
+      wc.id === SENDER_A ? { id: WINDOW_A } : { id: WINDOW_B }
+    );
+    distributeTerminalWorkerPortToViewMock.mockReturnValue({ token: "port-token" });
+
+    registerTerminalIOHandlers(buildDeps());
+  });
+
+  it("refuses to mint a port for a terminal owned by another window's project", async () => {
+    await expect(requestIngestPort(SENDER_A, "term-b")).resolves.toBeNull();
+    expect(distributeTerminalWorkerPortToViewMock).not.toHaveBeenCalled();
+  });
+
+  it("mints a port for a terminal the sender's own project owns", async () => {
+    await expect(requestIngestPort(SENDER_B, "term-b")).resolves.toEqual({ token: "port-token" });
+    expect(distributeTerminalWorkerPortToViewMock).toHaveBeenCalledOnce();
+  });
+
+  it("both windows are served their own terminal in the same session", async () => {
+    const [a, b] = await Promise.all([
+      requestIngestPort(SENDER_A, "term-a"),
+      requestIngestPort(SENDER_B, "term-b"),
+    ]);
+
+    expect(a).toEqual({ token: "port-token" });
+    expect(b).toEqual({ token: "port-token" });
+    expect(distributeTerminalWorkerPortToViewMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a terminal with no recorded owner — null means unknown, not unauthorized", async () => {
+    // Terminals spawned by an unbound (Cmd+N) window carry no project id, and
+    // that window's view is deliberately never registered. Both sides of the
+    // gate can be null; only a proven mismatch may be rejected.
+    getProjectForWebContentsMock.mockReturnValue(null);
+
+    await expect(requestIngestPort(SENDER_A, "term-unowned")).resolves.toEqual({
+      token: "port-token",
+    });
+    expect(distributeTerminalWorkerPortToViewMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns null for a terminal that no longer exists", async () => {
+    await expect(requestIngestPort(SENDER_A, "gone")).resolves.toBeNull();
+    expect(distributeTerminalWorkerPortToViewMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -324,6 +324,10 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     // Ownership gate: the terminal must exist and belong to the sender's
     // project. The host's per-window project filter already starves a foreign
     // dedicated port of bytes; this refuses to mint one in the first place.
+    // Only a *proven* mismatch is rejected: a null id on either side means
+    // "unknown owner", not "unauthorized". Unbound windows (Cmd+N, showing the
+    // project picker) are deliberately not registered as project views yet own
+    // a default terminal, so failing closed on null would break them.
     const info = await ptyClient.getTerminalAsync(id);
     if (!info) return null;
     if (info.projectId != null && ctx.projectId != null && info.projectId !== ctx.projectId) {

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -321,16 +321,19 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     const win = ctx.senderWindow;
     const wctx = win ? deps.windowRegistry?.getByWindowId(win.id) : undefined;
     if (!win || !wctx) return null;
-    // Ownership gate: the terminal must exist and belong to the sender's
-    // project. The host's per-window project filter already starves a foreign
-    // dedicated port of bytes; this refuses to mint one in the first place.
-    // Only a *proven* mismatch is rejected: a null id on either side means
-    // "unknown owner", not "unauthorized". Unbound windows (Cmd+N, showing the
-    // project picker) are deliberately not registered as project views yet own
-    // a default terminal, so failing closed on null would break them.
+    // Ownership gate: the terminal's owner must EQUAL the sender's project.
+    // Null is an identity here, not a wildcard — the two must still match, so
+    // an unbound window (Cmd+N, project picker) still gets a port for its own
+    // projectless default terminal, but a null-context sender cannot reach a
+    // project-owned terminal. Nothing downstream re-checks this: the pty-host's
+    // per-window filter skips windows whose project is null, so a foreign port
+    // minted here would be fed for real (#11100).
+    //
+    // A refusal costs the renderer only its dedicated parse-worker port, not
+    // the terminal — LiveWorkerIngest falls back to the shared ingest path.
     const info = await ptyClient.getTerminalAsync(id);
     if (!info) return null;
-    if (info.projectId != null && ctx.projectId != null && info.projectId !== ctx.projectId) {
+    if ((info.projectId ?? null) !== ctx.projectId) {
       return null;
     }
     return distributeTerminalWorkerPortToView(win, wctx, ctx.event.sender, ptyClient, id);

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -4,11 +4,11 @@ import {
   getWindowForWebContents,
   getAppWebContents,
   getAllAppWebContents,
+  getProjectForWebContents,
   getWebContentsForProject,
   hasRegisteredProjectViews,
   isCachedViewWebContents,
 } from "../window/webContentsRegistry.js";
-import { getProjectViewManager } from "../window/windowRef.js";
 import type { IpcInvokeMap, IpcEventMap } from "../types/index.js";
 import type { IpcContext } from "./types.js";
 import { ValidationError } from "./validationError.js";
@@ -527,6 +527,27 @@ export function typedHandleValidated<K extends keyof IpcInvokeMap, S extends z.Z
   return typedHandle(channel, wrapped);
 }
 
+/**
+ * Build the per-request {@link IpcContext} from the sender's identity.
+ *
+ * The project must come from `webContentsRegistry`, whose map spans every
+ * window: a `ProjectViewManager` only knows its own window's views, so
+ * resolving through one would return null for every sender outside it
+ * (#11100). `projectId` is legitimately null for senders with no project
+ * binding — an unbound "new window" showing the project picker, or a view
+ * whose project has not been registered yet — so handlers must treat it as
+ * "unknown", never as "unauthorized".
+ */
+function buildIpcContext(event: Electron.IpcMainInvokeEvent): IpcContext {
+  const webContentsId = event.sender.id;
+  return {
+    event,
+    webContentsId,
+    senderWindow: getWindowForWebContents(event.sender),
+    projectId: getProjectForWebContents(webContentsId),
+  };
+}
+
 export function typedHandleWithContext<K extends keyof IpcInvokeMap>(
   channel: K,
   handler: (
@@ -542,20 +563,14 @@ export function typedHandleWithContext<K extends keyof IpcInvokeMap>(
 
   if (!captureEnabled) {
     ipcMain.handle(channel as string, (event, ...args) => {
-      const webContentsId = event.sender.id;
-      const senderWindow = getWindowForWebContents(event.sender);
-      const projectId = getProjectViewManager()?.getProjectIdForWebContents(webContentsId) ?? null;
-      const ctx: IpcContext = { event, webContentsId, senderWindow, projectId };
+      const ctx = buildIpcContext(event);
       return handler(ctx, ...(args as IpcInvokeMap[K]["args"]));
     });
     return () => ipcMain.removeHandler(channel as string);
   }
 
   ipcMain.handle(channel as string, async (event, ...args) => {
-    const webContentsId = event.sender.id;
-    const senderWindow = getWindowForWebContents(event.sender);
-    const projectId = getProjectViewManager()?.getProjectIdForWebContents(webContentsId) ?? null;
-    const ctx: IpcContext = { event, webContentsId, senderWindow, projectId };
+    const ctx = buildIpcContext(event);
 
     const traceId = `${String(channel)}-${Date.now().toString(36)}-${(++requestCounter).toString(36)}`;
     const startedAt = performance.now();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -360,11 +360,13 @@ if (!gotTheLock) {
         const broker = getWorktreePortBrokerRef();
         const wsClient = getWorkspaceClientRef();
         if (broker && wsClient) {
-          const pvm = getProjectViewManager();
-          const projectId = pvm?.getProjectIdForWebContents(wc.id);
+          // This window's own manager, not the process-global one: the global
+          // points at the last-created window, so an older window's view
+          // reload would broker no port at all (#11100).
+          const projectId = pvm.getProjectIdForWebContents(wc.id);
           if (projectId) {
             // Find the project path from PVM to look up the host
-            const viewEntry = pvm?.getAllViews().find((v) => v.projectId === projectId);
+            const viewEntry = pvm.getAllViews().find((v) => v.projectId === projectId);
             if (viewEntry) {
               const host = wsClient.getHostForProject(viewEntry.projectPath);
               if (host) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -405,6 +405,13 @@ if (!gotTheLock) {
         // one-shot push was dropped on a true cold restore. No push needed here.
       },
     });
+    // Publish to this window's context immediately, not later in
+    // setupWindowServices: the renderer starts loading inside that call, so
+    // anything resolving the manager per-window (crash classification, the
+    // directory-open menu action) would otherwise see no manager for a window
+    // that has one, and fall back to a global or legacy path (#11100).
+    // setupWindowServices reassigns the same instance.
+    ctx.services.projectViewManager = pvm;
     setProjectViewManager(pvm);
 
     // Sync this window's fresh PVM to the live resource profile — the

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -9,7 +9,7 @@ import { isAssistantOnlyAgentId } from "../shared/config/agentIds.js";
 import type { CliAvailabilityService } from "./services/CliAvailabilityService.js";
 import { isAgentInstalled } from "../shared/utils/agentAvailability.js";
 import * as CliInstallService from "./services/CliInstallService.js";
-import { getWindowRegistry, getProjectViewManager } from "./window/windowRef.js";
+import { getWindowRegistry } from "./window/windowRef.js";
 import {
   getPtyClient,
   getWorkspaceClientRef,
@@ -607,8 +607,11 @@ export async function handleDirectoryOpen(
   try {
     const project = await projectStore.addProject(directoryPath);
 
-    // Use ProjectViewManager for multi-view switching when available
-    const pvm = getProjectViewManager();
+    // Use the target window's own ProjectViewManager for multi-view switching
+    // when available. The process-global manager points at the last-created
+    // window, so opening a directory from an older window's menu would switch
+    // the wrong window's view (#11100).
+    const pvm = getWindowRegistry()?.getByWindowId(targetWindow.id)?.services.projectViewManager;
     if (pvm) {
       const { view, isNew } = await pvm.switchTo(project.id, project.path);
       // Capture the outgoing project id before the pointer flips so we can

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -253,6 +253,27 @@ describe("webContentsRegistry", () => {
     expect(isCachedViewWebContents(wc.id)).toBe(false);
   });
 
+  // #11100: the IPC context reads projects from this map precisely because it
+  // spans windows, unlike a per-window ProjectViewManager. Both properties it
+  // relies on are pinned here: senders resolve independently, and teardown is
+  // scoped to the id that went away.
+  it("resolves each window's project independently and survives another window's teardown", async () => {
+    const { getProjectForWebContents, registerProjectView } = await loadRegistry();
+    const viewA = createWebContents(301);
+    const viewB = createWebContents(302);
+
+    registerProjectView("project-a", viewA as unknown as WebContents);
+    registerProjectView("project-b", viewB as unknown as WebContents);
+
+    expect(getProjectForWebContents(viewA.id)).toBe("project-a");
+    expect(getProjectForWebContents(viewB.id)).toBe("project-b");
+
+    viewB.emitDestroyed();
+
+    expect(getProjectForWebContents(viewB.id)).toBeNull();
+    expect(getProjectForWebContents(viewA.id)).toBe("project-a");
+  });
+
   it("clears the cached mark on unregisterProjectView so a reused id is never silenced", async () => {
     const {
       isCachedViewWebContents,

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -5,7 +5,8 @@ import {
   registerWebContents,
   registerAppView,
 } from "./webContentsRegistry.js";
-import { getProjectViewManager } from "./windowRef.js";
+import { getWindowRegistry } from "./windowRef.js";
+import type { ProjectViewManager } from "./ProjectViewManager.js";
 import path from "path";
 import { createWindowWithState } from "../windowState.js";
 import { store } from "../store.js";
@@ -57,6 +58,17 @@ const CRASH_LOOP_THRESHOLD = 3;
 
 function getAvailableMemoryMb(): number | null {
   return readAvailableSystemMemoryMb();
+}
+
+/**
+ * This window's own ProjectViewManager. Resolve it at call time and never
+ * hoist it: the window's services are wired after `setupBrowserWindow`
+ * returns, and the manager's active view changes as the user switches
+ * projects. Reaching for the process-global manager here would act on the
+ * last-created window instead of this one (#11100).
+ */
+function getProjectViewManagerFor(win: BrowserWindow): ProjectViewManager | null {
+  return getWindowRegistry()?.getByWindowId(win.id)?.services.projectViewManager ?? null;
 }
 
 let windowIpcHandlersRegistered = false;
@@ -330,7 +342,7 @@ export function setupBrowserWindow(
           unresponsiveDialogOpen = false;
           if (response === 1 && !win.isDestroyed()) {
             console.warn("[MAIN] User triggered force-restart of unresponsive renderer");
-            const activeWc = getProjectViewManager()?.getActiveView()?.webContents;
+            const activeWc = getProjectViewManagerFor(win)?.getActiveView()?.webContents;
             const target = activeWc && !activeWc.isDestroyed() ? activeWc : appWebContents;
             if (!target.isDestroyed()) target.forcefullyCrashRenderer();
           }
@@ -577,7 +589,7 @@ export function setupBrowserWindow(
     }
 
     const availableMb = getAvailableMemoryMb();
-    const lowMemThresholdMb = getProjectViewManager()?.getLowMemoryFreeThresholdMb() ?? null;
+    const lowMemThresholdMb = getProjectViewManagerFor(win)?.getLowMemoryFreeThresholdMb() ?? null;
     const isProbableOom =
       details.reason === "oom" ||
       ((details.reason === "crashed" || details.reason === "killed") &&


### PR DESCRIPTION
## Summary

- IPC context resolution was keyed off a single process-global `ProjectViewManager`, so any window other than the most-recently-created one resolved `ctx.projectId` to `null`. Around 97 handlers consume that context; the terminal write guard failed open and the help handlers failed closed as a result.
- Both branches of `typedHandleWithContext` now resolve context through sender identity via a shared `buildIpcContext` helper, backed by the cross-window `viewToProject` map that already lives in `webContentsRegistry`.
- With `ctx.projectId` resolving correctly, a second hole showed up in the terminal ownership gate: a `null` project id on either side acted as a wildcard. That gate now requires exact equality.

Resolves #11100

## The bug

`electron/window/windowRef.ts` holds a process-global `ProjectViewManager` that every new window overwrites and every window close nulls out. `typedHandleWithContext` in `electron/ipc/utils.ts` resolved `ctx.projectId` through that global, but each manager instance only knows about its own window's views. IPC from any window other than the last-created one looked up its webContents id in the wrong window's map and resolved to `null`.

## The fix

`webContentsRegistry` already maintains a `viewToProject` map that spans every window, keyed by webContents id and populated by every `ProjectViewManager` instance. That's the source of truth now: both branches of `typedHandleWithContext` build context through one shared `buildIpcContext` helper that calls `getProjectForWebContents(webContentsId)`. The two branches carried identical copies of the same bug, so collapsing them into one removes the divergence hazard instead of fixing it twice. The per-instance manager map and the registry map are written and deleted in lockstep (`ProjectViewManager` 310/311, `ProjectViewSwitchController` 238/239, `ProjectViewLifecycleController` 455/456), so this is behavior-identical for the correct window and only changes anything for the wrong-window case.

Three more sites reached per-window state through the same global and needed the same treatment:

- `main.ts`'s `onViewReady` used the global instead of the `pvm` already sitting in its closure scope, so reloading a view in an older window failed to broker a port.
- `createWindow.ts`: the unresponsive-window "Restart view" dialog force-crashed the newest window's view regardless of which window actually hung, and the low-memory check read another window's OOM threshold. Both now resolve `getWindowRegistry()?.getByWindowId(win.id)` lazily when the handler fires, not at setup time, which would just reintroduce the same stale-reference bug.
- `menu.ts`'s `handleDirectoryOpen` received the correct target window as an argument but called `switchTo` on the global manager, switching the wrong window's view.

Each window's manager is now published into its `WindowContext` at construction instead of partway through `setupWindowServices`, since the renderer starts loading during that call and crash classification / directory-open could otherwise run against a window whose manager wasn't published yet.

## Terminal ownership gate hardened

With `ctx.projectId` resolving correctly, the guard in `electron/terminal/io.ts` still had a hole: it only rejected a *proven* mismatch, so a `null` project id on either side acted as a wildcard. Nothing downstream double-checks this; `pty-host.ts` skips its per-window filter entirely when a window's project is `null`, so a port minted for a null-context sender would genuinely get fed a foreign project's bytes. The gate now requires exact equality. `null` is its own identity, not a wildcard: an unbound window (Cmd+N, no project attached) still gets a port for its own projectless default terminal, but can no longer reach a project-owned one. A refusal only costs the dedicated parse-worker ingest port; `LiveWorkerIngest` falls back to the shared ingest path, so the terminal keeps working.

Three senderless MCP/plugin dispatcher fallbacks are deliberately untouched. They already resolve per-window as their primary path and only reach for the global when there's no sender at all.

## Testing

New regression tests cover multi-window context resolution (both the capture and non-capture branches), independence from the global slot, closing window B leaving window A's context intact, the unbound-window null case, cross-window registry teardown isolation, cross-project ingest-port rejection in both null directions, and menu window targeting.

Every new test was validated red-before-green: reverting the production fix fails exactly the tests that should fail, while the unbound-window guard stays green under both, confirming the hardening didn't overshoot.

11,789 tests across 510 files pass locally. `tsc -b electron` is clean. eslint/prettier are clean on changed files with zero new warnings.
