### PR TITLE
fix(review): wire the Review panel's Close button and Escape to the real close callback

### DIFF
--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -8,11 +8,16 @@ import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry
 export interface ReviewPaneProps {
   id: string;
   worktreeId?: string;
+  onClose: (force?: boolean) => void;
 }
 
-const noop = () => {};
+export function ReviewPane({ id, worktreeId, onClose }: ReviewPaneProps) {
+  // ReviewHubContent wires its Close button as `onClick={onClose}`, so React
+  // would hand the MouseEvent straight through as `force` — a truthy object
+  // that routes the panel handler to permanent removal instead of the
+  // recoverable trash. Drop the argument here.
+  const handleContentClose = useCallback(() => onClose(), [onClose]);
 
-export function ReviewPane({ id, worktreeId }: ReviewPaneProps) {
   // Callback ref via useState so React re-renders once the container element
   // commits to the DOM. A plain useRef would freeze `current` at `null` for
   // the lifetime of the first render and `keyboardScope` would never receive
@@ -63,7 +68,7 @@ export function ReviewPane({ id, worktreeId }: ReviewPaneProps) {
       <ReviewHubContent
         isOpen={true}
         worktreePath={worktreePath}
-        onClose={noop}
+        onClose={handleContentClose}
         keyboardScope={containerEl ?? undefined}
       />
     </div>

--- a/src/panels/review/__tests__/ReviewPane.focus.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.focus.test.tsx
@@ -36,7 +36,7 @@ describe("ReviewPane focus target (#11109)", () => {
   });
 
   it("moves focus to its container and confirms the handoff", () => {
-    const { container } = render(<ReviewPane id="r-1" worktreeId="w-1" />);
+    const { container } = render(<ReviewPane id="r-1" worktreeId="w-1" onClose={vi.fn()} />);
     const root = container.firstElementChild;
 
     let accepted = false;
@@ -51,7 +51,7 @@ describe("ReviewPane focus target (#11109)", () => {
   it("accepts focus in the worktree-unavailable branch too", () => {
     // Both return branches render a container; only wiring the happy path
     // would leave Enter dead on a review pane whose worktree went away.
-    const { container } = render(<ReviewPane id="r-1" />);
+    const { container } = render(<ReviewPane id="r-1" onClose={vi.fn()} />);
     const root = container.firstElementChild;
 
     let accepted = false;
@@ -66,13 +66,13 @@ describe("ReviewPane focus target (#11109)", () => {
   it("still hands its container to ReviewHubContent as the keyboard scope", () => {
     // The container doubles as ReviewHubContent's Escape scope; a document-wide
     // fallback would swallow Escape across the whole app.
-    const { container } = render(<ReviewPane id="r-1" worktreeId="w-1" />);
+    const { container } = render(<ReviewPane id="r-1" worktreeId="w-1" onClose={vi.fn()} />);
 
     expect(keyboardScopes.at(-1)).toBe(container.firstElementChild);
   });
 
   it("releases the registry entry on unmount", () => {
-    const { unmount } = render(<ReviewPane id="r-1" worktreeId="w-1" />);
+    const { unmount } = render(<ReviewPane id="r-1" worktreeId="w-1" onClose={vi.fn()} />);
     unmount();
 
     expect(focusPanelInput("r-1")).toBe(false);

--- a/src/panels/review/__tests__/ReviewPane.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// #11116: ReviewPane dropped the grid-supplied `onClose` and handed
+// ReviewHubContent a literal no-op, leaving the pane's own Close button and its
+// Escape fallthrough dead. Both controls funnel through that single prop, so
+// stub the (very heavy) child to capture what the pane forwards and assert the
+// seam directly.
+//
+// The stub wires its close button as `onClick={props.onClose}` — bare, exactly
+// like the real ReviewHubContent. That matters: React hands a MouseEvent to a
+// bare handler, so a naive `onClose={onClose}` pass-through would deliver a
+// truthy object as `force` and route the panel handler to permanent removal
+// (removePanel) instead of the recoverable trash (trashPanelGroup, the source
+// of Reopen Last Closed). Reproducing the bare wiring is what lets this test
+// catch that.
+interface CapturedReviewHubProps {
+  isOpen: boolean;
+  worktreePath: string;
+  onClose: () => void;
+  keyboardScope?: Document | HTMLElement | null;
+}
+
+const reviewHubContentProps: CapturedReviewHubProps[] = [];
+
+vi.mock("@/components/Worktree/ReviewHub/ReviewHubContent", () => ({
+  ReviewHubContent: (props: CapturedReviewHubProps) => {
+    reviewHubContentProps.push(props);
+    return (
+      <button data-testid="review-hub-close" onClick={props.onClose}>
+        Close
+      </button>
+    );
+  },
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (state: unknown) => unknown) =>
+    selector({ worktrees: new Map([["wt-1", { path: "/repo/wt-1" }]]) }),
+}));
+
+import { ReviewPane } from "../ReviewPane";
+
+function lastReviewHubContentProps(): CapturedReviewHubProps {
+  const props = reviewHubContentProps.at(-1);
+  if (!props) throw new Error("ReviewHubContent was not rendered");
+  return props;
+}
+
+afterEach(() => {
+  reviewHubContentProps.length = 0;
+});
+
+describe("ReviewPane close wiring", () => {
+  it("closes the panel — recoverably, not forcibly — when the Close button is clicked", () => {
+    const onClose = vi.fn<(force?: boolean) => void>();
+    render(<ReviewPane id="review-1" worktreeId="wt-1" onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("review-hub-close"));
+
+    // The call itself is what the no-op regression killed. The argument is the
+    // subtler half: usePanelHandlers branches on `if (force)`, and a truthy
+    // value skips the optimistic trash to delete the panel outright, so Reopen
+    // Last Closed can't bring it back. The click's MouseEvent must not land
+    // there — assert both, or a no-op child would satisfy the arg check
+    // vacuously.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const [force] = onClose.mock.calls[0] ?? [];
+    expect(force).toBeFalsy();
+  });
+
+  it("closes the panel when Escape falls through the child's nested-state handling", () => {
+    const onClose = vi.fn<(force?: boolean) => void>();
+    render(<ReviewPane id="review-1" worktreeId="wt-1" onClose={onClose} />);
+
+    // ReviewHubContent's Escape handler clears selected files/paths first and
+    // only then calls onClose() with no argument. Drive that final branch.
+    lastReviewHubContentProps().onClose();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const [force] = onClose.mock.calls[0] ?? [];
+    expect(force).toBeFalsy();
+  });
+
+  it("scopes the child's Escape listener to the pane's own root element", () => {
+    const onClose = vi.fn<(force?: boolean) => void>();
+    const { container } = render(<ReviewPane id="review-1" worktreeId="wt-1" onClose={onClose} />);
+
+    // A missing scope makes ReviewHubContent fall back to a document-wide
+    // capture listener that swallows Escape across the whole app.
+    expect(lastReviewHubContentProps().keyboardScope).toBe(container.firstChild);
+  });
+});

--- a/src/panels/review/__tests__/ReviewPane.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.test.tsx
@@ -15,11 +15,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // (removePanel) instead of the recoverable trash (trashPanelGroup, the source
 // of Reopen Last Closed). Reproducing the bare wiring is what lets this test
 // catch that.
+//
+// The pane's other seam with this child — handing it the container as its
+// Escape `keyboardScope` — is covered in ReviewPane.focus.test.tsx.
 interface CapturedReviewHubProps {
   isOpen: boolean;
   worktreePath: string;
   onClose: () => void;
-  keyboardScope?: Document | HTMLElement | null;
 }
 
 const reviewHubContentProps: CapturedReviewHubProps[] = [];
@@ -91,14 +93,5 @@ describe("ReviewPane close wiring", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     const [force] = onClose.mock.calls[0] ?? [];
     expect(force).toBeFalsy();
-  });
-
-  it("scopes the child's Escape listener to the pane's own root element", () => {
-    const onClose = vi.fn<(force?: boolean) => void>();
-    const { container } = render(<ReviewPane id="review-1" worktreeId="wt-1" onClose={onClose} />);
-
-    // A missing scope makes ReviewHubContent fall back to a document-wide
-    // capture listener that swallows Escape across the whole app.
-    expect(lastReviewHubContentProps().keyboardScope).toBe(container.firstChild);
   });
 });

--- a/src/panels/review/__tests__/ReviewPane.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.test.tsx
@@ -27,6 +27,9 @@ const reviewHubContentProps: CapturedReviewHubProps[] = [];
 vi.mock("@/components/Worktree/ReviewHub/ReviewHubContent", () => ({
   ReviewHubContent: (props: CapturedReviewHubProps) => {
     reviewHubContentProps.push(props);
+    // The real child renders nothing when closed. Honour that here too, so a
+    // regression that stops opening the pane can't leave these tests green.
+    if (!props.isOpen) return null;
     return (
       <button data-testid="review-hub-close" onClick={props.onClose}>
         Close
@@ -57,6 +60,10 @@ describe("ReviewPane close wiring", () => {
     const onClose = vi.fn<(force?: boolean) => void>();
     render(<ReviewPane id="review-1" worktreeId="wt-1" onClose={onClose} />);
 
+    // Pin the click as the cause: a pane that closed itself on mount would
+    // otherwise land on the same call count.
+    expect(onClose).not.toHaveBeenCalled();
+
     fireEvent.click(screen.getByTestId("review-hub-close"));
 
     // The call itself is what the no-op regression killed. The argument is the
@@ -70,12 +77,15 @@ describe("ReviewPane close wiring", () => {
     expect(force).toBeFalsy();
   });
 
-  it("closes the panel when Escape falls through the child's nested-state handling", () => {
+  it("forwards a callback that closes the panel when invoked with no argument", () => {
     const onClose = vi.fn<(force?: boolean) => void>();
     render(<ReviewPane id="review-1" worktreeId="wt-1" onClose={onClose} />);
 
-    // ReviewHubContent's Escape handler clears selected files/paths first and
-    // only then calls onClose() with no argument. Drive that final branch.
+    // This is the shape ReviewHubContent's Escape handler uses: after clearing
+    // any selected file or path, its last resort is a bare `onClose()`. Driving
+    // real Escape would mean mounting the child for real (a ~25-mock IPC
+    // surface) to retest key handling this fix doesn't touch and the ReviewHub
+    // suites already cover — so assert the seam, not the child.
     lastReviewHubContentProps().onClose();
 
     expect(onClose).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Resolves #11116

`ReviewPane` declared neither `onClose` on its props nor destructured it, so the real close callback the grid hands every panel was silently dropped and `ReviewHubContent` got a literal `noop` instead. The pane's own Close button and its Escape fallthrough both routed into that dead callback. The panel stayed closable from the surrounding chrome, so the bug only showed up as "the two controls the pane advertises do nothing".

The fix declares `onClose` on `ReviewPaneProps` and forwards it — but not bare.

**The part worth reviewing:** `ReviewHubContent` wires its Close button as `onClick={onClose}`, so React passes the MouseEvent as the first argument. Forwarding the grid's `handleClose: (force?: boolean) => void` straight through would land that event in `force` — a truthy object — taking the `if (force)` branch in `usePanelHandlers` and calling `removePanel()` instead of the optimistic `trashPanelGroup()`. That's the destroy-without-recovery path (`PanelHeader` reaches it deliberately via `onClose(e.altKey)`, aria-label: "Hold Alt and click to force close without recovery"), and it's what backs Reopen Last Closed. So the obvious one-word fix would have made Close *work* while quietly making it unrecoverable. The forward goes through a zero-arg adapter instead, and there's a test that fails on the bare pass-through.

**Tests:** the panel path had no coverage at all — every existing review-hub test drives the `ReviewHub` modal wrapper, which always passed a real `onClose` and was never broken. New `ReviewPane.test.tsx` covers the close seam: the stub reproduces the real child's bare `onClick={onClose}` wiring, so it catches both the original no-op and the force-close hazard (verified red-before-green: a bare pass-through fails with `expected SyntheticBaseEvent{...} to be falsy`).

Rebasing picked up #11132, which added a focus handler to the same component. Its `ReviewPane.focus.test.tsx` rendered `ReviewPane` without `onClose`, which no longer typechecks now that the prop is required — passed a spy at its four render sites, and dropped my duplicate keyboard-scope assertion since that suite already covers it.

**Out of scope, but noted:** `ReviewPane` renders no `ContentPanel`, so `ReviewHubContent`'s header button is the panel's only in-body close control. In the worktree-unavailable branch the pane renders an `EmptyState` and therefore has no close affordance at all. Pre-existing, and it advertises no dead button so it isn't this bug's symptom — but it's a real gap if an orphaned review panel should be closable from its body.

Local checks: 116 tests green across the review/panel-focus/review-hub suites; eslint, prettier, and tsc clean on the changed files.