### PR TITLE
fix(ci): skip re-upload when re-tagging an already-published version

### DIFF
--- a/.github/actions/publish-daintree/action.yml
+++ b/.github/actions/publish-daintree/action.yml
@@ -72,12 +72,14 @@ runs:
       run: npm install --no-save --no-audit --no-fund --ignore-scripts js-yaml semver
 
     - name: Check version is monotonically increasing
+      id: version-check
       shell: bash
       env:
         RELEASE_PLATFORMS: ${{ inputs.release_platforms }}
       run: node scripts/ci/check-version-monotonic.mjs
 
     - name: Upload binaries to R2
+      if: steps.version-check.outputs.skip_upload != 'true'
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
@@ -99,12 +101,14 @@ runs:
           --cache-control "public, max-age=31536000, immutable"
 
     - name: Verify binaries reachable on R2
+      if: steps.version-check.outputs.skip_upload != 'true'
       shell: bash
       env:
         PUBLISH_URL: ${{ inputs.publish_url }}
       run: node scripts/ci/verify-r2-uploads.mjs
 
     - name: Upload metadata to R2
+      if: steps.version-check.outputs.skip_upload != 'true'
       shell: bash
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
@@ -121,6 +125,7 @@ runs:
           --cache-control "no-cache, no-store, must-revalidate"
 
     - name: Verify update metadata at CDN edge
+      if: steps.version-check.outputs.skip_upload != 'true'
       shell: bash
       env:
         PUBLISH_URL: ${{ inputs.publish_url }}

--- a/scripts/ci/check-version-monotonic.mjs
+++ b/scripts/ci/check-version-monotonic.mjs
@@ -173,9 +173,7 @@ export function checkVersionMonotonic(liveVersion, newVersion) {
  */
 export function shouldSkipUpload(platforms, skippedPlatforms, failures) {
   return (
-    platforms.length > 0 &&
-    failures.length === 0 &&
-    skippedPlatforms.length === platforms.length
+    platforms.length > 0 && failures.length === 0 && skippedPlatforms.length === platforms.length
   );
 }
 

--- a/scripts/ci/check-version-monotonic.mjs
+++ b/scripts/ci/check-version-monotonic.mjs
@@ -9,15 +9,25 @@
 // `release/${UPDATE_METADATA_PREFIX}{,-mac,-linux}.yml` (Windows uses the
 // no-suffix file), fetches the same files from
 // https://updates.daintree.org/releases/, and compares with `semver.gt`.
-// Equal versions also fail (republishing the same version is the same footgun).
+// Equal versions are treated as "already published" — the gate passes without
+// re-uploading (a re-tag of a version already live shouldn't red-build or
+// rewrite the artifacts already serving clients); see #11185.
 //
-// Failure modes:
+// Outcomes (per platform):
+//   - new > live                   -> OK, upload proceeds
+//   - new == live                  -> skip (already published; no re-upload)
+//   - new < live                   -> fail closed (a downgrade would strand clients)
 //   - 404 on the live feed         -> pass for that platform (first release in channel)
 //   - any other HTTP / network err -> fail closed
 //   - YAML parse / missing version -> fail closed
 //   - mac and linux disagree on    -> fail closed (split-brain build)
 //     the new version
+//
+// When every checked platform resolves to "already live", the script writes
+// `skip_upload=true` to $GITHUB_OUTPUT so the composite action skips the R2
+// upload and verify steps for this run (see .github/actions/publish-daintree).
 
+import { appendFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -131,6 +141,12 @@ export function checkVersionMonotonic(liveVersion, newVersion) {
   if (!semver.valid(newVersion)) {
     return { ok: false, error: `new version '${newVersion}' is not valid semver` };
   }
+  // Equal is not a regression — it's a re-tag of a version that already
+  // published successfully. Signal "skip" so the caller uploads nothing rather
+  // than either failing (the old behavior) or rewriting live artifacts.
+  if (semver.eq(newVersion, liveVersion)) {
+    return { ok: true, skip: true };
+  }
   if (!semver.gt(newVersion, liveVersion)) {
     return {
       ok: false,
@@ -138,6 +154,24 @@ export function checkVersionMonotonic(liveVersion, newVersion) {
     };
   }
   return { ok: true };
+}
+
+/**
+ * Aggregate the per-platform outcomes into the single `skip_upload` boolean the
+ * composite action gates its R2 upload/verify steps on. Skipping is only safe
+ * when *every* checked platform is already live and nothing failed — the upload
+ * steps `aws s3 sync` the whole `release/` dir, so a partial skip isn't
+ * expressible at the file level. Production invokes this gate one platform at a
+ * time (release-{macos,linux,windows}.yml), so this AND is unambiguous there;
+ * the aggregate only matters for a hypothetical caller that scopes several
+ * platforms at once.
+ */
+export function shouldSkipUpload(platforms, skippedPlatforms, failures) {
+  return (
+    platforms.length > 0 &&
+    failures.length === 0 &&
+    skippedPlatforms.length === platforms.length
+  );
 }
 
 async function fetchLiveVersion(prefix, platform) {
@@ -255,6 +289,7 @@ async function main() {
   );
 
   const failures = [];
+  const skippedPlatforms = [];
   for (let i = 0; i < platforms.length; i++) {
     const platform = platforms[i];
     const settled = fetchResults[i];
@@ -273,6 +308,11 @@ async function main() {
     const result = checkVersionMonotonic(live.version, newVersion);
     if (!result.ok) {
       failures.push(`${platform}: ${result.error} (feed: ${live.url})`);
+    } else if (result.skip) {
+      skippedPlatforms.push(platform);
+      console.log(
+        `[monotonic] ${platform}: ${newVersion} is already live (${live.url}) — already published, skipping re-upload for this platform.`
+      );
     } else {
       console.log(
         `[monotonic] ${platform}: ${newVersion} > ${live.version} (live ${live.url}) — OK.`
@@ -284,9 +324,32 @@ async function main() {
     fail(`version-monotonic gate failed:\n  - ${failures.join("\n  - ")}`);
   }
 
-  console.log(
-    `[monotonic] gate passed for channel '${prefix}': new version ${newVersion} is greater than every live feed.`
-  );
+  const skipUpload = shouldSkipUpload(platforms, skippedPlatforms, failures);
+  writeSkipUploadOutput(skipUpload);
+
+  if (skipUpload) {
+    console.log(
+      `[monotonic] channel '${prefix}': version ${newVersion} is already live on every checked platform — skipping re-upload for this run.`
+    );
+  } else {
+    const uploadCount = platforms.length - skippedPlatforms.length;
+    console.log(
+      `[monotonic] gate passed for channel '${prefix}': new version ${newVersion} cleared the monotonic check; upload enabled for ${uploadCount} platform(s).`
+    );
+  }
+}
+
+/**
+ * Communicate the skip decision to the composite action via $GITHUB_OUTPUT so
+ * later steps can gate on `steps.<id>.outputs.skip_upload`. No-op when the env
+ * var is unset (local runs / vitest self-execution). We deliberately do NOT
+ * swallow a write error: if the runner set GITHUB_OUTPUT but the append fails,
+ * the skip decision can't be communicated and the gate should fail closed.
+ */
+function writeSkipUploadOutput(skipUpload) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  appendFileSync(outputPath, `skip_upload=${skipUpload}\n`, "utf8");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/ci/check-version-monotonic.mjs
+++ b/scripts/ci/check-version-monotonic.mjs
@@ -141,10 +141,15 @@ export function checkVersionMonotonic(liveVersion, newVersion) {
   if (!semver.valid(newVersion)) {
     return { ok: false, error: `new version '${newVersion}' is not valid semver` };
   }
-  // Equal is not a regression — it's a re-tag of a version that already
-  // published successfully. Signal "skip" so the caller uploads nothing rather
-  // than either failing (the old behavior) or rewriting live artifacts.
-  if (semver.eq(newVersion, liveVersion)) {
+  // An identical version string is not a regression — it's a re-tag of a
+  // version that already published successfully. Signal "skip" so the caller
+  // uploads nothing rather than failing (the old behavior) or rewriting the
+  // live artifacts. Use exact identity, not semver.eq: build-metadata- or
+  // format-only variants (e.g. 1.0.0+a vs 1.0.0+b, or v1.0.0 vs 1.0.0) share
+  // updater precedence but were never actually the published version, so they
+  // fall through to the strict-greater check and fail closed. A genuine re-tag
+  // always produces a byte-identical version string (same package.json version).
+  if (newVersion === liveVersion) {
     return { ok: true, skip: true };
   }
   if (!semver.gt(newVersion, liveVersion)) {
@@ -346,7 +351,7 @@ async function main() {
  * swallow a write error: if the runner set GITHUB_OUTPUT but the append fails,
  * the skip decision can't be communicated and the gate should fail closed.
  */
-function writeSkipUploadOutput(skipUpload) {
+export function writeSkipUploadOutput(skipUpload) {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) return;
   appendFileSync(outputPath, `skip_upload=${skipUpload}\n`, "utf8");

--- a/scripts/ci/check-version-monotonic.test.mjs
+++ b/scripts/ci/check-version-monotonic.test.mjs
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   ALLOWED_PREFIXES,
   PLATFORMS,
@@ -7,6 +10,7 @@ import {
   resolvePlatforms,
   shouldSkipUpload,
   validatePrefix,
+  writeSkipUploadOutput,
 } from "./check-version-monotonic.mjs";
 
 describe("check-version-monotonic", () => {
@@ -27,8 +31,18 @@ describe("check-version-monotonic", () => {
       expect(checkVersionMonotonic("1.0.0", "1.0.0")).toEqual({ ok: true, skip: true });
     });
 
-    it("skips when equal on a pre-release channel (re-tag of a published rc)", () => {
+    it("skips identical prerelease versions (re-tag of a published rc)", () => {
       expect(checkVersionMonotonic("1.0.0-rc.1", "1.0.0-rc.1")).toEqual({ ok: true, skip: true });
+    });
+
+    it("does NOT skip a build-metadata-only difference — never actually published, fails closed", () => {
+      // semver.eq would treat these as equal (build metadata is ignored for
+      // precedence), but 1.0.0+b was never the live artifact. Exact identity
+      // means it falls through to the strict-greater check and fails closed.
+      const result = checkVersionMonotonic("1.0.0+a", "1.0.0+b");
+      expect(result.ok).toBe(false);
+      expect(result.skip).toBeUndefined();
+      expect(result.error).toContain("not strictly greater");
     });
 
     it("fails when new is older", () => {
@@ -91,8 +105,63 @@ describe("check-version-monotonic", () => {
       expect(shouldSkipUpload(["mac", "linux"], ["linux"], ["mac: downgrade"])).toBe(false);
     });
 
+    it("the failure veto is independent of the skip count (isolates failures.length === 0)", () => {
+      // skipped.length === platforms.length here, so ONLY the zero-failures
+      // clause can force false — this is the case that would regress if that
+      // clause were ever dropped.
+      expect(shouldSkipUpload(["mac"], ["mac"], ["mac: downgrade"])).toBe(false);
+    });
+
     it("does not skip an empty platform set", () => {
       expect(shouldSkipUpload([], [], [])).toBe(false);
+    });
+  });
+
+  describe("writeSkipUploadOutput", () => {
+    const originalOutput = process.env.GITHUB_OUTPUT;
+    let tmpDir;
+
+    afterEach(() => {
+      if (originalOutput === undefined) {
+        delete process.env.GITHUB_OUTPUT;
+      } else {
+        process.env.GITHUB_OUTPUT = originalOutput;
+      }
+      if (tmpDir) {
+        rmSync(tmpDir, { recursive: true, force: true });
+        tmpDir = undefined;
+      }
+    });
+
+    function useTmpOutput() {
+      tmpDir = mkdtempSync(path.join(tmpdir(), "monotonic-out-"));
+      const file = path.join(tmpDir, "github_output");
+      process.env.GITHUB_OUTPUT = file;
+      return file;
+    }
+
+    it("appends skip_upload=true when skipping", () => {
+      const file = useTmpOutput();
+      writeSkipUploadOutput(true);
+      expect(readFileSync(file, "utf8")).toBe("skip_upload=true\n");
+    });
+
+    it("appends skip_upload=false when not skipping", () => {
+      const file = useTmpOutput();
+      writeSkipUploadOutput(false);
+      expect(readFileSync(file, "utf8")).toBe("skip_upload=false\n");
+    });
+
+    it("is a no-op when GITHUB_OUTPUT is unset (local / vitest runs)", () => {
+      delete process.env.GITHUB_OUTPUT;
+      expect(() => writeSkipUploadOutput(true)).not.toThrow();
+    });
+
+    it("throws (fail-closed) when GITHUB_OUTPUT points at an unwritable path", () => {
+      // A set-but-broken output path must not be silently swallowed — the skip
+      // decision would go uncommunicated and the gate should fail closed.
+      process.env.GITHUB_OUTPUT = path.join(tmpdir(), "no-such-dir-monotonic", "out");
+      expect(() => writeSkipUploadOutput(true)).toThrow();
     });
   });
 

--- a/scripts/ci/check-version-monotonic.test.mjs
+++ b/scripts/ci/check-version-monotonic.test.mjs
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -140,10 +140,14 @@ describe("check-version-monotonic", () => {
       return file;
     }
 
-    it("appends skip_upload=true when skipping", () => {
+    it("appends skip_upload=true, preserving any lines a prior step already wrote", () => {
       const file = useTmpOutput();
+      // GITHUB_OUTPUT accumulates across a job — the write must APPEND, not
+      // clobber (a writeFileSync swap would pass an empty-file assertion but
+      // wipe another step's output).
+      writeFileSync(file, "prior-step=1\n");
       writeSkipUploadOutput(true);
-      expect(readFileSync(file, "utf8")).toBe("skip_upload=true\n");
+      expect(readFileSync(file, "utf8")).toBe("prior-step=1\nskip_upload=true\n");
     });
 
     it("appends skip_upload=false when not skipping", () => {
@@ -159,8 +163,11 @@ describe("check-version-monotonic", () => {
 
     it("throws (fail-closed) when GITHUB_OUTPUT points at an unwritable path", () => {
       // A set-but-broken output path must not be silently swallowed — the skip
-      // decision would go uncommunicated and the gate should fail closed.
-      process.env.GITHUB_OUTPUT = path.join(tmpdir(), "no-such-dir-monotonic", "out");
+      // decision would go uncommunicated and the gate should fail closed. The
+      // missing parent is nested inside a fresh temp dir so it's guaranteed
+      // absent (a predictable /tmp path could pre-exist and let the write land).
+      tmpDir = mkdtempSync(path.join(tmpdir(), "monotonic-out-"));
+      process.env.GITHUB_OUTPUT = path.join(tmpDir, "missing", "out");
       expect(() => writeSkipUploadOutput(true)).toThrow();
     });
   });

--- a/scripts/ci/check-version-monotonic.test.mjs
+++ b/scripts/ci/check-version-monotonic.test.mjs
@@ -5,6 +5,7 @@ import {
   checkVersionMonotonic,
   extractVersion,
   resolvePlatforms,
+  shouldSkipUpload,
   validatePrefix,
 } from "./check-version-monotonic.mjs";
 
@@ -22,15 +23,18 @@ describe("check-version-monotonic", () => {
       expect(checkVersionMonotonic("1.5.7", "2.0.0")).toEqual({ ok: true });
     });
 
-    it("fails when versions are equal (republishing the same tag is a regression footgun)", () => {
-      const result = checkVersionMonotonic("1.0.0", "1.0.0");
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain("not strictly greater");
+    it("skips when versions are equal (re-tag of an already-published version)", () => {
+      expect(checkVersionMonotonic("1.0.0", "1.0.0")).toEqual({ ok: true, skip: true });
+    });
+
+    it("skips when equal on a pre-release channel (re-tag of a published rc)", () => {
+      expect(checkVersionMonotonic("1.0.0-rc.1", "1.0.0-rc.1")).toEqual({ ok: true, skip: true });
     });
 
     it("fails when new is older", () => {
       const result = checkVersionMonotonic("1.0.0", "0.9.9");
       expect(result.ok).toBe(false);
+      expect(result.skip).toBeUndefined();
       expect(result.error).toContain("not strictly greater");
     });
 
@@ -46,9 +50,10 @@ describe("check-version-monotonic", () => {
       expect(checkVersionMonotonic("1.0.0", "1.0.1-rc.1")).toEqual({ ok: true });
     });
 
-    it("fails going from release to pre-release of same version", () => {
+    it("fails going from release to pre-release of same version (a downgrade, not a skip)", () => {
       const result = checkVersionMonotonic("1.0.0", "1.0.0-rc.1");
       expect(result.ok).toBe(false);
+      expect(result.skip).toBeUndefined();
       expect(result.error).toContain("not strictly greater");
     });
 
@@ -64,6 +69,30 @@ describe("check-version-monotonic", () => {
       expect(result.ok).toBe(false);
       expect(result.error).toContain("new version");
       expect(result.error).toContain("not valid semver");
+    });
+  });
+
+  describe("shouldSkipUpload", () => {
+    it("skips only when every checked platform is already live and nothing failed", () => {
+      expect(shouldSkipUpload(["mac"], ["mac"], [])).toBe(true);
+      expect(shouldSkipUpload(["mac", "linux"], ["mac", "linux"], [])).toBe(true);
+    });
+
+    it("does not skip when only some platforms are already live (others need upload)", () => {
+      expect(shouldSkipUpload(["mac", "linux"], ["mac"], [])).toBe(false);
+    });
+
+    it("does not skip when no platform is already live (a 404 first release / greater bump)", () => {
+      expect(shouldSkipUpload(["mac", "linux"], [], [])).toBe(false);
+    });
+
+    it("does not skip when any platform failed, even alongside a skip", () => {
+      expect(shouldSkipUpload(["mac"], [], ["mac: downgrade"])).toBe(false);
+      expect(shouldSkipUpload(["mac", "linux"], ["linux"], ["mac: downgrade"])).toBe(false);
+    });
+
+    it("does not skip an empty platform set", () => {
+      expect(shouldSkipUpload([], [], [])).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- The release version-monotonic gate (`scripts/ci/check-version-monotonic.mjs`) used to fail uniformly whenever a new version wasn't strictly greater than the version live on the update feed, so re-tagging an already-published version failed exactly like a genuine downgrade.
- During the v0.26.0 release, re-tagging to fix a flaky test caused platforms that had already published to fail the gate a second time, even though nothing needed to change.
- This splits the two cases: keep failing closed on real downgrades, but treat an already-published version as a calm per-platform skip that doesn't re-upload artifacts.

Resolves #11185

## Changes

- `scripts/ci/check-version-monotonic.mjs`: `checkVersionMonotonic` now returns a tri-state result: `ok: true` for `new > live`, `ok: true, skip: true` for `new == live` (exact string identity, not `semver.eq`, so a build-metadata-only variant that was never actually published still fails closed), and `ok: false` for `new < live` or invalid semver. `main()` tracks skipped platforms and writes a single `skip_upload` boolean to `GITHUB_OUTPUT`, true only when every checked platform is already live and nothing failed. The existing fail-closed paths (404 on first release, network/YAML errors, split-brain mismatch) are untouched.
- `.github/actions/publish-daintree/action.yml`: the gate step gets `id: version-check`, and the two R2 upload steps plus the two R2/CDN verify steps are gated on `if: steps.version-check.outputs.skip_upload != 'true'`. The verify steps need gating too: on a non-reproducible re-tag rebuild, the freshly built local YAML's `sha512`/`Content-Length` can differ from what's already live, so leaving verify unconditioned would false-fail one step later. The website notify webhook stays ungated since it's idempotent.
- `scripts/ci/check-version-monotonic.test.mjs`: flipped the equal-version case from fail to skip, added an identical-prerelease skip case and a build-metadata no-skip (fail-closed) case, added a `shouldSkipUpload` aggregate helper suite (including an isolating failure-veto case), and added `writeSkipUploadOutput` tests for append-not-clobber, no-op when unset, and fail-closed on an unwritable path. 35 → 47 tests.

## Testing

- `npm test -- scripts/ci/check-version-monotonic.test.mjs`: 47/47 pass.
- `prettier` clean on all changed files (`scripts/ci` sits outside the eslint surface).