### PR TITLE
fix(ui): animate the re-entry summary out instead of unmounting it instantly

### DIFF
--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -16,7 +16,7 @@ import {
 import type { ReEntrySummaryState } from "@/hooks/useReEntrySummary";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
-const AUTO_DISMISS_MS = 8000;
+export const AUTO_DISMISS_MS = 8000;
 
 const SEVERITY_ICON: Record<NotificationHistoryEntry["type"], typeof AlertCircle> = {
   error: AlertCircle,
@@ -40,19 +40,32 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
   });
   const [isPaused, setIsPaused] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
-  const entryCount = entries.length;
+
+  // Identity of the summary being shown. Entry ids are unique and a dismissed
+  // batch is never re-summarized, so this changes exactly when a new summary
+  // arrives — unlike the entry count or the worktree-id list, which collide
+  // when the same worktrees report again and would leave a replacement summary
+  // inheriting the previous one's pin and its already-half-elapsed timer.
+  const entriesKey = entries.map((e) => e.id).join(",");
 
   useEffect(() => {
     if (visible) setIsPinned(false);
-  }, [visible, entryCount]);
+  }, [visible, entriesKey]);
 
-  const rowsKey = rows.map((r) => r.worktreeId).join(",");
+  // Hover pause is transient: clear it once the card is gone. onMouseLeave does
+  // not fire for a node removed out from under the pointer (dismissing while
+  // hovering), and this component instance never unmounts — it just renders
+  // null — so a stuck `isPaused` would silently disable auto-dismiss for every
+  // later summary.
+  useEffect(() => {
+    if (!shouldRender) setIsPaused(false);
+  }, [shouldRender]);
 
   useEffect(() => {
     if (!visible || isPaused || isPinned) return;
     const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
     return () => clearTimeout(timer);
-  }, [visible, dismiss, isPaused, isPinned, rowsKey]);
+  }, [visible, dismiss, isPaused, isPinned, entriesKey]);
 
   // Latch the last visible content so the card keeps rendering the rows it had
   // while it slides out. `useReEntrySummary` returns EMPTY the instant `visible`
@@ -102,7 +115,6 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           // explicitly or the slide snaps and only the fade animates.
           "transition-[translate,opacity]",
           "motion-reduce:transition-none motion-reduce:duration-0",
-          // Inert while sliding out so a click can't land on a fading card.
           isVisible
             ? "pointer-events-auto translate-x-0 opacity-100"
             : "pointer-events-none translate-x-8 opacity-0",
@@ -112,6 +124,14 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
           transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
         }}
+        // Real inertness while sliding out: pointer-events alone still lets a
+        // Tab/Enter land on the fading card's buttons. `inert` also blurs the
+        // focused dismiss button for us — aria-hidden would not, and Chromium
+        // blocks aria-hidden over a focused element. Keyed on the incoming
+        // `visible`, not `isVisible`: the latter is also false for the hidden
+        // entry frame, and inert there would drop this role="status" live
+        // region out of the a11y tree exactly as it's inserted.
+        inert={!visible}
         role="status"
         onMouseEnter={() => setIsPaused(true)}
         onMouseLeave={() => setIsPaused(false)}

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -5,6 +5,14 @@ import { cn } from "@/lib/utils";
 import { useUIStore } from "@/store/uiStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
+import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+  getUiTransitionDuration,
+} from "@/lib/animationUtils";
 import type { ReEntrySummaryState } from "@/hooks/useReEntrySummary";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
@@ -26,19 +34,16 @@ const SEVERITY_CLASS: Record<NotificationHistoryEntry["type"], string> = {
 
 export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
   const { visible, dismiss, entries, rows, overflowCount } = state;
-  const [isVisible, setIsVisible] = useState(false);
+  const { isVisible, shouldRender } = useAnimatedPresence({
+    isOpen: visible,
+    animationDuration: getUiTransitionDuration("exit"),
+  });
   const [isPaused, setIsPaused] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
   const entryCount = entries.length;
 
   useEffect(() => {
-    if (!visible) {
-      setIsVisible(false);
-      return;
-    }
-    setIsPinned(false);
-    const handle = requestAnimationFrame(() => setIsVisible(true));
-    return () => cancelAnimationFrame(handle);
+    if (visible) setIsPinned(false);
   }, [visible, entryCount]);
 
   const rowsKey = rows.map((r) => r.worktreeId).join(",");
@@ -49,9 +54,21 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
     return () => clearTimeout(timer);
   }, [visible, dismiss, isPaused, isPinned, rowsKey]);
 
-  if (!state.visible) return null;
+  // Latch the last visible content so the card keeps rendering the rows it had
+  // while it slides out. `useReEntrySummary` returns EMPTY the instant `visible`
+  // flips false, so without this the exit would animate a blank card — the same
+  // bug ScrollIndicator solves for its count (#10316). State adjusted during
+  // render, not a ref: React discards an abandoned concurrent render's state
+  // update, so stale rows can't leak in.
+  const [content, setContent] = useState({ rows, overflowCount });
+  if (visible && (content.rows !== rows || content.overflowCount !== overflowCount)) {
+    setContent({ rows, overflowCount });
+  }
 
-  const hasUrgent = rows.some((r) => r.worstType === "error" || r.worstType === "warning");
+  if (!shouldRender) return null;
+
+  const { rows: displayRows, overflowCount: displayOverflowCount } = content;
+  const hasUrgent = displayRows.some((r) => r.worstType === "error" || r.worstType === "warning");
   const accentClass = hasUrgent ? "border-l-status-warning" : "border-l-status-success";
 
   const handleOpenNotifications = () => {
@@ -73,7 +90,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
     >
       <div
         className={cn(
-          "pointer-events-auto relative flex flex-col w-full max-w-[360px]",
+          "relative flex flex-col w-full max-w-[360px]",
           "rounded-[var(--radius-sm)] border-l-[3px] border border-tint/[0.08]",
           "bg-surface-panel/85 backdrop-blur-xl",
           "px-3 py-2.5 pr-2",
@@ -82,12 +99,19 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           "ring-1 ring-inset ring-tint/[0.05]",
           // Tailwind v4 translate-* emits the individual `translate` property,
           // which `transform` in a transition list does NOT cover — list it
-          // explicitly or the slide-in snaps and only the fade animates.
-          "transition-[translate,opacity] duration-300 ease-out",
+          // explicitly or the slide snaps and only the fade animates.
+          "transition-[translate,opacity]",
           "motion-reduce:transition-none motion-reduce:duration-0",
-          isVisible ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0",
+          // Inert while sliding out so a click can't land on a fading card.
+          isVisible
+            ? "pointer-events-auto translate-x-0 opacity-100"
+            : "pointer-events-none translate-x-8 opacity-0",
           accentClass
         )}
+        style={{
+          transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
+          transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
+        }}
         role="status"
         onMouseEnter={() => setIsPaused(true)}
         onMouseLeave={() => setIsPaused(false)}
@@ -131,7 +155,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
         </div>
 
         <ul className="mt-1.5 space-y-0.5">
-          {rows.map((row) => {
+          {displayRows.map((row) => {
             const Icon = SEVERITY_ICON[row.worstType];
             return (
               <li key={row.worktreeId}>
@@ -157,7 +181,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
               </li>
             );
           })}
-          {overflowCount > 0 && (
+          {displayOverflowCount > 0 && (
             <li>
               <button
                 type="button"
@@ -167,7 +191,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
                   "px-0.5 py-0.5 transition-colors duration-150"
                 )}
               >
-                +{overflowCount} more
+                +{displayOverflowCount} more
               </button>
             </li>
           )}

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
-import { ReEntrySummary } from "../ReEntrySummary";
+import { ReEntrySummary, AUTO_DISMISS_MS } from "../ReEntrySummary";
 import {
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
@@ -15,11 +15,9 @@ vi.mock("@/store/createWorktreeStore", () => ({
   getCurrentViewStoreOrNull: vi.fn(),
 }));
 
-vi.stubGlobal(
-  "requestAnimationFrame",
-  (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number
-);
-vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+// No requestAnimationFrame stub: `vi.useFakeTimers()` fakes rAF itself, so any
+// stub here is dead — the fake clock's rAF is what actually runs, and it fires
+// on a 16ms frame (see FRAME_MS below).
 
 function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
   return {
@@ -107,8 +105,8 @@ describe("ReEntrySummary", () => {
 
   // The entrance is RAF-deferred, so the card mounts hidden and only reaches its
   // visible state a frame later. `vi.useFakeTimers()` fakes requestAnimationFrame
-  // itself — overriding the module-level stub above — and its rAF fires on a
-  // 16ms frame, so the clock has to advance a full frame, not 0ms.
+  // itself, and its rAF fires on a 16ms frame — so the clock has to advance a
+  // full frame, not 0ms.
   const FRAME_MS = 16;
   const flushEntry = () =>
     act(() => {
@@ -255,7 +253,7 @@ describe("ReEntrySummary", () => {
     );
     expect(dismiss).not.toHaveBeenCalled();
     act(() => {
-      vi.advanceTimersByTime(8000);
+      vi.advanceTimersByTime(AUTO_DISMISS_MS);
     });
     expect(dismiss).toHaveBeenCalledOnce();
   });
@@ -274,13 +272,13 @@ describe("ReEntrySummary", () => {
 
     fireEvent.mouseEnter(card);
     act(() => {
-      vi.advanceTimersByTime(10000);
+      vi.advanceTimersByTime(AUTO_DISMISS_MS + 2000);
     });
     expect(dismiss).not.toHaveBeenCalled();
 
     fireEvent.mouseLeave(card);
     act(() => {
-      vi.advanceTimersByTime(8000);
+      vi.advanceTimersByTime(AUTO_DISMISS_MS);
     });
     expect(dismiss).toHaveBeenCalledOnce();
   });
@@ -327,7 +325,7 @@ describe("ReEntrySummary", () => {
     expect(pinButton.getAttribute("aria-pressed")).toBe("false");
 
     act(() => {
-      vi.advanceTimersByTime(8000);
+      vi.advanceTimersByTime(AUTO_DISMISS_MS);
     });
     expect(dismiss).toHaveBeenCalledOnce();
   });
@@ -464,21 +462,137 @@ describe("ReEntrySummary", () => {
       expect(screen.getByText("+2 more")).toBeTruthy();
     });
 
-    it("makes the exiting card inert without hiding it from assistive tech", () => {
+    it("makes the exiting card inert rather than aria-hidden", () => {
       const dismiss = vi.fn();
       const { rerender } = render(
         <ReEntrySummary state={makeState({ dismiss, rows: [makeRow()] })} />
       );
       flushEntry();
-      expect(screen.getByRole("status").className).toContain("pointer-events-auto");
+      expect(screen.getByRole("status").hasAttribute("inert")).toBe(false);
 
       rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
 
       const card = screen.getByRole("status");
-      expect(card.className).toContain("pointer-events-none");
-      // Never aria-hidden: the dismiss button still holds DOM focus during the
-      // exit, and Chromium blocks aria-hidden over a focused element.
+      // `inert` blocks pointer AND keyboard activation on the fading card and
+      // blurs the focused dismiss button. aria-hidden would do neither, and
+      // Chromium blocks it over a focused element.
+      expect(card.hasAttribute("inert")).toBe(true);
       expect(card.getAttribute("aria-hidden")).toBeNull();
+    });
+
+    it("clears a stuck hover pause when the card is dismissed while hovered", () => {
+      // onMouseLeave never fires for a node pulled out from under the pointer,
+      // and this component never unmounts — so a leaked `isPaused` would
+      // disable auto-dismiss for every later summary.
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            entries: [makeEntry({ id: "a" })],
+            rows: [makeRow({ worktreeId: "wt-1" })],
+          })}
+        />
+      );
+      flushEntry();
+
+      fireEvent.mouseEnter(screen.getByRole("status"));
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+      act(() => {
+        vi.advanceTimersByTime(UI_EXIT_DURATION);
+      });
+      expect(screen.queryByRole("status")).toBeNull();
+
+      rerender(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            entries: [makeEntry({ id: "b" })],
+            rows: [makeRow({ worktreeId: "wt-2" })],
+          })}
+        />
+      );
+      flushEntry();
+      dismiss.mockClear();
+
+      act(() => {
+        vi.advanceTimersByTime(AUTO_DISMISS_MS);
+      });
+      expect(dismiss).toHaveBeenCalledOnce();
+    });
+
+    it("restarts the auto-dismiss timer for a replacement summary on the same worktrees", () => {
+      // Same worktree ids and same entry count as the outgoing summary: keyed on
+      // either of those alone, the replacement would inherit the old, nearly
+      // expired timer and be dismissed almost immediately.
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            entries: [makeEntry({ id: "a" })],
+            rows: [makeRow({ worktreeId: "wt-1", highlightTitle: "First" })],
+          })}
+        />
+      );
+      flushEntry();
+
+      act(() => {
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+      });
+      expect(dismiss).not.toHaveBeenCalled();
+
+      rerender(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            entries: [makeEntry({ id: "b" })],
+            rows: [makeRow({ worktreeId: "wt-1", highlightTitle: "Second" })],
+          })}
+        />
+      );
+
+      // The old timer would have fired here; the replacement gets a full window.
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(dismiss).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(AUTO_DISMISS_MS);
+      });
+      expect(dismiss).toHaveBeenCalledOnce();
+    });
+
+    it("resets the pin for a replacement summary on the same worktrees", () => {
+      // The pin half of the same collision: a replacement summary must not
+      // silently inherit the outgoing summary's pin.
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            entries: [makeEntry({ id: "a" })],
+            rows: [makeRow({ worktreeId: "wt-1" })],
+          })}
+        />
+      );
+      flushEntry();
+
+      fireEvent.click(screen.getByLabelText("Pin summary"));
+      expect(screen.getByLabelText("Unpin summary").getAttribute("aria-pressed")).toBe("true");
+
+      rerender(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            entries: [makeEntry({ id: "b" })],
+            rows: [makeRow({ worktreeId: "wt-1" })],
+          })}
+        />
+      );
+
+      expect(screen.getByLabelText("Pin summary").getAttribute("aria-pressed")).toBe("false");
     });
 
     it("cancels the pending exit and swaps in new content when a summary arrives mid-exit", () => {

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -2,6 +2,12 @@
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { ReEntrySummary } from "../ReEntrySummary";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+} from "@/lib/animationUtils";
 import type { ReEntrySummaryState, WorktreeRow } from "@/hooks/useReEntrySummary";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
@@ -96,11 +102,24 @@ describe("ReEntrySummary", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    delete document.body.dataset.performanceMode;
   });
 
+  // The entrance is RAF-deferred, so the card mounts hidden and only reaches its
+  // visible state a frame later. `vi.useFakeTimers()` fakes requestAnimationFrame
+  // itself — overriding the module-level stub above — and its rAF fires on a
+  // 16ms frame, so the clock has to advance a full frame, not 0ms.
+  const FRAME_MS = 16;
+  const flushEntry = () =>
+    act(() => {
+      vi.advanceTimersByTime(FRAME_MS);
+    });
+
   it("renders nothing when state.visible is false", () => {
-    const { container } = render(<ReEntrySummary state={makeState({ visible: false })} />);
-    expect(container.innerHTML).toBe("");
+    // The card portals into document.body, so assert against the screen — the
+    // RTL container is empty either way.
+    render(<ReEntrySummary state={makeState({ visible: false })} />);
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("renders worktree rows with severity icon, name, and title", () => {
@@ -393,5 +412,143 @@ describe("ReEntrySummary", () => {
     );
     const card = screen.getByRole("status");
     expect(document.activeElement).not.toBe(card);
+  });
+
+  describe("exit animation (#11163)", () => {
+    // `useReEntrySummary` returns EMPTY content the instant `visible` flips
+    // false, so a dismissed card arrives here with no rows at all. These tests
+    // drive the real `useAnimatedPresence` rather than mocking it — the whole
+    // point of the fix is how long the card stays mounted.
+    const dismissedState = (dismiss: () => void) =>
+      makeState({ visible: false, dismiss, rows: [], overflowCount: 0 });
+
+    it("keeps the card mounted for the exit window, then unmounts it", () => {
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary state={makeState({ dismiss, rows: [makeRow()] })} />
+      );
+      flushEntry();
+      expect(screen.getByRole("status")).toBeTruthy();
+
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+      expect(screen.getByRole("status")).toBeTruthy();
+
+      act(() => {
+        vi.advanceTimersByTime(UI_EXIT_DURATION - 1);
+      });
+      expect(screen.queryByRole("status")).toBeTruthy();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    it("keeps rendering the dismissed summary's rows while it slides out", () => {
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            rows: [makeRow({ worktreeName: "feature-foo", highlightTitle: "Build failed" })],
+            overflowCount: 2,
+          })}
+        />
+      );
+      flushEntry();
+
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+
+      expect(screen.getByText("feature-foo")).toBeTruthy();
+      expect(screen.getByText("Build failed")).toBeTruthy();
+      expect(screen.getByText("+2 more")).toBeTruthy();
+    });
+
+    it("makes the exiting card inert without hiding it from assistive tech", () => {
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary state={makeState({ dismiss, rows: [makeRow()] })} />
+      );
+      flushEntry();
+      expect(screen.getByRole("status").className).toContain("pointer-events-auto");
+
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+
+      const card = screen.getByRole("status");
+      expect(card.className).toContain("pointer-events-none");
+      // Never aria-hidden: the dismiss button still holds DOM focus during the
+      // exit, and Chromium blocks aria-hidden over a focused element.
+      expect(card.getAttribute("aria-hidden")).toBeNull();
+    });
+
+    it("cancels the pending exit and swaps in new content when a summary arrives mid-exit", () => {
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary
+          state={makeState({
+            dismiss,
+            rows: [makeRow({ worktreeId: "wt-1", worktreeName: "first-wt" })],
+          })}
+        />
+      );
+      flushEntry();
+
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+      act(() => {
+        vi.advanceTimersByTime(Math.floor(UI_EXIT_DURATION / 2));
+      });
+      expect(screen.getByText("first-wt")).toBeTruthy();
+
+      rerender(
+        <ReEntrySummary
+          state={makeState({
+            visible: true,
+            dismiss,
+            rows: [makeRow({ worktreeId: "wt-2", worktreeName: "second-wt" })],
+          })}
+        />
+      );
+      flushEntry();
+
+      expect(screen.getByText("second-wt")).toBeTruthy();
+      expect(screen.queryByText("first-wt")).toBeNull();
+
+      // The superseded close timer must not fire and tear down the new card.
+      act(() => {
+        vi.advanceTimersByTime(UI_EXIT_DURATION);
+      });
+      expect(screen.getByText("second-wt")).toBeTruthy();
+    });
+
+    it("switches from the enter tier to the exit tier on dismiss", () => {
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary state={makeState({ dismiss, rows: [makeRow()] })} />
+      );
+      flushEntry();
+
+      const card = screen.getByRole("status");
+      expect(card.style.transitionDuration).toBe(`${UI_ENTER_DURATION}ms`);
+      expect(card.style.transitionTimingFunction).toBe(UI_ENTER_EASING);
+
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+
+      expect(card.style.transitionDuration).toBe(`${UI_EXIT_DURATION}ms`);
+      expect(card.style.transitionTimingFunction).toBe(UI_EXIT_EASING);
+    });
+
+    it("unmounts without an exit delay in performance mode", () => {
+      document.body.dataset.performanceMode = "true";
+      const dismiss = vi.fn();
+      const { rerender } = render(
+        <ReEntrySummary state={makeState({ dismiss, rows: [makeRow()] })} />
+      );
+      flushEntry();
+      expect(screen.getByRole("status")).toBeTruthy();
+
+      rerender(<ReEntrySummary state={dismissedState(dismiss)} />);
+
+      expect(screen.queryByRole("status")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `ReEntrySummary` returned `null` the instant `visible` flipped false, so dismissing the card removed it in a single frame with no chance for the exit transition to paint.
- Presence now routes through the shared `useAnimatedPresence` hook with `animationDuration` set from `getUiTransitionDuration('exit')`, so the card stays mounted for the shared 120ms exit tier and slides out via transform and opacity, matching how `AppDialog` and the fixed dropdown already animate out.
- Entry timing moved off a literal `duration-300 ease-out` class onto the shared `UI_ENTER_DURATION`/`UI_EXIT_DURATION` and `UI_ENTER_EASING`/`UI_EXIT_EASING` constants in `src/lib/animationUtils.ts`, applied as an inline style that switches on `isVisible`, the same pattern `AppDialog` uses. `motion-reduce` classes stay, and performance mode still unmounts synchronously since `getUiTransitionDuration` returns 0 there.

Resolves #11163

## Changes
- **Content latch**: `useReEntrySummary` clears its `rows`/`overflowCount` the instant `visible` flips false, so naively gating render on presence would have animated out a blank card. The component now latches the last visible rows and overflow count during render, the same pattern `ScrollIndicator` already uses for its count (#10316).
- **Stuck hover pause**: `isPaused` was only ever cleared by `onMouseLeave`, which never fires when the card is dismissed while the pointer is hovering it, since the old code rendered `null` instead of truly unmounting. Auto-dismiss silently stopped working for every summary after the first. It's now cleared once the card is gone.
- **Replacement summary inherited state**: pin reset keyed on entry count and the 8s auto-dismiss timer keyed on the worktree id list. When the same worktrees reported again with the same entry count, neither reset, so a replacement summary inherited the previous pin and an already half-elapsed timer, dismissing the new card almost immediately. Both now key on a single summary identity built from the entry ids (UUIDs).
- **Inert during exit**: the exiting card is now `inert` rather than just `pointer-events-none`, which still let Tab/Enter reach the fading card's buttons. Keyed on `visible` rather than `isVisible` so the `role="status"` live region isn't inert on the frame it's inserted. Deliberately not `aria-hidden`, since the dismiss button holds focus during the exit and Chromium blocks `aria-hidden` on a focused element.

## Testing
102 tests green across `reentry-summary.test.tsx`, `useReEntrySummary.test.tsx`, and the two `AppLayout` source-guard specs that scan `ReEntrySummary.tsx`. New coverage: exit-window DOM presence and unmount, content retained during exit, mid-exit re-entrancy (a new summary cancels the pending close timer), enter to exit tier switch, performance-mode instant unmount, stuck-hover-pause regression, and the replacement-summary timer/pin regression. Also removed a dead `requestAnimationFrame` stub in the test file (`vi.useFakeTimers` already fakes `requestAnimationFrame` on a 16ms frame, so the stub never ran), which cleared a pre-existing `no-unsafe-type-assertion` lint offense. `eslint` and `prettier` are clean on both files.

Reviewed with two adversarial passes; all findings applied and confirmed held.
