### PR TITLE
fix(ci): gate Linux and Windows releases on online E2E

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -103,9 +103,10 @@ jobs:
       suite: ${{ matrix.suite }}
       platform: linux
 
-  # Online E2E runs for signal only — nothing `needs:` it, so it never gates
-  # build or publish. Do NOT add job-level continue-on-error here: it is invalid
-  # on reusable-workflow (`uses:`) jobs and makes the whole workflow fail to start.
+  # Online E2E gates build and publish, same as core and full-* — a failing
+  # real-agent run must not ship. Do NOT add job-level continue-on-error here:
+  # it is invalid on reusable-workflow (`uses:`) jobs and makes the whole
+  # workflow fail to start.
   e2e-online-gate:
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml
@@ -115,7 +116,7 @@ jobs:
     secrets: inherit
 
   build-daintree:
-    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate, e2e-online-gate]
     name: Build Daintree (Linux)
     runs-on: ubuntu-22.04
     timeout-minutes: 90

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -114,9 +114,10 @@ jobs:
       suite: ${{ matrix.suite }}
       platform: macos
 
-  # Online E2E runs for signal only — nothing `needs:` it, so it never gates
-  # build or publish. Do NOT add job-level continue-on-error here: it is invalid
-  # on reusable-workflow (`uses:`) jobs and makes the whole workflow fail to start.
+  # Online E2E gates build and publish, same as core and full-* — a failing
+  # real-agent run must not ship. Do NOT add job-level continue-on-error here:
+  # it is invalid on reusable-workflow (`uses:`) jobs and makes the whole
+  # workflow fail to start.
   e2e-online-gate:
     needs: [checks, unit-tests]
     uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -123,9 +123,10 @@ jobs:
       suite: ${{ matrix.suite }}
       platform: windows
 
-  # Online E2E runs for signal only — nothing `needs:` it, so it never gates
-  # build or publish. Do NOT add job-level continue-on-error here: it is invalid
-  # on reusable-workflow (`uses:`) jobs and makes the whole workflow fail to start.
+  # Online E2E gates build and publish, same as core and full-* — a failing
+  # real-agent run must not ship. Do NOT add job-level continue-on-error here:
+  # it is invalid on reusable-workflow (`uses:`) jobs and makes the whole
+  # workflow fail to start.
   e2e-online-gate:
     if: github.event_name != 'workflow_dispatch' || inputs.smoke_artifact_run_id == ''
     needs: [checks, unit-tests]
@@ -137,7 +138,7 @@ jobs:
 
   build-daintree-x64:
     if: github.event_name != 'workflow_dispatch' || inputs.smoke_artifact_run_id == ''
-    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate, e2e-online-gate]
     name: Build Daintree (Windows x64)
     runs-on: windows-2022
     timeout-minutes: 90
@@ -325,7 +326,7 @@ jobs:
 
   build-daintree-arm64:
     if: github.event_name != 'workflow_dispatch' || inputs.smoke_artifact_run_id == ''
-    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate]
+    needs: [checks, unit-tests, e2e-core-gate, e2e-full-gate, e2e-online-gate]
     name: Build Daintree (Windows arm64)
     runs-on: windows-11-arm
     timeout-minutes: 90

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -483,9 +483,12 @@ jobs:
   # --smoke-test mode. Validates the four native modules including
   # win-job-object (asar.unpacked native that doesn't ship a prebuilt and so
   # is uniquely at risk if cross-compile for arm64 fails silently). Gates
-  # publish.
+  # publish. always() is only here so the smoke_artifact_run_id dispatch can
+  # smoke a prior run's artifact; otherwise assembly must have succeeded, or a
+  # gate failure would skip assembly and leave this job downloading an artifact
+  # that was never uploaded.
   smoke-packaged:
-    if: always() && (github.event_name != 'workflow_dispatch' || inputs.smoke_artifact_run_id != '' || needs.assemble-windows-release.result == 'success')
+    if: always() && ((github.event_name == 'workflow_dispatch' && inputs.smoke_artifact_run_id != '') || needs.assemble-windows-release.result == 'success')
     needs: [assemble-windows-release]
     name: Smoke (packaged NSIS)
     runs-on: windows-2022

--- a/scripts/ci/release-e2e-gates.test.mjs
+++ b/scripts/ci/release-e2e-gates.test.mjs
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+import yaml from "js-yaml";
+
+// Regression guard for #11117: the three per-OS release workflows are supposed
+// to share one gating contract — every e2e gate a workflow defines must be in
+// the dependency chain of every platform build it packages. macOS had the
+// online gate wired while Linux and Windows silently did not, so a failing
+// real-agent run could still publish on two of three platforms.
+//
+// These assertions are derived from the parsed graph, not copied from it: gate
+// and build jobs are discovered by shape, so a fourth gate added to one OS and
+// forgotten on another fails here without anyone editing this file.
+
+const workflowsDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../.github/workflows"
+);
+
+const RELEASE_WORKFLOWS = ["release-macos.yml", "release-linux.yml", "release-windows.yml"];
+
+const load = (file) => yaml.load(readFileSync(path.join(workflowsDir, file), "utf8"));
+
+const isGate = (jobId) => /^e2e-.+-gate$/.test(jobId);
+const isBuild = (jobId) => /^build-daintree/.test(jobId);
+
+const needsOf = (job) => {
+  const needs = job?.needs ?? [];
+  return Array.isArray(needs) ? needs : [needs];
+};
+
+// Every job reachable from `jobId` by walking `needs` edges backwards.
+const upstreamOf = (jobs, jobId) => {
+  const seen = new Set();
+  const queue = [...needsOf(jobs[jobId])];
+  while (queue.length > 0) {
+    const next = queue.pop();
+    if (seen.has(next) || !jobs[next]) continue;
+    seen.add(next);
+    queue.push(...needsOf(jobs[next]));
+  }
+  return seen;
+};
+
+const workflows = RELEASE_WORKFLOWS.map((file) => {
+  const jobs = load(file).jobs;
+  const jobIds = Object.keys(jobs);
+  return {
+    file,
+    jobs,
+    gates: jobIds.filter(isGate),
+    builds: jobIds.filter(isBuild),
+  };
+});
+
+describe("release workflow e2e gating contract (#11117)", () => {
+  it.each(workflows)("$file defines e2e gates and platform builds", ({ gates, builds }) => {
+    expect(gates.length).toBeGreaterThan(0);
+    expect(builds.length).toBeGreaterThan(0);
+  });
+
+  it.each(workflows)(
+    "$file: every build job depends on every e2e gate",
+    ({ jobs, gates, builds }) => {
+      for (const build of builds) {
+        expect(needsOf(jobs[build]), `${build} must gate on all of: ${gates.join(", ")}`).toEqual(
+          expect.arrayContaining(gates)
+        );
+      }
+    }
+  );
+
+  it.each(workflows)("$file: publish transitively depends on every e2e gate", ({ jobs, gates }) => {
+    expect(jobs["publish-daintree"], "expected a publish-daintree job").toBeTruthy();
+    const upstream = upstreamOf(jobs, "publish-daintree");
+    for (const gate of gates) {
+      expect(upstream.has(gate), `publish-daintree must be gated by ${gate}`).toBe(true);
+    }
+  });
+
+  // A gate scheduled under a different condition than the job it gates can skip
+  // while that job still runs — the dependency edge would silently evaporate.
+  // Windows guards its gates and builds with a smoke-artifact-reuse condition;
+  // whatever the guard is, gates and builds must share it exactly.
+  it.each(workflows)(
+    "$file: gates and builds are scheduled under one condition",
+    ({ jobs, gates, builds }) => {
+      const guards = new Set([...gates, ...builds].map((id) => jobs[id].if ?? null));
+      expect(
+        guards.size,
+        `divergent if: guards across gates/builds: ${[...guards].join(" | ")}`
+      ).toBe(1);
+    }
+  );
+
+  // continue-on-error is invalid on reusable-workflow (`uses:`) jobs — it makes
+  // the whole workflow fail to start. It was added and reverted once already;
+  // it would also defeat the gate.
+  it.each(workflows)("$file: no gate opts out of failing the release", ({ jobs, gates }) => {
+    for (const gate of gates) {
+      expect(
+        jobs[gate]["continue-on-error"],
+        `${gate} must be able to fail the release`
+      ).toBeFalsy();
+    }
+  });
+
+  it("all three platforms define the same set of gates", () => {
+    const [first, ...rest] = workflows.map((w) => [...w.gates].sort());
+    for (const gates of rest) {
+      expect(gates).toEqual(first);
+    }
+  });
+});

--- a/scripts/ci/release-e2e-gates.test.mjs
+++ b/scripts/ci/release-e2e-gates.test.mjs
@@ -6,16 +6,20 @@ import yaml from "js-yaml";
 
 // Regression guard for #11117: online E2E gated the macOS release but not Linux
 // or Windows, so a failing real-agent run could still publish on two of three
-// platforms. Release workflows only fire on a v* tag, so they can never be
-// exercised on a PR — these structural assertions are the only enforcement of
-// the gating contract in CI.
+// platforms. Release workflows only fire on a v* tag or a manual dispatch, so
+// they can never be exercised on a PR — these structural assertions are the
+// only enforcement of the gating contract in CI.
 //
-// The contract under test is behavioural, not cosmetic: every suite that must
-// gate a release (core + online, plus whatever full-* buckets exist) has to sit
-// in the dependency chain of every platform build, on every OS. Suites are
-// resolved from each gate's `with:`/matrix rather than from job names, because
-// a job called `e2e-online-gate` that passes `suite: core` would satisfy a
-// name-shaped assertion while testing the wrong thing.
+// The contract under test is behavioural, not cosmetic. Two things have to hold
+// for a gate to actually gate, and each has a failure mode that looks fine in
+// the YAML:
+//   1. The suite really runs. Suites are resolved from each gate's `with:`/
+//      matrix, not from job names — a job called `e2e-online-gate` passing
+//      `suite: core` would satisfy any name-shaped assertion while testing the
+//      wrong thing.
+//   2. Failure really propagates. A `needs:` edge only blocks while every job
+//      along it keeps its implicit success() check, which ANY status-check
+//      function silently replaces.
 
 const workflowsDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -24,10 +28,22 @@ const workflowsDir = path.resolve(
 
 const RELEASE_WORKFLOWS = ["release-macos.yml", "release-linux.yml", "release-windows.yml"];
 
-// The suites whose failure must block a publish, per docs/e2e-testing.md. Named
-// from the release contract, not copied from the workflows — deleting a gate
-// from every OS at once still has to fail this file.
-const RELEASE_BLOCKING_SUITES = ["core", "online"];
+// The suites whose failure must block a publish, per docs/e2e-testing.md. This
+// is the release policy, deliberately spelled out here rather than read back
+// out of the workflows — otherwise deleting a gate from all three OSes at once
+// would keep this file green. Adding a suite to the release gate is a decision,
+// so it should cost an edit here.
+const RELEASE_BLOCKING_SUITES = [
+  "core",
+  "online",
+  "full-terminal",
+  "full-worktree",
+  "full-presets",
+  "full-platform",
+  "full-panels",
+  "full-resilience",
+  "full-plugins",
+];
 
 const E2E_WORKFLOW = "./.github/workflows/e2e.yml";
 
@@ -39,14 +55,16 @@ const needsOf = (job) => {
   return Array.isArray(needs) ? needs : [needs];
 };
 
-// A gate either passes one literal suite or fans a matrix of them out. The
-// matrix form sets `with.suite: ${{ matrix.suite }}`, so the literal list lives
-// on the strategy.
+// A gate either passes one literal suite or fans a matrix of them out. Only
+// credit the matrix when the job actually forwards it: a strategy listing
+// `online` while `with.suite` hardcodes `core` runs core, whatever the matrix
+// says.
 const suitesOf = (job) => {
-  const matrixSuites = job.strategy?.matrix?.suite;
-  if (Array.isArray(matrixSuites)) return matrixSuites;
   const suite = job.with?.suite;
-  return typeof suite === "string" && !suite.includes("${{") ? [suite] : [];
+  if (typeof suite !== "string") return [];
+  const matrixSuites = job.strategy?.matrix?.suite;
+  if (Array.isArray(matrixSuites) && /\bmatrix\.suite\b/.test(suite)) return matrixSuites;
+  return suite.includes("${{") ? [] : [suite];
 };
 
 // Jobs that actually ship bits, found by the action they run rather than by
@@ -56,19 +74,28 @@ const publishersOf = (jobs) =>
     (jobs[id].steps ?? []).some((step) => step.uses?.includes("/publish-daintree"))
   );
 
-// always()/failure()/cancelled() replace the implicit success() check that makes
-// a `needs:` edge blocking. Anywhere on the gated path, they turn a gate into
-// decoration. (An explicit success() is redundant but harmless.)
-const OVERRIDES_SUCCESS = /\b(always|failure|cancelled)\s*\(/;
+// A job with no `if:` is implicitly `if: success()`, which is what makes a
+// `needs:` edge blocking. ANY status-check function replaces that implicit
+// check — including success() itself, which is why this matches all four rather
+// than just the obviously-dangerous three: `if: success() || github.ref_type ==
+// 'tag'` runs on a tag no matter what the gate did.
+const OVERRIDES_SUCCESS = /\b(success|always|failure|cancelled)\s*\(/;
 
-// Every job reachable from `jobId` by walking `needs` edges backwards.
-const upstreamOf = (jobs, jobId) => {
+const overridesSuccess = (job) => job.if !== undefined && OVERRIDES_SUCCESS.test(String(job.if));
+
+// Jobs reachable from `jobId` by `needs:` edges that actually propagate failure
+// — the walk stops at any job that overrides its success check, because a gate
+// failing upstream of one of those never reaches the other side. Reachability
+// alone would happily "prove" a release is gated through a chain of always().
+const blockingUpstreamOf = (jobs, jobId) => {
   const seen = new Set();
+  if (overridesSuccess(jobs[jobId])) return seen;
   const queue = [...needsOf(jobs[jobId])];
   while (queue.length > 0) {
     const next = queue.pop();
     if (seen.has(next) || !jobs[next]) continue;
     seen.add(next);
+    if (overridesSuccess(jobs[next])) continue;
     queue.push(...needsOf(jobs[next]));
   }
   return seen;
@@ -122,35 +149,34 @@ describe("release workflow e2e gating contract (#11117)", () => {
     }
   });
 
+  // The property that actually matters: a failing gate must be able to stop the
+  // publish. Walks only edges that propagate failure, so a chain of always()
+  // between the gate and the publisher reads as ungated — which is what a naive
+  // reachability check would miss, and how `assemble-windows-release` could
+  // quietly become a bypass.
   it.each(workflows)(
-    "$file: every publisher is downstream of every gate",
+    "$file: a failing gate blocks every publisher",
     ({ jobs, gates, publishers }) => {
       for (const publisher of publishers) {
-        const upstream = upstreamOf(jobs, publisher);
+        const blocking = blockingUpstreamOf(jobs, publisher);
         for (const gate of gates) {
-          expect(upstream.has(gate), `${publisher} must be gated by ${gate}`).toBe(true);
+          expect(
+            blocking.has(gate),
+            `${gate} failing must stop ${publisher}, but no chain of success-gated needs connects them`
+          ).toBe(true);
         }
       }
     }
   );
 
-  // A `needs:` edge only blocks while the dependent keeps its implicit success()
-  // check. This is the premise the whole contract rests on: uniformly slapping
-  // `if: always()` on the builds would leave the graph looking perfectly gated
-  // while shipping a failed release.
-  it.each(workflows)(
-    "$file: nothing on the gated path overrides the success check",
-    ({ jobs, builds, publishers }) => {
-      for (const jobId of [...builds, ...publishers]) {
-        const condition = jobs[jobId].if;
-        if (condition === undefined) continue;
-        expect(
-          OVERRIDES_SUCCESS.test(String(condition)),
-          `${jobId} would run past a failed gate: if: ${condition}`
-        ).toBe(false);
-      }
+  it.each(workflows)("$file: no build overrides its success check", ({ jobs, builds }) => {
+    for (const build of builds) {
+      expect(
+        overridesSuccess(jobs[build]),
+        `${build} would run past a failed gate: if: ${jobs[build].if}`
+      ).toBe(false);
     }
-  );
+  });
 
   it.each(workflows)(
     "$file: gates call the shared e2e workflow for this platform",

--- a/scripts/ci/release-e2e-gates.test.mjs
+++ b/scripts/ci/release-e2e-gates.test.mjs
@@ -4,15 +4,18 @@ import { fileURLToPath } from "url";
 import path from "path";
 import yaml from "js-yaml";
 
-// Regression guard for #11117: the three per-OS release workflows are supposed
-// to share one gating contract — every e2e gate a workflow defines must be in
-// the dependency chain of every platform build it packages. macOS had the
-// online gate wired while Linux and Windows silently did not, so a failing
-// real-agent run could still publish on two of three platforms.
+// Regression guard for #11117: online E2E gated the macOS release but not Linux
+// or Windows, so a failing real-agent run could still publish on two of three
+// platforms. Release workflows only fire on a v* tag, so they can never be
+// exercised on a PR — these structural assertions are the only enforcement of
+// the gating contract in CI.
 //
-// These assertions are derived from the parsed graph, not copied from it: gate
-// and build jobs are discovered by shape, so a fourth gate added to one OS and
-// forgotten on another fails here without anyone editing this file.
+// The contract under test is behavioural, not cosmetic: every suite that must
+// gate a release (core + online, plus whatever full-* buckets exist) has to sit
+// in the dependency chain of every platform build, on every OS. Suites are
+// resolved from each gate's `with:`/matrix rather than from job names, because
+// a job called `e2e-online-gate` that passes `suite: core` would satisfy a
+// name-shaped assertion while testing the wrong thing.
 
 const workflowsDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -21,7 +24,12 @@ const workflowsDir = path.resolve(
 
 const RELEASE_WORKFLOWS = ["release-macos.yml", "release-linux.yml", "release-windows.yml"];
 
-const load = (file) => yaml.load(readFileSync(path.join(workflowsDir, file), "utf8"));
+// The suites whose failure must block a publish, per docs/e2e-testing.md. Named
+// from the release contract, not copied from the workflows — deleting a gate
+// from every OS at once still has to fail this file.
+const RELEASE_BLOCKING_SUITES = ["core", "online"];
+
+const E2E_WORKFLOW = "./.github/workflows/e2e.yml";
 
 const isGate = (jobId) => /^e2e-.+-gate$/.test(jobId);
 const isBuild = (jobId) => /^build-daintree/.test(jobId);
@@ -30,6 +38,28 @@ const needsOf = (job) => {
   const needs = job?.needs ?? [];
   return Array.isArray(needs) ? needs : [needs];
 };
+
+// A gate either passes one literal suite or fans a matrix of them out. The
+// matrix form sets `with.suite: ${{ matrix.suite }}`, so the literal list lives
+// on the strategy.
+const suitesOf = (job) => {
+  const matrixSuites = job.strategy?.matrix?.suite;
+  if (Array.isArray(matrixSuites)) return matrixSuites;
+  const suite = job.with?.suite;
+  return typeof suite === "string" && !suite.includes("${{") ? [suite] : [];
+};
+
+// Jobs that actually ship bits, found by the action they run rather than by
+// name — a second publisher added under any other job id still gets traced.
+const publishersOf = (jobs) =>
+  Object.keys(jobs).filter((id) =>
+    (jobs[id].steps ?? []).some((step) => step.uses?.includes("/publish-daintree"))
+  );
+
+// always()/failure()/cancelled() replace the implicit success() check that makes
+// a `needs:` edge blocking. Anywhere on the gated path, they turn a gate into
+// decoration. (An explicit success() is redundant but harmless.)
+const OVERRIDES_SUCCESS = /\b(always|failure|cancelled)\s*\(/;
 
 // Every job reachable from `jobId` by walking `needs` edges backwards.
 const upstreamOf = (jobs, jobId) => {
@@ -45,72 +75,116 @@ const upstreamOf = (jobs, jobId) => {
 };
 
 const workflows = RELEASE_WORKFLOWS.map((file) => {
-  const jobs = load(file).jobs;
+  const jobs = yaml.load(readFileSync(path.join(workflowsDir, file), "utf8")).jobs;
   const jobIds = Object.keys(jobs);
+  const gates = jobIds.filter(isGate);
   return {
     file,
+    platform: file.replace(/^release-|\.yml$/g, ""),
     jobs,
-    gates: jobIds.filter(isGate),
+    gates,
     builds: jobIds.filter(isBuild),
+    publishers: publishersOf(jobs),
+    gatedSuites: gates.flatMap((gate) => suitesOf(jobs[gate])),
   };
 });
 
 describe("release workflow e2e gating contract (#11117)", () => {
-  it.each(workflows)("$file defines e2e gates and platform builds", ({ gates, builds }) => {
-    expect(gates.length).toBeGreaterThan(0);
-    expect(builds.length).toBeGreaterThan(0);
+  it.each(workflows)(
+    "$file wires gates, builds and a publisher",
+    ({ gates, builds, publishers }) => {
+      expect(gates.length).toBeGreaterThan(0);
+      expect(builds.length).toBeGreaterThan(0);
+      expect(publishers.length).toBeGreaterThan(0);
+    }
+  );
+
+  it.each(workflows)("$file: every build directly needs every gate", ({ jobs, gates, builds }) => {
+    for (const build of builds) {
+      expect(needsOf(jobs[build]), `${build} must gate on all of: ${gates.join(", ")}`).toEqual(
+        expect.arrayContaining(gates)
+      );
+    }
+  });
+
+  // #11117 itself: resolve the suites a build is actually gated on by following
+  // its own `needs:`, so both ways of losing the contract — unwiring the gate
+  // from the build, or deleting the gate job outright, on any number of OSes —
+  // land here.
+  it.each(workflows)("$file: the release-blocking suites gate every build", ({ jobs, builds }) => {
+    for (const build of builds) {
+      const suites = needsOf(jobs[build])
+        .filter(isGate)
+        .flatMap((gate) => suitesOf(jobs[gate]));
+      expect(suites, `${build} must be gated on: ${RELEASE_BLOCKING_SUITES.join(", ")}`).toEqual(
+        expect.arrayContaining(RELEASE_BLOCKING_SUITES)
+      );
+    }
   });
 
   it.each(workflows)(
-    "$file: every build job depends on every e2e gate",
-    ({ jobs, gates, builds }) => {
-      for (const build of builds) {
-        expect(needsOf(jobs[build]), `${build} must gate on all of: ${gates.join(", ")}`).toEqual(
-          expect.arrayContaining(gates)
-        );
+    "$file: every publisher is downstream of every gate",
+    ({ jobs, gates, publishers }) => {
+      for (const publisher of publishers) {
+        const upstream = upstreamOf(jobs, publisher);
+        for (const gate of gates) {
+          expect(upstream.has(gate), `${publisher} must be gated by ${gate}`).toBe(true);
+        }
       }
     }
   );
 
-  it.each(workflows)("$file: publish transitively depends on every e2e gate", ({ jobs, gates }) => {
-    expect(jobs["publish-daintree"], "expected a publish-daintree job").toBeTruthy();
-    const upstream = upstreamOf(jobs, "publish-daintree");
-    for (const gate of gates) {
-      expect(upstream.has(gate), `publish-daintree must be gated by ${gate}`).toBe(true);
-    }
-  });
-
-  // A gate scheduled under a different condition than the job it gates can skip
-  // while that job still runs — the dependency edge would silently evaporate.
-  // Windows guards its gates and builds with a smoke-artifact-reuse condition;
-  // whatever the guard is, gates and builds must share it exactly.
+  // A `needs:` edge only blocks while the dependent keeps its implicit success()
+  // check. This is the premise the whole contract rests on: uniformly slapping
+  // `if: always()` on the builds would leave the graph looking perfectly gated
+  // while shipping a failed release.
   it.each(workflows)(
-    "$file: gates and builds are scheduled under one condition",
-    ({ jobs, gates, builds }) => {
-      const guards = new Set([...gates, ...builds].map((id) => jobs[id].if ?? null));
-      expect(
-        guards.size,
-        `divergent if: guards across gates/builds: ${[...guards].join(" | ")}`
-      ).toBe(1);
+    "$file: nothing on the gated path overrides the success check",
+    ({ jobs, builds, publishers }) => {
+      for (const jobId of [...builds, ...publishers]) {
+        const condition = jobs[jobId].if;
+        if (condition === undefined) continue;
+        expect(
+          OVERRIDES_SUCCESS.test(String(condition)),
+          `${jobId} would run past a failed gate: if: ${condition}`
+        ).toBe(false);
+      }
     }
   );
 
-  // continue-on-error is invalid on reusable-workflow (`uses:`) jobs — it makes
-  // the whole workflow fail to start. It was added and reverted once already;
-  // it would also defeat the gate.
+  it.each(workflows)(
+    "$file: gates call the shared e2e workflow for this platform",
+    ({ jobs, gates, platform }) => {
+      for (const gate of gates) {
+        expect(jobs[gate].uses, `${gate} must call the shared e2e workflow`).toBe(E2E_WORKFLOW);
+        expect(jobs[gate].with.platform, `${gate} must target ${platform}`).toBe(platform);
+      }
+    }
+  );
+
+  // Online drives real agent CLIs against real APIs; without the secrets it
+  // cannot run at all, and a gate that cannot run is not a gate.
+  it.each(workflows)("$file: the online gate inherits secrets", ({ jobs, gates }) => {
+    const online = gates.filter((gate) => suitesOf(jobs[gate]).includes("online"));
+    expect(online.length).toBe(1);
+    expect(jobs[online[0]].secrets).toBe("inherit");
+  });
+
+  // continue-on-error is unsupported on reusable-workflow (`uses:`) jobs at any
+  // value — it makes the whole workflow fail to start. Added and reverted once
+  // already; it would also defeat the gate.
   it.each(workflows)("$file: no gate opts out of failing the release", ({ jobs, gates }) => {
     for (const gate of gates) {
-      expect(
-        jobs[gate]["continue-on-error"],
-        `${gate} must be able to fail the release`
-      ).toBeFalsy();
+      expect(jobs[gate], `${gate} must be able to fail the release`).not.toHaveProperty(
+        "continue-on-error"
+      );
     }
   });
 
-  it("all three platforms define the same set of gates", () => {
-    const [first, ...rest] = workflows.map((w) => [...w.gates].sort());
-    for (const gates of rest) {
-      expect(gates).toEqual(first);
+  it("all three platforms gate on the same suites", () => {
+    const [first, ...rest] = workflows.map((w) => [...w.gatedSuites].sort());
+    for (const gatedSuites of rest) {
+      expect(gatedSuites).toEqual(first);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Issue #11117: only macOS's `build-daintree` job had `e2e-online-gate` in its `needs:`. Linux and Windows defined the gate job but nothing depended on it, so a failing real-agent E2E run could still publish on two of three platforms, even though `docs/e2e-testing.md` and `CLAUDE.md` both document online E2E as gating all three.
- Root cause: `a0b2caf15` deliberately demoted online E2E from the release gate on all three platforms. `a9ee9141b` (PR #9473, an unrelated macOS notarization/signing PR) silently re-added it to macOS only as a rebase artifact. So the three files drifted apart by accident, and the identical "runs for signal only, nothing needs it" comment sitting above the gate job in all three was false on macOS.
- Added a structural test (`scripts/ci/release-e2e-gates.test.mjs`) that's now the only CI enforcement of this contract, since release workflows only fire on a `v*` tag and can never run on a PR.

Resolves #11117

## Changes
1. `release-linux.yml`: `build-daintree` now needs `e2e-online-gate`.
2. `release-windows.yml`: `build-daintree-x64` and `build-daintree-arm64` now need `e2e-online-gate`. Also fixed `smoke-packaged`'s `if:` so it no longer runs when assembly was skipped. On a tag push its first clause was unconditionally true, so a failed gate meant skipped builds, then skipped assembly, but smoke still ran and died on a misleading "artifact not found" error.
3. All three `release-*.yml`: rewrote the stale comment above `e2e-online-gate` to describe what the graph actually does, keeping the still-true warning that `continue-on-error` is invalid on reusable workflow (`uses:`) jobs.
4. New: `scripts/ci/release-e2e-gates.test.mjs` (25 tests). Walks the `needs` dependency graph and asserts a failing gate can actually stop a publish, following only `needs` edges that propagate failure (a chain of `always()` reads as ungated). Follows the precedent of `scripts/ci/release-windows-arm64-smoke.test.mjs`.

## Testing
- Red-before-green validated every assertion against four adversarial mutations: unwiring the online gate, deleting the gate job entirely, an `if: success() || ...` composite that silently suppresses the implicit success check on a build, and `if: always()` on the intermediate Windows assembly job. Each turns the suite red; reverting turns it green.
- Locally: 31 tests pass (new file plus sibling), full `scripts/ci` suite passes 277 tests, prettier and eslint clean on the four changed files.
- Online E2E has been (accidentally) gating macOS for about 7 weeks: of the last 15 `release-macos` runs, 2 failed and neither was the online gate. So this brings Linux and Windows up to a contract that's already proven itself in practice, not a new source of release friction.