### PR TITLE
fix(actions): surface ActionService dispatch failures at three UI call sites

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -309,7 +309,16 @@ export function BrowserPane({
   // timing it out would silently destroy that recovery surface (#11114).
   useEffect(() => {
     if (blockedNav?.phase !== "blocked") return;
-    const timer = setTimeout(() => setBlockedNav(null), 10_000);
+    const noticeId = blockedNav.noticeId;
+    const timer = setTimeout(() => {
+      // An already-queued timer callback can still run after the user clicks
+      // (clearTimeout in the cleanup can't cancel a callback the event loop has
+      // picked up). Clearing unconditionally here would null the notice that is
+      // mid-attempt, and the failure would then find no notice to attach to.
+      setBlockedNav((prev) =>
+        prev?.noticeId === noticeId && prev.phase === "blocked" ? null : prev
+      );
+    }, 10_000);
     return () => clearTimeout(timer);
   }, [blockedNav]);
 
@@ -1100,12 +1109,13 @@ export function BrowserPane({
                     <button
                       type="button"
                       disabled={blockedNav.phase === "opening"}
+                      aria-busy={blockedNav.phase === "opening" || undefined}
                       onClick={() =>
                         void handleOpenBlockedExternal(blockedNav.noticeId, blockedNav.url)
                       }
                       className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                     >
-                      Open in external browser
+                      {blockedNav.phase === "opening" ? "Opening…" : "Open in external browser"}
                     </button>
                   )}
                   <button

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -174,10 +174,19 @@ export function BrowserPane({
   } | null>(null);
   const crashTimestampsRef = useRef<number[]>([]);
   const crashReloadRef = useRef<() => void>(() => {});
+  // `phase` keeps the notice alive across an external-open attempt: dispatch()
+  // resolves an ActionDispatchResult and never rejects, so the old handler
+  // cleared this — the user's only recovery surface — even when the open had
+  // failed (#11114). `noticeId` identifies which notice an in-flight result
+  // belongs to, so a result for a superseded block can't clobber the current one.
   const [blockedNav, setBlockedNav] = useState<{
+    noticeId: number;
     url: string;
     canOpenExternal: boolean;
+    phase: "blocked" | "opening" | "error";
+    errorMessage: string | null;
   } | null>(null);
+  const blockedNavIdRef = useRef(0);
   const [pendingApproval, setPendingApproval] = useState<{
     url: string;
     hostname: string;
@@ -275,7 +284,13 @@ export function BrowserPane({
         clearTimeout(blockedNavTimerRef.current);
       }
       blockedNavTimerRef.current = setTimeout(() => {
-        setBlockedNav({ url: data.url, canOpenExternal: data.canOpenExternal });
+        setBlockedNav({
+          noticeId: ++blockedNavIdRef.current,
+          url: data.url,
+          canOpenExternal: data.canOpenExternal,
+          phase: "blocked",
+          errorMessage: null,
+        });
         blockedNavTimerRef.current = null;
       }, 150);
     });
@@ -288,12 +303,46 @@ export function BrowserPane({
     };
   }, [id]);
 
-  // Auto-dismiss blocked navigation notification after 10 seconds
+  // Auto-dismiss blocked navigation notification after 10 seconds. Only the
+  // untouched notice expires: once the user asks to open externally, the notice
+  // is carrying an in-flight attempt or a failure they still have to act on, and
+  // timing it out would silently destroy that recovery surface (#11114).
   useEffect(() => {
-    if (!blockedNav) return;
+    if (blockedNav?.phase !== "blocked") return;
     const timer = setTimeout(() => setBlockedNav(null), 10_000);
     return () => clearTimeout(timer);
   }, [blockedNav]);
+
+  // The notice is passed in rather than read off `blockedNav` after the await:
+  // by then the pane may be showing a different block, and the dispatch must
+  // still target the URL the user actually clicked.
+  const handleOpenBlockedExternal = useCallback(
+    async (noticeId: number, url: string) => {
+      // Keep any existing errorMessage so a retry leaves the error banner
+      // mounted (with a spinner) instead of flashing back to the warning row.
+      setBlockedNav((prev) =>
+        prev && prev.noticeId === noticeId ? { ...prev, phase: "opening" } : prev
+      );
+
+      const result = await actionService.dispatch(
+        "browser.openExternal",
+        { terminalId: id, url },
+        { source: "user" }
+      );
+      if (!result.ok) {
+        logError("[BrowserPane] openExternal failed", result.error);
+      }
+
+      setBlockedNav((prev) => {
+        // A newer block, a dismissal, or a navigation replaced the notice while
+        // we were awaiting — it owns the banner now, so leave it untouched.
+        if (!prev || prev.noticeId !== noticeId) return prev;
+        if (result.ok) return null;
+        return { ...prev, phase: "error", errorMessage: result.error.message };
+      });
+    },
+    [id]
+  );
 
   const handleRenderProcessGone = useCallback(
     (details: { reason: string; exitCode: number }) => {
@@ -1015,42 +1064,60 @@ export function BrowserPane({
                 onClose={() => setCrashState("none")}
               />
             )}
-            {blockedNav && (
-              <div
-                aria-live="polite"
-                aria-atomic="true"
-                className="flex items-center gap-2 px-3 py-1.5 text-xs bg-status-warning/10 border-b border-status-warning/20 text-daintree-text/80"
-              >
-                <ExternalLink className="h-3.5 w-3.5 shrink-0 text-status-warning" />
-                <span className="truncate flex-1">
-                  Navigation to external site blocked: {extractHostname(blockedNav.url)}
-                </span>
-                {blockedNav.canOpenExternal && (
+            {blockedNav &&
+              (blockedNav.errorMessage !== null ? (
+                <InlineStatusBanner
+                  icon={XCircle}
+                  title="Couldn't open in external browser"
+                  description={blockedNav.errorMessage}
+                  contextLine={extractHostname(blockedNav.url)}
+                  severity="error"
+                  animated={false}
+                  action={{
+                    id: "retry-open-external",
+                    label: "Retry",
+                    icon: RotateCw,
+                    variant: "dangerFilled",
+                    loading: blockedNav.phase === "opening",
+                    onClick: () =>
+                      void handleOpenBlockedExternal(blockedNav.noticeId, blockedNav.url),
+                    ariaLabel: "Retry opening in external browser",
+                  }}
+                  onClose={() => setBlockedNav(null)}
+                  closeAriaLabel="Dismiss navigation notice"
+                />
+              ) : (
+                <div
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="flex items-center gap-2 px-3 py-1.5 text-xs bg-status-warning/10 border-b border-status-warning/20 text-daintree-text/80"
+                >
+                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-status-warning" />
+                  <span className="truncate flex-1">
+                    Navigation to external site blocked: {extractHostname(blockedNav.url)}
+                  </span>
+                  {blockedNav.canOpenExternal && (
+                    <button
+                      type="button"
+                      disabled={blockedNav.phase === "opening"}
+                      onClick={() =>
+                        void handleOpenBlockedExternal(blockedNav.noticeId, blockedNav.url)
+                      }
+                      className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                      Open in external browser
+                    </button>
+                  )}
                   <button
                     type="button"
-                    onClick={() => {
-                      void actionService.dispatch(
-                        "browser.openExternal",
-                        { terminalId: id, url: blockedNav.url },
-                        { source: "user" }
-                      );
-                      setBlockedNav(null);
-                    }}
-                    className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+                    onClick={() => setBlockedNav(null)}
+                    className="shrink-0 text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+                    aria-label="Dismiss navigation notice"
                   >
-                    Open in external browser
+                    ×
                   </button>
-                )}
-                <button
-                  type="button"
-                  onClick={() => setBlockedNav(null)}
-                  className="shrink-0 text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
-                  aria-label="Dismiss navigation notice"
-                >
-                  ×
-                </button>
-              </div>
-            )}
+                </div>
+              ))}
             <div className="relative flex-1 min-h-0">
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
               {showLoadingOverlay && (

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -218,6 +218,9 @@ describe("BrowserPane webview lifecycle regression", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // dispatch() resolves an ActionDispatchResult union and never rejects;
+    // callers branch on `.ok`, so the mock must honour that shape.
+    actionDispatchMock.mockResolvedValue({ ok: true, result: undefined });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).window = globalThis.window ?? {};
@@ -934,6 +937,137 @@ describe("BrowserPane webview lifecycle regression", () => {
         { terminalId: "browser-panel-1", url: "https://oauth.provider.com/auth" },
         { source: "user" }
       );
+    });
+
+    // #11114: dispatch() resolves {ok:false} rather than rejecting, so the old
+    // handler cleared the notice unconditionally — destroying the user's only
+    // route to the blocked URL whenever the external open actually failed.
+    describe("failed external open (#11114)", () => {
+      const OPEN_FAILED = {
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "xdg-open exited with code 3" },
+      };
+
+      function blockNavigation(container: HTMLElement, url: string) {
+        const callback = getNavigationBlockedCallback();
+        act(() => {
+          callback({ panelId: "browser-panel-1", url, canOpenExternal: true });
+          vi.advanceTimersByTime(150);
+        });
+        return container;
+      }
+
+      function findButton(container: HTMLElement, text: string) {
+        return Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes(text)
+        );
+      }
+
+      it("clears the notice when the external open succeeds", async () => {
+        const { container } = render(<BrowserPane {...baseProps} />);
+        blockNavigation(container, "https://oauth.provider.com/auth");
+
+        await act(async () => {
+          findButton(container, "Open in external browser")!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true })
+          );
+        });
+
+        expect(container.textContent).not.toContain("oauth.provider.com");
+      });
+
+      it("keeps the notice and surfaces the reason when the external open fails", async () => {
+        actionDispatchMock.mockResolvedValue(OPEN_FAILED);
+        const { container } = render(<BrowserPane {...baseProps} />);
+        blockNavigation(container, "https://oauth.provider.com/auth");
+
+        await act(async () => {
+          findButton(container, "Open in external browser")!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true })
+          );
+        });
+
+        // The failure reason reaches the user, the blocked host is still named,
+        // and the recovery route survives.
+        expect(container.textContent).toContain(OPEN_FAILED.error.message);
+        expect(container.textContent).toContain("oauth.provider.com");
+        expect(findButton(container, "Retry")).toBeDefined();
+        // Tier 3 is pane-local: no redundant global toast.
+        expect(notifyMock).not.toHaveBeenCalled();
+      });
+
+      it("does not auto-dismiss a failed notice after the 10s blocked-notice timeout", async () => {
+        actionDispatchMock.mockResolvedValue(OPEN_FAILED);
+        const { container } = render(<BrowserPane {...baseProps} />);
+        blockNavigation(container, "https://oauth.provider.com/auth");
+
+        await act(async () => {
+          findButton(container, "Open in external browser")!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true })
+          );
+        });
+
+        act(() => {
+          vi.advanceTimersByTime(20_000);
+        });
+
+        // The auto-dismiss timer only owns the untouched notice — otherwise the
+        // error banner would silently delete itself and take the recovery with it.
+        expect(container.textContent).toContain(OPEN_FAILED.error.message);
+        expect(findButton(container, "Retry")).toBeDefined();
+      });
+
+      it("retries the same URL from the error banner and clears the notice once it succeeds", async () => {
+        actionDispatchMock.mockResolvedValue(OPEN_FAILED);
+        const { container } = render(<BrowserPane {...baseProps} />);
+        blockNavigation(container, "https://oauth.provider.com/auth");
+
+        await act(async () => {
+          findButton(container, "Open in external browser")!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true })
+          );
+        });
+
+        actionDispatchMock.mockResolvedValue({ ok: true, result: undefined });
+        await act(async () => {
+          findButton(container, "Retry")!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+
+        expect(actionDispatchMock).toHaveBeenLastCalledWith(
+          "browser.openExternal",
+          { terminalId: "browser-panel-1", url: "https://oauth.provider.com/auth" },
+          { source: "user" }
+        );
+        expect(container.textContent).not.toContain("oauth.provider.com");
+      });
+
+      it("does not let a superseded notice's failure overwrite a newer blocked navigation", async () => {
+        let resolveOpen: (value: unknown) => void = () => {};
+        actionDispatchMock.mockReturnValue(
+          new Promise((resolve) => {
+            resolveOpen = resolve;
+          })
+        );
+        const { container } = render(<BrowserPane {...baseProps} />);
+        blockNavigation(container, "https://first.com/auth");
+
+        act(() => {
+          findButton(container, "Open in external browser")!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true })
+          );
+        });
+
+        // A second navigation is blocked while the first open is still in flight.
+        blockNavigation(container, "https://second.com/auth");
+
+        await act(async () => {
+          resolveOpen(OPEN_FAILED);
+        });
+
+        // The stale failure belongs to first.com's notice, which no longer exists.
+        expect(container.textContent).toContain("second.com");
+        expect(container.textContent).not.toContain(OPEN_FAILED.error.message);
+      });
     });
 
     it("closes this panel when onCloseShortcut fires for it, and ignores other panels (#10859)", () => {

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -963,14 +963,31 @@ describe("BrowserPane webview lifecycle regression", () => {
         );
       }
 
-      it("clears the notice when the external open succeeds", async () => {
+      // Deferred on purpose: the old code cleared the notice synchronously, so a
+      // test that only checks the end state would pass on the pre-fix build. The
+      // load-bearing assertion is that the notice SURVIVES until the result lands.
+      it("holds the notice open until the external open resolves, then clears it", async () => {
+        let resolveOpen: (value: unknown) => void = () => {};
+        actionDispatchMock.mockReturnValue(
+          new Promise((resolve) => {
+            resolveOpen = resolve;
+          })
+        );
         const { container } = render(<BrowserPane {...baseProps} />);
         blockNavigation(container, "https://oauth.provider.com/auth");
 
-        await act(async () => {
+        act(() => {
           findButton(container, "Open in external browser")!.dispatchEvent(
             new MouseEvent("click", { bubbles: true })
           );
+        });
+
+        // Still pending: the notice must not be torn down before we know the outcome.
+        expect(container.textContent).toContain("oauth.provider.com");
+        expect(findButton(container, "Opening…")?.hasAttribute("disabled")).toBe(true);
+
+        await act(async () => {
+          resolveOpen({ ok: true, result: undefined });
         });
 
         expect(container.textContent).not.toContain("oauth.provider.com");
@@ -1017,6 +1034,37 @@ describe("BrowserPane webview lifecycle regression", () => {
         expect(findButton(container, "Retry")).toBeDefined();
       });
 
+      // The auto-dismiss timer is armed while the notice is "blocked". Its callback
+      // can still be picked up by the event loop after the user clicks — cleanup
+      // can't cancel a callback already in flight — so the callback itself has to
+      // re-check ownership. Otherwise it nulls the notice mid-attempt and the
+      // failure below has nothing left to attach to.
+      it("does not let a queued auto-dismiss timer destroy a notice that is mid-attempt", async () => {
+        let resolveOpen: (value: unknown) => void = () => {};
+        actionDispatchMock.mockReturnValue(
+          new Promise((resolve) => {
+            resolveOpen = resolve;
+          })
+        );
+        const { container } = render(<BrowserPane {...baseProps} />);
+        blockNavigation(container, "https://oauth.provider.com/auth");
+
+        act(() => {
+          findButton(container, "Open in external browser")!.dispatchEvent(
+            new MouseEvent("click", { bubbles: true })
+          );
+          // Fires the timer armed by the "blocked" render, in the same batch.
+          vi.advanceTimersByTime(10_000);
+        });
+
+        await act(async () => {
+          resolveOpen(OPEN_FAILED);
+        });
+
+        expect(container.textContent).toContain(OPEN_FAILED.error.message);
+        expect(findButton(container, "Retry")).toBeDefined();
+      });
+
       it("retries the same URL from the error banner and clears the notice once it succeeds", async () => {
         actionDispatchMock.mockResolvedValue(OPEN_FAILED);
         const { container } = render(<BrowserPane {...baseProps} />);
@@ -1056,6 +1104,10 @@ describe("BrowserPane webview lifecycle regression", () => {
             new MouseEvent("click", { bubbles: true })
           );
         });
+
+        // The first notice is still alive and mid-attempt (the old code had
+        // already destroyed it here, which is what made its result harmless).
+        expect(container.textContent).toContain("first.com");
 
         // A second navigation is blocked while the first open is still in flight.
         blockNavigation(container, "https://second.com/auth");

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -508,6 +508,9 @@ export function DevPreviewPane({
     handleZoomChange,
     handleOpenExternal,
     handlePromoteToPortal,
+    promoteToPortalError,
+    isPromotingToPortal,
+    clearPromoteToPortalError,
   } = useDevPreviewNavigation({
     id,
     currentProjectId,
@@ -855,7 +858,7 @@ export function DevPreviewPane({
           onReload={handleReload}
           onHardReload={handleHardReload}
           onOpenExternal={handleOpenExternal}
-          onPromoteToPortal={currentUrl ? handlePromoteToPortal : undefined}
+          onPromoteToPortal={currentUrl ? () => void handlePromoteToPortal() : undefined}
           onZoomChange={handleZoomChange}
           onCaptureScreenshot={handleCaptureScreenshot}
           onToggleDevTools={handleToggleDevTools}
@@ -865,6 +868,26 @@ export function DevPreviewPane({
           onViewportDprChange={handleViewportDprChange}
           onViewportFitToggle={handleViewportFitToggle}
         />
+
+        {promoteToPortalError && (
+          <InlineStatusBanner
+            icon={OctagonAlert}
+            title="Couldn't open in Portal"
+            description={promoteToPortalError}
+            severity="error"
+            action={{
+              id: "retry-promote-to-portal",
+              label: "Retry",
+              icon: RotateCw,
+              variant: "dangerFilled",
+              loading: isPromotingToPortal,
+              onClick: () => void handlePromoteToPortal(),
+              ariaLabel: "Retry opening in Portal",
+            }}
+            onClose={clearPromoteToPortalError}
+            closeAriaLabel="Dismiss Portal error"
+          />
+        )}
 
         {stuckTier >= 2 && (
           <DevPreviewStuckBanner

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1959,6 +1959,13 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         retry!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
 
+      // Retry must re-run the action, not merely dismiss the banner.
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenLastCalledWith(
+        "devPreview.promoteToPortal",
+        expect.objectContaining({ panelId: "dev-preview-panel-1" }),
+        { source: "user" }
+      );
       expect(container.textContent).not.toContain(message);
     });
   });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1905,6 +1905,64 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
   });
 
+  // #11114: the hook now exposes promotion failures; this covers the pane
+  // actually rendering them, which is the half the hook's own tests can't see.
+  describe("promote-to-portal failure banner (#11114)", () => {
+    type DispatchResult = Awaited<ReturnType<typeof actionService.dispatch>>;
+    const succeeded = (): DispatchResult => ({ ok: true, result: undefined });
+    const failed = (message: string): DispatchResult => ({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message },
+    });
+
+    const getPromoteHandler = () => {
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)?.[0] as {
+        onPromoteToPortal?: () => void;
+      };
+      return props.onPromoteToPortal;
+    };
+
+    it("renders the dispatch failure reason inline, without a global toast", async () => {
+      const message = "Portal is already showing this URL";
+      vi.spyOn(actionService, "dispatch").mockResolvedValue(failed(message));
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const promote = getPromoteHandler();
+      expect(promote).toBeDefined();
+
+      await act(async () => {
+        promote!();
+      });
+
+      expect(container.textContent).toContain(message);
+      // Tier 3 is pane-local — the failure must not also fire a toast.
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("removes the banner once a retry succeeds", async () => {
+      const message = "Portal promotion failed";
+      const dispatchSpy = vi.spyOn(actionService, "dispatch").mockResolvedValue(failed(message));
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await act(async () => {
+        getPromoteHandler()!();
+      });
+      expect(container.textContent).toContain(message);
+
+      dispatchSpy.mockResolvedValue(succeeded());
+      const retry = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Retry")
+      );
+      expect(retry).toBeDefined();
+
+      await act(async () => {
+        retry!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(container.textContent).not.toContain(message);
+    });
+  });
+
   describe("screenshot capture", () => {
     const getToolbarCapture = () => {
       const props = browserToolbarPropsSpy.mock.calls.at(-1)?.[0] as {

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -72,9 +72,9 @@ beforeEach(() => {
       mintBrowserToken: vi.fn().mockResolvedValue({ bootstrapUrl: "https://bootstrap.example" }),
     },
   };
-  vi.spyOn(actionService, "dispatch").mockResolvedValue({ ok: true } as Awaited<
-    ReturnType<typeof actionService.dispatch>
-  >);
+  // `{ok:true}` alone isn't a valid ActionDispatchSuccess — it needs `result`.
+  // The cast that used to hide that is exactly the class of mistake #11114 is about.
+  vi.spyOn(actionService, "dispatch").mockResolvedValue({ ok: true, result: undefined });
 });
 
 // #11114: dispatch() resolves {ok:false} rather than rejecting, so the old
@@ -138,8 +138,10 @@ describe("useDevPreviewNavigation — promote-to-portal failures (#11114)", () =
       inFlight.push(result.current.handlePromoteToPortal());
     });
 
-    // The synchronous isPromotingRef guard swallows the second click.
+    // The synchronous isPromotingRef guard swallows the second click...
     expect(dispatchMock()).toHaveBeenCalledTimes(1);
+    // ...and the pane reports the attempt as pending while it runs.
+    expect(result.current.isPromotingToPortal).toBe(true);
 
     await act(async () => {
       resolveDispatch(succeeded());
@@ -147,6 +149,49 @@ describe("useDevPreviewNavigation — promote-to-portal failures (#11114)", () =
     });
 
     expect(result.current.isPromotingToPortal).toBe(false);
+
+    // The guard genuinely released — a later click dispatches again.
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+    expect(dispatchMock()).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a stale result when the pane's project changed mid-flight", async () => {
+    let resolveDispatch!: (value: DispatchResult) => void;
+    dispatchMock().mockReturnValue(
+      new Promise<DispatchResult>((resolve) => {
+        resolveDispatch = resolve;
+      })
+    );
+
+    const { result, rerender } = renderHook(
+      (props: { currentProjectId: string }) =>
+        useDevPreviewNavigation(baseParams({ currentProjectId: props.currentProjectId })),
+      { initialProps: { currentProjectId: "proj-1" } }
+    );
+
+    act(() => {
+      void result.current.handlePromoteToPortal();
+    });
+
+    // The pane switches project while the promotion is still in flight.
+    rerender({ currentProjectId: "proj-2" });
+
+    await act(async () => {
+      resolveDispatch(failed("Promotion failed for the old project"));
+    });
+
+    // The obsolete failure belongs to proj-1 and must not surface against proj-2,
+    // and it must not leave the new context's guard stuck.
+    expect(result.current.promoteToPortalError).toBeNull();
+    expect(result.current.isPromotingToPortal).toBe(false);
+
+    dispatchMock().mockResolvedValue(succeeded());
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+    expect(dispatchMock()).toHaveBeenCalledTimes(2);
   });
 
   it("allows a retry after a failure, and a successful retry clears the error", async () => {

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -77,6 +77,111 @@ beforeEach(() => {
   >);
 });
 
+// #11114: dispatch() resolves {ok:false} rather than rejecting, so the old
+// `.finally(() => { isPromotingRef.current = false })` reset the guard but never
+// looked at the result — a failed promotion was indistinguishable from success.
+describe("useDevPreviewNavigation — promote-to-portal failures (#11114)", () => {
+  const dispatchMock = () => vi.mocked(actionService.dispatch);
+
+  // Built as typed values rather than `as`-cast literals: the dispatch result is
+  // a discriminated union, so the compiler can check these for us.
+  type DispatchResult = Awaited<ReturnType<typeof actionService.dispatch>>;
+  const succeeded = (): DispatchResult => ({ ok: true, result: undefined });
+  const failed = (message: string): DispatchResult => ({
+    ok: false,
+    error: { code: "EXECUTION_ERROR", message },
+  });
+
+  it("reports no error and releases the guard when promotion succeeds", async () => {
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams()));
+
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+
+    expect(dispatchMock()).toHaveBeenCalledWith(
+      "devPreview.promoteToPortal",
+      { panelId: PANE_ID, projectId: "proj-1" },
+      { source: "user" }
+    );
+    expect(result.current.promoteToPortalError).toBeNull();
+    expect(result.current.isPromotingToPortal).toBe(false);
+  });
+
+  it("exposes the dispatch error message when promotion fails", async () => {
+    const message = "Portal panel limit reached";
+    dispatchMock().mockResolvedValue(failed(message));
+
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams()));
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+
+    expect(result.current.promoteToPortalError).toBe(message);
+    // The guard must release even on failure, or Retry would be dead.
+    expect(result.current.isPromotingToPortal).toBe(false);
+  });
+
+  it("ignores a second click while a promotion is in flight", async () => {
+    let resolveDispatch!: (value: DispatchResult) => void;
+    dispatchMock().mockReturnValue(
+      new Promise<DispatchResult>((resolve) => {
+        resolveDispatch = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams()));
+
+    const inFlight: Array<Promise<void>> = [];
+    act(() => {
+      inFlight.push(result.current.handlePromoteToPortal());
+      inFlight.push(result.current.handlePromoteToPortal());
+    });
+
+    // The synchronous isPromotingRef guard swallows the second click.
+    expect(dispatchMock()).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDispatch(succeeded());
+      await Promise.all(inFlight);
+    });
+
+    expect(result.current.isPromotingToPortal).toBe(false);
+  });
+
+  it("allows a retry after a failure, and a successful retry clears the error", async () => {
+    dispatchMock().mockResolvedValue(failed("Promotion failed"));
+
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams()));
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+    expect(result.current.promoteToPortalError).toBe("Promotion failed");
+
+    dispatchMock().mockResolvedValue(succeeded());
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+
+    expect(dispatchMock()).toHaveBeenCalledTimes(2);
+    expect(result.current.promoteToPortalError).toBeNull();
+  });
+
+  it("clearPromoteToPortalError dismisses the error without dispatching", async () => {
+    dispatchMock().mockResolvedValue(failed("Promotion failed"));
+
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams()));
+    await act(async () => {
+      await result.current.handlePromoteToPortal();
+    });
+
+    act(() => result.current.clearPromoteToPortalError());
+
+    expect(result.current.promoteToPortalError).toBeNull();
+    expect(dispatchMock()).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("useDevPreviewNavigation — history handlers", () => {
   it("handleNavigate pushes a normalized (localhost-only) URL onto history", () => {
     const setHistory = vi.fn();

--- a/src/components/DevPreview/useDevPreviewNavigation.ts
+++ b/src/components/DevPreview/useDevPreviewNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import type { BrowserHistory } from "@shared/types/browser";
 import { normalizeBrowserUrl } from "../Browser/browserUtils";
@@ -78,6 +78,23 @@ export function useDevPreviewNavigation({
 }: UseDevPreviewNavigationParams) {
   const screenshotInFlightRef = useRef(false);
   const isPromotingRef = useRef(false);
+  // dispatch() resolves an ActionDispatchResult and never rejects, so the old
+  // .finally() reset dropped promotion failures on the floor (#11114). The
+  // error is surfaced by DevPreviewPane, which owns this hook's JSX.
+  const [promoteToPortalError, setPromoteToPortalError] = useState<string | null>(null);
+  const [isPromotingToPortal, setIsPromotingToPortal] = useState(false);
+  const promoteAttemptRef = useRef(0);
+
+  const clearPromoteToPortalError = useCallback(() => setPromoteToPortalError(null), []);
+
+  // A result that lands after the pane changed identity or project belongs to
+  // the previous context: drop it rather than surface it against the new one.
+  useEffect(() => {
+    promoteAttemptRef.current += 1;
+    setPromoteToPortalError(null);
+    setIsPromotingToPortal(false);
+    isPromotingRef.current = false;
+  }, [id, currentProjectId]);
 
   // Push history only; the imperative navigation effect (keyed on currentUrl
   // vs lastSetUrlRef) performs the actual loadURL. Pre-setting lastSetUrlRef
@@ -246,21 +263,30 @@ export function useDevPreviewNavigation({
     });
   }, [currentUrl, proxyOrigin, currentProjectId, id]);
 
-  const handlePromoteToPortal = useCallback(() => {
+  const handlePromoteToPortal = useCallback(async () => {
     if (isPromotingRef.current) return;
     isPromotingRef.current = true;
+    const attempt = ++promoteAttemptRef.current;
+    setIsPromotingToPortal(true);
     if (currentUrl) {
       setBrowserUrl(id, currentUrl);
     }
-    void actionService
-      .dispatch(
-        "devPreview.promoteToPortal",
-        { panelId: id, projectId: currentProjectId },
-        { source: "user" }
-      )
-      .finally(() => {
-        isPromotingRef.current = false;
-      });
+    const result = await actionService.dispatch(
+      "devPreview.promoteToPortal",
+      { panelId: id, projectId: currentProjectId },
+      { source: "user" }
+    );
+    // A newer attempt (or a context change) already reset the guard and owns
+    // the UI — an obsolete completion must not unlock it or overwrite state.
+    if (promoteAttemptRef.current !== attempt) return;
+    isPromotingRef.current = false;
+    setIsPromotingToPortal(false);
+    if (result.ok) {
+      setPromoteToPortalError(null);
+      return;
+    }
+    logError("[DevPreviewPane] promoteToPortal failed", result.error);
+    setPromoteToPortalError(result.error.message);
   }, [currentProjectId, currentUrl, id, setBrowserUrl]);
 
   const handleZoomChange = useCallback(
@@ -340,5 +366,8 @@ export function useDevPreviewNavigation({
     handleZoomChange,
     handleOpenExternal,
     handlePromoteToPortal,
+    promoteToPortalError,
+    isPromotingToPortal,
+    clearPromoteToPortalError,
   };
 }

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -34,7 +34,14 @@ export type UseWebviewEventsOptions = {
   setIsLoading: (v: boolean) => void;
   setLoadError: (v: LoadError | null) => void;
   setIsSlowLoad: (v: boolean) => void;
-  setBlockedNav: (v: { url: string; canOpenExternal: boolean } | null) => void;
+  /**
+   * Navigation events only ever *clear* the blocked-navigation notice — the
+   * notice itself is created by the onNavigationBlocked listener. Typing the
+   * parameter as `null` keeps this hook decoupled from the notice's shape
+   * (which carries retry/error state since #11114) while staying assignable
+   * from the owning `useState` setter.
+   */
+  setBlockedNav: (v: null) => void;
   setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
   onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
 };

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Check, ExternalLink, FileText, RefreshCw, Search, WrapText } from "lucide-react";
+import { Check, ExternalLink, FileText, RefreshCw, Search, WrapText, XCircle } from "lucide-react";
 import type { FileViewMode } from "@shared/types/panel";
 import { isFilePanel } from "@shared/types/panel";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
@@ -13,6 +13,7 @@ import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import {
   FILE_READ_ERROR_MESSAGES,
   toFileReadErrorCode,
@@ -372,11 +373,38 @@ export function FilePane({
       .catch((err) => logError("[FilePane] copy path failed", err));
   }, [filePath]);
 
-  const handleOpenInEditor = useCallback(() => {
+  // dispatch() resolves an ActionDispatchResult and never rejects, so a failed
+  // open used to vanish entirely (#11114). Surface it inline on the pane that
+  // owns the button rather than through a global toast.
+  const [openInEditorError, setOpenInEditorError] = useState<string | null>(null);
+  const [isOpeningInEditor, setIsOpeningInEditor] = useState(false);
+  const openInEditorAttemptRef = useRef(0);
+
+  // A result that lands after the pane switched files belongs to the old file:
+  // drop it, and clear any banner the old file left behind.
+  useEffect(() => {
+    openInEditorAttemptRef.current += 1;
+    setOpenInEditorError(null);
+    setIsOpeningInEditor(false);
+  }, [filePath]);
+
+  const handleOpenInEditor = useCallback(async () => {
     if (!filePath) return;
-    actionService
-      .dispatch("file.openInEditor", { path: filePath }, { source: "user" })
-      .catch((err) => logError("[FilePane] openInEditor failed", err));
+    const attempt = ++openInEditorAttemptRef.current;
+    setIsOpeningInEditor(true);
+    const result = await actionService.dispatch(
+      "file.openInEditor",
+      { path: filePath },
+      { source: "user" }
+    );
+    if (openInEditorAttemptRef.current !== attempt) return;
+    setIsOpeningInEditor(false);
+    if (result.ok) {
+      setOpenInEditorError(null);
+      return;
+    }
+    logError("[FilePane] openInEditor failed", result.error);
+    setOpenInEditorError(result.error.message);
   }, [filePath]);
 
   const [pickerQuery, setPickerQuery] = useState("");
@@ -394,64 +422,85 @@ export function FilePane({
   const { spanRef: pathSpanRef, display: fittedPath } = useFittedPath(displayPath);
 
   const toolbar = filePath ? (
-    <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay">
-      {isMarkdown && (
-        <SegmentedToggle<FileViewMode>
-          options={[
-            { value: "source", label: "Source" },
-            { value: "rendered", label: "Rendered" },
-          ]}
-          value={viewMode}
-          onChange={(mode) => setFileViewMode(id, mode)}
-        />
-      )}
-      {/* Path pill — mirrors the browser toolbar's address field. Click copies
+    <>
+      <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay">
+        {isMarkdown && (
+          <SegmentedToggle<FileViewMode>
+            options={[
+              { value: "source", label: "Source" },
+              { value: "rendered", label: "Rendered" },
+            ]}
+            value={viewMode}
+            onChange={(mode) => setFileViewMode(id, mode)}
+          />
+        )}
+        {/* Path pill — mirrors the browser toolbar's address field. Click copies
           the absolute path; the middle collapses to fit the available width
           while the file name always survives. */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={handleCopyPath}
-            aria-label="Copy file path"
-            className="relative flex items-center min-w-0 flex-1 group/path"
-          >
-            {pathCopied ? (
-              <Check className="absolute left-2 w-3.5 h-3.5 text-status-success pointer-events-none" />
-            ) : (
-              <FileText
-                aria-hidden="true"
-                className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
-              />
-            )}
-            <span
-              ref={pathSpanRef}
-              className="w-full pl-7 pr-2 py-1 text-left text-xs font-mono rounded bg-daintree-bg border border-overlay text-daintree-text/70 truncate transition-colors group-hover/path:border-border-strong group-hover/path:text-daintree-text"
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleCopyPath}
+              aria-label="Copy file path"
+              className="relative flex items-center min-w-0 flex-1 group/path"
             >
-              {fittedPath}
-            </span>
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{pathCopied ? "Copied!" : "Click to copy"}</TooltipContent>
-      </Tooltip>
-      <div className="ml-auto flex items-center gap-1.5 shrink-0">
-        {isMarkdown && viewMode === "source" && (
-          <ToolbarIconButton
-            label="Wrap long lines"
-            pressed={markdownWrapLines}
-            onClick={() => setMarkdownWrapLines(!markdownWrapLines)}
-          >
-            <WrapText className="w-4 h-4" />
+              {pathCopied ? (
+                <Check className="absolute left-2 w-3.5 h-3.5 text-status-success pointer-events-none" />
+              ) : (
+                <FileText
+                  aria-hidden="true"
+                  className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
+                />
+              )}
+              <span
+                ref={pathSpanRef}
+                className="w-full pl-7 pr-2 py-1 text-left text-xs font-mono rounded bg-daintree-bg border border-overlay text-daintree-text/70 truncate transition-colors group-hover/path:border-border-strong group-hover/path:text-daintree-text"
+              >
+                {fittedPath}
+              </span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{pathCopied ? "Copied!" : "Click to copy"}</TooltipContent>
+        </Tooltip>
+        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+          {isMarkdown && viewMode === "source" && (
+            <ToolbarIconButton
+              label="Wrap long lines"
+              pressed={markdownWrapLines}
+              onClick={() => setMarkdownWrapLines(!markdownWrapLines)}
+            >
+              <WrapText className="w-4 h-4" />
+            </ToolbarIconButton>
+          )}
+          <ToolbarIconButton label="Refresh" onClick={() => loadFile(false)}>
+            <RefreshCw className="w-4 h-4" />
           </ToolbarIconButton>
-        )}
-        <ToolbarIconButton label="Refresh" onClick={() => loadFile(false)}>
-          <RefreshCw className="w-4 h-4" />
-        </ToolbarIconButton>
-        <ToolbarIconButton label="Open in editor" onClick={handleOpenInEditor}>
-          <ExternalLink className="w-4 h-4" />
-        </ToolbarIconButton>
+          <ToolbarIconButton label="Open in editor" onClick={() => void handleOpenInEditor()}>
+            <ExternalLink className="w-4 h-4" />
+          </ToolbarIconButton>
+        </div>
       </div>
-    </div>
+      {openInEditorError && (
+        <InlineStatusBanner
+          icon={XCircle}
+          title="Couldn't open in editor"
+          description={openInEditorError}
+          severity="error"
+          action={{
+            id: "retry-open-in-editor",
+            label: "Retry",
+            icon: RefreshCw,
+            variant: "dangerFilled",
+            loading: isOpeningInEditor,
+            onClick: () => void handleOpenInEditor(),
+            ariaLabel: "Retry opening in editor",
+          }}
+          onClose={() => setOpenInEditorError(null)}
+          closeAriaLabel="Dismiss editor error"
+        />
+      )}
+    </>
   ) : undefined;
 
   return (

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -379,17 +379,24 @@ export function FilePane({
   const [openInEditorError, setOpenInEditorError] = useState<string | null>(null);
   const [isOpeningInEditor, setIsOpeningInEditor] = useState(false);
   const openInEditorAttemptRef = useRef(0);
+  // Synchronous re-entry guard: state can't stop a double-click in one tick.
+  // Without it a second launch could land after the first succeeded and report
+  // "Couldn't open in editor" over a file the editor did in fact open.
+  const openInEditorInFlightRef = useRef(false);
 
-  // A result that lands after the pane switched files belongs to the old file:
-  // drop it, and clear any banner the old file left behind.
+  // A result that lands after the pane switched files (or panels) belongs to the
+  // old file: drop it, and clear any banner the old file left behind.
   useEffect(() => {
     openInEditorAttemptRef.current += 1;
+    openInEditorInFlightRef.current = false;
     setOpenInEditorError(null);
     setIsOpeningInEditor(false);
-  }, [filePath]);
+  }, [id, filePath]);
 
   const handleOpenInEditor = useCallback(async () => {
     if (!filePath) return;
+    if (openInEditorInFlightRef.current) return;
+    openInEditorInFlightRef.current = true;
     const attempt = ++openInEditorAttemptRef.current;
     setIsOpeningInEditor(true);
     const result = await actionService.dispatch(
@@ -397,7 +404,10 @@ export function FilePane({
       { path: filePath },
       { source: "user" }
     );
+    // A newer attempt (or a file/panel switch) already reset the guard and owns
+    // the banner — an obsolete completion must not unlock it or overwrite state.
     if (openInEditorAttemptRef.current !== attempt) return;
+    openInEditorInFlightRef.current = false;
     setIsOpeningInEditor(false);
     if (result.ok) {
       setOpenInEditorError(null);

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -47,10 +47,14 @@ vi.mock("@/clients/filesClient", () => ({
 }));
 // dispatch() resolves an ActionDispatchResult union and never rejects; callers
 // branch on `.ok`, so the mock must honour that shape rather than resolve void.
-const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
+const { dispatchMock, notifyMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+  notifyMock: vi.fn(),
+}));
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: dispatchMock },
 }));
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({ CodeViewer: () => null }));
 
@@ -182,6 +186,45 @@ describe("FilePane open-in-editor failure feedback (#11114)", () => {
     const alert = container.querySelector('[role="alert"]');
     expect(alert).not.toBeNull();
     expect(alert!.textContent).toContain(message);
+    // Tier 3 is pane-local — the failure must not also fire a global toast.
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("drops a stale failure when the pane switched files mid-flight", async () => {
+    let resolveDispatch: (value: unknown) => void = () => {};
+    dispatchMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDispatch = resolve;
+      })
+    );
+
+    const { container, rerender } = renderFilePane();
+    await clickOpenInEditor(container);
+
+    // The pane is repointed at another file while the open is still in flight.
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/src/other.ts" };
+    rerender(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="other.ts"
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+
+    await act(async () => {
+      resolveDispatch({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "Stale failure for index.ts" },
+      });
+    });
+
+    // The old file's failure must not be reported against the new one.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 
   it("clears the error once a retry succeeds", async () => {
@@ -201,7 +244,13 @@ describe("FilePane open-in-editor failure feedback (#11114)", () => {
       retry!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
+    // Retry must re-run the action against the same file, not merely dismiss.
     expect(dispatchMock).toHaveBeenCalledTimes(2);
+    expect(dispatchMock).toHaveBeenLastCalledWith(
+      "file.openInEditor",
+      { path: "/repo/src/index.ts" },
+      { source: "user" }
+    );
     expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1,24 +1,30 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { render, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // FilePane forwards a fixed prop list to ContentPanel; #10991 was a dropped
 // `showRestoreControl`, which hid the inline "Move to grid" button on a docked
 // single file panel. Stub ContentPanel to capture what FilePane forwards, and
 // mock the heavy store/client/viewer surface so we render only FilePane's own
-// wiring — the seam that shipped the bug.
+// wiring — the seam that shipped the bug. The stub also renders `toolbar`, so
+// the toolbar-owned open-in-editor error banner (#11114) is observable.
 const contentPanelProps: Array<Record<string, unknown>> = [];
 
 vi.mock("@/components/Panel/ContentPanel", () => ({
-  ContentPanel: (props: Record<string, unknown>) => {
+  ContentPanel: (props: Record<string, unknown> & { toolbar?: ReactNode }) => {
     contentPanelProps.push(props);
-    return null;
+    return <>{props.toolbar}</>;
   },
 }));
 
+// Mutable so a test can seed a real file panel (giving FilePane a filePath, and
+// therefore a toolbar) without disturbing the prop-forwarding tests.
+const panelsById: Record<string, unknown> = {};
+
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (state: unknown) => unknown) =>
-    selector({ panelsById: {}, setFileViewMode: vi.fn(), setFilePanelPath: vi.fn() }),
+    selector({ panelsById, setFileViewMode: vi.fn(), setFilePanelPath: vi.fn() }),
 }));
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
@@ -39,13 +45,17 @@ vi.mock("@/clients/filesClient", () => ({
     search: vi.fn().mockResolvedValue({ files: [] }),
   },
 }));
+// dispatch() resolves an ActionDispatchResult union and never rejects; callers
+// branch on `.ok`, so the mock must honour that shape rather than resolve void.
+const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: vi.fn().mockResolvedValue(undefined) },
+  actionService: { dispatch: dispatchMock },
 }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({ CodeViewer: () => null }));
 
 import { FilePane } from "../FilePane";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 function lastContentPanelProps(): Record<string, unknown> {
   const props = contentPanelProps.at(-1);
@@ -53,8 +63,32 @@ function lastContentPanelProps(): Record<string, unknown> {
   return props;
 }
 
+beforeEach(() => {
+  dispatchMock.mockReset();
+  dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+  // InlineStatusBanner reads window.matchMedia at render time; jsdom does not
+  // implement it, so provide a no-op stub.
+  if (typeof window.matchMedia !== "function") {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
 afterEach(() => {
   contentPanelProps.length = 0;
+  for (const key of Object.keys(panelsById)) delete panelsById[key];
 });
 
 describe("FilePane restore-control wiring", () => {
@@ -92,5 +126,82 @@ describe("FilePane restore-control wiring", () => {
     );
 
     expect(lastContentPanelProps().showRestoreControl).toBe(false);
+  });
+});
+
+// #11114: dispatch() resolves {ok:false} rather than rejecting, so the old
+// `.catch(logError)` was dead code and a failed open produced no feedback at all.
+describe("FilePane open-in-editor failure feedback (#11114)", () => {
+  function renderFilePane() {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/src/index.ts" };
+    // The toolbar's path pill is a Radix Tooltip, which needs a provider once
+    // the ContentPanel stub actually renders the toolbar.
+    return render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="index.ts"
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  function clickOpenInEditor(container: HTMLElement) {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Open in editor"
+    );
+    if (!button) throw new Error("Open in editor button not rendered");
+    return act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  it("stays silent when the open succeeds", async () => {
+    const { container } = renderFilePane();
+    await clickOpenInEditor(container);
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "file.openInEditor",
+      { path: "/repo/src/index.ts" },
+      { source: "user" }
+    );
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("surfaces the dispatch error inline when the open fails", async () => {
+    const message = "No editor configured for .ts files";
+    dispatchMock.mockResolvedValue({ ok: false, error: { code: "EXECUTION_ERROR", message } });
+
+    const { container } = renderFilePane();
+    await clickOpenInEditor(container);
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert!.textContent).toContain(message);
+  });
+
+  it("clears the error once a retry succeeds", async () => {
+    dispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "Editor launch failed" },
+    });
+    const { container } = renderFilePane();
+    await clickOpenInEditor(container);
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+
+    dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+    const retry = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Retry")
+    );
+    await act(async () => {
+      retry!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -190,6 +190,37 @@ describe("FilePane open-in-editor failure feedback (#11114)", () => {
     expect(notifyMock).not.toHaveBeenCalled();
   });
 
+  it("collapses a double-click into a single editor launch", async () => {
+    let resolveDispatch: (value: unknown) => void = () => {};
+    dispatchMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDispatch = resolve;
+      })
+    );
+
+    const { container } = renderFilePane();
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Open in editor"
+    )!;
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // Without a synchronous guard the second click starts a second OS launch,
+    // whose late failure could then paper over the first launch's success.
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDispatch({ ok: true, result: undefined });
+    });
+
+    // The guard released — the button is usable again, not latched.
+    await clickOpenInEditor(container);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("drops a stale failure when the pane switched files mid-flight", async () => {
     let resolveDispatch: (value: unknown) => void = () => {};
     dispatchMock.mockReturnValue(
@@ -225,6 +256,16 @@ describe("FilePane open-in-editor failure feedback (#11114)", () => {
 
     // The old file's failure must not be reported against the new one.
     expect(container.querySelector('[role="alert"]')).toBeNull();
+
+    // ...and the switch must have released the in-flight guard, or the button
+    // would be permanently dead on the new file.
+    dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+    await clickOpenInEditor(container);
+    expect(dispatchMock).toHaveBeenLastCalledWith(
+      "file.openInEditor",
+      { path: "/repo/src/other.ts" },
+      { source: "user" }
+    );
   });
 
   it("clears the error once a retry succeeds", async () => {

--- a/src/services/actions/definitions/__tests__/devPreviewActions.promoteToPortal.test.ts
+++ b/src/services/actions/definitions/__tests__/devPreviewActions.promoteToPortal.test.ts
@@ -204,10 +204,15 @@ describe("devPreview.promoteToPortal", () => {
     ).rejects.toThrow(/not a dev preview/);
   });
 
-  it("rolls back the tab when portal.create rejects", async () => {
+  // The rollback must not also swallow the error: resolving normally made
+  // dispatch() report {ok:true} on a failed promotion, leaving the caller with
+  // nothing to surface and the user with no feedback at all (#11114).
+  it("rolls back the tab and rethrows when portal.create rejects", async () => {
     createMock.mockRejectedValueOnce(new Error("ipc boom"));
     const { run } = setupActions();
-    await run("devPreview.promoteToPortal", undefined, { projectId: "proj" });
+    await expect(
+      run("devPreview.promoteToPortal", undefined, { projectId: "proj" })
+    ).rejects.toThrow(/ipc boom/);
     expect(closeTabMock).toHaveBeenCalledTimes(1);
     expect(markTabCreatedMock).not.toHaveBeenCalled();
     expect(portalStoreMock.setState).not.toHaveBeenCalled();

--- a/src/services/actions/definitions/devPreviewActions.ts
+++ b/src/services/actions/definitions/devPreviewActions.ts
@@ -199,7 +199,11 @@ export function registerDevPreviewActions(
         }
       } catch (error) {
         logError("Failed to promote dev preview to portal", error);
+        // Roll the half-created tab back, then rethrow: swallowing here made
+        // dispatch() resolve {ok:true} on a failed promotion, so the caller had
+        // nothing to surface and the user saw nothing at all (#11114).
         usePortalStore.getState().closeTab(tabId);
+        throw error;
       }
     },
   }));


### PR DESCRIPTION
## Problem
`ActionService.dispatch()` always resolves an `ActionDispatchResult` union (`{ok:true,result}` | `{ok:false,error}`) and never rejects — this is deliberate (ActionService.ts has an explicit comment that callers are meant to surface errors themselves, from #8814). Three UI call sites treated it like a throwing promise or discarded the result entirely, so dispatch failures were silently swallowed:

- `FilePane.handleOpenInEditor` — `.catch(logError)` on a promise that never rejects: dead code.
- `useDevPreviewNavigation.handlePromoteToPortal` — `.finally()` reset the guard but never inspected the result.
- `BrowserPane`'s blocked-navigation banner — fired `void dispatch(...)` and cleared the banner **synchronously, without even awaiting**, destroying the user's only route to the blocked URL regardless of outcome.

## Fix
Each caller now awaits, branches on `result.ok`, and surfaces the failure inline in the pane that owns the action (Tier 3 per docs/architecture/notification-system.md — no global toast, matching the issue's requirement). Success paths are unchanged.

Two things surfaced during review that the issue didn't mention but that made the fix real:

1. **`devPreview.promoteToPortal` was swallowing its own IPC error.** It caught the `portal.create` rejection, rolled the tab back, logged, and returned normally — so `dispatch()` resolved `{ok:true}` on a *failed* promotion and the caller had nothing to surface. It now rethrows after the rollback. Without this the DevPreview half of the fix would have been decorative.
2. **The blocked-nav 10s auto-dismiss timer could re-open the same hole.** Its callback cleared unconditionally, and a callback already picked up by the event loop can't be cancelled by the effect cleanup — so it could null the notice *mid-attempt*, leaving the failure with no notice to attach to. It's now guarded on notice id + phase.

Stale results are handled with notice/attempt generations: a result that lands after a newer block, a file switch, or a project switch is dropped rather than surfaced against the wrong context.

## Testing
2452 tests green across the touched suites plus the full `actions/definitions` and `hooks` test directories; full composite typecheck clean. The new tests were red-before-green validated — reverting the auto-dismiss guard fails exactly the timer-race test and nothing else. Three initial tests that turned out to pass against the pre-fix code were rewritten to assert the pending state, which is what the old synchronous-clear could never satisfy.

## Known, deliberately out of scope
- `BrowserPane`'s **toolbar** "Open in browser" (`handleOpenExternal`) has the same unchecked-dispatch pattern, as do dozens of other `void dispatch(...)` call sites across the app. The issue scopes this to the three named sites; flagging the wider pattern rather than expanding the diff.
- `ActionService.dispatch()` has an unbounded await, so a hung IPC could latch the new in-flight guards. This matches the pre-existing `isPromotingRef` shape already in production; bounding the action layer is a separate concern.
- `PortalManager` can leave an orphaned `WebContentsView` if setup throws before the map insertion — a pre-existing main-process path, unrelated to this issue.

Resolves #11114