### PR TITLE
feat(terminal): jump by word on Option+Left/Right

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -286,6 +286,21 @@ export function XtermAdapter({
       terminalInstanceService.setVisible(terminalId, true);
 
       if (!managed.keyHandlerInstalled) {
+        const writeWordJump = (event: KeyboardEvent, sequence: string): boolean => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!managed.isInputLocked) {
+            writeTerminalInputOrFleet(terminalId, sequence);
+            // `return false` bypasses xterm's onData, so the listener-installed
+            // input tracking is replicated here (#8255). The payload stays empty
+            // on purpose: a cursor jump composes no text, and a non-empty one
+            // would count toward the agent's composition total.
+            terminalInstanceService.notifyUserInput(terminalId);
+            stableOnInput(sequence);
+          }
+          return false;
+        };
+
         managed.terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
           // Only process keydown events to avoid double-firing
           if (event.type !== "keydown") {
@@ -340,16 +355,22 @@ export function XtermAdapter({
             return true;
           }
 
-          // Resolved here, ahead of the repeat guard, so a held Option+Arrow
-          // keeps jumping. Enter can sit behind that guard because xterm's own
-          // mapping for it already equals the sequence we write; Option+Arrow
-          // can't — xterm would emit the CSI modifier arrow, which readline
-          // ignores, so holding the key would silently stop after one word.
-          const wordJumpSequence = isMac() ? getOptionWordJumpSequence(event) : null;
+          // Only the shell line editor needs the rewrite: it binds ESC b / ESC f
+          // to word motion but not the CSI modifier arrows xterm emits for
+          // Option+Arrow. A full-screen TUI decodes those arrows itself, so on
+          // the alt buffer we leave the key alone rather than handing the app a
+          // Meta+B/F it never asked for.
+          const wordJumpSequence =
+            isMac() && !terminalInstanceService.getAltBufferState(terminalId)
+              ? getOptionWordJumpSequence(event)
+              : null;
 
-          // Skip repeat events
-          if (event.repeat && !wordJumpSequence) {
-            return true;
+          // Skip repeat events. A held Option+Arrow is the exception — word jump
+          // has to keep firing while the key is down — and it resolves here so
+          // auto-repeats never reach the chord resolution below, where they could
+          // complete or invalidate a pending chord the user never re-pressed.
+          if (event.repeat) {
+            return wordJumpSequence ? writeWordJump(event, wordJumpSequence) : true;
           }
 
           // Let Shift+F10 and ContextMenu key bubble to DOM for panel context menu
@@ -426,18 +447,8 @@ export function XtermAdapter({
             return true;
           }
 
-          // Option+Left/Right jump by word. Returning `false` bypasses xterm's
-          // onData, so the listener-installed input tracking is replicated here
-          // the same way the Enter branches do it (#8255).
           if (wordJumpSequence) {
-            event.preventDefault();
-            event.stopPropagation();
-            if (!managed.isInputLocked) {
-              writeTerminalInputOrFleet(terminalId, wordJumpSequence);
-              terminalInstanceService.notifyUserInput(terminalId);
-              stableOnInput(wordJumpSequence);
-            }
-            return false;
+            return writeWordJump(event, wordJumpSequence);
           }
 
           if (

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef, useEffect, useState } fr
 import type { ITerminalOptions } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { cn } from "@/lib/utils";
+import { isMac } from "@/lib/platform";
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { writeTerminalInputOrFleet } from "@/services/terminal/fleetInputRouter";
@@ -14,6 +15,7 @@ import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { useTerminalFileTransfer } from "./useTerminalFileTransfer";
+import { getOptionWordJumpSequence } from "./terminalWordNavigation";
 
 export interface XtermAdapterProps {
   terminalId: string;
@@ -338,8 +340,15 @@ export function XtermAdapter({
             return true;
           }
 
+          // Resolved here, ahead of the repeat guard, so a held Option+Arrow
+          // keeps jumping. Enter can sit behind that guard because xterm's own
+          // mapping for it already equals the sequence we write; Option+Arrow
+          // can't — xterm would emit the CSI modifier arrow, which readline
+          // ignores, so holding the key would silently stop after one word.
+          const wordJumpSequence = isMac() ? getOptionWordJumpSequence(event) : null;
+
           // Skip repeat events
-          if (event.repeat) {
+          if (event.repeat && !wordJumpSequence) {
             return true;
           }
 
@@ -415,6 +424,20 @@ export function XtermAdapter({
           // Allow critical Ctrl+<key> bindings to reach the TUI
           if (event.ctrlKey && !event.shiftKey && TUI_KEYBINDS.has(event.key)) {
             return true;
+          }
+
+          // Option+Left/Right jump by word. Returning `false` bypasses xterm's
+          // onData, so the listener-installed input tracking is replicated here
+          // the same way the Enter branches do it (#8255).
+          if (wordJumpSequence) {
+            event.preventDefault();
+            event.stopPropagation();
+            if (!managed.isInputLocked) {
+              writeTerminalInputOrFleet(terminalId, wordJumpSequence);
+              terminalInstanceService.notifyUserInput(terminalId);
+              stableOnInput(wordJumpSequence);
+            }
+            return false;
           }
 
           if (

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -90,6 +90,9 @@ const mocks = vi.hoisted(() => {
       managed.isAttaching = false;
       (managed as { keyHandlerInstalled?: boolean }).keyHandlerInstalled = false;
       platform.isMac = true;
+      // vi.clearAllMocks() drops calls but keeps implementations, so a test that
+      // switches to the alt buffer would otherwise leak into the next one.
+      terminalInstanceService.getAltBufferState.mockReturnValue(false);
       Object.assign(appearance, defaultAppearance, { effectiveTheme: {} });
     },
   };
@@ -674,6 +677,30 @@ describe("XtermAdapter lifecycle", () => {
       // to xterm, so a held Option+Left would jump one word and then stall.
       expect(keyHandler(optionArrow("ArrowLeft", { repeat: true }))).toBe(false);
       expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bb");
+    });
+
+    it("keeps a held Option+Arrow out of the chord state machine", async () => {
+      const keyHandler = await mountAndGetKeyHandler();
+
+      // An auto-repeat must not be able to complete or invalidate a pending
+      // chord the user never re-pressed.
+      keyHandler(optionArrow("ArrowLeft", { repeat: true }));
+
+      expect(keybindingService.resolveKeybinding).not.toHaveBeenCalled();
+      expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bb");
+    });
+
+    it("leaves Option+Arrow to a full-screen TUI on the alt buffer", async () => {
+      // A TUI decodes xterm's CSI modifier arrow itself; rewriting it would hand
+      // the app a Meta+B/F instead of the Alt+Arrow it bound.
+      mocks.terminalInstanceService.getAltBufferState.mockReturnValue(true);
+      const onInput = vi.fn();
+      const keyHandler = await mountAndGetKeyHandler({ onInput });
+
+      expect(keyHandler(optionArrow("ArrowLeft"))).toBe(true);
+      expect(keyHandler(optionArrow("ArrowRight", { repeat: true }))).toBe(true);
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
+      expect(onInput).not.toHaveBeenCalled();
     });
 
     it("leaves Option+Arrow to xterm off macOS, including on repeat", async () => {

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
+import type { KeybindingResolutionResult } from "@/services/keybindingUtils";
 import { XtermAdapter } from "../XtermAdapter";
 
 const mocks = vi.hoisted(() => {
@@ -624,14 +625,16 @@ describe("XtermAdapter lifecycle", () => {
   });
 
   describe("Option+Arrow word navigation (#11154)", () => {
+    function resolution(shouldConsume: boolean): KeybindingResolutionResult {
+      return { match: undefined, chordPrefix: false, shouldConsume };
+    }
+
     beforeEach(() => {
       // vi.clearAllMocks() keeps implementations and queued `Once` values, so the
       // chord tests below would otherwise bleed into each other. mockReset drops
       // both; re-establish the pass-through defaults.
       vi.mocked(keybindingService.getPendingChord).mockReset().mockReturnValue(null);
-      vi.mocked(keybindingService.resolveKeybinding)
-        .mockReset()
-        .mockReturnValue({ shouldConsume: false });
+      vi.mocked(keybindingService.resolveKeybinding).mockReset().mockReturnValue(resolution(false));
     });
 
     async function mountAndGetKeyHandler(props: Parameters<typeof renderAdapter>[0] = {}) {
@@ -695,7 +698,7 @@ describe("XtermAdapter lifecycle", () => {
       // A chord IS pending and would consume the key — an auto-repeat must not
       // reach it, or a held arrow completes a chord the user never re-pressed.
       vi.mocked(keybindingService.getPendingChord).mockReturnValue("Cmd+K");
-      vi.mocked(keybindingService.resolveKeybinding).mockReturnValue({ shouldConsume: true });
+      vi.mocked(keybindingService.resolveKeybinding).mockReturnValue(resolution(true));
 
       expect(keyHandler(optionArrow("ArrowLeft", { repeat: true }))).toBe(false);
 
@@ -784,7 +787,7 @@ describe("XtermAdapter lifecycle", () => {
       const keyHandler = await mountAndGetKeyHandler();
 
       vi.mocked(keybindingService.getPendingChord).mockReturnValueOnce("Cmd+K");
-      vi.mocked(keybindingService.resolveKeybinding).mockReturnValueOnce({ shouldConsume: true });
+      vi.mocked(keybindingService.resolveKeybinding).mockReturnValueOnce(resolution(true));
 
       expect(keyHandler(optionArrow("ArrowLeft"))).toBe(false);
       expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -6,11 +6,13 @@ import { render, waitFor, cleanup } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
 import { actionService } from "@/services/ActionService";
+import { keybindingService } from "@/services/KeybindingService";
 import { XtermAdapter } from "../XtermAdapter";
 
 const mocks = vi.hoisted(() => {
   let keyHandler: ((event: KeyboardEvent) => boolean) | null = null;
   let exitHandler: ((exitCode: number) => void) | null = null;
+  const platform = { isMac: true };
 
   const defaultAppearance = {
     fontSize: 14,
@@ -75,6 +77,7 @@ const mocks = vi.hoisted(() => {
   return {
     appearance,
     managed,
+    platform,
     terminalInstanceService,
     writeTerminalInputOrFleet: vi.fn(),
     useTerminalFileTransfer: vi.fn(),
@@ -86,10 +89,16 @@ const mocks = vi.hoisted(() => {
       managed.isInputLocked = false;
       managed.isAttaching = false;
       (managed as { keyHandlerInstalled?: boolean }).keyHandlerInstalled = false;
+      platform.isMac = true;
       Object.assign(appearance, defaultAppearance, { effectiveTheme: {} });
     },
   };
 });
+
+vi.mock("@/lib/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/platform")>()),
+  isMac: () => mocks.platform.isMac,
+}));
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: mocks.terminalInstanceService,
@@ -609,5 +618,120 @@ describe("XtermAdapter lifecycle", () => {
     );
     expect(mocks.terminalInstanceService.updateOptions).toHaveBeenCalledTimes(1);
     expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
+  });
+
+  describe("Option+Arrow word navigation (#11154)", () => {
+    async function mountAndGetKeyHandler(props: Parameters<typeof renderAdapter>[0] = {}) {
+      renderAdapter(props);
+      await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+      const keyHandler = mocks.getKeyHandler();
+      expect(keyHandler).toBeTruthy();
+      return keyHandler!;
+    }
+
+    function optionArrow(key: "ArrowLeft" | "ArrowRight", init: KeyboardEventInit = {}) {
+      return new KeyboardEvent("keydown", {
+        key,
+        code: key,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      });
+    }
+
+    it("writes the backward-word sequence for Option+Left", async () => {
+      const onInput = vi.fn();
+      const keyHandler = await mountAndGetKeyHandler({ onInput });
+
+      const event = optionArrow("ArrowLeft");
+      const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+      const stopPropagationSpy = vi.spyOn(event, "stopPropagation");
+
+      // `false` suppresses xterm's own CSI modifier arrow, which readline ignores.
+      expect(keyHandler(event)).toBe(false);
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(stopPropagationSpy).toHaveBeenCalled();
+      expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bb");
+      // `return false` bypasses xterm's onData, so input tracking is replicated here.
+      expect(mocks.terminalInstanceService.notifyUserInput).toHaveBeenCalledWith("term-1");
+      expect(onInput).toHaveBeenCalledWith("\x1bb");
+    });
+
+    it("writes the forward-word sequence for Option+Right", async () => {
+      const onInput = vi.fn();
+      const keyHandler = await mountAndGetKeyHandler({ onInput });
+
+      expect(keyHandler(optionArrow("ArrowRight"))).toBe(false);
+      expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bf");
+      expect(onInput).toHaveBeenCalledWith("\x1bf");
+    });
+
+    it("keeps writing while the key is held", async () => {
+      const keyHandler = await mountAndGetKeyHandler();
+
+      // The shared `event.repeat` early return would otherwise hand repeats back
+      // to xterm, so a held Option+Left would jump one word and then stall.
+      expect(keyHandler(optionArrow("ArrowLeft", { repeat: true }))).toBe(false);
+      expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bb");
+    });
+
+    it("leaves Option+Arrow to xterm off macOS, including on repeat", async () => {
+      mocks.platform.isMac = false;
+      const onInput = vi.fn();
+      const keyHandler = await mountAndGetKeyHandler({ onInput });
+
+      expect(keyHandler(optionArrow("ArrowLeft"))).toBe(true);
+      expect(keyHandler(optionArrow("ArrowRight", { repeat: true }))).toBe(true);
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
+      expect(mocks.terminalInstanceService.notifyUserInput).not.toHaveBeenCalled();
+      expect(onInput).not.toHaveBeenCalled();
+    });
+
+    it("does not claim Option+Arrow combined with another modifier", async () => {
+      const keyHandler = await mountAndGetKeyHandler();
+
+      // Shift+Option extends a selection; Cmd+Option is bound to terminal.focus*.
+      keyHandler(optionArrow("ArrowLeft", { shiftKey: true }));
+      keyHandler(optionArrow("ArrowRight", { ctrlKey: true }));
+      keyHandler(optionArrow("ArrowLeft", { metaKey: true }));
+
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
+      expect(mocks.terminalInstanceService.notifyUserInput).not.toHaveBeenCalled();
+    });
+
+    it("leaves unmodified arrows to xterm", async () => {
+      const keyHandler = await mountAndGetKeyHandler();
+
+      const plainArrow = new KeyboardEvent("keydown", {
+        key: "ArrowLeft",
+        code: "ArrowLeft",
+        bubbles: true,
+        cancelable: true,
+      });
+      expect(keyHandler(plainArrow)).toBe(true);
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
+    });
+
+    it("swallows Option+Arrow without writing while input is locked", async () => {
+      const onInput = vi.fn();
+      const keyHandler = await mountAndGetKeyHandler({ isInputLocked: true, onInput });
+      mocks.managed.isInputLocked = true;
+
+      expect(keyHandler(optionArrow("ArrowLeft"))).toBe(false);
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
+      expect(mocks.terminalInstanceService.notifyUserInput).not.toHaveBeenCalled();
+      expect(onInput).not.toHaveBeenCalled();
+    });
+
+    it("lets a pending chord consume Option+Arrow before word navigation", async () => {
+      const keyHandler = await mountAndGetKeyHandler();
+
+      vi.mocked(keybindingService.getPendingChord).mockReturnValueOnce("Cmd+K");
+      vi.mocked(keybindingService.resolveKeybinding).mockReturnValueOnce({ shouldConsume: true });
+
+      expect(keyHandler(optionArrow("ArrowLeft"))).toBe(false);
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -624,6 +624,16 @@ describe("XtermAdapter lifecycle", () => {
   });
 
   describe("Option+Arrow word navigation (#11154)", () => {
+    beforeEach(() => {
+      // vi.clearAllMocks() keeps implementations and queued `Once` values, so the
+      // chord tests below would otherwise bleed into each other. mockReset drops
+      // both; re-establish the pass-through defaults.
+      vi.mocked(keybindingService.getPendingChord).mockReset().mockReturnValue(null);
+      vi.mocked(keybindingService.resolveKeybinding)
+        .mockReset()
+        .mockReturnValue({ shouldConsume: false });
+    });
+
     async function mountAndGetKeyHandler(props: Parameters<typeof renderAdapter>[0] = {}) {
       renderAdapter(props);
       await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
@@ -682,25 +692,44 @@ describe("XtermAdapter lifecycle", () => {
     it("keeps a held Option+Arrow out of the chord state machine", async () => {
       const keyHandler = await mountAndGetKeyHandler();
 
-      // An auto-repeat must not be able to complete or invalidate a pending
-      // chord the user never re-pressed.
-      keyHandler(optionArrow("ArrowLeft", { repeat: true }));
+      // A chord IS pending and would consume the key — an auto-repeat must not
+      // reach it, or a held arrow completes a chord the user never re-pressed.
+      vi.mocked(keybindingService.getPendingChord).mockReturnValue("Cmd+K");
+      vi.mocked(keybindingService.resolveKeybinding).mockReturnValue({ shouldConsume: true });
 
+      expect(keyHandler(optionArrow("ArrowLeft", { repeat: true }))).toBe(false);
+
+      expect(keybindingService.getPendingChord).not.toHaveBeenCalled();
       expect(keybindingService.resolveKeybinding).not.toHaveBeenCalled();
       expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bb");
     });
 
     it("leaves Option+Arrow to a full-screen TUI on the alt buffer", async () => {
-      // A TUI decodes xterm's CSI modifier arrow itself; rewriting it would hand
-      // the app a Meta+B/F instead of the Alt+Arrow it bound.
-      mocks.terminalInstanceService.getAltBufferState.mockReturnValue(true);
       const onInput = vi.fn();
       const keyHandler = await mountAndGetKeyHandler({ onInput });
 
+      // Flipped after the handler is installed: the handler is installed once, so
+      // reading the buffer mode at install time would silently freeze it.
+      mocks.terminalInstanceService.getAltBufferState.mockReturnValue(true);
+
+      // A TUI decodes xterm's CSI modifier arrow itself; rewriting it would hand
+      // the app a Meta+B/F instead of the Alt+Arrow it bound.
       expect(keyHandler(optionArrow("ArrowLeft"))).toBe(true);
       expect(keyHandler(optionArrow("ArrowRight", { repeat: true }))).toBe(true);
       expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
       expect(onInput).not.toHaveBeenCalled();
+
+      // ...and word jump resumes when the TUI exits back to the shell.
+      mocks.terminalInstanceService.getAltBufferState.mockReturnValue(false);
+      expect(keyHandler(optionArrow("ArrowLeft"))).toBe(false);
+      expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\x1bb");
+    });
+
+    it("leaves Option+Arrow to xterm's composition handling during IME input", async () => {
+      const keyHandler = await mountAndGetKeyHandler();
+
+      expect(keyHandler(optionArrow("ArrowLeft", { isComposing: true }))).toBe(true);
+      expect(mocks.writeTerminalInputOrFleet).not.toHaveBeenCalled();
     });
 
     it("leaves Option+Arrow to xterm off macOS, including on repeat", async () => {

--- a/src/components/Terminal/__tests__/terminalWordNavigation.test.ts
+++ b/src/components/Terminal/__tests__/terminalWordNavigation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { getOptionWordJumpSequence } from "../terminalWordNavigation";
+
+function makeKeyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    type: "keydown",
+    key: "ArrowLeft",
+    code: "ArrowLeft",
+    shiftKey: false,
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    repeat: false,
+    ...overrides,
+  } as unknown as KeyboardEvent;
+}
+
+describe("getOptionWordJumpSequence", () => {
+  it("maps Option+Left to the readline backward-word sequence", () => {
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft", altKey: true }))).toBe(
+      "\x1bb"
+    );
+  });
+
+  it("maps Option+Right to the readline forward-word sequence", () => {
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowRight", altKey: true }))).toBe(
+      "\x1bf"
+    );
+  });
+
+  it("keeps jumping on key repeat", () => {
+    expect(
+      getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft", altKey: true, repeat: true }))
+    ).toBe("\x1bb");
+  });
+
+  it("ignores arrows pressed without Option", () => {
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft" }))).toBeNull();
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowRight" }))).toBeNull();
+  });
+
+  it("leaves Cmd+Option+Arrow to the terminal.focus* pane bindings", () => {
+    expect(
+      getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft", altKey: true, metaKey: true }))
+    ).toBeNull();
+    expect(
+      getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowRight", altKey: true, metaKey: true }))
+    ).toBeNull();
+  });
+
+  it("leaves Shift+Option+Arrow to the selection-extend convention", () => {
+    expect(
+      getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft", altKey: true, shiftKey: true }))
+    ).toBeNull();
+  });
+
+  it("ignores Ctrl+Option+Arrow", () => {
+    expect(
+      getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft", altKey: true, ctrlKey: true }))
+    ).toBeNull();
+  });
+
+  it("ignores vertical arrows and non-arrow keys", () => {
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowUp", altKey: true }))).toBeNull();
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowDown", altKey: true }))).toBeNull();
+    expect(getOptionWordJumpSequence(makeKeyEvent({ key: "b", altKey: true }))).toBeNull();
+  });
+
+  it("matches on the semantic key, not the physical code", () => {
+    expect(
+      getOptionWordJumpSequence(
+        makeKeyEvent({ key: "Unidentified", code: "ArrowLeft", altKey: true })
+      )
+    ).toBeNull();
+  });
+});

--- a/src/components/Terminal/__tests__/terminalWordNavigation.test.ts
+++ b/src/components/Terminal/__tests__/terminalWordNavigation.test.ts
@@ -1,18 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { getOptionWordJumpSequence } from "../terminalWordNavigation";
+import { getOptionWordJumpSequence, type WordJumpKeyEvent } from "../terminalWordNavigation";
 
-function makeKeyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+function makeKeyEvent(overrides: Partial<WordJumpKeyEvent>): WordJumpKeyEvent {
   return {
-    type: "keydown",
     key: "ArrowLeft",
-    code: "ArrowLeft",
     shiftKey: false,
     ctrlKey: false,
     altKey: false,
     metaKey: false,
-    repeat: false,
     ...overrides,
-  } as unknown as KeyboardEvent;
+  };
 }
 
 describe("getOptionWordJumpSequence", () => {
@@ -26,12 +23,6 @@ describe("getOptionWordJumpSequence", () => {
     expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowRight", altKey: true }))).toBe(
       "\x1bf"
     );
-  });
-
-  it("keeps jumping on key repeat", () => {
-    expect(
-      getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowLeft", altKey: true, repeat: true }))
-    ).toBe("\x1bb");
   });
 
   it("ignores arrows pressed without Option", () => {
@@ -63,14 +54,13 @@ describe("getOptionWordJumpSequence", () => {
   it("ignores vertical arrows and non-arrow keys", () => {
     expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowUp", altKey: true }))).toBeNull();
     expect(getOptionWordJumpSequence(makeKeyEvent({ key: "ArrowDown", altKey: true }))).toBeNull();
+    // Option+B/F already reach the shell as meta sequences via `macOptionIsMeta`.
     expect(getOptionWordJumpSequence(makeKeyEvent({ key: "b", altKey: true }))).toBeNull();
   });
 
-  it("matches on the semantic key, not the physical code", () => {
+  it("ignores a key the browser could not identify", () => {
     expect(
-      getOptionWordJumpSequence(
-        makeKeyEvent({ key: "Unidentified", code: "ArrowLeft", altKey: true })
-      )
+      getOptionWordJumpSequence(makeKeyEvent({ key: "Unidentified", altKey: true }))
     ).toBeNull();
   });
 });

--- a/src/components/Terminal/terminalWordNavigation.ts
+++ b/src/components/Terminal/terminalWordNavigation.ts
@@ -16,6 +16,13 @@
 const META_BACKWARD_WORD = "\x1bb";
 const META_FORWARD_WORD = "\x1bf";
 
+/** The only fields the mapping reads — `code` is excluded so a remapped or
+ *  assistive-tech key can't be matched by its physical position. */
+export type WordJumpKeyEvent = Pick<
+  KeyboardEvent,
+  "key" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
 /**
  * The meta sequence Option+Left/Right should emit, or `null` when the event
  * isn't a bare Option+Arrow.
@@ -24,7 +31,7 @@ const META_FORWARD_WORD = "\x1bf";
  * the `terminal.focus*` pane navigation actions, and Shift+Option+Arrow is the
  * selection-extend convention.
  */
-export function getOptionWordJumpSequence(event: KeyboardEvent): string | null {
+export function getOptionWordJumpSequence(event: WordJumpKeyEvent): string | null {
   if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
     return null;
   }

--- a/src/components/Terminal/terminalWordNavigation.ts
+++ b/src/components/Terminal/terminalWordNavigation.ts
@@ -8,8 +8,10 @@
  * XtermAdapter substitutes those. `macOptionIsMeta` doesn't cover this: it only
  * applies to character keys, never arrows.
  *
- * Pure over the event — the macOS gate lives at the call site, since remapping
- * Alt+Arrow is a Mac convention (VS Code gates its equivalent on `isMac` too).
+ * Pure over the event. The two gates live at the call site: macOS, because
+ * remapping Alt+Arrow is a Mac convention (VS Code gates its equivalent on
+ * `isMac` too), and the normal buffer, because a full-screen TUI decodes the CSI
+ * modifier arrows itself and would only be confused by a Meta+B/F.
  */
 const META_BACKWARD_WORD = "\x1bb";
 const META_FORWARD_WORD = "\x1bf";

--- a/src/components/Terminal/terminalWordNavigation.ts
+++ b/src/components/Terminal/terminalWordNavigation.ts
@@ -1,0 +1,32 @@
+/**
+ * Option+Arrow word navigation for terminal panes.
+ *
+ * xterm's default mapping for Option+Left/Right is the CSI modifier arrow
+ * (`ESC [ 1 ; 3 D` / `C`), which neither zsh's ZLE nor bash's readline binds to
+ * word motion — so the keys do nothing in a default shell. Both bind the meta
+ * sequences `ESC b` / `ESC f` to backward-word/forward-word out of the box, so
+ * XtermAdapter substitutes those. `macOptionIsMeta` doesn't cover this: it only
+ * applies to character keys, never arrows.
+ *
+ * Pure over the event — the macOS gate lives at the call site, since remapping
+ * Alt+Arrow is a Mac convention (VS Code gates its equivalent on `isMac` too).
+ */
+const META_BACKWARD_WORD = "\x1bb";
+const META_FORWARD_WORD = "\x1bf";
+
+/**
+ * The meta sequence Option+Left/Right should emit, or `null` when the event
+ * isn't a bare Option+Arrow.
+ *
+ * Every other modifier is excluded deliberately: Cmd+Option+Arrow is bound to
+ * the `terminal.focus*` pane navigation actions, and Shift+Option+Arrow is the
+ * selection-extend convention.
+ */
+export function getOptionWordJumpSequence(event: KeyboardEvent): string | null {
+  if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+    return null;
+  }
+  if (event.key === "ArrowLeft") return META_BACKWARD_WORD;
+  if (event.key === "ArrowRight") return META_FORWARD_WORD;
+  return null;
+}


### PR DESCRIPTION
## Summary

- On macOS, Option+Left/Right did nothing in the terminal. xterm emits the CSI modifier arrow sequences for these keys (`\x1b[1;3D` / `\x1b[1;3C`), and neither zsh's ZLE nor bash's readline binds those to word motion by default. Both do bind the meta sequences `\x1bb` / `\x1bf` to `backward-word` / `forward-word` out of the box, which is why Option+B and Option+F already worked (`macOptionIsMeta` covers character keys, but never arrows).
- The fix: intercept bare Option+Left/Right in `XtermAdapter`'s `attachCustomKeyEventHandler` and write `\x1bb` / `\x1bf` instead of letting xterm emit the CSI sequence.
- This matches iTerm2's opt-in "Natural Text Editing" preset, not the out-of-the-box default for iTerm2 or Ghostty (both actually emit the CSI modifier arrows unless you turn that preset on). Worth being precise about that rather than repeating the issue's framing.

Resolves #11154

A few implementation details worth calling out:

1. **Scoped to the shell line editor.** On the alternate screen buffer, a full-screen TUI like vim or less, the key is left alone. A TUI decodes the CSI modifier arrow itself, so rewriting it there would hand the app a Meta+B/F binding it never asked for. The buffer mode is read live on every keypress, not snapshotted when the handler is installed.
2. **Held keys keep jumping.** The handler's shared `event.repeat` early return would otherwise hand repeats back to xterm, which emits the CSI sequence the shell ignores, so a held Option+Left would jump one word then silently stall. Repeats are written before chord resolution so an auto-repeat can't complete or invalidate a pending chord.
3. **macOS only, bare Option only.** Cmd+Option+Arrow stays bound to the `terminal.focus*` pane navigation actions, and Shift+Option+Arrow is left to the selection-extend convention. Nothing changes on Linux/Windows, same as how VS Code gates its equivalent keybinding on `isMac`.

## Changes

- `src/components/Terminal/XtermAdapter.tsx`: the intercept plus a `writeWordJump` helper.
- `src/components/Terminal/terminalWordNavigation.ts` (new): pure event-to-sequence mapping.
- `src/components/Terminal/__tests__/terminalWordNavigation.test.ts` (new): 8 unit tests.
- `src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx`: 10 integration tests through the real captured key handler.

## Testing

- 77 tests green across the Terminal suite: `terminalWordNavigation`, `XtermAdapter.lifecycle`, `xtermCompositionGuard`, `terminalFocus`, `useTerminalFileTransfer`.
- `tsc` clean.
- `eslint` / `prettier` clean on the changed files, no new warnings.

## Notes

Two pre-existing limitations, neither introduced here:

- `clearCommandDetection` treats the trailing `b`/`f` of a meta sequence as typed text. Option+B already does this today, so word-jump-by-arrow just inherits it.
- The key handler is installed once and closes over the first mount's `onInput`, so a remount reusing the managed terminal can reach a stale `InputTracker`. Affects the existing Enter branches identically.
