### PR TITLE
fix(focus): keep keyboard focus and the selected pane in agreement

### DIFF
--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -14,6 +14,7 @@ import {
   type DragHandleContextValue,
 } from "@/components/DragDrop/DragHandleContext";
 import { DockPanelContext, type DockPanelContextValue } from "./dockPanelPortalContext";
+import { focusPanelInput } from "@/components/Panel/panelFocusRegistry";
 
 // Stable "no drag handle" value. The portaled dock panel body is ALWAYS wrapped
 // in a DragHandleProvider (so the provider element type never toggles and the
@@ -103,9 +104,12 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
   const deleteTabGroup = usePanelStore((s) => s.deleteTabGroup);
   const setActiveTab = usePanelStore((s) => s.setActiveTab);
 
-  const handlePopoverClose = useCallback(() => {
-    closeDockTerminal();
-  }, [closeDockTerminal]);
+  const handlePopoverClose = useCallback(
+    (panelId: string) => {
+      closeDockTerminal(panelId);
+    },
+    [closeDockTerminal]
+  );
 
   useEffect(() => {
     if (!activeDockTerminalId) return;
@@ -113,7 +117,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
     // Harden against transient states where the panel exists in the canonical
     // store but hasn't yet landed in the filtered dockTerminals view (#7278).
     if (usePanelStore.getState().panelsById[activeDockTerminalId]) return;
-    closeDockTerminal();
+    closeDockTerminal(activeDockTerminalId);
   }, [activeDockTerminalId, dockTerminals, closeDockTerminal]);
 
   // Handler for adding a new tab to a single panel (creates a tab group)
@@ -224,14 +228,28 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
   const moveToDestination = useCallback((panelId: string, destination: HTMLElement | null) => {
     const wrapper = wrappersRef.current.get(panelId);
     if (!wrapper) return;
+    const isParking = destination === null;
     const dest = destination ?? offscreenContainerRef.current;
-    if (!dest || wrapper.parentElement === dest) return;
+    if (!dest) return;
 
     // Capture focus so we can restore it on the appendChild fallback path
     // (moveBefore preserves focus itself; appendChild does not) and to work
     // around the Cr148 quirk where moving a focused field drops it.
     const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const hadFocus = !!active && wrapper.contains(active);
+
+    // Parking a focused pane must drop its focus. The parking container is
+    // aria-hidden with `content-visibility: hidden`, so anything focused inside
+    // it is invisible to the user while still eating every keystroke — and
+    // restoring focus into it (as this used to do unconditionally) is exactly
+    // the "typing into a pane that isn't there" bug (#11133). The store's dock
+    // close reconciles `focusedId` onto a visible pane, whose own focus effect
+    // then claims the keyboard.
+    if (isParking && hadFocus && active) {
+      active.blur();
+    }
+
+    if (wrapper.parentElement === dest) return;
 
     if (wrapper.isConnected && dest.isConnected && typeof dest.moveBefore === "function") {
       try {
@@ -243,8 +261,22 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
       dest.appendChild(wrapper);
     }
 
+    if (isParking) return;
+
     if (hadFocus && active && active.isConnected && document.activeElement !== active) {
       active.focus();
+      return;
+    }
+
+    // A pane revealed into its popover may already be the focused pane — the
+    // store set `focusedId` before this wrapper had anywhere visible to live,
+    // so its own focus effect ran against a parked, unfocusable subtree and
+    // came up empty. Now that the pane is on screen, ask it again.
+    if (
+      !wrapper.contains(document.activeElement) &&
+      usePanelStore.getState().focusedId === panelId
+    ) {
+      focusPanelInput(panelId);
     }
   }, []);
 
@@ -335,7 +367,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
               >
                 <DockedPanel
                   terminal={terminal}
-                  onPopoverClose={handlePopoverClose}
+                  onPopoverClose={() => handlePopoverClose(terminal.id)}
                   onAddTab={
                     // Dock tab groups are PTY-only (ContentDock resolves groups
                     // through isPtyPanel), so only PTY panels get the add-tab

--- a/src/components/Layout/DockedNonPtyPanelItem.tsx
+++ b/src/components/Layout/DockedNonPtyPanelItem.tsx
@@ -85,7 +85,7 @@ export function DockedNonPtyPanelItem({ panel, displayTitle }: DockedNonPtyPanel
   useDndMonitor({
     onDragStart: ({ active }) => {
       if (active.id === panel.id && isOpen) {
-        closeDockTerminal();
+        closeDockTerminal(panel.id);
       }
     },
   });
@@ -95,7 +95,7 @@ export function DockedNonPtyPanelItem({ panel, displayTitle }: DockedNonPtyPanel
       if (open) {
         openDockTerminal(panel.id);
       } else {
-        closeDockTerminal();
+        closeDockTerminal(panel.id);
       }
     },
     [panel.id, openDockTerminal, closeDockTerminal]
@@ -103,7 +103,7 @@ export function DockedNonPtyPanelItem({ panel, displayTitle }: DockedNonPtyPanel
 
   const handleMoveToGrid = useCallback(() => {
     const moved = moveTerminalToGrid(panel.id);
-    if (moved) closeDockTerminal();
+    if (moved) closeDockTerminal(panel.id);
   }, [panel.id, moveTerminalToGrid, closeDockTerminal]);
 
   const chrome = useMemo(() => deriveTerminalChrome({ kind: panel.kind }), [panel.kind]);
@@ -133,7 +133,7 @@ export function DockedNonPtyPanelItem({ panel, displayTitle }: DockedNonPtyPanel
                   e.stopPropagation();
                   if (e.detail >= 2) return;
                   if (isOpen) {
-                    closeDockTerminal();
+                    closeDockTerminal(panel.id);
                   } else {
                     openDockTerminal(panel.id);
                   }

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -144,6 +144,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
 
   // Derive isOpen from store state - open if ANY panel in this group is active
   const isOpen = panels.some((p) => p.id === activeDockTerminalId);
+  // The pane this group actually has open in the dock — the id every close must
+  // name. Reading it from the store (rather than assuming the active tab) keeps
+  // a close honest even if a tab switch and the dock state ever disagree.
+  const openDockPanelId = isOpen ? activeDockTerminalId : null;
 
   const [tabListEl, setTabListEl] = useState<HTMLDivElement | null>(null);
 
@@ -230,7 +234,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     onDragStart: ({ active }) => {
       if (panels.some((p) => p.id === active.id)) {
         dismissTips();
-        if (isOpen) closeDockTerminal();
+        if (openDockPanelId) closeDockTerminal(openDockPanelId);
       }
     },
   });
@@ -288,13 +292,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     (open: boolean) => {
       if (open) {
         openDockTerminal(activeTabId);
-      } else {
+      } else if (openDockPanelId) {
         // Focus-driven dismissals are blocked upstream by onFocusOutside, so a
         // close here is a genuine pointer-outside or Escape and is honored.
-        closeDockTerminal();
+        closeDockTerminal(openDockPanelId);
       }
     },
-    [activeTabId, openDockTerminal, closeDockTerminal]
+    [activeTabId, openDockPanelId, openDockTerminal, closeDockTerminal]
   );
 
   const handleTabClick = useCallback(
@@ -595,8 +599,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 e.stopPropagation();
                 dismissTips();
                 if (e.detail >= 2) return;
-                if (isOpen) {
-                  closeDockTerminal();
+                if (openDockPanelId) {
+                  closeDockTerminal(openDockPanelId);
                 } else {
                   openDockTerminal(activeTabId);
                 }
@@ -605,7 +609,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 e.preventDefault();
                 e.stopPropagation();
                 const moved = moveTerminalToGrid(activePanel.id);
-                if (moved) closeDockTerminal();
+                if (moved && openDockPanelId) closeDockTerminal(openDockPanelId);
               }}
               aria-label={`${activePanel.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : ""} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
             >

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -147,7 +147,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     onDragStart: ({ active }) => {
       if (active.id === terminal.id) {
         dismissTips();
-        if (isOpen) closeDockTerminal();
+        if (isOpen) closeDockTerminal(terminal.id);
       }
     },
   });
@@ -174,7 +174,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
       } else {
         // Focus-driven dismissals are blocked upstream by onFocusOutside, so a
         // close here is a genuine pointer-outside or Escape and is honored.
-        closeDockTerminal();
+        closeDockTerminal(terminal.id);
       }
     },
     [terminal.id, openDockTerminal, closeDockTerminal]
@@ -185,7 +185,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   // (the store wrapper clears activeDockTerminalId — see #4997).
   const handleMoveToGrid = useCallback(() => {
     const moved = moveTerminalToGrid(terminal.id);
-    if (moved) closeDockTerminal();
+    if (moved) closeDockTerminal(terminal.id);
   }, [terminal.id, moveTerminalToGrid, closeDockTerminal]);
 
   const presetCustomPresets = useAgentSettingsStore((s) =>
@@ -354,7 +354,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                   dismissTips();
                   if (e.detail >= 2) return;
                   if (isOpen) {
-                    closeDockTerminal();
+                    closeDockTerminal(terminal.id);
                   } else {
                     openDockTerminal(terminal.id);
                   }

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -23,7 +23,7 @@ describe("ContentDock regression test", () => {
     const content = readFileSync(resolve(__dirname, "../DockPanelOffscreenContainer.tsx"), "utf-8");
 
     expect(content).toContain("activeDockTerminalId");
-    expect(content).toContain("closeDockTerminal()");
+    expect(content).toContain("closeDockTerminal(activeDockTerminalId)");
     expect(content).toContain("!s.trashedTerminals.has(t.id)");
   });
 
@@ -141,11 +141,11 @@ describe("ContentDock regression test", () => {
     const content = readFileSync(resolve(__dirname, "../DockPanelOffscreenContainer.tsx"), "utf-8");
 
     expect(content).toContain("usePanelStore.getState().panelsById[activeDockTerminalId]");
-    // The panelsById guard must appear before closeDockTerminal() inside the
+    // The panelsById guard must appear before the close call inside the
     // same useEffect block.
     const effectStart = content.indexOf("if (!activeDockTerminalId) return;");
     const panelsByIdGuard = content.indexOf("panelsById[activeDockTerminalId]");
-    const closeCall = content.indexOf("closeDockTerminal()", effectStart);
+    const closeCall = content.indexOf("closeDockTerminal(activeDockTerminalId)", effectStart);
 
     expect(effectStart).toBeGreaterThan(0);
     expect(panelsByIdGuard).toBeGreaterThan(effectStart);

--- a/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
+++ b/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
@@ -9,8 +9,8 @@
  * open/close/open cycles and that the moveBefore path and its appendChild
  * fallback both land the wrapper in the destination.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, cleanup } from "@testing-library/react";
 import type { PtyPanelData } from "@shared/types/panel";
 
 const closeDockTerminalMock = vi.fn();
@@ -21,11 +21,15 @@ vi.mock("zustand/react/shallow", () => ({
   useShallow: <T,>(fn: T) => fn,
 }));
 
-vi.mock("@/store", () => ({
-  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) => selector(mockState),
-  useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string | null }) => unknown) =>
-    selector({ activeWorktreeId: null }),
-}));
+vi.mock("@/store", () => {
+  const usePanelStore = (selector: (s: Record<string, unknown>) => unknown) => selector(mockState);
+  usePanelStore.getState = () => mockState;
+  return {
+    usePanelStore,
+    useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string | null }) => unknown) =>
+      selector({ activeWorktreeId: null }),
+  };
+});
 
 vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: (selector: (s: { terminalId: string | null }) => unknown) =>
@@ -46,7 +50,11 @@ vi.mock("@/components/Terminal/DockedPanel", async () => {
           data-pid={terminal.id}
           data-has-listeners={dragHandle?.listeners ? "true" : "false"}
           data-has-activator={dragHandle?.setActivatorNodeRef ? "true" : "false"}
-        />
+        >
+          {/* Stands in for the pane's real input surface, so focus has somewhere
+              to live inside the wrapper when it is parked or revealed. */}
+          <input data-testid="pane-input" data-pid={terminal.id} />
+        </div>
       );
     },
   };
@@ -66,6 +74,7 @@ vi.mock("@/components/ui/DockPopoverChildContext", () => ({
 }));
 
 import { DockPanelOffscreenContainer } from "../DockPanelOffscreenContainer";
+import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry";
 import {
   useDockPanelPortal,
   useDockPanelDragHandleRegistration,
@@ -382,5 +391,137 @@ describe("DockPanelOffscreenContainer drag-handle bridge (#10990)", () => {
 
     const panel = document.querySelector('[data-testid="docked-panel"]')!;
     expect(panel.getAttribute("data-has-listeners")).toBe("true");
+  });
+});
+
+/**
+ * The parking container is aria-hidden with `content-visibility: hidden`.
+ * moveToDestination used to restore focus after EVERY move, including the move
+ * that parks a wrapper there — so a dock pane dismissed while holding the
+ * keyboard kept it, invisibly, and went on receiving every keystroke (#11133).
+ */
+describe("DockPanelOffscreenContainer focus handoff (#11133)", () => {
+  beforeEach(() => {
+    closeDockTerminalMock.mockClear();
+    setPanels([makePanel({ id: "panel-1" })]);
+  });
+
+  afterEach(cleanup);
+
+  /**
+   * Model Chromium's `moveBefore`, which carries DOM focus across the move —
+   * that is the whole reason the dock relocates wrappers with it. jsdom has no
+   * `moveBefore`, and its `appendChild` fallback drops focus on its own, so
+   * without this stub a test would pass on jsdom's blur rather than on the code
+   * under test.
+   */
+  function stubFocusPreservingMove(dest: HTMLElement) {
+    (dest as unknown as { moveBefore: (node: Node, ref: Node | null) => void }).moveBefore =
+      function (this: HTMLElement, node: Node) {
+        const active = document.activeElement;
+        this.appendChild(node);
+        if (active instanceof HTMLElement && active.isConnected) active.focus();
+      };
+  }
+
+  // Scope every lookup to this render — the wrappers are long-lived DOM nodes
+  // and a document-wide query can pick up a previous test's container.
+  function nodesOf(container: HTMLElement) {
+    return {
+      offscreen: container.querySelector<HTMLElement>(".dock-panel-offscreen-container")!,
+      wrapper: container.querySelector<HTMLElement>('[data-dock-panel-wrapper="panel-1"]')!,
+      input: container.querySelector<HTMLInputElement>('[data-testid="pane-input"]')!,
+    };
+  }
+
+  it("drops focus when parking a pane that holds it", () => {
+    const { container } = renderContainer();
+    const { offscreen, wrapper, input } = nodesOf(container);
+    stubFocusPreservingMove(offscreen);
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    act(() => captured!("panel-1", target));
+
+    act(() => input.focus());
+    expect(document.activeElement).toBe(input);
+
+    act(() => captured!("panel-1", null));
+
+    // The move itself would carry focus along, so the pane has to be blurred
+    // before it goes — otherwise the keyboard lives in a pane nobody can see.
+    expect(wrapper.contains(document.activeElement)).toBe(false);
+    target.remove();
+  });
+
+  it("drops focus even when the pane is already parked", () => {
+    // A parked wrapper can still hold focus (a focus restore that raced the
+    // move). The early return for "already at the destination" must not skip
+    // the blur — there is no move left to dislodge it.
+    const { container } = renderContainer();
+    const { wrapper, input } = nodesOf(container);
+
+    act(() => input.focus());
+    expect(document.activeElement).toBe(input);
+
+    act(() => captured!("panel-1", null));
+
+    expect(wrapper.contains(document.activeElement)).toBe(false);
+  });
+
+  it("asks a revealed pane to take focus when the store says it is focused", () => {
+    // The store sets `focusedId` before the wrapper has anywhere visible to
+    // live, so the pane's own focus effect ran against a parked, unfocusable
+    // subtree and came up empty. Reveal is the retry.
+    const { container } = renderContainer();
+    void container;
+    mockState.focusedId = "panel-1";
+
+    const handler = vi.fn(() => true);
+    const release = registerPanelFocusHandler("panel-1", handler);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+
+    act(() => captured!("panel-1", target));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    release();
+    target.remove();
+  });
+
+  it("does not disturb a revealed pane that already owns the keyboard", () => {
+    const { container } = renderContainer();
+    const { input } = nodesOf(container);
+    mockState.focusedId = "panel-1";
+
+    const handler = vi.fn(() => true);
+    const release = registerPanelFocusHandler("panel-1", handler);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    act(() => input.focus());
+
+    act(() => captured!("panel-1", target));
+
+    expect(handler).not.toHaveBeenCalled();
+    release();
+    target.remove();
+  });
+
+  it("does not claim focus for a revealed pane the store is not focused on", () => {
+    // A pane can be relocated for reasons other than being focused — a tab
+    // switch inside a group parks one member and reveals another.
+    renderContainer();
+    mockState.focusedId = "grid-7";
+
+    const handler = vi.fn(() => true);
+    const release = registerPanelFocusHandler("panel-1", handler);
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+
+    act(() => captured!("panel-1", target));
+
+    expect(handler).not.toHaveBeenCalled();
+    release();
+    target.remove();
   });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -334,19 +334,39 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
     expect(openDockTerminalMock).not.toHaveBeenCalled();
   });
 
-  it("still honors a real onOpenChange(false) when mounted closed", () => {
-    // Regression guard against accidentally arming the ref unconditionally.
+  it("still honors a real onOpenChange(false) after mounting closed", () => {
+    // Regression guard against a close path that only works when the group was
+    // open at mount. Opening after mount must still arm a genuine dismissal.
     mockActiveDockTerminalId = null;
     const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+    const group = makeGroup(["t-1", "t-2"], "t-1");
 
-    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+    const { rerender } = render(<DockedTabGroup group={group} panels={panels} />);
+    mockActiveDockTerminalId = "t-1";
+    rerender(<DockedTabGroup group={group} panels={panels} />);
     expect(capturedOnOpenChange).not.toBeNull();
 
     act(() => {
       capturedOnOpenChange?.(false);
     });
 
-    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+    expect(closeDockTerminalMock).toHaveBeenCalledWith("t-1");
+  });
+
+  it("does not close another group's dock pane on a spurious dismissal", () => {
+    // Radix can fire onOpenChange(false) on a group that has nothing open. An
+    // unqualified close would clear `activeDockTerminalId` wholesale and dismiss
+    // whichever pane actually owns the dock (#11133).
+    mockActiveDockTerminalId = "other-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    act(() => {
+      capturedOnOpenChange?.(false);
+    });
+
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
   });
 
   it("ignores spurious close when active panel is not the group's stored active tab", () => {

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -23,7 +23,7 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { registerPanelFocusHandler } from "./panelFocusRegistry";
+import { usePanelRootFocus } from "./usePanelRootFocus";
 import { useWorktreeColorMap } from "@/hooks/useWorktreeColorMap";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
@@ -235,6 +235,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     },
     [externalRef]
   );
+  const getRootNode = useCallback(() => rootRef.current, []);
   const titleEditing = useTitleEditing();
   const editingStartedAt = titleEditing.editingStartedAt;
 
@@ -255,19 +256,12 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     (s) => isPtyKind && s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
   );
 
-  // Non-PTY panels have no input surface of their own, so the panel root is the
-  // focus target that macro-grid Enter and tab switches hand off to. PTY kinds
-  // are skipped: TerminalPane owns their registry entry and routes focus to
-  // xterm or the hybrid input bar, and two owners would race for one panel id.
-  useEffect(() => {
-    if (isPtyKind) return undefined;
-    return registerPanelFocusHandler(id, () => {
-      const node = rootRef.current;
-      if (!node) return false;
-      node.focus({ preventScroll: true });
-      return document.activeElement === node;
-    });
-  }, [id, isPtyKind]);
+  // The panel root is the focus target for every non-PTY kind — it takes DOM
+  // focus when the panel becomes focused, and yields to whatever child input
+  // the panel owns (FilePane's search box, a plugin's fields). PTY kinds are
+  // skipped: TerminalPane owns their registry entry and routes focus to xterm
+  // or the hybrid input bar, and two owners would race for one panel id.
+  usePanelRootFocus({ id, isFocused, getNode: getRootNode, enabled: !isPtyKind });
 
   // One-shot ring pulse when this pane becomes the new primary on fleet
   // exit. Listens for the CustomEvent dispatched from FleetArmingRibbon's

--- a/src/components/Panel/__tests__/ContentPanel.focus.test.tsx
+++ b/src/components/Panel/__tests__/ContentPanel.focus.test.tsx
@@ -70,25 +70,39 @@ import { focusPanelInput } from "../panelFocusRegistry";
 
 type PanelKind = "terminal" | "browser" | "dev-preview" | "review" | "file";
 
-function renderPanel(
-  id: string,
-  kind: PanelKind = "browser",
-  extra?: { tabIndex?: number; ref?: React.Ref<HTMLDivElement> }
-) {
-  return render(
+interface RenderExtras {
+  tabIndex?: number;
+  ref?: React.Ref<HTMLDivElement>;
+  isFocused?: boolean;
+  children?: React.ReactNode;
+}
+
+function panelElement(id: string, kind: PanelKind, extra?: RenderExtras) {
+  return (
     <ContentPanel
       id={id}
       title={`Panel ${id}`}
       kind={kind}
-      isFocused={false}
+      isFocused={extra?.isFocused ?? false}
       onFocus={() => {}}
       onClose={() => {}}
       tabIndex={extra?.tabIndex}
       ref={extra?.ref}
     >
-      <div data-testid="panel-body" />
+      {extra?.children ?? <div data-testid="panel-body" />}
     </ContentPanel>
   );
+}
+
+function renderPanel(id: string, kind: PanelKind = "browser", extra?: RenderExtras) {
+  const view = render(panelElement(id, kind, extra));
+  return {
+    ...view,
+    focus: (isFocused: boolean) =>
+      act(() => {
+        view.rerender(panelElement(id, kind, { ...extra, isFocused }));
+      }),
+  };
 }
 
 function panelRoot(container: HTMLElement, id: string): HTMLElement {
@@ -169,5 +183,79 @@ describe("ContentPanel focus target (#11109)", () => {
     unmount();
 
     expect(focusPanelInput("p-1")).toBe(false);
+  });
+});
+
+/**
+ * The registry alone only covers macro-grid Enter and in-group tab switches.
+ * Arrow navigation, Cmd+1..9, focusNext/Previous and agent-state cycling all
+ * just write `focusedId` — so becoming the focused pane has to move DOM focus
+ * on its own, or the pane paints as selected while keystrokes keep landing in
+ * whatever held the keyboard before.
+ */
+describe("ContentPanel reactive focus (#11133)", () => {
+  afterEach(cleanup);
+
+  it.each<PanelKind>(["browser", "dev-preview", "review", "file"])(
+    "claims DOM focus for a %s panel that becomes focused without the registry",
+    (kind) => {
+      const outside = document.createElement("button");
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const { container, focus } = renderPanel("p-1", kind);
+      expect(document.activeElement).toBe(outside);
+
+      focus(true);
+
+      expect(document.activeElement).toBe(panelRoot(container, "p-1"));
+      outside.remove();
+    }
+  );
+
+  it("leaves focus on the panel's own input rather than yanking it to the root", () => {
+    // FilePane's search box lives inside the root. Becoming the focused pane
+    // must not pull the caret out of the field the user is typing in.
+    const { container, focus } = renderPanel("p-1", "file", {
+      children: <input data-testid="search" />,
+    });
+    const search = container.querySelector<HTMLInputElement>('[data-testid="search"]')!;
+    act(() => search.focus());
+
+    focus(true);
+
+    expect(document.activeElement).toBe(search);
+  });
+
+  it("reports a handoff as accepted when the panel already owns the keyboard", () => {
+    const { container } = renderPanel("p-1", "file", {
+      children: <input data-testid="search" />,
+    });
+    const search = container.querySelector<HTMLInputElement>('[data-testid="search"]')!;
+    act(() => search.focus());
+
+    let accepted = false;
+    act(() => {
+      accepted = focusPanelInput("p-1");
+    });
+
+    // The pane has focus — that is the outcome the caller asked for, so the
+    // handoff completed even though nothing moved.
+    expect(accepted).toBe(true);
+    expect(document.activeElement).toBe(search);
+  });
+
+  it("does not reactively claim focus for PTY kinds", () => {
+    // TerminalPane routes PTY focus to xterm or the hybrid input bar. A second
+    // claimant here would land focus on the container instead.
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const { focus } = renderPanel("t-1", "terminal");
+    focus(true);
+
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
   });
 });

--- a/src/components/Panel/usePanelRootFocus.ts
+++ b/src/components/Panel/usePanelRootFocus.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { registerPanelFocusHandler } from "./panelFocusRegistry";
+
+/**
+ * Give a non-PTY panel real DOM focus whenever it becomes the focused pane.
+ *
+ * Registering a focus handler is not enough on its own: the registry is only
+ * *invoked* by macro-grid Enter and in-group tab switches. Every other path
+ * that moves focus — arrow navigation, Cmd+1..9, focusNext/Previous, agent-state
+ * cycling, worktree restore — just writes `focusedId`, which paints the selected
+ * highlight and stops. TerminalPane has always carried its own reactive effect
+ * to close that gap; without an equivalent here, a focused non-PTY panel looks
+ * selected while keystrokes keep landing in whatever held the keyboard before
+ * (#11133).
+ *
+ * Focus already inside the panel is left alone — FilePane's search box and a
+ * plugin's own inputs are inside the root, so re-focusing it would yank the
+ * user out of the surface they're typing in. That also makes "focus is already
+ * here" a successful handoff rather than a no-op that reports failure.
+ *
+ * `getNode` must be referentially stable (or change exactly when the element
+ * does): a consumer holding its root in state re-runs both effects when the
+ * element commits, which is what lets a late-mounting root still claim focus.
+ */
+export function usePanelRootFocus(options: {
+  id: string;
+  isFocused: boolean;
+  getNode: () => HTMLElement | null;
+  enabled?: boolean;
+}): void {
+  const { id, isFocused, getNode, enabled = true } = options;
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    return registerPanelFocusHandler(id, () => focusPanelRoot(getNode()));
+  }, [id, enabled, getNode]);
+
+  useEffect(() => {
+    if (!enabled || !isFocused) return;
+    focusPanelRoot(getNode());
+  }, [id, isFocused, enabled, getNode]);
+}
+
+/**
+ * Move DOM focus to a panel root, reporting whether the panel ended up owning
+ * the keyboard. Verified rather than assumed: focusing into a structurally
+ * hidden subtree (the dock's `content-visibility: hidden` parking container)
+ * is refused by the browser, and a handler that reported success there would
+ * strand focus on nothing.
+ */
+function focusPanelRoot(node: HTMLElement | null): boolean {
+  if (!node) return false;
+  if (node.contains(document.activeElement)) return true;
+  node.focus({ preventScroll: true });
+  return document.activeElement === node;
+}

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -1,6 +1,7 @@
 import {
   Suspense,
   lazy,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -12,7 +13,7 @@ import type { PanelViewProps } from "@shared/types/plugin";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { BrowserPaneSkeleton } from "@/components/Browser/BrowserPaneSkeleton";
 import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
-import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry";
+import { usePanelRootFocus } from "@/components/Panel/usePanelRootFocus";
 import type { PanelComponentProps } from "@/panels/registry";
 import { logWarn } from "@/utils/logger";
 
@@ -148,14 +149,11 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
 
     const rootRef = useRef<HTMLDivElement | null>(null);
     const panelId = props.id;
-    useEffect(() => {
-      return registerPanelFocusHandler(panelId, () => {
-        const node = rootRef.current;
-        if (!node) return false;
-        node.focus({ preventScroll: true });
-        return document.activeElement === node;
-      });
-    }, [panelId]);
+    // Focusing the host root establishes ownership in the parent document; it
+    // does not push focus into the plugin's guest frame. Focus already inside
+    // the host (a plugin input, an iframe) is left where it is.
+    const getRootNode = useCallback(() => rootRef.current, []);
+    usePanelRootFocus({ id: panelId, isFocused: props.isFocused, getNode: getRootNode });
 
     // The dispose controller lives in state because its signal is consumed
     // during render (passed to the plugin view as `disposeSignal`), and refs

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -415,3 +415,78 @@ describe("makePluginViewHost", () => {
     unmount();
   });
 });
+
+/**
+ * The plugin host bypasses ContentPanel, so it owns its focus target. Focusing
+ * the host root claims the keyboard in the parent document; it does not push
+ * focus into the plugin's guest frame, and it must never pull focus out of a
+ * plugin input the user is already typing in (#11133).
+ */
+describe("PluginViewHost reactive focus (#11133)", () => {
+  it("claims DOM focus when the host becomes the focused pane", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const { container, rerender } = render(
+      <Host
+        id="panel-1"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+    expect(document.activeElement).toBe(outside);
+
+    act(() => {
+      rerender(
+        <Host
+          id="panel-1"
+          title="Dashboard"
+          isFocused
+          onFocus={(): void => {}}
+          onClose={(): void => {}}
+        />
+      );
+    });
+
+    expect(document.activeElement).toBe(container.firstElementChild);
+    outside.remove();
+  });
+
+  it("leaves focus inside the plugin's own surface alone", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    // The suite resets modules between tests, so the registry must be resolved
+    // from the same module graph as the host — a static import would hold a
+    // stale Map and see none of the host's registrations.
+    const { focusPanelInput } = await import("@/components/Panel/panelFocusRegistry");
+    const Host = makePluginViewHost(makeConfig());
+
+    const { container } = render(
+      <Host
+        id="panel-1"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const guestInput = document.createElement("input");
+    root.appendChild(guestInput);
+    act(() => guestInput.focus());
+
+    let accepted = false;
+    act(() => {
+      accepted = focusPanelInput("panel-1");
+    });
+
+    expect(accepted).toBe(true);
+    expect(document.activeElement).toBe(guestInput);
+  });
+});

--- a/src/components/Terminal/ContentGridMaximizedSingle.tsx
+++ b/src/components/Terminal/ContentGridMaximizedSingle.tsx
@@ -33,9 +33,13 @@ export function ContentGridMaximizedSingle({
     >
       <GridNotificationBar className="mx-1 mt-1 shrink-0" />
       <div className="relative min-h-0 flex-1">
+        {/* Being the only pane on screen is not the same as owning the keyboard:
+            while a dock popover is open, focus belongs to the dock pane. Pinning
+            this to `true` meant the prop never changed on the way back, so the
+            pane never re-claimed DOM focus when the popover closed (#11133). */}
         <GridPanel
           terminalId={maximizedId}
-          isFocused={true}
+          isFocused={ctx.focusedId === maximizedId}
           isMaximized={true}
           isMultiPanelGrid={ctx.gridItemCount > 1}
         />

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -47,8 +47,8 @@ export function DockedPanel({
   }, [moveTerminalToGrid, terminal.id, onPopoverClose]);
 
   const handleMinimize = useCallback(() => {
-    closeDockTerminal();
-  }, [closeDockTerminal]);
+    closeDockTerminal(terminal.id);
+  }, [closeDockTerminal, terminal.id]);
 
   const focusedId = usePanelStore((state) => state.focusedId);
   const isFocused = focusedId === terminal.id;

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -119,6 +119,15 @@ type ApplyEditorValue = (
 
 const EMPTY_STALE_KEYS: ReadonlySet<string> = new Set<string>();
 
+/**
+ * Whether the editor holds the caret, judged by the DOM rather than by
+ * `view.hasFocus` — CodeMirror reports false there whenever the window is
+ * blurred, even though the editor is still `document.activeElement`.
+ */
+function editorOwnsDomFocus(view: EditorView): boolean {
+  return view.contentDOM.contains(document.activeElement);
+}
+
 const hybridInputE2EControllers = new Map<string, HybridInputE2EController>();
 
 function installHybridInputE2EBridge(): void {
@@ -605,13 +614,18 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           if (!view) return false;
           // Already holding the keyboard: callers want focus, not a caret move.
           // Re-running the cursor dispatch would drag the caret to the end of the
-          // draft from wherever the user just clicked (#11133).
-          if (view.hasFocus) return true;
+          // draft from wherever the user just clicked (#11133). Ownership is read
+          // from the DOM rather than `view.hasFocus`, which reports false whenever
+          // the window itself is blurred even though the editor still holds the
+          // caret — a background state change would otherwise move it.
+          if (editorOwnsDomFocus(view)) return true;
           const gen = focusGenerationRef.current;
           requestAnimationFrame(() => {
             if (focusGenerationRef.current !== gen) return;
             if (editorViewRef.current !== view) return;
             if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
+            // The user can click into the draft between the call and this frame.
+            if (editorOwnsDomFocus(view)) return;
             view.dispatch({
               selection: EditorSelection.cursor(view.state.doc.length),
               scrollIntoView: true,

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -603,6 +603,10 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           // No mounted editor (lazy CodeMirror still loading) means nothing can
           // take focus — say so rather than let the caller assume it landed.
           if (!view) return false;
+          // Already holding the keyboard: callers want focus, not a caret move.
+          // Re-running the cursor dispatch would drag the caret to the end of the
+          // draft from wherever the user just clicked (#11133).
+          if (view.hasFocus) return true;
           const gen = focusGenerationRef.current;
           requestAnimationFrame(() => {
             if (focusGenerationRef.current !== gen) return;

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -83,6 +83,7 @@ const LazyHybridInputBar = lazy(() =>
 import {
   getTerminalFocusTarget,
   isLikelyAtSynthesizedPointer,
+  resolvePaneFocusAction,
   shouldShowHybridInputBar,
   shouldSuppressUnfocusedClick,
 } from "./terminalFocus";
@@ -95,6 +96,23 @@ import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 export type {};
+
+/**
+ * Live selection/focus state of a pane's xterm, for `resolvePaneFocusAction`.
+ * Ownership is measured against `hostElement` — the xterm host specifically,
+ * not the pane container, which also holds the input bar and toolbar.
+ */
+function readXtermSelectionState(id: string): {
+  hasSelection: boolean;
+  xtermOwnsDomFocus: boolean;
+} {
+  const managed = terminalInstanceService.get(id);
+  if (!managed) return { hasSelection: false, xtermOwnsDomFocus: false };
+  return {
+    hasSelection: managed.terminal.hasSelection(),
+    xtermOwnsDomFocus: managed.hostElement.contains(document.activeElement),
+  };
+}
 
 export interface BannerSlotProps {
   visible: boolean;
@@ -969,24 +987,24 @@ function TerminalPaneComponent({
 
     if (!isFocused) return;
 
-    const focusTarget = getTerminalFocusTarget({
-      preferredTarget: preferredTerminalFocusTarget,
-      hasHybridInputSurface: showHybridInputBar,
-      isInputDisabled: isHybridInputDisabled,
-      hybridInputEnabled,
+    // Read selection and focus ownership synchronously, before any handoff.
+    // Deciding up front (rather than inside the deferred RAF) also keeps focus
+    // from briefly landing on the ContentPanel container, which made screen
+    // readers announce the container instead of the input bar.
+    const action = resolvePaneFocusAction({
+      focusTarget: getTerminalFocusTarget({
+        preferredTarget: preferredTerminalFocusTarget,
+        hasHybridInputSurface: showHybridInputBar,
+        isInputDisabled: isHybridInputDisabled,
+        hybridInputEnabled,
+      }),
+      ...readXtermSelectionState(id),
     });
 
-    if (focusTarget === "hybridInput") {
-      // xterm v6 clears selection on blur, so read selection state
-      // synchronously here — before any focus handoff. Don't steal focus from
-      // xterm when the user has an active text selection. Checking up front
-      // (rather than inside a deferred double-RAF) also avoids focus briefly
-      // landing on the ContentPanel container, which made screen readers
-      // announce the container instead of the input bar. A RAF then defers the
-      // handoff until the pane has painted; focus never lands on the container.
-      const managed = terminalInstanceService.get(id);
-      if (managed?.terminal.hasSelection()) return;
+    if (action === "preserve") return;
 
+    if (action === "hybridInput") {
+      // A RAF defers the handoff until the pane has painted.
       const rafId = requestAnimationFrame(() => {
         inputBarRef.current?.focusWithCursorAtEnd();
       });
@@ -1014,13 +1032,19 @@ function TerminalPaneComponent({
     // forcing the input; that's what the old model did, and tab switching
     // would otherwise yank focus out of xterm against the user's intent.
     return registerPanelFocusHandler(id, () => {
-      const focusTarget = getTerminalFocusTarget({
-        preferredTarget: usePanelStore.getState().preferredTerminalFocusTarget,
-        hasHybridInputSurface: showHybridInputBar,
-        isInputDisabled: isHybridInputDisabled,
-        hybridInputEnabled,
+      const action = resolvePaneFocusAction({
+        focusTarget: getTerminalFocusTarget({
+          preferredTarget: usePanelStore.getState().preferredTerminalFocusTarget,
+          hasHybridInputSurface: showHybridInputBar,
+          isInputDisabled: isHybridInputDisabled,
+          hybridInputEnabled,
+        }),
+        ...readXtermSelectionState(id),
       });
-      if (focusTarget === "hybridInput") {
+      // An xterm that already owns the keyboard while holding a selection is a
+      // completed handoff — the pane has focus, just not on the input bar.
+      if (action === "preserve") return true;
+      if (action === "hybridInput") {
         // The bar is rendered but its editor may still be lazy-loading. Decline
         // rather than falling through to xterm: focusing xterm flips the stored
         // preferred target, so a transient miss would silently and permanently

--- a/src/components/Terminal/__tests__/contentGridFocus.test.ts
+++ b/src/components/Terminal/__tests__/contentGridFocus.test.ts
@@ -76,8 +76,9 @@ describe("getMaximizedGroupFocusTarget", () => {
     };
 
     expect(getMaximizedGroupFocusTarget({ ...args, openDockPopoverId: "dock-1" })).toBeNull();
-    // `closeDockTerminal` clears only `activeDockTerminalId`, leaving focus on
-    // the closed dock terminal — enforcement resumes and reclaims the group.
+    // `closeDockTerminal` now hands focus back itself (#11133), but this stays
+    // the backstop for focus left on a dock pane by any other route — persisted
+    // state, a crash mid-close — so enforcement still reclaims the group.
     expect(getMaximizedGroupFocusTarget({ ...args, openDockPopoverId: null })).toBe("term-2");
   });
 

--- a/src/components/Terminal/__tests__/terminalFocus.test.ts
+++ b/src/components/Terminal/__tests__/terminalFocus.test.ts
@@ -2,9 +2,72 @@ import { describe, it, expect } from "vitest";
 import {
   getTerminalFocusTarget,
   isLikelyAtSynthesizedPointer,
+  resolvePaneFocusAction,
   shouldShowHybridInputBar,
   shouldSuppressUnfocusedClick,
 } from "../terminalFocus";
+
+/**
+ * The selection guard used to be unconditional: any selection in the pane's
+ * xterm cancelled the focus handoff outright. That stranded the keyboard on the
+ * pane the user had just left whenever the destination happened to be holding an
+ * old selection — highlight on one pane, keystrokes into another (#11133).
+ */
+describe("resolvePaneFocusAction", () => {
+  it("keeps focus in xterm when it holds both the selection and the keyboard", () => {
+    expect(
+      resolvePaneFocusAction({
+        focusTarget: "hybridInput",
+        hasSelection: true,
+        xtermOwnsDomFocus: true,
+      })
+    ).toBe("preserve");
+  });
+
+  it("hands off to the input bar when the selection sits in an unfocused xterm", () => {
+    // The pane is being focused from somewhere else, so this xterm is already
+    // blurred — its selection is inert and cannot be disturbed by the handoff.
+    expect(
+      resolvePaneFocusAction({
+        focusTarget: "hybridInput",
+        hasSelection: true,
+        xtermOwnsDomFocus: false,
+      })
+    ).toBe("hybridInput");
+  });
+
+  it("hands off to the input bar when xterm has focus but no selection", () => {
+    expect(
+      resolvePaneFocusAction({
+        focusTarget: "hybridInput",
+        hasSelection: false,
+        xtermOwnsDomFocus: true,
+      })
+    ).toBe("hybridInput");
+  });
+
+  it("hands off to the input bar when the pane holds neither", () => {
+    expect(
+      resolvePaneFocusAction({
+        focusTarget: "hybridInput",
+        hasSelection: false,
+        xtermOwnsDomFocus: false,
+      })
+    ).toBe("hybridInput");
+  });
+
+  it("never preserves when the resolved target is xterm itself", () => {
+    // A selection is not a reason to skip focusing xterm — that would leave the
+    // keyboard wherever it was.
+    for (const hasSelection of [true, false]) {
+      for (const xtermOwnsDomFocus of [true, false]) {
+        expect(
+          resolvePaneFocusAction({ focusTarget: "xterm", hasSelection, xtermOwnsDomFocus })
+        ).toBe("xterm");
+      }
+    }
+  });
+});
 
 describe("shouldShowHybridInputBar", () => {
   it("shows for agent terminals when enabled", () => {

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -43,6 +43,35 @@ export function getTerminalFocusTarget(options: {
   return "xterm";
 }
 
+export type PaneFocusAction = "preserve" | "hybridInput" | "xterm";
+
+/**
+ * Resolve what a focused pane should do with DOM focus, given the target
+ * `getTerminalFocusTarget` picked and the live selection/focus state of its
+ * xterm.
+ *
+ * The selection rule is about ownership, not about the selection itself: an
+ * xterm that holds keyboard focus *and* a selection keeps both, because
+ * handing focus to the input bar mid-selection is a yank the user didn't ask
+ * for. A selection in an xterm that does NOT hold keyboard focus is inert —
+ * the pane is being focused from elsewhere, so declining to move focus would
+ * strand the keyboard on the pane the user just left (#11133). Focus does not
+ * clear an xterm selection either way: `SelectionService` reacts to input and
+ * buffer events, never to DOM blur.
+ *
+ * `preserve` therefore means "focus is already where it belongs" — callers
+ * treat it as a completed handoff, not a failure.
+ */
+export function resolvePaneFocusAction(options: {
+  focusTarget: TerminalFocusTarget;
+  hasSelection: boolean;
+  xtermOwnsDomFocus: boolean;
+}): PaneFocusAction {
+  if (options.focusTarget !== "hybridInput") return "xterm";
+  if (options.hasSelection && options.xtermOwnsDomFocus) return "preserve";
+  return "hybridInput";
+}
+
 /**
  * Whether a pointerdown on the xterm area of an *unfocused* grid pane should
  * be swallowed before xterm sees it. Prevents stray clicks from poking at

--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -1,17 +1,18 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { GitPullRequest } from "lucide-react";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { ReviewHubContent } from "@/components/Worktree/ReviewHub/ReviewHubContent";
 import { EmptyState } from "@/components/ui/EmptyState";
-import { registerPanelFocusHandler } from "@/components/Panel/panelFocusRegistry";
+import { usePanelRootFocus } from "@/components/Panel/usePanelRootFocus";
 
 export interface ReviewPaneProps {
   id: string;
   worktreeId?: string;
   onClose: (force?: boolean) => void;
+  isFocused?: boolean;
 }
 
-export function ReviewPane({ id, worktreeId, onClose }: ReviewPaneProps) {
+export function ReviewPane({ id, worktreeId, onClose, isFocused = false }: ReviewPaneProps) {
   // ReviewHubContent wires its Close button as `onClick={onClose}`, so React
   // would hand the MouseEvent straight through as `force` — a truthy object
   // that routes the panel handler to permanent removal instead of the
@@ -25,15 +26,11 @@ export function ReviewPane({ id, worktreeId, onClose }: ReviewPaneProps) {
   // Escape listener that swallows the key across the whole app.
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
 
-  // Review renders no ContentPanel, so it registers its own focus target
-  // instead of inheriting ContentPanel's.
-  useEffect(() => {
-    if (!containerEl) return undefined;
-    return registerPanelFocusHandler(id, () => {
-      containerEl.focus({ preventScroll: true });
-      return document.activeElement === containerEl;
-    });
-  }, [id, containerEl]);
+  // Review renders no ContentPanel, so it owns its focus target instead of
+  // inheriting ContentPanel's. The getter changes identity with the element,
+  // which re-arms the reactive focus once the container commits.
+  const getContainer = useCallback(() => containerEl, [containerEl]);
+  usePanelRootFocus({ id, isFocused, getNode: getContainer });
 
   // Resolve worktree path fresh from the worktree store so renames/moves are
   // reflected without restarting the panel. Missing worktreeId yields an empty

--- a/src/panels/review/__tests__/ReviewPane.focus.test.tsx
+++ b/src/panels/review/__tests__/ReviewPane.focus.test.tsx
@@ -78,3 +78,44 @@ describe("ReviewPane focus target (#11109)", () => {
     expect(focusPanelInput("r-1")).toBe(false);
   });
 });
+
+/**
+ * Registration alone only answers macro-grid Enter. Arrow navigation, Cmd+1..9
+ * and the rest just write `focusedId`, so the pane has to claim DOM focus when
+ * it becomes focused or the keyboard stays behind (#11133).
+ */
+describe("ReviewPane reactive focus (#11133)", () => {
+  afterEach(() => {
+    keyboardScopes.length = 0;
+    cleanup();
+  });
+
+  it("claims DOM focus when it becomes the focused pane", () => {
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.focus();
+
+    const { container, rerender } = render(<ReviewPane id="r-1" worktreeId="w-1" />);
+    expect(document.activeElement).toBe(outside);
+
+    act(() => {
+      rerender(<ReviewPane id="r-1" worktreeId="w-1" isFocused />);
+    });
+
+    expect(document.activeElement).toBe(container.firstElementChild);
+    outside.remove();
+  });
+
+  it("leaves focus alone when it already sits inside the pane", () => {
+    const { container } = render(<ReviewPane id="r-1" worktreeId="w-1" isFocused />);
+    const hub = container.querySelector<HTMLElement>('[data-testid="review-hub"]')!;
+    hub.tabIndex = -1;
+    act(() => hub.focus());
+
+    act(() => {
+      expect(focusPanelInput("r-1")).toBe(true);
+    });
+
+    expect(document.activeElement).toBe(hub);
+  });
+});

--- a/src/store/__tests__/panelFocusFallback.test.ts
+++ b/src/store/__tests__/panelFocusFallback.test.ts
@@ -6,13 +6,26 @@
  * from inside an aria-hidden parking container.
  */
 import { describe, it, expect } from "vitest";
-import { isVisibleGridPanel, pickDockCloseFocusId } from "../panelFocusFallback";
+import {
+  isVisibleGridPanel,
+  isRenderedGridPanel,
+  pickDockCloseFocusId,
+  type GetPanelGroupInfo,
+} from "../panelFocusFallback";
 
 type Panel = Parameters<typeof isVisibleGridPanel>[0];
 
 function panel(id: string, overrides: Partial<Panel> = {}): Panel {
   return { id, worktreeId: "wt-1", location: "grid", ...overrides } as Panel;
 }
+
+const ungrouped: GetPanelGroupInfo = () => undefined;
+
+const baseOptions = {
+  activeWorktreeId: "wt-1",
+  maximizeTarget: null,
+  getPanelGroupInfo: ungrouped,
+};
 
 describe("isVisibleGridPanel", () => {
   it("accepts a grid panel in the active worktree", () => {
@@ -40,21 +53,64 @@ describe("isVisibleGridPanel", () => {
   });
 });
 
+/**
+ * Grid membership is necessary but not sufficient — a background tab and a pane
+ * behind a maximized one both still read as `location: "grid"`, and focusing
+ * either one recreates #11133 from the other end.
+ */
+describe("isRenderedGridPanel", () => {
+  it("accepts an ordinary grid pane with nothing maximized", () => {
+    expect(isRenderedGridPanel(panel("a"), baseOptions)).toBe(true);
+  });
+
+  it("rejects a background tab of a grid tab group", () => {
+    const grouped: GetPanelGroupInfo = () => ({ groupId: "g-1", activeTabId: "b" });
+
+    expect(isRenderedGridPanel(panel("a"), { ...baseOptions, getPanelGroupInfo: grouped })).toBe(
+      false
+    );
+    expect(isRenderedGridPanel(panel("b"), { ...baseOptions, getPanelGroupInfo: grouped })).toBe(
+      true
+    );
+  });
+
+  it("rejects every pane except the maximized one", () => {
+    const maximized = { ...baseOptions, maximizeTarget: { type: "panel", id: "b" } as const };
+
+    expect(isRenderedGridPanel(panel("a"), maximized)).toBe(false);
+    expect(isRenderedGridPanel(panel("b"), maximized)).toBe(true);
+  });
+
+  it("accepts the active tab of a maximized group and nothing else", () => {
+    const getPanelGroupInfo: GetPanelGroupInfo = (id) =>
+      id === "a" || id === "b" ? { groupId: "g-1", activeTabId: "b" } : undefined;
+    const maximized = {
+      ...baseOptions,
+      getPanelGroupInfo,
+      maximizeTarget: { type: "group", id: "g-1" } as const,
+    };
+
+    expect(isRenderedGridPanel(panel("b"), maximized)).toBe(true);
+    expect(isRenderedGridPanel(panel("a"), maximized)).toBe(false);
+    expect(isRenderedGridPanel(panel("outside"), maximized)).toBe(false);
+  });
+});
+
 describe("pickDockCloseFocusId", () => {
   it("hands the keyboard back to the pane the user came from", () => {
     const id = pickDockCloseFocusId({
+      ...baseOptions,
       panels: [panel("grid-1"), panel("grid-2"), panel("dock-1", { location: "dock" })],
-      activeWorktreeId: "wt-1",
       previousFocusedId: "grid-2",
     });
 
     expect(id).toBe("grid-2");
   });
 
-  it("falls back to the first visible grid pane when the previous one is gone", () => {
+  it("falls back to the first rendered grid pane when the previous one is gone", () => {
     const id = pickDockCloseFocusId({
+      ...baseOptions,
       panels: [panel("grid-1"), panel("grid-2")],
-      activeWorktreeId: "wt-1",
       previousFocusedId: "removed",
     });
 
@@ -62,25 +118,36 @@ describe("pickDockCloseFocusId", () => {
   });
 
   it("never hands focus back to a pane that is itself hidden", () => {
-    // A previous focus pointing at another dock pane, or at a pane in a
-    // worktree the user has since left, is not a place the keyboard can go.
+    // A previous focus pointing at another dock pane, or at a pane in a worktree
+    // the user has since left, is not a place the keyboard can go.
     const id = pickDockCloseFocusId({
+      ...baseOptions,
       panels: [
         panel("dock-2", { location: "dock" }),
         panel("other-wt", { worktreeId: "wt-9" }),
         panel("grid-1"),
       ],
-      activeWorktreeId: "wt-1",
       previousFocusedId: "dock-2",
     });
 
     expect(id).toBe("grid-1");
   });
 
-  it("returns null when the active worktree has no visible grid pane", () => {
+  it("prefers the maximized pane over an earlier pane hidden behind it", () => {
     const id = pickDockCloseFocusId({
+      ...baseOptions,
+      maximizeTarget: { type: "panel", id: "grid-2" },
+      panels: [panel("grid-1"), panel("grid-2")],
+      previousFocusedId: null,
+    });
+
+    expect(id).toBe("grid-2");
+  });
+
+  it("returns null when the active worktree has no rendered grid pane", () => {
+    const id = pickDockCloseFocusId({
+      ...baseOptions,
       panels: [panel("dock-1", { location: "dock" }), panel("other-wt", { worktreeId: "wt-9" })],
-      activeWorktreeId: "wt-1",
       previousFocusedId: "dock-1",
     });
 

--- a/src/store/__tests__/panelFocusFallback.test.ts
+++ b/src/store/__tests__/panelFocusFallback.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Where the keyboard lands when the pane holding it stops being visible.
+ *
+ * The dock popover is the case that motivated this (#11133): closing it used to
+ * leave `focusedId` on the dismissed pane, which then kept eating keystrokes
+ * from inside an aria-hidden parking container.
+ */
+import { describe, it, expect } from "vitest";
+import { isVisibleGridPanel, pickDockCloseFocusId } from "../panelFocusFallback";
+
+type Panel = Parameters<typeof isVisibleGridPanel>[0];
+
+function panel(id: string, overrides: Partial<Panel> = {}): Panel {
+  return { id, worktreeId: "wt-1", location: "grid", ...overrides } as Panel;
+}
+
+describe("isVisibleGridPanel", () => {
+  it("accepts a grid panel in the active worktree", () => {
+    expect(isVisibleGridPanel(panel("a"), "wt-1")).toBe(true);
+  });
+
+  it("accepts a legacy panel that carries no location", () => {
+    expect(isVisibleGridPanel(panel("a", { location: undefined }), "wt-1")).toBe(true);
+  });
+
+  it.each(["dock", "trash", "background", "overlay"] as const)(
+    "rejects a %s panel — the user cannot see it",
+    (location) => {
+      expect(isVisibleGridPanel(panel("a", { location }), "wt-1")).toBe(false);
+    }
+  );
+
+  it("rejects a grid panel belonging to another worktree", () => {
+    expect(isVisibleGridPanel(panel("a", { worktreeId: "wt-2" }), "wt-1")).toBe(false);
+  });
+
+  it("matches an unassigned panel against an unassigned worktree", () => {
+    expect(isVisibleGridPanel(panel("a", { worktreeId: undefined }), null)).toBe(true);
+    expect(isVisibleGridPanel(panel("a", { worktreeId: undefined }), "wt-1")).toBe(false);
+  });
+});
+
+describe("pickDockCloseFocusId", () => {
+  it("hands the keyboard back to the pane the user came from", () => {
+    const id = pickDockCloseFocusId({
+      panels: [panel("grid-1"), panel("grid-2"), panel("dock-1", { location: "dock" })],
+      activeWorktreeId: "wt-1",
+      previousFocusedId: "grid-2",
+    });
+
+    expect(id).toBe("grid-2");
+  });
+
+  it("falls back to the first visible grid pane when the previous one is gone", () => {
+    const id = pickDockCloseFocusId({
+      panels: [panel("grid-1"), panel("grid-2")],
+      activeWorktreeId: "wt-1",
+      previousFocusedId: "removed",
+    });
+
+    expect(id).toBe("grid-1");
+  });
+
+  it("never hands focus back to a pane that is itself hidden", () => {
+    // A previous focus pointing at another dock pane, or at a pane in a
+    // worktree the user has since left, is not a place the keyboard can go.
+    const id = pickDockCloseFocusId({
+      panels: [
+        panel("dock-2", { location: "dock" }),
+        panel("other-wt", { worktreeId: "wt-9" }),
+        panel("grid-1"),
+      ],
+      activeWorktreeId: "wt-1",
+      previousFocusedId: "dock-2",
+    });
+
+    expect(id).toBe("grid-1");
+  });
+
+  it("returns null when the active worktree has no visible grid pane", () => {
+    const id = pickDockCloseFocusId({
+      panels: [panel("dock-1", { location: "dock" }), panel("other-wt", { worktreeId: "wt-9" })],
+      activeWorktreeId: "wt-1",
+      previousFocusedId: "dock-1",
+    });
+
+    expect(id).toBeNull();
+  });
+});

--- a/src/store/__tests__/panelFocusFallback.test.ts
+++ b/src/store/__tests__/panelFocusFallback.test.ts
@@ -23,6 +23,7 @@ const ungrouped: GetPanelGroupInfo = () => undefined;
 
 const baseOptions = {
   activeWorktreeId: "wt-1",
+  maximizedId: null,
   maximizeTarget: null,
   getPanelGroupInfo: ungrouped,
 };
@@ -75,10 +76,36 @@ describe("isRenderedGridPanel", () => {
   });
 
   it("rejects every pane except the maximized one", () => {
-    const maximized = { ...baseOptions, maximizeTarget: { type: "panel", id: "b" } as const };
+    const maximized = {
+      ...baseOptions,
+      maximizedId: "b",
+      maximizeTarget: { type: "panel", id: "b" } as const,
+    };
 
     expect(isRenderedGridPanel(panel("a"), maximized)).toBe(false);
     expect(isRenderedGridPanel(panel("b"), maximized)).toBe(true);
+  });
+
+  it("follows maximizedId, not maximizeTarget, when the two disagree", () => {
+    // ContentGrid renders the pane named by `maximizedId`. Layout undo restores
+    // that half without the target, so a predicate keyed on the target would
+    // reject the pane actually on screen and elect the hidden one instead.
+    const desynced = {
+      ...baseOptions,
+      maximizedId: "b",
+      maximizeTarget: { type: "panel", id: "a" } as const,
+    };
+
+    expect(isRenderedGridPanel(panel("b"), desynced)).toBe(true);
+    expect(isRenderedGridPanel(panel("a"), desynced)).toBe(false);
+  });
+
+  it("does not filter at all when only one half of the maximize pair is set", () => {
+    // ContentGrid maximizes only when both are set; anything else is a normal grid.
+    const halfSet = { ...baseOptions, maximizedId: "b", maximizeTarget: null };
+
+    expect(isRenderedGridPanel(panel("a"), halfSet)).toBe(true);
+    expect(isRenderedGridPanel(panel("b"), halfSet)).toBe(true);
   });
 
   it("accepts the active tab of a maximized group and nothing else", () => {
@@ -87,6 +114,7 @@ describe("isRenderedGridPanel", () => {
     const maximized = {
       ...baseOptions,
       getPanelGroupInfo,
+      maximizedId: "b",
       maximizeTarget: { type: "group", id: "g-1" } as const,
     };
 
@@ -136,6 +164,7 @@ describe("pickDockCloseFocusId", () => {
   it("prefers the maximized pane over an earlier pane hidden behind it", () => {
     const id = pickDockCloseFocusId({
       ...baseOptions,
+      maximizedId: "grid-2",
       maximizeTarget: { type: "panel", id: "grid-2" },
       panels: [panel("grid-1"), panel("grid-2")],
       previousFocusedId: null,

--- a/src/store/panelFocusFallback.ts
+++ b/src/store/panelFocusFallback.ts
@@ -35,6 +35,7 @@ export function isRenderedGridPanel(
   panel: CarrierPanel,
   options: {
     activeWorktreeId: string | null;
+    maximizedId: string | null;
     maximizeTarget: MaximizeTarget;
     getPanelGroupInfo: GetPanelGroupInfo;
   }
@@ -44,10 +45,15 @@ export function isRenderedGridPanel(
   const group = options.getPanelGroupInfo(panel.id);
   if (group && group.activeTabId !== null && group.activeTabId !== panel.id) return false;
 
-  const target = options.maximizeTarget;
-  if (target?.type === "panel") return target.id === panel.id;
-  if (target?.type === "group") return group?.groupId === target.id;
-  return true;
+  // Mirror ContentGrid's own branching rather than paraphrasing it. It maximizes
+  // only when BOTH halves are set, and for a panel target it renders the pane
+  // named by `maximizedId` — not by `maximizeTarget.id`. The two can drift
+  // (layout undo restores `maximizedId` alone), and a predicate that trusted the
+  // target would then reject the very pane on screen and elect a hidden one.
+  const { maximizedId, maximizeTarget } = options;
+  if (!maximizedId || !maximizeTarget) return true;
+  if (maximizeTarget.type === "group") return group?.groupId === maximizeTarget.id;
+  return maximizedId === panel.id;
 }
 
 /**
@@ -63,6 +69,7 @@ export function pickDockCloseFocusId(options: {
   panels: CarrierPanel[];
   activeWorktreeId: string | null;
   previousFocusedId: string | null;
+  maximizedId: string | null;
   maximizeTarget: MaximizeTarget;
   getPanelGroupInfo: GetPanelGroupInfo;
 }): string | null {

--- a/src/store/panelFocusFallback.ts
+++ b/src/store/panelFocusFallback.ts
@@ -1,16 +1,23 @@
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import type { MaximizeTarget } from "@/store/slices/terminalFocusSlice";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
+/** The group a panel belongs to, and which of its tabs is currently on screen. */
+export interface PanelGroupInfo {
+  groupId: string;
+  activeTabId: string | null;
+}
+
+export type GetPanelGroupInfo = (panelId: string) => PanelGroupInfo | undefined;
+
 /**
- * Whether a panel is one the user can actually see and type into right now:
- * laid out in the grid of the active worktree. Legacy rows carry no `location`
- * and are grid panels by omission.
+ * Whether a panel is laid out in the grid of the active worktree. Legacy rows
+ * carry no `location` and are grid panels by omission.
  *
- * This is the eligibility half of every focus fallback — the panel a hidden or
- * removed pane can safely hand the keyboard to. Docked panels are excluded even
- * when their popover is open: the popover is a transient surface, and handing
- * focus back to one that is closing is the bug this guards against (#11133).
+ * Docked panels are excluded even while their popover is open: the popover is a
+ * transient surface, and handing focus back to one that is closing is the bug
+ * this guards against (#11133).
  */
 export function isVisibleGridPanel(panel: CarrierPanel, activeWorktreeId: string | null): boolean {
   if (panel.location && panel.location !== "grid") return false;
@@ -18,21 +25,48 @@ export function isVisibleGridPanel(panel: CarrierPanel, activeWorktreeId: string
 }
 
 /**
+ * Whether the user can actually see this panel right now — grid membership is
+ * necessary but not sufficient. A background tab of a grid tab group and a pane
+ * sitting behind a maximized one both still read as `location: "grid"`, so a
+ * fallback that stopped at `isVisibleGridPanel` could hand the keyboard to a
+ * pane nothing renders, which is the same divergence from the other end.
+ */
+export function isRenderedGridPanel(
+  panel: CarrierPanel,
+  options: {
+    activeWorktreeId: string | null;
+    maximizeTarget: MaximizeTarget;
+    getPanelGroupInfo: GetPanelGroupInfo;
+  }
+): boolean {
+  if (!isVisibleGridPanel(panel, options.activeWorktreeId)) return false;
+
+  const group = options.getPanelGroupInfo(panel.id);
+  if (group && group.activeTabId !== null && group.activeTabId !== panel.id) return false;
+
+  const target = options.maximizeTarget;
+  if (target?.type === "panel") return target.id === panel.id;
+  if (target?.type === "group") return group?.groupId === target.id;
+  return true;
+}
+
+/**
  * Where focus goes when the open dock panel is dismissed while holding it.
  *
  * `previousFocusedId` is preferred because `openDockTerminal` records the pane
- * the user came from, which makes the round trip exact — and, when the grid is
- * maximized, that pane is the maximized target, so the choice stays visible
- * without the picker having to know about maximize state at all.
+ * the user came from, so the round trip is exact. It is still checked against
+ * the rendered set rather than trusted: a dock-to-dock switch overwrites it with
+ * the other dock pane, and the pane it named can be trashed or maximized away
+ * while the popover is open.
  */
 export function pickDockCloseFocusId(options: {
   panels: CarrierPanel[];
   activeWorktreeId: string | null;
   previousFocusedId: string | null;
+  maximizeTarget: MaximizeTarget;
+  getPanelGroupInfo: GetPanelGroupInfo;
 }): string | null {
-  const visible = options.panels.filter((panel) =>
-    isVisibleGridPanel(panel, options.activeWorktreeId)
-  );
-  const previous = visible.find((panel) => panel.id === options.previousFocusedId);
-  return previous?.id ?? visible[0]?.id ?? null;
+  const rendered = options.panels.filter((panel) => isRenderedGridPanel(panel, options));
+  const previous = rendered.find((panel) => panel.id === options.previousFocusedId);
+  return previous?.id ?? rendered[0]?.id ?? null;
 }

--- a/src/store/panelFocusFallback.ts
+++ b/src/store/panelFocusFallback.ts
@@ -1,0 +1,38 @@
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
+
+/**
+ * Whether a panel is one the user can actually see and type into right now:
+ * laid out in the grid of the active worktree. Legacy rows carry no `location`
+ * and are grid panels by omission.
+ *
+ * This is the eligibility half of every focus fallback — the panel a hidden or
+ * removed pane can safely hand the keyboard to. Docked panels are excluded even
+ * when their popover is open: the popover is a transient surface, and handing
+ * focus back to one that is closing is the bug this guards against (#11133).
+ */
+export function isVisibleGridPanel(panel: CarrierPanel, activeWorktreeId: string | null): boolean {
+  if (panel.location && panel.location !== "grid") return false;
+  return (panel.worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
+}
+
+/**
+ * Where focus goes when the open dock panel is dismissed while holding it.
+ *
+ * `previousFocusedId` is preferred because `openDockTerminal` records the pane
+ * the user came from, which makes the round trip exact — and, when the grid is
+ * maximized, that pane is the maximized target, so the choice stays visible
+ * without the picker having to know about maximize state at all.
+ */
+export function pickDockCloseFocusId(options: {
+  panels: CarrierPanel[];
+  activeWorktreeId: string | null;
+  previousFocusedId: string | null;
+}): string | null {
+  const visible = options.panels.filter((panel) =>
+    isVisibleGridPanel(panel, options.activeWorktreeId)
+  );
+  const previous = visible.find((panel) => panel.id === options.previousFocusedId);
+  return previous?.id ?? visible[0]?.id ?? null;
+}

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -291,14 +291,18 @@ export const usePanelStore = create<PanelGridState>()(
 
     const getActiveWorktreeId = () => useWorktreeSelectionStore.getState().activeWorktreeId;
     // Which tab of a panel's group is on screen — the focus fallback needs it to
-    // avoid handing the keyboard to a background tab (#11133).
+    // avoid handing the keyboard to a background tab (#11133). The stored id is
+    // resolved the same way GridTabGroup resolves it for rendering: a stale one
+    // (member removed or moved) yields to the first member, so the fallback and
+    // the renderer never disagree about which tab is visible.
     const getPanelGroupInfo = (panelId: string) => {
-      const group = get().getPanelGroup(panelId);
+      const state = get();
+      const group = state.getPanelGroup(panelId);
       if (!group) return undefined;
-      return {
-        groupId: group.id,
-        activeTabId: get().tabGroups.get(group.id)?.activeTabId ?? null,
-      };
+      const stored = state.tabGroups.get(group.id)?.activeTabId ?? null;
+      const activeTabId =
+        stored && group.panelIds.includes(stored) ? stored : (group.panelIds[0] ?? null);
+      return { groupId: group.id, activeTabId };
     };
     const focusSlice = createTerminalFocusSlice(
       getTerminals,

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -290,8 +290,21 @@ export const usePanelStore = create<PanelGridState>()(
     })(set, get, api);
 
     const getActiveWorktreeId = () => useWorktreeSelectionStore.getState().activeWorktreeId;
-    const focusSlice = createTerminalFocusSlice(getTerminals, getActiveWorktreeId, (id) =>
-      get().stampLastActive(id)
+    // Which tab of a panel's group is on screen — the focus fallback needs it to
+    // avoid handing the keyboard to a background tab (#11133).
+    const getPanelGroupInfo = (panelId: string) => {
+      const group = get().getPanelGroup(panelId);
+      if (!group) return undefined;
+      return {
+        groupId: group.id,
+        activeTabId: get().tabGroups.get(group.id)?.activeTabId ?? null,
+      };
+    };
+    const focusSlice = createTerminalFocusSlice(
+      getTerminals,
+      getActiveWorktreeId,
+      (id) => get().stampLastActive(id),
+      getPanelGroupInfo
     )(set, get, api);
     const commandQueueSlice = createTerminalCommandQueueSlice(getTerminal)(set, get, api);
     const mruSlice = createTerminalMruSlice(set, get, api);

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
 import { createTerminalFocusSlice, type TerminalFocusSlice } from "../terminalFocusSlice";
+import type { GetPanelGroupInfo } from "@/store/panelFocusFallback";
 import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/services/TerminalInstanceService", () => ({
@@ -11,6 +12,11 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 
 const mockGetActiveWorktreeId = vi.fn(() => "worktree-1" as string | null);
 const mockStampLastActive = vi.fn();
+// Ungrouped by default. The slice captures this function once at construction,
+// so the swappable half has to live behind it — reassigning the argument itself
+// would never reach an already-built slice.
+let panelGroupInfoImpl: GetPanelGroupInfo = () => undefined;
+const mockGetPanelGroupInfo: GetPanelGroupInfo = (id) => panelGroupInfoImpl(id);
 const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 
 describe("TerminalFocusSlice - Layout Snapshot", () => {
@@ -56,11 +62,12 @@ describe("TerminalFocusSlice - Layout Snapshot", () => {
       state = { ...currentState, ...updates };
     });
     getState = vi.fn(() => state);
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState,
-      getState,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState, getState, {} as never);
   });
 
   it("should capture layout snapshot when maximizing", () => {
@@ -247,11 +254,12 @@ describe("TerminalFocusSlice - preferredTerminalFocusTarget", () => {
       state = { ...currentState, ...updates };
     });
     getState = vi.fn(() => state);
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState,
-      getState,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState, getState, {} as never);
   });
 
   it("defaults to hybridInput on slice creation", () => {
@@ -351,11 +359,12 @@ describe("TerminalFocusSlice - Tab Group Maximize", () => {
       state = { ...currentState, ...updates };
     });
     getState = vi.fn(() => state);
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState,
-      getState,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState, getState, {} as never);
   });
 
   it("should maximize entire group when panel is in a group with multiple panels", () => {
@@ -683,11 +692,12 @@ describe("TerminalFocusSlice - dock focus sync invariant", () => {
       makeTerminal("dock-2", "dock"),
     ];
     const { getTerminals, setState, getState } = setup();
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
   });
 
   it("focusDockDirection sets activeDockTerminalId when moving between dock terminals", () => {
@@ -867,7 +877,8 @@ describe("TerminalFocusSlice - focusNextBlockedDock", () => {
     const focusSlice = createTerminalFocusSlice(
       getTerminals,
       mockGetActiveWorktreeId,
-      mockStampLastActive
+      mockStampLastActive,
+      mockGetPanelGroupInfo
     )(setState, getState, {} as never);
     // Add setActiveTab stub — in the real store this comes from the registry slice
     state = { ...focusSlice, setActiveTab: vi.fn() } as TerminalFocusSlice & {
@@ -1010,11 +1021,12 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
   beforeEach(() => {
     vi.clearAllMocks();
     const { getTerminals, setState, getState } = setup();
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
   });
 
   const neverInTrash = () => false;
@@ -1188,11 +1200,12 @@ describe("TerminalFocusSlice - cycle from non-matching focus (issue #5834)", () 
         state = { ...currentState, ...updates };
       }
     );
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
   });
 
   const neverInTrash = () => false;
@@ -1358,11 +1371,12 @@ describe("TerminalFocusSlice - setFocused ping gating", () => {
       state = { ...currentState, ...updates };
     });
     getState = vi.fn(() => state);
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState,
-      getState,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState, getState, {} as never);
     // Spy on pingTerminal so we can assert without running the 1600ms timer.
     pingSpy = vi.fn();
     state.pingTerminal = pingSpy as unknown as TerminalFocusSlice["pingTerminal"];
@@ -1486,11 +1500,12 @@ describe("TerminalFocusSlice - focusAlternate (last-pane toggle)", () => {
       makeTerminal("dock-1", "dock"),
     ];
     const { getTerminals, setState, getState } = setup();
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
   });
 
   it("initializes previousFocusedId to null", () => {
@@ -1701,11 +1716,12 @@ describe("TerminalFocusSlice - lastActiveAt stamping (issue #8703)", () => {
         state = { ...currentState, ...updates };
       }
     );
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
   });
 
   it("activateTerminal stamps the focused panel", () => {
@@ -1793,11 +1809,12 @@ describe("TerminalFocusSlice - boot focus (issue #9933)", () => {
         state = { ...currentState, ...updates };
       }
     );
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
   });
 
   it("setBootFocus sets focusedId and clears activeDockTerminalId", () => {
@@ -1887,6 +1904,7 @@ describe("TerminalFocusSlice - closeDockTerminal focus reconciliation (#11133)",
 
   beforeEach(() => {
     vi.clearAllMocks();
+    panelGroupInfoImpl = () => undefined;
     panels = [
       makePanel("grid-1", "grid"),
       makePanel("grid-2", "grid"),
@@ -1906,11 +1924,12 @@ describe("TerminalFocusSlice - closeDockTerminal focus reconciliation (#11133)",
         state = { ...currentState, ...updates };
       }
     );
-    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
-      setState as never,
-      getState as never,
-      {} as never
-    );
+    state = createTerminalFocusSlice(
+      getTerminals,
+      mockGetActiveWorktreeId,
+      mockStampLastActive,
+      mockGetPanelGroupInfo
+    )(setState as never, getState as never, {} as never);
     state.activeDockTerminalId = "dock-1";
     state.focusedId = "dock-1";
     state.previousFocusedId = "grid-2";
@@ -1974,5 +1993,30 @@ describe("TerminalFocusSlice - closeDockTerminal focus reconciliation (#11133)",
 
     expect(state.activeDockTerminalId).toBe("dock-2");
     expect(state.focusedId).toBe("dock-2");
+  });
+
+  it("hands focus to the maximized pane, not the first pane in the grid", () => {
+    // Only the maximized pane is on screen. A dock-to-dock switch overwrites
+    // `previousFocusedId` with the other dock pane, so the fallback cannot lean
+    // on it here — picking the first grid pane would focus one nothing renders.
+    state.previousFocusedId = "dock-2";
+    state.maximizeTarget = { type: "panel", id: "grid-2" };
+
+    state.closeDockTerminal("dock-1");
+
+    expect(state.focusedId).toBe("grid-2");
+  });
+
+  it("hands focus to a group's visible tab, never a tab behind it", () => {
+    panelGroupInfoImpl = (panelId) =>
+      panelId === "grid-1" || panelId === "grid-2"
+        ? { groupId: "group-1", activeTabId: "grid-2" }
+        : undefined;
+    state.previousFocusedId = null;
+
+    state.closeDockTerminal("dock-1");
+
+    // grid-1 comes first in panel order but is a background tab of the group.
+    expect(state.focusedId).toBe("grid-2");
   });
 });

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -2000,6 +2000,7 @@ describe("TerminalFocusSlice - closeDockTerminal focus reconciliation (#11133)",
     // `previousFocusedId` with the other dock pane, so the fallback cannot lean
     // on it here — picking the first grid pane would focus one nothing renders.
     state.previousFocusedId = "dock-2";
+    state.maximizedId = "grid-2";
     state.maximizeTarget = { type: "panel", id: "grid-2" };
 
     state.closeDockTerminal("dock-1");

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1855,3 +1855,124 @@ describe("TerminalFocusSlice - boot focus (issue #9933)", () => {
     expect(state.pingSeq).toBe(0);
   });
 });
+
+/**
+ * Closing the dock popover used to clear `activeDockTerminalId` and nothing
+ * else. If the dismissed pane held focus, `focusedId` kept pointing at it while
+ * its DOM subtree was parked in an aria-hidden container — the pane the user
+ * could no longer see went on eating every keystroke (#11133).
+ */
+describe("TerminalFocusSlice - closeDockTerminal focus reconciliation (#11133)", () => {
+  const makePanel = (
+    id: string,
+    location: "grid" | "dock",
+    worktreeId: string | undefined = "worktree-1"
+  ): PtyPanelData =>
+    ({
+      id,
+      title: id,
+      kind: "terminal",
+      type: "terminal",
+      cwd: "/test",
+      location,
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId,
+    }) as PtyPanelData;
+
+  let panels: PtyPanelData[];
+  let state: TerminalFocusSlice;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    panels = [
+      makePanel("grid-1", "grid"),
+      makePanel("grid-2", "grid"),
+      makePanel("dock-1", "dock"),
+      makePanel("dock-2", "dock"),
+    ];
+    const getTerminals = vi.fn(() => panels);
+    const getState = vi.fn((): TerminalFocusSlice => state);
+    const setState = vi.fn(
+      (
+        updater:
+          | Partial<TerminalFocusSlice>
+          | ((s: TerminalFocusSlice) => Partial<TerminalFocusSlice>)
+      ) => {
+        const currentState = getState();
+        const updates = typeof updater === "function" ? updater(currentState) : updater;
+        state = { ...currentState, ...updates };
+      }
+    );
+    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId, mockStampLastActive)(
+      setState as never,
+      getState as never,
+      {} as never
+    );
+    state.activeDockTerminalId = "dock-1";
+    state.focusedId = "dock-1";
+    state.previousFocusedId = "grid-2";
+  });
+
+  it("hands focus back to the pane the user opened the dock from", () => {
+    state.closeDockTerminal("dock-1");
+
+    expect(state.activeDockTerminalId).toBeNull();
+    expect(state.focusedId).toBe("grid-2");
+    // Automatic hand-back, not a user navigation — there is no pane to bounce
+    // back to, so the alternate pointer must not survive.
+    expect(state.previousFocusedId).toBeNull();
+  });
+
+  it("falls back to a visible grid pane when the previous pane is gone", () => {
+    state.previousFocusedId = "deleted-panel";
+
+    state.closeDockTerminal("dock-1");
+
+    expect(state.focusedId).toBe("grid-1");
+  });
+
+  it("never hands focus to another dock pane", () => {
+    state.previousFocusedId = "dock-2";
+
+    state.closeDockTerminal("dock-1");
+
+    expect(state.focusedId).toBe("grid-1");
+  });
+
+  it("clears focus when the worktree has no visible grid pane left", () => {
+    panels = [makePanel("dock-1", "dock"), makePanel("dock-2", "dock")];
+    state.previousFocusedId = null;
+
+    state.closeDockTerminal("dock-1");
+
+    expect(state.focusedId).toBeNull();
+    expect(state.activeDockTerminalId).toBeNull();
+  });
+
+  it("leaves focus alone when the dismissed pane never held it", () => {
+    state.focusedId = "grid-1";
+    state.previousFocusedId = "grid-2";
+
+    state.closeDockTerminal("dock-1");
+
+    expect(state.activeDockTerminalId).toBeNull();
+    expect(state.focusedId).toBe("grid-1");
+    expect(state.previousFocusedId).toBe("grid-2");
+  });
+
+  it("ignores a stale close for a pane the dock has already moved on from", () => {
+    // Dock popovers open and close from several places at once (chip click,
+    // drag start, Escape, the phantom-panel watchdog). A late close for the
+    // pane that *was* open must not tear focus out of the one that just won it.
+    state.activeDockTerminalId = "dock-2";
+    state.focusedId = "dock-2";
+
+    state.closeDockTerminal("dock-1");
+
+    expect(state.activeDockTerminalId).toBe("dock-2");
+    expect(state.focusedId).toBe("dock-2");
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -723,7 +723,7 @@ describe("dock watchdog hardening (#7278)", () => {
 
     // Call closeDockTerminal anyway to verify it works (the actual
     // watchdog would not call this).
-    closeDockTerminal();
+    closeDockTerminal(targetId);
     expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
   });
 
@@ -744,7 +744,7 @@ describe("dock watchdog hardening (#7278)", () => {
       !state.activeDockTerminalId || state.panelsById[state.activeDockTerminalId]
     );
     if (!shouldSkipClose) {
-      closeDockTerminal();
+      closeDockTerminal("phantom-id");
     }
     expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
   });

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -639,6 +639,7 @@ export const createTerminalFocusSlice =
             panels: getTerminals(),
             activeWorktreeId: getActiveWorktreeId(),
             previousFocusedId: state.previousFocusedId,
+            maximizedId: state.maximizedId,
             maximizeTarget: state.maximizeTarget,
             getPanelGroupInfo,
           });

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -4,6 +4,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
+import { isVisibleGridPanel, pickDockCloseFocusId } from "@/store/panelFocusFallback";
 import type { TerminalFocusTarget } from "@/components/Terminal/terminalFocus";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
@@ -184,7 +185,8 @@ export interface TerminalFocusSlice {
 
   // Dock terminal activation
   openDockTerminal: (id: string) => void;
-  closeDockTerminal: () => void;
+  /** `expectedId` names the pane being dismissed; a stale close is ignored. */
+  closeDockTerminal: (expectedId: string) => void;
   activateTerminal: (id: string | null) => void;
 
   // Agent state navigation
@@ -613,7 +615,35 @@ export const createTerminalFocusSlice =
         stampLastActive(id);
       },
 
-      closeDockTerminal: () => set({ activeDockTerminalId: null }),
+      closeDockTerminal: (expectedId) =>
+        set((state) => {
+          // A close is always *for* a pane. Dock popovers open and close from
+          // several places (chip click, drag start, Escape, the phantom-panel
+          // watchdog), and a stale close firing after another pane has already
+          // opened would otherwise tear focus out of the pane that just won it.
+          if (state.activeDockTerminalId !== expectedId) return state;
+
+          if (state.focusedId !== expectedId) {
+            return { activeDockTerminalId: null };
+          }
+
+          // The pane being hidden owns the keyboard. Leaving `focusedId` on it
+          // parks focus in a pane the user can no longer see, and every
+          // keystroke keeps flowing into it (#11133).
+          const nextFocusedId = pickDockCloseFocusId({
+            panels: getTerminals(),
+            activeWorktreeId: getActiveWorktreeId(),
+            previousFocusedId: state.previousFocusedId,
+          });
+
+          return {
+            activeDockTerminalId: null,
+            focusedId: nextFocusedId,
+            // The round-trip pointer only means something between two panes the
+            // user chose. This hand-back is automatic, so it has no alternate.
+            previousFocusedId: null,
+          };
+        }),
 
       activateTerminal: (id) => {
         if (!id) {
@@ -793,21 +823,15 @@ export const createTerminalFocusSlice =
 
           if (state.focusedId === removedId) {
             const activeWorktreeId = getActiveWorktreeId();
-            const gridTerminals = remainingTerminals.filter(
-              (t) =>
-                (t.location === "grid" || !t.location) &&
-                (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
+            const gridTerminals = remainingTerminals.filter((t) =>
+              isVisibleGridPanel(t, activeWorktreeId)
             );
 
             if (gridTerminals.length > 0) {
               const boundedIndex = Math.max(0, removedIndex);
               const precedingCount = remainingTerminals
                 .slice(0, boundedIndex)
-                .filter(
-                  (t) =>
-                    (t.location === "grid" || !t.location) &&
-                    (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
-                ).length;
+                .filter((t) => isVisibleGridPanel(t, activeWorktreeId)).length;
               const nextIndex = Math.min(precedingCount, gridTerminals.length - 1);
               updates.focusedId = gridTerminals[nextIndex]?.id || null;
             } else {

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -4,7 +4,11 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
-import { isVisibleGridPanel, pickDockCloseFocusId } from "@/store/panelFocusFallback";
+import {
+  isVisibleGridPanel,
+  pickDockCloseFocusId,
+  type GetPanelGroupInfo,
+} from "@/store/panelFocusFallback";
 import type { TerminalFocusTarget } from "@/components/Terminal/terminalFocus";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
@@ -213,7 +217,8 @@ export const createTerminalFocusSlice =
   (
     getTerminals: () => CarrierPanel[],
     getActiveWorktreeId: () => string | null,
-    stampLastActive: (id: string) => void
+    stampLastActive: (id: string) => void,
+    getPanelGroupInfo: GetPanelGroupInfo
   ): StateCreator<TerminalFocusSlice, [], [], TerminalFocusSlice> =>
   (set, get) => {
     let pingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -634,6 +639,8 @@ export const createTerminalFocusSlice =
             panels: getTerminals(),
             activeWorktreeId: getActiveWorktreeId(),
             previousFocusedId: state.previousFocusedId,
+            maximizeTarget: state.maximizeTarget,
+            getPanelGroupInfo,
           });
 
           return {


### PR DESCRIPTION
## Summary

Keyboard (DOM) focus could silently diverge from the visible focused-pane highlight, so keystrokes landed in a pane the user wasn't looking at. That's the root cause behind most of the "I typed a prompt and it's not there" reports. The issue names three verified cases, and all three were still live after the recent #11132/#11127 focus work (that fixed the registry infrastructure, not these three paths).

Resolves #11133

## Changes

**1. Dock close.** `closeDockTerminal` only cleared `activeDockTerminalId`, never `focusedId`, so a dismissed dock pane kept the keyboard. It was worse than it looked: `DockPanelOffscreenContainer.moveToDestination` deliberately re-focused the previously focused element after moving the pane's wrapper into the offscreen parking container, which is `aria-hidden` and `content-visibility: hidden`. Chromium's `moveBefore` preserves focus across the move by design, so focus genuinely survived into a container the user can't see. Now the pane is blurred before parking, `closeDockTerminal(expectedId)` reconciles `focusedId` onto a visible grid pane, and a revealed pane is re-asked for focus. The close names the pane it's closing, so a stale close (drag start, watchdog, Radix ordering) can't steal focus from a pane that just won it.

**2. Non-PTY panels.** The issue said the file panel "registers no handler." That's stale, it does register. The real gap is that the focus registry is only *invoked* by macro-grid Enter and in-group tab switches. Every other path that moves focus (arrow nav, Cmd+1..9, `focusNext`/`focusPrevious`, agent-state cycling, worktree restore) just writes `focusedId`, which paints the highlight and stops there. `TerminalPane` always had its own reactive effect to close that gap; `ContentPanel`, `ReviewPane`, and `PluginViewHost` had none. Added a shared `usePanelRootFocus` hook that gives every non-PTY panel the same reactive claim, and it yields to focus already inside the panel so it never yanks the caret out of FilePane's search box or a plugin's own input.

**3. The selection early-return.** `TerminalPane` skipped the focus handoff entirely whenever the destination xterm had a text selection, on a comment claiming "xterm v6 clears selection on blur." That premise is wrong: in the pinned 6.x, `SelectionService` reacts to input and buffer events, never to DOM blur. So a stale selection in one pane stranded the keyboard on another pane's input. The guard now only preserves the selection when the xterm holds *both* the selection and the keyboard; if focus is elsewhere, the xterm is already blurred and its selection can't be disturbed by the handoff.

**Also fixed (found in review, same invariant):**
- The maximized pane was rendered with a hardcoded `isFocused={true}`, so the prop never transitioned when the dock popover handed focus back, it never re-claimed DOM focus. It now gets its real focused state.
- The dock-close fallback is render-aware: a background tab of a grid tab group and a pane behind a maximized one both still read as `location: "grid"`, and focusing either recreated the same divergence from the other end. The predicate now mirrors `ContentGrid`'s own branching, including keying on `maximizedId` (what the grid actually renders, layout undo can leave it desynced from `maximizeTarget`).
- `focusWithCursorAtEnd` no longer drags the caret to the end of a draft when the editor already owns focus.

**Known gap, not addressed here:** `activateTerminal` doesn't call `setActiveTab` for a grouped dock pane, so agent-state cycling onto a background dock tab leaves the group rendering one tab while `focusedId` names another. This is pre-existing (reproduces before this branch) and unaffected by these changes. Fixing it means making grouped activation atomic at the store boundary, worth its own issue.

## Testing

Unit-tested the contracts, xterm focus isn't observable in this repo's E2E setup (`DAINTREE_DISABLE_WEBGL` forces the DOM renderer). New/extended suites:
- `panelFocusFallback`: render predicate and picker
- `terminalFocusSlice`: dock-close reconciliation, stale close, maximize, group tabs
- `terminalFocus`: `resolvePaneFocusAction` matrix
- `ContentPanel`, `ReviewPane`, `PluginViewHost`: reactive focus and child-focus preservation
- `DockPanelOffscreenContainer`: blur-on-park, reveal retry

Every new spec was red-before-green validated, which caught two false-greens where jsdom's `appendChild` drops focus on its own and masks the bug; those tests now model Chromium's focus-preserving `moveBefore`. No new E2E specs (PR CI runs none, and they'd need a full app build to validate locally).

Local verification: ~7,200 tests green across every touched module (Terminal, Panel, Layout, Plugin, review, store, Fleet, HelpPanel, Recovery, config, hooks), typecheck clean, eslint clean on changed files, lint ratchet passes (1111 vs 1119 baseline, no per-rule regression).
