### PR TITLE
fix(notifications): add scroll shadows to the inbox list

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -330,7 +330,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           setShowJumpPill(entry.boundingClientRect.top > rootBounds.bottom);
         }
       },
-      { root: scrollContainer, threshold: 0 }
+      // Pull the bottom edge in by the height of the scroll fade (h-8 in
+      // ScrollShadow): a divider still under the gradient is washed out, so it
+      // doesn't count as reached and the pill stays up.
+      { root: scrollContainer, rootMargin: "0px 0px -32px 0px", threshold: 0 }
     );
     observer.observe(dividerEl);
     return () => observer.disconnect();

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -19,6 +19,7 @@ import { NotificationCenterEntry } from "./NotificationCenterEntry";
 import { useSnoozeExpiryTimer } from "./useSnoozeExpiryTimer";
 import { resolveSnoozeDuration, type SnoozeDurationOption } from "@shared/utils/snoozeTimestamps";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -216,7 +217,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const [filter, setFilter] = useState<"all" | "unread" | "archived" | "snoozed">("all");
   const [snoozePendingIndex, setSnoozePendingIndex] = useState<number | null>(null);
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
-  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [dividerEl, setDividerEl] = useState<HTMLDivElement | null>(null);
   const [showJumpPill, setShowJumpPill] = useState(false);
   const prevShowJumpPillRef = useRef(false);
@@ -306,6 +307,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   }, [open, isSessionMuted, quietUntil, quietHoursEnabled]);
 
   useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer || !dividerEl || typeof IntersectionObserver === "undefined") {
       setShowJumpPill(false);
       return;
@@ -332,7 +334,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     );
     observer.observe(dividerEl);
     return () => observer.disconnect();
-  }, [scrollContainer, dividerEl]);
+  }, [dividerEl]);
 
   useEffect(() => {
     if (showJumpPill && !prevShowJumpPillRef.current) {
@@ -1027,111 +1029,115 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         </div>
       )}
       <div className="relative flex-1 min-h-0">
-        <div
-          ref={setScrollContainer}
+        <ScrollShadow
+          ref={scrollContainerRef}
           onKeyDown={handleListKeyDown}
           role={rowCount > 0 ? "list" : undefined}
           aria-label={rowCount > 0 ? "Notifications" : undefined}
-          className="h-full overflow-y-auto"
+          className="h-full"
         >
-          {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
-            filter === "snoozed" && entries.length > 0 ? (
-              <EmptyState
-                variant="user-cleared"
-                scale="sidebar"
-                title="Nothing snoozed"
-                icon={<Clock />}
-                className="py-10"
-              />
-            ) : filter === "archived" && entries.length > 0 ? (
-              <EmptyState
-                variant="user-cleared"
-                scale="sidebar"
-                title="No archived notifications"
-                icon={<Archive />}
-                className="py-10"
-              />
-            ) : filter === "unread" && entries.length > 0 ? (
-              <EmptyState
-                variant="user-cleared"
-                scale="sidebar"
-                title="You're all caught up"
-                icon={<Bell />}
-                className="py-10"
-              />
-            ) : isSessionMuted || isScheduledMuted ? (
-              // OS DND alone does not trigger the "Notifications paused" copy
-              // — in-app toasts still fire, so naming them "paused" would be
-              // misleading. The pill above still surfaces the OS state.
-              <div data-testid="notification-muted-empty-state">
+          {/* One stable child: the shadow hook observes firstElementChild, so it
+              must outlive the empty-state/section swaps below. */}
+          <div>
+            {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
+              filter === "snoozed" && entries.length > 0 ? (
                 <EmptyState
-                  variant="zero-data"
-                  scale="canvas"
-                  title="Notifications paused"
-                  icon={<Moon />}
-                  description={mutedEmptyDescription}
+                  variant="user-cleared"
+                  scale="sidebar"
+                  title="Nothing snoozed"
+                  icon={<Clock />}
                   className="py-10"
                 />
-              </div>
+              ) : filter === "archived" && entries.length > 0 ? (
+                <EmptyState
+                  variant="user-cleared"
+                  scale="sidebar"
+                  title="No archived notifications"
+                  icon={<Archive />}
+                  className="py-10"
+                />
+              ) : filter === "unread" && entries.length > 0 ? (
+                <EmptyState
+                  variant="user-cleared"
+                  scale="sidebar"
+                  title="You're all caught up"
+                  icon={<Bell />}
+                  className="py-10"
+                />
+              ) : isSessionMuted || isScheduledMuted ? (
+                // OS DND alone does not trigger the "Notifications paused" copy
+                // — in-app toasts still fire, so naming them "paused" would be
+                // misleading. The pill above still surfaces the OS state.
+                <div data-testid="notification-muted-empty-state">
+                  <EmptyState
+                    variant="zero-data"
+                    scale="canvas"
+                    title="Notifications paused"
+                    icon={<Moon />}
+                    description={mutedEmptyDescription}
+                    className="py-10"
+                  />
+                </div>
+              ) : (
+                <EmptyState
+                  variant="zero-data"
+                  scale="popover"
+                  title="No notifications yet"
+                  icon={<Bell />}
+                  className="py-10"
+                />
+              )
             ) : (
-              <EmptyState
-                variant="zero-data"
-                scale="popover"
-                title="No notifications yet"
-                icon={<Bell />}
-                className="py-10"
-              />
-            )
-          ) : (
-            <>
-              {needsAttentionGroups.length > 0 && (
-                <NeedsAttentionSection
-                  groups={needsAttentionGroups}
-                  overflowCount={needsAttentionOverflow}
-                  indexOffset={0}
-                  focusedIndex={focusedIndex}
-                  setRowRef={setRowRef}
-                  onRowFocus={setFocusedIndex}
-                  onDropdownOpenChange={handleDropdownOpenChange}
-                  onDismiss={dismissEntry}
-                  onDismissThread={dismissByCorrelationId}
-                  snoozePendingIndex={snoozePendingIndex}
-                  snoozedThreads={snoozedThreads}
-                  snoozeRenderTime={snoozeRenderTime}
-                  onConsumeSnoozePending={consumeSnoozePending}
-                  onSnoozeRow={handleSnoozeForRow}
-                  onUnsnoozeRow={handleUnsnoozeForRow}
-                />
-              )}
-              {chronoSections.map((section, sectionIdx) => (
-                <ChronoSection
-                  key={section.key}
-                  section={section}
-                  indexOffset={
-                    needsAttentionGroups.length + (chronoSectionOffsets[sectionIdx] ?? 0)
-                  }
-                  focusedIndex={focusedIndex}
-                  setRowRef={setRowRef}
-                  onRowFocus={setFocusedIndex}
-                  onDropdownOpenChange={handleDropdownOpenChange}
-                  groupByContext={groupByContext}
-                  dividerGroupId={dividerGroupId}
-                  dividerRef={setDividerEl}
-                  lastClosedAt={lastClosedAt}
-                  onDismiss={dismissEntry}
-                  onDismissThread={dismissByCorrelationId}
-                  onMarkIdsRead={markIdsReadWithUndo}
-                  snoozePendingIndex={snoozePendingIndex}
-                  snoozedThreads={snoozedThreads}
-                  snoozeRenderTime={snoozeRenderTime}
-                  onConsumeSnoozePending={consumeSnoozePending}
-                  onSnoozeRow={handleSnoozeForRow}
-                  onUnsnoozeRow={handleUnsnoozeForRow}
-                />
-              ))}
-            </>
-          )}
-        </div>
+              <>
+                {needsAttentionGroups.length > 0 && (
+                  <NeedsAttentionSection
+                    groups={needsAttentionGroups}
+                    overflowCount={needsAttentionOverflow}
+                    indexOffset={0}
+                    focusedIndex={focusedIndex}
+                    setRowRef={setRowRef}
+                    onRowFocus={setFocusedIndex}
+                    onDropdownOpenChange={handleDropdownOpenChange}
+                    onDismiss={dismissEntry}
+                    onDismissThread={dismissByCorrelationId}
+                    snoozePendingIndex={snoozePendingIndex}
+                    snoozedThreads={snoozedThreads}
+                    snoozeRenderTime={snoozeRenderTime}
+                    onConsumeSnoozePending={consumeSnoozePending}
+                    onSnoozeRow={handleSnoozeForRow}
+                    onUnsnoozeRow={handleUnsnoozeForRow}
+                  />
+                )}
+                {chronoSections.map((section, sectionIdx) => (
+                  <ChronoSection
+                    key={section.key}
+                    section={section}
+                    indexOffset={
+                      needsAttentionGroups.length + (chronoSectionOffsets[sectionIdx] ?? 0)
+                    }
+                    focusedIndex={focusedIndex}
+                    setRowRef={setRowRef}
+                    onRowFocus={setFocusedIndex}
+                    onDropdownOpenChange={handleDropdownOpenChange}
+                    groupByContext={groupByContext}
+                    dividerGroupId={dividerGroupId}
+                    dividerRef={setDividerEl}
+                    lastClosedAt={lastClosedAt}
+                    onDismiss={dismissEntry}
+                    onDismissThread={dismissByCorrelationId}
+                    onMarkIdsRead={markIdsReadWithUndo}
+                    snoozePendingIndex={snoozePendingIndex}
+                    snoozedThreads={snoozedThreads}
+                    snoozeRenderTime={snoozeRenderTime}
+                    onConsumeSnoozePending={consumeSnoozePending}
+                    onSnoozeRow={handleSnoozeForRow}
+                    onUnsnoozeRow={handleUnsnoozeForRow}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        </ScrollShadow>
         {dividerGroupId !== null && (
           <button
             type="button"

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1035,6 +1035,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           role={rowCount > 0 ? "list" : undefined}
           aria-label={rowCount > 0 ? "Notifications" : undefined}
           className="h-full"
+          // The fades occlude the first and last 32px of the scrollport, so keep
+          // scroll-into-view targets (the jump-to-new divider, keyboard-focused
+          // rows) clear of them.
+          scrollClassName="scroll-py-8"
         >
           {/* One stable child: the shadow hook observes firstElementChild, so it
               must outlive the empty-state/section swaps below. */}

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -2658,6 +2658,22 @@ describe("NotificationCenter — scroll shadows", () => {
     expect(readCues(scroller)).toEqual([false, true]);
   });
 
+  it("cues content pushed past the fold when the list viewport shrinks", () => {
+    setEntries([makeEntry({ message: "One" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    expect(readCues(scroller)).toEqual([false, false]);
+
+    // The content never changed — the popover got shorter, so only a resize of
+    // the scrollport itself reveals that the same list now overflows.
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 300, clientHeight: 100 });
+    resizeContent(scroller);
+    flushFrames();
+
+    expect(readCues(scroller)).toEqual([false, true]);
+  });
+
   it("clears the cues when the content shrinks back to fit", () => {
     setEntries([makeEntry({ message: "One" }), makeEntry({ message: "Two" })]);
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -41,6 +41,18 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
     selector(worktreeStoreMock),
 }));
 
+// The inbox list renders ScrollShadow, which constructs a ResizeObserver; jsdom has none.
+let resizeCallbacks: ResizeObserverCallback[] = [];
+class MockResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallbacks.push(callback);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
 let entryCounter = 0;
 
 function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
@@ -65,6 +77,7 @@ function setEntries(entries: NotificationHistoryEntry[]) {
 }
 
 beforeEach(() => {
+  resizeCallbacks = [];
   useNotificationHistoryStore.getState().clearAll();
   useNotificationSettingsStore.setState({
     enabled: true,
@@ -1839,6 +1852,10 @@ describe("NotificationCenter — Jump to new pill", () => {
     const scrollDiv = container.querySelector(".overflow-y-auto");
     expect(scrollDiv).not.toBeNull();
     expect(root).toBe(scrollDiv);
+
+    // The pill anchors to the list's viewport, so it must sit outside the
+    // scrolling element rather than travel with the content.
+    expect(scrollDiv!.contains(screen.getByTestId("jump-to-new-pill"))).toBe(false);
   });
 
   it("disconnects the observer on unmount", () => {
@@ -2527,5 +2544,130 @@ describe("archived tab and 'e' archive keybinding", () => {
     expect(vi.mocked(notifyLib.notify)).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Marked 1 as read" })
     );
+  });
+});
+
+describe("NotificationCenter — scroll shadows", () => {
+  let rafSpy: MockInstance | undefined;
+  let cafSpy: MockInstance | undefined;
+  const frames: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    frames.length = 0;
+    rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => frames.push(cb));
+    cafSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rafSpy?.mockRestore();
+    cafSpy?.mockRestore();
+  });
+
+  function flushFrames() {
+    act(() => {
+      for (const cb of frames.splice(0)) cb(0);
+    });
+  }
+
+  // jsdom never lays anything out, so the scroll geometry has to be dictated.
+  function setScrollMetrics(
+    el: HTMLElement,
+    metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }
+  ) {
+    for (const [key, value] of Object.entries(metrics)) {
+      Object.defineProperty(el, key, { value, configurable: true });
+    }
+  }
+
+  // The two overlays are the scroller's siblings, in [top, bottom] document order.
+  function readCues(scroller: Element): boolean[] {
+    return Array.from(scroller.parentElement!.querySelectorAll(":scope > [data-visible]")).map(
+      (el) => el.getAttribute("data-visible") === "true"
+    );
+  }
+
+  it("cues the content hidden above and below the fold as the list scrolls", () => {
+    setEntries([makeEntry({ message: "One" }), makeEntry({ message: "Two" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    expect(scroller).not.toBeNull();
+
+    // Parked at the top of an overflowing list: only the content below is hidden.
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 500, clientHeight: 200 });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    flushFrames();
+    expect(readCues(scroller)).toEqual([false, true]);
+
+    // Mid-list: content is hidden in both directions.
+    setScrollMetrics(scroller, { scrollTop: 150, scrollHeight: 500, clientHeight: 200 });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    flushFrames();
+    expect(readCues(scroller)).toEqual([true, true]);
+
+    // Scrolled to the end: only the content above is hidden.
+    setScrollMetrics(scroller, { scrollTop: 300, scrollHeight: 500, clientHeight: 200 });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    flushFrames();
+    expect(readCues(scroller)).toEqual([true, false]);
+  });
+
+  it("shows no cues when the list fits", () => {
+    setEntries([makeEntry({ message: "Only one" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 120, clientHeight: 200 });
+    act(() => {
+      fireEvent.scroll(scroller);
+    });
+    flushFrames();
+
+    expect(readCues(scroller)).toEqual([false, false]);
+  });
+
+  it("keeps one resize target across content swaps", () => {
+    setEntries([makeEntry({ message: "One" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const scroller = () => container.querySelector(".overflow-y-auto")!;
+    const target = scroller().firstElementChild;
+    expect(target).not.toBeNull();
+
+    // Switching to a filter with no rows swaps the list body for an empty state.
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.getByText("No archived notifications")).toBeTruthy();
+
+    // The shadow hook observes firstElementChild once, at mount — if the swap
+    // replaced that node, its ResizeObserver would be left watching a detached
+    // element and the cues would freeze.
+    expect(scroller().firstElementChild).toBe(target);
+  });
+
+  it("recomputes the cues when the observed content resizes", () => {
+    setEntries([makeEntry({ message: "One" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    expect(readCues(scroller)).toEqual([false, false]);
+
+    // Content grew past the fold without any scrolling — only the ResizeObserver
+    // can notice.
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 500, clientHeight: 200 });
+    expect(resizeCallbacks.length).toBeGreaterThan(0);
+    act(() => {
+      for (const cb of resizeCallbacks) cb([], {} as ResizeObserver);
+    });
+    flushFrames();
+
+    expect(readCues(scroller)).toEqual([false, true]);
   });
 });

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -41,15 +41,25 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
     selector(worktreeStoreMock),
 }));
 
-// The inbox list renders ScrollShadow, which constructs a ResizeObserver; jsdom has none.
-let resizeCallbacks: ResizeObserverCallback[] = [];
+// The inbox list renders ScrollShadow, which constructs a ResizeObserver; jsdom
+// has none. Targets are tracked so a test can only fire a resize for an element
+// the hook actually observes — a real observer left watching a detached node
+// stays silent, and that is the failure the stable list wrapper guards against.
+let resizeObservers: MockResizeObserver[] = [];
 class MockResizeObserver implements ResizeObserver {
-  constructor(callback: ResizeObserverCallback) {
-    resizeCallbacks.push(callback);
+  readonly targets = new Set<Element>();
+  constructor(readonly callback: ResizeObserverCallback) {
+    resizeObservers.push(this);
   }
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  observe(target: Element) {
+    this.targets.add(target);
+  }
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
+  disconnect() {
+    this.targets.clear();
+  }
 }
 vi.stubGlobal("ResizeObserver", MockResizeObserver);
 
@@ -77,7 +87,7 @@ function setEntries(entries: NotificationHistoryEntry[]) {
 }
 
 beforeEach(() => {
-  resizeCallbacks = [];
+  resizeObservers = [];
   useNotificationHistoryStore.getState().clearAll();
   useNotificationSettingsStore.setState({
     enabled: true,
@@ -2588,6 +2598,17 @@ describe("NotificationCenter — scroll shadows", () => {
     );
   }
 
+  // Resize `target` the way a browser would: only observers actually watching a
+  // still-connected `target` hear about it.
+  function resizeContent(target: Element) {
+    act(() => {
+      for (const observer of resizeObservers) {
+        if (!observer.targets.has(target) || !target.isConnected) continue;
+        observer.callback([], observer);
+      }
+    });
+  }
+
   it("cues the content hidden above and below the fold as the list scrolls", () => {
     setEntries([makeEntry({ message: "One" }), makeEntry({ message: "Two" })]);
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
@@ -2620,52 +2641,62 @@ describe("NotificationCenter — scroll shadows", () => {
     expect(readCues(scroller)).toEqual([true, false]);
   });
 
-  it("shows no cues when the list fits", () => {
-    setEntries([makeEntry({ message: "Only one" })]);
+  it("cues content that grows past the fold without any scrolling", () => {
+    setEntries([makeEntry({ message: "One" })]);
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
 
     const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
-    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 120, clientHeight: 200 });
+    const listBody = scroller.firstElementChild!;
+    expect(readCues(scroller)).toEqual([false, false]);
+
+    // Nobody scrolled — only the ResizeObserver watching the list body can
+    // notice that the content now overflows.
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 500, clientHeight: 200 });
+    resizeContent(listBody);
+    flushFrames();
+
+    expect(readCues(scroller)).toEqual([false, true]);
+  });
+
+  it("clears the cues when the content shrinks back to fit", () => {
+    setEntries([makeEntry({ message: "One" }), makeEntry({ message: "Two" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    const listBody = scroller.firstElementChild!;
+
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 500, clientHeight: 200 });
     act(() => {
       fireEvent.scroll(scroller);
     });
+    flushFrames();
+    expect(readCues(scroller)).toEqual([false, true]);
+
+    setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 120, clientHeight: 200 });
+    resizeContent(listBody);
     flushFrames();
 
     expect(readCues(scroller)).toEqual([false, false]);
   });
 
-  it("keeps one resize target across content swaps", () => {
-    setEntries([makeEntry({ message: "One" })]);
-    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
-
-    const scroller = () => container.querySelector(".overflow-y-auto")!;
-    const target = scroller().firstElementChild;
-    expect(target).not.toBeNull();
-
-    // Switching to a filter with no rows swaps the list body for an empty state.
-    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
-    expect(screen.getByText("No archived notifications")).toBeTruthy();
-
-    // The shadow hook observes firstElementChild once, at mount — if the swap
-    // replaced that node, its ResizeObserver would be left watching a detached
-    // element and the cues would freeze.
-    expect(scroller().firstElementChild).toBe(target);
-  });
-
-  it("recomputes the cues when the observed content resizes", () => {
+  it("keeps observing the list body across content swaps", () => {
     setEntries([makeEntry({ message: "One" })]);
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
 
     const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
-    expect(readCues(scroller)).toEqual([false, false]);
+    const listBody = scroller.firstElementChild!;
 
-    // Content grew past the fold without any scrolling — only the ResizeObserver
-    // can notice.
+    // Switching to a filter with no rows swaps the list body's contents.
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.getByText("No archived notifications")).toBeTruthy();
+
+    // The hook observes firstElementChild once, at mount. If that node were the
+    // swapped-out section rather than a stable wrapper, its observer would now
+    // be watching a detached element and the cues would never update again.
+    expect(scroller.firstElementChild).toBe(listBody);
+
     setScrollMetrics(scroller, { scrollTop: 0, scrollHeight: 500, clientHeight: 200 });
-    expect(resizeCallbacks.length).toBeGreaterThan(0);
-    act(() => {
-      for (const cb of resizeCallbacks) cb([], {} as ResizeObserver);
-    });
+    resizeContent(listBody);
     flushFrames();
 
     expect(readCues(scroller)).toEqual([false, true]);


### PR DESCRIPTION
## Summary

- The notification inbox list was a bare `overflow-y-auto` div with no indication that content continued above or below the fold.
- Adopted the existing `ScrollShadow` primitive (`src/components/ui/ScrollShadow.tsx`) instead of building a bespoke solution.
- Two files changed: `src/components/Notifications/NotificationCenter.tsx` and its test file.

Resolves #11167

## Implementation notes

**Kept the existing wrapper.** The `relative flex-1 min-h-0` wrapper stays around the scroller because it's the positioning context for the absolutely-positioned "jump to new" pill. That pill has to stay a sibling of the scroller, not a child, or it would scroll away with the content.

**No new CSS variable wiring.** The inbox renders inside `FixedDropdown`, whose portaled box already carries the `surface-overlay` class, and `index.css` already sets `--scroll-shadow-color` there per theme (the comment at `index.css:2743` literally names `NotificationCenter`). The gradient inherits the right color in every theme for free.

**`useRef` instead of `useState` for the scroll container.** It's only ever read by the jump-pill `IntersectionObserver`, never during render. Passing a state setter as `ScrollShadow`'s forwarded ref would have re-fired on every commit, since the primitive rebuilds its merged ref callback each render.

**Stable wrapper div around the list body.** `useVerticalScrollShadows` captures `el.firstElementChild` once and only observes that child. Previously the first child was whichever branch rendered (empty state, needs-attention, or the chrono section), so switching filters would leave the `ResizeObserver` watching a detached node and the shadows would silently freeze.

**`scroll-py-8` on the scroller.** The fades occlude the first and last 32px of the scrollport, and the jump pill scrolls the unread divider to `block: "start"`, landing it directly under the top gradient. The scroll padding keeps scroll-into-view targets (that divider, keyboard-focused rows) clear of the fades.

**Pulled in the divider observer's bottom edge** by the fade height (`rootMargin: "0px 0px -32px 0px"`), so the pill holds until the divider is actually legible instead of hiding the moment it touches the washed-out bottom edge.

## Testing

Added 4 new tests: cues as the list scrolls, content growing past the fold, the scrollport shrinking, content shrinking back to fit, and the observer target surviving a filter swap.

Mutation-checked rather than trusted green: removing `observe(firstChild)` fails 3 of them, removing `observe(el)` fails 1, and deleting the stable wrapper div fails 1.

Locally: `npm run typecheck` clean, 244 tests passing across `NotificationCenter`, `NotificationCenterEntry`, `NotificationCenterToolbarButton`, `ScrollShadow`, and the focus-ring contract test, eslint and prettier clean on both changed files.

## Note for review

The `scroll-py-8` fix isn't unit-testable: jsdom computes no layout geometry, and asserting the class name would be a tautological test (banned by the repo's testing rules). It's only verifiable in a real browser.

The same scroll-padding gap likely affects the other `ScrollShadow` listbox consumers (`AutocompleteMenu`, `ExistingBranchPicker`, `RecipePickerPopover`). Deliberately left out of scope here rather than changing behavior at eleven call sites in a PR scoped to the inbox.
