### PR TITLE
feat(settings): animate the SettingsCheckbox checkmark on check-in

### DIFF
--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -73,7 +73,7 @@ export function SettingsCheckbox({
             isError && "border-status-error data-[state=checked]:border-status-error"
           )}
         >
-          <Checkbox.Indicator className="flex items-center justify-center w-full h-full text-text-inverse">
+          <Checkbox.Indicator className="animate-checkbox-check flex items-center justify-center w-full h-full text-text-inverse">
             <CheckIcon className="w-3 h-3 block" data-state="checked" />
             <MinusIcon className="w-3 h-3 hidden" data-state="indeterminate" />
           </Checkbox.Indicator>

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -12,12 +12,68 @@ import { SettingsCheckbox } from "../SettingsCheckbox";
 import { SettingsSwitch } from "../SettingsSwitch";
 import { PresetColorPicker } from "../PresetColorPicker";
 
+// Strip CSS comments without treating a `/*` inside a quoted string as one —
+// index.css opens with `@source not "../.lessons/**/*"`, whose glob contains a
+// literal `/*` ... `*/` pair.
+function stripComments(css: string): string {
+  let out = "";
+  let quote: string | null = null;
+
+  for (let i = 0; i < css.length; i += 1) {
+    const char = css[i];
+
+    if (quote !== null) {
+      out += char;
+      if (char === "\\") out += css[++i] ?? "";
+      else if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+      out += char;
+    } else if (char === "/" && css[i + 1] === "*") {
+      const close = css.indexOf("*/", i + 2);
+      i = close === -1 ? css.length : close + 1;
+    } else {
+      out += char;
+    }
+  }
+
+  return out;
+}
+
+// Split a block body into its top-level rules. Nested rules stay bundled inside
+// their parent's declarations, so a rule guarded by a nested at-rule (a media
+// query, say) is never mistaken for one that applies unconditionally.
+function topLevelRules(body: string): Array<{ prelude: string; declarations: string }> {
+  const rules: Array<{ prelude: string; declarations: string }> = [];
+  let depth = 0;
+  let start = 0;
+  let open = 0;
+
+  for (let i = 0; i < body.length; i += 1) {
+    if (body[i] === "{") {
+      if (depth === 0) open = i;
+      depth += 1;
+    } else if (body[i] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        rules.push({
+          prelude: body.slice(start, open),
+          declarations: body.slice(open + 1, i),
+        });
+        start = i + 1;
+      }
+    }
+  }
+
+  return rules;
+}
+
 // Collect every `animate-*` class that a `@variant reduce-motion` block silences
-// with `animation: none`. Comments are stripped first — index.css documents the
-// variant with a literal `@variant reduce-motion { ... }` inside a comment, which
-// would otherwise be scanned as a real block.
+// outright. Only bare `.animate-x` selector items count: `.animate-x::before`,
+// `.animate-x .child` and `:not(.animate-x)` all kill motion on something other
+// than the element carrying the class, and must not be read as coverage.
 function reduceMotionKilledClasses(css: string): Set<string> {
-  const source = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const source = stripComments(css);
   const killed = new Set<string>();
   const marker = "@variant reduce-motion";
 
@@ -33,11 +89,15 @@ function reduceMotionKilledClasses(css: string): Set<string> {
       end += 1;
     }
 
-    for (const [, selectors, declarations] of source
-      .slice(open + 1, end - 1)
-      .matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-      if (!/animation:\s*none/.test(declarations)) continue;
-      for (const [, name] of selectors.matchAll(/\.(animate-[\w-]+)/g)) killed.add(name);
+    for (const { prelude, declarations } of topLevelRules(source.slice(open + 1, end - 1))) {
+      // `(?<!-)` rules out a custom property such as `--animation: none`.
+      if (prelude.trimStart().startsWith("@")) continue;
+      if (!/(?<!-)animation:\s*none/.test(declarations)) continue;
+
+      for (const item of prelude.split(",")) {
+        const name = /^\.(animate-[\w-]+)$/.exec(item.trim())?.[1];
+        if (name !== undefined) killed.add(name);
+      }
     }
 
     from = end;
@@ -916,8 +976,9 @@ describe("SettingsCheckbox", () => {
   // carries must be registered in a reduce-motion kill-list, or the check-in
   // animation keeps playing for users who asked for no motion. Reads the classes
   // off the rendered node rather than naming them, so a rename in either file
-  // that isn't mirrored in the other fails here.
-  it("kills the checked indicator's animation under reduce-motion", () => {
+  // that isn't mirrored in the other fails here. This asserts source
+  // registration, not computed style — jsdom applies no stylesheet.
+  it("registers the checked indicator's animate-* classes in the reduce-motion kill-list", () => {
     render(
       <SettingsCheckbox
         label="Test Setting"

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { SettingsInput } from "../SettingsInput";
 import { SettingsSelect } from "../SettingsSelect";
@@ -9,6 +11,40 @@ import { SettingsChoicebox, type ChoiceboxOption } from "../SettingsChoicebox";
 import { SettingsCheckbox } from "../SettingsCheckbox";
 import { SettingsSwitch } from "../SettingsSwitch";
 import { PresetColorPicker } from "../PresetColorPicker";
+
+// Collect every `animate-*` class that a `@variant reduce-motion` block silences
+// with `animation: none`. Comments are stripped first — index.css documents the
+// variant with a literal `@variant reduce-motion { ... }` inside a comment, which
+// would otherwise be scanned as a real block.
+function reduceMotionKilledClasses(css: string): Set<string> {
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const killed = new Set<string>();
+  const marker = "@variant reduce-motion";
+
+  for (let from = source.indexOf(marker); from !== -1; from = source.indexOf(marker, from)) {
+    const open = source.indexOf("{", from);
+    if (open === -1) break;
+
+    let depth = 1;
+    let end = open + 1;
+    while (end < source.length && depth > 0) {
+      if (source[end] === "{") depth += 1;
+      else if (source[end] === "}") depth -= 1;
+      end += 1;
+    }
+
+    for (const [, selectors, declarations] of source
+      .slice(open + 1, end - 1)
+      .matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      if (!/animation:\s*none/.test(declarations)) continue;
+      for (const [, name] of selectors.matchAll(/\.(animate-[\w-]+)/g)) killed.add(name);
+    }
+
+    from = end;
+  }
+
+  return killed;
+}
 
 describe("SettingsInput", () => {
   it("renders label associated to input", () => {
@@ -874,6 +910,34 @@ describe("SettingsCheckbox", () => {
     const checkbox = screen.getByRole("checkbox");
     const indicator = checkbox.querySelector("svg");
     expect(indicator).toBeTruthy();
+  });
+
+  // Cross-source contract (#11166): whatever animation the checkmark indicator
+  // carries must be registered in a reduce-motion kill-list, or the check-in
+  // animation keeps playing for users who asked for no motion. Reads the classes
+  // off the rendered node rather than naming them, so a rename in either file
+  // that isn't mirrored in the other fails here.
+  it("kills the checked indicator's animation under reduce-motion", () => {
+    render(
+      <SettingsCheckbox
+        label="Test Setting"
+        description="A test description"
+        checked={true}
+        onChange={vi.fn()}
+      />
+    );
+    const indicator = screen.getByRole("checkbox").querySelector("svg")?.parentElement;
+    expect(indicator).toBeTruthy();
+
+    const animationClasses = [...indicator!.classList].filter((name) =>
+      name.startsWith("animate-")
+    );
+    expect(animationClasses.length).toBeGreaterThan(0);
+
+    const killed = reduceMotionKilledClasses(
+      readFileSync(resolve(__dirname, "../../../index.css"), "utf8")
+    );
+    animationClasses.forEach((name) => expect([...killed]).toContain(name));
   });
 
   it("uses error styling when error is present", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1006,6 +1006,23 @@ body,
   will-change: opacity, transform;
 }
 
+@keyframes checkbox-check-in {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* No will-change: unlike .animate-agent-pulse (dropped on animationend), this
+ * class stays on the indicator for the whole checked lifetime. */
+.animate-checkbox-check {
+  animation: checkbox-check-in var(--duration-150) var(--ease-out-expo) 1 both;
+}
+
 /* Organic breathing animation for waiting/loading states
  * Uses scale + opacity for a more premium feel with asymmetric timing.
  * Matches the 2s timing of other pulse animations.
@@ -1589,6 +1606,7 @@ body,
 @variant reduce-motion {
   .animate-activity-pulse,
   .animate-agent-pulse,
+  .animate-checkbox-check,
   .animate-breathe,
   .animate-spin,
   .animate-spin-slow,

--- a/src/index.css
+++ b/src/index.css
@@ -1017,10 +1017,15 @@ body,
   }
 }
 
-/* No will-change: unlike .animate-agent-pulse (dropped on animationend), this
- * class stays on the indicator for the whole checked lifetime. */
+/* The indicator mounts with this class already on it and keeps it for the whole
+ * checked lifetime — unlike .animate-agent-pulse, which is dropped on
+ * animationend. Hence `backwards` rather than `both`: it still pins the opening
+ * frame to `from` (no flash of an opaque checkmark before the animation runs),
+ * but releases the element on completion instead of parking a permanent
+ * scale(1) effect on it. For the same reason there is no will-change — the hint
+ * would outlive the 150ms it could help. */
 .animate-checkbox-check {
-  animation: checkbox-check-in var(--duration-150) var(--ease-out-expo) 1 both;
+  animation: checkbox-check-in var(--duration-150) var(--ease-out-expo) 1 backwards;
 }
 
 /* Organic breathing animation for waiting/loading states

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -280,7 +280,7 @@ describe("discrete-feedback easing CSS contract", () => {
     css.match(blockRegex(selector))?.[0].match(/\{([\s\S]*?)\}/)?.[1] ?? null;
 
   it("anchors the swap to the source-of-truth token value", () => {
-    // The 10 swaps only matter if --ease-out-expo still resolves to the
+    // The swaps only matter if --ease-out-expo still resolves to the
     // front-loaded curve. Link the CSS token to the TS constant so a silent
     // redefinition can't pass the per-selector reference checks below.
     const match = css.match(/--ease-out-expo\s*:\s*([^;]+);/);

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -259,6 +259,7 @@ describe("discrete-feedback easing CSS contract", () => {
   // keeps the symmetric literal (terminal-ping, --focus-transition-easing).
   const discreteFeedbackSelectors = [
     ".animate-badge-bump",
+    ".animate-checkbox-check",
     ".animate-action-row-bump",
     ".animate-diagnostics-flash",
     ".animate-upstream-badge-flash",


### PR DESCRIPTION
## Summary

- `Checkbox.Root`'s box fill already had `transition-colors duration-150`, but `Checkbox.Indicator` had no transition at all, so the checkmark popped in instantly. This adds a subtle 150ms scale and fade on check-in, opacity and transform only.
- New `@keyframes checkbox-check-in` plus `.animate-checkbox-check` in `src/index.css`, driven by the shared `--duration-150` / `--ease-out-expo` tokens rather than literal values, applied directly to `Checkbox.Indicator` in `src/components/Settings/SettingsCheckbox.tsx`.
- Two non-tautological tests: a cross-file contract test proving the indicator's animation classes are registered in the reduce-motion kill list, and an addition to the existing easing contract suite.

Resolves #11166

## Implementation notes

Radix mounts a brand new indicator DOM node on every check (no `forceMount`), so the one-shot animation replays naturally on each toggle. No `key` prop or remount trick needed.

The animation uses `backwards` fill mode rather than the `both` used by sibling `.animate-*` classes. The indicator mounts with the class and keeps it for the whole checked lifetime instead of removing it on `animationend` the way `.animate-agent-pulse` does, so `both` would park a permanent `scale(1)` effect on every checked box. `backwards` still pins the opening frame, so there's no flash of an opaque checkmark before the animation runs.

No `will-change` either, same reasoning: the precedent that sets it (`.animate-agent-pulse`) drops its class on `animationend`, so the hint stops mattering once the animation is done. This class never gets removed, so the hint would just linger past the 150ms it could actually help with.

## Accessibility

- Reduced motion: `.animate-checkbox-check` is registered in the existing `@variant reduce-motion` kill list, which covers both the OS `prefers-reduced-motion` setting and the app's own "Reduce UI animations" toggle. Under either, the checkmark appears instantly at full opacity.
- Performance mode: no new code needed. The global `body[data-performance-mode="true"] * { animation: none !important }` rule already neutralizes it.

## Testing

- `SettingsFormPrimitives.test.tsx` gained a cross-source contract test that reads the indicator's `animate-*` classes off the rendered DOM node and asserts each is registered in the reduce-motion kill list in `index.css`. It fails if the animation is dropped, if the class is renamed in only one of the two files, or if the reduce-motion registration is forgotten. Validated red-before-green: removing the registration makes it fail.
- `.animate-checkbox-check` was added to the existing `discreteFeedbackSelectors` list in `animationUtils.test.ts`, so it inherits the assertions that discrete feedback uses the front-loaded `--ease-out-expo` curve and never falls back to the symmetric Material easing.
- 448 tests pass across all 14 test files that read `index.css`, not just the Settings-specific ones. The color-system, forced-colors, and accent-token contract suites parse the same stylesheet. ESLint is clean on the changed files (2 pre-existing warnings, both on lines only shifted by the insertion). Prettier is clean.

## Worth a reviewer's eye

A checkbox that renders already checked plays the animation once on mount too, so opening a settings tab fades in its pre-checked boxes. Suppressing that needs render-phase ref logic to tell a first mount from a user toggle, which didn't seem worth the added complexity for a 150ms fade. Easy follow-up if it looks off in practice.

Also worth a look: the box fill still uses the default ease-out while the checkmark uses the more front-loaded `--ease-out-expo`, so the checkmark reaches full opacity slightly before the fill reaches its final color.
