### PR TITLE
feat(theme): crossfade programmatic theme changes

### DIFF
--- a/src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.importFeedback.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/clients/appThemeClient", () => ({
 
 vi.mock("@/lib/appThemeViewTransition", () => ({
   runThemeReveal: (_origin: unknown, cb: () => void) => cb(),
+  runThemeCrossfade: (cb: () => void) => cb(),
 }));
 
 const storeState: Record<string, unknown> = {};

--- a/src/components/Settings/__tests__/AppThemePicker.persistence.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.persistence.test.tsx
@@ -53,6 +53,8 @@ vi.mock("@/clients/appThemeClient", () => ({
 
 vi.mock("@/lib/appThemeViewTransition", () => ({
   runThemeReveal: (_origin: unknown, cb: () => void) => cb(),
+  // The real store imports this — the mock must supply it or the import fails.
+  runThemeCrossfade: (cb: () => void) => cb(),
 }));
 
 // Stub the DOM-writing layer so the real store's setters still run end to end

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -473,8 +473,9 @@ export function AgentSetupWizard({
     const targetId = prefersLight ? "bondi" : "daintree";
     if (selectedSchemeId !== targetId) {
       // Auto-select mirrors OS appearance — not a direct user pick, so use the
-      // silent setter to avoid polluting the recently-used list.
-      setSelectedSchemeIdSilent(targetId);
+      // silent setter to avoid polluting the recently-used list. The wizard has
+      // already painted, so crossfade the swap instead of cutting it.
+      setSelectedSchemeIdSilent(targetId, { crossfade: true });
       appThemeClient
         .setColorScheme(targetId)
         .catch((err) => logError("Failed to set color scheme", err));

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -48,12 +48,19 @@ vi.mock("@/store/cliAvailabilityStore", () => ({
     selector({ isLoading: false, isRefreshing: false, availability: {}, hasRealData: true }),
 }));
 
+// Hoisted so the auto-select assertion can reach the spy. Inline `vi.fn()`s inside
+// the selector would also hand the component a fresh action identity every render.
+const themeStoreMock = vi.hoisted(() => ({
+  setSelectedSchemeId: vi.fn(),
+  setSelectedSchemeIdSilent: vi.fn(),
+}));
+
 vi.mock("@/store/appThemeStore", () => ({
   useAppThemeStore: (selector: (s: unknown) => unknown) =>
     selector({
       selectedSchemeId: "daintree",
-      setSelectedSchemeId: vi.fn(),
-      setSelectedSchemeIdSilent: vi.fn(),
+      setSelectedSchemeId: themeStoreMock.setSelectedSchemeId,
+      setSelectedSchemeIdSilent: themeStoreMock.setSelectedSchemeIdSilent,
     }),
 }));
 
@@ -424,5 +431,50 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     expect(notifyMock).not.toHaveBeenCalled();
     // Wizard still closes — failure should not strand the user.
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("AgentSetupWizard first-run theme auto-select", () => {
+  beforeEach(() => {
+    themeStoreMock.setSelectedSchemeIdSilent.mockClear();
+  });
+
+  function setOsPrefersLight(prefersLight: boolean) {
+    window.matchMedia = ((query: string) => ({
+      matches: prefersLight && query.includes("prefers-color-scheme: light"),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      media: query,
+      onchange: null,
+    })) as unknown as typeof window.matchMedia;
+  }
+
+  it("crossfades into the OS-preferred theme", async () => {
+    // Store is mocked on "daintree" (dark); a light OS makes "bondi" the target.
+    setOsPrefersLight(true);
+
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={vi.fn()} isFirstRun initialAvailability={{}} />);
+    });
+
+    // The wizard has already painted, so the swap fades rather than cutting — but it
+    // stays silent, since mirroring the OS is not a user pick.
+    expect(themeStoreMock.setSelectedSchemeIdSilent).toHaveBeenCalledWith("bondi", {
+      crossfade: true,
+    });
+  });
+
+  it("does not re-apply a theme that already matches the OS", async () => {
+    // Dark OS + a store already on "daintree" — nothing to change, so nothing to fade.
+    setOsPrefersLight(false);
+
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={vi.fn()} isFirstRun initialAvailability={{}} />);
+    });
+
+    expect(themeStoreMock.setSelectedSchemeIdSilent).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -440,16 +440,20 @@ describe("AgentSetupWizard first-run theme auto-select", () => {
   });
 
   function setOsPrefersLight(prefersLight: boolean) {
-    window.matchMedia = ((query: string) => ({
-      matches: prefersLight && query.includes("prefers-color-scheme: light"),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-      media: query,
-      onchange: null,
-    })) as unknown as typeof window.matchMedia;
+    // Object.assign, not a cast — `as unknown as typeof window.matchMedia` trips the
+    // no-unsafe-type-assertion lint ratchet.
+    Object.assign(window, {
+      matchMedia: (query: string) => ({
+        matches: prefersLight && query.includes("prefers-color-scheme: light"),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        media: query,
+        onchange: null,
+      }),
+    });
   }
 
   it("crossfades into the OS-preferred theme", async () => {

--- a/src/hooks/__tests__/useAppThemeConfig.test.tsx
+++ b/src/hooks/__tests__/useAppThemeConfig.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { AppThemeConfig } from "@shared/types/appTheme";
+
+const setSelectedSchemeIdSilent = vi.fn();
+const storeActions = {
+  setSelectedSchemeIdSilent,
+  addCustomScheme: vi.fn(),
+  setColorVisionMode: vi.fn(),
+  setFollowSystem: vi.fn(),
+  setPreferredDarkSchemeId: vi.fn(),
+  setPreferredLightSchemeId: vi.fn(),
+  setRecentSchemeIds: vi.fn(),
+};
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: Object.assign((selector: (s: unknown) => unknown) => selector(storeActions), {
+    setState: vi.fn(),
+  }),
+}));
+
+const bootPromise = vi.fn();
+vi.mock("@/lib/bootPromise", () => ({
+  getSafeBootPromise: () => bootPromise(),
+}));
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: { get: vi.fn(() => new Promise(() => {})) },
+}));
+
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+import { useAppThemeConfig } from "../useAppThemeConfig";
+
+/** Captures the listener the hook registers, so tests can fire an OS appearance change. */
+let appearanceListener: ((payload: { schemeId: string }) => void) | null = null;
+const unsubscribe = vi.fn();
+
+function bootWith(appTheme: Partial<AppThemeConfig>) {
+  bootPromise.mockReturnValue(Promise.resolve({ ok: true, result: { appTheme } }));
+}
+
+describe("useAppThemeConfig", () => {
+  beforeEach(() => {
+    // Cleared here, not in afterEach: Testing Library's auto-cleanup unmounts the
+    // previous test's hook after our afterEach runs, re-calling `unsubscribe`.
+    vi.clearAllMocks();
+
+    appearanceListener = null;
+    (window as unknown as { electron: unknown }).electron = {
+      appTheme: {
+        onSystemAppearanceChanged: (cb: (payload: { schemeId: string }) => void) => {
+          appearanceListener = cb;
+          return unsubscribe;
+        },
+      },
+    };
+    // Never resolves by default — keeps hydration from racing the IPC assertions.
+    bootPromise.mockReturnValue(new Promise(() => {}));
+  });
+
+  it("hydrates the persisted scheme without a transition", async () => {
+    bootWith({ colorSchemeId: "bondi" });
+
+    renderHook(() => useAppThemeConfig());
+
+    await waitFor(() => expect(setSelectedSchemeIdSilent).toHaveBeenCalled());
+    // Startup has no prior theme to fade from — only the placeholder default, so
+    // hydration must stay an instant swap rather than animating that placeholder out.
+    expect(setSelectedSchemeIdSilent).toHaveBeenCalledWith("bondi");
+  });
+
+  it("crossfades an OS appearance change", async () => {
+    renderHook(() => useAppThemeConfig());
+
+    expect(appearanceListener).not.toBeNull();
+    appearanceListener!({ schemeId: "daintree" });
+
+    expect(setSelectedSchemeIdSilent).toHaveBeenCalledWith("daintree", { crossfade: true });
+  });
+
+  it("unsubscribes from the appearance listener on unmount", () => {
+    const { unmount } = renderHook(() => useAppThemeConfig());
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/useAppThemeConfig.test.tsx
+++ b/src/hooks/__tests__/useAppThemeConfig.test.tsx
@@ -48,14 +48,18 @@ describe("useAppThemeConfig", () => {
     vi.clearAllMocks();
 
     appearanceListener = null;
-    (window as unknown as { electron: unknown }).electron = {
-      appTheme: {
-        onSystemAppearanceChanged: (cb: (payload: { schemeId: string }) => void) => {
-          appearanceListener = cb;
-          return unsubscribe;
+    // Object.assign, not a cast — `window as unknown as {...}` trips the
+    // no-unsafe-type-assertion lint ratchet.
+    Object.assign(window, {
+      electron: {
+        appTheme: {
+          onSystemAppearanceChanged: (cb: (payload: { schemeId: string }) => void) => {
+            appearanceListener = cb;
+            return unsubscribe;
+          },
         },
       },
-    };
+    });
     // Never resolves by default — keeps hydration from racing the IPC assertions.
     bootPromise.mockReturnValue(new Promise(() => {}));
   });

--- a/src/hooks/useAppThemeConfig.ts
+++ b/src/hooks/useAppThemeConfig.ts
@@ -102,8 +102,10 @@ export function useAppThemeConfig() {
 
   useEffect(() => {
     return window.electron.appTheme.onSystemAppearanceChanged(({ schemeId }) => {
-      // OS-driven follow-system changes must not populate the recently-used list
-      setSelectedSchemeIdSilent(schemeId);
+      // OS-driven follow-system changes must not populate the recently-used list.
+      // The app has already painted the outgoing theme, so crossfade rather than
+      // cut — but without the directional wipe, which signals a deliberate pick.
+      setSelectedSchemeIdSilent(schemeId, { crossfade: true });
     });
   }, [setSelectedSchemeIdSilent]);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2889,9 +2889,12 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   }
 }
 
-/* Horizontal wipe for app theme switches.
-   The old snapshot sits on top and is clipped away via WAAPI clip-path:inset(),
-   revealing the new snapshot underneath. */
+/* App theme switches drive the root snapshots from WAAPI, not CSS: `animation: none`
+   kills the UA's default crossfade so `src/lib/appThemeViewTransition.ts` can animate
+   the old snapshot itself — clipped away for a deliberate pick (runThemeReveal), faded
+   out for a programmatic one (runThemeCrossfade). Either way the old snapshot sits on
+   top and the new one is revealed underneath, so a bare startViewTransition() on the
+   document root animates nothing. */
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation: none;

--- a/src/lib/__tests__/appThemeViewTransition.test.ts
+++ b/src/lib/__tests__/appThemeViewTransition.test.ts
@@ -300,12 +300,28 @@ describe("appThemeViewTransition", () => {
       expect(mutate).toHaveBeenCalledTimes(1);
     });
 
-    it("does not animate before the ready promise settles", () => {
-      const { animateSpy } = installViewTransitionMock();
+    it("waits for the ready promise before animating", async () => {
+      let markReady: (() => void) | null = null;
+      const animateSpy = vi.fn();
+      document.documentElement.animate =
+        animateSpy as unknown as typeof document.documentElement.animate;
+      (document as unknown as { startViewTransition: unknown }).startViewTransition = vi.fn(() => ({
+        ready: new Promise<void>((resolve) => {
+          markReady = resolve;
+        }),
+        finished: Promise.resolve(),
+      }));
 
       runThemeCrossfade(() => {});
+      await Promise.resolve();
 
+      // The pseudo-element tree doesn't exist until `ready` — animating early targets nothing.
       expect(animateSpy).not.toHaveBeenCalled();
+
+      markReady!();
+      await Promise.resolve();
+
+      expect(animateSpy).toHaveBeenCalledTimes(1);
     });
 
     it("fades the old root snapshot out rather than wiping it", async () => {
@@ -325,20 +341,20 @@ describe("appThemeViewTransition", () => {
         easing: "ease-out",
         fill: "forwards",
       });
+      // An ambient change should read as briefer than a deliberate pick's wipe.
+      expect(options.duration).toBeLessThan(THEME_WIPE_DURATION);
     });
 
-    it("leaves the new root snapshot untouched (its opacity is the crossfade)", async () => {
+    it("animates the old root snapshot only (its opacity IS the crossfade)", async () => {
       const { animateSpy } = installViewTransitionMock();
 
       runThemeCrossfade(() => {});
       await Promise.resolve();
 
+      // Fading the new snapshot in as well would double-composite the two and dip the
+      // midpoint brightness — the new one is already opaque underneath at z-index 1.
       const targets = animateSpy.mock.calls.map(([, options]) => options.pseudoElement);
-      expect(targets).not.toContain("::view-transition-new(root)");
-    });
-
-    it("is briefer than the deliberate-pick wipe", () => {
-      expect(UI_ENTER_DURATION).toBeLessThan(THEME_WIPE_DURATION);
+      expect(targets).toEqual(["::view-transition-old(root)"]);
     });
 
     it("skips an in-flight ViewTransition before starting a new one", () => {
@@ -374,12 +390,17 @@ describe("appThemeViewTransition", () => {
     it("swallows ready-promise rejections without throwing", async () => {
       const rejected = Promise.reject(new Error("aborted"));
       rejected.catch(() => {});
-      (document as unknown as { startViewTransition: unknown }).startViewTransition = vi.fn(() => ({
+      const startSpy = vi.fn(() => ({
         ready: rejected,
         finished: Promise.resolve(),
       }));
+      (document as unknown as { startViewTransition: unknown }).startViewTransition = startSpy;
+      const mutate = vi.fn();
 
-      expect(() => runThemeCrossfade(() => {})).not.toThrow();
+      // A superseding transition rejects `ready`; the mutation is already committed, so
+      // the abort must stay silent rather than surfacing an unhandled rejection.
+      expect(() => runThemeCrossfade(mutate)).not.toThrow();
+      expect(startSpy).toHaveBeenCalledTimes(1);
       await rejected.catch(() => {});
     });
   });

--- a/src/lib/__tests__/appThemeViewTransition.test.ts
+++ b/src/lib/__tests__/appThemeViewTransition.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runThemeReveal, prefersReducedMotion } from "../appThemeViewTransition";
+import {
+  runThemeReveal,
+  runThemeCrossfade,
+  prefersReducedMotion,
+  THEME_WIPE_DURATION,
+} from "../appThemeViewTransition";
+import { UI_ENTER_DURATION } from "../animationUtils";
 
 interface MockTransition {
   ready: Promise<void>;
@@ -239,6 +245,142 @@ describe("appThemeViewTransition", () => {
 
       expect(startSpy).not.toHaveBeenCalled();
       expect(skipTransition).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("runThemeCrossfade", () => {
+    it("calls mutate synchronously when startViewTransition is unavailable", () => {
+      const mutate = vi.fn();
+      runThemeCrossfade(mutate);
+      expect(mutate).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the transition when prefers-reduced-motion is set", () => {
+      const { startSpy } = installViewTransitionMock();
+      setReducedMotion(true);
+      const mutate = vi.fn();
+
+      runThemeCrossfade(mutate);
+
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips the transition when performance mode is enabled", () => {
+      const { startSpy } = installViewTransitionMock();
+      document.body.dataset.performanceMode = "true";
+      const mutate = vi.fn();
+
+      runThemeCrossfade(mutate);
+
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips the transition when the document is hidden", () => {
+      const { startSpy } = installViewTransitionMock();
+      setVisibility("hidden");
+      const mutate = vi.fn();
+
+      runThemeCrossfade(mutate);
+
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    it("defers mutate to the transition's update callback when guards pass", () => {
+      const { startSpy, capturedMutate } = installViewTransitionMock();
+      const mutate = vi.fn();
+
+      runThemeCrossfade(mutate);
+
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(mutate).not.toHaveBeenCalled();
+      capturedMutate()?.();
+      expect(mutate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not animate before the ready promise settles", () => {
+      const { animateSpy } = installViewTransitionMock();
+
+      runThemeCrossfade(() => {});
+
+      expect(animateSpy).not.toHaveBeenCalled();
+    });
+
+    it("fades the old root snapshot out rather than wiping it", async () => {
+      const { animateSpy } = installViewTransitionMock();
+
+      runThemeCrossfade(() => {});
+      await Promise.resolve();
+
+      expect(animateSpy).toHaveBeenCalledTimes(1);
+      const [keyframes, options] = animateSpy.mock.calls[0]!;
+      // Opacity only — a clip-path here would encode a direction the programmatic
+      // path has no gesture origin for.
+      expect(keyframes).toEqual({ opacity: [1, 0] });
+      expect(options).toMatchObject({
+        pseudoElement: "::view-transition-old(root)",
+        duration: UI_ENTER_DURATION,
+        easing: "ease-out",
+        fill: "forwards",
+      });
+    });
+
+    it("leaves the new root snapshot untouched (its opacity is the crossfade)", async () => {
+      const { animateSpy } = installViewTransitionMock();
+
+      runThemeCrossfade(() => {});
+      await Promise.resolve();
+
+      const targets = animateSpy.mock.calls.map(([, options]) => options.pseudoElement);
+      expect(targets).not.toContain("::view-transition-new(root)");
+    });
+
+    it("is briefer than the deliberate-pick wipe", () => {
+      expect(UI_ENTER_DURATION).toBeLessThan(THEME_WIPE_DURATION);
+    });
+
+    it("skips an in-flight ViewTransition before starting a new one", () => {
+      const skipTransition = vi.fn();
+      (
+        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
+      ).activeViewTransition = { skipTransition };
+      const { startSpy } = installViewTransitionMock();
+
+      runThemeCrossfade(() => {});
+
+      expect(skipTransition).toHaveBeenCalledTimes(1);
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      const skipOrder = skipTransition.mock.invocationCallOrder[0]!;
+      const startOrder = startSpy.mock.invocationCallOrder[0]!;
+      expect(skipOrder).toBeLessThan(startOrder);
+    });
+
+    it("does not call skipTransition when a guard skips the transition", () => {
+      const skipTransition = vi.fn();
+      (
+        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
+      ).activeViewTransition = { skipTransition };
+      const { startSpy } = installViewTransitionMock();
+      setReducedMotion(true);
+
+      runThemeCrossfade(() => {});
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(skipTransition).not.toHaveBeenCalled();
+    });
+
+    it("swallows ready-promise rejections without throwing", async () => {
+      const rejected = Promise.reject(new Error("aborted"));
+      rejected.catch(() => {});
+      (document as unknown as { startViewTransition: unknown }).startViewTransition = vi.fn(() => ({
+        ready: rejected,
+        finished: Promise.resolve(),
+      }));
+
+      expect(() => runThemeCrossfade(() => {})).not.toThrow();
+      await rejected.catch(() => {});
     });
   });
 });

--- a/src/lib/__tests__/appThemeViewTransition.test.ts
+++ b/src/lib/__tests__/appThemeViewTransition.test.ts
@@ -35,6 +35,17 @@ function installViewTransitionMock(): {
   return { startSpy, animateSpy, capturedMutate: () => captured };
 }
 
+type FakeTransition = { ready: Promise<void>; finished: Promise<void> };
+
+/** Cast-free stubs — `document as unknown as {...}` trips the no-unsafe-type-assertion ratchet. */
+function stubStartViewTransition(start: (callback: () => void) => FakeTransition) {
+  Object.assign(document, { startViewTransition: start });
+}
+
+function stubActiveViewTransition(skipTransition: () => void) {
+  Object.assign(document, { activeViewTransition: { skipTransition } });
+}
+
 function setReducedMotion(reduced: boolean) {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -302,10 +313,8 @@ describe("appThemeViewTransition", () => {
 
     it("waits for the ready promise before animating", async () => {
       let markReady: (() => void) | null = null;
-      const animateSpy = vi.fn();
-      document.documentElement.animate =
-        animateSpy as unknown as typeof document.documentElement.animate;
-      (document as unknown as { startViewTransition: unknown }).startViewTransition = vi.fn(() => ({
+      const { animateSpy } = installViewTransitionMock();
+      stubStartViewTransition(() => ({
         ready: new Promise<void>((resolve) => {
           markReady = resolve;
         }),
@@ -359,9 +368,7 @@ describe("appThemeViewTransition", () => {
 
     it("skips an in-flight ViewTransition before starting a new one", () => {
       const skipTransition = vi.fn();
-      (
-        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
-      ).activeViewTransition = { skipTransition };
+      stubActiveViewTransition(skipTransition);
       const { startSpy } = installViewTransitionMock();
 
       runThemeCrossfade(() => {});
@@ -375,9 +382,7 @@ describe("appThemeViewTransition", () => {
 
     it("does not call skipTransition when a guard skips the transition", () => {
       const skipTransition = vi.fn();
-      (
-        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
-      ).activeViewTransition = { skipTransition };
+      stubActiveViewTransition(skipTransition);
       const { startSpy } = installViewTransitionMock();
       setReducedMotion(true);
 
@@ -394,7 +399,7 @@ describe("appThemeViewTransition", () => {
         ready: rejected,
         finished: Promise.resolve(),
       }));
-      (document as unknown as { startViewTransition: unknown }).startViewTransition = startSpy;
+      stubStartViewTransition(startSpy);
       const mutate = vi.fn();
 
       // A superseding transition rejects `ready`; the mutation is already committed, so

--- a/src/lib/appThemeViewTransition.ts
+++ b/src/lib/appThemeViewTransition.ts
@@ -1,3 +1,5 @@
+import { UI_ENTER_DURATION } from "./animationUtils";
+
 // The 400ms wipe IS the theme-reveal signal — it encodes the origin/direction of the switch via clip-path animation (semantic exception).
 export const THEME_WIPE_DURATION = 400;
 
@@ -9,6 +11,10 @@ type ViewTransitionDocument = Document & {
   };
 };
 
+type TransitionCapableDocument = ViewTransitionDocument & {
+  startViewTransition: NonNullable<ViewTransitionDocument["startViewTransition"]>;
+};
+
 export function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return true;
   return (
@@ -18,23 +24,37 @@ export function prefersReducedMotion(): boolean {
   );
 }
 
-export function runThemeReveal(origin: { x: number; y: number } | null, mutate: () => void): void {
-  const doc = typeof document !== "undefined" ? (document as ViewTransitionDocument) : null;
+function canRunThemeTransition(
+  doc: ViewTransitionDocument | null
+): doc is TransitionCapableDocument {
+  return (
+    doc !== null &&
+    !prefersReducedMotion() &&
+    typeof doc.startViewTransition === "function" &&
+    doc.visibilityState === "visible"
+  );
+}
 
-  if (
-    !doc ||
-    prefersReducedMotion() ||
-    typeof doc.startViewTransition !== "function" ||
-    doc.visibilityState !== "visible"
-  ) {
+function themeTransitionDocument(): ViewTransitionDocument | null {
+  return typeof document !== "undefined" ? (document as ViewTransitionDocument) : null;
+}
+
+function startThemeTransition(doc: TransitionCapableDocument, mutate: () => void) {
+  doc.activeViewTransition?.skipTransition();
+  return doc.startViewTransition(mutate);
+}
+
+export function runThemeReveal(origin: { x: number; y: number } | null, mutate: () => void): void {
+  const doc = themeTransitionDocument();
+
+  if (!canRunThemeTransition(doc)) {
     mutate();
     return;
   }
 
   const wipeFromLeft = (origin?.x ?? 0) < window.innerWidth / 2;
 
-  doc.activeViewTransition?.skipTransition();
-  const transition = doc.startViewTransition(mutate);
+  const transition = startThemeTransition(doc, mutate);
 
   transition.ready
     .then(() => {
@@ -54,5 +74,42 @@ export function runThemeReveal(origin: { x: number; y: number } | null, mutate: 
     })
     .catch(() => {
       /* transition aborted (e.g. rapid reclick) — mutation already applied */
+    });
+}
+
+/**
+ * Crossfade a programmatic theme change (OS appearance switch, first-run auto-select)
+ * instead of hard-cutting every token in one frame. Deliberately NOT the directional
+ * wipe — that encodes a user gesture's origin, which these paths don't have.
+ *
+ * The root pseudo-elements carry `animation: none` (src/index.css) so the wipe can drive
+ * its own clip-path, which also kills the UA's default crossfade — hence the manual WAAPI
+ * fade here. Fading the old snapshot alone is enough: it sits at z-index 2 over an opaque
+ * new snapshot, so its opacity IS the crossfade.
+ */
+export function runThemeCrossfade(mutate: () => void): void {
+  const doc = themeTransitionDocument();
+
+  if (!canRunThemeTransition(doc)) {
+    mutate();
+    return;
+  }
+
+  const transition = startThemeTransition(doc, mutate);
+
+  transition.ready
+    .then(() => {
+      document.documentElement.animate(
+        { opacity: [1, 0] },
+        {
+          duration: UI_ENTER_DURATION,
+          easing: "ease-out",
+          pseudoElement: "::view-transition-old(root)",
+          fill: "forwards",
+        }
+      );
+    })
+    .catch(() => {
+      /* transition aborted (e.g. a newer theme change superseded it) — mutation already applied */
     });
 }

--- a/src/lib/viewTransition.ts
+++ b/src/lib/viewTransition.ts
@@ -9,7 +9,13 @@
 // their xterm canvases) aren't snapshotted; omit it for a document-level
 // transition. To morph a specific element between its before/after positions,
 // assign a matching `view-transition-name` to it in both states (the caller
-// owns naming); with no names the captured root simply crossfades.
+// owns naming); with no names a scoped root simply crossfades.
+//
+// Caveat for the DOCUMENT root: `src/index.css` sets `animation: none` on
+// `::view-transition-old/new(root)` so the theme transitions can drive their own
+// WAAPI animations, which also disables the UA's default crossfade. An unscoped
+// call therefore hard-cuts unless the caller animates the root pseudo-element
+// itself — see `runThemeCrossfade` in `./appThemeViewTransition`.
 import { prefersReducedMotion } from "./appThemeViewTransition";
 
 type ViewTransition = { ready: Promise<void>; finished: Promise<void> };

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BUILT_IN_APP_SCHEMES, DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
 import { flushPendingTheme, injectSchemeToDOM, useAppThemeStore } from "../appThemeStore";
 
@@ -240,5 +240,100 @@ describe("injectSchemeToDOM RAF coalescing", () => {
     // Second flush should not change anything
     flushPendingTheme();
     expect(document.documentElement.style.getPropertyValue("--theme-surface-canvas")).toBe(before);
+  });
+});
+
+describe("setSelectedSchemeIdSilent crossfade option", () => {
+  const daintree = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
+  const bondi = BUILT_IN_APP_SCHEMES.find((s) => s.id === "bondi")!;
+
+  beforeEach(() => {
+    flushPendingTheme();
+    // jsdom ships no matchMedia, and prefersReducedMotion() treats its absence as
+    // "reduce" — without this the crossfade would always take the fallback path.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    document.body.dataset.reduceAnimations = "false";
+    document.body.dataset.performanceMode = "false";
+
+    useAppThemeStore.setState({
+      selectedSchemeId: DEFAULT_APP_SCHEME_ID,
+      customSchemes: [],
+      colorVisionMode: "default",
+      followSystem: false,
+      accentColorOverride: null,
+      recentSchemeIds: [],
+    });
+    injectSchemeToDOM(daintree, { immediate: true });
+  });
+
+  afterEach(() => {
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    delete document.body.dataset.reduceAnimations;
+    delete document.body.dataset.performanceMode;
+    flushPendingTheme();
+    vi.restoreAllMocks();
+  });
+
+  const canvasToken = () =>
+    document.documentElement.style.getPropertyValue("--theme-surface-canvas");
+
+  it("defers the DOM write to the next frame when crossfade is not requested", () => {
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi");
+
+    // State is synchronous, the DOM write is RAF-coalesced — hydration keeps this path.
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe("bondi");
+    expect(canvasToken()).toBe(daintree.tokens["surface-canvas"]);
+
+    flushPendingTheme();
+    expect(canvasToken()).toBe(bondi.tokens["surface-canvas"]);
+  });
+
+  it("writes the DOM synchronously when crossfade falls back (no View Transition API)", () => {
+    // jsdom exposes no startViewTransition, so the crossfade guard degrades to a
+    // direct mutate — which must still apply immediately, not land a frame later.
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
+
+    expect(canvasToken()).toBe(bondi.tokens["surface-canvas"]);
+  });
+
+  it("routes the DOM write through the transition callback and applies it without a flush", () => {
+    let captured: (() => void) | null = null;
+    (
+      document as unknown as { startViewTransition: (cb: () => void) => unknown }
+    ).startViewTransition = (cb: () => void) => {
+      captured = cb;
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    };
+
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
+
+    // The mutation belongs to the transition — it must not have run yet.
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe("bondi");
+    expect(canvasToken()).toBe(daintree.tokens["surface-canvas"]);
+
+    captured!();
+
+    // Applied synchronously inside the callback ({ immediate: true }); a RAF-coalesced
+    // write here would be snapshotted by the API before it landed.
+    expect(canvasToken()).toBe(bondi.tokens["surface-canvas"]);
+    flushPendingTheme();
+    expect(canvasToken()).toBe(bondi.tokens["surface-canvas"]);
+  });
+
+  it("does not record the crossfaded scheme in recentSchemeIds", () => {
+    useAppThemeStore.getState().setSelectedSchemeId("svalbard");
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
+
+    // Crossfading is still a silent path — OS-driven changes are not user picks.
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["svalbard"]);
   });
 });

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -336,4 +336,74 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
     // Crossfading is still a silent path — OS-driven changes are not user picks.
     expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["svalbard"]);
   });
+
+  it("does not start a transition when the scheme is already selected", () => {
+    const startViewTransition = vi.fn(() => ({
+      ready: Promise.resolve(),
+      finished: Promise.resolve(),
+    }));
+    (document as unknown as { startViewTransition: unknown }).startViewTransition =
+      startViewTransition;
+
+    // Desync the DOM from state (state is daintree) so a skipped injection is visible —
+    // otherwise the DOM already holds the expected tokens and the test proves nothing.
+    injectSchemeToDOM(bondi, { immediate: true });
+
+    // The OS can re-announce the appearance it already reported. Fading between two
+    // identical snapshots would be pointless — and would abort any in-flight transition.
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("daintree", { crossfade: true });
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    // Still reconciles, via the plain coalesced path rather than a transition.
+    expect(canvasToken()).toBe(bondi.tokens["surface-canvas"]);
+    flushPendingTheme();
+    expect(canvasToken()).toBe(daintree.tokens["surface-canvas"]);
+  });
+
+  it("drops a crossfade superseded by a hover preview", () => {
+    let captured: (() => void) | null = null;
+    (
+      document as unknown as { startViewTransition: (cb: () => void) => unknown }
+    ).startViewTransition = (cb: () => void) => {
+      captured = cb;
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    };
+
+    const svalbard = BUILT_IN_APP_SCHEMES.find((s) => s.id === "svalbard")!;
+
+    // An OS change starts a crossfade, then the user hovers a theme card to preview it.
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
+    useAppThemeStore.getState().injectTheme(svalbard);
+
+    captured!();
+
+    // A preview never moves selectedSchemeId, so an identity check on it would miss this —
+    // the stale fade would cancel the preview's RAF and repaint bondi over it.
+    flushPendingTheme();
+    expect(canvasToken()).toBe(svalbard.tokens["surface-canvas"]);
+  });
+
+  it("drops a superseded crossfade rather than clobbering the newer scheme", () => {
+    let captured: (() => void) | null = null;
+    (
+      document as unknown as { startViewTransition: (cb: () => void) => unknown }
+    ).startViewTransition = (cb: () => void) => {
+      captured = cb;
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    };
+
+    // An OS appearance change starts a crossfade to bondi...
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
+    // ...but the user deliberately picks svalbard before the transition callback runs.
+    useAppThemeStore.getState().setSelectedSchemeId("svalbard");
+
+    captured!();
+
+    // The stale callback must bail entirely: its `immediate` write would otherwise
+    // cancel svalbard's pending RAF and leave the DOM on bondi while state says svalbard.
+    const svalbard = BUILT_IN_APP_SCHEMES.find((s) => s.id === "svalbard")!;
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe("svalbard");
+    flushPendingTheme();
+    expect(canvasToken()).toBe(svalbard.tokens["surface-canvas"]);
+  });
 });

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -247,6 +247,26 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
   const daintree = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
   const bondi = BUILT_IN_APP_SCHEMES.find((s) => s.id === "bondi")!;
 
+  type FakeTransition = { ready: Promise<void>; finished: Promise<void> };
+
+  /** Cast-free — `document as unknown as {...}` trips the no-unsafe-type-assertion ratchet. */
+  function stubStartViewTransition(start: (callback: () => void) => FakeTransition) {
+    Object.assign(document, { startViewTransition: start });
+  }
+
+  /** Stubs the API and hands back the update callback the store deferred to it. */
+  function captureTransitionCallback(): () => () => void {
+    let captured: (() => void) | null = null;
+    stubStartViewTransition((callback) => {
+      captured = callback;
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    });
+    return () => {
+      if (!captured) throw new Error("startViewTransition was never called");
+      return captured;
+    };
+  }
+
   beforeEach(() => {
     flushPendingTheme();
     // jsdom ships no matchMedia, and prefersReducedMotion() treats its absence as
@@ -276,7 +296,7 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
   });
 
   afterEach(() => {
-    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    Reflect.deleteProperty(document, "startViewTransition");
     delete document.body.dataset.reduceAnimations;
     delete document.body.dataset.performanceMode;
     flushPendingTheme();
@@ -306,13 +326,7 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
   });
 
   it("routes the DOM write through the transition callback and applies it without a flush", () => {
-    let captured: (() => void) | null = null;
-    (
-      document as unknown as { startViewTransition: (cb: () => void) => unknown }
-    ).startViewTransition = (cb: () => void) => {
-      captured = cb;
-      return { ready: Promise.resolve(), finished: Promise.resolve() };
-    };
+    const transitionCallback = captureTransitionCallback();
 
     useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
 
@@ -320,7 +334,7 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
     expect(useAppThemeStore.getState().selectedSchemeId).toBe("bondi");
     expect(canvasToken()).toBe(daintree.tokens["surface-canvas"]);
 
-    captured!();
+    transitionCallback()();
 
     // Applied synchronously inside the callback ({ immediate: true }); a RAF-coalesced
     // write here would be snapshotted by the API before it landed.
@@ -342,8 +356,7 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
       ready: Promise.resolve(),
       finished: Promise.resolve(),
     }));
-    (document as unknown as { startViewTransition: unknown }).startViewTransition =
-      startViewTransition;
+    stubStartViewTransition(startViewTransition);
 
     // Desync the DOM from state (state is daintree) so a skipped injection is visible —
     // otherwise the DOM already holds the expected tokens and the test proves nothing.
@@ -361,21 +374,14 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
   });
 
   it("drops a crossfade superseded by a hover preview", () => {
-    let captured: (() => void) | null = null;
-    (
-      document as unknown as { startViewTransition: (cb: () => void) => unknown }
-    ).startViewTransition = (cb: () => void) => {
-      captured = cb;
-      return { ready: Promise.resolve(), finished: Promise.resolve() };
-    };
-
+    const transitionCallback = captureTransitionCallback();
     const svalbard = BUILT_IN_APP_SCHEMES.find((s) => s.id === "svalbard")!;
 
     // An OS change starts a crossfade, then the user hovers a theme card to preview it.
     useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
     useAppThemeStore.getState().injectTheme(svalbard);
 
-    captured!();
+    transitionCallback()();
 
     // A preview never moves selectedSchemeId, so an identity check on it would miss this —
     // the stale fade would cancel the preview's RAF and repaint bondi over it.
@@ -384,20 +390,14 @@ describe("setSelectedSchemeIdSilent crossfade option", () => {
   });
 
   it("drops a superseded crossfade rather than clobbering the newer scheme", () => {
-    let captured: (() => void) | null = null;
-    (
-      document as unknown as { startViewTransition: (cb: () => void) => unknown }
-    ).startViewTransition = (cb: () => void) => {
-      captured = cb;
-      return { ready: Promise.resolve(), finished: Promise.resolve() };
-    };
+    const transitionCallback = captureTransitionCallback();
 
     // An OS appearance change starts a crossfade to bondi...
     useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi", { crossfade: true });
     // ...but the user deliberately picks svalbard before the transition callback runs.
     useAppThemeStore.getState().setSelectedSchemeId("svalbard");
 
-    captured!();
+    transitionCallback()();
 
     // The stale callback must bail entirely: its `immediate` write would otherwise
     // cancel svalbard's pending RAF and leave the DOM on bondi while state says svalbard.

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -51,6 +51,18 @@ interface AppThemeState {
 let pendingScheme: AppColorScheme | null = null;
 let pendingFrame: number | null = null;
 
+// Monotonic "latest theme intent". A crossfade's DOM write is deferred to a View
+// Transition callback a frame later, by which time a newer write (deliberate pick,
+// hover preview, accent change) may have superseded it. Claiming an intent up front
+// lets that stale callback recognise it lost and bail — critical because its
+// `{ immediate: true }` write would otherwise CANCEL the newer write's pending RAF
+// and strand the DOM out of sync with the store.
+let themeIntentSeq = 0;
+
+function claimThemeIntent(): number {
+  return ++themeIntentSeq;
+}
+
 function applySchemeToDOMNow(scheme: AppColorScheme): void {
   const { colorVisionMode, accentColorOverride } = useAppThemeStore.getState();
   const effective = applyAccentOverrideToScheme(scheme, accentColorOverride);
@@ -67,6 +79,9 @@ function applySchemeToDOMNow(scheme: AppColorScheme): void {
  * mutate callback or during unmount cleanup where synchronous DOM is required.
  */
 function injectSchemeToDOM(scheme: AppColorScheme, opts?: { immediate?: boolean }): void {
+  // Every direct write is itself the latest intent, superseding any deferred one.
+  claimThemeIntent();
+
   if (opts?.immediate) {
     if (pendingFrame !== null) {
       cancelAnimationFrame(pendingFrame);
@@ -138,13 +153,23 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   },
 
   setSelectedSchemeIdSilent: (id, opts) => {
-    const { customSchemes } = useAppThemeStore.getState();
+    const { customSchemes, selectedSchemeId: previousSchemeId } = useAppThemeStore.getState();
     const scheme = resolveAppTheme(id, customSchemes);
     set({ selectedSchemeId: scheme.id });
-    if (opts?.crossfade) {
-      // `immediate` is required inside a transition callback — the RAF-coalesced
-      // write would land after the API has already snapshotted the new state.
-      runThemeCrossfade(() => injectSchemeToDOM(scheme, { immediate: true }));
+
+    // Only transition on a real change. `nativeTheme` can re-fire for OS changes that
+    // don't move the light/dark bucket, and crossfading there would skipTransition() an
+    // in-flight wipe to animate between two identical snapshots.
+    if (opts?.crossfade && previousSchemeId !== scheme.id) {
+      // Claimed before the transition starts, so anything scheduled after this — including
+      // a second crossfade — outranks it regardless of which callback the browser runs first.
+      const intent = claimThemeIntent();
+      runThemeCrossfade(() => {
+        if (intent !== themeIntentSeq) return;
+        // `immediate` is required inside a transition callback: the RAF-coalesced write
+        // would land after the API has already snapshotted the new state.
+        injectSchemeToDOM(scheme, { immediate: true });
+      });
     } else {
       injectSchemeToDOM(scheme);
     }

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -3,6 +3,7 @@ import { BUILT_IN_APP_SCHEMES, DEFAULT_APP_SCHEME_ID } from "@/config/appColorSc
 import { applyAccentOverrideToScheme, resolveAppTheme, type AppColorScheme } from "@shared/theme";
 import type { ColorVisionMode } from "@shared/types";
 import { applyAppThemeToRoot, applyColorVisionMode } from "@/theme/applyAppTheme";
+import { runThemeCrossfade } from "@/lib/appThemeViewTransition";
 
 const RECENT_SCHEMES_LIMIT = 5;
 
@@ -29,8 +30,13 @@ interface AppThemeState {
    * Like setSelectedSchemeId, but does NOT update recentSchemeIds. Used for
    * OS-driven follow-system changes and startup hydration, where the change
    * does not reflect direct user intent.
+   *
+   * Pass `{ crossfade: true }` when the app has already painted the outgoing
+   * theme (OS appearance switch, first-run auto-select) so the swap fades
+   * rather than cutting. Startup hydration leaves it unset on purpose — there
+   * is no prior theme to fade from, only the placeholder default.
    */
-  setSelectedSchemeIdSilent: (id: string) => void;
+  setSelectedSchemeIdSilent: (id: string, opts?: { crossfade?: boolean }) => void;
   addCustomScheme: (scheme: AppColorScheme) => void;
   removeCustomScheme: (id: string) => void;
   injectTheme: (scheme: AppColorScheme) => void;
@@ -131,11 +137,17 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     }));
   },
 
-  setSelectedSchemeIdSilent: (id) => {
+  setSelectedSchemeIdSilent: (id, opts) => {
     const { customSchemes } = useAppThemeStore.getState();
     const scheme = resolveAppTheme(id, customSchemes);
     set({ selectedSchemeId: scheme.id });
-    injectSchemeToDOM(scheme);
+    if (opts?.crossfade) {
+      // `immediate` is required inside a transition callback — the RAF-coalesced
+      // write would land after the API has already snapshotted the new state.
+      runThemeCrossfade(() => injectSchemeToDOM(scheme, { immediate: true }));
+    } else {
+      injectSchemeToDOM(scheme);
+    }
   },
 
   addCustomScheme: (scheme) =>


### PR DESCRIPTION
## Summary
- Programmatic theme changes (OS dark mode at sunset, the first-run wizard's silent auto-select) swapped every CSS custom property in a single frame; deliberate picks already get a 400ms directional wipe via `runThemeReveal`.
- Adds a 200ms opacity crossfade at the standard entry-tier duration (`UI_ENTER_DURATION`) to those programmatic paths.
- Deliberately doesn't reuse the directional wipe: the wipe signals a deliberate action and has a gesture origin (click position) that programmatic changes don't have.

Resolves #11170

## Implementation notes

1. Can't reuse `withViewTransition()`. `src/index.css` sets `animation: none` on `::view-transition-old(root)` and `::view-transition-new(root)` so the wipe's clip-path can run uncontested, which also kills the browser's default crossfade. A bare `startViewTransition()` at the document root would animate nothing and hard-cut. Instead the crossfade drives its own Web Animations API animation directly on `::view-transition-old(root)`, mirroring the pattern `runThemeReveal` and `removeStartupSkeleton` already use. Fading only the old snapshot is enough: it sits above the new snapshot at a higher z-index, so its opacity is the crossfade. Animating both would double-composite and dip brightness at the midpoint.

2. Boot and config hydration stay instant on purpose. There's no prior theme to fade from at first paint, only a placeholder default, and animating that out would just flash.

3. Concurrency: the crossfade's DOM write is deferred to a transition callback that runs a frame later, and `injectSchemeToDOM`'s immediate mode cancels any pending `requestAnimationFrame` write. A stale callback wouldn't just paint an old scheme, it would destroy a newer scheme's write and strand the DOM out of sync with the store. Fixed with a monotonic theme-intent counter: claimed before a transition starts, bumped by every direct write, so a superseded crossfade can detect it's stale and bail instead of clobbering the newer write. Checking `selectedSchemeId` identity alone wasn't enough, since hover previews over theme options never move it.

Also: an unchanged scheme (light stays light, dark stays dark) skips the transition entirely, since the OS listener can re-fire without moving between light and dark buckets, and crossfading there would needlessly cancel an in-flight wipe to fade between two identical snapshots. Reduced motion, the reduce-animations setting, performance mode, and a hidden document all still fall back to a synchronous swap, reusing guards now shared between the wipe and the crossfade.

## Changes
- `src/lib/appThemeViewTransition.ts`, `src/store/appThemeStore.ts`, `src/hooks/useAppThemeConfig.ts`, `src/components/Setup/AgentSetupWizard.tsx`
- `src/index.css` and `src/lib/viewTransition.ts` (comments only)
- Six test files, including a new `src/hooks/__tests__/useAppThemeConfig.test.tsx`

## Testing
- 87 targeted tests pass: `appThemeViewTransition`, `appThemeStore`, `useAppThemeConfig`, `AgentSetupWizardSilentDefault`, `AppThemePicker.persistence`, `AppThemePicker.importFeedback`
- Full `npm run typecheck` clean
- ESLint: zero errors, `no-unsafe-type-assertion` held at its ratchet baseline
- Prettier clean