### PR TITLE
feat(pulse): reframe coaching from commit streaks to outcomes

### DIFF
--- a/docs/themes/visual-guide.md
+++ b/docs/themes/visual-guide.md
@@ -607,9 +607,8 @@ In Bondi: `#FDFDFE` with `0 1px 3px rgba(0,0,0,0.06)` — a white card with a ba
 
 The heatmap shows rectangular cells for each day. Color intensity represents activity level:
 
-- **Empty (no activity):** `pulse-empty-bg` (defaults to `surface-panel`)
+- **Empty (no activity):** `pulse-empty-bg` (defaults to `surface-panel`) — a day with no commits is simply quiet; the heatmap has no failure state
 - **Before range (future):** `pulse-before-bg` (defaults to `surface-sidebar`)
-- **Missed (failed):** `pulse-missed-bg` (defaults to `status-danger` at 18%)
 - **Low activity:** `accent-primary` at `pulse-heat-low-opacity` (14%)
 - **Medium activity:** `accent-primary` at `pulse-heat-medium-opacity` (30%)
 - **High activity:** `accent-primary` at `pulse-heat-high-opacity` (50%)

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -549,7 +549,7 @@ describe("built-in themes", () => {
   it("LIGHT themes clear the round-2 selection/elevation validation matrix (hard-fail)", () => {
     // Harden phase: the consolidated round-2 matrix (E6) — activity/pr/scrollbar
     // floors, input/placeholder legibility, filter-selected separation, settings
-    // card lift, pulse heat/missed, and the OKLab elevation-direction inversions
+    // card lift, pulse heat, and the OKLab elevation-direction inversions
     // (sidebar selected lift, grid-bg-below-panel, panel→elevated not smallest) —
     // is now a HARD FAILURE for LIGHT themes. Every check is behavioural: it
     // computes a real contrast ratio / OKLab ΔE / luminance relationship from the

--- a/shared/theme/builtInThemes/arashiyama.ts
+++ b/shared/theme/builtInThemes/arashiyama.ts
@@ -122,7 +122,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#A38C4A",
     "pulse-heat-4": "#E0B061",
     "pulse-heat-color": "#D9A752",
-    "pulse-missed-bg": "rgba(184,95,86,0.18)",
     "pulse-range-bg": "#1B1715",
     "pulse-ring-offset": "#261F1C",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #352E29 25%, #3E3530 50%, #352E29 75%)",

--- a/shared/theme/builtInThemes/atacama.ts
+++ b/shared/theme/builtInThemes/atacama.ts
@@ -169,8 +169,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#3FA4AC",
     "pulse-heat-4": "#0E6675",
     "pulse-heat-color": "#0E6675",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor.
-    "pulse-missed-bg": "#A33530",
     "pulse-range-bg": "#F6F0E5",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #E8D5B9 25%, #F6F0E5 50%, #E8D5B9 75%)",

--- a/shared/theme/builtInThemes/bali.ts
+++ b/shared/theme/builtInThemes/bali.ts
@@ -164,8 +164,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-low-opacity": "0.40",
     "pulse-heat-medium-opacity": "0.66",
     "pulse-heat-color": "#C8920F",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor.
-    "pulse-missed-bg": "#C0453A",
     "pulse-range-bg": "#F0F3E4",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #D2DEB4 25%, #F0F3E4 50%, #D2DEB4 75%)",

--- a/shared/theme/builtInThemes/bondi.ts
+++ b/shared/theme/builtInThemes/bondi.ts
@@ -172,8 +172,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-2": "#6BC9CC",
     "pulse-heat-3": "#0099A2",
     "pulse-heat-4": "#006171",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor.
-    "pulse-missed-bg": "#A83C34",
     "pulse-range-bg": "#F3F1EA",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #DCD8CA 25%, #F3F1EA 50%, #DCD8CA 75%)",

--- a/shared/theme/builtInThemes/daintree.ts
+++ b/shared/theme/builtInThemes/daintree.ts
@@ -113,7 +113,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-2": "#2b6243",
     "pulse-heat-3": "#319966",
     "pulse-heat-4": "#36CE94",
-    "pulse-missed-bg": "rgba(200,116,108,0.18)",
     "pulse-range-bg": "#19191a",
     "pulse-ring-offset": "#1d1d1e",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #2b2b2c 25%, #333335 50%, #2b2b2c 75%)",

--- a/shared/theme/builtInThemes/fiordland.ts
+++ b/shared/theme/builtInThemes/fiordland.ts
@@ -129,7 +129,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#42B59A",
     "pulse-heat-4": "#5FE6C1",
     "pulse-heat-color": "#5FE6C1",
-    "pulse-missed-bg": "rgba(191,101,101,0.18)",
     "pulse-range-bg": "#111919",
     "pulse-ring-offset": "#050809",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #222C2B 25%, #2D3837 50%, #222C2B 75%)",

--- a/shared/theme/builtInThemes/galapagos.ts
+++ b/shared/theme/builtInThemes/galapagos.ts
@@ -134,7 +134,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#377B62",
     "pulse-heat-4": "#4A9E7F",
     "pulse-heat-color": "#4A9E7F",
-    "pulse-missed-bg": "rgba(209,123,114,0.18)",
     "pulse-range-bg": "#161D1B",
     "pulse-ring-offset": "#1A2421",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #23322E 25%, #2C3D38 50%, #23322E 75%)",

--- a/shared/theme/builtInThemes/highlands.ts
+++ b/shared/theme/builtInThemes/highlands.ts
@@ -127,8 +127,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#A07EBE",
     "pulse-heat-4": "#BD92E4",
     "pulse-heat-color": "#BD92E4",
-    // Derived from danger #C08078.
-    "pulse-missed-bg": "rgba(192,128,120,0.18)",
     "pulse-range-bg": "#1F1E22",
     "pulse-ring-offset": "#2B292D",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #3C3A3F 25%, #454248 50%, #3C3A3F 75%)",

--- a/shared/theme/builtInThemes/hokkaido.ts
+++ b/shared/theme/builtInThemes/hokkaido.ts
@@ -185,8 +185,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-low-opacity": "0.35",
     "pulse-heat-medium-opacity": "0.6",
     "pulse-heat-color": "#A97416",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor.
-    "pulse-missed-bg": "#BE3C48",
     "pulse-range-bg": "#F1F0F7",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #D5D3F2 25%, #F1F0F7 50%, #D5D3F2 75%)",

--- a/shared/theme/builtInThemes/namib.ts
+++ b/shared/theme/builtInThemes/namib.ts
@@ -139,7 +139,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#CB7229",
     "pulse-heat-4": "#ECA851",
     "pulse-heat-color": "#ECA851",
-    "pulse-missed-bg": "rgba(196,122,107,0.18)",
     "pulse-range-bg": "#1F1B16",
     "pulse-ring-offset": "#161310",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #2F2922 25%, #3A332B 50%, #2F2922 75%)",

--- a/shared/theme/builtInThemes/redwoods.ts
+++ b/shared/theme/builtInThemes/redwoods.ts
@@ -139,7 +139,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#B28324",
     "pulse-heat-4": "#E0AF3B",
     "pulse-heat-color": "#E0AF3B",
-    "pulse-missed-bg": "rgba(184,92,82,0.18)",
     "pulse-range-bg": "#16110D",
     "pulse-ring-offset": "#1E1612",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #2A1E18 25%, #342820 50%, #2A1E18 75%)",

--- a/shared/theme/builtInThemes/serengeti.ts
+++ b/shared/theme/builtInThemes/serengeti.ts
@@ -168,9 +168,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-2": "#D5AA55",
     "pulse-heat-3": "#BF7B1F",
     "pulse-heat-4": "#9E5A03",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor; kept
-    // hue-distinct from the ember ramp.
-    "pulse-missed-bg": "#B13A28",
     "pulse-range-bg": "#F5F0D8",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #E2D7A0 25%, #F5F0D8 50%, #E2D7A0 75%)",

--- a/shared/theme/builtInThemes/svalbard.ts
+++ b/shared/theme/builtInThemes/svalbard.ts
@@ -174,9 +174,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#008D94",
     "pulse-heat-4": "#6A499B",
     "pulse-heat-color": "#6A499B",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor — the
-    // missed day stays unambiguous red, never aurora.
-    "pulse-missed-bg": "#C0413E",
     "pulse-range-bg": "#E9F0F5",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #C2D9E6 25%, #E9F0F5 50%, #C2D9E6 75%)",

--- a/shared/theme/builtInThemes/table-mountain.ts
+++ b/shared/theme/builtInThemes/table-mountain.ts
@@ -171,8 +171,6 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-3": "#407F4E",
     "pulse-heat-4": "#286830",
     "pulse-heat-color": "#286830",
-    // Opaque so the streak-break signal clears the 3:1 graphical floor.
-    "pulse-missed-bg": "#AE3D33",
     "pulse-range-bg": "#F5EFE5",
     "pulse-ring-offset": "#FFFFFF",
     "pulse-skeleton-gradient": "linear-gradient(90deg, #DFCFB8 25%, #F4EEE3 50%, #DFCFB8 75%)",

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -878,11 +878,11 @@ function runCardAboveDialogBody(scheme: AppColorScheme): AppThemeValidationWarni
 
 /**
  * The pulse heatmap composites a single hue at four alpha stops over the empty cell
- * (RC-2 in miniature). Light-only (P-Heat). Two failures this catches: (1) the
- * lowest heat stop is sub-JND against the empty cell, so a worked day is invisible;
- * (2) the missed-day film (a destructive streak-break signal) is sub-3:1 against the
- * empty cell. Requires `pulse-heat-color`; themes that leave it unset fall back at
- * the consumer and are skipped.
+ * (RC-2 in miniature). Light-only (P-Heat). Catches the lowest heat stop landing
+ * sub-JND against the empty cell, which makes a worked day invisible. Requires
+ * `pulse-heat-color`; themes that leave it unset fall back at the consumer and are
+ * skipped. The heatmap has no failure state to audit — a zero-commit day is just the
+ * empty cell (#11172).
  */
 function runPulseHeatSeparation(scheme: AppColorScheme): AppThemeValidationWarning[] {
   if (scheme.type !== "light") return [];
@@ -900,17 +900,6 @@ function runPulseHeatSeparation(scheme: AppColorScheme): AppThemeValidationWarni
       out.push({
         kind: "low-contrast",
         message: `[matrix] ${scheme.id}: pulse heat level-1 (heat-color @${lowOp}) ΔE=${de.toFixed(4)} vs empty cell is below JND (${RAMP_DL_JND_MATRIX}) — a worked day is invisible (P-Heat)`,
-      });
-    }
-  }
-
-  const missed = resolveToHex(extVal(scheme, "pulse-missed-bg"), empty.hex);
-  if (!("skip" in missed)) {
-    const ratio = contrastRatio(missed.hex, empty.hex);
-    if (ratio < 3.0) {
-      out.push({
-        kind: "low-contrast",
-        message: `[matrix] ${scheme.id}: pulse missed-day fill vs empty cell is ${ratio.toFixed(2)}:1; target is 3.0:1 — the streak-break signal is imperceptible (P-Heat)`,
       });
     }
   }
@@ -962,7 +951,7 @@ function runActivityWorkingWaitingSeparation(scheme: AppColorScheme): AppThemeVa
  *   input-text-vs-surface-input (AA) ..... runMatrixContrastPairs
  *   filter-selected separation (JND) ..... runMatrixSeparationPairs
  *   card-vs-dialog-body (light) .......... runCardAboveDialogBody
- *   pulse heat/missed separation ......... runPulseHeatSeparation
+ *   pulse heat separation ................ runPulseHeatSeparation
  *   activity working/waiting separation .. runActivityWorkingWaitingSeparation
  *   sidebar-selected-above-container ..... auditSidebarSelectedLift (oklch)
  *   grid-bg-below-panel (light) .......... auditGridBgBelowPanel (oklch)

--- a/shared/theme/extensionRegistry.ts
+++ b/shared/theme/extensionRegistry.ts
@@ -211,10 +211,19 @@ export const EXTENSION_KEY_REGISTRY = {
   "pulse-heat-high-opacity": OPTIONAL,
   "pulse-heat-low-opacity": OPTIONAL,
   "pulse-heat-medium-opacity": OPTIONAL,
-  "pulse-missed-bg": OPTIONAL,
   "pulse-range-bg": OPTIONAL,
   "pulse-ring-offset": OPTIONAL,
   "pulse-skeleton-gradient": OPTIONAL,
+  // Streak-flame tiers, shortest to longest. The consumer bakes the current
+  // ramp in as a fallback, so a theme that leaves these unset renders the same
+  // flame it always did.
+  "pulse-streak-1": OPTIONAL,
+  "pulse-streak-2": OPTIONAL,
+  "pulse-streak-3": OPTIONAL,
+  "pulse-streak-4": OPTIONAL,
+  "pulse-streak-5": OPTIONAL,
+  "pulse-streak-6": OPTIONAL,
+  "pulse-streak-7": OPTIONAL,
 
   // Settings
   "settings-card-bg": OPTIONAL,

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -281,10 +281,16 @@ export const EXTENSION_KEYS = [
   "pulse-heat-high-opacity",
   "pulse-heat-low-opacity",
   "pulse-heat-medium-opacity",
-  "pulse-missed-bg",
   "pulse-range-bg",
   "pulse-ring-offset",
   "pulse-skeleton-gradient",
+  "pulse-streak-1",
+  "pulse-streak-2",
+  "pulse-streak-3",
+  "pulse-streak-4",
+  "pulse-streak-5",
+  "pulse-streak-6",
+  "pulse-streak-7",
 
   // Settings tab
   "settings-card-bg",

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useId, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useShallow } from "zustand/react/shallow";
-import type { PulseRangeDays, ProjectPulse } from "@shared/types";
+import type { PulseRangeDays } from "@shared/types";
 import type { ForgeProjectHealthPayload } from "@shared/types/ipc/forge";
 import { usePulseStore, useProjectStore, PULSE_MAX_RETRIES } from "@/store";
 import { cn } from "@/lib/utils";
@@ -24,6 +24,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { Activity } from "@/components/icons";
 import { PulseHeatmap, getPulseHeatmapRowWidth, getPulseHeatLevelBackground } from "./PulseHeatmap";
 import { PulseSummary } from "./PulseSummary";
+import { getCoachLine, getUsableHealth } from "./coachLine";
 import { useProjectHealth } from "@/hooks/useProjectHealth";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { systemClient } from "@/clients/systemClient";
@@ -44,27 +45,6 @@ const RANGE_OPTIONS: { value: PulseRangeDays; label: string; srLabel: string }[]
   { value: 120, label: "120d", srLabel: "120 days" },
   { value: 180, label: "180d", srLabel: "180 days" },
 ];
-
-function getCoachLine(pulse: ProjectPulse): string {
-  const sortedCells = [...pulse.heatmap]
-    .filter((cell) => !isNaN(new Date(cell.date).getTime()))
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-
-  const today = sortedCells.find((c) => c.isToday) ?? sortedCells.at(-1);
-
-  const last7Days = sortedCells.slice(-7).filter((c) => c.count > 0).length;
-
-  if (today && today.count > 0) {
-    return `${today.count} commit${today.count !== 1 ? "s" : ""} today — nice.`;
-  }
-  if (pulse.currentStreakDays && pulse.currentStreakDays > 0) {
-    return "One small commit today keeps your streak going.";
-  }
-  if (last7Days > 0) {
-    return `Momentum's building: ${last7Days} active day${last7Days !== 1 ? "s" : ""} this week.`;
-  }
-  return "Make a tiny win: ship one small change today.";
-}
 
 function CIStatusIcon({ status }: { status: ForgeProjectHealthPayload["ciStatus"] }) {
   switch (status) {
@@ -376,6 +356,9 @@ function PulseHeatmapLegend({
 export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProps) {
   const projectName = useProjectStore((s) => s.currentProject?.name);
   const { health, loading: healthLoading, refresh: refreshHealth } = useProjectHealth();
+  // One source of truth for "can this health back a claim?", shared by the
+  // coach line and the chips so they can't contradict each other.
+  const usableHealth = getUsableHealth(health);
   const { pulse, isLoading, error, rangeDays, retryCount, fetchPulse, setRangeDays } =
     usePulseStore(
       useShallow((state) => ({
@@ -640,7 +623,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <PulseHeatmapLegend dayCount={pulse.heatmap.length} descriptionId={heatmapDescriptionId} />
 
-        <p className="text-xs text-daintree-text/80">{getCoachLine(pulse)}</p>
+        <p className="text-xs text-daintree-text/80">{getCoachLine(pulse, health)}</p>
 
         {/* Health section: always renders the wrapper so the 4 sub-variants
             (signals, skeleton, no-remote hint, offline hint) can swap without
@@ -648,8 +631,10 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
             height (h-5 chip + pt-3 padding) so the loaded HealthSignals row
             doesn't push siblings down when it resolves after pulse (#7671). */}
         <div className="border-t border-daintree-border pt-3 min-h-9">
-          {health && !health.error && health.repoUrl ? (
-            <HealthSignals health={health} rangeDays={rangeDays} />
+          {usableHealth ? (
+            // pulse.rangeDays, not the selector's — the chip describes the same
+            // snapshot the coach line above it does.
+            <HealthSignals health={usableHealth} rangeDays={pulse.rangeDays} />
           ) : healthLoading ? (
             <HealthSectionSkeleton />
           ) : health && !health.hasRemote ? (

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -356,8 +356,8 @@ function PulseHeatmapLegend({
 export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProps) {
   const projectName = useProjectStore((s) => s.currentProject?.name);
   const { health, loading: healthLoading, refresh: refreshHealth } = useProjectHealth();
-  // One source of truth for "can this health back a claim?", shared by the
-  // coach line and the chips so they can't contradict each other.
+  // Filtered once and handed to both the coach line and the chips, so the two
+  // can't contradict each other about whether forge data is usable.
   const usableHealth = getUsableHealth(health);
   const { pulse, isLoading, error, rangeDays, retryCount, fetchPulse, setRangeDays } =
     usePulseStore(
@@ -623,7 +623,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <PulseHeatmapLegend dayCount={pulse.heatmap.length} descriptionId={heatmapDescriptionId} />
 
-        <p className="text-xs text-daintree-text/80">{getCoachLine(pulse, health)}</p>
+        <p className="text-xs text-daintree-text/80">{getCoachLine(pulse, usableHealth)}</p>
 
         {/* Health section: always renders the wrapper so the 4 sub-variants
             (signals, skeleton, no-remote hint, offline hint) can swap without

--- a/src/components/Pulse/PulseHeatmap.tsx
+++ b/src/components/Pulse/PulseHeatmap.tsx
@@ -24,43 +24,11 @@ export function getPulseHeatmapRowWidth({
   return columns > 0 ? cellSize * columns + gap * (columns - 1) : 0;
 }
 
-interface RenderCell extends HeatCell {
-  isMissedDay: boolean;
-}
-
 const COLUMNS_PER_ROW = 60;
 const CELL_SIZE_PX = 10;
 const GAP_PX = 3;
 const COMPACT_CELL_SIZE_PX = 6;
 const COMPACT_GAP_PX = 2;
-const MISSED_DAY_WINDOW = 4;
-
-function isMissedDay(cells: HeatCell[], index: number): boolean {
-  const cell = cells[index];
-  if (!cell || cell.count > 0 || cell.isBeforeProject || cell.isToday) {
-    return false;
-  }
-
-  let hasRecentActivityBefore = false;
-  for (let i = Math.max(0, index - MISSED_DAY_WINDOW); i < index; i += 1) {
-    if (cells[i]!.count > 0) {
-      hasRecentActivityBefore = true;
-      break;
-    }
-  }
-
-  if (!hasRecentActivityBefore) {
-    return false;
-  }
-
-  for (let i = index + 1; i <= Math.min(cells.length - 1, index + MISSED_DAY_WINDOW); i += 1) {
-    if (cells[i]!.count > 0) {
-      return true;
-    }
-  }
-
-  return false;
-}
 
 // Per-theme opaque heat stops (pulse-heat-1..4) step in both lightness and
 // chroma (GitHub light-contributions model) rather than one hue at four alphas
@@ -108,17 +76,9 @@ export function getPulseHeatLevelBackground(level: 0 | 1 | 2 | 3 | 4): string {
   return level === 0 ? EMPTY_CELL_BACKGROUND : getHeatCellBackground(level);
 }
 
-function getCellStyle(cell: RenderCell): CSSProperties {
-  if (cell.isMissedDay) {
-    // Destructive-tier streak-break signal. Backed by an opaque danger tint
-    // (pulse-missed-bg, P-Heat authors these >=3:1 vs the empty cell) PLUS a
-    // non-colour shape cue (inset danger ring, light-only) so it stays distinct
-    // from heat levels and legible for colour-vision deficiency. The ring is
-    // drawn with an inset box-shadow via the .pulse-heat-cell-missed class.
-    // Every built-in defines pulse-missed-bg (P-Heat authors them opaque, >=3:1).
-    return { background: "var(--pulse-missed-bg)" };
-  }
-
+// A day with no commits is just quiet — every zero cell reads the same,
+// whatever its neighbours did. The heatmap has no way to express failure.
+function getCellStyle(cell: HeatCell): CSSProperties {
   if (cell.count === 0) {
     return { background: EMPTY_CELL_BACKGROUND };
   }
@@ -128,11 +88,7 @@ function getCellStyle(cell: RenderCell): CSSProperties {
   };
 }
 
-function getTooltipText(cell: RenderCell): string {
-  if (cell.isMissedDay) {
-    return "Missed day";
-  }
-
+function getTooltipText(cell: HeatCell): string {
   if (cell.count === 0) {
     return "No commits";
   }
@@ -146,7 +102,7 @@ function PulseHeatmapCell({
   isActive,
   onCellRef,
 }: {
-  cell: RenderCell;
+  cell: HeatCell;
   cellSize: number;
   isActive: boolean;
   onCellRef: (date: string, el: HTMLButtonElement | null) => void;
@@ -191,7 +147,6 @@ function PulseHeatmapCell({
           }}
           className={cn(
             "pulse-heat-cell relative overflow-hidden rounded-[2px] shrink-0 border-0 p-0 cursor-default transition-[transform,background-color,box-shadow] duration-150",
-            cell.isMissedDay && "pulse-heat-cell-missed",
             cell.isMostRecentActive && "ring-1 ring-daintree-text/25 ring-offset-1"
           )}
           aria-label={`${formatted}: ${getTooltipText(cell)}`}
@@ -219,16 +174,15 @@ export function PulseHeatmap({
       .filter((cell) => !Number.isNaN(new Date(cell.date).getTime()))
       .filter((cell) => !cell.isBeforeProject)
       .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-      .map((cell, index, allCells) => ({
+      .map((cell) => ({
         ...cell,
         level: Math.max(0, Math.min(4, cell.level)) as HeatCell["level"],
-        isMissedDay: isMissedDay(allCells, index),
       }));
 
     const columnsPerRow = compact
       ? Math.min(COLUMNS_PER_ROW, normalizedCells.length)
       : COLUMNS_PER_ROW;
-    const result: RenderCell[][] = [];
+    const result: HeatCell[][] = [];
     const firstRowSize = normalizedCells.length % columnsPerRow || columnsPerRow;
 
     if (normalizedCells.length > 0) {

--- a/src/components/Pulse/StreakFlame.tsx
+++ b/src/components/Pulse/StreakFlame.tsx
@@ -1,21 +1,40 @@
 import { type SVGProps } from "react";
 import { Flame } from "lucide-react";
 
-const STREAK_TIERS = [
-  { min: 240, color: "#9333EA" },
-  { min: 120, color: "#C026D3" },
-  { min: 60, color: "#DC2626" },
-  { min: 30, color: "#EF4444" },
-  { min: 15, color: "#F97316" },
-  { min: 8, color: "#FB923C" },
-  { min: 0, color: "#F59E0B" },
-] as const;
+type StreakTier = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
+export function getStreakTier(days: number): StreakTier {
+  if (days >= 240) return 7;
+  if (days >= 120) return 6;
+  if (days >= 60) return 5;
+  if (days >= 30) return 4;
+  if (days >= 15) return 3;
+  if (days >= 8) return 2;
+  return 1;
+}
+
+// Per-theme streak stops (pulse-streak-1..7), warm at the short end and cool at
+// the long end. Each is OPTIONAL and bakes the original ramp in as its fallback,
+// so a theme that never authors them renders exactly the flame it always did.
+// Static per-tier references (not a template literal over the tier index) so the
+// EXTENSION_KEYS drift scanner registers each stop as a consumer.
 export function getStreakColor(days: number): string {
-  for (const tier of STREAK_TIERS) {
-    if (days >= tier.min) return tier.color;
+  switch (getStreakTier(days)) {
+    case 7:
+      return "var(--pulse-streak-7, #9333EA)";
+    case 6:
+      return "var(--pulse-streak-6, #C026D3)";
+    case 5:
+      return "var(--pulse-streak-5, #DC2626)";
+    case 4:
+      return "var(--pulse-streak-4, #EF4444)";
+    case 3:
+      return "var(--pulse-streak-3, #F97316)";
+    case 2:
+      return "var(--pulse-streak-2, #FB923C)";
+    default:
+      return "var(--pulse-streak-1, #F59E0B)";
   }
-  return "#F59E0B";
 }
 
 interface StreakFlameProps extends Omit<SVGProps<SVGSVGElement>, "ref"> {

--- a/src/components/Pulse/__tests__/projectPulseCoach.test.ts
+++ b/src/components/Pulse/__tests__/projectPulseCoach.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import type { HeatCell, ProjectPulse, PulseRangeDays } from "@shared/types";
+import type { ForgeProjectHealthPayload } from "@shared/types/ipc/forge";
+import { getCoachLine, getUsableHealth } from "../coachLine";
+
+// #11172: coaching is framed around what shipped, never around commit
+// obligations, and no branch may express failure. Commit counts in Daintree
+// mostly measure how busy the agents were.
+
+function cell(daysAgo: number, count: number, isToday = false): HeatCell {
+  const date = new Date(Date.UTC(2026, 0, 20) - daysAgo * 86_400_000);
+  return {
+    date: date.toISOString().slice(0, 10),
+    count,
+    level: Math.min(4, count) as HeatCell["level"],
+    ...(isToday ? { isToday: true } : {}),
+  };
+}
+
+function makePulse(overrides: Partial<ProjectPulse> = {}): ProjectPulse {
+  return {
+    worktreeId: "wt-1",
+    worktreePath: "/repo",
+    mainBranch: "main",
+    rangeDays: 60,
+    generatedAt: 0,
+    heatmap: [],
+    commitsInRange: 0,
+    activeDays: 0,
+    projectAgeDays: 400,
+    recentCommits: [],
+    ...overrides,
+  };
+}
+
+function makeHealth(overrides: Partial<ForgeProjectHealthPayload> = {}): ForgeProjectHealthPayload {
+  return {
+    ciStatus: "success",
+    issueCount: 0,
+    prCount: 0,
+    latestRelease: null,
+    securityAlerts: { visible: false, count: 0 },
+    mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
+    repoUrl: "https://github.com/acme/repo",
+    hasRemote: true,
+    loading: false,
+    ...overrides,
+  };
+}
+
+function withMerges(counts: Partial<Record<PulseRangeDays, number>>): ForgeProjectHealthPayload {
+  return makeHealth({
+    mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0, ...counts } },
+  });
+}
+
+// A busy week AND a live streak — the conditions the old copy used to turn into
+// commit pressure. Every test that pairs this with merge data proves outcomes
+// outrank activity.
+const ACTIVE_PULSE = makePulse({
+  heatmap: [cell(3, 4), cell(2, 2), cell(1, 5), cell(0, 3, true)],
+  currentStreakDays: 12,
+});
+
+const QUIET_PULSE = makePulse({
+  heatmap: [cell(3, 0), cell(2, 0), cell(1, 0), cell(0, 0, true)],
+  currentStreakDays: 0,
+});
+
+describe("getCoachLine — outcomes lead", () => {
+  it("reports merged changes ahead of today's commits and a live streak", () => {
+    const line = getCoachLine(ACTIVE_PULSE, withMerges({ 60: 7 }));
+    expect(line).toContain("7 changes merged");
+    expect(line).not.toContain("activity today");
+  });
+
+  it("reads the merge count for the range the snapshot is showing", () => {
+    const health = withMerges({ 60: 3, 120: 9, 180: 40 });
+    expect(getCoachLine(makePulse({ rangeDays: 60 }), health)).toContain("3 changes");
+    expect(getCoachLine(makePulse({ rangeDays: 120 }), health)).toContain("9 changes");
+    expect(getCoachLine(makePulse({ rangeDays: 180 }), health)).toContain("40 changes");
+  });
+
+  it("names the range it is reporting over", () => {
+    expect(getCoachLine(makePulse({ rangeDays: 180 }), withMerges({ 180: 12 }))).toContain(
+      "last 180 days"
+    );
+  });
+
+  it("agrees with itself on singular and plural", () => {
+    expect(getCoachLine(makePulse(), withMerges({ 60: 1 }))).toContain("1 change merged");
+    expect(getCoachLine(makePulse(), withMerges({ 60: 2 }))).toContain("2 changes merged");
+  });
+
+  it("stays forge-neutral rather than naming GitHub's vocabulary", () => {
+    const line = getCoachLine(makePulse(), withMerges({ 60: 5 }));
+    expect(line.toLowerCase()).not.toContain("pull request");
+  });
+});
+
+describe("getCoachLine — degrading without usable merge data", () => {
+  const UNUSABLE: [string, ForgeProjectHealthPayload | null][] = [
+    ["no health yet", null],
+    ["a provider error", makeHealth({ error: "rate limited" })],
+    ["no remote", makeHealth({ hasRemote: false, repoUrl: "" })],
+    ["a blank repo url", makeHealth({ repoUrl: "" })],
+  ];
+
+  it.each(UNUSABLE)("falls back to activity on %s, never claiming an outcome", (_label, health) => {
+    const line = getCoachLine(ACTIVE_PULSE, health);
+    expect(line).not.toContain("merged");
+    expect(line.trim().length).toBeGreaterThan(0);
+  });
+
+  it("never claims an outcome from a zero merge count", () => {
+    // Zero is ambiguous — the provider zero-fills when its velocity query fails.
+    expect(getCoachLine(ACTIVE_PULSE, withMerges({ 60: 0 }))).not.toContain("merged");
+  });
+
+  it("mentions today when today has commits", () => {
+    expect(getCoachLine(ACTIVE_PULSE, null)).toContain("today");
+  });
+
+  it("falls back to the week when today is quiet but the week wasn't", () => {
+    const pulse = makePulse({ heatmap: [cell(3, 4), cell(2, 0), cell(1, 0), cell(0, 0, true)] });
+    const line = getCoachLine(pulse, null);
+    expect(line).toContain("this week");
+    expect(line).not.toContain("today");
+  });
+
+  it("stays calm when nothing has happened at all", () => {
+    expect(getCoachLine(QUIET_PULSE, null).trim().length).toBeGreaterThan(0);
+  });
+
+  it("does not treat a stale trailing cell as today", () => {
+    // No cell carries isToday — the old code fell back to the last cell and
+    // reported its commits as today's.
+    const pulse = makePulse({ heatmap: [cell(9, 6), cell(8, 4)] });
+    expect(getCoachLine(pulse, null)).not.toContain("today");
+  });
+});
+
+describe("getCoachLine — cannot express guilt or failure", () => {
+  const SCENARIOS: [string, ProjectPulse, ForgeProjectHealthPayload | null][] = [
+    ["shipped work", ACTIVE_PULSE, withMerges({ 60: 7 })],
+    ["active today", ACTIVE_PULSE, null],
+    ["active this week", makePulse({ heatmap: [cell(3, 4), cell(0, 0, true)] }), null],
+    ["fully quiet", QUIET_PULSE, null],
+    ["quiet but mid-streak", makePulse({ ...QUIET_PULSE, currentStreakDays: 30 }), null],
+  ];
+
+  // The old line was "One small commit today keeps your streak going." — an
+  // obligation triggered precisely by having a streak to lose.
+  const FORBIDDEN = /\b(streak|missed|keep|keeps|must|should|don't lose|maintain)\b/i;
+
+  it.each(SCENARIOS)("%s: no obligation or failure vocabulary", (_label, pulse, health) => {
+    expect(getCoachLine(pulse, health)).not.toMatch(FORBIDDEN);
+  });
+
+  it("never asks for a commit", () => {
+    for (const [, pulse, health] of SCENARIOS) {
+      expect(getCoachLine(pulse, health).toLowerCase()).not.toContain("commit");
+    }
+  });
+
+  it("says the same thing whether or not a streak is running", () => {
+    // A streak must not be able to change the coaching — that's what made the
+    // old copy leverage rather than encouragement.
+    const withStreak = makePulse({ ...QUIET_PULSE, currentStreakDays: 45 });
+    expect(getCoachLine(withStreak, null)).toBe(getCoachLine(QUIET_PULSE, null));
+  });
+});
+
+describe("getUsableHealth", () => {
+  it("passes through only health that can back a merge claim", () => {
+    const ok = makeHealth();
+    expect(getUsableHealth(ok)).toBe(ok);
+    expect(getUsableHealth(null)).toBeNull();
+    expect(getUsableHealth(makeHealth({ error: "boom" }))).toBeNull();
+    expect(getUsableHealth(makeHealth({ repoUrl: "" }))).toBeNull();
+  });
+
+  it("gates the coach line on exactly what it gates the chips on", () => {
+    // The card renders HealthSignals off this same call. If the two ever
+    // diverged, the line could claim merges above an error hint.
+    for (const health of [
+      makeHealth(),
+      makeHealth({ error: "boom" }),
+      makeHealth({ repoUrl: "" }),
+      null,
+    ]) {
+      const claimsMerges = getCoachLine(makePulse(), withMergesFrom(health)).includes("merged");
+      expect(claimsMerges).toBe(getUsableHealth(health) !== null);
+    }
+  });
+});
+
+// Give every candidate a positive merge count, so the only thing deciding
+// whether the line claims an outcome is the usability gate itself.
+function withMergesFrom(health: ForgeProjectHealthPayload | null) {
+  if (health === null) return null;
+  return { ...health, mergeVelocity: { mergedCounts: { 60: 5, 120: 5, 180: 5 } } };
+}

--- a/src/components/Pulse/__tests__/projectPulseCoach.test.ts
+++ b/src/components/Pulse/__tests__/projectPulseCoach.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
 import type { HeatCell, ProjectPulse, PulseRangeDays } from "@shared/types";
 import type { ForgeProjectHealthPayload } from "@shared/types/ipc/forge";
-import { getCoachLine, getUsableHealth } from "../coachLine";
+import { getCoachLine, getCoachSignal, getUsableHealth } from "../coachLine";
 
-// #11172: coaching is framed around what shipped, never around commit
-// obligations, and no branch may express failure. Commit counts in Daintree
-// mostly measure how busy the agents were.
+// #11172: coaching is framed around what landed, never around commit
+// obligations, and no branch may express failure. Precedence and data selection
+// are asserted on the signal so rewording the copy can't redden them; the copy
+// itself is held to a policy, not to exact strings.
 
 function cell(daysAgo: number, count: number, isToday = false): HeatCell {
   const date = new Date(Date.UTC(2026, 0, 20) - daysAgo * 86_400_000);
@@ -48,15 +49,18 @@ function makeHealth(overrides: Partial<ForgeProjectHealthPayload> = {}): ForgePr
   };
 }
 
-function withMerges(counts: Partial<Record<PulseRangeDays, number>>): ForgeProjectHealthPayload {
+function withMerges(
+  counts: Partial<Record<PulseRangeDays, number>>,
+  overrides: Partial<ForgeProjectHealthPayload> = {}
+): ForgeProjectHealthPayload {
   return makeHealth({
     mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0, ...counts } },
+    ...overrides,
   });
 }
 
-// A busy week AND a live streak — the conditions the old copy used to turn into
-// commit pressure. Every test that pairs this with merge data proves outcomes
-// outrank activity.
+// A busy week AND a live streak — the conditions the old copy turned into commit
+// pressure. Pairing this with merge data proves outcomes outrank activity.
 const ACTIVE_PULSE = makePulse({
   heatmap: [cell(3, 4), cell(2, 2), cell(1, 5), cell(0, 3, true)],
   currentStreakDays: 12,
@@ -67,99 +71,141 @@ const QUIET_PULSE = makePulse({
   currentStreakDays: 0,
 });
 
-describe("getCoachLine — outcomes lead", () => {
-  it("reports merged changes ahead of today's commits and a live streak", () => {
-    const line = getCoachLine(ACTIVE_PULSE, withMerges({ 60: 7 }));
-    expect(line).toContain("7 changes merged");
-    expect(line).not.toContain("activity today");
+describe("getCoachSignal — outcomes outrank activity", () => {
+  it("picks the merge outcome over today's commits and a live streak", () => {
+    expect(getCoachSignal(ACTIVE_PULSE, withMerges({ 60: 7 }))).toStrictEqual({
+      kind: "merged",
+      count: 7,
+      rangeDays: 60,
+    });
   });
 
   it("reads the merge count for the range the snapshot is showing", () => {
     const health = withMerges({ 60: 3, 120: 9, 180: 40 });
-    expect(getCoachLine(makePulse({ rangeDays: 60 }), health)).toContain("3 changes");
-    expect(getCoachLine(makePulse({ rangeDays: 120 }), health)).toContain("9 changes");
-    expect(getCoachLine(makePulse({ rangeDays: 180 }), health)).toContain("40 changes");
-  });
-
-  it("names the range it is reporting over", () => {
-    expect(getCoachLine(makePulse({ rangeDays: 180 }), withMerges({ 180: 12 }))).toContain(
-      "last 180 days"
-    );
-  });
-
-  it("agrees with itself on singular and plural", () => {
-    expect(getCoachLine(makePulse(), withMerges({ 60: 1 }))).toContain("1 change merged");
-    expect(getCoachLine(makePulse(), withMerges({ 60: 2 }))).toContain("2 changes merged");
-  });
-
-  it("stays forge-neutral rather than naming GitHub's vocabulary", () => {
-    const line = getCoachLine(makePulse(), withMerges({ 60: 5 }));
-    expect(line.toLowerCase()).not.toContain("pull request");
+    for (const [rangeDays, count] of [
+      [60, 3],
+      [120, 9],
+      [180, 40],
+    ] as const) {
+      expect(getCoachSignal(makePulse({ rangeDays }), health)).toStrictEqual({
+        kind: "merged",
+        count,
+        rangeDays,
+      });
+    }
   });
 });
 
-describe("getCoachLine — degrading without usable merge data", () => {
+describe("getCoachSignal — degrading without usable merge data", () => {
   const UNUSABLE: [string, ForgeProjectHealthPayload | null][] = [
     ["no health yet", null],
-    ["a provider error", makeHealth({ error: "rate limited" })],
-    ["no remote", makeHealth({ hasRemote: false, repoUrl: "" })],
-    ["a blank repo url", makeHealth({ repoUrl: "" })],
+    ["a provider error", withMerges({ 60: 5 }, { error: "rate limited" })],
+    ["no remote", withMerges({ 60: 5 }, { hasRemote: false, repoUrl: "" })],
+    ["a blank repo url", withMerges({ 60: 5 }, { repoUrl: "" })],
   ];
 
-  it.each(UNUSABLE)("falls back to activity on %s, never claiming an outcome", (_label, health) => {
-    const line = getCoachLine(ACTIVE_PULSE, health);
-    expect(line).not.toContain("merged");
-    expect(line.trim().length).toBeGreaterThan(0);
+  // Every candidate carries a positive merge count, so the only thing deciding
+  // whether an outcome is claimed is the usability gate itself.
+  it.each(UNUSABLE)("never claims an outcome from %s", (_label, health) => {
+    expect(getUsableHealth(health)).toBeNull();
+    expect(getCoachSignal(ACTIVE_PULSE, health).kind).not.toBe("merged");
   });
 
   it("never claims an outcome from a zero merge count", () => {
     // Zero is ambiguous — the provider zero-fills when its velocity query fails.
-    expect(getCoachLine(ACTIVE_PULSE, withMerges({ 60: 0 }))).not.toContain("merged");
+    expect(getCoachSignal(ACTIVE_PULSE, withMerges({ 60: 0 })).kind).not.toBe("merged");
   });
 
-  it("mentions today when today has commits", () => {
-    expect(getCoachLine(ACTIVE_PULSE, null)).toContain("today");
-  });
+  it("falls to today, then the recent window, then quiet", () => {
+    expect(getCoachSignal(ACTIVE_PULSE, null).kind).toBe("today");
 
-  it("falls back to the week when today is quiet but the week wasn't", () => {
-    const pulse = makePulse({ heatmap: [cell(3, 4), cell(2, 0), cell(1, 0), cell(0, 0, true)] });
-    const line = getCoachLine(pulse, null);
-    expect(line).toContain("this week");
-    expect(line).not.toContain("today");
-  });
+    const quietToday = makePulse({ heatmap: [cell(3, 4), cell(0, 0, true)] });
+    expect(getCoachSignal(quietToday, null).kind).toBe("recent");
 
-  it("stays calm when nothing has happened at all", () => {
-    expect(getCoachLine(QUIET_PULSE, null).trim().length).toBeGreaterThan(0);
-  });
-
-  it("does not treat a stale trailing cell as today", () => {
-    // No cell carries isToday — the old code fell back to the last cell and
-    // reported its commits as today's.
-    const pulse = makePulse({ heatmap: [cell(9, 6), cell(8, 4)] });
-    expect(getCoachLine(pulse, null)).not.toContain("today");
+    expect(getCoachSignal(QUIET_PULSE, null).kind).toBe("quiet");
   });
 });
 
-describe("getCoachLine — cannot express guilt or failure", () => {
-  const SCENARIOS: [string, ProjectPulse, ForgeProjectHealthPayload | null][] = [
-    ["shipped work", ACTIVE_PULSE, withMerges({ 60: 7 })],
-    ["active today", ACTIVE_PULSE, null],
-    ["active this week", makePulse({ heatmap: [cell(3, 4), cell(0, 0, true)] }), null],
-    ["fully quiet", QUIET_PULSE, null],
-    ["quiet but mid-streak", makePulse({ ...QUIET_PULSE, currentStreakDays: 30 }), null],
-  ];
-
-  // The old line was "One small commit today keeps your streak going." — an
-  // obligation triggered precisely by having a streak to lose.
-  const FORBIDDEN = /\b(streak|missed|keep|keeps|must|should|don't lose|maintain)\b/i;
-
-  it.each(SCENARIOS)("%s: no obligation or failure vocabulary", (_label, pulse, health) => {
-    expect(getCoachLine(pulse, health)).not.toMatch(FORBIDDEN);
+describe("getCoachSignal — recency is dated, not positional", () => {
+  it("does not count activity older than the window as recent", () => {
+    // The last 7 array entries are NOT the last 7 days. These commits are 8 and
+    // 9 days old; reading the tail of the array would call them "recent".
+    const stale = makePulse({
+      heatmap: [cell(9, 6), cell(8, 4), cell(0, 0, true)],
+    });
+    expect(getCoachSignal(stale, null).kind).toBe("quiet");
   });
 
-  it("never asks for a commit", () => {
-    for (const [, pulse, health] of SCENARIOS) {
-      expect(getCoachLine(pulse, health).toLowerCase()).not.toContain("commit");
+  it("counts activity inside the window, right up to its edge", () => {
+    const edge = makePulse({ heatmap: [cell(6, 2), cell(0, 0, true)] });
+    expect(getCoachSignal(edge, null).kind).toBe("recent");
+
+    const justOutside = makePulse({ heatmap: [cell(7, 2), cell(0, 0, true)] });
+    expect(getCoachSignal(justOutside, null).kind).toBe("quiet");
+  });
+
+  it("does not count a cell dated after today as recent activity", () => {
+    // Clock skew or a bad fixture — a future cell is not evidence of work done.
+    const future = makePulse({ heatmap: [cell(0, 0, true), cell(-2, 5)] });
+    expect(getCoachSignal(future, null).kind).toBe("quiet");
+  });
+
+  it("stays quiet when no cell is dated today, rather than guessing", () => {
+    // Without an isToday cell there is no way to date the activity, and a stale
+    // trailing cell must not be reported as today's.
+    const undated = makePulse({ heatmap: [cell(9, 6), cell(8, 4)] });
+    expect(getCoachSignal(undated, null).kind).toBe("quiet");
+  });
+});
+
+describe("getCoachLine — copy policy", () => {
+  const EVERY_LINE = [
+    getCoachLine(ACTIVE_PULSE, withMerges({ 60: 7 })),
+    getCoachLine(makePulse(), withMerges({ 60: 1 })),
+    getCoachLine(ACTIVE_PULSE, null),
+    getCoachLine(makePulse({ heatmap: [cell(3, 4), cell(0, 0, true)] }), null),
+    getCoachLine(QUIET_PULSE, null),
+    getCoachLine(makePulse({ ...QUIET_PULSE, currentStreakDays: 45 }), null),
+  ];
+
+  // Every line the retired ladder could produce. The guard has to reject all of
+  // them, or it isn't guarding anything.
+  const RETIRED_COPY = [
+    "3 commits today — nice.",
+    "One small commit today keeps your streak going.",
+    "Momentum's building: 2 active days this week.",
+    "Make a tiny win: ship one small change today.",
+  ];
+
+  // Streak leverage, imperatives, and the praise that made a commit count feel
+  // like a score. This is a regression guard on known-bad vocabulary, not a
+  // proof of calmness — it can't catch every way copy could turn into pressure.
+  // The invariance tests below are what actually pin the behaviour down.
+  const FORBIDDEN =
+    /\b(streak|missed|keeps?|maintain|must|should|need to|have to|make|ship|win|momentum|nice|tiny|don't)\b/i;
+
+  it("rejects every line the old ladder could produce", () => {
+    for (const retired of RETIRED_COPY) {
+      expect(retired).toMatch(FORBIDDEN);
+    }
+  });
+
+  it("uses no obligation, guilt, or praise vocabulary in any branch", () => {
+    for (const line of EVERY_LINE) {
+      expect(line).not.toMatch(FORBIDDEN);
+    }
+  });
+
+  it("never asks for a commit, or mentions commits at all", () => {
+    // A commit count measures how busy the agents were, not how the day went.
+    for (const line of EVERY_LINE) {
+      expect(line.toLowerCase()).not.toContain("commit");
+    }
+  });
+
+  it("says something in every branch", () => {
+    for (const line of EVERY_LINE) {
+      expect(line.trim().length).toBeGreaterThan(0);
     }
   });
 
@@ -169,35 +215,52 @@ describe("getCoachLine — cannot express guilt or failure", () => {
     const withStreak = makePulse({ ...QUIET_PULSE, currentStreakDays: 45 });
     expect(getCoachLine(withStreak, null)).toBe(getCoachLine(QUIET_PULSE, null));
   });
+
+  it("does not vary the activity lines with the amount of activity", () => {
+    // The old weekly line embedded an active-day count, which turned the heatmap
+    // into a score. Busier weeks must read identically.
+    const oneDay = makePulse({ heatmap: [cell(3, 1), cell(0, 0, true)] });
+    const fiveDays = makePulse({
+      heatmap: [cell(5, 9), cell(4, 7), cell(3, 8), cell(2, 6), cell(1, 9), cell(0, 0, true)],
+    });
+    expect(getCoachLine(oneDay, null)).toBe(getCoachLine(fiveDays, null));
+
+    const busyToday = makePulse({ heatmap: [cell(0, 40, true)] });
+    const quietToday = makePulse({ heatmap: [cell(0, 1, true)] });
+    expect(getCoachLine(busyToday, null)).toBe(getCoachLine(quietToday, null));
+  });
+
+  it("reports the merge count and range it selected", () => {
+    // The one branch that is allowed to carry numbers — they're the outcome.
+    const line = getCoachLine(makePulse({ rangeDays: 180 }), withMerges({ 180: 12 }));
+    expect(line).toContain("12");
+    expect(line).toContain("180");
+  });
+
+  it("agrees with itself on singular and plural", () => {
+    const one = getCoachLine(makePulse(), withMerges({ 60: 1 }));
+    const two = getCoachLine(makePulse(), withMerges({ 60: 2 }));
+
+    // Pluralization must change something beyond the digit — swapping the count
+    // in the singular line can't reproduce the plural one. Catches "1 changes".
+    expect(one.replace("1", "2")).not.toBe(two);
+    expect(one).toMatch(/\b1 [a-z]+\b(?<!s)/);
+    expect(two).toMatch(/\b2 [a-z]+s\b/);
+  });
+
+  it("stays forge-neutral rather than borrowing GitHub's vocabulary", () => {
+    expect(getCoachLine(makePulse(), withMerges({ 60: 5 })).toLowerCase()).not.toContain(
+      "pull request"
+    );
+  });
 });
 
 describe("getUsableHealth", () => {
-  it("passes through only health that can back a merge claim", () => {
+  it("passes through only health that can back a claim", () => {
     const ok = makeHealth();
     expect(getUsableHealth(ok)).toBe(ok);
     expect(getUsableHealth(null)).toBeNull();
     expect(getUsableHealth(makeHealth({ error: "boom" }))).toBeNull();
     expect(getUsableHealth(makeHealth({ repoUrl: "" }))).toBeNull();
   });
-
-  it("gates the coach line on exactly what it gates the chips on", () => {
-    // The card renders HealthSignals off this same call. If the two ever
-    // diverged, the line could claim merges above an error hint.
-    for (const health of [
-      makeHealth(),
-      makeHealth({ error: "boom" }),
-      makeHealth({ repoUrl: "" }),
-      null,
-    ]) {
-      const claimsMerges = getCoachLine(makePulse(), withMergesFrom(health)).includes("merged");
-      expect(claimsMerges).toBe(getUsableHealth(health) !== null);
-    }
-  });
 });
-
-// Give every candidate a positive merge count, so the only thing deciding
-// whether the line claims an outcome is the usability gate itself.
-function withMergesFrom(health: ForgeProjectHealthPayload | null) {
-  if (health === null) return null;
-  return { ...health, mergeVelocity: { mergedCounts: { 60: 5, 120: 5, 180: 5 } } };
-}

--- a/src/components/Pulse/__tests__/projectPulseCoach.test.ts
+++ b/src/components/Pulse/__tests__/projectPulseCoach.test.ts
@@ -8,12 +8,20 @@ import { getCoachLine, getCoachSignal, getUsableHealth } from "../coachLine";
 // are asserted on the signal so rewording the copy can't redden them; the copy
 // itself is held to a policy, not to exact strings.
 
+function heatLevel(count: number): HeatCell["level"] {
+  if (count >= 4) return 4;
+  if (count === 3) return 3;
+  if (count === 2) return 2;
+  if (count === 1) return 1;
+  return 0;
+}
+
 function cell(daysAgo: number, count: number, isToday = false): HeatCell {
   const date = new Date(Date.UTC(2026, 0, 20) - daysAgo * 86_400_000);
   return {
     date: date.toISOString().slice(0, 10),
     count,
-    level: Math.min(4, count) as HeatCell["level"],
+    level: heatLevel(count),
     ...(isToday ? { isToday: true } : {}),
   };
 }

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -7,7 +7,6 @@ const SUMMARY_PATH = resolve(__dirname, "../PulseSummary.tsx");
 const HEATMAP_PATH = resolve(__dirname, "../PulseHeatmap.tsx");
 const INDEX_CSS_PATH = resolve(__dirname, "../../../index.css");
 const PULSE_CSS_PATH = resolve(__dirname, "../../../styles/components/pulse.css");
-const COACH_PATH = resolve(__dirname, "../coachLine.ts");
 const FLAME_PATH = resolve(__dirname, "../StreakFlame.tsx");
 
 // Find a `@media (X)` opening brace and return the slice up to the matching
@@ -395,19 +394,9 @@ describe("Pulse — no surface can express failure (issue #11172)", () => {
     expect(content).not.toMatch(MISSED_DAY_SURFACE);
   });
 
-  it("the coaching line never asks for a commit or leans on a streak", async () => {
-    // The old copy was "One small commit today keeps your streak going." —
-    // obligation triggered by having a streak to lose. Branch coverage for the
-    // replacement lives in projectPulseCoach.test.ts; this guards the card
-    // itself from growing new guilt copy.
-    const content = await readFile(COACH_PATH, "utf-8");
-    const strings = [...content.matchAll(/"([^"\\]{12,})"|`([^`\\$]{12,})`/g)].map(
-      (m) => m[1] ?? m[2] ?? ""
-    );
-    for (const literal of strings) {
-      expect(literal).not.toMatch(/streak|keeps? (your|the)|missed/i);
-    }
-  });
+  // The coach line's own vocabulary is held to a policy in
+  // projectPulseCoach.test.ts, which checks every string the function can
+  // actually return rather than grepping the source for quoted literals.
 
   it("streak flame colors are theme tokens, not hardcoded hexes", async () => {
     const content = await readFile(FLAME_PATH, "utf-8");

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -7,6 +7,8 @@ const SUMMARY_PATH = resolve(__dirname, "../PulseSummary.tsx");
 const HEATMAP_PATH = resolve(__dirname, "../PulseHeatmap.tsx");
 const INDEX_CSS_PATH = resolve(__dirname, "../../../index.css");
 const PULSE_CSS_PATH = resolve(__dirname, "../../../styles/components/pulse.css");
+const COACH_PATH = resolve(__dirname, "../coachLine.ts");
+const FLAME_PATH = resolve(__dirname, "../StreakFlame.tsx");
 
 // Find a `@media (X)` opening brace and return the slice up to the matching
 // closing brace (or until the next top-level @media / @layer / @theme opens).
@@ -62,7 +64,7 @@ describe("ProjectPulseCard — visual contrast (issue #2645)", () => {
 
   it("coaching line does not use italic styling", async () => {
     const content = await readFile(CARD_PATH, "utf-8");
-    const coachLineMatch = content.match(/getCoachLine\(pulse\).*<\/p>/s);
+    const coachLineMatch = content.match(/getCoachLine\(.*?<\/p>/s);
     expect(coachLineMatch).toBeTruthy();
     const coachLineBlock = coachLineMatch![0];
     expect(coachLineBlock).not.toContain("italic");
@@ -140,7 +142,6 @@ describe("PulseHeatmap — contrast on elevated card (issue #2645)", () => {
     const content = await readFile(HEATMAP_PATH, "utf-8");
     expect(content).toContain("rounded-[2px]");
     expect(content).toContain("var(--pulse-empty-bg");
-    expect(content).toContain("var(--pulse-missed-bg)");
   });
 
   it("most-recent-active ring uses the pulse ring offset token", async () => {
@@ -360,14 +361,6 @@ describe("PulseHeatmap — high-contrast shape cue (issue #9819)", () => {
     );
   });
 
-  it("forced-colors block distinguishes missed-day via a solid CanvasText fill", async () => {
-    const content = await readFile(INDEX_CSS_PATH, "utf-8");
-    const block = mediaBlockSlice(content, "@media (forced-colors: active)");
-    expect(block).toContain(".pulse-heat-cell-missed");
-    // Missed cell must be the more salient signal (filled, not empty).
-    expect(block).toMatch(/\.pulse-heat-cell-missed\s*{[^}]*background:\s*CanvasText/);
-  });
-
   it("prefers-contrast block bumps heat-cell border to 1px theme-text", async () => {
     const content = await readFile(INDEX_CSS_PATH, "utf-8");
     const block = mediaBlockSlice(content, "@media (prefers-contrast: more)");
@@ -386,5 +379,42 @@ describe("PulseHeatmap — high-contrast shape cue (issue #9819)", () => {
     const forcedBlock = mediaBlockSlice(content, "@media (forced-colors: active)");
     const forcedEnd = content.indexOf(forcedBlock) + forcedBlock.length;
     expect(forcedEnd).toBeLessThanOrEqual(contrastStart);
+  });
+});
+
+describe("Pulse — no surface can express failure (issue #11172)", () => {
+  const MISSED_DAY_SURFACE = /pulse-missed-bg|pulse-heat-cell-missed|pulse-heat-missed|Missed day/i;
+
+  it.each([
+    ["PulseHeatmap.tsx", HEATMAP_PATH],
+    ["ProjectPulseCard.tsx", CARD_PATH],
+    ["pulse.css", PULSE_CSS_PATH],
+    ["index.css", INDEX_CSS_PATH],
+  ])("%s carries no missed-day token, class, or label", async (_name, path) => {
+    const content = await readFile(path, "utf-8");
+    expect(content).not.toMatch(MISSED_DAY_SURFACE);
+  });
+
+  it("the coaching line never asks for a commit or leans on a streak", async () => {
+    // The old copy was "One small commit today keeps your streak going." —
+    // obligation triggered by having a streak to lose. Branch coverage for the
+    // replacement lives in projectPulseCoach.test.ts; this guards the card
+    // itself from growing new guilt copy.
+    const content = await readFile(COACH_PATH, "utf-8");
+    const strings = [...content.matchAll(/"([^"\\]{12,})"|`([^`\\$]{12,})`/g)].map(
+      (m) => m[1] ?? m[2] ?? ""
+    );
+    for (const literal of strings) {
+      expect(literal).not.toMatch(/streak|keeps? (your|the)|missed/i);
+    }
+  });
+
+  it("streak flame colors are theme tokens, not hardcoded hexes", async () => {
+    const content = await readFile(FLAME_PATH, "utf-8");
+    // Each tier resolves through var(--pulse-streak-N, …) so a theme can
+    // restyle it; the raw hex survives only as the inline fallback.
+    expect(content).toMatch(/var\(--pulse-streak-1,/);
+    expect(content).toMatch(/var\(--pulse-streak-7,/);
+    expect(content).not.toMatch(/color:\s*"#[0-9A-Fa-f]{6}"/);
   });
 });

--- a/src/components/Pulse/__tests__/pulseHeatmapZeroActivity.test.tsx
+++ b/src/components/Pulse/__tests__/pulseHeatmapZeroActivity.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { HeatCell } from "@shared/types";
+import { PulseHeatmap } from "../PulseHeatmap";
+import { TooltipProvider } from "../../ui/tooltip";
+
+// #11172: the heatmap must have no way to express failure. A zero-commit day
+// bracketed by active days used to be styled as a "missed day" — a danger tint,
+// an inset ring, and a "Missed day" label. Every quiet day now reads the same,
+// whatever its neighbours did.
+
+function cell(day: number, count: number): HeatCell {
+  return {
+    date: `2026-01-${String(day).padStart(2, "0")}`,
+    count,
+    level: Math.min(4, count) as HeatCell["level"],
+  };
+}
+
+// Day 03 is a zero bracketed by activity on both sides — the exact shape the
+// old isMissedDay() flagged. Day 07 is an isolated zero with no activity near
+// it, which it never flagged.
+const CELLS: HeatCell[] = [
+  cell(1, 3),
+  cell(2, 2),
+  cell(3, 0),
+  cell(4, 4),
+  cell(5, 1),
+  cell(6, 0),
+  cell(7, 0),
+  cell(8, 0),
+];
+
+function renderHeatmap() {
+  return render(
+    <TooltipProvider>
+      <PulseHeatmap cells={CELLS} rangeDays={60} />
+    </TooltipProvider>
+  );
+}
+
+function cellByDate(date: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`[data-cell-date="${date}"]`);
+  if (!el) throw new Error(`no cell rendered for ${date}`);
+  return el;
+}
+
+describe("PulseHeatmap — a quiet day is never a failure", () => {
+  it("styles a zero day bracketed by activity exactly like an isolated zero day", () => {
+    renderHeatmap();
+    const bracketed = cellByDate("2026-01-03");
+    const isolated = cellByDate("2026-01-07");
+
+    expect(bracketed.style.background).toBe(isolated.style.background);
+    expect(bracketed.className).toBe(isolated.className);
+  });
+
+  it("labels every zero day 'No commits', including the formerly-missed one", () => {
+    renderHeatmap();
+    for (const date of ["2026-01-03", "2026-01-06", "2026-01-07", "2026-01-08"]) {
+      expect(cellByDate(date).getAttribute("aria-label")).toContain("No commits");
+    }
+    expect(screen.queryByLabelText(/missed/i)).toBeNull();
+  });
+
+  it("gives a zero day no heat level and no shape cue", () => {
+    renderHeatmap();
+    // data-heat-level and the shape span are what forced-colors mode keys off;
+    // a quiet day must carry neither, or it would paint as a signal.
+    const quiet = cellByDate("2026-01-03");
+    expect(quiet.hasAttribute("data-heat-level")).toBe(false);
+    expect(quiet.querySelector(".pulse-heat-cell-shape")).toBeNull();
+  });
+
+  it("still distinguishes days that actually had commits", () => {
+    renderHeatmap();
+    const worked = cellByDate("2026-01-04");
+    const quiet = cellByDate("2026-01-03");
+    expect(worked.style.background).not.toBe(quiet.style.background);
+    expect(worked.getAttribute("aria-label")).toContain("4 commits");
+    expect(worked.getAttribute("data-heat-level")).toBe("4");
+  });
+});

--- a/src/components/Pulse/__tests__/pulseHeatmapZeroActivity.test.tsx
+++ b/src/components/Pulse/__tests__/pulseHeatmapZeroActivity.test.tsx
@@ -10,11 +10,19 @@ import { TooltipProvider } from "../../ui/tooltip";
 // an inset ring, and a "Missed day" label. Every quiet day now reads the same,
 // whatever its neighbours did.
 
+function heatLevel(count: number): HeatCell["level"] {
+  if (count >= 4) return 4;
+  if (count === 3) return 3;
+  if (count === 2) return 2;
+  if (count === 1) return 1;
+  return 0;
+}
+
 function cell(day: number, count: number): HeatCell {
   return {
     date: `2026-01-${String(day).padStart(2, "0")}`,
     count,
-    level: Math.min(4, count) as HeatCell["level"],
+    level: heatLevel(count),
   };
 }
 

--- a/src/components/Pulse/__tests__/pulseHeatmapZeroActivity.test.tsx
+++ b/src/components/Pulse/__tests__/pulseHeatmapZeroActivity.test.tsx
@@ -46,39 +46,61 @@ function cellByDate(date: string): HTMLElement {
   return el;
 }
 
+// The date prefix differs per cell; the state description is what must match.
+function stateOf(date: string): string {
+  const label = cellByDate(date).getAttribute("aria-label") ?? "";
+  return label.slice(label.indexOf(":") + 1).trim();
+}
+
 describe("PulseHeatmap — a quiet day is never a failure", () => {
   it("styles a zero day bracketed by activity exactly like an isolated zero day", () => {
     renderHeatmap();
     const bracketed = cellByDate("2026-01-03");
     const isolated = cellByDate("2026-01-07");
 
+    // Under the old isMissedDay(), the bracketed cell alone got a danger tint
+    // and the .pulse-heat-cell-missed ring.
     expect(bracketed.style.background).toBe(isolated.style.background);
     expect(bracketed.className).toBe(isolated.className);
   });
 
-  it("labels every zero day 'No commits', including the formerly-missed one", () => {
+  it("describes every zero day the same way, whatever its neighbours did", () => {
     renderHeatmap();
-    for (const date of ["2026-01-03", "2026-01-06", "2026-01-07", "2026-01-08"]) {
-      expect(cellByDate(date).getAttribute("aria-label")).toContain("No commits");
+    const quietDays = ["2026-01-03", "2026-01-06", "2026-01-07", "2026-01-08"];
+    const described = quietDays.map(stateOf);
+
+    // Every zero day must actually SAY something — otherwise "they all match"
+    // would hold vacuously if the labels went missing.
+    for (const state of described) {
+      expect(state.length).toBeGreaterThan(0);
+      // Whatever the wording, it can't be a failure. The old one was "Missed day".
+      expect(state).not.toMatch(/miss|fail|break|broke|lost|skip/i);
     }
+    expect(new Set(described).size).toBe(1);
     expect(screen.queryByLabelText(/missed/i)).toBeNull();
   });
 
-  it("gives a zero day no heat level and no shape cue", () => {
+  it("gives a zero day no forced-colors shape cue", () => {
     renderHeatmap();
-    // data-heat-level and the shape span are what forced-colors mode keys off;
-    // a quiet day must carry neither, or it would paint as a signal.
-    const quiet = cellByDate("2026-01-03");
-    expect(quiet.hasAttribute("data-heat-level")).toBe(false);
-    expect(quiet.querySelector(".pulse-heat-cell-shape")).toBeNull();
+    // The shape span is painted solid CanvasText under forced-colors. A quiet
+    // day carrying one would become a signal again, by a different route than
+    // the background this suite guards above.
+    for (const date of ["2026-01-03", "2026-01-07"]) {
+      const quiet = cellByDate(date);
+      expect(quiet.querySelector(".pulse-heat-cell-shape")).toBeNull();
+      expect(quiet.hasAttribute("data-heat-level")).toBe(false);
+    }
   });
 
   it("still distinguishes days that actually had commits", () => {
+    // Positive control: the equality above must not be holding because every
+    // cell collapsed to one rendering.
     renderHeatmap();
     const worked = cellByDate("2026-01-04");
     const quiet = cellByDate("2026-01-03");
     expect(worked.style.background).not.toBe(quiet.style.background);
-    expect(worked.getAttribute("aria-label")).toContain("4 commits");
+    expect(stateOf("2026-01-04")).not.toBe(stateOf("2026-01-03"));
     expect(worked.getAttribute("data-heat-level")).toBe("4");
+    expect(worked.querySelector(".pulse-heat-cell-shape")).not.toBeNull();
   });
 });

--- a/src/components/Pulse/__tests__/streakFlame.test.ts
+++ b/src/components/Pulse/__tests__/streakFlame.test.ts
@@ -1,69 +1,81 @@
 import { describe, it, expect } from "vitest";
+import { getStreakColor, getStreakTier } from "../StreakFlame";
 
-describe("getStreakColor — tier boundaries", () => {
-  // Import the pure function directly
-  let getStreakColor: (days: number) => string;
+// The tier hexes are the implementation's source of truth — asserting them here
+// would just copy them. These tests cover what the hexes can't: that the tier
+// boundaries land where they should, that every tier is visually distinct, and
+// that each stop is theme-overridable with its legacy colour as the fallback.
 
-  it("can be imported", async () => {
-    const mod = await import("../StreakFlame");
-    getStreakColor = mod.getStreakColor;
-    expect(typeof getStreakColor).toBe("function");
+const TIER_BOUNDARIES = [8, 15, 30, 60, 120, 240];
+const TOKEN_FORM = /^var\(--pulse-streak-([1-7]), (#[0-9A-Fa-f]{6})\)$/;
+
+function parse(days: number): { level: number; fallback: string } {
+  const match = TOKEN_FORM.exec(getStreakColor(days));
+  if (!match) throw new Error(`getStreakColor(${days}) is not a themeable token`);
+  return { level: Number(match[1]), fallback: match[2]! };
+}
+
+describe("getStreakColor", () => {
+  it("emits a themeable token carrying a hex fallback at every tier", () => {
+    for (const days of [0, 1, 7, 8, 14, 15, 29, 30, 59, 60, 119, 120, 239, 240, 10_000]) {
+      expect(getStreakColor(days)).toMatch(TOKEN_FORM);
+    }
   });
 
-  it("returns amber (#F59E0B) for days 1-7", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(1)).toBe("#F59E0B");
-    expect(mod.getStreakColor(7)).toBe("#F59E0B");
+  it("steps to the next tier exactly at each boundary, not before", () => {
+    for (const boundary of TIER_BOUNDARIES) {
+      const below = parse(boundary - 1);
+      const at = parse(boundary);
+      expect(at.level).toBe(below.level + 1);
+      expect(at.fallback).not.toBe(below.fallback);
+    }
   });
 
-  it("returns orange (#FB923C) for days 8-14", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(8)).toBe("#FB923C");
-    expect(mod.getStreakColor(14)).toBe("#FB923C");
+  it("holds one colour across the whole span of a tier", () => {
+    // 8..14 is a full interior tier: every day in it resolves identically.
+    const span = [8, 9, 12, 14].map((d) => getStreakColor(d));
+    expect(new Set(span).size).toBe(1);
   });
 
-  it("returns orange-red (#F97316) for days 15-29", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(15)).toBe("#F97316");
-    expect(mod.getStreakColor(29)).toBe("#F97316");
+  it("gives every tier a distinct colour", () => {
+    const representatives = [1, 8, 15, 30, 60, 120, 240];
+    const tokens = representatives.map((d) => getStreakColor(d));
+    expect(new Set(tokens).size).toBe(representatives.length);
+    expect(new Set(representatives.map((d) => parse(d).fallback)).size).toBe(
+      representatives.length
+    );
   });
 
-  it("returns red (#EF4444) for days 30-59", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(30)).toBe("#EF4444");
-    expect(mod.getStreakColor(59)).toBe("#EF4444");
+  it("rises monotonically with streak length", () => {
+    const levels = [0, 8, 15, 30, 60, 120, 240, 10_000].map((d) => parse(d).level);
+    for (let i = 1; i < levels.length; i += 1) {
+      expect(levels[i]!).toBeGreaterThanOrEqual(levels[i - 1]!);
+    }
   });
 
-  it("returns deep red (#DC2626) for days 60-119", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(60)).toBe("#DC2626");
-    expect(mod.getStreakColor(119)).toBe("#DC2626");
+  it("clamps a zero or negative streak to the base tier", () => {
+    expect(parse(0).level).toBe(1);
+    expect(parse(-5).level).toBe(1);
+    expect(getStreakColor(0)).toBe(getStreakColor(1));
   });
 
-  it("returns fuchsia (#C026D3) for days 120-239", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(120)).toBe("#C026D3");
-    expect(mod.getStreakColor(239)).toBe("#C026D3");
+  it("keeps 240+ in one open-ended top tier", () => {
+    expect(getStreakColor(10_000)).toBe(getStreakColor(240));
+    expect(parse(240).level).toBe(7);
   });
 
-  it("returns a distinct celebratory hex for days 240+ (issue #9820)", async () => {
-    const mod = await import("../StreakFlame");
-    // The 240+ tier must read at full color fidelity in PulseSummary.Stat —
-    // not borrow --color-accent-primary, which the release chip in the same
-    // region already spends. A plain hex keeps it consistent with the other
-    // six tiers and avoids a second accent in one focus region.
-    const top240 = mod.getStreakColor(240);
-    const top10k = mod.getStreakColor(10000);
-    expect(top240).toMatch(/^#[0-9A-Fa-f]{6}$/);
-    expect(top10k).toBe(top240);
-    expect(top240).not.toContain("var(");
-    expect(top240).not.toBe("var(--color-accent-primary)");
-    expect(top240).not.toBe(mod.getStreakColor(120));
-    expect(top240).not.toBe(mod.getStreakColor(239));
+  it("never borrows the accent token (issue #9820)", () => {
+    // The release chip in the same focus region already spends the accent; a
+    // flame that co-opted it would put two accent signals in one region.
+    for (const days of [1, 8, 15, 30, 60, 120, 240]) {
+      expect(getStreakColor(days)).not.toContain("--color-accent-primary");
+    }
   });
+});
 
-  it("returns amber for 0 days (fallback)", async () => {
-    const mod = await import("../StreakFlame");
-    expect(mod.getStreakColor(0)).toBe("#F59E0B");
+describe("getStreakTier", () => {
+  it("maps each boundary to a successive tier and spans 1..7", () => {
+    const tiers = [0, 8, 15, 30, 60, 120, 240].map(getStreakTier);
+    expect(tiers).toStrictEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 });

--- a/src/components/Pulse/coachLine.ts
+++ b/src/components/Pulse/coachLine.ts
@@ -1,0 +1,59 @@
+import type { ProjectPulse } from "@shared/types";
+import type { ForgeProjectHealthPayload } from "@shared/types/ipc/forge";
+
+/**
+ * Narrows health down to the payload the chips below the coach line are willing
+ * to render, so the two can never disagree about whether forge data is usable —
+ * a coach line claiming "12 changes merged" above an error hint would be a lie.
+ *
+ * Returns the payload rather than a `health is ForgeProjectHealthPayload`
+ * predicate on purpose: an errored payload is still a payload, so a type
+ * predicate's false branch would wrongly narrow callers to `null` and hide the
+ * `hasRemote` they need to pick an error hint.
+ */
+export function getUsableHealth(
+  health: ForgeProjectHealthPayload | null
+): ForgeProjectHealthPayload | null {
+  if (health === null || health.error || !health.repoUrl) return null;
+  return health;
+}
+
+/**
+ * Coaching is framed around what shipped, not what got committed (#11172). A
+ * commit count in Daintree mostly measures how busy the agents were; merged
+ * changes are the outcome the user actually cares about. Every branch is
+ * neutral or positive — none can express failure, and none asks for a commit.
+ */
+export function getCoachLine(
+  pulse: ProjectPulse,
+  health: ForgeProjectHealthPayload | null
+): string {
+  // Only a positive merge count is claimed as an outcome: zero is ambiguous,
+  // because the provider zero-fills when its supplementary velocity query
+  // fails. Read pulse.rangeDays rather than the selector's — the line describes
+  // the snapshot on screen.
+  const usable = getUsableHealth(health);
+  const merged = usable ? (usable.mergeVelocity.mergedCounts[pulse.rangeDays] ?? 0) : 0;
+
+  if (merged > 0) {
+    // "change", not "pull request" — the forge layer is provider-neutral.
+    return `${merged} change${merged !== 1 ? "s" : ""} merged in the last ${pulse.rangeDays} days — that's shipped work.`;
+  }
+
+  const sortedCells = [...pulse.heatmap]
+    .filter((cell) => !isNaN(new Date(cell.date).getTime()))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  // No `.at(-1)` fallback: with no real isToday cell, a stale trailing cell
+  // would get reported as activity "today".
+  const today = sortedCells.find((c) => c.isToday);
+  if (today && today.count > 0) {
+    return "There's fresh activity today.";
+  }
+
+  if (sortedCells.slice(-7).some((c) => c.count > 0)) {
+    return "There's been activity this week.";
+  }
+
+  return "It's quiet right now — that's part of the work too.";
+}

--- a/src/components/Pulse/coachLine.ts
+++ b/src/components/Pulse/coachLine.ts
@@ -1,10 +1,24 @@
-import type { ProjectPulse } from "@shared/types";
+import type { ProjectPulse, PulseRangeDays } from "@shared/types";
 import type { ForgeProjectHealthPayload } from "@shared/types/ipc/forge";
+
+const RECENT_WINDOW_DAYS = 7;
+const DAY_MS = 86_400_000;
+
+/**
+ * What the card has to say, before it's put into words. Splitting the decision
+ * from the copy keeps the branch order and the data it selects testable without
+ * pinning down the wording.
+ */
+export type CoachSignal =
+  | { kind: "merged"; count: number; rangeDays: PulseRangeDays }
+  | { kind: "today" }
+  | { kind: "recent" }
+  | { kind: "quiet" };
 
 /**
  * Narrows health down to the payload the chips below the coach line are willing
  * to render, so the two can never disagree about whether forge data is usable —
- * a coach line claiming "12 changes merged" above an error hint would be a lie.
+ * a coach line claiming merges above an error hint would be a lie.
  *
  * Returns the payload rather than a `health is ForgeProjectHealthPayload`
  * predicate on purpose: an errored payload is still a payload, so a type
@@ -19,41 +33,74 @@ export function getUsableHealth(
 }
 
 /**
- * Coaching is framed around what shipped, not what got committed (#11172). A
+ * Coaching is framed around what landed, not what got committed (#11172). A
  * commit count in Daintree mostly measures how busy the agents were; merged
- * changes are the outcome the user actually cares about. Every branch is
- * neutral or positive — none can express failure, and none asks for a commit.
+ * changes are the outcome the user actually cares about.
+ */
+export function getCoachSignal(
+  pulse: ProjectPulse,
+  health: ForgeProjectHealthPayload | null
+): CoachSignal {
+  // Only a positive merge count is claimed as an outcome: zero is ambiguous,
+  // because the provider zero-fills when its supplementary velocity query
+  // fails. Read pulse.rangeDays rather than the selector's — the signal
+  // describes the snapshot on screen.
+  const usable = getUsableHealth(health);
+  const merged = usable ? (usable.mergeVelocity.mergedCounts[pulse.rangeDays] ?? 0) : 0;
+  if (merged > 0) return { kind: "merged", count: merged, rangeDays: pulse.rangeDays };
+
+  const cells = [...pulse.heatmap]
+    .filter((cell) => !Number.isNaN(new Date(cell.date).getTime()))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  // Recency is anchored to the cell the service marked as today, never to the
+  // tail of the array: a heatmap that stops short of today would otherwise have
+  // its last entries read as "recent" no matter how old they are. With no such
+  // cell there is no way to date the activity, so the card stays quiet.
+  const today = cells.find((cell) => cell.isToday);
+  if (!today) return { kind: "quiet" };
+  if (today.count > 0) return { kind: "today" };
+
+  // Bounded at both ends: a cell dated past today (clock skew, a bad fixture)
+  // isn't evidence of recent work either.
+  const todayAt = new Date(today.date).getTime();
+  const cutoff = todayAt - (RECENT_WINDOW_DAYS - 1) * DAY_MS;
+  const recently = cells.some((cell) => {
+    if (cell.count === 0) return false;
+    const at = new Date(cell.date).getTime();
+    return at >= cutoff && at <= todayAt;
+  });
+  return recently ? { kind: "recent" } : { kind: "quiet" };
+}
+
+/**
+ * States what happened. Never asks for anything, never praises, and never
+ * frames a quiet stretch as a shortfall — no branch here can express failure.
  */
 export function getCoachLine(
   pulse: ProjectPulse,
   health: ForgeProjectHealthPayload | null
 ): string {
-  // Only a positive merge count is claimed as an outcome: zero is ambiguous,
-  // because the provider zero-fills when its supplementary velocity query
-  // fails. Read pulse.rangeDays rather than the selector's — the line describes
-  // the snapshot on screen.
-  const usable = getUsableHealth(health);
-  const merged = usable ? (usable.mergeVelocity.mergedCounts[pulse.rangeDays] ?? 0) : 0;
-
-  if (merged > 0) {
-    // "change", not "pull request" — the forge layer is provider-neutral.
-    return `${merged} change${merged !== 1 ? "s" : ""} merged in the last ${pulse.rangeDays} days — that's shipped work.`;
+  const signal = getCoachSignal(pulse, health);
+  switch (signal.kind) {
+    case "merged":
+      // "change" and "landed", not "pull request" or "shipped" — the forge layer
+      // is provider-neutral, and a merge means it landed on the base branch, not
+      // that it reached anyone's machine.
+      return `${signal.count} change${signal.count !== 1 ? "s" : ""} landed in the last ${signal.rangeDays} days.`;
+    case "today":
+      return "There's activity today.";
+    case "recent":
+      return "There's been activity in the last seven days.";
+    case "quiet":
+      // Deliberately unscoped: this branch also covers a heatmap with no cell
+      // dated today, where no particular window can be vouched for.
+      return "It's been quiet lately.";
+    default:
+      return assertNever(signal);
   }
+}
 
-  const sortedCells = [...pulse.heatmap]
-    .filter((cell) => !isNaN(new Date(cell.date).getTime()))
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-
-  // No `.at(-1)` fallback: with no real isToday cell, a stale trailing cell
-  // would get reported as activity "today".
-  const today = sortedCells.find((c) => c.isToday);
-  if (today && today.count > 0) {
-    return "There's fresh activity today.";
-  }
-
-  if (sortedCells.slice(-7).some((c) => c.count > 0)) {
-    return "There's been activity this week.";
-  }
-
-  return "It's quiet right now — that's part of the work too.";
+function assertNever(signal: never): never {
+  throw new Error(`unhandled coach signal: ${JSON.stringify(signal)}`);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2669,13 +2669,13 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   }
 
   /* Project Pulse heatmap (issue #9819). Theme-authored backgrounds collapse
-   * to Canvas under forced-colors, so the four heat levels + missed-day cell
-   * become indistinguishable. Use a system-paint + size-coded inner square
-   * (GitHub's 2023+ contribution-graph approach) keyed off data-heat-level,
-   * and a solid fill for the missed-day streak-break signal. The shape span
-   * is rendered always (display: none baseline) so theme switches don't
+   * to Canvas under forced-colors, so the four heat levels become
+   * indistinguishable. Use a system-paint + size-coded inner square (GitHub's
+   * 2023+ contribution-graph approach) keyed off data-heat-level. The shape
+   * span is rendered always (display: none baseline) so theme switches don't
    * reflow; the !important on the heat cell background is required to beat
-   * the inline author style set in PulseHeatmap.getCellStyle. */
+   * the inline author style set in PulseHeatmap.getCellStyle. A zero-commit
+   * day carries no shape at all — quiet, never a failure signal. */
   .pulse-heat-cell {
     background: Canvas !important;
   }
@@ -2698,9 +2698,6 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   .pulse-heat-cell[data-heat-level="4"] .pulse-heat-cell-shape {
     width: 90%;
     height: 90%;
-  }
-  .pulse-heat-cell-missed {
-    background: CanvasText !important;
   }
   /* The empty (level 0) legend swatch is a <span>, so it misses both the
      global button ButtonText border above and the shape-span cue (empty cells

--- a/src/styles/components/pulse.css
+++ b/src/styles/components/pulse.css
@@ -49,16 +49,6 @@
   background: var(--pulse-empty-bg, var(--theme-surface-panel));
 }
 
-/* Missed-day fill: an opaque danger tint rather than a low-alpha film that
- * washed out to ~1:1 vs the empty cell on light. Themes ship pulse-missed-bg as
- * an opaque hex (P-Heat re-authors these to clear >=3:1); the fallback is full
- * opaque status-danger — the boldest destructive default, which clears >=3:1 vs
- * a near-white empty cell where a partial mix could not (status-danger is mid-L,
- * so a 42% mix over near-white only reaches ~1.8:1). */
-.pulse-heat-missed {
-  background: var(--pulse-missed-bg, var(--theme-status-danger));
-}
-
 /* Forced-colors shape cue: a child element painted with CanvasText whose size
  * scales with the heat level, so the four levels stay distinguishable when the
  * UA strips theme background colors (issue #9819). Display is none by default;
@@ -70,18 +60,6 @@
   margin: auto;
   display: none;
   pointer-events: none;
-}
-
-/* Shape cue for the missed-day cell (P-Heat): a destructive-tier inset ring so
- * the streak-break signal survives colour-vision deficiency and never reads as
- * just another heat level. Inset box-shadow keeps the cell footprint identical
- * to its neighbours (no layout shift) and stacks under the most-recent-active
- * ring. transition-[box-shadow] is already on the cell (Tier-1 150ms). Light-
- * only (P-Heat is a light refinement); dark missed-day cells keep their authored
- * pulse-missed-bg fill verbatim — `.light` is toggled on the root by
- * applyAppThemeToRoot, mirroring the `.light .panel-state-*` precedent. */
-.light .pulse-heat-cell-missed {
-  box-shadow: inset 0 0 0 1.5px var(--theme-status-danger);
 }
 
 .pulse-skeleton-shimmer {


### PR DESCRIPTION
## Summary

Project Pulse used to coach commit streaks: `getCoachLine` would say things like "One small commit today keeps your streak going," and the heatmap painted a missed day with a danger tint and an inset ring. That's guilt pressure in a product that's meant to feel calm, and a commit count in Daintree mostly measures how busy the agents were, not how the user's day actually went. This PR reframes the coaching toward outcomes and removes the failure visual entirely.

Resolves #11172

## Changes

- **Coach lines lead with outcomes.** The ladder now leads with merged changes, drawn from the same `mergeVelocity.mergedCounts` data that already renders the "N merged" chip: "12 changes landed in the last 60 days." It degrades to calm activity phrasing when forge health is absent, errored, or there's no remote ("There's activity today." / "There's been activity in the last seven days." / "It's been quiet lately."). No branch asks for a commit, praises busyness, or frames a quiet stretch as a shortfall, and a zero merge count is never claimed as an outcome, since the provider zero-fills when its velocity query fails. The decision is split from the wording (`getCoachSignal` returns a `CoachSignal` union, `getCoachLine` is a pure formatter), so the branch order and the data it selects are tested without pinning the copy.
- **The missed-day failure visual is gone end to end**: `isMissedDay()`, the danger tint, the light-mode inset ring, the forced-colors `CanvasText` fill, the "Missed day" label, the `pulse-missed-bg` token (registry and all 14 built-in themes), and the P-Heat missed-day contrast audit. A day with no commits is just quiet, and it reads identically regardless of its neighbors.
- **Streaks stay, quietly.** `PulseSummary` and `ProjectPulseStrip` already gated the flame on `currentStreakDays > 1`, so streaks were positive-only at the widget level. The heatmap and coach line were the only places failure could still be expressed, and both are fixed now. `StreakFlame`'s 7 hardcoded tier hexes resolve through new `pulse-streak-1..7` theme tokens, each carrying its original hex as the CSS fallback, so no theme file needed new authoring and rendering stays pixel-identical.
- Recency is anchored to the `isToday` cell and bounded at both ends. The first draft checked the last 7 array entries, which reported an 8-day-old commit as "this week."

Files touched: `src/components/Pulse/{coachLine.ts (new), ProjectPulseCard.tsx, PulseHeatmap.tsx, StreakFlame.tsx}`, 4 test files under `src/components/Pulse/__tests__/` (2 new), `src/index.css`, `src/styles/components/pulse.css`, `shared/theme/{types.ts, extensionRegistry.ts, contrast.ts}`, all 14 `shared/theme/builtInThemes/*.ts`, `shared/theme/__tests__/builtInThemes.test.ts`, `docs/themes/visual-guide.md`. 29 files in total.

## Testing

- `vitest src/components/Pulse/__tests__/` - 101 passing
- `vitest shared/theme/__tests__/{builtInThemes,contrast}.test.ts` - 115 passing, including the bidirectional `EXTENSION_KEYS` drift guard, which is what makes the token retirement atomic
- `tsc --noEmit` clean; eslint 0 errors on changed files; `lint:ratchet` passing (total warnings down 11); prettier clean
