### PR TITLE
fix(security): write persisted runtime data owner-only on POSIX

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -15,7 +15,13 @@ import { store, windowStatesStore } from "../store.js";
 import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { getActionBreadcrumbService } from "./ActionBreadcrumbService.js";
-import { resilientAtomicWriteFileSync, resilientRenameSync } from "../utils/fs.js";
+import {
+  resilientAtomicWriteFileSync,
+  resilientRenameSync,
+  tightenDirPermissionsSync,
+  OWNER_RW_FILE_MODE,
+  OWNER_RWX_DIR_MODE,
+} from "../utils/fs.js";
 import { WATCHDOG_KILL_FLAG_NAME } from "../watchdog-host-core.js";
 
 const MAX_CRASH_LOGS = 10;
@@ -206,9 +212,12 @@ export class CrashRecoveryService {
    * file that exists.
    */
   private writeCrashLog(entry: CrashLogEntry): string {
-    fs.mkdirSync(this.crashesDir, { recursive: true });
+    fs.mkdirSync(this.crashesDir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
+    tightenDirPermissionsSync(this.crashesDir);
     const logPath = path.join(this.crashesDir, `crash-${entry.id}.json`);
-    resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8");
+    resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8", {
+      mode: OWNER_RW_FILE_MODE,
+    });
     return logPath;
   }
 
@@ -338,7 +347,8 @@ export class CrashRecoveryService {
   takeBackup(): void {
     try {
       const backupDir = path.join(this.userData, BACKUP_DIR);
-      fs.mkdirSync(backupDir, { recursive: true });
+      fs.mkdirSync(backupDir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
+      tightenDirPermissionsSync(backupDir);
 
       const snapshot = this.captureSessionSnapshot();
 
@@ -362,7 +372,9 @@ export class CrashRecoveryService {
       // the write and the previous file just isn't refreshed this cycle.
       this.rotateBackup();
 
-      resilientAtomicWriteFileSync(this.backupPath, JSON.stringify(snapshot), "utf-8");
+      resilientAtomicWriteFileSync(this.backupPath, JSON.stringify(snapshot), "utf-8", {
+        mode: OWNER_RW_FILE_MODE,
+      });
       this.lastWrittenStateJson = stateJson;
     } catch (err) {
       console.error("[CrashRecovery] Failed to take backup:", err);
@@ -597,7 +609,9 @@ export class CrashRecoveryService {
         // is non-fatal — the in-memory entry is the source of truth.
         if (logPath) {
           try {
-            resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8");
+            resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8", {
+              mode: OWNER_RW_FILE_MODE,
+            });
           } catch (err) {
             console.error("[CrashRecovery] Failed to persist watchdog annotation:", err);
           }
@@ -688,7 +702,9 @@ export class CrashRecoveryService {
     } catch (renameErr) {
       try {
         const content = fs.readFileSync(this.backupPath, "utf-8");
-        resilientAtomicWriteFileSync(crashedBackupPath, content, "utf-8");
+        resilientAtomicWriteFileSync(crashedBackupPath, content, "utf-8", {
+          mode: OWNER_RW_FILE_MODE,
+        });
         try {
           fs.unlinkSync(this.backupPath);
         } catch {
@@ -868,7 +884,9 @@ export class CrashRecoveryService {
           ? path.join(this.crashesDir, `crash-${crashEntry.id}.json`)
           : undefined,
       };
-      resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(marker), "utf-8");
+      resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(marker), "utf-8", {
+        mode: OWNER_RW_FILE_MODE,
+      });
     } catch (err) {
       console.error("[CrashRecovery] Failed to write marker:", err);
     }
@@ -887,7 +905,9 @@ export class CrashRecoveryService {
       const marker = JSON.parse(raw) as MarkerFile;
       if (!isValidMarker(marker)) return;
       mutate(marker);
-      resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(marker), "utf-8");
+      resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(marker), "utf-8", {
+        mode: OWNER_RW_FILE_MODE,
+      });
     } catch (err) {
       console.warn("[CrashRecovery] Failed to mutate marker:", err);
     }

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -19,6 +19,7 @@ import {
   resilientAtomicWriteFileSync,
   resilientRenameSync,
   tightenDirPermissionsSync,
+  tightenFilePermissionsSync,
   OWNER_RW_FILE_MODE,
   OWNER_RWX_DIR_MODE,
 } from "../utils/fs.js";
@@ -385,6 +386,10 @@ export class CrashRecoveryService {
     if (!fs.existsSync(this.backupPath)) return;
     try {
       resilientRenameSync(this.backupPath, this.previousBackupPath);
+      // rename preserves the source mode: on the first rotation after an
+      // upgrade, the pre-fix 0o644 current backup would land as `previous`
+      // still world-readable. Tighten the rotated file explicitly.
+      tightenFilePermissionsSync(this.previousBackupPath);
     } catch (err) {
       // Rotation is best-effort; the new write below will still proceed and
       // overwrite the (possibly stale) previous file on the next cycle.
@@ -692,12 +697,19 @@ export class CrashRecoveryService {
     // Idempotency: if a prior consumeMarker run completed the rename but
     // was killed before deleteMarker, the destination is already on disk
     // and the live backup is gone. Reuse the existing crashed-* file.
-    if (fs.existsSync(crashedBackupPath)) return crashedBackupPath;
+    if (fs.existsSync(crashedBackupPath)) {
+      // A pre-fix run may have left this forensic copy world-readable.
+      tightenFilePermissionsSync(crashedBackupPath);
+      return crashedBackupPath;
+    }
 
     if (!fs.existsSync(this.backupPath)) return null;
 
     try {
       resilientRenameSync(this.backupPath, crashedBackupPath);
+      // rename preserves the source mode — tighten in case the live backup was
+      // a legacy 0o644 file from before this change.
+      tightenFilePermissionsSync(crashedBackupPath);
       return crashedBackupPath;
     } catch (renameErr) {
       try {

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -11,6 +11,7 @@ import {
 } from "./persistence/db.js";
 import { runDbWork } from "./persistence/dbWorkerClient.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
+import { tightenFilePermissionsSync } from "../utils/fs.js";
 import type { DbProbeResult } from "./persistence/dbWorkerProtocol.js";
 import type { DatabaseRecovery } from "../../shared/types/ipc/app.js";
 
@@ -304,6 +305,11 @@ class DatabaseMaintenanceService {
 
     try {
       await sqlite.backup(tmpPath);
+
+      // sqlite.backup() creates the temp copy at the umask default. Tighten it to
+      // owner-only before the rename below so the promoted .backup — a verbatim
+      // copy of the whole database — is never world-readable at its final path.
+      tightenFilePermissionsSync(tmpPath);
 
       // sqlite.backup() copies pages verbatim and never validates them, so a
       // corrupt source yields a corrupt copy with no error at all. Probe the

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -11,7 +11,7 @@ import {
 } from "./persistence/db.js";
 import { runDbWork } from "./persistence/dbWorkerClient.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
-import { tightenFilePermissionsSync } from "../utils/fs.js";
+import { tightenFilePermissionsSync, OWNER_RW_FILE_MODE } from "../utils/fs.js";
 import type { DbProbeResult } from "./persistence/dbWorkerProtocol.js";
 import type { DatabaseRecovery } from "../../shared/types/ipc/app.js";
 
@@ -49,6 +49,11 @@ class DatabaseMaintenanceService {
     this.initialized = true;
 
     const dbPath = getDbPath();
+
+    // Retroactively tighten a legacy .backup written by a pre-fix version before
+    // recovery reads or copies it. runBackup rewrites it 0o600 on every tick, but
+    // this closes the boot→first-tick window and the corruption-recovery path.
+    tightenFilePermissionsSync(getBackupPath());
 
     // On clean-exit boots corruption is impossible — skip the O(size) page scan
     // and do a cheap open instead. The full quick_check runs from the idle
@@ -304,11 +309,22 @@ class DatabaseMaintenanceService {
     const tmpPath = backupPath + ".tmp";
 
     try {
+      // Pre-create the candidate owner-only so it is never world-readable during
+      // the (potentially slow) page copy — the temp is a verbatim copy of the
+      // whole database. "w" truncates any stale temp from a crashed run; better-
+      // sqlite3 backs up correctly into a pre-existing empty file. POSIX-only.
+      if (process.platform !== "win32") {
+        try {
+          fs.closeSync(fs.openSync(tmpPath, "w", OWNER_RW_FILE_MODE));
+        } catch {
+          // best-effort; the post-backup chmod below still tightens the result
+        }
+      }
+
       await sqlite.backup(tmpPath);
 
-      // sqlite.backup() creates the temp copy at the umask default. Tighten it to
-      // owner-only before the rename below so the promoted .backup — a verbatim
-      // copy of the whole database — is never world-readable at its final path.
+      // Re-assert owner-only after the copy (exactness + covers the win32/no-
+      // precreate path) before the rename promotes it to the final .backup path.
       tightenFilePermissionsSync(tmpPath);
 
       // sqlite.backup() copies pages verbatim and never validates them, so a

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -29,6 +29,9 @@ const browserWindowMock = vi.hoisted(() => ({
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenDirPermissionsSync: vi.fn(),
+  OWNER_RW_FILE_MODE: 0o600,
+  OWNER_RWX_DIR_MODE: 0o700,
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -29,6 +29,7 @@ const browserWindowMock = vi.hoisted(() => ({
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenFilePermissionsSync: vi.fn(),
   tightenDirPermissionsSync: vi.fn(),
   OWNER_RW_FILE_MODE: 0o600,
   OWNER_RWX_DIR_MODE: 0o700,

--- a/electron/services/__tests__/CrashRecoveryService.backup.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.backup.test.ts
@@ -32,6 +32,7 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenFilePermissionsSync: vi.fn(),
   tightenDirPermissionsSync: vi.fn(),
   OWNER_RW_FILE_MODE: 0o600,
   OWNER_RWX_DIR_MODE: 0o700,
@@ -300,6 +301,53 @@ describe("CrashRecoveryService", () => {
       expect(rotated.capturedAt).toBe(1_000);
       const fresh = JSON.parse(fs.readFileSync(currentPath, "utf8"));
       expect(fresh.appState.sidebarWidth).toBe(200);
+    });
+
+    it("tightens the rotated previous backup (rename carries the source mode)", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const currentPath = path.join(backupDir, "session-state.json");
+      const previousPath = path.join(backupDir, "session-state.previous.json");
+      fs.writeFileSync(currentPath, JSON.stringify({ capturedAt: 1_000, appState: {} }));
+
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 200, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      windowStatesStoreMock.get.mockReturnValue({});
+
+      const svc = makeService();
+      svc.initialize();
+      utilsMock.tightenFilePermissionsSync.mockClear();
+      svc.takeBackup();
+
+      // rename preserves the source mode, so a pre-fix 0644 current would land as
+      // `previous` world-readable — the service must tighten it explicitly.
+      expect(utilsMock.tightenFilePermissionsSync).toHaveBeenCalledWith(previousPath);
+    });
+
+    it("tightens the crashed backup preserved on consumeMarker", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({ capturedAt: Date.now(), appState: { terminals: [] } })
+      );
+      const markerSessionStart = Date.now() - 5000;
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs: markerSessionStart,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      const crashedPath = path.join(backupDir, `session-state.crashed-${markerSessionStart}.json`);
+      expect(utilsMock.tightenFilePermissionsSync).toHaveBeenCalledWith(crashedPath);
     });
 
     it("does not rotate when no current backup exists yet", () => {

--- a/electron/services/__tests__/CrashRecoveryService.backup.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.backup.test.ts
@@ -32,6 +32,9 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenDirPermissionsSync: vi.fn(),
+  OWNER_RW_FILE_MODE: 0o600,
+  OWNER_RWX_DIR_MODE: 0o700,
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);

--- a/electron/services/__tests__/CrashRecoveryService.blurAndWatchdog.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.blurAndWatchdog.test.ts
@@ -32,6 +32,9 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenDirPermissionsSync: vi.fn(),
+  OWNER_RW_FILE_MODE: 0o600,
+  OWNER_RWX_DIR_MODE: 0o700,
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);

--- a/electron/services/__tests__/CrashRecoveryService.blurAndWatchdog.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.blurAndWatchdog.test.ts
@@ -32,6 +32,7 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenFilePermissionsSync: vi.fn(),
   tightenDirPermissionsSync: vi.fn(),
   OWNER_RW_FILE_MODE: 0o600,
   OWNER_RWX_DIR_MODE: 0o700,
@@ -469,6 +470,13 @@ describe("CrashRecoveryService", () => {
       expect(onDisk.watchdogKilledAt).toBe(killedAt);
       expect(onDisk.watchdogMissedBeats).toBe(3);
       expect(onDisk.watchdogMainPid).toBe(4242);
+      // The annotation rewrite of the crash log must request owner-only perms.
+      expect(utilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+        crashLogPath,
+        expect.any(String),
+        "utf-8",
+        { mode: 0o600 }
+      );
     });
 
     it("surfaces a dev-mode crash with a fresh watchdog flag (otherwise discarded as orphan)", () => {

--- a/electron/services/__tests__/CrashRecoveryService.lifecycle.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.lifecycle.test.ts
@@ -32,6 +32,7 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenFilePermissionsSync: vi.fn(),
   tightenDirPermissionsSync: vi.fn(),
   OWNER_RW_FILE_MODE: 0o600,
   OWNER_RWX_DIR_MODE: 0o700,
@@ -92,19 +93,12 @@ describe("CrashRecoveryService", () => {
     storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
     storeMock.set.mockImplementation(() => {});
     utilsMock.resilientAtomicWriteFileSync.mockImplementation(
-      (fp: string, data: string, enc?: BufferEncoding, opts?: { mode?: number }) => {
+      (fp: string, data: string, enc?: BufferEncoding) => {
         fs.writeFileSync(fp, data, enc ?? "utf-8");
-        // Mirror the real helper: apply the requested mode on POSIX.
-        if (opts?.mode !== undefined && process.platform !== "win32") {
-          fs.chmodSync(fp, opts.mode);
-        }
       }
     );
     utilsMock.resilientRenameSync.mockImplementation((src: string, dest: string) => {
       fs.renameSync(src, dest);
-    });
-    utilsMock.tightenDirPermissionsSync.mockImplementation((dir: string) => {
-      if (process.platform !== "win32") fs.chmodSync(dir, 0o700);
     });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -135,24 +129,27 @@ describe("CrashRecoveryService", () => {
       expect(svc.getPendingCrash()).toBeNull();
     });
 
-    // chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
-    const posixIt = process.platform === "win32" ? it.skip : it;
-
-    posixIt("writes the marker, crash log, and crashes directory owner-only", () => {
+    it("requests owner-only writes and tightens the crashes directory", () => {
       const svc = makeService();
       svc.initialize();
+      utilsMock.resilientAtomicWriteFileSync.mockClear();
+      utilsMock.tightenDirPermissionsSync.mockClear();
+
       svc.recordCrash(new Error("boom"));
 
-      const markerPath = path.join(userData, "running.lock");
       const crashesDir = path.join(userData, "crashes");
-      expect(fs.statSync(markerPath).mode & 0o777).toBe(0o600);
-      expect(fs.statSync(crashesDir).mode & 0o777).toBe(0o700);
+      // The service asks the (separately unit-tested) helper to tighten the dir —
+      // this is what fixes an upgrading install's pre-existing 0755 crashes dir.
+      expect(utilsMock.tightenDirPermissionsSync).toHaveBeenCalledWith(crashesDir);
 
-      const crashLog = fs
-        .readdirSync(crashesDir)
-        .find((name) => name.startsWith("crash-") && name.endsWith(".json"));
-      expect(crashLog).toBeDefined();
-      expect(fs.statSync(path.join(crashesDir, crashLog!)).mode & 0o777).toBe(0o600);
+      // Every crash-recovery write requests 0o600 as its 4th argument. Asserting
+      // the requested mode (not a mock-produced file mode) proves the real service
+      // behavior; the helper's own suite proves the mode is honored on disk.
+      const calls = utilsMock.resilientAtomicWriteFileSync.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      for (const call of calls) {
+        expect(call[3]).toEqual({ mode: 0o600 });
+      }
     });
 
     it("detects crash from orphaned marker on next launch", () => {

--- a/electron/services/__tests__/CrashRecoveryService.lifecycle.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.lifecycle.test.ts
@@ -32,6 +32,9 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenDirPermissionsSync: vi.fn(),
+  OWNER_RW_FILE_MODE: 0o600,
+  OWNER_RWX_DIR_MODE: 0o700,
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);
@@ -89,12 +92,19 @@ describe("CrashRecoveryService", () => {
     storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
     storeMock.set.mockImplementation(() => {});
     utilsMock.resilientAtomicWriteFileSync.mockImplementation(
-      (fp: string, data: string, enc?: BufferEncoding) => {
+      (fp: string, data: string, enc?: BufferEncoding, opts?: { mode?: number }) => {
         fs.writeFileSync(fp, data, enc ?? "utf-8");
+        // Mirror the real helper: apply the requested mode on POSIX.
+        if (opts?.mode !== undefined && process.platform !== "win32") {
+          fs.chmodSync(fp, opts.mode);
+        }
       }
     );
     utilsMock.resilientRenameSync.mockImplementation((src: string, dest: string) => {
       fs.renameSync(src, dest);
+    });
+    utilsMock.tightenDirPermissionsSync.mockImplementation((dir: string) => {
+      if (process.platform !== "win32") fs.chmodSync(dir, 0o700);
     });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -123,6 +133,26 @@ describe("CrashRecoveryService", () => {
       const svc = makeService();
       svc.initialize();
       expect(svc.getPendingCrash()).toBeNull();
+    });
+
+    // chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
+    const posixIt = process.platform === "win32" ? it.skip : it;
+
+    posixIt("writes the marker, crash log, and crashes directory owner-only", () => {
+      const svc = makeService();
+      svc.initialize();
+      svc.recordCrash(new Error("boom"));
+
+      const markerPath = path.join(userData, "running.lock");
+      const crashesDir = path.join(userData, "crashes");
+      expect(fs.statSync(markerPath).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(crashesDir).mode & 0o777).toBe(0o700);
+
+      const crashLog = fs
+        .readdirSync(crashesDir)
+        .find((name) => name.startsWith("crash-") && name.endsWith(".json"));
+      expect(crashLog).toBeDefined();
+      expect(fs.statSync(path.join(crashesDir, crashLog!)).mode & 0o777).toBe(0o600);
     });
 
     it("detects crash from orphaned marker on next launch", () => {

--- a/electron/services/__tests__/CrashRecoveryService.panelMetadata.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.panelMetadata.test.ts
@@ -32,6 +32,9 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenDirPermissionsSync: vi.fn(),
+  OWNER_RW_FILE_MODE: 0o600,
+  OWNER_RWX_DIR_MODE: 0o700,
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);

--- a/electron/services/__tests__/CrashRecoveryService.panelMetadata.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.panelMetadata.test.ts
@@ -32,6 +32,7 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenFilePermissionsSync: vi.fn(),
   tightenDirPermissionsSync: vi.fn(),
   OWNER_RW_FILE_MODE: 0o600,
   OWNER_RWX_DIR_MODE: 0o700,

--- a/electron/services/__tests__/CrashRecoveryService.resetAndMarkerParsing.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.resetAndMarkerParsing.test.ts
@@ -32,6 +32,7 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenFilePermissionsSync: vi.fn(),
   tightenDirPermissionsSync: vi.fn(),
   OWNER_RW_FILE_MODE: 0o600,
   OWNER_RWX_DIR_MODE: 0o700,
@@ -270,6 +271,9 @@ describe("CrashRecoveryService", () => {
       expect(markerCalls).toHaveLength(1);
       expect(crashLogCalls[0][2]).toBe("utf-8");
       expect(markerCalls[0][2]).toBe("utf-8");
+      // Both writes must request owner-only permissions.
+      expect(crashLogCalls[0][3]).toEqual({ mode: 0o600 });
+      expect(markerCalls[0][3]).toEqual({ mode: 0o600 });
     });
 
     it("routes takeBackup() through resilientAtomicWriteFileSync", () => {

--- a/electron/services/__tests__/CrashRecoveryService.resetAndMarkerParsing.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.resetAndMarkerParsing.test.ts
@@ -32,6 +32,9 @@ const appMock = vi.hoisted(() => {
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
   resilientRenameSync: vi.fn(),
+  tightenDirPermissionsSync: vi.fn(),
+  OWNER_RW_FILE_MODE: 0o600,
+  OWNER_RWX_DIR_MODE: 0o700,
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);
@@ -244,7 +247,8 @@ describe("CrashRecoveryService", () => {
       expect(utilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
         markerPath,
         expect.any(String),
-        "utf-8"
+        "utf-8",
+        { mode: 0o600 }
       );
     });
 
@@ -279,7 +283,8 @@ describe("CrashRecoveryService", () => {
       expect(utilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
         backupPath,
         expect.any(String),
-        "utf-8"
+        "utf-8",
+        { mode: 0o600 }
       );
     });
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -487,9 +487,13 @@ describe("DatabaseMaintenanceService", () => {
     const realDir = actual.mkdtempSync(path.join(os.tmpdir(), "daintree-dbmaint-perms-"));
     const backupPath = path.join(realDir, "daintree.db.backup");
     mockDbModule.getBackupPath.mockReturnValue(backupPath);
-    // sqlite.backup() writes the candidate at the umask default; simulate that.
+    let tmpModeAtBackupStart: number | undefined;
     mockSqlite.backup.mockImplementation(async (tmp: string) => {
+      // The candidate is pre-created owner-only BEFORE the copy runs, so it is
+      // never world-readable during the (potentially slow) page transfer.
+      tmpModeAtBackupStart = actual.statSync(tmp).mode & 0o777;
       actual.writeFileSync(tmp, "backup-bytes");
+      // Simulate a copy that reset perms — the post-backup chmod must recover them.
       actual.chmodSync(tmp, 0o644);
     });
     // Let the promotion rename actually run, and assert the candidate is ALREADY
@@ -506,11 +510,32 @@ describe("DatabaseMaintenanceService", () => {
       // dispose() runs the final backup on main (probeOnMain), no worker needed.
       await service.dispose();
 
+      expect(tmpModeAtBackupStart).toBe(0o600);
       expect(tmpModeAtRename).toBe(0o600);
       expect(actual.existsSync(backupPath)).toBe(true);
       expect(actual.statSync(backupPath).mode & 0o777).toBe(0o600);
     } finally {
       actual.rmSync(realDir, { recursive: true, force: true });
+    }
+  });
+
+  posixIt("tightens a legacy world-readable backup on initialize", () => {
+    const realDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-dbmaint-legacy-"));
+    const backupPath = path.join(realDir, "daintree.db.backup");
+    try {
+      // A .backup written by a pre-fix version, still world-readable.
+      fs.writeFileSync(backupPath, "legacy backup bytes");
+      fs.chmodSync(backupPath, 0o644);
+      mockDbModule.getBackupPath.mockReturnValue(backupPath);
+      mockDbModule.probeDb.mockReturnValue(true); // healthy → no recovery path
+
+      const service = new DatabaseMaintenanceService();
+      // initialize() alone starts no timers/listeners, so no dispose is needed.
+      service.initialize(true);
+
+      expect(fs.statSync(backupPath).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(realDir, { recursive: true, force: true });
     }
   });
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPowerMonitor = vi.hoisted(() => ({
@@ -475,6 +477,36 @@ describe("DatabaseMaintenanceService", () => {
       "/fake/daintree.db.backup"
     );
     await service.dispose();
+  });
+
+  // chmod is a POSIX no-op on Windows, so the mode-bit assertion only runs there.
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt("promotes the backup file owner-only", async () => {
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const realDir = actual.mkdtempSync(path.join(os.tmpdir(), "daintree-dbmaint-perms-"));
+    const backupPath = path.join(realDir, "daintree.db.backup");
+    mockDbModule.getBackupPath.mockReturnValue(backupPath);
+    // sqlite.backup() writes the candidate at the umask default; simulate that.
+    mockSqlite.backup.mockImplementation(async (tmp: string) => {
+      actual.writeFileSync(tmp, "backup-bytes");
+      actual.chmodSync(tmp, 0o644);
+    });
+    // Let the promotion rename actually run against the real filesystem.
+    vi.mocked(fs.renameSync).mockImplementation(
+      actual.renameSync as unknown as typeof fs.renameSync
+    );
+
+    try {
+      const service = new DatabaseMaintenanceService();
+      // dispose() runs the final backup on main (probeOnMain), no worker needed.
+      await service.dispose();
+
+      expect(actual.existsSync(backupPath)).toBe(true);
+      expect(actual.statSync(backupPath).mode & 0o777).toBe(0o600);
+    } finally {
+      actual.rmSync(realDir, { recursive: true, force: true });
+    }
   });
 
   it("suspends all backups once the deferred quick_check reports corruption", async () => {

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -492,16 +492,21 @@ describe("DatabaseMaintenanceService", () => {
       actual.writeFileSync(tmp, "backup-bytes");
       actual.chmodSync(tmp, 0o644);
     });
-    // Let the promotion rename actually run against the real filesystem.
-    vi.mocked(fs.renameSync).mockImplementation(
-      actual.renameSync as unknown as typeof fs.renameSync
-    );
+    // Let the promotion rename actually run, and assert the candidate is ALREADY
+    // 0o600 at rename time — this proves the chmod happens BEFORE promotion, so
+    // the final .backup is never briefly world-readable at its real path.
+    let tmpModeAtRename: number | undefined;
+    vi.mocked(fs.renameSync).mockImplementation(((src: string, dest: string) => {
+      tmpModeAtRename = actual.statSync(src).mode & 0o777;
+      return actual.renameSync(src, dest);
+    }) as unknown as typeof fs.renameSync);
 
     try {
       const service = new DatabaseMaintenanceService();
       // dispose() runs the final backup on main (probeOnMain), no worker needed.
       await service.dispose();
 
+      expect(tmpModeAtRename).toBe(0o600);
       expect(actual.existsSync(backupPath)).toBe(true);
       expect(actual.statSync(backupPath).mode & 0o777).toBe(0o600);
     } finally {

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -87,6 +87,40 @@ describe("openDb (integration)", () => {
     }
   });
 
+  // chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt("creates the database and its WAL/SHM sidecars owner-only", () => {
+    const dbPath = path.join(tmpDir, "perms.db");
+    const { sqlite } = openDb(dbPath, migrationsFolder);
+    try {
+      expect(fs.statSync(dbPath).mode & 0o777).toBe(0o600);
+      // WAL mode + the migrate()/backfill writes create -wal and -shm by now.
+      for (const suffix of ["-wal", "-shm"]) {
+        const sidecar = dbPath + suffix;
+        if (fs.existsSync(sidecar)) {
+          expect(fs.statSync(sidecar).mode & 0o777).toBe(0o600);
+        }
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  posixIt("tightens a pre-existing world-readable database on reopen (upgrade case)", () => {
+    const dbPath = path.join(tmpDir, "legacy.db");
+    openDb(dbPath, migrationsFolder).sqlite.close();
+    // Simulate a database written by a pre-fix app version at the umask default.
+    fs.chmodSync(dbPath, 0o644);
+
+    const reopened = openDb(dbPath, migrationsFolder);
+    try {
+      expect(fs.statSync(dbPath).mode & 0o777).toBe(0o600);
+    } finally {
+      reopened.sqlite.close();
+    }
+  });
+
   it("is idempotent — opening the same DB twice does not throw or duplicate rows", () => {
     const dbPath = path.join(tmpDir, "twice.db");
     const first = openDb(dbPath, migrationsFolder);

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -94,16 +94,33 @@ describe("openDb (integration)", () => {
     const dbPath = path.join(tmpDir, "perms.db");
     const { sqlite } = openDb(dbPath, migrationsFolder);
     try {
+      // Force a WAL frame so -wal/-shm are guaranteed to materialize (a no-op
+      // migrate could otherwise checkpoint them away and leave the loop vacuous).
+      sqlite.pragma("user_version = 42");
+
       expect(fs.statSync(dbPath).mode & 0o777).toBe(0o600);
-      // WAL mode + the migrate()/backfill writes create -wal and -shm by now.
       for (const suffix of ["-wal", "-shm"]) {
         const sidecar = dbPath + suffix;
-        if (fs.existsSync(sidecar)) {
-          expect(fs.statSync(sidecar).mode & 0o777).toBe(0o600);
-        }
+        expect(fs.existsSync(sidecar)).toBe(true);
+        expect(fs.statSync(sidecar).mode & 0o777).toBe(0o600);
       }
     } finally {
       sqlite.close();
+    }
+  });
+
+  posixIt("pre-creates a fresh database with an exclusive owner-only handle", () => {
+    // The final-mode assertion above would still pass with only the post-open
+    // chmod, so pin the TOCTOU protection: the fresh file is created via an
+    // exclusive 0o600 handle BEFORE better-sqlite3 opens it.
+    const dbPath = path.join(tmpDir, "toctou.db");
+    const openSyncSpy = vi.spyOn(fs, "openSync");
+    const { sqlite } = openDb(dbPath, migrationsFolder);
+    try {
+      expect(openSyncSpy).toHaveBeenCalledWith(dbPath, "wx", 0o600);
+    } finally {
+      sqlite.close();
+      openSyncSpy.mockRestore();
     }
   });
 

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -195,6 +195,49 @@ describe("attemptRecovery", () => {
     expect(files.filter((f) => f.includes(".corrupt-")).length).toBe(3);
   });
 
+  // chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt("tightens the restored database and the quarantined file to owner-only", () => {
+    const dbPath = path.join(tmpDir, "daintree.db");
+    const backupPath = dbPath + ".backup";
+
+    // Simulate a pre-fix install: everything world-readable.
+    fs.writeFileSync(dbPath, "corrupt");
+    fs.writeFileSync(backupPath, "valid backup");
+    fs.chmodSync(dbPath, 0o644);
+    fs.chmodSync(backupPath, 0o644);
+
+    const result = attemptRecovery(dbPath);
+
+    expect(result!.kind).toBe("restored-from-backup");
+    // Restored copy is owner-only despite the 0o644 backup source.
+    expect(fs.statSync(dbPath).mode & 0o777).toBe(0o600);
+    // The quarantined forensic copy is tightened too, not left at 0o644.
+    expect(fs.statSync(result!.quarantinedPath!).mode & 0o777).toBe(0o600);
+  });
+
+  posixIt("tightens a preserved-aside backup to owner-only", () => {
+    const dbPath = path.join(tmpDir, "daintree.db");
+    const backupPath = dbPath + ".backup";
+    fs.writeFileSync(dbPath, "corrupt");
+    fs.writeFileSync(backupPath, "the user's real data");
+    fs.chmodSync(backupPath, 0o644);
+
+    // Unverifiable backup → preserved aside rather than restored.
+    mockPragma.mockImplementation(() => {
+      throw Object.assign(new Error("io error"), { code: "SQLITE_IOERR_SHORT_READ" });
+    });
+
+    attemptRecovery(dbPath);
+
+    const preserved = fs
+      .readdirSync(tmpDir)
+      .find((f) => f.startsWith("daintree.db.backup.corrupt-"));
+    expect(preserved).toBeDefined();
+    expect(fs.statSync(path.join(tmpDir, preserved!)).mode & 0o777).toBe(0o600);
+  });
+
   it("resets to a fresh database when no backup exists", () => {
     const dbPath = path.join(tmpDir, "daintree.db");
     fs.writeFileSync(dbPath, "corrupt");

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -6,6 +6,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
 import { getWritesSuppressed } from "../diskPressureState.js";
+import { tightenFilePermissionsSync, OWNER_RW_FILE_MODE } from "../../utils/fs.js";
 import * as schema from "./schema.js";
 import type { DatabaseRecovery } from "../../../shared/types/ipc/app.js";
 import type { DbProbeResult } from "./dbWorkerProtocol.js";
@@ -24,6 +25,17 @@ export function getBackupPath(): string {
 
 export function getMigrationsFolder(): string {
   return path.join(app.getAppPath(), "electron/services/persistence/migrations");
+}
+
+// better-sqlite3 12.x exposes no file-mode option, and the -wal/-shm sidecars are
+// each opened independently at the process umask — none inherit the main file's
+// bits. chmod the whole family (best-effort, POSIX-gated, skips missing sidecars)
+// so the database and its journals are owner-only. Doubles as the retroactive fix
+// for installs that predate this change and still hold a 0o644 daintree.db.
+function tightenDatabaseFilePermissions(dbPath: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    tightenFilePermissionsSync(dbPath + suffix);
+  }
 }
 
 export function getSharedDb(): AppDb {
@@ -81,6 +93,21 @@ export function openDb(
     throw new Error("Cannot open database: disk space is critical");
   }
 
+  // Create a brand-new database owner-only from the very first byte. better-sqlite3
+  // creates the file at the umask default (world-readable) on open, so we win the
+  // race by pre-creating it with an exclusive 0o600 handle before handing the path
+  // to the constructor. Best-effort: EEXIST is the normal existing-DB case, and any
+  // other failure (missing parent, permissions) resurfaces from `new Database`
+  // below — which stays the authority on open errors — while the post-open chmod
+  // still tightens whatever it manages to create. POSIX-only.
+  if (process.platform !== "win32") {
+    try {
+      fs.closeSync(fs.openSync(dbPath, "wx", OWNER_RW_FILE_MODE));
+    } catch {
+      // Intentionally ignored — see comment above.
+    }
+  }
+
   const sqlite = new Database(dbPath);
   try {
     sqlite.pragma("journal_mode = WAL");
@@ -103,6 +130,11 @@ export function openDb(
     sqlite
       .prepare("UPDATE projects SET last_accessed_at = ? WHERE last_accessed_at = 0")
       .run(Date.now());
+
+    // Tighten the whole family once here: migrate()/the backfill above are the
+    // first WAL-mode writes, so -wal/-shm exist by now, and an existing 0o644
+    // daintree.db from a pre-fix install gets corrected in place too.
+    tightenDatabaseFilePermissions(dbPath);
 
     return { sqlite, db };
   } catch (error) {
@@ -244,6 +276,11 @@ export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
       const verdict = probeDbFile(backupPath);
       if (verdict === "ok") {
         fs.copyFileSync(backupPath, dbPath);
+        // copyFileSync's mode propagation is platform/filesystem-dependent, so
+        // tighten the restored database explicitly (openDb will re-tighten the
+        // full family on reopen, but this keeps the restored copy owner-only in
+        // the interim).
+        tightenFilePermissionsSync(dbPath);
         console.log("[DB] Restored database from backup");
         return { kind: "restored-from-backup", quarantinedPath };
       }

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -27,11 +27,13 @@ export function getMigrationsFolder(): string {
   return path.join(app.getAppPath(), "electron/services/persistence/migrations");
 }
 
-// better-sqlite3 12.x exposes no file-mode option, and the -wal/-shm sidecars are
-// each opened independently at the process umask — none inherit the main file's
-// bits. chmod the whole family (best-effort, POSIX-gated, skips missing sidecars)
-// so the database and its journals are owner-only. Doubles as the retroactive fix
-// for installs that predate this change and still hold a 0o644 daintree.db.
+// better-sqlite3 12.x exposes no file-mode option, so the main daintree.db lands
+// at the umask default on creation and must be chmod'd. Bundled SQLite derives
+// the -wal/-shm sidecar mode from the main file's mode, so tightening the main
+// file BEFORE the WAL journal is enabled makes those sidecars owner-only too;
+// we still chmod them here as belt-and-suspenders and to cover any that already
+// exist. Best-effort, POSIX-gated, skips missing sidecars. Doubles as the
+// retroactive fix for installs that predate this change and hold a 0o644 db.
 function tightenDatabaseFilePermissions(dbPath: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     tightenFilePermissionsSync(dbPath + suffix);
@@ -110,6 +112,12 @@ export function openDb(
 
   const sqlite = new Database(dbPath);
   try {
+    // Tighten the main file up front — before the WAL journal is enabled and
+    // before migrations run. This makes an upgrading install's pre-existing
+    // 0o644 database owner-only for the whole migration, and lets SQLite create
+    // the -wal/-shm sidecars from the (now 0o600) main file's mode.
+    tightenDatabaseFilePermissions(dbPath);
+
     sqlite.pragma("journal_mode = WAL");
     sqlite.pragma("busy_timeout = 3000");
     sqlite.pragma("synchronous = NORMAL");
@@ -245,6 +253,10 @@ export function attemptRecovery(dbPath: string): DatabaseRecovery | null {
     if (!fs.existsSync(filePath)) continue;
     try {
       fs.renameSync(filePath, filePath + corruptSuffix);
+      // rename preserves the source mode, so an upgrading install's 0o644 db
+      // would keep world-readable (corrupt but still sensitive) contents in the
+      // forensic copy. Tighten the quarantined file explicitly.
+      tightenFilePermissionsSync(filePath + corruptSuffix);
       if (suffix === "") quarantinedPath = filePath + corruptSuffix;
     } catch (error) {
       if (suffix === "") {
@@ -305,6 +317,9 @@ function preserveStaleBackup(backupPath: string, corruptSuffix: string): void {
   try {
     if (fs.existsSync(backupPath)) {
       fs.renameSync(backupPath, backupPath + corruptSuffix);
+      // rename carries the source mode forward; tighten in case a pre-fix
+      // install's backup was world-readable.
+      tightenFilePermissionsSync(backupPath + corruptSuffix);
     }
   } catch (error) {
     console.error("[DB] Could not move the unusable backup aside:", error);

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -65,6 +65,39 @@ describe("agentSessionHistory", () => {
     expect(records).toEqual([]);
   });
 
+  // chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt("writes the history file owner-only across persist, prune, and clear", async () => {
+    const filePath = getSessionHistoryPath(userDataDir)!;
+    const base = {
+      agentId: "claude",
+      worktreeId: "wt-1",
+      title: null,
+      projectId: null,
+    };
+
+    await persistAgentSession({ ...base, sessionId: "s1" }, userDataDir);
+    expect((await fsp.stat(filePath)).mode & 0o777).toBe(0o600);
+
+    await pruneAgentSessions(30, userDataDir);
+    expect((await fsp.stat(filePath)).mode & 0o777).toBe(0o600);
+
+    await clearAgentSessions(undefined, userDataDir);
+    expect((await fsp.stat(filePath)).mode & 0o777).toBe(0o600);
+  });
+
+  posixIt("tightens a pre-existing world-readable parent directory (upgrade case)", async () => {
+    await fsp.chmod(userDataDir, 0o755);
+
+    await persistAgentSession(
+      { agentId: "claude", worktreeId: "wt-1", title: null, projectId: null, sessionId: "s1" },
+      userDataDir
+    );
+
+    expect((await fsp.stat(userDataDir)).mode & 0o777).toBe(0o700);
+  });
+
   it("persists and reads a session record", async () => {
     await persistAgentSession(
       {

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -83,6 +83,11 @@ describe("agentSessionHistory", () => {
     await pruneAgentSessions(30, userDataDir);
     expect((await fsp.stat(filePath)).mode & 0o777).toBe(0o600);
 
+    // Worktree-filtered clear rewrites the file through a separate branch.
+    await persistAgentSession({ ...base, sessionId: "s2", worktreeId: "wt-2" }, userDataDir);
+    await clearAgentSessions("wt-1", userDataDir);
+    expect((await fsp.stat(filePath)).mode & 0o777).toBe(0o600);
+
     await clearAgentSessions(undefined, userDataDir);
     expect((await fsp.stat(filePath)).mode & 0o777).toBe(0o600);
   });

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -97,12 +97,22 @@ describe("terminalSessionPersistence", () => {
     expect(fs.statSync(getHibernatedMarkerPath("term-perm-sync")!).mode & 0o777).toBe(0o600);
   });
 
-  posixIt("tightens a pre-existing world-readable session directory (upgrade case)", async () => {
+  posixIt("tightens a pre-existing world-readable session directory (async path)", async () => {
     const sessionDir = path.join(userDataDir, "terminal-sessions");
     fs.mkdirSync(sessionDir, { recursive: true });
     fs.chmodSync(sessionDir, 0o755);
 
     await persistSessionSnapshotAsync("term-upgrade", "payload");
+
+    expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
+  });
+
+  posixIt("tightens a pre-existing world-readable session directory (sync path)", () => {
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.chmodSync(sessionDir, 0o755);
+
+    persistSessionSnapshotSync("term-upgrade-sync", "payload");
 
     expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
   });

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -82,6 +82,31 @@ describe("terminalSessionPersistence", () => {
     warnSpy.mockRestore();
   });
 
+  // chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt("writes the session directory, snapshots, and marker owner-only", async () => {
+    persistSessionSnapshotSync("term-perm-sync", "sync payload");
+    await persistSessionSnapshotAsync("term-perm-async", "async payload");
+    writeHibernatedMarker("term-perm-sync");
+
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(path.join(sessionDir, "term-perm-sync.restore")).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.join(sessionDir, "term-perm-async.restore")).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(getHibernatedMarkerPath("term-perm-sync")!).mode & 0o777).toBe(0o600);
+  });
+
+  posixIt("tightens a pre-existing world-readable session directory (upgrade case)", async () => {
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.chmodSync(sessionDir, 0o755);
+
+    await persistSessionSnapshotAsync("term-upgrade", "payload");
+
+    expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
+  });
+
   it("persists and restores snapshots via the atomic write helpers", async () => {
     persistSessionSnapshotSync("term-rt-sync", "sync payload");
     await persistSessionSnapshotAsync("term-rt-async", "async payload");

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -2,7 +2,12 @@
 import { readFileSync, statSync } from "fs";
 import { mkdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import { resilientAtomicWriteFile } from "../../utils/fs.js";
+import {
+  resilientAtomicWriteFile,
+  tightenDirPermissions,
+  OWNER_RW_FILE_MODE,
+  OWNER_RWX_DIR_MODE,
+} from "../../utils/fs.js";
 import type {
   AgentSessionRecord,
   AgentSessionRetentionDays,
@@ -218,7 +223,8 @@ export async function persistAgentSession(
 
   await enqueueWrite(async () => {
     const dir = path.dirname(filePath);
-    await mkdir(dir, { recursive: true });
+    await mkdir(dir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
+    await tightenDirPermissions(dir);
 
     const now = Date.now();
     const fullRecord: AgentSessionRecord = { ...record, savedAt: now };
@@ -226,7 +232,9 @@ export async function persistAgentSession(
     const existing = await readSessionHistory(userData);
     const updated = evictRecords([fullRecord, ...existing], now, retentionDaysToMs(retentionDays));
 
-    await resilientAtomicWriteFile(filePath, JSON.stringify(updated, null, 2));
+    await resilientAtomicWriteFile(filePath, JSON.stringify(updated, null, 2), "utf-8", {
+      mode: OWNER_RW_FILE_MODE,
+    });
     refreshCacheAfterWrite(filePath, updated);
   });
 }
@@ -261,7 +269,9 @@ export async function pruneAgentSessions(
   await enqueueWrite(async () => {
     const existing = await readSessionHistory(userData);
     const pruned = evictRecords(existing, Date.now(), retentionDaysToMs(retentionDays));
-    await resilientAtomicWriteFile(filePath, JSON.stringify(pruned, null, 2));
+    await resilientAtomicWriteFile(filePath, JSON.stringify(pruned, null, 2), "utf-8", {
+      mode: OWNER_RW_FILE_MODE,
+    });
     refreshCacheAfterWrite(filePath, pruned);
   });
 }
@@ -275,14 +285,16 @@ export async function clearAgentSessions(worktreeId?: string, userData?: string)
   await enqueueWrite(async () => {
     if (!worktreeId) {
       // Clear all
-      await resilientAtomicWriteFile(filePath, "[]");
+      await resilientAtomicWriteFile(filePath, "[]", "utf-8", { mode: OWNER_RW_FILE_MODE });
       refreshCacheAfterWrite(filePath, []);
       return;
     }
 
     const existing = await readSessionHistory(userData);
     const filtered = existing.filter((r) => r.worktreeId !== worktreeId);
-    await resilientAtomicWriteFile(filePath, JSON.stringify(filtered, null, 2));
+    await resilientAtomicWriteFile(filePath, JSON.stringify(filtered, null, 2), "utf-8", {
+      mode: OWNER_RW_FILE_MODE,
+    });
     refreshCacheAfterWrite(filePath, filtered);
   });
 }

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -1,7 +1,14 @@
 // eager-import-allow: reads/writes terminal session snapshots via sync fs
-import { readFileSync, statSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { readFileSync, statSync, unlinkSync, mkdirSync } from "fs";
 import { mkdir, readdir, stat, unlink } from "node:fs/promises";
-import { resilientAtomicWriteFile, resilientAtomicWriteFileSync } from "../../utils/fs.js";
+import {
+  resilientAtomicWriteFile,
+  resilientAtomicWriteFileSync,
+  tightenDirPermissions,
+  tightenDirPermissionsSync,
+  OWNER_RW_FILE_MODE,
+  OWNER_RWX_DIR_MODE,
+} from "../../utils/fs.js";
 import path from "node:path";
 import type { Terminal as HeadlessTerminalType, IMarker } from "@xterm/headless";
 
@@ -191,8 +198,11 @@ export function persistSessionSnapshotSync(terminalId: string, state: string): v
     return;
   }
 
-  mkdirSync(dir, { recursive: true });
-  resilientAtomicWriteFileSync(sessionPath, SESSION_HEADER + state, "utf8");
+  mkdirSync(dir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
+  tightenDirPermissionsSync(dir);
+  resilientAtomicWriteFileSync(sessionPath, SESSION_HEADER + state, "utf8", {
+    mode: OWNER_RW_FILE_MODE,
+  });
 }
 
 export async function persistSessionSnapshotAsync(
@@ -210,8 +220,11 @@ export async function persistSessionSnapshotAsync(
     return;
   }
 
-  await mkdir(dir, { recursive: true });
-  await resilientAtomicWriteFile(sessionPath, SESSION_HEADER + state, "utf8");
+  await mkdir(dir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
+  await tightenDirPermissions(dir);
+  await resilientAtomicWriteFile(sessionPath, SESSION_HEADER + state, "utf8", {
+    mode: OWNER_RW_FILE_MODE,
+  });
 }
 
 export async function deleteSessionFile(terminalId: string): Promise<void> {
@@ -243,8 +256,9 @@ export function writeHibernatedMarker(terminalId: string): void {
   const dir = getSessionDir();
   if (!dir) return;
   try {
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(markerPath, "", "utf8");
+    mkdirSync(dir, { recursive: true, mode: OWNER_RWX_DIR_MODE });
+    tightenDirPermissionsSync(dir);
+    resilientAtomicWriteFileSync(markerPath, "", "utf8", { mode: OWNER_RW_FILE_MODE });
   } catch {
     // best-effort
   }

--- a/electron/utils/__tests__/fs.permissions.test.ts
+++ b/electron/utils/__tests__/fs.permissions.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
+import path from "path";
+import os from "os";
+import {
+  OWNER_RW_FILE_MODE,
+  OWNER_RWX_DIR_MODE,
+  tightenDirPermissions,
+  tightenDirPermissionsSync,
+  tightenFilePermissionsSync,
+} from "../fs.js";
+
+// chmod is a POSIX no-op on Windows, so the mode-bit assertions only run there.
+const posixIt = process.platform === "win32" ? it.skip : it;
+
+function mode(p: string): number {
+  return statSync(p).mode & 0o777;
+}
+
+describe("tightenFilePermissionsSync", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "daintree-perms-file-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  posixIt("tightens a world-readable file to owner-only", () => {
+    const target = path.join(tmpDir, "data.json");
+    writeFileSync(target, "{}");
+    chmodSync(target, 0o644);
+
+    tightenFilePermissionsSync(target);
+
+    expect(mode(target)).toBe(OWNER_RW_FILE_MODE);
+  });
+
+  it("does not throw on a missing path", () => {
+    expect(() => tightenFilePermissionsSync(path.join(tmpDir, "absent.json"))).not.toThrow();
+  });
+
+  it("does not throw on an empty path", () => {
+    expect(() => tightenFilePermissionsSync("")).not.toThrow();
+  });
+
+  it("skips chmod entirely on win32", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const target = path.join(tmpDir, "data.json");
+    writeFileSync(target, "{}");
+
+    tightenFilePermissionsSync(target);
+
+    // With the platform mocked as Windows, the function must bail before chmod.
+    expect(platformSpy).toHaveBeenCalled();
+  });
+});
+
+describe("tightenDirPermissionsSync / tightenDirPermissions", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "daintree-perms-dir-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  posixIt("tightens a pre-existing 0755 directory in place (upgrade case)", () => {
+    const dir = path.join(tmpDir, "sessions");
+    mkdirSync(dir);
+    chmodSync(dir, 0o755);
+
+    tightenDirPermissionsSync(dir);
+
+    expect(mode(dir)).toBe(OWNER_RWX_DIR_MODE);
+  });
+
+  posixIt("async variant tightens a pre-existing 0755 directory", async () => {
+    const dir = path.join(tmpDir, "history");
+    mkdirSync(dir);
+    chmodSync(dir, 0o755);
+
+    await tightenDirPermissions(dir);
+
+    expect(mode(dir)).toBe(OWNER_RWX_DIR_MODE);
+  });
+
+  it("does not throw on a missing directory", async () => {
+    const absent = path.join(tmpDir, "absent");
+    expect(() => tightenDirPermissionsSync(absent)).not.toThrow();
+    await expect(tightenDirPermissions(absent)).resolves.toBeUndefined();
+  });
+});

--- a/electron/utils/__tests__/fs.permissions.test.ts
+++ b/electron/utils/__tests__/fs.permissions.test.ts
@@ -3,8 +3,6 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } fr
 import path from "path";
 import os from "os";
 import {
-  OWNER_RW_FILE_MODE,
-  OWNER_RWX_DIR_MODE,
   tightenDirPermissions,
   tightenDirPermissionsSync,
   tightenFilePermissionsSync,
@@ -36,7 +34,19 @@ describe("tightenFilePermissionsSync", () => {
 
     tightenFilePermissionsSync(target);
 
-    expect(mode(target)).toBe(OWNER_RW_FILE_MODE);
+    expect(mode(target)).toBe(0o600);
+  });
+
+  posixIt("leaves a world-readable file untouched when platform is win32", () => {
+    const target = path.join(tmpDir, "data.json");
+    writeFileSync(target, "{}");
+    chmodSync(target, 0o644);
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    tightenFilePermissionsSync(target);
+
+    // The win32 guard must bail before chmod — mode stays exactly as it was.
+    expect(mode(target)).toBe(0o644);
   });
 
   it("does not throw on a missing path", () => {
@@ -45,17 +55,6 @@ describe("tightenFilePermissionsSync", () => {
 
   it("does not throw on an empty path", () => {
     expect(() => tightenFilePermissionsSync("")).not.toThrow();
-  });
-
-  it("skips chmod entirely on win32", () => {
-    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const target = path.join(tmpDir, "data.json");
-    writeFileSync(target, "{}");
-
-    tightenFilePermissionsSync(target);
-
-    // With the platform mocked as Windows, the function must bail before chmod.
-    expect(platformSpy).toHaveBeenCalled();
   });
 });
 
@@ -78,7 +77,7 @@ describe("tightenDirPermissionsSync / tightenDirPermissions", () => {
 
     tightenDirPermissionsSync(dir);
 
-    expect(mode(dir)).toBe(OWNER_RWX_DIR_MODE);
+    expect(mode(dir)).toBe(0o700);
   });
 
   posixIt("async variant tightens a pre-existing 0755 directory", async () => {
@@ -88,7 +87,23 @@ describe("tightenDirPermissionsSync / tightenDirPermissions", () => {
 
     await tightenDirPermissions(dir);
 
-    expect(mode(dir)).toBe(OWNER_RWX_DIR_MODE);
+    expect(mode(dir)).toBe(0o700);
+  });
+
+  posixIt("both variants leave a 0755 directory untouched on win32", async () => {
+    const syncDir = path.join(tmpDir, "sync");
+    const asyncDir = path.join(tmpDir, "async");
+    mkdirSync(syncDir);
+    mkdirSync(asyncDir);
+    chmodSync(syncDir, 0o755);
+    chmodSync(asyncDir, 0o755);
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    tightenDirPermissionsSync(syncDir);
+    await tightenDirPermissions(asyncDir);
+
+    expect(mode(syncDir)).toBe(0o755);
+    expect(mode(asyncDir)).toBe(0o755);
   });
 
   it("does not throw on a missing directory", async () => {

--- a/electron/utils/fs.ts
+++ b/electron/utils/fs.ts
@@ -103,10 +103,11 @@ function syncParentDirectorySync(filePath: string): void {
  * target path. If any step fails the temp file is cleaned up best-effort.
  * Accepts strings (encoded with `encoding`) or binary buffers.
  *
- * `mode` (POSIX only) is applied to the temp file before rename so the
- * destination has the right permissions atomically — closing the window
- * where a sensitive file would briefly be world-readable at the umask
- * default. Silently skipped on Windows.
+ * `mode` (POSIX only) is applied both when the temp file is first created and
+ * again before rename, so the file is never observable at the umask default —
+ * not during the write, and not at the destination path. A crash mid-write
+ * therefore can't strand a world-readable temp with sensitive contents.
+ * Silently skipped on Windows.
  */
 export async function resilientAtomicWriteFile(
   filePath: string,
@@ -115,14 +116,17 @@ export async function resilientAtomicWriteFile(
   options?: { mode?: number }
 ): Promise<void> {
   const tempPath = generateTempPath(filePath);
-  const writeOptions =
-    typeof data === "string"
-      ? ({ encoding, flush: true } as Parameters<typeof writeFileSync>[2])
-      : ({ flush: true } as Parameters<typeof writeFileSync>[2]);
+  const applyMode = options?.mode !== undefined && process.platform !== "win32";
+  const baseWriteOptions = typeof data === "string" ? { encoding, flush: true } : { flush: true };
+  const writeOptions = (
+    applyMode ? { ...baseWriteOptions, mode: options!.mode } : baseWriteOptions
+  ) as Parameters<typeof writeFileSync>[2];
   try {
     await stubbornFs.retry.writeFile({ timeout: RETRY_TIMEOUT_MS })(tempPath, data, writeOptions);
-    if (options?.mode !== undefined && process.platform !== "win32") {
-      await fsChmod(tempPath, options.mode);
+    // Re-assert after write: writeFile's mode only applies on creation and is
+    // masked by umask, so chmod guarantees exact bits even if the temp existed.
+    if (applyMode) {
+      await fsChmod(tempPath, options!.mode!);
     }
     await resilientRename(tempPath, filePath);
     await syncParentDirectory(filePath);
@@ -144,10 +148,17 @@ export function resilientAtomicWriteFileSync(
   options?: { mode?: number }
 ): void {
   const tempPath = generateTempPath(filePath);
+  const applyMode = options?.mode !== undefined && process.platform !== "win32";
   try {
-    writeFileSync(tempPath, data, { encoding, flush: true } as Parameters<typeof writeFileSync>[2]);
-    if (options?.mode !== undefined && process.platform !== "win32") {
-      chmodSync(tempPath, options.mode);
+    writeFileSync(tempPath, data, {
+      encoding,
+      flush: true,
+      ...(applyMode ? { mode: options!.mode } : {}),
+    } as Parameters<typeof writeFileSync>[2]);
+    // Re-assert after write: writeFileSync's mode only applies on creation and
+    // is masked by umask, so chmod guarantees exact bits.
+    if (applyMode) {
+      chmodSync(tempPath, options!.mode!);
     }
     resilientRenameSync(tempPath, filePath);
     syncParentDirectorySync(filePath);

--- a/electron/utils/fs.ts
+++ b/electron/utils/fs.ts
@@ -161,6 +161,67 @@ export function resilientAtomicWriteFileSync(
   }
 }
 
+// Owner-only permission bits for persisted runtime data (POSIX). Files land at
+// 0o600 (rw-------), directories at 0o700 (rwx------) so nothing durable is
+// left world-readable at the umask default on shared macOS/Linux machines.
+export const OWNER_RW_FILE_MODE = 0o600;
+export const OWNER_RWX_DIR_MODE = 0o700;
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    error != null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+/**
+ * chmod a file to owner-only read/write (0o600). POSIX-only — a no-op on Windows
+ * (which ignores mode bits) and on missing paths. Best-effort: a chmod failure
+ * warns and returns rather than throwing, so hardening never breaks a boot or a
+ * write path. Use for retroactively tightening files an earlier app version
+ * created at the umask default; new atomic writes should pass `{ mode }` instead.
+ */
+export function tightenFilePermissionsSync(filePath: string): void {
+  if (process.platform === "win32" || !filePath) return;
+  try {
+    chmodSync(filePath, OWNER_RW_FILE_MODE);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    console.warn("[fs] Failed to tighten file permissions:", filePath, error);
+  }
+}
+
+/**
+ * chmod a directory to owner-only (0o700), POSIX-only, best-effort.
+ *
+ * `mkdir(dir, { recursive: true, mode })` only applies `mode` to segments it
+ * newly creates — a pre-existing directory (every install upgrading from a
+ * version that wrote it at 0o755) is left untouched. Call this unconditionally
+ * after such an mkdir to tighten the directory in place regardless of age.
+ */
+export function tightenDirPermissionsSync(dirPath: string): void {
+  if (process.platform === "win32" || !dirPath) return;
+  try {
+    chmodSync(dirPath, OWNER_RWX_DIR_MODE);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    console.warn("[fs] Failed to tighten directory permissions:", dirPath, error);
+  }
+}
+
+/** Async counterpart to {@link tightenDirPermissionsSync}. */
+export async function tightenDirPermissions(dirPath: string): Promise<void> {
+  if (process.platform === "win32" || !dirPath) return;
+  try {
+    await fsChmod(dirPath, OWNER_RWX_DIR_MODE);
+  } catch (error) {
+    if (isMissingPathError(error)) return;
+    console.warn("[fs] Failed to tighten directory permissions:", dirPath, error);
+  }
+}
+
 // stubborn-fs only provides attempt.unlink (swallows all errors), not retry.unlink.
 // We need retry-and-throw for callers that must know about ENOENT/permission failures.
 const TRANSIENT_CODES = new Set(["EPERM", "EBUSY", "EACCES"]);


### PR DESCRIPTION
## Summary
- Tightens permissions on the app's durable runtime data (SQLite db family, terminal scrollback, agent session history, crash logs) to owner-only on POSIX: `0600` for files, `0700` for directories. Windows keeps default umask behavior since all `chmod` calls are no-ops there.
- Adds shared helpers to `electron/utils/fs.ts`: `tightenFilePermissionsSync`, `tightenDirPermissions`/`tightenDirPermissionsSync`, and the `OWNER_RW_FILE_MODE`/`OWNER_RWX_DIR_MODE` constants. Atomic writes now create their temp file owner-only from the first byte instead of `chmod`ing after the fact.
- Closes a creation-time TOCTOU race on the SQLite database by pre-creating it with an exclusive `0600` handle, and tightens the db/`-wal`/`-shm` family before the WAL pragma runs so SQLite derives the sidecar files' mode from the main file. Backups get the same treatment (temp file pre-created at `0600`), and both the db and backup tightening also run retroactively on every boot so upgrading installs get fixed automatically.

Resolves #11120

## Changes
- `electron/utils/fs.ts`: shared permission-tightening helpers and mode constants; atomic writes create temp files owner-only up front.
- `electron/services/persistence/db.ts`: pre-create the db file with an exclusive `0600` handle, tighten the db/`-wal`/`-shm` family before the WAL pragma, retroactive tightening on boot.
- `electron/services/DatabaseMaintenanceService.ts`: pre-create backup temp files at `0600`, retroactively tighten legacy backups.
- `electron/services/CrashRecoveryService.ts`: cover the write and rename paths for crash logs.
- `electron/services/pty/terminalSessionPersistence.ts` and `electron/services/pty/agentSessionHistory.ts`: owner-only writes for scrollback and session history.
- New `electron/utils/__tests__/fs.permissions.test.ts`, plus mode-assertion coverage added to the db, backup, terminal, agent, and crash recovery test suites.

## Testing
- 334 targeted tests green locally across the touched suites (db, backup, terminal, agent session history, crash recovery, and the new fs.permissions suite).
- Prettier clean, 0 new lint errors.