### PR TITLE
feat(settings): slide the nav active indicator between items

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -699,6 +699,15 @@ export default tseslint.config(
     rules: { "no-restricted-imports": "off" },
   },
 
+  // Allowlist — framer-motion settings nav sliding active indicator. Costs the
+  // eager graph nothing: App.tsx already static-imports framer-motion to mount
+  // LazyMotion, and SettingsDialog is itself lazy (see lazyPanels.ts), so the
+  // shared-layout indicator rides a chunk that is already downstream of boot.
+  {
+    files: ["src/components/Settings/SettingsDialog.tsx"],
+    rules: { "no-restricted-imports": "off" },
+  },
+
   // Allowlist — framer-motion Fleet, Layout chrome.
   {
     files: [

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "react";
 import { LayoutGroup, m } from "framer-motion";
 import { logError } from "@/utils/logger";
-import { UI_ANIMATION_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
+import { getUiAnimationDuration, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 import {
   usePortalStore,
   usePerformanceModeStore,
@@ -1267,12 +1267,17 @@ export function NavItem({
         // projects this same node to its new position (transform-only) instead
         // of unmounting and remounting the marker. Scoping the id keeps a
         // cross-scope jump (a search hit in the other scope) from sliding the
-        // marker between two unrelated nav trees.
-        <m.div
+        // marker between two unrelated nav trees. A span, not a div: <button>
+        // takes phrasing content only, and `absolute` makes it block anyway.
+        // Duration comes from getUiAnimationDuration() rather than the raw
+        // constant because performance mode has to collapse this to 0 — it
+        // suppresses CSS transitions, but cannot stop motion's JS transform
+        // writes, which are exactly what a projection animation emits.
+        <m.span
           layoutId={`active-indicator-${scopeForTab(tab)}`}
           layout="position"
           className="pointer-events-none absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r bg-daintree-accent"
-          transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_OUT_EXPO_FM }}
+          transition={{ duration: getUiAnimationDuration() / 1000, ease: EASE_OUT_EXPO_FM }}
           aria-hidden="true"
           data-settings-nav-indicator="true"
         />

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -11,7 +11,9 @@ import {
   useContext,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
+import { LayoutGroup, m } from "framer-motion";
 import { logError } from "@/utils/logger";
+import { UI_ANIMATION_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 import {
   usePortalStore,
   usePerformanceModeStore,
@@ -638,36 +640,38 @@ function SettingsDialogInner({
             aria-label="Settings sections"
             onKeyDown={handleTablistKeyDown}
           >
-            {getSettingsNavGroups(activeScope).map((group) => (
-              <NavGroup key={group.label} label={group.label}>
-                {group.entries.map((entry) => {
-                  const tabId = entry.id as SettingsTab;
-                  const isLazy = entry.importKind === "lazy";
-                  return (
-                    <NavItem
-                      key={entry.id}
-                      tab={tabId}
-                      icon={entry.icon}
-                      label={entry.label}
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts[tabId]}
-                      modified={modifiedTabs.has(tabId)}
-                      hasError={tabsWithErrors.has(tabId)}
-                      onSelect={handleNavSelect}
-                      onPrefetchImport={isLazy ? entry.importer : undefined}
-                      onPrefetchMount={
-                        isLazy
-                          ? () => {
-                              if (isOpenRef.current) markTabVisited(tabId);
-                            }
-                          : undefined
-                      }
-                    />
-                  );
-                })}
-              </NavGroup>
-            ))}
+            <LayoutGroup id="settings-nav">
+              {getSettingsNavGroups(activeScope).map((group) => (
+                <NavGroup key={group.label} label={group.label}>
+                  {group.entries.map((entry) => {
+                    const tabId = entry.id as SettingsTab;
+                    const isLazy = entry.importKind === "lazy";
+                    return (
+                      <NavItem
+                        key={entry.id}
+                        tab={tabId}
+                        icon={entry.icon}
+                        label={entry.label}
+                        activeTab={activeTab}
+                        isSearching={isSearching}
+                        matchCount={matchCounts[tabId]}
+                        modified={modifiedTabs.has(tabId)}
+                        hasError={tabsWithErrors.has(tabId)}
+                        onSelect={handleNavSelect}
+                        onPrefetchImport={isLazy ? entry.importer : undefined}
+                        onPrefetchMount={
+                          isLazy
+                            ? () => {
+                                if (isOpenRef.current) markTabVisited(tabId);
+                              }
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
+                </NavGroup>
+              ))}
+            </LayoutGroup>
           </ScrollShadow>
 
           <div className="pt-2 mt-2 border-t border-daintree-border px-2">
@@ -1183,7 +1187,7 @@ function SettingsTabScrollEffect({
   return null;
 }
 
-function NavGroup({ label, children }: { label: string; children: React.ReactNode }) {
+export function NavGroup({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div role="none">
       <span
@@ -1218,7 +1222,7 @@ interface NavItemProps {
   onPrefetchMount?: () => void;
 }
 
-function NavItem({
+export function NavItem({
   tab,
   icon,
   label,
@@ -1254,12 +1258,25 @@ function NavItem({
         "relative text-left px-3 py-1.5 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2 w-full",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
         "settings-nav-item",
-        active
-          ? "text-daintree-text before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-          : "text-text-secondary hover:text-daintree-text"
+        active ? "text-daintree-text" : "text-text-secondary hover:text-daintree-text"
       )}
       data-active={active ? "true" : undefined}
     >
+      {active && (
+        // Shared across every nav item in this scope, so selecting another tab
+        // projects this same node to its new position (transform-only) instead
+        // of unmounting and remounting the marker. Scoping the id keeps a
+        // cross-scope jump (a search hit in the other scope) from sliding the
+        // marker between two unrelated nav trees.
+        <m.div
+          layoutId={`active-indicator-${scopeForTab(tab)}`}
+          layout="position"
+          className="pointer-events-none absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r bg-daintree-accent"
+          transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_OUT_EXPO_FM }}
+          aria-hidden="true"
+          data-settings-nav-indicator="true"
+        />
+      )}
       <span className="relative">
         {icon}
         {(hasError || modified) && (

--- a/src/components/Settings/__tests__/SettingsDialogNav.test.tsx
+++ b/src/components/Settings/__tests__/SettingsDialogNav.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { UI_ANIMATION_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 import { NavGroup, NavItem } from "../SettingsDialog";
@@ -18,22 +18,22 @@ const recorded = vi.hoisted(() => ({ motion: [] as MotionRecord[] }));
 // the indicator is queryable in jsdom, capture the projection props (which
 // framer-motion would otherwise swallow rather than forward to the DOM).
 vi.mock("framer-motion", () => {
-  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  const MotionSpan = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
     ({ children, ...props }, ref) => {
       const { layoutId, layout, transition, ...rest } = props as MotionRecord &
-        React.HTMLAttributes<HTMLDivElement>;
+        React.HTMLAttributes<HTMLSpanElement>;
       recorded.motion.push({ layoutId, layout, transition });
       return (
-        <div ref={ref} {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+        <span ref={ref} {...(rest as React.HTMLAttributes<HTMLSpanElement>)}>
           {children}
-        </div>
+        </span>
       );
     }
   );
-  MotionDiv.displayName = "MotionDiv";
+  MotionSpan.displayName = "MotionSpan";
   return {
     LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    m: { div: MotionDiv },
+    m: { span: MotionSpan },
   };
 });
 
@@ -95,6 +95,11 @@ function Nav({
 describe("settings nav active indicator (issue #11164)", () => {
   beforeEach(() => {
     recorded.motion.length = 0;
+    delete document.body.dataset.performanceMode;
+  });
+
+  afterEach(() => {
+    delete document.body.dataset.performanceMode;
   });
 
   it("mounts a single indicator, owned by the active item", () => {
@@ -177,5 +182,16 @@ describe("settings nav active indicator (issue #11164)", () => {
     expect(record.layout).toBe("position");
     expect(record.transition?.duration).toBe(UI_ANIMATION_DURATION / 1000);
     expect(record.transition?.ease).toBe(EASE_OUT_EXPO_FM);
+  });
+
+  it("collapses the slide to zero under performance mode", () => {
+    // Performance mode suppresses CSS transitions, but a projection animation
+    // is JS writing transforms every frame — CSS can't reach it. The duration
+    // has to come from the helper that zeroes out, not the raw tier constant.
+    document.body.dataset.performanceMode = "true";
+
+    render(<Nav activeTab="general" />);
+
+    expect(soleRecord().transition?.duration).toBe(0);
   });
 });

--- a/src/components/Settings/__tests__/SettingsDialogNav.test.tsx
+++ b/src/components/Settings/__tests__/SettingsDialogNav.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UI_ANIMATION_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
+import { NavGroup, NavItem } from "../SettingsDialog";
+import type { SettingsTab } from "../settingsTabRegistry";
+
+interface MotionRecord {
+  layoutId?: string;
+  layout?: unknown;
+  transition?: { duration?: number; ease?: unknown };
+}
+
+const recorded = vi.hoisted(() => ({ motion: [] as MotionRecord[] }));
+
+// Mirrors the mock in Panel/__tests__/TabButton.test.tsx: render a plain div so
+// the indicator is queryable in jsdom, capture the projection props (which
+// framer-motion would otherwise swallow rather than forward to the DOM).
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => {
+      const { layoutId, layout, transition, ...rest } = props as MotionRecord &
+        React.HTMLAttributes<HTMLDivElement>;
+      recorded.motion.push({ layoutId, layout, transition });
+      return (
+        <div ref={ref} {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+          {children}
+        </div>
+      );
+    }
+  );
+  MotionDiv.displayName = "MotionDiv";
+  return {
+    LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    m: { div: MotionDiv },
+  };
+});
+
+const INDICATOR = "[data-settings-nav-indicator]";
+
+function indicators(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(INDICATOR));
+}
+
+/** The nav tab that currently owns the indicator, or null if none does. */
+function indicatorOwner(): string | null {
+  const node = document.querySelector<HTMLElement>(INDICATOR);
+  return node?.closest("button")?.getAttribute("data-tab") ?? null;
+}
+
+/** The projection props of the sole mounted indicator. */
+function soleRecord(): MotionRecord {
+  expect(recorded.motion).toHaveLength(1);
+  return recorded.motion[0]!;
+}
+
+/**
+ * Two nav groups, mirroring the real dialog: NavItems live in separate NavGroup
+ * subtrees rather than as flat siblings, which is exactly the case a shared
+ * layoutId has to survive.
+ */
+function Nav({
+  activeTab,
+  isSearching = false,
+}: {
+  activeTab: SettingsTab;
+  isSearching?: boolean;
+}) {
+  const item = (tab: SettingsTab, label: string) => (
+    <NavItem
+      key={tab}
+      tab={tab}
+      icon={<svg />}
+      label={label}
+      activeTab={activeTab}
+      isSearching={isSearching}
+      onSelect={() => {}}
+    />
+  );
+  return (
+    <div role="tablist">
+      <NavGroup label="Group one">
+        {item("general", "General")}
+        {item("keyboard", "Keyboard")}
+      </NavGroup>
+      <NavGroup label="Group two">
+        {item("agents", "Agents")}
+        {item("plugins", "Plugins")}
+      </NavGroup>
+    </div>
+  );
+}
+
+describe("settings nav active indicator (issue #11164)", () => {
+  beforeEach(() => {
+    recorded.motion.length = 0;
+  });
+
+  it("mounts a single indicator, owned by the active item", () => {
+    render(<Nav activeTab="general" />);
+
+    expect(indicators()).toHaveLength(1);
+    expect(indicatorOwner()).toBe("general");
+  });
+
+  it("reuses one indicator node across groups rather than one per item", () => {
+    // The bug: a per-item marker meant every item could own one. Rendering four
+    // items across two groups must still yield exactly one indicator.
+    render(<Nav activeTab="agents" />);
+
+    expect(screen.getAllByRole("tab")).toHaveLength(4);
+    expect(indicators()).toHaveLength(1);
+    expect(indicatorOwner()).toBe("agents");
+  });
+
+  it("keeps one shared layoutId when the selection crosses a group boundary", () => {
+    // This is the fix. The marker slides only because the node projected out of
+    // the old item and the node projected into the new one are the *same*
+    // layoutId — a per-item id would unmount and remount instead (the blink).
+    const { rerender } = render(<Nav activeTab="general" />);
+    const before = soleRecord().layoutId;
+
+    recorded.motion.length = 0;
+    rerender(<Nav activeTab="agents" />);
+    const after = soleRecord().layoutId;
+
+    expect(indicatorOwner()).toBe("agents");
+    expect(after).toBe(before);
+  });
+
+  it("gives the global and project scopes separate layoutIds", () => {
+    // Search results are not scope-restricted, so activating a project hit can
+    // swap scope and tab together. Distinct ids stop the marker from sliding
+    // between two unrelated nav trees.
+    render(<Nav activeTab="general" />);
+    const globalId = soleRecord().layoutId;
+
+    recorded.motion.length = 0;
+    render(
+      <div role="tablist">
+        <NavGroup label="Project">
+          <NavItem
+            tab="project:general"
+            icon={<svg />}
+            label="Project general"
+            activeTab="project:general"
+            isSearching={false}
+            onSelect={() => {}}
+          />
+        </NavGroup>
+      </div>
+    );
+    const projectId = soleRecord().layoutId;
+
+    expect(projectId).not.toBe(globalId);
+  });
+
+  it("drops the indicator while searching but leaves the tab selected", () => {
+    // `active` is suppressed during search; `selected` is not. The marker keys
+    // off the former, ARIA off the latter.
+    render(<Nav activeTab="general" isSearching />);
+
+    expect(indicators()).toHaveLength(0);
+    expect(screen.getByRole("tab", { name: /general/i }).getAttribute("aria-selected")).toBe(
+      "true"
+    );
+  });
+
+  it("projects position only, on the shared motion tier", () => {
+    // layout="position" keeps the move on the compositor (translate only, no
+    // width/height writes). Duration and easing track the shared constants, so
+    // retuning the tier moves this with it.
+    render(<Nav activeTab="general" />);
+    const record = soleRecord();
+
+    expect(record.layout).toBe("position");
+    expect(record.transition?.duration).toBe(UI_ANIMATION_DURATION / 1000);
+    expect(record.transition?.ease).toBe(EASE_OUT_EXPO_FM);
+  });
+});

--- a/src/styles/components/settings.css
+++ b/src/styles/components/settings.css
@@ -60,8 +60,10 @@
 
 /* Active nav item ELEVATES toward surface-panel-elevated (overlay-raised),
    it does not darken a recessed sidebar. The single load-bearing accent for
-   the active item is the 2px accent marker (a left-edge before: pseudo-element)
-   in SettingsDialog.tsx. The inset ring is polarity-scoped through the token:
+   the active item is the 2px accent marker — a shared left-edge indicator that
+   slides between items, rendered in SettingsDialog.tsx as a layoutId-projected
+   motion node (not a pseudo-element, which motion cannot animate). The inset
+   ring is polarity-scoped through the token:
    dark palettes set --settings-nav-active-shadow to a subtle ring; light
    palettes drop the value so it falls back to `none`, leaving the 2px marker
    as the sole accent cue (S1). Keeping the consumer wired preserves the dark


### PR DESCRIPTION
## Summary

- The settings dialog nav shows a 2px accent active indicator. It used to be created and destroyed per nav item (a Tailwind `before:` pseudo-element), so switching items made it teleport instantly instead of animating.
- Replaced it with a single shared framer-motion node: an `m.span` with a per-scope `layoutId` (`active-indicator-${scopeForTab(tab)}`) in `layout="position"` mode, inside a `LayoutGroup` named `settings-nav`. Selecting a tab now slides the same bar to its new position with a transform-only projection animation instead of unmounting and remounting it.
- Exported `NavItem` and `NavGroup` from `SettingsDialog.tsx` for testing, matching the module's existing pattern of exporting `useHoverIntentPrefetch` and `useSettingsScrollToSection` for the same reason.

Resolves #11164

## Changes

- `src/components/Settings/SettingsDialog.tsx`: shared `m.span` indicator with a scoped `layoutId`, `LayoutGroup`, and `NavItem`/`NavGroup` exports.
- `src/components/Settings/__tests__/SettingsDialogNav.test.tsx` (new): 7 tests covering the single-indicator invariant across multiple nav groups, a shared `layoutId` across a group boundary (proving the slide works across groups), separate `layoutId`s per settings scope, the indicator being suppressed while searching but `aria-selected` staying correct, `layout="position"` plus shared timing constants, and the animation duration collapsing to 0 in performance mode.
- `src/styles/components/settings.css`: comment-only fix. It previously documented the marker as a `before:` pseudo-element, which is no longer true.
- `eslint.config.js`: added `SettingsDialog.tsx` to the existing per-file framer-motion allowlist (`no-restricted-imports` normally bans importing it directly). Safe because `App.tsx` already imports framer-motion statically to mount `LazyMotion`, and `SettingsDialog` is itself lazy-loaded via `lazyPanels.ts`, so the eager bundle graph is unaffected.

Two design decisions worth calling out:

- Reduced motion needs no special handling. The app-level `<MotionConfig reducedMotion="user">` already snaps `layout`/`layoutId` transitions to instant.
- Performance mode does need explicit handling, and got it. It normally suppresses CSS transitions, but a projection animation writes transforms in JS every frame, so CSS alone can't reach it. Duration now comes from `getUiAnimationDuration()`, which zeroes out in performance mode, matching the approach in `DndProvider.tsx`.
- The `layoutId` is scoped per settings scope rather than shared globally, because search results aren't scope-restricted: a cross-scope search hit commits scope and tab together, and one shared `layoutId` would slide the marker between two unrelated nav trees.

## Testing

- Ran 9 covering test suites, 309 tests total, all passing, including the `accentGuard` and `focusRingFallback` contract guards.
- `eslint` and `prettier` clean on all 4 changed files (4 pre-existing lint warnings remain on untouched lines, already in the ratchet baseline).