### PR TITLE
fix(projectview): keep a running Daintree Assistant's view out of the LRU pool

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -286,11 +286,17 @@ if (!gotTheLock) {
       // out of the routine LRU pool (#11157) — evicting it would run the
       // revoke-and-kill path below and take the assistant's sub-agents and
       // background shells with it. Injected here rather than imported by
-      // electron/window/ so the eviction controller stays free of the service.
+      // electron/window/ so the eviction controller stays free of both services.
       // The static import is free: PtyClient already value-imports
       // HelpSessionService, so it is in the eager graph either way.
-      assistantTerminalIdForProject: (projectId) =>
-        helpSessionService.getAssistantTerminalId(projectId),
+      assistantBackendForProject: (projectId) => helpSessionService.getAssistantBackend(projectId),
+      // The liveness half. PtyClient's spawn registry is main-local and
+      // synchronous — written by spawn() before the host round-trip, dropped on
+      // exit and on kill — so it is authoritative from the assistant's first
+      // instant. The pty-host's terminal snapshot is not a substitute: it is
+      // async, and a shard that times out comes back as an empty list, which
+      // would read as "the assistant is gone" and unprotect a live one.
+      isTerminalLive: (terminalId) => getPtyClient()?.hasTerminal(terminalId) === true,
       onViewEvicted: (wcId) => {
         // Each cleanup is isolated: if removeDirectPort throws, the worktree
         // port must still close. Partial cleanup leaves a live producer

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,7 @@ import {
 } from "./window/windowRef.js";
 import { WindowRegistry } from "./window/WindowRegistry.js";
 import { ProjectViewManager } from "./window/ProjectViewManager.js";
+import { helpSessionService } from "./services/HelpSessionService.js";
 import { effectiveCachedProjectViews } from "./utils/cachedProjectViews.js";
 import { setupBrowserWindow } from "./window/createWindow.js";
 import { distributePortsToView } from "./window/portDistribution.js";
@@ -281,6 +282,15 @@ if (!gotTheLock) {
       cachedProjectViews: effectiveCachedProjectViews(
         store.get("terminalConfig")?.cachedProjectViews
       ),
+      // Lets the eviction policy keep a view whose assistant is still running
+      // out of the routine LRU pool (#11157) — evicting it would run the
+      // revoke-and-kill path below and take the assistant's sub-agents and
+      // background shells with it. Injected here rather than imported by
+      // electron/window/ so the eviction controller stays free of the service.
+      // The static import is free: PtyClient already value-imports
+      // HelpSessionService, so it is in the eager graph either way.
+      assistantTerminalIdForProject: (projectId) =>
+        helpSessionService.getAssistantTerminalId(projectId),
       onViewEvicted: (wcId) => {
         // Each cleanup is isolated: if removeDirectPort throws, the worktree
         // port must still close. Partial cleanup leaves a live producer

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -398,26 +398,40 @@ export class HelpSessionService {
   }
 
   /**
-   * The assistant PTY currently bound to `projectId`, or null when the project
-   * has no help session backend. ProjectViewManager's eviction policy reads
-   * this synchronously to keep a cached view whose assistant is still running
-   * out of the routine LRU candidate pool (#11157): destroying that view fires
-   * `onViewEvicted` → `revokeByWebContentsId` → `gracefulKill`, which tears
-   * down the whole PTY process tree — every sub-agent and background shell the
-   * assistant spawned dies with it. A grid terminal has no such coupling (its
-   * PTY lives in the pty-host and reconnects on switch-back), which is why the
-   * hard floor is scoped to help sessions rather than `hasActiveAgent()`.
+   * The assistant backend bound to `projectId` — its PTY and the WebContents
+   * the session pinned at provision time — or null when the project has no
+   * unrevoked help session with a spawned terminal.
    *
-   * NOT a liveness signal on its own. The binding is dropped on revoke,
+   * ProjectViewManager's eviction policy reads this synchronously to keep the
+   * view hosting a running assistant out of the routine LRU candidate pool
+   * (#11157): destroying that view fires `onViewEvicted` →
+   * `revokeByWebContentsId` → `gracefulKill`, tearing down the whole PTY
+   * process tree, so every sub-agent and background shell the assistant spawned
+   * dies with it. A grid terminal has no such coupling (its PTY lives in the
+   * pty-host and reconnects on switch-back), which is why the floor is scoped
+   * to help sessions rather than to `hasActiveAgent()` at large.
+   *
+   * `webContentsId` is the same pin `revokeByWebContentsId` matches on, so the
+   * caller can protect exactly the view whose eviction would do the killing —
+   * a second window's cached view of the same project kills nothing and stays
+   * an ordinary LRU candidate.
+   *
+   * NOT a liveness signal on its own: the binding is dropped on revoke,
    * displacement, and unbind, but nothing drops it when the PTY exits under its
-   * own steam — the orphan sweep deliberately skips bound sessions. Callers
-   * using this to protect a resource must cross-check the returned id against a
-   * registry that tracks PTY exits, or a quit assistant would pin its view
-   * forever.
+   * own steam (the orphan sweep deliberately skips bound sessions). Callers
+   * must cross-check `terminalId` against a registry that tracks PTY exits, or
+   * an assistant the user quit would pin its view forever.
    */
-  getAssistantTerminalId(projectId: string): string | null {
+  getAssistantBackend(projectId: string): { terminalId: string; webContentsId: number } | null {
     if (!projectId) return null;
-    return this.activeHelpTerminalByProjectId.get(projectId) ?? null;
+    const terminalId = this.activeHelpTerminalByProjectId.get(projectId);
+    if (!terminalId) return null;
+    for (const record of this.sessionsById.values()) {
+      if (record.revoked) continue;
+      if (this.terminalBySessionId.get(record.sessionId) !== terminalId) continue;
+      return { terminalId, webContentsId: record.projectViewWebContentsId };
+    }
+    return null;
   }
 
   /**

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -398,6 +398,29 @@ export class HelpSessionService {
   }
 
   /**
+   * The assistant PTY currently bound to `projectId`, or null when the project
+   * has no help session backend. ProjectViewManager's eviction policy reads
+   * this synchronously to keep a cached view whose assistant is still running
+   * out of the routine LRU candidate pool (#11157): destroying that view fires
+   * `onViewEvicted` → `revokeByWebContentsId` → `gracefulKill`, which tears
+   * down the whole PTY process tree — every sub-agent and background shell the
+   * assistant spawned dies with it. A grid terminal has no such coupling (its
+   * PTY lives in the pty-host and reconnects on switch-back), which is why the
+   * hard floor is scoped to help sessions rather than `hasActiveAgent()`.
+   *
+   * NOT a liveness signal on its own. The binding is dropped on revoke,
+   * displacement, and unbind, but nothing drops it when the PTY exits under its
+   * own steam — the orphan sweep deliberately skips bound sessions. Callers
+   * using this to protect a resource must cross-check the returned id against a
+   * registry that tracks PTY exits, or a quit assistant would pin its view
+   * forever.
+   */
+  getAssistantTerminalId(projectId: string): string | null {
+    if (!projectId) return null;
+    return this.activeHelpTerminalByProjectId.get(projectId) ?? null;
+  }
+
+  /**
    * Looks up the renderer WebContents id pinned to a help-session bearer at
    * provision time. The MCP server uses this at handshake to pin each
    * transport session to the window that minted it, so a tool call from the

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -428,6 +428,11 @@ export class HelpSessionService {
     if (!terminalId) return null;
     for (const record of this.sessionsById.values()) {
       if (record.revoked) continue;
+      // Match on the project too, not just the terminal id: nothing enforces
+      // terminal-id uniqueness across projects, and picking up another
+      // project's record would return the wrong pin — which reads as "this view
+      // isn't the pinned one" and hands the running assistant back to the LRU.
+      if (record.projectId !== projectId) continue;
       if (this.terminalBySessionId.get(record.sessionId) !== terminalId) continue;
       return { terminalId, webContentsId: record.projectViewWebContentsId };
     }

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1103,20 +1103,26 @@ describe("HelpSessionService", () => {
 
   // The project-view eviction guard (#11157) reads this to decide whether
   // destroying a cached view would kill a running assistant, so the binding
-  // must track the PTY's whole lifetime — not just its spawn.
-  describe("getAssistantTerminalId (#11157)", () => {
+  // must track the PTY's whole lifetime — not just its spawn — and must carry
+  // the pinned WebContents so only the view that would do the killing is
+  // protected.
+  describe("getAssistantBackend (#11157)", () => {
     it("resolves only once a terminal is bound, and only for the owning project", async () => {
       const result = await service.provisionSession(provisionInput());
       if (!result) throw new Error("expected result");
 
       // Provisioned but not spawned: the bearer exists, the backend does not.
-      expect(service.getAssistantTerminalId("proj-1")).toBeNull();
+      expect(service.getAssistantBackend("proj-1")).toBeNull();
 
       expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
 
-      expect(service.getAssistantTerminalId("proj-1")).toBe("term-1");
-      expect(service.getAssistantTerminalId("proj-2")).toBeNull();
-      expect(service.getAssistantTerminalId("")).toBeNull();
+      // provisionInput() pins the session to WebContents 42.
+      expect(service.getAssistantBackend("proj-1")).toEqual({
+        terminalId: "term-1",
+        webContentsId: 42,
+      });
+      expect(service.getAssistantBackend("proj-2")).toBeNull();
+      expect(service.getAssistantBackend("")).toBeNull();
     });
 
     it("follows the binding through displacement", async () => {
@@ -1127,7 +1133,7 @@ describe("HelpSessionService", () => {
 
       // The displaced PTY is dead; protecting the view on its behalf would pin
       // a project whose assistant is gone.
-      expect(service.getAssistantTerminalId("proj-1")).toBe("term-new");
+      expect(service.getAssistantBackend("proj-1")?.terminalId).toBe("term-new");
     });
 
     it("clears on unbind", async () => {
@@ -1137,7 +1143,7 @@ describe("HelpSessionService", () => {
 
       service.unbindTerminal("term-1");
 
-      expect(service.getAssistantTerminalId("proj-1")).toBeNull();
+      expect(service.getAssistantBackend("proj-1")).toBeNull();
     });
 
     it("clears on revoke", async () => {
@@ -1147,7 +1153,7 @@ describe("HelpSessionService", () => {
 
       await service.revokeSession(result.sessionId);
 
-      expect(service.getAssistantTerminalId("proj-1")).toBeNull();
+      expect(service.getAssistantBackend("proj-1")).toBeNull();
     });
   });
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1101,6 +1101,56 @@ describe("HelpSessionService", () => {
     });
   });
 
+  // The project-view eviction guard (#11157) reads this to decide whether
+  // destroying a cached view would kill a running assistant, so the binding
+  // must track the PTY's whole lifetime — not just its spawn.
+  describe("getAssistantTerminalId (#11157)", () => {
+    it("resolves only once a terminal is bound, and only for the owning project", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      // Provisioned but not spawned: the bearer exists, the backend does not.
+      expect(service.getAssistantTerminalId("proj-1")).toBeNull();
+
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
+
+      expect(service.getAssistantTerminalId("proj-1")).toBe("term-1");
+      expect(service.getAssistantTerminalId("proj-2")).toBeNull();
+      expect(service.getAssistantTerminalId("")).toBeNull();
+    });
+
+    it("follows the binding through displacement", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-old")).toBe(true);
+      expect(service.markTerminalForToken(result.token, "term-new")).toBe(true);
+
+      // The displaced PTY is dead; protecting the view on its behalf would pin
+      // a project whose assistant is gone.
+      expect(service.getAssistantTerminalId("proj-1")).toBe("term-new");
+    });
+
+    it("clears on unbind", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
+
+      service.unbindTerminal("term-1");
+
+      expect(service.getAssistantTerminalId("proj-1")).toBeNull();
+    });
+
+    it("clears on revoke", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
+
+      await service.revokeSession(result.sessionId);
+
+      expect(service.getAssistantTerminalId("proj-1")).toBeNull();
+    });
+  });
+
   describe("orphan-bearer sweep (#10698)", () => {
     it("revokes an unbound bearer older than the ceiling and tears down its MCP session", async () => {
       const result = await service.provisionSession(provisionInput());

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1155,6 +1155,30 @@ describe("HelpSessionService", () => {
 
       expect(service.getAssistantBackend("proj-1")).toBeNull();
     });
+
+    it("returns the owning project's pin when two projects share a terminal id", async () => {
+      // Nothing enforces terminal-id uniqueness across projects. Resolving to
+      // the wrong project's record would return the wrong pin, which the
+      // eviction guard reads as "this isn't the pinned view" — handing a
+      // running assistant back to the LRU.
+      const one = await service.provisionSession({
+        ...provisionInput(),
+        projectId: "proj-1",
+        projectViewWebContentsId: 42,
+      });
+      const two = await service.provisionSession({
+        ...provisionInput(),
+        projectId: "proj-2",
+        projectViewWebContentsId: 77,
+      });
+      if (!one || !two) throw new Error("expected both provisions");
+
+      expect(service.markTerminalForToken(one.token, "shared-term")).toBe(true);
+      expect(service.markTerminalForToken(two.token, "shared-term")).toBe(true);
+
+      expect(service.getAssistantBackend("proj-1")?.webContentsId).toBe(42);
+      expect(service.getAssistantBackend("proj-2")?.webContentsId).toBe(77);
+    });
   });
 
   describe("orphan-bearer sweep (#10698)", () => {

--- a/electron/window/ProjectViewAgentStateCache.ts
+++ b/electron/window/ProjectViewAgentStateCache.ts
@@ -104,30 +104,3 @@ export function hasActiveAgent(host: ProjectViewManager, projectId: string): boo
   }
   return false;
 }
-
-/**
- * Whether `projectId` still has a live Daintree Assistant backend — a help
- * session PTY that HelpSessionService has bound to the project AND that the
- * terminal cache still knows about (#11157).
- *
- * Both halves are load-bearing. HelpSessionService holds its project→terminal
- * binding until the session is revoked, displaced, or unbound; nothing drops it
- * when the assistant's PTY exits on its own, so the binding alone would keep
- * protecting the view of a project whose assistant quit long ago. The terminal
- * cache is the liveness half: `initAgentStateCache` deletes a terminal from
- * `projectByTerminal` on its `exit` event, so a dead assistant stops protecting
- * its view and normal LRU resumes.
- *
- * Agent state is deliberately not consulted. The assistant can dispatch a
- * sub-agent or a background shell and go idle itself while that work runs on,
- * and killing it is exactly the bug this guards against — so a bound, live
- * assistant PTY protects its view whatever the parent's FSM state.
- *
- * Conservative before the first seed resolves: the cache is empty, so this
- * returns false and the view stays evictable, matching hasActiveAgent().
- */
-export function hasLiveAssistantBackend(host: ProjectViewManager, projectId: string): boolean {
-  const terminalId = host.assistantTerminalIdForProject?.(projectId);
-  if (!terminalId) return false;
-  return host.projectByTerminal.get(terminalId) === projectId;
-}

--- a/electron/window/ProjectViewAgentStateCache.ts
+++ b/electron/window/ProjectViewAgentStateCache.ts
@@ -104,3 +104,30 @@ export function hasActiveAgent(host: ProjectViewManager, projectId: string): boo
   }
   return false;
 }
+
+/**
+ * Whether `projectId` still has a live Daintree Assistant backend — a help
+ * session PTY that HelpSessionService has bound to the project AND that the
+ * terminal cache still knows about (#11157).
+ *
+ * Both halves are load-bearing. HelpSessionService holds its project→terminal
+ * binding until the session is revoked, displaced, or unbound; nothing drops it
+ * when the assistant's PTY exits on its own, so the binding alone would keep
+ * protecting the view of a project whose assistant quit long ago. The terminal
+ * cache is the liveness half: `initAgentStateCache` deletes a terminal from
+ * `projectByTerminal` on its `exit` event, so a dead assistant stops protecting
+ * its view and normal LRU resumes.
+ *
+ * Agent state is deliberately not consulted. The assistant can dispatch a
+ * sub-agent or a background shell and go idle itself while that work runs on,
+ * and killing it is exactly the bug this guards against — so a bound, live
+ * assistant PTY protects its view whatever the parent's FSM state.
+ *
+ * Conservative before the first seed resolves: the cache is empty, so this
+ * returns false and the view stays evictable, matching hasActiveAgent().
+ */
+export function hasLiveAssistantBackend(host: ProjectViewManager, projectId: string): boolean {
+  const terminalId = host.assistantTerminalIdForProject?.(projectId);
+  if (!terminalId) return false;
+  return host.projectByTerminal.get(terminalId) === projectId;
+}

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -8,10 +8,13 @@
 import { getAppMetricsSnapshot } from "../utils/appMetricsSnapshot.js";
 import { logInfo } from "../utils/logger.js";
 import { cleanupEntry, sumGuestMemoryKb } from "./ProjectViewLifecycleController.js";
-import { hasActiveAgent } from "./ProjectViewAgentStateCache.js";
+import { hasActiveAgent, hasLiveAssistantBackend } from "./ProjectViewAgentStateCache.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import type { EvictionReason, ViewEntry } from "./ProjectViewManagerTypes.js";
 import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
+
+/** `[projectId, entry, activeAgent, liveAssistantBackend]` — the last two are carried into the eviction log line. */
+type EvictionCandidate = [string, ViewEntry, boolean, boolean];
 
 /**
  * Evict a cached view whose renderer is already gone (OS memory eviction or
@@ -125,25 +128,48 @@ export function evictStaleViews(
     // in practice; Array.sort stability handles them deterministically.
     .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
 
-  // Partition: evict views without active agents first, only fall back to
-  // active-agent views when safe candidates are exhausted. This keeps memory
-  // bounded (each WebContentsView is ~400-500MB) without silently killing
-  // agent renderers mid-task.
-  const safeToEvict: Array<[string, ViewEntry, boolean]> = [];
-  const activeAgentFallback: Array<[string, ViewEntry, boolean]> = [];
+  // Partition into three tiers, each LRU-ordered internally.
+  //
+  // Views without active agents go first, then active-agent views — the
+  // long-standing soft guard: it keeps memory bounded (each WebContentsView is
+  // ~400-500MB) without silently killing agent renderers mid-task, but it does
+  // evict them once safe candidates run out.
+  //
+  // A view with a live assistant backend is a HARD floor for routine passes
+  // (#11157). It is not merely expensive to evict, it is destructive:
+  // destroying the view fires `onViewEvicted` → `revokeByWebContentsId` →
+  // `gracefulKill`, which kills the assistant's whole PTY process tree, so
+  // every sub-agent and background shell it spawned dies with no completion
+  // record. Only the transcript's resume id survives. An ordinary grid terminal
+  // has no such coupling — its PTY lives in the pty-host and reconnects on
+  // switch-back — which is why the floor is scoped to assistant backends and
+  // not to `hasActiveAgent()` at large, whose views are safe to evict and whose
+  // projects would otherwise pin the cache for no benefit.
+  //
+  // The floor yields to genuine memory pressure: `lowMemoryOverride` puts these
+  // views back in the pool, but LAST, so every ordinary renderer is reclaimed
+  // before an assistant's work is. Losing the assistant beats an OOM, and the
+  // hibernation capture on that path still preserves the conversation.
+  const safeToEvict: EvictionCandidate[] = [];
+  const activeAgentFallback: EvictionCandidate[] = [];
+  const assistantProtected: EvictionCandidate[] = [];
   for (const [projectId, entry] of evictable) {
     const active = hasActiveAgent(host, projectId);
-    if (active) {
-      activeAgentFallback.push([projectId, entry, true]);
+    if (hasLiveAssistantBackend(host, projectId)) {
+      assistantProtected.push([projectId, entry, active, true]);
+    } else if (active) {
+      activeAgentFallback.push([projectId, entry, true, false]);
     } else {
-      safeToEvict.push([projectId, entry, false]);
+      safeToEvict.push([projectId, entry, false, false]);
     }
   }
 
-  const candidates = [...safeToEvict, ...activeAgentFallback];
+  const candidates = lowMemoryOverride
+    ? [...safeToEvict, ...activeAgentFallback, ...assistantProtected]
+    : [...safeToEvict, ...activeAgentFallback];
 
   while (host.views.size > effectiveMax && candidates.length > 0) {
-    const [projectId, entry, activeAgent] = candidates.shift()!;
+    const [projectId, entry, activeAgent, liveAssistantBackend] = candidates.shift()!;
     const ageMs = Date.now() - entry.lastUsed;
     const memoryKb = memoryFor(entry);
     const guestMemoryKb = guestMemoryFor(entry);
@@ -153,12 +179,26 @@ export function evictStaleViews(
       ageMs,
       activeAgent,
     };
+    if (liveAssistantBackend) ctx.liveAssistantBackend = true;
     if (memoryKb > 0) ctx.memoryKb = memoryKb;
     if (guestMemoryKb > 0) ctx.guestMemoryKb = guestMemoryKb;
     if (availableMb != null) ctx.memoryAvailableMb = availableMb;
     logInfo("projectview.eviction", ctx);
     host.evictionTimestamps.set(projectId, Date.now());
     cleanupEntry(host, projectId);
+  }
+
+  // The cache is deliberately over its cap because protecting a running
+  // assistant outranks the limit. Emit it so the extra resident renderers are
+  // attributable — otherwise this reads as a leak in the memory logs.
+  if (!lowMemoryOverride && host.views.size > effectiveMax && assistantProtected.length > 0) {
+    logInfo("projectview.eviction-skipped", {
+      reason: effectiveReason,
+      viewCount: host.views.size,
+      effectiveMax,
+      overflow: host.views.size - effectiveMax,
+      protectedProjectIds: assistantProtected.map(([projectId]) => projectId),
+    });
   }
 }
 

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -8,13 +8,49 @@
 import { getAppMetricsSnapshot } from "../utils/appMetricsSnapshot.js";
 import { logInfo } from "../utils/logger.js";
 import { cleanupEntry, sumGuestMemoryKb } from "./ProjectViewLifecycleController.js";
-import { hasActiveAgent, hasLiveAssistantBackend } from "./ProjectViewAgentStateCache.js";
+import { hasActiveAgent } from "./ProjectViewAgentStateCache.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import type { EvictionReason, ViewEntry } from "./ProjectViewManagerTypes.js";
 import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 
 /** `[projectId, entry, activeAgent, liveAssistantBackend]` — the last two are carried into the eviction log line. */
 type EvictionCandidate = [string, ViewEntry, boolean, boolean];
+
+/**
+ * Whether destroying `entry` would kill a running Daintree Assistant (#11157).
+ *
+ * Three conditions, all load-bearing:
+ *
+ * 1. HelpSessionService has an unrevoked session for the project with a spawned
+ *    PTY bound to it.
+ * 2. That PTY is still alive. The binding alone is NOT liveness — it survives
+ *    an assistant that exits under its own steam (nothing drops it, and the
+ *    orphan sweep skips bound sessions), so without this half a quit assistant
+ *    would pin its view for the rest of the session. `isTerminalLive` is
+ *    PtyClient's main-local spawn registry: written synchronously by `spawn()`
+ *    and dropped on both exit and kill, so it is authoritative from the
+ *    assistant's first instant — no seed to wait for, and no pty-host snapshot
+ *    that a shard timeout could silently truncate.
+ * 3. This is the view the session pinned. `revokeByWebContentsId` only kills
+ *    the session whose pinned WebContents matches the destroyed view, so a
+ *    second window's cached view of the same project kills nothing on eviction
+ *    and stays an ordinary LRU candidate.
+ *
+ * Agent state is deliberately not consulted: the assistant can dispatch a
+ * sub-agent or background shell and go idle while that work runs on, which is
+ * precisely the case the issue reports losing.
+ */
+function hasLiveAssistantBackend(
+  host: ProjectViewManager,
+  projectId: string,
+  entry: ViewEntry
+): boolean {
+  const backend = host.assistantBackendForProject?.(projectId);
+  if (!backend) return false;
+  if (host.isTerminalLive?.(backend.terminalId) !== true) return false;
+  const wc = entry.view.webContents;
+  return !wc.isDestroyed() && wc.id === backend.webContentsId;
+}
 
 /**
  * Evict a cached view whose renderer is already gone (OS memory eviction or
@@ -155,7 +191,7 @@ export function evictStaleViews(
   const assistantProtected: EvictionCandidate[] = [];
   for (const [projectId, entry] of evictable) {
     const active = hasActiveAgent(host, projectId);
-    if (hasLiveAssistantBackend(host, projectId)) {
+    if (hasLiveAssistantBackend(host, projectId, entry)) {
       assistantProtected.push([projectId, entry, active, true]);
     } else if (active) {
       activeAgentFallback.push([projectId, entry, true, false]);

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -135,13 +135,23 @@ export interface ProjectViewManagerOptions {
    */
   warmPaintGateHardTimeoutMs?: number;
   /**
-   * Resolve the Daintree Assistant PTY bound to a project, or null when it has
-   * no help session. Injected from the composition root so the eviction policy
-   * can consult HelpSessionService without electron/window/ depending on it
-   * (#11157). Absent — as in tests that don't exercise the assistant — every
-   * project reads as having no backend, which is the pre-#11157 behavior.
+   * Resolve the Daintree Assistant backend bound to a project — its PTY and the
+   * WebContents its help session pinned — or null when it has no session.
+   * Injected from the composition root so the eviction policy can consult
+   * HelpSessionService without electron/window/ depending on it (#11157).
+   * Absent — as in tests that don't exercise the assistant — every project reads
+   * as having no backend, which is the pre-#11157 behavior.
    */
-  assistantTerminalIdForProject?: (projectId: string) => string | null;
+  assistantBackendForProject?: (projectId: string) => {
+    terminalId: string;
+    webContentsId: number;
+  } | null;
+  /**
+   * Whether a PTY is still running. Paired with `assistantBackendForProject`:
+   * the help-session binding outlives an assistant that exits on its own, so
+   * eviction protection needs a liveness source that tracks exits.
+   */
+  isTerminalLive?: (terminalId: string) => boolean;
 }
 
 export class ProjectViewManager {
@@ -163,7 +173,11 @@ export class ProjectViewManager {
   onViewCached?: (webContentsId: number) => void;
   onViewReady?: (webContents: Electron.WebContents) => void;
   onViewCrashed?: (webContents: Electron.WebContents) => void;
-  assistantTerminalIdForProject?: (projectId: string) => string | null;
+  assistantBackendForProject?: (projectId: string) => {
+    terminalId: string;
+    webContentsId: number;
+  } | null;
+  isTerminalLive?: (terminalId: string) => boolean;
   windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
   private resizeHandler: (() => void) | null = null;
@@ -205,7 +219,8 @@ export class ProjectViewManager {
     this.onViewCached = opts.onViewCached;
     this.onViewReady = opts.onViewReady;
     this.onViewCrashed = opts.onViewCrashed;
-    this.assistantTerminalIdForProject = opts.assistantTerminalIdForProject;
+    this.assistantBackendForProject = opts.assistantBackendForProject;
+    this.isTerminalLive = opts.isTerminalLive;
     this.windowRegistry = opts.windowRegistry;
     if (opts.cachedProjectViews != null) {
       this.maxCachedViews = opts.cachedProjectViews;

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -134,6 +134,14 @@ export interface ProjectViewManagerOptions {
    * renderer stalled in its wake fan-out can't wedge the reactivation.
    */
   warmPaintGateHardTimeoutMs?: number;
+  /**
+   * Resolve the Daintree Assistant PTY bound to a project, or null when it has
+   * no help session. Injected from the composition root so the eviction policy
+   * can consult HelpSessionService without electron/window/ depending on it
+   * (#11157). Absent — as in tests that don't exercise the assistant — every
+   * project reads as having no backend, which is the pre-#11157 behavior.
+   */
+  assistantTerminalIdForProject?: (projectId: string) => string | null;
 }
 
 export class ProjectViewManager {
@@ -155,6 +163,7 @@ export class ProjectViewManager {
   onViewCached?: (webContentsId: number) => void;
   onViewReady?: (webContents: Electron.WebContents) => void;
   onViewCrashed?: (webContents: Electron.WebContents) => void;
+  assistantTerminalIdForProject?: (projectId: string) => string | null;
   windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
   private resizeHandler: (() => void) | null = null;
@@ -196,6 +205,7 @@ export class ProjectViewManager {
     this.onViewCached = opts.onViewCached;
     this.onViewReady = opts.onViewReady;
     this.onViewCrashed = opts.onViewCrashed;
+    this.assistantTerminalIdForProject = opts.assistantTerminalIdForProject;
     this.windowRegistry = opts.windowRegistry;
     if (opts.cachedProjectViews != null) {
       this.maxCachedViews = opts.cachedProjectViews;

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -192,6 +192,13 @@ const mockPtyClient = {
   off: vi.fn(),
 };
 
+// Stands in for HelpSessionService's projectId → assistant PTY binding, which
+// main.ts injects as `assistantTerminalIdForProject` (#11157). Tests that never
+// touch it leave it empty, so every project reads as assistant-free.
+const assistantTerminals = new Map<string, string>();
+const assistantTerminalIdForProject = (projectId: string): string | null =>
+  assistantTerminals.get(projectId) ?? null;
+
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { events } from "../../services/events.js";
 import { logInfo } from "../../utils/logger.js";
@@ -240,6 +247,7 @@ describe("ProjectViewManager — eviction safety", () => {
     mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
+    assistantTerminals.clear();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -248,6 +256,7 @@ describe("ProjectViewManager — eviction safety", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
+      assistantTerminalIdForProject,
     });
   });
 
@@ -653,6 +662,249 @@ describe("ProjectViewManager — eviction safety", () => {
       "projectview.eviction",
       expect.objectContaining({ projectId: "proj-b", activeAgent: true })
     );
+  });
+
+  // ── Daintree Assistant backends are a hard floor (issue #11157) ──
+  //
+  // Evicting a view whose assistant is running destroys its WebContents, which
+  // revokes the help session and kills the PTY tree — every sub-agent and
+  // background shell the assistant spawned dies with it. Unlike a grid
+  // terminal, whose PTY lives in the pty-host and reconnects on switch-back,
+  // there is no recovery. So these views leave the routine LRU pool entirely
+  // rather than merely sorting last.
+  describe("live assistant backends (#11157)", () => {
+    function makeManager(cachedProjectViews: number) {
+      return new ProjectViewManager(win as never, {
+        dirname: "/test",
+        paintGateTimeoutMs: 0,
+        paintGateHardTimeoutMs: 0,
+        warmPaintGateTimeoutMs: 0,
+        warmPaintGateHardTimeoutMs: 0,
+        cachedProjectViews,
+        assistantTerminalIdForProject,
+      });
+    }
+
+    const evictedProjectIds = () =>
+      vi
+        .mocked(logInfo)
+        .mock.calls.filter(([event]) => event === "projectview.eviction")
+        .map(([, ctx]) => (ctx as { projectId: string }).projectId);
+
+    it("evicts a newer ordinary view rather than the LRU view whose assistant is idle", async () => {
+      // The assistant is "idle" — it dispatched a sub-agent or a background
+      // shell and is waiting on it. That work is invisible to the agent FSM, so
+      // protection cannot key off ACTIVE_AGENT_STATES: an idle assistant with a
+      // live PTY is exactly the case the issue reports losing.
+      const managerWithLimit = makeManager(2);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+
+      assistantTerminals.set("proj-a", "t-help-a");
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-help-a", projectId: "proj-a", agentState: "idle" },
+      ]);
+      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+      const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
+        .webContents as ReturnType<typeof createMockWebContents> | undefined;
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+      expect(remaining).toContain("proj-a");
+      expect(remaining).not.toContain("proj-b");
+      expect(wcA.close).not.toHaveBeenCalled();
+      expect(wcB?.close).toHaveBeenCalled();
+    });
+
+    it("holds the cache above its limit rather than evict the only remaining assistant-backed views", async () => {
+      // No safe candidate is left. The old policy fell back to evicting a
+      // protected view; the assistant floor lets the cache run over instead.
+      const managerWithLimit = makeManager(2);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+
+      assistantTerminals.set("proj-a", "t-help-a");
+      assistantTerminals.set("proj-b", "t-help-b");
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-help-a", projectId: "proj-a", agentState: "working" },
+        { id: "t-help-b", projectId: "proj-b", agentState: "idle" },
+      ]);
+      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+      const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
+        .webContents as ReturnType<typeof createMockWebContents> | undefined;
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      expect(
+        managerWithLimit
+          .getAllViews()
+          .map((v) => v.projectId)
+          .sort()
+      ).toEqual(["proj-a", "proj-b", "proj-c"]);
+      expect(wcA.close).not.toHaveBeenCalled();
+      expect(wcB?.close).not.toHaveBeenCalled();
+
+      // The overflow is deliberate — say so, or it reads as a leak in the logs.
+      expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+        "projectview.eviction-skipped",
+        expect.objectContaining({
+          reason: "lru",
+          viewCount: 3,
+          effectiveMax: 2,
+          overflow: 1,
+          protectedProjectIds: ["proj-a", "proj-b"],
+        })
+      );
+    });
+
+    it("does not protect a view whose assistant PTY has exited", async () => {
+      // HelpSessionService keeps its project→terminal binding until the session
+      // is revoked, displaced, or unbound — an assistant that quit on its own
+      // leaves it behind. Without the terminal-cache cross-check, that stale
+      // binding would pin proj-a's view for the rest of the session.
+      const managerWithLimit = makeManager(2);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+
+      assistantTerminals.set("proj-a", "t-help-a");
+      // Seeded, but the assistant's PTY is gone: the cache knows proj-b's
+      // terminal and nothing else, so t-help-a is dead.
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-b", projectId: "proj-b", agentState: "idle" },
+      ]);
+      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+      expect(remaining).not.toContain("proj-a");
+      expect(wcA.close).toHaveBeenCalled();
+    });
+
+    it("stops protecting a view once its assistant terminal exits", async () => {
+      // Same staleness, reached the way it happens in practice: the assistant
+      // was live and protected, then its PTY exited mid-session.
+      const managerWithLimit = makeManager(2);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+
+      assistantTerminals.set("proj-a", "t-help-a");
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-help-a", projectId: "proj-a", agentState: "working" },
+      ]);
+      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+      // The assistant exits. HelpSessionService's binding survives (nothing
+      // drops it on a self-inflicted exit), but the terminal cache does not.
+      ptyClientHandlers.get("exit")?.("t-help-a");
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+      expect(remaining).not.toContain("proj-a");
+      expect(wcA.close).toHaveBeenCalled();
+    });
+
+    it("reclaims assistant-backed views under memory pressure, but only after ordinary ones", async () => {
+      // The floor yields to a real OOM risk: losing the assistant beats losing
+      // the app, and the revoke path still captures the conversation for
+      // resume. Ordering is the guarantee — every ordinary renderer is
+      // reclaimed first, even though the assistant's view is the LRU.
+      const managerWithLimit = makeManager(3);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      assistantTerminals.set("proj-a", "t-help-a");
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-help-a", projectId: "proj-a", agentState: "working" },
+        { id: "t-b", projectId: "proj-b", agentState: "idle" },
+      ]);
+      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+      managerWithLimit.reclaimCachedViewsUnderPressure();
+
+      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+      // LRU alone would have taken proj-a first; the floor pushes it last.
+      expect(evictedProjectIds()).toEqual(["proj-b", "proj-a"]);
+      expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+        "projectview.eviction",
+        expect.objectContaining({
+          projectId: "proj-a",
+          reason: "pressure",
+          liveAssistantBackend: true,
+        })
+      );
+    });
+
+    it("still evicts a crashed cached view that has a live assistant backend", async () => {
+      // The renderer is already gone — there is nothing left to protect, and
+      // holding the entry would leak a dead view. evictDeadView stays
+      // unconditional.
+      const managerWithLimit = makeManager(3);
+
+      const wcA = createMockWebContents();
+      const viewA = { webContents: wcA, setBounds: vi.fn() };
+      managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+      // proj-b's view is created by switchTo, so setupViewHandlers wires its
+      // render-process-gone listener — registerInitialView does not.
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")!.view
+        .webContents as unknown as ReturnType<typeof createMockWebContents>;
+
+      assistantTerminals.set("proj-b", "t-help-b");
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-help-b", projectId: "proj-b", agentState: "working" },
+      ]);
+      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+
+      // Cache proj-b (limit 3 holds all three, so no LRU pass interferes).
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      const goneCall = wcB.on.mock.calls.find(([event]) => event === "render-process-gone");
+      expect(goneCall).toBeDefined();
+      goneCall![1]({}, { reason: "crashed", exitCode: 1 });
+      await flushImmediates();
+
+      expect(wcB.close).toHaveBeenCalled();
+      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).not.toContain("proj-b");
+    });
   });
 
   // ── LRU eviction with memory logging (issue #8602) ──
@@ -2105,6 +2357,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
+    assistantTerminals.clear();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -2113,6 +2366,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
+      assistantTerminalIdForProject,
     });
   });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -192,12 +192,16 @@ const mockPtyClient = {
   off: vi.fn(),
 };
 
-// Stands in for HelpSessionService's projectId → assistant PTY binding, which
-// main.ts injects as `assistantTerminalIdForProject` (#11157). Tests that never
-// touch it leave it empty, so every project reads as assistant-free.
-const assistantTerminals = new Map<string, string>();
-const assistantTerminalIdForProject = (projectId: string): string | null =>
-  assistantTerminals.get(projectId) ?? null;
+// The two halves main.ts injects for the assistant eviction floor (#11157):
+// HelpSessionService's projectId → {assistant PTY, pinned view} binding, and
+// PtyClient's synchronous liveness registry. They are separate because the
+// binding outlives a PTY that exits on its own — a stale binding must not
+// protect a view. Tests that never touch these leave them empty, so every
+// project reads as assistant-free.
+const assistantBackends = new Map<string, { terminalId: string; webContentsId: number }>();
+const liveTerminals = new Set<string>();
+const assistantBackendForProject = (projectId: string) => assistantBackends.get(projectId) ?? null;
+const isTerminalLive = (terminalId: string): boolean => liveTerminals.has(terminalId);
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { events } from "../../services/events.js";
@@ -247,7 +251,8 @@ describe("ProjectViewManager — eviction safety", () => {
     mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
-    assistantTerminals.clear();
+    assistantBackends.clear();
+    liveTerminals.clear();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -256,7 +261,8 @@ describe("ProjectViewManager — eviction safety", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
-      assistantTerminalIdForProject,
+      assistantBackendForProject,
+      isTerminalLive,
     });
   });
 
@@ -681,7 +687,8 @@ describe("ProjectViewManager — eviction safety", () => {
         warmPaintGateTimeoutMs: 0,
         warmPaintGateHardTimeoutMs: 0,
         cachedProjectViews,
-        assistantTerminalIdForProject,
+        assistantBackendForProject,
+        isTerminalLive,
       });
     }
 
@@ -690,6 +697,13 @@ describe("ProjectViewManager — eviction safety", () => {
         .mocked(logInfo)
         .mock.calls.filter(([event]) => event === "projectview.eviction")
         .map(([, ctx]) => (ctx as { projectId: string }).projectId);
+
+    /** Bind a running assistant to the project's current view — the view the session pinned. */
+    function bindLiveAssistant(mgr: ProjectViewManager, projectId: string, terminalId: string) {
+      const wc = mgr.getAllViews().find((v) => v.projectId === projectId)!.view.webContents;
+      assistantBackends.set(projectId, { terminalId, webContentsId: wc.id });
+      liveTerminals.add(terminalId);
+    }
 
     it("evicts a newer ordinary view rather than the LRU view whose assistant is idle", async () => {
       // The assistant is "idle" — it dispatched a sub-agent or a background
@@ -705,7 +719,7 @@ describe("ProjectViewManager — eviction safety", () => {
       await managerWithLimit.switchTo("proj-b", "/path/b");
       await flushImmediates();
 
-      assistantTerminals.set("proj-a", "t-help-a");
+      bindLiveAssistant(managerWithLimit, "proj-a", "t-help-a");
       mockGetAllTerminals.mockResolvedValue([
         { id: "t-help-a", projectId: "proj-a", agentState: "idle" },
       ]);
@@ -736,8 +750,8 @@ describe("ProjectViewManager — eviction safety", () => {
       await managerWithLimit.switchTo("proj-b", "/path/b");
       await flushImmediates();
 
-      assistantTerminals.set("proj-a", "t-help-a");
-      assistantTerminals.set("proj-b", "t-help-b");
+      bindLiveAssistant(managerWithLimit, "proj-a", "t-help-a");
+      bindLiveAssistant(managerWithLimit, "proj-b", "t-help-b");
       mockGetAllTerminals.mockResolvedValue([
         { id: "t-help-a", projectId: "proj-a", agentState: "working" },
         { id: "t-help-b", projectId: "proj-b", agentState: "idle" },
@@ -772,11 +786,12 @@ describe("ProjectViewManager — eviction safety", () => {
       );
     });
 
-    it("does not protect a view whose assistant PTY has exited", async () => {
-      // HelpSessionService keeps its project→terminal binding until the session
-      // is revoked, displaced, or unbound — an assistant that quit on its own
-      // leaves it behind. Without the terminal-cache cross-check, that stale
-      // binding would pin proj-a's view for the rest of the session.
+    it("stops protecting a view once its assistant PTY exits", async () => {
+      // The binding is not liveness. HelpSessionService holds it until the
+      // session is revoked, displaced, or unbound — an assistant the user quit
+      // leaves it behind, and the orphan sweep skips bound sessions. Without the
+      // liveness half, that stale binding would pin proj-a's view for the rest
+      // of the session.
       const managerWithLimit = makeManager(2);
 
       const wcA = createMockWebContents();
@@ -786,13 +801,12 @@ describe("ProjectViewManager — eviction safety", () => {
       await managerWithLimit.switchTo("proj-b", "/path/b");
       await flushImmediates();
 
-      assistantTerminals.set("proj-a", "t-help-a");
-      // Seeded, but the assistant's PTY is gone: the cache knows proj-b's
-      // terminal and nothing else, so t-help-a is dead.
-      mockGetAllTerminals.mockResolvedValue([
-        { id: "t-b", projectId: "proj-b", agentState: "idle" },
-      ]);
-      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+      bindLiveAssistant(managerWithLimit, "proj-a", "t-help-a");
+
+      // The assistant's PTY exits: PtyClient drops it from the spawn registry,
+      // while HelpSessionService's binding survives.
+      liveTerminals.delete("t-help-a");
+      expect(assistantBackendForProject("proj-a")).not.toBeNull();
 
       await managerWithLimit.switchTo("proj-c", "/path/c");
       await flushImmediates();
@@ -802,9 +816,10 @@ describe("ProjectViewManager — eviction safety", () => {
       expect(wcA.close).toHaveBeenCalled();
     });
 
-    it("stops protecting a view once its assistant terminal exits", async () => {
-      // Same staleness, reached the way it happens in practice: the assistant
-      // was live and protected, then its PTY exited mid-session.
+    it("protects only the view the session pinned, not another window's view of the same project", async () => {
+      // The binding is projectId-scoped but views are per-window. Evicting a
+      // non-pinned view kills nothing — revokeByWebContentsId only matches the
+      // session's own pinned WebContents — so it stays an ordinary candidate.
       const managerWithLimit = makeManager(2);
 
       const wcA = createMockWebContents();
@@ -814,15 +829,10 @@ describe("ProjectViewManager — eviction safety", () => {
       await managerWithLimit.switchTo("proj-b", "/path/b");
       await flushImmediates();
 
-      assistantTerminals.set("proj-a", "t-help-a");
-      mockGetAllTerminals.mockResolvedValue([
-        { id: "t-help-a", projectId: "proj-a", agentState: "working" },
-      ]);
-      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
-
-      // The assistant exits. HelpSessionService's binding survives (nothing
-      // drops it on a self-inflicted exit), but the terminal cache does not.
-      ptyClientHandlers.get("exit")?.("t-help-a");
+      // A live assistant for proj-a, but minted in another window: its pin
+      // points at a WebContents this manager doesn't own.
+      assistantBackends.set("proj-a", { terminalId: "t-help-a", webContentsId: wcA.id + 5000 });
+      liveTerminals.add("t-help-a");
 
       await managerWithLimit.switchTo("proj-c", "/path/c");
       await flushImmediates();
@@ -848,7 +858,7 @@ describe("ProjectViewManager — eviction safety", () => {
       await managerWithLimit.switchTo("proj-c", "/path/c");
       await flushImmediates();
 
-      assistantTerminals.set("proj-a", "t-help-a");
+      bindLiveAssistant(managerWithLimit, "proj-a", "t-help-a");
       mockGetAllTerminals.mockResolvedValue([
         { id: "t-help-a", projectId: "proj-a", agentState: "working" },
         { id: "t-b", projectId: "proj-b", agentState: "idle" },
@@ -887,11 +897,7 @@ describe("ProjectViewManager — eviction safety", () => {
       const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")!.view
         .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
-      assistantTerminals.set("proj-b", "t-help-b");
-      mockGetAllTerminals.mockResolvedValue([
-        { id: "t-help-b", projectId: "proj-b", agentState: "working" },
-      ]);
-      await managerWithLimit.initAgentStateCache(mockPtyClient as never);
+      bindLiveAssistant(managerWithLimit, "proj-b", "t-help-b");
 
       // Cache proj-b (limit 3 holds all three, so no LRU pass interferes).
       await managerWithLimit.switchTo("proj-c", "/path/c");
@@ -2357,7 +2363,8 @@ describe("ProjectViewManager — low-memory eviction", () => {
     mockGetAllTerminals.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockReturnValue([]);
-    assistantTerminals.clear();
+    assistantBackends.clear();
+    liveTerminals.clear();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -2366,7 +2373,8 @@ describe("ProjectViewManager — low-memory eviction", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
-      assistantTerminalIdForProject,
+      assistantBackendForProject,
+      isTerminalLive,
     });
   });
 


### PR DESCRIPTION
## Summary

- Switching the active project evicts the WebContentsView backing the Daintree Assistant panel under the ordinary LRU cache policy in `ProjectViewSwitchController`. Destroying that view tears down the Assistant's PTY process tree via `HelpSessionService.revokeByWebContentsId` and `ptyClient.gracefulKill`, killing every background sub-agent and shell it had spawned mid-run, with only a transcript resume id surviving.
- Ordinary grid terminals don't have this problem: their PTY lives in a separate pty-host process and reconnects over a MessagePort on switch-back. Only the Assistant's view eviction is destructive.
- Adds a third eviction bucket in `ProjectViewEvictionController`: a project view backing a live Assistant PTY is excluded entirely from routine LRU and limit-change eviction, a hard floor rather than a soft sort-last preference.

Resolves #11157

## Changes

- `ProjectViewEvictionController`: new eviction bucket checks `PtyClient.hasTerminal` (main-local, updated synchronously on spawn/exit/kill) and pulls any view backing a live Assistant PTY out of the routine candidate pool. Under genuine memory pressure (a low-memory override or forced reclaim), those views can still be evicted, but always last, after every ordinary view. `evictDeadView` (crashed / OS-evicted views) stays unconditional since there's nothing left to protect.
- Protection is scoped to the exact WebContents id `HelpSessionService` pinned when it provisioned the Assistant session, so a second window viewing the same project is unaffected and stays an ordinary eviction candidate.
- New telemetry: `liveAssistantBackend` on forced evictions, and a `projectview.eviction-skipped` event when the floor holds the cache above its normal cap, so the resulting overflow is attributable in logs instead of looking like a leak.
- `main.ts` and `HelpSessionService.ts`: wiring to expose the pinned WebContents id and scope the liveness lookup to the owning project.

**Alternative considered and rejected**: detaching the backend instead of killing it on eviction. Two problems. The MCP session-to-WebContents pin is a deliberate security boundary from a previously fixed cross-window trust bug, and repointing it would need a full token re-handshake rather than a field mutation. Separately, the Assistant/help panel sits outside the app's generic panel-persistence and orphan-adoption model, so a surviving orphan session would just get killed anyway on the next cold provision.

**Known limitation**: the protected cache has no fixed numeric ceiling. It's bounded only by the forced-pressure reclaim path, not a fixed cap. A fixed ceiling would just reintroduce silent work loss at an arbitrary threshold.

## Testing

- 361 tests pass across the `ProjectViewManager` suites and `HelpSessionService`, including 11 new cases: hard floor with an idle assistant, holding the cache over its cap, non-protection of a stale binding or exited PTY, protection scoped to only the pinned view, pressure ordering, crashed-view eviction, and the help-session accessor lifecycle.
- `npm run typecheck` clean.
- Prettier and ESLint clean on all changed files.
