### PR TITLE
feat(launcher): add entry stagger and press feedback

### DIFF
--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -30,8 +30,14 @@ const PATH_TRUNCATE_LENGTH = 52;
 // which is what honours Daintree's own reduce-animations toggle — a `body`
 // attribute no Tailwind variant can reach from here. Performance mode is
 // already killed globally.
+//
+// The duration rides `--tw-animation-duration` rather than `duration-200`, for
+// the same reason the ladder below avoids `delay-*`: `duration-200` also emits
+// `transition-duration`, and with no `transition-property` on these wrappers
+// that lands on CSS's `all` default — an every-property transition nobody asked
+// for. Setting the animation's own slot keeps the transition set empty.
 const SECTION_ENTRY =
-  "launcher-section-enter motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200";
+  "launcher-section-enter motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:[--tw-animation-duration:200ms]";
 
 // The stagger ladder. Sequencing IS the signal here, so the per-step delay is a
 // literal ladder rather than one of the shared duration tiers.

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -31,13 +31,14 @@ const PATH_TRUNCATE_LENGTH = 52;
 // attribute no Tailwind variant can reach from here. Performance mode is
 // already killed globally.
 //
-// The duration rides `--tw-animation-duration` rather than `duration-200`, for
-// the same reason the ladder below avoids `delay-*`: `duration-200` also emits
-// `transition-duration`, and with no `transition-property` on these wrappers
-// that lands on CSS's `all` default — an every-property transition nobody asked
-// for. Setting the animation's own slot keeps the transition set empty.
+// The duration is the shared entry tier (`--duration-200`), fed to the
+// animation's own slot rather than via `duration-200`. That utility would also
+// emit `transition-duration`, and with no `transition-property` on these
+// wrappers it lands on CSS's `all` default — an every-property transition
+// nobody asked for. Setting `--tw-animation-duration` keeps the transition set
+// empty, for the same reason the ladder below avoids `delay-*`.
 const SECTION_ENTRY =
-  "launcher-section-enter motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:[--tw-animation-duration:200ms]";
+  "launcher-section-enter motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:[--tw-animation-duration:var(--duration-200)]";
 
 // The stagger ladder. Sequencing IS the signal here, so the per-step delay is a
 // literal ladder rather than one of the shared duration tiers.

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -4,6 +4,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { Button } from "@/components/ui/button";
 import { ProjectPulseStrip } from "@/components/Pulse";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
+import { cn } from "@/lib/utils";
 import { svgToDataUrl, sanitizeSvg } from "@/lib/svg";
 import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
@@ -16,6 +17,45 @@ import { ResumeSessionLine } from "./ResumeSessionLine";
 import { LauncherQuickActions } from "./LauncherQuickActions";
 
 const PATH_TRUNCATE_LENGTH = 52;
+
+// Entry motion for each launcher section — the column arrives as a sequence
+// rather than one flat block. Static classes, so the animation plays once when
+// a section enters the DOM and never replays on re-render; a section whose
+// condition flips later (recipes finish loading, the pulse is unhidden) simply
+// runs its own entry then.
+//
+// Two suppressors, both needed, exactly as `ContentFadeIn` does it:
+// `motion-safe:` covers the OS preference, and the `launcher-section-enter`
+// marker registers these sections with the reduce-motion block in `index.css`,
+// which is what honours Daintree's own reduce-animations toggle — a `body`
+// attribute no Tailwind variant can reach from here. Performance mode is
+// already killed globally.
+const SECTION_ENTRY =
+  "launcher-section-enter motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200";
+
+// The stagger ladder. Sequencing IS the signal here, so the per-step delay is a
+// literal ladder rather than one of the shared duration tiers.
+//
+// NOT `delay-*`: Tailwind's own `delay-*` wins over the animation library's
+// same-named utility and compiles to `transition-delay`, which an `animate-in`
+// keyframe animation never reads — the sections would all arrive at once. The
+// animation's delay slot is the `--tw-animation-delay` custom property, so the
+// ladder sets that directly. (`duration-*` needs no such workaround: it also
+// sets `--tw-duration`, which the animation does read.)
+//
+// Every non-zero delay MUST carry `fill-mode-backwards`. The underlying `enter`
+// animation defaults to `fill-mode: none`, which paints a section fully visible
+// for the length of its delay and then snaps it hidden before fading it in.
+const SECTION_ENTRY_DELAY_1 =
+  "motion-safe:[--tw-animation-delay:30ms] motion-safe:fill-mode-backwards";
+const SECTION_ENTRY_DELAY_2 =
+  "motion-safe:[--tw-animation-delay:60ms] motion-safe:fill-mode-backwards";
+const SECTION_ENTRY_DELAY_3 =
+  "motion-safe:[--tw-animation-delay:90ms] motion-safe:fill-mode-backwards";
+const SECTION_ENTRY_DELAY_4 =
+  "motion-safe:[--tw-animation-delay:120ms] motion-safe:fill-mode-backwards";
+const SECTION_ENTRY_DELAY_5 =
+  "motion-safe:[--tw-animation-delay:150ms] motion-safe:fill-mode-backwards";
 
 // The active workspace is a project OR a scratch (#11076). `hasLaunchTarget`
 // gates the launcher column on having somewhere to launch INTO — a scratch has
@@ -109,8 +149,11 @@ export function ContentGridEmptyState({
     <DaintreeIcon className="h-25 w-25 text-daintree-text/65" aria-hidden="true" />
   );
 
+  // The container no longer fades as one block — each launcher section below
+  // carries its own entry, and the no-launch-target branches keep the entry
+  // fade `EmptyState` already owns.
   return (
-    <div className="relative h-full w-full overflow-hidden animate-in fade-in duration-200">
+    <div className="relative h-full w-full overflow-hidden">
       {/* Content scrolls independently of the fixed watermark so an expanded
           pulse (or a tall recipe list) on a short canvas stays reachable
           instead of being clipped; `min-h-full` keeps it centered when short. */}
@@ -118,7 +161,7 @@ export function ContentGridEmptyState({
         <div className="flex min-h-full flex-col items-center justify-center p-8">
           <div className="max-w-3xl w-full flex flex-col items-center">
             {hasLaunchTarget && (
-              <div className="mb-6 flex flex-col items-center text-center">
+              <div className={cn("mb-6 flex flex-col items-center text-center", SECTION_ENTRY)}>
                 <div className="mb-4">{identityMark}</div>
                 {hasWorkspaceIdentity ? (
                   <div className="flex flex-col items-center gap-1.5 min-w-0 max-w-full">
@@ -206,31 +249,57 @@ export function ContentGridEmptyState({
             )}
 
             {hasLaunchTarget && recipesProjectId !== null && !recipesLoading && (
-              <div className="mb-3 w-full flex justify-center">
+              <div
+                className={cn(
+                  "mb-3 w-full flex justify-center",
+                  SECTION_ENTRY,
+                  SECTION_ENTRY_DELAY_1
+                )}
+              >
                 <RecipeRunner activeWorktreeId={activeWorktreeId} defaultCwd={defaultCwd} />
               </div>
             )}
 
             {hasLaunchTarget && (
-              <div className="mb-3 w-full flex justify-center">
+              <div
+                className={cn(
+                  "mb-3 w-full flex justify-center",
+                  SECTION_ENTRY,
+                  SECTION_ENTRY_DELAY_2
+                )}
+              >
                 <ResumeSessionLine />
               </div>
             )}
 
             {hasLaunchTarget && (
-              <div className="mb-6 w-full flex justify-center">
+              <div
+                className={cn(
+                  "mb-6 w-full flex justify-center",
+                  SECTION_ENTRY,
+                  SECTION_ENTRY_DELAY_3
+                )}
+              >
                 <LauncherQuickActions />
               </div>
             )}
 
             {showProjectPulse && hasLaunchTarget && activeWorktreeId && (
-              <div className="w-full flex justify-center">
+              <div
+                className={cn("w-full flex justify-center", SECTION_ENTRY, SECTION_ENTRY_DELAY_4)}
+              >
                 <ProjectPulseStrip worktreeId={activeWorktreeId} />
               </div>
             )}
 
             {hasLaunchTarget && hasProjectContext && hasEverLaunchedAgent && (
-              <div className="flex flex-col items-center gap-4 mt-6">
+              <div
+                className={cn(
+                  "flex flex-col items-center gap-4 mt-6",
+                  SECTION_ENTRY,
+                  SECTION_ENTRY_DELAY_5
+                )}
+              >
                 <RotatingTip />
               </div>
             )}

--- a/src/components/Terminal/LauncherQuickActions.tsx
+++ b/src/components/Terminal/LauncherQuickActions.tsx
@@ -27,7 +27,7 @@ function QuickAction({ icon, label, actionId, onClick }: QuickActionProps) {
       type="button"
       onClick={onClick}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className="group inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-border-subtle bg-overlay-subtle px-2.5 py-1.5 text-sm text-daintree-text/80 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-soft hover:border-border-default hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="launcher-press group inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-border-subtle bg-overlay-subtle px-2.5 py-1.5 text-sm text-daintree-text/80 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-soft hover:border-border-default hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <span className="shrink-0">{icon}</span>
       <span className="truncate">{label}</span>
@@ -64,7 +64,7 @@ function PaletteSearchButton() {
       type="button"
       onClick={handleClick}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-soft px-3 py-2.5 text-sm text-daintree-text/70 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-medium hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="launcher-press flex w-full items-center gap-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-soft px-3 py-2.5 text-sm text-daintree-text/70 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-medium hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <Search className="h-4 w-4 shrink-0 text-daintree-text/55" aria-hidden="true" />
       <span className="min-w-0 flex-1 truncate text-left">Search agents &amp; panels…</span>

--- a/src/components/Terminal/LauncherQuickActions.tsx
+++ b/src/components/Terminal/LauncherQuickActions.tsx
@@ -27,7 +27,7 @@ function QuickAction({ icon, label, actionId, onClick }: QuickActionProps) {
       type="button"
       onClick={onClick}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className="group inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-border-subtle bg-overlay-subtle px-2.5 py-1.5 text-sm text-daintree-text/80 transition-colors hover:bg-overlay-soft hover:border-border-default hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="group inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-border-subtle bg-overlay-subtle px-2.5 py-1.5 text-sm text-daintree-text/80 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-soft hover:border-border-default hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <span className="shrink-0">{icon}</span>
       <span className="truncate">{label}</span>
@@ -64,7 +64,7 @@ function PaletteSearchButton() {
       type="button"
       onClick={handleClick}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-soft px-3 py-2.5 text-sm text-daintree-text/70 transition-colors hover:bg-overlay-medium hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+      className="flex w-full items-center gap-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-soft px-3 py-2.5 text-sm text-daintree-text/70 transition-colors active:scale-[0.98] active:duration-[1ms] hover:bg-overlay-medium hover:text-daintree-text focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
     >
       <Search className="h-4 w-4 shrink-0 text-daintree-text/55" aria-hidden="true" />
       <span className="min-w-0 flex-1 truncate text-left">Search agents &amp; panels…</span>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -68,7 +68,12 @@ export function RecipeRunnerItem({
               // is inside the recipe group (group-focus-within) — at rest the
               // default-focused first card must NOT glow accent, or the hero
               // recipe reads as a focused input on every empty grid.
-              "group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
+              //
+              // `transition-colors` stays narrow: transform is deliberately out
+              // of the property list, so the press scale snaps instead of easing
+              // over 150ms. A disabled card never enters :active, so the scale
+              // needs no disabled: reset.
+              "group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors active:scale-[0.98] active:duration-[1ms] text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
               recipe.shadowedBy && "opacity-60"
             )}
           >
@@ -124,7 +129,7 @@ export function RecipeRunnerItem({
           disabled={disabled}
           tabIndex={disabled ? -1 : (tabIndex ?? 0)}
           className={cn(
-            "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
+            "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors active:scale-[0.98] active:duration-[1ms] text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
             recipe.shadowedBy && "opacity-60"
           )}
         >

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -72,8 +72,9 @@ export function RecipeRunnerItem({
               // `transition-colors` stays narrow: transform is deliberately out
               // of the property list, so the press scale snaps instead of easing
               // over 150ms. A disabled card never enters :active, so the scale
-              // needs no disabled: reset.
-              "group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors active:scale-[0.98] active:duration-[1ms] text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
+              // needs no disabled: reset. `launcher-press` is what lets reduced
+              // motion suppress the scale — see the rule in `index.css`.
+              "launcher-press group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors active:scale-[0.98] active:duration-[1ms] text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
               recipe.shadowedBy && "opacity-60"
             )}
           >
@@ -129,7 +130,7 @@ export function RecipeRunnerItem({
           disabled={disabled}
           tabIndex={disabled ? -1 : (tabIndex ?? 0)}
           className={cn(
-            "group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors active:scale-[0.98] active:duration-[1ms] text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
+            "launcher-press group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors active:scale-[0.98] active:duration-[1ms] text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle group-focus-within/recipes:aria-selected:ring-2 group-focus-within/recipes:aria-selected:ring-daintree-accent/60",
             recipe.shadowedBy && "opacity-60"
           )}
         >

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { buttonVariants } from "@/components/ui/button";
+import { RecipeRunnerItem } from "../RecipeRunnerItem";
+import type { TerminalRecipe } from "@/types";
+
+const recipe: TerminalRecipe = {
+  id: "alpha",
+  name: "Alpha",
+  terminals: [{ type: "terminal", env: {} }],
+  createdAt: 0,
+};
+
+const noop = () => {};
+
+const renderItem = (mode: "grid" | "list", props?: { disabled?: boolean }) =>
+  render(
+    <RecipeRunnerItem
+      recipe={recipe}
+      isFocused={false}
+      mode={mode}
+      id="recipe-alpha"
+      onRun={noop}
+      onEdit={noop}
+      onDuplicate={noop}
+      onPin={noop}
+      onUnpin={noop}
+      onDelete={noop}
+      {...props}
+    />
+  );
+
+/**
+ * The press treatment every shared `Button` inherits, read out of the cva
+ * itself rather than copied: the `ghost` variant contributes no `active:`
+ * classes of its own, so what survives is exactly the base press recipe. A
+ * recipe card is a hand-rolled button, so nothing makes it inherit that — this
+ * is what keeps it from drifting back to feeling inert on click.
+ */
+const basePressTreatment = () =>
+  buttonVariants({ variant: "ghost" })
+    .split(/\s+/)
+    .filter((token) => token.startsWith("active:"));
+
+describe("RecipeRunnerItem — press feedback", () => {
+  it.each(["grid", "list"] as const)(
+    "carries the same press treatment the shared Button owns (%s mode)",
+    (mode) => {
+      const press = basePressTreatment();
+      // Guard: if the shared recipe ever loses its `active:` classes there is
+      // nothing left to enforce, and the loop below would pass vacuously.
+      expect(press.length).toBeGreaterThan(0);
+
+      renderItem(mode);
+
+      const classes = screen.getByRole("option").className.split(/\s+/);
+      for (const token of press) expect(classes).toContain(token);
+    }
+  );
+
+  it.each(["grid", "list"] as const)(
+    "keeps transform out of its transition set, so the press snaps (%s mode)",
+    (mode) => {
+      renderItem(mode);
+
+      // A bare `transition`/`transition-all` — or an explicit
+      // `transition-transform` — would ease the scale back over the shared
+      // 150ms instead of snapping it.
+      const widened = screen
+        .getByRole("option")
+        .className.split(/\s+/)
+        .filter((c) => ["transition", "transition-all", "transition-transform"].includes(c));
+
+      expect(widened).toEqual([]);
+    }
+  );
+});

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { buttonVariants } from "@/components/ui/button";
 import { RecipeRunnerItem } from "../RecipeRunnerItem";
+import {
+  basePressTreatment,
+  reduceMotionSelectors,
+  TRANSITION_WIDENERS,
+} from "../../__tests__/launcherMotionContract";
 import type { TerminalRecipe } from "@/types";
 
 const recipe: TerminalRecipe = {
@@ -31,18 +35,6 @@ const renderItem = (mode: "grid" | "list", props?: { disabled?: boolean }) =>
     />
   );
 
-/**
- * The press treatment every shared `Button` inherits, read out of the cva
- * itself rather than copied: the `ghost` variant contributes no `active:`
- * classes of its own, so what survives is exactly the base press recipe. A
- * recipe card is a hand-rolled button, so nothing makes it inherit that — this
- * is what keeps it from drifting back to feeling inert on click.
- */
-const basePressTreatment = () =>
-  buttonVariants({ variant: "ghost" })
-    .split(/\s+/)
-    .filter((token) => token.startsWith("active:"));
-
 describe("RecipeRunnerItem — press feedback", () => {
   it.each(["grid", "list"] as const)(
     "carries the same press treatment the shared Button owns (%s mode)",
@@ -70,9 +62,32 @@ describe("RecipeRunnerItem — press feedback", () => {
       const widened = screen
         .getByRole("option")
         .className.split(/\s+/)
-        .filter((c) => ["transition", "transition-all", "transition-transform"].includes(c));
+        .filter((c) => TRANSITION_WIDENERS.includes(c));
 
       expect(widened).toEqual([]);
+    }
+  );
+
+  // `active:scale-*` emits the individual `scale` property, which the app's
+  // `transform: none` reduced-motion button reset cannot neutralize. A recipe
+  // card is doubly exposed: it is a Radix context-menu trigger, so it carries a
+  // `data-state` attribute, and that reset excludes `[data-state]` buttons
+  // outright. Only a class the reduce-motion block names can stop the scale.
+  it.each(["grid", "list"] as const)(
+    "registers the press scale with the reduce-animations kill switch (%s mode)",
+    (mode) => {
+      const suppressed = reduceMotionSelectors();
+      expect(suppressed.size).toBeGreaterThan(0);
+
+      renderItem(mode);
+      const button = screen.getByRole("option");
+
+      // The exclusion this guards against is only real while the card is a
+      // Radix trigger — assert that premise rather than trusting it.
+      expect(button.getAttribute("data-state")).toBeTruthy();
+
+      const covered = button.className.split(/\s+/).filter((c) => suppressed.has(c));
+      expect(covered.length).toBeGreaterThan(0);
     }
   );
 });

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerItem.test.tsx
@@ -5,7 +5,7 @@ import { RecipeRunnerItem } from "../RecipeRunnerItem";
 import {
   basePressTreatment,
   reduceMotionSelectors,
-  TRANSITION_WIDENERS,
+  transitionWideners,
 } from "../../__tests__/launcherMotionContract";
 import type { TerminalRecipe } from "@/types";
 
@@ -37,17 +37,23 @@ const renderItem = (mode: "grid" | "list", props?: { disabled?: boolean }) =>
 
 describe("RecipeRunnerItem — press feedback", () => {
   it.each(["grid", "list"] as const)(
-    "carries the same press treatment the shared Button owns (%s mode)",
+    "carries exactly the press treatment the shared Button owns (%s mode)",
     (mode) => {
       const press = basePressTreatment();
       // Guard: if the shared recipe ever loses its `active:` classes there is
-      // nothing left to enforce, and the loop below would pass vacuously.
+      // nothing left to enforce, and the comparison below would pass vacuously.
       expect(press.length).toBeGreaterThan(0);
 
       renderItem(mode);
 
-      const classes = screen.getByRole("option").className.split(/\s+/);
-      for (const token of press) expect(classes).toContain(token);
+      // Exact, not superset: a class the shared recipe has dropped must not
+      // linger here either.
+      const pressed = screen
+        .getByRole("option")
+        .className.split(/\s+/)
+        .filter((c) => c.startsWith("active:"));
+
+      expect(new Set(pressed)).toEqual(new Set(press));
     }
   );
 
@@ -56,23 +62,15 @@ describe("RecipeRunnerItem — press feedback", () => {
     (mode) => {
       renderItem(mode);
 
-      // A bare `transition`/`transition-all` — or an explicit
-      // `transition-transform` — would ease the scale back over the shared
-      // 150ms instead of snapping it.
-      const widened = screen
-        .getByRole("option")
-        .className.split(/\s+/)
-        .filter((c) => TRANSITION_WIDENERS.includes(c));
-
-      expect(widened).toEqual([]);
+      // Anything that pulls a transform into the transition set would ease the
+      // scale back over the shared 150ms instead of snapping it.
+      expect(transitionWideners(screen.getByRole("option").className)).toEqual([]);
     }
   );
 
   // `active:scale-*` emits the individual `scale` property, which the app's
-  // `transform: none` reduced-motion button reset cannot neutralize. A recipe
-  // card is doubly exposed: it is a Radix context-menu trigger, so it carries a
-  // `data-state` attribute, and that reset excludes `[data-state]` buttons
-  // outright. Only a class the reduce-motion block names can stop the scale.
+  // `transform: none` reduced-motion button reset cannot neutralize — so only a
+  // class the reduce-motion block actually names can stop the press scale.
   it.each(["grid", "list"] as const)(
     "registers the press scale with the reduce-animations kill switch (%s mode)",
     (mode) => {
@@ -80,13 +78,12 @@ describe("RecipeRunnerItem — press feedback", () => {
       expect(suppressed.size).toBeGreaterThan(0);
 
       renderItem(mode);
-      const button = screen.getByRole("option");
 
-      // The exclusion this guards against is only real while the card is a
-      // Radix trigger — assert that premise rather than trusting it.
-      expect(button.getAttribute("data-state")).toBeTruthy();
+      const covered = screen
+        .getByRole("option")
+        .className.split(/\s+/)
+        .filter((c) => suppressed.has(c));
 
-      const covered = button.className.split(/\s+/).filter((c) => suppressed.has(c));
       expect(covered.length).toBeGreaterThan(0);
     }
   );

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -1,6 +1,33 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Every class the app's `@variant reduce-motion` blocks neutralize. That block
+ * is the only thing that reads the in-app reduce-animations toggle (a `body`
+ * attribute), so it is the authority on which animations that toggle can stop.
+ */
+const reduceMotionSelectors = (): Set<string> => {
+  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf-8");
+  const classes = new Set<string>();
+
+  const MARKER = "@variant reduce-motion";
+  for (let i = css.indexOf(MARKER); i !== -1; i = css.indexOf(MARKER, i + 1)) {
+    let depth = 0;
+    for (let k = css.indexOf("{", i); k < css.length; k++) {
+      if (css[k] === "{") depth++;
+      if (css[k] === "}" && --depth === 0) {
+        for (const [, name] of css.slice(i, k).matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) {
+          classes.add(name);
+        }
+        break;
+      }
+    }
+  }
+  return classes;
+};
 
 // Hoisted mutable state so each mock reads its slice at call time and a test can
 // reshape the stores before rendering.
@@ -198,6 +225,103 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
       render(<ContentGridEmptyState {...PROJECT_PROPS} showProjectPulse={false} />);
 
       expect(screen.queryByTestId("project-pulse")).toBeNull();
+    });
+  });
+
+  // The launcher arrives as a sequence of sections rather than one flat block.
+  // These assert the structural rules the stagger depends on, not the utilities
+  // themselves — a class name copied out of the component would be a tautology,
+  // but "every delayed section fills backwards" is a real invariant: the
+  // underlying `enter` animation defaults to `fill-mode: none`, which paints a
+  // delayed section fully visible for the length of its delay and then snaps it
+  // hidden before fading it in.
+  describe("entry stagger", () => {
+    // Utilities that animate. Each must be gated on `motion-safe:` so the OS
+    // reduced-motion preference suppresses it.
+    const MOTION_UTILITY =
+      /(^|:)(animate-in|fade-in|slide-in-from-[a-z]+-\d+|duration-\d+|fill-mode-[a-z]+|\[--tw-animation-delay:\d+ms\])$/;
+
+    const classesOf = (el: Element) => el.className.split(/\s+/).filter(Boolean);
+
+    // The ladder rides `--tw-animation-delay` rather than `delay-*`, because
+    // Tailwind's `delay-*` compiles to `transition-delay` — which a keyframe
+    // animation never reads. Parsing the property (not a `delay-N` class name)
+    // is what keeps this suite honest: a regression back to `delay-*` reads as
+    // "no delay at all" here, which is exactly what it would be on screen.
+    const delayOf = (el: Element) => {
+      const token = classesOf(el).find((c) => /\[--tw-animation-delay:\d+ms\]$/.test(c));
+      const ms = token?.match(/(\d+)ms/);
+      return ms ? Number(ms[1]) : 0;
+    };
+
+    /** Every section carrying an entry animation, in DOM order. */
+    const animatedSections = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('[class*="animate-in"]'));
+
+    // Every gate satisfied, so all six sections render at once.
+    const renderWholeLauncher = () => {
+      markLaunchedAnAgent();
+      h.recipes.currentProjectId = "project-1";
+      return render(<ContentGridEmptyState {...PROJECT_PROPS} />).container;
+    };
+
+    it("animates each launcher section rather than the container as one block", () => {
+      const container = renderWholeLauncher();
+
+      // Six sections: hero, recipes, resume, quick actions, pulse, tip. An
+      // animation left on the container itself would show up as a seventh.
+      expect(animatedSections(container)).toHaveLength(6);
+    });
+
+    it("staggers the sections by a single uniform step, in DOM order", () => {
+      const container = renderWholeLauncher();
+
+      const delays = animatedSections(container).map(delayOf);
+      const steps = delays.slice(1).map((delay, i) => delay - delays[i]);
+
+      expect(delays[0]).toBe(0);
+      expect(steps.every((step) => step > 0)).toBe(true);
+      expect(new Set(steps).size).toBe(1);
+    });
+
+    it("fills backwards on every delayed section, so none flashes before its turn", () => {
+      const container = renderWholeLauncher();
+
+      for (const section of animatedSections(container)) {
+        if (delayOf(section) === 0) continue;
+        expect(classesOf(section).some((c) => /(^|:)fill-mode-backwards$/.test(c))).toBe(true);
+      }
+    });
+
+    it("gates every animating utility on motion-safe, so the OS preference suppresses it", () => {
+      const container = renderWholeLauncher();
+
+      for (const section of animatedSections(container)) {
+        const motionUtilities = classesOf(section).filter((c) => MOTION_UTILITY.test(c));
+
+        expect(motionUtilities.length).toBeGreaterThan(0);
+        for (const utility of motionUtilities) {
+          expect(utility.startsWith("motion-safe:")).toBe(true);
+        }
+      }
+    });
+
+    // `motion-safe:` only sees the OS preference. Daintree's own
+    // reduce-animations toggle is a `body` attribute, and the only thing that
+    // reads it is the `@variant reduce-motion` block in index.css — so a
+    // section is suppressible by that toggle if, and only if, one of its
+    // classes is named in that block. This asserts the wiring between the
+    // component and the stylesheet, which nothing else would catch.
+    it("registers every animated section with the in-app reduce-animations kill switch", () => {
+      const suppressed = reduceMotionSelectors();
+      expect(suppressed.size).toBeGreaterThan(0);
+
+      const container = renderWholeLauncher();
+
+      for (const section of animatedSections(container)) {
+        const covered = classesOf(section).filter((c) => suppressed.has(c));
+        expect(covered.length).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -1,33 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { readFileSync } from "fs";
-import { resolve } from "path";
-
-/**
- * Every class the app's `@variant reduce-motion` blocks neutralize. That block
- * is the only thing that reads the in-app reduce-animations toggle (a `body`
- * attribute), so it is the authority on which animations that toggle can stop.
- */
-const reduceMotionSelectors = (): Set<string> => {
-  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf-8");
-  const classes = new Set<string>();
-
-  const MARKER = "@variant reduce-motion";
-  for (let i = css.indexOf(MARKER); i !== -1; i = css.indexOf(MARKER, i + 1)) {
-    let depth = 0;
-    for (let k = css.indexOf("{", i); k < css.length; k++) {
-      if (css[k] === "{") depth++;
-      if (css[k] === "}" && --depth === 0) {
-        for (const [, name] of css.slice(i, k).matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) {
-          classes.add(name);
-        }
-        break;
-      }
-    }
-  }
-  return classes;
-};
+import { reduceMotionSelectors } from "./launcherMotionContract";
 
 // Hoisted mutable state so each mock reads its slice at call time and a test can
 // reshape the stores before rendering.
@@ -239,7 +213,7 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
     // Utilities that animate. Each must be gated on `motion-safe:` so the OS
     // reduced-motion preference suppresses it.
     const MOTION_UTILITY =
-      /(^|:)(animate-in|fade-in|slide-in-from-[a-z]+-\d+|duration-\d+|fill-mode-[a-z]+|\[--tw-animation-delay:\d+ms\])$/;
+      /(^|:)(animate-in|fade-in|slide-in-from-[a-z]+-\d+|fill-mode-[a-z]+|\[--tw-animation-(delay|duration):\d+ms\])$/;
 
     const classesOf = (el: Element) => el.className.split(/\s+/).filter(Boolean);
 
@@ -290,6 +264,23 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
       for (const section of animatedSections(container)) {
         if (delayOf(section) === 0) continue;
         expect(classesOf(section).some((c) => /(^|:)fill-mode-backwards$/.test(c))).toBe(true);
+      }
+    });
+
+    // `duration-*` and `delay-*` compile to `transition-duration` /
+    // `transition-delay`, which a keyframe animation never reads — so they
+    // cannot drive this stagger. Worse, these wrappers declare no
+    // `transition-property`, so either one would land on CSS's `all` default
+    // and silently give every section an every-property transition. The entry
+    // rides the animation's own custom properties instead.
+    it("drives the entry from the animation, never leaking into the transition system", () => {
+      const container = renderWholeLauncher();
+
+      for (const section of animatedSections(container)) {
+        const transitionUtilities = classesOf(section).filter((c) =>
+          /(^|:)(duration|delay)-/.test(c)
+        );
+        expect(transitionUtilities).toEqual([]);
       }
     });
 

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -242,8 +242,13 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
     it("animates each launcher section rather than the container as one block", () => {
       const container = renderWholeLauncher();
 
-      // Six sections: hero, recipes, resume, quick actions, pulse, tip. An
-      // animation left on the container itself would show up as a seventh.
+      // The whole point of the issue: the launcher must not arrive as one flat
+      // block, so its root carries no entry animation of its own…
+      for (const root of Array.from(container.children)) {
+        expect(classesOf(root).some((c) => /(^|:)animate-in$/.test(c))).toBe(false);
+      }
+      // …and every section that renders arrives on its own: hero, recipes,
+      // resume, quick actions, pulse, tip.
       expect(animatedSections(container)).toHaveLength(6);
     });
 

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -256,8 +256,10 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
       const container = renderWholeLauncher();
 
       const delays = animatedSections(container).map(delayOf);
-      const steps = delays.slice(1).map((delay, i) => delay - delays[i]);
+      const steps = delays.slice(1).map((delay, i) => delay - (delays[i] ?? 0));
 
+      // The head of the ladder carries no delay, each step is forward, and the
+      // cadence never varies — without asserting the step's literal size.
       expect(delays[0]).toBe(0);
       expect(steps.every((step) => step > 0)).toBe(true);
       expect(new Set(steps).size).toBe(1);

--- a/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
+++ b/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
@@ -64,20 +64,12 @@ vi.mock("@/components/ui/Kbd", () => ({
   KbdChord: ({ shortcut }: { shortcut: string }) => <span data-testid="kbd">{shortcut}</span>,
 }));
 
-import { buttonVariants } from "@/components/ui/button";
 import { LauncherQuickActions } from "../LauncherQuickActions";
-
-/**
- * The press treatment every shared `Button` inherits, read out of the cva
- * itself rather than copied: the `ghost` variant contributes no `active:`
- * classes of its own, so what survives is exactly the base press recipe. The
- * launcher's raw buttons don't use `Button`, so this is what keeps them from
- * drifting away from it.
- */
-const basePressTreatment = () =>
-  buttonVariants({ variant: "ghost" })
-    .split(/\s+/)
-    .filter((token) => token.startsWith("active:"));
+import {
+  basePressTreatment,
+  reduceMotionSelectors,
+  TRANSITION_WIDENERS,
+} from "./launcherMotionContract";
 
 beforeEach(() => {
   h.dispatch.mockClear();
@@ -240,8 +232,24 @@ describe("LauncherQuickActions", () => {
         // 150ms instead of snapping it.
         const widened = button.className
           .split(/\s+/)
-          .filter((c) => ["transition", "transition-all", "transition-transform"].includes(c));
+          .filter((c) => TRANSITION_WIDENERS.includes(c));
         expect(widened).toEqual([]);
+      }
+    });
+
+    // `active:scale-*` emits the individual `scale` property, which the app's
+    // `transform: none` reduced-motion button reset cannot neutralize. Without
+    // a class the reduce-motion block actually names, the press scale keeps
+    // animating for users who asked for no motion.
+    it("registers the press scale with the reduce-animations kill switch", () => {
+      const suppressed = reduceMotionSelectors();
+      expect(suppressed.size).toBeGreaterThan(0);
+
+      render(<LauncherQuickActions />);
+
+      for (const button of launcherButtons()) {
+        const covered = button.className.split(/\s+/).filter((c) => suppressed.has(c));
+        expect(covered.length).toBeGreaterThan(0);
       }
     });
   });

--- a/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
+++ b/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
@@ -64,7 +64,20 @@ vi.mock("@/components/ui/Kbd", () => ({
   KbdChord: ({ shortcut }: { shortcut: string }) => <span data-testid="kbd">{shortcut}</span>,
 }));
 
+import { buttonVariants } from "@/components/ui/button";
 import { LauncherQuickActions } from "../LauncherQuickActions";
+
+/**
+ * The press treatment every shared `Button` inherits, read out of the cva
+ * itself rather than copied: the `ghost` variant contributes no `active:`
+ * classes of its own, so what survives is exactly the base press recipe. The
+ * launcher's raw buttons don't use `Button`, so this is what keeps them from
+ * drifting away from it.
+ */
+const basePressTreatment = () =>
+  buttonVariants({ variant: "ghost" })
+    .split(/\s+/)
+    .filter((token) => token.startsWith("active:"));
 
 beforeEach(() => {
   h.dispatch.mockClear();
@@ -192,5 +205,44 @@ describe("LauncherQuickActions", () => {
     expect(claude.getAttribute("aria-keyshortcuts")).toBe("Meta+Alt+C");
     expect(claude.getAttribute("aria-label")).toBeNull();
     expect(screen.getByTestId("kbd").textContent).toBe("Cmd+Alt+C");
+  });
+
+  // These are hand-rolled buttons, not the shared `Button`, so nothing makes
+  // them inherit its press feedback — without this they drift back to feeling
+  // inert on click while every other button in the app snaps.
+  describe("press feedback", () => {
+    const launcherButtons = () => [
+      screen.getByRole("button", { name: /Claude/i }),
+      screen.getByRole("button", { name: /New terminal/i }),
+      screen.getByRole("button", { name: /Search agents & panels/i }),
+    ];
+
+    it("carries the same press treatment the shared Button owns", () => {
+      const press = basePressTreatment();
+      // Guard: if the shared recipe ever loses its `active:` classes there is
+      // nothing left to enforce, and the loop below would pass vacuously.
+      expect(press.length).toBeGreaterThan(0);
+
+      render(<LauncherQuickActions />);
+
+      for (const button of launcherButtons()) {
+        const classes = button.className.split(/\s+/);
+        for (const token of press) expect(classes).toContain(token);
+      }
+    });
+
+    it("keeps transform out of its transition set, so the press snaps", () => {
+      render(<LauncherQuickActions />);
+
+      for (const button of launcherButtons()) {
+        // A bare `transition`/`transition-all` — or an explicit
+        // `transition-transform` — would ease the scale back over the shared
+        // 150ms instead of snapping it.
+        const widened = button.className
+          .split(/\s+/)
+          .filter((c) => ["transition", "transition-all", "transition-transform"].includes(c));
+        expect(widened).toEqual([]);
+      }
+    });
   });
 });

--- a/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
+++ b/src/components/Terminal/__tests__/LauncherQuickActions.test.tsx
@@ -68,7 +68,7 @@ import { LauncherQuickActions } from "../LauncherQuickActions";
 import {
   basePressTreatment,
   reduceMotionSelectors,
-  TRANSITION_WIDENERS,
+  transitionWideners,
 } from "./launcherMotionContract";
 
 beforeEach(() => {
@@ -209,17 +209,19 @@ describe("LauncherQuickActions", () => {
       screen.getByRole("button", { name: /Search agents & panels/i }),
     ];
 
-    it("carries the same press treatment the shared Button owns", () => {
+    it("carries exactly the press treatment the shared Button owns", () => {
       const press = basePressTreatment();
       // Guard: if the shared recipe ever loses its `active:` classes there is
-      // nothing left to enforce, and the loop below would pass vacuously.
+      // nothing left to enforce, and the comparison below would pass vacuously.
       expect(press.length).toBeGreaterThan(0);
 
       render(<LauncherQuickActions />);
 
       for (const button of launcherButtons()) {
-        const classes = button.className.split(/\s+/);
-        for (const token of press) expect(classes).toContain(token);
+        // Exact, not superset: a class the shared recipe has dropped must not
+        // linger here either.
+        const pressed = button.className.split(/\s+/).filter((c) => c.startsWith("active:"));
+        expect(new Set(pressed)).toEqual(new Set(press));
       }
     });
 
@@ -227,13 +229,9 @@ describe("LauncherQuickActions", () => {
       render(<LauncherQuickActions />);
 
       for (const button of launcherButtons()) {
-        // A bare `transition`/`transition-all` — or an explicit
-        // `transition-transform` — would ease the scale back over the shared
-        // 150ms instead of snapping it.
-        const widened = button.className
-          .split(/\s+/)
-          .filter((c) => TRANSITION_WIDENERS.includes(c));
-        expect(widened).toEqual([]);
+        // Anything that pulls a transform into the transition set would ease
+        // the scale back over the shared 150ms instead of snapping it.
+        expect(transitionWideners(button.className)).toEqual([]);
       }
     });
 

--- a/src/components/Terminal/__tests__/launcherMotionContract.ts
+++ b/src/components/Terminal/__tests__/launcherMotionContract.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { buttonVariants } from "@/components/ui/button";
+
+/**
+ * Shared motion contracts for the empty-grid launcher (issue #11169). Both
+ * helpers derive their expectation from a source of truth rather than restating
+ * it, so a change to the canonical recipe fails the launcher's tests instead of
+ * quietly diverging from it.
+ */
+
+/**
+ * Every class name the app's `@variant reduce-motion` blocks neutralize.
+ *
+ * That block is the only thing that reads Daintree's in-app reduce-animations
+ * toggle (a `body` attribute), so it is the authority on which motion that
+ * toggle can actually stop. Tailwind's `motion-safe:` variant sees only the OS
+ * preference, and no Tailwind variant can reach the body attribute from a
+ * utility class — so a launcher animation is suppressible by the in-app toggle
+ * if, and only if, one of its class names is named in this block.
+ */
+export const reduceMotionSelectors = (): Set<string> => {
+  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf-8");
+  const classes = new Set<string>();
+
+  const MARKER = "@variant reduce-motion";
+  for (let i = css.indexOf(MARKER); i !== -1; i = css.indexOf(MARKER, i + 1)) {
+    let depth = 0;
+    for (let k = css.indexOf("{", i); k < css.length; k++) {
+      if (css[k] === "{") depth++;
+      if (css[k] === "}" && --depth === 0) {
+        for (const [, name] of css.slice(i, k).matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) {
+          classes.add(name);
+        }
+        break;
+      }
+    }
+  }
+  return classes;
+};
+
+/**
+ * The press treatment every shared `Button` inherits, read out of the cva
+ * itself rather than copied: the `ghost` variant contributes no `active:`
+ * classes of its own, so what survives is exactly the base press recipe.
+ *
+ * The launcher's recipe cards and quick actions are hand-rolled buttons, not
+ * `Button`, so nothing makes them inherit this — which is what these assertions
+ * are for.
+ */
+export const basePressTreatment = (): string[] =>
+  buttonVariants({ variant: "ghost" })
+    .split(/\s+/)
+    .filter((token) => token.startsWith("active:"));
+
+/** Class names that widen a transition set to cover the press transform. */
+export const TRANSITION_WIDENERS = ["transition", "transition-all", "transition-transform"];

--- a/src/components/Terminal/__tests__/launcherMotionContract.ts
+++ b/src/components/Terminal/__tests__/launcherMotionContract.ts
@@ -37,8 +37,11 @@ export const reduceMotionSelectors = (): Set<string> => {
       if (css[k] === "}" && --depth === 0) {
         // Selector text only — the chunk preceding each `{`. A class name that
         // appears inside a declaration value is not a rule, and must not count.
-        for (const [, selectorText] of css.slice(i, k).matchAll(/(?:^|[};])([^{};]*)\{/g)) {
-          for (const [, name] of selectorText.matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) classes.add(name);
+        for (const rule of css.slice(i, k).matchAll(/(?:^|[};])([^{};]*)\{/g)) {
+          const selectorText = rule[1] ?? "";
+          for (const name of selectorText.matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) {
+            if (name[1]) classes.add(name[1]);
+          }
         }
         break;
       }
@@ -72,8 +75,8 @@ export const widensTransitionToTransform = (cls: string): boolean => {
   const utility = cls.slice(cls.lastIndexOf(":") + 1);
   if (["transition", "transition-all", "transition-transform"].includes(utility)) return true;
 
-  const arbitrary = /^transition-\[(.+)\]$/.exec(utility);
-  return arbitrary ? /\b(transform|scale|translate|rotate|all)\b/.test(arbitrary[1]) : false;
+  const properties = /^transition-\[(.+)\]$/.exec(utility)?.[1];
+  return properties ? /\b(transform|scale|translate|rotate|all)\b/.test(properties) : false;
 };
 
 /** The transform-widening classes on an element, if any. */

--- a/src/components/Terminal/__tests__/launcherMotionContract.ts
+++ b/src/components/Terminal/__tests__/launcherMotionContract.ts
@@ -20,7 +20,13 @@ import { buttonVariants } from "@/components/ui/button";
  * if, and only if, one of its class names is named in this block.
  */
 export const reduceMotionSelectors = (): Set<string> => {
-  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf-8");
+  // Comments are stripped first, or a class merely *mentioned* in prose would
+  // count as neutralized — which would let this contract pass against a rule
+  // that no longer exists.
+  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf-8").replace(
+    /\/\*[\s\S]*?\*\//g,
+    ""
+  );
   const classes = new Set<string>();
 
   const MARKER = "@variant reduce-motion";
@@ -29,8 +35,10 @@ export const reduceMotionSelectors = (): Set<string> => {
     for (let k = css.indexOf("{", i); k < css.length; k++) {
       if (css[k] === "{") depth++;
       if (css[k] === "}" && --depth === 0) {
-        for (const [, name] of css.slice(i, k).matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) {
-          classes.add(name);
+        // Selector text only — the chunk preceding each `{`. A class name that
+        // appears inside a declaration value is not a rule, and must not count.
+        for (const [, selectorText] of css.slice(i, k).matchAll(/(?:^|[};])([^{};]*)\{/g)) {
+          for (const [, name] of selectorText.matchAll(/\.(-?[a-zA-Z][\w-]*)/g)) classes.add(name);
         }
         break;
       }
@@ -53,5 +61,21 @@ export const basePressTreatment = (): string[] =>
     .split(/\s+/)
     .filter((token) => token.startsWith("active:"));
 
-/** Class names that widen a transition set to cover the press transform. */
-export const TRANSITION_WIDENERS = ["transition", "transition-all", "transition-transform"];
+/**
+ * Does this class pull a transform property into the element's transition set?
+ *
+ * If it does, the press scale interpolates over the shared 150ms instead of
+ * snapping. Variant prefixes are stripped first, and arbitrary lists are read,
+ * so `md:transition-all` and `transition-[opacity,scale]` are both caught.
+ */
+export const widensTransitionToTransform = (cls: string): boolean => {
+  const utility = cls.slice(cls.lastIndexOf(":") + 1);
+  if (["transition", "transition-all", "transition-transform"].includes(utility)) return true;
+
+  const arbitrary = /^transition-\[(.+)\]$/.exec(utility);
+  return arbitrary ? /\b(transform|scale|translate|rotate|all)\b/.test(arbitrary[1]) : false;
+};
+
+/** The transform-widening classes on an element, if any. */
+export const transitionWideners = (className: string): string[] =>
+  className.split(/\s+/).filter(widensTransitionToTransform);

--- a/src/index.css
+++ b/src/index.css
@@ -1669,6 +1669,16 @@ body,
     transform: none;
   }
 
+  /* Launcher press controls (recipe cards, quick actions). `active:scale-*`
+   * emits the individual `scale` property, so the `transform: none` button
+   * reset below cannot neutralize it — see the Tailwind v4 trap in
+   * `docs/themes/interaction-state-recipes.md`. That reset also excludes these
+   * recipe cards outright: they are Radix context-menu triggers, so they carry
+   * a `data-state` attribute. Kill the press scale explicitly. */
+  .launcher-press {
+    scale: none !important;
+  }
+
   /* Fleet polish animations — opacity-only already, but drop the keyframe
    * entirely to keep WCAG 2.3.3 strict compliance. The bar stripe pseudos
    * stay at their static opacity (1); only the dedicated exit overlay is

--- a/src/index.css
+++ b/src/index.css
@@ -1659,6 +1659,16 @@ body,
     opacity: 1;
   }
 
+  /* Empty-grid launcher entry stagger — drop the keyframes and snap every
+   * section to its resting state. The sections' `motion-safe:` utilities
+   * already cover the OS preference; this rule is what honours the in-app
+   * reduce-animations toggle, which `motion-safe:` cannot see. */
+  .launcher-section-enter {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
   /* Fleet polish animations — opacity-only already, but drop the keyframe
    * entirely to keep WCAG 2.3.3 strict compliance. The bar stripe pseudos
    * stay at their static opacity (1); only the dedicated exit overlay is


### PR DESCRIPTION
## Summary

The empty-grid launcher used to fade in as one flat block, a single `animate-in fade-in duration-200` on the container. Its recipe cards and quick actions had hover states but no press feedback. This adds a per-section entry stagger and the standard press treatment.

Resolves #11169

## Changes

- `src/components/Terminal/ContentGridEmptyState.tsx`: replaced the container's single fade-in with a per-section entry (opacity plus a 4px rise) across the six launcher sections (hero, recipes, resume, quick actions, pulse, tip), on a 30ms ladder.
- `src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx` and `src/components/Terminal/LauncherQuickActions.tsx`: added the canonical `Button` press treatment (`active:scale-[0.98] active:duration-[1ms]`) to all four raw buttons, with `transition-colors` kept narrow so the scale snaps rather than easing.
- `src/index.css`: two new rules in the `@variant reduce-motion` block so the in-app reduce-animations toggle actually stops both the stagger and the press scale.

## Three things worth calling out for reviewers

**1. The stagger can't use Tailwind's `delay-*` utility.** Tailwind core's `delay-*` wins over tw-animate-css's same-named utility and compiles to `transition-delay`, which a keyframe animation never reads. The stagger would have been completely inert, all six sections arriving at once, and no class-name test would have caught it since the classes were present and correct. It sets `--tw-animation-delay` directly on the ladder instead. Same reason the duration rides `--tw-animation-duration`, fed from the shared `--duration-200` tier: `duration-200` also emits `transition-duration`, and with no `transition-property` on those wrappers that lands on CSS's `all` default, giving every section an unintended every-property transition.

**2. Every non-zero delay must carry `fill-mode-backwards`.** The `enter` animation defaults to `fill-mode: none`, so a delayed section would paint fully visible for the length of its delay, then snap hidden, then fade in. Reads as a glitch, not a stagger.

**3. Reduced motion needed real work.** `active:scale-*` emits the individual `scale` property, which the app's existing `transform: none !important` reduced-motion button reset can't neutralize, the exact Tailwind v4 trap flagged in `docs/themes/interaction-state-recipes.md`. Recipe cards were doubly exposed: they're Radix context-menu triggers, so they carry a `data-state` attribute, and that reset's `:not([data-state=...])` guard skips them entirely. Both the sections and the press controls now carry marker classes registered in the reduce-motion block, the same pattern `ContentFadeIn` already uses. `motion-safe:` alone isn't enough either, since it only sees the OS preference, not Daintree's in-app reduce-animations toggle.

## Known scope left alone on purpose

`button.tsx`'s own `active:scale-[0.98]` has the identical reduced-motion hole for every `Button` in the app, same scale-vs-transform trap. Left alone deliberately: fixing it app-wide needs an audit of all Radix/`asChild` cases and belongs in its own change.

## Testing

Added a new `launcherMotionContract.ts` shared test module, a new `RecipeRunnerItem.test.tsx`, and extended `ContentGridEmptyState.workspace.test.tsx` and `LauncherQuickActions.test.tsx`. The tests assert structural invariants and component-to-stylesheet wiring rather than copied class literals:

- Every animated section carries a class actually named in the reduce-motion block.
- Every non-zero delay carries `fill-mode-backwards`.
- Delays strictly increase by a uniform step.
- No `duration-*`/`delay-*` leaks into the transition system.
- The four press controls carry exactly the shared Button press recipe, derived at runtime from `buttonVariants`, not hardcoded.

Locally: 679 tests across 149 files green (includes every suite that parses `index.css`), `npm run typecheck` clean, eslint and prettier clean on changed files.
