### PR TITLE
feat(forge): detect newly-added git origin without reload

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -79,6 +79,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:panel-badges-changed": "external",
   "plugin:panel-badges-cleared": "external",
   "plugin:provenance-changed": "external",
+  "forge:remote-changed": "external",
   "plugin:bg-update-available": "external",
   "run-history:update": "external",
   "plugin:deep-link": "external",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2627,6 +2627,8 @@ function buildElectronApi(): ElectronAPI {
           data: import("../shared/types/ipc/forge.js").ForgeTokenHealthChangedPayload
         ) => void
       ) => _typedOn(CHANNELS.FORGE_TOKEN_HEALTH_CHANGED, callback),
+      onRemoteChanged: (callback: (payload: { projectId: string }) => void) =>
+        _eventBusOn("forge:remote-changed", callback),
       classifyPushError: (payload: { cwd: string; stderr: string }) =>
         _unwrappingInvoke(CHANNELS.FORGE_CLASSIFY_PUSH_ERROR, payload),
       getRepoStats: (payload: { cwd: string; bypassCache?: boolean }) =>

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -204,6 +204,21 @@ class PullRequestService {
   constructor() {
     this.unsubscribers.push(events.on("sys:worktree:update", this.handleWorktreeUpdate.bind(this)));
     this.unsubscribers.push(events.on("sys:worktree:remove", this.handleWorktreeRemove.bind(this)));
+    this.unsubscribers.push(
+      events.on("sys:forge:remote-changed", this.handleForgeRemoteChanged.bind(this))
+    );
+  }
+
+  /**
+   * The repo's remotes changed (#11155) — `WorkspaceService` emits this only
+   * after a `.git/config` write actually altered the remote table. A cached
+   * "no-match" may now resolve, so drop the resolution and re-check. This is
+   * the ONLY worktree-adjacent signal allowed to release the no-match pause:
+   * `handleWorktreeUpdate` must stay inert on it, or #9997's 5s-forever spin
+   * on remote-less repos returns.
+   */
+  private handleForgeRemoteChanged(): void {
+    this.notifyForgeProviderRegistryUpdated();
   }
 
   private handleWorktreeUpdate(state: WorktreeState): void {

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -1086,6 +1086,7 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "topology-watcher-recovered":
       case "forge-rate-limit-changed":
       case "forge-token-health-changed":
+      case "forge-remote-changed":
         this.emit("host-event", event);
         break;
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1935,6 +1935,61 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
+    it("re-resolves after a no-match when the repo's git remotes change (#11155)", async () => {
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+
+      await pullRequestService.start(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const callsWhilePaused = bridge.resolveProvider.mock.calls.length;
+
+      // `git remote add origin` — the one signal narrow enough to release the
+      // pause. Unlike a worktree update, it means the input to resolution
+      // itself changed, so the cached no-match is now stale.
+      events.emit("sys:forge:remote-changed", { timestamp: Date.now() });
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(bridge.resolveProvider.mock.calls.length).toBeGreaterThan(callsWhilePaused);
+
+      pullRequestService.destroy();
+    });
+
+    it("re-pauses after a remote change that still resolves to no-match", async () => {
+      mockForgeProviderUnresolved({ status: "no-match" });
+      const bridge = lastMockBridge!;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+      );
+      await pullRequestService.start(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // A remote pointing at a host no provider claims: the re-resolve happens
+      // once, then the pause must re-arm. Without this, adding an unsupported
+      // remote would reopen #9997's forever-5s spin.
+      events.emit("sys:forge:remote-changed", { timestamp: Date.now() });
+      await vi.advanceTimersByTimeAsync(10_000);
+      const callsAfterRemoteChange = bridge.resolveProvider.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAfterRemoteChange);
+
+      pullRequestService.destroy();
+    });
+
     it("re-resolves after a no-match when forge settings change (setForgeSettings + refresh)", async () => {
       mockForgeProviderUnresolved({ status: "no-match" });
       const bridge = lastMockBridge!;

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -117,6 +117,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Forge provider confirmed issue does not exist on current repo",
   },
+  "sys:forge:remote-changed": {
+    category: "system",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Repo's git remotes changed — forge provider must be re-resolved",
+  },
 
   // File events
   "file:open": {
@@ -511,6 +517,18 @@ export type DaintreeEventMap = {
   "sys:issue:not-found": {
     worktreeId: string;
     issueNumber: number;
+    timestamp: number;
+  };
+
+  /**
+   * The repo's git remote table changed (`git remote add` / `set-url` /
+   * `remove`), detected from a `.git/config` write (#11155). Repo-level, so it
+   * carries no worktree id. Deliberately distinct from `sys:worktree:update`:
+   * `PullRequestService` pauses provider resolution forever on a "no-match"
+   * (#9997), and only a signal this narrow may release that pause — a generic
+   * worktree update must not.
+   */
+  "sys:forge:remote-changed": {
     timestamp: number;
   };
 

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -5,6 +5,7 @@ import { broadcastToRenderer } from "../../ipc/utils.js";
 import { notifyError } from "../../ipc/errorHandlers.js";
 import { clearWslGitEntry } from "../../store.js";
 import { gitServiceCache } from "../GitServiceCache.js";
+import { generateProjectId } from "../projectStorePaths.js";
 import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } from "./types.js";
 import type { WorkspaceHostEvent, WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 
@@ -313,6 +314,23 @@ export class WorkspaceHostEventRouter {
         broadcastToRenderer(CHANNELS.FORGE_TOKEN_HEALTH_CHANGED, {
           providerId: event.providerId,
           isUnhealthy: event.isUnhealthy,
+        });
+        break;
+      }
+
+      case "forge-remote-changed": {
+        // The repo gained/changed/lost a remote (#11155). Signal-only: the
+        // renderer drops its cached provider resolution for this project and
+        // re-resolves through main's precedence chain (per-project override →
+        // global default → hostname match), which is the only place that
+        // answer is authoritative. Project-scoped so views on other projects
+        // ignore it. No cache to drop on main's side: `GitService.getRemoteUrl`
+        // re-runs `getRemotes` on every call, and `GitServiceCache` only pools
+        // the client instance, never the URL.
+        const projectId = generateProjectId(entry.projectPath);
+        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+          name: "forge:remote-changed",
+          payload: { projectId },
         });
         break;
       }

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../GitServiceCache.js", () => ({
 import { broadcastToRenderer } from "../../../ipc/utils.js";
 import { events } from "../../events.js";
 import { gitServiceCache } from "../../GitServiceCache.js";
+import { generateProjectId } from "../../projectStorePaths.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
 import type { RateLimitInfo } from "../../../../shared/types/forge.js";
 
@@ -1024,6 +1025,41 @@ describe("WorkspaceHostEventRouter", () => {
         providerId: FAKE_PROVIDER_ID,
         isUnhealthy: true,
       });
+    });
+  });
+
+  describe("forge-remote-changed (#11155)", () => {
+    it("broadcasts a project-scoped signal so the renderer re-resolves its provider", () => {
+      const entry = makeEntry({ projectPath: "/project/test" });
+      router.routeHostEvent(entry, { type: "forge-remote-changed" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+      expect(broadcastToRenderer).toHaveBeenCalledWith(CHANNELS.EVENTS_PUSH, {
+        name: "forge:remote-changed",
+        payload: { projectId: generateProjectId("/project/test") },
+      });
+    });
+
+    it("scopes the signal to the emitting host's project", () => {
+      router.routeHostEvent(makeEntry({ projectPath: "/a" }), { type: "forge-remote-changed" });
+      router.routeHostEvent(makeEntry({ projectPath: "/b" }), { type: "forge-remote-changed" });
+
+      const projectIds = vi
+        .mocked(broadcastToRenderer)
+        .mock.calls.map(([, payload]) => (payload as { payload: { projectId: string } }).payload);
+      expect(projectIds).toEqual([
+        { projectId: generateProjectId("/a") },
+        { projectId: generateProjectId("/b") },
+      ]);
+    });
+
+    it("carries no remote URL — https remotes can embed credentials", () => {
+      router.routeHostEvent(makeEntry(), { type: "forge-remote-changed" });
+
+      const [, payload] = vi.mocked(broadcastToRenderer).mock.calls[0]!;
+      expect(Object.keys((payload as { payload: Record<string, unknown> }).payload)).toEqual([
+        "projectId",
+      ]);
     });
   });
 });

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -236,6 +236,114 @@ describe("GitFileWatcher", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  // ---- onGitConfigChanged: the `git remote add` signal (#11155) ----
+
+  describe("onGitConfigChanged", () => {
+    const gitDir = pathJoin("/repo", ".git");
+
+    /** Arms a watcher and returns the gitDir directory-event callback. */
+    async function armAndGetGitDirCallback(options: {
+      onChange: () => void;
+      onGitConfigChanged?: () => void;
+      debounceMs?: number;
+    }): Promise<(eventType: string, filename: string | Buffer | null) => void> {
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: options.debounceMs ?? 100,
+        onChange: options.onChange,
+        onGitConfigChanged: options.onGitConfigChanged,
+      });
+      await expect(gitWatcher.start()).resolves.toBe(true);
+
+      const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
+        | [unknown, unknown, unknown]
+        | undefined;
+      expect(dotGitCall).toBeDefined();
+      return dotGitCall?.[2] as (eventType: string, filename: string | Buffer | null) => void;
+    }
+
+    it("fires on a config write — the file `git remote add` edits", async () => {
+      const onChange = vi.fn();
+      const onGitConfigChanged = vi.fn();
+      const cb = await armAndGetGitDirCallback({ onChange, onGitConfigChanged });
+
+      cb("rename", "config");
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onGitConfigChanged).toHaveBeenCalledTimes(1);
+      // The status pass still runs: a config write can also change tracking info.
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays silent for non-config git files — a remote re-read costs a subprocess", async () => {
+      const onChange = vi.fn();
+      const onGitConfigChanged = vi.fn();
+      const cb = await armAndGetGitDirCallback({ onChange, onGitConfigChanged });
+
+      cb("rename", "HEAD");
+      cb("rename", "index");
+      cb("rename", "packed-refs");
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onGitConfigChanged).not.toHaveBeenCalled();
+    });
+
+    it("fires for the config.lock half of git's lock-then-rename write", async () => {
+      const onChange = vi.fn();
+      const onGitConfigChanged = vi.fn();
+      const cb = await armAndGetGitDirCallback({ onChange, onGitConfigChanged });
+
+      // git writes config.lock, then renames it over config. Both land in the
+      // same debounce burst and must collapse into ONE probe.
+      cb("rename", "config.lock");
+      cb("rename", "config");
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onGitConfigChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not leak the config flag into the next burst", async () => {
+      const onChange = vi.fn();
+      const onGitConfigChanged = vi.fn();
+      const cb = await armAndGetGitDirCallback({ onChange, onGitConfigChanged });
+
+      cb("rename", "config");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onGitConfigChanged).toHaveBeenCalledTimes(1);
+
+      // A later HEAD-only burst must not re-fire the (already consumed) flag.
+      cb("rename", "HEAD");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onGitConfigChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats an unnamed event as possibly-config rather than missing the write", async () => {
+      const onChange = vi.fn();
+      const onGitConfigChanged = vi.fn();
+      const cb = await armAndGetGitDirCallback({ onChange, onGitConfigChanged });
+
+      // A null filename means the platform couldn't say what changed. A false
+      // positive costs one git spawn that emits nothing; a false negative would
+      // strand the toolbar pills until a reload.
+      cb("rename", null);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(onGitConfigChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("is optional — a watcher without the callback still drives onChange", async () => {
+      const onChange = vi.fn();
+      const cb = await armAndGetGitDirCallback({ onChange });
+
+      expect(() => cb("rename", "config")).not.toThrow();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("detects commits via reflog changes", async () => {
     const gitDir = pathJoin("/repo", ".git");
     const onChange = vi.fn();

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -23,6 +23,9 @@ const MACOS_EMFILE_LIMIT_HELP =
  * .git is included for both the bare worktree pointer file and
  * all child paths, replacing the old JS-side prefix check.
  */
+/** Name of the git config file inside the common dir. */
+const GIT_CONFIG_FILE_NAME = "config";
+
 const WORKTREE_IGNORE_GLOBS = [
   "**/node_modules/**",
   "**/dist/**",
@@ -53,6 +56,14 @@ export interface GitFileWatcherOptions {
   branch?: string;
   debounceMs: number;
   onChange: () => void;
+  /**
+   * Fired alongside `onChange` when the flushed burst included a write to
+   * `.git/config` — the file `git remote add` / `set-url` / `remove` edits.
+   * Separate from `onChange` because re-reading the repo's remotes costs a git
+   * subprocess: gating it on the specific file keeps the cost at one spawn per
+   * config write instead of one per status pass (#9997).
+   */
+  onGitConfigChanged?: () => void;
   /** Watch the working tree recursively for file edits (macOS FSEvents). */
   watchWorktree?: boolean;
   /** Minimum debounce delay for worktree events — first event in a burst fires at this delay. */
@@ -102,6 +113,11 @@ export class GitFileWatcher {
   /** Per-event ramp applied inside the min..max range. Private tuning constant. */
   private readonly worktreeDebounceRampMs = 10;
   private readonly onChange: () => void;
+  private readonly onGitConfigChanged: (() => void) | undefined;
+  /** Set when the current (unflushed) burst touched `.git/config`. */
+  private gitConfigChangePending = false;
+  /** Directory holding `.git/config` — always the common dir. */
+  private gitConfigDir: string | null = null;
   private readonly onWatcherFailed: (() => void) | undefined;
   private readonly onInotifyLimitReached: (() => void) | undefined;
   private readonly onEmfileLimitReached: (() => void) | undefined;
@@ -117,6 +133,7 @@ export class GitFileWatcher {
     this.worktreeLeadingDebounceMs = options.worktreeLeadingDebounceMs;
     this.worktreeQuietWindowMs = options.worktreeQuietWindowMs ?? 2_000;
     this.onChange = options.onChange;
+    this.onGitConfigChanged = options.onGitConfigChanged;
     this.onWatcherFailed = options.onWatcherFailed;
     this.onInotifyLimitReached = options.onInotifyLimitReached;
     this.onEmfileLimitReached = options.onEmfileLimitReached;
@@ -149,7 +166,10 @@ export class GitFileWatcher {
       // Watch .git/config so `git push -u` / `git branch --set-upstream-to`
       // triggers a poll deterministically — without this the new tracking
       // info from `git status` only surfaces on the next timed poll.
-      this.watchFile(pathJoin(commonDir, "config"));
+      // Also the file `git remote add` writes, which is what drives
+      // onGitConfigChanged (#11155).
+      this.gitConfigDir = commonDir;
+      this.watchFile(pathJoin(commonDir, GIT_CONFIG_FILE_NAME));
 
       // For linked worktrees, the per-worktree reflog lives under gitDir, not commonDir.
       // Watch it so branch changes in linked worktrees trigger the onChange callback.
@@ -227,6 +247,7 @@ export class GitFileWatcher {
       this.worktreeMaxWaitTimer = null;
     }
     this.worktreeBurstCount = 0;
+    this.gitConfigChangePending = false;
 
     for (const watcher of this.watchers) {
       try {
@@ -376,6 +397,9 @@ export class GitFileWatcher {
       const trackedFiles = new Set<string>([fileName]);
       const watcher = fsWatch(watchDir, { persistent: false }, (_eventType, changedFileName) => {
         if (this.shouldHandleDirectoryEvent(changedFileName, trackedFiles)) {
+          if (this.isGitConfigEvent(watchDir, changedFileName)) {
+            this.gitConfigChangePending = true;
+          }
           this.handleGitFileChange();
         }
       });
@@ -412,6 +436,24 @@ export class GitFileWatcher {
     return false;
   }
 
+  /**
+   * Whether a directory event names `.git/config` (or its `.lock` twin — git
+   * writes the file lock-then-rename, so both land in the burst). Only the
+   * common dir holds the config, so events from the per-worktree gitDir are
+   * never config writes even when a same-named file appears there.
+   */
+  private isGitConfigEvent(watchDir: string, changedFileName: string | Buffer | null): boolean {
+    if (this.gitConfigDir === null) return false;
+    if (pathNormalize(watchDir) !== pathNormalize(this.gitConfigDir)) return false;
+    // A null filename means the platform couldn't say what changed. Treat it as
+    // possibly-config: the probe it triggers re-reads the remotes and emits
+    // nothing when they're unchanged, so a false positive costs one git spawn,
+    // while a false negative would silently strand the toolbar pills.
+    if (!changedFileName) return true;
+    const changedName = changedFileName.toString().replaceAll("\\", "/");
+    return this.matchesTrackedFile(changedName, GIT_CONFIG_FILE_NAME);
+  }
+
   private matchesTrackedFile(changedName: string, trackedFile: string): boolean {
     if (changedName === trackedFile || changedName === `${trackedFile}.lock`) {
       return true;
@@ -436,8 +478,14 @@ export class GitFileWatcher {
 
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
-      if (!this.disposed) {
-        this.onChange();
+      if (this.disposed) return;
+      // Read and clear before the callbacks: a config write landing while they
+      // run belongs to the next burst, not this one.
+      const configChanged = this.gitConfigChangePending;
+      this.gitConfigChangePending = false;
+      this.onChange();
+      if (configChanged) {
+        this.onGitConfigChanged?.();
       }
     }, this.debounceMs);
   }

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -53,6 +53,13 @@ export interface WatcherControllerHost {
    * guards and clear the persistent degraded indicator.
    */
   onWatcherRecovered?(): void;
+  /**
+   * Fired when the flushed watcher burst included a `.git/config` write — the
+   * file `git remote add` / `set-url` / `remove` edits. Lets the host re-read
+   * the repo's remotes and re-resolve its forge provider without a project
+   * reload (#11155), without paying a git subprocess on every status pass.
+   */
+  onGitConfigChanged?(): void;
 }
 
 /**
@@ -155,6 +162,7 @@ export class WatcherController {
       branch: this.host.branch,
       debounceMs: this.host.gitWatchDebounceMs,
       onChange: () => this.handleGitFileChange(),
+      onGitConfigChanged: () => this.host.onGitConfigChanged?.(),
       watchWorktree: mode === "recursive",
       worktreeMinDebounceMs: WATCHER_WORKTREE_MIN_DEBOUNCE_MS,
       worktreeMaxDebounceMs: WATCHER_WORKTREE_MAX_DEBOUNCE_MS,

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -201,6 +201,10 @@ export class WorkspaceService {
   private forgeRemoteSignature: string | null = null;
   private forgeRemoteProbeSeq = 0;
   private forgeRemoteReprobeTimer: NodeJS.Timeout | null = null;
+  // Bumped whenever a `.git/config` write is OBSERVED. A baseline read that
+  // spans a bump may already contain the change it was meant to precede, so it
+  // is discarded rather than seeded.
+  private forgeConfigEpoch = 0;
   // Watcher-independent backstop: `GitFileWatcher` swallows `fs.watch` failures
   // (silent fallback to polling) and Linux inotify exhaustion is a live failure
   // mode, so a repo can miss the config event entirely. Costs one stat per
@@ -603,7 +607,7 @@ export class WorkspaceService {
       }
       this.projectRootPath = projectRootPath;
       // Backstop for a disabled or silently-degraded git watcher (#11155).
-      this.startForgeConfigPoll();
+      this.startForgeRemoteDetection();
       if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
         // Merge instead of replacing: a `set-wsl-opt-in` message arriving
         // during this load-project's async work would otherwise be silently
@@ -1258,7 +1262,7 @@ export class WorkspaceService {
         onInotifyLimitReached: () => this.handleInotifyLimitReached(),
         onEmfileLimitReached: () => this.handleEmfileLimitReached(),
         onWatcherRecovered: () => this.handleWatcherRecovered(),
-        onGitConfigChanged: () => this.scheduleForgeRemoteReprobe(),
+        onGitConfigChanged: () => this.scheduleForgeRemoteReprobe({ observedConfigWrite: true }),
         onScheduleFetch: async (worktreeId, _isCurrent, force) => {
           const target = this.monitors.get(worktreeId);
           if (!target || !target.isRunning) return;
@@ -1621,11 +1625,12 @@ export class WorkspaceService {
         ? matchProviderForRemoteUrl(probed.fetchUrl, this.forgeProviderMatchers)
         : null
     );
-    // Seed the change baseline from whichever monitor probes first. A later
-    // monitor start must NOT overwrite it: a config write that slipped past the
-    // watcher would then be absorbed silently instead of caught by the next
-    // reprobe.
-    this.forgeRemoteSignature ??= probed.signature;
+    // Deliberately does NOT seed `forgeRemoteSignature`. A monitor start probe
+    // races the user: it can complete AFTER a `git remote add` and would then
+    // record the post-change remotes as the "before" baseline, leaving the
+    // reprobe with an equal signature and nothing to emit — the toolbar would
+    // stay stale for exactly the case this feature exists to catch. The
+    // baseline is seeded once at load instead (`startForgeRemoteDetection`).
   }
 
   /**
@@ -1633,8 +1638,13 @@ export class WorkspaceService {
    * sibling worktree reports the same write (and git writes config as
    * lock-then-rename) — a trailing debounce collapses the burst into one probe.
    */
-  private scheduleForgeRemoteReprobe(): void {
+  private scheduleForgeRemoteReprobe(opts: { observedConfigWrite: boolean }): void {
     if (this._shutdownController.signal.aborted) return;
+    // Bump on a real observed write even when a reprobe is already pending: it
+    // marks an in-flight baseline seed as spanning the write, so it can't record
+    // a snapshot that already absorbed the change. The backstop tick observes
+    // nothing, so it must not invalidate the seed.
+    if (opts.observedConfigWrite) this.forgeConfigEpoch++;
     if (this.forgeRemoteReprobeTimer) return;
     this.forgeRemoteReprobeTimer = setTimeout(() => {
       this.forgeRemoteReprobeTimer = null;
@@ -1654,11 +1664,33 @@ export class WorkspaceService {
     const cwd = this.forgeProbeCwd();
     if (!cwd) return;
     const seq = ++this.forgeRemoteProbeSeq;
+
+    // Cheap gate in front of the subprocess. Two callers land here — the git
+    // watcher and the 5-minute backstop — and neither proves the remotes moved:
+    // `fs.watch` may report a change with NO filename (so we conservatively
+    // assume config), and the backstop fires on a timer. Without this gate a
+    // repo emitting unnamed `.git/` events would spawn `git remote` every
+    // debounce window.
+    //
+    // Safe to gate on, because git writes `.git/config` lock-then-rename — a
+    // real `git remote add/set-url/remove` ALWAYS lands a new inode, so it can
+    // never be mistaken for "unchanged". Stat failure fails open (probe anyway).
+    const fingerprint = await this.readForgeConfigFingerprint();
+    if (seq !== this.forgeRemoteProbeSeq) return;
+    if (fingerprint !== null && fingerprint === this.forgeConfigFingerprint) return;
+
     const probed = await this.readForgeRemotes(cwd);
     // A dispose (or a newer probe) landed while git ran: the monitors this one
     // would touch may already be stopped, and its read is no longer the truth.
     if (!probed || seq !== this.forgeRemoteProbeSeq) return;
     if (this._shutdownController.signal.aborted) return;
+
+    // Consume the fingerprint only now that this probe has actually READ the
+    // remotes that go with it. Recording it up front (before the git read) loses
+    // changes two ways: a superseding probe would see the fingerprint already
+    // consumed and bail while the superseded probe dies on the seq check, and a
+    // transient git failure would leave the change permanently marked as seen.
+    this.forgeConfigFingerprint = fingerprint;
 
     const matchedProviderId = probed.fetchUrl
       ? matchProviderForRemoteUrl(probed.fetchUrl, this.forgeProviderMatchers)
@@ -1696,7 +1728,13 @@ export class WorkspaceService {
     return this.projectRootPath;
   }
 
-  /** `<commonDir>/config` fingerprint, or null when it can't be read. */
+  /**
+   * Identity fingerprint of `<commonDir>/config`, or null when it can't be read.
+   * Includes the inode: git writes config lock-then-rename, so every real
+   * `git remote` mutation lands a NEW inode. That makes the fingerprint a
+   * trustworthy "did this file actually change" gate even on filesystems whose
+   * timestamp granularity is too coarse to catch a same-size rewrite.
+   */
   private async readForgeConfigFingerprint(): Promise<string | null> {
     const rootPath = this.projectRootPath;
     if (!rootPath) return null;
@@ -1704,41 +1742,60 @@ export class WorkspaceService {
       const commonDir = await getGitCommonDir(rootPath, { logErrors: false });
       if (!commonDir) return null;
       const stats = await stat(pathResolve(commonDir, "config"));
-      return `${stats.mtimeMs}:${stats.size}`;
+      return `${stats.ino}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}`;
     } catch {
       return null;
     }
   }
 
   /**
-   * Arm the watcher-independent backstop. Seeds the baseline immediately (from
-   * project load, NOT from the first tick — otherwise a remote added before
-   * that tick would be absorbed into the seed and never detected).
+   * Seed the change baseline and arm the watcher-independent backstop. Called
+   * at project load, before any monitor (and therefore any git watcher) starts.
+   *
+   * The load-time read is the ONLY one allowed to establish the "before"
+   * snapshot: it provably precedes the watcher, whereas a per-monitor start
+   * probe races the user and can absorb the very `git remote add` we need to
+   * detect. `??=` keeps a reprobe that already landed from being overwritten by
+   * this slower read.
    */
-  private startForgeConfigPoll(): void {
+  private startForgeRemoteDetection(): void {
     if (this.forgeConfigPollTimer) return;
-    void this.readForgeConfigFingerprint().then((fingerprint) => {
-      this.forgeConfigFingerprint ??= fingerprint;
-    });
+    const rootPath = this.projectRootPath;
+    if (!rootPath) return;
+
+    const seq = this.forgeRemoteProbeSeq;
+    const epoch = this.forgeConfigEpoch;
+    void (async () => {
+      // stat → read → stat. The remote table and the fingerprint must describe
+      // the SAME config, or the pair is incoherent: pre-change remotes stamped
+      // with a post-change fingerprint would make the backstop consider the
+      // change already seen and never emit it. Reading them concurrently cannot
+      // guarantee that; bracketing the git read with two stats can.
+      const before = await this.readForgeConfigFingerprint();
+      const probed = await this.readForgeRemotes(rootPath);
+      const after = await this.readForgeConfigFingerprint();
+
+      // Discard when: the project unloaded mid-read, a config write was observed
+      // mid-read, or the config moved between the stats (so this read may
+      // already contain the change it is supposed to precede). Leaving the
+      // baseline null is the safe failure — the next reprobe then sees
+      // `signature !== null` and emits.
+      if (seq !== this.forgeRemoteProbeSeq || epoch !== this.forgeConfigEpoch) return;
+      if (before !== after) return;
+      if (probed) this.forgeRemoteSignature ??= probed.signature;
+      this.forgeConfigFingerprint ??= after;
+    })();
+
+    // The backstop only has to WAKE the reprobe — the reprobe itself stats the
+    // config and skips the git spawn when nothing moved, so an idle tick costs
+    // one stat.
     this.forgeConfigPollTimer = setInterval(() => {
-      void this.checkForgeConfigFingerprint();
+      this.scheduleForgeRemoteReprobe({ observedConfigWrite: false });
     }, FORGE_CONFIG_POLL_INTERVAL_MS);
     this.forgeConfigPollTimer.unref?.();
   }
 
-  private async checkForgeConfigFingerprint(): Promise<void> {
-    if (this._shutdownController.signal.aborted) return;
-    const fingerprint = await this.readForgeConfigFingerprint();
-    if (fingerprint === null) return;
-    const previous = this.forgeConfigFingerprint;
-    this.forgeConfigFingerprint = fingerprint;
-    // A null baseline means the seed read failed — record and compare next tick
-    // rather than firing a probe against an unknown previous state.
-    if (previous === null || previous === fingerprint) return;
-    this.scheduleForgeRemoteReprobe();
-  }
-
-  private stopForgeConfigPoll(): void {
+  private stopForgeRemoteDetection(): void {
     if (this.forgeConfigPollTimer) {
       clearInterval(this.forgeConfigPollTimer);
       this.forgeConfigPollTimer = null;
@@ -1747,8 +1804,9 @@ export class WorkspaceService {
       clearTimeout(this.forgeRemoteReprobeTimer);
       this.forgeRemoteReprobeTimer = null;
     }
-    // Invalidate any in-flight probe so a late completion can't touch stopped
-    // monitors or signal on behalf of a project that is no longer loaded.
+    // Invalidate every in-flight read (baseline seed and reprobe alike) so a
+    // late completion can't touch stopped monitors, seed the incoming project's
+    // baseline, or signal on behalf of a project that is no longer loaded.
     this.forgeRemoteProbeSeq++;
     this.forgeRemoteSignature = null;
     this.forgeConfigFingerprint = null;
@@ -3369,7 +3427,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // Drops the forge-remote baseline with the project: the next one's own
     // start probe re-seeds it, and an in-flight probe from this project must
     // not signal against the incoming one.
-    this.stopForgeConfigPoll();
+    this.stopForgeRemoteDetection();
 
     this.activeWorktreeId = null;
     this.mainBranch = "main";
@@ -3499,7 +3557,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.fetchCoordinator.destroy();
     this.authFailureConfirmedNotified.clear();
     this.pollQueue.clear();
-    this.stopForgeConfigPoll();
+    this.stopForgeRemoteDetection();
     this.listService.invalidateCache();
   }
 }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -128,6 +128,16 @@ const POLL_QUEUE_TASK_TIMEOUT_MS = 60_000;
 // a silent no-op, even when the underlying pipelines are degraded.
 const HOST_REFRESH_TIMEOUT_MS = 45_000;
 
+// Coalescing window for `.git/config` writes (#11155). Every worktree sharing
+// the common dir reports the same write, and git itself writes config as
+// lock-then-rename (two events), so a short trailing debounce collapses the
+// burst into one `getRemotes()` spawn.
+const FORGE_REMOTE_REPROBE_DEBOUNCE_MS = 250;
+
+// Backstop cadence for the config fingerprint check when the git watcher is
+// disabled or has silently degraded. A stat, not a subprocess.
+const FORGE_CONFIG_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
 // FIFO cap on the acknowledged-mutation dedup set. Mutation ids are arbitrary
 // UUIDs (not path-keyed), so size-capping is the only viable pruning strategy;
 // a session sees well under 100 deletes, so 500 never evicts a live id.
@@ -180,6 +190,23 @@ export class WorkspaceService {
   // Empty until the first relay lands (after plugin load), so monitors start
   // unmatched and re-resolve when the table arrives or changes.
   private forgeProviderMatchers: ForgeProviderMatcher[] = [];
+  // Repo-level forge-remote state (#11155). Remotes live in the shared
+  // `.git/config`, so every worktree's watcher reports the same write — the
+  // service coalesces them into ONE probe and fans the result out to all
+  // monitors. `forgeRemoteSignature` is the last-seen remote table (names +
+  // fetch URLs, host-local and never transmitted — remote URLs can embed
+  // credentials). Events fire only when it genuinely changes, so the unrelated
+  // config writes that already wake the watcher (`git push -u`,
+  // `branch --set-upstream-to`) cost nothing and cannot churn the provider.
+  private forgeRemoteSignature: string | null = null;
+  private forgeRemoteProbeSeq = 0;
+  private forgeRemoteReprobeTimer: NodeJS.Timeout | null = null;
+  // Watcher-independent backstop: `GitFileWatcher` swallows `fs.watch` failures
+  // (silent fallback to polling) and Linux inotify exhaustion is a live failure
+  // mode, so a repo can miss the config event entirely. Costs one stat per
+  // interval; the git subprocess runs only when the fingerprint actually moved.
+  private forgeConfigPollTimer: NodeJS.Timeout | null = null;
+  private forgeConfigFingerprint: string | null = null;
   private git: SimpleGit | null = null;
   private pollingEnabled: boolean = true;
   private projectRootPath: string | null = null;
@@ -575,6 +602,8 @@ export class WorkspaceService {
         throw new Error(`Project directory does not exist: ${projectRootPath}`);
       }
       this.projectRootPath = projectRootPath;
+      // Backstop for a disabled or silently-degraded git watcher (#11155).
+      this.startForgeConfigPoll();
       if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
         // Merge instead of replacing: a `set-wsl-opt-in` message arriving
         // during this load-project's async work would otherwise be silently
@@ -1229,6 +1258,7 @@ export class WorkspaceService {
         onInotifyLimitReached: () => this.handleInotifyLimitReached(),
         onEmfileLimitReached: () => this.handleEmfileLimitReached(),
         onWatcherRecovered: () => this.handleWatcherRecovered(),
+        onGitConfigChanged: () => this.scheduleForgeRemoteReprobe(),
         onScheduleFetch: async (worktreeId, _isCurrent, force) => {
           const target = this.monitors.get(worktreeId);
           if (!target || !target.isRunning) return;
@@ -1552,6 +1582,30 @@ export class WorkspaceService {
   }
 
   /**
+   * Read the repo's remote table once. Returns origin's (or the first remote's)
+   * fetch URL plus a stable signature of every name→fetch-URL pair, used to tell
+   * a real remote change from an unrelated `.git/config` write. The signature
+   * stays in this process — remote URLs can carry embedded credentials.
+   */
+  private async readForgeRemotes(
+    cwd: string
+  ): Promise<{ fetchUrl: string | undefined; signature: string } | null> {
+    try {
+      const git = await createHardenedGit(cwd);
+      const remotes = await git.getRemotes(true);
+      const origin = remotes.find((r) => r.name === "origin") ?? remotes[0];
+      const signature = remotes
+        .map((remote) => `${remote.name} ${remote.refs?.fetch ?? ""}`)
+        .sort()
+        .join("");
+      return { fetchUrl: origin?.refs?.fetch, signature };
+    } catch {
+      // Remote probe is best-effort; keep the affordance hidden on failure.
+      return null;
+    }
+  }
+
+  /**
    * Probe origin's fetch URL once at monitor start, remember it on the
    * monitor, and resolve it against the relayed provider-matcher table. Runs
    * off the critical path — failures are silent (the affordance simply stays
@@ -1559,18 +1613,145 @@ export class WorkspaceService {
    * lets `setForgeProviderMatchers` re-match without re-probing git.
    */
   private async probeForgeRemoteAsync(monitor: WorktreeMonitor): Promise<void> {
-    try {
-      const git = await createHardenedGit(monitor.path);
-      const remotes = await git.getRemotes(true);
-      const origin = remotes.find((r) => r.name === "origin") ?? remotes[0];
-      const fetchUrl = origin?.refs?.fetch;
-      monitor.setRemoteFetchUrl(fetchUrl);
-      monitor.setMatchedForgeProviderId(
-        fetchUrl ? matchProviderForRemoteUrl(fetchUrl, this.forgeProviderMatchers) : null
-      );
-    } catch {
-      // Remote probe is best-effort; keep the affordance hidden on failure.
+    const probed = await this.readForgeRemotes(monitor.path);
+    if (!probed) return;
+    monitor.setRemoteFetchUrl(probed.fetchUrl);
+    monitor.setMatchedForgeProviderId(
+      probed.fetchUrl
+        ? matchProviderForRemoteUrl(probed.fetchUrl, this.forgeProviderMatchers)
+        : null
+    );
+    // Seed the change baseline from whichever monitor probes first. A later
+    // monitor start must NOT overwrite it: a config write that slipped past the
+    // watcher would then be absorbed silently instead of caught by the next
+    // reprobe.
+    this.forgeRemoteSignature ??= probed.signature;
+  }
+
+  /**
+   * A worktree's `.git/config` was written. Remotes are repo-level, so every
+   * sibling worktree reports the same write (and git writes config as
+   * lock-then-rename) — a trailing debounce collapses the burst into one probe.
+   */
+  private scheduleForgeRemoteReprobe(): void {
+    if (this._shutdownController.signal.aborted) return;
+    if (this.forgeRemoteReprobeTimer) return;
+    this.forgeRemoteReprobeTimer = setTimeout(() => {
+      this.forgeRemoteReprobeTimer = null;
+      void this.reprobeForgeRemoteAsync();
+    }, FORGE_REMOTE_REPROBE_DEBOUNCE_MS);
+  }
+
+  /**
+   * Re-read the repo's remotes after a `.git/config` write and, when the remote
+   * table actually changed, re-resolve every monitor's forge affordance and
+   * signal both the in-process PR poller and the renderer (#11155). An
+   * unchanged signature emits nothing — that restraint is what keeps
+   * `PullRequestService`'s no-match pause (#9997) meaningful, since the same
+   * config file is written by `git push -u` on every first push.
+   */
+  private async reprobeForgeRemoteAsync(): Promise<void> {
+    const cwd = this.forgeProbeCwd();
+    if (!cwd) return;
+    const seq = ++this.forgeRemoteProbeSeq;
+    const probed = await this.readForgeRemotes(cwd);
+    // A dispose (or a newer probe) landed while git ran: the monitors this one
+    // would touch may already be stopped, and its read is no longer the truth.
+    if (!probed || seq !== this.forgeRemoteProbeSeq) return;
+    if (this._shutdownController.signal.aborted) return;
+
+    const matchedProviderId = probed.fetchUrl
+      ? matchProviderForRemoteUrl(probed.fetchUrl, this.forgeProviderMatchers)
+      : null;
+    for (const monitor of this.monitors.values()) {
+      if (!monitor.isRunning) continue;
+      monitor.setRemoteFetchUrl(probed.fetchUrl);
+      monitor.setMatchedForgeProviderId(matchedProviderId);
     }
+
+    if (probed.signature === this.forgeRemoteSignature) return;
+    this.forgeRemoteSignature = probed.signature;
+
+    // In-process: releases PullRequestService's sticky "no-match" pause so the
+    // per-worktree PR badges resolve against the new remote.
+    events.emit("sys:forge:remote-changed", { timestamp: Date.now() });
+    // Cross-process: main relays this to the renderer, which drops its cached
+    // provider resolution and re-runs the full precedence chain (per-project
+    // override → global default → hostname match).
+    this.sendEvent({ type: "forge-remote-changed" });
+  }
+
+  /**
+   * Any running monitor resolves the same remotes — they share one common dir.
+   * Prefer the main worktree (longest-lived), then any running monitor, then
+   * the project root for the window between load and the first monitor start.
+   */
+  private forgeProbeCwd(): string | null {
+    for (const monitor of this.monitors.values()) {
+      if (monitor.isRunning && monitor.isMainWorktree) return monitor.path;
+    }
+    for (const monitor of this.monitors.values()) {
+      if (monitor.isRunning) return monitor.path;
+    }
+    return this.projectRootPath;
+  }
+
+  /** `<commonDir>/config` fingerprint, or null when it can't be read. */
+  private async readForgeConfigFingerprint(): Promise<string | null> {
+    const rootPath = this.projectRootPath;
+    if (!rootPath) return null;
+    try {
+      const commonDir = await getGitCommonDir(rootPath, { logErrors: false });
+      if (!commonDir) return null;
+      const stats = await stat(pathResolve(commonDir, "config"));
+      return `${stats.mtimeMs}:${stats.size}`;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Arm the watcher-independent backstop. Seeds the baseline immediately (from
+   * project load, NOT from the first tick — otherwise a remote added before
+   * that tick would be absorbed into the seed and never detected).
+   */
+  private startForgeConfigPoll(): void {
+    if (this.forgeConfigPollTimer) return;
+    void this.readForgeConfigFingerprint().then((fingerprint) => {
+      this.forgeConfigFingerprint ??= fingerprint;
+    });
+    this.forgeConfigPollTimer = setInterval(() => {
+      void this.checkForgeConfigFingerprint();
+    }, FORGE_CONFIG_POLL_INTERVAL_MS);
+    this.forgeConfigPollTimer.unref?.();
+  }
+
+  private async checkForgeConfigFingerprint(): Promise<void> {
+    if (this._shutdownController.signal.aborted) return;
+    const fingerprint = await this.readForgeConfigFingerprint();
+    if (fingerprint === null) return;
+    const previous = this.forgeConfigFingerprint;
+    this.forgeConfigFingerprint = fingerprint;
+    // A null baseline means the seed read failed — record and compare next tick
+    // rather than firing a probe against an unknown previous state.
+    if (previous === null || previous === fingerprint) return;
+    this.scheduleForgeRemoteReprobe();
+  }
+
+  private stopForgeConfigPoll(): void {
+    if (this.forgeConfigPollTimer) {
+      clearInterval(this.forgeConfigPollTimer);
+      this.forgeConfigPollTimer = null;
+    }
+    if (this.forgeRemoteReprobeTimer) {
+      clearTimeout(this.forgeRemoteReprobeTimer);
+      this.forgeRemoteReprobeTimer = null;
+    }
+    // Invalidate any in-flight probe so a late completion can't touch stopped
+    // monitors or signal on behalf of a project that is no longer loaded.
+    this.forgeRemoteProbeSeq++;
+    this.forgeRemoteSignature = null;
+    this.forgeConfigFingerprint = null;
   }
 
   /**
@@ -3185,6 +3366,10 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // re-surface its toast instead of being silently suppressed.
     this.authFailureConfirmedNotified.clear();
     this.pollQueue.clear();
+    // Drops the forge-remote baseline with the project: the next one's own
+    // start probe re-seeds it, and an in-flight probe from this project must
+    // not signal against the incoming one.
+    this.stopForgeConfigPoll();
 
     this.activeWorktreeId = null;
     this.mainBranch = "main";
@@ -3314,6 +3499,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.fetchCoordinator.destroy();
     this.authFailureConfirmedNotified.clear();
     this.pollQueue.clear();
+    this.stopForgeConfigPoll();
     this.listService.invalidateCache();
   }
 }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -81,6 +81,13 @@ export interface WorktreeMonitorCallbacks {
   onEmfileLimitReached?: (worktreeId: string) => void;
   onWatcherRecovered?: (worktreeId: string) => void;
   /**
+   * The worktree's `.git/config` was written — `git remote add` / `set-url` /
+   * `remove` all land here. Routed to `WorkspaceService` (not handled locally)
+   * because remotes are a repo-level fact: every worktree sharing the common
+   * dir sees the same event, and the service coalesces them into one probe.
+   */
+  onGitConfigChanged?: (worktreeId: string) => void;
+  /**
    * Schedule a background `git fetch` for this worktree's repo. Routed through
    * `WorkspaceService` so per-repo serialization and failure-cache state are
    * shared across sibling monitors. Resolves regardless of fetch outcome.
@@ -391,6 +398,7 @@ export class WorktreeMonitor {
       onEmfileLimitReached: (worktreeId: string) =>
         monitor.callbacks.onEmfileLimitReached?.(worktreeId),
       onWatcherRecovered: () => monitor.callbacks.onWatcherRecovered?.(monitor.id),
+      onGitConfigChanged: () => monitor.callbacks.onGitConfigChanged?.(monitor.id),
     };
     this.watcherController = new WatcherController(watcherHost);
 

--- a/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorktreeMonitor } from "../WorktreeMonitor.js";
+import type { Worktree } from "../../../shared/types/worktree.js";
+
+type Remote = { name: string; refs: { fetch: string; push: string } };
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+  getRemotes: vi.fn<() => Promise<Remote[]>>().mockResolvedValue([]),
+};
+
+function remote(name: string, url: string): Remote {
+  return { name, refs: { fetch: url, push: url } };
+}
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/fs.js", () => ({
+  waitForPathExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+  getWorktreeChangesWithStats: vi.fn().mockResolvedValue({
+    head: "abc123",
+    isDirty: false,
+    changedFileCount: 0,
+    changes: [],
+    lastUpdated: 0,
+  }),
+}));
+
+const mockGetGitCommonDir = vi.fn().mockResolvedValue("/test/root/.git");
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue("/test/root/.git"),
+  getGitCommonDir: (...args: unknown[]) => mockGetGitCommonDir(...args),
+  clearGitDirCache: vi.fn(),
+  clearGitCommonDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../services/worktree/index.js", () => ({
+  AdaptivePollingStrategy: vi.fn(function () {
+    return {
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+      updateConfig: vi.fn(),
+      isCircuitBreakerTripped: vi.fn().mockReturnValue(false),
+      reset: vi.fn(),
+      setBaseInterval: vi.fn(),
+      calculateNextInterval: vi.fn().mockReturnValue(2000),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+    };
+  }),
+  NoteFileReader: vi.fn(function () {
+    return { read: vi.fn().mockResolvedValue({}) };
+  }),
+}));
+
+const mockPullRequestService = {
+  initialize: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  cleanup: vi.fn(),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  getStatus: vi.fn().mockReturnValue({
+    state: "idle",
+    isPolling: false,
+    candidateCount: 0,
+    resolvedCount: 0,
+    isEnabled: true,
+  }),
+};
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: mockPullRequestService,
+}));
+
+// A real emitter so the in-process `sys:forge:remote-changed` hop is observable.
+const mockEvents = new EventEmitter();
+vi.mock("../../services/events.js", () => ({
+  events: mockEvents,
+}));
+
+vi.mock("../../utils/gitFileWatcher.js", () => {
+  return {
+    GitFileWatcher: class {
+      start() {
+        return Promise.resolve(false);
+      }
+      dispose() {}
+    },
+  };
+});
+
+const mockStat = vi.fn();
+vi.mock("fs/promises", () => ({
+  stat: (...args: unknown[]) => mockStat(...args),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+  realpath: vi.fn((p: string) => Promise.resolve(p)),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function createTestWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: "/test/worktree",
+    path: "/test/worktree",
+    name: "feature/test",
+    branch: "feature/test",
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: "/test/worktree/.git",
+    ...overrides,
+  };
+}
+
+const GITHUB_PROVIDER_ID = "daintree.github.github";
+
+describe("WorkspaceService forge-remote detection (#11155)", () => {
+  let service: WorkspaceService;
+  let mockSendEvent: ReturnType<typeof vi.fn>;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+  let sysRemoteChanged: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockSendEvent = vi.fn();
+    mockSimpleGit.getRemotes.mockResolvedValue([]);
+    mockStat.mockRejectedValue(new Error("ENOENT"));
+
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(mockSendEvent as never);
+
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+
+    service["projectRootPath"] = "/test/root";
+    service["git"] = mockSimpleGit as never;
+    service["forgeProviderMatchers"] = [
+      { providerId: GITHUB_PROVIDER_ID, hostnames: ["github.com"] },
+    ];
+
+    sysRemoteChanged = vi.fn();
+    mockEvents.on("sys:forge:remote-changed", sysRemoteChanged);
+  });
+
+  afterEach(() => {
+    mockEvents.removeAllListeners();
+    for (const monitor of service["monitors"].values()) {
+      monitor.stop();
+    }
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function registerMonitor(id: string, opts: { isMainWorktree?: boolean } = {}): WorktreeMonitor {
+    const monitor = new WorktreeMonitorClass(
+      createTestWorktree({
+        id,
+        path: id,
+        gitDir: `${id}/.git`,
+        isMainWorktree: opts.isMainWorktree ?? false,
+      }),
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: false,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(id, monitor);
+    monitor.start();
+    return monitor;
+  }
+
+  /** Drive the `.git/config`-write path and let the debounced probe settle. */
+  async function fireConfigChange(times = 1): Promise<void> {
+    for (let i = 0; i < times; i++) {
+      service["scheduleForgeRemoteReprobe"]();
+    }
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  /** Establish a known baseline signature, as a monitor's start probe would. */
+  async function seedBaseline(monitor: WorktreeMonitor, remotes: Remote[]): Promise<void> {
+    mockSimpleGit.getRemotes.mockResolvedValue(remotes);
+    await service["probeForgeRemoteAsync"](monitor);
+    mockSimpleGit.getRemotes.mockClear();
+  }
+
+  it("resolves the provider after an origin is added to a repo that had none", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline(main, []);
+    expect(main.getSnapshot().matchedForgeProviderId).toBeUndefined();
+
+    mockSimpleGit.getRemotes.mockResolvedValue([
+      remote("origin", "https://github.com/acme/app.git"),
+    ]);
+    await fireConfigChange();
+
+    expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+    expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+    expect(mockSendEvent).toHaveBeenCalledWith({ type: "forge-remote-changed" });
+  });
+
+  it("coalesces every sibling worktree's config event into ONE git read", async () => {
+    // All worktrees share the common dir, so each one's watcher reports the
+    // same write. Without coalescing this is N subprocess spawns per write.
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    registerMonitor("/test/feature-1");
+    registerMonitor("/test/feature-2");
+    await seedBaseline(main, []);
+
+    mockSimpleGit.getRemotes.mockResolvedValue([
+      remote("origin", "https://github.com/acme/app.git"),
+    ]);
+    await fireConfigChange(3);
+
+    expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
+    expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("fans the new provider out to every running monitor", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    const feature = registerMonitor("/test/feature");
+    await seedBaseline(main, []);
+
+    mockSimpleGit.getRemotes.mockResolvedValue([
+      remote("origin", "https://github.com/acme/app.git"),
+    ]);
+    await fireConfigChange();
+
+    // Remotes are repo-level: one probe must update the sibling's card too,
+    // not just the worktree whose watcher happened to fire.
+    expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+    expect(feature.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+  });
+
+  it("emits nothing when a config write leaves the remotes unchanged", async () => {
+    // `.git/config` is also written by `git push -u` and
+    // `git branch --set-upstream-to`. Those must not churn the provider, or
+    // PullRequestService's no-match pause (#9997) stops meaning anything.
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    const remotes = [remote("origin", "https://github.com/acme/app.git")];
+    await seedBaseline(main, remotes);
+
+    mockSimpleGit.getRemotes.mockResolvedValue(remotes);
+    await fireConfigChange();
+
+    expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
+    expect(sysRemoteChanged).not.toHaveBeenCalled();
+    expect(mockSendEvent).not.toHaveBeenCalledWith({ type: "forge-remote-changed" });
+  });
+
+  it("detects a remote whose URL was repointed at another host", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline(main, [remote("origin", "https://gitlab.com/acme/app.git")]);
+    expect(main.getSnapshot().matchedForgeProviderId).toBeUndefined();
+
+    mockSimpleGit.getRemotes.mockResolvedValue([
+      remote("origin", "https://github.com/acme/app.git"),
+    ]);
+    await fireConfigChange();
+
+    expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+    expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+  });
+
+  it("clears the provider when the origin is removed", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline(main, [remote("origin", "https://github.com/acme/app.git")]);
+    expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+
+    mockSimpleGit.getRemotes.mockResolvedValue([]);
+    await fireConfigChange();
+
+    expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+    // The snapshot carries `undefined` for "no provider" (SnapshotBuilder maps
+    // null → undefined), so the cleared state is the absence of an id.
+    expect(main.getSnapshot().matchedForgeProviderId).toBeUndefined();
+  });
+
+  it("stays forge-neutral — an unmatched host resolves to no provider without erroring", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline(main, []);
+
+    mockSimpleGit.getRemotes.mockResolvedValue([
+      remote("origin", "https://git.internal.example/acme/app.git"),
+    ]);
+    await fireConfigChange();
+
+    // The remote table changed, so the signal still fires (main re-runs the
+    // full precedence chain, which may resolve via an override or a default) —
+    // but no hostname matcher claims it.
+    expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+    expect(main.getSnapshot().matchedForgeProviderId).toBeUndefined();
+  });
+
+  it("emits nothing when the git read fails", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline(main, [remote("origin", "https://github.com/acme/app.git")]);
+
+    mockSimpleGit.getRemotes.mockRejectedValue(new Error("not a git repository"));
+    await fireConfigChange();
+
+    expect(sysRemoteChanged).not.toHaveBeenCalled();
+    // The last-known provider survives a transient failure.
+    expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+  });
+
+  it("drops a probe that lands after teardown", async () => {
+    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline(main, []);
+
+    let releaseGit: (remotes: Remote[]) => void = () => {};
+    mockSimpleGit.getRemotes.mockReturnValue(
+      new Promise<Remote[]>((resolve) => {
+        releaseGit = resolve;
+      })
+    );
+
+    service["scheduleForgeRemoteReprobe"]();
+    await vi.advanceTimersByTimeAsync(300);
+
+    // The project unloads while git is still running. A late completion must
+    // not signal on behalf of a project that is no longer loaded.
+    service["stopForgeConfigPoll"]();
+    releaseGit([remote("origin", "https://github.com/acme/app.git")]);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sysRemoteChanged).not.toHaveBeenCalled();
+    expect(mockSendEvent).not.toHaveBeenCalledWith({ type: "forge-remote-changed" });
+  });
+
+  describe("watcher-independent fallback", () => {
+    it("probes when the config fingerprint moves, and not before", async () => {
+      // Covers a disabled or silently-degraded git watcher: `fs.watch` failures
+      // fall back to polling without telling anyone, and inotify exhaustion is
+      // a live failure mode on Linux.
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline(main, []);
+
+      mockStat.mockResolvedValue({ mtimeMs: 1000, size: 200 });
+      service["startForgeConfigPoll"]();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Unchanged file: a stat, no subprocess.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(300);
+      expect(mockSimpleGit.getRemotes).not.toHaveBeenCalled();
+
+      // `git remote add` rewrote the file.
+      mockStat.mockResolvedValue({ mtimeMs: 2000, size: 260 });
+      mockSimpleGit.getRemotes.mockResolvedValue([
+        remote("origin", "https://github.com/acme/app.git"),
+      ]);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+      expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+    });
+
+    it("stops on teardown", async () => {
+      mockStat.mockResolvedValue({ mtimeMs: 1000, size: 200 });
+      service["startForgeConfigPoll"]();
+      await vi.advanceTimersByTimeAsync(0);
+
+      service["stopForgeConfigPoll"]();
+      mockStat.mockResolvedValue({ mtimeMs: 2000, size: 260 });
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+      expect(mockSimpleGit.getRemotes).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.forgeRemote.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { EventEmitter } from "events";
 import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorktreeMonitor } from "../WorktreeMonitor.js";
@@ -151,7 +151,7 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
   let service: WorkspaceService;
   let mockSendEvent: ReturnType<typeof vi.fn>;
   let WorktreeMonitorClass: typeof WorktreeMonitor;
-  let sysRemoteChanged: ReturnType<typeof vi.fn>;
+  let sysRemoteChanged: Mock<(payload: { timestamp: number }) => void>;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -172,7 +172,7 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
       { providerId: GITHUB_PROVIDER_ID, hostnames: ["github.com"] },
     ];
 
-    sysRemoteChanged = vi.fn();
+    sysRemoteChanged = vi.fn<(payload: { timestamp: number }) => void>();
     mockEvents.on("sys:forge:remote-changed", sysRemoteChanged);
   });
 
@@ -208,30 +208,68 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
     return monitor;
   }
 
-  /** Drive the `.git/config`-write path and let the debounced probe settle. */
-  async function fireConfigChange(times = 1): Promise<void> {
-    for (let i = 0; i < times; i++) {
-      service["scheduleForgeRemoteReprobe"]();
+  /**
+   * Advance the config file's identity so the reprobe's stat gate sees a real
+   * change. Git rewrites `.git/config` lock-then-rename, so a real
+   * `git remote` mutation always lands a new inode.
+   */
+  let configStat = { ino: 1, mtimeMs: 1000, ctimeMs: 1000, size: 200 };
+  function setConfigStat(next: Partial<typeof configStat>): void {
+    configStat = { ...configStat, ...next };
+    mockStat.mockResolvedValue({ ...configStat });
+  }
+  function touchConfigFile(): void {
+    setConfigStat({
+      ino: configStat.ino + 1,
+      mtimeMs: configStat.mtimeMs + 1000,
+      ctimeMs: configStat.ctimeMs + 1000,
+      size: configStat.size + 1,
+    });
+  }
+  /** A rewrite that moved ONLY the inode — mtime, ctime and size all unchanged. */
+  function touchConfigInodeOnly(): void {
+    setConfigStat({ ino: configStat.ino + 1 });
+  }
+
+  /**
+   * Drive the `.git/config`-write path and let the debounced probe settle.
+   * `touch: false` simulates a watcher event that did NOT correspond to a real
+   * config write (an unnamed `fs.watch` event).
+   */
+  async function fireConfigChange(opts: { times?: number; touch?: boolean } = {}): Promise<void> {
+    if (opts.touch !== false) touchConfigFile();
+    for (let i = 0; i < (opts.times ?? 1); i++) {
+      service["scheduleForgeRemoteReprobe"]({ observedConfigWrite: true });
     }
     await vi.advanceTimersByTimeAsync(300);
     await vi.advanceTimersByTimeAsync(0);
   }
 
-  /** Establish a known baseline signature, as a monitor's start probe would. */
-  async function seedBaseline(monitor: WorktreeMonitor, remotes: Remote[]): Promise<void> {
+  /** Establish the load-time baseline, as `startForgeRemoteDetection` does. */
+  async function seedBaseline(remotes: Remote[]): Promise<void> {
+    mockSimpleGit.getRemotes.mockResolvedValue(remotes);
+    touchConfigFile();
+    service["startForgeRemoteDetection"]();
+    await vi.advanceTimersByTimeAsync(0);
+    mockSimpleGit.getRemotes.mockClear();
+  }
+
+  /** Run a monitor's start probe (which must never seed the baseline). */
+  async function runStartProbe(monitor: WorktreeMonitor, remotes: Remote[]): Promise<void> {
     mockSimpleGit.getRemotes.mockResolvedValue(remotes);
     await service["probeForgeRemoteAsync"](monitor);
     mockSimpleGit.getRemotes.mockClear();
   }
 
+  const ORIGIN_GITHUB = remote("origin", "https://github.com/acme/app.git");
+
   it("resolves the provider after an origin is added to a repo that had none", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });
-    await seedBaseline(main, []);
+    await seedBaseline([]);
+    await runStartProbe(main, []);
     expect(main.getSnapshot().matchedForgeProviderId).toBeUndefined();
 
-    mockSimpleGit.getRemotes.mockResolvedValue([
-      remote("origin", "https://github.com/acme/app.git"),
-    ]);
+    mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
     await fireConfigChange();
 
     expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
@@ -242,15 +280,13 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
   it("coalesces every sibling worktree's config event into ONE git read", async () => {
     // All worktrees share the common dir, so each one's watcher reports the
     // same write. Without coalescing this is N subprocess spawns per write.
-    const main = registerMonitor("/test/main", { isMainWorktree: true });
+    registerMonitor("/test/main", { isMainWorktree: true });
     registerMonitor("/test/feature-1");
     registerMonitor("/test/feature-2");
-    await seedBaseline(main, []);
+    await seedBaseline([]);
 
-    mockSimpleGit.getRemotes.mockResolvedValue([
-      remote("origin", "https://github.com/acme/app.git"),
-    ]);
-    await fireConfigChange(3);
+    mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+    await fireConfigChange({ times: 3 });
 
     expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
     expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
@@ -259,11 +295,9 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
   it("fans the new provider out to every running monitor", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });
     const feature = registerMonitor("/test/feature");
-    await seedBaseline(main, []);
+    await seedBaseline([]);
 
-    mockSimpleGit.getRemotes.mockResolvedValue([
-      remote("origin", "https://github.com/acme/app.git"),
-    ]);
+    mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
     await fireConfigChange();
 
     // Remotes are repo-level: one probe must update the sibling's card too,
@@ -274,13 +308,14 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
 
   it("emits nothing when a config write leaves the remotes unchanged", async () => {
     // `.git/config` is also written by `git push -u` and
-    // `git branch --set-upstream-to`. Those must not churn the provider, or
-    // PullRequestService's no-match pause (#9997) stops meaning anything.
-    const main = registerMonitor("/test/main", { isMainWorktree: true });
-    const remotes = [remote("origin", "https://github.com/acme/app.git")];
-    await seedBaseline(main, remotes);
+    // `git branch --set-upstream-to`. The file genuinely changes (so the stat
+    // gate opens and git runs), but the remote table doesn't — and a provider
+    // churn here would make PullRequestService's no-match pause (#9997)
+    // meaningless.
+    registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline([ORIGIN_GITHUB]);
 
-    mockSimpleGit.getRemotes.mockResolvedValue(remotes);
+    mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
     await fireConfigChange();
 
     expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
@@ -288,14 +323,28 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
     expect(mockSendEvent).not.toHaveBeenCalledWith({ type: "forge-remote-changed" });
   });
 
+  it("skips the git spawn when the watcher fires but the config never moved", async () => {
+    // `fs.watch` can report a change with NO filename, which we conservatively
+    // treat as possibly-config. The stat gate is what keeps that conservatism
+    // from turning into a `git remote` spawn storm.
+    registerMonitor("/test/main", { isMainWorktree: true });
+    await seedBaseline([ORIGIN_GITHUB]);
+
+    await fireConfigChange({ touch: false });
+    await fireConfigChange({ touch: false });
+
+    expect(mockSimpleGit.getRemotes).not.toHaveBeenCalled();
+    expect(sysRemoteChanged).not.toHaveBeenCalled();
+  });
+
   it("detects a remote whose URL was repointed at another host", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });
-    await seedBaseline(main, [remote("origin", "https://gitlab.com/acme/app.git")]);
+    const gitlab = remote("origin", "https://gitlab.com/acme/app.git");
+    await seedBaseline([gitlab]);
+    await runStartProbe(main, [gitlab]);
     expect(main.getSnapshot().matchedForgeProviderId).toBeUndefined();
 
-    mockSimpleGit.getRemotes.mockResolvedValue([
-      remote("origin", "https://github.com/acme/app.git"),
-    ]);
+    mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
     await fireConfigChange();
 
     expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
@@ -304,7 +353,8 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
 
   it("clears the provider when the origin is removed", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });
-    await seedBaseline(main, [remote("origin", "https://github.com/acme/app.git")]);
+    await seedBaseline([ORIGIN_GITHUB]);
+    await runStartProbe(main, [ORIGIN_GITHUB]);
     expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
 
     mockSimpleGit.getRemotes.mockResolvedValue([]);
@@ -318,7 +368,7 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
 
   it("stays forge-neutral — an unmatched host resolves to no provider without erroring", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });
-    await seedBaseline(main, []);
+    await seedBaseline([]);
 
     mockSimpleGit.getRemotes.mockResolvedValue([
       remote("origin", "https://git.internal.example/acme/app.git"),
@@ -334,7 +384,8 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
 
   it("emits nothing when the git read fails", async () => {
     const main = registerMonitor("/test/main", { isMainWorktree: true });
-    await seedBaseline(main, [remote("origin", "https://github.com/acme/app.git")]);
+    await seedBaseline([ORIGIN_GITHUB]);
+    await runStartProbe(main, [ORIGIN_GITHUB]);
 
     mockSimpleGit.getRemotes.mockRejectedValue(new Error("not a git repository"));
     await fireConfigChange();
@@ -344,52 +395,206 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
     expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
   });
 
-  it("drops a probe that lands after teardown", async () => {
-    const main = registerMonitor("/test/main", { isMainWorktree: true });
-    await seedBaseline(main, []);
+  describe("baseline seeding", () => {
+    it("a monitor start probe that races the user cannot absorb the change", async () => {
+      // The sharp edge: a start probe still in flight when the user runs
+      // `git remote add` reads the NEW table. If it were allowed to seed the
+      // baseline, the reprobe would compare equal and emit nothing — the
+      // worktree card would light up while the toolbar stayed dark forever.
+      //
+      // No baseline is established first, precisely so that a `??=` seed inside
+      // `probeForgeRemoteAsync` WOULD take effect — that's what makes this a
+      // real regression test rather than one an unfixed build also passes.
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      touchConfigFile();
 
-    let releaseGit: (remotes: Remote[]) => void = () => {};
-    mockSimpleGit.getRemotes.mockReturnValue(
-      new Promise<Remote[]>((resolve) => {
-        releaseGit = resolve;
-      })
-    );
+      // The start probe reads the post-add table (it lost the race with the user).
+      await runStartProbe(main, [ORIGIN_GITHUB]);
+      expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+      expect(service["forgeRemoteSignature"]).toBeNull();
 
-    service["scheduleForgeRemoteReprobe"]();
-    await vi.advanceTimersByTimeAsync(300);
+      // The watcher's reprobe must still see this as a change.
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+      await fireConfigChange({ touch: false });
 
-    // The project unloads while git is still running. A late completion must
-    // not signal on behalf of a project that is no longer loaded.
-    service["stopForgeConfigPoll"]();
-    releaseGit([remote("origin", "https://github.com/acme/app.git")]);
-    await vi.advanceTimersByTimeAsync(0);
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+      expect(mockSendEvent).toHaveBeenCalledWith({ type: "forge-remote-changed" });
+    });
 
-    expect(sysRemoteChanged).not.toHaveBeenCalled();
-    expect(mockSendEvent).not.toHaveBeenCalledWith({ type: "forge-remote-changed" });
+    it("discards a load-time baseline read that spanned a config write", async () => {
+      registerMonitor("/test/main", { isMainWorktree: true });
+
+      // The seed's git read is still in flight when the user adds the remote.
+      let releaseSeed: (remotes: Remote[]) => void = () => {};
+      mockSimpleGit.getRemotes.mockReturnValue(
+        new Promise<Remote[]>((resolve) => {
+          releaseSeed = resolve;
+        })
+      );
+      touchConfigFile();
+      service["startForgeRemoteDetection"]();
+
+      // Watcher observes the write while the seed read is outstanding.
+      service["scheduleForgeRemoteReprobe"]({ observedConfigWrite: true });
+
+      // The seed now returns the POST-add table — it must not become the
+      // baseline, or the reprobe below would find nothing changed.
+      releaseSeed([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(service["forgeRemoteSignature"]).toBeNull();
+
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+      touchConfigFile();
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+    });
   });
 
-  describe("watcher-independent fallback", () => {
-    it("probes when the config fingerprint moves, and not before", async () => {
+  describe("teardown", () => {
+    it("drops a probe that lands after teardown", async () => {
+      registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+
+      let releaseGit: (remotes: Remote[]) => void = () => {};
+      mockSimpleGit.getRemotes.mockReturnValue(
+        new Promise<Remote[]>((resolve) => {
+          releaseGit = resolve;
+        })
+      );
+
+      touchConfigFile();
+      service["scheduleForgeRemoteReprobe"]({ observedConfigWrite: true });
+      await vi.advanceTimersByTimeAsync(300);
+
+      // The project unloads while git is still running. A late completion must
+      // not signal on behalf of a project that is no longer loaded.
+      service["stopForgeRemoteDetection"]();
+      releaseGit([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sysRemoteChanged).not.toHaveBeenCalled();
+      expect(mockSendEvent).not.toHaveBeenCalledWith({ type: "forge-remote-changed" });
+    });
+
+    it("drops a baseline seed that lands after teardown", async () => {
+      // Otherwise project A's remotes become project B's baseline, and B's real
+      // `git remote add` could compare equal and be suppressed.
+      let releaseSeed: (remotes: Remote[]) => void = () => {};
+      mockSimpleGit.getRemotes.mockReturnValue(
+        new Promise<Remote[]>((resolve) => {
+          releaseSeed = resolve;
+        })
+      );
+      touchConfigFile();
+      service["startForgeRemoteDetection"]();
+
+      service["stopForgeRemoteDetection"]();
+      releaseSeed([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(service["forgeRemoteSignature"]).toBeNull();
+      expect(service["forgeConfigFingerprint"]).toBeNull();
+    });
+
+    it("stops the backstop timer", async () => {
+      await seedBaseline([]);
+      service["stopForgeRemoteDetection"]();
+
+      touchConfigFile();
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+      expect(mockSimpleGit.getRemotes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("in-flight probe races", () => {
+    it("a duplicate event mid-probe cannot cancel the pending detection", async () => {
+      // Probe A stats the changed config, then stalls in git. A late sibling (or
+      // unnamed) event supersedes it with probe B. If A had already *consumed*
+      // the fingerprint, B would see "nothing changed" and bail — and A would
+      // then die on its sequence check. The remote change would vanish entirely.
+      registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+
+      let releaseA: (remotes: Remote[]) => void = () => {};
+      mockSimpleGit.getRemotes.mockReturnValueOnce(
+        new Promise<Remote[]>((resolve) => {
+          releaseA = resolve;
+        })
+      );
+      touchConfigFile();
+      await fireConfigChange({ touch: false });
+
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+      await fireConfigChange({ touch: false });
+
+      releaseA([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Exactly one emit: B detected it, and superseded A stayed silent.
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("a failed git read leaves the change visible to the next probe", async () => {
+      // The fingerprint must not be consumed by a probe that never managed to
+      // read the remotes — otherwise a transient git failure marks the change as
+      // seen and the backstop skips it forever.
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([]);
+
+      mockSimpleGit.getRemotes.mockRejectedValueOnce(new Error("git spawn failed"));
+      await fireConfigChange();
+      expect(sysRemoteChanged).not.toHaveBeenCalled();
+
+      // The backstop tick re-stats: the fingerprint still differs from the
+      // baseline, so it probes again rather than treating it as already seen.
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+      expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+    });
+  });
+
+  describe("watcher-independent backstop", () => {
+    it("detects a rewrite that moved only the inode", async () => {
+      // Coarse-timestamp and network filesystems can leave mtime, ctime AND size
+      // identical across git's lock-then-rename. The inode still moves — which is
+      // exactly why the fingerprint includes it. A mtime+size fingerprint would
+      // call this "unchanged" and never probe.
+      const main = registerMonitor("/test/main", { isMainWorktree: true });
+      await seedBaseline([remote("origin", "https://gitlab.com/acme/app.git")]);
+
+      touchConfigInodeOnly();
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
+      expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
+    });
+
+    it("probes when the config moves, and not before", async () => {
       // Covers a disabled or silently-degraded git watcher: `fs.watch` failures
       // fall back to polling without telling anyone, and inotify exhaustion is
       // a live failure mode on Linux.
       const main = registerMonitor("/test/main", { isMainWorktree: true });
-      await seedBaseline(main, []);
+      await seedBaseline([]);
 
-      mockStat.mockResolvedValue({ mtimeMs: 1000, size: 200 });
-      service["startForgeConfigPoll"]();
-      await vi.advanceTimersByTimeAsync(0);
-
-      // Unchanged file: a stat, no subprocess.
+      // Unchanged file: the tick stats, and stops there.
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
       await vi.advanceTimersByTimeAsync(300);
       expect(mockSimpleGit.getRemotes).not.toHaveBeenCalled();
 
-      // `git remote add` rewrote the file.
-      mockStat.mockResolvedValue({ mtimeMs: 2000, size: 260 });
-      mockSimpleGit.getRemotes.mockResolvedValue([
-        remote("origin", "https://github.com/acme/app.git"),
-      ]);
+      // `git remote add` rewrote the file (lock-then-rename → new inode).
+      touchConfigFile();
+      mockSimpleGit.getRemotes.mockResolvedValue([ORIGIN_GITHUB]);
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
       await vi.advanceTimersByTimeAsync(300);
       await vi.advanceTimersByTimeAsync(0);
@@ -397,18 +602,6 @@ describe("WorkspaceService forge-remote detection (#11155)", () => {
       expect(mockSimpleGit.getRemotes).toHaveBeenCalledTimes(1);
       expect(sysRemoteChanged).toHaveBeenCalledTimes(1);
       expect(main.getSnapshot().matchedForgeProviderId).toBe(GITHUB_PROVIDER_ID);
-    });
-
-    it("stops on teardown", async () => {
-      mockStat.mockResolvedValue({ mtimeMs: 1000, size: 200 });
-      service["startForgeConfigPoll"]();
-      await vi.advanceTimersByTimeAsync(0);
-
-      service["stopForgeConfigPoll"]();
-      mockStat.mockResolvedValue({ mtimeMs: 2000, size: 260 });
-      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
-
-      expect(mockSimpleGit.getRemotes).not.toHaveBeenCalled();
     });
   });
 });

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1489,6 +1489,13 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       callback: (data: import("./forge.js").ForgeTokenHealthChangedPayload) => void
     ): () => void;
     /**
+     * The project's git remote table changed (#11155) — e.g. `git remote add
+     * origin` in an already-open project. Signal-only: re-resolve the provider
+     * for `projectId` via `resolveProvider`, which is where the precedence
+     * chain (per-project override → global default → hostname match) lives.
+     */
+    onRemoteChanged(callback: (payload: { projectId: string }) => void): () => void;
+    /**
      * Classify a `git push` failure via the resolved forge provider. Returns
      * the provider's canonical `{pluginId}.{contributionId}` id (for routing
      * the push-error banner's settings CTA) plus the provider's classification

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1909,6 +1909,13 @@ export interface IpcEventMap {
   // renderer re-pulls via `plugin:list` for the full data.
   "plugin:provenance-changed": Record<string, never>;
 
+  // The project's git remote table changed (main → renderer, #11155) — e.g.
+  // `git remote add origin`. Signal-only and project-scoped: the renderer drops
+  // its cached forge-provider resolution for `projectId` and re-resolves via
+  // `forge:resolve-provider`. No remote URL crosses the bridge (https remotes
+  // can embed credentials).
+  "forge:remote-changed": { projectId: string };
+
   // Background plugin update check found available updates (main → renderer,
   // #10893). Carries the batched set so the renderer can raise one low-priority
   // inbox notification. Broadcast only when at least one update is available.
@@ -2035,6 +2042,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:panel-badges-cleared"
   // Plugin provenance record changed (global broadcast)
   | "plugin:provenance-changed"
+  // Project's git remotes changed — re-resolve the forge provider (global broadcast)
+  | "forge:remote-changed"
   // Background plugin update check found updates (global broadcast)
   | "plugin:bg-update-available"
   // Run history changed (global broadcast)

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -720,6 +720,13 @@ export type WorkspaceHostEvent =
       providerId: string;
       isUnhealthy: boolean;
     }
+  // The repo's git remote table changed (#11155) — `git remote add` / `set-url`
+  // / `remove`, detected from a `.git/config` write. Signal-only and repo-level:
+  // the host already applied it to its own monitors, and main derives the
+  // projectId from the emitting host's project path. Carries no remote URL —
+  // https remotes can embed credentials, and the renderer re-resolves through
+  // main's own precedence chain anyway.
+  | { type: "forge-remote-changed" }
   // CopyTree events
   | { type: "copytree:progress"; operationId: string; progress: CopyTreeProgress }
   | {

--- a/src/hooks/__tests__/useResolvedForgeProvider.test.tsx
+++ b/src/hooks/__tests__/useResolvedForgeProvider.test.tsx
@@ -17,12 +17,25 @@ function fireProvenanceChanged(): void {
   for (const cb of [...provenanceCallbacks]) cb();
 }
 
+// Same multiplexer shape for `forge:remote-changed` (#11155), which unlike
+// provenance carries the project it applies to.
+let remoteChangedCallbacks: Array<(payload: { projectId: string }) => void> = [];
+function fireRemoteChanged(projectId: string): void {
+  for (const cb of [...remoteChangedCallbacks]) cb({ projectId });
+}
+
 vi.stubGlobal("electron", undefined);
 Object.defineProperty(window, "electron", {
   configurable: true,
   value: {
     forge: {
       resolveProvider: (projectId: string) => resolveProviderMock(projectId),
+      onRemoteChanged: (cb: (payload: { projectId: string }) => void) => {
+        remoteChangedCallbacks.push(cb);
+        return () => {
+          remoteChangedCallbacks = remoteChangedCallbacks.filter((c) => c !== cb);
+        };
+      },
     },
     plugin: {
       onProvenanceChanged: (cb: () => void) => {
@@ -46,6 +59,7 @@ function nextProjectId(): string {
 describe("useResolvedForgeProvider", () => {
   beforeEach(() => {
     provenanceCallbacks = [];
+    remoteChangedCallbacks = [];
     resolveProviderMock.mockReset();
   });
 
@@ -139,5 +153,82 @@ describe("useResolvedForgeProvider", () => {
     // No unresolved flash: initial state comes straight from the cache.
     expect(second.result.current.entry).toEqual(GITHUB_ENTRY);
     expect(second.result.current.loading).toBe(false);
+  });
+
+  describe("remote-changed invalidation (#11155)", () => {
+    it("resolves a provider after an origin is added to an open project", async () => {
+      // The bug: `git remote add origin` in an already-open project left the
+      // toolbar pills hidden until a reload, because the hook resolved once on
+      // mount (unresolved) and the toolbar never unmounts to re-ask.
+      resolveProviderMock.mockResolvedValue({ entry: null, resolvedVia: null });
+      const projectId = nextProjectId();
+
+      const { result } = renderHook(() => useResolvedForgeProvider(projectId));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.providerId).toBeNull();
+
+      resolveProviderMock.mockResolvedValue({ entry: GITHUB_ENTRY, resolvedVia: "hostname" });
+      act(() => fireRemoteChanged(projectId));
+
+      await waitFor(() => expect(result.current.entry).toEqual(GITHUB_ENTRY));
+      expect(result.current.providerId).toBe("daintree.github.github");
+    });
+
+    it("ignores a remote change on a different project", async () => {
+      resolveProviderMock.mockResolvedValue({ entry: null, resolvedVia: null });
+      const projectId = nextProjectId();
+      const otherProjectId = nextProjectId();
+
+      const { result } = renderHook(() => useResolvedForgeProvider(projectId));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      const callsAfterMount = resolveProviderMock.mock.calls.length;
+
+      resolveProviderMock.mockResolvedValue({ entry: GITHUB_ENTRY, resolvedVia: "hostname" });
+      act(() => fireRemoteChanged(otherProjectId));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // A sibling project's remote says nothing about this one's resolution.
+      expect(resolveProviderMock.mock.calls.length).toBe(callsAfterMount);
+      expect(result.current.entry).toBeNull();
+    });
+
+    it("converges every concurrently-mounted instance for the project", async () => {
+      // Same fan-out as the provenance case: the toolbar, the stats pill and
+      // the sidebar each hold an instance, and all must see the new provider.
+      resolveProviderMock.mockResolvedValue({ entry: null, resolvedVia: null });
+      const projectId = nextProjectId();
+
+      const instances = Array.from({ length: 3 }, () =>
+        renderHook(() => useResolvedForgeProvider(projectId))
+      );
+      for (const { result } of instances) {
+        await waitFor(() => expect(result.current.loading).toBe(false));
+      }
+
+      resolveProviderMock.mockResolvedValue({ entry: GITHUB_ENTRY, resolvedVia: "hostname" });
+      act(() => fireRemoteChanged(projectId));
+
+      for (const { result } of instances) {
+        await waitFor(() => expect(result.current.entry).toEqual(GITHUB_ENTRY));
+      }
+    });
+
+    it("unsubscribes on unmount", async () => {
+      resolveProviderMock.mockResolvedValue({ entry: null, resolvedVia: null });
+      const projectId = nextProjectId();
+
+      const { unmount, result } = renderHook(() => useResolvedForgeProvider(projectId));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(remoteChangedCallbacks).toHaveLength(1);
+
+      unmount();
+      expect(remoteChangedCallbacks).toHaveLength(0);
+
+      const callsAfterUnmount = resolveProviderMock.mock.calls.length;
+      act(() => fireRemoteChanged(projectId));
+      expect(resolveProviderMock.mock.calls.length).toBe(callsAfterUnmount);
+    });
   });
 });

--- a/src/hooks/useResolvedForgeProvider.ts
+++ b/src/hooks/useResolvedForgeProvider.ts
@@ -100,7 +100,7 @@ export function useResolvedForgeProvider(
     run();
 
     const plugin = window.electron?.plugin;
-    const unsubscribe =
+    const unsubscribeProvenance =
       typeof plugin?.onProvenanceChanged === "function"
         ? plugin.onProvenanceChanged(() => {
             resolutionCache.clear();
@@ -108,9 +108,26 @@ export function useResolvedForgeProvider(
           })
         : null;
 
+    // A remote was added/changed/removed on this project's repo (#11155) —
+    // `git remote add origin` in an already-open project used to leave the
+    // toolbar pills hidden until a reload, because nothing invalidated this
+    // cache. Scoped to the project that changed (unlike provenance, which
+    // invalidates wholesale): a sibling project's remote says nothing about
+    // this one's resolution.
+    const forge = window.electron?.forge;
+    const unsubscribeRemote =
+      typeof forge?.onRemoteChanged === "function"
+        ? forge.onRemoteChanged((payload) => {
+            if (payload.projectId !== projectId) return;
+            resolutionCache.delete(projectId);
+            run();
+          })
+        : null;
+
     return () => {
       cancelled = true;
-      unsubscribe?.();
+      unsubscribeProvenance?.();
+      unsubscribeRemote?.();
     };
   }, [projectId, resolve]);
 


### PR DESCRIPTION
## Summary

- Adding a git origin to an already-open project (`git remote add origin ...`) left the forge toolbar's PR/issue count pills hidden until a full project reload.
- Main's provider-resolution handler already re-read the remote on every call. The stale piece was the renderer's module-level `resolutionCache` in `useResolvedForgeProvider`, which only invalidated on a project switch or a plugin-provenance event, and the toolbar never unmounts, so it resolved once and never asked again.
- Adds a forge-neutral signal path (no GitHub special-casing anywhere) that tells the renderer to re-run the host's existing precedence chain: per-project override, then global default, then hostname match.

Resolves #11155

## Changes

- `GitFileWatcher` already watched `.git/config` for `git push -u`; it now also reports which file changed via a new `onGitConfigChanged` callback.
- That flows through `WatcherController` to `WorktreeMonitor` to `WorkspaceService`, which coalesces every sibling worktree's event (they share one common `.git` directory) into a single `getRemotes()` probe and fans the result out to all monitors.
- `WorkspaceService` diffs a remote signature and only emits when the remote table actually changed, so the unrelated config writes that already wake the watcher (`git push -u`, `--set-upstream-to`) cost nothing.
- An in-process `sys:forge:remote-changed` event releases `PullRequestService`'s sticky no-match pause, so per-worktree PR badges resolve too.
- A `forge-remote-changed` host event reaches main, which broadcasts `forge:remote-changed` (project-scoped, riding the existing `EVENTS_PUSH` multiplexer, no new IPC channel) to the renderer. `useResolvedForgeProvider` drops that project's cache entry and re-resolves. No remote URL crosses the bridge, since https remotes can embed credentials.
- A 5-minute config-fingerprint backstop covers a disabled or silently-degraded file watcher (`fs.watch` failures fall back to polling silently, and Linux inotify exhaustion is a live failure mode). It costs one `stat` per tick; the git subprocess only runs when the config's inode, mtime, or size actually moved.

Worth flagging: #9997 made `PullRequestService`'s no-match provider cache sticky on purpose, since remote-less or non-forge projects were spawning around 17,000 git subprocesses a day. This signal is deliberately narrow, a distinct event rather than a widening of the existing `sys:worktree:update` handler, so it releases the pause without reopening that spin. The existing regression test asserting a worktree update must not re-resolve stays green, and a new test asserts the pause re-arms after a remote change that still resolves to no-match.

## Testing

- `npm run typecheck`
- 3,003 tests across every touched module: `electron/workspace-host` (830, including the new `WorkspaceService.forgeRemote.test.ts`), `electron/ipc` (1,947), `PullRequestService` plus `WorkspaceHostEventRouter` (127), `useResolvedForgeProvider` plus `useRepositoryStats` (99)
- `npm run check:ipc`, `npm run lint:ratchet`, prettier/eslint on changed files, all clean
- The 4 race-regression tests were verified red-before-green (reverting each fix fails exactly its own test)

19 files changed. `useRepositoryStats` needed no change, since its corrective-refetch effect already re-arms when `providerId` flips from `null` to resolved.