### PR TITLE
fix(notifications): key notification state per owning renderer

### DIFF
--- a/electron/ipc/handlers/__tests__/notifications.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/notifications.adversarial.test.ts
@@ -21,12 +21,14 @@ const notificationServiceMock = vi.hoisted(() => ({
   updateNotifications: vi.fn(),
   showNativeNotification: vi.fn(),
   showWatchNotification: vi.fn(),
+  removeOwner: vi.fn(),
 }));
 
 const agentNotificationServiceMock = vi.hoisted(() => ({
   syncWatchedPanels: vi.fn(),
   acknowledgeWaiting: vi.fn(),
   acknowledgeWorkingPulse: vi.fn(),
+  removeOwner: vi.fn(),
 }));
 
 const soundServiceMock = vi.hoisted(() => ({
@@ -67,9 +69,41 @@ function getListener(channel: string): Listener {
   return fn;
 }
 
-function fakeEvent(): Electron.IpcMainInvokeEvent {
-  return { sender: {} as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+/**
+ * A sender stands in for a project view's renderer. Its `id` is the owner key,
+ * and `destroy()` fires the one-shot listener the handlers use to purge it.
+ */
+function createSender(id: number) {
+  const destroyListeners: Array<() => void> = [];
+  return {
+    id,
+    once: vi.fn((event: string, listener: () => void) => {
+      if (event === "destroyed") destroyListeners.push(listener);
+    }),
+    destroy: () => destroyListeners.splice(0).forEach((fn) => fn()),
+  };
 }
+
+type Sender = ReturnType<typeof createSender>;
+
+function fakeEvent(sender: Sender = createSender(1)): Electron.IpcMainInvokeEvent {
+  return { sender: sender as unknown as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+/** A window whose `cleanup` store the handlers register an owner purge into. */
+function createWindowRegistryMock() {
+  const disposables: Array<{ dispose: () => void }> = [];
+  return {
+    registry: {
+      getByWebContentsId: vi.fn(() => ({
+        cleanup: { add: (d: { dispose: () => void }) => disposables.push(d) },
+      })),
+    },
+    closeWindow: () => disposables.splice(0).forEach((d) => d.dispose()),
+  };
+}
+
+const drainMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
 
 const defaultSettings = {
   enabled: true,
@@ -180,17 +214,14 @@ describe("notifications IPC adversarial", () => {
   });
 
   it("syncWatched filters non-string entries from the id array", async () => {
-    getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(fakeEvent() as Electron.IpcMainEvent, [
-      "a",
-      1,
-      null,
-      "b",
-      { id: "nope" },
-    ]);
+    getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(
+      fakeEvent(createSender(7)) as Electron.IpcMainEvent,
+      ["a", 1, null, "b", { id: "nope" }]
+    );
 
     // Listener uses fire-and-forget dynamic import — await microtask drain
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(agentNotificationServiceMock.syncWatchedPanels).toHaveBeenCalledWith(["a", "b"]);
+    await drainMicrotasks();
+    expect(agentNotificationServiceMock.syncWatchedPanels).toHaveBeenCalledWith(7, ["a", "b"]);
   });
 
   it("syncWatched ignores non-array payload", () => {
@@ -232,5 +263,111 @@ describe("notifications IPC adversarial", () => {
     cleanup();
     expect(ipcHandlers.size).toBe(0);
     expect(ipcListeners.size).toBe(0);
+  });
+
+  // #11110 — every handler used to discard `_event`, so main had no idea which
+  // renderer reported what and the last caller overwrote everyone else.
+  describe("owner attribution", () => {
+    it("attributes a badge update to the sending renderer", () => {
+      getListener(CHANNELS.NOTIFICATION_UPDATE)(
+        fakeEvent(createSender(42)) as Electron.IpcMainEvent,
+        { waitingCount: 3 }
+      );
+
+      expect(notificationServiceMock.updateNotifications).toHaveBeenCalledWith(42, {
+        waitingCount: 3,
+      });
+    });
+
+    it("attributes a watch notification to the sending renderer", () => {
+      getListener(CHANNELS.NOTIFICATION_SHOW_WATCH)(
+        fakeEvent(createSender(42)) as Electron.IpcMainEvent,
+        { title: "T", body: "B", panelId: "p-1" }
+      );
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "T",
+        "B",
+        expect.objectContaining({ panelId: "p-1" }),
+        CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
+        { ownerWebContentsId: 42 }
+      );
+    });
+
+    it("keeps two renderers' syncs independent", async () => {
+      getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(
+        fakeEvent(createSender(1)) as Electron.IpcMainEvent,
+        ["term-1"]
+      );
+      getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(
+        fakeEvent(createSender(2)) as Electron.IpcMainEvent,
+        []
+      );
+      await drainMicrotasks();
+
+      expect(agentNotificationServiceMock.syncWatchedPanels).toHaveBeenNthCalledWith(1, 1, [
+        "term-1",
+      ]);
+      expect(agentNotificationServiceMock.syncWatchedPanels).toHaveBeenNthCalledWith(2, 2, []);
+    });
+  });
+
+  describe("owner lifecycle", () => {
+    it("purges an owner from both services when its renderer is destroyed", async () => {
+      const sender = createSender(42);
+      getListener(CHANNELS.NOTIFICATION_UPDATE)(fakeEvent(sender) as Electron.IpcMainEvent, {
+        waitingCount: 3,
+      });
+
+      sender.destroy();
+      await drainMicrotasks();
+
+      expect(notificationServiceMock.removeOwner).toHaveBeenCalledWith(42);
+      expect(agentNotificationServiceMock.removeOwner).toHaveBeenCalledWith(42);
+    });
+
+    it("tracks each owner's destroy listener exactly once", () => {
+      const sender = createSender(42);
+      const event = fakeEvent(sender) as Electron.IpcMainEvent;
+
+      getListener(CHANNELS.NOTIFICATION_UPDATE)(event, { waitingCount: 1 });
+      getListener(CHANNELS.NOTIFICATION_UPDATE)(event, { waitingCount: 2 });
+      getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(event, ["term-1"]);
+
+      expect(sender.once).toHaveBeenCalledTimes(1);
+    });
+
+    it("purges the owner when its window tears down", async () => {
+      cleanup();
+      const { registry, closeWindow } = createWindowRegistryMock();
+      cleanup = registerNotificationHandlers({
+        windowRegistry: registry,
+      } as unknown as HandlerDependencies);
+
+      getListener(CHANNELS.NOTIFICATION_UPDATE)(
+        fakeEvent(createSender(42)) as Electron.IpcMainEvent,
+        { waitingCount: 3 }
+      );
+
+      closeWindow();
+      await drainMicrotasks();
+
+      expect(notificationServiceMock.removeOwner).toHaveBeenCalledWith(42);
+      expect(agentNotificationServiceMock.removeOwner).toHaveBeenCalledWith(42);
+    });
+
+    it("does not resurrect a destroyed owner with a sync that lands late", async () => {
+      const sender = createSender(42);
+
+      // The service import is async: destroy the sender before it settles.
+      getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(fakeEvent(sender) as Electron.IpcMainEvent, [
+        "term-1",
+      ]);
+      sender.destroy();
+      await drainMicrotasks();
+
+      expect(agentNotificationServiceMock.syncWatchedPanels).not.toHaveBeenCalled();
+      expect(agentNotificationServiceMock.removeOwner).toHaveBeenCalledWith(42);
+    });
   });
 });

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -49,14 +49,47 @@ async function soundFiles(): Promise<SoundFilesMap> {
   return cachedSoundFiles;
 }
 
-export function registerNotificationHandlers(_deps: HandlerDependencies): () => void {
+export function registerNotificationHandlers(deps: HandlerDependencies): () => void {
   const cleanups: Array<() => void> = [];
 
+  // Owners are the renderers that reported notification state — identified by
+  // `event.sender.id`, never by a "current window/project" global (the bug this
+  // whole change exists to kill). Each is tracked once so its state can be
+  // purged when it goes away.
+  const trackedOwners = new Map<number, Electron.WebContents>();
+
+  const purgeOwner = (ownerId: number): void => {
+    trackedOwners.delete(ownerId);
+    notificationService.removeOwner(ownerId);
+    void getAgentNotificationService()
+      .then((svc) => svc.removeOwner(ownerId))
+      .catch((err) => console.error("[notifications] removeOwner failed:", err));
+  };
+
+  const trackOwner = (sender: Electron.WebContents): number => {
+    const ownerId = sender.id;
+    if (trackedOwners.has(ownerId)) return ownerId;
+    trackedOwners.set(ownerId, sender);
+
+    // A view's webContents is destroyed when its window closes AND when it is
+    // evicted under memory pressure (eviction closes it). A *deactivated*
+    // (cached, still-alive) view fires nothing — which is exactly right: its
+    // watched panels and waiting count must survive until the user returns.
+    sender.once("destroyed", () => purgeOwner(ownerId));
+
+    // Belt and braces for window teardown, where the view's "destroyed" event
+    // can race the registry's own unwinding.
+    const windowCleanup = deps.windowRegistry?.getByWebContentsId(ownerId)?.cleanup;
+    windowCleanup?.add({ dispose: () => purgeOwner(ownerId) });
+
+    return ownerId;
+  };
+
   const handleNotificationUpdate = (
-    _event: Electron.IpcMainEvent,
+    event: Electron.IpcMainEvent,
     state: NotificationState
   ): void => {
-    notificationService.updateNotifications(state);
+    notificationService.updateNotifications(trackOwner(event.sender), state);
   };
 
   const handleSettingsGet = async (): Promise<NotificationSettings> => {
@@ -138,11 +171,18 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
     sound.previewFile(soundFile);
   };
 
-  const handleSyncWatched = (_event: Electron.IpcMainEvent, payload: unknown): void => {
+  const handleSyncWatched = (event: Electron.IpcMainEvent, payload: unknown): void => {
     if (!Array.isArray(payload)) return;
     const ids = payload.filter((v): v is string => typeof v === "string");
+    // Pin the sender synchronously: the service import is async, and a view
+    // destroyed while it settles would otherwise have its state resurrected by
+    // the late sync — a leak no destroy event can clean up.
+    const ownerId = trackOwner(event.sender);
     void getAgentNotificationService()
-      .then((svc) => svc.syncWatchedPanels(ids))
+      .then((svc) => {
+        if (!trackedOwners.has(ownerId)) return;
+        svc.syncWatchedPanels(ownerId, ids);
+      })
       .catch((err) => console.error("[notifications] syncWatched failed:", err));
   };
 
@@ -192,7 +232,7 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
     notificationService.showNativeNotification(p.title, p.body);
   };
 
-  const handleShowWatch = (_event: Electron.IpcMainEvent, payload: unknown): void => {
+  const handleShowWatch = (event: Electron.IpcMainEvent, payload: unknown): void => {
     if (!payload || typeof payload !== "object") return;
     const p = payload as Record<string, unknown>;
     if (typeof p.title !== "string" || typeof p.body !== "string") return;
@@ -204,11 +244,14 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
       worktreeId: typeof p.worktreeId === "string" ? p.worktreeId : undefined,
     };
 
+    // The renderer that asked for the notification owns the panel it names, so
+    // a click on it belongs back in that same renderer's window.
     notificationService.showWatchNotification(
       p.title,
       p.body,
       context,
-      CHANNELS.NOTIFICATION_WATCH_NAVIGATE
+      CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
+      { ownerWebContentsId: event.sender.id }
     );
   };
 
@@ -242,6 +285,7 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
       handleWorkingPulseAcknowledge
     );
     ipcMain.removeListener(CHANNELS.NOTIFICATION_SESSION_MUTE_SET, handleSessionMuteSet);
+    trackedOwners.clear();
     cleanups.forEach((c) => c());
   };
 }

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -59,7 +59,11 @@ export function registerNotificationHandlers(deps: HandlerDependencies): () => v
   const trackedOwners = new Map<number, Electron.WebContents>();
 
   const purgeOwner = (ownerId: number): void => {
-    trackedOwners.delete(ownerId);
+    // Short-circuit: the webContents "destroyed" listener and the owning
+    // window's cleanup both fire for the same owner on window close, and the
+    // window's DisposableStore keeps a purge for every view it ever hosted.
+    if (!trackedOwners.delete(ownerId)) return;
+
     notificationService.removeOwner(ownerId);
     void getAgentNotificationService()
       .then((svc) => svc.removeOwner(ownerId))

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -149,8 +149,16 @@ class AgentNotificationService {
     }
 
     for (const [panelId, ownerId] of [...this.lastOwnerByPanel]) {
-      if (ownerId === ownerWebContentsId) {
+      if (ownerId !== ownerWebContentsId) continue;
+      // Hand the hint to a surviving watcher rather than dropping it: with the
+      // same project open in two windows, the dead renderer may not have been
+      // the panel's only owner, and orphaning it here would send the click to
+      // the primary window instead of the window that still shows the panel.
+      const survivor = this.firstOwnerOf(panelId);
+      if (survivor === undefined) {
         this.lastOwnerByPanel.delete(panelId);
+      } else {
+        this.lastOwnerByPanel.set(panelId, survivor);
       }
     }
   }
@@ -168,6 +176,13 @@ class AgentNotificationService {
     return this.ownersByPanel.has(terminalId);
   }
 
+  private firstOwnerOf(panelId: string): NotificationOwnerId | undefined {
+    for (const ownerId of this.ownersByPanel.get(panelId) ?? []) {
+      return ownerId;
+    }
+    return undefined;
+  }
+
   /**
    * The renderer a notification for this panel should navigate. Prefers a live
    * watcher; falls back to the last one that watched it, which is what survives
@@ -175,11 +190,20 @@ class AgentNotificationService {
    */
   private resolveOwner(terminalId?: string): NotificationOwnerId | undefined {
     if (!terminalId) return undefined;
-    const owners = this.ownersByPanel.get(terminalId);
-    for (const ownerId of owners ?? []) {
-      return ownerId;
-    }
-    return this.lastOwnerByPanel.get(terminalId);
+    return this.firstOwnerOf(terminalId) ?? this.lastOwnerByPanel.get(terminalId);
+  }
+
+  /**
+   * Owner for a notification that is about to be shown. Re-resolving at emit
+   * time matters because an owner captured when the event arrived can be
+   * destroyed during the burst/debounce window, while a sibling window that
+   * watches the same panel is still alive and is the right click target.
+   */
+  private emitOwner(
+    terminalId?: string,
+    capturedOwnerId?: NotificationOwnerId
+  ): NotificationOwnerId | undefined {
+    return this.resolveOwner(terminalId) ?? capturedOwnerId;
   }
 
   private forgetPanelOwnership(terminalId: string): void {
@@ -247,7 +271,23 @@ class AgentNotificationService {
       }
     });
 
-    this.unsubscribers.push(unsubStateChanged, unsubSpawned, unsubDetected, unsubExited);
+    // A killed terminal never emits agent:exited (TerminalExitHandler suppresses
+    // it for `wasKilled`), so without this the routing hint for every killed
+    // agent would sit in the map for the rest of the session.
+    const unsubKilled = events.on("agent:killed", (payload) => {
+      if (payload.terminalId) {
+        this.agentSpawnTimestamps.delete(payload.terminalId);
+        this.forgetPanelOwnership(payload.terminalId);
+      }
+    });
+
+    this.unsubscribers.push(
+      unsubStateChanged,
+      unsubSpawned,
+      unsubDetected,
+      unsubExited,
+      unsubKilled
+    );
   }
 
   private isWithinBootGrace(): boolean {
@@ -551,6 +591,8 @@ class AgentNotificationService {
     const first = dedupedItems[0];
     this.playNotificationSound(first.soundEnabled, first.soundFile);
 
+    const ownerWebContentsId = this.emitOwner(first.terminalId, first.ownerWebContentsId);
+
     if (dedupedItems.length === 1) {
       const label = this.getLabel(first.agentId, first.worktreeId);
       const context = this.makeContext(first.terminalId, first.agentId, first.worktreeId);
@@ -559,7 +601,7 @@ class AgentNotificationService {
         describeWaiting(label, first.waitingReason),
         context,
         CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-        { silent: true, ownerWebContentsId: first.ownerWebContentsId }
+        { silent: true, ownerWebContentsId }
       );
     } else {
       const context = this.makeContext(first.terminalId, first.agentId, first.worktreeId);
@@ -576,7 +618,7 @@ class AgentNotificationService {
         describeWaitingMany(dedupedItems.length, uniformReason ?? undefined),
         context,
         CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-        { silent: true, ownerWebContentsId: first.ownerWebContentsId }
+        { silent: true, ownerWebContentsId }
       );
     }
   }
@@ -651,9 +693,13 @@ class AgentNotificationService {
       // destroyed since. A docked terminal that was never watched has no known
       // owner — the click then falls back to the primary window, which is
       // explicit and no worse than today's dead click.
+      // Take the worktree from the terminal as it is NOW, not as it was when the
+      // timer was armed: the body below already uses the fresh title, and a panel
+      // dragged to another worktree during the wait would otherwise navigate to
+      // the worktree it used to live in. The agent id can't change for a terminal.
       const navigation = {
         channel: CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-        context: this.makeContext(terminalId, agentId, worktreeId),
+        context: this.makeContext(terminalId, agentId, currentTerminal.worktreeId ?? worktreeId),
       };
       const ownerWebContentsId = this.resolveOwner(terminalId);
 
@@ -826,7 +872,7 @@ class AgentNotificationService {
       item.body,
       context,
       CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-      { silent: true, ownerWebContentsId: item.ownerWebContentsId }
+      { silent: true, ownerWebContentsId: this.emitOwner(item.terminalId, item.ownerWebContentsId) }
     );
 
     if (this.notificationQueue.length > 0) {

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -1,5 +1,9 @@
 import { events } from "./events.js";
-import { notificationService, type WatchNotificationContext } from "./NotificationService.js";
+import {
+  notificationService,
+  type NotificationOwnerId,
+  type WatchNotificationContext,
+} from "./NotificationService.js";
 import { store, type StoreSchema } from "../store.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
 import { projectStore } from "./ProjectStore.js";
@@ -47,6 +51,7 @@ interface PendingNotification {
   agentId?: string;
   triggerSound: boolean;
   soundFile?: string;
+  ownerWebContentsId?: NotificationOwnerId;
 }
 
 interface BurstWaitingEntry {
@@ -56,6 +61,7 @@ interface BurstWaitingEntry {
   waitingReason?: WaitingReason;
   soundFile: string;
   soundEnabled: boolean;
+  ownerWebContentsId?: NotificationOwnerId;
 }
 
 class AgentNotificationService {
@@ -66,7 +72,21 @@ class AgentNotificationService {
   private notificationQueue: PendingNotification[] = [];
   private staggerTimer: NodeJS.Timeout | null = null;
   private unsubscribers: Array<() => void> = [];
-  private watchedTerminals = new Set<string>();
+  /** Watched panels per owning renderer — a sync replaces only its own set. */
+  private watchedPanelsByOwner = new Map<NotificationOwnerId, Set<string>>();
+  /**
+   * Reverse index. A set, not a single owner: the same project can be open in
+   * two windows (#11101), so two renderers can watch the same panel, and a
+   * single value would reintroduce last-writer-wins inside the fix.
+   */
+  private ownersByPanel = new Map<string, Set<NotificationOwnerId>>();
+  /**
+   * Last renderer known to own a panel, kept after it stops being watched.
+   * Routing metadata only — never a watched-state source. The renderer unwatches
+   * one-shot the instant a state lands, so by the time a completion debounce or
+   * a minutes-later escalation fires, the live index no longer knows the owner.
+   */
+  private lastOwnerByPanel = new Map<string, NotificationOwnerId>();
   private hasEverGoneWorking = false;
   private peakConcurrentWorking = 0;
   private allClearTimer: NodeJS.Timeout | null = null;
@@ -84,8 +104,86 @@ class AgentNotificationService {
   /** Session-mute expiry mirrored from the renderer's quick-action buttons. */
   private sessionMuteUntil = 0;
 
-  syncWatchedPanels(panelIds: string[]): void {
-    this.watchedTerminals = new Set(panelIds);
+  syncWatchedPanels(ownerWebContentsId: NotificationOwnerId, panelIds: string[]): void {
+    const previous = this.watchedPanelsByOwner.get(ownerWebContentsId);
+    const next = new Set(panelIds);
+
+    if (previous) {
+      for (const panelId of previous) {
+        if (next.has(panelId)) continue;
+        this.detachOwnerFromPanel(panelId, ownerWebContentsId);
+      }
+    }
+
+    for (const panelId of next) {
+      let owners = this.ownersByPanel.get(panelId);
+      if (!owners) {
+        owners = new Set();
+        this.ownersByPanel.set(panelId, owners);
+      }
+      owners.add(ownerWebContentsId);
+      this.lastOwnerByPanel.set(panelId, ownerWebContentsId);
+    }
+
+    if (next.size === 0) {
+      this.watchedPanelsByOwner.delete(ownerWebContentsId);
+    } else {
+      this.watchedPanelsByOwner.set(ownerWebContentsId, next);
+    }
+  }
+
+  /**
+   * Drop everything owned by a renderer that no longer exists. Idempotent — the
+   * webContents "destroyed" listener and its window's cleanup can both fire.
+   *
+   * Deliberately does not touch `waitingTerminalIds` or escalation timers: those
+   * track main-process terminal state, which outlives any renderer watching it.
+   */
+  removeOwner(ownerWebContentsId: NotificationOwnerId): void {
+    const watched = this.watchedPanelsByOwner.get(ownerWebContentsId);
+    if (watched) {
+      for (const panelId of watched) {
+        this.detachOwnerFromPanel(panelId, ownerWebContentsId);
+      }
+      this.watchedPanelsByOwner.delete(ownerWebContentsId);
+    }
+
+    for (const [panelId, ownerId] of [...this.lastOwnerByPanel]) {
+      if (ownerId === ownerWebContentsId) {
+        this.lastOwnerByPanel.delete(panelId);
+      }
+    }
+  }
+
+  private detachOwnerFromPanel(panelId: string, ownerWebContentsId: NotificationOwnerId): void {
+    const owners = this.ownersByPanel.get(panelId);
+    if (!owners) return;
+    owners.delete(ownerWebContentsId);
+    if (owners.size === 0) {
+      this.ownersByPanel.delete(panelId);
+    }
+  }
+
+  private isWatched(terminalId: string): boolean {
+    return this.ownersByPanel.has(terminalId);
+  }
+
+  /**
+   * The renderer a notification for this panel should navigate. Prefers a live
+   * watcher; falls back to the last one that watched it, which is what survives
+   * the renderer's one-shot unwatch.
+   */
+  private resolveOwner(terminalId?: string): NotificationOwnerId | undefined {
+    if (!terminalId) return undefined;
+    const owners = this.ownersByPanel.get(terminalId);
+    for (const ownerId of owners ?? []) {
+      return ownerId;
+    }
+    return this.lastOwnerByPanel.get(terminalId);
+  }
+
+  private forgetPanelOwnership(terminalId: string): void {
+    this.lastOwnerByPanel.delete(terminalId);
   }
 
   setSessionMuteUntil(timestampMs: number): void {
@@ -142,6 +240,10 @@ class AgentNotificationService {
     const unsubExited = events.on("agent:exited", (payload) => {
       if (payload.terminalId) {
         this.agentSpawnTimestamps.delete(payload.terminalId);
+        // Bound the routing hint's lifetime to the agent's. A re-watch of the
+        // same panel repopulates it; notifications already in flight captured
+        // their owner when the event fired.
+        this.forgetPanelOwnership(payload.terminalId);
       }
     });
 
@@ -306,11 +408,16 @@ class AgentNotificationService {
     // The renderer one-shot unwatches immediately on state change, so by the time
     // the 2s completion debounce fires, the terminal is already removed from the
     // watched set. Capturing here preserves the intent.
-    const isWatched = terminalId !== undefined && this.watchedTerminals.has(terminalId);
+    const isWatched = terminalId !== undefined && this.isWatched(terminalId);
     if (!isWatched) return;
 
+    // Capture the owner alongside the watched snapshot — same reason the
+    // snapshot exists at all: the renderer unwatches one-shot on this very
+    // transition, so the live index is empty by the time the notification fires.
+    const ownerWebContentsId = this.resolveOwner(terminalId);
+
     if ((state === "completed" || state === "exited") && settings.completedEnabled) {
-      this.scheduleCompletionNotification(key, worktreeId, terminalId, agentId);
+      this.scheduleCompletionNotification(key, worktreeId, terminalId, agentId, ownerWebContentsId);
     } else if (
       state === "waiting" &&
       settings.waitingEnabled &&
@@ -323,6 +430,7 @@ class AgentNotificationService {
         waitingReason: coerceWaitingReason(payload.waitingReason),
         soundFile: settings.waitingSoundFile,
         soundEnabled: settings.soundEnabled,
+        ownerWebContentsId,
       });
       if (this.waitingBurstTimer === null) {
         this.waitingBurstTimer = setTimeout(() => this.flushWaitingBurst(), BURST_WINDOW_MS);
@@ -389,7 +497,8 @@ class AgentNotificationService {
     key: string,
     worktreeId?: string,
     terminalId?: string,
-    agentId?: string
+    agentId?: string,
+    ownerWebContentsId?: NotificationOwnerId
   ): void {
     if (this.completionTimers.has(key)) {
       clearTimeout(this.completionTimers.get(key)!);
@@ -407,6 +516,7 @@ class AgentNotificationService {
         terminalId,
         agentId,
         triggerSound: settings.soundEnabled,
+        ownerWebContentsId,
       });
       if (!this.completionBurstSoundFile) {
         this.completionBurstSoundFile = settings.completedSoundFile;
@@ -449,7 +559,7 @@ class AgentNotificationService {
         describeWaiting(label, first.waitingReason),
         context,
         CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-        true
+        { silent: true, ownerWebContentsId: first.ownerWebContentsId }
       );
     } else {
       const context = this.makeContext(first.terminalId, first.agentId, first.worktreeId);
@@ -459,12 +569,14 @@ class AgentNotificationService {
       const uniformReason = dedupedItems.every((item) => item.waitingReason === first.waitingReason)
         ? actionableWaitingReason(first.waitingReason)
         : null;
+      // Context and owner both come from `first` so the click lands on the
+      // panel the body is about, in the renderer that actually owns it.
       notificationService.showWatchNotification(
         "Agents waiting",
         describeWaitingMany(dedupedItems.length, uniformReason ?? undefined),
         context,
         CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-        true
+        { silent: true, ownerWebContentsId: first.ownerWebContentsId }
       );
     }
   }
@@ -488,6 +600,7 @@ class AgentNotificationService {
           terminalId: first.terminalId,
           agentId: first.agentId,
           triggerSound: first.triggerSound,
+          ownerWebContentsId: first.ownerWebContentsId,
         },
         true,
         soundFile
@@ -531,6 +644,19 @@ class AgentNotificationService {
 
       this.playNotificationSound(currentSettings.soundEnabled, currentSettings.escalationSoundFile);
 
+      // Escalation is the most urgent notification and was the only one with no
+      // click handler at all, so it could never navigate anywhere. Attach panel
+      // context and resolve the owner now rather than at schedule time: minutes
+      // have passed, and the renderer that watched this panel may have been
+      // destroyed since. A docked terminal that was never watched has no known
+      // owner — the click then falls back to the primary window, which is
+      // explicit and no worse than today's dead click.
+      const navigation = {
+        channel: CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
+        context: this.makeContext(terminalId, agentId, worktreeId),
+      };
+      const ownerWebContentsId = this.resolveOwner(terminalId);
+
       if (waitingDockTerminalIds.length > 1) {
         // Cancel sibling escalation timers so only one grouped notification fires
         for (const siblingId of waitingDockTerminalIds) {
@@ -540,7 +666,8 @@ class AgentNotificationService {
         }
         notificationService.showNativeNotification(
           "Agents still waiting",
-          `${waitingDockTerminalIds.length} agents have been waiting for input`
+          `${waitingDockTerminalIds.length} agents have been waiting for input`,
+          { ownerWebContentsId, navigation }
         );
       } else {
         const label = currentTerminal.title || this.getLabel(agentId, worktreeId);
@@ -551,7 +678,8 @@ class AgentNotificationService {
         const reason = actionableWaitingReason(waitingReason);
         notificationService.showNativeNotification(
           "Agent still waiting",
-          reason ? describeWaiting(label, reason) : `${label} has been waiting for input`
+          reason ? describeWaiting(label, reason) : `${label} has been waiting for input`,
+          { ownerWebContentsId, navigation }
         );
       }
     }, settings.waitingEscalationDelayMs);
@@ -585,7 +713,7 @@ class AgentNotificationService {
     if (!settings.workingPulseEnabled || !settings.soundEnabled) return;
 
     // Eligibility: watched OR (docked + escalation enabled)
-    const isWatched = this.watchedTerminals.has(terminalId);
+    const isWatched = this.isWatched(terminalId);
     if (!isWatched) {
       const terminal = terminals.find((t) => t.id === terminalId);
       if (!terminal || terminal.location !== "dock" || !settings.waitingEscalationEnabled) return;
@@ -698,7 +826,7 @@ class AgentNotificationService {
       item.body,
       context,
       CHANNELS.NOTIFICATION_WATCH_NAVIGATE,
-      true
+      { silent: true, ownerWebContentsId: item.ownerWebContentsId }
     );
 
     if (this.notificationQueue.length > 0) {
@@ -797,6 +925,9 @@ class AgentNotificationService {
 
     this.waitingTerminalIds.clear();
     this.agentSpawnTimestamps.clear();
+    this.watchedPanelsByOwner.clear();
+    this.ownersByPanel.clear();
+    this.lastOwnerByPanel.clear();
     this.notificationQueue = [];
     this.hasEverGoneWorking = false;
     this.peakConcurrentWorking = 0;

--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -1,6 +1,7 @@
-import { app, Notification } from "electron";
+import { app, Notification, webContents as webContentsModule } from "electron";
 import type { WindowRegistry, WindowContext } from "../window/WindowRegistry.js";
 import { sendToRenderer } from "../ipc/utils.js";
+import { getAppWebContents, getWindowForWebContents } from "../window/webContentsRegistry.js";
 
 export interface NotificationState {
   waitingCount: number;
@@ -10,6 +11,33 @@ export interface WatchNotificationContext {
   worktreeId?: string;
   panelId: string;
   panelTitle: string;
+}
+
+/**
+ * A notification owner is the renderer that reported the state — a project
+ * view's `webContents.id`, taken from `event.sender` at IPC time.
+ *
+ * Not the window id: one window hosts an active project view plus any number of
+ * cached ones, each its own renderer with its own panel store. Not the project
+ * id: `null` is a legitimate distinct identity (an unbound window showing the
+ * project picker), and one project can be open in two windows at once (#11101).
+ */
+export type NotificationOwnerId = number;
+
+export interface NotificationNavigation {
+  channel: string;
+  context: WatchNotificationContext;
+}
+
+export interface WatchNotificationOptions {
+  silent?: boolean;
+  /** Renderer that owns the panel — decides which window a click focuses. */
+  ownerWebContentsId?: NotificationOwnerId;
+}
+
+export interface NativeNotificationOptions extends WatchNotificationOptions {
+  /** Attach to make the notification clickable. Without it, a click does nothing. */
+  navigation?: NotificationNavigation;
 }
 
 const DEBOUNCE_MS = 300;
@@ -24,7 +52,7 @@ interface TrackedWindow {
 class NotificationService {
   private registry: WindowRegistry | null = null;
   private debounceTimer: NodeJS.Timeout | null = null;
-  private currentState: NotificationState = { waitingCount: 0 };
+  private statesByOwner = new Map<NotificationOwnerId, NotificationState>();
   private focusedWindows = new Set<number>();
   private trackedWindows = new Map<number, TrackedWindow>();
   private activeNotifications = new Set<Notification>();
@@ -46,6 +74,24 @@ class NotificationService {
     }
   }
 
+  /**
+   * The webContents id of the view a window is currently showing — the renderer
+   * that receives the DOM focus event and zeroes its own count. Clearing only
+   * this owner on window focus keeps a cached project view's unseen waiting
+   * agents counted: the user hasn't looked at them yet, and switching to that
+   * view focuses its webContents, which zeroes it through the normal path.
+   */
+  private activeOwnerOf(
+    browserWindow: import("electron").BrowserWindow
+  ): NotificationOwnerId | null {
+    try {
+      const webContents = getAppWebContents(browserWindow);
+      return typeof webContents?.id === "number" ? webContents.id : null;
+    } catch {
+      return null;
+    }
+  }
+
   private attachWindowListeners(ctx: WindowContext): void {
     const windowId = ctx.windowId;
 
@@ -57,14 +103,18 @@ class NotificationService {
 
     const focusHandler = () => {
       this.focusedWindows.add(windowId);
-      this.currentState = { waitingCount: 0 };
+
+      const activeOwner = this.activeOwnerOf(ctx.browserWindow);
+      if (activeOwner !== null) {
+        this.statesByOwner.delete(activeOwner);
+      }
 
       if (this.debounceTimer) {
         clearTimeout(this.debounceTimer);
         this.debounceTimer = null;
       }
 
-      this.clearNotifications();
+      this.applyNotifications();
     };
 
     const blurHandler = () => {
@@ -90,8 +140,8 @@ class NotificationService {
     }
   }
 
-  updateNotifications(state: NotificationState): void {
-    this.currentState = state;
+  updateNotifications(ownerWebContentsId: NotificationOwnerId, state: NotificationState): void {
+    this.statesByOwner.set(ownerWebContentsId, state);
 
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
@@ -104,25 +154,50 @@ class NotificationService {
     }, DEBOUNCE_MS);
   }
 
+  /**
+   * Drop an owner's state when its renderer is gone. Idempotent — a destroyed
+   * webContents and its window's cleanup can both fire.
+   */
+  removeOwner(ownerWebContentsId: NotificationOwnerId): void {
+    if (!this.statesByOwner.delete(ownerWebContentsId)) return;
+    this.applyNotifications();
+  }
+
   private applyNotifications(): void {
     if (!this.registry) return;
 
-    if (this.isWindowFocused()) {
-      this.clearNotifications();
-      return;
+    // An owner that no longer resolves to a window is dead or dying: a view's
+    // webContents id is indexed at creation, before its renderer can send any
+    // IPC, and is unindexed only on eviction (which closes it) or window
+    // teardown. Pruning here keeps the badge honest even if a "destroyed"
+    // event is missed.
+    const countsByWindow = new Map<number, number>();
+    for (const [ownerId, state] of [...this.statesByOwner]) {
+      const ctx = this.registry.getByWebContentsId(ownerId);
+      if (!ctx) {
+        this.statesByOwner.delete(ownerId);
+        continue;
+      }
+      countsByWindow.set(
+        ctx.windowId,
+        (countsByWindow.get(ctx.windowId) ?? 0) + state.waitingCount
+      );
     }
 
-    const { waitingCount } = this.currentState;
-    const title = waitingCount > 0 ? `(${waitingCount}) ${DEFAULT_TITLE}` : DEFAULT_TITLE;
-
+    let totalWaiting = 0;
     for (const ctx of this.registry.all()) {
+      const waitingCount = countsByWindow.get(ctx.windowId) ?? 0;
+      totalWaiting += waitingCount;
+
       if (!ctx.browserWindow.isDestroyed()) {
-        ctx.browserWindow.setTitle(title);
+        ctx.browserWindow.setTitle(
+          waitingCount > 0 ? `(${waitingCount}) ${DEFAULT_TITLE}` : DEFAULT_TITLE
+        );
       }
     }
 
     if (process.platform === "darwin") {
-      app.setBadgeCount(waitingCount);
+      app.setBadgeCount(totalWaiting);
     }
   }
 
@@ -144,28 +219,12 @@ class NotificationService {
     return this.focusedWindows.size > 0;
   }
 
-  showNativeNotification(title: string, body: string): void {
-    if (!Notification.isSupported()) return;
-
-    const notification = new Notification({ title, body, silent: true });
-    this.activeNotifications.add(notification);
-
-    const cleanup = () => {
-      this.activeNotifications.delete(notification);
-    };
-    notification.once("close", cleanup);
-    notification.once("failed", (_event, error) => {
-      // Electron 42 routes macOS notifications through UNNotification, which
-      // silently emits "failed" on unsigned dev builds instead of displaying.
-      // Surface it as a diagnostic — signed release builds never hit this.
-      console.warn(
-        "[NotificationService] native notification failed (unsigned macOS dev build?):",
-        error
-      );
-      cleanup();
-    });
-
-    notification.show();
+  showNativeNotification(
+    title: string,
+    body: string,
+    options: NativeNotificationOptions = {}
+  ): void {
+    this.showNotification(title, body, options);
   }
 
   showWatchNotification(
@@ -173,10 +232,18 @@ class NotificationService {
     body: string,
     context: WatchNotificationContext,
     navigateChannel: string,
-    silent = true
+    options: WatchNotificationOptions = {}
   ): void {
+    this.showNotification(title, body, {
+      ...options,
+      navigation: { channel: navigateChannel, context },
+    });
+  }
+
+  private showNotification(title: string, body: string, options: NativeNotificationOptions): void {
     if (!Notification.isSupported()) return;
 
+    const { silent = true, ownerWebContentsId, navigation } = options;
     const notification = new Notification({ title, body, silent });
     this.activeNotifications.add(notification);
 
@@ -195,20 +262,64 @@ class NotificationService {
       cleanup();
     });
 
-    notification.once("click", () => {
-      cleanup();
-      const targetWin = this.registry?.getPrimary()?.browserWindow;
-      if (targetWin && !targetWin.isDestroyed()) {
-        if (targetWin.isMinimized()) {
-          targetWin.restore();
-        }
-        targetWin.show();
-        targetWin.focus();
-        sendToRenderer(targetWin, navigateChannel, context);
-      }
-    });
+    if (navigation) {
+      notification.once("click", () => {
+        cleanup();
+        this.routeNavigation(navigation.channel, navigation.context, ownerWebContentsId);
+      });
+    }
 
     notification.show();
+  }
+
+  /**
+   * Focus the window that owns the panel and hand the navigate to the owning
+   * renderer itself. The owner is re-resolved here rather than captured when
+   * the notification was created: a view can be evicted or its window closed
+   * while the banner sits on screen.
+   *
+   * `sendToRenderer` would deliver to whichever project view the window happens
+   * to be showing, so a panel in a cached view would never receive it — send
+   * straight to the owning webContents instead. The primary window is the
+   * explicit last resort for a notification whose owner is gone.
+   */
+  private routeNavigation(
+    navigateChannel: string,
+    context: WatchNotificationContext,
+    ownerWebContentsId?: NotificationOwnerId
+  ): void {
+    const ownerWebContents =
+      ownerWebContentsId === undefined
+        ? null
+        : (webContentsModule.fromId(ownerWebContentsId) ?? null);
+
+    if (ownerWebContents && !ownerWebContents.isDestroyed()) {
+      const ownerWindow = getWindowForWebContents(ownerWebContents);
+      if (ownerWindow && !ownerWindow.isDestroyed()) {
+        if (ownerWindow.isMinimized()) {
+          ownerWindow.restore();
+        }
+        ownerWindow.show();
+        ownerWindow.focus();
+      }
+
+      try {
+        ownerWebContents.send(navigateChannel, context);
+      } catch {
+        // Renderer torn down between the guard and the send.
+      }
+      return;
+    }
+
+    const fallbackWindow = this.registry?.getPrimary()?.browserWindow;
+    if (!fallbackWindow || fallbackWindow.isDestroyed()) return;
+
+    if (fallbackWindow.isMinimized()) {
+      fallbackWindow.restore();
+    }
+    fallbackWindow.show();
+    fallbackWindow.focus();
+    sendToRenderer(fallbackWindow, navigateChannel, context);
   }
 
   dispose(): void {
@@ -219,6 +330,7 @@ class NotificationService {
 
     this.detachAllWindowListeners();
     this.clearNotifications();
+    this.statesByOwner.clear();
 
     for (const notification of this.activeNotifications) {
       notification.removeAllListeners();

--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -174,7 +174,7 @@ class NotificationService {
     const countsByWindow = new Map<number, number>();
     for (const [ownerId, state] of [...this.statesByOwner]) {
       const ctx = this.registry.getByWebContentsId(ownerId);
-      if (!ctx) {
+      if (!ctx || ctx.browserWindow.isDestroyed()) {
         this.statesByOwner.delete(ownerId);
         continue;
       }
@@ -282,44 +282,61 @@ class NotificationService {
    * to be showing, so a panel in a cached view would never receive it — send
    * straight to the owning webContents instead. The primary window is the
    * explicit last resort for a notification whose owner is gone.
+   *
+   * Known limit: if the owning view is cached (its project isn't the one the
+   * window is showing), the panel is focused in that renderer's store but the
+   * project is not switched to — making a background project visible from main
+   * means driving the full renderer-owned project-switch path, which persists
+   * outgoing layout state. Still strictly better than before, when the click
+   * went to the primary window's active view and matched no panel at all.
    */
   private routeNavigation(
     navigateChannel: string,
     context: WatchNotificationContext,
     ownerWebContentsId?: NotificationOwnerId
   ): void {
-    const ownerWebContents =
-      ownerWebContentsId === undefined
-        ? null
-        : (webContentsModule.fromId(ownerWebContentsId) ?? null);
+    if (this.sendToOwner(navigateChannel, context, ownerWebContentsId)) return;
 
-    if (ownerWebContents && !ownerWebContents.isDestroyed()) {
-      const ownerWindow = getWindowForWebContents(ownerWebContents);
-      if (ownerWindow && !ownerWindow.isDestroyed()) {
-        if (ownerWindow.isMinimized()) {
-          ownerWindow.restore();
-        }
-        ownerWindow.show();
-        ownerWindow.focus();
-      }
-
-      try {
-        ownerWebContents.send(navigateChannel, context);
-      } catch {
-        // Renderer torn down between the guard and the send.
-      }
-      return;
-    }
-
+    // The owner is gone, or died between the guard and the send. Falling back to
+    // the primary window is a guess — it delivers to whichever view that window
+    // is showing — but a click that does nothing at all is worse.
     const fallbackWindow = this.registry?.getPrimary()?.browserWindow;
     if (!fallbackWindow || fallbackWindow.isDestroyed()) return;
 
-    if (fallbackWindow.isMinimized()) {
-      fallbackWindow.restore();
-    }
-    fallbackWindow.show();
-    fallbackWindow.focus();
+    this.revealWindow(fallbackWindow);
     sendToRenderer(fallbackWindow, navigateChannel, context);
+  }
+
+  /** False when the owner could not be reached, so the caller falls back. */
+  private sendToOwner(
+    navigateChannel: string,
+    context: WatchNotificationContext,
+    ownerWebContentsId?: NotificationOwnerId
+  ): boolean {
+    if (ownerWebContentsId === undefined) return false;
+
+    const ownerWebContents = webContentsModule.fromId(ownerWebContentsId);
+    if (!ownerWebContents || ownerWebContents.isDestroyed()) return false;
+
+    const ownerWindow = getWindowForWebContents(ownerWebContents);
+    if (ownerWindow && !ownerWindow.isDestroyed()) {
+      this.revealWindow(ownerWindow);
+    }
+
+    try {
+      ownerWebContents.send(navigateChannel, context);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private revealWindow(browserWindow: import("electron").BrowserWindow): void {
+    if (browserWindow.isMinimized()) {
+      browserWindow.restore();
+    }
+    browserWindow.show();
+    browserWindow.focus();
   }
 
   dispose(): void {

--- a/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
@@ -51,6 +51,9 @@ vi.mock("../OsDndService.js", () => ({
 import { events } from "../events.js";
 import { agentNotificationService } from "../AgentNotificationService.js";
 
+/** Stand-in for a project view's webContents id — the renderer that owns the watched panels. */
+const OWNER = 101;
+
 const BASE_TIME = new Date("2026-01-01T00:00:00.000Z");
 
 const DEFAULT_NOTIFICATION_SETTINGS = {
@@ -158,7 +161,7 @@ describe("AgentNotificationService adversarial", () => {
     vi.clearAllMocks();
     mockStore();
     agentNotificationService.initialize();
-    agentNotificationService.syncWatchedPanels(["term-1"]);
+    agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
   });
 
   afterEach(() => {
@@ -179,7 +182,7 @@ describe("AgentNotificationService adversarial", () => {
       "agent-1 is waiting for input",
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
     expect(soundServiceMock.playFile).toHaveBeenCalledTimes(1);
   });
@@ -198,7 +201,7 @@ describe("AgentNotificationService adversarial", () => {
       "agent-1 finished its task",
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
     expect(soundServiceMock.playFile).toHaveBeenCalledTimes(1);
   });
@@ -268,7 +271,7 @@ describe("AgentNotificationService adversarial", () => {
       "agent-1 is waiting for input",
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
     expect(notificationServiceMock.showWatchNotification).toHaveBeenNthCalledWith(
       2,
@@ -276,7 +279,7 @@ describe("AgentNotificationService adversarial", () => {
       "agent-1 finished its task",
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
   });
 });

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -55,6 +55,16 @@ vi.mock("../OsDndService.js", () => ({
 import { events } from "../events.js";
 import { agentNotificationService } from "../AgentNotificationService.js";
 
+/** Stand-in for a project view's webContents id — the renderer that owns the watched panels. */
+const OWNER = 101;
+
+/** Escalation now carries a click target; the owner decides which window it focuses. */
+const escalationOptions = (ownerWebContentsId: number | undefined = OWNER) =>
+  expect.objectContaining({
+    ownerWebContentsId,
+    navigation: expect.objectContaining({ channel: "notification:watch-navigate" }),
+  });
+
 const DEFAULT_NOTIFICATION_SETTINGS = {
   completedEnabled: false,
   waitingEnabled: false,
@@ -121,7 +131,7 @@ describe("AgentNotificationService", () => {
     osDndServiceMock.getState.mockReturnValue(undefined);
     agentNotificationService.initialize();
     // Register the test terminal as watched so gate passes by default
-    agentNotificationService.syncWatchedPanels(["term-1"]);
+    agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
   });
 
   afterEach(() => {
@@ -147,7 +157,7 @@ describe("AgentNotificationService", () => {
     mockStore({ completedEnabled: true, waitingEnabled: true });
 
     // Clear watched set — no terminals are watched
-    agentNotificationService.syncWatchedPanels([]);
+    agentNotificationService.syncWatchedPanels(OWNER, []);
 
     events.emit("agent:state-changed", makePayload("completed"));
     vi.advanceTimersByTime(5000);
@@ -191,7 +201,7 @@ describe("AgentNotificationService", () => {
       expect.stringContaining("finished"),
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
   });
 
@@ -206,7 +216,7 @@ describe("AgentNotificationService", () => {
       expect.stringContaining("waiting for input"),
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
   });
 
@@ -307,7 +317,7 @@ describe("AgentNotificationService", () => {
       expect.stringContaining("waiting for input"),
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
   });
 
@@ -334,7 +344,7 @@ describe("AgentNotificationService", () => {
 
     // Simulate one-shot unwatch: renderer removes the terminal from watched set
     // (this happens before the 2s debounce fires)
-    agentNotificationService.syncWatchedPanels([]);
+    agentNotificationService.syncWatchedPanels(OWNER, []);
 
     // Advance past the 2000ms debounce — should still fire because isWatched was captured at event time
     vi.advanceTimersByTime(3000);
@@ -344,7 +354,7 @@ describe("AgentNotificationService", () => {
       expect.stringContaining("finished"),
       expect.objectContaining({ panelId: "term-1" }),
       "notification:watch-navigate",
-      true
+      { silent: true, ownerWebContentsId: OWNER }
     );
   });
 
@@ -357,7 +367,8 @@ describe("AgentNotificationService", () => {
 
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
-        expect.stringContaining("has been waiting")
+        expect.stringContaining("has been waiting"),
+        escalationOptions()
       );
     });
 
@@ -372,7 +383,8 @@ describe("AgentNotificationService", () => {
 
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
-        expect.stringContaining("is blocked by an error")
+        expect.stringContaining("is blocked by an error"),
+        escalationOptions()
       );
     });
 
@@ -387,7 +399,8 @@ describe("AgentNotificationService", () => {
 
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
-        expect.stringContaining("has been waiting for input")
+        expect.stringContaining("has been waiting for input"),
+        escalationOptions()
       );
     });
 
@@ -402,7 +415,8 @@ describe("AgentNotificationService", () => {
 
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
-        expect.stringContaining("has been waiting for input")
+        expect.stringContaining("has been waiting for input"),
+        escalationOptions()
       );
     });
 
@@ -503,7 +517,8 @@ describe("AgentNotificationService", () => {
 
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
-        "My Custom Agent has been waiting for input"
+        "My Custom Agent has been waiting for input",
+        escalationOptions()
       );
     });
 
@@ -641,7 +656,7 @@ describe("AgentNotificationService", () => {
     it("coalesces multiple simultaneous waiting events into one notification", () => {
       const appState = makeMultiTerminalAppState(3);
       mockStore({ waitingEnabled: true, soundEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2", "term-3"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2", "term-3"]);
 
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
       events.emit("agent:state-changed", makePayloadFor("term-2", "agent-2", "waiting"));
@@ -654,7 +669,7 @@ describe("AgentNotificationService", () => {
         "3 agents waiting for input",
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
       expect(soundServiceMock.playFile).toHaveBeenCalledTimes(1);
     });
@@ -671,7 +686,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("agent-1 is waiting for input"),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -689,7 +704,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("agent-1 is waiting for approval"),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -707,7 +722,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("agent-1 is waiting for input"),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -731,14 +746,14 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("is waiting for approval"),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
     it("uses reason-specific plural copy when every burst member shares the reason", () => {
       const appState = makeMultiTerminalAppState(3);
       mockStore({ waitingEnabled: true, soundEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2", "term-3"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2", "term-3"]);
 
       for (const i of [1, 2, 3]) {
         events.emit("agent:state-changed", {
@@ -753,14 +768,14 @@ describe("AgentNotificationService", () => {
         "3 agents waiting for approval",
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
     it("keeps the generic plural copy for mixed-reason bursts", () => {
       const appState = makeMultiTerminalAppState(2);
       mockStore({ waitingEnabled: true, soundEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2"]);
 
       events.emit("agent:state-changed", {
         ...makePayloadFor("term-1", "agent-1", "waiting"),
@@ -777,14 +792,14 @@ describe("AgentNotificationService", () => {
         "2 agents waiting for input",
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
     it("produces separate notifications for events in different burst windows", () => {
       const appState = makeMultiTerminalAppState(2);
       mockStore({ waitingEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2"]);
 
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
       vi.advanceTimersByTime(200); // first burst flushes
@@ -798,7 +813,7 @@ describe("AgentNotificationService", () => {
     it("coalesces simultaneous completion debounces into one notification", () => {
       const appState = makeMultiTerminalAppState(3);
       mockStore({ completedEnabled: true, soundEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2", "term-3"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2", "term-3"]);
 
       // All 3 agents complete at the same time
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "completed"));
@@ -814,14 +829,14 @@ describe("AgentNotificationService", () => {
         "3 agents finished their tasks",
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
     it("groups escalation notifications for multiple waiting dock terminals", () => {
       const appState = makeMultiTerminalAppState(3);
       mockStore({ waitingEnabled: true, soundEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2", "term-3"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2", "term-3"]);
 
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
       events.emit("agent:state-changed", makePayloadFor("term-2", "agent-2", "waiting"));
@@ -834,7 +849,8 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledTimes(1);
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agents still waiting",
-        "3 agents have been waiting for input"
+        "3 agents have been waiting for input",
+        escalationOptions()
       );
     });
 
@@ -895,7 +911,7 @@ describe("AgentNotificationService", () => {
           ],
         }
       );
-      agentNotificationService.syncWatchedPanels([]);
+      agentNotificationService.syncWatchedPanels(OWNER, []);
 
       events.emit("agent:state-changed", makePayload("working", "idle"));
       vi.advanceTimersByTime(30_000);
@@ -952,7 +968,7 @@ describe("AgentNotificationService", () => {
 
     it("starts pulse for docked terminal with escalation enabled", () => {
       mockStore({ soundEnabled: true, workingPulseEnabled: true });
-      agentNotificationService.syncWatchedPanels([]);
+      agentNotificationService.syncWatchedPanels(OWNER, []);
 
       events.emit("agent:state-changed", makePayload("working", "idle"));
       vi.advanceTimersByTime(10_000);
@@ -1126,7 +1142,7 @@ describe("AgentNotificationService", () => {
         expect.any(String),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -1275,7 +1291,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("finished"),
         expect.objectContaining({ worktreeId: "wt-B" }),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -1305,7 +1321,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("waiting"),
         expect.objectContaining({ worktreeId: "wt-B" }),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -1338,7 +1354,7 @@ describe("AgentNotificationService", () => {
         expect.any(String),
         expect.objectContaining({ worktreeId: "wt-fresh" }),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -1360,7 +1376,7 @@ describe("AgentNotificationService", () => {
         expect.any(String),
         expect.objectContaining({ worktreeId: undefined }),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
   });
@@ -1478,7 +1494,7 @@ describe("AgentNotificationService", () => {
         ],
       };
       mockStore({ completedEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2"]);
 
       events.emit("agent:state-changed", {
         state: "completed" as const,
@@ -1509,7 +1525,7 @@ describe("AgentNotificationService", () => {
         "2 agents finished their tasks",
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -1536,7 +1552,7 @@ describe("AgentNotificationService", () => {
         ],
       };
       mockStore({ waitingEnabled: true, soundEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2"]);
       vi.advanceTimersByTime(10_000);
 
       // Both terminals detect "claude" — each seeds its own grace entry
@@ -1609,7 +1625,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("claude"),
         expect.objectContaining({ panelId: "term-1" }),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
   });
@@ -1677,7 +1693,7 @@ describe("AgentNotificationService", () => {
         expect.any(String),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
   });
@@ -1717,7 +1733,7 @@ describe("AgentNotificationService", () => {
 
     it("purges a buffered waiting entry when the same terminal transitions to completed", () => {
       mockStore({ waitingEnabled: true });
-      agentNotificationService.syncWatchedPanels(["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
 
       // Buffer a waiting entry.
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
@@ -1733,7 +1749,7 @@ describe("AgentNotificationService", () => {
 
     it("purges a buffered waiting entry when the same terminal transitions to exited", () => {
       mockStore({ waitingEnabled: true });
-      agentNotificationService.syncWatchedPanels(["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
 
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "exited", "waiting"));
@@ -1745,7 +1761,7 @@ describe("AgentNotificationService", () => {
     it("only splices the matching terminal — entries for other terminals are preserved", () => {
       const appState = makeMultiTerminalAppState(2);
       mockStore({ waitingEnabled: true }, appState);
-      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1", "term-2"]);
 
       // Both terminals go waiting inside the same burst window.
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
@@ -1764,7 +1780,7 @@ describe("AgentNotificationService", () => {
         expect.stringContaining("agent-2 is waiting for input"),
         expect.any(Object),
         "notification:watch-navigate",
-        true
+        { silent: true, ownerWebContentsId: OWNER }
       );
     });
 
@@ -1780,7 +1796,7 @@ describe("AgentNotificationService", () => {
       // on the same event tick as the `completed`/`exited` event and
       // uses the event's own `state` field.)
       mockStore({ waitingEnabled: true });
-      agentNotificationService.syncWatchedPanels(["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
 
       events.emit("agent:state-changed", makePayloadFor("term-1", "agent-1", "waiting"));
       events.emit(
@@ -1790,6 +1806,161 @@ describe("AgentNotificationService", () => {
       vi.advanceTimersByTime(300);
 
       expect(notificationServiceMock.showWatchNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // #11110 — watched panels used to be one process-wide Set, so whichever
+  // window synced last erased every other window's watches.
+  describe("per-owner watched panels", () => {
+    const OWNER_B = 202;
+
+    function makePayloadFor(
+      terminalId: string,
+      agentId: string,
+      state: AgentState,
+      previousState: AgentState = "working"
+    ) {
+      return {
+        ...makePayload(state, previousState),
+        terminalId,
+        agentId,
+      };
+    }
+
+    it("one owner's sync does not erase another owner's watches", () => {
+      mockStore({ waitingEnabled: true });
+
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-2"]);
+
+      // Window B stops watching everything — the old code replaced the whole
+      // Set here, silently unwatching term-1 for window A.
+      agentNotificationService.syncWatchedPanels(OWNER_B, []);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+      vi.advanceTimersByTime(200);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.any(String),
+        expect.objectContaining({ panelId: "term-1" }),
+        "notification:watch-navigate",
+        { silent: true, ownerWebContentsId: OWNER }
+      );
+    });
+
+    it("routes a notification to the owner that watched the panel", () => {
+      mockStore({ waitingEnabled: true });
+
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-2"]);
+
+      events.emit("agent:state-changed", makePayloadFor("term-2", "agent-2", "waiting"));
+      vi.advanceTimersByTime(200);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.any(String),
+        expect.objectContaining({ panelId: "term-2" }),
+        "notification:watch-navigate",
+        { silent: true, ownerWebContentsId: OWNER_B }
+      );
+    });
+
+    it("keeps the panel watched when a second owner drops its watch", () => {
+      mockStore({ waitingEnabled: true });
+
+      // Same project open in two windows — both renderers watch the same panel.
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, []);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+      vi.advanceTimersByTime(200);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.any(String),
+        expect.objectContaining({ panelId: "term-1" }),
+        "notification:watch-navigate",
+        { silent: true, ownerWebContentsId: OWNER }
+      );
+    });
+
+    it("removeOwner drops that owner's watches and leaves the others alone", () => {
+      mockStore({ waitingEnabled: true });
+
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-2"]);
+
+      agentNotificationService.removeOwner(OWNER);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+      vi.advanceTimersByTime(200);
+
+      // term-1's only watcher is gone — nothing fires for it.
+      expect(notificationServiceMock.showWatchNotification).not.toHaveBeenCalled();
+
+      events.emit("agent:state-changed", makePayloadFor("term-2", "agent-2", "waiting"));
+      vi.advanceTimersByTime(200);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.any(String),
+        expect.objectContaining({ panelId: "term-2" }),
+        "notification:watch-navigate",
+        { silent: true, ownerWebContentsId: OWNER_B }
+      );
+    });
+
+    it("removeOwner is idempotent", () => {
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+
+      expect(() => {
+        agentNotificationService.removeOwner(OWNER);
+        agentNotificationService.removeOwner(OWNER);
+        agentNotificationService.removeOwner(999);
+      }).not.toThrow();
+    });
+
+    it("escalates to the owner that watched the panel, even after the one-shot unwatch", () => {
+      mockStore({ waitingEnabled: true });
+
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      events.emit("agent:state-changed", makePayload("waiting"));
+
+      // The renderer unwatches immediately once the waiting notification fires,
+      // so the live watch index is empty long before escalation runs.
+      agentNotificationService.syncWatchedPanels(OWNER, []);
+      vi.advanceTimersByTime(180_000);
+
+      expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
+        "Agent still waiting",
+        expect.any(String),
+        expect.objectContaining({
+          ownerWebContentsId: OWNER,
+          navigation: {
+            channel: "notification:watch-navigate",
+            context: expect.objectContaining({ panelId: "term-1" }),
+          },
+        })
+      );
+    });
+
+    it("escalation for a never-watched docked terminal has no owner and falls back", () => {
+      mockStore({ waitingEnabled: true });
+
+      // Nothing watched at all — escalation still fires for docked terminals.
+      agentNotificationService.syncWatchedPanels(OWNER, []);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+      vi.advanceTimersByTime(180_000);
+
+      expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
+        "Agent still waiting",
+        expect.any(String),
+        escalationOptions(undefined)
+      );
     });
   });
 });

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -59,11 +59,20 @@ import { agentNotificationService } from "../AgentNotificationService.js";
 const OWNER = 101;
 
 /** Escalation now carries a click target; the owner decides which window it focuses. */
-const escalationOptions = (ownerWebContentsId: number | undefined = OWNER) =>
+const escalationOptions = (ownerWebContentsId: number) =>
   expect.objectContaining({
     ownerWebContentsId,
     navigation: expect.objectContaining({ channel: "notification:watch-navigate" }),
   });
+
+/** Options of the last showNativeNotification call — read them, don't match a default. */
+function lastEscalationOptions(): {
+  ownerWebContentsId?: number;
+  navigation?: { channel: string; context: { panelId: string; worktreeId?: string } };
+} {
+  const calls = notificationServiceMock.showNativeNotification.mock.calls;
+  return calls.at(-1)?.[2] ?? {};
+}
 
 const DEFAULT_NOTIFICATION_SETTINGS = {
   completedEnabled: false,
@@ -368,7 +377,7 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
         expect.stringContaining("has been waiting"),
-        escalationOptions()
+        escalationOptions(OWNER)
       );
     });
 
@@ -384,7 +393,7 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
         expect.stringContaining("is blocked by an error"),
-        escalationOptions()
+        escalationOptions(OWNER)
       );
     });
 
@@ -400,7 +409,7 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
         expect.stringContaining("has been waiting for input"),
-        escalationOptions()
+        escalationOptions(OWNER)
       );
     });
 
@@ -416,7 +425,7 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
         expect.stringContaining("has been waiting for input"),
-        escalationOptions()
+        escalationOptions(OWNER)
       );
     });
 
@@ -518,7 +527,7 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agent still waiting",
         "My Custom Agent has been waiting for input",
-        escalationOptions()
+        escalationOptions(OWNER)
       );
     });
 
@@ -850,7 +859,7 @@ describe("AgentNotificationService", () => {
       expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
         "Agents still waiting",
         "3 agents have been waiting for input",
-        escalationOptions()
+        escalationOptions(OWNER)
       );
     });
 
@@ -1913,14 +1922,67 @@ describe("AgentNotificationService", () => {
       );
     });
 
-    it("removeOwner is idempotent", () => {
-      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+    it("removeOwner is idempotent and does not disturb the surviving owner", () => {
+      mockStore({ waitingEnabled: true });
 
-      expect(() => {
-        agentNotificationService.removeOwner(OWNER);
-        agentNotificationService.removeOwner(OWNER);
-        agentNotificationService.removeOwner(999);
-      }).not.toThrow();
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-2"]);
+
+      agentNotificationService.removeOwner(OWNER);
+      agentNotificationService.removeOwner(OWNER);
+      agentNotificationService.removeOwner(999);
+
+      // A implementation that cleared everything on removeOwner would pass a
+      // not.toThrow() check — assert B's watch actually still fires.
+      events.emit("agent:state-changed", makePayloadFor("term-2", "agent-2", "waiting"));
+      vi.advanceTimersByTime(200);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.any(String),
+        expect.objectContaining({ panelId: "term-2" }),
+        "notification:watch-navigate",
+        { silent: true, ownerWebContentsId: OWNER_B }
+      );
+    });
+
+    it("hands the routing hint to a surviving owner when the sticky one dies", () => {
+      mockStore({ waitingEnabled: true });
+
+      // Same project in two windows: both watch term-1, so B becomes the most
+      // recent (sticky) owner. B's window then closes.
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-1"]);
+      agentNotificationService.removeOwner(OWNER_B);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+      // A's renderer does its one-shot unwatch, so only the sticky hint remains.
+      agentNotificationService.syncWatchedPanels(OWNER, []);
+      vi.advanceTimersByTime(180_000);
+
+      // Dropping B's hint outright would orphan the panel and send the click to
+      // the primary window, even though A still shows it.
+      expect(lastEscalationOptions().ownerWebContentsId).toBe(OWNER);
+    });
+
+    it("re-resolves the owner at emit time when the captured one dies mid-burst", () => {
+      mockStore({ waitingEnabled: true });
+
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+      agentNotificationService.syncWatchedPanels(OWNER_B, ["term-1"]);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+      // The owner captured when the event arrived dies inside the burst window.
+      agentNotificationService.removeOwner(OWNER_B);
+      vi.advanceTimersByTime(200);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent waiting",
+        expect.any(String),
+        expect.objectContaining({ panelId: "term-1" }),
+        "notification:watch-navigate",
+        { silent: true, ownerWebContentsId: OWNER }
+      );
     });
 
     it("escalates to the owner that watched the panel, even after the one-shot unwatch", () => {
@@ -1947,20 +2009,50 @@ describe("AgentNotificationService", () => {
       );
     });
 
-    it("escalation for a never-watched docked terminal has no owner and falls back", () => {
-      mockStore({ waitingEnabled: true });
+    it("escalation for a never-watched docked terminal has no owner", () => {
+      // term-9 is docked but no renderer ever watched it, so main genuinely
+      // cannot know which window owns it — the click falls back to primary.
+      mockStore(
+        { waitingEnabled: true },
+        {
+          terminals: [
+            ...DEFAULT_APP_STATE.terminals,
+            {
+              id: "term-9",
+              kind: "terminal",
+              agentId: "agent-9",
+              title: "Unwatched Agent",
+              location: "dock",
+              worktreeId: "wt-1",
+            },
+          ],
+        }
+      );
 
-      // Nothing watched at all — escalation still fires for docked terminals.
-      agentNotificationService.syncWatchedPanels(OWNER, []);
-
-      events.emit("agent:state-changed", makePayload("waiting"));
+      events.emit("agent:state-changed", makePayloadFor("term-9", "agent-9", "waiting"));
       vi.advanceTimersByTime(180_000);
 
-      expect(notificationServiceMock.showNativeNotification).toHaveBeenCalledWith(
-        "Agent still waiting",
-        expect.any(String),
-        escalationOptions(undefined)
+      const options = lastEscalationOptions();
+      expect(options.ownerWebContentsId).toBeUndefined();
+      expect(options.navigation?.context.panelId).toBe("term-9");
+    });
+
+    it("escalation navigates to the worktree the panel is in now, not where it started", () => {
+      mockStore({ waitingEnabled: true });
+      agentNotificationService.syncWatchedPanels(OWNER, ["term-1"]);
+
+      events.emit("agent:state-changed", makePayload("waiting"));
+
+      // The panel is dragged to another worktree while the escalation timer runs.
+      mockStore(
+        { waitingEnabled: true },
+        {
+          terminals: [{ ...DEFAULT_APP_STATE.terminals[0], worktreeId: "wt-moved" }],
+        }
       );
+      vi.advanceTimersByTime(180_000);
+
+      expect(lastEscalationOptions().navigation?.context.worktreeId).toBe("wt-moved");
     });
   });
 });

--- a/electron/services/__tests__/NotificationService.test.ts
+++ b/electron/services/__tests__/NotificationService.test.ts
@@ -417,6 +417,77 @@ describe("NotificationService", () => {
       expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(2);
     });
 
+    it("one owner reporting zero does not clear another owner's count", () => {
+      // This is the renderer's real focus/unmount path: useWindowNotifications
+      // pushes { waitingCount: 0 } for its own view. Under the old global
+      // `currentState` that zero wiped every other window's title and the badge.
+      const win1 = createWindowMock(false, [11]);
+      const win2 = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([win1, win2]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      notificationService.updateNotifications(21, { waitingCount: 3 });
+      notificationService.updateNotifications(11, { waitingCount: 0 });
+      vi.advanceTimersByTime(301);
+
+      expect(win1.setTitle).toHaveBeenLastCalledWith("Daintree");
+      expect(win2.setTitle).toHaveBeenLastCalledWith("(3) Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(3);
+    });
+
+    it("drops an owner that no longer resolves to a live window", () => {
+      const win = createWindowMock(false, [11, 12]);
+      const registry = createRegistryMock([win]);
+      notificationService.initialize(registry as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 1 });
+      notificationService.updateNotifications(12, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(3);
+
+      // The view was evicted: WindowRegistry unindexes it before closing its
+      // webContents, so it stops resolving. Its count must not linger.
+      win.ownerIds = [11];
+
+      notificationService.updateNotifications(11, { waitingCount: 1 });
+      vi.advanceTimersByTime(301);
+
+      expect(win.setTitle).toHaveBeenLastCalledWith("(1) Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(1);
+    });
+
+    it("drops owners whose window is destroyed", () => {
+      const win = createWindowMock(false, [11]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 4 });
+      vi.advanceTimersByTime(301);
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(4);
+
+      win.isDestroyed.mockReturnValue(true);
+      notificationService.updateNotifications(11, { waitingCount: 4 });
+      vi.advanceTimersByTime(301);
+
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(0);
+    });
+
+    it("dispose forgets every owner's state", () => {
+      const win = createWindowMock(false, [11, 12]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+
+      notificationService.dispose();
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.updateNotifications(12, { waitingCount: 3 });
+      vi.advanceTimersByTime(301);
+
+      // 3, never 5 — owner 11's pre-dispose count must not survive.
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(3);
+    });
+
     it("removeOwner drops that owner's count from the badge and title", () => {
       const win = createWindowMock(false, [11, 12]);
       notificationService.initialize(createRegistryMock([win]) as never);
@@ -538,6 +609,36 @@ describe("NotificationService", () => {
       electronMock.notificationInstances.at(-1)!.trigger("click");
 
       expect(ownerSend(21)).not.toHaveBeenCalled();
+      expect(sendToRendererMock).toHaveBeenCalledWith(
+        primary,
+        "notification:watch-navigate",
+        context
+      );
+    });
+
+    it("falls back to the primary window when the send to the owner throws", () => {
+      const primary = createWindowMock(true, [11]);
+      const secondary = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([primary, secondary]) as never);
+
+      // Alive at the guard, torn down by the time we send.
+      electronMock.webContentsById.set(21, {
+        id: 21,
+        isDestroyed: () => false,
+        send: vi.fn(() => {
+          throw new Error("render frame was disposed");
+        }),
+      });
+
+      notificationService.showWatchNotification(
+        "Agent waiting",
+        "Needs input",
+        context,
+        "notification:watch-navigate",
+        { ownerWebContentsId: 21 }
+      );
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
       expect(sendToRendererMock).toHaveBeenCalledWith(
         primary,
         "notification:watch-navigate",

--- a/electron/services/__tests__/NotificationService.test.ts
+++ b/electron/services/__tests__/NotificationService.test.ts
@@ -2,6 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const electronMock = vi.hoisted(() => {
   const notificationInstances: NotificationMockInstance[] = [];
+  const webContentsById = new Map<number, WebContentsMock>();
+
+  interface WebContentsMock {
+    id: number;
+    isDestroyed: () => boolean;
+    send: ReturnType<typeof vi.fn>;
+  }
 
   interface NotificationMockInstance {
     options: { title: string; body: string; silent?: boolean };
@@ -34,7 +41,11 @@ const electronMock = vi.hoisted(() => {
       setBadgeCount: vi.fn(),
     },
     Notification: NotificationMock,
+    webContents: {
+      fromId: vi.fn((id: number) => webContentsById.get(id)),
+    },
     notificationInstances,
+    webContentsById,
   };
 });
 
@@ -47,20 +58,45 @@ vi.mock("../../ipc/utils.js", () => ({
   sendToRenderer: vi.fn(),
 }));
 
+// The service asks the registry which view a window is currently showing, and
+// which window owns a webContents. Both are keyed off the ids the mocks hand out.
+const registryMock = vi.hoisted(() => ({
+  getAppWebContents: vi.fn(),
+  getWindowForWebContents: vi.fn(),
+}));
+
+vi.mock("../../window/webContentsRegistry.js", () => registryMock);
+
+import { sendToRenderer } from "../../ipc/utils.js";
 import { notificationService } from "../NotificationService.js";
+
+const sendToRendererMock = vi.mocked(sendToRenderer);
 
 interface WindowListeners {
   focus?: () => void;
   blur?: () => void;
 }
 
-function createWindowMock(isFocused = false) {
+let nextWindowId = 1;
+
+/**
+ * A window plus the project views it hosts. `ownerIds[0]` is the view the window
+ * is currently showing; the rest are cached (deactivated) views — alive, holding
+ * their own waiting counts, invisible to the user.
+ */
+function createWindowMock(isFocused = false, ownerIds: number[] = []) {
   const listeners: WindowListeners = {};
+  const id = nextWindowId++;
   return {
-    id: Math.floor(Math.random() * 10000),
+    id,
+    ownerIds,
     listeners,
     isDestroyed: vi.fn(() => false),
     isFocused: vi.fn(() => isFocused),
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
     setTitle: vi.fn(),
     on: vi.fn((event: "focus" | "blur", handler: () => void) => {
       listeners[event] = handler;
@@ -74,7 +110,9 @@ function createWindowMock(isFocused = false) {
   };
 }
 
-function createRegistryMock(windows: ReturnType<typeof createWindowMock>[]) {
+type WindowMock = ReturnType<typeof createWindowMock>;
+
+function createRegistryMock(windows: WindowMock[]) {
   const contexts = windows.map((w) => ({
     windowId: w.id,
     webContentsId: w.id + 1000,
@@ -85,14 +123,42 @@ function createRegistryMock(windows: ReturnType<typeof createWindowMock>[]) {
     cleanup: [],
   }));
 
+  const windowForOwner = (ownerId: number) =>
+    windows.find((w) => w.ownerIds.includes(ownerId)) ?? null;
+
+  // Wire the webContents lookups the service uses for focus scoping and click
+  // routing so they agree with the window/owner topology under test.
+  registryMock.getAppWebContents.mockImplementation((win: WindowMock) => ({
+    id: win.ownerIds[0] ?? win.id + 1000,
+  }));
+  registryMock.getWindowForWebContents.mockImplementation(
+    (wc: { id: number }) => windowForOwner(wc.id) ?? null
+  );
+
+  for (const w of windows) {
+    for (const ownerId of w.ownerIds) {
+      electronMock.webContentsById.set(ownerId, {
+        id: ownerId,
+        isDestroyed: () => false,
+        send: vi.fn(),
+      });
+    }
+  }
+
   return {
     all: () => contexts,
     getPrimary: () => contexts[0],
     getByWindowId: (id: number) => contexts.find((c) => c.windowId === id),
-    getByWebContentsId: (id: number) => contexts.find((c) => c.webContentsId === id),
+    getByWebContentsId: (id: number) => {
+      const owned = windowForOwner(id);
+      if (owned) return contexts.find((c) => c.windowId === owned.id);
+      return contexts.find((c) => c.webContentsId === id);
+    },
     size: contexts.length,
   };
 }
+
+const ownerSend = (ownerId: number) => electronMock.webContentsById.get(ownerId)!.send;
 
 describe("NotificationService", () => {
   const originalPlatform = process.platform;
@@ -100,6 +166,7 @@ describe("NotificationService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    electronMock.webContentsById.clear();
     Object.defineProperty(process, "platform", { value: "darwin", writable: true });
   });
 
@@ -115,8 +182,8 @@ describe("NotificationService", () => {
   });
 
   it("detaches old window listeners when reinitialized with a new registry", () => {
-    const firstWindow = createWindowMock(false);
-    const secondWindow = createWindowMock(false);
+    const firstWindow = createWindowMock(false, [11]);
+    const secondWindow = createWindowMock(false, [12]);
 
     notificationService.initialize(createRegistryMock([firstWindow]) as never);
     notificationService.initialize(createRegistryMock([secondWindow]) as never);
@@ -127,57 +194,29 @@ describe("NotificationService", () => {
   });
 
   it("clears title when focus event fires", () => {
-    const windowMock = createWindowMock(false);
+    const windowMock = createWindowMock(false, [11]);
     notificationService.initialize(createRegistryMock([windowMock]) as never);
 
-    notificationService.updateNotifications({ waitingCount: 2 });
+    notificationService.updateNotifications(11, { waitingCount: 2 });
     vi.advanceTimersByTime(301);
     expect(windowMock.setTitle).toHaveBeenCalledWith("(2) Daintree");
 
     windowMock.trigger("focus");
     expect(windowMock.setTitle).toHaveBeenCalledWith("Daintree");
+    expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(0);
   });
 
   it("does not throw if update is called after dispose", () => {
-    const windowMock = createWindowMock(false);
+    const windowMock = createWindowMock(false, [11]);
     notificationService.initialize(createRegistryMock([windowMock]) as never);
     notificationService.dispose();
 
-    expect(() => notificationService.updateNotifications({ waitingCount: 1 })).not.toThrow();
-  });
-
-  it("tracks focus across multiple windows — badge is 0 when any window focused", () => {
-    const win1 = createWindowMock(false);
-    const win2 = createWindowMock(true); // win2 starts focused
-    notificationService.initialize(createRegistryMock([win1, win2]) as never);
-
-    notificationService.updateNotifications({ waitingCount: 3 });
-    vi.advanceTimersByTime(301);
-
-    // win2 is focused, so no title update should show count
-    expect(win1.setTitle).toHaveBeenCalledWith("Daintree");
-    expect(win2.setTitle).toHaveBeenCalledWith("Daintree");
-    expect(electronMock.app.setBadgeCount).toHaveBeenCalledWith(0);
-  });
-
-  it("shows badge and title when all windows are blurred", () => {
-    const win1 = createWindowMock(true);
-    const win2 = createWindowMock(false);
-    notificationService.initialize(createRegistryMock([win1, win2]) as never);
-
-    // Blur win1 so both windows are blurred
-    win1.trigger("blur");
-
-    notificationService.updateNotifications({ waitingCount: 5 });
-    vi.advanceTimersByTime(301);
-
-    expect(win1.setTitle).toHaveBeenCalledWith("(5) Daintree");
-    expect(win2.setTitle).toHaveBeenCalledWith("(5) Daintree");
+    expect(() => notificationService.updateNotifications(11, { waitingCount: 1 })).not.toThrow();
   });
 
   it("dispose detaches listeners from all tracked windows", () => {
-    const win1 = createWindowMock(false);
-    const win2 = createWindowMock(false);
+    const win1 = createWindowMock(false, [11]);
+    const win2 = createWindowMock(false, [21]);
     notificationService.initialize(createRegistryMock([win1, win2]) as never);
     notificationService.dispose();
 
@@ -188,7 +227,7 @@ describe("NotificationService", () => {
   });
 
   it("detachWindowListeners clears focus state when the window was destroyed mid-session", () => {
-    const win = createWindowMock(true);
+    const win = createWindowMock(true, [11]);
     notificationService.initialize(createRegistryMock([win]) as never);
 
     expect(notificationService.isWindowFocused()).toBe(true);
@@ -207,7 +246,7 @@ describe("NotificationService", () => {
   });
 
   it("detachWindowListeners removes focus/blur listeners when the window is still alive", () => {
-    const win = createWindowMock(true);
+    const win = createWindowMock(true, [11]);
     notificationService.initialize(createRegistryMock([win]) as never);
 
     expect(notificationService.isWindowFocused()).toBe(true);
@@ -220,8 +259,8 @@ describe("NotificationService", () => {
   });
 
   it("detachWindowListeners only clears the targeted window in a multi-window setup", () => {
-    const win1 = createWindowMock(true);
-    const win2 = createWindowMock(true);
+    const win1 = createWindowMock(true, [11]);
+    const win2 = createWindowMock(true, [21]);
     notificationService.initialize(createRegistryMock([win1, win2]) as never);
 
     expect(notificationService.isWindowFocused()).toBe(true);
@@ -241,8 +280,8 @@ describe("NotificationService", () => {
   });
 
   it("isWindowFocused returns true if any window is focused", () => {
-    const win1 = createWindowMock(false);
-    const win2 = createWindowMock(false);
+    const win1 = createWindowMock(false, [11]);
+    const win2 = createWindowMock(false, [21]);
     notificationService.initialize(createRegistryMock([win1, win2]) as never);
 
     expect(notificationService.isWindowFocused()).toBe(false);
@@ -300,5 +339,234 @@ describe("NotificationService", () => {
       expect.stringContaining("native notification failed"),
       "unsigned dev build"
     );
+  });
+
+  // #11110 — state used to be one global `currentState` that any renderer could
+  // overwrite, so the last window to report won and every other window's title
+  // and the dock badge followed it.
+  describe("per-owner waiting counts", () => {
+    it("aggregates the badge across owners instead of taking the last writer", () => {
+      const win1 = createWindowMock(false, [11]);
+      const win2 = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([win1, win2]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      notificationService.updateNotifications(21, { waitingCount: 3 });
+      vi.advanceTimersByTime(301);
+
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(5);
+    });
+
+    it("titles each window from its own owners only", () => {
+      const win1 = createWindowMock(false, [11]);
+      const win2 = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([win1, win2]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      notificationService.updateNotifications(21, { waitingCount: 3 });
+      vi.advanceTimersByTime(301);
+
+      expect(win1.setTitle).toHaveBeenLastCalledWith("(2) Daintree");
+      expect(win2.setTitle).toHaveBeenLastCalledWith("(3) Daintree");
+    });
+
+    it("sums the cached project views a window hosts into one title", () => {
+      // One window, active view + a cached one, each with waiting agents.
+      const win = createWindowMock(false, [11, 12]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 1 });
+      notificationService.updateNotifications(12, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+
+      expect(win.setTitle).toHaveBeenLastCalledWith("(3) Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(3);
+    });
+
+    it("focusing one window leaves another window's title and its badge share intact", () => {
+      const win1 = createWindowMock(false, [11]);
+      const win2 = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([win1, win2]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 2 });
+      notificationService.updateNotifications(21, { waitingCount: 3 });
+      vi.advanceTimersByTime(301);
+
+      // Old behavior: this zeroed the badge and reset every window's title.
+      win2.trigger("focus");
+
+      expect(win1.setTitle).toHaveBeenLastCalledWith("(2) Daintree");
+      expect(win2.setTitle).toHaveBeenLastCalledWith("Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(2);
+    });
+
+    it("focus clears only the view the window is showing, not its cached views", () => {
+      // The user focuses the window and sees view 11. View 12's waiting agents
+      // are still unseen, so they must survive — the renderer only re-reports on
+      // a count *change*, so discarding them here would lose the signal for good.
+      const win = createWindowMock(false, [11, 12]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 1 });
+      notificationService.updateNotifications(12, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+
+      win.trigger("focus");
+
+      expect(win.setTitle).toHaveBeenLastCalledWith("(2) Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(2);
+    });
+
+    it("removeOwner drops that owner's count from the badge and title", () => {
+      const win = createWindowMock(false, [11, 12]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.updateNotifications(11, { waitingCount: 1 });
+      notificationService.updateNotifications(12, { waitingCount: 2 });
+      vi.advanceTimersByTime(301);
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(3);
+
+      notificationService.removeOwner(12);
+
+      expect(win.setTitle).toHaveBeenLastCalledWith("(1) Daintree");
+      expect(electronMock.app.setBadgeCount).toHaveBeenLastCalledWith(1);
+
+      // Idempotent — the webContents "destroyed" listener and the window's
+      // cleanup can both fire for the same owner.
+      expect(() => notificationService.removeOwner(12)).not.toThrow();
+    });
+  });
+
+  describe("click routing", () => {
+    const context = { panelId: "term-9", panelTitle: "Agent", worktreeId: "wt-1" };
+
+    it("focuses the window that owns the panel, not the primary window", () => {
+      const primary = createWindowMock(true, [11]);
+      const secondary = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([primary, secondary]) as never);
+
+      notificationService.showWatchNotification(
+        "Agent waiting",
+        "Needs input",
+        context,
+        "notification:watch-navigate",
+        { ownerWebContentsId: 21 }
+      );
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
+      expect(secondary.focus).toHaveBeenCalled();
+      expect(primary.focus).not.toHaveBeenCalled();
+    });
+
+    it("sends the navigate to the owning view, not whichever view the window is showing", () => {
+      // Owner 12 is a cached view: sendToRenderer would deliver to the active
+      // view (11) and the navigate would land in the wrong renderer.
+      const win = createWindowMock(false, [11, 12]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.showWatchNotification(
+        "Agent waiting",
+        "Needs input",
+        context,
+        "notification:watch-navigate",
+        { ownerWebContentsId: 12 }
+      );
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
+      expect(ownerSend(12)).toHaveBeenCalledWith("notification:watch-navigate", context);
+      expect(ownerSend(11)).not.toHaveBeenCalled();
+      expect(sendToRendererMock).not.toHaveBeenCalled();
+    });
+
+    it("restores a minimized owner window", () => {
+      const win = createWindowMock(false, [11]);
+      win.isMinimized.mockReturnValue(true);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.showWatchNotification(
+        "Agent waiting",
+        "Needs input",
+        context,
+        "notification:watch-navigate",
+        { ownerWebContentsId: 11 }
+      );
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
+      expect(win.restore).toHaveBeenCalled();
+      expect(win.show).toHaveBeenCalled();
+    });
+
+    it("falls back to the primary window when the owner is gone", () => {
+      const primary = createWindowMock(true, [11]);
+      notificationService.initialize(createRegistryMock([primary]) as never);
+
+      notificationService.showWatchNotification(
+        "Agent waiting",
+        "Needs input",
+        context,
+        "notification:watch-navigate",
+        { ownerWebContentsId: 999 }
+      );
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
+      expect(primary.focus).toHaveBeenCalled();
+      expect(sendToRendererMock).toHaveBeenCalledWith(
+        primary,
+        "notification:watch-navigate",
+        context
+      );
+    });
+
+    it("falls back to the primary window when the owner's webContents is destroyed", () => {
+      const primary = createWindowMock(true, [11]);
+      const secondary = createWindowMock(false, [21]);
+      notificationService.initialize(createRegistryMock([primary, secondary]) as never);
+
+      electronMock.webContentsById.set(21, {
+        id: 21,
+        isDestroyed: () => true,
+        send: vi.fn(),
+      });
+
+      notificationService.showWatchNotification(
+        "Agent waiting",
+        "Needs input",
+        context,
+        "notification:watch-navigate",
+        { ownerWebContentsId: 21 }
+      );
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
+      expect(ownerSend(21)).not.toHaveBeenCalled();
+      expect(sendToRendererMock).toHaveBeenCalledWith(
+        primary,
+        "notification:watch-navigate",
+        context
+      );
+    });
+
+    it("navigates from an escalation notification — the path that had no click handler", () => {
+      const win = createWindowMock(false, [11]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.showNativeNotification("Agent still waiting", "3 minutes", {
+        ownerWebContentsId: 11,
+        navigation: { channel: "notification:watch-navigate", context },
+      });
+      electronMock.notificationInstances.at(-1)!.trigger("click");
+
+      expect(win.focus).toHaveBeenCalled();
+      expect(ownerSend(11)).toHaveBeenCalledWith("notification:watch-navigate", context);
+    });
+
+    it("a native notification with no navigation stays unclickable", () => {
+      const win = createWindowMock(false, [11]);
+      notificationService.initialize(createRegistryMock([win]) as never);
+
+      notificationService.showNativeNotification("Disk space low", "2GB left");
+      const instance = electronMock.notificationInstances.at(-1)!;
+
+      expect(instance.handlers.click).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Problem

Agent notification state was a set of process-global singletons that every renderer overwrote wholesale, so with two windows open the notification system only ever reflected one of them:

- `AgentNotificationService.syncWatchedPanels` did `this.watchedTerminals = new Set(panelIds)`. Window B's sync, even an empty one, erased window A's watches.
- `NotificationService` held a single `currentState`, titled every window from it, and set the dock badge globally. `useWindowNotifications` pushes `0` on focus and unmount, so one window reporting zero cleared another window's badge and title.
- The watch-notification click handler always targeted `registry.getPrimary()`, so clicking a notification for a panel in a secondary window focused the wrong window.
- The waiting-escalation notification, the most urgent path, went through `showNativeNotification`, which wired no click handler at all, so it couldn't navigate anywhere.

## Approach

State is now keyed by **owner**: the sending renderer's `webContents.id` (`event.sender.id`), taken from the IPC event. Not the window id (one window hosts an active project view plus N cached ones, each its own renderer with its own panel store) and not the project id (`null` is a legitimate distinct identity for an unbound window, and one project can be open in two windows since #11101). No wire-format change: the identity comes free from the IPC event.

- **Watched panels**: `Map<ownerId, Set<panelId>>` plus a reverse `panelId -> Set<ownerId>` index (a set, because two windows showing the same project can both watch the same panel). A sync replaces only the calling owner's set.
- **Waiting counts**: `Map<ownerId, NotificationState>`. Each window is titled from its own owners; the macOS dock badge aggregates across all of them (it's the one genuinely process-level surface).
- **Focus**: a window focus clears only the owner of the view that window is actually showing, so a cached project view's genuinely-unseen waiting agents survive. Verified that `ProjectViewSwitchController` focuses the incoming view's webContents on every activation path, so a view that becomes visible zeroes itself through the normal renderer path.
- **Click routing**: the owner is re-resolved at click time (never captured in the closure), its window is focused, and the navigate is sent straight to the owning webContents, since `sendToRenderer` would deliver to whichever view the window happens to be showing and a panel in a cached view would never receive it. The primary window is now an explicit last resort, only when the owner is gone.
- **Escalation** gained panel context and a click handler.
- **Cleanup**: an owner's state is purged on webContents `"destroyed"`, which covers both window close and memory-pressure eviction (eviction calls `wc.close()`), but never on deactivation, since a cached view is alive and must keep its state.

## Out of scope

- `AgentNotificationService`'s `store.get("appState").terminals` reads. That field is a stale legacy snapshot written only by migration and crash recovery, not by live renderers; fixing it reaches into `CrashRecoveryService`/`AppHydrationService`/migrations and deserves its own issue.
- A Windows badge. `app.setBadgeCount` is macOS + Linux(Unity) only; the Windows equivalent (`BrowserWindow.setOverlayIcon`) is per-window and needs a rendered nativeImage: a net-new feature, not a fix.
- **Known limit**: clicking a notification whose panel lives in a cached project view focuses the correct window and updates the correct renderer's store, but doesn't switch that window to the project. Making a background project visible from main means driving the renderer-owned project-switch path (which persists outgoing layout state). Still strictly better than before, when the click went to the primary window's active view and matched no panel at all.

## Testing

206 tests pass locally across the notification suites (`NotificationService`, `AgentNotificationService` plus adversarial and allClear, `notifications` IPC adversarial, `IdleTerminalNotificationService`), plus composite typecheck, prettier and eslint on the changed files.

Because the fix changes method signatures, the new tests can't fail against the parent commit, so they were validated by mutation: reverting the implementation to last-writer-wins semantics, while keeping the new signatures, fails exactly the 11 new per-owner tests and nothing else. New coverage includes: one owner's sync not erasing another's; a panel watched by two owners surviving one of them unwatching or dying; the badge aggregating across owners while each window's title reflects only its own; one owner reporting zero not clearing another's count; focus clearing only the shown view, not cached ones; owner purge on renderer destroy (and the late-sync race not resurrecting a destroyed owner); and clicks routing to the owning window and the owning webContents rather than the primary.

Resolves #11110