### PR TITLE
fix(theme): paint accent CTA text with the contrast-validated foreground

### DIFF
--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -159,7 +159,7 @@ export function GitHubListItem({
                 isSelectionActive || isSelected ? "flex" : "hidden group-hover/icon:flex"
               )}
             >
-              {isSelected && <Check className="w-3 h-3 text-text-inverse" />}
+              {isSelected && <Check className="w-3 h-3 text-accent-primary-foreground" />}
             </span>
           </span>
         ) : (

--- a/shared/theme/__tests__/accentOverride.test.ts
+++ b/shared/theme/__tests__/accentOverride.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { accentOverrideHasLowContrast } from "../contrast.js";
 import {
   applyAccentOverrideToScheme,
   BUILT_IN_APP_SCHEMES,
@@ -72,18 +73,27 @@ describe("computeAccentOverrideTokens", () => {
     expect(softAlpha).toBeLessThan(mutedAlpha);
   });
 
-  it("picks a high-contrast accent-foreground for a very light accent", () => {
-    // A near-white accent must choose a dark foreground for readability.
-    const tokens = computeAccentOverrideTokens("#fafafa", darkScheme);
-    // Candidate order: text-inverse, text-primary, #ffffff, #000000.
-    // On a dark theme, text-inverse is dark, so contrast is very high.
-    // Either way, the winner must NOT be #ffffff.
-    expect(tokens["accent-foreground"]).not.toBe("#ffffff");
-  });
-
-  it("picks a high-contrast accent-foreground for a very dark accent", () => {
-    const tokens = computeAccentOverrideTokens("#050505", lightScheme);
-    expect(tokens["accent-foreground"]).not.toBe("#000000");
+  // Adversarial accents, both polarities (#11115). The old assertions only said the
+  // derived foreground wasn't pure white/black — a 2.4:1 near-miss satisfied that.
+  // Assert the property components actually depend on, through the production
+  // validator (which owns the threshold): whatever accent-foreground is derived, it
+  // never fails foreground-mode against the accent fill it will be painted on.
+  // A `surface`-mode failure is expected and allowed here — a near-white accent IS
+  // hard to see on a light canvas, which is a different finding from illegible
+  // text-on-accent, and is what the theme picker warns about separately.
+  describe.each([
+    ["very light", "#fafafa"],
+    ["very dark", "#050505"],
+    ["mid-luminance (worst case for both polarities)", "#808080"],
+  ])("a %s accent", (_label, accent) => {
+    it.each([
+      ["dark", darkScheme],
+      ["light", lightScheme],
+    ])("derives a foreground that survives the validator on a %s base scheme", (_type, base) => {
+      const scheme = applyAccentOverrideToScheme(base, accent);
+      const failure = accentOverrideHasLowContrast(scheme);
+      expect(failure?.mode, `accent-foreground is illegible on ${accent}`).not.toBe("foreground");
+    });
   });
 
   it("throws on invalid hex input", () => {

--- a/shared/theme/__tests__/accentOverride.test.ts
+++ b/shared/theme/__tests__/accentOverride.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { accentOverrideHasLowContrast } from "../contrast.js";
+import { ACCENT_CONTRAST_PAIR, accentOverrideHasLowContrast, contrastRatio } from "../contrast.js";
 import {
   applyAccentOverrideToScheme,
   BUILT_IN_APP_SCHEMES,
@@ -75,24 +75,37 @@ describe("computeAccentOverrideTokens", () => {
 
   // Adversarial accents, both polarities (#11115). The old assertions only said the
   // derived foreground wasn't pure white/black — a 2.4:1 near-miss satisfied that.
-  // Assert the property components actually depend on, through the production
-  // validator (which owns the threshold): whatever accent-foreground is derived, it
-  // never fails foreground-mode against the accent fill it will be painted on.
-  // A `surface`-mode failure is expected and allowed here — a near-white accent IS
-  // hard to see on a light canvas, which is a different finding from illegible
-  // text-on-accent, and is what the theme picker warns about separately.
+  // #757575 is the genuinely hardest 8-bit neutral: white clears it by only 4.61:1
+  // and black by 4.56:1, so a derivation that picks the wrong candidate fails here
+  // while #808080 (black clears at 5.32:1) would let it pass.
   describe.each([
     ["very light", "#fafafa"],
     ["very dark", "#050505"],
-    ["mid-luminance (worst case for both polarities)", "#808080"],
+    ["boundary mid-luminance", "#757575"],
   ])("a %s accent", (_label, accent) => {
     it.each([
       ["dark", darkScheme],
       ["light", lightScheme],
-    ])("derives a foreground that survives the validator on a %s base scheme", (_type, base) => {
+    ])("derives a foreground legible on the accent fill, on a %s base scheme", (_type, base) => {
       const scheme = applyAccentOverrideToScheme(base, accent);
+
+      // Assert the ratio directly, with the threshold read from the validator's own
+      // pair. Going through accentOverrideHasLowContrast alone would fail OPEN: it
+      // skips the foreground branch entirely when the derived value isn't a hex, so
+      // a derivation regressing to an rgba()/var() string would report no failure.
+      const ratio = contrastRatio(
+        scheme.tokens[ACCENT_CONTRAST_PAIR.foreground],
+        scheme.tokens[ACCENT_CONTRAST_PAIR.background]
+      );
+      expect(ratio, `accent-foreground is illegible on ${accent}`).toBeGreaterThanOrEqual(
+        ACCENT_CONTRAST_PAIR.minimum
+      );
+
+      // And the production validator must agree. A `surface`-mode failure is expected
+      // and allowed — a near-white accent IS hard to see on a light canvas, which is a
+      // separate finding the theme picker warns about on its own.
       const failure = accentOverrideHasLowContrast(scheme);
-      expect(failure?.mode, `accent-foreground is illegible on ${accent}`).not.toBe("foreground");
+      expect(failure?.mode).not.toBe("foreground");
     });
   });
 

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -577,7 +577,9 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
   return warnings;
 }
 
-const ACCENT_MIN_CONTRAST = 4.5;
+// The override gate and the validation matrix must enforce the same threshold — a second
+// literal here could silently drift from the pair everything else is derived from.
+const ACCENT_MIN_CONTRAST = ACCENT_CONTRAST_PAIR.minimum;
 const ACCENT_OUTLINE_MIN_CONTRAST = 3.0;
 
 // Structured result describing how an accent override fails its contrast gate, so

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -27,6 +27,16 @@ const DISPLAY_SURFACES: AppThemeTokenKey[] = [
   "surface-panel-elevated",
 ];
 
+// Text painted on a solid accent fill. Exported because it governs more than this
+// module: the component-level guard (accentForeground.contract.test.ts) derives the
+// token names and threshold it enforces from this pair, so a rename or a relaxed
+// minimum here can't silently leave the components behind (#11115).
+export const ACCENT_CONTRAST_PAIR = {
+  foreground: "accent-foreground",
+  background: "accent-primary",
+  minimum: 4.5,
+} as const;
+
 const CONTRAST_PAIRS: Array<{
   foreground: AppThemeTokenKey;
   background: AppThemeTokenKey;
@@ -91,7 +101,7 @@ const CONTRAST_PAIRS: Array<{
   { foreground: "status-info", background: "surface-sidebar", minimum: 3.0 },
   { foreground: "status-info", background: "surface-canvas", minimum: 3.0 },
   { foreground: "status-info", background: "surface-panel-elevated", minimum: 3.0 },
-  { foreground: "accent-foreground", background: "accent-primary", minimum: 4.5 },
+  ACCENT_CONTRAST_PAIR,
   { foreground: "search-highlight-text", background: "search-highlight-background", minimum: 3.0 },
 ];
 

--- a/src/components/Browser/WebviewDialog.tsx
+++ b/src/components/Browser/WebviewDialog.tsx
@@ -170,7 +170,7 @@ export function WebviewDialog({ dialog, onRespond }: WebviewDialogProps) {
             ref={okRef}
             type="button"
             onClick={handleOk}
-            className="px-3 py-1.5 text-xs font-medium text-text-inverse bg-daintree-accent hover:bg-daintree-accent/90 rounded-md transition-colors focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50"
+            className="px-3 py-1.5 text-xs font-medium text-accent-primary-foreground bg-daintree-accent hover:bg-daintree-accent/90 rounded-md transition-colors focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50"
           >
             OK
           </button>

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -453,7 +453,7 @@ export function SettingsShortcutCapture({
             onClick={handleSave}
             disabled={Boolean(validationError)}
             className={cn(
-              "bg-daintree-accent text-text-inverse rounded hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+              "bg-daintree-accent text-accent-primary-foreground rounded hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
               compact ? "px-2 py-0.5 text-xs" : "px-3 py-1.5 text-sm"
             )}
           >

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -33,7 +33,7 @@ function CheckBadge({ done, isPopping, onPopEnd }: CheckBadgeProps) {
         isPopping && "animate-badge-bump"
       )}
     >
-      {done && <Check className="h-2.5 w-2.5 text-daintree-bg" />}
+      {done && <Check className="h-2.5 w-2.5 text-accent-primary-foreground" />}
     </div>
   );
 }
@@ -252,7 +252,7 @@ export function GettingStartedChecklist({
             {/* Endowed progress: Install Daintree (always complete) */}
             <div className="flex items-start gap-2.5 rounded-[var(--radius-xs)] px-2 py-1.5 opacity-60">
               <div className="h-4 w-4 rounded-full bg-daintree-accent border border-daintree-accent flex items-center justify-center shrink-0">
-                <Check className="h-2.5 w-2.5 text-daintree-bg" />
+                <Check className="h-2.5 w-2.5 text-accent-primary-foreground" />
               </div>
               <Download className="h-3.5 w-3.5 text-daintree-text/40 shrink-0" />
               <span className="text-xs leading-snug text-daintree-text/40">Install Daintree</span>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -611,7 +611,7 @@ function InlineChecklist({
             <>
               <div className="flex items-start gap-2.5 px-2 py-1.5 opacity-60">
                 <div className="h-4 w-4 rounded-full bg-daintree-accent border border-daintree-accent flex items-center justify-center shrink-0">
-                  <Check className="h-2.5 w-2.5 text-daintree-bg" />
+                  <Check className="h-2.5 w-2.5 text-accent-primary-foreground" />
                 </div>
                 <Download className="h-3.5 w-3.5 text-daintree-text/40 shrink-0" />
                 <span className="text-xs leading-snug text-daintree-text/40">Install Daintree</span>
@@ -631,7 +631,7 @@ function InlineChecklist({
                           : "border-daintree-text/30"
                       )}
                     >
-                      {done && <Check className="h-2.5 w-2.5 text-daintree-bg" />}
+                      {done && <Check className="h-2.5 w-2.5 text-accent-primary-foreground" />}
                     </div>
                     <Icon
                       className={cn(

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -265,7 +265,7 @@ export function EditorIntegrationTab() {
             <button
               onClick={handleSave}
               disabled={isSaving || !activeProjectId}
-              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
+              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-accent-primary-foreground text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
             >
               {isSaving ? "Saving…" : "Save"}
             </button>

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -179,7 +179,7 @@ export function ImageViewerTab() {
             <button
               onClick={handleSave}
               disabled={isSaving || isLoading || Boolean(loadError)}
-              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
+              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-accent-primary-foreground text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
             >
               {isSaving ? "Saving…" : "Save"}
             </button>

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -373,7 +373,7 @@ export function PortalSettingsTab() {
                 type="button"
                 onClick={handleCustomUrlSave}
                 aria-label="Save custom URL"
-                className="px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm hover:bg-daintree-accent/90 transition-colors"
+                className="px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-accent-primary-foreground text-sm hover:bg-daintree-accent/90 transition-colors"
               >
                 <Check className="w-4 h-4" />
               </button>
@@ -450,7 +450,7 @@ export function PortalSettingsTab() {
             <button
               onClick={handleAddLink}
               disabled={!newLinkName.trim() || !newLinkUrl.trim()}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:bg-daintree-accent/90 transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-accent-primary-foreground text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:bg-daintree-accent/90 transition-colors"
             >
               <Plus className="w-4 h-4" />
               Add

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -297,7 +297,7 @@ export function WorktreeSettingsTab() {
               className={cn(
                 "px-4 py-1.5 text-sm font-medium rounded-[var(--radius-md)] transition-colors",
                 hasChanges && validation.valid
-                  ? "bg-daintree-accent text-text-inverse hover:bg-daintree-accent/90"
+                  ? "bg-daintree-accent text-accent-primary-foreground hover:bg-daintree-accent/90"
                   : "bg-daintree-border text-daintree-text/50 cursor-not-allowed"
               )}
             >

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -395,7 +395,7 @@ export function AgentCliStep({
           type="button"
           disabled={isBatchRunning}
           onClick={handleInstallAll}
-          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:pointer-events-none"
+          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-accent-primary-foreground text-sm font-medium hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {isBatchRunning ? (
             <>

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -114,7 +114,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
         <div className="flex items-center gap-2.5 shrink-0">
           {isArmed && armBadge !== undefined && (
             <span
-              className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-daintree-accent px-1 text-[9px] font-mono font-semibold text-[var(--color-daintree-bg)] tabular-nums"
+              className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-daintree-accent px-1 text-[9px] font-mono font-semibold text-accent-primary-foreground tabular-nums"
               aria-label={`Armed position ${armBadge}`}
             >
               {armBadge}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,8 +10,13 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
+        // Accent-filled variants pair `primary` (the accent fill) with
+        // `primary-foreground` — the contrast-validated counterpart, guaranteed
+        // >= 4.5:1 against the fill for any custom accent. No text-shadow: the
+        // label's polarity flips with the accent, so a fixed white emboss would
+        // smudge a dark label on a light accent.
         default:
-          "bg-primary text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none",
+          "bg-primary text-primary-foreground ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none",
         destructive:
           "bg-destructive text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none focus-visible:outline-destructive",
         outline:
@@ -43,9 +48,9 @@ const buttonVariants = cva(
         "ghost-success": "text-status-success hover:bg-status-success/10",
         "ghost-info": "text-status-info hover:bg-status-info/10",
         info: "bg-status-info text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none",
-        glow: "bg-primary text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] shadow-[0_0_15px_rgb(from_var(--theme-accent-primary)_r_g_b/0.3)] ring-1 ring-tint/25 hover:shadow-[0_0_25px_rgb(from_var(--theme-accent-primary)_r_g_b/0.45)] hover:brightness-110 active:shadow-inner active:brightness-95",
+        glow: "bg-primary text-primary-foreground shadow-[0_0_15px_rgb(from_var(--theme-accent-primary)_r_g_b/0.3)] ring-1 ring-tint/25 hover:shadow-[0_0_25px_rgb(from_var(--theme-accent-primary)_r_g_b/0.45)] hover:brightness-110 active:shadow-inner active:brightness-95",
         vibrant:
-          "bg-gradient-to-b from-primary to-primary/80 text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] shadow-[var(--theme-shadow-floating)] ring-1 ring-tint/25 hover:brightness-110 active:brightness-90 active:shadow-inner",
+          "bg-gradient-to-b from-primary to-primary/80 text-primary-foreground shadow-[var(--theme-shadow-floating)] ring-1 ring-tint/25 hover:brightness-110 active:brightness-90 active:shadow-inner",
       },
       size: {
         default: "h-8 px-4 py-1.5 gap-2 [&_svg]:size-4",

--- a/src/config/__tests__/accentForeground.contract.test.ts
+++ b/src/config/__tests__/accentForeground.contract.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-import { ACCENT_CONTRAST_PAIR } from "@shared/theme";
+import { ACCENT_CONTRAST_PAIR, BUILT_IN_APP_SCHEMES } from "@shared/theme";
 
 // Contrast validation (shared/theme/contrast.ts) checks abstract theme tokens: it
 // guarantees `accent-foreground` clears 4.5:1 on `accent-primary`. It cannot see which
@@ -18,8 +18,18 @@ import { ACCENT_CONTRAST_PAIR } from "@shared/theme";
 //
 // Nothing here is a hardcoded class name. The tokens come from the validator's own pair,
 // and the classes that reach them are derived from the CSS graph — so the guard accepts
-// any spelling that resolves correctly, rejects any that does not, and breaks loudly if
-// the pair is renamed or its threshold removed.
+// any spelling that resolves correctly and rejects any that does not.
+//
+// KNOWN LIMITS (deliberate — this is a regression guard, not a sound Tailwind checker):
+//   - A className built by a call we cannot resolve (`getClasses(x)`, an imported
+//     constant) is not analyzed. Local `const` string bindings ARE resolved, and a
+//     whole-file literal sweep still catches a fill and a bad foreground sharing one
+//     string wherever it is written.
+//   - Classes flowing in through a `className` prop from a caller are not tracked across
+//     components.
+//   - Tailwind's generated source order can differ from class-attribute order when two
+//     utilities set the same property. Rather than model that, ANY unvalidated foreground
+//     that can coexist with an accent fill is reported, even if another class might win.
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -30,26 +40,41 @@ const SCAN_ROOTS = [
   path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
 ];
 
-// Derived from the validator, not restated. Renaming the pair or dropping it from
-// CONTRAST_PAIRS makes this guard fail rather than silently stop guarding.
+// Derived from the validator, not restated.
 const ACCENT_FILL_TOKEN = `--theme-${ACCENT_CONTRAST_PAIR.background}`;
 const ACCENT_FOREGROUND_TOKEN = `--theme-${ACCENT_CONTRAST_PAIR.foreground}`;
 
-const FOREGROUND_PREFIXES = ["text-", "fill-", "stroke-"];
+// `text-`, `fill-` and `stroke-` set DIFFERENT CSS properties — they never override one
+// another, so each is resolved on its own.
+const FOREGROUND_PROPS: Array<{ prefix: string; property: string }> = [
+  { prefix: "text-", property: "color" },
+  { prefix: "fill-", property: "fill" },
+  { prefix: "stroke-", property: "stroke" },
+];
 const GRADIENT_STOP_PREFIXES = ["from-", "via-", "to-"];
-// A gradient only paints once a gradient image utility is active; bare `from-*` is inert.
 const GRADIENT_IMAGE = /^bg-(gradient-|linear-|radial|conic)/;
-// `bg-cover`, `bg-center`, `bg-clip-*`, `bg-no-repeat` — background utilities that paint
-// no color, so they never shield a descendant from an ancestor's accent fill.
 const CLASS_CONSTRUCTORS = new Set(["cn", "clsx", "cx", "classNames", "twMerge", "twJoin"]);
-const CVA_CONSTRUCTORS = new Set(["cva", "tv"]);
-// A literal color escapes the token system: it can never be the validated token.
 const LITERAL_COLOR = /^(#[0-9a-f]{3,8}|(rgb|hsl|oklch|oklab|lab|lch|color)a?\()/i;
+// An arbitrary value that is a length/number is a size, not a color: text-[9px], text-[2].
+const LENGTH_VALUE = /^-?[\d.]+([a-z%]*)$/i;
+const OPAQUE_MODIFIER = /^(100|\[1]|\[100%]|\[1\.0]) *$/;
+const SOLID_HEX = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const TEXT_BEARING_INTRINSICS = new Set(["input", "textarea", "select", "option"]);
+// A checkbox or radio paints no text of its own — the UA draws its mark, which is
+// graphical-object contrast (WCAG 1.4.11), not the text contrast this pair governs.
+const NON_TEXT_INPUT_TYPES = new Set([
+  "checkbox",
+  "radio",
+  "range",
+  "color",
+  "file",
+  "hidden",
+  "image",
+]);
 const MAX_FEASIBLE_SETS = 512;
 
 // ── CSS variable graph ─────────────────────────────────────────────────
 
-/** Every `--name: value` in index.css, in document order — later wins, as the cascade does. */
 function parseCssVariables(css: string): Map<string, string> {
   const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
   const declarations = new Map<string, string>();
@@ -62,8 +87,8 @@ function parseCssVariables(css: string): Map<string, string> {
 
 /**
  * Follow a variable through pure `var(--x)` aliases to the name it ultimately points at.
- * Stops at a `--theme-*` semantic token (the runtime theme supplies its value, and it is
- * the vocabulary the contrast validator speaks), or at any value that is not a bare alias.
+ * Stops at a `--theme-*` semantic token — the vocabulary the contrast validator speaks —
+ * or at any value that is not a bare alias.
  */
 function resolveToTerminalToken(name: string, declarations: Map<string, string>): string {
   const seen = new Set<string>();
@@ -81,14 +106,25 @@ function resolveToTerminalToken(name: string, declarations: Map<string, string>)
 }
 
 type ColorGraph = {
-  /** Terminal token for a Tailwind color name, e.g. "primary" -> "--theme-accent-primary". */
   terminalOfName: (colorName: string) => string | null;
-  /** Terminal token for a raw CSS variable, e.g. "--color-primary" / "--theme-accent-primary". */
   terminalOfVar: (varName: string) => string;
+  /** Is this terminal token opaque in EVERY built-in theme? Only then can it hide accent. */
+  isOpaqueToken: (terminal: string) => boolean;
 };
 
 function buildColorGraph(css: string): ColorGraph {
   const declarations = parseCssVariables(css);
+  // A token like `overlay-soft` is an rgba() wash in every theme — painting it over an
+  // accent fill does not hide the accent, so it must not shield a descendant's text.
+  const opaque = new Map<string, boolean>();
+  const schemeTokens = BUILT_IN_APP_SCHEMES.map((scheme) => new Map(Object.entries(scheme.tokens)));
+  for (const key of new Set(schemeTokens.flatMap((tokens) => [...tokens.keys()]))) {
+    const solidEverywhere = schemeTokens.every((tokens) => {
+      const value = tokens.get(key);
+      return typeof value === "string" && SOLID_HEX.test(value);
+    });
+    opaque.set(`--theme-${key}`, solidEverywhere);
+  }
   return {
     terminalOfName(colorName) {
       const varName = `--color-${colorName}`;
@@ -97,6 +133,10 @@ function buildColorGraph(css: string): ColorGraph {
     terminalOfVar(varName) {
       return resolveToTerminalToken(varName, declarations);
     },
+    isOpaqueToken(terminal) {
+      if (terminal === "literal-opaque") return true;
+      return opaque.get(terminal) ?? false;
+    },
   };
 }
 
@@ -104,11 +144,8 @@ function buildColorGraph(css: string): ColorGraph {
 
 type Util = {
   raw: string;
-  /** Variant chain (`hover`, `data-[state=on]`, `before`), normalized, order-insensitive. */
   variants: string[];
-  /** The utility with variants, `!` and any opacity modifier removed. */
   base: string;
-  /** The `/50` or `/[.5]` modifier, if present. */
   opacity: string | null;
 };
 
@@ -125,9 +162,7 @@ function indexAtDepthZero(text: string, ch: string): number {
 }
 
 function parseUtil(raw: string): Util {
-  // Tailwind v4 `bg-primary!` and v3 `!bg-primary`.
   let rest = raw.endsWith("!") ? raw.slice(0, -1) : raw;
-  if (rest.startsWith("!")) rest = rest.slice(1);
 
   const variants: string[] = [];
   for (;;) {
@@ -137,60 +172,66 @@ function parseUtil(raw: string): Util {
     rest = rest.slice(cut + 1);
   }
 
-  // A slash inside `[...]` or `(...)` is part of the value (`bg-[url(a/b.png)]`,
+  // The v3 important prefix sits AFTER the variant chain: `hover:!bg-primary`.
+  if (rest.startsWith("!")) rest = rest.slice(1);
+
+  // A slash inside `[...]`/`(...)` belongs to the value (`bg-[url(a/b.png)]`,
   // `w-[calc(1/2)]`); only a depth-zero slash is an opacity modifier. Variant names can
-  // also carry slashes (`group-hover/icon:`) — already stripped above.
+  // carry slashes (`group-hover/icon:`) but those are already stripped above.
   const slash = indexAtDepthZero(rest, "/");
   const base = slash === -1 ? rest : rest.slice(0, slash);
-  const opacity = slash === -1 ? null : rest.slice(slash + 1);
+  const modifier = slash === -1 ? null : rest.slice(slash + 1);
+  // `/100` is fully opaque — not a wash.
+  const opacity = modifier !== null && OPAQUE_MODIFIER.test(modifier) ? null : modifier;
 
   return { raw, variants, base, opacity };
 }
 
-/** A pseudo-element paints a separate box — neither the element's fill nor its own text. */
 function isPseudoElement(util: Util): boolean {
   return util.variants.some((v) => v === "before" || v === "after");
 }
 
 /**
- * The terminal token a color-bearing utility resolves to, `"literal"` for a hardcoded
- * color that escapes the token system, or null when the utility is not a color at all
- * (`text-sm`, `text-center`, `text-[9px]`, `bg-cover`).
+ * The terminal token a color utility resolves to, `"literal-opaque"` for a hardcoded color
+ * that escapes the token system, or null when the utility is not a color at all
+ * (`text-sm`, `text-[9px]`, `bg-cover`).
  */
 function colorTerminal(base: string, prefix: string, graph: ColorGraph): string | null {
   const value = base.slice(prefix.length);
 
+  // Tailwind v4 shorthand for a CSS variable: bg-(--color-primary).
+  const parenVar = /^\((--[\w-]+)\)$/.exec(value);
+  if (parenVar?.[1] !== undefined) return graph.terminalOfVar(parenVar[1]);
+
   const arbitrary = /^\[(.+)]$/.exec(value);
   if (arbitrary?.[1] !== undefined) {
-    // A type hint is allowed: text-[color:var(--x)].
-    const inner = arbitrary[1].replace(/^color:/, "");
-    const varRef = /^var\(\s*(--[\w-]+)\s*\)$/.exec(inner);
+    const inner = arbitrary[1].replace(/^color:/, "").trim();
+    const varRef = /^var\(\s*(--[\w-]+)[^)]*\)$/.exec(inner);
     if (varRef?.[1] !== undefined) return graph.terminalOfVar(varRef[1]);
-    if (LITERAL_COLOR.test(inner)) return "literal";
+    if (inner.startsWith("--")) return graph.terminalOfVar(inner);
+    if (LENGTH_VALUE.test(inner)) return null;
+    if (inner === "transparent" || inner === "currentColor" || inner === "inherit") return null;
+    // A hex, an rgb()/hsl(), or a named color like `red` — a real color, but not the token.
+    if (LITERAL_COLOR.test(inner) || /^[a-z]+$/i.test(inner)) return "literal-opaque";
     return null;
   }
 
-  if (value === "white" || value === "black") return "literal";
-  // Inherits or paints nothing — not a determinable foreground of its own.
+  if (value === "white" || value === "black") return "literal-opaque";
   if (value === "transparent" || value === "current" || value === "inherit") return null;
 
   return graph.terminalOfName(value);
 }
 
-/** A solid, unconditional-in-this-state accent fill behind the element's own text. */
 function accentFills(utils: Util[], graph: ColorGraph): Util[] {
   const hasGradientImage = utils.some((u) => GRADIENT_IMAGE.test(u.base));
   return utils.filter((u) => {
     if (isPseudoElement(u)) return false;
-
     if (u.base.startsWith("bg-")) {
-      // An opacity-modified fill is a wash over the surface, not solid accent.
-      if (u.opacity !== null) return false;
+      if (u.opacity !== null) return false; // a wash over the surface, not solid accent
       return colorTerminal(u.base, "bg-", graph) === ACCENT_FILL_TOKEN;
     }
-
-    // Gradient stops only paint when a gradient image utility is active. A stop keeps
-    // showing accent even at reduced alpha, so opacity does not disqualify it.
+    // Gradient stops paint only when a gradient image utility is active. A stop keeps
+    // showing accent at reduced alpha, so opacity does not disqualify it.
     const stop = GRADIENT_STOP_PREFIXES.find((p) => u.base.startsWith(p));
     if (stop === undefined || !hasGradientImage) return false;
     return colorTerminal(u.base, stop, graph) === ACCENT_FILL_TOKEN;
@@ -198,55 +239,35 @@ function accentFills(utils: Util[], graph: ColorGraph): Util[] {
 }
 
 /**
- * Does this class set repaint its own background, shielding its text from an ancestor's
- * accent fill? Only an unconditional, fully opaque, actually-colored background does.
- * A `hover:` background leaves the base state on the accent; an opacity-modified one is
- * translucent; and `bg-cover` paints no color at all.
+ * Does this class set repaint its own background, hiding an ancestor's accent fill?
+ * Only an unconditional, provably OPAQUE, actually-colored background does. A `hover:`
+ * background leaves the base state on the accent; a translucent one (an opacity modifier,
+ * or a wash token like `overlay-soft` whose theme value is rgba) still shows it; and
+ * `bg-cover` paints no color at all.
  */
 function shieldsBackground(utils: Util[], graph: ColorGraph): boolean {
-  const hasGradientImage = utils.some((u) => GRADIENT_IMAGE.test(u.base));
   return utils.some((u) => {
     if (u.variants.length > 0 || u.opacity !== null) return false;
-    if (u.base.startsWith("bg-")) return colorTerminal(u.base, "bg-", graph) !== null;
-    const stop = GRADIENT_STOP_PREFIXES.find((p) => u.base.startsWith(p));
-    if (stop === undefined || !hasGradientImage) return false;
-    return colorTerminal(u.base, stop, graph) !== null;
+    if (!u.base.startsWith("bg-")) return false;
+    const terminal = colorTerminal(u.base, "bg-", graph);
+    if (terminal === null) return false;
+    return graph.isOpaqueToken(terminal);
   });
 }
 
-type Foreground = { util: Util; terminal: string };
+type Foreground = { util: Util; property: string; terminal: string };
 
-function foregrounds(utils: Util[], graph: ColorGraph): Foreground[] {
+function foregroundsOf(utils: Util[], graph: ColorGraph): Foreground[] {
   const out: Foreground[] = [];
   for (const util of utils) {
     if (isPseudoElement(util)) continue;
-    const prefix = FOREGROUND_PREFIXES.find((p) => util.base.startsWith(p));
-    if (prefix === undefined) continue;
-    const terminal = colorTerminal(util.base, prefix, graph);
+    const match = FOREGROUND_PROPS.find((p) => util.base.startsWith(p.prefix));
+    if (match === undefined) continue;
+    const terminal = colorTerminal(util.base, match.prefix, graph);
     if (terminal === null) continue;
-    out.push({ util, terminal });
+    out.push({ util, property: match.property, terminal });
   }
   return out;
-}
-
-/**
- * The foreground actually painted while `fillVariants` is the active state. A foreground
- * applies if its own variant chain is satisfied in that state — a base `text-*` applies
- * always, a `hover:text-*` only once `hover` is active. The most specific wins, matching
- * how the cascade resolves them; a later declaration breaks a tie.
- */
-function effectiveForeground(
-  utils: Util[],
-  fillVariants: string[],
-  graph: ColorGraph
-): Foreground | null {
-  const active = new Set(fillVariants);
-  let best: Foreground | null = null;
-  for (const fg of foregrounds(utils, graph)) {
-    if (!fg.util.variants.every((v) => active.has(v))) continue;
-    if (best === null || fg.util.variants.length >= best.util.variants.length) best = fg;
-  }
-  return best;
 }
 
 /** The 4.5:1 guarantee covers the opaque token; alpha below 1 is no longer guaranteed. */
@@ -254,106 +275,198 @@ function isValidated(fg: Foreground): boolean {
   return fg.terminal === ACCENT_FOREGROUND_TOKEN && fg.util.opacity === null;
 }
 
-// ── Feasible class sets ────────────────────────────────────────────────
+/**
+ * Every foreground that can be painted while an accent fill with `fillVariants` is showing.
+ *
+ * A fill with variant chain V is painted in EVERY state that includes V — so a base
+ * `bg-primary` is still there on hover, and a `hover:text-white` lands on it. Conversely a
+ * foreground with chain W only applies in states including W. So V and W coexist in state
+ * V ∪ W. Rather than model which of two same-property classes Tailwind emits last, report
+ * any unvalidated foreground that can coexist with the fill — conservative in the safe
+ * direction. A foreground is exempt only when a MORE specific one for the same property
+ * overrides it in that state (`text-daintree-text hover:bg-primary hover:text-...`).
+ */
+function coexistingForegrounds(
+  utils: Util[],
+  fillVariants: string[],
+  graph: ColorGraph
+): { offending: Foreground[]; colorInState: Foreground | null } {
+  const foregrounds = foregroundsOf(utils, graph);
+  const offending: Foreground[] = [];
 
-// A className is rarely one string. `cn("a", cond ? "b" : "c", flag && "d")` renders one
-// of several class sets, and only classes that can co-occur may be compared: flattening
-// them into one union would pair an accent fill from one ternary branch with a foreground
-// from the other and report a bug that cannot happen. So expand the expression into the
-// sets that can actually render, and check each independently.
+  for (const fg of foregrounds) {
+    const state = new Set([...fillVariants, ...fg.util.variants]);
+    // Something strictly more specific for the same property, also active here, wins.
+    const overridden = foregrounds.some(
+      (other) =>
+        other !== fg &&
+        other.property === fg.property &&
+        other.util.variants.every((v) => state.has(v)) &&
+        other.util.variants.length > fg.util.variants.length
+    );
+    if (overridden) continue;
+    if (!isValidated(fg)) offending.push(fg);
+  }
 
-function tokensOf(text: string): string[] {
-  return text.split(/\s+/).filter((t) => t.length > 0);
+  // What paints the element's own text in the fill's exact state (null => it inherits).
+  const active = new Set(fillVariants);
+  let colorInState: Foreground | null = null;
+  for (const fg of foregrounds) {
+    if (fg.property !== "color") continue;
+    if (!fg.util.variants.every((v) => active.has(v))) continue;
+    if (colorInState === null || fg.util.variants.length >= colorInState.util.variants.length) {
+      colorInState = fg;
+    }
+  }
+
+  return { offending, colorInState };
 }
 
-function crossProduct(groups: string[][][]): string[][] {
-  let acc: string[][] = [[]];
+// ── Feasible class sets ────────────────────────────────────────────────
+
+// A className is rarely one string. `cn("a", cond ? "b" : "c", flag && "d")` renders one of
+// several sets, and only classes that can co-occur may be compared: flattening them into
+// one union would pair an accent fill from one ternary branch with a foreground from the
+// other and report a bug that cannot happen. So expand the expression into the sets that
+// can actually render — carrying each branch's predicate so that two ternaries on the SAME
+// condition never produce an impossible combination — and check each set independently.
+
+type ClassSet = { utils: Util[]; constraints: Map<string, boolean> };
+
+function tokensOf(text: string): Util[] {
+  return text
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .map(parseUtil);
+}
+
+function mergeSets(a: ClassSet, b: ClassSet): ClassSet | null {
+  const constraints = new Map(a.constraints);
+  for (const [key, value] of b.constraints) {
+    const existing = constraints.get(key);
+    if (existing !== undefined && existing !== value) return null; // contradiction
+    constraints.set(key, value);
+  }
+  return { utils: [...a.utils, ...b.utils], constraints };
+}
+
+function crossProduct(groups: ClassSet[][]): ClassSet[] {
+  let acc: ClassSet[] = [{ utils: [], constraints: new Map() }];
   for (const group of groups) {
-    const next: string[][] = [];
+    const next: ClassSet[] = [];
     for (const prefix of acc) {
-      for (const suffix of group) next.push([...prefix, ...suffix]);
+      for (const suffix of group) {
+        const merged = mergeSets(prefix, suffix);
+        if (merged !== null) next.push(merged);
+      }
     }
+    // Refuse to guess past the cap rather than flattening to a union — a union can hide a
+    // violation by letting a validated class from one branch cover an invalid one.
     if (next.length > MAX_FEASIBLE_SETS) {
-      // Degrade to the flat union rather than exploding. Over-approximates (may pair
-      // classes that never co-occur), which can only over-report, never under-report.
-      return [[...new Set(next.flat())]];
+      throw new Error("accent-foreground guard: className too complex to analyze");
     }
     acc = next;
   }
   return acc;
 }
 
-function feasibleSets(node: ts.Node | undefined): string[][] {
-  if (node === undefined) return [[]];
+function withConstraint(sets: ClassSet[], key: string, value: boolean): ClassSet[] {
+  const out: ClassSet[] = [];
+  for (const set of sets) {
+    const existing = set.constraints.get(key);
+    if (existing !== undefined && existing !== value) continue;
+    const constraints = new Map(set.constraints);
+    constraints.set(key, value);
+    out.push({ utils: set.utils, constraints });
+  }
+  return out;
+}
+
+const EMPTY_SET = (): ClassSet[] => [{ utils: [], constraints: new Map() }];
+
+function feasibleSets(node: ts.Node | undefined, locals: Map<string, string>): ClassSet[] {
+  if (node === undefined) return EMPTY_SET();
 
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-    return [tokensOf(node.text)];
+    return [{ utils: tokensOf(node.text), constraints: new Map() }];
   }
   if (ts.isJsxExpression(node) || ts.isParenthesizedExpression(node)) {
-    return feasibleSets(node.expression);
+    return feasibleSets(node.expression, locals);
+  }
+  if (ts.isIdentifier(node)) {
+    // Resolve a local `const cls = "bg-primary text-white"` binding.
+    const value = locals.get(node.text);
+    if (value !== undefined) return [{ utils: tokensOf(value), constraints: new Map() }];
+    return EMPTY_SET();
   }
   if (ts.isConditionalExpression(node)) {
-    return [...feasibleSets(node.whenTrue), ...feasibleSets(node.whenFalse)];
+    const key = node.condition.getText().replace(/\s+/g, "");
+    return [
+      ...withConstraint(feasibleSets(node.whenTrue, locals), key, true),
+      ...withConstraint(feasibleSets(node.whenFalse, locals), key, false),
+    ];
   }
   if (ts.isBinaryExpression(node)) {
     const kind = node.operatorToken.kind;
-    // `flag && "cls"` renders the classes or nothing.
     if (kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-      return [...feasibleSets(node.right), []];
+      const key = node.left.getText().replace(/\s+/g, "");
+      return [
+        ...withConstraint(feasibleSets(node.right, locals), key, true),
+        ...withConstraint(EMPTY_SET(), key, false),
+      ];
     }
-    if (
-      kind === ts.SyntaxKind.BarBarToken ||
-      kind === ts.SyntaxKind.QuestionQuestionToken ||
-      kind === ts.SyntaxKind.PlusToken
-    ) {
-      return [...feasibleSets(node.left), ...feasibleSets(node.right)];
+    if (kind === ts.SyntaxKind.PlusToken) {
+      // String concatenation — both sides render together.
+      return crossProduct([feasibleSets(node.left, locals), feasibleSets(node.right, locals)]);
     }
-    return [[]];
+    if (kind === ts.SyntaxKind.BarBarToken || kind === ts.SyntaxKind.QuestionQuestionToken) {
+      return [...feasibleSets(node.left, locals), ...feasibleSets(node.right, locals)];
+    }
+    return EMPTY_SET();
   }
   if (ts.isTemplateExpression(node)) {
-    const groups: string[][][] = [[tokensOf(node.head.text)]];
+    const groups: ClassSet[][] = [[{ utils: tokensOf(node.head.text), constraints: new Map() }]];
     for (const span of node.templateSpans) {
-      groups.push(feasibleSets(span.expression), [tokensOf(span.literal.text)]);
+      groups.push(feasibleSets(span.expression, locals));
+      groups.push([{ utils: tokensOf(span.literal.text), constraints: new Map() }]);
     }
     return crossProduct(groups);
   }
   if (ts.isArrayLiteralExpression(node)) {
-    return crossProduct(node.elements.map((e) => feasibleSets(e)));
+    return crossProduct(node.elements.map((e) => feasibleSets(e, locals)));
   }
   if (ts.isObjectLiteralExpression(node)) {
-    // clsx's object form: each key is independently present or absent.
+    // clsx's object form: each key renders when its value is truthy.
     return crossProduct(
       node.properties.flatMap((prop) => {
         if (!ts.isPropertyAssignment(prop)) return [];
         const name = prop.name;
-        const text = ts.isStringLiteral(name)
-          ? name.text
-          : ts.isIdentifier(name)
-            ? name.text
-            : null;
+        const text = ts.isStringLiteral(name) || ts.isIdentifier(name) ? name.text : null;
         if (text === null) return [];
-        return [[tokensOf(text), []]];
+        const key = prop.initializer.getText().replace(/\s+/g, "");
+        return [
+          [
+            { utils: tokensOf(text), constraints: new Map([[key, true]]) },
+            { utils: [], constraints: new Map([[key, false]]) },
+          ],
+        ];
       })
     );
   }
   if (ts.isCallExpression(node)) {
     const callee = ts.isIdentifier(node.expression) ? node.expression.text : null;
     if (callee !== null && CLASS_CONSTRUCTORS.has(callee)) {
-      return crossProduct(node.arguments.map((arg) => feasibleSets(arg)));
+      return crossProduct(node.arguments.map((arg) => feasibleSets(arg, locals)));
     }
-    return [[]];
+    return EMPTY_SET();
   }
-  // An identifier, member access, or anything else we cannot resolve statically.
-  return [[]];
-}
-
-function parseSets(sets: string[][]): Util[][] {
-  return sets.map((set) => set.map(parseUtil));
+  return EMPTY_SET();
 }
 
 // ── Source analysis ────────────────────────────────────────────────────
 
 export type Violation = { file: string; line: number; utility: string; context: string };
+type Analysis = { violations: Violation[]; accentSurfaces: number };
 
 function classNameExprOf(
   element: ts.JsxOpeningElement | ts.JsxSelfClosingElement
@@ -364,27 +477,38 @@ function classNameExprOf(
   return undefined;
 }
 
-/** Renders characters of its own — as opposed to rendering only child elements. */
-function rendersText(child: ts.JsxChild): boolean {
-  if (ts.isJsxText(child)) return child.text.trim().length > 0;
-  if (!ts.isJsxExpression(child) || child.expression === undefined) return false;
-  // `{done && <Check />}` renders an element, not text. `{count}` renders text.
-  let hasJsx = false;
-  const look = (n: ts.Node): void => {
-    if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) hasJsx = true;
-    ts.forEachChild(n, look);
+/** Local `const x = "…"` string bindings, so `className={x}` still resolves. */
+function collectLocalStrings(source: ts.SourceFile): Map<string, string> {
+  const locals = new Map<string, string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined &&
+      (ts.isStringLiteral(node.initializer) || ts.isNoSubstitutionTemplateLiteral(node.initializer))
+    ) {
+      locals.set(node.name.text, node.initializer.text);
+    }
+    ts.forEachChild(node, visit);
   };
-  look(child.expression);
-  return !hasJsx;
+  visit(source);
+  return locals;
 }
 
-/** A glyph that inherits `currentColor` — an icon component or a raw <svg>. */
-function isGlyph(element: ts.JsxSelfClosingElement): boolean {
-  const tag = element.tagName.getText();
-  return tag === "svg" || /^[A-Z]/.test(tag);
+/** Names imported from an icon package — they render a glyph inheriting `currentColor`. */
+function collectGlyphNames(source: ts.SourceFile): Set<string> {
+  const glyphs = new Set<string>();
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const from = statement.moduleSpecifier;
+    if (!ts.isStringLiteral(from)) continue;
+    if (!/lucide-react|components\/icons/.test(from.text)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings === undefined || !ts.isNamedImports(bindings)) continue;
+    for (const spec of bindings.elements) glyphs.add(spec.name.text);
+  }
+  return glyphs;
 }
-
-type Analysis = { violations: Violation[]; accentSurfaces: number };
 
 function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph): Analysis {
   const source = ts.createSourceFile(
@@ -394,147 +518,264 @@ function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph):
     /* setParentNodes */ true,
     ts.ScriptKind.TSX
   );
+  const locals = collectLocalStrings(source);
+  const glyphNames = collectGlyphNames(source);
+
   const violations: Violation[] = [];
   const seen = new Set<string>();
+  const reportedUtilities = new Set<string>();
   let accentSurfaces = 0;
 
   // One element can carry several accent fills (a gradient's `from-` and `to-` stops are
-  // both accent), and each would otherwise re-report the same offending foreground.
+  // both accent) and several feasible sets, and the literal sweep may re-find what the
+  // structural pass already reported. Key on the offending class at its line, not on which
+  // rule happened to catch it.
   const report = (node: ts.Node, utility: string, context: string): void => {
     const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
-    const key = `${line}:${utility}:${context}`;
+    const key = `${line}:${utility}`;
     if (seen.has(key)) return;
     seen.add(key);
+    reportedUtilities.add(utility);
     violations.push({ file: fileName, line, utility, context });
   };
 
-  const utilsOf = (element: ts.JsxOpeningElement | ts.JsxSelfClosingElement): Util[][] =>
-    parseSets(feasibleSets(classNameExprOf(element)));
+  const setsOf = (element: ts.JsxOpeningElement | ts.JsxSelfClosingElement): ClassSet[] =>
+    feasibleSets(classNameExprOf(element), locals);
 
-  // Walk an accent-filled element's subtree. Text inherits the nearest foreground set by
-  // an ancestor, so carry it down; a descendant that repaints its background is off the
-  // accent and ends the descent.
+  const isGlyphElement = (element: ts.JsxOpeningElement | ts.JsxSelfClosingElement): boolean => {
+    const tag = element.tagName.getText();
+    return tag === "svg" || glyphNames.has(tag);
+  };
+
+  const attrText = (
+    element: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
+    name: string
+  ): string | null => {
+    for (const prop of element.attributes.properties) {
+      if (!ts.isJsxAttribute(prop) || prop.name.getText() !== name) continue;
+      const init = prop.initializer;
+      if (init !== undefined && ts.isStringLiteral(init)) return init.text;
+    }
+    return null;
+  };
+
+  /** Does this element paint text or a glyph of its own, inheriting `color`? */
+  const bearsOwnText = (element: ts.JsxOpeningElement | ts.JsxSelfClosingElement): boolean => {
+    if (isGlyphElement(element)) return true;
+    const tag = element.tagName.getText();
+    if (!TEXT_BEARING_INTRINSICS.has(tag)) return false;
+    if (tag !== "input") return true;
+    const type = attrText(element, "type");
+    return type === null || !NON_TEXT_INPUT_TYPES.has(type);
+  };
+
+  /** Renders characters of its own, as opposed to rendering only child elements. */
+  const rendersText = (child: ts.JsxChild): boolean => {
+    if (ts.isJsxText(child)) return child.text.trim().length > 0;
+    if (!ts.isJsxExpression(child) || child.expression === undefined) return false;
+    // `{done && <Check />}` renders an element. `{count}` and `{ok ? <X/> : "Save"}`
+    // render text — so look for a branch that is NOT JSX rather than for "contains JSX".
+    const expr = child.expression;
+    const branches: ts.Node[] = ts.isConditionalExpression(expr)
+      ? [expr.whenTrue, expr.whenFalse]
+      : ts.isBinaryExpression(expr) &&
+          expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+        ? [expr.right]
+        : [expr];
+    return branches.some(
+      (b) =>
+        !ts.isJsxElement(b) &&
+        !ts.isJsxSelfClosingElement(b) &&
+        !ts.isJsxFragment(b) &&
+        b.kind !== ts.SyntaxKind.NullKeyword &&
+        b.kind !== ts.SyntaxKind.FalseKeyword
+    );
+  };
+
+  // Walk one feasible path of an accent-filled element's subtree. Text inherits the
+  // nearest foreground an ancestor set, so carry it down; a descendant that provably
+  // repaints its background is off the accent and ends this path.
   const walkSubtree = (
     children: readonly ts.JsxChild[],
     fillVariants: string[],
     inherited: Foreground | null
   ): void => {
     for (const child of children) {
-      if (rendersText(child)) {
-        if (inherited === null) {
-          report(
-            child,
-            "(inherited)",
-            "renders text on an accent fill with no accent foreground — inherits body-text color"
-          );
-        }
+      if (rendersText(child) && inherited === null) {
+        report(
+          child,
+          "(inherited)",
+          "renders text on an accent fill with no accent foreground — inherits body-text color"
+        );
+      }
+
+      if (ts.isJsxFragment(child)) {
+        walkSubtree(child.children, fillVariants, inherited);
         continue;
       }
-
-      const element = ts.isJsxElement(child)
-        ? child
-        : ts.isJsxSelfClosingElement(child)
-          ? child
-          : null;
-
-      if (element === null) {
-        // A fragment or an expression wrapping elements — keep looking inside it.
-        if (ts.isJsxFragment(child)) walkSubtree(child.children, fillVariants, inherited);
-        else if (ts.isJsxExpression(child) && child.expression !== undefined) {
-          const nested: ts.JsxChild[] = [];
-          const collect = (n: ts.Node): void => {
-            if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) {
-              nested.push(n);
-              return;
-            }
-            ts.forEachChild(n, collect);
-          };
-          collect(child.expression);
-          walkSubtree(nested, fillVariants, inherited);
-        }
+      if (ts.isJsxExpression(child)) {
+        if (child.expression === undefined) continue;
+        const nested: ts.JsxChild[] = [];
+        const collect = (n: ts.Node): void => {
+          if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) {
+            nested.push(n);
+            return;
+          }
+          ts.forEachChild(n, collect);
+        };
+        collect(child.expression);
+        walkSubtree(nested, fillVariants, inherited);
         continue;
       }
+      if (!ts.isJsxElement(child) && !ts.isJsxSelfClosingElement(child)) continue;
 
-      const opening = ts.isJsxElement(element) ? element.openingElement : element;
-      const sets = utilsOf(opening);
-      if (sets.some((utils) => shieldsBackground(utils, graph))) continue;
+      const opening = ts.isJsxElement(child) ? child.openingElement : child;
 
-      // A descendant's own foreground overrides what it inherits from the accent element.
-      let here = inherited;
-      for (const utils of sets) {
-        const own = effectiveForeground(utils, fillVariants, graph);
-        if (own === null) continue;
-        if (!isValidated(own)) {
-          report(opening, own.util.raw, "text painted on an ancestor's accent fill");
+      // Each of the descendant's own feasible paths is independent: a branch that shields
+      // must not excuse a branch that does not.
+      for (const set of setsOf(opening)) {
+        if (shieldsBackground(set.utils, graph)) continue;
+
+        const { offending, colorInState } = coexistingForegrounds(set.utils, fillVariants, graph);
+        for (const fg of offending) {
+          report(opening, fg.util.raw, "text painted on an ancestor's accent fill");
         }
-        here = own;
-      }
 
-      if (ts.isJsxSelfClosingElement(element)) {
-        if (here === null && isGlyph(element)) {
+        const here = colorInState ?? inherited;
+        if (here === null && bearsOwnText(opening)) {
           report(
             opening,
             "(inherited)",
             "glyph on an accent fill with no accent foreground — inherits body-text color"
           );
         }
-        continue;
+        if (ts.isJsxElement(child)) walkSubtree(child.children, fillVariants, here);
       }
-      walkSubtree(element.children, fillVariants, here);
     }
   };
 
   const checkElement = (element: ts.JsxElement | ts.JsxSelfClosingElement): void => {
     const opening = ts.isJsxElement(element) ? element.openingElement : element;
-    for (const utils of utilsOf(opening)) {
-      const fills = accentFills(utils, graph);
+    for (const set of setsOf(opening)) {
+      const fills = accentFills(set.utils, graph);
       if (fills.length === 0) continue;
       accentSurfaces++;
 
       for (const fill of fills) {
-        const own = effectiveForeground(utils, fill.variants, graph);
-        if (own !== null && !isValidated(own)) {
-          report(opening, own.util.raw, "text painted on this element's accent fill");
+        const { offending, colorInState } = coexistingForegrounds(set.utils, fill.variants, graph);
+        for (const fg of offending) {
+          report(opening, fg.util.raw, "text painted on this element's accent fill");
         }
-        if (ts.isJsxElement(element)) walkSubtree(element.children, fill.variants, own);
+        if (colorInState === null && bearsOwnText(opening)) {
+          report(
+            opening,
+            "(inherited)",
+            "renders text on an accent fill with no accent foreground — inherits body-text color"
+          );
+        }
+        if (ts.isJsxElement(element)) walkSubtree(element.children, fill.variants, colorInState);
       }
     }
   };
 
-  // cva/tv: the base classes apply to EVERY variant, so a foreground in the base and a
-  // fill in a variant do co-occur. Pair the base with each variant string in turn.
+  // cva: the base classes apply to EVERY rendered variant, and one value is selected per
+  // variant KEY — so a fill in `variant` and a foreground in `size` do co-occur. Build the
+  // real products rather than pairing the base with one literal at a time.
   const checkCva = (call: ts.CallExpression): void => {
     const [baseArg, config] = call.arguments;
-    const baseSets = parseSets(feasibleSets(baseArg));
-    const variantLiterals: ts.StringLiteralLike[] = [];
-    if (config !== undefined) {
-      const collect = (n: ts.Node): void => {
-        if (ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n)) variantLiterals.push(n);
-        ts.forEachChild(n, collect);
-      };
-      collect(config);
-    }
+    const baseSets = feasibleSets(baseArg, locals);
 
-    const combos: Array<{ node: ts.Node; utils: Util[] }> = [];
-    for (const base of baseSets) {
-      if (variantLiterals.length === 0) combos.push({ node: call, utils: base });
-      for (const literal of variantLiterals) {
-        combos.push({ node: literal, utils: [...base, ...tokensOf(literal.text).map(parseUtil)] });
+    const keyGroups: Array<Array<{ node: ts.Node; utils: Util[] }>> = [];
+    const compounds: Array<{ node: ts.Node; utils: Util[] }> = [];
+
+    if (config !== undefined && ts.isObjectLiteralExpression(config)) {
+      for (const prop of config.properties) {
+        if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+
+        if (prop.name.text === "variants" && ts.isObjectLiteralExpression(prop.initializer)) {
+          for (const key of prop.initializer.properties) {
+            if (!ts.isPropertyAssignment(key) || !ts.isObjectLiteralExpression(key.initializer)) {
+              continue;
+            }
+            const options: Array<{ node: ts.Node; utils: Util[] }> = [];
+            for (const option of key.initializer.properties) {
+              if (!ts.isPropertyAssignment(option)) continue;
+              const value = option.initializer;
+              if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
+                options.push({ node: value, utils: tokensOf(value.text) });
+              }
+            }
+            // A key can also be omitted by the caller.
+            if (options.length > 0) keyGroups.push([...options, { node: key, utils: [] }]);
+          }
+        }
+
+        if (
+          prop.name.text === "compoundVariants" &&
+          ts.isArrayLiteralExpression(prop.initializer)
+        ) {
+          for (const entry of prop.initializer.elements) {
+            if (!ts.isObjectLiteralExpression(entry)) continue;
+            for (const field of entry.properties) {
+              if (!ts.isPropertyAssignment(field) || !ts.isIdentifier(field.name)) continue;
+              if (field.name.text !== "class" && field.name.text !== "className") continue;
+              const value = field.initializer;
+              if (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) {
+                compounds.push({ node: value, utils: tokensOf(value.text) });
+              }
+            }
+          }
+        }
       }
     }
 
-    for (const { node, utils } of combos) {
-      const fills = accentFills(utils, graph);
+    // One value per variant key, every combination — plus each compound class on its own.
+    let combos: Array<{ nodes: ts.Node[]; utils: Util[] }> = baseSets.map((s) => ({
+      nodes: [call],
+      utils: s.utils,
+    }));
+    for (const group of keyGroups) {
+      const next: Array<{ nodes: ts.Node[]; utils: Util[] }> = [];
+      for (const combo of combos) {
+        for (const option of group) {
+          next.push({
+            nodes: [...combo.nodes, option.node],
+            utils: [...combo.utils, ...option.utils],
+          });
+        }
+      }
+      if (next.length > MAX_FEASIBLE_SETS) {
+        throw new Error("accent-foreground guard: cva has too many variant combinations");
+      }
+      combos = next;
+    }
+    for (const compound of compounds) {
+      combos = [
+        ...combos,
+        ...baseSets.map((s) => ({
+          nodes: [compound.node],
+          utils: [...s.utils, ...compound.utils],
+        })),
+      ];
+    }
+
+    for (const combo of combos) {
+      const fills = accentFills(combo.utils, graph);
       if (fills.length === 0) continue;
       accentSurfaces++;
+      const anchor = combo.nodes[combo.nodes.length - 1] ?? call;
       for (const fill of fills) {
-        const own = effectiveForeground(utils, fill.variants, graph);
-        if (own !== null && !isValidated(own)) {
-          report(node, own.util.raw, "text painted on an accent fill in a class-variant string");
+        const { offending, colorInState } = coexistingForegrounds(
+          combo.utils,
+          fill.variants,
+          graph
+        );
+        for (const fg of offending) {
+          report(anchor, fg.util.raw, "text painted on an accent fill in a class-variant string");
         }
-        if (own === null) {
+        if (colorInState === null) {
           report(
-            node,
+            anchor,
             "(inherited)",
             "accent-filled variant sets no accent foreground — text inherits body-text color"
           );
@@ -543,18 +784,39 @@ function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph):
     }
   };
 
+  // A whole-file literal sweep, as a fallback. Structural analysis cannot follow a class
+  // string into an expression it cannot resolve, but a fill and a bad foreground sharing
+  // ONE string are a bug wherever that string is written. Stay quiet about anything the
+  // structural pass already reported — that has the better source location.
+  const sweepLiterals = (): void => {
+    const visit = (node: ts.Node): void => {
+      if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+        const utils = tokensOf(node.text);
+        for (const fill of accentFills(utils, graph)) {
+          for (const fg of coexistingForegrounds(utils, fill.variants, graph).offending) {
+            if (reportedUtilities.has(fg.util.raw)) continue;
+            report(node, fg.util.raw, "text painted on an accent fill in the same class string");
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  };
+
   const visit = (node: ts.Node): void => {
     if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) checkElement(node);
     if (
       ts.isCallExpression(node) &&
       ts.isIdentifier(node.expression) &&
-      CVA_CONSTRUCTORS.has(node.expression.text)
+      node.expression.text === "cva"
     ) {
       checkCva(node);
     }
     ts.forEachChild(node, visit);
   };
   visit(source);
+  sweepLiterals();
 
   return { violations, accentSurfaces };
 }
@@ -601,6 +863,12 @@ describe("accent color graph", () => {
     expect(graph.terminalOfName("text-inverse")).not.toBe(ACCENT_FOREGROUND_TOKEN);
     expect(graph.terminalOfName("daintree-bg")).not.toBe(ACCENT_FOREGROUND_TOKEN);
   });
+
+  it("treats only genuinely opaque tokens as able to hide an accent fill", () => {
+    expect(graph.isOpaqueToken("--theme-surface-panel")).toBe(true);
+    // A wash: its theme value is an rgba(), so painting it over accent still shows accent.
+    expect(graph.isOpaqueToken("--theme-overlay-soft")).toBe(false);
+  });
 });
 
 describe("utility parser", () => {
@@ -613,12 +881,16 @@ describe("utility parser", () => {
       base: "text-text-inverse",
       opacity: "[.5]",
     });
-    // Slashes inside an arbitrary value belong to the value, not to an opacity modifier.
     expect(parseUtil("bg-[url(a/b.png)]")).toMatchObject({
       base: "bg-[url(a/b.png)]",
       opacity: null,
     });
     expect(parseUtil("w-[calc(1/2)]")).toMatchObject({ base: "w-[calc(1/2)]", opacity: null });
+  });
+
+  it("treats a fully-opaque modifier as no modifier at all", () => {
+    expect(parseUtil("bg-primary/100").opacity).toBeNull();
+    expect(parseUtil("text-primary-foreground/[1]").opacity).toBeNull();
   });
 
   it("strips variant chains without tripping on colons or slashes inside them", () => {
@@ -630,18 +902,20 @@ describe("utility parser", () => {
       variants: ["supports-[display:grid]"],
       base: "bg-primary",
     });
-    // The slash lives in the variant name, not in an opacity modifier.
     expect(parseUtil("group-hover/icon:text-white")).toMatchObject({
       variants: ["group-hover/icon"],
       base: "text-white",
       opacity: null,
     });
-    expect(parseUtil("hover:focus:bg-primary")).toMatchObject({ variants: ["hover", "focus"] });
   });
 
-  it("strips the important modifier in both Tailwind spellings", () => {
+  it("strips the important modifier in both spellings, including after a variant", () => {
     expect(parseUtil("bg-primary!").base).toBe("bg-primary");
     expect(parseUtil("!bg-primary").base).toBe("bg-primary");
+    expect(parseUtil("hover:!bg-primary")).toMatchObject({
+      variants: ["hover"],
+      base: "bg-primary",
+    });
   });
 });
 
@@ -656,22 +930,43 @@ describe("accent foreground detector", () => {
   });
 
   it("flags a fill and foreground that only meet after composition", () => {
-    // The bypass a per-literal check misses: neither string is a violation alone.
     expect(
       analyze(`const x = <button className={cn("text-text-inverse", active && "bg-primary")} />;`)
     ).toEqual(["text-text-inverse"]);
   });
 
-  it("flags a cva base foreground against a fill introduced by a variant", () => {
+  it("flags an accent class string reached through a local constant", () => {
     expect(
       analyze(`
-        const v = cva("text-text-inverse", { variants: { tone: { accent: "bg-primary" } } });
+        const accentButton = "bg-primary text-white";
+        const x = <button className={accentButton}>Save</button>;
       `)
-    ).toEqual(["text-text-inverse"]);
+    ).toEqual(["text-white"]);
+  });
+
+  it("flags a foreground that only lands on a base accent fill in a hover state", () => {
+    // The fill is unconditional, so it is still there on hover — where the label turns white.
+    expect(
+      analyze(
+        `const x = <button className="bg-primary text-primary-foreground hover:text-white">Go</button>;`
+      )
+    ).toEqual(["hover:text-white"]);
+  });
+
+  it("does not flag a checkbox — the UA draws its mark, which is not text", () => {
+    expect(
+      analyze(`const x = <input type="checkbox" className="checked:bg-daintree-accent" />;`)
+    ).toEqual([]);
+  });
+
+  it("resolves each of color, fill and stroke independently", () => {
+    // `fill-*` cannot override `color`; the white label stands.
+    expect(
+      analyze(`const x = <button className="bg-primary text-white fill-primary-foreground" />;`)
+    ).toEqual(["text-white"]);
   });
 
   it("does not pair classes from opposite ternary branches", () => {
-    // The accent branch is validated; the neutral branch's dim text never lands on accent.
     expect(
       analyze(`
         const x = (
@@ -688,6 +983,24 @@ describe("accent foreground detector", () => {
     ).toEqual([]);
   });
 
+  it("does not pair branches of two ternaries on the same condition", () => {
+    // `on` cannot be true and false at once — the accent fill never meets the neutral text.
+    expect(
+      analyze(`
+        const x = (
+          <button
+            className={cn(
+              on ? "bg-primary" : "bg-surface-panel",
+              on ? "text-primary-foreground" : "text-daintree-text"
+            )}
+          >
+            Save
+          </button>
+        );
+      `)
+    ).toEqual([]);
+  });
+
   it("flags text that inherits body-text color on an accent fill", () => {
     expect(analyze(`const x = <button className="bg-primary">Save</button>;`)).toEqual([
       "(inherited)",
@@ -697,10 +1010,32 @@ describe("accent foreground detector", () => {
     ]);
   });
 
-  it("flags a glyph that inherits body-text color on an accent fill", () => {
-    expect(analyze(`const x = <div className="bg-daintree-accent"><Check /></div>;`)).toEqual([
-      "(inherited)",
-    ]);
+  it("flags text kept in the non-JSX branch of a conditional child", () => {
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-primary">
+            {ok ? <Check className="text-primary-foreground" /> : "Save"}
+          </div>
+        );
+      `)
+    ).toEqual(["(inherited)"]);
+  });
+
+  it("flags an icon that inherits body-text color on an accent fill", () => {
+    expect(
+      analyze(`
+        import { Check } from "lucide-react";
+        const x = <div className="bg-daintree-accent"><Check /></div>;
+      `)
+    ).toEqual(["(inherited)"]);
+  });
+
+  it("does not treat an arbitrary child component as an icon", () => {
+    // SomeChart paints itself; only known glyphs inherit currentColor.
+    expect(analyze(`const x = <div className="bg-daintree-accent"><SomeChart /></div>;`)).toEqual(
+      []
+    );
   });
 
   it("accepts a decorative accent fill that renders nothing", () => {
@@ -719,21 +1054,10 @@ describe("accent foreground detector", () => {
     ).toEqual(["text-daintree-bg"]);
   });
 
-  it("flags a child glyph reached through a conditional expression", () => {
-    expect(
-      analyze(`
-        const x = (
-          <span className={cn("border", isSelected ? "bg-daintree-accent" : "border-daintree-border")}>
-            {isSelected && <Check className="w-3 h-3 text-text-inverse" />}
-          </span>
-        );
-      `)
-    ).toEqual(["text-text-inverse"]);
-  });
-
   it("accepts a child glyph that supplies the validated foreground itself", () => {
     expect(
       analyze(`
+        import { Check } from "lucide-react";
         const x = (
           <div className="bg-daintree-accent">
             {done && <Check className="text-accent-primary-foreground" />}
@@ -747,7 +1071,7 @@ describe("accent foreground detector", () => {
     // The accent only exists on hover, and hover repaints the label — safe.
     expect(
       analyze(
-        `const x = <button className="text-daintree-text hover:bg-primary hover:text-primary-foreground" />;`
+        `const x = <button className="text-daintree-text hover:bg-primary hover:text-primary-foreground">Go</button>;`
       )
     ).toEqual([]);
     // Same accent-on-hover, but the label is never repainted — the base text lands on it.
@@ -758,52 +1082,53 @@ describe("accent foreground detector", () => {
 
   it("ignores a pseudo-element's own fill and foreground", () => {
     expect(
-      analyze(`const x = <div className="after:bg-daintree-accent text-daintree-text" />;`)
+      analyze(`const x = <div className="after:bg-daintree-accent text-daintree-text">Hi</div>;`)
     ).toEqual([]);
     expect(
       analyze(
-        `const x = <div className="bg-primary text-primary-foreground before:text-white before:content-['!']" />;`
+        `const x = <div className="bg-primary text-primary-foreground before:text-white">Hi</div>;`
       )
     ).toEqual([]);
   });
 
-  it("flags an arbitrary-value foreground that escapes the validated token", () => {
+  it("flags arbitrary and hardcoded colors that escape the validated token", () => {
     expect(
       analyze(`const x = <span className="bg-daintree-accent text-[var(--color-daintree-bg)]" />;`)
     ).toEqual(["text-[var(--color-daintree-bg)]"]);
-    expect(
-      analyze(
-        `const x = <span className="bg-daintree-accent text-[color:var(--theme-text-primary)]" />;`
-      )
-    ).toEqual(["text-[color:var(--theme-text-primary)]"]);
     expect(analyze(`const x = <span className="bg-daintree-accent text-[#0b1220]" />;`)).toEqual([
       "text-[#0b1220]",
     ]);
-  });
-
-  it("flags hardcoded palette colors and alpha-reduced foregrounds on an accent fill", () => {
+    expect(analyze(`const x = <span className="bg-daintree-accent text-[red]" />;`)).toEqual([
+      "text-[red]",
+    ]);
     expect(analyze(`const x = <button className="bg-primary text-white" />;`)).toEqual([
       "text-white",
     ]);
-    // The 4.5:1 guarantee covers the opaque token — not a faded copy of it.
+  });
+
+  it("flags an alpha-reduced copy of the validated foreground", () => {
     expect(
       analyze(`const x = <button className="bg-primary text-primary-foreground/50" />;`)
     ).toEqual(["text-primary-foreground/50"]);
+    // …but a fully-opaque modifier is the validated token.
+    expect(
+      analyze(`const x = <button className="bg-primary text-primary-foreground/100" />;`)
+    ).toEqual([]);
   });
 
-  it("resolves an accent fill written as an arbitrary value", () => {
+  it("resolves an accent fill written in either arbitrary-value syntax", () => {
     expect(
       analyze(`const x = <button className="bg-[var(--color-accent-primary)] text-white" />;`)
     ).toEqual(["text-white"]);
+    expect(analyze(`const x = <button className="bg-(--color-primary) text-white" />;`)).toEqual([
+      "text-white",
+    ]);
   });
 
-  it("accepts either validated foreground alias", () => {
-    expect(analyze(`const x = <button className="bg-primary text-primary-foreground" />;`)).toEqual(
-      []
-    );
+  it("sees through an important modifier on the fill", () => {
     expect(
-      analyze(`const x = <button className="bg-daintree-accent text-accent-primary-foreground" />;`)
-    ).toEqual([]);
+      analyze(`const x = <button className="hover:!bg-primary hover:text-white">Go</button>;`)
+    ).toEqual(["hover:text-white"]);
   });
 
   it("ignores non-color text utilities on an accent fill", () => {
@@ -829,17 +1154,11 @@ describe("accent foreground detector", () => {
         `const x = <button className="bg-gradient-to-b from-primary to-primary/80 text-text-inverse" />;`
       )
     ).toEqual(["text-text-inverse"]);
-    // A later accent stop still paints accent under the label.
-    expect(
-      analyze(
-        `const x = <button className="bg-gradient-to-b from-primary/80 to-primary text-white" />;`
-      )
-    ).toEqual(["text-white"]);
     // `from-*` without a gradient image paints nothing.
     expect(analyze(`const x = <div className="from-primary text-white">Hi</div>;`)).toEqual([]);
   });
 
-  it("stops descending only at a descendant that truly repaints its background", () => {
+  it("stops descending only at a descendant that provably repaints its background", () => {
     expect(
       analyze(`
         const x = (
@@ -861,12 +1180,12 @@ describe("accent foreground detector", () => {
         );
       `)
     ).toEqual(["text-text-inverse"]);
-    // A translucent background does not shield either.
+    // A translucent wash token does not shield: the accent still shows through.
     expect(
       analyze(`
         const x = (
           <div className="bg-primary">
-            <span className="bg-surface-panel/10 text-text-inverse">still on accent</span>
+            <span className="bg-overlay-soft text-text-inverse">still on accent</span>
           </div>
         );
       `)
@@ -881,6 +1200,55 @@ describe("accent foreground detector", () => {
         );
       `)
     ).toEqual(["text-text-inverse"]);
+    // A shielding branch must not excuse the branch that does not shield.
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-primary">
+            <span className={ok ? "bg-surface-panel text-daintree-text" : "text-white"}>Save</span>
+          </div>
+        );
+      `)
+    ).toEqual(["text-white"]);
+  });
+
+  it("flags a cva base foreground against a fill introduced by a variant", () => {
+    expect(
+      analyze(
+        `const v = cva("text-text-inverse", { variants: { tone: { accent: "bg-primary" } } });`
+      )
+    ).toEqual(["text-text-inverse"]);
+  });
+
+  it("flags a cva fill and foreground that meet across two variant keys", () => {
+    // tone="accent" and size="sm" render together — the white label lands on the accent.
+    expect(
+      analyze(`
+        const v = cva("text-primary-foreground", {
+          variants: {
+            tone: { accent: "bg-primary" },
+            size: { sm: "text-white" },
+          },
+        });
+      `)
+    ).toEqual(["text-white"]);
+  });
+
+  it("does not flag a cva whose accent variants each carry the validated foreground", () => {
+    expect(
+      analyze(`
+        const v = cva("inline-flex", {
+          variants: {
+            variant: {
+              default: "bg-primary text-primary-foreground",
+              ghost: "text-text-secondary hover:bg-overlay-soft",
+            },
+            size: { sm: "h-7 px-3 text-xs" },
+          },
+          defaultVariants: { variant: "default", size: "sm" },
+        });
+      `)
+    ).toEqual([]);
   });
 });
 
@@ -889,7 +1257,6 @@ describe("accent foreground contract", () => {
   const files = filesByRoot.flatMap((r) => r.files);
 
   it("scans every root", () => {
-    // Without this, a mistyped root would silently shrink the scan and still pass.
     for (const { root, files: rootFiles } of filesByRoot) {
       expect(rootFiles.length, `no .tsx files found under ${root}`).toBeGreaterThan(0);
     }

--- a/src/config/__tests__/accentForeground.contract.test.ts
+++ b/src/config/__tests__/accentForeground.contract.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import { ACCENT_CONTRAST_PAIR } from "@shared/theme";
 
 // Contrast validation (shared/theme/contrast.ts) checks abstract theme tokens: it
 // guarantees `accent-foreground` clears 4.5:1 on `accent-primary`. It cannot see which
@@ -15,10 +16,10 @@ import ts from "typescript";
 // utility through src/index.css's real variable graph and asserts that anything painting
 // text on a solid accent fill lands on the same terminal token the validator checks.
 //
-// Everything below is derived from the graph, never from a hardcoded class name — so it
-// accepts any spelling that resolves correctly (`text-primary-foreground`,
-// `text-accent-primary-foreground`, a future alias), rejects any that does not, and
-// stays honest if the token wiring is renamed.
+// Nothing here is a hardcoded class name. The tokens come from the validator's own pair,
+// and the classes that reach them are derived from the CSS graph — so the guard accepts
+// any spelling that resolves correctly, rejects any that does not, and breaks loudly if
+// the pair is renamed or its threshold removed.
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -29,22 +30,30 @@ const SCAN_ROOTS = [
   path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
 ];
 
-// The terminal tokens the contrast validator pairs. A utility is an "accent fill" iff it
-// resolves here; a foreground is valid iff it resolves to the foreground counterpart.
-const ACCENT_FILL_TOKEN = "--theme-accent-primary";
-const ACCENT_FOREGROUND_TOKEN = "--theme-accent-foreground";
+// Derived from the validator, not restated. Renaming the pair or dropping it from
+// CONTRAST_PAIRS makes this guard fail rather than silently stop guarding.
+const ACCENT_FILL_TOKEN = `--theme-${ACCENT_CONTRAST_PAIR.background}`;
+const ACCENT_FOREGROUND_TOKEN = `--theme-${ACCENT_CONTRAST_PAIR.foreground}`;
 
-// Utility prefixes that paint a solid fill behind an element's own text.
-const FILL_PREFIXES = ["bg-", "from-"];
-// Utility prefixes that paint text/icon glyphs.
 const FOREGROUND_PREFIXES = ["text-", "fill-", "stroke-"];
+const GRADIENT_STOP_PREFIXES = ["from-", "via-", "to-"];
+// A gradient only paints once a gradient image utility is active; bare `from-*` is inert.
+const GRADIENT_IMAGE = /^bg-(gradient-|linear-|radial|conic)/;
+// `bg-cover`, `bg-center`, `bg-clip-*`, `bg-no-repeat` — background utilities that paint
+// no color, so they never shield a descendant from an ancestor's accent fill.
+const CLASS_CONSTRUCTORS = new Set(["cn", "clsx", "cx", "classNames", "twMerge", "twJoin"]);
+const CVA_CONSTRUCTORS = new Set(["cva", "tv"]);
+// A literal color escapes the token system: it can never be the validated token.
+const LITERAL_COLOR = /^(#[0-9a-f]{3,8}|(rgb|hsl|oklch|oklab|lab|lch|color)a?\()/i;
+const MAX_FEASIBLE_SETS = 512;
 
 // ── CSS variable graph ─────────────────────────────────────────────────
 
 /** Every `--name: value` in index.css, in document order — later wins, as the cascade does. */
 function parseCssVariables(css: string): Map<string, string> {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
   const declarations = new Map<string, string>();
-  for (const [, name, value] of css.matchAll(/(--[\w-]+)\s*:\s*([^;{}]+);/g)) {
+  for (const [, name, value] of withoutComments.matchAll(/(--[\w-]+)\s*:\s*([^;{}]+);/g)) {
     if (name === undefined || value === undefined) continue;
     declarations.set(name, value.trim());
   }
@@ -53,14 +62,14 @@ function parseCssVariables(css: string): Map<string, string> {
 
 /**
  * Follow a variable through pure `var(--x)` aliases to the name it ultimately points at.
- * Stops at the first variable whose value is not a bare alias (a literal color, a
- * color-mix, or undefined here because a theme supplies it at runtime) and returns that
- * variable's *name* — the semantic destination.
+ * Stops at a `--theme-*` semantic token (the runtime theme supplies its value, and it is
+ * the vocabulary the contrast validator speaks), or at any value that is not a bare alias.
  */
 function resolveToTerminalToken(name: string, declarations: Map<string, string>): string {
   const seen = new Set<string>();
   let current = name;
   while (!seen.has(current)) {
+    if (current.startsWith("--theme-")) return current;
     seen.add(current);
     const value = declarations.get(current);
     if (value === undefined) return current;
@@ -72,193 +81,312 @@ function resolveToTerminalToken(name: string, declarations: Map<string, string>)
 }
 
 type ColorGraph = {
-  /** Terminal token a `--color-*` utility name lands on, e.g. "primary" -> "--theme-accent-primary". */
-  terminalOf: (utilityName: string) => string | null;
+  /** Terminal token for a Tailwind color name, e.g. "primary" -> "--theme-accent-primary". */
+  terminalOfName: (colorName: string) => string | null;
+  /** Terminal token for a raw CSS variable, e.g. "--color-primary" / "--theme-accent-primary". */
+  terminalOfVar: (varName: string) => string;
 };
 
 function buildColorGraph(css: string): ColorGraph {
   const declarations = parseCssVariables(css);
-  const cache = new Map<string, string | null>();
   return {
-    terminalOf(utilityName) {
-      const cached = cache.get(utilityName);
-      if (cached !== undefined) return cached;
-      const varName = `--color-${utilityName}`;
-      const terminal = declarations.has(varName)
-        ? resolveToTerminalToken(varName, declarations)
-        : null;
-      cache.set(utilityName, terminal);
-      return terminal;
+    terminalOfName(colorName) {
+      const varName = `--color-${colorName}`;
+      return declarations.has(varName) ? resolveToTerminalToken(varName, declarations) : null;
+    },
+    terminalOfVar(varName) {
+      return resolveToTerminalToken(varName, declarations);
     },
   };
 }
 
-// ── Utility classification ─────────────────────────────────────────────
+// ── Utility parsing ────────────────────────────────────────────────────
 
-/** Strip variant prefixes (`hover:`, `data-[state=on]:`, …), keeping the base utility. */
-function stripVariants(utility: string): { base: string; variants: string[] } {
+type Util = {
+  raw: string;
+  /** Variant chain (`hover`, `data-[state=on]`, `before`), normalized, order-insensitive. */
+  variants: string[];
+  /** The utility with variants, `!` and any opacity modifier removed. */
+  base: string;
+  /** The `/50` or `/[.5]` modifier, if present. */
+  opacity: string | null;
+};
+
+/** Index of `ch` at bracket/paren depth zero, or -1. */
+function indexAtDepthZero(text: string, ch: string): number {
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === "[" || c === "(") depth++;
+    else if (c === "]" || c === ")") depth--;
+    else if (c === ch && depth === 0) return i;
+  }
+  return -1;
+}
+
+function parseUtil(raw: string): Util {
+  // Tailwind v4 `bg-primary!` and v3 `!bg-primary`.
+  let rest = raw.endsWith("!") ? raw.slice(0, -1) : raw;
+  if (rest.startsWith("!")) rest = rest.slice(1);
+
   const variants: string[] = [];
-  let rest = utility;
-  // Split on ":" that is not inside [...] — data-[state=checked]:bg-x has a ":" free colon only at the end.
   for (;;) {
-    let depth = 0;
-    let cut = -1;
-    for (let i = 0; i < rest.length; i++) {
-      const ch = rest[i];
-      if (ch === "[") depth++;
-      else if (ch === "]") depth--;
-      else if (ch === ":" && depth === 0) {
-        cut = i;
-        break;
-      }
-    }
+    const cut = indexAtDepthZero(rest, ":");
     if (cut === -1) break;
     variants.push(rest.slice(0, cut));
     rest = rest.slice(cut + 1);
   }
-  return { base: rest, variants };
+
+  // A slash inside `[...]` or `(...)` is part of the value (`bg-[url(a/b.png)]`,
+  // `w-[calc(1/2)]`); only a depth-zero slash is an opacity modifier. Variant names can
+  // also carry slashes (`group-hover/icon:`) — already stripped above.
+  const slash = indexAtDepthZero(rest, "/");
+  const base = slash === -1 ? rest : rest.slice(0, slash);
+  const opacity = slash === -1 ? null : rest.slice(slash + 1);
+
+  return { raw, variants, base, opacity };
 }
 
-/** `bg-daintree-accent/10` -> { name: "bg-daintree-accent", hasOpacity: true } */
-function splitOpacity(base: string): { name: string; hasOpacity: boolean } {
-  const slash = base.lastIndexOf("/");
-  // Ignore a "/" inside an arbitrary value: text-[var(--x)]/50 is rare; bracket-aware enough.
-  if (slash === -1 || base.indexOf("]") > slash) return { name: base, hasOpacity: false };
-  return { name: base.slice(0, slash), hasOpacity: true };
-}
-
-/** A pseudo-element variant paints a separate box — not the element's own text surface. */
-function isPseudoElement(variants: string[]): boolean {
-  return variants.some((v) => v === "before" || v === "after");
+/** A pseudo-element paints a separate box — neither the element's fill nor its own text. */
+function isPseudoElement(util: Util): boolean {
+  return util.variants.some((v) => v === "before" || v === "after");
 }
 
 /**
- * Does this utility paint a SOLID accent fill behind its own text?
- * Opacity-modified fills (`bg-daintree-accent/10`) are washes over the surface, not solid
- * accent, and `accent-soft`/`accent-muted` resolve to different terminal tokens — both
- * fall out naturally, the first by the opacity check, the second by the graph.
+ * The terminal token a color-bearing utility resolves to, `"literal"` for a hardcoded
+ * color that escapes the token system, or null when the utility is not a color at all
+ * (`text-sm`, `text-center`, `text-[9px]`, `bg-cover`).
  */
-function isSolidAccentFill(utility: string, graph: ColorGraph): boolean {
-  const { base, variants } = stripVariants(utility);
-  if (isPseudoElement(variants)) return false;
-  const { name, hasOpacity } = splitOpacity(base);
-  if (hasOpacity) return false;
-  const prefix = FILL_PREFIXES.find((p) => name.startsWith(p));
-  if (prefix === undefined) return false;
-  return graph.terminalOf(name.slice(prefix.length)) === ACCENT_FILL_TOKEN;
-}
+function colorTerminal(base: string, prefix: string, graph: ColorGraph): string | null {
+  const value = base.slice(prefix.length);
 
-/** Any background paint at all — a descendant carrying one re-paints, so its text is not on the accent. */
-function isAnyBackground(utility: string): boolean {
-  const { base, variants } = stripVariants(utility);
-  if (isPseudoElement(variants)) return false;
-  const { name } = splitOpacity(base);
-  return name.startsWith("bg-") && name !== "bg-transparent" && !name.startsWith("bg-gradient-");
-}
-
-type Foreground = { utility: string; terminal: string | null };
-
-/**
- * Classify a utility as a text/icon color, if it is one. Returns null for non-color `text-*`
- * utilities (text-xs, text-center, text-[9px]) so sizing/alignment never trips the guard.
- */
-function asForeground(utility: string, graph: ColorGraph): Foreground | null {
-  const { base } = stripVariants(utility);
-  const { name } = splitOpacity(base);
-  const prefix = FOREGROUND_PREFIXES.find((p) => name.startsWith(p));
-  if (prefix === undefined) return null;
-  const value = name.slice(prefix.length);
-
-  // Arbitrary value: text-[var(--color-daintree-bg)] / text-[#0b1220] / text-[9px]
   const arbitrary = /^\[(.+)]$/.exec(value);
   if (arbitrary?.[1] !== undefined) {
-    const inner = arbitrary[1];
-    const varRef = /^var\(\s*--color-([\w-]+)\s*\)$/.exec(inner);
-    if (varRef?.[1] !== undefined) {
-      return { utility, terminal: graph.terminalOf(varRef[1]) };
-    }
-    // A literal color escapes the token system entirely; anything else (a length,
-    // a font-size) is not a color at all.
-    if (/^#[0-9a-f]{3,8}$/i.test(inner) || /^(rgb|hsl|oklch|color)\(/i.test(inner)) {
-      return { utility, terminal: null };
-    }
+    // A type hint is allowed: text-[color:var(--x)].
+    const inner = arbitrary[1].replace(/^color:/, "");
+    const varRef = /^var\(\s*(--[\w-]+)\s*\)$/.exec(inner);
+    if (varRef?.[1] !== undefined) return graph.terminalOfVar(varRef[1]);
+    if (LITERAL_COLOR.test(inner)) return "literal";
     return null;
   }
 
-  // Hardcoded palette colors bypass theming outright.
-  if (value === "white" || value === "black") return { utility, terminal: null };
+  if (value === "white" || value === "black") return "literal";
+  // Inherits or paints nothing — not a determinable foreground of its own.
+  if (value === "transparent" || value === "current" || value === "inherit") return null;
 
-  const terminal = graph.terminalOf(value);
-  // Not a known color token => a sizing/alignment/decoration utility. Ignore.
-  if (terminal === null) return null;
-  return { utility, terminal };
+  return graph.terminalOfName(value);
 }
 
-function isValidAccentForeground(fg: Foreground): boolean {
-  return fg.terminal === ACCENT_FOREGROUND_TOKEN;
+/** A solid, unconditional-in-this-state accent fill behind the element's own text. */
+function accentFills(utils: Util[], graph: ColorGraph): Util[] {
+  const hasGradientImage = utils.some((u) => GRADIENT_IMAGE.test(u.base));
+  return utils.filter((u) => {
+    if (isPseudoElement(u)) return false;
+
+    if (u.base.startsWith("bg-")) {
+      // An opacity-modified fill is a wash over the surface, not solid accent.
+      if (u.opacity !== null) return false;
+      return colorTerminal(u.base, "bg-", graph) === ACCENT_FILL_TOKEN;
+    }
+
+    // Gradient stops only paint when a gradient image utility is active. A stop keeps
+    // showing accent even at reduced alpha, so opacity does not disqualify it.
+    const stop = GRADIENT_STOP_PREFIXES.find((p) => u.base.startsWith(p));
+    if (stop === undefined || !hasGradientImage) return false;
+    return colorTerminal(u.base, stop, graph) === ACCENT_FILL_TOKEN;
+  });
+}
+
+/**
+ * Does this class set repaint its own background, shielding its text from an ancestor's
+ * accent fill? Only an unconditional, fully opaque, actually-colored background does.
+ * A `hover:` background leaves the base state on the accent; an opacity-modified one is
+ * translucent; and `bg-cover` paints no color at all.
+ */
+function shieldsBackground(utils: Util[], graph: ColorGraph): boolean {
+  const hasGradientImage = utils.some((u) => GRADIENT_IMAGE.test(u.base));
+  return utils.some((u) => {
+    if (u.variants.length > 0 || u.opacity !== null) return false;
+    if (u.base.startsWith("bg-")) return colorTerminal(u.base, "bg-", graph) !== null;
+    const stop = GRADIENT_STOP_PREFIXES.find((p) => u.base.startsWith(p));
+    if (stop === undefined || !hasGradientImage) return false;
+    return colorTerminal(u.base, stop, graph) !== null;
+  });
+}
+
+type Foreground = { util: Util; terminal: string };
+
+function foregrounds(utils: Util[], graph: ColorGraph): Foreground[] {
+  const out: Foreground[] = [];
+  for (const util of utils) {
+    if (isPseudoElement(util)) continue;
+    const prefix = FOREGROUND_PREFIXES.find((p) => util.base.startsWith(p));
+    if (prefix === undefined) continue;
+    const terminal = colorTerminal(util.base, prefix, graph);
+    if (terminal === null) continue;
+    out.push({ util, terminal });
+  }
+  return out;
+}
+
+/**
+ * The foreground actually painted while `fillVariants` is the active state. A foreground
+ * applies if its own variant chain is satisfied in that state — a base `text-*` applies
+ * always, a `hover:text-*` only once `hover` is active. The most specific wins, matching
+ * how the cascade resolves them; a later declaration breaks a tie.
+ */
+function effectiveForeground(
+  utils: Util[],
+  fillVariants: string[],
+  graph: ColorGraph
+): Foreground | null {
+  const active = new Set(fillVariants);
+  let best: Foreground | null = null;
+  for (const fg of foregrounds(utils, graph)) {
+    if (!fg.util.variants.every((v) => active.has(v))) continue;
+    if (best === null || fg.util.variants.length >= best.util.variants.length) best = fg;
+  }
+  return best;
+}
+
+/** The 4.5:1 guarantee covers the opaque token; alpha below 1 is no longer guaranteed. */
+function isValidated(fg: Foreground): boolean {
+  return fg.terminal === ACCENT_FOREGROUND_TOKEN && fg.util.opacity === null;
+}
+
+// ── Feasible class sets ────────────────────────────────────────────────
+
+// A className is rarely one string. `cn("a", cond ? "b" : "c", flag && "d")` renders one
+// of several class sets, and only classes that can co-occur may be compared: flattening
+// them into one union would pair an accent fill from one ternary branch with a foreground
+// from the other and report a bug that cannot happen. So expand the expression into the
+// sets that can actually render, and check each independently.
+
+function tokensOf(text: string): string[] {
+  return text.split(/\s+/).filter((t) => t.length > 0);
+}
+
+function crossProduct(groups: string[][][]): string[][] {
+  let acc: string[][] = [[]];
+  for (const group of groups) {
+    const next: string[][] = [];
+    for (const prefix of acc) {
+      for (const suffix of group) next.push([...prefix, ...suffix]);
+    }
+    if (next.length > MAX_FEASIBLE_SETS) {
+      // Degrade to the flat union rather than exploding. Over-approximates (may pair
+      // classes that never co-occur), which can only over-report, never under-report.
+      return [[...new Set(next.flat())]];
+    }
+    acc = next;
+  }
+  return acc;
+}
+
+function feasibleSets(node: ts.Node | undefined): string[][] {
+  if (node === undefined) return [[]];
+
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return [tokensOf(node.text)];
+  }
+  if (ts.isJsxExpression(node) || ts.isParenthesizedExpression(node)) {
+    return feasibleSets(node.expression);
+  }
+  if (ts.isConditionalExpression(node)) {
+    return [...feasibleSets(node.whenTrue), ...feasibleSets(node.whenFalse)];
+  }
+  if (ts.isBinaryExpression(node)) {
+    const kind = node.operatorToken.kind;
+    // `flag && "cls"` renders the classes or nothing.
+    if (kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+      return [...feasibleSets(node.right), []];
+    }
+    if (
+      kind === ts.SyntaxKind.BarBarToken ||
+      kind === ts.SyntaxKind.QuestionQuestionToken ||
+      kind === ts.SyntaxKind.PlusToken
+    ) {
+      return [...feasibleSets(node.left), ...feasibleSets(node.right)];
+    }
+    return [[]];
+  }
+  if (ts.isTemplateExpression(node)) {
+    const groups: string[][][] = [[tokensOf(node.head.text)]];
+    for (const span of node.templateSpans) {
+      groups.push(feasibleSets(span.expression), [tokensOf(span.literal.text)]);
+    }
+    return crossProduct(groups);
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    return crossProduct(node.elements.map((e) => feasibleSets(e)));
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    // clsx's object form: each key is independently present or absent.
+    return crossProduct(
+      node.properties.flatMap((prop) => {
+        if (!ts.isPropertyAssignment(prop)) return [];
+        const name = prop.name;
+        const text = ts.isStringLiteral(name)
+          ? name.text
+          : ts.isIdentifier(name)
+            ? name.text
+            : null;
+        if (text === null) return [];
+        return [[tokensOf(text), []]];
+      })
+    );
+  }
+  if (ts.isCallExpression(node)) {
+    const callee = ts.isIdentifier(node.expression) ? node.expression.text : null;
+    if (callee !== null && CLASS_CONSTRUCTORS.has(callee)) {
+      return crossProduct(node.arguments.map((arg) => feasibleSets(arg)));
+    }
+    return [[]];
+  }
+  // An identifier, member access, or anything else we cannot resolve statically.
+  return [[]];
+}
+
+function parseSets(sets: string[][]): Util[][] {
+  return sets.map((set) => set.map(parseUtil));
 }
 
 // ── Source analysis ────────────────────────────────────────────────────
 
 export type Violation = { file: string; line: number; utility: string; context: string };
 
-function utilitiesOf(text: string): string[] {
-  return text.split(/\s+/).filter((t) => t.length > 0);
-}
-
-// Every node kind that can carry class text. Typed as the union rather than ts.Node so
-// `.text` reads without a cast (the no-unsafe-type-assertion lint ratchet is per-rule).
-type ClassLiteral =
-  | ts.StringLiteral
-  | ts.NoSubstitutionTemplateLiteral
-  | ts.TemplateHead
-  | ts.TemplateMiddle
-  | ts.TemplateTail;
-
-/** Every class-ish string literal inside a node (covers cn(), cva variants, template chunks). */
-function literalsIn(node: ts.Node): ClassLiteral[] {
-  const out: ClassLiteral[] = [];
-  const visit = (n: ts.Node): void => {
-    if (
-      ts.isStringLiteral(n) ||
-      ts.isNoSubstitutionTemplateLiteral(n) ||
-      ts.isTemplateHead(n) ||
-      ts.isTemplateMiddle(n) ||
-      ts.isTemplateTail(n)
-    ) {
-      out.push(n);
-    }
-    ts.forEachChild(n, visit);
-  };
-  visit(node);
-  return out;
-}
-
-function classNameAttrOf(
+function classNameExprOf(
   element: ts.JsxOpeningElement | ts.JsxSelfClosingElement
-): ts.JsxAttribute | null {
+): ts.Node | undefined {
   for (const prop of element.attributes.properties) {
-    if (ts.isJsxAttribute(prop) && prop.name.getText() === "className") return prop;
+    if (ts.isJsxAttribute(prop) && prop.name.getText() === "className") return prop.initializer;
   }
-  return null;
+  return undefined;
 }
 
-/**
- * Utilities on an element's className. Conditional branches are merged deliberately: an
- * element that is accent-filled only when selected still has to be legible when selected.
- */
-function elementUtilities(
-  element: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
-  source: ts.SourceFile
-): { utilities: string[]; line: number } {
-  const attr = classNameAttrOf(element);
-  const line = source.getLineAndCharacterOfPosition(element.getStart(source)).line + 1;
-  if (attr?.initializer === undefined) return { utilities: [], line };
-  const utilities = literalsIn(attr.initializer).flatMap((lit) => utilitiesOf(lit.text));
-  return { utilities, line };
+/** Renders characters of its own — as opposed to rendering only child elements. */
+function rendersText(child: ts.JsxChild): boolean {
+  if (ts.isJsxText(child)) return child.text.trim().length > 0;
+  if (!ts.isJsxExpression(child) || child.expression === undefined) return false;
+  // `{done && <Check />}` renders an element, not text. `{count}` renders text.
+  let hasJsx = false;
+  const look = (n: ts.Node): void => {
+    if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) hasJsx = true;
+    ts.forEachChild(n, look);
+  };
+  look(child.expression);
+  return !hasJsx;
 }
 
-function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph): Violation[] {
+/** A glyph that inherits `currentColor` — an icon component or a raw <svg>. */
+function isGlyph(element: ts.JsxSelfClosingElement): boolean {
+  const tag = element.tagName.getText();
+  return tag === "svg" || /^[A-Z]/.test(tag);
+}
+
+type Analysis = { violations: Violation[]; accentSurfaces: number };
+
+function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph): Analysis {
   const source = ts.createSourceFile(
     fileName,
     sourceText,
@@ -267,58 +395,168 @@ function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph):
     ts.ScriptKind.TSX
   );
   const violations: Violation[] = [];
-  const lineOf = (n: ts.Node): number =>
-    source.getLineAndCharacterOfPosition(n.getStart(source)).line + 1;
+  const seen = new Set<string>();
+  let accentSurfaces = 0;
 
-  const report = (node: ts.Node, fg: Foreground, context: string): void => {
-    violations.push({ file: fileName, line: lineOf(node), utility: fg.utility, context });
+  // One element can carry several accent fills (a gradient's `from-` and `to-` stops are
+  // both accent), and each would otherwise re-report the same offending foreground.
+  const report = (node: ts.Node, utility: string, context: string): void => {
+    const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+    const key = `${line}:${utility}:${context}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    violations.push({ file: fileName, line, utility, context });
   };
 
-  // Rule A — a single class string that both fills with accent and paints its own text.
-  // Catches cva variant strings and plain className literals.
-  for (const literal of literalsIn(source)) {
-    const utilities = utilitiesOf(literal.text);
-    if (!utilities.some((u) => isSolidAccentFill(u, graph))) continue;
-    for (const utility of utilities) {
-      const fg = asForeground(utility, graph);
-      if (fg !== null && !isValidAccentForeground(fg)) {
-        report(literal, fg, "text painted on an accent fill in the same class string");
+  const utilsOf = (element: ts.JsxOpeningElement | ts.JsxSelfClosingElement): Util[][] =>
+    parseSets(feasibleSets(classNameExprOf(element)));
+
+  // Walk an accent-filled element's subtree. Text inherits the nearest foreground set by
+  // an ancestor, so carry it down; a descendant that repaints its background is off the
+  // accent and ends the descent.
+  const walkSubtree = (
+    children: readonly ts.JsxChild[],
+    fillVariants: string[],
+    inherited: Foreground | null
+  ): void => {
+    for (const child of children) {
+      if (rendersText(child)) {
+        if (inherited === null) {
+          report(
+            child,
+            "(inherited)",
+            "renders text on an accent fill with no accent foreground — inherits body-text color"
+          );
+        }
+        continue;
+      }
+
+      const element = ts.isJsxElement(child)
+        ? child
+        : ts.isJsxSelfClosingElement(child)
+          ? child
+          : null;
+
+      if (element === null) {
+        // A fragment or an expression wrapping elements — keep looking inside it.
+        if (ts.isJsxFragment(child)) walkSubtree(child.children, fillVariants, inherited);
+        else if (ts.isJsxExpression(child) && child.expression !== undefined) {
+          const nested: ts.JsxChild[] = [];
+          const collect = (n: ts.Node): void => {
+            if (ts.isJsxElement(n) || ts.isJsxSelfClosingElement(n) || ts.isJsxFragment(n)) {
+              nested.push(n);
+              return;
+            }
+            ts.forEachChild(n, collect);
+          };
+          collect(child.expression);
+          walkSubtree(nested, fillVariants, inherited);
+        }
+        continue;
+      }
+
+      const opening = ts.isJsxElement(element) ? element.openingElement : element;
+      const sets = utilsOf(opening);
+      if (sets.some((utils) => shieldsBackground(utils, graph))) continue;
+
+      // A descendant's own foreground overrides what it inherits from the accent element.
+      let here = inherited;
+      for (const utils of sets) {
+        const own = effectiveForeground(utils, fillVariants, graph);
+        if (own === null) continue;
+        if (!isValidated(own)) {
+          report(opening, own.util.raw, "text painted on an ancestor's accent fill");
+        }
+        here = own;
+      }
+
+      if (ts.isJsxSelfClosingElement(element)) {
+        if (here === null && isGlyph(element)) {
+          report(
+            opening,
+            "(inherited)",
+            "glyph on an accent fill with no accent foreground — inherits body-text color"
+          );
+        }
+        continue;
+      }
+      walkSubtree(element.children, fillVariants, here);
+    }
+  };
+
+  const checkElement = (element: ts.JsxElement | ts.JsxSelfClosingElement): void => {
+    const opening = ts.isJsxElement(element) ? element.openingElement : element;
+    for (const utils of utilsOf(opening)) {
+      const fills = accentFills(utils, graph);
+      if (fills.length === 0) continue;
+      accentSurfaces++;
+
+      for (const fill of fills) {
+        const own = effectiveForeground(utils, fill.variants, graph);
+        if (own !== null && !isValidated(own)) {
+          report(opening, own.util.raw, "text painted on this element's accent fill");
+        }
+        if (ts.isJsxElement(element)) walkSubtree(element.children, fill.variants, own);
       }
     }
-  }
+  };
 
-  // Rule B — an accent-filled JSX element whose descendants paint the text (the badge/icon
-  // shape: fill on the <div>, color on the child <Check>). Rule A cannot see across
-  // elements, and every check-badge offender in #11115 had exactly this shape.
-  const checkSubtree = (element: ts.JsxElement): void => {
-    const { utilities } = elementUtilities(element.openingElement, source);
-    if (!utilities.some((u) => isSolidAccentFill(u, graph))) return;
+  // cva/tv: the base classes apply to EVERY variant, so a foreground in the base and a
+  // fill in a variant do co-occur. Pair the base with each variant string in turn.
+  const checkCva = (call: ts.CallExpression): void => {
+    const [baseArg, config] = call.arguments;
+    const baseSets = parseSets(feasibleSets(baseArg));
+    const variantLiterals: ts.StringLiteralLike[] = [];
+    if (config !== undefined) {
+      const collect = (n: ts.Node): void => {
+        if (ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n)) variantLiterals.push(n);
+        ts.forEachChild(n, collect);
+      };
+      collect(config);
+    }
 
-    const descend = (node: ts.Node): void => {
-      if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
-        const opening = ts.isJsxElement(node) ? node.openingElement : node;
-        const own = elementUtilities(opening, source).utilities;
-        // A descendant that paints its own background is no longer on the accent.
-        if (own.some(isAnyBackground)) return;
-        for (const utility of own) {
-          const fg = asForeground(utility, graph);
-          if (fg !== null && !isValidAccentForeground(fg)) {
-            report(opening, fg, "text painted on an ancestor's accent fill");
-          }
+    const combos: Array<{ node: ts.Node; utils: Util[] }> = [];
+    for (const base of baseSets) {
+      if (variantLiterals.length === 0) combos.push({ node: call, utils: base });
+      for (const literal of variantLiterals) {
+        combos.push({ node: literal, utils: [...base, ...tokensOf(literal.text).map(parseUtil)] });
+      }
+    }
+
+    for (const { node, utils } of combos) {
+      const fills = accentFills(utils, graph);
+      if (fills.length === 0) continue;
+      accentSurfaces++;
+      for (const fill of fills) {
+        const own = effectiveForeground(utils, fill.variants, graph);
+        if (own !== null && !isValidated(own)) {
+          report(node, own.util.raw, "text painted on an accent fill in a class-variant string");
+        }
+        if (own === null) {
+          report(
+            node,
+            "(inherited)",
+            "accent-filled variant sets no accent foreground — text inherits body-text color"
+          );
         }
       }
-      ts.forEachChild(node, descend);
-    };
-    for (const child of element.children) descend(child);
+    }
   };
 
   const visit = (node: ts.Node): void => {
-    if (ts.isJsxElement(node)) checkSubtree(node);
+    if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) checkElement(node);
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      CVA_CONSTRUCTORS.has(node.expression.text)
+    ) {
+      checkCva(node);
+    }
     ts.forEachChild(node, visit);
   };
   visit(source);
 
-  return violations;
+  return { violations, accentSurfaces };
 }
 
 // ── File collection ────────────────────────────────────────────────────
@@ -341,88 +579,222 @@ function collectSourceFiles(dir: string): string[] {
 
 const graph = buildColorGraph(fs.readFileSync(INDEX_CSS_PATH, "utf-8"));
 
-describe("accent foreground graph", () => {
+describe("accent color graph", () => {
   // If the wiring is renamed and these resolve nowhere, every scan below would pass
-  // vacuously. Pin the two ends of the graph the whole guard is built on.
-  it("resolves the shadcn and daintree fill aliases to one accent token", () => {
-    expect(graph.terminalOf("primary")).toBe(ACCENT_FILL_TOKEN);
-    expect(graph.terminalOf("daintree-accent")).toBe(ACCENT_FILL_TOKEN);
-    expect(graph.terminalOf("accent-primary")).toBe(ACCENT_FILL_TOKEN);
+  // vacuously. Pin both ends of the graph the whole guard is built on.
+  it("resolves the shadcn and daintree fill aliases to the validated fill token", () => {
+    expect(graph.terminalOfName("primary")).toBe(ACCENT_FILL_TOKEN);
+    expect(graph.terminalOfName("daintree-accent")).toBe(ACCENT_FILL_TOKEN);
+    expect(graph.terminalOfName("accent-primary")).toBe(ACCENT_FILL_TOKEN);
   });
 
-  it("resolves every accent foreground alias to the contrast-validated token", () => {
-    expect(graph.terminalOf("primary-foreground")).toBe(ACCENT_FOREGROUND_TOKEN);
-    expect(graph.terminalOf("accent-primary-foreground")).toBe(ACCENT_FOREGROUND_TOKEN);
-    // Once shadowed by a duplicate shadcn declaration, which silently pointed it at body
-    // text (#11115). It must land on the validated token or not exist at all.
-    const accentForeground = graph.terminalOf("accent-foreground");
+  it("resolves every accent foreground alias to the validated foreground token", () => {
+    expect(graph.terminalOfName("primary-foreground")).toBe(ACCENT_FOREGROUND_TOKEN);
+    expect(graph.terminalOfName("accent-primary-foreground")).toBe(ACCENT_FOREGROUND_TOKEN);
+    // Once shadowed by a duplicate shadcn declaration that silently pointed it at body
+    // text (#11115). It must reach the validated token, or not exist at all.
+    const accentForeground = graph.terminalOfName("accent-foreground");
     if (accentForeground !== null) expect(accentForeground).toBe(ACCENT_FOREGROUND_TOKEN);
   });
 
-  it("does not resolve the unvalidated foregrounds to the accent token", () => {
-    expect(graph.terminalOf("text-inverse")).not.toBe(ACCENT_FOREGROUND_TOKEN);
-    expect(graph.terminalOf("daintree-bg")).not.toBe(ACCENT_FOREGROUND_TOKEN);
+  it("does not resolve the body-text foregrounds to the accent foreground token", () => {
+    expect(graph.terminalOfName("text-inverse")).not.toBe(ACCENT_FOREGROUND_TOKEN);
+    expect(graph.terminalOfName("daintree-bg")).not.toBe(ACCENT_FOREGROUND_TOKEN);
+  });
+});
+
+describe("utility parser", () => {
+  it("splits an opacity modifier only at bracket depth zero", () => {
+    expect(parseUtil("bg-daintree-accent/10")).toMatchObject({
+      base: "bg-daintree-accent",
+      opacity: "10",
+    });
+    expect(parseUtil("text-text-inverse/[.5]")).toMatchObject({
+      base: "text-text-inverse",
+      opacity: "[.5]",
+    });
+    // Slashes inside an arbitrary value belong to the value, not to an opacity modifier.
+    expect(parseUtil("bg-[url(a/b.png)]")).toMatchObject({
+      base: "bg-[url(a/b.png)]",
+      opacity: null,
+    });
+    expect(parseUtil("w-[calc(1/2)]")).toMatchObject({ base: "w-[calc(1/2)]", opacity: null });
+  });
+
+  it("strips variant chains without tripping on colons or slashes inside them", () => {
+    expect(parseUtil("data-[state=checked]:bg-primary")).toMatchObject({
+      variants: ["data-[state=checked]"],
+      base: "bg-primary",
+    });
+    expect(parseUtil("supports-[display:grid]:bg-primary")).toMatchObject({
+      variants: ["supports-[display:grid]"],
+      base: "bg-primary",
+    });
+    // The slash lives in the variant name, not in an opacity modifier.
+    expect(parseUtil("group-hover/icon:text-white")).toMatchObject({
+      variants: ["group-hover/icon"],
+      base: "text-white",
+      opacity: null,
+    });
+    expect(parseUtil("hover:focus:bg-primary")).toMatchObject({ variants: ["hover", "focus"] });
+  });
+
+  it("strips the important modifier in both Tailwind spellings", () => {
+    expect(parseUtil("bg-primary!").base).toBe("bg-primary");
+    expect(parseUtil("!bg-primary").base).toBe("bg-primary");
   });
 });
 
 describe("accent foreground detector", () => {
-  const analyze = (src: string): Violation[] => analyzeSource("fixture.tsx", src, graph);
+  const analyze = (src: string): string[] =>
+    analyzeSource("fixture.tsx", src, graph).violations.map((v) => v.utility);
 
   it("flags an unvalidated foreground in the same class string as an accent fill", () => {
-    const found = analyze(`const x = <button className="bg-daintree-accent text-text-inverse" />;`);
-    expect(found.map((v) => v.utility)).toEqual(["text-text-inverse"]);
+    expect(
+      analyze(`const x = <button className="bg-daintree-accent text-text-inverse" />;`)
+    ).toEqual(["text-text-inverse"]);
   });
 
-  it("flags a cva variant independently of its siblings", () => {
-    const found = analyze(`
-      const v = cva("base", {
-        variants: {
-          variant: {
-            default: "bg-primary text-text-inverse",
-            contrast: "bg-daintree-text text-text-inverse",
-            ghost: "text-text-secondary hover:bg-overlay-soft",
-          },
-        },
-      });
-    `);
-    // Only the accent-filled variant is a violation; the inverse-CTA and ghost variants
-    // are not accent fills at all.
-    expect(found).toHaveLength(1);
-    expect(found[0]?.utility).toBe("text-text-inverse");
+  it("flags a fill and foreground that only meet after composition", () => {
+    // The bypass a per-literal check misses: neither string is a violation alone.
+    expect(
+      analyze(`const x = <button className={cn("text-text-inverse", active && "bg-primary")} />;`)
+    ).toEqual(["text-text-inverse"]);
   });
 
-  it("flags a child icon painted on an ancestor's accent fill", () => {
-    const found = analyze(`
-      const x = (
-        <div className="rounded-full bg-daintree-accent">
-          <Check className="h-2.5 w-2.5 text-daintree-bg" />
-        </div>
-      );
-    `);
-    expect(found.map((v) => v.utility)).toEqual(["text-daintree-bg"]);
+  it("flags a cva base foreground against a fill introduced by a variant", () => {
+    expect(
+      analyze(`
+        const v = cva("text-text-inverse", { variants: { tone: { accent: "bg-primary" } } });
+      `)
+    ).toEqual(["text-text-inverse"]);
   });
 
-  it("flags a child icon reached through a conditional expression", () => {
-    const found = analyze(`
-      const x = (
-        <span className={cn("border", isSelected ? "bg-daintree-accent" : "border-daintree-border")}>
-          {isSelected && <Check className="w-3 h-3 text-text-inverse" />}
-        </span>
-      );
-    `);
-    expect(found.map((v) => v.utility)).toEqual(["text-text-inverse"]);
+  it("does not pair classes from opposite ternary branches", () => {
+    // The accent branch is validated; the neutral branch's dim text never lands on accent.
+    expect(
+      analyze(`
+        const x = (
+          <button
+            className={cn(
+              "px-4",
+              enabled
+                ? "bg-daintree-accent text-accent-primary-foreground"
+                : "bg-daintree-border text-daintree-text/50"
+            )}
+          />
+        );
+      `)
+    ).toEqual([]);
+  });
+
+  it("flags text that inherits body-text color on an accent fill", () => {
+    expect(analyze(`const x = <button className="bg-primary">Save</button>;`)).toEqual([
+      "(inherited)",
+    ]);
+    expect(analyze(`const x = <span className="bg-daintree-accent">{count}</span>;`)).toEqual([
+      "(inherited)",
+    ]);
+  });
+
+  it("flags a glyph that inherits body-text color on an accent fill", () => {
+    expect(analyze(`const x = <div className="bg-daintree-accent"><Check /></div>;`)).toEqual([
+      "(inherited)",
+    ]);
+  });
+
+  it("accepts a decorative accent fill that renders nothing", () => {
+    expect(analyze(`const x = <div className="h-1 w-full bg-daintree-accent" />;`)).toEqual([]);
+  });
+
+  it("flags a child glyph painted on an ancestor's accent fill", () => {
+    expect(
+      analyze(`
+        const x = (
+          <div className="rounded-full bg-daintree-accent">
+            <Check className="h-2.5 w-2.5 text-daintree-bg" />
+          </div>
+        );
+      `)
+    ).toEqual(["text-daintree-bg"]);
+  });
+
+  it("flags a child glyph reached through a conditional expression", () => {
+    expect(
+      analyze(`
+        const x = (
+          <span className={cn("border", isSelected ? "bg-daintree-accent" : "border-daintree-border")}>
+            {isSelected && <Check className="w-3 h-3 text-text-inverse" />}
+          </span>
+        );
+      `)
+    ).toEqual(["text-text-inverse"]);
+  });
+
+  it("accepts a child glyph that supplies the validated foreground itself", () => {
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-daintree-accent">
+            {done && <Check className="text-accent-primary-foreground" />}
+          </div>
+        );
+      `)
+    ).toEqual([]);
+  });
+
+  it("matches a foreground to the state its fill is in", () => {
+    // The accent only exists on hover, and hover repaints the label — safe.
+    expect(
+      analyze(
+        `const x = <button className="text-daintree-text hover:bg-primary hover:text-primary-foreground" />;`
+      )
+    ).toEqual([]);
+    // Same accent-on-hover, but the label is never repainted — the base text lands on it.
+    expect(
+      analyze(`const x = <button className="text-daintree-text hover:bg-primary">Go</button>;`)
+    ).toEqual(["text-daintree-text"]);
+  });
+
+  it("ignores a pseudo-element's own fill and foreground", () => {
+    expect(
+      analyze(`const x = <div className="after:bg-daintree-accent text-daintree-text" />;`)
+    ).toEqual([]);
+    expect(
+      analyze(
+        `const x = <div className="bg-primary text-primary-foreground before:text-white before:content-['!']" />;`
+      )
+    ).toEqual([]);
   });
 
   it("flags an arbitrary-value foreground that escapes the validated token", () => {
-    const found = analyze(
-      `const x = <span className="bg-daintree-accent text-[var(--color-daintree-bg)]" />;`
-    );
-    expect(found.map((v) => v.utility)).toEqual(["text-[var(--color-daintree-bg)]"]);
+    expect(
+      analyze(`const x = <span className="bg-daintree-accent text-[var(--color-daintree-bg)]" />;`)
+    ).toEqual(["text-[var(--color-daintree-bg)]"]);
+    expect(
+      analyze(
+        `const x = <span className="bg-daintree-accent text-[color:var(--theme-text-primary)]" />;`
+      )
+    ).toEqual(["text-[color:var(--theme-text-primary)]"]);
+    expect(analyze(`const x = <span className="bg-daintree-accent text-[#0b1220]" />;`)).toEqual([
+      "text-[#0b1220]",
+    ]);
   });
 
-  it("flags hardcoded palette colors on an accent fill", () => {
-    const found = analyze(`const x = <button className="bg-primary text-white" />;`);
-    expect(found.map((v) => v.utility)).toEqual(["text-white"]);
+  it("flags hardcoded palette colors and alpha-reduced foregrounds on an accent fill", () => {
+    expect(analyze(`const x = <button className="bg-primary text-white" />;`)).toEqual([
+      "text-white",
+    ]);
+    // The 4.5:1 guarantee covers the opaque token — not a faded copy of it.
+    expect(
+      analyze(`const x = <button className="bg-primary text-primary-foreground/50" />;`)
+    ).toEqual(["text-primary-foreground/50"]);
+  });
+
+  it("resolves an accent fill written as an arbitrary value", () => {
+    expect(
+      analyze(`const x = <button className="bg-[var(--color-accent-primary)] text-white" />;`)
+    ).toEqual(["text-white"]);
   });
 
   it("accepts either validated foreground alias", () => {
@@ -435,63 +807,115 @@ describe("accent foreground detector", () => {
   });
 
   it("ignores non-color text utilities on an accent fill", () => {
-    const found = analyze(
-      `const x = <button className="bg-primary text-accent-primary-foreground text-sm text-center text-[9px]" />;`
-    );
-    expect(found).toEqual([]);
+    expect(
+      analyze(
+        `const x = <button className="bg-primary text-accent-primary-foreground text-sm text-center text-[9px]" />;`
+      )
+    ).toEqual([]);
   });
 
   it("ignores tinted accent washes — the text sits on the surface, not on solid accent", () => {
     expect(
-      analyze(`const x = <div className="bg-daintree-accent/10 text-daintree-text" />;`)
+      analyze(`const x = <div className="bg-daintree-accent/10 text-daintree-text">Hi</div>;`)
     ).toEqual([]);
-    expect(analyze(`const x = <div className="bg-accent-soft text-daintree-text" />;`)).toEqual([]);
-  });
-
-  it("ignores a pseudo-element accent fill — it paints a separate box, not the text surface", () => {
     expect(
-      analyze(`const x = <div className="after:bg-daintree-accent text-daintree-text" />;`)
+      analyze(`const x = <div className="bg-accent-soft text-daintree-text">Hi</div>;`)
     ).toEqual([]);
   });
 
-  it("stops descending at a child that repaints its own background", () => {
-    const found = analyze(`
-      const x = (
-        <div className="bg-daintree-accent">
-          <div className="bg-surface-panel">
-            <span className="text-daintree-text">safe — on the panel, not the accent</span>
-          </div>
-        </div>
-      );
-    `);
-    expect(found).toEqual([]);
+  it("only treats gradient stops as a fill when a gradient is actually painted", () => {
+    expect(
+      analyze(
+        `const x = <button className="bg-gradient-to-b from-primary to-primary/80 text-text-inverse" />;`
+      )
+    ).toEqual(["text-text-inverse"]);
+    // A later accent stop still paints accent under the label.
+    expect(
+      analyze(
+        `const x = <button className="bg-gradient-to-b from-primary/80 to-primary text-white" />;`
+      )
+    ).toEqual(["text-white"]);
+    // `from-*` without a gradient image paints nothing.
+    expect(analyze(`const x = <div className="from-primary text-white">Hi</div>;`)).toEqual([]);
   });
 
-  it("flags a gradient accent fill", () => {
-    const found = analyze(
-      `const x = <button className="bg-gradient-to-b from-primary to-primary/80 text-text-inverse" />;`
-    );
-    expect(found.map((v) => v.utility)).toEqual(["text-text-inverse"]);
+  it("stops descending only at a descendant that truly repaints its background", () => {
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-daintree-accent">
+            <div className="bg-surface-panel">
+              <span className="text-daintree-text">safe — on the panel, not the accent</span>
+            </div>
+          </div>
+        );
+      `)
+    ).toEqual([]);
+    // A conditional background does not shield the base state.
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-primary">
+            <span className="hover:bg-surface-panel text-text-inverse">bad before hover</span>
+          </div>
+        );
+      `)
+    ).toEqual(["text-text-inverse"]);
+    // A translucent background does not shield either.
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-primary">
+            <span className="bg-surface-panel/10 text-text-inverse">still on accent</span>
+          </div>
+        );
+      `)
+    ).toEqual(["text-text-inverse"]);
+    // `bg-cover` paints no color at all.
+    expect(
+      analyze(`
+        const x = (
+          <div className="bg-primary">
+            <span className="bg-cover text-text-inverse">paints no background</span>
+          </div>
+        );
+      `)
+    ).toEqual(["text-text-inverse"]);
   });
 });
 
 describe("accent foreground contract", () => {
-  const files = SCAN_ROOTS.flatMap(collectSourceFiles);
+  const filesByRoot = SCAN_ROOTS.map((root) => ({ root, files: collectSourceFiles(root) }));
+  const files = filesByRoot.flatMap((r) => r.files);
 
-  it("scans a non-trivial number of components", () => {
-    // Guards the whole suite against passing because the walker silently found nothing.
+  it("scans every root", () => {
+    // Without this, a mistyped root would silently shrink the scan and still pass.
+    for (const { root, files: rootFiles } of filesByRoot) {
+      expect(rootFiles.length, `no .tsx files found under ${root}`).toBeGreaterThan(0);
+    }
     expect(files.length).toBeGreaterThan(100);
   });
 
-  it("paints text on a solid accent fill only with the contrast-validated foreground", () => {
-    const violations = files.flatMap((file) =>
-      analyzeSource(path.relative(REPO_ROOT, file), fs.readFileSync(file, "utf-8"), graph)
-    );
+  const results = files.map((file) =>
+    analyzeSource(path.relative(REPO_ROOT, file), fs.readFileSync(file, "utf-8"), graph)
+  );
 
-    const report = violations.map((v) => `${v.file}:${v.line} — ${v.utility} (${v.context})`);
+  it("actually finds accent surfaces to check", () => {
+    // The assertion that makes a vacuous pass impossible: if the walker, the parser, or
+    // the CSS graph silently stopped recognizing accent fills, the contract below would
+    // pass with zero violations while every offender sailed through.
+    const surfaces = results.reduce((sum, r) => sum + r.accentSurfaces, 0);
+    expect(surfaces).toBeGreaterThan(10);
+  });
+
+  it("paints text on a solid accent fill only with the contrast-validated foreground", () => {
+    const report = results
+      .flatMap((r) => r.violations)
+      .map((v) => `${v.file}:${v.line} — ${v.utility} (${v.context})`);
+
     expect(
       report,
-      "Text on a solid accent fill must use a foreground that resolves to " +
+      "Text on a solid accent fill must use a foreground resolving to " +
         `${ACCENT_FOREGROUND_TOKEN} (e.g. text-primary-foreground on bg-primary, ` +
         "text-accent-primary-foreground on bg-daintree-accent). Tokens like text-text-inverse " +
         "and text-daintree-bg are keyed to the theme's body-text polarity, not to the accent, " +

--- a/src/config/__tests__/accentForeground.contract.test.ts
+++ b/src/config/__tests__/accentForeground.contract.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// Contrast validation (shared/theme/contrast.ts) checks abstract theme tokens: it
+// guarantees `accent-foreground` clears 4.5:1 on `accent-primary`. It cannot see which
+// Tailwind class a component actually paints on an accent fill, so a component reaching
+// for `text-text-inverse` (keyed to the theme's *body text* polarity, not the accent)
+// stays invisible to it — a custom accent can pass validation and still ship an
+// unreadable CTA. That is #11115.
+//
+// This guard closes the loop the validator structurally cannot: it resolves every color
+// utility through src/index.css's real variable graph and asserts that anything painting
+// text on a solid accent fill lands on the same terminal token the validator checks.
+//
+// Everything below is derived from the graph, never from a hardcoded class name — so it
+// accepts any spelling that resolves correctly (`text-primary-foreground`,
+// `text-accent-primary-foreground`, a future alias), rejects any that does not, and
+// stays honest if the token wiring is renamed.
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const INDEX_CSS_PATH = path.join(REPO_ROOT, "src/index.css");
+
+const SCAN_ROOTS = [
+  path.join(REPO_ROOT, "src"),
+  path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
+];
+
+// The terminal tokens the contrast validator pairs. A utility is an "accent fill" iff it
+// resolves here; a foreground is valid iff it resolves to the foreground counterpart.
+const ACCENT_FILL_TOKEN = "--theme-accent-primary";
+const ACCENT_FOREGROUND_TOKEN = "--theme-accent-foreground";
+
+// Utility prefixes that paint a solid fill behind an element's own text.
+const FILL_PREFIXES = ["bg-", "from-"];
+// Utility prefixes that paint text/icon glyphs.
+const FOREGROUND_PREFIXES = ["text-", "fill-", "stroke-"];
+
+// ── CSS variable graph ─────────────────────────────────────────────────
+
+/** Every `--name: value` in index.css, in document order — later wins, as the cascade does. */
+function parseCssVariables(css: string): Map<string, string> {
+  const declarations = new Map<string, string>();
+  for (const [, name, value] of css.matchAll(/(--[\w-]+)\s*:\s*([^;{}]+);/g)) {
+    if (name === undefined || value === undefined) continue;
+    declarations.set(name, value.trim());
+  }
+  return declarations;
+}
+
+/**
+ * Follow a variable through pure `var(--x)` aliases to the name it ultimately points at.
+ * Stops at the first variable whose value is not a bare alias (a literal color, a
+ * color-mix, or undefined here because a theme supplies it at runtime) and returns that
+ * variable's *name* — the semantic destination.
+ */
+function resolveToTerminalToken(name: string, declarations: Map<string, string>): string {
+  const seen = new Set<string>();
+  let current = name;
+  while (!seen.has(current)) {
+    seen.add(current);
+    const value = declarations.get(current);
+    if (value === undefined) return current;
+    const alias = /^var\(\s*(--[\w-]+)\s*\)$/.exec(value);
+    if (alias?.[1] === undefined) return current;
+    current = alias[1];
+  }
+  return current;
+}
+
+type ColorGraph = {
+  /** Terminal token a `--color-*` utility name lands on, e.g. "primary" -> "--theme-accent-primary". */
+  terminalOf: (utilityName: string) => string | null;
+};
+
+function buildColorGraph(css: string): ColorGraph {
+  const declarations = parseCssVariables(css);
+  const cache = new Map<string, string | null>();
+  return {
+    terminalOf(utilityName) {
+      const cached = cache.get(utilityName);
+      if (cached !== undefined) return cached;
+      const varName = `--color-${utilityName}`;
+      const terminal = declarations.has(varName)
+        ? resolveToTerminalToken(varName, declarations)
+        : null;
+      cache.set(utilityName, terminal);
+      return terminal;
+    },
+  };
+}
+
+// ── Utility classification ─────────────────────────────────────────────
+
+/** Strip variant prefixes (`hover:`, `data-[state=on]:`, …), keeping the base utility. */
+function stripVariants(utility: string): { base: string; variants: string[] } {
+  const variants: string[] = [];
+  let rest = utility;
+  // Split on ":" that is not inside [...] — data-[state=checked]:bg-x has a ":" free colon only at the end.
+  for (;;) {
+    let depth = 0;
+    let cut = -1;
+    for (let i = 0; i < rest.length; i++) {
+      const ch = rest[i];
+      if (ch === "[") depth++;
+      else if (ch === "]") depth--;
+      else if (ch === ":" && depth === 0) {
+        cut = i;
+        break;
+      }
+    }
+    if (cut === -1) break;
+    variants.push(rest.slice(0, cut));
+    rest = rest.slice(cut + 1);
+  }
+  return { base: rest, variants };
+}
+
+/** `bg-daintree-accent/10` -> { name: "bg-daintree-accent", hasOpacity: true } */
+function splitOpacity(base: string): { name: string; hasOpacity: boolean } {
+  const slash = base.lastIndexOf("/");
+  // Ignore a "/" inside an arbitrary value: text-[var(--x)]/50 is rare; bracket-aware enough.
+  if (slash === -1 || base.indexOf("]") > slash) return { name: base, hasOpacity: false };
+  return { name: base.slice(0, slash), hasOpacity: true };
+}
+
+/** A pseudo-element variant paints a separate box — not the element's own text surface. */
+function isPseudoElement(variants: string[]): boolean {
+  return variants.some((v) => v === "before" || v === "after");
+}
+
+/**
+ * Does this utility paint a SOLID accent fill behind its own text?
+ * Opacity-modified fills (`bg-daintree-accent/10`) are washes over the surface, not solid
+ * accent, and `accent-soft`/`accent-muted` resolve to different terminal tokens — both
+ * fall out naturally, the first by the opacity check, the second by the graph.
+ */
+function isSolidAccentFill(utility: string, graph: ColorGraph): boolean {
+  const { base, variants } = stripVariants(utility);
+  if (isPseudoElement(variants)) return false;
+  const { name, hasOpacity } = splitOpacity(base);
+  if (hasOpacity) return false;
+  const prefix = FILL_PREFIXES.find((p) => name.startsWith(p));
+  if (prefix === undefined) return false;
+  return graph.terminalOf(name.slice(prefix.length)) === ACCENT_FILL_TOKEN;
+}
+
+/** Any background paint at all — a descendant carrying one re-paints, so its text is not on the accent. */
+function isAnyBackground(utility: string): boolean {
+  const { base, variants } = stripVariants(utility);
+  if (isPseudoElement(variants)) return false;
+  const { name } = splitOpacity(base);
+  return name.startsWith("bg-") && name !== "bg-transparent" && !name.startsWith("bg-gradient-");
+}
+
+type Foreground = { utility: string; terminal: string | null };
+
+/**
+ * Classify a utility as a text/icon color, if it is one. Returns null for non-color `text-*`
+ * utilities (text-xs, text-center, text-[9px]) so sizing/alignment never trips the guard.
+ */
+function asForeground(utility: string, graph: ColorGraph): Foreground | null {
+  const { base } = stripVariants(utility);
+  const { name } = splitOpacity(base);
+  const prefix = FOREGROUND_PREFIXES.find((p) => name.startsWith(p));
+  if (prefix === undefined) return null;
+  const value = name.slice(prefix.length);
+
+  // Arbitrary value: text-[var(--color-daintree-bg)] / text-[#0b1220] / text-[9px]
+  const arbitrary = /^\[(.+)]$/.exec(value);
+  if (arbitrary?.[1] !== undefined) {
+    const inner = arbitrary[1];
+    const varRef = /^var\(\s*--color-([\w-]+)\s*\)$/.exec(inner);
+    if (varRef?.[1] !== undefined) {
+      return { utility, terminal: graph.terminalOf(varRef[1]) };
+    }
+    // A literal color escapes the token system entirely; anything else (a length,
+    // a font-size) is not a color at all.
+    if (/^#[0-9a-f]{3,8}$/i.test(inner) || /^(rgb|hsl|oklch|color)\(/i.test(inner)) {
+      return { utility, terminal: null };
+    }
+    return null;
+  }
+
+  // Hardcoded palette colors bypass theming outright.
+  if (value === "white" || value === "black") return { utility, terminal: null };
+
+  const terminal = graph.terminalOf(value);
+  // Not a known color token => a sizing/alignment/decoration utility. Ignore.
+  if (terminal === null) return null;
+  return { utility, terminal };
+}
+
+function isValidAccentForeground(fg: Foreground): boolean {
+  return fg.terminal === ACCENT_FOREGROUND_TOKEN;
+}
+
+// ── Source analysis ────────────────────────────────────────────────────
+
+export type Violation = { file: string; line: number; utility: string; context: string };
+
+function utilitiesOf(text: string): string[] {
+  return text.split(/\s+/).filter((t) => t.length > 0);
+}
+
+// Every node kind that can carry class text. Typed as the union rather than ts.Node so
+// `.text` reads without a cast (the no-unsafe-type-assertion lint ratchet is per-rule).
+type ClassLiteral =
+  | ts.StringLiteral
+  | ts.NoSubstitutionTemplateLiteral
+  | ts.TemplateHead
+  | ts.TemplateMiddle
+  | ts.TemplateTail;
+
+/** Every class-ish string literal inside a node (covers cn(), cva variants, template chunks). */
+function literalsIn(node: ts.Node): ClassLiteral[] {
+  const out: ClassLiteral[] = [];
+  const visit = (n: ts.Node): void => {
+    if (
+      ts.isStringLiteral(n) ||
+      ts.isNoSubstitutionTemplateLiteral(n) ||
+      ts.isTemplateHead(n) ||
+      ts.isTemplateMiddle(n) ||
+      ts.isTemplateTail(n)
+    ) {
+      out.push(n);
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return out;
+}
+
+function classNameAttrOf(
+  element: ts.JsxOpeningElement | ts.JsxSelfClosingElement
+): ts.JsxAttribute | null {
+  for (const prop of element.attributes.properties) {
+    if (ts.isJsxAttribute(prop) && prop.name.getText() === "className") return prop;
+  }
+  return null;
+}
+
+/**
+ * Utilities on an element's className. Conditional branches are merged deliberately: an
+ * element that is accent-filled only when selected still has to be legible when selected.
+ */
+function elementUtilities(
+  element: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
+  source: ts.SourceFile
+): { utilities: string[]; line: number } {
+  const attr = classNameAttrOf(element);
+  const line = source.getLineAndCharacterOfPosition(element.getStart(source)).line + 1;
+  if (attr?.initializer === undefined) return { utilities: [], line };
+  const utilities = literalsIn(attr.initializer).flatMap((lit) => utilitiesOf(lit.text));
+  return { utilities, line };
+}
+
+function analyzeSource(fileName: string, sourceText: string, graph: ColorGraph): Violation[] {
+  const source = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+  const violations: Violation[] = [];
+  const lineOf = (n: ts.Node): number =>
+    source.getLineAndCharacterOfPosition(n.getStart(source)).line + 1;
+
+  const report = (node: ts.Node, fg: Foreground, context: string): void => {
+    violations.push({ file: fileName, line: lineOf(node), utility: fg.utility, context });
+  };
+
+  // Rule A — a single class string that both fills with accent and paints its own text.
+  // Catches cva variant strings and plain className literals.
+  for (const literal of literalsIn(source)) {
+    const utilities = utilitiesOf(literal.text);
+    if (!utilities.some((u) => isSolidAccentFill(u, graph))) continue;
+    for (const utility of utilities) {
+      const fg = asForeground(utility, graph);
+      if (fg !== null && !isValidAccentForeground(fg)) {
+        report(literal, fg, "text painted on an accent fill in the same class string");
+      }
+    }
+  }
+
+  // Rule B — an accent-filled JSX element whose descendants paint the text (the badge/icon
+  // shape: fill on the <div>, color on the child <Check>). Rule A cannot see across
+  // elements, and every check-badge offender in #11115 had exactly this shape.
+  const checkSubtree = (element: ts.JsxElement): void => {
+    const { utilities } = elementUtilities(element.openingElement, source);
+    if (!utilities.some((u) => isSolidAccentFill(u, graph))) return;
+
+    const descend = (node: ts.Node): void => {
+      if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+        const opening = ts.isJsxElement(node) ? node.openingElement : node;
+        const own = elementUtilities(opening, source).utilities;
+        // A descendant that paints its own background is no longer on the accent.
+        if (own.some(isAnyBackground)) return;
+        for (const utility of own) {
+          const fg = asForeground(utility, graph);
+          if (fg !== null && !isValidAccentForeground(fg)) {
+            report(opening, fg, "text painted on an ancestor's accent fill");
+          }
+        }
+      }
+      ts.forEachChild(node, descend);
+    };
+    for (const child of element.children) descend(child);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxElement(node)) checkSubtree(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return violations;
+}
+
+// ── File collection ────────────────────────────────────────────────────
+
+function collectSourceFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") return [];
+      return collectSourceFiles(fullPath);
+    }
+    if (!entry.name.endsWith(".tsx")) return [];
+    if (entry.name.includes(".test.") || entry.name.includes(".stories.")) return [];
+    return [fullPath];
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const graph = buildColorGraph(fs.readFileSync(INDEX_CSS_PATH, "utf-8"));
+
+describe("accent foreground graph", () => {
+  // If the wiring is renamed and these resolve nowhere, every scan below would pass
+  // vacuously. Pin the two ends of the graph the whole guard is built on.
+  it("resolves the shadcn and daintree fill aliases to one accent token", () => {
+    expect(graph.terminalOf("primary")).toBe(ACCENT_FILL_TOKEN);
+    expect(graph.terminalOf("daintree-accent")).toBe(ACCENT_FILL_TOKEN);
+    expect(graph.terminalOf("accent-primary")).toBe(ACCENT_FILL_TOKEN);
+  });
+
+  it("resolves every accent foreground alias to the contrast-validated token", () => {
+    expect(graph.terminalOf("primary-foreground")).toBe(ACCENT_FOREGROUND_TOKEN);
+    expect(graph.terminalOf("accent-primary-foreground")).toBe(ACCENT_FOREGROUND_TOKEN);
+    // Once shadowed by a duplicate shadcn declaration, which silently pointed it at body
+    // text (#11115). It must land on the validated token or not exist at all.
+    const accentForeground = graph.terminalOf("accent-foreground");
+    if (accentForeground !== null) expect(accentForeground).toBe(ACCENT_FOREGROUND_TOKEN);
+  });
+
+  it("does not resolve the unvalidated foregrounds to the accent token", () => {
+    expect(graph.terminalOf("text-inverse")).not.toBe(ACCENT_FOREGROUND_TOKEN);
+    expect(graph.terminalOf("daintree-bg")).not.toBe(ACCENT_FOREGROUND_TOKEN);
+  });
+});
+
+describe("accent foreground detector", () => {
+  const analyze = (src: string): Violation[] => analyzeSource("fixture.tsx", src, graph);
+
+  it("flags an unvalidated foreground in the same class string as an accent fill", () => {
+    const found = analyze(`const x = <button className="bg-daintree-accent text-text-inverse" />;`);
+    expect(found.map((v) => v.utility)).toEqual(["text-text-inverse"]);
+  });
+
+  it("flags a cva variant independently of its siblings", () => {
+    const found = analyze(`
+      const v = cva("base", {
+        variants: {
+          variant: {
+            default: "bg-primary text-text-inverse",
+            contrast: "bg-daintree-text text-text-inverse",
+            ghost: "text-text-secondary hover:bg-overlay-soft",
+          },
+        },
+      });
+    `);
+    // Only the accent-filled variant is a violation; the inverse-CTA and ghost variants
+    // are not accent fills at all.
+    expect(found).toHaveLength(1);
+    expect(found[0]?.utility).toBe("text-text-inverse");
+  });
+
+  it("flags a child icon painted on an ancestor's accent fill", () => {
+    const found = analyze(`
+      const x = (
+        <div className="rounded-full bg-daintree-accent">
+          <Check className="h-2.5 w-2.5 text-daintree-bg" />
+        </div>
+      );
+    `);
+    expect(found.map((v) => v.utility)).toEqual(["text-daintree-bg"]);
+  });
+
+  it("flags a child icon reached through a conditional expression", () => {
+    const found = analyze(`
+      const x = (
+        <span className={cn("border", isSelected ? "bg-daintree-accent" : "border-daintree-border")}>
+          {isSelected && <Check className="w-3 h-3 text-text-inverse" />}
+        </span>
+      );
+    `);
+    expect(found.map((v) => v.utility)).toEqual(["text-text-inverse"]);
+  });
+
+  it("flags an arbitrary-value foreground that escapes the validated token", () => {
+    const found = analyze(
+      `const x = <span className="bg-daintree-accent text-[var(--color-daintree-bg)]" />;`
+    );
+    expect(found.map((v) => v.utility)).toEqual(["text-[var(--color-daintree-bg)]"]);
+  });
+
+  it("flags hardcoded palette colors on an accent fill", () => {
+    const found = analyze(`const x = <button className="bg-primary text-white" />;`);
+    expect(found.map((v) => v.utility)).toEqual(["text-white"]);
+  });
+
+  it("accepts either validated foreground alias", () => {
+    expect(analyze(`const x = <button className="bg-primary text-primary-foreground" />;`)).toEqual(
+      []
+    );
+    expect(
+      analyze(`const x = <button className="bg-daintree-accent text-accent-primary-foreground" />;`)
+    ).toEqual([]);
+  });
+
+  it("ignores non-color text utilities on an accent fill", () => {
+    const found = analyze(
+      `const x = <button className="bg-primary text-accent-primary-foreground text-sm text-center text-[9px]" />;`
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("ignores tinted accent washes — the text sits on the surface, not on solid accent", () => {
+    expect(
+      analyze(`const x = <div className="bg-daintree-accent/10 text-daintree-text" />;`)
+    ).toEqual([]);
+    expect(analyze(`const x = <div className="bg-accent-soft text-daintree-text" />;`)).toEqual([]);
+  });
+
+  it("ignores a pseudo-element accent fill — it paints a separate box, not the text surface", () => {
+    expect(
+      analyze(`const x = <div className="after:bg-daintree-accent text-daintree-text" />;`)
+    ).toEqual([]);
+  });
+
+  it("stops descending at a child that repaints its own background", () => {
+    const found = analyze(`
+      const x = (
+        <div className="bg-daintree-accent">
+          <div className="bg-surface-panel">
+            <span className="text-daintree-text">safe — on the panel, not the accent</span>
+          </div>
+        </div>
+      );
+    `);
+    expect(found).toEqual([]);
+  });
+
+  it("flags a gradient accent fill", () => {
+    const found = analyze(
+      `const x = <button className="bg-gradient-to-b from-primary to-primary/80 text-text-inverse" />;`
+    );
+    expect(found.map((v) => v.utility)).toEqual(["text-text-inverse"]);
+  });
+});
+
+describe("accent foreground contract", () => {
+  const files = SCAN_ROOTS.flatMap(collectSourceFiles);
+
+  it("scans a non-trivial number of components", () => {
+    // Guards the whole suite against passing because the walker silently found nothing.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("paints text on a solid accent fill only with the contrast-validated foreground", () => {
+    const violations = files.flatMap((file) =>
+      analyzeSource(path.relative(REPO_ROOT, file), fs.readFileSync(file, "utf-8"), graph)
+    );
+
+    const report = violations.map((v) => `${v.file}:${v.line} — ${v.utility} (${v.context})`);
+    expect(
+      report,
+      "Text on a solid accent fill must use a foreground that resolves to " +
+        `${ACCENT_FOREGROUND_TOKEN} (e.g. text-primary-foreground on bg-primary, ` +
+        "text-accent-primary-foreground on bg-daintree-accent). Tokens like text-text-inverse " +
+        "and text-daintree-bg are keyed to the theme's body-text polarity, not to the accent, " +
+        "so the contrast validator never checks them against the accent fill (#11115)."
+    ).toEqual([]);
+  });
+});

--- a/src/config/__tests__/colorSystem.contract.test.ts
+++ b/src/config/__tests__/colorSystem.contract.test.ts
@@ -211,9 +211,26 @@ describe("color system contract", () => {
     expect(indexCss).not.toMatch(/rgba\(0,\s*0,\s*0/);
   });
 
-  it("--color-accent-foreground in @theme inline resolves through shadcn --accent-foreground (preserves hover behavior)", () => {
-    const themeBlock = indexCss.match(/@theme\s+inline\s*\{[\s\S]*?\}/)?.[0] ?? "";
-    expect(themeBlock).toMatch(/--color-accent-foreground:\s*var\(--accent-foreground\)/);
+  // A --color-* declared twice in one @theme inline block silently resolves to the
+  // last one; Tailwind emits no warning. That is how --color-accent-foreground came
+  // to resolve to body text instead of the contrast-validated accent foreground
+  // (#11115), and how --color-accent-primary regressed before it (#2687). Uniqueness
+  // is the invariant that catches the whole class.
+  it("declares every --color-* exactly once inside @theme inline", () => {
+    const themeBlock = indexCss.match(/@theme\s+inline\s*\{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(themeBlock, "could not locate the @theme inline block").not.toBe("");
+
+    const counts = new Map<string, number>();
+    for (const [, name] of themeBlock.matchAll(/^\s*(--color-[\w-]+)\s*:/gm)) {
+      if (name === undefined) continue;
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    expect(counts.size, "no --color-* declarations found — regex is stale").toBeGreaterThan(0);
+
+    const duplicated = [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([name, count]) => `${name} (x${count})`);
+    expect(duplicated, "duplicate --color-* declarations silently shadow each other").toEqual([]);
   });
 
   it("sets color-scheme: normal on webview elements to prevent dark-mode inheritance", () => {

--- a/src/config/__tests__/colorSystem.contract.test.ts
+++ b/src/config/__tests__/colorSystem.contract.test.ts
@@ -216,14 +216,18 @@ describe("color system contract", () => {
   // to resolve to body text instead of the contrast-validated accent foreground
   // (#11115), and how --color-accent-primary regressed before it (#2687). Uniqueness
   // is the invariant that catches the whole class.
-  it("declares every --color-* exactly once inside @theme inline", () => {
-    const themeBlock = indexCss.match(/@theme\s+inline\s*\{[\s\S]*?\n\}/)?.[0] ?? "";
-    expect(themeBlock, "could not locate the @theme inline block").not.toBe("");
+  it("declares every --color-* exactly once across @theme inline", () => {
+    // Count across EVERY @theme inline block, not just the first — a second block
+    // would reintroduce cross-block shadowing that a single-block scan can't see.
+    const blocks = [...indexCss.matchAll(/@theme\s+inline\s*\{[\s\S]*?\n\}/g)].map((m) => m[0]);
+    expect(blocks.length, "could not locate any @theme inline block").toBeGreaterThan(0);
 
     const counts = new Map<string, number>();
-    for (const [, name] of themeBlock.matchAll(/^\s*(--color-[\w-]+)\s*:/gm)) {
-      if (name === undefined) continue;
-      counts.set(name, (counts.get(name) ?? 0) + 1);
+    for (const block of blocks) {
+      for (const [, name] of block.matchAll(/^\s*(--color-[\w-]+)\s*:/gm)) {
+        if (name === undefined) continue;
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+      }
     }
     expect(counts.size, "no --color-* declarations found — regex is stale").toBeGreaterThan(0);
 

--- a/src/index.css
+++ b/src/index.css
@@ -367,8 +367,6 @@
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
@@ -733,8 +731,6 @@ code.hljs {
   --secondary-foreground: var(--theme-text-primary);
   --muted: var(--theme-surface-panel);
   --muted-foreground: var(--theme-text-secondary);
-  --accent: var(--theme-accent-soft);
-  --accent-foreground: var(--theme-text-primary);
   --destructive: var(--theme-status-danger);
   --destructive-foreground: var(--theme-text-inverse);
   --border: var(--theme-border-default);


### PR DESCRIPTION
## The bug
`shared/theme/contrast.ts` validates exactly one accent pair — `accent-foreground` on `accent-primary`, 4.5:1. But the components that actually paint text on accent fills used `text-text-inverse` and `text-daintree-bg`, which are keyed to the theme's *body-text* polarity, not to the accent. The validator never sees them. So a custom accent could pass validation and still ship an unreadable CTA — a dark accent on a dark theme yields dark-on-dark text, exactly where `accent-foreground` would have computed a light one.

## What changed
- **17 foregrounds across 12 components** now use the validated token: `text-primary-foreground` on `bg-primary`, `text-accent-primary-foreground` on `bg-daintree-accent`. The issue named 3 sites; an audit found 17 (button.tsx had 3 broken variants, not 1).
- **Removed a dead shadcn token pair from `src/index.css`.** A duplicate `--color-accent-foreground` inside the single `@theme inline` block silently shadowed the validated one, so the class a developer would most naturally reach for — `text-accent-foreground` — resolved to *body text*. Same class of bug as #2687. Verified zero production consumers of the bare `accent` namespace before deleting.
- **Dropped the white `text-shadow` from the three accent button variants.** The label's polarity now flips with the accent, so a fixed white emboss under a dark label on a light accent is a smudge, not an emboss. The fill's inset highlight and ring stay — they sit on the fill, not under the glyph.

## Preventing the regression
The real complaint in #11115 is that the validator *structurally cannot* see component token choices. So `src/config/__tests__/accentForeground.contract.test.ts` closes that loop: it parses `src/index.css` into a CSS-variable graph and asserts that anything painting text on a solid accent fill resolves, through that real graph, to the same terminal token the validator checks.

It asserts a semantic destination, not a class literal — so it accepts any correct spelling, rejects any incorrect one, and would also have caught the duplicate-declaration trap itself. Its tokens and threshold are derived from `ACCENT_CONTRAST_PAIR` (newly exported and referenced inside `CONTRAST_PAIRS`), so renaming the pair breaks the guard rather than silently retiring it.

It models feasible class sets — expanding ternaries, `&&`, `cn()` and cva base-plus-variant into combinations that can actually render — so composed classes are compared while opposite ternary branches are not. It resolves the effective foreground per fill *state* (a `hover:` foreground only applies on hover; a base fill is still there on hover), and flags text that inherits body-text color on an accent fill with no foreground at all. Known limits are documented in the file: it's a regression guard, not a sound Tailwind checker.

Two other tests got teeth: the `colorSystem` test that *enshrined* the shadowing ("resolves through shadcn `--accent-foreground`") is replaced by a uniqueness invariant over `--color-*` declarations, which would have caught both this bug and #2687. And the adversarial accent fixtures now assert a computed contrast ratio against the pair's own minimum, using `#757575` — the genuinely hardest neutral (white clears it by 4.61:1, black by 4.56:1) where the old `#808080` let a wrong pick pass at 5.32:1.

## Verification
- Red-before-green: reintroducing the offenders made the guard fail with exactly those, via each detection path.
- 634 tests across 19 files, full `tsc --noEmit`, and own-file lint/format all pass locally.

## Follow-ups found but deliberately out of scope
Both are a different WCAG criterion than this issue and deserve their own change:
- **`destructive` buttons already fail AA in two shipped themes** (Arashiyama 4.08:1, Redwoods 4.19:1). Status-color fills (`bg-destructive`, `bg-status-info`) have no validated foreground pair at all — the same structural gap as #11115, one level over. `text-destructive-foreground` wouldn't help; it maps to the same `text-inverse`.
- **Toggle knobs and accent checkboxes** (`after:bg-text-inverse` on `bg-daintree-accent`, 4 sites incl. two in `AgentSetupWizard`) can score as low as 1.03:1 against an adversarial accent. That's graphical-object contrast (WCAG 1.4.11, 3:1), not text contrast.

Resolves #11115