### PR TITLE
fix(toolbar): ease forge stat pill hover tint and press snap

### DIFF
--- a/src/components/Layout/ForgeStatPill.tsx
+++ b/src/components/Layout/ForgeStatPill.tsx
@@ -71,7 +71,12 @@ export function ForgeStatPill({
             onPointerLeave={onPointerLeave}
             onClick={onClick}
             className={cn(
-              "h-full flex-1 justify-center gap-2 rounded-none px-2 text-daintree-text transition-opacity hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
+              // `scale` is in the set so the base cva's `active:scale-[0.98]
+              // active:duration-[1ms]` press snap has a transitioned property to
+              // act on — a bare `transition-opacity` here replaces the cva's
+              // `transition` outright under tailwind-merge, which left both the
+              // hover tint and the press scale uninterpolated.
+              "toolbar-stat-pill h-full flex-1 justify-center gap-2 rounded-none px-2 text-daintree-text transition-[opacity,background-color,scale] hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
               activityChip != null && "relative",
               className,
               open &&

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshness.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
+import { extractAtRuleBlocks, transitionPropertiesFor } from "./cssBlocks";
 
 /**
  * ForgeStatsToolbarButton — freshness tier wiring (issue #6536, updated #8849).
@@ -73,30 +74,53 @@ describe("ForgeStatsToolbarButton freshness wiring", () => {
     expect(source).toContain("animKey={commitAnimKey}");
   });
 
-  it("ForgeStatPill scopes the transition to opacity, background-color and scale (issue #11168)", async () => {
-    // A bare `transition-opacity` here replaced the base Button cva's
-    // `transition` outright under tailwind-merge (same conflict group), leaving
-    // the hover tint AND the cva's `active:scale-[0.98]` press snap with no
-    // transitioned property. `scale` must stay in the set for the press to read.
-    const pillSource = await fs.readFile(path.resolve(__dirname, "../ForgeStatPill.tsx"), "utf-8");
-    expect(pillSource).toContain("transition-[opacity,background-color,scale]");
-    expect(pillSource).not.toMatch(/\btransition-all\b/);
-  });
-
-  it("ForgeStatPill opts into the reduced-motion rule that drops its press-scale", async () => {
-    // The pill is a Radix tooltip trigger, so it always carries a data-state and
-    // the global reduced-motion button rule in index.css (which excludes
-    // data-state buttons) never reaches it. The opt-in is a two-file contract:
-    // the class on the pill, the @variant rule in toolbar.css. WCAG 2.3.3.
+  it("ForgeStatPill transitions its scale, and drops exactly that under reduced motion (#11168)", async () => {
+    // Two coupled halves, one invariant. The pill must transition `scale` — a
+    // bare `transition-opacity` sat in the same tailwind-merge conflict group as
+    // the base Button cva's `transition` and replaced it outright, leaving both
+    // the hover tint and the cva's `active:scale-[0.98]` press snap with no
+    // transitioned property. And because the pill is a Radix tooltip trigger it
+    // always carries a data-state, so index.css's global reduced-motion control
+    // rule (which excludes [data-state="closed"]) misses it at rest — toolbar.css
+    // must drop the scale interpolation itself. WCAG 2.3.3.
+    //
+    // Asserted as a RELATIONSHIP between the two files, not as literal class
+    // strings: reduced-motion transitions exactly the normal set minus `scale`.
+    // Renaming a property or the opt-in class keeps this green; deleting either
+    // half of the contract turns it red.
     const pillSource = await fs.readFile(path.resolve(__dirname, "../ForgeStatPill.tsx"), "utf-8");
     const toolbarCss = await fs.readFile(
       path.resolve(__dirname, "../../../styles/components/toolbar.css"),
       "utf-8"
     );
-    expect(pillSource).toContain("toolbar-stat-pill");
-    expect(toolbarCss).toMatch(
-      /@variant reduce-motion \{\s*\.toolbar-stat-pill \{\s*transition-property: opacity, background-color;/
+
+    const pillClasses = pillSource.match(/"(toolbar-stat-pill[^"]*)"/)?.[1].split(/\s+/);
+    expect(pillClasses).toBeDefined();
+    expect(pillClasses).not.toContain("transition-all");
+
+    const scoped = pillClasses!.find((token) => /^transition-\[[^\]]+\]$/.test(token));
+    expect(scoped, "pill must scope its transition to an explicit property set").toBeDefined();
+    const normal = new Set(
+      scoped!
+        .slice("transition-[".length, -1)
+        .split(",")
+        .map((property) => property.trim())
     );
+    expect(normal.has("scale"), "scale must be transitioned for the press snap to read").toBe(true);
+
+    // The reduced-motion override must live INSIDE a reduce-motion block and
+    // target a class the pill actually carries.
+    let optIn: Set<string> | null = null;
+    for (const block of extractAtRuleBlocks(toolbarCss, "@variant reduce-motion")) {
+      for (const token of pillClasses!) {
+        optIn = transitionPropertiesFor(block, token);
+        if (optIn) break;
+      }
+      if (optIn) break;
+    }
+    expect(optIn, "no reduce-motion rule targets any of the pill's classes").not.toBeNull();
+    expect(optIn!.has("scale"), "reduced motion must not interpolate the press scale").toBe(false);
+    expect(optIn).toEqual(new Set([...normal].filter((property) => property !== "scale")));
   });
 
   it("Stats pills use stable equal-width hit boxes for titlebar no-drag regions", async () => {

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshness.test.ts
@@ -94,8 +94,8 @@ describe("ForgeStatsToolbarButton freshness wiring", () => {
       "utf-8"
     );
 
-    const pillClasses = pillSource.match(/"(toolbar-stat-pill[^"]*)"/)?.[1].split(/\s+/);
-    expect(pillClasses).toBeDefined();
+    const pillClasses = pillSource.match(/"(toolbar-stat-pill[^"]*)"/)?.[1]?.split(/\s+/);
+    expect(pillClasses, "pill must carry the toolbar-stat-pill opt-in class").toBeDefined();
     expect(pillClasses).not.toContain("transition-all");
 
     const scoped = pillClasses!.find((token) => /^transition-\[[^\]]+\]$/.test(token));

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshness.test.ts
@@ -73,10 +73,30 @@ describe("ForgeStatsToolbarButton freshness wiring", () => {
     expect(source).toContain("animKey={commitAnimKey}");
   });
 
-  it("ForgeStatPill uses scoped transition-opacity, not transition-all", async () => {
+  it("ForgeStatPill scopes the transition to opacity, background-color and scale (issue #11168)", async () => {
+    // A bare `transition-opacity` here replaced the base Button cva's
+    // `transition` outright under tailwind-merge (same conflict group), leaving
+    // the hover tint AND the cva's `active:scale-[0.98]` press snap with no
+    // transitioned property. `scale` must stay in the set for the press to read.
     const pillSource = await fs.readFile(path.resolve(__dirname, "../ForgeStatPill.tsx"), "utf-8");
-    expect(pillSource).toContain("transition-opacity");
+    expect(pillSource).toContain("transition-[opacity,background-color,scale]");
     expect(pillSource).not.toMatch(/\btransition-all\b/);
+  });
+
+  it("ForgeStatPill opts into the reduced-motion rule that drops its press-scale", async () => {
+    // The pill is a Radix tooltip trigger, so it always carries a data-state and
+    // the global reduced-motion button rule in index.css (which excludes
+    // data-state buttons) never reaches it. The opt-in is a two-file contract:
+    // the class on the pill, the @variant rule in toolbar.css. WCAG 2.3.3.
+    const pillSource = await fs.readFile(path.resolve(__dirname, "../ForgeStatPill.tsx"), "utf-8");
+    const toolbarCss = await fs.readFile(
+      path.resolve(__dirname, "../../../styles/components/toolbar.css"),
+      "utf-8"
+    );
+    expect(pillSource).toContain("toolbar-stat-pill");
+    expect(toolbarCss).toMatch(
+      /@variant reduce-motion \{\s*\.toolbar-stat-pill \{\s*transition-property: opacity, background-color;/
+    );
   });
 
   it("Stats pills use stable equal-width hit boxes for titlebar no-drag regions", async () => {

--- a/src/components/Layout/__tests__/Toolbar.overflow.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.overflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
+import { extractAtRuleBlocks } from "./cssBlocks";
 
 const TOOLBAR_PATH = path.resolve(__dirname, "../Toolbar.tsx");
 const TOOLBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/toolbar.css");
@@ -166,9 +167,14 @@ describe("Toolbar overflow menu state preservation — issue #9821", () => {
     it("keeps a timed (not none) display swap under reduced motion — lesson #6182", () => {
       // Inside the @variant reduce-motion block the trigger must still toggle
       // display (display 0s, not transition: none) so the discrete swap lands.
-      expect(css).toMatch(
-        /@variant reduce-motion\s*\{[\s\S]*?\[data-toolbar-overflow-trigger\]\s*\{[\s\S]*?display\s+0s/
+      // Brace-walk the blocks rather than regexing across them: toolbar.css now
+      // has more than one reduce-motion block, and a lazy `[\s\S]*?` match would
+      // happily start in an earlier one and run out of it, proving nothing.
+      const trigger = extractAtRuleBlocks(css, "@variant reduce-motion").find((block) =>
+        block.includes("[data-toolbar-overflow-trigger]")
       );
+      expect(trigger, "no reduce-motion block styles the overflow trigger").toBeDefined();
+      expect(trigger).toMatch(/\[data-toolbar-overflow-trigger\]\s*\{[^{}]*display\s+0s/);
     });
   });
 });

--- a/src/components/Layout/__tests__/cssBlocks.ts
+++ b/src/components/Layout/__tests__/cssBlocks.ts
@@ -47,11 +47,12 @@ export function extractAtRuleBlocks(css: string, marker: string): string[] {
  */
 export function transitionPropertiesFor(css: string, selector: string): Set<string> | null {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const rule = new RegExp(`\\.${escaped}\\s*\\{([^{}]*)\\}`).exec(css);
-  if (!rule) return null;
+  const body = new RegExp(`\\.${escaped}\\s*\\{([^{}]*)\\}`).exec(css)?.[1];
+  if (body === undefined) return null;
 
-  const declarations = [...rule[1].matchAll(/\btransition-property\s*:\s*([^;}]+)/g)];
-  if (declarations.length !== 1) return null;
+  const declarations = [...body.matchAll(/\btransition-property\s*:\s*([^;}]+)/g)];
+  const value = declarations.length === 1 ? declarations[0]?.[1] : undefined;
+  if (value === undefined) return null;
 
-  return new Set(declarations[0][1].split(",").map((property) => property.trim()));
+  return new Set(value.split(",").map((property) => property.trim()));
 }

--- a/src/components/Layout/__tests__/cssBlocks.ts
+++ b/src/components/Layout/__tests__/cssBlocks.ts
@@ -1,0 +1,57 @@
+/**
+ * Brace-balanced extraction of at-rule bodies from CSS source.
+ *
+ * CSS rules that only exist inside an at-rule (`@variant reduce-motion`,
+ * `@media (forced-colors: active)`) are invisible to jsdom, so they are guarded
+ * by asserting on source. A lazy `/@variant reduce-motion[\s\S]*?\.foo/` regex
+ * does NOT prove containment — it happily scans out of one block and into a
+ * later one, so the assertion silently stops meaning anything as soon as a
+ * second block of the same kind is added above it. Walk the braces instead.
+ */
+export function extractAtRuleBlocks(css: string, marker: string): string[] {
+  const blocks: string[] = [];
+
+  let searchFrom = 0;
+  for (;;) {
+    const start = css.indexOf(marker, searchFrom);
+    if (start === -1) break;
+
+    const open = css.indexOf("{", start);
+    if (open === -1) break;
+
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < css.length; i++) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    blocks.push(css.slice(open, end + 1));
+    searchFrom = end + 1;
+  }
+
+  return blocks;
+}
+
+/**
+ * The declared `transition-property` values for `.selector` within `css`, as a
+ * set — or null when no such rule declares exactly one. Callers pass Tailwind
+ * class tokens, which carry regex metacharacters (`hover:bg-[var(--x)]`), so the
+ * selector is escaped rather than interpolated raw.
+ */
+export function transitionPropertiesFor(css: string, selector: string): Set<string> | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const rule = new RegExp(`\\.${escaped}\\s*\\{([^{}]*)\\}`).exec(css);
+  if (!rule) return null;
+
+  const declarations = [...rule[1].matchAll(/\btransition-property\s*:\s*([^;}]+)/g)];
+  if (declarations.length !== 1) return null;
+
+  return new Set(declarations[0][1].split(",").map((property) => property.trim()));
+}

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -204,13 +204,18 @@
 }
 
 /* The stat pills transition opacity, background-color and scale as Tailwind
- * utilities (ForgeStatPill.tsx) — scale carries the base Button cva's press
- * snap. Each pill is a Radix tooltip trigger, so it always has a data-state and
- * the global reduced-motion button rule in index.css — which excludes
- * data-state buttons — never reaches it. Drop the press-scale interpolation
- * here instead; the tint fades are not spatial motion and stay, matching the
- * reduce-motion block further down. The scale still applies on :active, it just
- * snaps rather than easing back. WCAG 2.3.3. */
+ * utilities (ForgeStatPill.tsx) — scale is what gives the base Button cva's
+ * `active:scale-[0.98]` press snap a property to interpolate.
+ *
+ * Each pill is a Radix tooltip trigger, so it always carries a data-state, and
+ * the global reduced-motion control rule in index.css only excludes
+ * [data-state="open"] and [data-state="closed"]. Radix emits "closed" at rest
+ * (and "delayed-open"/"instant-open" while the tooltip shows), so at rest the
+ * pill falls through that rule's exclusion and would keep easing its scale.
+ * Drop the scale interpolation here to cover it. The tint fades are not spatial
+ * motion, so they stay — matching the reduce-motion block further down. The
+ * scale still applies on :active; it just snaps instead of easing back.
+ * WCAG 2.3.3. */
 @variant reduce-motion {
   .toolbar-stat-pill {
     transition-property: opacity, background-color;

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -203,6 +203,20 @@
   box-shadow: var(--_shadow);
 }
 
+/* The stat pills transition opacity, background-color and scale as Tailwind
+ * utilities (ForgeStatPill.tsx) — scale carries the base Button cva's press
+ * snap. Each pill is a Radix tooltip trigger, so it always has a data-state and
+ * the global reduced-motion button rule in index.css — which excludes
+ * data-state buttons — never reaches it. Drop the press-scale interpolation
+ * here instead; the tint fades are not spatial motion and stay, matching the
+ * reduce-motion block further down. The scale still applies on :active, it just
+ * snaps rather than easing back. WCAG 2.3.3. */
+@variant reduce-motion {
+  .toolbar-stat-pill {
+    transition-property: opacity, background-color;
+  }
+}
+
 .toolbar-project-pill {
   --_bg: var(
     --toolbar-project-bg,


### PR DESCRIPTION
## Summary

- The forge stat pills only transitioned `opacity`, so the hover tint snapped instead of easing and clicking gave no press feedback at all.
- Root cause: `ForgeStatPill`'s className carried a bare `transition-opacity`, which sits in the same tailwind-merge conflict group as the base `Button` cva's `transition` (`button.tsx:9`). Since the consumer className merges last, it replaced the cva's transition instead of narrowing it, so the effective transition-property was `opacity` only.
- That one cause produced two symptoms: the hover/open-state background swap had nothing to animate, and the cva's `active:scale-[0.98] active:duration-[1ms]` press snap survived the merge but had no property to interpolate, so the scale flipped instantly both ways instead of the intended 1ms snap-in / 150ms ease-back-out.

Resolves #11168

## Changes

- `ForgeStatPill.tsx`: transition-property set is now `transition-[opacity,background-color,scale]`, matching existing precedent for scoped multi-property transitions elsewhere in the repo (`ScrollPill`, `PanelHeader`, `ContentDock`). `scale` is deliberately in there because Tailwind v4 compiles it to a discrete `scale` CSS property, not `transform`, confirmed against the compiled output, and it's what the cva's press snap needs to interpolate.
- `toolbar.css`: added a `@variant reduce-motion` rule for the pill. It's a Radix tooltip trigger, so it always carries a `data-state`, and the global reduced-motion rule in `index.css` only excludes `data-state="open"`/`"closed"`. Radix sets `closed` at rest, so without this the pill would keep easing its scale at rest under reduced motion. The tint fade stays since it isn't spatial motion (WCAG 2.3.3).
- `ForgeStatsToolbarButton.freshness.test.ts`: swapped a tautological literal-string assertion for a relational one: reduced motion transitions exactly the pill's normal property set minus `scale`. Verified it red-before-green by breaking each half of the contract independently.
- `Toolbar.overflow.test.ts` + new `cssBlocks.ts`: the old lazy regex for scanning the reduced-motion block would've started matching at the new rule and scanned past it without actually proving containment. Added a small brace-balanced block-extraction helper and switched the test to use it.

One thing left as-is, noted but out of scope: `index.css`'s global `transform: none !important` under reduced motion doesn't touch Tailwind v4's discrete `scale` property, so every `Button` in the app still snaps 2% under reduced motion. That's repo-wide and an instant state change with no interpolated frames isn't motion animation under WCAG, so leaving it alone here.

## Testing

- Full project `tsc --noEmit`: clean
- vitest on the Layout suite, ui suite, and the accent/focus-ring/forced-colors contract tests: 1858 passing
- eslint + prettier on all changed files: clean
- Mutation-verified the new contract test red-before-green