### PR TITLE
fix(dock): stop docked-terminal arrow keys from roving the dock rail

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -346,14 +346,16 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const handleDockKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLElement>) => {
-      // Issue #11156 — React synthetic events bubble through the React tree, so
-      // keydowns inside portaled children (a docked terminal's Radix Popover
-      // content, rendered in document.body) still reach this handler. xterm
-      // preventDefaults the keys it handles but never stops propagation, so
-      // arrows typed into a docked terminal would rove the rail and steal focus
-      // off the terminal. The DOM containment check excludes portal content —
-      // it is not a DOM descendant of the rail. Mirrors Toolbar.tsx.
-      if (!scrollContainerRef.current?.contains(e.target as Node)) return;
+      // Issue #11156 — React synthetic events bubble the React tree, so keydowns
+      // from a docked panel's Radix Popover content (portaled to document.body)
+      // still reach this handler. Not every input surface cancels them first:
+      // xterm stops propagation for keys it handles but deliberately does not in
+      // screenReaderMode, and the CodeMirror input bar preventDefaults without
+      // stopping propagation. Either way an arrow typed into a docked terminal
+      // would rove the rail and yank focus off the panel mid-type. Gate on DOM
+      // containment — portal content is not a DOM descendant of the rail — so
+      // key ownership follows the real tree. Mirrors Toolbar.tsx.
+      if (!(e.target instanceof Node) || !scrollContainerRef.current?.contains(e.target)) return;
 
       // dnd-kit's KeyboardSensor owns Space/Enter (lift) and arrows (move)
       // while a drag is active. Early-return so reordering still works.

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -346,6 +346,15 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const handleDockKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLElement>) => {
+      // Issue #11156 — React synthetic events bubble through the React tree, so
+      // keydowns inside portaled children (a docked terminal's Radix Popover
+      // content, rendered in document.body) still reach this handler. xterm
+      // preventDefaults the keys it handles but never stops propagation, so
+      // arrows typed into a docked terminal would rove the rail and steal focus
+      // off the terminal. The DOM containment check excludes portal content —
+      // it is not a DOM descendant of the rail. Mirrors Toolbar.tsx.
+      if (!scrollContainerRef.current?.contains(e.target as Node)) return;
+
       // dnd-kit's KeyboardSensor owns Space/Enter (lift) and arrows (move)
       // while a drag is active. Early-return so reordering still works.
       if (dndActive !== null) return;

--- a/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
@@ -5,10 +5,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PtyPanelData } from "@shared/types/panel";
 
 // Issue #11156 — a docked terminal's Radix Popover content is portaled to
-// document.body but stays a React descendant of the dock rail, so its keydowns
-// bubble up the fiber tree into the rail's roving-tabindex handler. The chip
-// stub below reproduces exactly that shape: a [data-dock-item] chip plus a
-// portaled input that, like xterm, preventDefaults without stopping propagation.
+// document.body, so it sits outside the dock rail's DOM tree while its keydowns
+// still arrive at the rail's roving-tabindex handler through React. Typing an
+// arrow in a docked terminal roved the rail and yanked focus onto the next chip.
+//
+// This is a handler-level test of that contract, not a replica of the production
+// panel topology (which relocates the panel through DockPanelOffscreenContainer
+// into the popover). It asserts what the rail owes its portaled children: a key
+// whose target is outside the rail's DOM is none of the rail's business.
 //
 // vi.mock factories are hoisted above the module body, so everything they read
 // has to live in vi.hoisted or it is still in TDZ when they run.
@@ -134,7 +138,17 @@ vi.mock("@/components/ui/context-menu", () => ({
   ContextMenuSubTrigger: fixture.passthrough,
 }));
 
-// Stands in for the real Radix Popover trigger + its portaled terminal content.
+// Stands in for the real Radix Popover trigger plus its portaled panel content.
+// Two inputs, because production has two kinds of key-cancelling behaviour and
+// the guard must be blind to both:
+//   - "cancelled": xterm in its default mode stops propagation on keys it
+//     handles. This is the benign case.
+//   - "uncancelled": xterm in screenReaderMode deliberately does NOT cancel
+//     arrows (see CoreBrowserTerminal's keydown handler), and the CodeMirror
+//     input bar preventDefaults without stopping propagation. These are the
+//     events that actually escape into the rail — the real #11156 trigger.
+// A guard keyed on `defaultPrevented` would pass the cancelled case and still
+// let the uncancelled one steal focus, so both are asserted.
 vi.mock("../DockedTerminalItem", () => ({
   DockedTerminalItem: ({ terminal }: { terminal: PtyPanelData }) => (
     <>
@@ -143,10 +157,13 @@ vi.mock("../DockedTerminalItem", () => ({
       </button>
       {terminal.id === fixture.PORTAL_TERMINAL_ID
         ? createPortal(
-            <textarea
-              aria-label="Docked terminal input"
-              onKeyDown={(event) => event.preventDefault()}
-            />,
+            <>
+              <textarea
+                aria-label="Cancelled terminal input"
+                onKeyDown={(event) => event.preventDefault()}
+              />
+              <textarea aria-label="Uncancelled terminal input" />
+            </>,
             document.body
           )
         : null}
@@ -179,8 +196,11 @@ function renderDock() {
     chip.scrollIntoView = vi.fn();
   }
 
-  const terminalInput = screen.getByRole("textbox", { name: "Docked terminal input" });
-  return { rail, chips, terminalInput };
+  const inputs = {
+    cancelled: screen.getByRole("textbox", { name: "Cancelled terminal input" }),
+    uncancelled: screen.getByRole("textbox", { name: "Uncancelled terminal input" }),
+  };
+  return { rail, chips, inputs };
 }
 
 /** Roving tabindex keeps the active chip as the rail's only tab stop. */
@@ -202,31 +222,35 @@ describe("ContentDock — arrow keys from a docked terminal (issue #11156)", () 
     expect(tabStops(chips)).toEqual([-1, 0]);
   });
 
-  it.each(["ArrowLeft", "ArrowRight", "Home", "End"] as const)(
-    "leaves focus and rail tab stops untouched for %s typed into the portaled terminal",
-    (key) => {
-      const { rail, chips, terminalInput } = renderDock();
+  const KEYS = ["ArrowLeft", "ArrowRight", "Home", "End"] as const;
+  const SURFACES = ["cancelled", "uncancelled"] as const;
+
+  it.each(SURFACES.flatMap((surface) => KEYS.map((key) => [surface, key] as const)))(
+    "leaves focus and rail tab stops untouched for %s %s typed into the portaled terminal",
+    (surface, key) => {
+      const { rail, chips, inputs } = renderDock();
+      const input = inputs[surface];
 
       chips[0]!.focus();
       const stopsBefore = tabStops(chips);
 
-      terminalInput.focus();
-      // The terminal is a React descendant of the rail but not a DOM one — that
-      // divergence is the whole bug.
-      expect(rail.contains(terminalInput)).toBe(false);
+      input.focus();
+      // The terminal reaches this handler through the React tree while sitting
+      // outside the rail's DOM tree. That divergence is the whole bug.
+      expect(rail.contains(input)).toBe(false);
 
-      fireEvent.keyDown(terminalInput, { key });
+      fireEvent.keyDown(input, { key });
 
-      expect(document.activeElement).toBe(terminalInput);
+      expect(document.activeElement).toBe(input);
       expect(tabStops(chips)).toEqual(stopsBefore);
     }
   );
 
   it("does not adopt the portaled terminal as the rail's active chip on focus", () => {
-    const { chips, terminalInput } = renderDock();
+    const { chips, inputs } = renderDock();
 
     chips[0]!.focus();
-    terminalInput.focus();
+    inputs.uncancelled.focus();
 
     // Focus events bubble the fiber tree too. The rail must not treat the
     // terminal as one of its chips: ArrowRight from the first chip still lands

--- a/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { createPortal } from "react-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
+
+// Issue #11156 — a docked terminal's Radix Popover content is portaled to
+// document.body but stays a React descendant of the dock rail, so its keydowns
+// bubble up the fiber tree into the rail's roving-tabindex handler. The chip
+// stub below reproduces exactly that shape: a [data-dock-item] chip plus a
+// portaled input that, like xterm, preventDefaults without stopping propagation.
+//
+// vi.mock factories are hoisted above the module body, so everything they read
+// has to live in vi.hoisted or it is still in TDZ when they run.
+const fixture = vi.hoisted(() => {
+  const PORTAL_TERMINAL_ID = "dock-1";
+  const dockPanels = [
+    {
+      id: PORTAL_TERMINAL_ID,
+      kind: "terminal",
+      title: "First panel",
+      location: "dock",
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+    },
+    {
+      id: "dock-2",
+      kind: "terminal",
+      title: "Second panel",
+      location: "dock",
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+    },
+  ] satisfies PtyPanelData[];
+
+  return {
+    PORTAL_TERMINAL_ID,
+    dockPanels,
+    panelState: {
+      panelsById: Object.fromEntries(dockPanels.map((panel) => [panel.id, panel])),
+      panelIds: dockPanels.map((panel) => panel.id),
+      trashedTerminals: new Map<string, never>(),
+      tabGroups: new Map<string, never>(),
+      getTabGroups: () => [],
+      getTabGroupPanels: () => [],
+    },
+    // Returning children needs no JSX, which keeps this usable from vi.hoisted.
+    passthrough: ({ children }: { children?: React.ReactNode }) => children,
+  };
+});
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: typeof fixture.panelState) => unknown) =>
+    selector(fixture.panelState),
+  useProjectStore: (selector: (s: { currentProject: null }) => unknown) =>
+    selector({ currentProject: null }),
+  useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: null }) => unknown) =>
+    selector({ activeWorktreeId: null }),
+}));
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: (selector: (s: { currentScratch: null }) => unknown) =>
+    selector({ currentScratch: null }),
+}));
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: (selector: (s: { terminalId: null }) => unknown) =>
+    selector({ terminalId: null }),
+}));
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: { availability: null }) => unknown) =>
+    selector({ availability: null }),
+}));
+vi.mock("@/store/toolbarPreferencesStore", () => ({
+  useToolbarPreferencesStore: (selector: (s: { layout: { leftButtons: string[] } }) => unknown) =>
+    selector({ layout: { leftButtons: [] } }),
+}));
+vi.mock("@/store/preferencesStore", () => ({
+  usePreferencesStore: (selector: (s: { setDockDensity: () => void }) => unknown) =>
+    selector({ setDockDensity: () => {} }),
+}));
+vi.mock("@/hooks", () => ({
+  useHorizontalScrollControls: () => ({
+    canScrollLeft: false,
+    canScrollRight: false,
+    scrollLeft: vi.fn(),
+    scrollRight: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useWorktrees", () => ({ useWorktrees: () => ({ worktrees: [] }) }));
+vi.mock("@/hooks/useProjectSettings", () => ({ useProjectSettings: () => ({ settings: null }) }));
+vi.mock("@/utils/workspaceCwd", () => ({ resolveWorkspaceCwd: () => "/tmp" }));
+vi.mock("@/config/agents", () => ({ getAgentIds: () => [], getAgentConfig: () => undefined }));
+vi.mock("@/lib/agentMenuOrder", () => ({
+  sortAgentsByToolbarPin: () => ({ sorted: [], pinnedCount: 0 }),
+}));
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDndContext: () => ({ active: null }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: fixture.passthrough,
+  horizontalListSortingStrategy: vi.fn(),
+}));
+vi.mock("@/components/DragDrop", () => ({
+  SortableDockItem: fixture.passthrough,
+  SortableDockPlaceholder: () => null,
+  DOCK_PLACEHOLDER_ID: "__dock-placeholder__",
+  useIsWorktreeSortDragging: () => false,
+  useDndPlaceholder: () => ({ activeTerminal: null, isDragging: false }),
+}));
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: fixture.passthrough,
+  TooltipTrigger: fixture.passthrough,
+  TooltipContent: () => null,
+}));
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: fixture.passthrough,
+  ContextMenuTrigger: fixture.passthrough,
+  ContextMenuContent: () => null,
+  ContextMenuItem: fixture.passthrough,
+  ContextMenuLabel: fixture.passthrough,
+  ContextMenuRadioGroup: fixture.passthrough,
+  ContextMenuRadioItem: fixture.passthrough,
+  ContextMenuSeparator: () => null,
+  ContextMenuSub: fixture.passthrough,
+  ContextMenuSubContent: fixture.passthrough,
+  ContextMenuSubTrigger: fixture.passthrough,
+}));
+
+// Stands in for the real Radix Popover trigger + its portaled terminal content.
+vi.mock("../DockedTerminalItem", () => ({
+  DockedTerminalItem: ({ terminal }: { terminal: PtyPanelData }) => (
+    <>
+      <button type="button" data-dock-item="" data-testid={`chip-${terminal.id}`}>
+        {terminal.title}
+      </button>
+      {terminal.id === fixture.PORTAL_TERMINAL_ID
+        ? createPortal(
+            <textarea
+              aria-label="Docked terminal input"
+              onKeyDown={(event) => event.preventDefault()}
+            />,
+            document.body
+          )
+        : null}
+    </>
+  ),
+}));
+vi.mock("../DockedNonPtyPanelItem", () => ({ DockedNonPtyPanelItem: () => null }));
+vi.mock("../DockedTabGroup", () => ({ DockedTabGroup: () => null }));
+vi.mock("../DockLaunchButton", () => ({ DockLaunchButton: () => null }));
+vi.mock("../DockLaunchMenuItems", () => ({ DockLaunchMenuItems: () => null }));
+vi.mock("../TrashContainer", () => ({ TrashContainer: () => null }));
+vi.mock("../WaitingContainer", () => ({ WaitingContainer: () => null }));
+vi.mock("../ErrorsContainer", () => ({ ErrorsContainer: () => null }));
+vi.mock("../BackgroundContainer", () => ({ BackgroundContainer: () => null }));
+
+import { ContentDock } from "../ContentDock";
+
+function renderDock() {
+  render(<ContentDock />);
+
+  const rail = screen.getByRole("toolbar", { name: "Docked panels" });
+  const chips = fixture.dockPanels.map((panel) => screen.getByTestId(`chip-${panel.id}`));
+
+  // getDockItems() filters on `offsetParent !== null`, and jsdom has no layout,
+  // so it reports null for every element. Without this the item list comes back
+  // empty, the handler bails before the switch, and the regression below would
+  // pass even with the guard removed — a worthless green.
+  for (const chip of chips) {
+    Object.defineProperty(chip, "offsetParent", { configurable: true, get: () => rail });
+    chip.scrollIntoView = vi.fn();
+  }
+
+  const terminalInput = screen.getByRole("textbox", { name: "Docked terminal input" });
+  return { rail, chips, terminalInput };
+}
+
+/** Roving tabindex keeps the active chip as the rail's only tab stop. */
+const tabStops = (chips: HTMLElement[]) => chips.map((chip) => chip.tabIndex);
+
+afterEach(cleanup);
+
+describe("ContentDock — arrow keys from a docked terminal (issue #11156)", () => {
+  it("roves focus across rail chips for arrows that originate on a chip", () => {
+    const { chips } = renderDock();
+    const [first, second] = chips as [HTMLElement, HTMLElement];
+
+    first.focus();
+    expect(tabStops(chips)).toEqual([0, -1]);
+
+    fireEvent.keyDown(first, { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(second);
+    expect(tabStops(chips)).toEqual([-1, 0]);
+  });
+
+  it.each(["ArrowLeft", "ArrowRight", "Home", "End"] as const)(
+    "leaves focus and rail tab stops untouched for %s typed into the portaled terminal",
+    (key) => {
+      const { rail, chips, terminalInput } = renderDock();
+
+      chips[0]!.focus();
+      const stopsBefore = tabStops(chips);
+
+      terminalInput.focus();
+      // The terminal is a React descendant of the rail but not a DOM one — that
+      // divergence is the whole bug.
+      expect(rail.contains(terminalInput)).toBe(false);
+
+      fireEvent.keyDown(terminalInput, { key });
+
+      expect(document.activeElement).toBe(terminalInput);
+      expect(tabStops(chips)).toEqual(stopsBefore);
+    }
+  );
+
+  it("does not adopt the portaled terminal as the rail's active chip on focus", () => {
+    const { chips, terminalInput } = renderDock();
+
+    chips[0]!.focus();
+    terminalInput.focus();
+
+    // Focus events bubble the fiber tree too. The rail must not treat the
+    // terminal as one of its chips: ArrowRight from the first chip still lands
+    // on the second, proving the active index survived the terminal's focus.
+    fireEvent.keyDown(chips[0]!, { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(chips[1]);
+  });
+});


### PR DESCRIPTION
## Summary

Pressing ArrowLeft or ArrowRight while typing in a docked terminal was sending keyboard focus to the adjacent dock rail chip, kicking the user out of the terminal mid-type. Grid terminals were unaffected.

The cause: `ContentDock`'s roving-tabindex handler, `handleDockKeyDown`, handled any arrow keydown that reached it without checking where the event came from. React synthetic events bubble the fiber tree, not the DOM tree, so a docked panel's Radix Popover content (portaled to `document.body`, and therefore outside the rail's DOM) still delivered its keydowns to the rail's handler. `Toolbar.tsx`, the canonical roving-tabindex pattern that `ContentDock`'s own comment says it mirrors, already carries exactly this guard, so this restores parity rather than inventing a new pattern.

Resolves #11156

## Changes

- Added one guard at the top of `handleDockKeyDown` in `src/components/Layout/ContentDock.tsx` that bails unless the event target is a DOM descendant of the rail container. Key ownership now follows the real DOM tree instead of the fiber tree.
- Worth noting which keys actually escape: xterm stops propagation for keys it handles but deliberately does not in `screenReaderMode`, and the CodeMirror input bar prevents default without stopping propagation. Those uncancelled events are the ones that reached the rail. The guard is source-agnostic, so it covers both.
- Deliberately not done: no `stopPropagation` added near xterm, `XtermAdapter` left untouched. The project has a history of repeated reverts from over-broad key interception there. Also left `DockedTabGroup` alone: its tablist is a DOM and React sibling of the terminal body, so terminal keydowns structurally cannot reach it. The issue's second suggested fix turned out to be unnecessary.

## Testing

Added `ContentDock.portalKeydown.test.tsx`, which renders the real `ContentDock` and drives arrow keys, Home, and End from a portaled terminal, asserting that both focus and the rail's roving tab index stay put. Validated red-before-green (removing the guard fails 8 of 10 assertions), and hardened the test against a false-positive fix that guards on `defaultPrevented` instead of DOM containment, which fails on the four uncancelled cases (the real screen-reader-mode path). 141 tests pass across the dock and toolbar test suites.