### PR TITLE
fix(settings): surface and roll back failed settings persistence

### DIFF
--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -128,6 +128,7 @@ interface AppThemePickerProps {
 type EpochKey = "scheme" | "accent" | "followSystem" | "preferredDark" | "preferredLight";
 
 interface SaveError {
+  domain: EpochKey;
   title: string;
   description: string;
   retry: () => void;
@@ -161,6 +162,15 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   // input previews through `setAccentColorOverride` on every `onInput` tick
   // without persisting, so by the time `onChange` commits, the store already
   // holds the new color and can no longer say what the old one was.
+  //
+  // It is deliberately NOT re-seeded from the store while mounted. The store is
+  // not a truthful picture of disk — the accent preview writes to it without
+  // persisting, and `app.setTheme` (appActions) applies a scheme optimistically
+  // and leaves it applied even when its own save fails. Syncing from it would
+  // record never-persisted values as durable. The cost is that a durable change
+  // made elsewhere while this dialog sits open (an OS appearance switch) is not
+  // picked up as the rollback baseline; reading it back from disk on failure
+  // would be the fix if that ever bites.
   const confirmedRef = useRef({
     selectedSchemeId,
     recentSchemeIds: useAppThemeStore.getState().recentSchemeIds,
@@ -181,6 +191,11 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     preferredLight: 0,
   });
 
+  // One banner at a time, but tagged with the field that raised it: an unrelated
+  // field succeeding must not clear a failure the user hasn't dealt with.
+  const clearErrorFor = (domain: EpochKey) =>
+    setSaveError((current) => (current?.domain === domain ? null : current));
+
   // Optimistic write, then persist, then revert to the last value known to be on
   // disk if the write is rejected. `apply` goes through the store setters so the
   // rollback re-runs their DOM injection and the rendered theme matches what the
@@ -195,18 +210,22 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     failure: { title: string; description: string }
   ): Promise<void> => {
     const epoch = ++epochsRef.current[domain];
+    // A fresh intent for this field retires the banner its predecessor left, so a
+    // stale Retry can't sit there waiting to resurrect a superseded value.
+    clearErrorFor(domain);
     apply(next);
 
     try {
       await persist(next);
       writeConfirmed(next);
-      if (epoch === epochsRef.current[domain]) setSaveError(null);
+      if (epoch === epochsRef.current[domain]) clearErrorFor(domain);
     } catch (error) {
       logError(`Failed to persist app theme setting: ${domain}`, error);
       if (epoch !== epochsRef.current[domain]) return;
       apply(readConfirmed());
       setSaveError({
         ...failure,
+        domain,
         retry: () =>
           void persistSetting(domain, next, readConfirmed, writeConfirmed, apply, persist, failure),
       });
@@ -278,9 +297,26 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   // was already turned off reverts the theme without turning matching back on.
   const handleSelect = async (id: string, origin?: { x: number; y: number }) => {
     const epoch = ++epochsRef.current.scheme;
-    const wasFollowingSystem = followSystem;
+    clearErrorFor("scheme");
 
-    if (wasFollowingSystem) setFollowSystem(false);
+    // Read live rather than closing over the render's value: Retry re-invokes an
+    // older render's handleSelect, and a stale `followSystem` there would either
+    // skip the turn-off or leave the store showing matching that is really off.
+    const storeFollowSystem = useAppThemeStore.getState().followSystem;
+    // Write the turn-off if EITHER source says matching is on: disk may still
+    // have it on (an in-flight toggle-off could yet fail), or the store may have
+    // it on with a toggle-on in flight. The write is idempotent, and issuing it
+    // last is what guarantees disk ends with matching off — otherwise the app
+    // boots following the system and overrides the very theme being saved.
+    const mustDisableFollowSystem = confirmedRef.current.followSystem || storeFollowSystem;
+    // Claim the follow-system field, so a toggle racing this selection cannot
+    // reconcile it behind our back, and so we reconcile it only while we own it.
+    const followEpoch = mustDisableFollowSystem ? ++epochsRef.current.followSystem : null;
+    const ownsScheme = () => epoch === epochsRef.current.scheme;
+    const ownsFollowSystem = () =>
+      followEpoch !== null && followEpoch === epochsRef.current.followSystem;
+
+    if (storeFollowSystem) setFollowSystem(false);
     commitSchemeSelection(id);
     const targetRecents = useAppThemeStore.getState().recentSchemeIds;
     const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
@@ -288,7 +324,10 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
 
     const restoreConfirmed = () => {
       const confirmed = confirmedRef.current;
-      setFollowSystem(confirmed.followSystem);
+      // Only put system matching back if this selection is what turned it off.
+      // Otherwise a newer toggle the user made while this write was in flight
+      // would be silently undone.
+      if (ownsFollowSystem()) setFollowSystem(confirmed.followSystem);
       // commitSchemeSelection re-seeds the MRU as a side effect, so the recents
       // list has to be put back after it, not before.
       commitSchemeSelection(confirmed.selectedSchemeId);
@@ -300,17 +339,27 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     };
 
     try {
-      if (wasFollowingSystem) {
+      if (mustDisableFollowSystem) {
         await appThemeClient.setFollowSystem(false);
         confirmedRef.current.followSystem = false;
+        // Matching is now off on disk, so a banner an earlier failed toggle left
+        // behind is describing a state that no longer exists.
+        clearErrorFor("followSystem");
       }
+      // A newer selection may have overtaken us while we awaited. Sending the
+      // scheme now would land on disk AFTER the newer one and leave the app
+      // booting into a theme the UI never showed — bail instead. Whatever we
+      // already wrote stays written and stays reflected in confirmedRef.
+      if (!ownsScheme()) return;
+
       await appThemeClient.setColorScheme(id);
       confirmedRef.current.selectedSchemeId = id;
     } catch (error) {
       logError("Failed to persist app theme", error);
-      if (epoch !== epochsRef.current.scheme) return;
+      if (!ownsScheme()) return;
       restoreConfirmed();
       setSaveError({
+        domain: "scheme",
         title: "Couldn't save theme",
         description: "The previous theme was restored, so it won't change on restart.",
         retry: () => void handleSelect(id),
@@ -318,7 +367,8 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       return;
     }
 
-    if (epoch === epochsRef.current.scheme) setSaveError(null);
+    if (!ownsScheme()) return;
+    clearErrorFor("scheme");
 
     // The MRU list drives the theme browser's "recent" row and is invisible from
     // here, so a failure to save it gives the user nothing to see and nothing to
@@ -329,9 +379,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       confirmedRef.current.recentSchemeIds = targetRecents;
     } catch (error) {
       logError("Failed to persist recent app themes", error);
-      if (epoch === epochsRef.current.scheme) {
-        setRecentSchemeIds(confirmedRef.current.recentSchemeIds);
-      }
+      if (ownsScheme()) setRecentSchemeIds(confirmedRef.current.recentSchemeIds);
     }
   };
 

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -148,6 +148,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   const accentColorOverride = useAppThemeStore((s) => s.accentColorOverride);
   const setAccentColorOverride = useAppThemeStore((s) => s.setAccentColorOverride);
   const setRecentSchemeIds = useAppThemeStore((s) => s.setRecentSchemeIds);
+  const recentSchemeIds = useAppThemeStore((s) => s.recentSchemeIds);
   const [importWarnings, setImportWarnings] = useState<AppThemeValidationWarning[]>([]);
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<SaveError | null>(null);
@@ -173,7 +174,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   // would be the fix if that ever bites.
   const confirmedRef = useRef({
     selectedSchemeId,
-    recentSchemeIds: useAppThemeStore.getState().recentSchemeIds,
+    recentSchemeIds,
     followSystem,
     preferredDarkSchemeId,
     preferredLightSchemeId,

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -6,7 +6,7 @@ import {
   type FormEvent,
   type MouseEvent,
 } from "react";
-import { AlertTriangle, Monitor, Shuffle } from "lucide-react";
+import { AlertCircle, AlertTriangle, Monitor, Shuffle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
 import { injectSchemeToDOM, useAppThemeStore } from "@/store/appThemeStore";
@@ -20,6 +20,7 @@ import {
 } from "@shared/theme";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { Button } from "@/components/ui/button";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { APP_THEME_PREVIEW_KEYS } from "@shared/theme";
 import type {
   AppColorScheme,
@@ -124,6 +125,14 @@ interface AppThemePickerProps {
   onClose?: () => void;
 }
 
+type EpochKey = "scheme" | "accent" | "followSystem" | "preferredDark" | "preferredLight";
+
+interface SaveError {
+  title: string;
+  description: string;
+  retry: () => void;
+}
+
 export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   const selectedSchemeId = useAppThemeStore((s) => s.selectedSchemeId);
   const customSchemes = useAppThemeStore((s) => s.customSchemes);
@@ -137,10 +146,72 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   const setPreferredLightSchemeId = useAppThemeStore((s) => s.setPreferredLightSchemeId);
   const accentColorOverride = useAppThemeStore((s) => s.accentColorOverride);
   const setAccentColorOverride = useAppThemeStore((s) => s.setAccentColorOverride);
+  const setRecentSchemeIds = useAppThemeStore((s) => s.setRecentSchemeIds);
   const [importWarnings, setImportWarnings] = useState<AppThemeValidationWarning[]>([]);
   const [importMessage, setImportMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<SaveError | null>(null);
 
   const shuffleQueueRef = useRef<string[]>([]);
+
+  // What each field currently looks like on disk. Seeded from the hydrated store
+  // on mount and advanced only as writes land, so a rollback restores durable
+  // truth instead of an earlier optimistic value that never reached disk.
+  //
+  // The accent entry is why this is a ref and not a read of the store: the color
+  // input previews through `setAccentColorOverride` on every `onInput` tick
+  // without persisting, so by the time `onChange` commits, the store already
+  // holds the new color and can no longer say what the old one was.
+  const confirmedRef = useRef({
+    selectedSchemeId,
+    recentSchemeIds: useAppThemeStore.getState().recentSchemeIds,
+    followSystem,
+    preferredDarkSchemeId,
+    preferredLightSchemeId,
+    accentColorOverride,
+  });
+
+  // One counter per field. A rejection only reconciles the field if it is still
+  // the newest write for it — otherwise a slow failure could drag a newer value
+  // that did persist back to a stale one.
+  const epochsRef = useRef<Record<EpochKey, number>>({
+    scheme: 0,
+    accent: 0,
+    followSystem: 0,
+    preferredDark: 0,
+    preferredLight: 0,
+  });
+
+  // Optimistic write, then persist, then revert to the last value known to be on
+  // disk if the write is rejected. `apply` goes through the store setters so the
+  // rollback re-runs their DOM injection and the rendered theme matches what the
+  // app will boot with.
+  const persistSetting = async <T,>(
+    domain: EpochKey,
+    next: T,
+    readConfirmed: () => T,
+    writeConfirmed: (value: T) => void,
+    apply: (value: T) => void,
+    persist: (value: T) => Promise<void>,
+    failure: { title: string; description: string }
+  ): Promise<void> => {
+    const epoch = ++epochsRef.current[domain];
+    apply(next);
+
+    try {
+      await persist(next);
+      writeConfirmed(next);
+      if (epoch === epochsRef.current[domain]) setSaveError(null);
+    } catch (error) {
+      logError(`Failed to persist app theme setting: ${domain}`, error);
+      if (epoch !== epochsRef.current[domain]) return;
+      apply(readConfirmed());
+      setSaveError({
+        ...failure,
+        retry: () =>
+          void persistSetting(domain, next, readConfirmed, writeConfirmed, apply, persist, failure),
+      });
+    }
+  };
 
   const allSchemes = useMemo(() => [...BUILT_IN_APP_SCHEMES, ...customSchemes], [customSchemes]);
   const darkSchemes = useMemo(() => allSchemes.filter((s) => s.type !== "light"), [allSchemes]);
@@ -178,67 +249,134 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     setAccentColorOverride(e.currentTarget.value);
   };
 
+  const persistAccent = (color: string | null) =>
+    persistSetting<string | null>(
+      "accent",
+      color,
+      () => confirmedRef.current.accentColorOverride,
+      (value) => (confirmedRef.current.accentColorOverride = value),
+      setAccentColorOverride,
+      (value) => appThemeClient.setAccentColorOverride(value),
+      {
+        title: "Couldn't save accent color",
+        description: "The accent went back to the last saved color, so it won't change on restart.",
+      }
+    );
+
   const handleAccentCommit = (e: ChangeEvent<HTMLInputElement>) => {
-    setAccentColorOverride(e.target.value);
-    appThemeClient.setAccentColorOverride(e.target.value).catch((error) => {
-      logError("Failed to persist accent color override", error);
-    });
+    void persistAccent(e.target.value);
   };
 
   const handleAccentReset = () => {
-    setAccentColorOverride(null);
-    appThemeClient.setAccentColorOverride(null).catch((error) => {
-      logError("Failed to clear accent color override", error);
-    });
+    void persistAccent(null);
   };
 
+  // Three independently durable writes: turning system matching off, saving the
+  // scheme, then saving the MRU list. They are not atomic, so each confirmed
+  // value advances as its own write lands and the rollback restores every field
+  // to whatever is actually on disk — a scheme that failed after system matching
+  // was already turned off reverts the theme without turning matching back on.
   const handleSelect = async (id: string, origin?: { x: number; y: number }) => {
-    if (followSystem) {
-      setFollowSystem(false);
-      appThemeClient
-        .setFollowSystem(false)
-        .catch((err) => logError("Failed to clear follow system", err));
-    }
+    const epoch = ++epochsRef.current.scheme;
+    const wasFollowingSystem = followSystem;
 
+    if (wasFollowingSystem) setFollowSystem(false);
     commitSchemeSelection(id);
+    const targetRecents = useAppThemeStore.getState().recentSchemeIds;
     const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
     runThemeReveal(origin ?? null, () => injectSchemeToDOM(scheme, { immediate: true }));
 
+    const restoreConfirmed = () => {
+      const confirmed = confirmedRef.current;
+      setFollowSystem(confirmed.followSystem);
+      // commitSchemeSelection re-seeds the MRU as a side effect, so the recents
+      // list has to be put back after it, not before.
+      commitSchemeSelection(confirmed.selectedSchemeId);
+      setRecentSchemeIds(confirmed.recentSchemeIds);
+      injectSchemeToDOM(
+        resolveAppTheme(confirmed.selectedSchemeId, useAppThemeStore.getState().customSchemes),
+        { immediate: true }
+      );
+    };
+
     try {
+      if (wasFollowingSystem) {
+        await appThemeClient.setFollowSystem(false);
+        confirmedRef.current.followSystem = false;
+      }
       await appThemeClient.setColorScheme(id);
-      await appThemeClient.setRecentSchemeIds(useAppThemeStore.getState().recentSchemeIds);
+      confirmedRef.current.selectedSchemeId = id;
     } catch (error) {
       logError("Failed to persist app theme", error);
+      if (epoch !== epochsRef.current.scheme) return;
+      restoreConfirmed();
+      setSaveError({
+        title: "Couldn't save theme",
+        description: "The previous theme was restored, so it won't change on restart.",
+        retry: () => void handleSelect(id),
+      });
+      return;
+    }
+
+    if (epoch === epochsRef.current.scheme) setSaveError(null);
+
+    // The MRU list drives the theme browser's "recent" row and is invisible from
+    // here, so a failure to save it gives the user nothing to see and nothing to
+    // act on. Keep memory matching disk and log it rather than raising a banner
+    // over a theme change that did save.
+    try {
+      await appThemeClient.setRecentSchemeIds(targetRecents);
+      confirmedRef.current.recentSchemeIds = targetRecents;
+    } catch (error) {
+      logError("Failed to persist recent app themes", error);
+      if (epoch === epochsRef.current.scheme) {
+        setRecentSchemeIds(confirmedRef.current.recentSchemeIds);
+      }
     }
   };
 
-  const handleToggleFollowSystem = async () => {
-    const newValue = !followSystem;
-    setFollowSystem(newValue);
-    try {
-      await appThemeClient.setFollowSystem(newValue);
-    } catch (error) {
-      logError("Failed to persist follow system", error);
-    }
-  };
+  const handleToggleFollowSystem = () =>
+    persistSetting<boolean>(
+      "followSystem",
+      !followSystem,
+      () => confirmedRef.current.followSystem,
+      (value) => (confirmedRef.current.followSystem = value),
+      setFollowSystem,
+      (value) => appThemeClient.setFollowSystem(value),
+      {
+        title: "Couldn't save appearance setting",
+        description:
+          "System appearance matching went back to its last saved state, so it won't change on restart.",
+      }
+    );
 
-  const handlePreferredDarkChange = async (id: string) => {
-    setPreferredDarkSchemeId(id);
-    try {
-      await appThemeClient.setPreferredDarkScheme(id);
-    } catch (error) {
-      logError("Failed to persist preferred dark scheme", error);
-    }
-  };
+  const handlePreferredDarkChange = (id: string) =>
+    persistSetting<string>(
+      "preferredDark",
+      id,
+      () => confirmedRef.current.preferredDarkSchemeId,
+      (value) => (confirmedRef.current.preferredDarkSchemeId = value),
+      setPreferredDarkSchemeId,
+      (value) => appThemeClient.setPreferredDarkScheme(value),
+      {
+        title: "Couldn't save preferred dark theme",
+        description: "The previous dark theme was restored, so it won't change on restart.",
+      }
+    );
 
-  const handlePreferredLightChange = async (id: string) => {
-    setPreferredLightSchemeId(id);
-    try {
-      await appThemeClient.setPreferredLightScheme(id);
-    } catch (error) {
-      logError("Failed to persist preferred light scheme", error);
-    }
-  };
+  const handlePreferredLightChange = (id: string) =>
+    persistSetting<string>(
+      "preferredLight",
+      id,
+      () => confirmedRef.current.preferredLightSchemeId,
+      (value) => (confirmedRef.current.preferredLightSchemeId = value),
+      setPreferredLightSchemeId,
+      (value) => appThemeClient.setPreferredLightScheme(value),
+      {
+        title: "Couldn't save preferred light theme",
+        description: "The previous light theme was restored, so it won't change on restart.",
+      }
+    );
 
   // The import result block mounts after an async resolve, so screen-reader users
   // get no announcement from it appearing. Route the summary through the shared
@@ -315,12 +453,25 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
 
   return (
     <div className="space-y-3">
+      {saveError && (
+        <InlineStatusBanner
+          className="rounded-[var(--radius-md)]"
+          severity="error"
+          icon={AlertCircle}
+          title={saveError.title}
+          description={saveError.description}
+          action={{ id: "retry", label: "Retry", onClick: saveError.retry }}
+          onClose={() => setSaveError(null)}
+          closeAriaLabel="Dismiss theme error"
+        />
+      )}
+
       <SettingsSwitchCard
         icon={Monitor}
         title="Match system appearance"
         subtitle="Automatically switch between dark and light themes"
         isEnabled={followSystem}
-        onChange={handleToggleFollowSystem}
+        onChange={() => void handleToggleFollowSystem()}
         ariaLabel="Toggle automatic theme switching"
         variant="compact"
       />
@@ -331,13 +482,13 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
             label="Preferred dark theme"
             schemes={darkSchemes}
             selectedId={preferredDarkSchemeId}
-            onSelect={handlePreferredDarkChange}
+            onSelect={(id) => void handlePreferredDarkChange(id)}
           />
           <PreferredSchemePicker
             label="Preferred light theme"
             schemes={lightSchemes}
             selectedId={preferredLightSchemeId}
-            onSelect={handlePreferredLightChange}
+            onSelect={(id) => void handlePreferredLightChange(id)}
           />
         </div>
       )}

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -27,6 +27,9 @@ const COLOR_VISION_OPTIONS: Array<{ id: ColorVisionMode; label: string; descript
   },
 ];
 
+const isColorVisionMode = (value: string): value is ColorVisionMode =>
+  COLOR_VISION_OPTIONS.some((option) => option.id === value);
+
 const SWATCH_TOKENS = [
   { label: "Success", var: "--theme-status-success" },
   { label: "Danger", var: "--theme-status-danger" },
@@ -108,7 +111,9 @@ export function ColorVisionPicker() {
     <div>
       <Select
         value={colorVisionMode}
-        onValueChange={(v) => void handleChange(v as ColorVisionMode)}
+        onValueChange={(value) => {
+          if (isColorVisionMode(value)) void handleChange(value);
+        }}
       >
         <SelectTrigger aria-label="Color vision mode">
           <SelectValue />

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { AlertCircle } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -8,6 +9,7 @@ import {
 } from "@/components/ui/select";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import type { ColorVisionMode } from "@shared/types";
 import { logError } from "@/utils/logger";
 
@@ -71,19 +73,40 @@ export function ColorVisionPicker() {
   const colorVisionMode = useAppThemeStore((s) => s.colorVisionMode);
   const setColorVisionMode = useAppThemeStore((s) => s.setColorVisionMode);
 
-  const handleChange = async (value: string) => {
-    const mode = value as ColorVisionMode;
+  // The mode last known to be on disk. Seeded from the hydrated store on mount
+  // and advanced only when a write lands, so a rollback always restores durable
+  // truth rather than an earlier optimistic value that never persisted.
+  const confirmedModeRef = useRef(colorVisionMode);
+  // Only the newest change may reconcile the field: an older rejection arriving
+  // after a newer write succeeded must not drag the UI back.
+  const epochRef = useRef(0);
+  const [failedMode, setFailedMode] = useState<ColorVisionMode | null>(null);
+
+  const handleChange = async (mode: ColorVisionMode) => {
+    const epoch = ++epochRef.current;
     setColorVisionMode(mode);
+
     try {
       await appThemeClient.setColorVisionMode(mode);
+      confirmedModeRef.current = mode;
+      if (epoch === epochRef.current) setFailedMode(null);
     } catch (error) {
       logError("Failed to persist color vision mode", error);
+      if (epoch !== epochRef.current) return;
+      // Going back through the store setter (not a raw setState) re-runs the
+      // documentElement filter swap, so the rendered colors match the mode the
+      // app will actually boot with.
+      setColorVisionMode(confirmedModeRef.current);
+      setFailedMode(mode);
     }
   };
 
   return (
     <div>
-      <Select value={colorVisionMode} onValueChange={(v) => void handleChange(v)}>
+      <Select
+        value={colorVisionMode}
+        onValueChange={(v) => void handleChange(v as ColorVisionMode)}
+      >
         <SelectTrigger aria-label="Color vision mode">
           <SelectValue />
         </SelectTrigger>
@@ -95,6 +118,18 @@ export function ColorVisionPicker() {
           ))}
         </SelectContent>
       </Select>
+      {failedMode && (
+        <InlineStatusBanner
+          className="mt-2 rounded-[var(--radius-md)]"
+          severity="error"
+          icon={AlertCircle}
+          title="Couldn't save color vision mode"
+          description="The mode was restored to the last saved one, so it won't be lost on restart."
+          action={{ id: "retry", label: "Retry", onClick: () => void handleChange(failedMode) }}
+          onClose={() => setFailedMode(null)}
+          closeAriaLabel="Dismiss color vision error"
+        />
+      )}
       <SwatchPreview />
     </div>
   );

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -74,8 +74,8 @@ export function ColorVisionPicker() {
   const setColorVisionMode = useAppThemeStore((s) => s.setColorVisionMode);
 
   // The mode last known to be on disk. Seeded from the hydrated store on mount
-  // and advanced only when a write lands, so a rollback always restores durable
-  // truth rather than an earlier optimistic value that never persisted.
+  // and advanced only when a write lands, so a rollback restores durable truth
+  // rather than an earlier optimistic value that never persisted.
   const confirmedModeRef = useRef(colorVisionMode);
   // Only the newest change may reconcile the field: an older rejection arriving
   // after a newer write succeeded must not drag the UI back.
@@ -84,6 +84,9 @@ export function ColorVisionPicker() {
 
   const handleChange = async (mode: ColorVisionMode) => {
     const epoch = ++epochRef.current;
+    // A fresh choice retires the previous banner, so its Retry can't linger and
+    // resurrect a superseded mode.
+    setFailedMode(null);
     setColorVisionMode(mode);
 
     try {

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import { Search, X, RotateCcw } from "lucide-react";
+import { Search, X, RotateCcw, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { keybindingService, type RegisteredKeybindingConfig } from "@/services/KeybindingService";
 import { formatShortcutForTooltip } from "@/lib/platform";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { KeybindingProfileActions } from "./KeybindingProfileActions";
 import { SettingsShortcutCapture } from "@/components/KeyboardShortcuts";
@@ -15,16 +16,69 @@ interface ShortcutBinding extends RegisteredKeybindingConfig {
   isOverridden: boolean;
 }
 
+// KeybindingService writes to disk before it touches its in-memory maps, so a
+// failed dispatch leaves no optimistic state to undo — the binding on screen is
+// still the durable one. What a failure must do is refuse to *look* like a
+// success: hold the editor open and offer the retry, rather than closing and
+// reloading as if the edit had landed.
+type ShortcutError =
+  | { kind: "save"; actionId: string; combo: string }
+  | { kind: "reset"; actionId: string }
+  | { kind: "reset-all" };
+
+type RowError = Extract<ShortcutError, { actionId: string }>;
+
 interface ShortcutRowProps {
   binding: ShortcutBinding;
   isEditing: boolean;
+  error: RowError | null;
   onEdit: () => void;
   onSave: (combo: string) => void;
   onCancel: () => void;
   onReset: () => void;
+  onRetry: () => void;
+  onDismissError: () => void;
 }
 
-function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: ShortcutRowProps) {
+function ShortcutRowError({
+  error,
+  onRetry,
+  onDismissError,
+}: {
+  error: RowError;
+  onRetry: () => void;
+  onDismissError: () => void;
+}) {
+  const isSave = error.kind === "save";
+  return (
+    <InlineStatusBanner
+      className="mt-2 rounded-[var(--radius-md)]"
+      severity="error"
+      icon={AlertCircle}
+      title={isSave ? "Couldn't save shortcut" : "Couldn't reset shortcut"}
+      description={
+        isSave
+          ? "The shortcut still has its previous binding. Retry to save the one you captured."
+          : "The shortcut keeps its custom binding for now."
+      }
+      action={{ id: "retry", label: "Retry", onClick: onRetry }}
+      onClose={onDismissError}
+      closeAriaLabel="Dismiss shortcut error"
+    />
+  );
+}
+
+function ShortcutRow({
+  binding,
+  isEditing,
+  error,
+  onEdit,
+  onSave,
+  onCancel,
+  onReset,
+  onRetry,
+  onDismissError,
+}: ShortcutRowProps) {
   const handleCapture = (combo: string) => {
     onSave(combo);
   };
@@ -43,52 +97,59 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
           excludeActionId={binding.actionId}
           scope={binding.scope}
         />
+        {error && (
+          <ShortcutRowError error={error} onRetry={onRetry} onDismissError={onDismissError} />
+        )}
       </div>
     );
   }
 
   return (
-    <div
-      data-testid="shortcut-row"
-      className="flex items-center justify-between py-2 border-b border-daintree-border/50 group/row"
-    >
-      <span className="text-sm text-daintree-text">{binding.description || binding.actionId}</span>
-      <div className="flex items-center gap-2">
-        {binding.effectiveCombo ? (
-          <span
-            className={cn(
-              "px-2 py-0.5 text-xs font-mono rounded",
-              binding.isOverridden
-                ? "bg-status-info/15 text-status-info"
-                : "bg-daintree-border text-daintree-text"
-            )}
+    <div data-testid="shortcut-row" className="py-2 border-b border-daintree-border/50">
+      <div className="flex items-center justify-between group/row">
+        <span className="text-sm text-daintree-text">
+          {binding.description || binding.actionId}
+        </span>
+        <div className="flex items-center gap-2">
+          {binding.effectiveCombo ? (
+            <span
+              className={cn(
+                "px-2 py-0.5 text-xs font-mono rounded",
+                binding.isOverridden
+                  ? "bg-status-info/15 text-status-info"
+                  : "bg-daintree-border text-daintree-text"
+              )}
+            >
+              {keybindingService.formatComboForDisplay(binding.effectiveCombo)}
+            </span>
+          ) : (
+            <span className="text-xs text-daintree-text/60 italic">unbound</span>
+          )}
+          <button
+            onClick={onEdit}
+            className="px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 transition-opacity"
           >
-            {keybindingService.formatComboForDisplay(binding.effectiveCombo)}
-          </span>
-        ) : (
-          <span className="text-xs text-daintree-text/60 italic">unbound</span>
-        )}
-        <button
-          onClick={onEdit}
-          className="px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 transition-opacity"
-        >
-          Edit
-        </button>
-        {binding.isOverridden && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={onReset}
-                className="p-0.5 text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 transition-opacity"
-                aria-label="Reset to default"
-              >
-                <RotateCcw className="w-3 h-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Reset to default</TooltipContent>
-          </Tooltip>
-        )}
+            Edit
+          </button>
+          {binding.isOverridden && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onReset}
+                  className="p-0.5 text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 transition-opacity"
+                  aria-label="Reset to default"
+                >
+                  <RotateCcw className="w-3 h-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Reset to default</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       </div>
+      {error && (
+        <ShortcutRowError error={error} onRetry={onRetry} onDismissError={onDismissError} />
+      )}
     </div>
   );
 }
@@ -101,6 +162,9 @@ export function KeyboardShortcutsTab() {
   const [, setUpdateKey] = useState(0);
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
+  // One error at a time across the whole tab, so a stale banner can never sit
+  // under a row the user has since moved on from.
+  const [shortcutError, setShortcutError] = useState<ShortcutError | null>(null);
 
   const loadBindings = useCallback(() => {
     const allBindings = keybindingService.getAllBindingsWithEffectiveCombos();
@@ -156,7 +220,12 @@ export function KeyboardShortcutsTab() {
     );
     if (!result.ok) {
       logError("Failed to save keybinding override", undefined, { error: result.error });
+      // Hold the editor open on the failing row. Closing here would show the old
+      // binding with no hint that the capture was thrown away.
+      setShortcutError({ kind: "save", actionId, combo });
+      return;
     }
+    setShortcutError(null);
     setEditingActionId(null);
     loadBindings();
   };
@@ -169,18 +238,24 @@ export function KeyboardShortcutsTab() {
     );
     if (!result.ok) {
       logError("Failed to reset keybinding override", undefined, { error: result.error });
+      setShortcutError({ kind: "reset", actionId });
+      return;
     }
+    setShortcutError(null);
     loadBindings();
   };
 
   const handleOpenResetDialog = () => {
     setEditingActionId(null);
+    setShortcutError(null);
     setIsResetDialogOpen(true);
   };
 
   const handleConfirmReset = async () => {
     if (isResetting) return;
     setIsResetting(true);
+    // Clear first so a second failure remounts the banner and is announced again.
+    setShortcutError(null);
     try {
       const result = await actionService.dispatch("keybinding.resetAll", undefined, {
         source: "user",
@@ -188,6 +263,8 @@ export function KeyboardShortcutsTab() {
       });
       if (!result.ok) {
         logError("Failed to reset all keybinding overrides", undefined, { error: result.error });
+        // Stay open: the dialog's own "Reset shortcuts" button is the retry.
+        setShortcutError({ kind: "reset-all" });
         return;
       }
       await keybindingService.loadOverrides();
@@ -200,7 +277,21 @@ export function KeyboardShortcutsTab() {
 
   const handleCancelReset = () => {
     if (isResetting) return;
+    setShortcutError(null);
     setIsResetDialogOpen(false);
+  };
+
+  const handleCancelEdit = () => {
+    setShortcutError(null);
+    setEditingActionId(null);
+  };
+
+  const handleRetryRow = (error: RowError) => {
+    if (error.kind === "save") {
+      void handleSaveShortcut(error.actionId, error.combo);
+      return;
+    }
+    void handleResetShortcut(error.actionId);
   };
 
   const hasOverrides = bindings.some((b) => b.isOverridden);
@@ -281,17 +372,31 @@ export function KeyboardShortcutsTab() {
               {category}
             </h4>
             <div className="space-y-0">
-              {categoryBindings.map((binding) => (
-                <ShortcutRow
-                  key={binding.actionId}
-                  binding={binding}
-                  isEditing={editingActionId === binding.actionId}
-                  onEdit={() => setEditingActionId(binding.actionId)}
-                  onSave={(combo) => handleSaveShortcut(binding.actionId, combo)}
-                  onCancel={() => setEditingActionId(null)}
-                  onReset={() => handleResetShortcut(binding.actionId)}
-                />
-              ))}
+              {categoryBindings.map((binding) => {
+                const rowError =
+                  shortcutError !== null &&
+                  shortcutError.kind !== "reset-all" &&
+                  shortcutError.actionId === binding.actionId
+                    ? shortcutError
+                    : null;
+                return (
+                  <ShortcutRow
+                    key={binding.actionId}
+                    binding={binding}
+                    isEditing={editingActionId === binding.actionId}
+                    error={rowError}
+                    onEdit={() => {
+                      setShortcutError(null);
+                      setEditingActionId(binding.actionId);
+                    }}
+                    onSave={(combo) => handleSaveShortcut(binding.actionId, combo)}
+                    onCancel={handleCancelEdit}
+                    onReset={() => handleResetShortcut(binding.actionId)}
+                    onRetry={() => rowError && handleRetryRow(rowError)}
+                    onDismissError={() => setShortcutError(null)}
+                  />
+                );
+              })}
             </div>
           </div>
         ))}
@@ -351,7 +456,17 @@ export function KeyboardShortcutsTab() {
         onConfirm={handleConfirmReset}
         isConfirmLoading={isResetting}
         variant="destructive"
-      />
+      >
+        {shortcutError?.kind === "reset-all" && (
+          <InlineStatusBanner
+            className="rounded-[var(--radius-md)]"
+            severity="error"
+            icon={AlertCircle}
+            title="Couldn't reset shortcuts"
+            description="Your customized shortcuts are still in place. Reset shortcuts to try again."
+          />
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -14,6 +14,13 @@ import { SettingsShortcutCapture } from "@/components/KeyboardShortcuts";
 interface ShortcutBinding extends RegisteredKeybindingConfig {
   effectiveCombo: string;
   isOverridden: boolean;
+  /**
+   * One action can be registered more than once under different scopes (e.g.
+   * `fleet.armFocused` is bound both globally and in the worktree grid), so the
+   * action ID alone does not identify a row. Keying editor and error state by
+   * action ID would open both editors at once and render the same alert twice.
+   */
+  rowId: string;
 }
 
 // KeybindingService writes to disk before it touches its in-memory maps, so a
@@ -22,11 +29,11 @@ interface ShortcutBinding extends RegisteredKeybindingConfig {
 // success: hold the editor open and offer the retry, rather than closing and
 // reloading as if the edit had landed.
 type ShortcutError =
-  | { kind: "save"; actionId: string; combo: string }
-  | { kind: "reset"; actionId: string }
+  | { kind: "save"; rowId: string; actionId: string; combo: string }
+  | { kind: "reset"; rowId: string; actionId: string }
   | { kind: "reset-all" };
 
-type RowError = Extract<ShortcutError, { actionId: string }>;
+type RowError = Extract<ShortcutError, { rowId: string }>;
 
 interface ShortcutRowProps {
   binding: ShortcutBinding;
@@ -157,7 +164,7 @@ function ShortcutRow({
 export function KeyboardShortcutsTab() {
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const [editingActionId, setEditingActionId] = useState<string | null>(null);
+  const [editingRowId, setEditingRowId] = useState<string | null>(null);
   const [bindings, setBindings] = useState<ShortcutBinding[]>([]);
   const [, setUpdateKey] = useState(0);
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
@@ -169,9 +176,15 @@ export function KeyboardShortcutsTab() {
   const loadBindings = useCallback(() => {
     const allBindings = keybindingService.getAllBindingsWithEffectiveCombos();
     setBindings(
-      allBindings.map((b) => ({
+      allBindings.map((b, index) => ({
         ...b,
         isOverridden: keybindingService.hasOverride(b.actionId),
+        // `combo` is the DEFAULT binding, so this stays stable when an override
+        // changes `effectiveCombo`. The index disambiguates the registry's few
+        // legal exact duplicates (a plugin may register the same action, scope
+        // and combo as a built-in); registration order is what produces the list,
+        // so it does not shift as overrides come and go.
+        rowId: `${b.actionId}::${b.scope}::${b.combo}::${index}`,
       }))
     );
   }, []);
@@ -212,41 +225,61 @@ export function KeyboardShortcutsTab() {
     return groups;
   }, [filteredBindings]);
 
-  const handleSaveShortcut = async (actionId: string, combo: string) => {
+  // An imported profile replaces every binding, which invalidates any edit that
+  // was in flight when it landed: a save resolving afterwards would either raise
+  // a banner about a binding that no longer exists, or let its Retry overwrite
+  // the freshly imported profile with a stale captured combo. Bump the epoch on
+  // import; operations started before it no longer touch the UI.
+  const bindingsEpochRef = useRef(0);
+
+  const handleSaveShortcut = async (rowId: string, actionId: string, combo: string) => {
+    const epoch = bindingsEpochRef.current;
     const result = await actionService.dispatch(
       "keybinding.setOverride",
       { actionId, combo: combo === "" ? [] : [combo] },
       { source: "user" }
     );
+    if (epoch !== bindingsEpochRef.current) return;
+
     if (!result.ok) {
       logError("Failed to save keybinding override", undefined, { error: result.error });
       // Hold the editor open on the failing row. Closing here would show the old
       // binding with no hint that the capture was thrown away.
-      setShortcutError({ kind: "save", actionId, combo });
+      setShortcutError({ kind: "save", rowId, actionId, combo });
       return;
     }
     setShortcutError(null);
-    setEditingActionId(null);
+    setEditingRowId(null);
     loadBindings();
   };
 
-  const handleResetShortcut = async (actionId: string) => {
+  const handleResetShortcut = async (rowId: string, actionId: string) => {
+    const epoch = bindingsEpochRef.current;
     const result = await actionService.dispatch(
       "keybinding.removeOverride",
       { actionId },
       { source: "user" }
     );
+    if (epoch !== bindingsEpochRef.current) return;
+
     if (!result.ok) {
       logError("Failed to reset keybinding override", undefined, { error: result.error });
-      setShortcutError({ kind: "reset", actionId });
+      setShortcutError({ kind: "reset", rowId, actionId });
       return;
     }
     setShortcutError(null);
     loadBindings();
   };
 
+  const handleImportComplete = () => {
+    bindingsEpochRef.current++;
+    setShortcutError(null);
+    setEditingRowId(null);
+    loadBindings();
+  };
+
   const handleOpenResetDialog = () => {
-    setEditingActionId(null);
+    setEditingRowId(null);
     setShortcutError(null);
     setIsResetDialogOpen(true);
   };
@@ -283,15 +316,15 @@ export function KeyboardShortcutsTab() {
 
   const handleCancelEdit = () => {
     setShortcutError(null);
-    setEditingActionId(null);
+    setEditingRowId(null);
   };
 
   const handleRetryRow = (error: RowError) => {
     if (error.kind === "save") {
-      void handleSaveShortcut(error.actionId, error.combo);
+      void handleSaveShortcut(error.rowId, error.actionId, error.combo);
       return;
     }
-    void handleResetShortcut(error.actionId);
+    void handleResetShortcut(error.rowId, error.actionId);
   };
 
   const hasOverrides = bindings.some((b) => b.isOverridden);
@@ -347,7 +380,7 @@ export function KeyboardShortcutsTab() {
             </button>
           )}
         </div>
-        <KeybindingProfileActions onImportComplete={loadBindings} />
+        <KeybindingProfileActions onImportComplete={handleImportComplete} />
         <button
           onClick={handleOpenResetDialog}
           disabled={isResetting}
@@ -376,22 +409,22 @@ export function KeyboardShortcutsTab() {
                 const rowError =
                   shortcutError !== null &&
                   shortcutError.kind !== "reset-all" &&
-                  shortcutError.actionId === binding.actionId
+                  shortcutError.rowId === binding.rowId
                     ? shortcutError
                     : null;
                 return (
                   <ShortcutRow
-                    key={binding.actionId}
+                    key={binding.rowId}
                     binding={binding}
-                    isEditing={editingActionId === binding.actionId}
+                    isEditing={editingRowId === binding.rowId}
                     error={rowError}
                     onEdit={() => {
                       setShortcutError(null);
-                      setEditingActionId(binding.actionId);
+                      setEditingRowId(binding.rowId);
                     }}
-                    onSave={(combo) => handleSaveShortcut(binding.actionId, combo)}
+                    onSave={(combo) => handleSaveShortcut(binding.rowId, binding.actionId, combo)}
                     onCancel={handleCancelEdit}
-                    onReset={() => handleResetShortcut(binding.actionId)}
+                    onReset={() => handleResetShortcut(binding.rowId, binding.actionId)}
                     onRetry={() => rowError && handleRetryRow(rowError)}
                     onDismissError={() => setShortcutError(null)}
                   />

--- a/src/components/Settings/__tests__/AppThemePicker.persistence.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.persistence.test.tsx
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+// jsdom ships no matchMedia; InlineStatusBanner reads it to honour reduced motion.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+vi.mock("@/store/accessibilityAnnouncerStore", () => ({
+  useAnnouncerStore: { getState: () => ({ announce: vi.fn() }) },
+}));
+
+// Same seam the existing AppThemePicker suites use: the real contrast engine
+// wants a full token map, and these fixtures deliberately carry only the keys the
+// picker itself reads. Contrast warnings are covered by the theme suites.
+vi.mock("@shared/theme", () => ({
+  APP_THEME_PREVIEW_KEYS: { background: "--daintree-bg" },
+  accentOverrideHasLowContrast: () => null,
+  applyAccentOverrideToScheme: (scheme: unknown) => scheme,
+  resolveAppTheme: (id: string, customSchemes: { id: string }[]) =>
+    [
+      ...customSchemes,
+      { id: "dark-a", name: "Dark A", type: "dark", tokens: { "accent-primary": "#111111" } },
+      { id: "dark-b", name: "Dark B", type: "dark", tokens: { "accent-primary": "#222222" } },
+      { id: "light-a", name: "Light A", type: "light", tokens: { "accent-primary": "#eeeeee" } },
+    ].find((s) => s.id === id) ?? { id, name: id, type: "dark", tokens: {} },
+}));
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: {
+    setColorScheme: vi.fn().mockResolvedValue(undefined),
+    setFollowSystem: vi.fn().mockResolvedValue(undefined),
+    setPreferredDarkScheme: vi.fn().mockResolvedValue(undefined),
+    setPreferredLightScheme: vi.fn().mockResolvedValue(undefined),
+    setAccentColorOverride: vi.fn().mockResolvedValue(undefined),
+    setRecentSchemeIds: vi.fn().mockResolvedValue(undefined),
+    setCustomSchemes: vi.fn().mockResolvedValue(undefined),
+    importTheme: vi.fn(),
+    exportTheme: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/appThemeViewTransition", () => ({
+  runThemeReveal: (_origin: unknown, cb: () => void) => cb(),
+}));
+
+// Stub the DOM-writing layer so the real store's setters still run end to end
+// while we observe which scheme was actually injected.
+vi.mock("@/theme/applyAppTheme", () => ({
+  applyAppThemeToRoot: vi.fn(),
+  applyColorVisionMode: vi.fn(),
+}));
+
+vi.mock("@/config/appColorSchemes", () => ({
+  DEFAULT_APP_SCHEME_ID: "dark-a",
+  BUILT_IN_APP_SCHEMES: [
+    { id: "dark-a", name: "Dark A", type: "dark", tokens: { "accent-primary": "#111111" } },
+    { id: "dark-b", name: "Dark B", type: "dark", tokens: { "accent-primary": "#222222" } },
+    { id: "light-a", name: "Light A", type: "light", tokens: { "accent-primary": "#eeeeee" } },
+  ],
+}));
+
+import { appThemeClient } from "@/clients/appThemeClient";
+import { useAppThemeStore } from "@/store/appThemeStore";
+import { AppThemePicker } from "../AppThemePicker";
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const client = vi.mocked(appThemeClient);
+const state = () => useAppThemeStore.getState();
+
+async function settle(promise: Promise<unknown>) {
+  await act(async () => {
+    await promise.catch(() => {});
+  });
+}
+
+const clickText = async (label: string) => act(async () => screen.getByText(label).click());
+const retry = async () => act(async () => screen.getByRole("button", { name: "Retry" }).click());
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const fn of [
+    client.setColorScheme,
+    client.setFollowSystem,
+    client.setPreferredDarkScheme,
+    client.setPreferredLightScheme,
+    client.setAccentColorOverride,
+    client.setRecentSchemeIds,
+  ]) {
+    fn.mockResolvedValue(undefined);
+  }
+  act(() =>
+    useAppThemeStore.setState({
+      selectedSchemeId: "dark-a",
+      customSchemes: [],
+      recentSchemeIds: ["dark-a"],
+      followSystem: false,
+      preferredDarkSchemeId: "dark-a",
+      preferredLightSchemeId: "light-a",
+      accentColorOverride: null,
+    })
+  );
+});
+
+describe("AppThemePicker — accent colour persistence", () => {
+  const setAccent = (color: string) => {
+    const input = screen.getByTestId("accent-color-override-input");
+    // The live-drag preview writes to the store WITHOUT persisting; the commit is
+    // what persists. Firing both is what makes this a real regression test: a
+    // rollback that reads its baseline from the store at commit time would read
+    // the previewed colour and silently restore nothing.
+    fireEvent.input(input, { target: { value: color } });
+    fireEvent.change(input, { target: { value: color } });
+  };
+
+  it("restores the last saved accent — not the previewed one — when the commit is rejected", async () => {
+    const write = deferred();
+    client.setAccentColorOverride.mockReturnValue(write.promise);
+
+    render(<AppThemePicker />);
+    await act(async () => setAccent("#ff0000"));
+    expect(state().accentColorOverride).toBe("#ff0000"); // optimistic
+
+    write.reject(new Error("nope"));
+    await settle(write.promise);
+
+    expect(state().accentColorOverride).toBeNull();
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("rolls back to the previously saved override rather than to no override at all", async () => {
+    // A first accent that DID save becomes the new baseline.
+    render(<AppThemePicker />);
+    await act(async () => setAccent("#00ff00"));
+    expect(state().accentColorOverride).toBe("#00ff00");
+
+    const failing = deferred();
+    client.setAccentColorOverride.mockReturnValue(failing.promise);
+    await act(async () => setAccent("#0000ff"));
+
+    await act(async () => {
+      failing.reject(new Error("disk"));
+      await failing.promise.catch(() => {});
+    });
+
+    // Back to the last colour that reached disk, not to null.
+    expect(state().accentColorOverride).toBe("#00ff00");
+  });
+
+  it("re-applies and re-persists the requested accent on Retry", async () => {
+    const failing = deferred();
+    client.setAccentColorOverride.mockReturnValueOnce(failing.promise);
+
+    render(<AppThemePicker />);
+    await act(async () => setAccent("#abcdef"));
+    await act(async () => {
+      failing.reject(new Error("x"));
+      await failing.promise.catch(() => {});
+    });
+    expect(state().accentColorOverride).toBeNull();
+
+    await retry();
+
+    expect(client.setAccentColorOverride.mock.calls.at(-1)?.[0]).toBe("#abcdef");
+    expect(state().accentColorOverride).toBe("#abcdef");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("AppThemePicker — follow-system and preferred schemes", () => {
+  it("reverts the follow-system toggle when its write is rejected", async () => {
+    const write = deferred();
+    client.setFollowSystem.mockReturnValue(write.promise);
+
+    render(<AppThemePicker />);
+    await act(async () => screen.getByLabelText("Toggle automatic theme switching").click());
+    expect(state().followSystem).toBe(true);
+
+    await act(async () => {
+      write.reject(new Error("nope"));
+      await write.promise.catch(() => {});
+    });
+
+    expect(state().followSystem).toBe(false);
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("reverts only the preferred dark scheme, leaving the light one untouched", async () => {
+    act(() => useAppThemeStore.setState({ followSystem: true }));
+    const write = deferred();
+    client.setPreferredDarkScheme.mockReturnValue(write.promise);
+
+    render(<AppThemePicker />);
+    await clickText("Dark B");
+    expect(state().preferredDarkSchemeId).toBe("dark-b");
+
+    await act(async () => {
+      write.reject(new Error("nope"));
+      await write.promise.catch(() => {});
+    });
+
+    expect(state().preferredDarkSchemeId).toBe("dark-a");
+    expect(state().preferredLightSchemeId).toBe("light-a");
+  });
+});
+
+describe("AppThemePicker — theme selection is three separate durable writes", () => {
+  const selectDarkB = async () => {
+    // Shuffle is the in-component path that calls handleSelect with a concrete id.
+    await act(async () => screen.getByText("Random theme").click());
+  };
+
+  it("restores the scheme AND the recents list when the scheme write is rejected", async () => {
+    const write = deferred();
+    client.setColorScheme.mockReturnValue(write.promise);
+
+    render(<AppThemePicker />);
+    await selectDarkB();
+    const optimisticId = state().selectedSchemeId;
+    expect(optimisticId).not.toBe("dark-a");
+
+    await act(async () => {
+      write.reject(new Error("nope"));
+      await write.promise.catch(() => {});
+    });
+
+    expect(state().selectedSchemeId).toBe("dark-a");
+    // commitSchemeSelection mutates the MRU as a side effect; the rollback has to
+    // put the list back too, or the recents row keeps a theme that never saved.
+    expect(state().recentSchemeIds).toEqual(["dark-a"]);
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("keeps system matching off when it saved but the scheme that followed did not", async () => {
+    act(() => useAppThemeStore.setState({ followSystem: true }));
+    client.setFollowSystem.mockResolvedValue(undefined);
+    const schemeWrite = deferred();
+    client.setColorScheme.mockReturnValue(schemeWrite.promise);
+
+    render(<AppThemePicker />);
+    await selectDarkB();
+
+    await act(async () => {
+      schemeWrite.reject(new Error("nope"));
+      await schemeWrite.promise.catch(() => {});
+    });
+
+    // Turning matching off DID reach disk — rolling it back would misrepresent
+    // durable state just as badly as leaving the failed theme on screen.
+    expect(state().followSystem).toBe(false);
+    expect(state().selectedSchemeId).toBe("dark-a");
+  });
+
+  it("keeps the saved theme but restores the recents list when only the MRU write fails", async () => {
+    client.setColorScheme.mockResolvedValue(undefined);
+    const recentsWrite = deferred();
+    client.setRecentSchemeIds.mockReturnValue(recentsWrite.promise);
+
+    render(<AppThemePicker />);
+    await selectDarkB();
+    const savedId = state().selectedSchemeId;
+
+    await act(async () => {
+      recentsWrite.reject(new Error("nope"));
+      await recentsWrite.promise.catch(() => {});
+    });
+
+    // The theme itself is durable, so it stays — and no banner interrupts a
+    // change that actually succeeded.
+    expect(state().selectedSchemeId).toBe(savedId);
+    expect(state().recentSchemeIds).toEqual(["dark-a"]);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not let a stale scheme rejection roll back a newer scheme that saved", async () => {
+    const stale = deferred();
+    client.setColorScheme.mockReturnValueOnce(stale.promise).mockResolvedValueOnce(undefined);
+
+    render(<AppThemePicker />);
+    await selectDarkB(); // in flight, fails late
+    await selectDarkB(); // supersedes it, succeeds
+    const newestId = state().selectedSchemeId;
+
+    await act(async () => {
+      stale.reject(new Error("late"));
+      await stale.promise.catch(() => {});
+    });
+
+    expect(state().selectedSchemeId).toBe(newestId);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/src/components/Settings/__tests__/AppThemePicker.persistence.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.persistence.test.tsx
@@ -205,6 +205,30 @@ describe("AppThemePicker — follow-system and preferred schemes", () => {
     expect(screen.getByRole("alert")).toBeTruthy();
   });
 
+  it("keeps an unresolved accent error visible when an unrelated field saves", async () => {
+    act(() => useAppThemeStore.setState({ followSystem: false }));
+    const accentWrite = deferred();
+    client.setAccentColorOverride.mockReturnValue(accentWrite.promise);
+
+    render(<AppThemePicker />);
+    const input = screen.getByTestId("accent-color-override-input");
+    await act(async () => {
+      fireEvent.input(input, { target: { value: "#123456" } });
+      fireEvent.change(input, { target: { value: "#123456" } });
+    });
+    await act(async () => {
+      accentWrite.reject(new Error("nope"));
+      await accentWrite.promise.catch(() => {});
+    });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    // A successful write to a DIFFERENT field must not dismiss a failure the
+    // user has not dealt with.
+    await act(async () => screen.getByLabelText("Toggle automatic theme switching").click());
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
   it("reverts only the preferred dark scheme, leaving the light one untouched", async () => {
     act(() => useAppThemeStore.setState({ followSystem: true }));
     const write = deferred();
@@ -308,5 +332,77 @@ describe("AppThemePicker — theme selection is three separate durable writes", 
 
     expect(state().selectedSchemeId).toBe(newestId);
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("never writes a superseded selection to disk after the newer one", async () => {
+    // System matching on, so the first selection has to await setFollowSystem
+    // before it can send its scheme. A second selection starts during that await.
+    // If the first is allowed to resume, its setColorScheme lands AFTER the
+    // second's and the app boots into a theme the UI never showed.
+    act(() => useAppThemeStore.setState({ followSystem: true }));
+    const followWrite = deferred();
+    client.setFollowSystem.mockReturnValue(followWrite.promise);
+
+    render(<AppThemePicker />);
+    await selectDarkB(); // stalls awaiting setFollowSystem
+    expect(client.setColorScheme).not.toHaveBeenCalled();
+
+    await selectDarkB(); // supersedes it; follow-system is already off optimistically
+
+    await act(async () => {
+      followWrite.resolve();
+      await followWrite.promise;
+    });
+
+    const written = client.setColorScheme.mock.calls.map(([id]) => id);
+    // The superseded selection must not have appended a later write.
+    expect(written.at(-1)).toBe(state().selectedSchemeId);
+  });
+
+  it("still turns system matching off on disk when a toggle-on is in flight", async () => {
+    // Disk says matching is off. The user turns it ON (write pending), then picks
+    // a theme. If the selection decided from disk alone it would skip its own
+    // turn-off write, the pending toggle-on would land, and the app would boot
+    // following the system — overriding the theme the user just chose.
+    const toggleWrite = deferred();
+    client.setFollowSystem.mockReturnValueOnce(toggleWrite.promise);
+
+    render(<AppThemePicker />);
+    await act(async () => screen.getByLabelText("Toggle automatic theme switching").click());
+    expect(state().followSystem).toBe(true);
+
+    client.setFollowSystem.mockResolvedValue(undefined);
+    await selectDarkB();
+    await act(async () => {
+      toggleWrite.resolve();
+      await toggleWrite.promise;
+    });
+
+    // The selection must have written matching OFF, after the toggle-on.
+    expect(client.setFollowSystem.mock.calls.at(-1)?.[0]).toBe(false);
+    expect(state().followSystem).toBe(false);
+  });
+
+  it("does not undo a follow-system toggle it never made when an unrelated scheme write fails", async () => {
+    // Matching starts off, so this selection does not own the follow-system field.
+    const schemeWrite = deferred();
+    client.setColorScheme.mockReturnValue(schemeWrite.promise);
+
+    render(<AppThemePicker />);
+    await selectDarkB(); // in flight, will fail
+
+    // User turns system matching ON while that write is pending; it saves.
+    await act(async () => screen.getByLabelText("Toggle automatic theme switching").click());
+    expect(state().followSystem).toBe(true);
+
+    await act(async () => {
+      schemeWrite.reject(new Error("nope"));
+      await schemeWrite.promise.catch(() => {});
+    });
+
+    // The scheme rolls back, but the newer follow-system choice — which IS on
+    // disk — must survive.
+    expect(state().selectedSchemeId).toBe("dark-a");
+    expect(state().followSystem).toBe(true);
   });
 });

--- a/src/components/Settings/__tests__/ColorVisionPicker.persistence.test.tsx
+++ b/src/components/Settings/__tests__/ColorVisionPicker.persistence.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import React from "react";
+
+// jsdom ships no matchMedia; InlineStatusBanner reads it to honour reduced motion.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: { setColorVisionMode: vi.fn() },
+}));
+
+// Stub the DOM-writing layer so the real store still runs its side effect, but we
+// can observe *which* mode was pushed to documentElement. That is the half of the
+// rollback that matters: restoring JS state without re-running the filter swap
+// would leave the user looking at colors the app won't boot with.
+vi.mock("@/theme/applyAppTheme", () => ({
+  applyAppThemeToRoot: vi.fn(),
+  applyColorVisionMode: vi.fn(),
+}));
+
+// The real Radix Select needs pointer-event plumbing jsdom doesn't provide. This
+// stand-in keeps the same contract — a controlled `value` plus an `onValueChange`
+// per item — so the assertions still read the value the component renders.
+const SelectCtx = React.createContext<((value: string) => void) | null>(null);
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <SelectCtx.Provider value={onValueChange}>
+      <div data-testid="mode-select" data-value={value}>
+        {children}
+      </div>
+    </SelectCtx.Provider>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => {
+    const onValueChange = React.useContext(SelectCtx);
+    return (
+      <button type="button" onClick={() => onValueChange?.(value)}>
+        {children}
+      </button>
+    );
+  },
+}));
+
+import { appThemeClient } from "@/clients/appThemeClient";
+import { applyColorVisionMode } from "@/theme/applyAppTheme";
+import { useAppThemeStore } from "@/store/appThemeStore";
+import { ColorVisionPicker } from "../ColorVisionPicker";
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const renderedMode = () => screen.getByTestId("mode-select").getAttribute("data-value");
+const storedMode = () => useAppThemeStore.getState().colorVisionMode;
+const selectMode = (label: string) => act(() => screen.getByText(label).click());
+
+beforeEach(() => {
+  vi.mocked(appThemeClient.setColorVisionMode).mockReset();
+  vi.mocked(applyColorVisionMode).mockClear();
+  act(() => useAppThemeStore.setState({ colorVisionMode: "default" }));
+});
+
+describe("ColorVisionPicker persistence failures", () => {
+  it("restores the last saved mode — in state and on the document — when the write is rejected", async () => {
+    const write = deferred();
+    vi.mocked(appThemeClient.setColorVisionMode).mockReturnValue(write.promise);
+
+    render(<ColorVisionPicker />);
+    selectMode("Red-Green");
+
+    // Optimistic: the new mode is applied before the write resolves.
+    expect(renderedMode()).toBe("red-green");
+
+    await act(async () => {
+      write.reject(new Error("EACCES"));
+      await write.promise.catch(() => {});
+    });
+
+    expect(storedMode()).toBe("default");
+    expect(renderedMode()).toBe("default");
+    // The rollback must go back through the store setter so the CVD filter is
+    // re-applied, not just the JS value.
+    expect(vi.mocked(applyColorVisionMode).mock.calls.at(-1)?.[1]).toBe("default");
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("re-applies and re-persists the requested mode on Retry, clearing the error once it lands", async () => {
+    const failed = deferred();
+    vi.mocked(appThemeClient.setColorVisionMode).mockReturnValueOnce(failed.promise);
+
+    render(<ColorVisionPicker />);
+    selectMode("Blue-Yellow");
+
+    await act(async () => {
+      failed.reject(new Error("disk full"));
+      await failed.promise.catch(() => {});
+    });
+    expect(storedMode()).toBe("default");
+
+    vi.mocked(appThemeClient.setColorVisionMode).mockResolvedValue(undefined);
+    await act(async () => screen.getByRole("button", { name: "Retry" }).click());
+
+    // Retry re-applies the mode the user asked for, not the rolled-back one.
+    expect(vi.mocked(appThemeClient.setColorVisionMode).mock.calls.at(-1)?.[0]).toBe("blue-yellow");
+    expect(storedMode()).toBe("blue-yellow");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not let a stale rejection roll back a newer mode that saved successfully", async () => {
+    const stale = deferred();
+    vi.mocked(appThemeClient.setColorVisionMode)
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce(undefined);
+
+    render(<ColorVisionPicker />);
+    selectMode("Red-Green"); // in flight, will fail late
+    await act(async () => screen.getByText("Blue-Yellow").click()); // supersedes it, succeeds
+
+    expect(storedMode()).toBe("blue-yellow");
+
+    await act(async () => {
+      stale.reject(new Error("late failure"));
+      await stale.promise.catch(() => {});
+    });
+
+    // The superseded failure owns nothing: it must not drag the UI back to the
+    // value that preceded it, which is no longer what is on disk.
+    expect(storedMode()).toBe("blue-yellow");
+    expect(renderedMode()).toBe("blue-yellow");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("surfaces the failure inline rather than leaving the successful-looking value in place", async () => {
+    const write = deferred();
+    vi.mocked(appThemeClient.setColorVisionMode).mockReturnValue(write.promise);
+
+    const { container } = render(<ColorVisionPicker />);
+    selectMode("Red-Green");
+
+    await act(async () => {
+      write.reject(new Error("nope"));
+      await write.promise.catch(() => {});
+    });
+
+    // The alert lives inside the component (an inline banner), not in a global
+    // toast host, and it is the live region that announces to assistive tech.
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(container.querySelectorAll('[role="alert"]')).toHaveLength(1);
+  });
+});

--- a/src/components/Settings/__tests__/KeyboardShortcutsTab.persistence.test.tsx
+++ b/src/components/Settings/__tests__/KeyboardShortcutsTab.persistence.test.tsx
@@ -65,8 +65,14 @@ vi.mock("@/components/KeyboardShortcuts", () => ({
   ),
 }));
 
+// Exposes the import callback as a button so a test can land an import while a
+// save is still in flight.
 vi.mock("@/components/Settings/KeybindingProfileActions", () => ({
-  KeybindingProfileActions: () => null,
+  KeybindingProfileActions: ({ onImportComplete }: { onImportComplete: () => void }) => (
+    <button type="button" onClick={onImportComplete}>
+      Finish import
+    </button>
+  ),
 }));
 
 vi.mock("@/services/KeybindingService", () => ({
@@ -181,6 +187,28 @@ describe("KeyboardShortcutsTab — failed shortcut save", () => {
 
     expect(screen.queryByText(/raw ipc detail/)).toBeNull();
     expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("does not raise a banner for a save that was superseded by a profile import", async () => {
+    const pending = deferred<typeof FAILURE>();
+    dispatch.mockReturnValue(pending.promise);
+
+    await renderTab();
+    await openEditor();
+    await clickText("Capture combo"); // dispatch in flight
+
+    // A profile import lands while that save is still pending. It replaced every
+    // binding, so the save's failure is about a binding that no longer exists —
+    // and its Retry would overwrite the imported profile with the stale combo.
+    await clickText("Finish import");
+
+    await act(async () => {
+      pending.resolve(FAILURE);
+      await pending.promise;
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 
   it("discards the error when the user cancels the editor", async () => {

--- a/src/components/Settings/__tests__/KeyboardShortcutsTab.persistence.test.tsx
+++ b/src/components/Settings/__tests__/KeyboardShortcutsTab.persistence.test.tsx
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, within } from "@testing-library/react";
+
+// jsdom ships no matchMedia; InlineStatusBanner reads it to honour reduced motion.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+// ...nor ResizeObserver, which the dialog's scroll-shadow hook observes with.
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+// vi.mock factories are hoisted above the module body, so every mutable handle a
+// factory touches has to be created inside vi.hoisted or it is still in TDZ.
+const { dispatch, notify, overrides, loadOverrides, CAPTURED_COMBO } = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  notify: vi.fn(),
+  overrides: new Set<string>(),
+  loadOverrides: vi.fn().mockResolvedValue(undefined),
+  CAPTURED_COMBO: "Cmd+Shift+J",
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify }));
+
+// Stands in for the real capture widget: reports a known combo, so a test can
+// prove the *captured* value survives a failed save rather than only that a
+// callback fired.
+vi.mock("@/components/KeyboardShortcuts", () => ({
+  SettingsShortcutCapture: ({
+    onCapture,
+    onCancel,
+  }: {
+    onCapture: (combo: string) => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="shortcut-capture">
+      <button type="button" onClick={() => onCapture(CAPTURED_COMBO)}>
+        Capture combo
+      </button>
+      <button type="button" onClick={() => onCapture("")}>
+        Capture unbind
+      </button>
+      <button type="button" onClick={onCancel}>
+        Cancel capture
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/Settings/KeybindingProfileActions", () => ({
+  KeybindingProfileActions: () => null,
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    getAllBindingsWithEffectiveCombos: () => [
+      {
+        actionId: "app.save",
+        description: "Save file",
+        category: "File",
+        scope: "global",
+        effectiveCombo: "Cmd+S",
+      },
+    ],
+    hasOverride: (actionId: string) => overrides.has(actionId),
+    formatComboForDisplay: (combo: string) => combo,
+    loadOverrides,
+    subscribe: () => () => {},
+  },
+}));
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { KeyboardShortcutsTab } from "../KeyboardShortcutsTab";
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const FAILURE = { ok: false as const, error: { code: "IPC_FAILED", message: "raw ipc detail" } };
+const SUCCESS = { ok: true as const, result: undefined };
+
+const row = () => screen.getByTestId("shortcut-row");
+const clickText = async (label: string) =>
+  act(async () => {
+    screen.getByText(label).click();
+  });
+
+async function renderTab() {
+  // The per-row reset button is a tooltip trigger, so it needs Radix's provider —
+  // in the app that comes from the Settings dialog's tree.
+  render(
+    <TooltipProvider>
+      <KeyboardShortcutsTab />
+    </TooltipProvider>
+  );
+  // Flush the mount-time loadOverrides().then(loadBindings) chain.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+const openEditor = () => clickText("Edit");
+
+beforeEach(() => {
+  dispatch.mockReset();
+  notify.mockClear();
+  loadOverrides.mockClear();
+  overrides.clear();
+});
+
+describe("KeyboardShortcutsTab — failed shortcut save", () => {
+  it("keeps the editor open and reports the failure instead of closing as if it saved", async () => {
+    dispatch.mockResolvedValue(FAILURE);
+
+    await renderTab();
+    await openEditor();
+    await clickText("Capture combo");
+
+    // The editor must still be mounted — closing here is exactly the bug: the
+    // user would see the old binding with no sign the capture was discarded.
+    expect(screen.getByTestId("shortcut-capture")).toBeTruthy();
+    expect(within(row()).getByRole("alert")).toBeTruthy();
+  });
+
+  it("retries with the combo the user captured, then closes the editor once it lands", async () => {
+    dispatch.mockResolvedValueOnce(FAILURE).mockResolvedValueOnce(SUCCESS);
+
+    await renderTab();
+    await openEditor();
+    await clickText("Capture combo");
+    await act(async () => screen.getByRole("button", { name: "Retry" }).click());
+
+    const [action, args] = dispatch.mock.calls.at(-1) as [string, { combo: string[] }];
+    expect(action).toBe("keybinding.setOverride");
+    // The captured combo survived the failure — Retry re-sends it, not a default.
+    expect(args.combo).toEqual([CAPTURED_COMBO]);
+    expect(screen.queryByTestId("shortcut-capture")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("preserves an unbind (empty combo) across a retry rather than resending a key", async () => {
+    dispatch.mockResolvedValueOnce(FAILURE).mockResolvedValueOnce(SUCCESS);
+
+    await renderTab();
+    await openEditor();
+    await clickText("Capture unbind");
+    await act(async () => screen.getByRole("button", { name: "Retry" }).click());
+
+    const [, args] = dispatch.mock.calls.at(-1) as [string, { combo: string[] }];
+    expect(args.combo).toEqual([]);
+  });
+
+  it("keeps the raw dispatch error out of the UI", async () => {
+    dispatch.mockResolvedValue(FAILURE);
+
+    await renderTab();
+    await openEditor();
+    await clickText("Capture combo");
+
+    expect(screen.queryByText(/raw ipc detail/)).toBeNull();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("discards the error when the user cancels the editor", async () => {
+    dispatch.mockResolvedValue(FAILURE);
+
+    await renderTab();
+    await openEditor();
+    await clickText("Capture combo");
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    await clickText("Cancel capture");
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByTestId("shortcut-capture")).toBeNull();
+  });
+});
+
+describe("KeyboardShortcutsTab — failed shortcut reset", () => {
+  it("reports the failure on the row and leaves the custom binding in place", async () => {
+    overrides.add("app.save");
+    dispatch.mockResolvedValue(FAILURE);
+
+    await renderTab();
+    await act(async () => screen.getByLabelText("Reset to default").click());
+
+    expect(within(row()).getByRole("alert")).toBeTruthy();
+    // Retry re-issues the reset for that row.
+    dispatch.mockResolvedValue(SUCCESS);
+    await act(async () => screen.getByRole("button", { name: "Retry" }).click());
+
+    const [action, args] = dispatch.mock.calls.at(-1) as [string, { actionId: string }];
+    expect(action).toBe("keybinding.removeOverride");
+    expect(args.actionId).toBe("app.save");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("KeyboardShortcutsTab — failed reset all", () => {
+  it("holds the dialog open with an inline error and never reloads the overrides", async () => {
+    dispatch.mockResolvedValue(FAILURE);
+
+    await renderTab();
+    await clickText("Reset all");
+    await act(async () => screen.getByRole("button", { name: "Reset shortcuts" }).click());
+
+    // Dialog stays up, explains itself, and its own confirm button is the retry.
+    expect(screen.getByRole("button", { name: "Reset shortcuts" })).toBeTruthy();
+    expect(screen.getByRole("alert")).toBeTruthy();
+    // Only the mount-time load — a failed reset must not re-read overrides, which
+    // would redraw the list as though the reset had happened.
+    expect(loadOverrides).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the dialog and reloads overrides only once the reset actually lands", async () => {
+    const pending = deferred<typeof SUCCESS>();
+    dispatch.mockReturnValue(pending.promise);
+
+    await renderTab();
+    await clickText("Reset all");
+    await act(async () => screen.getByRole("button", { name: "Reset shortcuts" }).click());
+
+    await act(async () => {
+      pending.resolve(SUCCESS);
+      await pending.promise;
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(loadOverrides).toHaveBeenCalledTimes(2); // mount + successful reset
+  });
+});

--- a/src/components/Settings/__tests__/KeyboardShortcutsTab.persistence.test.tsx
+++ b/src/components/Settings/__tests__/KeyboardShortcutsTab.persistence.test.tsx
@@ -18,16 +18,28 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 // ...nor ResizeObserver, which the dialog's scroll-shadow hook observes with.
-globalThis.ResizeObserver ??= class {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-} as unknown as typeof ResizeObserver;
+class ResizeObserverStub implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub;
 
 // vi.mock factories are hoisted above the module body, so every mutable handle a
 // factory touches has to be created inside vi.hoisted or it is still in TDZ.
+//
+// `dispatch` is typed at the source rather than cast at each read: casting
+// `.mock.calls` would add no-unsafe-type-assertion warnings, which the lint
+// ratchet scores per rule.
 const { dispatch, notify, overrides, loadOverrides, CAPTURED_COMBO } = vi.hoisted(() => ({
-  dispatch: vi.fn(),
+  dispatch:
+    vi.fn<
+      (
+        actionId: string,
+        args?: { actionId: string; combo?: string[] },
+        opts?: { source?: string; confirmed?: boolean }
+      ) => Promise<{ ok: boolean }>
+    >(),
   notify: vi.fn(),
   overrides: new Set<string>(),
   loadOverrides: vi.fn().mockResolvedValue(undefined),
@@ -158,10 +170,10 @@ describe("KeyboardShortcutsTab — failed shortcut save", () => {
     await clickText("Capture combo");
     await act(async () => screen.getByRole("button", { name: "Retry" }).click());
 
-    const [action, args] = dispatch.mock.calls.at(-1) as [string, { combo: string[] }];
-    expect(action).toBe("keybinding.setOverride");
+    const lastCall = dispatch.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe("keybinding.setOverride");
     // The captured combo survived the failure — Retry re-sends it, not a default.
-    expect(args.combo).toEqual([CAPTURED_COMBO]);
+    expect(lastCall?.[1]?.combo).toEqual([CAPTURED_COMBO]);
     expect(screen.queryByTestId("shortcut-capture")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
   });
@@ -174,8 +186,7 @@ describe("KeyboardShortcutsTab — failed shortcut save", () => {
     await clickText("Capture unbind");
     await act(async () => screen.getByRole("button", { name: "Retry" }).click());
 
-    const [, args] = dispatch.mock.calls.at(-1) as [string, { combo: string[] }];
-    expect(args.combo).toEqual([]);
+    expect(dispatch.mock.calls.at(-1)?.[1]?.combo).toEqual([]);
   });
 
   it("keeps the raw dispatch error out of the UI", async () => {
@@ -239,9 +250,9 @@ describe("KeyboardShortcutsTab — failed shortcut reset", () => {
     dispatch.mockResolvedValue(SUCCESS);
     await act(async () => screen.getByRole("button", { name: "Retry" }).click());
 
-    const [action, args] = dispatch.mock.calls.at(-1) as [string, { actionId: string }];
-    expect(action).toBe("keybinding.removeOverride");
-    expect(args.actionId).toBe("app.save");
+    const lastCall = dispatch.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe("keybinding.removeOverride");
+    expect(lastCall?.[1]?.actionId).toBe("app.save");
     expect(screen.queryByRole("alert")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Three Settings surfaces (`KeyboardShortcutsTab.tsx`, `AppThemePicker.tsx`, `ColorVisionPicker.tsx`) applied changes optimistically to the Zustand store and the DOM, persisted over IPC, and on failure only called `logError`. The UI kept showing a value that wouldn't survive a restart, and for the color vision picker that's an accessibility preference silently lost.
- Each surface now either rolls back the optimistic change or keeps the editor open with an inline error and a Retry, per the failure mode that actually applies to it.
- Found and fixed a couple of adjacent bugs along the way: a duplicate action registration that opened two shortcut editors at once, and a race between an in-flight save and a profile import.

Resolves #11113

## Changes

**`KeyboardShortcutsTab.tsx`**: `KeybindingService` already writes to disk before mutating its in-memory maps, so there's no optimistic state to roll back here. The actual bug was closing the editor and reloading bindings as if the save had landed. Now the editor stays open on the failing row with an inline error and a Retry that resends the captured key combo, so an unbind stays an unbind. A failed reset-all keeps its dialog open, using the dialog's own "Reset shortcuts" button as the retry.

**`AppThemePicker.tsx`**: accent color, the follow-system toggle, and preferred light/dark mode all roll back to the last value confirmed to be on disk. Theme selection is three independently durable writes in sequence (turn off system matching, save the scheme, save the most-recently-used list), and the fix reconciles each field on its own terms: a scheme save that fails after system matching was already turned off reverts the theme without turning matching back on, while a failure of the invisible MRU list alone leaves the saved theme in place and fails silently.

**`ColorVisionPicker.tsx`**: rolls back through the store setter so the color-vision-deficiency filter is actually re-applied, not just the JS value reset.

**Confirmed-value ref over reading the store**: the accent `<input type="color">` previews through the store on every `onInput` tick without persisting, so by the time `onChange` commits, the store can no longer report the previous color. Each field instead tracks the value last known to be on disk, advanced only when a write lands.

**Concurrency** (found in review): each field carries an epoch. A superseded selection stops issuing writes rather than letting its `setColorScheme` land after a newer one already did, which would otherwise boot the app into a theme the UI never showed. A stale rejection can no longer roll back a newer value that did persist, and a selection only reconciles system-matching when it was the one that turned it off.

**Surfacing**: a component-owned `InlineStatusBanner` (`role="alert"`, one Retry action), no global toast while the failing control is visible, per the issue. Since it lives inside the Settings dialog's `aria-modal` subtree, `role="alert"` is announced to assistive technology without a redundant announcer call.

**Also fixed**: `fleet.armFocused` was registered twice (once globally, once for the worktree grid), so keying editor rows by `actionId` opened two editors at once and rendered the alert, and its live region, twice. Rows are now keyed by action id plus scope plus key combo. An in-flight save is also fenced against a concurrent profile import, whose Retry would otherwise overwrite the just-imported profile.

## Testing

Three new test files, 50 tests total combined with the two existing `AppThemePicker` suites: rollback behavior per field, Retry re-applying and re-persisting, a stage-aware partial-failure matrix, and the write-ordering races from the concurrency fix.

Known follow-ups left out of this PR, outside the three handlers the issue named: `handleImport` doesn't roll back `addCustomScheme` when `persistCustomSchemes` fails (pre-existing), the MRU list can record a scheme whose save later failed (cosmetic), and the confirmed baseline isn't refreshed if a durable change happens elsewhere while the dialog is open (documented in-code, since the store isn't a truthful picture of disk state: `app.setTheme` leaves an optimistic scheme applied on failure).

Locally: 50/50 targeted tests pass; eslint, prettier, and tsc are clean on the changed files with zero new per-rule lint warnings.
