### PR TITLE
fix(menu): track project open/close in the File-menu enabled gates

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -98,7 +98,9 @@ const projectStoreMock = vi.hoisted(() => ({
   getCurrentProjectId: vi.fn<() => string | null>(() => null),
   addProject: vi.fn<(path: string) => Promise<{ id: string; path: string }>>(),
   setCurrentProject: vi.fn<(id: string) => Promise<void>>(async () => {}),
-  getProjectById: vi.fn<(id: string) => { id: string; path: string } | null>(() => null),
+  getProjectById: vi.fn<(id: string) => { id: string; path: string; status?: string } | null>(
+    () => null
+  ),
 }));
 
 vi.mock("../services/ProjectStore.js", () => ({
@@ -360,24 +362,35 @@ describe("createApplicationMenu", () => {
     });
   });
 
-  describe("File menu Project Settings item", () => {
+  describe("File menu project-gated items", () => {
     afterEach(() => {
-      // mockReturnValue survives vi.clearAllMocks(), so restore the default or an
+      // mockReturnValue survives vi.clearAllMocks(), so restore the defaults or an
       // active project leaks into every later test in this file.
       projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+      projectStoreMock.getProjectById.mockReturnValue(null);
     });
 
-    function rebuildWithProject(projectId: string | null): Electron.MenuItemConstructorOptions {
+    // No window registry in this suite, so the menu resolver falls back to the
+    // global pointer — but it still validates the row, so the project must exist.
+    function rebuildWithProject(projectId: string | null): void {
       projectStoreMock.getCurrentProjectId.mockReturnValue(projectId);
+      projectStoreMock.getProjectById.mockImplementation((id) =>
+        projectId !== null && id === projectId
+          ? { id: projectId, path: `/tmp/${projectId}`, status: "active" }
+          : null
+      );
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
-      const item = findMenuItem(capturedTemplate, "File", "Project Settings…");
+    }
+
+    function fileItem(label: string): Electron.MenuItemConstructorOptions {
+      const item = findMenuItem(capturedTemplate, "File", label);
       expect(item).toBeDefined();
       return item!;
     }
 
     it("sends the project-settings action, not the app-settings one", () => {
-      const item = rebuildWithProject("project-1");
-      item.click!(
+      rebuildWithProject("project-1");
+      fileItem("Project Settings…").click!(
         {} as Electron.MenuItem,
         mockBrowserWindow as unknown as Electron.BaseWindow,
         {} as Electron.KeyboardEvent
@@ -388,9 +401,35 @@ describe("createApplicationMenu", () => {
       });
     });
 
-    it("is enabled only while a project is active", () => {
-      expect(rebuildWithProject("project-1").enabled).toBe(true);
-      expect(rebuildWithProject(null).enabled).toBe(false);
+    it("enables both project items only while a project is open", () => {
+      rebuildWithProject("project-1");
+      expect(fileItem("Project Settings…").enabled).toBe(true);
+      expect(fileItem("Close Project").enabled).toBe(true);
+
+      rebuildWithProject(null);
+      expect(fileItem("Project Settings…").enabled).toBe(false);
+      expect(fileItem("Close Project").enabled).toBe(false);
+    });
+
+    it("disables both items when the pointed-at project row is closed", () => {
+      // The pointer can outlive the open project: the row's status is what
+      // decides, not the id's presence.
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-1");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-1",
+        path: "/tmp/project-1",
+        status: "closed",
+      });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      expect(fileItem("Project Settings…").enabled).toBe(false);
+      expect(fileItem("Close Project").enabled).toBe(false);
+    });
+
+    it("gives both items stable ids so the live refresh can address them", () => {
+      rebuildWithProject("project-1");
+      expect(fileItem("Project Settings…").id).toBe("file-project-settings");
+      expect(fileItem("Close Project").id).toBe("file-close-project");
     });
   });
 
@@ -820,6 +859,7 @@ describe("handleDirectoryOpen window targeting", () => {
         view: { webContents: { isDestroyed: () => false, send: vi.fn() } },
         isNew: true,
       })),
+      getActiveProjectId: vi.fn<() => string | null>(() => null),
     };
   }
 
@@ -839,6 +879,9 @@ describe("handleDirectoryOpen window targeting", () => {
     windowRefMock.getWindowRegistry.mockReturnValue({
       getByWindowId: (id: number) =>
         id === 7 ? { services: { projectViewManager: targetManager } } : undefined,
+      // handleDirectoryOpen rebuilds the menu, and the rebuild resolves the
+      // project gates against the focused window.
+      getPrimary: () => ({ services: { projectViewManager: targetManager } }),
     });
     windowRefMock.getProjectViewManager.mockReturnValue(newestManager);
 

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -431,6 +431,19 @@ describe("createApplicationMenu", () => {
       expect(fileItem("Project Settings…").id).toBe("file-project-settings");
       expect(fileItem("Close Project").id).toBe("file-close-project");
     });
+
+    it("resolves the gate from repaired project rows, not a pre-repair snapshot", () => {
+      vi.clearAllMocks();
+      rebuildWithProject("project-1");
+
+      // Building Open Recent calls getAllProjects(), which repairs stale status
+      // rows as a side effect (a "closed" row that is still the current pointer
+      // is promoted back to "active"). Resolving the gate first would snapshot
+      // pre-repair rows and install a template the repair contradicts.
+      expect(projectStoreMock.getAllProjects.mock.invocationCallOrder[0]).toBeLessThan(
+        projectStoreMock.getCurrentProjectId.mock.invocationCallOrder[0]
+      );
+    });
   });
 
   describe("View menu Toggle Full Screen item", () => {
@@ -860,6 +873,7 @@ describe("handleDirectoryOpen window targeting", () => {
         isNew: true,
       })),
       getActiveProjectId: vi.fn<() => string | null>(() => null),
+      getOutgoingBridgeProjectId: vi.fn<() => string | null>(() => null),
     };
   }
 

--- a/electron/__tests__/projectMenuState.test.ts
+++ b/electron/__tests__/projectMenuState.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+interface FakeProject {
+  id: string;
+  path: string;
+  status: string;
+}
+
+const projectStoreMock = vi.hoisted(() => ({
+  getCurrentProjectId: vi.fn<() => string | null>(() => null),
+  getProjectById: vi.fn<(id: string) => FakeProject | null>(() => null),
+}));
+
+vi.mock("../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+const windowRefMock = vi.hoisted(() => ({
+  getWindowRegistry: vi.fn<() => unknown>(() => undefined),
+}));
+
+vi.mock("../window/windowRef.js", () => windowRefMock);
+
+// Mirrors the real menu: getMenuItemById hands back the live MenuItem, and
+// assigning .enabled on it is what repaints the native menu.
+const menuItems = new Map<string, { enabled: boolean }>();
+const applicationMenu = {
+  getMenuItemById: vi.fn((id: string) => menuItems.get(id) ?? null),
+};
+const getApplicationMenuMock = vi.hoisted(() => vi.fn<() => unknown>());
+
+vi.mock("electron", () => ({
+  Menu: { getApplicationMenu: getApplicationMenuMock },
+}));
+
+const { PROJECT_MENU_ITEM_IDS, refreshProjectMenuState, resolveProjectIdForApplicationMenu } =
+  await import("../projectMenuState.js");
+
+const [SETTINGS_ID, CLOSE_ID] = PROJECT_MENU_ITEM_IDS;
+
+function openProject(id: string, status = "active"): FakeProject {
+  return { id, path: `/tmp/${id}`, status };
+}
+
+/** A window whose ProjectViewManager reports `activeId` as its active workspace. */
+function pvmWindow(activeId: string | null) {
+  return { services: { projectViewManager: { getActiveProjectId: () => activeId } } };
+}
+
+/** A window with no ProjectViewManager at all (legacy host). */
+function legacyWindow() {
+  return { services: {} };
+}
+
+function registryWith(primary: unknown) {
+  return { getPrimary: () => primary };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  projectStoreMock.getCurrentProjectId.mockReturnValue(null);
+  projectStoreMock.getProjectById.mockReturnValue(null);
+  windowRefMock.getWindowRegistry.mockReturnValue(undefined);
+
+  menuItems.clear();
+  menuItems.set(SETTINGS_ID, { enabled: false });
+  menuItems.set(CLOSE_ID, { enabled: false });
+  getApplicationMenuMock.mockReturnValue(applicationMenu);
+});
+
+describe("resolveProjectIdForApplicationMenu", () => {
+  it("reads the focused window's project, not the global most-recently-switched pointer", () => {
+    // The classic multi-window trap: the global pointer names the project that
+    // switched last, which is NOT what the focused window is showing.
+    projectStoreMock.getCurrentProjectId.mockReturnValue("other-window-project");
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("focused-project")));
+
+    expect(resolveProjectIdForApplicationMenu()).toBe("focused-project");
+  });
+
+  it("reports no project when the focused window shows none, even if the pointer names one", () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("other-window-project");
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow(null)));
+
+    expect(resolveProjectIdForApplicationMenu()).toBeNull();
+  });
+
+  it("rejects a project whose row is closed even while the window is still bound to it", () => {
+    // Closing a project marks the row "closed" but leaves the window's PVM
+    // pointing at it. Trusting the raw PVM id would leave the gates stuck open —
+    // this is the close half of #11136.
+    projectStoreMock.getProjectById.mockReturnValue(openProject("project-1", "closed"));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-1")));
+
+    expect(resolveProjectIdForApplicationMenu()).toBeNull();
+  });
+
+  it("rejects a scratch workspace, which has a PVM id but no project row", () => {
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("scratch-uuid")));
+
+    expect(resolveProjectIdForApplicationMenu()).toBeNull();
+  });
+
+  it("keeps a project open when its row is background (status is process-global)", () => {
+    // A project visible in a non-focused window is legitimately "background",
+    // so only "closed" may disable the gates.
+    projectStoreMock.getProjectById.mockReturnValue(openProject("project-1", "background"));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-1")));
+
+    expect(resolveProjectIdForApplicationMenu()).toBe("project-1");
+  });
+
+  it("reports no project when the app is windowless, without falling back to the pointer", () => {
+    // macOS keeps the menu bar alive with zero windows; nothing is on screen.
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-1");
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(undefined));
+
+    expect(resolveProjectIdForApplicationMenu()).toBeNull();
+  });
+
+  it("falls back to the global pointer for a window with no ProjectViewManager", () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-1");
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(legacyWindow()));
+
+    expect(resolveProjectIdForApplicationMenu()).toBe("project-1");
+  });
+
+  it("falls back to the global pointer when there is no window layer at all", () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-1");
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+    windowRefMock.getWindowRegistry.mockReturnValue(undefined);
+
+    expect(resolveProjectIdForApplicationMenu()).toBe("project-1");
+  });
+
+  it("still validates the row when falling back to the global pointer", () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-1");
+    projectStoreMock.getProjectById.mockReturnValue(openProject("project-1", "closed"));
+    windowRefMock.getWindowRegistry.mockReturnValue(undefined);
+
+    expect(resolveProjectIdForApplicationMenu()).toBeNull();
+  });
+});
+
+describe("refreshProjectMenuState", () => {
+  it("enables both gates when a project opens in the focused window", () => {
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-1")));
+
+    refreshProjectMenuState();
+
+    expect(menuItems.get(SETTINGS_ID)!.enabled).toBe(true);
+    expect(menuItems.get(CLOSE_ID)!.enabled).toBe(true);
+  });
+
+  it("disables both gates when the focused project closes", () => {
+    // Drive the real transition: enabled while open, then the row goes "closed"
+    // with the PVM binding left intact, exactly as handleProjectClose leaves it.
+    projectStoreMock.getProjectById.mockReturnValue(openProject("project-1"));
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-1")));
+    refreshProjectMenuState();
+    expect(menuItems.get(CLOSE_ID)!.enabled).toBe(true);
+
+    projectStoreMock.getProjectById.mockReturnValue(openProject("project-1", "closed"));
+    refreshProjectMenuState();
+
+    expect(menuItems.get(SETTINGS_ID)!.enabled).toBe(false);
+    expect(menuItems.get(CLOSE_ID)!.enabled).toBe(false);
+  });
+
+  it("tracks focus moving between a project window and a welcome window", () => {
+    projectStoreMock.getProjectById.mockImplementation((id) => openProject(id));
+
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-1")));
+    refreshProjectMenuState();
+    expect(menuItems.get(CLOSE_ID)!.enabled).toBe(true);
+
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow(null)));
+    refreshProjectMenuState();
+    expect(menuItems.get(CLOSE_ID)!.enabled).toBe(false);
+
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-2")));
+    refreshProjectMenuState();
+    expect(menuItems.get(CLOSE_ID)!.enabled).toBe(true);
+  });
+
+  it("does not throw when no application menu has been built yet", () => {
+    getApplicationMenuMock.mockReturnValue(null);
+    expect(() => refreshProjectMenuState()).not.toThrow();
+  });
+
+  it("does not throw when the menu is missing the project items", () => {
+    menuItems.clear();
+    expect(() => refreshProjectMenuState()).not.toThrow();
+  });
+});

--- a/electron/__tests__/projectMenuState.test.ts
+++ b/electron/__tests__/projectMenuState.test.ts
@@ -40,9 +40,19 @@ function openProject(id: string, status = "active"): FakeProject {
   return { id, path: `/tmp/${id}`, status };
 }
 
-/** A window whose ProjectViewManager reports `activeId` as its active workspace. */
-function pvmWindow(activeId: string | null) {
-  return { services: { projectViewManager: { getActiveProjectId: () => activeId } } };
+/**
+ * A window whose ProjectViewManager reports `activeId` as its active workspace,
+ * and `bridgeId` as the still-painted outgoing project of an open paint gate.
+ */
+function pvmWindow(activeId: string | null, bridgeId: string | null = null) {
+  return {
+    services: {
+      projectViewManager: {
+        getActiveProjectId: () => activeId,
+        getOutgoingBridgeProjectId: () => bridgeId,
+      },
+    },
+  };
 }
 
 /** A window with no ProjectViewManager at all (legacy host). */
@@ -143,6 +153,31 @@ describe("resolveProjectIdForApplicationMenu", () => {
 
     expect(resolveProjectIdForApplicationMenu()).toBeNull();
   });
+
+  it("answers with the project still painted behind an open paint gate", () => {
+    // Mid cold-switch from project-1 to a scratch: the PVM already reports the
+    // scratch as active, but project-1's view is still on screen as the
+    // anti-flash bridge. Reading only the active id would blink the gates off.
+    projectStoreMock.getProjectById.mockImplementation((id) =>
+      id === "project-1" ? openProject("project-1") : null
+    );
+    windowRefMock.getWindowRegistry.mockReturnValue(
+      registryWith(pvmWindow("scratch-uuid", "project-1"))
+    );
+
+    expect(resolveProjectIdForApplicationMenu()).toBe("project-1");
+  });
+
+  it("ignores a bridge whose project is no longer open", () => {
+    projectStoreMock.getProjectById.mockImplementation((id) =>
+      id === "project-2" ? openProject("project-2") : openProject("project-1", "closed")
+    );
+    windowRefMock.getWindowRegistry.mockReturnValue(
+      registryWith(pvmWindow("project-2", "project-1"))
+    );
+
+    expect(resolveProjectIdForApplicationMenu()).toBe("project-2");
+  });
 });
 
 describe("refreshProjectMenuState", () => {
@@ -195,5 +230,20 @@ describe("refreshProjectMenuState", () => {
   it("does not throw when the menu is missing the project items", () => {
     menuItems.clear();
     expect(() => refreshProjectMenuState()).not.toThrow();
+  });
+
+  it("swallows a resolver failure instead of masking the caller's error", () => {
+    // Callers refresh from a `finally` after a project switch, so a throw here
+    // would REPLACE the original rejection and hide the real failure.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    projectStoreMock.getProjectById.mockImplementation(() => {
+      throw new Error("SQLITE_IOERR");
+    });
+    windowRefMock.getWindowRegistry.mockReturnValue(registryWith(pvmWindow("project-1")));
+
+    expect(() => refreshProjectMenuState()).not.toThrow();
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 });

--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -42,6 +42,11 @@ vi.mock("../../../services/ProjectSwitchService.js", () => ({
   },
 }));
 
+const refreshProjectMenuStateMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../projectMenuState.js", () => ({
+  refreshProjectMenuState: refreshProjectMenuStateMock,
+}));
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
@@ -102,6 +107,15 @@ describe("project:close handler", () => {
     expect(projectStoreMock.clearProjectState).toHaveBeenCalledWith("project-active");
     expect(projectStoreMock.clearCurrentProject).toHaveBeenCalled();
     expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-active", "closed");
+
+    // The File-menu project gates must drop with the project (#11136), and the
+    // refresh has to run AFTER the "closed" write: the closing window's
+    // ProjectViewManager still points at this project, so the row's status is
+    // what tells the resolver it is no longer open.
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+    expect(refreshProjectMenuStateMock.mock.invocationCallOrder[0]).toBeGreaterThan(
+      projectStoreMock.updateProjectStatus.mock.invocationCallOrder[0]
+    );
   });
 
   it("rejects closing the active project when not killing terminals", async () => {

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -44,6 +44,11 @@ const windowStateMock = vi.hoisted(() => ({
 
 vi.mock("../../../windowState.js", () => windowStateMock);
 
+const refreshProjectMenuStateMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../projectMenuState.js", () => ({
+  refreshProjectMenuState: refreshProjectMenuStateMock,
+}));
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
@@ -89,6 +94,9 @@ describe("project:remove handler", () => {
     const killOrder = ptyClient.killByProject.mock.invocationCallOrder[0];
     const removeOrder = projectStoreMock.removeProject.mock.invocationCallOrder[0];
     expect(killOrder).toBeLessThan(removeOrder);
+
+    // The row is gone, so a window still bound to it has no project open (#11136).
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
   });
 
   it("still removes the project when killByProject fails", async () => {

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -102,6 +102,11 @@ vi.mock("../../projectSwitchBroadcast.js", () => ({
     mockBroadcastProjectSwitchUpdates(previousProjectId, activeProjectId),
 }));
 
+const refreshProjectMenuStateMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../projectMenuState.js", () => ({
+  refreshProjectMenuState: refreshProjectMenuStateMock,
+}));
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { distributePortsToView } from "../../../window/portDistribution.js";
@@ -143,6 +148,113 @@ function makeWindowRegistry(contexts: WindowContext[]): WindowRegistry {
     },
   } as unknown as WindowRegistry;
 }
+
+// #11136: the File-menu "Close Project" / "Project Settings…" gates are computed
+// when the menu is built, so every path that opens a project has to refresh them
+// or they stay disabled until something unrelated rebuilds the menu.
+describe("project switch/reopen refreshes the File-menu project gates (#11136)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWindowForWebContents.mockReturnValue({ id: 1, isDestroyed: () => false });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+  });
+
+  function handlerFor(channel: string, deps: HandlerDependencies) {
+    registerProjectCrudHandlers(deps);
+    const call = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === channel
+    );
+    expect(call).toBeDefined();
+    return call![1] as (...args: unknown[]) => Promise<unknown>;
+  }
+
+  function depsWith(pvm: unknown | null): HandlerDependencies {
+    const ctx = makeWindowContext(
+      1,
+      10,
+      pvm ? { projectViewManager: pvm as never } : {} // no PVM ⇒ legacy path
+    );
+    return {
+      mainWindow: { id: 1 } as unknown,
+      windowRegistry: makeWindowRegistry([ctx]),
+      ...(pvm ? { projectViewManager: pvm } : {}),
+    } as unknown as HandlerDependencies;
+  }
+
+  function makePvm() {
+    return {
+      switchTo: vi.fn().mockResolvedValue({
+        view: { webContents: { id: 200, isDestroyed: () => false, send: vi.fn() } },
+        isNew: false,
+      }),
+      getProjectIdForWebContents: vi.fn(),
+      setPendingFocusIntent: vi.fn(),
+    };
+  }
+
+  it("refreshes after a PVM-backed switch", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New",
+      path: "/projects/new",
+    });
+    const handler = handlerFor(CHANNELS.PROJECT_SWITCH, depsWith(makePvm()));
+
+    await handler({ sender: { id: 10 } }, "proj-new");
+
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+
+  it("refreshes after a legacy (no-PVM) switch", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New",
+      path: "/projects/new",
+    });
+    const handler = handlerFor(CHANNELS.PROJECT_SWITCH, depsWith(null));
+
+    await handler({ sender: { id: 10 } }, "proj-new");
+
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+
+  it("refreshes after a PVM-backed reopen", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-bg",
+      name: "Backgrounded",
+      path: "/projects/bg",
+      status: "background",
+    });
+    const handler = handlerFor(CHANNELS.PROJECT_REOPEN, depsWith(makePvm()));
+
+    await handler({ sender: { id: 10 } }, "proj-bg");
+
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+
+  it("refreshes after a legacy (no-PVM) reopen", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-bg",
+      name: "Backgrounded",
+      path: "/projects/bg",
+      status: "background",
+    });
+    const handler = handlerFor(CHANNELS.PROJECT_REOPEN, depsWith(null));
+
+    await handler({ sender: { id: 10 } }, "proj-bg");
+
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+
+  it("does not refresh when the switch is rejected for an unknown project", async () => {
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    const handler = handlerFor(CHANNELS.PROJECT_SWITCH, depsWith(makePvm()));
+
+    await expect(handler({ sender: { id: 10 } }, "ghost")).rejects.toThrow();
+
+    expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("project:switch multi-window PVM routing", () => {
   beforeEach(() => {

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -252,7 +252,25 @@ describe("project switch/reopen refreshes the File-menu project gates (#11136)",
 
     await expect(handler({ sender: { id: 10 } }, "ghost")).rejects.toThrow();
 
+    // Rejected before the swap ran, so nothing moved and there is nothing to converge.
     expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes when the swap fails, so a rolled-back binding converges", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New",
+      path: "/projects/new",
+    });
+    const pvm = makePvm();
+    pvm.switchTo.mockRejectedValue(new Error("view failed to load"));
+    const handler = handlerFor(CHANNELS.PROJECT_SWITCH, depsWith(pvm));
+
+    await expect(handler({ sender: { id: 10 } }, "proj-new")).rejects.toThrow();
+
+    // Once the swap has run, the PVM binding has moved or been rolled back — the
+    // gates must reflect where we actually landed, not stay stale.
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../window/activeProjectIds.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
+import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
@@ -100,6 +101,8 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       pruneWindowStateForPath(removedPath);
     }
     broadcastToRenderer(CHANNELS.PROJECT_REMOVED, projectId);
+    // The row is gone, so a window still bound to it no longer has a project open.
+    refreshProjectMenuState();
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_REMOVE, handleProjectRemove));
 
@@ -207,6 +210,11 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
           projectStore.clearCurrentProject();
         }
         projectStore.updateProjectStatus(projectId, "closed");
+
+        // After the "closed" write, not merely after clearCurrentProject(): the
+        // closing window's ProjectViewManager still points at this project, so
+        // the row's status is what tells the menu resolver it isn't open.
+        refreshProjectMenuState();
 
         console.log(
           `[IPC] project:close: Killed ${terminalsKilled} process(es) ` +

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -11,6 +11,7 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js";
 import { broadcastProjectSwitchUpdates } from "../../projectSwitchBroadcast.js";
+import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { logInfo } from "../../../utils/logger.js";
 import {
@@ -69,6 +70,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
         resumeWorkspace: true,
       });
       await persistOutgoing;
+      refreshProjectMenuState();
       return project;
     }
 
@@ -86,7 +88,9 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       }
       deps.worktreeService.resumeProject(project.path);
     }
-    return await projectSwitchService.switchProject(projectId);
+    const switched = await projectSwitchService.switchProject(projectId);
+    refreshProjectMenuState();
+    return switched;
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_SWITCH, handleProjectSwitch));
 
@@ -133,6 +137,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
         resumeWorkspace: true,
       });
       await persistOutgoing;
+      refreshProjectMenuState();
       return project;
     }
 
@@ -140,7 +145,9 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     if (deps.worktreeService) {
       deps.worktreeService.resumeProject(project.path);
     }
-    return await projectSwitchService.reopenProject(projectId);
+    const reopened = await projectSwitchService.reopenProject(projectId);
+    refreshProjectMenuState();
+    return reopened;
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));
 

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -65,12 +65,19 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       // Rapid switch-back: a cold-start hydrate of the target must not read
       // its state file while a previous switch's persist is still writing it.
       await awaitPendingOutgoingPersist(projectId);
-      await activateProjectView(deps, operation, pvm, project, {
-        logPrefix: "[ProjectSwitch]",
-        resumeWorkspace: true,
-      });
-      await persistOutgoing;
-      refreshProjectMenuState();
+      try {
+        await activateProjectView(deps, operation, pvm, project, {
+          logPrefix: "[ProjectSwitch]",
+          resumeWorkspace: true,
+        });
+        await persistOutgoing;
+      } finally {
+        // In `finally`, not after the awaits: once the swap has run, the PVM
+        // binding has moved (or been rolled back), so the gates must converge on
+        // whatever state we actually landed in — including when the outgoing
+        // persist rejects after a visually successful activation.
+        refreshProjectMenuState();
+      }
       return project;
     }
 
@@ -88,9 +95,11 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       }
       deps.worktreeService.resumeProject(project.path);
     }
-    const switched = await projectSwitchService.switchProject(projectId);
-    refreshProjectMenuState();
-    return switched;
+    try {
+      return await projectSwitchService.switchProject(projectId);
+    } finally {
+      refreshProjectMenuState();
+    }
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_SWITCH, handleProjectSwitch));
 
@@ -131,13 +140,16 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
 
     if (pvm) {
       await awaitPendingOutgoingPersist(projectId);
-      await activateProjectView(deps, operation, pvm, project, {
-        logPrefix: "[ProjectReopen]",
-        markActive: true,
-        resumeWorkspace: true,
-      });
-      await persistOutgoing;
-      refreshProjectMenuState();
+      try {
+        await activateProjectView(deps, operation, pvm, project, {
+          logPrefix: "[ProjectReopen]",
+          markActive: true,
+          resumeWorkspace: true,
+        });
+        await persistOutgoing;
+      } finally {
+        refreshProjectMenuState();
+      }
       return project;
     }
 
@@ -145,9 +157,11 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     if (deps.worktreeService) {
       deps.worktreeService.resumeProject(project.path);
     }
-    const reopened = await projectSwitchService.reopenProject(projectId);
-    refreshProjectMenuState();
-    return reopened;
+    try {
+      return await projectSwitchService.reopenProject(projectId);
+    } finally {
+      refreshProjectMenuState();
+    }
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));
 

--- a/electron/ipc/handlers/scratch/__tests__/switch.test.ts
+++ b/electron/ipc/handlers/scratch/__tests__/switch.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue(os.tmpdir()),
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+const scratchStoreMock = vi.hoisted(() => ({
+  getAllScratches: vi.fn(() => []),
+  getCurrentScratch: vi.fn(() => null),
+  getScratchById: vi.fn<(id: string) => { id: string; path: string } | null>(),
+  createScratch: vi.fn(),
+  updateScratch: vi.fn(),
+  removeScratch: vi.fn(),
+  setCurrentScratch: vi.fn<(id: string) => unknown>(),
+}));
+
+vi.mock("../../../../services/ScratchStore.js", () => ({
+  scratchStore: scratchStoreMock,
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  clearCurrentProject: vi.fn(),
+}));
+
+vi.mock("../../../../services/ProjectStore.js", () => ({
+  projectStore: projectStoreMock,
+}));
+
+const refreshProjectMenuStateMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../../projectMenuState.js", () => ({
+  refreshProjectMenuState: refreshProjectMenuStateMock,
+}));
+
+// buildIpcContext resolves the sender's project through this registry, so the
+// factory has to export it even though this suite never asserts on it.
+vi.mock("../../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: vi.fn(() => null),
+  getProjectForWebContents: vi.fn(() => null),
+}));
+
+const broadcastMock = vi.hoisted(() => ({ broadcastToRenderer: vi.fn() }));
+vi.mock("../../../utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../utils.js")>();
+  return { ...actual, broadcastToRenderer: broadcastMock.broadcastToRenderer };
+});
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../../channels.js";
+import { registerScratchHandlers } from "../index.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+function getHandler(channel: string) {
+  const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+    .calls;
+  return calls.find((c) => c[0] === channel)?.[1] as (
+    event: unknown,
+    ...args: unknown[]
+  ) => Promise<unknown>;
+}
+
+const fakeEvent = { sender: { id: 1 }, senderFrame: { url: "http://localhost:5173" } };
+
+// #11136: a scratch is not a project. Switching to one leaves the window's
+// ProjectViewManager holding a scratch id that has no project row, so the
+// File-menu project gates have to drop — but only a refresh makes the menu notice.
+describe("scratch:switch refreshes the File-menu project gates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scratchStoreMock.getScratchById.mockReturnValue({ id: "scratch-1", path: "/tmp/scratch-1" });
+    scratchStoreMock.setCurrentScratch.mockReturnValue({
+      id: "scratch-1",
+      path: "/tmp/scratch-1",
+    });
+  });
+
+  function makeDeps(): HandlerDependencies {
+    return { mainWindow: {} as unknown } as unknown as HandlerDependencies;
+  }
+
+  it("refreshes after the canonical pointers move to the scratch", async () => {
+    registerScratchHandlers(makeDeps());
+
+    await getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, "scratch-1");
+
+    expect(projectStoreMock.clearCurrentProject).toHaveBeenCalled();
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+
+    // Refreshing before the project pointer is cleared would re-read the old
+    // project and leave the gates enabled.
+    expect(refreshProjectMenuStateMock.mock.invocationCallOrder[0]).toBeGreaterThan(
+      projectStoreMock.clearCurrentProject.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("does not refresh when the scratch does not exist", async () => {
+    scratchStoreMock.getScratchById.mockReturnValue(null);
+    registerScratchHandlers(makeDeps());
+
+    await expect(getHandler(CHANNELS.SCRATCH_SWITCH)(fakeEvent, "ghost")).rejects.toThrow();
+
+    expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -19,6 +19,7 @@ import { getWindowForWebContents } from "../../../window/webContentsRegistry.js"
 import { distributePortsToView } from "../../../window/portDistribution.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import { addProjectByPath } from "../projectCrud/crud.js";
 import { createHardenedGit } from "../../../utils/hardenedGit.js";
 import { logError } from "../../../utils/logger.js";
@@ -110,6 +111,10 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
           // renderer's `getCurrentProject` does not race-restore the previous project.
           const updated = scratchStore.setCurrentScratch(scratchId);
           projectStore.clearCurrentProject();
+
+          // A scratch is not a project: the window's PVM now holds a scratch id
+          // with no project row, so the File-menu project gates must drop.
+          refreshProjectMenuState();
 
           // Tell the PTY host the active workspace changed. PtyClient treats the ID
           // as an opaque string and the path as a working directory, so passing a

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -433,6 +433,35 @@ describe("registerAppLifecycleHandlers – window-all-closed", () => {
     expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
   });
 
+  it("refreshes the gates after a closing window's survivor is promoted", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    const createdCall = appMock.on.mock.calls.find(
+      ([event]: string[]) => event === "browser-window-created"
+    );
+    expect(createdCall).toBeDefined();
+
+    const winListeners: Record<string, () => void> = {};
+    const fakeWin = {
+      once: (event: string, cb: () => void) => {
+        winListeners[event] = cb;
+      },
+    };
+    (createdCall![1] as (event: unknown, win: unknown) => void)({}, fakeWin);
+
+    winListeners.closed();
+
+    // Must NOT be synchronous: WindowRegistry promotes the surviving window in
+    // its own "closed" listener, registered after this one. Refreshing now would
+    // still resolve against the window that is going away.
+    expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+
   it("refreshes the File-menu project gates whenever a window takes focus", async () => {
     const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
     registerAppLifecycleHandlers(makeOpts());

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -457,7 +457,7 @@ describe("registerAppLifecycleHandlers – window-all-closed", () => {
     // still resolve against the window that is going away.
     expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
 
-    await new Promise((resolve) => setImmediate(resolve));
+    await Promise.resolve();
 
     expect(refreshProjectMenuStateMock).toHaveBeenCalled();
   });

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -27,6 +27,11 @@ vi.mock("../../menu.js", () => ({
   handleDirectoryOpen: vi.fn(() => Promise.resolve()),
 }));
 
+const refreshProjectMenuStateMock = vi.hoisted(() => vi.fn());
+vi.mock("../../projectMenuState.js", () => ({
+  refreshProjectMenuState: refreshProjectMenuStateMock,
+}));
+
 const setSignalShutdownMock = vi.fn();
 const setSafetyBeltTimerMock = vi.fn();
 vi.mock("../signalShutdownState.js", () => ({
@@ -401,6 +406,45 @@ describe("registerAppLifecycleHandlers – window-all-closed", () => {
 
     // Suppressing the quit during OOM recreate is the whole point of #5724.
     expect(appMock.quit).not.toHaveBeenCalled();
+  });
+
+  it("clears the File-menu project gates when the app goes windowless", async () => {
+    // `browser-window-focus` never fires when focus drops to zero windows, so on
+    // macOS (which survives windowless) this is the only signal that can drop the
+    // gates (#11136).
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    getWindowAllClosedHandler()();
+
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+  });
+
+  it("does not touch the menu gates while a window recreation is in flight", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    isWindowRecreatingMock.mockReturnValue(true);
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    getWindowAllClosedHandler()();
+
+    // The replacement window is about to take focus and refresh them anyway.
+    expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the File-menu project gates whenever a window takes focus", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    const focusCall = appMock.on.mock.calls.find(
+      ([event]: string[]) => event === "browser-window-focus"
+    );
+    expect(focusCall).toBeDefined();
+    (focusCall![1] as () => void)();
+
+    // The menu is process-global but its gates track the focused window's project.
+    expect(refreshProjectMenuStateMock).toHaveBeenCalled();
   });
 
   it("does not call app.quit on darwin even when no recreation is in flight", async () => {

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -282,10 +282,12 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     win.once("closed", () => {
       // Closing the focused window promotes a survivor that may never take focus
       // (minimized/hidden), so `browser-window-focus` can't be relied on here.
-      // Deferred a tick because WindowRegistry attaches its own "closed" listener
-      // at register() — after this one — and that listener is what performs the
-      // promotion; refreshing synchronously would still read the closing window.
-      setImmediate(() => refreshProjectMenuState());
+      // Deferred because WindowRegistry attaches its own "closed" listener at
+      // register() — after this one — and that listener performs the promotion
+      // synchronously; refreshing inline would still read the closing window. A
+      // microtask runs once every listener for this emit has, which is exactly
+      // the ordering we need.
+      queueMicrotask(() => refreshProjectMenuState());
     });
   });
 

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -278,6 +278,17 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     refreshProjectMenuState();
   });
 
+  app.on("browser-window-created", (_event, win) => {
+    win.once("closed", () => {
+      // Closing the focused window promotes a survivor that may never take focus
+      // (minimized/hidden), so `browser-window-focus` can't be relied on here.
+      // Deferred a tick because WindowRegistry attaches its own "closed" listener
+      // at register() — after this one — and that listener is what performs the
+      // promotion; refreshing synchronously would still read the closing window.
+      setImmediate(() => refreshProjectMenuState());
+    });
+  });
+
   app.on("window-all-closed", () => {
     // `BrowserWindow.destroy()` in the OOM recreate path synchronously emits
     // `window-all-closed` before the replacement window registers. On

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { handleDirectoryOpen } from "../menu.js";
+import { refreshProjectMenuState } from "../projectMenuState.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -271,12 +272,24 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     }
   });
 
+  // The application menu is process-global but its project gates track the
+  // focused window, so every focus change can flip them (#11136).
+  app.on("browser-window-focus", () => {
+    refreshProjectMenuState();
+  });
+
   app.on("window-all-closed", () => {
     // `BrowserWindow.destroy()` in the OOM recreate path synchronously emits
     // `window-all-closed` before the replacement window registers. On
     // non-darwin this would call `app.quit()` mid-recreate; the flag suppresses
     // that until the recreation settles. See `windowRecreationState.ts`.
     if (isWindowRecreating()) return;
+
+    // `browser-window-focus` never fires when focus drops to zero windows, so
+    // this is the only signal that clears the gates on macOS, where the app
+    // survives windowless with just its menu bar.
+    refreshProjectMenuState();
+
     if (process.platform !== "darwin") {
       app.quit();
     }

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -170,6 +170,15 @@ export function createApplicationMenu(
   const terminalPluginItems = buildPluginMenuItems("terminal");
   const helpPluginItems = buildPluginMenuItems("help");
 
+  // Built BEFORE the gate is resolved: this reads getAllProjects(), which
+  // repairs stale status rows as a side effect (a "closed" row that is still the
+  // current pointer gets promoted back to "active"). Resolving first would snapshot
+  // the gate from pre-repair rows and install a template the repair contradicts.
+  const recentProjectsMenu = buildRecentProjectsMenu(
+    getTargetBrowserWindow,
+    cliAvailabilityService
+  );
+
   // Same resolver the live refresh uses, so the cold build and every later
   // refresh agree on what "a project is open" means.
   const projectMenuEnabled = resolveProjectIdForApplicationMenu() !== null;
@@ -214,7 +223,7 @@ export function createApplicationMenu(
         },
         {
           label: "Open Recent",
-          submenu: buildRecentProjectsMenu(getTargetBrowserWindow, cliAvailabilityService),
+          submenu: recentProjectsMenu,
         },
         { type: "separator" },
         ...(process.platform !== "darwin"

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -22,6 +22,7 @@ import { getAutoUpdaterServiceRef } from "./window/serviceRefs.js";
 import { getPluginMenuItems } from "./services/pluginMenuRegistry.js";
 import { evaluateWhen } from "./services/WhenClauseService.js";
 import { getAppWebContents } from "./window/webContentsRegistry.js";
+import { PROJECT_MENU_ITEM_IDS, resolveProjectIdForApplicationMenu } from "./projectMenuState.js";
 import { PRODUCT_NAME, PRODUCT_WEBSITE, PRODUCT_COPYRIGHT_ORG } from "./utils/productBranding.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 import { isWindowsStoreBuild, getBuildChannelLabel } from "../shared/config/distribution.js";
@@ -169,6 +170,10 @@ export function createApplicationMenu(
   const terminalPluginItems = buildPluginMenuItems("terminal");
   const helpPluginItems = buildPluginMenuItems("help");
 
+  // Same resolver the live refresh uses, so the cold build and every later
+  // refresh agree on what "a project is open" means.
+  const projectMenuEnabled = resolveProjectIdForApplicationMenu() !== null;
+
   const template: Electron.MenuItemConstructorOptions[] = [
     {
       label: "File",
@@ -228,16 +233,18 @@ export function createApplicationMenu(
             ]
           : []),
         {
+          id: PROJECT_MENU_ITEM_IDS[0],
           label: "Project Settings…",
-          enabled: !!projectStore.getCurrentProjectId(),
+          enabled: projectMenuEnabled,
           click: (_item, browserWindow) =>
             sendAction("project.settings.open", getTargetBrowserWindow(browserWindow)),
         },
         ...(filePluginItems.length > 0 ? [{ type: "separator" as const }, ...filePluginItems] : []),
         { type: "separator" },
         {
+          id: PROJECT_MENU_ITEM_IDS[1],
           label: "Close Project",
-          enabled: !!projectStore.getCurrentProjectId(),
+          enabled: projectMenuEnabled,
           click: (_item, browserWindow) =>
             sendAction("project.closeActive", getTargetBrowserWindow(browserWindow)),
         },

--- a/electron/projectMenuState.ts
+++ b/electron/projectMenuState.ts
@@ -39,7 +39,17 @@ export function resolveProjectIdForApplicationMenu(): string | null {
   if (!primary) return null;
 
   const pvm = primary.services.projectViewManager;
-  if (pvm) return validateOpenProject(pvm.getActiveProjectId());
+  if (pvm) {
+    // A cold switch flips `activeProjectId` to the incoming workspace while the
+    // outgoing project's view stays on screen as the anti-flash bridge until the
+    // paint gate settles. If that bridge names an open project, a project IS
+    // still displayed — so answer with it rather than the not-yet-visible
+    // incoming id, which would blink the gates off mid-switch.
+    const bridged = validateOpenProject(pvm.getOutgoingBridgeProjectId());
+    if (bridged) return bridged;
+
+    return validateOpenProject(pvm.getActiveProjectId());
+  }
 
   // Window without a ProjectViewManager: no per-window state exists, so the
   // global pointer is the best available answer.
@@ -54,18 +64,24 @@ function validateOpenProject(projectId: string | null): string | null {
 }
 
 /**
- * Re-evaluate the project gate and push it onto the live menu items. Best-effort:
- * a missing menu (before the first build) or missing items must never reject the
- * project operation that triggered the refresh.
+ * Re-evaluate the project gate and push it onto the live menu items.
+ *
+ * Best-effort by construction: callers invoke this from a `finally` after a
+ * project switch, so a throw here would REPLACE the original rejection and mask
+ * the real failure. A cosmetic menu update must never do that — swallow and log.
  */
 export function refreshProjectMenuState(): void {
-  const menu = Menu.getApplicationMenu();
-  if (!menu) return;
+  try {
+    const menu = Menu.getApplicationMenu();
+    if (!menu) return;
 
-  const enabled = resolveProjectIdForApplicationMenu() !== null;
-  for (const id of PROJECT_MENU_ITEM_IDS) {
-    const item = menu.getMenuItemById(id);
-    if (!item) continue;
-    item.enabled = enabled;
+    const enabled = resolveProjectIdForApplicationMenu() !== null;
+    for (const id of PROJECT_MENU_ITEM_IDS) {
+      const item = menu.getMenuItemById(id);
+      if (!item) continue;
+      item.enabled = enabled;
+    }
+  } catch (err) {
+    console.error("[MAIN] Failed to refresh the File-menu project gates:", err);
   }
 }

--- a/electron/projectMenuState.ts
+++ b/electron/projectMenuState.ts
@@ -1,0 +1,71 @@
+import { Menu } from "electron";
+import { projectStore } from "./services/ProjectStore.js";
+import { getWindowRegistry } from "./window/windowRef.js";
+
+// Stable ids for the File-menu items gated on "is a project open". Live mutation
+// through Menu.getApplicationMenu().getMenuItemById() is the only way to keep
+// them fresh without rebuilding the menu — a rebuild dismisses an open menu on
+// macOS/Windows and briefly re-registers accelerators.
+export const PROJECT_MENU_ITEM_IDS = ["file-project-settings", "file-close-project"] as const;
+
+/**
+ * Which project the process-global application menu should reflect.
+ *
+ * The menu bar is process-global but project state is per-window, so the answer
+ * is "whatever the focused window shows". `projectStore.getCurrentProjectId()`
+ * is a global most-recently-switched pointer, NOT per-window state (#5541 /
+ * #6016 / #11101), so it is only ever a fallback for windows that genuinely have
+ * no per-window state to read.
+ *
+ * The candidate is then validated against the project rows, because a raw
+ * ProjectViewManager id is not proof that a project is open:
+ *   - scratch workspaces share the PVM and surface an id with no project row;
+ *   - closing a project marks its row "closed" but leaves the window's PVM
+ *     binding pointing at it, so the id outlives the open project.
+ * Only "closed" is rejected (mirroring getOpenProjectById in ipc/projectContext.ts):
+ * project status is process-global, so a project visible in a non-focused window
+ * is legitimately "background" rather than "active".
+ */
+export function resolveProjectIdForApplicationMenu(): string | null {
+  const registry = getWindowRegistry();
+  // No window layer at all (early boot, legacy hosts): the global pointer is the
+  // only signal there is.
+  if (!registry) return validateOpenProject(projectStore.getCurrentProjectId());
+
+  const primary = registry.getPrimary();
+  // A registry with no focused window means the app is windowless (macOS keeps
+  // the menu bar alive). Nothing is on screen, so nothing is open — do NOT fall
+  // back to the global pointer here, or the gate stays stuck enabled.
+  if (!primary) return null;
+
+  const pvm = primary.services.projectViewManager;
+  if (pvm) return validateOpenProject(pvm.getActiveProjectId());
+
+  // Window without a ProjectViewManager: no per-window state exists, so the
+  // global pointer is the best available answer.
+  return validateOpenProject(projectStore.getCurrentProjectId());
+}
+
+function validateOpenProject(projectId: string | null): string | null {
+  if (!projectId) return null;
+  const project = projectStore.getProjectById(projectId);
+  if (!project) return null;
+  return project.status === "closed" ? null : projectId;
+}
+
+/**
+ * Re-evaluate the project gate and push it onto the live menu items. Best-effort:
+ * a missing menu (before the first build) or missing items must never reject the
+ * project operation that triggered the refresh.
+ */
+export function refreshProjectMenuState(): void {
+  const menu = Menu.getApplicationMenu();
+  if (!menu) return;
+
+  const enabled = resolveProjectIdForApplicationMenu() !== null;
+  for (const id of PROJECT_MENU_ITEM_IDS) {
+    const item = menu.getMenuItemById(id);
+    if (!item) continue;
+    item.enabled = enabled;
+  }
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -8,6 +8,7 @@ import { registerErrorHandlers, flushPendingErrors } from "../ipc/errorHandlers.
 import { getWorkspaceClient } from "../services/WorkspaceClient.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
+import { refreshProjectMenuState } from "../projectMenuState.js";
 import { getMainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { scratchStore } from "../services/ScratchStore.js";
@@ -598,6 +599,9 @@ export async function setupWindowServices(
       restoreProject.id,
       restoreProject.path
     );
+    // The menu was built before this binding existed, so its project gates
+    // resolved against a PVM with no active project. Converge them now (#11136).
+    refreshProjectMenuState();
   }
 
   // Load worktrees — prefer initialProjectPath, else restoreProject for


### PR DESCRIPTION
## Summary

- The File menu's `Close Project` and `Project Settings…` items compute `enabled` once, when `createApplicationMenu()` builds the template, from `projectStore.getCurrentProjectId()`. Nothing refreshes them afterward except the native Open Directory dialog path, so opening a project from the welcome screen or the project switcher left both items disabled, and closing the active project left both items enabled.
- Fixes it with a new module, `electron/projectMenuState.ts`, that owns the gate and is refreshed at every point the answer can actually change.

Resolves #11136

## Changes

`electron/projectMenuState.ts` resolves the project the FOCUSED window is showing, via that window's `ProjectViewManager`, rather than the global current-project pointer. That pointer only tracks whichever project most recently switched anywhere, not what a specific window displays, and conflating the two is the bug class behind #5541, #6016, and #11101. The global pointer is only used as a fallback for windows that genuinely have no per-window state.

The resolved id is validated against the project rows, rejecting only rows with `status === "closed"`, mirroring `getOpenProjectById` in `electron/ipc/projectContext.ts`. That validation is load-bearing in two ways: a scratch workspace shares the `ProjectViewManager` and can yield an id with no project row, and closing a project marks the row closed but leaves the window's `ProjectViewManager` binding still pointing at it, so without validation the close case wouldn't actually be fixed.

The gate is applied by live-mutating the two menu items by id, via `Menu.getApplicationMenu().getMenuItemById()`, mirroring the existing `applyUpdateMenuState` pattern in `electron/menu.ts`. A full menu rebuild was rejected: on macOS and Windows it dismisses an open menu and briefly re-registers accelerators, risking a dropped keystroke. The same resolver computes the initial `enabled` state at cold build time, so it agrees with every later refresh.

The refresh is now wired at every point the answer can change: project switch and reopen, on both the `ProjectViewManager` and legacy code paths (in a `finally` block, so a rolled-back or partially failed switch still converges), project close (after the closed status write), project remove, scratch switch, startup view binding, window focus, window close (deferred by a microtask so the registry's survivor promotion has run first), and last-window close, since `browser-window-focus` never fires when focus drops to zero windows, which would otherwise leave the gates stuck enabled on macOS.

Files touched: `electron/projectMenuState.ts` (new), `electron/menu.ts`, `electron/ipc/handlers/projectCrud/switch.ts`, `electron/ipc/handlers/projectCrud/crud.ts`, `electron/ipc/handlers/scratch/index.ts`, `electron/window/windowServices.ts`, `electron/lifecycle/appLifecycle.ts`, plus tests.

## Testing

337 tests green locally across every suite touching a changed module. New `electron/__tests__/projectMenuState.test.ts` covers the resolver matrix and live-mutation transitions, new `electron/ipc/handlers/scratch/__tests__/switch.test.ts`, and extended coverage in the menu, project switch/close/remove, and `appLifecycle` suites. Native menu state isn't observable from Playwright, so this is unit-tested at the contract level.

**Not covered:** two related but pre-existing races are deliberately out of scope here. Free-memory/idle auto-close logic can race a project into the foreground and then mark it closed. Missing-project detection and the Locate Project flow aren't per-window aware, so relocating a project can strand a `ProjectViewManager` pointing at a replaced row id. Both are `ProjectStore`/`ProjectViewManager`-binding correctness issues bigger than the menu; refreshing the menu would only make it faithfully reflect an already-wrong row, not fix the underlying race.
