### PR TITLE
feat(forge): drive forge toolbar count refreshes from local git signals

### DIFF
--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -264,6 +264,71 @@ describe("GitFileWatcher", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  // ---- Remote-tracking refs arm (#11151) ----
+
+  it("watches refs/remotes/origin so an external fetch advancing origin surfaces", async () => {
+    const originDir = pathJoin("/repo", ".git", "refs", "remotes", "origin");
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 150,
+      onChange: vi.fn(),
+    });
+
+    await expect(gitWatcher.start()).resolves.toBe(true);
+
+    const watchedPaths = vi.mocked(watch).mock.calls.map(([path]) => path);
+    expect(watchedPaths).toContain(originDir);
+  });
+
+  it("triggers a debounced onChange for any change under refs/remotes/origin", async () => {
+    const originDir = pathJoin("/repo", ".git", "refs", "remotes", "origin");
+    const onChange = vi.fn();
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 150,
+      onChange,
+    });
+
+    await expect(gitWatcher.start()).resolves.toBe(true);
+
+    const originCall = vi.mocked(watch).mock.calls.find(([path]) => path === originDir) as
+      | [unknown, unknown, unknown]
+      | undefined;
+    expect(originCall).toBeDefined();
+    const originCallback = originCall?.[2] as
+      | ((eventType: string, filename: string | Buffer | null) => void)
+      | undefined;
+    expect(originCallback).toBeDefined();
+
+    // A fetch writing origin/main; the arm is filename-agnostic (any event here
+    // means upstream may have moved), and a burst coalesces into one refresh.
+    originCallback?.("rename", "main");
+    originCallback?.("rename", "main.lock");
+    originCallback?.("change", null);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades silently when refs/remotes/origin cannot be watched", async () => {
+    const originDir = pathJoin("/repo", ".git", "refs", "remotes", "origin");
+    vi.mocked(watch).mockImplementation(((path: string) => {
+      if (path === originDir) throw new Error("ENOENT: no such directory");
+      return createMockWatcher();
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 150,
+      onChange: vi.fn(),
+    });
+
+    // A missing origin dir (no fetch yet / all refs packed) must not fail start.
+    await expect(gitWatcher.start()).resolves.toBe(true);
+  });
+
   // ---- Worktree debounce tests ----
 
   it("worktree events debounce normally for short bursts", async () => {

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -177,6 +177,17 @@ export class GitFileWatcher {
       // pattern git uses for atomic index writes.
       this.watchFile(pathJoin(gitDir, "index"));
 
+      // Watch loose remote-tracking refs under refs/remotes/origin so an
+      // external `git fetch` — from a terminal, or any tool outside Daintree's
+      // own fetch scheduler — that advances origin/<branch> triggers a status
+      // pass. The behind-count then updates, driving the forge-count recheck
+      // (#11151). Non-recursive on purpose: the default branch's ref (e.g.
+      // refs/remotes/origin/main) sits at the top level here, and recursive
+      // fs.watch is unreliable and inotify-limit-prone on Linux. packed-refs
+      // (watched above) covers the post-`git gc` packed case; nested
+      // feature-branch remote refs don't affect the repo-level toolbar counts.
+      this.watchRemoteRefsDir(pathJoin(commonDir, "refs", "remotes", "origin"));
+
       if (this.watchWorktree) {
         // Fire-and-forget: subscribe() schedules the native watcher
         // asynchronously. Startup failures (ENOSPC, EMFILE) route through
@@ -319,6 +330,35 @@ export class GitFileWatcher {
     });
     if (phase === "startup") {
       this.onWatcherFailed?.();
+    }
+  }
+
+  /**
+   * Watch a git-internal directory for *any* change and route it through the
+   * fast debounce. Used for refs/remotes/origin, where the relevant events are
+   * loose-ref writes (and their `.lock` churn) from a fetch rather than a fixed
+   * set of tracked filenames — so unlike `watchFile`, every event in the
+   * directory is a conservative "refs may have moved" signal.
+   */
+  private watchRemoteRefsDir(dirPath: string): void {
+    try {
+      const watcher = fsWatch(dirPath, { persistent: false }, () => {
+        this.handleGitFileChange();
+      });
+
+      watcher.on("error", (error) => {
+        logWarn("Git remote-refs watcher error", {
+          path: dirPath,
+          error: error.message,
+        });
+      });
+
+      this.watchers.push(watcher);
+    } catch {
+      // The directory may not exist yet (no fetch has written loose remote
+      // refs, or they are all packed). Silent fallback: packed-refs watching,
+      // Daintree's own fetch-triggered status refresh, and the timed poll
+      // still cover origin movement.
     }
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1504,14 +1504,18 @@ export class WorkspaceService {
   }
 
   /**
-   * Force a fresh git-status pass on every monitor sharing the triggering
-   * worktree's `git common-dir` after a real fetch completes (#11151). Linked
-   * worktrees back the same object store, so one `git fetch origin` advances
-   * upstream refs for all of them — but only the triggering monitor was being
-   * refreshed, leaving siblings (notably the main worktree, whose behind-count
-   * feeds the forge-count auto-recheck) on a stale count until their own next
-   * poll. `triggerRefreshIfUpdating()` invalidates the git-status cache and
-   * kicks a forced pass, mirroring the single-monitor call this replaced.
+   * Force a fresh git-status pass after a real fetch completes (#11151). One
+   * `git fetch origin` advances upstream refs for every linked worktree sharing
+   * the object store, but a fetch triggered by one worktree (e.g. the focused
+   * feature worktree) would only re-poll that worktree — leaving the main
+   * worktree, whose behind-count feeds the forge-count auto-recheck, on a stale
+   * count until its own slower background tier.
+   *
+   * Refreshes the triggering worktree (as the prior single-monitor call did)
+   * plus the main worktree — and *only* those two. Fanning out to every
+   * common-dir sibling would turn one fetch on a many-worktree repo into an
+   * N-way `git status` storm (these passes run outside the poll queue), so the
+   * fan-out is deliberately bounded to the one sibling the toolbar reads from.
    *
    * Only invoked from `onFetchSuccess` (a genuine completed fetch), never from
    * the recency-cache/skip paths, so it can't fan status work out on a no-op.
@@ -1519,19 +1523,31 @@ export class WorkspaceService {
   private async refreshStatusForFetchSiblings(triggeringWorktreeId: string): Promise<void> {
     const triggering = this.monitors.get(triggeringWorktreeId);
     if (!triggering || !triggering.isRunning) return;
-    const triggeringCommonDir = await getGitCommonDir(triggering.path, { logErrors: false });
-    if (!triggeringCommonDir) {
-      // Without a commondir we can't identify siblings. Refresh the triggering
-      // monitor alone — its own counts still benefit.
-      triggering.triggerRefreshIfUpdating();
-      return;
-    }
+    // The triggering worktree's own counts are freshest to it — refresh it
+    // first, matching the single-monitor behaviour this replaced.
+    triggering.triggerRefreshIfUpdating();
+
+    // Find the main worktree; skip when it's the trigger (already refreshed) or
+    // not running.
+    let mainWorktree: WorktreeMonitor | undefined;
     for (const monitor of this.monitors.values()) {
-      if (!monitor.isRunning) continue;
-      const monitorCommonDir = await getGitCommonDir(monitor.path, { logErrors: false });
-      if (monitorCommonDir === triggeringCommonDir) {
-        monitor.triggerRefreshIfUpdating();
+      if (monitor.isMainWorktree && monitor !== triggering) {
+        mainWorktree = monitor;
+        break;
       }
+    }
+    if (!mainWorktree || !mainWorktree.isRunning) return;
+
+    // Only refresh the main worktree if it shares the fetched repo's common dir
+    // (linked worktree of the same repo). Re-check `isRunning` after the awaits:
+    // the monitor can be stopped/removed while the commondir resolutions are
+    // pending.
+    const [triggeringCommonDir, mainCommonDir] = await Promise.all([
+      getGitCommonDir(triggering.path, { logErrors: false }),
+      getGitCommonDir(mainWorktree.path, { logErrors: false }),
+    ]);
+    if (triggeringCommonDir && mainCommonDir === triggeringCommonDir && mainWorktree.isRunning) {
+      mainWorktree.triggerRefreshIfUpdating();
     }
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -284,13 +284,16 @@ export class WorkspaceService {
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.fetchCoordinator = new RepoFetchCoordinator({
       onFetchSuccess: (worktreeId) => {
-        const monitor = this.monitors.get(worktreeId);
-        if (!monitor || !monitor.isRunning) return;
         // A successful fetch updated remote refs, so the next `rev-list` for
-        // ahead/behind will return fresh counts. Trigger a status refresh
-        // immediately rather than waiting for the next poll tick — but
-        // fire-and-forget; fetch success must never block.
-        monitor.triggerRefreshIfUpdating();
+        // ahead/behind returns fresh counts for *every* worktree sharing this
+        // repo's common dir — not just the one that triggered the fetch. Force
+        // a status refresh across all siblings so a sibling-triggered fetch
+        // still surfaces the main worktree's new behind-count promptly (drives
+        // the forge-count recheck, #11151) instead of waiting for that
+        // worktree's own next poll tick. Fire-and-forget; fetch success must
+        // never block, and a commondir-resolution race during teardown must
+        // not surface as an unhandled rejection.
+        void this.refreshStatusForFetchSiblings(worktreeId).catch(() => {});
       },
       onAuthFailureConfirmed: (commonDir, reason) =>
         this.handleAuthFailureConfirmed(commonDir, reason),
@@ -1496,6 +1499,38 @@ export class WorkspaceService {
       const monitorCommonDir = await getGitCommonDir(monitor.path, { logErrors: false });
       if (monitorCommonDir === triggeringCommonDir) {
         monitor.setFetchState(result.lastFetchedAt, result.authFailed, result.networkFailed);
+      }
+    }
+  }
+
+  /**
+   * Force a fresh git-status pass on every monitor sharing the triggering
+   * worktree's `git common-dir` after a real fetch completes (#11151). Linked
+   * worktrees back the same object store, so one `git fetch origin` advances
+   * upstream refs for all of them — but only the triggering monitor was being
+   * refreshed, leaving siblings (notably the main worktree, whose behind-count
+   * feeds the forge-count auto-recheck) on a stale count until their own next
+   * poll. `triggerRefreshIfUpdating()` invalidates the git-status cache and
+   * kicks a forced pass, mirroring the single-monitor call this replaced.
+   *
+   * Only invoked from `onFetchSuccess` (a genuine completed fetch), never from
+   * the recency-cache/skip paths, so it can't fan status work out on a no-op.
+   */
+  private async refreshStatusForFetchSiblings(triggeringWorktreeId: string): Promise<void> {
+    const triggering = this.monitors.get(triggeringWorktreeId);
+    if (!triggering || !triggering.isRunning) return;
+    const triggeringCommonDir = await getGitCommonDir(triggering.path, { logErrors: false });
+    if (!triggeringCommonDir) {
+      // Without a commondir we can't identify siblings. Refresh the triggering
+      // monitor alone — its own counts still benefit.
+      triggering.triggerRefreshIfUpdating();
+      return;
+    }
+    for (const monitor of this.monitors.values()) {
+      if (!monitor.isRunning) continue;
+      const monitorCommonDir = await getGitCommonDir(monitor.path, { logErrors: false });
+      if (monitorCommonDir === triggeringCommonDir) {
+        monitor.triggerRefreshIfUpdating();
       }
     }
   }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1513,7 +1513,13 @@ export class WorktreeMonitor {
     if (this._isUpdating) {
       this.watcherController.markPending();
     } else {
-      void this.updateGitStatus(true);
+      // Fire-and-forget, but guarded: GitStatusPass surfaces expected failures
+      // as mood=error and then rethrows, so a detached call would turn a
+      // transient `git status` failure into an unhandled rejection — which the
+      // workspace-host's exit-on-unhandled-rejection guard escalates to a
+      // process exit. The error is already reflected in monitor state, so
+      // swallowing the rethrow here loses nothing (#11151 review).
+      void this.updateGitStatus(true).catch(() => {});
     }
   }
 

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchSiblingRefresh.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchSiblingRefresh.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorktreeMonitor } from "../WorktreeMonitor.js";
+import type { Worktree } from "../../../shared/types/worktree.js";
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/fs.js", () => ({
+  waitForPathExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+  getWorktreeChangesWithStats: vi.fn().mockResolvedValue({
+    head: "abc123",
+    isDirty: false,
+    changedFileCount: 0,
+    changes: [],
+    lastUpdated: 0,
+  }),
+}));
+
+// Controllable per-path common-dir resolution — this is what decides which
+// monitors count as fetch siblings.
+const mockGetGitCommonDir = vi.fn();
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: (...args: unknown[]) => mockGetGitCommonDir(...args),
+  clearGitDirCache: vi.fn(),
+  clearGitCommonDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../services/worktree/index.js", () => ({
+  AdaptivePollingStrategy: vi.fn(function () {
+    return {
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+      updateConfig: vi.fn(),
+      isCircuitBreakerTripped: vi.fn().mockReturnValue(false),
+      reset: vi.fn(),
+      setBaseInterval: vi.fn(),
+      calculateNextInterval: vi.fn().mockReturnValue(2000),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+    };
+  }),
+  NoteFileReader: vi.fn(function () {
+    return { read: vi.fn().mockResolvedValue({}) };
+  }),
+}));
+
+const mockPullRequestService = {
+  initialize: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  getStatus: vi.fn().mockReturnValue({
+    state: "idle",
+    isPolling: false,
+    candidateCount: 0,
+    resolvedCount: 0,
+    isEnabled: true,
+  }),
+};
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: mockPullRequestService,
+}));
+
+vi.mock("../../services/events.js", () => ({
+  events: new EventEmitter(),
+}));
+
+vi.mock("../../utils/gitFileWatcher.js", () => {
+  return {
+    GitFileWatcher: class {
+      start() {
+        return Promise.resolve(false);
+      }
+      dispose() {}
+    },
+  };
+});
+
+vi.mock("fs/promises", () => ({
+  stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function createTestWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: "/test/worktree",
+    path: "/test/worktree",
+    name: "feature/test",
+    branch: "feature/test",
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: "/test/worktree/.git",
+    ...overrides,
+  };
+}
+
+describe("WorkspaceService fetch-sibling status refresh (#11151)", () => {
+  let service: WorkspaceService;
+  let mockSendEvent: ReturnType<typeof vi.fn>;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockSendEvent = vi.fn();
+
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(mockSendEvent as never);
+
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+
+    service["projectRootPath"] = "/test/root";
+    service["git"] = mockSimpleGit as never;
+  });
+
+  afterEach(() => {
+    for (const monitor of service["monitors"].values()) {
+      monitor.stop();
+    }
+    vi.restoreAllMocks();
+  });
+
+  function registerMonitor(id: string): WorktreeMonitor {
+    const monitor = new WorktreeMonitorClass(
+      createTestWorktree({ id, path: id, gitDir: `${id}/.git` }),
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: false,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(id, monitor);
+    monitor.start();
+    return monitor;
+  }
+
+  it("forces a status refresh on every running sibling sharing the common dir", async () => {
+    const m1 = registerMonitor("/test/wt-1");
+    const m2 = registerMonitor("/test/wt-2");
+    const other = registerMonitor("/test/other");
+    const s1 = vi.spyOn(m1, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const s2 = vi.spyOn(m2, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const sOther = vi.spyOn(other, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    // wt-1 and wt-2 are linked worktrees of one repo; "other" is a separate repo.
+    mockGetGitCommonDir.mockImplementation((path: string) =>
+      path === "/test/other" ? "/test/other/.git" : "/test/shared/.git"
+    );
+
+    await service["refreshStatusForFetchSiblings"]("/test/wt-1");
+
+    expect(s1).toHaveBeenCalledTimes(1);
+    expect(s2).toHaveBeenCalledTimes(1);
+    expect(sOther).not.toHaveBeenCalled();
+  });
+
+  it("skips stopped monitors sharing the common dir", async () => {
+    const m1 = registerMonitor("/test/wt-1");
+    const m2 = registerMonitor("/test/wt-2");
+    const s1 = vi.spyOn(m1, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const s2 = vi.spyOn(m2, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    mockGetGitCommonDir.mockResolvedValue("/test/shared/.git");
+    m2.stop();
+
+    await service["refreshStatusForFetchSiblings"]("/test/wt-1");
+
+    expect(s1).toHaveBeenCalledTimes(1);
+    expect(s2).not.toHaveBeenCalled();
+  });
+
+  it("refreshes only the triggering monitor when the common dir can't be resolved", async () => {
+    const m1 = registerMonitor("/test/wt-1");
+    const m2 = registerMonitor("/test/wt-2");
+    const s1 = vi.spyOn(m1, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const s2 = vi.spyOn(m2, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    mockGetGitCommonDir.mockResolvedValue(null);
+
+    await service["refreshStatusForFetchSiblings"]("/test/wt-1");
+
+    expect(s1).toHaveBeenCalledTimes(1);
+    expect(s2).not.toHaveBeenCalled();
+  });
+
+  it("no-ops without throwing when the triggering monitor is gone", async () => {
+    registerMonitor("/test/wt-1");
+    mockGetGitCommonDir.mockResolvedValue("/test/shared/.git");
+
+    await expect(
+      service["refreshStatusForFetchSiblings"]("/test/missing")
+    ).resolves.toBeUndefined();
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchSiblingRefresh.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchSiblingRefresh.test.ts
@@ -161,9 +161,14 @@ describe("WorkspaceService fetch-sibling status refresh (#11151)", () => {
     vi.restoreAllMocks();
   });
 
-  function registerMonitor(id: string): WorktreeMonitor {
+  function registerMonitor(id: string, opts: { isMainWorktree?: boolean } = {}): WorktreeMonitor {
     const monitor = new WorktreeMonitorClass(
-      createTestWorktree({ id, path: id, gitDir: `${id}/.git` }),
+      createTestWorktree({
+        id,
+        path: id,
+        gitDir: `${id}/.git`,
+        isMainWorktree: opts.isMainWorktree ?? false,
+      }),
       {
         basePollingInterval: 10000,
         adaptiveBackoff: false,
@@ -179,54 +184,71 @@ describe("WorkspaceService fetch-sibling status refresh (#11151)", () => {
     return monitor;
   }
 
-  it("forces a status refresh on every running sibling sharing the common dir", async () => {
-    const m1 = registerMonitor("/test/wt-1");
-    const m2 = registerMonitor("/test/wt-2");
-    const other = registerMonitor("/test/other");
-    const s1 = vi.spyOn(m1, "triggerRefreshIfUpdating").mockImplementation(() => {});
-    const s2 = vi.spyOn(m2, "triggerRefreshIfUpdating").mockImplementation(() => {});
-    const sOther = vi.spyOn(other, "triggerRefreshIfUpdating").mockImplementation(() => {});
-    // wt-1 and wt-2 are linked worktrees of one repo; "other" is a separate repo.
-    mockGetGitCommonDir.mockImplementation((path: string) =>
-      path === "/test/other" ? "/test/other/.git" : "/test/shared/.git"
-    );
+  it("refreshes the triggering worktree and the main worktree, but not other siblings", async () => {
+    const feature = registerMonitor("/test/feature");
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    const otherFeature = registerMonitor("/test/feature-2");
+    const sFeature = vi.spyOn(feature, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const sMain = vi.spyOn(main, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const sOther = vi.spyOn(otherFeature, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    // All three are linked worktrees of the same repo (shared common dir).
+    mockGetGitCommonDir.mockResolvedValue("/test/shared/.git");
 
-    await service["refreshStatusForFetchSiblings"]("/test/wt-1");
+    await service["refreshStatusForFetchSiblings"]("/test/feature");
 
-    expect(s1).toHaveBeenCalledTimes(1);
-    expect(s2).toHaveBeenCalledTimes(1);
+    // Trigger + main refresh; the non-main sibling is deliberately left out so
+    // one fetch can't fan into an N-way status storm on a many-worktree repo.
+    expect(sFeature).toHaveBeenCalledTimes(1);
+    expect(sMain).toHaveBeenCalledTimes(1);
     expect(sOther).not.toHaveBeenCalled();
   });
 
-  it("skips stopped monitors sharing the common dir", async () => {
-    const m1 = registerMonitor("/test/wt-1");
-    const m2 = registerMonitor("/test/wt-2");
-    const s1 = vi.spyOn(m1, "triggerRefreshIfUpdating").mockImplementation(() => {});
-    const s2 = vi.spyOn(m2, "triggerRefreshIfUpdating").mockImplementation(() => {});
+  it("refreshes only the triggering worktree once when it is itself the main worktree", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    const feature = registerMonitor("/test/feature");
+    const sMain = vi.spyOn(main, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const sFeature = vi.spyOn(feature, "triggerRefreshIfUpdating").mockImplementation(() => {});
     mockGetGitCommonDir.mockResolvedValue("/test/shared/.git");
-    m2.stop();
 
-    await service["refreshStatusForFetchSiblings"]("/test/wt-1");
+    await service["refreshStatusForFetchSiblings"]("/test/main");
 
-    expect(s1).toHaveBeenCalledTimes(1);
-    expect(s2).not.toHaveBeenCalled();
+    // No double-refresh: the trigger is the main worktree.
+    expect(sMain).toHaveBeenCalledTimes(1);
+    expect(sFeature).not.toHaveBeenCalled();
   });
 
-  it("refreshes only the triggering monitor when the common dir can't be resolved", async () => {
-    const m1 = registerMonitor("/test/wt-1");
-    const m2 = registerMonitor("/test/wt-2");
-    const s1 = vi.spyOn(m1, "triggerRefreshIfUpdating").mockImplementation(() => {});
-    const s2 = vi.spyOn(m2, "triggerRefreshIfUpdating").mockImplementation(() => {});
-    mockGetGitCommonDir.mockResolvedValue(null);
+  it("skips the main worktree when it is stopped", async () => {
+    const feature = registerMonitor("/test/feature");
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    const sFeature = vi.spyOn(feature, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const sMain = vi.spyOn(main, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    mockGetGitCommonDir.mockResolvedValue("/test/shared/.git");
+    main.stop();
 
-    await service["refreshStatusForFetchSiblings"]("/test/wt-1");
+    await service["refreshStatusForFetchSiblings"]("/test/feature");
 
-    expect(s1).toHaveBeenCalledTimes(1);
-    expect(s2).not.toHaveBeenCalled();
+    expect(sFeature).toHaveBeenCalledTimes(1);
+    expect(sMain).not.toHaveBeenCalled();
+  });
+
+  it("skips the main worktree when it does not share the fetched repo's common dir", async () => {
+    const feature = registerMonitor("/test/feature");
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    const sFeature = vi.spyOn(feature, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    const sMain = vi.spyOn(main, "triggerRefreshIfUpdating").mockImplementation(() => {});
+    // The main worktree belongs to a different repo than the fetched one.
+    mockGetGitCommonDir.mockImplementation((path: string) =>
+      path === "/test/main" ? "/test/other/.git" : "/test/shared/.git"
+    );
+
+    await service["refreshStatusForFetchSiblings"]("/test/feature");
+
+    expect(sFeature).toHaveBeenCalledTimes(1);
+    expect(sMain).not.toHaveBeenCalled();
   });
 
   it("no-ops without throwing when the triggering monitor is gone", async () => {
-    registerMonitor("/test/wt-1");
+    registerMonitor("/test/main", { isMainWorktree: true });
     mockGetGitCommonDir.mockResolvedValue("/test/shared/.git");
 
     await expect(

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -46,9 +46,13 @@ vi.mock("@/clients/forgeClient", () => ({
 // provider and gate polling. The persisted counts it seeds from (#11078) come
 // off the project returned by `projectClient.getCurrent()`, which is main's
 // authoritative row, so seed tests drive `getCurrentMock` rather than this.
+const { currentProjectRef } = vi.hoisted(() => ({
+  currentProjectRef: { current: { id: "test-project" } as { id: string } | null },
+}));
+
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
-    selector({ currentProject: { id: "test-project" } }),
+    selector({ currentProject: currentProjectRef.current }),
 }));
 
 // The hook reads the main worktree's ahead/behind counts off the per-project
@@ -156,6 +160,7 @@ describe("useRepositoryStats", () => {
     // Reset the mocked worktree store so a prior test's main-worktree counts
     // can't leak in as a spurious first-render baseline / delta.
     worktreeStateRef.current = { worktrees: new Map() };
+    currentProjectRef.current = { id: "test-project" };
     useSystemWakeStore.setState({
       wakeEpoch: 0,
       lastSleepDuration: 0,
@@ -2770,7 +2775,7 @@ describe("useRepositoryStats", () => {
       lastUpdated: 1000,
     };
 
-    it("forces a recheck when the main worktree's ahead-count moves", async () => {
+    it("triggers a recheck when the main worktree's ahead-count moves", async () => {
       getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
       onSwitchMock.mockReturnValue(() => {});
       getRepoStatsMock.mockResolvedValue(stats);
@@ -2783,11 +2788,14 @@ describe("useRepositoryStats", () => {
       rerender();
 
       await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
-      // The signal-driven recheck bypasses the cache (force = true).
-      expect(getRepoStatsMock).toHaveBeenLastCalledWith("/repo", true);
+      // Plain (unforced) refresh — the cheap conditional-REST path, not the
+      // forced GraphQL page query reserved for explicit user refreshes.
+      const lastCall = getRepoStatsMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe("/repo");
+      expect(lastCall?.[1]).not.toBe(true);
     });
 
-    it("forces a recheck when the behind-count increases", async () => {
+    it("triggers a recheck when the behind-count increases", async () => {
       getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
       onSwitchMock.mockReturnValue(() => {});
       getRepoStatsMock.mockResolvedValue(stats);
@@ -2800,7 +2808,11 @@ describe("useRepositoryStats", () => {
       rerender();
 
       await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
-      expect(getRepoStatsMock).toHaveBeenLastCalledWith("/repo", true);
+      // Plain (unforced) refresh — the cheap conditional-REST path, not the
+      // forced GraphQL page query reserved for explicit user refreshes.
+      const lastCall = getRepoStatsMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe("/repo");
+      expect(lastCall?.[1]).not.toBe(true);
     });
 
     it("re-baselines a behind-count decrease without refreshing, then fires on the next increase", async () => {
@@ -2822,7 +2834,11 @@ describe("useRepositoryStats", () => {
       act(() => setMainWorktreeCounts({ ahead: 0, behind: 3 }));
       rerender();
       await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
-      expect(getRepoStatsMock).toHaveBeenLastCalledWith("/repo", true);
+      // Plain (unforced) refresh — the cheap conditional-REST path, not the
+      // forced GraphQL page query reserved for explicit user refreshes.
+      const lastCall = getRepoStatsMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe("/repo");
+      expect(lastCall?.[1]).not.toBe(true);
     });
 
     it("coalesces a burst of signal changes into a single forced recheck", async () => {
@@ -2893,6 +2909,34 @@ describe("useRepositoryStats", () => {
       rerender();
       await wait(1300);
       expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-baselines when the project id flips before the worktree store swaps", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      setMainWorktreeCounts({ ahead: 5, behind: 0, id: "/repo" });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      // The project id flips while the store still exposes the outgoing
+      // project's worktree (same id) with different counts — the switch-first,
+      // store-later ordering. The composite scope key changes on the project id
+      // alone, so the ahead 5->9 jump re-baselines instead of firing. (Without
+      // the project id in the scope key, the unchanged worktree id would let it
+      // read as local movement.)
+      act(() => {
+        currentProjectRef.current = { id: "project-b" };
+        setMainWorktreeCounts({ ahead: 9, behind: 0, id: "/repo" });
+      });
+      rerender();
+      // Let any immediate project-switch refetch settle, then confirm the
+      // debounce window produces no signal-driven recheck.
+      await wait(100);
+      const afterSwitch = getRepoStatsMock.mock.calls.length;
+      await wait(1300);
+      expect(getRepoStatsMock.mock.calls.length).toBe(afterSwitch);
     });
   });
 

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -51,6 +51,20 @@ vi.mock("@/store/projectStore", () => ({
     selector({ currentProject: { id: "test-project" } }),
 }));
 
+// The hook reads the main worktree's ahead/behind counts off the per-project
+// worktree store to drive local-git-signal rechecks (#11151). Mock the store
+// hook so `renderHook` doesn't need a real `WorktreeStoreProvider`; tests mutate
+// `worktreeStateRef.current` and `rerender()` to simulate git movement.
+const { worktreeStateRef } = vi.hoisted(() => ({
+  worktreeStateRef: {
+    current: { worktrees: new Map<string, Record<string, unknown>>() },
+  },
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (s: unknown) => unknown) => selector(worktreeStateRef.current),
+}));
+
 const { resolvedProviderRef, makeResolvedProvider } = vi.hoisted(() => {
   const makeResolvedProvider = (providerId: string | null) => ({
     entry: providerId
@@ -97,6 +111,38 @@ function createDeferred<T>() {
   return { promise, resolve: resolve!, reject: reject! };
 }
 
+// Real-timer wait — the debounce and poll lifecycle in this hook use real
+// timers throughout this file (fake timers deadlock the poll loop), so signal
+// tests wait past the 1s debounce (LOCAL_GIT_SIGNAL_REFRESH_DEBOUNCE_MS) with a
+// real delay to assert a flush fired (or, with a negative assertion, didn't).
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Point the mocked worktree store at a single main worktree carrying the given
+// ahead/behind counts. `undefined` counts model an absent upstream (the field
+// is optional in WorktreeSnapshot); a distinct `id` models a project switch.
+function setMainWorktreeCounts(counts: { ahead?: number; behind?: number; id?: string }) {
+  const id = counts.id ?? "/repo";
+  worktreeStateRef.current = {
+    worktrees: new Map<string, Record<string, unknown>>([
+      [
+        id,
+        {
+          id,
+          path: id,
+          name: "repo",
+          isCurrent: true,
+          isMainWorktree: true,
+          worktreeId: id,
+          aheadCount: counts.ahead,
+          behindCount: counts.behind,
+        },
+      ],
+    ]),
+  };
+}
+
 describe("useRepositoryStats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -107,6 +153,9 @@ describe("useRepositoryStats", () => {
     resolvedProviderRef.current = makeResolvedProvider("test.forge.provider");
     _resetPollingLifecycleForTests();
     _resetSwitchBackCacheForTests();
+    // Reset the mocked worktree store so a prior test's main-worktree counts
+    // can't leak in as a spurious first-render baseline / delta.
+    worktreeStateRef.current = { worktrees: new Map() };
     useSystemWakeStore.setState({
       wakeEpoch: 0,
       lastSleepDuration: 0,
@@ -2708,6 +2757,142 @@ describe("useRepositoryStats", () => {
       await waitFor(() => {
         expect(getRepoStatsMock).toHaveBeenCalledTimes(3);
       });
+    });
+  });
+
+  describe("local git signal refresh (#11151)", () => {
+    const stats: ForgeRepositoryStats = {
+      commitCount: 1,
+      issueCount: 1,
+      prCount: 1,
+      loading: false,
+      stale: false,
+      lastUpdated: 1000,
+    };
+
+    it("forces a recheck when the main worktree's ahead-count moves", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      setMainWorktreeCounts({ ahead: 0, behind: 0 });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      act(() => setMainWorktreeCounts({ ahead: 1, behind: 0 }));
+      rerender();
+
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
+      // The signal-driven recheck bypasses the cache (force = true).
+      expect(getRepoStatsMock).toHaveBeenLastCalledWith("/repo", true);
+    });
+
+    it("forces a recheck when the behind-count increases", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      setMainWorktreeCounts({ ahead: 0, behind: 1 });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      act(() => setMainWorktreeCounts({ ahead: 0, behind: 2 }));
+      rerender();
+
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
+      expect(getRepoStatsMock).toHaveBeenLastCalledWith("/repo", true);
+    });
+
+    it("re-baselines a behind-count decrease without refreshing, then fires on the next increase", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      setMainWorktreeCounts({ ahead: 0, behind: 3 });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      // Decrease 3 -> 2 is a local catch-up, not new remote content: no recheck.
+      act(() => setMainWorktreeCounts({ ahead: 0, behind: 2 }));
+      rerender();
+      await wait(1300);
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+
+      // Increase 2 -> 3 fires — proving the decrease moved the baseline to 2.
+      act(() => setMainWorktreeCounts({ ahead: 0, behind: 3 }));
+      rerender();
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
+      expect(getRepoStatsMock).toHaveBeenLastCalledWith("/repo", true);
+    });
+
+    it("coalesces a burst of signal changes into a single forced recheck", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      setMainWorktreeCounts({ ahead: 0, behind: 0 });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      // A rebase burst: several ahead/behind moves inside the debounce window.
+      act(() => setMainWorktreeCounts({ ahead: 1, behind: 0 }));
+      rerender();
+      act(() => setMainWorktreeCounts({ ahead: 2, behind: 1 }));
+      rerender();
+      act(() => setMainWorktreeCounts({ ahead: 3, behind: 2 }));
+      rerender();
+
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
+      // No second flush arrives after the window — the burst collapsed to one.
+      await wait(1300);
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("suppresses the forced recheck while the rate limit is parked", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      let pushHandler: ((p: unknown) => void) | undefined;
+      onRateLimitChangedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb as typeof pushHandler;
+        return () => {};
+      });
+      setMainWorktreeCounts({ ahead: 0, behind: 0 });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      // Park the poller against a future reset (the abuse/limit band).
+      act(() => {
+        pushHandler?.({
+          providerId: PROVIDER_ID,
+          state: { limit: 5000, remaining: 0, resetAt: Date.now() + 60_000 },
+        });
+      });
+
+      // A real signal arrives while parked — it must not bypass the backoff.
+      act(() => setMainWorktreeCounts({ ahead: 1, behind: 0 }));
+      rerender();
+      await wait(1300);
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-baselines on a project switch instead of reading the new counts as movement", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue(stats);
+      setMainWorktreeCounts({ ahead: 5, behind: 0, id: "/repo" });
+
+      const { rerender } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      // Project switch: the store swaps to a different main worktree (new id)
+      // whose counts differ. The identity change must reset the baseline, not
+      // fire a recheck off the incoming project's numbers.
+      act(() => setMainWorktreeCounts({ ahead: 9, behind: 4, id: "/repo2" }));
+      rerender();
+      await wait(1300);
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
 import type { ForgeRateLimitKind, ForgeRepositoryStats } from "@shared/types/ipc/forge";
 import type { ProjectRepoStats } from "@shared/types/project";
 import { projectClient } from "@/clients";
@@ -9,6 +10,7 @@ import { buildCacheKey, getCache, markCountStale, setCache } from "@/lib/forgeRe
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
 import { useResolvedForgeProvider } from "@/hooks/useResolvedForgeProvider";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
 import {
@@ -41,6 +43,15 @@ const ERROR_BACKOFF_MAX_INTERVAL = 2 * 60 * 1000;
 // own buffer, this keeps the next attempt safely past reset even under clock
 // skew.
 const RATE_LIMIT_RESUME_BUFFER_MS = 2_000;
+
+// Debounce for forced rechecks triggered by local git signals (local ref
+// movement / origin advancing). A single shared slot collapses a burst — a
+// rebase's ref writes, or a fetch landing alongside a local commit — into one
+// forced recheck. 1s stays responsive (counts settle within a second of the
+// git event) while coalescing the near-simultaneous snapshot emissions the
+// git-file watcher produces. Additive to the base 30s/5min poll, never a
+// replacement (#11151).
+const LOCAL_GIT_SIGNAL_REFRESH_DEBOUNCE_MS = 1_000;
 
 // Freshness tier thresholds keyed off the active poll cadence
 // (`ACTIVE_POLL_INTERVAL` = 30s). 90s is 3× the active poll — long enough that
@@ -195,6 +206,19 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
   const mountedRef = useRef(true);
   const lastErrorRef = useRef<string | null>(null);
+
+  // Local-git-signal trigger state (#11151). Baselines track the main
+  // worktree's ahead/behind counts so a genuine *delta* — not a snapshot
+  // identity bump from an unrelated field (mood, note, PR state) — drives the
+  // forced recheck. Keyed on the main worktree's id so a project switch (which
+  // swaps the store's worktrees asynchronously) resets the baselines instead of
+  // reading the incoming project's counts as movement. The debounce timer is a
+  // single shared slot; it is the pending state, always armed to a bounded
+  // flush (never a bare pending flag, #7469).
+  const previousMainWorktreeIdRef = useRef<string | null>(null);
+  const previousAheadCountRef = useRef<number | null>(null);
+  const previousBehindCountRef = useRef<number | null>(null);
+  const gitSignalDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Unbroken failure-run tracking behind `errorSeverity`. `consecutiveFailures`
   // counts applied failures since the last success; `errorSince` anchors the
@@ -445,6 +469,26 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // the first fetch doesn't race a provider that is about to resolve.
   const currentProjectId = useProjectStore((s) => s.currentProject?.id ?? null);
   const { providerId, loading: providerLoading } = useResolvedForgeProvider(currentProjectId);
+
+  // Local git signals for the project's main worktree (#11151). The forge
+  // toolbar counts are repo-level (fetched by project path), so the divergence
+  // that matters for auto-rechecks lives on the main worktree — its default
+  // branch is where website merges land (behind-count up) and where local
+  // merges accumulate (ahead-count moves). Selecting `isMainWorktree` (not a
+  // raw path key) sidesteps path-normalization mismatch, and the shallow tuple
+  // of three scalars keeps this hook from re-rendering on unrelated worktree
+  // fields. Each project runs its own WebContentsView/worktree store, so the
+  // read is inherently scoped to the active project.
+  const [mainWorktreeId, mainWorktreeAheadCount, mainWorktreeBehindCount] = useWorktreeStore(
+    useShallow((state): [string | null, number | null, number | null] => {
+      for (const worktree of state.worktrees.values()) {
+        if (worktree.isMainWorktree) {
+          return [worktree.id, worktree.aheadCount ?? null, worktree.behindCount ?? null];
+        }
+      }
+      return [null, null, null];
+    })
+  );
   // Ref mirror for the push subscriptions: payloads are providerId-keyed, and
   // the subscriber closures must compare against the live resolution without
   // re-subscribing on every resolve.
@@ -982,6 +1026,106 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     });
     return cleanup;
   }, [polling, isWorkerInstance]);
+
+  // Local git signals force a forge-count recheck ahead of the time-based poll
+  // so counts don't lag during merge sprees (#11151). Additive to the /events
+  // probe and the 30s/5min cadence — never a replacement. Two free, already-
+  // computed signals off the main worktree drive it:
+  //   Signal A — the ahead-count moved: local ref/HEAD movement relative to
+  //     upstream (a local merge/commit, or the push that follows). This is a
+  //     purer "ref moved" trigger than dirty-file activity, which would fire on
+  //     every unrelated file save.
+  //   Signal B — the behind-count increased: origin advanced, i.e. a merge
+  //     landed on the forge website and the next fetch surfaced it. A decrease
+  //     is a local catch-up (pull/rebase), not new remote content, so it only
+  //     re-baselines.
+  // The forced recheck reuses `polling.refresh({ force: true })` exactly like
+  // wake/focus/rate-limit-clear, so it inherits the cheap REST-count path,
+  // cross-window singleflight, cache/dedup, and backoff instead of re-deriving
+  // them.
+  const enqueueGitSignalRefresh = useCallback(() => {
+    // Single shared debounce slot: the first signal in a burst arms a bounded
+    // flush; later signals inside the window are absorbed by this guard rather
+    // than resetting the timer, so a sustained burst can't starve the flush
+    // (#7469 — a pending signal always drains on its own timer, never waits for
+    // an unrelated trigger).
+    if (gitSignalDebounceTimerRef.current !== null) return;
+    gitSignalDebounceTimerRef.current = setTimeout(() => {
+      gitSignalDebounceTimerRef.current = null;
+      if (!mountedRef.current) return;
+      // Respect the active rate-limit park exactly like `onRateLimitChanged`:
+      // a forced recheck must never bypass backoff. While parked, just
+      // reschedule against the reset time; the rate-limit-clear handler runs
+      // the immediate recovery refresh.
+      const resetAt = rateLimitResetAtRef.current;
+      if (resetAt !== null && resetAt > Date.now()) {
+        polling.scheduleNextPoll();
+        return;
+      }
+      void polling.refresh({ force: true });
+    }, LOCAL_GIT_SIGNAL_REFRESH_DEBOUNCE_MS);
+  }, [polling]);
+
+  useEffect(() => {
+    // Signal-driven rechecks are automatic background fetches — suppressed on
+    // worker instances like the polling loop itself (#10123), matching the
+    // wake and rate-limit-clear handlers above.
+    if (isWorkerInstance) return;
+
+    // Scope guard: on project switch (and first hydration) the main worktree's
+    // identity changes while the store repopulates asynchronously. Re-baseline
+    // to the new scope's current counts and drop any pending recheck rather
+    // than reading the swap as local movement.
+    if (previousMainWorktreeIdRef.current !== mainWorktreeId) {
+      previousMainWorktreeIdRef.current = mainWorktreeId;
+      previousAheadCountRef.current = mainWorktreeAheadCount;
+      previousBehindCountRef.current = mainWorktreeBehindCount;
+      if (gitSignalDebounceTimerRef.current !== null) {
+        clearTimeout(gitSignalDebounceTimerRef.current);
+        gitSignalDebounceTimerRef.current = null;
+      }
+      return;
+    }
+
+    const previousAhead = previousAheadCountRef.current;
+    const previousBehind = previousBehindCountRef.current;
+    // Signal A: any ahead-count delta, both sides known. Guarding on non-null
+    // avoids firing on the null→value transition when upstream tracking first
+    // resolves.
+    const localRefMoved =
+      previousAhead !== null &&
+      mainWorktreeAheadCount !== null &&
+      mainWorktreeAheadCount !== previousAhead;
+    // Signal B: behind-count increase only.
+    const originAdvanced =
+      previousBehind !== null &&
+      mainWorktreeBehindCount !== null &&
+      mainWorktreeBehindCount > previousBehind;
+
+    previousAheadCountRef.current = mainWorktreeAheadCount;
+    previousBehindCountRef.current = mainWorktreeBehindCount;
+
+    if (localRefMoved || originAdvanced) {
+      enqueueGitSignalRefresh();
+    }
+  }, [
+    mainWorktreeId,
+    mainWorktreeAheadCount,
+    mainWorktreeBehindCount,
+    isWorkerInstance,
+    enqueueGitSignalRefresh,
+  ]);
+
+  // Clear the shared debounce slot on unmount so a queued recheck can't fire
+  // after teardown.
+  useEffect(() => {
+    return () => {
+      if (gitSignalDebounceTimerRef.current !== null) {
+        clearTimeout(gitSignalDebounceTimerRef.current);
+        gitSignalDebounceTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const isTokenError = isTokenRelatedError(error);
 

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -399,9 +399,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       const nextResetAt = repoStats.rateLimitResetAt ?? null;
       const nextKind = repoStats.rateLimitKind ?? null;
       rateLimitResetAtRef.current = nextResetAt;
-      // A stats result carrying a reset time is the provider reporting it is
-      // currently parked; absence means the quota is clear.
-      rateLimitBlockedRef.current = nextResetAt !== null;
+      // A stats result carrying a rate-limit kind or a reset time is the
+      // provider reporting it is currently parked; absence of both means the
+      // quota is clear. (Kind alone can mark an active secondary throttle whose
+      // reset time is unknown.)
+      rateLimitBlockedRef.current = nextKind !== null || nextResetAt !== null;
       setRateLimitResetAt(nextResetAt);
       setRateLimitKind(nextKind);
 
@@ -717,6 +719,10 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       // the fixed active interval until its first poll reports one (issue #9741).
       nextPollIntervalRef.current = null;
       rateLimitResetAtRef.current = null;
+      // Clear the git-signal park flag too — otherwise switching away from a
+      // blocked project would suppress the incoming project's first signal
+      // recheck until its own stats result lands.
+      rateLimitBlockedRef.current = false;
       setRateLimitResetAt(null);
       setRateLimitKind(null);
       // Reset error state too — without this the previous project's failure
@@ -1057,7 +1063,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // probe, cross-window singleflight, cache/dedup, and backoff as a scheduled
   // poll, just ahead of schedule. (Trade-off: on a deeply-idle repo the plain
   // refresh can fall inside the provider's adaptive /events backoff window and
-  // no-op; the base poll remains the correctness backstop.)
+  // no-op, and `refresh()` re-arms the next poll a full interval out — so a
+  // signal that no-ops can defer the base poll rather than pull it in. The
+  // affected window is a quiet *remote* where the counts it would fetch haven't
+  // moved anyway; the base poll remains the correctness backstop. Fetching
+  // fresh counts through the backoff would need a dedicated count-only
+  // revalidate mode on the provider, deferred as out of scope here.)
   const enqueueGitSignalRefresh = useCallback(() => {
     // Single shared debounce slot: the first signal in a burst arms a bounded
     // flush; later signals inside the window are absorbed by this guard rather

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -174,6 +174,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const [rateLimitResetAt, setRateLimitResetAt] = useState<number | null>(null);
   const [rateLimitKind, setRateLimitKind] = useState<ForgeRateLimitKind | null>(null);
   const rateLimitResetAtRef = useRef<number | null>(null);
+  // Live "poller is parked" flag mirroring `onRateLimitChanged`'s `blocked`
+  // calculation. Read at signal-flush time to suppress a forced recheck during
+  // an active park — a boolean, not a `resetAt` timestamp, because the reset
+  // time is nullable even while blocked (a secondary throttle can lack one).
+  const rateLimitBlockedRef = useRef(false);
   // Mirrors the `lastUpdated` state for synchronous reads from event-handler
   // closures (push subscribers). Used to skip stale stat pushes whose
   // `fetchedAt` is older than what we've already applied.
@@ -210,12 +215,13 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // Local-git-signal trigger state (#11151). Baselines track the main
   // worktree's ahead/behind counts so a genuine *delta* — not a snapshot
   // identity bump from an unrelated field (mood, note, PR state) — drives the
-  // forced recheck. Keyed on the main worktree's id so a project switch (which
-  // swaps the store's worktrees asynchronously) resets the baselines instead of
-  // reading the incoming project's counts as movement. The debounce timer is a
-  // single shared slot; it is the pending state, always armed to a bounded
-  // flush (never a bare pending flag, #7469).
-  const previousMainWorktreeIdRef = useRef<string | null>(null);
+  // recheck. Keyed on a composite of the current project id and the main
+  // worktree's id so a project switch resets the baselines instead of reading
+  // the incoming project's counts as movement — covering both the project-id
+  // flip and the asynchronous worktree-store swap that can lag behind it. The
+  // debounce timer is a single shared slot; it is the pending state, always
+  // armed to a bounded flush (never a bare pending flag, #7469).
+  const previousGitSignalScopeRef = useRef<string | null>(null);
   const previousAheadCountRef = useRef<number | null>(null);
   const previousBehindCountRef = useRef<number | null>(null);
   const gitSignalDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -393,6 +399,9 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       const nextResetAt = repoStats.rateLimitResetAt ?? null;
       const nextKind = repoStats.rateLimitKind ?? null;
       rateLimitResetAtRef.current = nextResetAt;
+      // A stats result carrying a reset time is the provider reporting it is
+      // currently parked; absence means the quota is clear.
+      rateLimitBlockedRef.current = nextResetAt !== null;
       setRateLimitResetAt(nextResetAt);
       setRateLimitKind(nextKind);
 
@@ -1008,6 +1017,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           : "primary"
         : null;
       rateLimitResetAtRef.current = nextResetAt;
+      rateLimitBlockedRef.current = blocked;
       setRateLimitResetAt(nextResetAt);
       setRateLimitKind(nextKind);
 
@@ -1027,10 +1037,10 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     return cleanup;
   }, [polling, isWorkerInstance]);
 
-  // Local git signals force a forge-count recheck ahead of the time-based poll
-  // so counts don't lag during merge sprees (#11151). Additive to the /events
-  // probe and the 30s/5min cadence — never a replacement. Two free, already-
-  // computed signals off the main worktree drive it:
+  // Local git signals trigger a forge-count recheck ahead of the time-based
+  // poll so counts don't lag during merge sprees (#11151). Additive to the
+  // /events probe and the 30s/5min cadence — never a replacement. Two free,
+  // already-computed signals off the main worktree drive it:
   //   Signal A — the ahead-count moved: local ref/HEAD movement relative to
   //     upstream (a local merge/commit, or the push that follows). This is a
   //     purer "ref moved" trigger than dirty-file activity, which would fire on
@@ -1039,10 +1049,15 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   //     landed on the forge website and the next fetch surfaced it. A decrease
   //     is a local catch-up (pull/rebase), not new remote content, so it only
   //     re-baselines.
-  // The forced recheck reuses `polling.refresh({ force: true })` exactly like
-  // wake/focus/rate-limit-clear, so it inherits the cheap REST-count path,
-  // cross-window singleflight, cache/dedup, and backoff instead of re-deriving
-  // them.
+  // The recheck reuses the ordinary `polling.refresh()` (NOT `{ force: true }`):
+  // `force` maps to `bypassCache`, which on GitHub skips the cheap conditional
+  // REST-count pair and runs the ~6-point GraphQL page query reserved for
+  // explicit user refreshes (#10122). An auto-trigger must prefer the cheap
+  // REST path, so it uses the plain refresh — inheriting the same /events 304
+  // probe, cross-window singleflight, cache/dedup, and backoff as a scheduled
+  // poll, just ahead of schedule. (Trade-off: on a deeply-idle repo the plain
+  // refresh can fall inside the provider's adaptive /events backoff window and
+  // no-op; the base poll remains the correctness backstop.)
   const enqueueGitSignalRefresh = useCallback(() => {
     // Single shared debounce slot: the first signal in a burst arms a bounded
     // flush; later signals inside the window are absorbed by this guard rather
@@ -1054,15 +1069,15 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       gitSignalDebounceTimerRef.current = null;
       if (!mountedRef.current) return;
       // Respect the active rate-limit park exactly like `onRateLimitChanged`:
-      // a forced recheck must never bypass backoff. While parked, just
-      // reschedule against the reset time; the rate-limit-clear handler runs
-      // the immediate recovery refresh.
-      const resetAt = rateLimitResetAtRef.current;
-      if (resetAt !== null && resetAt > Date.now()) {
+      // never issue a recheck into an active block. Gate on the `blocked` flag
+      // (not a reset timestamp — the reset time is nullable even while blocked).
+      // While parked, just reschedule; the rate-limit-clear handler runs the
+      // recovery refresh.
+      if (rateLimitBlockedRef.current) {
         polling.scheduleNextPoll();
         return;
       }
-      void polling.refresh({ force: true });
+      void polling.refresh();
     }, LOCAL_GIT_SIGNAL_REFRESH_DEBOUNCE_MS);
   }, [polling]);
 
@@ -1072,12 +1087,15 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     // wake and rate-limit-clear handlers above.
     if (isWorkerInstance) return;
 
-    // Scope guard: on project switch (and first hydration) the main worktree's
-    // identity changes while the store repopulates asynchronously. Re-baseline
-    // to the new scope's current counts and drop any pending recheck rather
-    // than reading the swap as local movement.
-    if (previousMainWorktreeIdRef.current !== mainWorktreeId) {
-      previousMainWorktreeIdRef.current = mainWorktreeId;
+    // Scope guard: on project switch (and first hydration) the scope key
+    // changes — either the project id flips or the worktree store swaps to the
+    // new project's main worktree (the two can happen a render apart, since the
+    // store repopulates asynchronously). Re-baseline to the new scope's current
+    // counts and drop any pending recheck rather than reading the swap as local
+    // movement.
+    const gitSignalScope = `${currentProjectId ?? ""}::${mainWorktreeId ?? ""}`;
+    if (previousGitSignalScopeRef.current !== gitSignalScope) {
+      previousGitSignalScopeRef.current = gitSignalScope;
       previousAheadCountRef.current = mainWorktreeAheadCount;
       previousBehindCountRef.current = mainWorktreeBehindCount;
       if (gitSignalDebounceTimerRef.current !== null) {
@@ -1109,6 +1127,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       enqueueGitSignalRefresh();
     }
   }, [
+    currentProjectId,
     mainWorktreeId,
     mainWorktreeAheadCount,
     mainWorktreeBehindCount,


### PR DESCRIPTION
## Summary

- Wires two already-computed, free local git signals off a project's main worktree to trigger a forge toolbar count recheck ahead of the existing time-based poll (30s active / 5min idle), so commit/issue/PR counts don't lag during merge sprees. This is additive to the existing `/events` probe, never a replacement.
- **Signal A**: the main worktree's ahead-count moving (local ref/HEAD movement relative to upstream: a local merge/commit, or the push that follows).
- **Signal B**: the main worktree's behind-count increasing (origin advanced: a merge landed on the forge website and the next fetch surfaced it).

Resolves #11151

## Changes

- Both signals are read off the per-project worktree store via a shallow `isMainWorktree` selector, keyed on a composite `project-id::worktree-id` scope so a project switch re-baselines instead of false-firing.
- A single shared, bounded debounce coalesces bursts into one recheck (self-arming flush, per #7469).
- The recheck calls the plain, unforced `polling.refresh()`, so it takes the cheap conditional-REST count path instead of the heavy GraphQL page query reserved for explicit user refreshes, and it respects the active rate-limit park.
- Two in-scope sub-tasks tighten Signal B latency:
  - On a real fetch success, `WorkspaceService` now also forces a git-status refresh on the main worktree, bounded to the triggering worktree plus main only (not all siblings), to avoid an N-way status storm.
  - `gitFileWatcher` now watches `refs/remotes/origin`, so an external `git fetch` advancing origin triggers a status pass.
- Hardened `triggerRefreshIfUpdating`'s detached status pass with a `.catch` so a transient git-status failure can't crash the workspace host.

Files touched: `src/hooks/useRepositoryStats.ts`, `electron/workspace-host/WorkspaceService.ts`, `electron/workspace-host/WorktreeMonitor.ts`, `electron/utils/gitFileWatcher.ts`, plus tests in `src/hooks/__tests__/useRepositoryStats.test.tsx`, `electron/workspace-host/__tests__/WorkspaceService.fetchSiblingRefresh.test.ts`, and `electron/utils/__tests__/gitFileWatcher.test.ts`.

## Testing

195 targeted tests passing locally across five suites: `useRepositoryStats` (90), `gitFileWatcher` (48), `fetchSiblingRefresh` (5), `WorktreeMonitor.scheduling` (21), `RepoFetchCoordinator` (31).

Reviewed across 3 passes with Codex; findings fixed covering the cheap REST path, bounded fan-out, the composite scope key, rate-limit coherence, and the host-crash guard.

## Known trade-off

On a deeply quiet remote, a signal's plain refresh can land inside the forge provider's adaptive `/events` backoff window and no-op, while still re-arming the next poll a full interval out. The base time-based poll remains the correctness backstop in that case. Fetching fresh counts through the backoff would need a dedicated count-only revalidate mode on the provider, deferred as out of scope here.
