### PR TITLE
fix(settings): stop silently falling back to stable when the update channel fails to load

### DIFF
--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { DaintreeIcon, Activity } from "@/components/icons";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
+import { SettingsLoadErrorBanner } from "@/components/Settings/SettingsLoadErrorBanner";
 import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
 import { getAgentIds, getAgentConfig } from "@/config/agents";
@@ -143,6 +144,8 @@ export function GeneralTab({
   const [agentSettings, setAgentSettings] = useState<AgentSettings | null>(null);
   const [shortcuts, setShortcuts] = useState<ShortcutCategory[]>([]);
   const [updateChannel, setUpdateChannel] = useState<"stable" | "nightly" | null>(null);
+  const [updateChannelLoadFailed, setUpdateChannelLoadFailed] = useState(false);
+  const [channelRetryNonce, setChannelRetryNonce] = useState(0);
   const [channelSaving, setChannelSaving] = useState(false);
   const [lastUpdateCheck, setLastUpdateCheck] = useState<number | null>(null);
   const [storeUpdateNotificationsEnabled, setStoreUpdateNotificationsEnabled] = useState<
@@ -166,6 +169,7 @@ export function GeneralTab({
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
 
   useEffect(() => {
+    setUpdateChannelLoadFailed(false);
     if (updatesManagedByStore) return;
     let cancelled = false;
     window.electron.update
@@ -174,13 +178,16 @@ export function GeneralTab({
         if (!cancelled) setUpdateChannel(ch);
       })
       .catch((error) => {
-        if (!cancelled) setUpdateChannel("stable");
+        // Never fall back to a channel here: an unknown channel must stay unknown,
+        // or a nightly user sees "stable" selected and silently gets moved to it.
+        if (cancelled) return;
+        setUpdateChannelLoadFailed(true);
         logError("Failed to get update channel", error);
       });
     return () => {
       cancelled = true;
     };
-  }, [updatesManagedByStore]);
+  }, [updatesManagedByStore, channelRetryNonce]);
 
   useEffect(() => {
     if (updatesManagedByStore) return;
@@ -857,28 +864,37 @@ export function GeneralTab({
               description="Choose between stable releases and nightly builds."
               id="general-update-channel"
             >
-              <div className="flex gap-2">
-                {(["stable", "nightly"] as const).map((ch) => (
-                  <button
-                    key={ch}
-                    disabled={updateChannel === null}
-                    onClick={() => void handleChannelChange(ch)}
-                    className={cn(
-                      "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
-                      updateChannel === ch
-                        ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
-                        : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
-                    )}
-                  >
-                    {ch}
-                  </button>
-                ))}
-              </div>
-              {updateChannel === "nightly" && (
-                <p className="text-xs text-status-warning/80">
-                  Nightly builds may contain unstable features. You can switch back to stable at any
-                  time.
-                </p>
+              {updateChannelLoadFailed ? (
+                <SettingsLoadErrorBanner
+                  message="Couldn't load the update channel"
+                  onRetry={() => setChannelRetryNonce((n) => n + 1)}
+                />
+              ) : (
+                <>
+                  <div className="flex gap-2">
+                    {(["stable", "nightly"] as const).map((ch) => (
+                      <button
+                        key={ch}
+                        disabled={updateChannel === null}
+                        onClick={() => void handleChannelChange(ch)}
+                        className={cn(
+                          "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
+                          updateChannel === ch
+                            ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
+                            : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
+                        )}
+                      >
+                        {ch}
+                      </button>
+                    ))}
+                  </div>
+                  {updateChannel === "nightly" && (
+                    <p className="text-xs text-status-warning/80">
+                      Nightly builds may contain unstable features. You can switch back to stable at
+                      any time.
+                    </p>
+                  )}
+                </>
               )}
               {lastUpdateCheck && (
                 <p className="text-xs text-text-secondary">

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -179,7 +179,7 @@ export function GeneralTab({
       })
       .catch((error) => {
         // Never fall back to a channel here: an unknown channel must stay unknown,
-        // or a nightly user sees "stable" selected and silently gets moved to it.
+        // or a nightly user sees "stable" selected as though it were authoritative.
         if (cancelled) return;
         setUpdateChannelLoadFailed(true);
         logError("Failed to get update channel", error);

--- a/src/components/Settings/__tests__/GeneralTab.updateChannel.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.updateChannel.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { CliAvailability, AgentSettings, HibernationConfig } from "@shared/types";
+import { useDistributionStore } from "@/store/distributionStore";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("../SettingsSection", () => ({
+  SettingsSection: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <section data-testid={`section-${title}`}>
+      <h3>{title}</h3>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock("../SettingsSubtabBar", () => ({
+  SettingsSubtabBar: () => null,
+}));
+
+vi.mock("@/components/Settings/SettingsSwitchCard", () => ({
+  SettingsSwitchCard: () => null,
+}));
+
+vi.mock("@/store", () => ({
+  usePreferencesStore: (selector: (state: Record<string, boolean>) => unknown) =>
+    selector({
+      showProjectPulse: true,
+      showDeveloperTools: false,
+      showGridAgentHighlights: true,
+      showDockAgentHighlights: true,
+    }),
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    subscribe: vi.fn(() => () => {}),
+    loadOverrides: vi.fn(() => Promise.resolve()),
+    getBinding: vi.fn(() => null),
+    getEffectiveCombo: vi.fn(() => null),
+    formatComboForDisplay: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentIds: () => ["claude"],
+  getAgentConfig: (id: string) => ({ name: id.charAt(0).toUpperCase() + id.slice(1) }),
+}));
+
+const mockLogError = vi.fn<(message: string, error?: unknown) => void>();
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: (message: string, error?: unknown) => mockLogError(message, error),
+}));
+
+const mockDispatch = vi.fn();
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (actionId: string, ...rest: unknown[]) => mockDispatch(actionId, ...rest),
+  },
+}));
+
+function setupDispatchMock() {
+  mockDispatch.mockImplementation(async (actionId: string) => {
+    if (actionId === "cliAvailability.get") {
+      return { ok: true, result: { claude: "ready" } as CliAvailability };
+    }
+    if (actionId === "agentSettings.get") {
+      return {
+        ok: true,
+        result: { agents: { claude: { pinned: true } } } as unknown as AgentSettings,
+      };
+    }
+    if (actionId === "hibernation.getConfig") {
+      return {
+        ok: true,
+        result: { enabled: false, inactiveThresholdHours: 24 } as HibernationConfig,
+      };
+    }
+    return { ok: true, result: undefined };
+  });
+}
+
+/** A promise whose settlement this test controls, so we can observe the in-flight state. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // Keep the rejection from tripping an unhandled-rejection warning before the component attaches.
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+type GetChannel = () => Promise<"stable" | "nightly">;
+
+function setupElectron(getChannel: GetChannel, lastCheck: number | null = null) {
+  const setChannel = vi.fn<(ch: "stable" | "nightly") => Promise<"stable" | "nightly">>((ch) =>
+    Promise.resolve(ch)
+  );
+  (window as unknown as { electron: unknown }).electron = {
+    update: {
+      getChannel: vi.fn(getChannel),
+      setChannel,
+      getLastCheck: vi.fn(() => Promise.resolve(lastCheck)),
+    },
+  };
+  return { setChannel };
+}
+
+function electronUpdate() {
+  return (
+    window as unknown as {
+      electron: { update: { getChannel: { mock: { calls: unknown[] } } } };
+    }
+  ).electron.update;
+}
+
+async function renderGeneralTab() {
+  const { GeneralTab } = await import("../GeneralTab");
+  return render(
+    <GeneralTab
+      appVersion="1.0.0"
+      onNavigateToAgents={vi.fn()}
+      activeSubtab="overview"
+      onSubtabChange={vi.fn()}
+    />
+  );
+}
+
+const BANNER_TEXT = "Couldn't load the update channel";
+
+describe("GeneralTab — update channel load failure (issue #11119)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDispatchMock();
+    useDistributionStore.setState({ isWindowsStore: false });
+  });
+
+  afterEach(() => {
+    useDistributionStore.setState({ isWindowsStore: false });
+  });
+
+  it("never selects a channel when the load fails", async () => {
+    setupElectron(() => Promise.reject(new Error("ipc down")));
+
+    await renderGeneralTab();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(BANNER_TEXT);
+
+    // The whole point of #11119: a failed load must not manufacture a "stable" selection.
+    expect(screen.queryByRole("button", { name: "stable" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "nightly" })).toBeNull();
+    expect(screen.queryByText(/Nightly builds may contain unstable features/)).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith("Failed to get update channel", expect.anything());
+  });
+
+  it("shows the real channel and no banner when the load succeeds", async () => {
+    setupElectron(() => Promise.resolve("nightly"));
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "nightly" }).hasAttribute("disabled")).toBe(false);
+    });
+    expect(screen.getByText(/Nightly builds may contain unstable features/)).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps the channel buttons disabled while the load is still in flight", async () => {
+    const pending = deferred<"stable" | "nightly">();
+    setupElectron(() => pending.promise);
+
+    await renderGeneralTab();
+
+    const stable = await screen.findByRole("button", { name: "stable" });
+    expect(stable.hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    await act(async () => {
+      pending.resolve("stable");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "stable" }).hasAttribute("disabled")).toBe(false);
+    });
+  });
+
+  it("keeps the independently-loaded last-checked line visible when the channel fails", async () => {
+    setupElectron(() => Promise.reject(new Error("ipc down")), 1_700_000_000_000);
+
+    await renderGeneralTab();
+
+    await screen.findByRole("alert");
+    await waitFor(() => {
+      expect(screen.getByText(/Last checked:/)).toBeTruthy();
+    });
+  });
+
+  it("retry refetches and shows the recovered channel", async () => {
+    const getChannel = vi
+      .fn<GetChannel>()
+      .mockRejectedValueOnce(new Error("ipc down"))
+      .mockResolvedValueOnce("nightly");
+    setupElectron(getChannel);
+
+    await renderGeneralTab();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "nightly" }).hasAttribute("disabled")).toBe(false);
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(getChannel).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the banner again when the retry also fails", async () => {
+    const second = deferred<"stable" | "nightly">();
+    const getChannel = vi
+      .fn<GetChannel>()
+      .mockRejectedValueOnce(new Error("ipc down"))
+      .mockImplementationOnce(() => second.promise);
+    setupElectron(getChannel);
+
+    await renderGeneralTab();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+
+    // The retry clears the error and returns to the loading (disabled) state...
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    await act(async () => {
+      second.reject(new Error("still down"));
+    });
+
+    // ...and a second failure must surface the banner again, still retryable.
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(BANNER_TEXT);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(getChannel).toHaveBeenCalledTimes(2);
+    expect(mockLogError).toHaveBeenCalledTimes(2);
+  });
+
+  it("discards an in-flight channel rejection when Windows Store hydration lands", async () => {
+    const pending = deferred<"stable" | "nightly">();
+    setupElectron(() => pending.promise);
+
+    await renderGeneralTab();
+    expect(electronUpdate().getChannel.mock.calls).toHaveLength(1);
+
+    // isWindowsStore hydrates asynchronously and can flip false -> true after mount.
+    await act(async () => {
+      useDistributionStore.getState().setIsWindowsStore(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("section-Updates")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("section-Update channel")).toBeNull();
+
+    await act(async () => {
+      pending.reject(new Error("ipc down"));
+    });
+
+    // The superseded attempt owns no UI: it must neither raise the banner nor log.
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("button", { name: "stable" })).toBeNull();
+    expect(mockLogError).not.toHaveBeenCalledWith(
+      "Failed to get update channel",
+      expect.anything()
+    );
+  });
+});

--- a/src/components/Settings/__tests__/GeneralTab.updateChannel.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.updateChannel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { StrictMode } from "react";
+import { render, screen, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import type { CliAvailability, AgentSettings, HibernationConfig } from "@shared/types";
 import { useDistributionStore } from "@/store/distributionStore";
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
@@ -66,25 +66,19 @@ vi.mock("@/services/ActionService", () => ({
 function setupDispatchMock() {
   mockDispatch.mockImplementation(async (actionId: string) => {
     if (actionId === "cliAvailability.get") {
-      return { ok: true, result: { claude: "ready" } as CliAvailability };
+      return { ok: true, result: { claude: "ready" } };
     }
     if (actionId === "agentSettings.get") {
-      return {
-        ok: true,
-        result: { agents: { claude: { pinned: true } } } as unknown as AgentSettings,
-      };
+      return { ok: true, result: { agents: { claude: { pinned: true } } } };
     }
     if (actionId === "hibernation.getConfig") {
-      return {
-        ok: true,
-        result: { enabled: false, inactiveThresholdHours: 24 } as HibernationConfig,
-      };
+      return { ok: true, result: { enabled: false, inactiveThresholdHours: 24 } };
     }
     return { ok: true, result: undefined };
   });
 }
 
-/** A promise whose settlement this test controls, so we can observe the in-flight state. */
+/** A promise whose settlement this test controls, so the in-flight state stays observable. */
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -92,48 +86,64 @@ function deferred<T>() {
     resolve = res;
     reject = rej;
   });
-  // Keep the rejection from tripping an unhandled-rejection warning before the component attaches.
+  // An independent handler, so a rejection we settle late doesn't trip an unhandled-rejection
+  // warning. The component attaches its own catch to the same promise and still observes it.
   promise.catch(() => {});
   return { promise, resolve, reject };
 }
 
-type GetChannel = () => Promise<"stable" | "nightly">;
+type Channel = "stable" | "nightly";
+type GetChannel = () => Promise<Channel>;
 
 function setupElectron(getChannel: GetChannel, lastCheck: number | null = null) {
-  const setChannel = vi.fn<(ch: "stable" | "nightly") => Promise<"stable" | "nightly">>((ch) =>
-    Promise.resolve(ch)
-  );
-  (window as unknown as { electron: unknown }).electron = {
-    update: {
-      getChannel: vi.fn(getChannel),
-      setChannel,
-      getLastCheck: vi.fn(() => Promise.resolve(lastCheck)),
+  const setChannel = vi.fn<(ch: Channel) => Promise<Channel>>((ch) => Promise.resolve(ch));
+  const getChannelMock = vi.fn(getChannel);
+  Object.assign(window, {
+    electron: {
+      update: {
+        getChannel: getChannelMock,
+        setChannel,
+        getLastCheck: vi.fn(() => Promise.resolve(lastCheck)),
+      },
     },
-  };
-  return { setChannel };
+  });
+  return { getChannel: getChannelMock, setChannel };
 }
 
-function electronUpdate() {
-  return (
-    window as unknown as {
-      electron: { update: { getChannel: { mock: { calls: unknown[] } } } };
-    }
-  ).electron.update;
+function channelButtons() {
+  return {
+    stable: screen.queryByRole("button", { name: "stable" }),
+    nightly: screen.queryByRole("button", { name: "nightly" }),
+  };
+}
+
+const NIGHTLY_WARNING = /Nightly builds may contain unstable features/;
+/** The banner must name the thing that failed — matched semantically, not by exact prose. */
+const BANNER_MESSAGE = /update channel/i;
+
+function props() {
+  return {
+    appVersion: "1.0.0",
+    onNavigateToAgents: vi.fn(),
+    activeSubtab: "overview",
+    onSubtabChange: vi.fn(),
+  };
 }
 
 async function renderGeneralTab() {
   const { GeneralTab } = await import("../GeneralTab");
-  return render(
-    <GeneralTab
-      appVersion="1.0.0"
-      onNavigateToAgents={vi.fn()}
-      activeSubtab="overview"
-      onSubtabChange={vi.fn()}
-    />
-  );
+  return render(<GeneralTab {...props()} />);
 }
 
-const BANNER_TEXT = "Couldn't load the update channel";
+/** Mirrors the real root (src/main.tsx), where StrictMode double-invokes mount effects. */
+async function renderGeneralTabStrict() {
+  const { GeneralTab } = await import("../GeneralTab");
+  return render(
+    <StrictMode>
+      <GeneralTab {...props()} />
+    </StrictMode>
+  );
+}
 
 describe("GeneralTab — update channel load failure (issue #11119)", () => {
   beforeEach(() => {
@@ -143,45 +153,63 @@ describe("GeneralTab — update channel load failure (issue #11119)", () => {
   });
 
   afterEach(() => {
+    // Unmount before restoring the real store, or the last test's reset re-renders a live
+    // component outside act() and kicks off another channel load.
+    cleanup();
     useDistributionStore.setState({ isWindowsStore: false });
   });
 
-  it("never selects a channel when the load fails", async () => {
-    setupElectron(() => Promise.reject(new Error("ipc down")));
+  it("never fabricates a channel when the load fails", async () => {
+    const error = new Error("ipc down");
+    const { setChannel } = setupElectron(() => Promise.reject(error));
 
     await renderGeneralTab();
 
     const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toContain(BANNER_TEXT);
+    expect(alert.textContent).toMatch(BANNER_MESSAGE);
 
-    // The whole point of #11119: a failed load must not manufacture a "stable" selection.
-    expect(screen.queryByRole("button", { name: "stable" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "nightly" })).toBeNull();
-    expect(screen.queryByText(/Nightly builds may contain unstable features/)).toBeNull();
-    expect(mockLogError).toHaveBeenCalledWith("Failed to get update channel", expect.anything());
+    // The heart of #11119: a failed load must not manufacture a selection. If it fabricated
+    // "stable", the buttons would render (enabled, with stable selected) instead of the banner.
+    const { stable, nightly } = channelButtons();
+    expect(stable).toBeNull();
+    expect(nightly).toBeNull();
+    expect(screen.queryByText(NIGHTLY_WARNING)).toBeNull();
+
+    // ...and nothing on the load path may ever write the channel back to main.
+    expect(setChannel).not.toHaveBeenCalled();
+    expect(mockLogError).toHaveBeenCalledWith(expect.any(String), error);
   });
 
   it("shows the real channel and no banner when the load succeeds", async () => {
-    setupElectron(() => Promise.resolve("nightly"));
+    const { setChannel } = setupElectron(() => Promise.resolve("nightly"));
 
     await renderGeneralTab();
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "nightly" }).hasAttribute("disabled")).toBe(false);
     });
-    expect(screen.getByText(/Nightly builds may contain unstable features/)).toBeTruthy();
+    // The nightly warning is the semantic proof that the REAL channel landed, not a fabricated one.
+    expect(screen.getByText(NIGHTLY_WARNING)).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
+    expect(setChannel).not.toHaveBeenCalled();
   });
 
-  it("keeps the channel buttons disabled while the load is still in flight", async () => {
-    const pending = deferred<"stable" | "nightly">();
-    setupElectron(() => pending.promise);
+  it("leaves the channel unknown and un-settable while the load is in flight", async () => {
+    const pending = deferred<Channel>();
+    const { setChannel } = setupElectron(() => pending.promise);
 
     await renderGeneralTab();
 
     const stable = await screen.findByRole("button", { name: "stable" });
+    const nightly = screen.getByRole("button", { name: "nightly" });
     expect(stable.hasAttribute("disabled")).toBe(true);
+    expect(nightly.hasAttribute("disabled")).toBe(true);
     expect(screen.queryByRole("alert")).toBeNull();
+
+    // A disabled button is a real browser gate, but prove the invariant, not the markup.
+    fireEvent.click(stable);
+    fireEvent.click(nightly);
+    expect(setChannel).not.toHaveBeenCalled();
 
     await act(async () => {
       pending.resolve("stable");
@@ -190,6 +218,7 @@ describe("GeneralTab — update channel load failure (issue #11119)", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "stable" }).hasAttribute("disabled")).toBe(false);
     });
+    expect(setChannel).not.toHaveBeenCalled();
   });
 
   it("keeps the independently-loaded last-checked line visible when the channel fails", async () => {
@@ -203,59 +232,78 @@ describe("GeneralTab — update channel load failure (issue #11119)", () => {
     });
   });
 
-  it("retry refetches and shows the recovered channel", async () => {
-    const getChannel = vi
-      .fn<GetChannel>()
-      .mockRejectedValueOnce(new Error("ipc down"))
-      .mockResolvedValueOnce("nightly");
-    setupElectron(getChannel);
+  it("retry refetches and recovers the real channel", async () => {
+    const { getChannel, setChannel } = setupElectron(
+      vi
+        .fn<GetChannel>()
+        .mockRejectedValueOnce(new Error("ipc down"))
+        .mockResolvedValueOnce("nightly")
+    );
 
     await renderGeneralTab();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    const callsBeforeRetry = getChannel.mock.calls.length;
+    fireEvent.click(retry);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "nightly" }).hasAttribute("disabled")).toBe(false);
+      expect(screen.getByText(NIGHTLY_WARNING)).toBeTruthy();
     });
+    // Both controls come back live, and the recovered value is the real one — not a fallback.
+    const { stable, nightly } = channelButtons();
+    expect(stable?.hasAttribute("disabled")).toBe(false);
+    expect(nightly?.hasAttribute("disabled")).toBe(false);
     expect(screen.queryByRole("alert")).toBeNull();
-    expect(getChannel).toHaveBeenCalledTimes(2);
+    expect(getChannel.mock.calls.length).toBe(callsBeforeRetry + 1);
+    expect(setChannel).not.toHaveBeenCalled();
   });
 
-  it("shows the banner again when the retry also fails", async () => {
-    const second = deferred<"stable" | "nightly">();
-    const getChannel = vi
-      .fn<GetChannel>()
-      .mockRejectedValueOnce(new Error("ipc down"))
-      .mockImplementationOnce(() => second.promise);
-    setupElectron(getChannel);
+  it("holds the channel unknown across a retry that also fails", async () => {
+    const firstError = new Error("ipc down");
+    const secondError = new Error("still down");
+    const second = deferred<Channel>();
+    const { setChannel } = setupElectron(
+      vi
+        .fn<GetChannel>()
+        .mockRejectedValueOnce(firstError)
+        .mockImplementationOnce(() => second.promise)
+    );
 
     await renderGeneralTab();
 
     fireEvent.click(await screen.findByRole("button", { name: "Retry" }));
 
-    // The retry clears the error and returns to the loading (disabled) state...
+    // The retry clears the error and returns to the loading state. This window is where a
+    // fabricated "stable" from the FIRST failure would surface as enabled/selected buttons.
     await waitFor(() => {
       expect(screen.queryByRole("alert")).toBeNull();
     });
+    const { stable, nightly } = channelButtons();
+    expect(stable?.hasAttribute("disabled")).toBe(true);
+    expect(nightly?.hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByText(NIGHTLY_WARNING)).toBeNull();
 
     await act(async () => {
-      second.reject(new Error("still down"));
+      second.reject(secondError);
     });
 
-    // ...and a second failure must surface the banner again, still retryable.
+    // A second failure surfaces the banner again, still retryable, still no channel written.
     const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toContain(BANNER_TEXT);
+    expect(alert.textContent).toMatch(BANNER_MESSAGE);
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
-    expect(getChannel).toHaveBeenCalledTimes(2);
-    expect(mockLogError).toHaveBeenCalledTimes(2);
+    expect(setChannel).not.toHaveBeenCalled();
+
+    // Each attempt logged its OWN error — a repeat of the first would also reach a bare count of 2.
+    expect(mockLogError).toHaveBeenCalledWith(expect.any(String), firstError);
+    expect(mockLogError).toHaveBeenCalledWith(expect.any(String), secondError);
   });
 
   it("discards an in-flight channel rejection when Windows Store hydration lands", async () => {
-    const pending = deferred<"stable" | "nightly">();
+    const staleError = new Error("ipc down");
+    const pending = deferred<Channel>();
     setupElectron(() => pending.promise);
 
     await renderGeneralTab();
-    expect(electronUpdate().getChannel.mock.calls).toHaveLength(1);
 
     // isWindowsStore hydrates asynchronously and can flip false -> true after mount.
     await act(async () => {
@@ -268,15 +316,84 @@ describe("GeneralTab — update channel load failure (issue #11119)", () => {
     expect(screen.queryByTestId("section-Update channel")).toBeNull();
 
     await act(async () => {
-      pending.reject(new Error("ipc down"));
+      pending.reject(staleError);
     });
 
-    // The superseded attempt owns no UI: it must neither raise the banner nor log.
+    // The superseded attempt owns no UI: it must not log. (Matched on the error INSTANCE, so
+    // rewording the log message can't make this pass vacuously.)
+    expect(mockLogError).not.toHaveBeenCalledWith(expect.anything(), staleError);
     expect(screen.queryByRole("alert")).toBeNull();
-    expect(screen.queryByRole("button", { name: "stable" })).toBeNull();
-    expect(mockLogError).not.toHaveBeenCalledWith(
-      "Failed to get update channel",
-      expect.anything()
+  });
+});
+
+// The Store branch hides the channel UI, so it cannot prove a stale write was DISCARDED rather
+// than merely hidden. StrictMode's mount double-invoke supersedes an attempt while the channel
+// UI is still on screen, which makes the cancellation guard observable.
+describe("GeneralTab — superseded channel loads under StrictMode (issue #11119)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDispatchMock();
+    useDistributionStore.setState({ isWindowsStore: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useDistributionStore.setState({ isWindowsStore: false });
+  });
+
+  it("ignores a rejection from a superseded mount attempt", async () => {
+    const staleError = new Error("stale ipc failure");
+    const stale = deferred<Channel>();
+    const { getChannel } = setupElectron(
+      vi
+        .fn<GetChannel>()
+        .mockImplementationOnce(() => stale.promise)
+        .mockImplementationOnce(() => Promise.resolve("nightly"))
     );
+
+    await renderGeneralTabStrict();
+
+    // Precondition: StrictMode really did double-invoke, so attempt #1 is the superseded one.
+    await waitFor(() => {
+      expect(getChannel.mock.calls.length).toBe(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(NIGHTLY_WARNING)).toBeTruthy();
+    });
+
+    await act(async () => {
+      stale.reject(staleError);
+    });
+
+    // The live channel survives: the dead attempt must not raise a banner over a loaded value.
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText(NIGHTLY_WARNING)).toBeTruthy();
+    expect(mockLogError).not.toHaveBeenCalledWith(expect.anything(), staleError);
+  });
+
+  it("ignores a late resolution from a superseded mount attempt", async () => {
+    const stale = deferred<Channel>();
+    const { getChannel } = setupElectron(
+      vi
+        .fn<GetChannel>()
+        .mockImplementationOnce(() => stale.promise)
+        .mockImplementationOnce(() => Promise.resolve("nightly"))
+    );
+
+    await renderGeneralTabStrict();
+
+    await waitFor(() => {
+      expect(getChannel.mock.calls.length).toBe(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(NIGHTLY_WARNING)).toBeTruthy();
+    });
+
+    await act(async () => {
+      stale.resolve("stable");
+    });
+
+    // A slow superseded attempt must not overwrite the live one with an outdated channel.
+    expect(screen.getByText(NIGHTLY_WARNING)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Summary:
GeneralTab's update-channel effect caught a failed `window.electron.update.getChannel()` IPC call and did `setUpdateChannel("stable")`. `updateChannel` is typed `"stable" | "nightly" | null` and `null` is already the "unknown" sentinel, so that catch was actively destroying information: a nightly user whose channel failed to load saw "stable" selected and enabled, as though it were authoritative. That's the "no silent fallback defaults" anti-pattern (precedent #7880).

What changed:
- The rejection path no longer guesses. `updateChannel` stays `null` (unknown) and a new `updateChannelLoadFailed` flag drives the UI.
- On failure the stable/nightly button pair and the nightly warning are replaced by the existing shared `SettingsLoadErrorBanner` (role="alert", inline "Retry"). A retry nonce re-runs the same effect. No new component, no new tokens.
- Inline banner, not a toast: this is a Tier-3 signal per docs/architecture/notification-system.md — the failure originates in this component and its recovery lives right next to it. (The issue pointed at `handleChannelChange`'s notify() "Try again" toast as a model, but that's a *save*-failure toast; this copies its spirit, not its surface. Hence "Retry", per the inline-banner microcopy rule.)
- A superseded/cancelled rejection is now a total no-op, including the log. The effect keeps its `updatesManagedByStore` dependency — `isWindowsStore` hydrates asynchronously and can flip false→true after mount, and the dep-array re-run is what discards an in-flight `getChannel()` before it can write state for a branch that is no longer rendered.

Tests (`GeneralTab.updateChannel.test.tsx`, 9 cases):
The suite pins the actual invariant — the channel stays unknown and no load path ever calls `setChannel` — rather than merely asserting "a banner appears". That distinction is load-bearing: an earlier version of these tests stayed green against a hybrid regression that restored the `"stable"` fabrication *behind* the banner. The retry window is the only state where a fabricated value is observable (during the initial failure the buttons are unmounted), so that's where it's asserted. Two StrictMode cases cover a superseded mount attempt's late rejection and late resolution, which the Windows-Store branch alone can't prove (it hides the channel UI, so it can't distinguish "discarded" from "hidden").

Follow-up (not in this PR):
The sibling Windows-Store effect does `setStoreUpdateNotificationsEnabled(true)` when `storeUpdate.getSettings()` rejects — same bug class: an IPC failure doesn't prove the key is absent, so a user who persisted `false` would see notifications shown as enabled. It's a different surface with its own older-preload compat branch and needs its own retry/error design, so I left it alone rather than expand the scope here.

Verification:
- 114 tests green across the touched suites (new spec + GeneralTab systemStatus/subtabs/navigation + accentGuard/themeReadiness contract guards)
- Full `npm run typecheck` clean; prettier clean; eslint adds zero warnings (the 13 on GeneralTab.tsx are pre-existing and per-rule identical to develop)

Resolves #11119