### PR TITLE
feat(ui): slide a thumb between SegmentedToggle segments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -712,8 +712,17 @@ export default tseslint.config(
   {
     files: [
       "src/components/Fleet/FleetArmingRibbon.tsx",
+      "src/components/Fleet/FleetPickerPalette.tsx",
       "src/components/Layout/DockedTabGroup.tsx",
     ],
+    rules: { "no-restricted-imports": "off" },
+  },
+
+  // Allowlist — framer-motion segmented-control thumb. Both import `m` (the
+  // feature-less component) and the reduced-motion hook, not the animation
+  // features themselves; those still arrive lazily via loadMotionFeatures().
+  {
+    files: ["src/components/ui/SegmentedToggle.tsx", "src/hooks/useShouldSkipMotion.ts"],
     rules: { "no-restricted-imports": "off" },
   },
 

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -1,13 +1,20 @@
-import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useId, useMemo, useState, type ReactElement } from "react";
+import { m } from "framer-motion";
 import { Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { FleetPickerContent, FleetPickerFooterHint } from "@/components/Fleet/FleetPickerContent";
 import { useFleetPicker } from "@/hooks/useFleetPicker";
+import { useUiMotionTransition } from "@/hooks/useShouldSkipMotion";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 
 type CommitMode = "replace" | "append";
+
+const COMMIT_MODES: { mode: CommitMode; label: string }[] = [
+  { mode: "replace", label: "Replace" },
+  { mode: "append", label: "Append" },
+];
 
 export interface FleetPickerPaletteProps {
   isOpen: boolean;
@@ -34,6 +41,8 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
   const armIds = useFleetArmingStore((s) => s.armIds);
   const addToFleet = useFleetArmingStore((s) => s.addToFleet);
   const [commitMode, setCommitMode] = useState<CommitMode>("replace");
+  const thumbLayoutId = `${useId()}-segmented-thumb`;
+  const thumbTransition = useUiMotionTransition();
 
   useEffect(() => {
     if (!isOpen) setCommitMode("replace");
@@ -196,43 +205,46 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
 
             <div className="flex flex-nowrap items-center justify-between gap-2 border-t border-daintree-border px-3 py-2">
               <div
-                className="flex gap-1 text-[11px]"
+                className="relative isolate flex bg-tint/[0.04] rounded p-0.5 text-[11px]"
                 role="radiogroup"
                 aria-label="Commit mode"
                 data-testid="fleet-picker-cold-start-commit-mode"
               >
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={commitMode === "replace"}
-                  onClick={() => setCommitMode("replace")}
-                  data-testid="fleet-picker-cold-start-commit-mode-replace"
-                  className={cn(
-                    "rounded px-2 py-1 transition-colors",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
-                    commitMode === "replace"
-                      ? "bg-tint/[0.14] text-daintree-text"
-                      : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
-                  )}
-                >
-                  Replace
-                </button>
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={commitMode === "append"}
-                  onClick={() => setCommitMode("append")}
-                  data-testid="fleet-picker-cold-start-commit-mode-append"
-                  className={cn(
-                    "rounded px-2 py-1 transition-colors",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
-                    commitMode === "append"
-                      ? "bg-tint/[0.14] text-daintree-text"
-                      : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
-                  )}
-                >
-                  Append
-                </button>
+                {COMMIT_MODES.map(({ mode, label }) => {
+                  const isActive = commitMode === mode;
+
+                  return (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="radio"
+                      aria-checked={isActive}
+                      onClick={() => setCommitMode(mode)}
+                      data-testid={`fleet-picker-cold-start-commit-mode-${mode}`}
+                      className={cn(
+                        "relative rounded px-2 py-0.5 transition-colors",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+                        isActive
+                          ? "text-daintree-text"
+                          : "text-daintree-text/70 hover:bg-tint/[0.04]"
+                      )}
+                    >
+                      {isActive && (
+                        <m.div
+                          data-slot="segmented-thumb"
+                          layout
+                          layoutId={thumbLayoutId}
+                          layoutCrossfade={false}
+                          transition={thumbTransition}
+                          style={{ borderRadius: 4 }}
+                          className="absolute inset-0 z-0 bg-tint/[0.10] pointer-events-none"
+                          aria-hidden="true"
+                        />
+                      )}
+                      <span className="relative z-10">{label}</span>
+                    </button>
+                  );
+                })}
               </div>
               <div className="flex items-center gap-1.5">
                 <button

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -42,7 +42,10 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
   const addToFleet = useFleetArmingStore((s) => s.addToFleet);
   const [commitMode, setCommitMode] = useState<CommitMode>("replace");
   const thumbLayoutId = `${useId()}-segmented-thumb`;
-  const thumbTransition = useUiMotionTransition();
+  const uiMotionTransition = useUiMotionTransition();
+  // Closing resets the mode to Replace while the palette is still fading out, which
+  // would otherwise slide the thumb back across a disappearing dialog.
+  const thumbTransition = isOpen ? uiMotionTransition : { ...uiMotionTransition, duration: 0 };
 
   useEffect(() => {
     if (!isOpen) setCommitMode("replace");
@@ -205,7 +208,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
 
             <div className="flex flex-nowrap items-center justify-between gap-2 border-t border-daintree-border px-3 py-2">
               <div
-                className="relative isolate flex bg-tint/[0.04] rounded p-0.5 text-[11px]"
+                className="relative isolate flex bg-tint/[0.04] rounded text-[11px]"
                 role="radiogroup"
                 aria-label="Commit mode"
                 data-testid="fleet-picker-cold-start-commit-mode"
@@ -222,7 +225,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
                       onClick={() => setCommitMode(mode)}
                       data-testid={`fleet-picker-cold-start-commit-mode-${mode}`}
                       className={cn(
-                        "relative rounded px-2 py-0.5 transition-colors",
+                        "relative rounded px-2 py-1 transition-colors",
                         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
                         isActive
                           ? "text-daintree-text"
@@ -236,8 +239,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
                           layoutId={thumbLayoutId}
                           layoutCrossfade={false}
                           transition={thumbTransition}
-                          style={{ borderRadius: 4 }}
-                          className="absolute inset-0 z-0 bg-tint/[0.10] pointer-events-none"
+                          className="absolute inset-0 z-0 rounded bg-tint/[0.10] pointer-events-none"
                           aria-hidden="true"
                         />
                       )}

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -9,8 +9,9 @@ vi.mock("@/components/ui/ScrollShadow", () => ({
 
 // Spread the real module rather than hand-listing exports: the palette pulls in
 // more of animationUtils than this test cares about, and a factory that misses a
-// single constant fails every test in the file at render time. Only the timing
-// values that would make the palette animate are overridden.
+// single constant fails every test in the file at render time (e.g. the commit-mode
+// thumb's duration). Only the timing values that would make the palette animate are
+// overridden.
 vi.mock("@/lib/animationUtils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/animationUtils")>()),
   UI_ENTER_DURATION: 0,
@@ -597,6 +598,27 @@ describe("FleetPickerPalette", () => {
       expect(append.getAttribute("aria-checked")).toBe("false");
       const confirm = screen.getByTestId("fleet-picker-cold-start-confirm");
       expect(confirm.textContent).toContain("Arm 1 selected");
+    });
+
+    it("keeps a single sliding thumb, owned by the checked mode", async () => {
+      seedTerminals([makeTerminal("t1", { worktreeId: "wt-1" })]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const group = screen.getByTestId("fleet-picker-cold-start-commit-mode");
+      const thumbOwner = () => {
+        const thumbs = group.querySelectorAll("[data-slot='segmented-thumb']");
+        expect(thumbs.length).toBe(1);
+        return thumbs[0]?.closest("[role='radio']");
+      };
+
+      expect(thumbOwner()).toBe(screen.getByTestId("fleet-picker-cold-start-commit-mode-replace"));
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-commit-mode-append"));
+      });
+
+      expect(thumbOwner()).toBe(screen.getByTestId("fleet-picker-cold-start-commit-mode-append"));
     });
 
     it("switching to Append updates aria-checked and confirm label", async () => {

--- a/src/components/ui/SegmentedToggle.tsx
+++ b/src/components/ui/SegmentedToggle.tsx
@@ -49,7 +49,7 @@ export function SegmentedToggle<T extends string>({
             aria-pressed={isActive}
             className={cn(
               "relative px-2.5 py-1 text-xs font-medium rounded transition-colors",
-              "disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none",
+              "disabled:cursor-not-allowed disabled:pointer-events-none",
               isActive ? "text-daintree-text" : "text-muted-foreground hover:text-daintree-text"
             )}
           >
@@ -60,14 +60,19 @@ export function SegmentedToggle<T extends string>({
                 layoutId={thumbLayoutId}
                 layoutCrossfade={false}
                 transition={thumbTransition}
-                // Inline so framer scale-corrects the corners while the thumb resizes
-                // between segments of different widths; a `rounded` class it cannot read.
-                style={{ borderRadius: 4 }}
-                className="absolute inset-0 z-0 bg-daintree-border pointer-events-none"
+                className={cn(
+                  "absolute inset-0 z-0 rounded bg-daintree-border pointer-events-none",
+                  option.disabled && "opacity-40"
+                )}
                 aria-hidden="true"
               />
             )}
-            <span className="relative z-10">{option.label}</span>
+            {/* Dimming a disabled segment has to happen on its contents, never on the
+                button: opacity below 1 would make the button a stacking context and trap
+                this label beneath a thumb sliding across it from a sibling. */}
+            <span className={cn("relative z-10", option.disabled && "opacity-40")}>
+              {option.label}
+            </span>
           </button>
         );
       })}

--- a/src/components/ui/SegmentedToggle.tsx
+++ b/src/components/ui/SegmentedToggle.tsx
@@ -1,3 +1,6 @@
+import { useId } from "react";
+import { m } from "framer-motion";
+import { useUiMotionTransition } from "@/hooks/useShouldSkipMotion";
 import { cn } from "@/lib/utils";
 
 export interface SegmentedToggleOption<T extends string> {
@@ -12,6 +15,12 @@ export interface SegmentedToggleOption<T extends string> {
  * Compact two-to-three-way mode switch used in viewer chrome (file viewer's
  * View/Diff and Split/Unified, markdown Rendered/Source). Extracted from
  * FileViewerModal so panel and dialog surfaces share one control.
+ *
+ * The active segment is marked by a single thumb that slides between segments:
+ * one `m.div` moves via shared-layout projection rather than a background class
+ * hopping from button to button. The layout id is instance-scoped — several
+ * toggles render at once (FileViewerModal alone has three) and a shared id would
+ * fling the thumb between unrelated controls.
  */
 export function SegmentedToggle<T extends string>({
   options,
@@ -22,26 +31,46 @@ export function SegmentedToggle<T extends string>({
   value: T;
   onChange: (value: T) => void;
 }) {
+  const thumbLayoutId = `${useId()}-segmented-thumb`;
+  const thumbTransition = useUiMotionTransition();
+
   return (
-    <div className="flex bg-daintree-sidebar rounded p-0.5 shrink-0">
-      {options.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          onClick={() => onChange(option.value)}
-          disabled={option.disabled}
-          aria-label={option.ariaLabel}
-          aria-pressed={value === option.value}
-          className={cn(
-            "px-2.5 py-1 text-xs font-medium rounded transition-colors",
-            value === option.value
-              ? "bg-daintree-border text-daintree-text"
-              : "text-muted-foreground hover:text-daintree-text disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
-          )}
-        >
-          {option.label}
-        </button>
-      ))}
+    <div className="relative isolate flex bg-daintree-sidebar rounded p-0.5 shrink-0">
+      {options.map((option) => {
+        const isActive = value === option.value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            disabled={option.disabled}
+            aria-label={option.ariaLabel}
+            aria-pressed={isActive}
+            className={cn(
+              "relative px-2.5 py-1 text-xs font-medium rounded transition-colors",
+              "disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none",
+              isActive ? "text-daintree-text" : "text-muted-foreground hover:text-daintree-text"
+            )}
+          >
+            {isActive && (
+              <m.div
+                data-slot="segmented-thumb"
+                layout
+                layoutId={thumbLayoutId}
+                layoutCrossfade={false}
+                transition={thumbTransition}
+                // Inline so framer scale-corrects the corners while the thumb resizes
+                // between segments of different widths; a `rounded` class it cannot read.
+                style={{ borderRadius: 4 }}
+                className="absolute inset-0 z-0 bg-daintree-border pointer-events-none"
+                aria-hidden="true"
+              />
+            )}
+            <span className="relative z-10">{option.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ui/SegmentedToggle.tsx
+++ b/src/components/ui/SegmentedToggle.tsx
@@ -60,6 +60,11 @@ export function SegmentedToggle<T extends string>({
                 layoutId={thumbLayoutId}
                 layoutCrossfade={false}
                 transition={thumbTransition}
+                // `rounded` tracks the theme (it resolves to --theme-radius-scale), which an
+                // inline pixel radius would not. framer can only scale-correct a radius it
+                // reads from `style`, so the corners stretch slightly while the thumb morphs
+                // between segments of different widths — a frame or two, and worth it to stay
+                // theme-correct at rest.
                 className={cn(
                   "absolute inset-0 z-0 rounded bg-daintree-border pointer-events-none",
                   option.disabled && "opacity-40"

--- a/src/components/ui/__tests__/SegmentedToggle.test.tsx
+++ b/src/components/ui/__tests__/SegmentedToggle.test.tsx
@@ -174,6 +174,26 @@ describe("SegmentedToggle", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("dims a disabled segment without turning the button into a stacking context", () => {
+    render(
+      <SegmentedToggle
+        options={[
+          { value: "view", label: "View" },
+          { value: "diff", label: "Diff", disabled: true },
+        ]}
+        value="view"
+        onChange={() => {}}
+      />
+    );
+    const disabled = screen.getByRole("button", { name: "Diff" });
+
+    // `opacity` below 1 makes an element a stacking context, which would trap this
+    // label at its own z-index and let a thumb sliding over from a sibling paint on
+    // top of it. The dimming has to sit on the contents, never on the button.
+    expect(disabled.className).not.toMatch(/(^|:)opacity-/);
+    expect(within(disabled).getByText("Diff").className).toMatch(/opacity-/);
+  });
+
   it("keeps the thumb on a segment that is both selected and disabled", () => {
     render(
       <SegmentedToggle

--- a/src/components/ui/__tests__/SegmentedToggle.test.tsx
+++ b/src/components/ui/__tests__/SegmentedToggle.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+// Framer's projection engine needs a real layout engine, so jsdom can never prove
+// the thumb *slides*. What it can prove is the configuration framer is handed:
+// surface the layout props as attributes and assert the invariants that break the
+// effect when they're wrong (a shared id, a lost thumb, a crossfade).
+interface MockThumbProps {
+  layoutId?: string;
+  layoutCrossfade?: boolean;
+  transition?: { duration?: number };
+  style?: CSSProperties;
+  className?: string;
+  children?: ReactNode;
+  "data-slot"?: string;
+  "aria-hidden"?: boolean;
+}
+
+vi.mock("framer-motion", () => ({
+  useReducedMotion: () => false,
+  m: {
+    div: ({ layoutId, layoutCrossfade, transition, ...rest }: MockThumbProps) => (
+      <div
+        {...rest}
+        data-layout-id={layoutId}
+        data-crossfade={String(layoutCrossfade)}
+        data-duration={String(transition?.duration)}
+      />
+    ),
+  },
+}));
+
+import { SegmentedToggle, type SegmentedToggleOption } from "../SegmentedToggle";
+
+type Mode = "view" | "diff" | "blame";
+
+const OPTIONS: SegmentedToggleOption<Mode>[] = [
+  { value: "view", label: "View" },
+  { value: "diff", label: "Diff" },
+];
+
+const thumbs = () => document.querySelectorAll("[data-slot='segmented-thumb']");
+
+/** The button the sole thumb currently lives in — the whole point of the control. */
+function thumbOwner(): Element | null {
+  expect(thumbs().length).toBe(1);
+  return thumbs()[0]?.closest("button") ?? null;
+}
+
+function Controlled({ options = OPTIONS }: { options?: SegmentedToggleOption<Mode>[] }) {
+  const [value, setValue] = useState<Mode>("view");
+  return <SegmentedToggle options={options} value={value} onChange={setValue} />;
+}
+
+afterEach(() => {
+  delete document.body.dataset.performanceMode;
+});
+
+describe("SegmentedToggle", () => {
+  it("gives the sole thumb to the pressed segment", () => {
+    render(<Controlled />);
+
+    expect(thumbOwner()).toBe(screen.getByRole("button", { pressed: true }));
+  });
+
+  it("hands the thumb to the newly pressed segment on change", () => {
+    render(<Controlled />);
+    expect(thumbOwner()).toBe(screen.getByRole("button", { name: "View" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Diff" }));
+
+    expect(thumbOwner()).toBe(screen.getByRole("button", { name: "Diff" }));
+    expect(screen.getByRole("button", { name: "Diff" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("moves the thumb across a three-way toggle", () => {
+    render(<Controlled options={[...OPTIONS, { value: "blame", label: "Blame" }]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Blame" }));
+
+    expect(thumbOwner()).toBe(screen.getByRole("button", { name: "Blame" }));
+  });
+
+  it("scopes the layout id per instance so sibling toggles don't share a thumb", () => {
+    render(
+      <>
+        <Controlled />
+        <Controlled />
+      </>
+    );
+
+    const ids = [...thumbs()].map((thumb) => thumb.getAttribute("data-layout-id"));
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+    expect(ids.every((id) => id && id.length > 0)).toBe(true);
+  });
+
+  it("keeps one instance's layout id stable across a value change, so framer can track it", () => {
+    render(<Controlled />);
+    const before = thumbs()[0]?.getAttribute("data-layout-id");
+
+    fireEvent.click(screen.getByRole("button", { name: "Diff" }));
+
+    expect(thumbs()[0]?.getAttribute("data-layout-id")).toBe(before);
+  });
+
+  it("moves the thumb without crossfading it, keeping the motion transform-only", () => {
+    render(<Controlled />);
+
+    expect(thumbs()[0]?.getAttribute("data-crossfade")).toBe("false");
+  });
+
+  it("hides the thumb from assistive tech and from pointers", () => {
+    render(<Controlled />);
+    const thumb = thumbs()[0];
+
+    expect(thumb?.getAttribute("aria-hidden")).toBe("true");
+    expect(thumb?.className).toContain("pointer-events-none");
+  });
+
+  it("animates by default and resolves instantly in performance mode", () => {
+    const { unmount } = render(<Controlled />);
+    expect(Number(thumbs()[0]?.getAttribute("data-duration"))).toBeGreaterThan(0);
+    unmount();
+
+    document.body.dataset.performanceMode = "true";
+    render(<Controlled />);
+
+    expect(Number(thumbs()[0]?.getAttribute("data-duration"))).toBe(0);
+  });
+
+  it("reports the label to assistive tech, overridden by ariaLabel when given", () => {
+    render(
+      <SegmentedToggle
+        options={[
+          { value: "view", label: "S", ariaLabel: "Small" },
+          { value: "diff", label: "Diff" },
+        ]}
+        value="view"
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Small" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Diff" })).toBeTruthy();
+  });
+
+  it("keeps the label readable above the thumb", () => {
+    render(<Controlled />);
+    const active = screen.getByRole("button", { pressed: true });
+
+    // The thumb is a positioned sibling of the label, so painting order alone
+    // would put it over the text — the label has to carry its own stacking.
+    expect(within(active).getByText("View").className).toContain("z-10");
+  });
+
+  it("does not fire onChange for a disabled segment", () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedToggle
+        options={[
+          { value: "view", label: "View" },
+          { value: "diff", label: "Diff", disabled: true },
+        ]}
+        value="view"
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Diff" }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the thumb on a segment that is both selected and disabled", () => {
+    render(
+      <SegmentedToggle
+        options={[
+          { value: "view", label: "View", disabled: true },
+          { value: "diff", label: "Diff" },
+        ]}
+        value="view"
+        onChange={() => {}}
+      />
+    );
+
+    // Unavailable is not unselected: the control must still show what's active.
+    expect(thumbOwner()).toBe(screen.getByRole("button", { name: "View" }));
+  });
+
+  it("renders no thumb when the value matches no option", () => {
+    render(<SegmentedToggle options={OPTIONS} value={"gone" as Mode} onChange={() => {}} />);
+
+    expect(thumbs().length).toBe(0);
+  });
+});

--- a/src/components/ui/__tests__/SegmentedToggle.test.tsx
+++ b/src/components/ui/__tests__/SegmentedToggle.test.tsx
@@ -231,7 +231,9 @@ describe("SegmentedToggle", () => {
   });
 
   it("renders no thumb when the value matches no option", () => {
-    render(<SegmentedToggle options={OPTIONS} value={"gone" as Mode} onChange={() => {}} />);
+    // "blame" is a legal Mode, but it isn't among these options — a controlled value
+    // with nothing to point at must show nothing, not pin the thumb to a stale segment.
+    render(<SegmentedToggle options={OPTIONS} value="blame" onChange={() => {}} />);
 
     expect(thumbs().length).toBe(0);
   });

--- a/src/components/ui/__tests__/SegmentedToggle.test.tsx
+++ b/src/components/ui/__tests__/SegmentedToggle.test.tsx
@@ -43,6 +43,20 @@ const OPTIONS: SegmentedToggleOption<Mode>[] = [
 
 const thumbs = () => document.querySelectorAll("[data-slot='segmented-thumb']");
 
+/** Tailwind's `z-<n>`, ignoring variants — jsdom has no stylesheet to compute against. */
+function stackLevel(el: Element): number {
+  const match = /(?:^|\s)z-(\d+)(?=\s|$)/.exec(el.className);
+  return match?.[1] === undefined ? 0 : Number(match[1]);
+}
+
+/** Does any utility on this element drop it below full opacity (in any state)? */
+function dimsBelowFullOpacity(el: Element): boolean {
+  return el.className.split(/\s+/).some((utility) => {
+    const match = /(?:^|:)opacity-(\d+)$/.exec(utility);
+    return match?.[1] !== undefined && Number(match[1]) < 100;
+  });
+}
+
 /** The button the sole thumb currently lives in — the whole point of the control. */
 function thumbOwner(): Element | null {
   expect(thumbs().length).toBe(1);
@@ -147,13 +161,17 @@ describe("SegmentedToggle", () => {
     expect(screen.getByRole("button", { name: "Diff" })).toBeTruthy();
   });
 
-  it("keeps the label readable above the thumb", () => {
+  it("keeps every label stacked above the thumb, including its neighbours'", () => {
     render(<Controlled />);
-    const active = screen.getByRole("button", { pressed: true });
+    const thumb = thumbs()[0];
 
-    // The thumb is a positioned sibling of the label, so painting order alone
-    // would put it over the text — the label has to carry its own stacking.
-    expect(within(active).getByText("View").className).toContain("z-10");
+    // The thumb is a positioned element, so painting order alone would put it over
+    // the text — and it overflows into the neighbouring segment mid-slide, so it has
+    // to sit below EVERY label, not just the one it shares a button with.
+    expect(thumb).toBeDefined();
+    for (const label of ["View", "Diff"]) {
+      expect(stackLevel(screen.getByText(label))).toBeGreaterThan(stackLevel(thumb!));
+    }
   });
 
   it("does not fire onChange for a disabled segment", () => {
@@ -187,14 +205,14 @@ describe("SegmentedToggle", () => {
     );
     const disabled = screen.getByRole("button", { name: "Diff" });
 
-    // `opacity` below 1 makes an element a stacking context, which would trap this
-    // label at its own z-index and let a thumb sliding over from a sibling paint on
-    // top of it. The dimming has to sit on the contents, never on the button.
-    expect(disabled.className).not.toMatch(/(^|:)opacity-/);
-    expect(within(disabled).getByText("Diff").className).toMatch(/opacity-/);
+    // Opacity below 1 makes an element a stacking context, which would trap this label
+    // at its own z-index and let a thumb sliding over from a sibling paint on top of
+    // it. The dimming has to sit on the contents, never on the button.
+    expect(dimsBelowFullOpacity(disabled)).toBe(false);
+    expect(dimsBelowFullOpacity(within(disabled).getByText("Diff"))).toBe(true);
   });
 
-  it("keeps the thumb on a segment that is both selected and disabled", () => {
+  it("dims a selected-but-disabled segment whole, thumb included, and keeps its thumb", () => {
     render(
       <SegmentedToggle
         options={[
@@ -208,6 +226,8 @@ describe("SegmentedToggle", () => {
 
     // Unavailable is not unselected: the control must still show what's active.
     expect(thumbOwner()).toBe(screen.getByRole("button", { name: "View" }));
+    expect(dimsBelowFullOpacity(thumbs()[0]!)).toBe(true);
+    expect(dimsBelowFullOpacity(screen.getByText("View"))).toBe(true);
   });
 
   it("renders no thumb when the value matches no option", () => {

--- a/src/hooks/__tests__/useShouldSkipMotion.test.tsx
+++ b/src/hooks/__tests__/useShouldSkipMotion.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const prefersReducedMotion = vi.hoisted(() => ({ current: false as boolean | null }));
+
+vi.mock("framer-motion", () => ({
+  useReducedMotion: () => prefersReducedMotion.current,
+}));
+
+import {
+  shouldSkipMotion,
+  useShouldSkipMotion,
+  useUiMotionTransition,
+} from "@/hooks/useShouldSkipMotion";
+
+afterEach(() => {
+  prefersReducedMotion.current = false;
+  delete document.body.dataset.reduceAnimations;
+  delete document.body.dataset.performanceMode;
+});
+
+describe("shouldSkipMotion", () => {
+  it("animates only when every signal is off", () => {
+    expect(
+      shouldSkipMotion({
+        prefersReducedMotion: false,
+        reduceAnimations: false,
+        performanceMode: false,
+      })
+    ).toBe(false);
+  });
+
+  it("treats an unresolved OS media query as 'not reduced'", () => {
+    expect(
+      shouldSkipMotion({
+        prefersReducedMotion: null,
+        reduceAnimations: false,
+        performanceMode: false,
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    ["OS reduced motion", { prefersReducedMotion: true }],
+    ["the in-app reduce-animations preference", { reduceAnimations: true }],
+    ["performance mode", { performanceMode: true }],
+  ])("skips motion when %s is on, independent of the others", (_label, signal) => {
+    expect(
+      shouldSkipMotion({
+        prefersReducedMotion: false,
+        reduceAnimations: false,
+        performanceMode: false,
+        ...signal,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("useShouldSkipMotion", () => {
+  it("reads both app flags off document.body", () => {
+    expect(renderHook(() => useShouldSkipMotion()).result.current).toBe(false);
+
+    document.body.dataset.reduceAnimations = "true";
+    expect(renderHook(() => useShouldSkipMotion()).result.current).toBe(true);
+
+    delete document.body.dataset.reduceAnimations;
+    document.body.dataset.performanceMode = "true";
+    expect(renderHook(() => useShouldSkipMotion()).result.current).toBe(true);
+  });
+
+  it('ignores body flags that are present but not exactly "true"', () => {
+    document.body.dataset.reduceAnimations = "false";
+    document.body.dataset.performanceMode = "";
+    expect(renderHook(() => useShouldSkipMotion()).result.current).toBe(false);
+  });
+
+  it("re-reads the body flags on every render rather than caching at mount", () => {
+    const { result, rerender } = renderHook(() => useShouldSkipMotion());
+    expect(result.current).toBe(false);
+
+    document.body.dataset.performanceMode = "true";
+    rerender();
+
+    expect(result.current).toBe(true);
+  });
+
+  it("follows the OS media query", () => {
+    prefersReducedMotion.current = true;
+    expect(renderHook(() => useShouldSkipMotion()).result.current).toBe(true);
+  });
+});
+
+describe("useUiMotionTransition", () => {
+  it("emits a non-zero duration in seconds when motion is allowed", () => {
+    const { duration } = renderHook(() => useUiMotionTransition()).result.current;
+
+    expect(duration).toBeGreaterThan(0);
+    // framer takes seconds; the shared tier is defined in ms, so a value >= 1
+    // means the conversion was dropped and the thumb would crawl for seconds.
+    expect(duration).toBeLessThan(1);
+  });
+
+  it("collapses to an instant transition when motion is skipped", () => {
+    document.body.dataset.performanceMode = "true";
+
+    expect(renderHook(() => useUiMotionTransition()).result.current.duration).toBe(0);
+  });
+
+  it("keeps the shared easing curve in both modes", () => {
+    const animated = renderHook(() => useUiMotionTransition()).result.current;
+
+    document.body.dataset.reduceAnimations = "true";
+    const instant = renderHook(() => useUiMotionTransition()).result.current;
+
+    expect(instant.ease).toEqual(animated.ease);
+  });
+});

--- a/src/hooks/__tests__/useShouldSkipMotion.test.tsx
+++ b/src/hooks/__tests__/useShouldSkipMotion.test.tsx
@@ -107,8 +107,13 @@ describe("useUiMotionTransition", () => {
     expect(renderHook(() => useUiMotionTransition()).result.current.duration).toBe(0);
   });
 
-  it("keeps the shared easing curve in both modes", () => {
+  it("keeps one real easing curve in both modes", () => {
     const animated = renderHook(() => useUiMotionTransition()).result.current;
+
+    // framer 12 rejects CSS string easings, so the curve has to be a bezier tuple —
+    // an assertion of equality alone would hold even if both modes emitted undefined.
+    expect(animated.ease).toHaveLength(4);
+    expect(animated.ease.every((point) => Number.isFinite(point))).toBe(true);
 
     document.body.dataset.reduceAnimations = "true";
     const instant = renderHook(() => useUiMotionTransition()).result.current;

--- a/src/hooks/useShouldSkipMotion.ts
+++ b/src/hooks/useShouldSkipMotion.ts
@@ -1,0 +1,49 @@
+import { useReducedMotion } from "framer-motion";
+import { EASE_OUT_EXPO_FM, UI_ANIMATION_DURATION } from "@/lib/animationUtils";
+
+export interface MotionSkipSignals {
+  /** OS `prefers-reduced-motion`. `null` until the media query resolves. */
+  prefersReducedMotion: boolean | null;
+  /** The in-app "Reduce animations" preference. */
+  reduceAnimations: boolean;
+  performanceMode: boolean;
+}
+
+export function shouldSkipMotion({
+  prefersReducedMotion,
+  reduceAnimations,
+  performanceMode,
+}: MotionSkipSignals): boolean {
+  return prefersReducedMotion === true || reduceAnimations || performanceMode;
+}
+
+/**
+ * Whether motion should resolve instantly. Framer's `MotionConfig` only knows
+ * about reduced motion, so performance mode has to be read here; framer's
+ * `useReducedMotion` in turn only sees the OS media query, not the in-app
+ * preference. Both app-level flags live on `document.body` (set by AppLayout),
+ * read at render — always fresh, because whatever animates re-renders anyway.
+ */
+export function useShouldSkipMotion(): boolean {
+  const prefersReducedMotion = useReducedMotion();
+  const dataset = typeof document === "undefined" ? undefined : document.body?.dataset;
+
+  return shouldSkipMotion({
+    prefersReducedMotion,
+    reduceAnimations: dataset?.reduceAnimations === "true",
+    performanceMode: dataset?.performanceMode === "true",
+  });
+}
+
+/** The shared 150ms tier as a framer-motion transition, instant when motion is skipped. */
+export function useUiMotionTransition(): {
+  duration: number;
+  ease: typeof EASE_OUT_EXPO_FM;
+} {
+  const skipMotion = useShouldSkipMotion();
+
+  return {
+    duration: skipMotion ? 0 : UI_ANIMATION_DURATION / 1000,
+    ease: EASE_OUT_EXPO_FM,
+  };
+}


### PR DESCRIPTION
## Summary

- `SegmentedToggle` used to swap its active background instantly between buttons, softened only by `transition-colors`. It now renders a single thumb that slides behind the active segment, built as one framer-motion `m.div` with a `useId`-scoped `layoutId` so framer FLIPs it between segments (transform-only, `layoutCrossfade` off, shared 150ms tier via `UI_ANIMATION_DURATION`/`EASE_OUT_EXPO_FM`).
- Applied the same treatment to `FleetPickerPalette`'s Replace/Append commit-mode control, the issue's optional secondary ask, keeping its radio semantics, `aria-checked` state, and `data-testid`s intact.
- Added `useShouldSkipMotion` / `useUiMotionTransition` hooks (`src/hooks/useShouldSkipMotion.ts`) that collapse the thumb to an instant move when motion should be skipped.

Resolves #11165

## Changes

- `src/components/ui/SegmentedToggle.tsx`: replaced the per-segment background swap with one sliding thumb.
- `src/components/Fleet/FleetPickerPalette.tsx`: same thumb treatment on the commit-mode toggle.
- `src/hooks/useShouldSkipMotion.ts` (new): ORs three signals together because none is sufficient alone. Framer's `MotionConfig` can't see Daintree's performance mode, and `useReducedMotion()` only reads the OS media query, not the in-app "Reduce animations" preference. Both app flags live on `document.body` (`data-performance-mode`, `data-reduce-animations`), read at render, matching the existing pattern in `TabButton` and `DockedTabGroup`.
- `eslint.config.js`: added the three new framer-motion importers to the existing per-file restricted-import allowlist rather than bumping the lint ratchet baseline.

A few details worth flagging in review:

- The `layoutId` is scoped per component instance via `useId()`. `FileViewerModal` renders three toggles at once, so a shared literal id would fling the thumb between unrelated controls.
- A disabled segment dims its contents, never the button itself: opacity below 1 on the button would make it a stacking context and trap its label under a thumb sliding in from a sibling.
- The thumb's radius uses the `rounded` class rather than an inline pixel value, since `rounded` resolves to `calc(0.625rem * var(--theme-radius-scale))` and a literal would break theme radius scaling. Tradeoff: framer can only scale-correct a radius it reads from `style`, so corners visibly stretch for a frame or two while the thumb morphs between segments of very different widths.

## Testing

- 251 unit tests pass across 9 suites covering every changed module: the 2 new suites plus `FleetPickerPalette`, `FileViewerModal`, `ImageDiffViewer`, `FilePane`, `FileDiffModal`, and the accentGuard/focusRingFallback contract tests.
- `e2e/full/panels/core-file-panel.spec.ts` (`--project=full-panels`) passes, 10 tests, driving the Rendered/Source `SegmentedToggle`.
- `npm run lint:ratchet` and `npm run typecheck` both pass clean; prettier/eslint clean on all changed files.
