### PR TITLE
fix(window): use platform-appropriate fullscreen APIs; wire Project Settings menu item

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -128,6 +128,11 @@ const windowRefMock = vi.hoisted(() => ({
 
 vi.mock("../window/windowRef.js", () => windowRefMock);
 
+const toggleWindowFullscreenMock = vi.hoisted(() => vi.fn<(win: unknown) => boolean>(() => true));
+vi.mock("../window/fullscreen.js", () => ({
+  toggleWindowFullscreen: toggleWindowFullscreenMock,
+}));
+
 const autoUpdaterServiceMock = vi.hoisted(() => {
   let menuState: "idle" | "checking" | "ready" = "idle";
   return {
@@ -304,6 +309,53 @@ describe("createApplicationMenu", () => {
         actionId: "project.cloneRepo",
         args: undefined,
       });
+    });
+  });
+
+  describe("File menu Project Settings item", () => {
+    afterEach(() => {
+      // mockReturnValue survives vi.clearAllMocks(), so restore the default or an
+      // active project leaks into every later test in this file.
+      projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+    });
+
+    function rebuildWithProject(projectId: string | null): Electron.MenuItemConstructorOptions {
+      projectStoreMock.getCurrentProjectId.mockReturnValue(projectId);
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+      const item = findMenuItem(capturedTemplate, "File", "Project Settings…");
+      expect(item).toBeDefined();
+      return item!;
+    }
+
+    it("sends the project-settings action, not the app-settings one", () => {
+      const item = rebuildWithProject("project-1");
+      item.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(mockWebContents.send).toHaveBeenCalledWith("menu-action", {
+        actionId: "project.settings.open",
+        args: undefined,
+      });
+    });
+
+    it("is enabled only while a project is active", () => {
+      expect(rebuildWithProject("project-1").enabled).toBe(true);
+      expect(rebuildWithProject(null).enabled).toBe(false);
+    });
+  });
+
+  describe("View menu Toggle Full Screen item", () => {
+    it("delegates to the shared platform-aware fullscreen helper", () => {
+      const item = findMenuItem(capturedTemplate, "View", "Toggle Full Screen");
+      expect(item).toBeDefined();
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(toggleWindowFullscreenMock).toHaveBeenCalledWith(mockBrowserWindow);
     });
   });
 
@@ -579,7 +631,7 @@ describe("update menu lifecycle", () => {
       expect(settings).toBeDefined();
       expect(settings!.accelerator).toBe("CommandOrControl+,");
 
-      expect(items.some((i) => i.label === "Project Settings")).toBe(true);
+      expect(items.some((i) => i.label === "Project Settings…")).toBe(true);
     });
 
     it("on linux: File menu ends with separator + Exit (role: quit) and exposes Settings... with CommandOrControl+,", () => {

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -630,8 +630,6 @@ describe("update menu lifecycle", () => {
       const settings = items.find((i) => i.label === "Settings…");
       expect(settings).toBeDefined();
       expect(settings!.accelerator).toBe("CommandOrControl+,");
-
-      expect(items.some((i) => i.label === "Project Settings…")).toBe(true);
     });
 
     it("on linux: File menu ends with separator + Exit (role: quit) and exposes Settings... with CommandOrControl+,", () => {

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -10,6 +10,7 @@ import type { CliAvailabilityService } from "./services/CliAvailabilityService.j
 import { isAgentInstalled } from "../shared/utils/agentAvailability.js";
 import * as CliInstallService from "./services/CliInstallService.js";
 import { getWindowRegistry } from "./window/windowRef.js";
+import { toggleWindowFullscreen } from "./window/fullscreen.js";
 import {
   getPtyClient,
   getWorkspaceClientRef,
@@ -219,9 +220,10 @@ export function createApplicationMenu(
             ]
           : []),
         {
-          label: "Project Settings",
+          label: "Project Settings…",
+          enabled: !!projectStore.getCurrentProjectId(),
           click: (_item, browserWindow) =>
-            sendAction("app.settings", getTargetBrowserWindow(browserWindow)),
+            sendAction("project.settings.open", getTargetBrowserWindow(browserWindow)),
         },
         ...(filePluginItems.length > 0 ? [{ type: "separator" as const }, ...filePluginItems] : []),
         { type: "separator" },
@@ -384,9 +386,7 @@ export function createApplicationMenu(
           click: (_item, browserWindow) => {
             const win = getTargetBrowserWindow(browserWindow);
             if (!win) return;
-            // Use simpleFullScreen for pre-Lion behavior that extends into the notch area
-            const isSimpleFullScreen = win.isSimpleFullScreen();
-            win.setSimpleFullScreen(!isSimpleFullScreen);
+            toggleWindowFullscreen(win);
           },
         },
         ...(viewPluginItems.length > 0 ? [{ type: "separator" as const }, ...viewPluginItems] : []),

--- a/electron/window/__tests__/fullscreen.test.ts
+++ b/electron/window/__tests__/fullscreen.test.ts
@@ -51,15 +51,6 @@ describe("toggleWindowFullscreen", () => {
       expect(win.setFullScreen).not.toHaveBeenCalled();
     });
 
-    it("round-trips windowed → simple fullscreen → windowed", () => {
-      const win = createTarget();
-
-      expect(toggleWindowFullscreen(win)).toBe(true);
-      expect(toggleWindowFullscreen(win)).toBe(false);
-      expect(win.setSimpleFullScreen).toHaveBeenNthCalledWith(1, true);
-      expect(win.setSimpleFullScreen).toHaveBeenNthCalledWith(2, false);
-    });
-
     // A macOS window reaches native fullscreen via the green traffic-light button,
     // and restoreWindowState reopens a saved-fullscreen window with setFullScreen(true).
     // Toggling out of that must exit native rather than stack simple fullscreen on top.
@@ -71,6 +62,9 @@ describe("toggleWindowFullscreen", () => {
       expect(win.setSimpleFullScreen).not.toHaveBeenCalled();
     });
 
+    // The pre-fix code could stack simple fullscreen onto a natively-fullscreen
+    // window, so an upgrading user can start in this state. Unwind the simple
+    // layer first and leave AppKit's async native layer for the next toggle.
     it("exits simple fullscreen without touching native fullscreen when both report active", () => {
       const win = createTarget({ simple: true, native: true });
 
@@ -108,19 +102,5 @@ describe("toggleWindowFullscreen", () => {
       expect(win.setSimpleFullScreen).not.toHaveBeenCalled();
       expect(win.isSimpleFullScreen).not.toHaveBeenCalled();
     });
-  });
-
-  it("reads process.platform per call rather than capturing it at module load", () => {
-    const mac = createTarget();
-    setPlatform("darwin");
-    toggleWindowFullscreen(mac);
-
-    const win32 = createTarget();
-    setPlatform("win32");
-    toggleWindowFullscreen(win32);
-
-    expect(mac.setSimpleFullScreen).toHaveBeenCalledWith(true);
-    expect(win32.setFullScreen).toHaveBeenCalledWith(true);
-    expect(win32.setSimpleFullScreen).not.toHaveBeenCalled();
   });
 });

--- a/electron/window/__tests__/fullscreen.test.ts
+++ b/electron/window/__tests__/fullscreen.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toggleWindowFullscreen } from "../fullscreen.js";
+
+function createTarget(state: { simple?: boolean; native?: boolean } = {}) {
+  let simple = state.simple ?? false;
+  let native = state.native ?? false;
+  return {
+    isSimpleFullScreen: vi.fn(() => simple),
+    setSimpleFullScreen: vi.fn((value: boolean) => {
+      simple = value;
+    }),
+    isFullScreen: vi.fn(() => native),
+    setFullScreen: vi.fn((value: boolean) => {
+      native = value;
+    }),
+  };
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+describe("toggleWindowFullscreen", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+  });
+
+  describe("on macOS", () => {
+    beforeEach(() => {
+      setPlatform("darwin");
+    });
+
+    it("enters simple fullscreen from a windowed window", () => {
+      const win = createTarget();
+
+      expect(toggleWindowFullscreen(win)).toBe(true);
+      expect(win.setSimpleFullScreen).toHaveBeenCalledWith(true);
+      expect(win.setFullScreen).not.toHaveBeenCalled();
+    });
+
+    it("leaves simple fullscreen when simple fullscreen is active", () => {
+      const win = createTarget({ simple: true });
+
+      expect(toggleWindowFullscreen(win)).toBe(false);
+      expect(win.setSimpleFullScreen).toHaveBeenCalledWith(false);
+      expect(win.setFullScreen).not.toHaveBeenCalled();
+    });
+
+    it("round-trips windowed → simple fullscreen → windowed", () => {
+      const win = createTarget();
+
+      expect(toggleWindowFullscreen(win)).toBe(true);
+      expect(toggleWindowFullscreen(win)).toBe(false);
+      expect(win.setSimpleFullScreen).toHaveBeenNthCalledWith(1, true);
+      expect(win.setSimpleFullScreen).toHaveBeenNthCalledWith(2, false);
+    });
+
+    // A macOS window reaches native fullscreen via the green traffic-light button,
+    // and restoreWindowState reopens a saved-fullscreen window with setFullScreen(true).
+    // Toggling out of that must exit native rather than stack simple fullscreen on top.
+    it("leaves native fullscreen instead of stacking simple fullscreen on top", () => {
+      const win = createTarget({ native: true });
+
+      expect(toggleWindowFullscreen(win)).toBe(false);
+      expect(win.setFullScreen).toHaveBeenCalledWith(false);
+      expect(win.setSimpleFullScreen).not.toHaveBeenCalled();
+    });
+
+    it("exits simple fullscreen without touching native fullscreen when both report active", () => {
+      const win = createTarget({ simple: true, native: true });
+
+      expect(toggleWindowFullscreen(win)).toBe(false);
+      expect(win.setSimpleFullScreen).toHaveBeenCalledWith(false);
+      expect(win.setFullScreen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe.each(["win32", "linux"] as const)("on %s", (platform) => {
+    beforeEach(() => {
+      setPlatform(platform);
+    });
+
+    it("enters native fullscreen from a windowed window", () => {
+      const win = createTarget();
+
+      expect(toggleWindowFullscreen(win)).toBe(true);
+      expect(win.setFullScreen).toHaveBeenCalledWith(true);
+    });
+
+    it("leaves native fullscreen when native fullscreen is active", () => {
+      const win = createTarget({ native: true });
+
+      expect(toggleWindowFullscreen(win)).toBe(false);
+      expect(win.setFullScreen).toHaveBeenCalledWith(false);
+    });
+
+    it("never calls the macOS-only simple fullscreen APIs", () => {
+      const win = createTarget();
+
+      toggleWindowFullscreen(win);
+      toggleWindowFullscreen(win);
+
+      expect(win.setSimpleFullScreen).not.toHaveBeenCalled();
+      expect(win.isSimpleFullScreen).not.toHaveBeenCalled();
+    });
+  });
+
+  it("reads process.platform per call rather than capturing it at module load", () => {
+    const mac = createTarget();
+    setPlatform("darwin");
+    toggleWindowFullscreen(mac);
+
+    const win32 = createTarget();
+    setPlatform("win32");
+    toggleWindowFullscreen(win32);
+
+    expect(mac.setSimpleFullScreen).toHaveBeenCalledWith(true);
+    expect(win32.setFullScreen).toHaveBeenCalledWith(true);
+    expect(win32.setSimpleFullScreen).not.toHaveBeenCalled();
+  });
+});

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -6,6 +6,7 @@ import {
   registerAppView,
 } from "./webContentsRegistry.js";
 import { getWindowRegistry } from "./windowRef.js";
+import { toggleWindowFullscreen } from "./fullscreen.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import path from "path";
 import { createWindowWithState } from "../windowState.js";
@@ -86,9 +87,7 @@ function registerWindowIpcHandlers(onCreateWindow?: (projectPath?: string) => Pr
   ipcMain.handle(CHANNELS.WINDOW_TOGGLE_FULLSCREEN, (event) => {
     const bw = getWindowForWebContents(event.sender);
     if (bw && !bw.isDestroyed()) {
-      const isSimpleFullScreen = bw.isSimpleFullScreen();
-      bw.setSimpleFullScreen(!isSimpleFullScreen);
-      return !isSimpleFullScreen;
+      return toggleWindowFullscreen(bw);
     }
     return false;
   });

--- a/electron/window/fullscreen.ts
+++ b/electron/window/fullscreen.ts
@@ -21,8 +21,11 @@ type FullscreenTarget = Pick<
  * A macOS window can also land in *native* fullscreen — the green traffic-light
  * button puts it there, and `restoreWindowState` reopens a saved-fullscreen
  * window with `setFullScreen(true)`. Exiting that takes priority over entering
- * simple fullscreen, so the two modes are never stacked, and no single call both
- * leaves one mode and enters the other.
+ * simple fullscreen, so a settled window is never left with both modes stacked,
+ * and no single call both leaves one mode and enters the other. macOS only
+ * promises `isFullScreen()` is accurate once `enter-full-screen`/
+ * `leave-full-screen` has fired, so a toggle landing mid-transition can still
+ * read the pre-transition value; exiting simple first keeps that recoverable.
  */
 export function toggleWindowFullscreen(win: FullscreenTarget): boolean {
   if (process.platform !== "darwin") {

--- a/electron/window/fullscreen.ts
+++ b/electron/window/fullscreen.ts
@@ -1,0 +1,46 @@
+import type { BrowserWindow } from "electron";
+
+/**
+ * The subset of BrowserWindow the toggle touches. Narrow on purpose: callers
+ * still pass a real window, but tests can drive the platform matrix with four
+ * spies instead of faking a whole window.
+ */
+type FullscreenTarget = Pick<
+  BrowserWindow,
+  "isFullScreen" | "setFullScreen" | "isSimpleFullScreen" | "setSimpleFullScreen"
+>;
+
+/**
+ * Toggle fullscreen using the API that fits the platform, returning the new state.
+ *
+ * `setSimpleFullScreen`/`isSimpleFullScreen` are macOS-only. macOS wants them:
+ * simple fullscreen stays on the current Space, skips the transition animation,
+ * and extends into the menu-bar/notch area. Windows and Linux only define the
+ * native fullScreen APIs.
+ *
+ * A macOS window can also land in *native* fullscreen — the green traffic-light
+ * button puts it there, and `restoreWindowState` reopens a saved-fullscreen
+ * window with `setFullScreen(true)`. Exiting that takes priority over entering
+ * simple fullscreen, so the two modes are never stacked, and no single call both
+ * leaves one mode and enters the other.
+ */
+export function toggleWindowFullscreen(win: FullscreenTarget): boolean {
+  if (process.platform !== "darwin") {
+    const next = !win.isFullScreen();
+    win.setFullScreen(next);
+    return next;
+  }
+
+  if (win.isSimpleFullScreen()) {
+    win.setSimpleFullScreen(false);
+    return false;
+  }
+
+  if (win.isFullScreen()) {
+    win.setFullScreen(false);
+    return false;
+  }
+
+  win.setSimpleFullScreen(true);
+  return true;
+}

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1077,7 +1077,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   window: {
     /** Subscribe to fullscreen state changes */
     onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void;
-    /** Toggle simple fullscreen mode (extends into notch area on MacBook) */
+    /** Toggle fullscreen; resolves to the new state. Simple fullscreen on macOS, native elsewhere. */
     toggleFullscreen(): Promise<boolean>;
     /** Reload the window via Electron webContents */
     reload(): Promise<void>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1077,7 +1077,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   window: {
     /** Subscribe to fullscreen state changes */
     onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void;
-    /** Toggle fullscreen; resolves to the new state. Simple fullscreen on macOS, native elsewhere. */
+    /**
+     * Toggle fullscreen: simple fullscreen on macOS, native elsewhere. Resolves to the
+     * requested state, which macOS may not have settled yet — subscribe to
+     * onFullscreenChange for the observed one.
+     */
     toggleFullscreen(): Promise<boolean>;
     /** Reload the window via Electron webContents */
     reload(): Promise<void>;


### PR DESCRIPTION
## Summary

- Fullscreen used the macOS-only `isSimpleFullScreen`/`setSimpleFullScreen` APIs unconditionally, in both the `toggle-fullscreen` IPC handler (`electron/window/createWindow.ts`) and the View menu's Toggle Full Screen item (`electron/menu.ts`). They only worked on Windows and Linux because Electron's views backend quietly aliases them to the native `setFullScreen`/`isFullScreen`, which is undocumented behavior we shouldn't be leaning on. `electron/windowState.ts` already used the native APIs for persistence, so the two paths disagreed on what "fullscreen" even meant.
- On macOS specifically, the old code could stack simple fullscreen on top of native fullscreen.
- File > Project Settings sent `app.settings` instead of the existing `project.settings.open` action, so it opened application settings rather than project settings.

Resolves #11112

## Changes

**Shared fullscreen helper.** New `electron/window/fullscreen.ts` exports `toggleWindowFullscreen(win)`, called from both the IPC handler and the menu item. macOS keeps its simple-fullscreen behavior (stays on the current Space, no transition animation, extends into the notch/menu-bar area); Windows and Linux use the native fullscreen APIs directly. `process.platform` is read on every call. The helper takes a narrow structural `Pick<BrowserWindow, ...>` so tests can drive it with four spies instead of a full fake window; the `null`/`isDestroyed` checks stay at the call sites, since those legitimately differ.

**Stop stacking fullscreen modes on macOS.** A macOS window reaches native fullscreen two ways: the green traffic-light button, and our own `restoreWindowState`, which reopens a saved-fullscreen window with `setFullScreen(true)`. From that state, the old code read `isSimpleFullScreen()` as false and called `setSimpleFullScreen(true)`, layering the two modes. The helper's macOS branch now exits whichever mode is active before entering simple fullscreen, and never leaves one mode and enters the other in a single call. This goes a bit beyond the literal issue text, but it's the same root cause: two disagreeing notions of fullscreen colliding.

**Project Settings wired to the right action.** The File menu item now reads "Project Settings…" (matching the ellipsis convention every other dialog-opening item uses), sends `project.settings.open` (`src/services/actions/definitions/projectActions.ts`), and is gated on `enabled: !!projectStore.getCurrentProjectId()`, the same convention the adjacent Close Project item already uses.

**Doc fix.** The `toggleFullscreen` doc comment in `shared/types/ipc/api.ts` claimed the channel always performed simple fullscreen. It now documents that the resolved value is the requested state (macOS may not have settled the transition yet), and points readers at `onFullscreenChange` for the observed state.

### Known limitation (pre-existing)

The new `enabled` gate on Project Settings is computed when the application menu is built. A renderer-driven project open/close (welcome screen, project switcher) doesn't rebuild the menu, since `electron/ipc/handlers/projectCrud/` has no references to it, so the gate can go stale until something else triggers a rebuild. This isn't new: the adjacent Close Project item has used this exact gate and carries the identical staleness on `develop` today. Fixing it properly means deciding which window's project a single process-global menu bar should reflect when there are multiple windows open, which is this repo's most-repeated bug class (#5541, #6016, #11101) and deserves its own issue rather than getting smuggled into this one. Filing a follow-up.

## Testing

- New `electron/window/__tests__/fullscreen.test.ts` imports the real helper and drives the platform matrix with four spies: macOS entering/exiting simple fullscreen, macOS exiting native fullscreen instead of stacking, macOS unwinding the simple layer first when both modes report active, and win32/linux entering/exiting native fullscreen while never touching the macOS-only APIs. This is a step up from `createWindow.platform-options.test.ts`, which replicates the production platform branching inside the test file instead of importing the real implementation.
- `electron/__tests__/menu.test.ts` gained coverage that the View menu delegates to the shared helper (the regression that actually matters is the two call sites drifting apart again), that Project Settings sends `project.settings.open`, and that it's enabled only while a project is active. Removed a tautological hard-coded "Project Settings" label assertion from the win32 File-menu test.
- Locally: 98 tests green across `fullscreen.test.ts`, `menu.test.ts`, `windowState.test.ts`, `createWindow.platform-options.test.ts`, and `ipcHandleCoverage.test.ts`. `npm run typecheck` clean. ESLint and Prettier clean on all six changed files.
