### PR TITLE
fix: stable builds no longer identify as Beta

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -34,6 +34,13 @@ const mockBrowserWindow = vi.hoisted(() => ({
   id: 1,
 }));
 
+// setAboutPanelOptions runs once at menu.ts import time (module scope), before
+// any beforeEach vi.clearAllMocks() can wipe the mock's call history — so
+// capture the argument in a hoisted holder that survives the reset.
+const aboutPanelCapture = vi.hoisted(() => ({
+  options: undefined as Electron.AboutPanelOptionsOptions | undefined,
+}));
+
 let capturedTemplate: Electron.MenuItemConstructorOptions[] = [];
 
 const menuItemRegistry = vi.hoisted(() => new Map<string, { label: string; enabled: boolean }>());
@@ -71,7 +78,9 @@ vi.mock("electron", () => ({
   app: {
     isPackaged: false,
     getVersion: vi.fn(() => "1.0.0"),
-    setAboutPanelOptions: vi.fn(),
+    setAboutPanelOptions: vi.fn((options: Electron.AboutPanelOptionsOptions) => {
+      aboutPanelCapture.options = options;
+    }),
     setPath: vi.fn(),
     getPath: vi.fn(() => "/mock/path"),
     commandLine: {
@@ -166,7 +175,11 @@ vi.mock("../window/webContentsRegistry.js", () => ({
 }));
 
 const isWindowsStoreBuildMock = vi.hoisted(() => vi.fn(() => true));
-vi.mock("../../shared/config/distribution.js", () => ({
+// Keep the real build-channel helpers (getBuildChannel/getBuildChannelLabel)
+// so the module-load About-panel wiring is exercised for real; only override
+// the Windows Store detection the update-menu tests need to drive.
+vi.mock("../../shared/config/distribution.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../shared/config/distribution.js")>()),
   isWindowsStoreBuild: isWindowsStoreBuildMock,
 }));
 
@@ -182,6 +195,17 @@ function findMenuItem(
   if (!menu || !Array.isArray(menu.submenu)) return undefined;
   return (menu.submenu as Electron.MenuItemConstructorOptions[]).find((i) => i.label === itemLabel);
 }
+
+describe("About panel build channel (#11121)", () => {
+  it("passes the raw version as applicationVersion and leaves the build-version slot blank for stable builds", () => {
+    // Captured at module import: app.getVersion() is mocked to "1.0.0" (no
+    // prerelease suffix → stable channel), so the build-version slot that used
+    // to hardcode "Beta" is now empty and the real version flows through.
+    expect(aboutPanelCapture.options).toBeDefined();
+    expect(aboutPanelCapture.options?.applicationVersion).toBe("1.0.0");
+    expect(aboutPanelCapture.options?.version).toBe("");
+  });
+});
 
 describe("createApplicationMenu", () => {
   beforeEach(() => {

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -183,7 +183,8 @@ vi.mock("../../shared/config/distribution.js", async (importOriginal) => ({
   isWindowsStoreBuild: isWindowsStoreBuildMock,
 }));
 
-import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
+import { createApplicationMenu, handleDirectoryOpen, buildAboutPanelOptions } from "../menu.js";
+import { getBuildChannelLabel } from "../../shared/config/distribution.js";
 import { webContents, app, Menu } from "electron";
 
 function findMenuItem(
@@ -197,13 +198,36 @@ function findMenuItem(
 }
 
 describe("About panel build channel (#11121)", () => {
-  it("passes the raw version as applicationVersion and leaves the build-version slot blank for stable builds", () => {
-    // Captured at module import: app.getVersion() is mocked to "1.0.0" (no
-    // prerelease suffix → stable channel), so the build-version slot that used
-    // to hardcode "Beta" is now empty and the real version flows through.
+  it("wires setAboutPanelOptions at import with the real running version", () => {
+    // Captured at module import: app.getVersion() is mocked to "1.0.0", proving
+    // the About options are actually applied (not dead code) and the raw
+    // version flows through as applicationVersion.
     expect(aboutPanelCapture.options).toBeDefined();
     expect(aboutPanelCapture.options?.applicationVersion).toBe("1.0.0");
     expect(aboutPanelCapture.options?.version).toBe("");
+  });
+
+  describe("buildAboutPanelOptions", () => {
+    it("passes the raw version through and leaves the build-version slot blank for stable builds", () => {
+      const options = buildAboutPanelOptions("1.0.0");
+      expect(options.applicationVersion).toBe("1.0.0");
+      // Stable → no channel label → empty slot (no more hardcoded "Beta").
+      expect(options.version).toBe("");
+    });
+
+    it("surfaces the channel label in the build-version slot for prerelease builds", () => {
+      // Compare against the shared helper rather than duplicating label strings.
+      for (const version of [
+        "0.25.0-nightly.20260713120000.abc1234",
+        "1.0.0-beta.1",
+        "1.0.0-rc.2",
+      ]) {
+        const options = buildAboutPanelOptions(version);
+        expect(options.applicationVersion).toBe(version);
+        expect(options.version).toBe(getBuildChannelLabel(version));
+        expect(options.version).toBeTruthy();
+      }
+    });
   });
 });
 

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -24,12 +24,16 @@ import { evaluateWhen } from "./services/WhenClauseService.js";
 import { getAppWebContents } from "./window/webContentsRegistry.js";
 import { PRODUCT_NAME, PRODUCT_WEBSITE, PRODUCT_COPYRIGHT_ORG } from "./utils/productBranding.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
-import { isWindowsStoreBuild } from "../shared/config/distribution.js";
+import { isWindowsStoreBuild, getBuildChannelLabel } from "../shared/config/distribution.js";
 
+// The About panel's build-version slot shows the release channel for
+// prerelease builds (Nightly/Beta/RC) and stays blank for stable releases —
+// an empty string suppresses the secondary line rather than falling back to
+// CFBundleVersion (which would duplicate the version on macOS).
 app.setAboutPanelOptions({
   applicationName: PRODUCT_NAME,
   applicationVersion: app.getVersion(),
-  version: "Beta",
+  version: getBuildChannelLabel(app.getVersion()) ?? "",
   copyright: `© ${new Date().getFullYear()} ${PRODUCT_COPYRIGHT_ORG}`,
   website: PRODUCT_WEBSITE,
 });

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -30,13 +30,17 @@ import { isWindowsStoreBuild, getBuildChannelLabel } from "../shared/config/dist
 // prerelease builds (Nightly/Beta/RC) and stays blank for stable releases —
 // an empty string suppresses the secondary line rather than falling back to
 // CFBundleVersion (which would duplicate the version on macOS).
-app.setAboutPanelOptions({
-  applicationName: PRODUCT_NAME,
-  applicationVersion: app.getVersion(),
-  version: getBuildChannelLabel(app.getVersion()) ?? "",
-  copyright: `© ${new Date().getFullYear()} ${PRODUCT_COPYRIGHT_ORG}`,
-  website: PRODUCT_WEBSITE,
-});
+export function buildAboutPanelOptions(version: string): Electron.AboutPanelOptionsOptions {
+  return {
+    applicationName: PRODUCT_NAME,
+    applicationVersion: version,
+    version: getBuildChannelLabel(version) ?? "",
+    copyright: `© ${new Date().getFullYear()} ${PRODUCT_COPYRIGHT_ORG}`,
+    website: PRODUCT_WEBSITE,
+  };
+}
+
+app.setAboutPanelOptions(buildAboutPanelOptions(app.getVersion()));
 
 function convertShortcutToAccelerator(shortcut: string): string {
   return shortcut.replace("Cmd/Ctrl", "CommandOrControl");

--- a/shared/config/__tests__/distribution.test.ts
+++ b/shared/config/__tests__/distribution.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getRuntimePlatform, isWindowsStoreBuild } from "../distribution.js";
+import {
+  getBuildChannel,
+  getBuildChannelLabel,
+  getRuntimePlatform,
+  isWindowsStoreBuild,
+} from "../distribution.js";
 
 type WithStoreFlag = NodeJS.Process & { windowsStore?: boolean };
 
@@ -49,6 +54,44 @@ describe("distribution config", () => {
     it("explicit argument wins over process.windowsStore", () => {
       (process as WithStoreFlag).windowsStore = true;
       expect(isWindowsStoreBuild(false)).toBe(false);
+    });
+  });
+
+  describe("getBuildChannel", () => {
+    it("classifies a plain semantic version as stable", () => {
+      expect(getBuildChannel("0.25.0")).toBe("stable");
+      expect(getBuildChannel("1.0.0")).toBe("stable");
+    });
+
+    it("classifies the nightly stamp format as nightly", () => {
+      expect(getBuildChannel("0.25.0-nightly.20260713120000.abc1234")).toBe("nightly");
+    });
+
+    it("classifies beta and rc prerelease tags", () => {
+      expect(getBuildChannel("1.0.0-beta.1")).toBe("beta");
+      expect(getBuildChannel("1.0.0-rc.2")).toBe("rc");
+    });
+
+    it("applies deterministic precedence for combined tags (nightly > rc > beta)", () => {
+      expect(getBuildChannel("1.0.0-nightly.1-rc.1")).toBe("nightly");
+      expect(getBuildChannel("1.0.0-rc.1-beta.1")).toBe("rc");
+    });
+
+    it("falls back to stable for unrecognized prerelease tags", () => {
+      expect(getBuildChannel("1.0.0-alpha.1")).toBe("stable");
+      expect(getBuildChannel("1.0.0-canary")).toBe("stable");
+    });
+  });
+
+  describe("getBuildChannelLabel", () => {
+    it("returns null for stable so callers render no channel marker", () => {
+      expect(getBuildChannelLabel("1.0.0")).toBeNull();
+    });
+
+    it("returns the human-readable label for each prerelease channel", () => {
+      expect(getBuildChannelLabel("0.25.0-nightly.20260713120000.abc1234")).toBe("Nightly");
+      expect(getBuildChannelLabel("1.0.0-beta.1")).toBe("Beta");
+      expect(getBuildChannelLabel("1.0.0-rc.2")).toBe("RC");
     });
   });
 

--- a/shared/config/__tests__/distribution.test.ts
+++ b/shared/config/__tests__/distribution.test.ts
@@ -84,14 +84,23 @@ describe("distribution config", () => {
   });
 
   describe("getBuildChannelLabel", () => {
-    it("returns null for stable so callers render no channel marker", () => {
+    it("returns null for stable builds so callers render no channel marker", () => {
       expect(getBuildChannelLabel("1.0.0")).toBeNull();
+      expect(getBuildChannelLabel("0.25.0")).toBeNull();
     });
 
-    it("returns the human-readable label for each prerelease channel", () => {
-      expect(getBuildChannelLabel("0.25.0-nightly.20260713120000.abc1234")).toBe("Nightly");
-      expect(getBuildChannelLabel("1.0.0-beta.1")).toBe("Beta");
-      expect(getBuildChannelLabel("1.0.0-rc.2")).toBe("RC");
+    it("returns a visible label for every prerelease channel", () => {
+      // Assert the badge-visibility invariant (non-stable → shown), not the
+      // exact display strings, which would just duplicate the label table.
+      for (const version of [
+        "0.25.0-nightly.20260713120000.abc1234",
+        "1.0.0-beta.1",
+        "1.0.0-rc.2",
+      ]) {
+        const label = getBuildChannelLabel(version);
+        expect(label).toBeTruthy();
+        expect(getBuildChannel(version)).not.toBe("stable");
+      }
     });
   });
 

--- a/shared/config/__tests__/distribution.test.ts
+++ b/shared/config/__tests__/distribution.test.ts
@@ -89,18 +89,19 @@ describe("distribution config", () => {
       expect(getBuildChannelLabel("0.25.0")).toBeNull();
     });
 
-    it("returns a visible label for every prerelease channel", () => {
-      // Assert the badge-visibility invariant (non-stable → shown), not the
-      // exact display strings, which would just duplicate the label table.
-      for (const version of [
-        "0.25.0-nightly.20260713120000.abc1234",
-        "1.0.0-beta.1",
-        "1.0.0-rc.2",
-      ]) {
+    it("returns a distinct, visible label for every prerelease channel", () => {
+      // Assert the invariants (non-stable → shown, one label per channel), not
+      // the exact display strings, which would just duplicate the label table.
+      const versions = ["0.25.0-nightly.20260713120000.abc1234", "1.0.0-beta.1", "1.0.0-rc.2"];
+      const labels = versions.map((version) => {
         const label = getBuildChannelLabel(version);
         expect(label).toBeTruthy();
         expect(getBuildChannel(version)).not.toBe("stable");
-      }
+        return label;
+      });
+      // Each channel maps to its own label — guards against a table where every
+      // channel collapses to the same string.
+      expect(new Set(labels).size).toBe(versions.length);
     });
   });
 

--- a/shared/config/distribution.ts
+++ b/shared/config/distribution.ts
@@ -44,3 +44,47 @@ export function isWindowsStoreBuild(windowsStore?: boolean): boolean {
   }
   return false;
 }
+
+/**
+ * Release channel a build was published on, derived from the semver prerelease
+ * suffix baked into `app.getVersion()`. This is the single source of truth for
+ * build/version provenance — distinct from the user-selected update-feed
+ * preference in `AutoUpdaterService` (`updateChannel`), which describes which
+ * feed to poll, not what the running binary is.
+ */
+export type BuildChannel = "stable" | "nightly" | "beta" | "rc";
+
+/**
+ * Classifies a version string into its release channel by matching the
+ * prerelease suffix. Mirrors the `.includes()` convention in
+ * `electron-builder.config.cjs` (the build-time publisher) so runtime UI and
+ * the packager agree on channel identity.
+ *
+ * The nightly workflow strips any existing suffix before stamping
+ * `-nightly.*`, so combined tags never occur in the real pipeline; precedence
+ * (`nightly > rc > beta`) only matters for manually stamped builds and is kept
+ * deterministic regardless. Anything without a recognized suffix — including a
+ * plain `1.0.0` stable release — is `"stable"`.
+ */
+export function getBuildChannel(version: string): BuildChannel {
+  if (version.includes("-nightly")) return "nightly";
+  if (version.includes("-rc")) return "rc";
+  if (version.includes("-beta")) return "beta";
+  return "stable";
+}
+
+const BUILD_CHANNEL_LABELS = {
+  stable: null,
+  nightly: "Nightly",
+  beta: "Beta",
+  rc: "RC",
+} satisfies Record<BuildChannel, string | null>;
+
+/**
+ * Human-readable channel label for surfacing in UI (About panel, Settings
+ * badge). Returns `null` for stable builds so callers render no channel marker
+ * at all — a stable release shows only its plain semantic version.
+ */
+export function getBuildChannelLabel(version: string): string | null {
+  return BUILD_CHANNEL_LABELS[getBuildChannel(version)];
+}

--- a/shared/config/distribution.ts
+++ b/shared/config/distribution.ts
@@ -63,8 +63,14 @@ export type BuildChannel = "stable" | "nightly" | "beta" | "rc";
  * The nightly workflow strips any existing suffix before stamping
  * `-nightly.*`, so combined tags never occur in the real pipeline; precedence
  * (`nightly > rc > beta`) only matters for manually stamped builds and is kept
- * deterministic regardless. Anything without a recognized suffix — including a
- * plain `1.0.0` stable release — is `"stable"`.
+ * deterministic regardless.
+ *
+ * Anything without a recognized suffix — a plain `1.0.0` stable release, but
+ * also an unsupported prerelease like `-alpha` — falls back to `"stable"`. The
+ * pipeline only ever ships stable/nightly/beta/rc, and the full version string
+ * is always shown alongside this label, so an unknown suffix is never hidden.
+ * Introducing a new channel means extending this union, `BUILD_CHANNEL_LABELS`,
+ * the release pipeline, and the tests together.
  */
 export function getBuildChannel(version: string): BuildChannel {
   if (version.includes("-nightly")) return "nightly";

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -40,6 +40,7 @@ import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { getBuildChannelLabel } from "@shared/config/distribution";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { formatTimeAgo } from "@/utils/timeAgo";
@@ -129,6 +130,10 @@ export function GeneralTab({
 }: GeneralTabProps) {
   const effectiveSubtab =
     activeSubtab && GENERAL_SUBTABS.some((t) => t.id === activeSubtab) ? activeSubtab : "overview";
+
+  // Build provenance from the running version — stable builds get no channel
+  // badge. Distinct from the user-selected update-feed `updateChannel`.
+  const buildChannelLabel = getBuildChannelLabel(appVersion);
 
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
   const [hibernationConfig, setHibernationConfig] = useState<HibernationConfig | null>(null);
@@ -703,9 +708,14 @@ export function GeneralTab({
             <div className="flex-1 min-w-0 space-y-1">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-semibold text-daintree-text">Daintree</span>
-                <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-status-info/15 text-status-info leading-none">
-                  Beta
-                </span>
+                {buildChannelLabel && (
+                  <span
+                    data-testid="about-build-channel"
+                    className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-status-info/15 text-status-info leading-none"
+                  >
+                    {buildChannelLabel}
+                  </span>
+                )}
                 <span className="text-xs text-text-muted font-mono ml-auto">v{appVersion}</span>
               </div>
               {buildArch && (

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -92,11 +92,11 @@ function setupElectron() {
   };
 }
 
-async function renderGeneralTab() {
+async function renderGeneralTab(appVersion = "1.0.0") {
   const { GeneralTab } = await import("../GeneralTab");
   return render(
     <GeneralTab
-      appVersion="1.0.0"
+      appVersion={appVersion}
       onNavigateToAgents={vi.fn()}
       activeSubtab="overview"
       onSubtabChange={vi.fn()}
@@ -449,4 +449,46 @@ describe("GeneralTab — build architecture line (issue #10501)", () => {
     });
     expect(screen.queryByTestId("about-build-arch")).toBeNull();
   });
+});
+
+describe("GeneralTab — build channel badge (#11121)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectron();
+    setupDispatchMock(
+      {
+        claude: "ready",
+        gemini: "missing",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
+      { agents: { claude: { pinned: true } } } as unknown as AgentSettings
+    );
+  });
+
+  it("shows no channel badge for a stable build and renders the plain version", async () => {
+    await renderGeneralTab("1.0.0");
+
+    await waitFor(() => {
+      expect(screen.getByText("v1.0.0")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("about-build-channel")).toBeNull();
+  });
+
+  it.each([
+    { version: "0.25.0-nightly.20260713120000.abc1234", label: "Nightly" },
+    { version: "1.0.0-beta.1", label: "Beta" },
+    { version: "1.0.0-rc.2", label: "RC" },
+  ])(
+    "labels a $label prerelease build with its channel and keeps the full version",
+    async ({ version, label }) => {
+      await renderGeneralTab(version);
+
+      const badge = await screen.findByTestId("about-build-channel");
+      expect(badge.textContent).toBe(label);
+      // The full prerelease-tagged version stays visible for traceability.
+      expect(screen.getByText(`v${version}`)).toBeTruthy();
+    }
+  );
 });

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { CliAvailability, AgentSettings, HibernationConfig } from "@shared/types";
+import { getBuildChannelLabel } from "@shared/config/distribution";
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
 
@@ -476,17 +477,15 @@ describe("GeneralTab — build channel badge (#11121)", () => {
     expect(screen.queryByTestId("about-build-channel")).toBeNull();
   });
 
-  it.each([
-    { version: "0.25.0-nightly.20260713120000.abc1234", label: "Nightly" },
-    { version: "1.0.0-beta.1", label: "Beta" },
-    { version: "1.0.0-rc.2", label: "RC" },
-  ])(
-    "labels a $label prerelease build with its channel and keeps the full version",
-    async ({ version, label }) => {
+  it.each(["0.25.0-nightly.20260713120000.abc1234", "1.0.0-beta.1", "1.0.0-rc.2"])(
+    "labels the prerelease build %s with its channel and keeps the full version",
+    async (version) => {
       await renderGeneralTab(version);
 
+      // Assert the component renders whatever the shared helper produces (wiring),
+      // rather than duplicating the canonical label strings.
       const badge = await screen.findByTestId("about-build-channel");
-      expect(badge.textContent).toBe(label);
+      expect(badge.textContent).toBe(getBuildChannelLabel(version));
       // The full prerelease-tagged version stays visible for traceability.
       expect(screen.getByText(`v${version}`)).toBeTruthy();
     }

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -95,6 +95,13 @@ describe("filterSettings", () => {
     expect(filterSettings(SETTINGS_SEARCH_INDEX, "zzznomatch999")).toHaveLength(0);
   });
 
+  it("no longer surfaces the About entry for a 'beta' search (#11121)", () => {
+    // The stale "beta" keyword was removed from the general-about metadata so
+    // stable builds don't advertise a Beta identity through settings search.
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "beta");
+    expect(results.some((r) => r.id === "general-about")).toBe(false);
+  });
+
   it("matches the forge access-token entry for a github token query", () => {
     const results = filterSettings(SETTINGS_SEARCH_INDEX, "github token");
     expect(results.some((r) => r.id === "forge-access-token")).toBe(true);

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -98,8 +98,14 @@ describe("filterSettings", () => {
   it("no longer surfaces the About entry for a 'beta' search (#11121)", () => {
     // The stale "beta" keyword was removed from the general-about metadata so
     // stable builds don't advertise a Beta identity through settings search.
-    const results = filterSettings(SETTINGS_SEARCH_INDEX, "beta");
-    expect(results.some((r) => r.id === "general-about")).toBe(false);
+    expect(
+      filterSettings(SETTINGS_SEARCH_INDEX, "beta").some((r) => r.id === "general-about")
+    ).toBe(false);
+    // Control: the About entry is still discoverable by its real keywords, so
+    // the assertion above can't pass vacuously by the entry dropping out entirely.
+    expect(
+      filterSettings(SETTINGS_SEARCH_INDEX, "about").some((r) => r.id === "general-about")
+    ).toBe(true);
   });
 
   it("matches the forge access-token entry for a github token query", () => {

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -246,7 +246,7 @@ export const SETTINGS_REGISTRY = [
         section: "About",
         title: "About Daintree",
         description: "App version and description",
-        keywords: ["version", "about", "info", "beta"],
+        keywords: ["version", "about", "info"],
       },
       {
         id: "general-system-status",


### PR DESCRIPTION
## Summary
- Stable builds hardcoded "Beta" in two trust surfaces: the native macOS About panel (`app.setAboutPanelOptions` in `electron/menu.ts`) and the Settings General tab About card (`GeneralTab.tsx`), plus a stale `beta` keyword in settings search metadata.
- Adds `getBuildChannel` and `getBuildChannelLabel` to `shared/config/distribution.ts` as the single source of truth: they derive the release channel (Nightly, Beta, RC, or none) by parsing the semver prerelease suffix of the running app version.
- Both the macOS About panel and the Settings About card now call this shared logic, so a channel label only shows for prerelease builds. Stable builds show nothing.

Resolves #11121

## Changes
- `shared/config/distribution.ts`: new `getBuildChannel` / `getBuildChannelLabel` helpers.
- `electron/menu.ts`: native About panel uses `getBuildChannelLabel` instead of a hardcoded `"Beta"` string.
- `src/components/Settings/GeneralTab.tsx`: About card uses the same shared logic for its channel badge.
- `src/components/Settings/settingsTabRegistry.tsx`: removed the stale `beta` search keyword.
- Matching test coverage in all four corresponding test files.

## Testing
- 188 targeted tests pass across the touched source and test files.
- Manual smoke check still needed: the native macOS About panel's build-version slot rendering (empty for stable builds) can't be exercised in Vitest, since it depends on Electron's native dialog.