### PR TITLE
feat(terminal): type-anywhere rescue and off-screen focus locator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,8 @@ import {
 import { useResourceProfile } from "./hooks/useResourceProfile";
 import { AppLayout } from "./components/Layout";
 import { ContentGrid } from "./components/Terminal";
+import { TypingLocator } from "./components/Terminal/TypingLocator";
+import { useTypeAnywhere } from "./hooks/useTypeAnywhere";
 
 import { useResumeAgentSession } from "./hooks/useResumeAgentSession";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
@@ -379,6 +381,9 @@ function AppInner() {
   // Global keybinding handler - provides chord support and priority resolution
   // All keybindings dispatch through ActionService via this centralized handler
   useGlobalKeybindings(electronAvailable);
+  // Registered after the central keybindings so a handled shortcut has already
+  // claimed the event before the rescue considers it (#11134).
+  useTypeAnywhere();
   useGlobalEscapeDispatcher();
 
   // App lifecycle hooks
@@ -493,12 +498,15 @@ function AppInner() {
                     resetKeys={[workspaceId].filter((k): k is string => k != null)}
                   >
                     <Profiler id="content-grid" onRender={onContentGridRender}>
-                      <ContentGrid
-                        className="h-full w-full"
-                        agentAvailability={availability}
-                        defaultCwd={defaultTerminalCwd}
-                        emptyContent={emptyContent}
-                      />
+                      <div className="relative h-full w-full">
+                        <ContentGrid
+                          className="h-full w-full"
+                          agentAvailability={availability}
+                          defaultCwd={defaultTerminalCwd}
+                          emptyContent={emptyContent}
+                        />
+                        <TypingLocator />
+                      </div>
                     </Profiler>
                   </ErrorBoundary>
                 </AppLayout>

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -10,6 +10,7 @@ import { useFileAutocomplete } from "@/hooks/useFileAutocomplete";
 import { useSlashCommandAutocomplete } from "@/hooks/useSlashCommandAutocomplete";
 import { useSlashCommandList } from "@/hooks/useSlashCommandList";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { AutocompleteMenu, type AutocompleteItem } from "./AutocompleteMenu";
 import {
   getDaintreeAtClaim,
@@ -202,7 +203,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const currentProject = useProjectStore((s) => s.currentProject);
     const voiceStatus = useVoiceRecordingStore((s) => s.status);
     const activeVoicePanelId = useVoiceRecordingStore((s) => s.activeTarget?.panelId ?? null);
-    const voiceDraftRevision = useTerminalInputStore((s) => s.voiceDraftRevision);
+    const externalDraftRevision = useTerminalInputStore((s) => s.externalDraftRevision);
     const panelWorktreeId = usePanelStore((s) => s.panelsById[terminalId]?.worktreeId);
     const panelWorktree = useWorktreeStore((s) =>
       panelWorktreeId ? s.worktrees.get(panelWorktreeId) : undefined
@@ -470,7 +471,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     });
 
     useEffect(() => {
-      if (voiceDraftRevision === 0) return;
+      if (externalDraftRevision === 0) return;
       const draft = useTerminalInputStore.getState().getDraftInput(terminalId, currentProject?.id);
       const view = editorViewRef.current;
       if (!view) return;
@@ -485,7 +486,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           scrollIntoView: true,
         });
       }
-    }, [voiceDraftRevision, terminalId, currentProject?.id]);
+    }, [externalDraftRevision, terminalId, currentProject?.id]);
 
     useVoiceDecorations({ terminalId, editorViewRef });
 
@@ -622,6 +623,19 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       [focusEditor]
     );
 
+    // Claim the type-anywhere routing target (#11134) whenever the user really
+    // types here. Agent panels only — `agentId` is absent for the fleet-armed
+    // raw-shell branch of `shouldShowHybridInputBar`, and routing into a shell
+    // is exactly what the rescue must never do. While a broadcast is live the
+    // user typed to a fleet, not to one agent, so claim nothing.
+    const recordTypedTarget = () => {
+      if (agentId === undefined) return;
+      if (useFleetArmingStore.getState().armedIds.size >= 2) return;
+      const workspaceId = getViewWorkspaceId();
+      if (workspaceId === null) return;
+      useTerminalInputStore.getState().recordLastTypedAgentTarget(terminalId, workspaceId);
+    };
+
     const { handleUpdateRef: contextUpdateRef } = useContextDetection({
       latestRef,
       activeTriggers,
@@ -637,6 +651,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         return true;
       },
       setActiveCompletionContext,
+      onUserType: recordTypedTarget,
     });
 
     const {
@@ -782,6 +797,10 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const barContent = (
       <div
         className="relative group cursor-text px-3.5 pb-2.5 pt-2.5"
+        // Anchors the type-anywhere rescue (#11134): marks this subtree as a
+        // real typing surface, and lets the rescue verify focus actually landed
+        // here rather than trusting a handle's boolean return.
+        data-hybrid-input-root={terminalId}
         style={{ backgroundColor: inputBarColors.background, ...shellVars }}
       >
         <div className="flex items-end gap-2">

--- a/src/components/Terminal/TypingLocator.tsx
+++ b/src/components/Terminal/TypingLocator.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  UI_PALETTE_ENTER_DURATION,
+  UI_PALETTE_EXIT_DURATION,
+  UI_TRANSIENT_HINT_DWELL_MS,
+} from "@/lib/animationUtils";
+import { useTypingLocatorStore } from "@/store/typingLocatorStore";
+
+/**
+ * Transient pill naming the pane the user's typing is landing in (#11134).
+ *
+ * Neutral surface, no accent: the accent budget belongs to the focus anchor,
+ * and the pulse on the pane itself is already carrying the signal. `aria-hidden`
+ * because it is redundant for assistive tech — the rescue is disabled outright
+ * under a screen reader, and the locator only restates where focus already is.
+ */
+export function TypingLocator() {
+  const label = useTypingLocatorStore((s) => s.label);
+  const revision = useTypingLocatorStore((s) => s.revision);
+  const clearLocator = useTypingLocatorStore((s) => s.clearLocator);
+  const [isLeaving, setIsLeaving] = useState(false);
+
+  useEffect(() => {
+    if (label === null) return;
+    setIsLeaving(false);
+
+    const dwell = window.setTimeout(() => setIsLeaving(true), UI_TRANSIENT_HINT_DWELL_MS);
+    const exit = window.setTimeout(
+      clearLocator,
+      UI_TRANSIENT_HINT_DWELL_MS + UI_PALETTE_EXIT_DURATION
+    );
+    return () => {
+      window.clearTimeout(dwell);
+      window.clearTimeout(exit);
+    };
+    // `revision` restarts the dwell when the same pane is located again.
+  }, [label, revision, clearLocator]);
+
+  if (label === null) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-x-0 top-3 z-30 flex justify-center"
+    >
+      <div
+        className={cn(
+          "rounded-full border border-border-subtle bg-overlay-subtle px-3 py-1",
+          "text-xs text-content-secondary shadow-sm backdrop-blur-sm",
+          "motion-safe:transition-opacity",
+          isLeaving ? "opacity-0" : "opacity-100"
+        )}
+        style={{
+          transitionDuration: `${isLeaving ? UI_PALETTE_EXIT_DURATION : UI_PALETTE_ENTER_DURATION}ms`,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/hooks/__tests__/useContextDetectionFocus.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useContextDetectionFocus.test.ts
@@ -20,13 +20,20 @@ function makeUpdate(opts: {
   selectionSet?: boolean;
   text?: string;
   caret?: number;
+  /** CM6 user-event names, one per simulated transaction (e.g. "input.type"). */
+  userEvents?: string[];
 }): ViewUpdate {
   const text = opts.text ?? "";
+  // CM6 user events are hierarchical: a transaction tagged "input.type"
+  // satisfies isUserEvent("input") as well as isUserEvent("input.type").
+  const transactions = (opts.userEvents ?? []).map((event) => ({
+    isUserEvent: (probe: string) => event === probe || event.startsWith(`${probe}.`),
+  }));
   return {
     focusChanged: opts.focusChanged,
     docChanged: opts.docChanged ?? false,
     selectionSet: opts.selectionSet ?? false,
-    transactions: [],
+    transactions,
     state: {
       doc: { toString: () => text, length: text.length },
       selection: { main: { head: opts.caret ?? 0 } },
@@ -40,6 +47,7 @@ function setupHook(activeTriggers: CompletionTrigger[] = ["/", "$", "@"]) {
   const setActiveCompletionContext = vi.fn();
   const applyDocChange = vi.fn(() => false);
   const consumeExternalValueFlag = vi.fn(() => false);
+  const onUserType = vi.fn();
 
   const { result } = renderHook(() => {
     const latestRef = useRef<LatestRefShape | null>({
@@ -54,10 +62,11 @@ function setupHook(activeTriggers: CompletionTrigger[] = ["/", "$", "@"]) {
       consumeExternalValueFlag,
       setActiveCompletionContext,
       setIsEditorFocused,
+      onUserType,
     });
   });
 
-  return { result, setIsEditorFocused, setActiveCompletionContext };
+  return { result, setIsEditorFocused, setActiveCompletionContext, onUserType };
 }
 
 describe("useContextDetection focus tracking", () => {
@@ -79,6 +88,71 @@ describe("useContextDetection focus tracking", () => {
       makeUpdate({ focusChanged: false, hasFocus: true, docChanged: true })
     );
     expect(setIsEditorFocused).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * "Last agent typed to" (#11134) must mean *typing*, not focus and not any
+ * document change — otherwise the type-anywhere rescue routes a prompt into an
+ * agent the user merely pasted into, or never touched at all.
+ */
+describe("useContextDetection user-typing signal", () => {
+  it("fires when the user types", () => {
+    const { result, onUserType } = setupHook();
+    result.current.handleUpdateRef.current(
+      makeUpdate({
+        focusChanged: false,
+        hasFocus: true,
+        docChanged: true,
+        text: "a",
+        userEvents: ["input.type"],
+      })
+    );
+    expect(onUserType).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires once even when an update carries several typing transactions", () => {
+    const { result, onUserType } = setupHook();
+    result.current.handleUpdateRef.current(
+      makeUpdate({
+        focusChanged: false,
+        hasFocus: true,
+        docChanged: true,
+        text: "ab",
+        userEvents: ["input.type", "input.type"],
+      })
+    );
+    expect(onUserType).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire on paste, deletion, or history navigation", () => {
+    const { result, onUserType } = setupHook();
+    for (const event of ["input.paste", "delete.backward", "select.pointer"]) {
+      result.current.handleUpdateRef.current(
+        makeUpdate({
+          focusChanged: false,
+          hasFocus: true,
+          docChanged: true,
+          text: "x",
+          userEvents: [event],
+        })
+      );
+    }
+    expect(onUserType).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on a programmatic doc change with no user event", () => {
+    const { result, onUserType } = setupHook();
+    result.current.handleUpdateRef.current(
+      makeUpdate({ focusChanged: false, hasFocus: true, docChanged: true, text: "x" })
+    );
+    expect(onUserType).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on a focus-only update", () => {
+    const { result, onUserType } = setupHook();
+    result.current.handleUpdateRef.current(makeUpdate({ focusChanged: true, hasFocus: true }));
+    expect(onUserType).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Terminal/hooks/useContextDetection.ts
+++ b/src/components/Terminal/hooks/useContextDetection.ts
@@ -23,6 +23,13 @@ interface UseContextDetectionParams {
   consumeExternalValueFlag: () => boolean;
   setActiveCompletionContext: Dispatch<SetStateAction<ActiveCompletionContext | null>>;
   setIsEditorFocused?: Dispatch<SetStateAction<boolean>>;
+  /**
+   * Fires once per update in which the user actually *typed* — `input.type`
+   * only, so paste, deletion, history navigation and programmatic writes are
+   * all excluded. Backs the type-anywhere rescue's "last agent typed to"
+   * notion (#11134), which must be typing, not focus.
+   */
+  onUserType?: () => void;
 }
 
 function contextsEqual(
@@ -46,6 +53,7 @@ export function useContextDetection({
   consumeExternalValueFlag,
   setActiveCompletionContext,
   setIsEditorFocused,
+  onUserType,
 }: UseContextDetectionParams) {
   // Route the listener body through a ref updated in an effect. The extension is
   // built once with a stable callback that reads handleUpdateRef at invocation
@@ -73,6 +81,10 @@ export function useContextDetection({
           const latest = latestRef.current;
           if (latest?.isInHistoryMode) {
             latest.resetHistoryIndex(latest.terminalId, latest.projectId);
+          }
+
+          if (update.transactions.some((tr) => tr.isUserEvent("input.type"))) {
+            onUserType?.();
           }
 
           const isUserChange = update.transactions.some(

--- a/src/components/Terminal/hooks/useVoiceWaitSubmit.ts
+++ b/src/components/Terminal/hooks/useVoiceWaitSubmit.ts
@@ -57,7 +57,7 @@ export function useVoiceWaitSubmit({
 
         if (!useTerminalInputStore.getState().isVoiceSubmitting(terminalId)) return;
 
-        // `stop()` bumps voiceDraftRevision after writing the final transcript
+        // `stop()` bumps externalDraftRevision after writing the final transcript
         // to the input store, but HybridInputBar's sync useEffect doesn't fire
         // until the next React render — which is AFTER this microtask. Sync
         // the editor here so sendFromEditor reads the final dictated text and

--- a/src/hooks/__tests__/useTypeAnywhere.test.tsx
+++ b/src/hooks/__tests__/useTypeAnywhere.test.tsx
@@ -7,7 +7,7 @@ const pingTerminal = vi.fn();
 const setFocused = vi.fn();
 const exitMaximize = vi.fn();
 const setPreferredTerminalFocusTarget = vi.fn();
-const focusPanelInput = vi.fn(() => true);
+const focusPanelInput = vi.fn<(id: string) => boolean>(() => true);
 
 let panelState: {
   panelsById: Record<string, PanelInstance>;

--- a/src/hooks/__tests__/useTypeAnywhere.test.tsx
+++ b/src/hooks/__tests__/useTypeAnywhere.test.tsx
@@ -13,6 +13,7 @@ let panelState: {
   panelsById: Record<string, PanelInstance>;
   panelIds: string[];
   maximizedId: string | null;
+  backendStatus: string;
 };
 let armedIds: Set<string>;
 let screenReaderEnabled: boolean;
@@ -81,7 +82,12 @@ function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanel
 function setPanels(panels: PanelInstance[], maximizedId: string | null = null) {
   const panelsById: Record<string, PanelInstance> = {};
   for (const p of panels) panelsById[p.id] = p;
-  panelState = { panelsById, panelIds: panels.map((p) => p.id), maximizedId };
+  panelState = {
+    panelsById,
+    panelIds: panels.map((p) => p.id),
+    maximizedId,
+    backendStatus: "connected",
+  };
 }
 
 /** Dispatch a keydown as the browser would: at the window, in capture phase. */
@@ -115,6 +121,7 @@ describe("useTypeAnywhere", () => {
       externalDraftRevision: 0,
       lastTypedAgentTarget: null,
       voiceSubmittingPanels: new Set(),
+      hybridInputEnabled: true,
     });
     useTypingLocatorStore.setState({ label: null, revision: 0 });
   });
@@ -214,6 +221,31 @@ describe("useTypeAnywhere", () => {
       expect(draftOf("a1")).toBe("h");
     });
 
+    it("refuses when the hybrid input bar is switched off — the draft would be invisible", () => {
+      // With the setting off no agent renders a draft bar, so a routed character
+      // would land in a store nothing displays: the same silent loss, one layer
+      // deeper. Refusing lets the key fall through untouched instead.
+      useTerminalInputStore.setState({ hybridInputEnabled: false });
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+      expect(setFocused).not.toHaveBeenCalled();
+    });
+
+    it("refuses while the PTY backend is down", () => {
+      setPanels([agentPanel("a1")]);
+      panelState.backendStatus = "recovering";
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
     it("refuses when a screen reader is active — single letters are quick-nav keys", () => {
       screenReaderEnabled = true;
       renderHook(() => useTypeAnywhere());
@@ -250,6 +282,29 @@ describe("useTypeAnywhere", () => {
       renderHook(() => useTypeAnywhere());
 
       const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("leaves menu typeahead alone", () => {
+      // An open menu consumes bare letters to jump between items. Stealing "h"
+      // would break navigation and silently append it to an agent draft.
+      document.body.innerHTML = `
+        <div role="menu"><div id="mi" role="menuitem" tabindex="-1">Hide</div></div>`;
+      const item = document.getElementById("mi");
+      item?.focus();
+      renderHook(() => useTypeAnywhere());
+
+      const e = new KeyboardEvent("keydown", {
+        key: "h",
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      });
+      act(() => {
+        item?.dispatchEvent(e);
+      });
 
       expect(e.defaultPrevented).toBe(false);
       expect(draftOf("a1")).toBe("");

--- a/src/hooks/__tests__/useTypeAnywhere.test.tsx
+++ b/src/hooks/__tests__/useTypeAnywhere.test.tsx
@@ -1,0 +1,348 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+
+const pingTerminal = vi.fn();
+const setFocused = vi.fn();
+const exitMaximize = vi.fn();
+const setPreferredTerminalFocusTarget = vi.fn();
+const focusPanelInput = vi.fn(() => true);
+
+let panelState: {
+  panelsById: Record<string, PanelInstance>;
+  panelIds: string[];
+  maximizedId: string | null;
+};
+let armedIds: Set<string>;
+let screenReaderEnabled: boolean;
+let activePaletteId: string | null;
+let workspaceId: string | null;
+
+vi.mock("@/store", () => ({
+  usePanelStore: {
+    getState: () => ({
+      ...panelState,
+      pingTerminal,
+      setFocused,
+      exitMaximize,
+      setPreferredTerminalFocusTarget,
+    }),
+  },
+}));
+
+vi.mock("@/store/fleetArmingStore", () => ({
+  useFleetArmingStore: { getState: () => ({ armedIds }) },
+}));
+
+vi.mock("@/store/screenReaderStore", () => ({
+  useScreenReaderStore: {
+    getState: () => ({ resolvedScreenReaderEnabled: () => screenReaderEnabled }),
+  },
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId }) },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: { getState: () => ({ currentProject: { id: "proj" } }) },
+}));
+
+vi.mock("@/store/viewWorkspaceId", () => ({
+  getViewWorkspaceId: () => workspaceId,
+}));
+
+vi.mock("@/components/Panel/panelFocusRegistry", () => ({
+  focusPanelInput: (id: string) => focusPanelInput(id),
+}));
+
+import { useTypeAnywhere } from "../useTypeAnywhere";
+import { useTerminalInputStore } from "@/store/terminalInputStore";
+import { useTypingLocatorStore } from "@/store/typingLocatorStore";
+
+function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id,
+    kind: "terminal",
+    title: "Claude",
+    location: "grid",
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    hasPty: true,
+    runtimeStatus: "running",
+    launchAgentId: "claude",
+    isVisible: true,
+    ...overrides,
+  };
+}
+
+function setPanels(panels: PanelInstance[], maximizedId: string | null = null) {
+  const panelsById: Record<string, PanelInstance> = {};
+  for (const p of panels) panelsById[p.id] = p;
+  panelState = { panelsById, panelIds: panels.map((p) => p.id), maximizedId };
+}
+
+/** Dispatch a keydown as the browser would: at the window, in capture phase. */
+function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init });
+  act(() => {
+    window.dispatchEvent(e);
+  });
+  return e;
+}
+
+function draftOf(id: string): string {
+  return useTerminalInputStore.getState().getDraftInput(id, "proj");
+}
+
+describe("useTypeAnywhere", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+    // jsdom ships no scrollIntoView; without this the reveal step throws and
+    // aborts the handler mid-way. Tests asserting the scroll shadow this with
+    // an element-level spy.
+    Element.prototype.scrollIntoView = vi.fn();
+    setPanels([agentPanel("a1")]);
+    armedIds = new Set();
+    screenReaderEnabled = false;
+    activePaletteId = null;
+    workspaceId = "proj";
+    useTerminalInputStore.setState({
+      draftInputs: new Map(),
+      externalDraftRevision: 0,
+      lastTypedAgentTarget: null,
+      voiceSubmittingPanels: new Set(),
+    });
+    useTypingLocatorStore.setState({ label: null, revision: 0 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("rescue", () => {
+    it("routes the keystroke into the sole agent's draft and consumes it", () => {
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(draftOf("a1")).toBe("h");
+      expect(e.defaultPrevented).toBe(true);
+      expect(setFocused).toHaveBeenCalledWith("a1");
+      expect(setPreferredTerminalFocusTarget).toHaveBeenCalledWith("hybridInput");
+    });
+
+    it("appends to an existing draft rather than replacing it", () => {
+      useTerminalInputStore.getState().setDraftInput("a1", "fix the ", "proj");
+      renderHook(() => useTypeAnywhere());
+
+      press("b");
+
+      expect(draftOf("a1")).toBe("fix the b");
+    });
+
+    it("never submits — it only bumps the draft revision", () => {
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+
+      // Enter stays the user's decision; the rescue's only external signal is
+      // the draft-sync revision.
+      expect(useTerminalInputStore.getState().externalDraftRevision).toBe(1);
+    });
+
+    it("prefers the last agent typed to over other open agents", () => {
+      setPanels([agentPanel("a1"), agentPanel("a2")]);
+      useTerminalInputStore.setState({
+        lastTypedAgentTarget: { terminalId: "a2", workspaceId: "proj" },
+      });
+      renderHook(() => useTypeAnywhere());
+
+      press("x");
+
+      expect(draftOf("a2")).toBe("x");
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("ignores a target claimed by a sibling project view", () => {
+      setPanels([agentPanel("a1"), agentPanel("a2")]);
+      useTerminalInputStore.setState({
+        lastTypedAgentTarget: { terminalId: "a2", workspaceId: "other-view" },
+      });
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("x");
+
+      // No history usable here + two agents = ambiguous = refuse.
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a2")).toBe("");
+    });
+
+    it("reveals the pane: un-maximizes a different pane and scrolls the target in", () => {
+      const scrollIntoView = vi.fn();
+      document.body.innerHTML = `<div data-panel-id="a1"></div>`;
+      const host = document.querySelector<HTMLElement>('[data-panel-id="a1"]');
+      host!.scrollIntoView = scrollIntoView;
+      setPanels([agentPanel("a1")], "other");
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+
+      expect(exitMaximize).toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalled();
+    });
+
+    it("refuses while a fleet broadcast is live", () => {
+      armedIds = new Set(["a1", "a2"]);
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("still rescues when a single agent is armed — that is a preview, not a broadcast", () => {
+      armedIds = new Set(["a1"]);
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+
+      expect(draftOf("a1")).toBe("h");
+    });
+
+    it("refuses when a screen reader is active — single letters are quick-nav keys", () => {
+      screenReaderEnabled = true;
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("refuses while a modal is open", () => {
+      document.body.innerHTML = `<div role="dialog" aria-modal="true"></div>`;
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("refuses while a palette is open", () => {
+      activePaletteId = "actions";
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("leaves typing in a real input alone", () => {
+      document.body.innerHTML = `<input id="i" />`;
+      document.getElementById("i")?.focus();
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(e.defaultPrevented).toBe(false);
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("ignores Enter, Space and modifier chords", () => {
+      renderHook(() => useTypeAnywhere());
+
+      press("Enter");
+      press(" ");
+      press("s", { metaKey: true });
+
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("retries focus until it lands in the target's hybrid input", async () => {
+      vi.useFakeTimers();
+      const rafSpy = vi
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation((cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0));
+      renderHook(() => useTypeAnywhere());
+
+      press("h");
+      // The lazy editor is not mounted yet, so the first attempts cannot land.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(focusPanelInput).toHaveBeenCalledWith("a1");
+
+      rafSpy.mockRestore();
+    });
+  });
+
+  describe("locate", () => {
+    function focusOffscreenTerminal(id: string) {
+      document.body.innerHTML = `
+        <div data-panel-id="${id}">
+          <div class="xterm"><div id="x" tabindex="0"></div></div>
+        </div>`;
+      document.getElementById("x")?.focus();
+    }
+
+    it("reveals an off-screen focused terminal without stealing the keystroke", () => {
+      setPanels([agentPanel("a1", { isVisible: false })]);
+      focusOffscreenTerminal("a1");
+      const host = document.querySelector<HTMLElement>('[data-panel-id="a1"]');
+      const scrollIntoView = vi.fn();
+      host!.scrollIntoView = scrollIntoView;
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(scrollIntoView).toHaveBeenCalled();
+      expect(pingTerminal).toHaveBeenCalledWith("a1");
+      expect(useTypingLocatorStore.getState().label).toContain("Claude");
+      // The key belongs to that terminal — it must land there, untouched.
+      expect(e.defaultPrevented).toBe(false);
+      expect(setFocused).not.toHaveBeenCalled();
+      expect(draftOf("a1")).toBe("");
+    });
+
+    it("stays silent when the focused terminal is already visible", () => {
+      setPanels([agentPanel("a1", { isVisible: true })]);
+      focusOffscreenTerminal("a1");
+      renderHook(() => useTypeAnywhere());
+
+      const e = press("h");
+
+      expect(pingTerminal).not.toHaveBeenCalled();
+      expect(useTypingLocatorStore.getState().label).toBeNull();
+      expect(e.defaultPrevented).toBe(false);
+    });
+
+    it("locates a raw shell too — the keystroke is legitimately its own", () => {
+      // The rescue must never route INTO a shell, but a focused off-screen shell
+      // still deserves to be found.
+      setPanels([agentPanel("sh", { isVisible: false, launchAgentId: undefined, title: "zsh" })]);
+      focusOffscreenTerminal("sh");
+      renderHook(() => useTypeAnywhere());
+
+      press("l");
+
+      expect(pingTerminal).toHaveBeenCalledWith("sh");
+      expect(useTypingLocatorStore.getState().label).toContain("zsh");
+    });
+  });
+
+  it("removes its listener on unmount", () => {
+    const { unmount } = renderHook(() => useTypeAnywhere());
+    unmount();
+
+    press("h");
+
+    expect(draftOf("a1")).toBe("");
+  });
+});

--- a/src/hooks/usePromptHistoryPalette.ts
+++ b/src/hooks/usePromptHistoryPalette.ts
@@ -55,7 +55,7 @@ export function usePromptHistoryPalette({ terminalId, projectId }: UsePromptHist
     (entry: PromptHistoryEntry) => {
       const store = useTerminalInputStore.getState();
       store.setDraftInput(terminalId, entry.prompt, projectId);
-      store.bumpVoiceDraftRevision();
+      store.bumpExternalDraftRevision();
       palette.close();
     },
     [terminalId, projectId, palette]

--- a/src/hooks/useTypeAnywhere.ts
+++ b/src/hooks/useTypeAnywhere.ts
@@ -12,6 +12,7 @@ import { getTerminalDisplayTitle } from "@/utils/terminalTitleDisplay";
 import { focusPanelInput } from "@/components/Panel/panelFocusRegistry";
 import {
   findPanelIdForElement,
+  getFocusTarget,
   hasBlockingOverlay,
   hasUsefulFocus,
   isRescuableKeystroke,
@@ -74,7 +75,9 @@ export function useTypeAnywhere(): void {
       if (hasBlockingOverlay()) return;
       if (usePaletteStore.getState().activePaletteId !== null) return;
 
-      const active = document.activeElement;
+      // Not `document.activeElement`: it retargets to the shadow host, which
+      // would make a focused shadow-DOM input look inert and get its key stolen.
+      const active = getFocusTarget(e);
       const panelStore = usePanelStore.getState();
 
       // --- Locate: focus is in a real terminal that has scrolled away ---
@@ -123,7 +126,9 @@ export function useTypeAnywhere(): void {
         panelsById: panelStore.panelsById,
         panelIds: panelStore.panelIds,
         lastTypedTerminalId,
-        unavailableTerminalIds: inputStore.voiceSubmittingPanels,
+        voiceSubmittingIds: inputStore.voiceSubmittingPanels,
+        hybridInputEnabled: inputStore.hybridInputEnabled,
+        isBackendReady: panelStore.backendStatus === "connected",
       });
       if (targetId === null) return;
 

--- a/src/hooks/useTypeAnywhere.ts
+++ b/src/hooks/useTypeAnywhere.ts
@@ -1,0 +1,192 @@
+import { useEffect, useRef } from "react";
+import { isPtyPanel } from "@shared/types/panel";
+import { usePanelStore } from "@/store";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useProjectStore } from "@/store/projectStore";
+import { useScreenReaderStore } from "@/store/screenReaderStore";
+import { useTerminalInputStore } from "@/store/terminalInputStore";
+import { useTypingLocatorStore } from "@/store/typingLocatorStore";
+import { usePaletteStore } from "@/store/paletteStore";
+import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
+import { getTerminalDisplayTitle } from "@/utils/terminalTitleDisplay";
+import { focusPanelInput } from "@/components/Panel/panelFocusRegistry";
+import {
+  findPanelIdForElement,
+  hasBlockingOverlay,
+  hasUsefulFocus,
+  isRescuableKeystroke,
+  resolveRescueTarget,
+} from "@/lib/typeAnywhere";
+
+/** Best-effort focus retry budget — the draft is already safe by the time we try. */
+const FOCUS_ATTEMPT_FRAMES = 30;
+
+/**
+ * Panel ids are opaque and may contain characters that are not selector-safe,
+ * so match on the attribute value rather than interpolating into a selector.
+ */
+function findElementByAttr(attr: string, value: string): HTMLElement | null {
+  for (const el of document.querySelectorAll<HTMLElement>(`[${attr}]`)) {
+    if (el.getAttribute(attr) === value) return el;
+  }
+  return null;
+}
+
+function scrollPanelIntoView(terminalId: string): void {
+  const host = findElementByAttr("data-panel-id", terminalId);
+  host?.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });
+}
+
+/** Did DOM focus actually land inside this panel's hybrid input? */
+function isFocusInHybridInput(terminalId: string): boolean {
+  const root = document.activeElement?.closest("[data-hybrid-input-root]");
+  return root?.getAttribute("data-hybrid-input-root") === terminalId;
+}
+
+/**
+ * Type-anywhere rescue + off-screen focus locator (#11134).
+ *
+ * One capture-phase listener, two mutually exclusive branches:
+ *
+ *  - **Locate.** A real terminal owns focus but its pane is scrolled out of the
+ *    grid viewport. The destination is legitimate — the user just cannot see it.
+ *    Scroll it back, pulse it, name it. The event is never touched.
+ *
+ *  - **Rescue.** Nothing useful owns focus, so the keystroke is about to be
+ *    eaten. Route it into the draft of the last agent the user typed to, focus
+ *    that draft and reveal the pane. Consumes the event — but only after the
+ *    character is durably in the store, so a failed focus handoff can never
+ *    lose it.
+ *
+ * Nothing here submits: the character lands in a draft and Enter stays the
+ * user's decision.
+ */
+export function useTypeAnywhere(): void {
+  // Route the body through a ref so the listener is registered exactly once and
+  // never churns; all state is read imperatively at event time anyway.
+  const handlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
+  const focusFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    handlerRef.current = (e: KeyboardEvent) => {
+      if (!isRescuableKeystroke(e)) return;
+      // A modal or palette owns every key while open.
+      if (hasBlockingOverlay()) return;
+      if (usePaletteStore.getState().activePaletteId !== null) return;
+
+      const active = document.activeElement;
+      const panelStore = usePanelStore.getState();
+
+      // --- Locate: focus is in a real terminal that has scrolled away ---
+      if (active?.closest(".xterm") !== null && active !== null) {
+        const panelId = findPanelIdForElement(active);
+        if (panelId === null) return;
+        const panel = panelStore.panelsById[panelId];
+        // `isVisible` is the existing per-pane IntersectionObserver signal
+        // (TerminalPane), rooted at the grid scroll container. Its rootMargin
+        // pre-warms a full row, so this only fires for panes that are
+        // meaningfully off-screen — not near-misses.
+        if (panel === undefined || panel.isVisible !== false) return;
+
+        scrollPanelIntoView(panelId);
+        panelStore.pingTerminal(panelId);
+        useTypingLocatorStore
+          .getState()
+          .showLocator(`Typing into ${getTerminalDisplayTitle(panel, "compact")}`);
+        // Deliberately no preventDefault: the keystroke belongs to that
+        // terminal and stays exactly where the user aimed it.
+        return;
+      }
+
+      // --- Rescue: the keystroke is about to go nowhere ---
+      if (hasUsefulFocus(active)) return;
+
+      // Screen-reader browse mode uses single letters as quick-nav keys —
+      // hijacking them would break navigation outright.
+      if (useScreenReaderStore.getState().resolvedScreenReaderEnabled()) return;
+
+      // A live broadcast means a routed draft could silently fan out to every
+      // armed agent. One armed id is only a preview, matching the threshold
+      // `tryFleetBroadcastFromEditor` uses.
+      if (useFleetArmingStore.getState().armedIds.size >= 2) return;
+
+      const workspaceId = getViewWorkspaceId();
+      if (workspaceId === null) return;
+
+      const inputStore = useTerminalInputStore.getState();
+      const recorded = inputStore.lastTypedAgentTarget;
+      // A target claimed by a sibling view must never be routed into from here.
+      const lastTypedTerminalId =
+        recorded !== null && recorded.workspaceId === workspaceId ? recorded.terminalId : null;
+
+      const targetId = resolveRescueTarget({
+        panelsById: panelStore.panelsById,
+        panelIds: panelStore.panelIds,
+        lastTypedTerminalId,
+        unavailableTerminalIds: inputStore.voiceSubmittingPanels,
+      });
+      if (targetId === null) return;
+
+      const target = panelStore.panelsById[targetId];
+      if (target === undefined || !isPtyPanel(target)) return;
+
+      // Persist the character BEFORE consuming the event. Everything after this
+      // point is reveal/focus polish — if any of it fails, the keystroke is
+      // still safely in the draft rather than eaten.
+      const projectId = useProjectStore.getState().currentProject?.id;
+      const draft = inputStore.getDraftInput(targetId, projectId);
+      inputStore.setDraftInput(targetId, draft + e.key, projectId);
+      inputStore.bumpExternalDraftRevision();
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Reveal the landing site: un-maximize a different pane, surface the tab,
+      // then focus. `setFocused` also promotes the target's worktree, which is
+      // wanted here — it is what makes the draft visible when the agent lives in
+      // a worktree the user isn't currently looking at.
+      if (panelStore.maximizedId !== null && panelStore.maximizedId !== targetId) {
+        panelStore.exitMaximize();
+      }
+      panelStore.setPreferredTerminalFocusTarget("hybridInput");
+      panelStore.setFocused(targetId);
+      scrollPanelIntoView(targetId);
+      useTypingLocatorStore
+        .getState()
+        .showLocator(`Typing into ${getTerminalDisplayTitle(target, "compact")}`);
+
+      // The pane's own focus effect drives the editor focus, but the editor is a
+      // lazy chunk and its worktree may still be mounting — so poll until DOM
+      // focus actually lands inside the target's hybrid input rather than
+      // trusting any handle's boolean (which reports "a view is mounted", not
+      // "focus landed"). Best-effort: the draft is already safe.
+      if (focusFrameRef.current !== null) cancelAnimationFrame(focusFrameRef.current);
+      let framesLeft = FOCUS_ATTEMPT_FRAMES;
+      const settleFocus = () => {
+        if (isFocusInHybridInput(targetId)) {
+          focusFrameRef.current = null;
+          return;
+        }
+        if (framesLeft-- <= 0) {
+          focusFrameRef.current = null;
+          return;
+        }
+        focusPanelInput(targetId);
+        focusFrameRef.current = requestAnimationFrame(settleFocus);
+      };
+      focusFrameRef.current = requestAnimationFrame(settleFocus);
+    };
+  });
+
+  useEffect(() => {
+    const listener = (e: KeyboardEvent) => handlerRef.current(e);
+    window.addEventListener("keydown", listener, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", listener, { capture: true });
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current);
+        focusFrameRef.current = null;
+      }
+    };
+  }, []);
+}

--- a/src/lib/__tests__/typeAnywhere.test.ts
+++ b/src/lib/__tests__/typeAnywhere.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+import {
+  findPanelIdForElement,
+  hasBlockingOverlay,
+  hasUsefulFocus,
+  isRescuableKeystroke,
+  resolveRescueTarget,
+  type RescueContext,
+} from "../typeAnywhere";
+
+/**
+ * The safety rules in #11134 are a contract, not preferences: a rescue that
+ * fires when it shouldn't sends the user's prompt to an agent they never chose,
+ * or executes it against a raw shell. These tests are that contract.
+ */
+
+function keydown(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  const { key, ...rest } = init;
+  return new KeyboardEvent("keydown", { key, ...rest });
+}
+
+/** AltGr can't be expressed via KeyboardEventInit — `getModifierState` needs a stub. */
+function altGrKeydown(key: string): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { key, ctrlKey: true, altKey: true });
+  Object.defineProperty(e, "getModifierState", {
+    value: (mod: string) => mod === "AltGraph",
+  });
+  return e;
+}
+
+/** PTY panels are `kind: "terminal"`; agent identity is derived from `launchAgentId`. */
+function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
+  return {
+    id,
+    kind: "terminal",
+    title: "Claude",
+    location: "grid",
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    hasPty: true,
+    runtimeStatus: "running",
+    launchAgentId: "claude",
+    ...overrides,
+  };
+}
+
+function makeContext(panels: PanelInstance[], overrides: Partial<RescueContext> = {}) {
+  const panelsById: Record<string, PanelInstance> = {};
+  for (const p of panels) panelsById[p.id] = p;
+  return {
+    panelsById,
+    panelIds: panels.map((p) => p.id),
+    lastTypedTerminalId: null,
+    unavailableTerminalIds: new Set<string>(),
+    ...overrides,
+  };
+}
+
+describe("isRescuableKeystroke", () => {
+  it("accepts a plain printable character", () => {
+    expect(isRescuableKeystroke(keydown({ key: "a" }))).toBe(true);
+  });
+
+  it("accepts a shifted character", () => {
+    expect(isRescuableKeystroke(keydown({ key: "A", shiftKey: true }))).toBe(true);
+  });
+
+  it("accepts punctuation and digits", () => {
+    expect(isRescuableKeystroke(keydown({ key: "7" }))).toBe(true);
+    expect(isRescuableKeystroke(keydown({ key: "?" }))).toBe(true);
+  });
+
+  it("accepts an AltGr character even though ctrl and alt are both set", () => {
+    // German layout: AltGr+Q yields '@' with ctrlKey && altKey. A naive chord
+    // test would refuse to rescue ordinary typing on these layouts.
+    expect(isRescuableKeystroke(altGrKeydown("@"))).toBe(true);
+  });
+
+  it("rejects modifier chords", () => {
+    expect(isRescuableKeystroke(keydown({ key: "a", metaKey: true }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: "a", ctrlKey: true }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: "a", altKey: true }))).toBe(false);
+  });
+
+  it("rejects Enter, Backspace and Space as the first key", () => {
+    expect(isRescuableKeystroke(keydown({ key: "Enter" }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: "Backspace" }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: " " }))).toBe(false);
+  });
+
+  it("rejects named navigation and function keys", () => {
+    expect(isRescuableKeystroke(keydown({ key: "ArrowLeft" }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: "F1" }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: "Escape" }))).toBe(false);
+  });
+
+  it("rejects key repeats", () => {
+    expect(isRescuableKeystroke(keydown({ key: "a", repeat: true }))).toBe(false);
+  });
+
+  it("rejects IME composition, including Chromium's pre-isComposing 229 signal", () => {
+    expect(isRescuableKeystroke(keydown({ key: "a", isComposing: true }))).toBe(false);
+    expect(isRescuableKeystroke(keydown({ key: "a", keyCode: 229 }))).toBe(false);
+  });
+
+  it("rejects dead keys", () => {
+    expect(isRescuableKeystroke(keydown({ key: "Dead" }))).toBe(false);
+  });
+});
+
+describe("hasUsefulFocus", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("treats nothing and the body as not useful", () => {
+    expect(hasUsefulFocus(null)).toBe(false);
+    expect(hasUsefulFocus(document.body)).toBe(false);
+  });
+
+  it("treats a detached element as not useful", () => {
+    expect(hasUsefulFocus(document.createElement("div"))).toBe(false);
+  });
+
+  it("treats form controls and editable content as useful", () => {
+    document.body.innerHTML = `
+      <input id="i" />
+      <textarea id="t"></textarea>
+      <div id="c" contenteditable="true"></div>`;
+    expect(hasUsefulFocus(document.getElementById("i"))).toBe(true);
+    expect(hasUsefulFocus(document.getElementById("t"))).toBe(true);
+    expect(hasUsefulFocus(document.getElementById("c"))).toBe(true);
+  });
+
+  it("treats a terminal as useful even when it is the off-screen case", () => {
+    document.body.innerHTML = `<div class="xterm"><div id="x" tabindex="0"></div></div>`;
+    expect(hasUsefulFocus(document.getElementById("x"))).toBe(true);
+  });
+
+  it("treats an embedded browsing context as useful", () => {
+    document.body.innerHTML = `<iframe id="f"></iframe>`;
+    expect(hasUsefulFocus(document.getElementById("f"))).toBe(true);
+  });
+
+  it("treats a read-only viewer surface as NOT useful — it silently eats the key", () => {
+    // The file viewer: focusable chrome, no typing target. This is the exact
+    // reported failure ("is my prompt in my codes now?!").
+    document.body.innerHTML = `<div id="v" tabindex="0" class="file-viewer"></div>`;
+    expect(hasUsefulFocus(document.getElementById("v"))).toBe(false);
+  });
+});
+
+describe("hasBlockingOverlay", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("is false with no modal", () => {
+    expect(hasBlockingOverlay()).toBe(false);
+  });
+
+  it("detects a modal portalled outside the focused subtree", () => {
+    // Radix renders dialog content in a portal, so an ancestry check from the
+    // focused node would miss it and the rescue would steal the key.
+    document.body.innerHTML = `<div role="dialog" aria-modal="true"></div>`;
+    expect(hasBlockingOverlay()).toBe(true);
+  });
+
+  it("ignores a non-modal dialog", () => {
+    document.body.innerHTML = `<div role="dialog"></div>`;
+    expect(hasBlockingOverlay()).toBe(false);
+  });
+});
+
+describe("findPanelIdForElement", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("walks up to the owning panel", () => {
+    document.body.innerHTML = `<div data-panel-id="p1"><span id="leaf"></span></div>`;
+    expect(findPanelIdForElement(document.getElementById("leaf"))).toBe("p1");
+  });
+
+  it("returns null outside any panel", () => {
+    document.body.innerHTML = `<span id="leaf"></span>`;
+    expect(findPanelIdForElement(document.getElementById("leaf"))).toBeNull();
+  });
+});
+
+describe("resolveRescueTarget", () => {
+  it("routes to the agent the user last typed to, even with other agents open", () => {
+    const ctx = makeContext([agentPanel("a1"), agentPanel("a2"), agentPanel("a3")], {
+      lastTypedTerminalId: "a2",
+    });
+    expect(resolveRescueTarget(ctx)).toBe("a2");
+  });
+
+  it("refuses rather than falling through when the known target is mid-voice-submit", () => {
+    // Falling back to another agent would route the prompt to an agent the user
+    // never chose — the precise harm the issue is about.
+    const ctx = makeContext([agentPanel("a1"), agentPanel("a2")], {
+      lastTypedTerminalId: "a2",
+      unavailableTerminalIds: new Set(["a2"]),
+    });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("refuses when the known target has exited", () => {
+    const ctx = makeContext([agentPanel("a1"), agentPanel("a2", { runtimeStatus: "exited" })], {
+      lastTypedTerminalId: "a2",
+    });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("falls back to the sole agent when there is no typing history yet", () => {
+    const ctx = makeContext([agentPanel("only")]);
+    expect(resolveRescueTarget(ctx)).toBe("only");
+  });
+
+  it("refuses with no history and multiple agents — nothing disambiguates them", () => {
+    const ctx = makeContext([agentPanel("a1"), agentPanel("a2")]);
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("refuses with no agents at all", () => {
+    expect(resolveRescueTarget(makeContext([]))).toBeNull();
+  });
+
+  it("never routes into a raw shell — a draft there would execute on Enter", () => {
+    const shell = agentPanel("sh", { launchAgentId: undefined, title: "zsh" });
+    expect(resolveRescueTarget(makeContext([shell]))).toBeNull();
+  });
+
+  it("does not treat a lone shell as the sole-candidate fallback", () => {
+    const ctx = makeContext([agentPanel("sh", { launchAgentId: undefined }), agentPanel("a1")]);
+    // Only a1 is a real agent, so it is unambiguous despite two panels.
+    expect(resolveRescueTarget(ctx)).toBe("a1");
+  });
+
+  it("ignores agents outside the grid (dock, background)", () => {
+    const ctx = makeContext([agentPanel("docked", { location: "dock" })]);
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("refuses when a stale target id is no longer present", () => {
+    const ctx = makeContext([agentPanel("a1")], { lastTypedTerminalId: "gone" });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/typeAnywhere.test.ts
+++ b/src/lib/__tests__/typeAnywhere.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import {
   findPanelIdForElement,
+  getFocusTarget,
   hasBlockingOverlay,
   hasUsefulFocus,
   isRescuableKeystroke,
@@ -47,14 +48,19 @@ function agentPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanel
   };
 }
 
-function makeContext(panels: PanelInstance[], overrides: Partial<RescueContext> = {}) {
+function makeContext(
+  panels: PanelInstance[],
+  overrides: Partial<RescueContext> = {}
+): RescueContext {
   const panelsById: Record<string, PanelInstance> = {};
   for (const p of panels) panelsById[p.id] = p;
   return {
     panelsById,
     panelIds: panels.map((p) => p.id),
     lastTypedTerminalId: null,
-    unavailableTerminalIds: new Set<string>(),
+    voiceSubmittingIds: new Set<string>(),
+    hybridInputEnabled: true,
+    isBackendReady: true,
     ...overrides,
   };
 }
@@ -151,6 +157,62 @@ describe("hasUsefulFocus", () => {
     document.body.innerHTML = `<div id="v" tabindex="0" class="file-viewer"></div>`;
     expect(hasUsefulFocus(document.getElementById("v"))).toBe(false);
   });
+
+  it("treats a menu item as useful — menus use bare letters for typeahead", () => {
+    // Typing "r" in an open menu jumps to the first item starting with "r".
+    // Rescuing it would break menu navigation and append "r" to an agent draft.
+    document.body.innerHTML = `
+      <div role="menu"><div id="mi" role="menuitem" tabindex="-1">Rename</div></div>`;
+    expect(hasUsefulFocus(document.getElementById("mi"))).toBe(true);
+  });
+
+  it("treats a listbox option as useful", () => {
+    document.body.innerHTML = `
+      <div role="listbox"><div id="opt" role="option" tabindex="-1">One</div></div>`;
+    expect(hasUsefulFocus(document.getElementById("opt"))).toBe(true);
+  });
+
+  it("treats a shadow host as useful — it may own a focused input we cannot see", () => {
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "open" });
+    document.body.appendChild(host);
+    expect(hasUsefulFocus(host)).toBe(true);
+  });
+});
+
+describe("getFocusTarget", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns the real focused node inside a shadow root, not the host", () => {
+    // `document.activeElement` retargets to the host, which would make a focused
+    // shadow-DOM input look inert and get its keystroke stolen. The composed path
+    // is only live *during* dispatch, which is exactly when the listener reads it.
+    const host = document.createElement("div");
+    const shadow = host.attachShadow({ mode: "open" });
+    const input = document.createElement("input");
+    shadow.appendChild(input);
+    document.body.appendChild(host);
+    input.focus();
+
+    let seen: Element | null = null;
+    const listener = (ev: Event) => {
+      seen = getFocusTarget(ev as KeyboardEvent);
+    };
+    window.addEventListener("keydown", listener, { capture: true });
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true, composed: true }));
+    window.removeEventListener("keydown", listener, { capture: true });
+
+    expect(seen).toBe(input);
+    expect(hasUsefulFocus(seen)).toBe(true);
+  });
+
+  it("falls back to the active element when the path carries no element", () => {
+    // A window-level dispatch puts `window` at the head of the path.
+    const e = new KeyboardEvent("keydown", { key: "a" });
+    expect(getFocusTarget(e)).toBe(document.body);
+  });
 });
 
 describe("hasBlockingOverlay", () => {
@@ -204,8 +266,34 @@ describe("resolveRescueTarget", () => {
     // never chose — the precise harm the issue is about.
     const ctx = makeContext([agentPanel("a1"), agentPanel("a2")], {
       lastTypedTerminalId: "a2",
-      unavailableTerminalIds: new Set(["a2"]),
+      voiceSubmittingIds: new Set(["a2"]),
     });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  /**
+   * If the draft the character lands in isn't visible and editable, the rescue
+   * has merely moved the silent-loss bug one layer deeper.
+   */
+  it("refuses when the hybrid input bar is switched off globally — no draft would render", () => {
+    const ctx = makeContext([agentPanel("a1")], { hybridInputEnabled: false });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("refuses while the PTY backend is down — every editor is disabled", () => {
+    const ctx = makeContext([agentPanel("a1")], { isBackendReady: false });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("refuses a locked target, and does not fall through to another agent", () => {
+    const ctx = makeContext([agentPanel("a1"), agentPanel("a2", { isInputLocked: true })], {
+      lastTypedTerminalId: "a2",
+    });
+    expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+
+  it("refuses a restarting target", () => {
+    const ctx = makeContext([agentPanel("a1", { isRestarting: true })]);
     expect(resolveRescueTarget(ctx)).toBeNull();
   });
 

--- a/src/lib/typeAnywhere.ts
+++ b/src/lib/typeAnywhere.ts
@@ -48,6 +48,36 @@ export function isRescuableKeystroke(e: KeyboardEvent): boolean {
 const EDITABLE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
 
 /**
+ * Composite widgets that consume bare printable keys for typeahead / quick-nav
+ * — a focused menu item eats "r" to jump to the first item starting with "r".
+ * Stealing those keys would break menu, listbox and combobox navigation.
+ */
+const TYPEAHEAD_ROLES = [
+  '[role="menu"]',
+  '[role="menubar"]',
+  '[role="listbox"]',
+  '[role="combobox"]',
+  '[role="tree"]',
+  '[role="treegrid"]',
+  '[role="grid"]',
+  '[role="tablist"]',
+].join(",");
+
+/**
+ * The element the keystroke actually landed on.
+ *
+ * `document.activeElement` retargets to the shadow *host* when focus is inside
+ * a shadow root, which would make a focused shadow-DOM input look like nothing
+ * is focused — and the rescue would steal its keystroke. The event's composed
+ * path starts at the true focused node, across shadow boundaries.
+ */
+export function getFocusTarget(e: KeyboardEvent): Element | null {
+  const leaf = e.composedPath()[0];
+  if (leaf instanceof Element) return leaf;
+  return document.activeElement;
+}
+
+/**
  * Is the current focus somewhere that legitimately owns the keystroke?
  *
  * "Useful" is deliberately broad: anything that could plausibly be consuming
@@ -79,6 +109,11 @@ export function hasUsefulFocus(el: Element | null): boolean {
   if (el.closest(".xterm") !== null) return true;
   // The hybrid editor itself, focused but not yet reporting contentEditable.
   if (el.closest("[data-hybrid-input-root]") !== null) return true;
+  // Menus, listboxes and comboboxes use bare letters for typeahead.
+  if (el.closest(TYPEAHEAD_ROLES) !== null) return true;
+  // A custom element with a shadow root may host its own focused input that we
+  // cannot see from here — refuse rather than risk swallowing its keystroke.
+  if (el.shadowRoot !== null) return true;
 
   return false;
 }
@@ -105,8 +140,16 @@ export interface RescueContext {
   panelIds: string[];
   /** `terminalId` of the last agent the user actually typed into, if any. */
   lastTypedTerminalId: string | null;
-  /** Panels that cannot currently accept a draft (locked, restarting, mid-voice-submit). */
-  unavailableTerminalIds: ReadonlySet<string>;
+  /** Panels mid-voice-submit: the editor is read-only and submits asynchronously. */
+  voiceSubmittingIds: ReadonlySet<string>;
+  /**
+   * The global hybrid-input setting. With it off, `shouldShowHybridInputBar`
+   * renders no draft bar for ANY panel — routing a character into a draft
+   * nothing displays would silently eat it, which is the exact bug being fixed.
+   */
+  hybridInputEnabled: boolean;
+  /** False while the PTY backend is disconnected or recovering — every editor is disabled then. */
+  isBackendReady: boolean;
 }
 
 /**
@@ -125,15 +168,30 @@ export interface RescueContext {
  *     with one agent there is nothing to guess between, and this is precisely
  *     the first-use case the feature exists to serve.
  *  4. Zero or multiple candidates with no history: refuse.
+ *
+ * A target is only routable if its draft would actually be *visible and
+ * editable*. Routing into a bar that is switched off, disabled, locked or
+ * restarting would drop the character into an invisible draft — the same
+ * silent loss the rescue exists to prevent, just one layer deeper.
  */
 export function resolveRescueTarget(ctx: RescueContext): string | null {
+  // Both of these disable every agent's editor at once, so there is no target
+  // worth resolving.
+  if (!ctx.hybridInputEnabled) return null;
+  if (!ctx.isBackendReady) return null;
+
   const isRoutable = (id: string): boolean => {
-    if (ctx.unavailableTerminalIds.has(id)) return false;
+    if (ctx.voiceSubmittingIds.has(id)) return false;
     const panel = ctx.panelsById[id];
     // Agent identity + live PTY + grid location. Excludes raw shells (no agent
     // identity — routing a draft there would execute on Enter against a shell),
     // exited panels, and dock/background panels.
-    return isAgentFleetActionEligible(panel);
+    if (!isAgentFleetActionEligible(panel)) return false;
+    // Mirrors `isHybridInputDisabled` in TerminalPane: a locked or restarting
+    // editor is read-only, and focus would fall back to the raw xterm.
+    if (panel.isInputLocked === true) return false;
+    if (panel.isRestarting === true) return false;
+    return true;
   };
 
   if (ctx.lastTypedTerminalId !== null) {

--- a/src/lib/typeAnywhere.ts
+++ b/src/lib/typeAnywhere.ts
@@ -1,0 +1,145 @@
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import { isAgentFleetActionEligible } from "@/store/fleetEligibility";
+
+/**
+ * Pure decision logic for the type-anywhere rescue and the off-screen focus
+ * locator (#11134). Kept free of React and store imports so the whole safety
+ * matrix is directly testable.
+ *
+ * The two behaviours are deliberately asymmetric:
+ *   - Rescue *consumes* the keystroke and moves focus, so it is gated hard.
+ *   - Locate never touches the event; it only reveals where the key already went.
+ */
+
+/**
+ * Does this keydown qualify as the "plain printable first keystroke" that may
+ * initiate routing?
+ *
+ * `key.length === 1` is the printable test: it accepts letters, digits,
+ * punctuation and any single-codepoint character a layout produces, while
+ * rejecting every named key ("Enter", "Backspace", "ArrowLeft", "Dead", "F1").
+ * Space is excluded separately — it is printable but is far more often a
+ * scroll/activate gesture than the start of a prompt.
+ *
+ * AltGr is the subtle one: on Windows and Linux layouts, AltGr-produced
+ * characters (e.g. `@` on a German keyboard) arrive with BOTH `ctrlKey` and
+ * `altKey` set, so a naive "no ctrl, no alt" chord test would silently refuse
+ * to rescue perfectly ordinary typing for those users. `getModifierState`
+ * distinguishes the real AltGr from a hand-held Ctrl+Alt chord.
+ */
+export function isRescuableKeystroke(e: KeyboardEvent): boolean {
+  if (e.repeat) return false;
+  // During IME composition the browser/IME owns the event lifecycle; stealing
+  // focus mid-composition corrupts the input. keyCode 229 is Chromium's
+  // "Process" signal on the first keydown, before `isComposing` flips.
+  if (e.isComposing || e.keyCode === 229) return false;
+  if (e.key === "Dead") return false;
+  if (e.metaKey) return false;
+
+  const isAltGraph = e.getModifierState("AltGraph");
+  if (!isAltGraph && (e.ctrlKey || e.altKey)) return false;
+
+  if (e.key.length !== 1) return false;
+  if (e.key === " ") return false;
+
+  return true;
+}
+
+const EDITABLE_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+
+/**
+ * Is the current focus somewhere that legitimately owns the keystroke?
+ *
+ * "Useful" is deliberately broad: anything that could plausibly be consuming
+ * typed characters — a form control, a live editor, an embedded browsing
+ * context, a terminal — keeps the key. The rescue only fires for focus that is
+ * genuinely inert (document body, a detached element, or the chrome of a
+ * read-only panel such as the file viewer).
+ *
+ * A read-only CodeMirror surface (`contentEditable === "false"` inside
+ * `.cm-editor`) is NOT useful: it swallows the keystroke silently, which is
+ * exactly the reported failure.
+ */
+export function hasUsefulFocus(el: Element | null): boolean {
+  if (el === null) return false;
+  if (!el.isConnected) return false;
+  if (el === document.body || el === document.documentElement) return false;
+
+  if (el instanceof HTMLElement && el.isContentEditable) return true;
+  // Read the attribute too: `isContentEditable` is a computed property, and an
+  // explicit `contenteditable="false"` (a read-only CodeMirror surface) must
+  // stay *not* useful — it swallows the key silently.
+  const editableAttr = el.getAttribute("contenteditable");
+  if (editableAttr !== null && editableAttr !== "false") return true;
+  if (EDITABLE_TAGS.has(el.tagName)) return true;
+  // Embedded browsing contexts (browser panel, dev preview) own their own input.
+  if (el.tagName === "IFRAME" || el.tagName === "WEBVIEW") return true;
+  // A terminal owns the key even when it is scrolled off-screen — that is the
+  // locator's case, never the rescue's.
+  if (el.closest(".xterm") !== null) return true;
+  // The hybrid editor itself, focused but not yet reporting contentEditable.
+  if (el.closest("[data-hybrid-input-root]") !== null) return true;
+
+  return false;
+}
+
+/**
+ * Modal surfaces own every key while open.
+ *
+ * Existence, not ancestry: Radix portals dialog content outside the dialog's
+ * DOM subtree, so `closest()` from the focused element misses it and the
+ * listener would steal keys from an open modal.
+ */
+export function hasBlockingOverlay(): boolean {
+  return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
+}
+
+/** The panel that owns the currently focused DOM node, if any. */
+export function findPanelIdForElement(el: Element | null): string | null {
+  const host = el?.closest("[data-panel-id]");
+  return host?.getAttribute("data-panel-id") ?? null;
+}
+
+export interface RescueContext {
+  panelsById: Record<string, PanelInstance>;
+  panelIds: string[];
+  /** `terminalId` of the last agent the user actually typed into, if any. */
+  lastTypedTerminalId: string | null;
+  /** Panels that cannot currently accept a draft (locked, restarting, mid-voice-submit). */
+  unavailableTerminalIds: ReadonlySet<string>;
+}
+
+/**
+ * Resolve the single agent a rescued keystroke may be routed into, or `null`
+ * to refuse.
+ *
+ * The issue's contract is "refuse to guess when there isn't exactly one
+ * plausible target". Operationally:
+ *
+ *  1. A recorded last-typed agent IS the one plausible target even with other
+ *     agents open — real typing history disambiguates it.
+ *  2. If that known target exists but cannot currently take input, refuse.
+ *     Falling through to a different agent would route the user's prompt to an
+ *     agent they never chose, which is the exact harm being fixed.
+ *  3. With no history yet (fresh session), fall back to the sole open agent —
+ *     with one agent there is nothing to guess between, and this is precisely
+ *     the first-use case the feature exists to serve.
+ *  4. Zero or multiple candidates with no history: refuse.
+ */
+export function resolveRescueTarget(ctx: RescueContext): string | null {
+  const isRoutable = (id: string): boolean => {
+    if (ctx.unavailableTerminalIds.has(id)) return false;
+    const panel = ctx.panelsById[id];
+    // Agent identity + live PTY + grid location. Excludes raw shells (no agent
+    // identity — routing a draft there would execute on Enter against a shell),
+    // exited panels, and dock/background panels.
+    return isAgentFleetActionEligible(panel);
+  };
+
+  if (ctx.lastTypedTerminalId !== null) {
+    return isRoutable(ctx.lastTypedTerminalId) ? ctx.lastTypedTerminalId : null;
+  }
+
+  const candidates = ctx.panelIds.filter((id) => isPtyPanel(ctx.panelsById[id]) && isRoutable(id));
+  return candidates.length === 1 ? (candidates[0] ?? null) : null;
+}

--- a/src/lib/typeAnywhere.ts
+++ b/src/lib/typeAnywhere.ts
@@ -1,4 +1,4 @@
-import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import type { PanelInstance } from "@shared/types/panel";
 import { isAgentFleetActionEligible } from "@/store/fleetEligibility";
 
 /**
@@ -198,6 +198,7 @@ export function resolveRescueTarget(ctx: RescueContext): string | null {
     return isRoutable(ctx.lastTypedTerminalId) ? ctx.lastTypedTerminalId : null;
   }
 
-  const candidates = ctx.panelIds.filter((id) => isPtyPanel(ctx.panelsById[id]) && isRoutable(id));
+  // `isRoutable` already requires a live agent PTY panel — no separate kind check.
+  const candidates = ctx.panelIds.filter(isRoutable);
   return candidates.length === 1 ? (candidates[0] ?? null) : null;
 }

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -134,7 +134,7 @@ class VoiceRecordingService {
               useVoiceRecordingStore.getState().setActiveParagraphStart(panelId, insertStart);
             }
             inputStore.setDraftInput(panelId, base + separator + finalText, projectId);
-            inputStore.bumpVoiceDraftRevision();
+            inputStore.bumpExternalDraftRevision();
           }
         }
         useVoiceRecordingStore.getState().completeSegment(text);
@@ -158,7 +158,7 @@ class VoiceRecordingService {
           const before = draft.slice(0, idx);
           const after = draft.slice(idx + description.length);
           inputStore.setDraftInput(panelId, before + replacement + after, projectId);
-          inputStore.bumpVoiceDraftRevision();
+          inputStore.bumpExternalDraftRevision();
         } else {
           logDebug(`${LOG_PREFIX} File token description not found in draft, discarding`, {
             description,
@@ -184,7 +184,7 @@ class VoiceRecordingService {
 
         // Insert a newline to visually separate paragraphs and reset paragraph state.
         inputStore.setDraftInput(panelId, draft + "\n", projectId);
-        inputStore.bumpVoiceDraftRevision();
+        inputStore.bumpExternalDraftRevision();
 
         voiceState.resetParagraphState(panelId);
       })
@@ -978,7 +978,7 @@ class VoiceRecordingService {
               const base = segmentStart >= 0 ? draft.slice(0, segmentStart) : draft;
               const { separator } = getVoiceInsertMetadata(base);
               inputStore.setDraftInput(panelId, base + separator + remaining, projectId);
-              inputStore.bumpVoiceDraftRevision();
+              inputStore.bumpExternalDraftRevision();
             }
           }
         }
@@ -1058,7 +1058,7 @@ class VoiceRecordingService {
     useVoiceRecordingStore
       .getState()
       .setCorrectionRange(panelId, { from: sessionStart, to: draftBefore.length });
-    inputStore.bumpVoiceDraftRevision();
+    inputStore.bumpExternalDraftRevision();
 
     let correctedText = rawText;
     try {
@@ -1076,7 +1076,7 @@ class VoiceRecordingService {
     // don't clobber it.
     if (this.generation !== stopGeneration) {
       logDebug(`${LOG_PREFIX} Correction result stale (new session), discarding`);
-      inputStore.bumpVoiceDraftRevision();
+      inputStore.bumpExternalDraftRevision();
       return;
     }
 
@@ -1112,7 +1112,7 @@ class VoiceRecordingService {
     // worth suggesting for the custom dictionary (#9749).
     useVoiceRecordingStore.getState().setSessionCorrectedText(panelId, correctedText);
 
-    inputStore.bumpVoiceDraftRevision();
+    inputStore.bumpExternalDraftRevision();
   }
 
   async toggleFocusedPanel(): Promise<void> {

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -114,7 +114,7 @@ const runtime = vi.hoisted(() => ({
   terminalInputFns: {
     getDraftInput: vi.fn<(panelId: string, projectId?: string) => string>(),
     setDraftInput: vi.fn<(panelId: string, value: string, projectId?: string) => void>(),
-    bumpVoiceDraftRevision: vi.fn<() => void>(),
+    bumpExternalDraftRevision: vi.fn<() => void>(),
   },
   statusListeners: new Set<VoiceStatusCallback>(),
   errorListeners: new Set<VoiceErrorCallback>(),
@@ -253,7 +253,7 @@ function resetRuntime(): void {
   runtime.terminalInputFns.setDraftInput.mockImplementation((panelId, value) => {
     runtime.drafts[panelId] = value;
   });
-  runtime.terminalInputFns.bumpVoiceDraftRevision.mockImplementation(() => undefined);
+  runtime.terminalInputFns.bumpExternalDraftRevision.mockImplementation(() => undefined);
 
   runtime.voiceInput.getSettings.mockResolvedValue({
     enabled: true,

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -61,7 +61,7 @@ vi.mock("@/store/terminalInputStore", () => {
   const fns = {
     getDraftInput: vi.fn(() => ""),
     setDraftInput: vi.fn(),
-    bumpVoiceDraftRevision: vi.fn(),
+    bumpExternalDraftRevision: vi.fn(),
   };
   const getState = () => fns;
   return { useTerminalInputStore: Object.assign(getState, { getState }) };
@@ -1115,7 +1115,7 @@ describe("VoiceRecordingService — interim delta handling (#9172)", () => {
 
     // The interim path must not mutate the draft store — that's the entire fix.
     expect(inputStore.setDraftInput).not.toHaveBeenCalled();
-    expect(inputStore.bumpVoiceDraftRevision).not.toHaveBeenCalled();
+    expect(inputStore.bumpExternalDraftRevision).not.toHaveBeenCalled();
 
     __state.activeTarget = null;
   });
@@ -1171,7 +1171,7 @@ describe("VoiceRecordingService — interim delta handling (#9172)", () => {
     completeCallback!({ text: "hello world!" });
 
     expect(inputStore.setDraftInput).toHaveBeenCalledTimes(1);
-    expect(inputStore.bumpVoiceDraftRevision).toHaveBeenCalledTimes(1);
+    expect(inputStore.bumpExternalDraftRevision).toHaveBeenCalledTimes(1);
 
     voiceModule.__state.activeTarget = null;
     voiceModule.__state.panelBuffers = {};
@@ -1208,12 +1208,12 @@ describe("VoiceRecordingService — interim delta handling (#9172)", () => {
     // Defeat any cross-test fn-instance reuse (Vitest may keep top-level
     // mock factory closures across re-imports).
     (inputStore.setDraftInput as ReturnType<typeof vi.fn>).mockClear();
-    (inputStore.bumpVoiceDraftRevision as ReturnType<typeof vi.fn>).mockClear();
+    (inputStore.bumpExternalDraftRevision as ReturnType<typeof vi.fn>).mockClear();
 
     completeCallback!({ text: "   " });
 
     expect(inputStore.setDraftInput).not.toHaveBeenCalled();
-    expect(inputStore.bumpVoiceDraftRevision).not.toHaveBeenCalled();
+    expect(inputStore.bumpExternalDraftRevision).not.toHaveBeenCalled();
 
     voiceModule.__state.activeTarget = null;
     voiceModule.__state.panelBuffers = {};

--- a/src/store/__tests__/terminalInputStore.test.ts
+++ b/src/store/__tests__/terminalInputStore.test.ts
@@ -18,6 +18,8 @@ describe("terminalInputStore", () => {
       pendingDrafts: new Map(),
       pendingDraftRevision: 0,
       stashedEditorStates: new Map(),
+      externalDraftRevision: 0,
+      lastTypedAgentTarget: null,
     });
   });
 
@@ -723,6 +725,81 @@ describe("terminalInputStore", () => {
       );
       // project-b was cleared and not restored
       expect(useTerminalInputStore.getState().getDraftInput("term-3", "project-b")).toBe("");
+    });
+  });
+
+  /**
+   * The routing target for the type-anywhere rescue (#11134). A stale target is
+   * worse than none: routing a prompt into a terminal that has been removed, or
+   * one owned by another view, is exactly the harm the feature exists to fix.
+   */
+  describe("lastTypedAgentTarget", () => {
+    it("records the agent and workspace that were typed into", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget).toEqual({
+        terminalId: "term-1",
+        workspaceId: "ws-1",
+      });
+    });
+
+    it("moves the target when the user types into a different agent", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-2", "ws-1");
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget?.terminalId).toBe("term-2");
+    });
+
+    it("keeps a referentially stable target when re-recording the same agent", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+      const first = useTerminalInputStore.getState().lastTypedAgentTarget;
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+
+      // Every keystroke re-records; a fresh object each time would wake every
+      // subscriber for nothing.
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget).toBe(first);
+    });
+
+    it("drops the target when its terminal is removed", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+      useTerminalInputStore.getState().clearTerminalState("term-1");
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget).toBeNull();
+    });
+
+    it("keeps the target when a different terminal is removed", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+      useTerminalInputStore.getState().clearTerminalState("term-2");
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget?.terminalId).toBe("term-1");
+    });
+
+    it("drops the target when a project switch discards its terminal", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "project-a");
+      useTerminalInputStore.getState().resetForProjectSwitch("project-a");
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget).toBeNull();
+    });
+
+    it("keeps the target when a project switch preserves its terminal", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "project-a");
+      useTerminalInputStore.getState().resetForProjectSwitch("project-a", new Set(["term-1"]));
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget?.terminalId).toBe("term-1");
+    });
+
+    it("keeps a target belonging to another workspace when a project resets", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "project-b");
+      useTerminalInputStore.getState().resetForProjectSwitch("project-a");
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget?.terminalId).toBe("term-1");
+    });
+
+    it("drops the target on a full reset", () => {
+      useTerminalInputStore.getState().recordLastTypedAgentTarget("term-1", "ws-1");
+      useTerminalInputStore.getState().clearAllDraftInputs();
+
+      expect(useTerminalInputStore.getState().lastTypedAgentTarget).toBeNull();
     });
   });
 });

--- a/src/store/terminalInputStore.ts
+++ b/src/store/terminalInputStore.ts
@@ -87,13 +87,32 @@ function deleteProjectKeys<V>(
   return next;
 }
 
+/**
+ * The agent a user last actually typed into — the routing target for the
+ * type-anywhere rescue (#11134).
+ *
+ * Deliberately NOT derived from panel selection or `lastFocusedTerminalByWorktree`:
+ * selection is overloaded by fleet membership and can point at a file or browser
+ * panel, and focus is not typing. This is recorded only from real `input.type`
+ * transactions in an agent's hybrid editor.
+ *
+ * `workspaceId` pins the record to the view that produced it, so a sibling
+ * project view can never route into it.
+ */
+export interface LastTypedAgentTarget {
+  workspaceId: string;
+  terminalId: string;
+}
+
 export interface TerminalInputState {
   hybridInputEnabled: boolean;
   hybridInputAutoFocus: boolean;
   draftInputs: Map<string, string>;
-  /** Incremented when voice transcription appends to a draft, so
-   *  UI components can detect external draft mutations. */
-  voiceDraftRevision: number;
+  /** Incremented when something outside the editor writes a draft (voice
+   *  transcription, prompt history, the type-anywhere rescue), so a mounted
+   *  editor can detect the external mutation and sync its document. */
+  externalDraftRevision: number;
+  lastTypedAgentTarget: LastTypedAgentTarget | null;
   commandHistory: Map<string, string[]>;
   historyIndex: Map<string, number>;
   tempDraft: Map<string, string>;
@@ -103,7 +122,8 @@ export interface TerminalInputState {
   setHybridInputAutoFocus: (enabled: boolean) => void;
   getDraftInput: (terminalId: string, projectId?: string) => string;
   setDraftInput: (terminalId: string, value: string, projectId?: string) => void;
-  bumpVoiceDraftRevision: () => void;
+  bumpExternalDraftRevision: () => void;
+  recordLastTypedAgentTarget: (terminalId: string, workspaceId: string) => void;
   clearDraftInput: (terminalId: string, projectId?: string) => void;
   clearAllDraftInputs: () => void;
   setPendingDraft: (terminalId: string, value: string, projectId?: string) => void;
@@ -135,7 +155,8 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
   hybridInputEnabled: true,
   hybridInputAutoFocus: true,
   draftInputs: new Map(),
-  voiceDraftRevision: 0,
+  externalDraftRevision: 0,
+  lastTypedAgentTarget: null,
   commandHistory: new Map(),
   historyIndex: new Map(),
   tempDraft: new Map(),
@@ -198,8 +219,17 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
       newDraftInputs.delete(key);
       return { draftInputs: newDraftInputs };
     }),
-  bumpVoiceDraftRevision: () =>
-    set((state) => ({ voiceDraftRevision: state.voiceDraftRevision + 1 })),
+  bumpExternalDraftRevision: () =>
+    set((state) => ({ externalDraftRevision: state.externalDraftRevision + 1 })),
+
+  recordLastTypedAgentTarget: (terminalId, workspaceId) =>
+    set((state) => {
+      const current = state.lastTypedAgentTarget;
+      if (current?.terminalId === terminalId && current.workspaceId === workspaceId) {
+        return state;
+      }
+      return { lastTypedAgentTarget: { terminalId, workspaceId } };
+    }),
 
   clearAllDraftInputs: () =>
     set({
@@ -210,6 +240,7 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
       commandHistory: new Map(),
       historyIndex: new Map(),
       tempDraft: new Map(),
+      lastTypedAgentTarget: null,
     }),
 
   stashEditorState: (terminalId, editorState, projectId) =>
@@ -385,6 +416,10 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
           })()
         : state.voiceSubmittingPanels;
 
+      // A removed terminal can never be a routing target again.
+      const newLastTyped =
+        state.lastTypedAgentTarget?.terminalId === terminalId ? null : state.lastTypedAgentTarget;
+
       const changed =
         newDraftInputs !== state.draftInputs ||
         newPendingDrafts !== state.pendingDrafts ||
@@ -392,7 +427,8 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
         newHistory !== state.commandHistory ||
         newIndex !== state.historyIndex ||
         newTempDraft !== state.tempDraft ||
-        newVoiceSubmitting !== state.voiceSubmittingPanels;
+        newVoiceSubmitting !== state.voiceSubmittingPanels ||
+        newLastTyped !== state.lastTypedAgentTarget;
 
       if (!changed) return state;
 
@@ -404,6 +440,7 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
         historyIndex: newIndex,
         tempDraft: newTempDraft,
         voiceSubmittingPanels: newVoiceSubmitting,
+        lastTypedAgentTarget: newLastTyped,
       };
     }),
 
@@ -424,13 +461,24 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
       const newIndex = deleteProjectKeys(state.historyIndex, projectId, preserveTerminalIds);
       const newTempDraft = deleteProjectKeys(state.tempDraft, projectId, preserveTerminalIds);
 
+      // Drop the routing target only if this switch actually discards it — a
+      // preserved terminal keeps its claim.
+      const target = state.lastTypedAgentTarget;
+      const newLastTyped =
+        target !== null &&
+        target.workspaceId === projectId &&
+        !preserveTerminalIds?.has(target.terminalId)
+          ? null
+          : target;
+
       const changed =
         newDraftInputs !== state.draftInputs ||
         newPendingDrafts !== state.pendingDrafts ||
         newStashed !== state.stashedEditorStates ||
         newHistory !== state.commandHistory ||
         newIndex !== state.historyIndex ||
-        newTempDraft !== state.tempDraft;
+        newTempDraft !== state.tempDraft ||
+        newLastTyped !== state.lastTypedAgentTarget;
 
       if (!changed) return state;
 
@@ -441,6 +489,7 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
         commandHistory: newHistory,
         historyIndex: newIndex,
         tempDraft: newTempDraft,
+        lastTypedAgentTarget: newLastTyped,
       };
     }),
 

--- a/src/store/typingLocatorStore.ts
+++ b/src/store/typingLocatorStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+/**
+ * Transient "here is where your typing is going" label (#11134).
+ *
+ * Deliberately not routed through `notify()`: this is ephemeral typing
+ * feedback the user is already looking for, not an event they could otherwise
+ * miss, and it must leave no inbox history. The grid-bar and InlineStatusBanner
+ * surfaces are both wrong for the same reason — they are for runtime signals
+ * with recovery actions.
+ */
+interface TypingLocatorState {
+  label: string | null;
+  /** Bumped on every show so a repeat locator for the same pane restarts the dwell. */
+  revision: number;
+  showLocator: (label: string) => void;
+  clearLocator: () => void;
+}
+
+export const useTypingLocatorStore = create<TypingLocatorState>()((set) => ({
+  label: null,
+  revision: 0,
+  showLocator: (label) => set((s) => ({ label, revision: s.revision + 1 })),
+  clearLocator: () => set({ label: null }),
+}));


### PR DESCRIPTION
## Summary

- Adds one global, capture-phase keydown listener implementing two deliberately asymmetric behaviours for the terminal grid: a type-anywhere rescue and an off-screen focus locator.
- **Type-anywhere rescue**: when a plain printable key is pressed and nothing useful holds focus (document body, or a read-only surface like the file viewer), the character is appended to the prompt draft of the last agent the user typed to, that draft is focused, and its pane is revealed. The keydown event is only consumed after the character is durably written to the store, so a failed focus handoff can never eat the keystroke. Nothing is ever submitted automatically, Enter stays the user's decision.
- **Off-screen focus locator**: when a real terminal legitimately holds focus but its pane is scrolled out of the grid viewport, the keystroke is not rerouted. The pane scrolls back into view, pulses (reusing the existing `pingTerminal` / `animate-terminal-ping` affordance), and a transient pill names it ("Typing into Claude"). The event is left untouched so the key lands exactly where the user aimed it.

Resolves #11134

## Design notes

- **"Last agent typed to" is its own notion.** It's recorded only from real CodeMirror `input.type` transactions in an agent's hybrid editor, not from focus or panel selection. The existing `lastFocusedTerminalByWorktree` updates on every focus change for any panel kind, including file and browser panels, so it wasn't usable here.
- **The rescue refuses rather than guesses.** No unambiguous target, a live fleet broadcast (`armedIds.size >= 2`), an active screen reader, an open modal or command palette, or a target whose draft wouldn't be visible and editable (hybrid input switched off globally, backend down, target locked or restarting) all refuse and let the key fall through untouched.
- It never routes into a raw shell PTY, only into an agent's draft where nothing happens until Enter.
- Reuses the existing screen-reader setting (`useScreenReaderStore` / `resolvedScreenReaderEnabled`) instead of adding a new toggle, and the existing per-pane `IntersectionObserver` visibility signal instead of adding a new observer.
- AltGr-produced characters (`ctrlKey` and `altKey` both set, as produced by Windows/Linux keyboard layouts) are correctly treated as printable, not as a modifier chord.
- Focus is read from the keydown event's composed path rather than `document.activeElement`, so a focused shadow-DOM input keeps its keystroke; menu/listbox/combobox typeahead surfaces are treated as owning the key.
- `voiceDraftRevision` was renamed to `externalDraftRevision`. The rescue is now a second, non-voice writer of that external-draft-sync channel.

## Changes

17 files changed. New:
- `src/lib/typeAnywhere.ts`
- `src/hooks/useTypeAnywhere.ts`
- `src/components/Terminal/TypingLocator.tsx`
- `src/store/typingLocatorStore.ts`

## Testing

190 targeted tests in two new suites, `src/lib/__tests__/typeAnywhere.test.ts` and `src/hooks/__tests__/useTypeAnywhere.test.tsx`, covering the full safety matrix: AltGr, IME/dead keys, key repeats, modal/palette/menu/shadow-DOM focus, fleet-armed state, screen reader active, raw-shell refusal, locked/restarting/backend-down refusal, and the locator's non-consuming behaviour.

1146 tests pass across this branch's suites plus all Terminal component tests. eslint and prettier are clean on changed files.
