### PR TITLE
fix(panels): scope maximize state per worktree

### DIFF
--- a/e2e/full/worktree/core-worktree-cross-boundary.spec.ts
+++ b/e2e/full/worktree/core-worktree-cross-boundary.spec.ts
@@ -159,6 +159,53 @@ test.describe.serial("Core: Cross-Worktree Terminal Isolation", () => {
     });
   });
 
+  test("maximizing in one worktree leaves another worktree's grid intact", async () => {
+    test.setTimeout(process.env.CI ? 180_000 : 120_000);
+
+    // Both worktrees carry a terminal from the preceding tests in this serial block.
+    let window = await switchMainWorktree(ctx);
+    const restoreBtn = window.locator(SEL.panel.restore);
+
+    const mainPanelId = await test.step("maximize the main worktree's panel", async () => {
+      const [panelId] = await getGridPanelIds(window);
+      expect(panelId).toBeTruthy();
+
+      const panel = getPanelById(window, panelId!);
+      await panel.hover();
+      await panel.locator(SEL.panel.maximize).first().click();
+      await expect(restoreBtn.first()).toBeVisible({ timeout: T_SHORT });
+      return panelId!;
+    });
+
+    await test.step("the feature worktree still renders its own panels", async () => {
+      window = await switchNamedWorktree(ctx, FEATURE);
+
+      // The regression (#11183): maximize was a single global pointer, so it
+      // survived the switch and ContentGrid took its maximize branch, failed to
+      // find the main worktree's panel among this worktree's grid panels, and
+      // rendered nothing at all — a blank screen.
+      const featurePanelIds = await getGridPanelIds(window);
+      expect(featurePanelIds.length).toBeGreaterThan(0);
+      expect(featurePanelIds).not.toContain(mainPanelId);
+      await expect(getPanelById(window, featurePanelIds[0]!)).toBeVisible({ timeout: T_LONG });
+
+      // ...and this worktree is not itself maximized: nothing leaked into it.
+      await expect(window.locator(SEL.panel.restore)).toHaveCount(0, { timeout: T_SHORT });
+    });
+
+    await test.step("returning to the main worktree restores its maximized panel", async () => {
+      window = await switchMainWorktree(ctx);
+
+      await expect(window.locator(SEL.panel.restore).first()).toBeVisible({ timeout: T_LONG });
+      await expect(getPanelById(window, mainPanelId)).toBeVisible({ timeout: T_LONG });
+    });
+
+    await test.step("unmaximize so later tests start from the grid", async () => {
+      await window.locator(SEL.panel.restore).first().click();
+      await expect(window.locator(SEL.panel.restore)).toHaveCount(0, { timeout: T_SHORT });
+    });
+  });
+
   test("overview modal opens and shows worktree cards", async () => {
     // Re-acquire the active window — worktree switches in the preceding
     // test may have changed the active WebContentsView.

--- a/e2e/full/worktree/core-worktree-cross-boundary.spec.ts
+++ b/e2e/full/worktree/core-worktree-cross-boundary.spec.ts
@@ -162,19 +162,27 @@ test.describe.serial("Core: Cross-Worktree Terminal Isolation", () => {
   test("maximizing in one worktree leaves another worktree's grid intact", async () => {
     test.setTimeout(process.env.CI ? 180_000 : 120_000);
 
-    // Both worktrees carry a terminal from the preceding tests in this serial block.
+    // Don't lean on panels spawned by earlier tests in this serial block — a
+    // --grep'd run of this test alone would otherwise fail before it starts.
+    async function ensureGridPanel(page: Page): Promise<string> {
+      const existing = await getGridPanelIds(page);
+      if (existing.length > 0) return existing[0]!;
+      const panel = await spawnTerminalAndVerify(page);
+      return getPanelId(panel);
+    }
+
     let window = await switchMainWorktree(ctx);
     const restoreBtn = window.locator(SEL.panel.restore);
 
     const mainPanelId = await test.step("maximize the main worktree's panel", async () => {
-      const [panelId] = await getGridPanelIds(window);
+      const panelId = await ensureGridPanel(window);
       expect(panelId).toBeTruthy();
 
-      const panel = getPanelById(window, panelId!);
+      const panel = getPanelById(window, panelId);
       await panel.hover();
       await panel.locator(SEL.panel.maximize).first().click();
       await expect(restoreBtn.first()).toBeVisible({ timeout: T_SHORT });
-      return panelId!;
+      return panelId;
     });
 
     await test.step("the feature worktree still renders its own panels", async () => {
@@ -183,7 +191,8 @@ test.describe.serial("Core: Cross-Worktree Terminal Isolation", () => {
       // The regression (#11183): maximize was a single global pointer, so it
       // survived the switch and ContentGrid took its maximize branch, failed to
       // find the main worktree's panel among this worktree's grid panels, and
-      // rendered nothing at all — a blank screen.
+      // rendered nothing at all — a blank screen. Reverting the fix fails
+      // exactly here, on a grid with zero panels.
       const featurePanelIds = await getGridPanelIds(window);
       expect(featurePanelIds.length).toBeGreaterThan(0);
       expect(featurePanelIds).not.toContain(mainPanelId);

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -417,6 +417,63 @@ describe("rendererStoreOrchestrator", () => {
 
       expect(stashedIds().get("wt-1")?.maximizedId).toBe("term-1");
     });
+
+    it("keeps one worktree's stash when another worktree's is purged", () => {
+      seedPanels([
+        { id: "term-1", worktreeId: "wt-1" },
+        { id: "term-2", worktreeId: "wt-2" },
+      ]);
+      useWorktreeSelectionStore.setState({
+        maximizeByWorktree: new Map([
+          [
+            "wt-1",
+            {
+              maximizedId: "term-1",
+              maximizeTarget: { type: "panel" as const, id: "term-1" },
+              preMaximizeLayout: null,
+            },
+          ],
+          [
+            "wt-2",
+            {
+              maximizedId: "term-2",
+              maximizeTarget: { type: "panel" as const, id: "term-2" },
+              preMaximizeLayout: null,
+            },
+          ],
+        ]),
+      });
+
+      usePanelStore.getState().trashPanel("term-1");
+
+      expect(stashedIds().has("wt-1")).toBe(false);
+      expect(stashedIds().get("wt-2")?.maximizedId).toBe("term-2");
+    });
+
+    it("purges a group stash when the panel it was maximized on is trashed", () => {
+      seedPanels([
+        { id: "term-1", worktreeId: "wt-1" },
+        { id: "term-2", worktreeId: "wt-1" },
+      ]);
+      useWorktreeSelectionStore.setState({
+        maximizeByWorktree: new Map([
+          [
+            "wt-1",
+            {
+              maximizedId: "term-1",
+              maximizeTarget: { type: "group" as const, id: "group-1" },
+              preMaximizeLayout: null,
+            },
+          ],
+        ]),
+      });
+
+      usePanelStore.getState().trashPanel("term-1");
+
+      // The stash is keyed on the maximized panel regardless of target kind:
+      // losing it leaves the group target with nothing to anchor to.
+      expect(stashedIds().has("wt-1")).toBe(false);
+    });
   });
 
   it("records terminal MRU on focus change", () => {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -347,6 +347,78 @@ describe("rendererStoreOrchestrator", () => {
     );
   });
 
+  describe("stashed maximize cleanup (#11183)", () => {
+    /** An inactive worktree whose maximized panel is `panelId`. */
+    function stashMaximize(worktreeId: string, panelId: string) {
+      useWorktreeSelectionStore.setState({
+        maximizeByWorktree: new Map([
+          [
+            worktreeId,
+            {
+              maximizedId: panelId,
+              maximizeTarget: { type: "panel" as const, id: panelId },
+              preMaximizeLayout: null,
+            },
+          ],
+        ]),
+      });
+    }
+    function seedPanels(panels: { id: string; worktreeId: string }[]) {
+      usePanelStore.setState({
+        panelsById: Object.fromEntries(
+          panels.map((p) => [
+            p.id,
+            {
+              id: p.id,
+              title: p.id,
+              kind: "terminal" as const,
+              cwd: "/test",
+              cols: 80,
+              rows: 24,
+              location: "grid" as const,
+              worktreeId: p.worktreeId,
+            },
+          ])
+        ),
+        panelIds: panels.map((p) => p.id),
+      });
+    }
+    const stashedIds = () => useWorktreeSelectionStore.getState().maximizeByWorktree;
+
+    it("drops the stash when the maximized panel of an inactive worktree is removed", () => {
+      seedPanels([{ id: "term-1", worktreeId: "wt-1" }]);
+      stashMaximize("wt-1", "term-1");
+
+      usePanelStore.getState().removePanel("term-1");
+
+      expect(stashedIds().has("wt-1")).toBe(false);
+    });
+
+    it("drops the stash when the maximized panel of an inactive worktree is trashed", () => {
+      seedPanels([{ id: "term-1", worktreeId: "wt-1" }]);
+      stashMaximize("wt-1", "term-1");
+
+      usePanelStore.getState().trashPanel("term-1");
+
+      // `trashPanel` flips `location` without shrinking `panelIds`, so the
+      // removal subscriber never sees this — it needs the trash listener.
+      expect(usePanelStore.getState().panelIds).toContain("term-1");
+      expect(stashedIds().has("wt-1")).toBe(false);
+    });
+
+    it("keeps a stash when an unrelated panel in the same worktree is removed", () => {
+      seedPanels([
+        { id: "term-1", worktreeId: "wt-1" },
+        { id: "term-2", worktreeId: "wt-1" },
+      ]);
+      stashMaximize("wt-1", "term-1");
+
+      usePanelStore.getState().removePanel("term-2");
+
+      expect(stashedIds().get("wt-1")?.maximizedId).toBe("term-1");
+    });
+  });
+
   it("records terminal MRU on focus change", () => {
     const recordMruSpy = vi.spyOn(usePanelStore.getState(), "recordMru");
 

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -1401,6 +1401,25 @@ describe("worktreeStore", () => {
         expect(terminalStoreState.maximizedId).toBe("a1");
       });
 
+      it("clears the flat trio on a scoped switch so an empty armed set can't blank the grid", () => {
+        twoWorktrees();
+        const token = useWorktreeSelectionStore.getState().enterFleetScope();
+        // Maximize inside scope (terminal.maximize has no fleet guard), then let
+        // a focus promotion move the active worktree out from under it.
+        maximizePanel("a1");
+        terminalStoreState.focusedId = "b1";
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+
+        // The fleet branch only renders while the armed set is non-empty
+        // (`isFleetScopeRender`), so clearing the fleet selection without leaving
+        // scope falls through to the maximize branch. A trio still pointing at
+        // wt-a's panel would resolve against wt-b's grid and render nothing.
+        expect(terminalStoreState.maximizedId).toBeNull();
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+        useWorktreeSelectionStore.getState().exitFleetScope(token);
+      });
+
       it("does not strand a foreign maximize when scope exits after a promotion", () => {
         twoWorktrees();
         const token = useWorktreeSelectionStore.getState().enterFleetScope();

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -78,15 +78,29 @@ type MockTerminal = {
   location?: "grid" | "dock" | "trash" | "background";
   hasPty?: boolean;
 };
+type MockTabGroup = {
+  id: string;
+  location: "grid" | "dock";
+  worktreeId?: string;
+  activeTabId: string;
+  panelIds: string[];
+};
+type MockMaximizeTarget = { type: "panel" | "group"; id: string } | null;
+type MockPreMaximizeLayout = {
+  gridCols: number;
+  gridItemCount: number;
+  worktreeId: string | undefined;
+} | null;
 const terminalStoreState = {
   panelsById: {} as Record<string, MockTerminal>,
   panelIds: [] as string[],
+  tabGroups: new Map<string, MockTabGroup>(),
   activeDockTerminalId: null as string | null,
   focusedId: null as string | null,
   mruList: [] as string[],
   maximizedId: null as string | null,
-  maximizeTarget: null as { type: string; id: string } | null,
-  preMaximizeLayout: null as { gridCols: number } | null,
+  maximizeTarget: null as MockMaximizeTarget,
+  preMaximizeLayout: null as MockPreMaximizeLayout,
   recordMru: recordMruMock,
   setFocused: setFocusedMock,
 };
@@ -146,6 +160,7 @@ describe("worktreeStore", () => {
     useWorktreeSelectionStore.getState().reset();
     terminalStoreState.panelsById = {};
     terminalStoreState.panelIds = [];
+    terminalStoreState.tabGroups = new Map();
     terminalStoreState.activeDockTerminalId = null;
     terminalStoreState.focusedId = null;
     terminalStoreState.mruList = [];
@@ -757,7 +772,11 @@ describe("worktreeStore", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-with-maximize" });
       terminalStoreState.maximizedId = "term-maxed";
       terminalStoreState.maximizeTarget = { type: "panel", id: "term-maxed" };
-      terminalStoreState.preMaximizeLayout = { gridCols: 2 };
+      terminalStoreState.preMaximizeLayout = {
+        gridCols: 2,
+        gridItemCount: 2,
+        worktreeId: "wt-with-maximize",
+      };
 
       useWorktreeSelectionStore.getState().enterFleetScope();
 
@@ -775,7 +794,11 @@ describe("worktreeStore", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
       const token = useWorktreeSelectionStore.getState().enterFleetScope();
 
-      terminalStoreState.preMaximizeLayout = { gridCols: 3 };
+      terminalStoreState.preMaximizeLayout = {
+        gridCols: 3,
+        gridItemCount: 3,
+        worktreeId: "wt-pre-scope",
+      };
       panelSetStateMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
@@ -915,6 +938,317 @@ describe("worktreeStore", () => {
       expect(wakeMock).toHaveBeenCalledWith("term-armed-remote");
       expect(wakeMock).not.toHaveBeenCalledWith("term-idle-remote");
       armedIdsForFleet = new Set();
+    });
+  });
+
+  describe("per-worktree maximize (#11183)", () => {
+    /** Put `panelId` on screen full-size in whichever worktree is active. */
+    function maximizePanel(panelId: string, layout?: MockPreMaximizeLayout) {
+      terminalStoreState.maximizedId = panelId;
+      terminalStoreState.maximizeTarget = { type: "panel", id: panelId };
+      terminalStoreState.preMaximizeLayout = layout ?? null;
+    }
+    function maximizeGroup(panelId: string, groupId: string) {
+      terminalStoreState.maximizedId = panelId;
+      terminalStoreState.maximizeTarget = { type: "group", id: groupId };
+      terminalStoreState.preMaximizeLayout = null;
+    }
+    function stashedFor(worktreeId: string) {
+      return useWorktreeSelectionStore.getState().maximizeByWorktree.get(worktreeId);
+    }
+    /** Two worktrees, one grid panel each. */
+    function twoWorktrees() {
+      setMockTerminals([
+        { id: "a1", worktreeId: "wt-a", location: "grid" },
+        { id: "a2", worktreeId: "wt-a", location: "grid" },
+        { id: "b1", worktreeId: "wt-b", location: "grid" },
+        { id: "b2", worktreeId: "wt-b", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
+    }
+
+    it("clears the maximize when switching to a worktree that doesn't own the panel", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      // The whole bug: leaving `a1` in the flat fields makes ContentGrid take
+      // its maximize branch and find nothing in wt-b's grid — a blank screen.
+      expect(terminalStoreState.maximizedId).toBeNull();
+      expect(terminalStoreState.maximizeTarget).toBeNull();
+    });
+
+    it("restores each worktree's own maximize across a round trip", () => {
+      twoWorktrees();
+      maximizePanel("a1", { gridCols: 3, gridItemCount: 4, worktreeId: "wt-a" });
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+      maximizePanel("b1");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      expect(terminalStoreState.maximizedId).toBe("a1");
+      expect(terminalStoreState.maximizeTarget).toEqual({ type: "panel", id: "a1" });
+      // The column count captured before wt-a maximized rides along, so
+      // unmaximizing here restores wt-a's layout rather than recomputing it.
+      expect(terminalStoreState.preMaximizeLayout).toMatchObject({
+        gridCols: 3,
+        worktreeId: "wt-a",
+      });
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+      expect(terminalStoreState.maximizedId).toBe("b1");
+    });
+
+    it("moves a worktree's maximize out of the map once it is active", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+      expect(stashedFor("wt-a")?.maximizedId).toBe("a1");
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+      // A worktree's maximize lives in exactly one place. Now that wt-a is
+      // active again the flat fields own it; a lingering slot would resurrect a
+      // stale maximize the next time wt-a is switched into.
+      expect(stashedFor("wt-a")).toBeUndefined();
+    });
+
+    it("writes all three maximize fields in a single panel-store patch", () => {
+      twoWorktrees();
+      maximizePanel("a1", { gridCols: 2, gridItemCount: 3, worktreeId: "wt-a" });
+      panelSetStateMock.mockClear();
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      // Dropping only the id strands the target and the next toggleMaximize
+      // reads it as an unmaximize request (#9935) — the trio must move together.
+      const patch = panelSetStateMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(Object.keys(patch).sort()).toEqual([
+        "maximizeTarget",
+        "maximizedId",
+        "preMaximizeLayout",
+      ]);
+    });
+
+    it("does not round-trip the live maximize when re-activating the current worktree", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-a");
+
+      expect(terminalStoreState.maximizedId).toBe("a1");
+      expect(stashedFor("wt-a")).toBeUndefined();
+    });
+
+    it("stashes nothing for a worktree that was left unmaximized", () => {
+      twoWorktrees();
+      // `exitMaximize` deliberately preserves preMaximizeLayout, so a worktree
+      // can be left with a layout snapshot and no maximize. That is not a
+      // maximize and must not become one on the way back.
+      terminalStoreState.preMaximizeLayout = { gridCols: 4, gridItemCount: 4, worktreeId: "wt-a" };
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      expect(stashedFor("wt-a")).toBeUndefined();
+      expect(terminalStoreState.preMaximizeLayout).toBeNull();
+    });
+
+    it("replaces the map reference on every write so subscribers are notified", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+      const before = useWorktreeSelectionStore.getState().maximizeByWorktree;
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      // Zustand 5 only notifies on a new reference — an in-place Map.set() is
+      // invisible to selectors.
+      expect(useWorktreeSelectionStore.getState().maximizeByWorktree).not.toBe(before);
+    });
+
+    it("reset drops every stashed maximize", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      useWorktreeSelectionStore.getState().reset();
+
+      expect(useWorktreeSelectionStore.getState().maximizeByWorktree.size).toBe(0);
+    });
+
+    describe("stale stashes are never written back", () => {
+      /** Maximize a1 in wt-a, then leave — wt-a's maximize is now stashed. */
+      function stashWtA() {
+        twoWorktrees();
+        maximizePanel("a1");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+      }
+
+      it.each([
+        ["the panel was trashed", () => (terminalStoreState.panelsById["a1"]!.location = "trash")],
+        ["the panel was docked", () => (terminalStoreState.panelsById["a1"]!.location = "dock")],
+        [
+          "the panel was backgrounded",
+          () => (terminalStoreState.panelsById["a1"]!.location = "background"),
+        ],
+        [
+          "the panel moved to another worktree",
+          () => (terminalStoreState.panelsById["a1"]!.worktreeId = "wt-b"),
+        ],
+        [
+          "the panel is gone entirely",
+          () => setMockTerminals([{ id: "b1", worktreeId: "wt-b", location: "grid" }]),
+        ],
+      ])("clears rather than restoring when %s", (_case, invalidate) => {
+        stashWtA();
+        invalidate();
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        // Restoring any of these blanks the grid all over again: none of them
+        // can satisfy ContentGrid's maximize branch.
+        expect(terminalStoreState.maximizedId).toBeNull();
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+        expect(stashedFor("wt-a")).toBeUndefined();
+      });
+
+      it("drops a foreign layout snapshot but keeps the maximize itself", () => {
+        twoWorktrees();
+        maximizePanel("a1", { gridCols: 5, gridItemCount: 2, worktreeId: "wt-b" });
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        expect(terminalStoreState.maximizedId).toBe("a1");
+        expect(terminalStoreState.preMaximizeLayout).toBeNull();
+      });
+    });
+
+    describe("group targets", () => {
+      function groupedWtA(panelIds: string[], location: "grid" | "dock" = "grid") {
+        twoWorktrees();
+        terminalStoreState.tabGroups.set("g1", {
+          id: "g1",
+          location,
+          worktreeId: "wt-a",
+          activeTabId: panelIds[0]!,
+          panelIds,
+        });
+        maximizeGroup("a1", "g1");
+      }
+
+      it("restores a maximized group", () => {
+        groupedWtA(["a1", "a2"]);
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        expect(terminalStoreState.maximizeTarget).toEqual({ type: "group", id: "g1" });
+        expect(terminalStoreState.maximizedId).toBe("a1");
+      });
+
+      it("downgrades to a panel maximize when the group shrank to one member", () => {
+        groupedWtA(["a1", "a2"]);
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        terminalStoreState.tabGroups.get("g1")!.panelIds = ["a1"];
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        // A one-member group renders no tab strip, so the surviving panel is
+        // still shown — just as a plain panel maximize.
+        expect(terminalStoreState.maximizeTarget).toEqual({ type: "panel", id: "a1" });
+      });
+
+      it("clears when the group dissolved while the worktree was inactive", () => {
+        groupedWtA(["a1", "a2"]);
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        terminalStoreState.tabGroups.delete("g1");
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+      });
+
+      it("clears when the group moved to the dock", () => {
+        groupedWtA(["a1", "a2"]);
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        terminalStoreState.tabGroups.get("g1")!.location = "dock";
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        // ContentGrid only ever resolves grid groups — a docked one renders as
+        // an empty group and blanks the screen.
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+      });
+    });
+
+    describe("focus promotions reveal the panel they promoted for", () => {
+      /** wt-b has b1 maximized and stashed; wt-a is active. */
+      function stashWtB() {
+        twoWorktrees();
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        maximizePanel("b1");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+      }
+
+      it("does not bury the panel a focus promotion was fired to reveal", () => {
+        stashWtB();
+        // A draft/spawn lands on b2 and focuses it, which promotes wt-b. Its
+        // stashed maximize covers b1 — restoring it would hide b2 behind a
+        // fullscreen b1, defeating the reveal (useTypeAnywhere, panelSpawning,
+        // recipeStore all rely on this).
+        terminalStoreState.focusedId = "b2";
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+
+        expect(terminalStoreState.maximizedId).toBeNull();
+        expect(stashedFor("wt-b")).toBeUndefined();
+      });
+
+      it("restores when the promotion targets the maximized panel itself", () => {
+        stashWtB();
+        // Navigating straight back to b1 (quick switcher, HelpPanel): the
+        // maximize *is* how b1 gets revealed, so dropping it would silently
+        // destroy the user's maximize.
+        terminalStoreState.focusedId = "b1";
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+
+        expect(terminalStoreState.maximizedId).toBe("b1");
+      });
+
+      it("restores when the promotion targets a member of the maximized group", () => {
+        twoWorktrees();
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        terminalStoreState.tabGroups.set("g2", {
+          id: "g2",
+          location: "grid",
+          worktreeId: "wt-b",
+          activeTabId: "b1",
+          panelIds: ["b1", "b2"],
+        });
+        maximizeGroup("b1", "g2");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+        // b2 is a tab inside the maximized group, so the group shows it.
+        terminalStoreState.focusedId = "b2";
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+
+        expect(terminalStoreState.maximizeTarget).toEqual({ type: "group", id: "g2" });
+      });
+    });
+
+    it("does not restore a maximize into fleet scope", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+      useWorktreeSelectionStore.setState({ isFleetScopeActive: true });
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      // A maximize shadows the fleet grid — the exact reason enterFleetScope
+      // clears the trio on the way in.
+      expect(terminalStoreState.maximizedId).toBeNull();
     });
   });
 });

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -803,7 +803,11 @@ describe("worktreeStore", () => {
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
 
-      expect(panelSetStateMock).toHaveBeenCalledWith({ preMaximizeLayout: null });
+      // Exit now reconciles the whole trio for the restored worktree (#11183),
+      // so the stale snapshot is replaced rather than merely nulled on its own.
+      expect(panelSetStateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ preMaximizeLayout: null })
+      );
       expect(terminalStoreState.preMaximizeLayout).toBeNull();
     });
 
@@ -1014,31 +1018,106 @@ describe("worktreeStore", () => {
       expect(stashedFor("wt-a")).toBeUndefined();
     });
 
-    it("writes all three maximize fields in a single panel-store patch", () => {
+    it("writes the maximize trio to the panel store exactly once per switch", () => {
       twoWorktrees();
       maximizePanel("a1", { gridCols: 2, gridItemCount: 3, worktreeId: "wt-a" });
       panelSetStateMock.mockClear();
+      // Zustand notifies subscribers on every setState, so a partial write
+      // followed by a corrective one still exposes a frame where the trio is
+      // half-applied. Dropping only the id strands the target and the next
+      // toggleMaximize reads it as an unmaximize request (#9935).
+      const activeWhenPatched: (string | null)[] = [];
+      panelSetStateMock.mockImplementation((patch: Record<string, unknown>) => {
+        activeWhenPatched.push(useWorktreeSelectionStore.getState().activeWorktreeId);
+        Object.assign(terminalStoreState, patch);
+      });
 
       useWorktreeSelectionStore.getState().selectWorktree("wt-b");
 
-      // Dropping only the id strands the target and the next toggleMaximize
-      // reads it as an unmaximize request (#9935) — the trio must move together.
-      const patch = panelSetStateMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
-      expect(Object.keys(patch).sort()).toEqual([
-        "maximizeTarget",
-        "maximizedId",
-        "preMaximizeLayout",
-      ]);
+      expect(panelSetStateMock).toHaveBeenCalledTimes(1);
+      expect(panelSetStateMock).toHaveBeenCalledWith({
+        maximizedId: null,
+        maximizeTarget: null,
+        preMaximizeLayout: null,
+      });
+      // The worktree store is written first, so anything the panel-store write
+      // wakes already sees the incoming worktree rather than the outgoing one.
+      expect(activeWhenPatched).toEqual(["wt-b"]);
     });
 
-    it("does not round-trip the live maximize when re-activating the current worktree", () => {
+    it("leaves the live maximize alone when re-activating the current worktree", () => {
       twoWorktrees();
       maximizePanel("a1");
+      const mapBefore = useWorktreeSelectionStore.getState().maximizeByWorktree;
+      panelSetStateMock.mockClear();
+
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-a");
+
+      // A no-op re-activation must not round-trip the live maximize through the
+      // map — an identity swap that happened to work would still churn state.
+      expect(panelSetStateMock).not.toHaveBeenCalled();
+      expect(useWorktreeSelectionStore.getState().maximizeByWorktree).toBe(mapBefore);
+      expect(terminalStoreState.maximizedId).toBe("a1");
+    });
+
+    it("setActiveWorktree isolates and restores maximize just like selectWorktree", () => {
+      twoWorktrees();
+      maximizePanel("a1", { gridCols: 3, gridItemCount: 4, worktreeId: "wt-a" });
+
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-b");
+
+      // Both switch entry points must swap: setActiveWorktree is the
+      // programmatic activation path (worktree created, restored, removed).
+      expect(terminalStoreState.maximizedId).toBeNull();
+      expect(terminalStoreState.maximizeTarget).toBeNull();
+      expect(stashedFor("wt-a")?.maximizedId).toBe("a1");
 
       useWorktreeSelectionStore.getState().setActiveWorktree("wt-a");
 
       expect(terminalStoreState.maximizedId).toBe("a1");
+      expect(terminalStoreState.preMaximizeLayout).toMatchObject({ gridCols: 3, gridItemCount: 4 });
       expect(stashedFor("wt-a")).toBeUndefined();
+    });
+
+    it("setActiveWorktree(null) stashes the outgoing maximize and clears the grid", () => {
+      twoWorktrees();
+      maximizePanel("a1");
+
+      useWorktreeSelectionStore.getState().setActiveWorktree(null);
+
+      expect(terminalStoreState.maximizedId).toBeNull();
+      expect(stashedFor("wt-a")?.maximizedId).toBe("a1");
+
+      useWorktreeSelectionStore.getState().setActiveWorktree("wt-a");
+      expect(terminalStoreState.maximizedId).toBe("a1");
+    });
+
+    it("does not stash a half-populated maximize pair", () => {
+      twoWorktrees();
+      // Layout undo restores `maximizedId` without `maximizeTarget`
+      // (layoutUndoStore's snapshot omits the target entirely), so the flat
+      // fields can legitimately hold one half of the pair. ContentGrid needs
+      // both, so half a pair is not a maximize and must not become one.
+      terminalStoreState.maximizedId = "a1";
+      terminalStoreState.maximizeTarget = null;
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+
+      expect(stashedFor("wt-a")).toBeUndefined();
+    });
+
+    it("clears a stash whose target id disagrees with the maximized panel", () => {
+      twoWorktrees();
+      // Same desync source: a target pointing at a different panel than
+      // `maximizedId` cannot resolve to one thing on screen.
+      terminalStoreState.maximizedId = "a1";
+      terminalStoreState.maximizeTarget = { type: "panel", id: "a2" };
+
+      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+      expect(terminalStoreState.maximizedId).toBeNull();
+      expect(terminalStoreState.maximizeTarget).toBeNull();
     });
 
     it("stashes nothing for a worktree that was left unmaximized", () => {
@@ -1141,10 +1220,37 @@ describe("worktreeStore", () => {
         groupedWtA(["a1", "a2"]);
 
         useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        // Load-bearing: without the swap the group maximize simply leaks into
+        // wt-b and the round-trip below would "pass" without proving anything.
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+        expect(stashedFor("wt-a")?.maximizeTarget).toEqual({ type: "group", id: "g1" });
+
         useWorktreeSelectionStore.getState().selectWorktree("wt-a");
 
         expect(terminalStoreState.maximizeTarget).toEqual({ type: "group", id: "g1" });
         expect(terminalStoreState.maximizedId).toBe("a1");
+      });
+
+      it("clears when the group belongs to another worktree", () => {
+        groupedWtA(["a1", "a2"]);
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        terminalStoreState.tabGroups.get("g1")!.worktreeId = "wt-b";
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+      });
+
+      it("clears when the group no longer contains the maximized panel", () => {
+        groupedWtA(["a1", "a2"]);
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        // a1 was pulled out of the group while wt-a was inactive.
+        terminalStoreState.tabGroups.get("g1")!.panelIds = ["a2", "a3"];
+
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+        expect(terminalStoreState.maximizedId).toBeNull();
       });
 
       it("downgrades to a panel maximize when the group shrank to one member", () => {
@@ -1207,6 +1313,7 @@ describe("worktreeStore", () => {
 
       it("restores when the promotion targets the maximized panel itself", () => {
         stashWtB();
+        expect(terminalStoreState.maximizedId).toBeNull();
         // Navigating straight back to b1 (quick switcher, HelpPanel): the
         // maximize *is* how b1 gets revealed, so dropping it would silently
         // destroy the user's maximize.
@@ -1217,38 +1324,123 @@ describe("worktreeStore", () => {
         expect(terminalStoreState.maximizedId).toBe("b1");
       });
 
-      it("restores when the promotion targets a member of the maximized group", () => {
-        twoWorktrees();
-        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
-        terminalStoreState.tabGroups.set("g2", {
-          id: "g2",
-          location: "grid",
-          worktreeId: "wt-b",
-          activeTabId: "b1",
-          panelIds: ["b1", "b2"],
-        });
-        maximizeGroup("b1", "g2");
-        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
-        // b2 is a tab inside the maximized group, so the group shows it.
-        terminalStoreState.focusedId = "b2";
+      it("drops the stash when a promotion arrives with no focused panel", () => {
+        stashWtB();
+        terminalStoreState.focusedId = null;
 
         useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
 
-        expect(terminalStoreState.maximizeTarget).toEqual({ type: "group", id: "g2" });
+        // Nothing to reveal means nothing proves the maximize still serves the
+        // user's intent — fall back to the visible grid rather than guessing.
+        expect(terminalStoreState.maximizedId).toBeNull();
+        expect(stashedFor("wt-b")).toBeUndefined();
+      });
+
+      describe("group stashes", () => {
+        function stashGroupedWtB() {
+          twoWorktrees();
+          useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+          terminalStoreState.tabGroups.set("g2", {
+            id: "g2",
+            location: "grid",
+            worktreeId: "wt-b",
+            activeTabId: "b1",
+            panelIds: ["b1", "b2"],
+          });
+          maximizeGroup("b1", "g2");
+          useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+        }
+
+        it("restores when the promotion targets a member of the maximized group", () => {
+          stashGroupedWtB();
+          expect(terminalStoreState.maximizeTarget).toBeNull();
+          // b2 is a tab inside the maximized group, so the group shows it.
+          terminalStoreState.focusedId = "b2";
+
+          useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+
+          expect(terminalStoreState.maximizeTarget).toEqual({ type: "group", id: "g2" });
+        });
+
+        it("drops the stash when the promotion targets a panel outside the group", () => {
+          stashGroupedWtB();
+          setMockTerminals([
+            ...Object.values(terminalStoreState.panelsById),
+            { id: "b3", worktreeId: "wt-b", location: "grid" },
+          ]);
+          // b3 is not in the group, so a maximized g2 would hide it.
+          terminalStoreState.focusedId = "b3";
+
+          useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+
+          expect(terminalStoreState.maximizeTarget).toBeNull();
+          expect(stashedFor("wt-b")).toBeUndefined();
+        });
       });
     });
 
-    it("does not restore a maximize into fleet scope", () => {
-      twoWorktrees();
-      maximizePanel("a1");
-      useWorktreeSelectionStore.getState().selectWorktree("wt-b");
-      useWorktreeSelectionStore.setState({ isFleetScopeActive: true });
+    describe("fleet scope", () => {
+      it("leaves parked maximizes untouched while scoped", () => {
+        twoWorktrees();
+        maximizePanel("a1");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        const token = useWorktreeSelectionStore.getState().enterFleetScope();
 
-      useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+        // The fleet grid shows armed panels from every worktree, so focusing one
+        // promotes its worktree. That must not consume wt-a's parked maximize:
+        // the user never left the fleet view, and returning to wt-a later still
+        // owes them their maximized panel.
+        terminalStoreState.focusedId = "a1";
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a", { source: "focus" });
 
-      // A maximize shadows the fleet grid — the exact reason enterFleetScope
-      // clears the trio on the way in.
-      expect(terminalStoreState.maximizedId).toBeNull();
+        expect(stashedFor("wt-a")?.maximizedId).toBe("a1");
+        expect(terminalStoreState.maximizedId).toBeNull();
+
+        useWorktreeSelectionStore.getState().exitFleetScope(token);
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+        expect(terminalStoreState.maximizedId).toBe("a1");
+      });
+
+      it("does not strand a foreign maximize when scope exits after a promotion", () => {
+        twoWorktrees();
+        const token = useWorktreeSelectionStore.getState().enterFleetScope();
+
+        // Inside the fleet view: focus promotes wt-b, then the user maximizes.
+        // `terminal.maximize` has no fleet guard, so the flat trio now describes
+        // wt-b even though the pre-scope worktree is wt-a.
+        terminalStoreState.focusedId = "b1";
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b", { source: "focus" });
+        maximizePanel("b1");
+
+        useWorktreeSelectionStore.getState().exitFleetScope(token);
+
+        // Exit snaps activeWorktreeId back to wt-a. Leaving b1 in the flat trio
+        // would make ContentGrid hunt for it among wt-a's panels and render
+        // nothing — the original #11183 blank grid, via the back door.
+        expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-a");
+        expect(terminalStoreState.maximizedId).toBeNull();
+        expect(terminalStoreState.maximizeTarget).toBeNull();
+      });
+
+      it("a quiet scope round-trip leaves the grid unmaximized and other parks intact", () => {
+        twoWorktrees();
+        // wt-b has a parked maximize; wt-a is active and maximized.
+        useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+        maximizePanel("b1");
+        useWorktreeSelectionStore.getState().selectWorktree("wt-a");
+        maximizePanel("a1");
+
+        const token = useWorktreeSelectionStore.getState().enterFleetScope();
+        // Entry discards the *active* worktree's maximize, as it always has.
+        expect(terminalStoreState.maximizedId).toBeNull();
+
+        useWorktreeSelectionStore.getState().exitFleetScope(token);
+
+        expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-a");
+        expect(terminalStoreState.maximizedId).toBeNull();
+        // ...but an inactive worktree's park is none of fleet scope's business.
+        expect(stashedFor("wt-b")?.maximizedId).toBe("b1");
+      });
     });
   });
 });

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -271,6 +271,16 @@ export function initStoreOrchestrator(): () => void {
               if (lastFocused === removedId) {
                 worktreeState.clearWorktreeFocusTracking(removed.worktreeId);
               }
+              // Same hygiene for an inactive worktree's stashed maximize
+              // (#11183): the switch-boundary validator would reject a snapshot
+              // pointing at a dead panel anyway, but nothing else writes an
+              // inactive worktree's slot, so leaving it pins a dead panel id for
+              // the rest of the session.
+              if (
+                worktreeState.maximizeByWorktree.get(removed.worktreeId)?.maximizedId === removedId
+              ) {
+                worktreeState.clearWorktreeMaximizeTracking(removed.worktreeId);
+              }
             }
           }
         },
@@ -342,6 +352,19 @@ export function initStoreOrchestrator(): () => void {
           for (const id of trashed.keys()) {
             if (!prevTrashed.has(id)) {
               removeArtifactsForTerminal(id);
+              // Drop an inactive worktree's stashed maximize when its panel is
+              // trashed (#11183). `trashPanel` doesn't shrink `panelIds`, so the
+              // removal subscriber above never fires for this — the same
+              // constraint that put the artifact cleanup here. The panel is
+              // still in `panelsById` (flipped to "trash"), so it can still be
+              // asked which worktree it belonged to.
+              const worktreeId = usePanelStore.getState().panelsById[id]?.worktreeId;
+              if (worktreeId) {
+                const worktreeState = useWorktreeSelectionStore.getState();
+                if (worktreeState.maximizeByWorktree.get(worktreeId)?.maximizedId === id) {
+                  worktreeState.clearWorktreeMaximizeTracking(worktreeId);
+                }
+              }
             }
           }
         }

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -392,14 +392,14 @@ function maximizeShowsPanel(
  *
  * Restore is skipped — and the stash dropped — when:
  *  - the snapshot no longer resolves in the incoming worktree (stale target), or
- *  - fleet scope is active: a maximize would shadow the fleet grid, which is
- *    exactly what `enterFleetScope`'s own trio-clear exists to prevent, or
  *  - the switch is a `"focus"` promotion whose focused panel this maximize would
  *    bury. A promotion means "reveal this panel" — it is how `useTypeAnywhere`,
  *    panel spawning and the quick switcher surface a panel living in a worktree
  *    the user isn't looking at, and those callers' defensive `exitMaximize()`
  *    only clears the *outgoing* worktree's. Restoring a maximize that does show
  *    the panel (navigating straight back to it) is still correct.
+ *
+ * Callers must NOT run this while fleet scope is active — see the call sites.
  */
 function prepareWorktreeMaximizeSwap(
   state: WorktreeSelectionState,
@@ -425,7 +425,7 @@ function prepareWorktreeMaximizeSwap(
     // The incoming worktree becomes active, so its maximize moves back into the
     // flat fields — drop the slot whether or not it survives validation.
     next.delete(toWorktreeId);
-    if (stashed && !state.isFleetScopeActive) {
+    if (stashed) {
       const candidate = resolveMaximizeForWorktree(stashed, toWorktreeId, panels);
       const buriesFocusedPanel =
         source === "focus" &&
@@ -508,9 +508,15 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     let panelPatch: PanelMaximizeFields | null = null;
     if (previousId !== id) {
       updates.expandedTerminals = new Set<string>();
-      const swap = prepareWorktreeMaximizeSwap(get(), previousId, id, "user");
-      updates.maximizeByWorktree = swap.maximizeByWorktree;
-      panelPatch = swap.panelPatch;
+      // Fleet scope renders ahead of the maximize branch and spans every
+      // worktree, so it has no maximize of its own: switches inside it leave
+      // each worktree's parked maximize untouched, and `exitFleetScope`
+      // reconciles the flat trio on the way out.
+      if (!get().isFleetScopeActive) {
+        const swap = prepareWorktreeMaximizeSwap(get(), previousId, id, "user");
+        updates.maximizeByWorktree = swap.maximizeByWorktree;
+        panelPatch = swap.panelPatch;
+      }
     }
 
     set(updates);
@@ -564,21 +570,29 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       fromWorktreeId: previousId ?? null,
       toWorktreeId: id,
     });
-    const maximizeSwap = prepareWorktreeMaximizeSwap(get(), previousId, id, source);
+    // Fleet scope owns the render path and spans every worktree, so a switch
+    // inside it must leave the parked maximizes alone — including the incoming
+    // worktree's, which a focus promotion between fleet panels would otherwise
+    // consume and destroy. `exitFleetScope` reconciles the trio on the way out.
+    const maximizeSwap = get().isFleetScopeActive
+      ? null
+      : prepareWorktreeMaximizeSwap(get(), previousId, id, source);
     // Auto-collapse terminals accordion when switching worktrees
     set({
       activeWorktreeId: id,
       focusedWorktreeId: id,
       _policyGeneration: generation,
       expandedTerminals: new Set<string>(),
-      maximizeByWorktree: maximizeSwap.maximizeByWorktree,
+      ...(maximizeSwap ? { maximizeByWorktree: maximizeSwap.maximizeByWorktree } : {}),
       ...(source === "user" ? { restoreWorktreeId: id } : {}),
     });
     // Hand the incoming worktree's maximize (or a clear) to the panel store in
     // the same tick as the switch, and before the terminal policy / focus
     // restore below — a frame in between would render the outgoing worktree's
     // maximize target against this worktree's grid, i.e. nothing at all (#11183).
-    usePanelStore.setState(maximizeSwap.panelPatch);
+    if (maximizeSwap) {
+      usePanelStore.setState(maximizeSwap.panelPatch);
+    }
     scheduleWorktreeSwitchPaintedMark(previousId ?? null, id, switchStartedAt);
 
     if (source === "user") {
@@ -949,12 +963,23 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // the value used for focus restore is stable against any reads/writes
     // the in-tick clears below might trigger.
     const primaryTerminalId = getFleetLastArmedId();
+    // Reconcile maximize for the worktree we're returning to (#11183). Scope
+    // entry cleared the trio, but `activeWorktreeId` can move *during* scope (a
+    // fleet panel in another worktree gains focus and promotes it), and
+    // `terminal.maximize` still works while scoped — so the flat trio can now
+    // describe a worktree we're about to leave. Restoring `restoreId` to the
+    // active slot without reconciling would strand that foreign target and
+    // blank the grid, which is the very bug this map exists to fix. A maximize
+    // made *during* scope is discarded rather than stashed: the fleet branch
+    // renders ahead of the maximize branch, so it was never visible anyway.
+    const maximizeSwap = prepareWorktreeMaximizeSwap(get(), null, restoreId, "user");
     set({
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
       _previousRestoreWorktreeId: null,
       _fleetScopeToken: null,
       activeWorktreeId: restoreId,
+      maximizeByWorktree: maximizeSwap.maximizeByWorktree,
       // Restore the durable selection captured at entry so a focus-promotion
       // that happened before scope entry survives the cycle (#9512).
       restoreWorktreeId: previousRestoreId,
@@ -962,9 +987,10 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       _policyGeneration: generation,
     });
     persistActiveWorktree(restoreId);
-    // Defensive: drop any preMaximizeLayout snapshot that may have survived
-    // scope entry. The restored worktree's layout should be computed fresh.
-    usePanelStore.setState({ preMaximizeLayout: null });
+    // Hand the restored worktree its own maximize back, or clear the trio
+    // outright. Either way `preMaximizeLayout` is replaced, so a snapshot that
+    // survived scope entry can no longer restore a foreign column count.
+    usePanelStore.setState(maximizeSwap.panelPatch);
     // Focus the primary (most-recently-armed) terminal so the user lands on
     // a known pane instead of whatever `focusedId` happened to be during
     // fleet scope. Runs in-tick now, so the prior token/generation guards

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -1,6 +1,6 @@
 import { create, type StateCreator } from "zustand";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { TerminalRefreshTier, isPtyPanel } from "@shared/types/panel";
+import { TerminalRefreshTier, isGridPanelLocation, isPtyPanel } from "@shared/types/panel";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { Issue, PR } from "@shared/types/forge";
 import type { FleetScopeToken } from "@shared/types/worktree";
@@ -72,6 +72,22 @@ interface WorktreeSelectionState {
   crossDiffDialog: CrossDiffDialogState;
   _policyGeneration: number;
   lastFocusedTerminalByWorktree: Map<string, string>;
+  /**
+   * Maximize state for every worktree that is *not* the active one (#11183).
+   *
+   * The panel store's `maximizedId`/`maximizeTarget`/`preMaximizeLayout` are
+   * flat singular fields describing what the grid is showing *right now*, so
+   * they can only ever describe one worktree. Left alone across a switch, they
+   * keep pointing at a panel the incoming worktree doesn't own — `ContentGrid`
+   * takes its maximize branch, fails to find the target among the active
+   * worktree's grid panels, and renders nothing.
+   *
+   * Invariant: a worktree's maximize lives in exactly ONE place — the panel
+   * store's flat fields while it is active, this map while it is not. Switching
+   * out writes the outgoing worktree's slot; switching in deletes the incoming
+   * one (restorable or not) and moves it back into the flat fields.
+   */
+  maximizeByWorktree: Map<string, WorktreeMaximizeSnapshot>;
   isFleetScopeActive: boolean;
   _previousActiveWorktreeId: string | null;
   /** Durable selection captured at fleet-scope entry, restored on exit (#9512). */
@@ -111,6 +127,7 @@ interface WorktreeSelectionState {
   closeCrossWorktreeDiff: () => void;
   trackTerminalFocus: (worktreeId: string, terminalId: string) => void;
   clearWorktreeFocusTracking: (worktreeId: string) => void;
+  clearWorktreeMaximizeTracking: (worktreeId: string) => void;
   enterFleetScope: () => FleetScopeToken;
   exitFleetScope: (token: FleetScopeToken) => void;
   reset: () => void;
@@ -260,6 +277,169 @@ function persistActiveWorktree(id: string | null): void {
     });
 }
 
+/** The panel-store fields that together describe one worktree's maximize. */
+type PanelMaximizeFields = Pick<
+  ReturnType<typeof usePanelStore.getState>,
+  "maximizedId" | "maximizeTarget" | "preMaximizeLayout"
+>;
+
+/** What the swap needs to read to decide whether a stashed maximize still holds. */
+type PanelMaximizeLookup = Pick<
+  ReturnType<typeof usePanelStore.getState>,
+  "panelsById" | "tabGroups" | "focusedId"
+>;
+
+/**
+ * A stashed maximize. Both halves of the pair are non-null by construction:
+ * `ContentGrid` only takes its maximize branch when `maximizedId` AND
+ * `maximizeTarget` are set, and a half-populated pair is the stale-target bug
+ * class of #9935. `preMaximizeLayout` rides along so unmaximizing after a
+ * round-trip restores the column count the worktree had before it maximized.
+ */
+export interface WorktreeMaximizeSnapshot {
+  maximizedId: string;
+  maximizeTarget: NonNullable<PanelMaximizeFields["maximizeTarget"]>;
+  preMaximizeLayout: PanelMaximizeFields["preMaximizeLayout"];
+}
+
+const CLEARED_MAXIMIZE: PanelMaximizeFields = {
+  maximizedId: null,
+  maximizeTarget: null,
+  preMaximizeLayout: null,
+};
+
+function captureMaximizeSnapshot(panels: PanelMaximizeFields): WorktreeMaximizeSnapshot | null {
+  const { maximizedId, maximizeTarget, preMaximizeLayout } = panels;
+  if (!maximizedId || !maximizeTarget) return null;
+  return { maximizedId, maximizeTarget, preMaximizeLayout };
+}
+
+/**
+ * Is a stashed maximize still renderable in `worktreeId`? Returns the snapshot
+ * to write back (normalized), or null to clear.
+ *
+ * Runs *before* the flat fields are written, unlike `validateMaximizeTarget`,
+ * which repairs already-live state from a render effect — too late to stop the
+ * grid painting a blank frame. The panel must be a grid panel *of this
+ * worktree*: a docked, backgrounded or trashed panel can't satisfy
+ * `ContentGrid`'s maximize branch either, and a panel that has since moved to
+ * another worktree is no longer ours to show.
+ */
+function resolveMaximizeForWorktree(
+  snapshot: WorktreeMaximizeSnapshot,
+  worktreeId: string,
+  panels: PanelMaximizeLookup
+): WorktreeMaximizeSnapshot | null {
+  const panel = panels.panelsById[snapshot.maximizedId];
+  if (!panel || panel.worktreeId !== worktreeId || !isGridPanelLocation(panel.location)) {
+    return null;
+  }
+
+  // The layout snapshot is stamped with the worktree it was captured in; one
+  // from elsewhere would restore a foreign column count. Drop just that field
+  // rather than the whole maximize — the grid recomputes columns from scratch.
+  const preMaximizeLayout =
+    snapshot.preMaximizeLayout?.worktreeId === worktreeId ? snapshot.preMaximizeLayout : null;
+
+  if (snapshot.maximizeTarget.type === "panel") {
+    if (snapshot.maximizeTarget.id !== snapshot.maximizedId) return null;
+    return { ...snapshot, preMaximizeLayout };
+  }
+
+  const group = panels.tabGroups.get(snapshot.maximizeTarget.id);
+  if (
+    !group ||
+    group.location !== "grid" ||
+    group.worktreeId !== worktreeId ||
+    !group.panelIds.includes(snapshot.maximizedId)
+  ) {
+    return null;
+  }
+  if (group.panelIds.length === 1) {
+    // The group shrank to a single panel while we were away. Downgrade to a
+    // panel maximize rather than dropping the maximize entirely, mirroring
+    // `validateMaximizeTarget`'s repair of the same case on live state.
+    return {
+      maximizedId: snapshot.maximizedId,
+      maximizeTarget: { type: "panel", id: snapshot.maximizedId },
+      preMaximizeLayout,
+    };
+  }
+  return { ...snapshot, preMaximizeLayout };
+}
+
+/** Would this maximize leave `panelId` on screen? */
+function maximizeShowsPanel(
+  snapshot: WorktreeMaximizeSnapshot,
+  panelId: string,
+  panels: PanelMaximizeLookup
+): boolean {
+  if (snapshot.maximizeTarget.type === "panel") {
+    return snapshot.maximizeTarget.id === panelId;
+  }
+  return panels.tabGroups.get(snapshot.maximizeTarget.id)?.panelIds.includes(panelId) ?? false;
+}
+
+/**
+ * Move maximize state across a worktree switch: stash the outgoing worktree's,
+ * restore the incoming worktree's.
+ *
+ * Returns the next map plus the patch to write to the panel store. The caller
+ * writes the worktree store first so any panel-store subscriber woken by the
+ * patch already sees the new `activeWorktreeId`. Both writes land synchronously
+ * in the same tick (React 19 batches them), so the grid never paints a frame
+ * where the trio points at a panel the active worktree can't render.
+ *
+ * Restore is skipped — and the stash dropped — when:
+ *  - the snapshot no longer resolves in the incoming worktree (stale target), or
+ *  - fleet scope is active: a maximize would shadow the fleet grid, which is
+ *    exactly what `enterFleetScope`'s own trio-clear exists to prevent, or
+ *  - the switch is a `"focus"` promotion whose focused panel this maximize would
+ *    bury. A promotion means "reveal this panel" — it is how `useTypeAnywhere`,
+ *    panel spawning and the quick switcher surface a panel living in a worktree
+ *    the user isn't looking at, and those callers' defensive `exitMaximize()`
+ *    only clears the *outgoing* worktree's. Restoring a maximize that does show
+ *    the panel (navigating straight back to it) is still correct.
+ */
+function prepareWorktreeMaximizeSwap(
+  state: WorktreeSelectionState,
+  fromWorktreeId: string | null,
+  toWorktreeId: string | null,
+  source: "user" | "focus"
+): { maximizeByWorktree: Map<string, WorktreeMaximizeSnapshot>; panelPatch: PanelMaximizeFields } {
+  const panels = usePanelStore.getState();
+  const next = new Map(state.maximizeByWorktree);
+
+  if (fromWorktreeId) {
+    const outgoing = captureMaximizeSnapshot(panels);
+    if (outgoing) {
+      next.set(fromWorktreeId, outgoing);
+    } else {
+      next.delete(fromWorktreeId);
+    }
+  }
+
+  let restored: WorktreeMaximizeSnapshot | null = null;
+  if (toWorktreeId) {
+    const stashed = next.get(toWorktreeId);
+    // The incoming worktree becomes active, so its maximize moves back into the
+    // flat fields — drop the slot whether or not it survives validation.
+    next.delete(toWorktreeId);
+    if (stashed && !state.isFleetScopeActive) {
+      const candidate = resolveMaximizeForWorktree(stashed, toWorktreeId, panels);
+      const buriesFocusedPanel =
+        source === "focus" &&
+        (panels.focusedId === null ||
+          !maximizeShowsPanel(candidate ?? stashed, panels.focusedId, panels));
+      if (candidate && !buriesFocusedPanel) {
+        restored = candidate;
+      }
+    }
+  }
+
+  return { maximizeByWorktree: next, panelPatch: restored ?? CLEARED_MAXIMIZE };
+}
+
 const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set, get) => ({
   activeWorktreeId: null,
   restoreWorktreeId: null,
@@ -287,6 +467,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   crossDiffDialog: { isOpen: false, initialWorktreeId: null },
   _policyGeneration: 0,
   lastFocusedTerminalByWorktree: new Map<string, string>(),
+  maximizeByWorktree: new Map<string, WorktreeMaximizeSnapshot>(),
   isFleetScopeActive: false,
   _previousActiveWorktreeId: null,
   _previousRestoreWorktreeId: null,
@@ -320,11 +501,22 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       updates.restoreWorktreeId = null;
     }
 
+    // An explicit activation is a deliberate selection, so it restores the
+    // incoming worktree's maximize the same way `selectWorktree({source:"user"})`
+    // does. Guarded on an actual change: re-activating the current worktree must
+    // not round-trip its live maximize through the map (#11183).
+    let panelPatch: PanelMaximizeFields | null = null;
     if (previousId !== id) {
       updates.expandedTerminals = new Set<string>();
+      const swap = prepareWorktreeMaximizeSwap(get(), previousId, id, "user");
+      updates.maximizeByWorktree = swap.maximizeByWorktree;
+      panelPatch = swap.panelPatch;
     }
 
     set(updates);
+    if (panelPatch) {
+      usePanelStore.setState(panelPatch);
+    }
     scheduleWorktreeSwitchPaintedMark(previousId ?? null, id ?? null, switchStartedAt);
 
     persistActiveWorktree(id);
@@ -372,14 +564,21 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       fromWorktreeId: previousId ?? null,
       toWorktreeId: id,
     });
+    const maximizeSwap = prepareWorktreeMaximizeSwap(get(), previousId, id, source);
     // Auto-collapse terminals accordion when switching worktrees
     set({
       activeWorktreeId: id,
       focusedWorktreeId: id,
       _policyGeneration: generation,
       expandedTerminals: new Set<string>(),
+      maximizeByWorktree: maximizeSwap.maximizeByWorktree,
       ...(source === "user" ? { restoreWorktreeId: id } : {}),
     });
+    // Hand the incoming worktree's maximize (or a clear) to the panel store in
+    // the same tick as the switch, and before the terminal policy / focus
+    // restore below — a frame in between would render the outgoing worktree's
+    // maximize target against this worktree's grid, i.e. nothing at all (#11183).
+    usePanelStore.setState(maximizeSwap.panelPatch);
     scheduleWorktreeSwitchPaintedMark(previousId ?? null, id, switchStartedAt);
 
     if (source === "user") {
@@ -686,6 +885,13 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       return { lastFocusedTerminalByWorktree: next };
     }),
 
+  clearWorktreeMaximizeTracking: (worktreeId) =>
+    set((state) => {
+      const next = new Map(state.maximizeByWorktree);
+      next.delete(worktreeId);
+      return { maximizeByWorktree: next };
+    }),
+
   enterFleetScope: () => {
     // Idempotent: first pre-scope activeWorktreeId wins so the restoration
     // target isn't corrupted by a double-enter. Return the existing token so
@@ -818,6 +1024,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       quickCreate: { isOpen: false, issue: null, pr: null },
       crossDiffDialog: { isOpen: false, initialWorktreeId: null },
       lastFocusedTerminalByWorktree: new Map<string, string>(),
+      maximizeByWorktree: new Map<string, WorktreeMaximizeSnapshot>(),
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
       _previousRestoreWorktreeId: null,

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -399,7 +399,11 @@ function maximizeShowsPanel(
  *    only clears the *outgoing* worktree's. Restoring a maximize that does show
  *    the panel (navigating straight back to it) is still correct.
  *
- * Callers must NOT run this while fleet scope is active — see the call sites.
+ * Worktree switches *inside* fleet scope don't swap at all — they clear the flat
+ * trio and leave the parked maximizes alone (see the call sites). Fleet scope
+ * spans every worktree, so no single worktree owns the grid while it's up;
+ * `exitFleetScope` is the one fleet caller that does swap, reconciling the trio
+ * for the worktree being returned to.
  */
 function prepareWorktreeMaximizeSwap(
   state: WorktreeSelectionState,
@@ -508,11 +512,19 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     let panelPatch: PanelMaximizeFields | null = null;
     if (previousId !== id) {
       updates.expandedTerminals = new Set<string>();
-      // Fleet scope renders ahead of the maximize branch and spans every
-      // worktree, so it has no maximize of its own: switches inside it leave
-      // each worktree's parked maximize untouched, and `exitFleetScope`
-      // reconciles the flat trio on the way out.
-      if (!get().isFleetScopeActive) {
+      if (get().isFleetScopeActive) {
+        // Inside fleet scope: clear the trio, but leave the parked maximizes
+        // alone — the user hasn't left the fleet view, so an inactive worktree's
+        // maximize is still owed to them on their way back.
+        //
+        // The clear is not optional. It is tempting to skip it because the fleet
+        // branch renders ahead of the maximize branch, but `isFleetScopeRender`
+        // also requires a non-empty armed set (useContentGridContext) — clearing
+        // the fleet selection without leaving scope drops straight through to the
+        // maximize branch, where a trio left describing the *previous* worktree
+        // resolves against this one's panels and renders nothing (#11183).
+        panelPatch = CLEARED_MAXIMIZE;
+      } else {
         const swap = prepareWorktreeMaximizeSwap(get(), previousId, id, "user");
         updates.maximizeByWorktree = swap.maximizeByWorktree;
         panelPatch = swap.panelPatch;
@@ -570,10 +582,6 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       fromWorktreeId: previousId ?? null,
       toWorktreeId: id,
     });
-    // Fleet scope owns the render path and spans every worktree, so a switch
-    // inside it must leave the parked maximizes alone — including the incoming
-    // worktree's, which a focus promotion between fleet panels would otherwise
-    // consume and destroy. `exitFleetScope` reconciles the trio on the way out.
     const maximizeSwap = get().isFleetScopeActive
       ? null
       : prepareWorktreeMaximizeSwap(get(), previousId, id, source);
@@ -590,9 +598,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // the same tick as the switch, and before the terminal policy / focus
     // restore below — a frame in between would render the outgoing worktree's
     // maximize target against this worktree's grid, i.e. nothing at all (#11183).
-    if (maximizeSwap) {
-      usePanelStore.setState(maximizeSwap.panelPatch);
-    }
+    usePanelStore.setState(maximizeSwap?.panelPatch ?? CLEARED_MAXIMIZE);
     scheduleWorktreeSwitchPaintedMark(previousId ?? null, id, switchStartedAt);
 
     if (source === "user") {


### PR DESCRIPTION
## Summary

- `maximizedId` / `maximizeTarget` / `preMaximizeLayout` were flat, singular fields on the per-project-view `usePanelStore` (`terminalFocusSlice`), so they could only ever describe one worktree. Maximize a panel in worktree A, switch to worktree B, and the pointer survives: `ContentGrid` takes its maximize branch, fails to find A's panel among B's grid panels, and returns null. Blank grid.
- Fix adds a per-worktree shadow map, `maximizeByWorktree`, in `worktreeStore`, following the existing `lastFocusedTerminalByWorktree` precedent.
- 254 unit tests pass (12 new), plus a new e2e regression, validated red-before-green against the exact blank-screen failure from the issue.

Resolves #11183

## The bug

The grid inputs are strictly worktree-scoped, but the maximize pointer wasn't. In `ContentGrid.tsx`, the maximize branch ran in every worktree because the flag was global. The maximized panel or group belonged to whichever worktree set it last, so the lookup missed in every other worktree and fell through to `return null`. Nothing cleared or re-scoped the state on switch: `validateMaximizeTarget` only clears when the maximized panel no longer exists anywhere, and a panel in another worktree still exists in the global `panelsById`, so the maximize survived the switch untouched.

## The fix

A worktree's maximize state now lives in exactly one place at a time: the panel store's flat fields while that worktree is active, or `maximizeByWorktree` while it's inactive. Both switch sites, `setActiveWorktree` and `selectWorktree`, stash the outgoing worktree's trio of fields and restore the incoming worktree's trio, writing all three in a single panel-store patch. A half-written pair was the stale-target bug class from #9935, so this has to be atomic. The roughly 50 read-only consumers of the flat fields are untouched. They still mean "the active worktree's maximize" by construction.

**Restores are validated before they're written back, not repaired afterward.** The panel must still exist, still belong to that worktree, and still be a grid panel. A group target must still be a live grid group of that worktree containing the panel (a group shrunk to one member downgrades to a panel maximize). `validateMaximizeTarget` runs from a render effect, which is too late to stop a blank frame from painting, so this check now runs at the switch boundary instead.

**Focus promotions reveal the panel they fired for.** A promotion with `source: "focus"` (quick switcher, `HelpPanel`, `useTypeAnywhere` drafts, panel spawning) means "make this panel visible," so the destination worktree's stashed maximize is only restored when doing so would still show that panel. Navigate straight back to a maximized panel and it restores. Land on a different panel and the stash gets dropped instead of burying the reveal.

**Fleet scope gets its own handling.** A switch inside fleet scope clears the flat trio but leaves parked maximizes alone, and `exitFleetScope` reconciles the trio for the worktree it returns to. This matters because `activeWorktreeId` can move during scope (focusing a fleet panel from another worktree promotes it), and `terminal.maximize` has no fleet guard, so the trio could end up describing a worktree the user is leaving. It also can't be left incoherent-but-masked: `isFleetScopeRender` requires a non-empty armed set, so clearing the fleet selection without exiting scope drops straight through to the maximize branch.

**Cleanup.** A worktree's stash is purged when its maximized panel is removed or trashed while that worktree is inactive, mirroring `clearWorktreeFocusTracking`. `trashPanel` doesn't shrink `panelIds`, so this needed a trash listener in addition to the removal listener.

## Testing

254 unit tests pass, 12 new, covering both switch sites, stale/moved/docked/trashed targets, group ownership and dissolution, focus-promotion burial, and fleet-scope exit. Added a new e2e regression at `e2e/full/worktree/core-worktree-cross-boundary.spec.ts`, validated red-before-green: with the fix reverted it fails on a grid with zero panels, the literal blank screen from the issue. Full build (`tsc`) passes.

## Known follow-on (not in this PR)

`layoutUndoStore`'s `LayoutSnapshot` captures and restores `maximizedId` without `maximizeTarget` (the field isn't in the type), and `GridTabGroup` writes `setMaximizedId` alone. That pair can desync. It can't blank the grid here since `ContentGrid` requires both fields and this PR's validator rejects a mismatched pair rather than restoring it, but the two writers should move the pair atomically. Worth a separate issue.
