### PR TITLE
fix(pty): respect an inherited NO_COLOR when defaulting FORCE_COLOR

### DIFF
--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -803,9 +803,15 @@ export class PtyPool {
 
     // TUI reliability: ensure rich terminal capabilities for Claude/Gemini CLIs.
     // Mirrors `buildTerminalEnv` so agent CLIs get the same color-rendering
-    // hints whether they spawn fresh or come out of the pool.
+    // hints whether they spawn fresh or come out of the pool — including its
+    // NO_COLOR guard: FORCE_COLOR wins over NO_COLOR downstream, so injecting
+    // the default would override an inherited or caller-supplied opt-out.
+    // A caller-supplied NO_COLOR keys its own pool slot (`computePoolEnvHash`
+    // hashes it), so a warm shell can never cross that boundary.
     filtered.TERM = "xterm-256color";
-    filtered.FORCE_COLOR = filtered.FORCE_COLOR ?? "3";
+    if (filtered.NO_COLOR === undefined) {
+      filtered.FORCE_COLOR = filtered.FORCE_COLOR ?? "3";
+    }
     filtered.COLORTERM = "truecolor";
 
     // Avoid tools treating the environment as CI/non-interactive

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -6,6 +6,7 @@ import {
   filterEnvironment,
   filterSensitiveOnly,
   ensureUtf8Locale,
+  shouldInjectForceColor,
 } from "./pty/EnvironmentFilter.js";
 import { POOL_ENV_EMPTY_HASH } from "./pty/ptyPoolEnvHash.js";
 import { isHostPerformanceCaptureEnabled, markHostPerformance } from "../utils/hostPerformance.js";
@@ -804,13 +805,12 @@ export class PtyPool {
     // TUI reliability: ensure rich terminal capabilities for Claude/Gemini CLIs.
     // Mirrors `buildTerminalEnv` so agent CLIs get the same color-rendering
     // hints whether they spawn fresh or come out of the pool — including its
-    // NO_COLOR guard: FORCE_COLOR wins over NO_COLOR downstream, so injecting
-    // the default would override an inherited or caller-supplied opt-out.
-    // A caller-supplied NO_COLOR keys its own pool slot (`computePoolEnvHash`
-    // hashes it), so a warm shell can never cross that boundary.
+    // NO_COLOR opt-out (#11118). A caller-supplied NO_COLOR keys its own pool
+    // slot (`computePoolEnvHash` hashes it), so a shell warmed with the
+    // FORCE_COLOR default can never be handed to a caller that opted out.
     filtered.TERM = "xterm-256color";
-    if (filtered.NO_COLOR === undefined) {
-      filtered.FORCE_COLOR = filtered.FORCE_COLOR ?? "3";
+    if (shouldInjectForceColor(filtered)) {
+      filtered.FORCE_COLOR = "3";
     }
     filtered.COLORTERM = "truecolor";
 

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PtyPool, destroyPty } from "../PtyPool.js";
+import { computePoolEnvHash } from "../pty/ptyPoolEnvHash.js";
 import type { IPty } from "node-pty";
 
 const spawnMock = vi.fn();
@@ -94,6 +95,8 @@ describe("PtyPool", () => {
   const originalCi = process.env.CI;
   const originalLang = process.env.LANG;
   const originalLcAll = process.env.LC_ALL;
+  const originalNoColor = process.env.NO_COLOR;
+  const originalForceColor = process.env.FORCE_COLOR;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -103,6 +106,11 @@ describe("PtyPool", () => {
     process.env.CI = "true";
     delete process.env.LANG;
     delete process.env.LC_ALL;
+    // buildSpawnEnv inherits from process.env and now yields to NO_COLOR
+    // (#11118), so a host shell exporting either colour variable would decide
+    // the spawn-env assertions instead of the code under test.
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
   });
 
   afterEach(() => {
@@ -113,6 +121,10 @@ describe("PtyPool", () => {
     else delete process.env.LANG;
     if (originalLcAll !== undefined) process.env.LC_ALL = originalLcAll;
     else delete process.env.LC_ALL;
+    if (originalNoColor !== undefined) process.env.NO_COLOR = originalNoColor;
+    else delete process.env.NO_COLOR;
+    if (originalForceColor !== undefined) process.env.FORCE_COLOR = originalForceColor;
+    else delete process.env.FORCE_COLOR;
   });
 
   it("falls back to default pool size when configured pool size is invalid", () => {
@@ -274,6 +286,59 @@ describe("PtyPool", () => {
     expect(spawnOptions.env?.LANG).toBe("en_US.UTF-8");
     expect(spawnOptions.env?.LC_ALL).toBeUndefined();
     pool.dispose();
+  });
+
+  it.each([
+    ["a non-empty NO_COLOR", "1"],
+    ["an empty NO_COLOR", ""],
+  ])("does not inject FORCE_COLOR into a warm shell when the host exports %s", async (_, value) => {
+    process.env.NO_COLOR = value;
+    spawnMock.mockReturnValue(createFakeProcess(402));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    await pool.warmPool();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.FORCE_COLOR).toBeUndefined();
+    expect(spawnOptions.env?.NO_COLOR).toBe(value);
+    // COLORTERM only selects depth once colour is on — it never forces it.
+    expect(spawnOptions.env?.COLORTERM).toBe("truecolor");
+    expect(spawnOptions.env?.TERM).toBe("xterm-256color");
+    pool.dispose();
+  });
+
+  it("does not inject FORCE_COLOR into a warm shell when the caller sets NO_COLOR", async () => {
+    spawnMock.mockReturnValue(createFakeProcess(403));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    pool.warmForKey("/repo", { NO_COLOR: "1" }, computePoolEnvHash({ NO_COLOR: "1" }));
+    await flushMicrotasks();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.FORCE_COLOR).toBeUndefined();
+    expect(spawnOptions.env?.NO_COLOR).toBe("1");
+    pool.dispose();
+  });
+
+  it("preserves an explicit caller FORCE_COLOR rather than rewriting it", async () => {
+    spawnMock.mockReturnValue(createFakeProcess(404));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    pool.warmForKey("/repo", { FORCE_COLOR: "0" }, computePoolEnvHash({ FORCE_COLOR: "0" }));
+    await flushMicrotasks();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.FORCE_COLOR).toBe("0");
+    pool.dispose();
+  });
+
+  it("keys NO_COLOR callers to their own pool slot", () => {
+    // The pooled half of the NO_COLOR fix only holds because a caller-supplied
+    // NO_COLOR changes the env hash: without this, a shell warmed with
+    // FORCE_COLOR=3 could be acquired by a caller that opted out of colour.
+    expect(computePoolEnvHash({ NO_COLOR: "1" })).not.toBe(computePoolEnvHash(undefined));
+    expect(computePoolEnvHash({ NO_COLOR: "" })).not.toBe(computePoolEnvHash(undefined));
+    expect(computePoolEnvHash({ NO_COLOR: "1" })).not.toBe(computePoolEnvHash({ NO_COLOR: "" }));
   });
 
   it("filters secrets out of caller env before baking into the pool entry", async () => {

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -304,8 +304,6 @@ describe("PtyPool", () => {
     const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
     expect(spawnOptions.env?.FORCE_COLOR).toBeUndefined();
     expect(spawnOptions.env?.NO_COLOR).toBe(value);
-    // The depth hints survive: they inform colour support, they don't force it.
-    expect(spawnOptions.env?.COLORTERM).toBeDefined();
     pool.dispose();
   });
 
@@ -335,9 +333,10 @@ describe("PtyPool", () => {
   });
 
   it("never hands a colour-forcing warm shell to a NO_COLOR caller", async () => {
-    // The pooled half of the NO_COLOR fix rests on the env hash isolating the
-    // slot: a shell already warmed with the FORCE_COLOR default must not
-    // satisfy an acquire from a caller that opted out of colour.
+    // The pooled opt-out rests on hash isolation, not on the spawn guard: a
+    // shell already warmed with the FORCE_COLOR default must MISS an acquire
+    // from a NO_COLOR caller. Excluding NO_COLOR from computePoolEnvHash (the
+    // mutant this kills) would serve that colour-forcing shell straight to them.
     spawnMock.mockReturnValue(createFakeProcess(405));
     const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
     await pool.warmPool();
@@ -350,9 +349,9 @@ describe("PtyPool", () => {
   });
 
   it("keeps FORCE_COLOR out of the shell that refills an acquired NO_COLOR slot", async () => {
-    // acquireByKey refills the same key from the entry's caller env. The
-    // replacement shell has to inherit the opt-out too, not quietly fall back
-    // to the default the way the acquired one would have.
+    // acquireByKey refills the same key by feeding the acquired entry's own
+    // built env back through buildSpawnEnv. The replacement has to come out
+    // colour-free too, rather than regaining the default on the way through.
     spawnMock.mockReturnValue(createFakeProcess(406));
     const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
     const envHash = computePoolEnvHash({ NO_COLOR: "1" });

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -113,18 +113,21 @@ describe("PtyPool", () => {
     delete process.env.FORCE_COLOR;
   });
 
+  // Assigning `undefined` to process.env stringifies it to "undefined", which
+  // leaves an absent var looking *set* (a restored CI="undefined" is truthy).
+  const restoreEnv = (key: string, original: string | undefined) => {
+    if (original !== undefined) process.env[key] = original;
+    else delete process.env[key];
+  };
+
   afterEach(() => {
-    process.env.SHELL = originalShell;
-    process.env.HOME = originalHome;
-    process.env.CI = originalCi;
-    if (originalLang !== undefined) process.env.LANG = originalLang;
-    else delete process.env.LANG;
-    if (originalLcAll !== undefined) process.env.LC_ALL = originalLcAll;
-    else delete process.env.LC_ALL;
-    if (originalNoColor !== undefined) process.env.NO_COLOR = originalNoColor;
-    else delete process.env.NO_COLOR;
-    if (originalForceColor !== undefined) process.env.FORCE_COLOR = originalForceColor;
-    else delete process.env.FORCE_COLOR;
+    restoreEnv("SHELL", originalShell);
+    restoreEnv("HOME", originalHome);
+    restoreEnv("CI", originalCi);
+    restoreEnv("LANG", originalLang);
+    restoreEnv("LC_ALL", originalLcAll);
+    restoreEnv("NO_COLOR", originalNoColor);
+    restoreEnv("FORCE_COLOR", originalForceColor);
   });
 
   it("falls back to default pool size when configured pool size is invalid", () => {
@@ -301,9 +304,8 @@ describe("PtyPool", () => {
     const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
     expect(spawnOptions.env?.FORCE_COLOR).toBeUndefined();
     expect(spawnOptions.env?.NO_COLOR).toBe(value);
-    // COLORTERM only selects depth once colour is on — it never forces it.
-    expect(spawnOptions.env?.COLORTERM).toBe("truecolor");
-    expect(spawnOptions.env?.TERM).toBe("xterm-256color");
+    // The depth hints survive: they inform colour support, they don't force it.
+    expect(spawnOptions.env?.COLORTERM).toBeDefined();
     pool.dispose();
   });
 
@@ -332,13 +334,39 @@ describe("PtyPool", () => {
     pool.dispose();
   });
 
-  it("keys NO_COLOR callers to their own pool slot", () => {
-    // The pooled half of the NO_COLOR fix only holds because a caller-supplied
-    // NO_COLOR changes the env hash: without this, a shell warmed with
-    // FORCE_COLOR=3 could be acquired by a caller that opted out of colour.
-    expect(computePoolEnvHash({ NO_COLOR: "1" })).not.toBe(computePoolEnvHash(undefined));
-    expect(computePoolEnvHash({ NO_COLOR: "" })).not.toBe(computePoolEnvHash(undefined));
-    expect(computePoolEnvHash({ NO_COLOR: "1" })).not.toBe(computePoolEnvHash({ NO_COLOR: "" }));
+  it("never hands a colour-forcing warm shell to a NO_COLOR caller", async () => {
+    // The pooled half of the NO_COLOR fix rests on the env hash isolating the
+    // slot: a shell already warmed with the FORCE_COLOR default must not
+    // satisfy an acquire from a caller that opted out of colour.
+    spawnMock.mockReturnValue(createFakeProcess(405));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+    await pool.warmPool();
+
+    const warmed = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(warmed.env?.FORCE_COLOR).toBeDefined();
+
+    expect(pool.acquireByKey("/repo", computePoolEnvHash({ NO_COLOR: "1" }))).toBeNull();
+    pool.dispose();
+  });
+
+  it("keeps FORCE_COLOR out of the shell that refills an acquired NO_COLOR slot", async () => {
+    // acquireByKey refills the same key from the entry's caller env. The
+    // replacement shell has to inherit the opt-out too, not quietly fall back
+    // to the default the way the acquired one would have.
+    spawnMock.mockReturnValue(createFakeProcess(406));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+    const envHash = computePoolEnvHash({ NO_COLOR: "1" });
+
+    pool.warmForKey("/repo", { NO_COLOR: "1" }, envHash);
+    await settleRefill();
+    expect(pool.acquireByKey("/repo", envHash)).not.toBeNull();
+    await settleRefill();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const refill = spawnMock.mock.calls[1]?.[2] as { env?: Record<string, string> };
+    expect(refill.env?.FORCE_COLOR).toBeUndefined();
+    expect(refill.env?.NO_COLOR).toBe("1");
+    pool.dispose();
   });
 
   it("filters secrets out of caller env before baking into the pool entry", async () => {

--- a/electron/services/pty/EnvironmentFilter.ts
+++ b/electron/services/pty/EnvironmentFilter.ts
@@ -115,6 +115,30 @@ export function filterSensitiveOnly(
   return result;
 }
 
+/**
+ * Whether a spawn env should receive Daintree's `FORCE_COLOR` default.
+ *
+ * False once the env already carries `FORCE_COLOR` (the user's own value wins)
+ * or `NO_COLOR` (#11118). chalk/supports-color/ink read `FORCE_COLOR` first and
+ * short-circuit, so injecting it alongside `NO_COLOR` would override the opt-out
+ * and make Node print "NO_COLOR is ignored because FORCE_COLOR is set" in every
+ * terminal. Presence — not truthiness — is the test, so `NO_COLOR=` counts.
+ *
+ * Windows env names are case-insensitive, but the filters above return plain
+ * objects that preserve whatever casing the OS reported, so a `no_color` set via
+ * PowerShell would slip past an uppercase lookup and land in a child process
+ * that does resolve it case-insensitively. Fold case there only — on POSIX,
+ * `no_color` is a genuinely different variable and must not suppress anything.
+ */
+export function shouldInjectForceColor(env: Record<string, string>): boolean {
+  const foldCase = process.platform === "win32";
+  for (const key of Object.keys(env)) {
+    const name = foldCase ? key.toUpperCase() : key;
+    if (name === "NO_COLOR" || name === "FORCE_COLOR") return false;
+  }
+  return true;
+}
+
 const UTF8_PATTERN = /utf-?8/i;
 
 /**

--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -1,10 +1,51 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   isSensitiveVar,
   filterEnvironment,
   injectDaintreeMetadata,
   ensureUtf8Locale,
+  shouldInjectForceColor,
 } from "../EnvironmentFilter.js";
+
+describe("shouldInjectForceColor", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (platform: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  };
+
+  afterEach(() => setPlatform(realPlatform));
+
+  it("injects when the env states no colour preference", () => {
+    setPlatform("darwin");
+    expect(shouldInjectForceColor({ TERM: "xterm-256color" })).toBe(true);
+  });
+
+  it("yields to NO_COLOR", () => {
+    setPlatform("darwin");
+    expect(shouldInjectForceColor({ NO_COLOR: "1" })).toBe(false);
+  });
+
+  it("yields to an empty NO_COLOR, which is still present", () => {
+    setPlatform("darwin");
+    expect(shouldInjectForceColor({ NO_COLOR: "" })).toBe(false);
+  });
+
+  it("leaves an explicit FORCE_COLOR for the caller to own", () => {
+    setPlatform("darwin");
+    expect(shouldInjectForceColor({ FORCE_COLOR: "0" })).toBe(false);
+  });
+
+  it("folds case on Windows, where the child resolves env names case-insensitively", () => {
+    setPlatform("win32");
+    expect(shouldInjectForceColor({ no_color: "1" })).toBe(false);
+    expect(shouldInjectForceColor({ Force_Color: "1" })).toBe(false);
+  });
+
+  it("keeps POSIX case-sensitive, where no_color is a different variable", () => {
+    setPlatform("linux");
+    expect(shouldInjectForceColor({ no_color: "1" })).toBe(true);
+  });
+});
 
 describe("isSensitiveVar", () => {
   describe("exact blocklist", () => {

--- a/electron/services/pty/__tests__/terminalSpawn.env.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.env.test.ts
@@ -131,7 +131,6 @@ describe("buildTerminalEnv colour hints", () => {
   it("defaults FORCE_COLOR when neither colour variable is set", () => {
     const env = buildTerminalEnv(baseOptions, "pane-1", "/bin/bash");
     expect(env.FORCE_COLOR).toBeDefined();
-    expect(env.COLORTERM).toBe("truecolor");
   });
 
   it("does not inject FORCE_COLOR when NO_COLOR is inherited", () => {

--- a/electron/services/pty/__tests__/terminalSpawn.env.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.env.test.ts
@@ -106,3 +106,79 @@ describe("buildTerminalEnv NODE_COMPILE_CACHE injection", () => {
     expect(env.NODE_COMPILE_CACHE).toBe("/custom/path");
   });
 });
+
+describe("buildTerminalEnv colour hints", () => {
+  let originalNoColor: string | undefined;
+  let originalForceColor: string | undefined;
+
+  beforeEach(() => {
+    // buildTerminalEnv inherits from process.env, so a NO_COLOR or FORCE_COLOR
+    // exported by the host shell would decide these assertions for us — the
+    // exact ambient dependency this suite exists to pin down (#11118).
+    originalNoColor = process.env.NO_COLOR;
+    originalForceColor = process.env.FORCE_COLOR;
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+  });
+
+  afterEach(() => {
+    if (originalNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = originalNoColor;
+    if (originalForceColor === undefined) delete process.env.FORCE_COLOR;
+    else process.env.FORCE_COLOR = originalForceColor;
+  });
+
+  it("defaults FORCE_COLOR when neither colour variable is set", () => {
+    const env = buildTerminalEnv(baseOptions, "pane-1", "/bin/bash");
+    expect(env.FORCE_COLOR).toBeDefined();
+    expect(env.COLORTERM).toBe("truecolor");
+  });
+
+  it("does not inject FORCE_COLOR when NO_COLOR is inherited", () => {
+    process.env.NO_COLOR = "1";
+    const env = buildTerminalEnv(baseOptions, "pane-1", "/bin/bash");
+    expect(env.FORCE_COLOR).toBeUndefined();
+    expect(env.NO_COLOR).toBe("1");
+  });
+
+  it("treats an empty inherited NO_COLOR as set", () => {
+    process.env.NO_COLOR = "";
+    const env = buildTerminalEnv(baseOptions, "pane-1", "/bin/bash");
+    expect(env.FORCE_COLOR).toBeUndefined();
+  });
+
+  it("does not inject FORCE_COLOR when NO_COLOR comes from intentionalEnv", () => {
+    const env = buildTerminalEnv({ ...baseOptions, env: { NO_COLOR: "1" } }, "pane-1", "/bin/bash");
+    expect(env.FORCE_COLOR).toBeUndefined();
+    expect(env.NO_COLOR).toBe("1");
+  });
+
+  it("preserves an explicit FORCE_COLOR rather than rewriting it", () => {
+    const env = buildTerminalEnv(
+      { ...baseOptions, env: { FORCE_COLOR: "0" } },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.FORCE_COLOR).toBe("0");
+  });
+
+  it("leaves a user-supplied FORCE_COLOR/NO_COLOR pairing alone", () => {
+    const env = buildTerminalEnv(
+      { ...baseOptions, env: { FORCE_COLOR: "1", NO_COLOR: "1" } },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.FORCE_COLOR).toBe("1");
+    expect(env.NO_COLOR).toBe("1");
+  });
+
+  it("still defaults FORCE_COLOR when only COLORTERM is inherited", () => {
+    const env = buildTerminalEnv(
+      { ...baseOptions, env: { COLORTERM: "24bit" } },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.FORCE_COLOR).toBeDefined();
+    expect(env.COLORTERM).toBe("24bit");
+  });
+});

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -109,8 +109,9 @@ export function buildTerminalEnv(
   // FORCE_COLOR first and short-circuit, so injecting it would override the
   // user's stated preference and make Node print "NO_COLOR is ignored because
   // FORCE_COLOR is set" in every terminal. Presence — not truthiness — is the
-  // test, so `NO_COLOR=` is honoured too. COLORTERM is unaffected: it only
-  // selects depth once colour is already on, and never forces it.
+  // test, so `NO_COLOR=` is honoured too. COLORTERM stays unconditional: it
+  // feeds depth detection behind NO_COLOR's own check, so it cannot resurrect
+  // colour the user opted out of.
   if (mergedEnv.NO_COLOR === undefined) {
     mergedEnv.FORCE_COLOR = mergedEnv.FORCE_COLOR ?? "3";
   }

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -103,9 +103,17 @@ export function buildTerminalEnv(
   );
 
   // Universal colour hints — xterm.js supports truecolor, and most CLIs
-  // (chalk, supports-color, termenv, ink) honour these. Plain shells and
-  // agent CLIs both benefit; neither suffers.
-  mergedEnv.FORCE_COLOR = mergedEnv.FORCE_COLOR ?? "3";
+  // (chalk, supports-color, termenv, ink) honour these.
+  //
+  // FORCE_COLOR yields to an inherited NO_COLOR: chalk/supports-color/ink read
+  // FORCE_COLOR first and short-circuit, so injecting it would override the
+  // user's stated preference and make Node print "NO_COLOR is ignored because
+  // FORCE_COLOR is set" in every terminal. Presence — not truthiness — is the
+  // test, so `NO_COLOR=` is honoured too. COLORTERM is unaffected: it only
+  // selects depth once colour is already on, and never forces it.
+  if (mergedEnv.NO_COLOR === undefined) {
+    mergedEnv.FORCE_COLOR = mergedEnv.FORCE_COLOR ?? "3";
+  }
   mergedEnv.COLORTERM = mergedEnv.COLORTERM ?? "truecolor";
 
   // V8 bytecode cache for Node-based agent CLIs. Path is per-agent to

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -4,6 +4,7 @@ import {
   filterEnvironment,
   injectDaintreeMetadata,
   ensureUtf8Locale,
+  shouldInjectForceColor,
 } from "./EnvironmentFilter.js";
 import { getDefaultShell, getDefaultShellArgs } from "./terminalShell.js";
 import { computePoolEnvHash } from "./ptyPoolEnvHash.js";
@@ -103,17 +104,12 @@ export function buildTerminalEnv(
   );
 
   // Universal colour hints — xterm.js supports truecolor, and most CLIs
-  // (chalk, supports-color, termenv, ink) honour these.
-  //
-  // FORCE_COLOR yields to an inherited NO_COLOR: chalk/supports-color/ink read
-  // FORCE_COLOR first and short-circuit, so injecting it would override the
-  // user's stated preference and make Node print "NO_COLOR is ignored because
-  // FORCE_COLOR is set" in every terminal. Presence — not truthiness — is the
-  // test, so `NO_COLOR=` is honoured too. COLORTERM stays unconditional: it
-  // feeds depth detection behind NO_COLOR's own check, so it cannot resurrect
-  // colour the user opted out of.
-  if (mergedEnv.NO_COLOR === undefined) {
-    mergedEnv.FORCE_COLOR = mergedEnv.FORCE_COLOR ?? "3";
+  // (chalk, supports-color, termenv, ink) honour these. The FORCE_COLOR default
+  // yields to a NO_COLOR the user already set; see `shouldInjectForceColor`.
+  // COLORTERM stays unconditional: it feeds depth detection behind NO_COLOR's
+  // own check, so it cannot resurrect colour the user opted out of.
+  if (shouldInjectForceColor(mergedEnv)) {
+    mergedEnv.FORCE_COLOR = "3";
   }
   mergedEnv.COLORTERM = mergedEnv.COLORTERM ?? "truecolor";
 


### PR DESCRIPTION
## Summary

Both PTY spawn paths, `buildTerminalEnv` in `electron/services/pty/terminalSpawn.ts` and `PtyPool.buildSpawnEnv` in `electron/services/PtyPool.ts`, were defaulting `FORCE_COLOR` to `'3'` whenever it wasn't already set, without checking `NO_COLOR` first. Because `chalk`, `supports-color`, and `ink` all check `FORCE_COLOR` first and short circuit, the injected default was overriding the user's explicit opt-out. Every spawned terminal printed `NO_COLOR is ignored because FORCE_COLOR is set`. It even showed up in the hero terminal in the marketing screenshot.

Resolves #11118

## Changes

- Added a shared `shouldInjectForceColor()` helper in `electron/services/pty/EnvironmentFilter.ts`, used by both spawn paths. It only injects the default when neither `FORCE_COLOR` nor `NO_COLOR` is already present, checking for presence rather than truthiness, so an empty `NO_COLOR=` is honoured too. An explicit user `FORCE_COLOR` is preserved untouched: the point is to stop creating the conflict, not to rewrite deliberate config. `COLORTERM` stays unconditional on purpose, since it only feeds colour depth detection behind `NO_COLOR`'s own check and can't resurrect colour the user opted out of.
- On Windows, the helper folds env variable name case before checking. Windows treats env names as case-insensitive, but our env filters return plain JS objects that preserve the OS's casing, so a PowerShell `no_color=1` would otherwise slip past an uppercase lookup and still get `FORCE_COLOR` injected. POSIX stays case-sensitive, where `no_color` is genuinely a different variable.
- On the pool side, a caller-supplied `NO_COLOR` keys its own pool slot, since `computePoolEnvHash` already hashes it. That means a shell warmed with the `FORCE_COLOR` default can never be handed to a caller that opted out. Added a behavioural test for that, plus one proving that refilling an acquired `NO_COLOR` slot doesn't regain `FORCE_COLOR`.
- `PtyPool.test.ts` was asserting `FORCE_COLOR === '3'` against the ambient `process.env` without isolating `NO_COLOR` or `FORCE_COLOR`. After this change that would have flipped behaviour on any dev machine exporting `NO_COLOR`, which is exactly the population hitting this bug. Its env hooks now isolate both variables. Also fixed a latent bug in those hooks: restoring an absent variable by assignment stringifies it to the literal text `undefined`, leaving an unset variable truthy for later tests. The hooks now `delete` instead of assign.

## Known gap

A user with `NO_COLOR=1` exported in their `.zshrc` who launches the packaged app from the Dock still sees the warning. Daintree's startup only imports `PATH` from the login shell via `runRefreshPath` in `electron/setup/environment.ts`, so `process.env` never learns the user's `NO_COLOR` before the PTY host builds its environment. The spawned shell then sources the profile and sets `NO_COLOR` after the environment was already built. Closing that gap is race-free, since `electron/window/windowServices.ts` already awaits the environment refresh before forking the PTY host, but it means deciding which environment variables are allowed to cross the login-shell boundary. That's a policy call beyond this fix, and worth its own follow-up issue rather than a quiet patch here.

## Testing

1673 tests pass across `electron/services/pty/`, `PtyPool`, and the terminal IPC handlers. Re-ran the suites green with `NO_COLOR=1` and `COLORTERM=24bit` exported to prove they're no longer host-shell dependent.