### PR TITLE
fix(ui): keep the opacity fade under reduced motion in AppDialog

### DIFF
--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -7,7 +7,12 @@ vi.mock("@/components/ui/ScrollShadow", () => ({
   ScrollShadow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
-vi.mock("@/lib/animationUtils", () => ({
+// Spread the real module rather than hand-listing exports: the palette pulls in
+// more of animationUtils than this test cares about, and a factory that misses a
+// single constant fails every test in the file at render time. Only the timing
+// values that would make the palette animate are overridden.
+vi.mock("@/lib/animationUtils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/animationUtils")>()),
   UI_ENTER_DURATION: 0,
   UI_EXIT_DURATION: 0,
   UI_ENTER_EASING: "linear",

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -29,6 +29,7 @@ import {
   UI_EXIT_DURATION,
   UI_ENTER_EASING,
   UI_EXIT_EASING,
+  UI_SCRIM_EASING,
   getUiTransitionDuration,
 } from "@/lib/animationUtils";
 import { X } from "lucide-react";
@@ -372,13 +373,15 @@ export function AppDialog({
         className={cn(
           "fixed inset-0 flex items-center justify-center bg-scrim-medium backdrop-blur-[var(--theme-scrim-blur)] backdrop-saturate-[var(--theme-material-saturation)]",
           zIndex === "nested" ? "z-[var(--z-nested-dialog)]" : "z-[var(--z-modal)]",
+          // Opacity-only, so reduced motion leaves it alone: a scrim fade is not
+          // spatial motion. WCAG 2.3.3.
           "transition-opacity",
-          "motion-reduce:transition-none motion-reduce:duration-0",
           isVisible ? "opacity-100" : "opacity-0"
         )}
         style={{
           right: portalOffset,
           transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
+          transitionTimingFunction: UI_SCRIM_EASING,
         }}
         onPointerDown={handleBackdropPointerDown}
         onPointerUp={handleBackdropPointerUp}
@@ -401,7 +404,9 @@ export function AppDialog({
             // and `scale` properties, which `transform` in a transition list
             // does NOT cover — list them explicitly or the rise/zoom snaps.
             "transition-[opacity,translate,scale]",
-            "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:translate-none motion-reduce:scale-none",
+            // Reduced motion keeps the fade and drops only the rise/zoom: opacity
+            // is not vestibular, movement is. WCAG 2.3.3.
+            "motion-reduce:transition-opacity motion-reduce:translate-none motion-reduce:scale-none",
             isVisible
               ? "opacity-100 translate-y-0 scale-100"
               : "opacity-0 translate-y-1 scale-[0.98]",

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -28,6 +28,7 @@ import {
   UI_PALETTE_EXIT_DURATION,
   UI_ENTER_EASING,
   UI_EXIT_EASING,
+  UI_SCRIM_EASING,
   UI_PALETTE_STALE_DELAY,
   getUiPaletteTransitionDuration,
 } from "@/lib/animationUtils";
@@ -204,15 +205,16 @@ export function AppPaletteDialog({
     <div
       className={cn(
         "fixed inset-0 z-[var(--z-modal)] flex items-start justify-center pt-[15vh] bg-scrim-medium backdrop-blur-[var(--theme-scrim-blur-palette)] backdrop-saturate-[var(--theme-material-saturation)]",
+        // Opacity-only, so reduced motion leaves it alone: a scrim fade is not
+        // spatial motion. WCAG 2.3.3.
         "transition-opacity",
-        "motion-reduce:transition-none motion-reduce:duration-0",
         isVisible ? "opacity-100" : "opacity-0"
       )}
       style={{
         transitionDuration: isVisible
           ? `${UI_PALETTE_ENTER_DURATION}ms`
           : `${UI_PALETTE_EXIT_DURATION}ms`,
-        transitionTimingFunction: "linear",
+        transitionTimingFunction: UI_SCRIM_EASING,
       }}
       onClick={handleBackdropClick}
     >

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -852,6 +852,12 @@ describe("AppDialog reduced-motion policy", () => {
     _resetForTests();
   });
 
+  function getCard(): Element {
+    const card = screen.getByTestId("test-dialog").firstElementChild;
+    if (!card) throw new Error("AppDialog rendered no card inside the backdrop");
+    return card;
+  }
+
   it("keeps the backdrop scrim fading under reduced motion", () => {
     renderDialog();
     const backdrop = screen.getByTestId("test-dialog");
@@ -862,20 +868,18 @@ describe("AppDialog reduced-motion policy", () => {
 
   it("narrows the card to an opacity-only transition under reduced motion", () => {
     renderDialog();
-    const card = screen.getByTestId("test-dialog").firstElementChild as HTMLElement;
 
-    expect(card.className).toContain("motion-reduce:transition-opacity");
-    expect(card.className).not.toContain("motion-reduce:transition-none");
+    expect(getCard().className).toContain("motion-reduce:transition-opacity");
+    expect(getCard().className).not.toContain("motion-reduce:transition-none");
   });
 
   it("freezes the card's translate and scale under reduced motion", () => {
     renderDialog();
-    const card = screen.getByTestId("test-dialog").firstElementChild as HTMLElement;
 
     // Tailwind v4 emits `translate`/`scale` as individual properties, so both
     // need explicit neutralizers — `transform-none` would not cover them.
-    expect(card.className).toContain("motion-reduce:translate-none");
-    expect(card.className).toContain("motion-reduce:scale-none");
+    expect(getCard().className).toContain("motion-reduce:translate-none");
+    expect(getCard().className).toContain("motion-reduce:scale-none");
   });
 
   it("gives the backdrop an explicit easing rather than the Tailwind default", () => {

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -835,3 +835,53 @@ describe("AppDialog co-located live region", () => {
     expect(liveRegions.length).toBeGreaterThan(0);
   });
 });
+
+// WCAG 2.3.3: opacity is not vestibular, movement is. Reduced motion must strip
+// the card's rise/zoom while leaving both fades intact. jsdom evaluates neither
+// Tailwind's output nor the `motion-reduce` media query, so the policy is only
+// observable here as the set of variant utilities the component elects to emit.
+describe("AppDialog reduced-motion policy", () => {
+  beforeEach(() => {
+    mockPrevOpen = false;
+    _resetForTests();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("keeps the backdrop scrim fading under reduced motion", () => {
+    renderDialog();
+    const backdrop = screen.getByTestId("test-dialog");
+
+    expect(backdrop.className).toContain("transition-opacity");
+    expect(backdrop.className).not.toContain("motion-reduce:transition-none");
+  });
+
+  it("narrows the card to an opacity-only transition under reduced motion", () => {
+    renderDialog();
+    const card = screen.getByTestId("test-dialog").firstElementChild as HTMLElement;
+
+    expect(card.className).toContain("motion-reduce:transition-opacity");
+    expect(card.className).not.toContain("motion-reduce:transition-none");
+  });
+
+  it("freezes the card's translate and scale under reduced motion", () => {
+    renderDialog();
+    const card = screen.getByTestId("test-dialog").firstElementChild as HTMLElement;
+
+    // Tailwind v4 emits `translate`/`scale` as individual properties, so both
+    // need explicit neutralizers — `transform-none` would not cover them.
+    expect(card.className).toContain("motion-reduce:translate-none");
+    expect(card.className).toContain("motion-reduce:scale-none");
+  });
+
+  it("gives the backdrop an explicit easing rather than the Tailwind default", () => {
+    renderDialog();
+    const backdrop = screen.getByTestId("test-dialog");
+
+    expect(backdrop.style.transitionTimingFunction).not.toBe("");
+  });
+});

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -279,9 +279,17 @@ describe("AppPaletteDialog reduced-motion policy", () => {
     _resetForTests();
   });
 
+  // The scrim is the panel's parent: unlike AppDialog, the palette puts
+  // `role="dialog"` on the inner panel rather than the backdrop.
+  function getScrim(): HTMLElement {
+    const scrim = screen.getByRole("dialog", { name: "Test palette" }).parentElement;
+    if (!scrim) throw new Error("AppPaletteDialog rendered no scrim around the panel");
+    return scrim;
+  }
+
   it("keeps the scrim fading under reduced motion", () => {
     renderPalette({ isOpen: true });
-    const scrim = screen.getByRole("dialog", { name: "Test palette" }).parentElement as HTMLElement;
+    const scrim = getScrim();
 
     expect(scrim.className).toContain("bg-scrim-medium");
     expect(scrim.className).toContain("transition-opacity");
@@ -290,8 +298,7 @@ describe("AppPaletteDialog reduced-motion policy", () => {
 
   it("gives the scrim an explicit easing rather than the Tailwind default", () => {
     renderPalette({ isOpen: true });
-    const scrim = screen.getByRole("dialog", { name: "Test palette" }).parentElement as HTMLElement;
 
-    expect(scrim.style.transitionTimingFunction).not.toBe("");
+    expect(getScrim().style.transitionTimingFunction).not.toBe("");
   });
 });

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -262,3 +262,36 @@ describe("AppPaletteDialog co-located live region", () => {
     expect(liveRegions.length).toBeGreaterThan(0);
   });
 });
+
+// WCAG 2.3.3: the scrim only interpolates opacity, which is not vestibular, so
+// reduced motion must leave its fade intact — only the panel's zoom is spatial.
+// Mirrors the policy asserted in AppDialog.test.tsx; both overlay families dim
+// identically.
+describe("AppPaletteDialog reduced-motion policy", () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    usePaletteStore.setState({ activePaletteId: null });
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("keeps the scrim fading under reduced motion", () => {
+    renderPalette({ isOpen: true });
+    const scrim = screen.getByRole("dialog", { name: "Test palette" }).parentElement as HTMLElement;
+
+    expect(scrim.className).toContain("bg-scrim-medium");
+    expect(scrim.className).toContain("transition-opacity");
+    expect(scrim.className).not.toContain("motion-reduce:transition-none");
+  });
+
+  it("gives the scrim an explicit easing rather than the Tailwind default", () => {
+    renderPalette({ isOpen: true });
+    const scrim = screen.getByRole("dialog", { name: "Test palette" }).parentElement as HTMLElement;
+
+    expect(scrim.style.transitionTimingFunction).not.toBe("");
+  });
+});

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -128,6 +128,12 @@ export const UI_TOOLTIP_SKIP_DELAY_DURATION = DURATION_300;
 export const UI_ENTER_EASING = EASE_SPRING_CRITICAL;
 export const UI_EXIT_EASING = "cubic-bezier(0.2, 0, 0.7, 0)";
 
+/** Scrim/backdrop fade easing. A dialog backdrop only interpolates opacity, and
+ *  opacity has no perceived mass — the eased and spring curves used for the card
+ *  read as inertia the scrim doesn't have. Shared by `AppDialog` and
+ *  `AppPaletteDialog` so both overlay families dim identically. */
+export const UI_SCRIM_EASING = "linear";
+
 /** Framer-motion-compatible easing tuples. framer-motion 12.x tightened
  *  Transition.ease to its own Easing type and rejects CSS string easings. */
 export const UI_ENTER_EASING_FM: [number, number, number, number] = [0.2, 0, 0, 1];


### PR DESCRIPTION
## What & why

Daintree had three inconsistent reduced-motion policies across overlay surfaces. `AppDialog` set `motion-reduce:transition-none`, which rewrites `transition-property` to `none` and killed the opacity fade along with the spatial motion, so dialogs popped in and out with zero feedback. WCAG 2.3.3 is about movement: opacity fades aren't vestibular triggers, translate and scale transforms are. The palette card and the global Radix `[data-state][data-side]` rule in `index.css` already had this right (the latter's own comment cites WCAG 2.3.3). This brings the dialogs in line.

## Changes

- `AppDialog` card: `motion-reduce:transition-none motion-reduce:duration-0` becomes `motion-reduce:transition-opacity`, keeping the existing `motion-reduce:translate-none motion-reduce:scale-none` neutralizers. The fade survives, the rise and zoom get stripped.
- Both dialog backdrops (`AppDialog` and `AppPaletteDialog`): dropped the `motion-reduce:` transition kill outright. A scrim only ever interpolates opacity, so there was no spatial motion to remove, those classes were just deleting the fade. The issue described the palette as already correct, but that's only true of its card. Its backdrop carried the identical bug, so it's fixed here too. Otherwise fixing `AppDialog` alone would have left the very surface cited as the reference half wrong.
- Swept `motion-reduce:duration-0`, which was already inert: both elements set `transitionDuration` as an inline style, and inline styles outrank a non `!important` utility. Only `transition-none` was ever doing the damage.
- Added `UI_SCRIM_EASING = "linear"` to `animationUtils.ts`, shared by both backdrops. This gives `AppDialog`'s backdrop an explicit easing (it previously fell through to Tailwind's default ease) and replaces the bare `"linear"` literal `AppPaletteDialog` was inlining. Linear is right for a scrim: opacity has no perceived mass, so the eased and spring curves used for the cards would read as inertia the scrim doesn't have.

## Verification

- Verified the Tailwind v4 cascade by compiling `index.css` against the locked 4.3.0 toolchain: the base `transition-[opacity,translate,scale]` is emitted before `motion-reduce:transition-opacity`, both at specificity (0,1,0), so the variant wins on source order. No `!important` needed.
- Resting positions are unchanged. Before this change, the hidden card under reduced motion already computed to `translate: none` and `scale: none` (the neutralizers were already present), it just also had `transition-property: none`. Now only opacity transitions; the transform endpoints are identical.
- New unit suites cover the policy in both dialogs (6 tests: 4 for `AppDialog`, 2 for `AppPaletteDialog`). 118 tests pass across the 5 affected files. Own-file prettier and eslint are clean, with zero net-new lint warnings against the per-rule ratchet.

## Known gaps (pre-existing, deliberately not fixed here)

- **In-app toggle vs OS preference.** The "Reduce UI animations" setting drives `body[data-reduce-animations="true"]` via the custom `reduce-motion` variant, but these components use Tailwind's built-in `motion-reduce:`, which only matches the OS media query. So the in-app toggle doesn't strip the dialog card's rise and zoom. Unchanged by this PR, affects roughly 36 component files, and wants its own issue. Trap for whoever takes it: don't just swap `motion-reduce:` for `reduce-motion:`. As a utility prefix, the custom variant's body-attribute branch compiles to `.reduce-motion\:… body[data-reduce-animations="true"]`, which can never match. That would be a silent no-op.
- **`*:focus-visible { transition: none !important }`** inside the reduce-motion block will still kill the card's own fade in the narrow case where a dialog has no tabbable child at all (no close button, no footer), since it then focuses the card itself. The scrim still fades, so there's always feedback. Narrowing that global rule affects every focused element, so it's out of scope here.

Resolves #11171
