### PR TITLE
fix(dock): dismiss preview on X instead of killing terminal

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -1222,16 +1222,23 @@ function PanelHeaderComponent({
               className="p-1.5 rounded-sm hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-status-error focus-visible:outline-offset-2 text-daintree-text/60 hover:text-status-error transition-colors"
               data-testid="panel-close"
               aria-label={formatShortcutForTooltip(
-                "Close session. Hold Alt and click to force close without recovery."
+                location === "dock"
+                  ? "Dismiss preview. Hold Alt and click to force close without recovery."
+                  : "Close session. Hold Alt and click to force close without recovery."
               )}
-              aria-keyshortcuts={closeAriaShortcut}
+              // Dock previews dismiss non-destructively; the terminal.close chord
+              // (Cmd+W) still trashes the focused panel, so don't advertise it as
+              // the way to dismiss the preview (#11186).
+              aria-keyshortcuts={location === "dock" ? undefined : closeAriaShortcut}
             >
               <X className="w-3 h-3" aria-hidden="true" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
             <div className="flex flex-col gap-1">
-              {createTooltipContent("Close Session", closeShortcut)}
+              {location === "dock"
+                ? createTooltipContent("Dismiss preview")
+                : createTooltipContent("Close Session", closeShortcut)}
               <span className="text-daintree-text/50 text-[11px]">
                 {formatShortcutForTooltip("Alt+Click to force close")}
               </span>

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -45,7 +45,10 @@ vi.mock("@/hooks", () => ({
   useBackgroundPanelStats: () => ({ activeCount: 0, workingCount: 0 }),
   useTabOverflow: () => mockHiddenTabIds,
   useKeybindingDisplay: () => "",
-  useAriaKeyshortcuts: () => undefined,
+  // Sentinel so tests can prove the close button's aria-keyshortcuts is present
+  // on grid but omitted on dock. Only terminal.close resolves — keeps other
+  // buttons (maximize, etc.) shortcut-less so unrelated tests are unaffected.
+  useAriaKeyshortcuts: (actionId: string) => (actionId === "terminal.close" ? "Meta+W" : undefined),
 }));
 
 let mockDragHandle: {
@@ -439,21 +442,26 @@ describe("PanelHeader", () => {
     const tooltipTexts = () =>
       screen.getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
 
-    it("labels the grid close button as a destructive close", () => {
+    it("labels the grid close button as a destructive close and keeps its shortcut", () => {
       render(<PanelHeader {...makeProps({ location: "grid" })} />);
       const closeBtn = screen.getByTestId("panel-close");
       expect(closeBtn.getAttribute("aria-label")).toMatch(/close session/i);
       expect(closeBtn.getAttribute("aria-label")).not.toMatch(/dismiss/i);
+      // Grid keeps advertising the terminal.close chord (it closes the panel).
+      expect(closeBtn.getAttribute("aria-keyshortcuts")).toBe("Meta+W");
       expect(tooltipTexts().some((t) => /close session/i.test(t))).toBe(true);
     });
 
-    it("labels the dock close button as a non-destructive dismiss, not a close", () => {
+    it("labels the dock close button as a non-destructive dismiss and drops the destructive chord", () => {
       // The dock X only collapses the preview (the PTY keeps running), so its
-      // accessible name and tooltip must not read as a destructive "close".
+      // accessible name and tooltip must not read as a destructive "close", and
+      // it must not advertise the terminal.close chord (Cmd+W) — that key still
+      // trashes the focused panel, so it isn't a way to dismiss the preview.
       render(<PanelHeader {...makeProps({ location: "dock" })} />);
       const closeBtn = screen.getByTestId("panel-close");
       expect(closeBtn.getAttribute("aria-label")).toMatch(/dismiss preview/i);
       expect(closeBtn.getAttribute("aria-label")).not.toMatch(/close session/i);
+      expect(closeBtn.getAttribute("aria-keyshortcuts")).toBeNull();
       const texts = tooltipTexts();
       expect(texts.some((t) => /dismiss preview/i.test(t))).toBe(true);
       expect(texts.every((t) => !/close session/i.test(t))).toBe(true);

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -435,6 +435,44 @@ describe("PanelHeader", () => {
     });
   });
 
+  describe("close button dismiss-vs-destroy copy (#11186)", () => {
+    const tooltipTexts = () =>
+      screen.getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+
+    it("labels the grid close button as a destructive close", () => {
+      render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const closeBtn = screen.getByTestId("panel-close");
+      expect(closeBtn.getAttribute("aria-label")).toMatch(/close session/i);
+      expect(closeBtn.getAttribute("aria-label")).not.toMatch(/dismiss/i);
+      expect(tooltipTexts().some((t) => /close session/i.test(t))).toBe(true);
+    });
+
+    it("labels the dock close button as a non-destructive dismiss, not a close", () => {
+      // The dock X only collapses the preview (the PTY keeps running), so its
+      // accessible name and tooltip must not read as a destructive "close".
+      render(<PanelHeader {...makeProps({ location: "dock" })} />);
+      const closeBtn = screen.getByTestId("panel-close");
+      expect(closeBtn.getAttribute("aria-label")).toMatch(/dismiss preview/i);
+      expect(closeBtn.getAttribute("aria-label")).not.toMatch(/close session/i);
+      const texts = tooltipTexts();
+      expect(texts.some((t) => /dismiss preview/i.test(t))).toBe(true);
+      expect(texts.every((t) => !/close session/i.test(t))).toBe(true);
+    });
+
+    it("keeps the Alt+Click force-close affordance on both surfaces", () => {
+      // Relabeling the dock X as "dismiss" must not drop the escape hatch that
+      // still lets the user force-kill (Alt+Click) — nothing loses the ability
+      // to be destroyed.
+      for (const location of ["grid", "dock"] as const) {
+        const { unmount } = render(<PanelHeader {...makeProps({ location })} />);
+        expect(screen.getByTestId("panel-close").getAttribute("aria-label")).toMatch(
+          /force close/i
+        );
+        unmount();
+      }
+    });
+  });
+
   describe("Move to grid button", () => {
     it("renders when docked with onRestore and showRestoreControl", () => {
       const onRestore = vi.fn();

--- a/src/hooks/__tests__/usePanelHandlers.test.ts
+++ b/src/hooks/__tests__/usePanelHandlers.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/utils/logger", () => ({
 const {
   setFocusedMock,
   trashPanelGroupMock,
+  closeDockTerminalMock,
   removePanelMock,
   updateTitleMock,
   getPanelGroupMock,
@@ -18,6 +19,7 @@ const {
 } = vi.hoisted(() => ({
   setFocusedMock: vi.fn(),
   trashPanelGroupMock: vi.fn(),
+  closeDockTerminalMock: vi.fn(),
   removePanelMock: vi.fn(),
   updateTitleMock: vi.fn(),
   getPanelGroupMock: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock("@/store", () => {
   const state = {
     setFocused: setFocusedMock,
     trashPanelGroup: trashPanelGroupMock,
+    closeDockTerminal: closeDockTerminalMock,
     removePanel: removePanelMock,
     updateTitle: updateTitleMock,
     getPanelGroup: getPanelGroupMock,
@@ -47,6 +50,7 @@ describe("usePanelHandlers", () => {
   beforeEach(() => {
     setFocusedMock.mockClear();
     trashPanelGroupMock.mockReset();
+    closeDockTerminalMock.mockClear();
     removePanelMock.mockClear();
     updateTitleMock.mockClear();
     getPanelGroupMock.mockReset();
@@ -130,13 +134,40 @@ describe("usePanelHandlers", () => {
     expect(removePanelMock).not.toHaveBeenCalled();
   });
 
-  it("dock-surface close trashes synchronously, bypassing the optimistic coordinator", () => {
-    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", surface: "dock" }));
+  it("dock-surface close dismisses the preview without trashing or killing the terminal", () => {
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", surface: "dock", onAfterClose })
+    );
 
     act(() => result.current.handleClose());
 
-    expect(trashPanelGroupMock).toHaveBeenCalledWith("p1");
+    expect(closeDockTerminalMock).toHaveBeenCalledWith("p1");
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+    expect(removePanelMock).not.toHaveBeenCalled();
     expect(requestPanelCloseMock).not.toHaveBeenCalled();
+    expect(onAfterClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dock-surface dismiss stays repeatable across reopen cycles (no trashedRef latch)", () => {
+    // The DockedPanel hook instance survives collapse/reopen, so the X must
+    // dismiss every time — not latch after the first like the destructive paths.
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", surface: "dock" }));
+
+    act(() => result.current.handleClose());
+    act(() => result.current.handleClose());
+
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("dock-surface force-close still destroys via removePanel, never dismissing", () => {
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", surface: "dock" }));
+
+    act(() => result.current.handleClose(true));
+
+    expect(removePanelMock).toHaveBeenCalledWith("p1");
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
   });
 
   it("handleFocus delegates to setFocused", () => {

--- a/src/hooks/__tests__/usePanelHandlers.test.ts
+++ b/src/hooks/__tests__/usePanelHandlers.test.ts
@@ -152,12 +152,16 @@ describe("usePanelHandlers", () => {
   it("dock-surface dismiss stays repeatable across reopen cycles (no trashedRef latch)", () => {
     // The DockedPanel hook instance survives collapse/reopen, so the X must
     // dismiss every time — not latch after the first like the destructive paths.
-    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", surface: "dock" }));
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", surface: "dock", onAfterClose })
+    );
 
     act(() => result.current.handleClose());
     act(() => result.current.handleClose());
 
     expect(closeDockTerminalMock).toHaveBeenCalledTimes(2);
+    expect(onAfterClose).toHaveBeenCalledTimes(2);
   });
 
   it("dock-surface force-close still destroys via removePanel, never dismissing", () => {

--- a/src/hooks/usePanelHandlers.ts
+++ b/src/hooks/usePanelHandlers.ts
@@ -7,10 +7,12 @@ export interface UsePanelHandlersConfig {
   terminalId: string;
   onAfterClose?: () => void;
   /**
-   * Surface this panel renders on. The optimistic-close overlay only filters
-   * the grid, so dock panels close canonically and synchronously instead of
-   * routing through the coordinator (where they'd just sit visible until the
-   * deferred commit). Defaults to "grid".
+   * Surface this panel renders on. Grid panels route their close through the
+   * optimistic-close overlay (which only filters the grid). Dock panels are a
+   * floating preview, so a plain close *dismisses* the preview non-destructively
+   * via closeDockTerminal — collapsing it while the PTY keeps running, matching
+   * Escape / click-outside / chip re-toggle (#11186). Alt+Click still force-closes
+   * (removePanel) on either surface. Defaults to "grid".
    */
   surface?: "grid" | "dock";
 }
@@ -28,6 +30,7 @@ export function usePanelHandlers({
 }: UsePanelHandlersConfig): PanelHandlers {
   const setFocused = usePanelStore((state) => state.setFocused);
   const trashPanelGroup = usePanelStore((state) => state.trashPanelGroup);
+  const closeDockTerminal = usePanelStore((state) => state.closeDockTerminal);
   const removePanel = usePanelStore((state) => state.removePanel);
   const getPanelGroup = usePanelStore((state) => state.getPanelGroup);
   const updateTitle = usePanelStore((state) => state.updateTitle);
@@ -42,23 +45,24 @@ export function usePanelHandlers({
 
   const handleClose = useCallback(
     (force?: boolean) => {
+      // Dock preview dismissal: collapse the floating preview but leave the PTY
+      // running (matches Escape / click-outside / chip re-toggle — #11186).
+      // Intentionally runs BEFORE the trashedRef latch: the DockedPanel hook
+      // instance survives collapse/reopen cycles, so latching here would let the
+      // X dismiss only once per mount. closeDockTerminal is an idempotent pure
+      // setter, so it needs no double-fire guard. Alt+Click (force) falls through
+      // to the destructive removePanel path below.
+      if (surface === "dock" && !force) {
+        closeDockTerminal(terminalId);
+        onAfterClose?.();
+        return;
+      }
+
       if (trashedRef.current) return;
       trashedRef.current = true;
 
       if (force) {
         removePanel(terminalId);
-        onAfterClose?.();
-        return;
-      }
-
-      // Dock panels aren't covered by the grid's optimistic-hide overlay, so
-      // close them canonically and synchronously — there's nothing to defer to.
-      if (surface === "dock") {
-        try {
-          trashPanelGroup(terminalId);
-        } catch (error) {
-          logError("Failed to trash terminal", error);
-        }
         onAfterClose?.();
         return;
       }
@@ -79,7 +83,15 @@ export function usePanelHandlers({
       });
       onAfterClose?.();
     },
-    [removePanel, trashPanelGroup, getPanelGroup, terminalId, onAfterClose, surface]
+    [
+      removePanel,
+      trashPanelGroup,
+      closeDockTerminal,
+      getPanelGroup,
+      terminalId,
+      onAfterClose,
+      surface,
+    ]
   );
 
   const handleTitleChange = useCallback(


### PR DESCRIPTION
## Summary

- Clicking the X on the docked (floating preview) terminal pane was killing the running terminal instead of just dismissing the preview.
- The X routed through `trashPanelGroup()`, which soft-parks the terminal. `TerminalRegistry` then auto-kills parked terminals after their ~20s TTL, so a long-running process (a dev server, a `docker restart`, a build) the user only meant to tuck away got torn down a few seconds later.
- Every other dock dismiss gesture (Escape, click-outside, re-toggling the chip) already collapsed the preview non-destructively via `closeDockTerminal()`, leaving the process running. The X was the only one that destroyed it.

Resolves #11186

## Changes

- `src/hooks/usePanelHandlers.ts`: route the dock pane's plain close (`surface: "dock"`) to `closeDockTerminal()` instead of `trashPanelGroup()`, so the preview collapses while the terminal keeps running. This routing runs before the `trashedRef` double-fire latch, so the X stays clickable across collapse/reopen cycles (the `DockedPanel` hook instance survives collapse and reopen). The grid pane's X and Alt+Click force-close still call `removePanel()` and remain destructive.
- `src/components/Panel/PanelHeader.tsx`: on the dock surface, the close button's label and tooltip change to "Dismiss preview" (aria-label and tooltip), and the destructive Cmd+W (`terminal.close`) shortcut and its `aria-keyshortcuts` attribute are dropped from that surface, since that key still trashes the focused panel. Grid surface copy and shortcuts are unchanged.
- `src/hooks/__tests__/usePanelHandlers.test.ts` and `src/components/Panel/__tests__/PanelHeader.test.tsx`: regression coverage for the dock X dismissing (not trashing/killing), staying repeatable across reopen, Alt+Click still force-destroying, and the dock surface omitting the destructive shortcut while grid keeps it.

Dedicated kill paths (the chip's right-click Kill/Trash menu, the pane's overflow menu Trash option) are untouched.

## Testing

- 92 targeted tests passing locally: `usePanelHandlers`, `PanelHeader`, plus `ReviewPane` and `DockedTerminalItem.mountGuard` consumers.
- Prettier clean.
- ESLint: 0 errors on changed files.
