### PR TITLE
fix(dock): show running/finished state on plain terminal chips

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -63,6 +63,7 @@ import {
 import {
   getDockDisplayActivityState,
   getGroupDockDisplayActivityState,
+  getGroupActivityScopeKey,
   useTransientDockFinishedCue,
 } from "./useDockActivityState";
 import { SortableTabButton } from "@/components/Panel/SortableTabButton";
@@ -511,11 +512,12 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
 
   // Plain-terminal activity for the group aggregates across tabs: any plain tab
-  // running → spinner. The scope key is the sorted membership so closing a
-  // running tab re-baselines rather than flashing a false "finished" cue.
+  // running → spinner. The scope key tracks the plain contributors (see
+  // getGroupActivityScopeKey) so a tab leaving the aggregate — closed or
+  // agent-detected — re-baselines rather than flashing a false "finished" cue.
   // Declared before the early return below to keep hook order stable.
   const groupPlainActivityState = getGroupDockDisplayActivityState(panels);
-  const groupActivityScopeKey = `${group.id}:${[...panels.map((p) => p.id)].sort().join("|")}`;
+  const groupActivityScopeKey = `${group.id}:${getGroupActivityScopeKey(panels)}`;
   const showFinishedCue = useTransientDockFinishedCue(
     groupPlainActivityState,
     groupActivityScopeKey

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -20,7 +20,8 @@ import {
 } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { LayoutGroup, AnimatePresence, m } from "framer-motion";
-import { ChevronDown, CopyPlus } from "lucide-react";
+import { ChevronDown, CopyPlus, CheckCircle2 } from "lucide-react";
+import { SpinnerCircle } from "@/components/icons";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import {
@@ -59,6 +60,11 @@ import {
   getGroupBlockedAgentState,
   isGroupDeprioritized,
 } from "./useDockBlockedState";
+import {
+  getDockDisplayActivityState,
+  getGroupDockDisplayActivityState,
+  useTransientDockFinishedCue,
+} from "./useDockActivityState";
 import { SortableTabButton } from "@/components/Panel/SortableTabButton";
 import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import type { TabGroup } from "@/types";
@@ -504,6 +510,18 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const isDeprioritized = !isOpen && isGroupDeprioritized(panels);
   const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
 
+  // Plain-terminal activity for the group aggregates across tabs: any plain tab
+  // running → spinner. The scope key is the sorted membership so closing a
+  // running tab re-baselines rather than flashing a false "finished" cue.
+  // Declared before the early return below to keep hook order stable.
+  const groupPlainActivityState = getGroupDockDisplayActivityState(panels);
+  const groupActivityScopeKey = `${group.id}:${[...panels.map((p) => p.id)].sort().join("|")}`;
+  const showFinishedCue = useTransientDockFinishedCue(
+    groupPlainActivityState,
+    groupActivityScopeKey
+  );
+  const groupPlainWorking = groupPlainActivityState === "working";
+
   const agentSettingsAll = useAgentSettingsStore((s) => s.settings);
   const ccrPresetsByAgent = useCcrPresetsStore((s) => s.ccrPresetsByAgent);
   const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
@@ -568,6 +586,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const isWaiting = agentState === "waiting";
   const isActive = isWorking || isWaiting;
   const commandText = activePanel.activityHeadline || activePanel.lastCommand;
+  // Command text belongs to the active tab, so gate it on the active panel's own
+  // status — not the group aggregate — so an idle active tab never shows a
+  // background tab's command.
+  const activePlainWorking = getDockDisplayActivityState(activePanel) === "working";
   const displayTitle = activePanel.title;
   const displayAgentState = getTerminalAgentDisplayState(activeChrome, agentState);
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
@@ -611,7 +633,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 const moved = moveTerminalToGrid(activePanel.id);
                 if (moved && openDockPanelId) closeDockTerminal(openDockPanelId);
               }}
-              aria-label={`${activePanel.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : ""} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
+              aria-label={`${activePanel.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : groupPlainWorking ? " — command running" : ""} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
             >
               <div className="flex items-center justify-center shrink-0">
                 <TerminalIcon
@@ -630,7 +652,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 ({panels.length})
               </span>
 
-              {isActive && commandText && (
+              {(isActive || activePlainWorking) && commandText && (
                 <>
                   <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
                   <Tooltip open={commandTip.open} onOpenChange={commandTip.onOpenChange}>
@@ -642,6 +664,26 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                     <TooltipContent side="bottom">{commandText}</TooltipContent>
                   </Tooltip>
                 </>
+              )}
+
+              {/* Plain-terminal running/finished cue (group aggregate) — same
+                  icon slot as the agent state icon, shown only when no agent
+                  state occupies it. aria-hidden mirrors the single chip. */}
+              {!displayAgentState && (groupPlainWorking || showFinishedCue) && (
+                <div
+                  className={cn(
+                    "ml-1.5 flex items-center shrink-0",
+                    groupPlainWorking ? "text-daintree-text/50" : "text-status-success"
+                  )}
+                  data-dock-activity-state={groupPlainWorking ? "working" : "finished"}
+                  aria-hidden="true"
+                >
+                  {groupPlainWorking ? (
+                    <SpinnerCircle className="w-3.5 h-3.5 animate-spin-slow motion-reduce:animate-none" />
+                  ) : (
+                    <CheckCircle2 className="w-3.5 h-3.5" />
+                  )}
+                </div>
               )}
 
               {displayAgentState && StateIcon && (

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDndMonitor } from "@dnd-kit/core";
 import type { DraggableSyntheticListeners } from "@dnd-kit/core";
+import { CheckCircle2 } from "lucide-react";
+import { SpinnerCircle } from "@/components/icons";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { cn } from "@/lib/utils";
@@ -30,6 +32,7 @@ import {
   isDockAgentStateDeprioritized,
   useDockBlockedState,
 } from "./useDockBlockedState";
+import { getDockDisplayActivityState, useTransientDockFinishedCue } from "./useDockActivityState";
 import {
   handleDockInteractOutside,
   handleDockEscapeKeyDown,
@@ -301,6 +304,11 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const isActive = isWorking || isWaiting;
   const commandText = terminal.activityHeadline || terminal.lastCommand;
   const blockedState = useDockBlockedState(agentState);
+  // Plain (non-agent) terminals surface their own running/finished affordance —
+  // the agent path above returns undefined for them by design.
+  const plainActivityState = getDockDisplayActivityState(terminal);
+  const showFinishedCue = useTransientDockFinishedCue(plainActivityState, terminal.id);
+  const plainWorking = plainActivityState === "working";
   const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
   // Use shortened title without command summary for dock items
   const displayTitle = terminal.title;
@@ -364,7 +372,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                   e.stopPropagation();
                   handleMoveToGrid();
                 }}
-                aria-label={`${terminal.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : ""} - Click to preview, double-click to move to grid, drag to reorder`}
+                aria-label={`${terminal.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : plainWorking ? " — command running" : ""} - Click to preview, double-click to move to grid, drag to reorder`}
               >
                 <div className="flex items-center justify-center shrink-0">
                   <TerminalIcon
@@ -378,7 +386,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                   {displayTitle}
                 </span>
 
-                {isActive && commandText && (
+                {(isActive || plainWorking) && commandText && (
                   <>
                     <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
                     <Tooltip open={commandTip.open} onOpenChange={commandTip.onOpenChange}>
@@ -390,6 +398,27 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                       <TooltipContent side="bottom">{commandText}</TooltipContent>
                     </Tooltip>
                   </>
+                )}
+
+                {/* Plain-terminal running/finished cue — same icon slot as the
+                    agent state icon, but only when there is no agent state.
+                    aria-hidden: the running state rides the accessible name; the
+                    finished cue is transient and must not spam a live region. */}
+                {!displayAgentState && (plainWorking || showFinishedCue) && (
+                  <div
+                    className={cn(
+                      "ml-1.5 flex items-center shrink-0",
+                      plainWorking ? "text-daintree-text/50" : "text-status-success"
+                    )}
+                    data-dock-activity-state={plainWorking ? "working" : "finished"}
+                    aria-hidden="true"
+                  >
+                    {plainWorking ? (
+                      <SpinnerCircle className="w-3.5 h-3.5 animate-spin-slow motion-reduce:animate-none" />
+                    ) : (
+                      <CheckCircle2 className="w-3.5 h-3.5" />
+                    )}
+                  </div>
                 )}
 
                 {/* State icon (compact spacing from title) */}

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -387,4 +387,45 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
       }
     });
   });
+
+  // #11187 — plain-terminal running/finished cue aggregates across the group's
+  // tabs (any plain tab working → spinner). The real useDockActivityState helper
+  // runs here; deriveTerminalChrome is mocked to isAgent:false so tabs resolve
+  // as plain shells.
+  describe("plain-terminal group activity cue (#11187)", () => {
+    it("shows a running spinner when any plain tab in the group is working", () => {
+      const panels = [
+        makePanel({ id: "t-1" }),
+        makePanel({ id: "t-2", activityStatus: "working" }),
+      ];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+      expect(container.querySelector('[data-dock-activity-state="working"]')).not.toBeNull();
+    });
+
+    it("announces 'command running' in the group chip accessible name while aggregating working", () => {
+      const panels = [
+        makePanel({ id: "t-1" }),
+        makePanel({ id: "t-2", activityStatus: "working" }),
+      ];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+      const chip = container.querySelector('[data-dock-item=""]') as HTMLElement | null;
+      expect(chip).not.toBeNull();
+      expect(chip!.getAttribute("aria-label")).toContain("command running");
+    });
+
+    it("shows no cue when every plain tab is idle", () => {
+      const panels = [
+        makePanel({ id: "t-1", activityStatus: "success" }),
+        makePanel({ id: "t-2", activityStatus: "success" }),
+      ];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+      expect(container.querySelector("[data-dock-activity-state]")).toBeNull();
+    });
+  });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -9,10 +9,11 @@
  *   3. The active row in the overflow dropdown carries a leading accent bar.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { useEffect } from "react";
 import type { PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
+import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 
 const trashPanelMock = vi.fn();
 const setActiveTabMock = vi.fn();
@@ -426,6 +427,60 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
         <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
       );
       expect(container.querySelector("[data-dock-activity-state]")).toBeNull();
+    });
+
+    it("flashes a finished cue when the last running tab finishes, then clears it", () => {
+      const { container, rerender } = render(
+        <DockedTabGroup
+          group={makeGroup(["t-1", "t-2"], "t-1")}
+          panels={[
+            makePanel({ id: "t-1", activityStatus: "success" }),
+            makePanel({ id: "t-2", activityStatus: "working" }),
+          ]}
+        />
+      );
+      expect(container.querySelector('[data-dock-activity-state="working"]')).not.toBeNull();
+
+      rerender(
+        <DockedTabGroup
+          group={makeGroup(["t-1", "t-2"], "t-1")}
+          panels={[
+            makePanel({ id: "t-1", activityStatus: "success" }),
+            makePanel({ id: "t-2", activityStatus: "success" }),
+          ]}
+        />
+      );
+      const finished = container.querySelector('[data-dock-activity-state="finished"]');
+      expect(finished).not.toBeNull();
+      expect(finished!.querySelector("svg")).not.toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS);
+      });
+      expect(container.querySelector('[data-dock-activity-state="finished"]')).toBeNull();
+    });
+
+    it("does not flash a finished cue when a running tab is removed while an idle tab remains", () => {
+      const { container, rerender } = render(
+        <DockedTabGroup
+          group={makeGroup(["t-1", "t-2"], "t-1")}
+          panels={[
+            makePanel({ id: "t-1", activityStatus: "success" }),
+            makePanel({ id: "t-2", activityStatus: "working" }),
+          ]}
+        />
+      );
+      expect(container.querySelector('[data-dock-activity-state="working"]')).not.toBeNull();
+
+      // The running tab is closed; only the idle tab remains. The aggregate flips
+      // working→success but membership changed, so no false completion.
+      rerender(
+        <DockedTabGroup
+          group={makeGroup(["t-1"], "t-1")}
+          panels={[makePanel({ id: "t-1", activityStatus: "success" })]}
+        />
+      );
+      expect(container.querySelector('[data-dock-activity-state="finished"]')).toBeNull();
     });
   });
 });

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -9,8 +9,9 @@
  * dock popover only closes when moveTerminalToGrid succeeds.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { PtyPanelData } from "@shared/types/panel";
+import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 
 const openDockTerminalMock = vi.fn();
 const closeDockTerminalMock = vi.fn();
@@ -271,5 +272,30 @@ describe("DockedTerminalItem plain-terminal activity cue (#11187)", () => {
       <DockedTerminalItem terminal={makeTerminal({ id: "t-1", activityStatus: "working" })} />
     );
     expect(container.querySelector("[data-dock-activity-state]")).toBeNull();
+  });
+
+  it("flashes a finished cue on working→success, then clears it after the dwell", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <DockedTerminalItem terminal={makeTerminal({ id: "t-1", activityStatus: "working" })} />
+      );
+      expect(container.querySelector('[data-dock-activity-state="working"]')).not.toBeNull();
+
+      rerender(
+        <DockedTerminalItem terminal={makeTerminal({ id: "t-1", activityStatus: "success" })} />
+      );
+      const finished = container.querySelector('[data-dock-activity-state="finished"]');
+      expect(finished).not.toBeNull();
+      // A visible glyph, not just an empty wrapper.
+      expect(finished!.querySelector("svg")).not.toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS);
+      });
+      expect(container.querySelector('[data-dock-activity-state="finished"]')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -238,3 +238,38 @@ describe("DockedTerminalItem drag wiring", () => {
     expect(screen.getByRole("button", { name: /drag to reorder/i })).not.toBeNull();
   });
 });
+
+// #11187 — plain (non-agent) terminals must show a running/finished affordance
+// on their dock chip. The real useDockActivityState helper/hook run here (only
+// useDockBlockedState is mocked); deriveTerminalChrome is mocked to isAgent:false
+// so these terminals resolve as plain.
+describe("DockedTerminalItem plain-terminal activity cue (#11187)", () => {
+  beforeEach(() => {
+    mockActiveDockTerminalId = null;
+    mockDockAgentState = undefined;
+  });
+
+  it("shows a running spinner and 'command running' accessible name while a plain command runs", () => {
+    const { container } = render(
+      <DockedTerminalItem terminal={makeTerminal({ id: "t-1", activityStatus: "working" })} />
+    );
+    expect(container.querySelector('[data-dock-activity-state="working"]')).not.toBeNull();
+    expect(screen.getByRole("button", { name: /command running/ })).not.toBeNull();
+  });
+
+  it("shows no cue for an idle plain terminal that never transitioned from working", () => {
+    const { container } = render(
+      <DockedTerminalItem terminal={makeTerminal({ id: "t-1", activityStatus: "success" })} />
+    );
+    expect(container.querySelector("[data-dock-activity-state]")).toBeNull();
+    expect(screen.queryByRole("button", { name: /command running/ })).toBeNull();
+  });
+
+  it("yields the indicator slot to an active agent state (no plain cue on agent chips)", () => {
+    mockDockAgentState = "working";
+    const { container } = render(
+      <DockedTerminalItem terminal={makeTerminal({ id: "t-1", activityStatus: "working" })} />
+    );
+    expect(container.querySelector("[data-dock-activity-state]")).toBeNull();
+  });
+});

--- a/src/components/Layout/__tests__/useDockActivityState.test.tsx
+++ b/src/components/Layout/__tests__/useDockActivityState.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+/**
+ * useDockActivityState (#11187) — plain-terminal dock running/finished state.
+ *
+ * Covers the pure resolution helpers (agent suppression, group aggregation,
+ * the deliberately-ignored waiting/failure statuses) and the transient
+ * "finished" cue hook: the working→success flash, its dwell, and the guards
+ * against a rapid flap or a group-membership change manufacturing a stale or
+ * spurious cue.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
+import {
+  getDockDisplayActivityState,
+  getGroupDockDisplayActivityState,
+  useTransientDockFinishedCue,
+  type DockDisplayActivityState,
+} from "../useDockActivityState";
+
+// Isolate the helpers from chrome derivation: an agent is anything carrying an
+// agent identity field. Mirrors the real isAgentTerminal contract for the
+// suppression branch without pulling in the full chrome pipeline.
+vi.mock("@/utils/terminalType", () => ({
+  isAgentTerminal: (t: { launchAgentId?: string; detectedAgentId?: string }) =>
+    Boolean(t.launchAgentId || t.detectedAgentId),
+}));
+
+type State = DockDisplayActivityState | undefined;
+
+describe("getDockDisplayActivityState", () => {
+  it("returns 'working' for a running plain terminal", () => {
+    expect(getDockDisplayActivityState({ activityStatus: "working" })).toBe("working");
+  });
+
+  it("returns 'success' for an idle plain terminal", () => {
+    expect(getDockDisplayActivityState({ activityStatus: "success" })).toBe("success");
+  });
+
+  it("ignores 'waiting' and 'failure' — shells never emit them", () => {
+    expect(getDockDisplayActivityState({ activityStatus: "waiting" })).toBeUndefined();
+    expect(getDockDisplayActivityState({ activityStatus: "failure" })).toBeUndefined();
+  });
+
+  it("returns undefined when there is no activity status", () => {
+    expect(getDockDisplayActivityState({})).toBeUndefined();
+  });
+
+  it("suppresses activity for agent terminals — the agent path owns their slot", () => {
+    expect(
+      getDockDisplayActivityState({ launchAgentId: "claude", activityStatus: "working" })
+    ).toBeUndefined();
+  });
+});
+
+describe("getGroupDockDisplayActivityState", () => {
+  it("returns 'working' when any plain terminal is running", () => {
+    expect(
+      getGroupDockDisplayActivityState([
+        { activityStatus: "success" },
+        { activityStatus: "working" },
+      ])
+    ).toBe("working");
+  });
+
+  it("returns 'success' when every plain terminal is idle", () => {
+    expect(
+      getGroupDockDisplayActivityState([
+        { activityStatus: "success" },
+        { activityStatus: "success" },
+      ])
+    ).toBe("success");
+  });
+
+  it("skips agent terminals when aggregating", () => {
+    expect(
+      getGroupDockDisplayActivityState([{ launchAgentId: "claude", activityStatus: "working" }])
+    ).toBeUndefined();
+    // A running agent alongside an idle plain shell aggregates to the shell's
+    // idle state — the agent's activity does not leak into the plain path.
+    expect(
+      getGroupDockDisplayActivityState([
+        { launchAgentId: "claude", activityStatus: "working" },
+        { activityStatus: "success" },
+      ])
+    ).toBe("success");
+  });
+
+  it("returns undefined for an empty group", () => {
+    expect(getGroupDockDisplayActivityState([])).toBeUndefined();
+  });
+});
+
+describe("useTransientDockFinishedCue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays quiet on mount even when starting in 'success'", () => {
+    const { result } = renderHook(() => useTransientDockFinishedCue("success", "t-1"));
+    expect(result.current).toBe(false);
+  });
+
+  it("shows the cue on working→success and clears it after the dwell", () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
+      { initialProps: { state: "working" as State } }
+    );
+    expect(result.current).toBe(false);
+
+    act(() => rerender({ state: "success" }));
+    expect(result.current).toBe(true);
+
+    // Still visible right up to the dwell boundary…
+    act(() => vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 1));
+    expect(result.current).toBe(true);
+
+    // …then gone.
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(false);
+  });
+
+  it("hides the cue immediately when a command restarts (working wins)", () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
+      { initialProps: { state: "working" as State } }
+    );
+    act(() => rerender({ state: "success" }));
+    expect(result.current).toBe(true);
+
+    act(() => rerender({ state: "working" }));
+    expect(result.current).toBe(false);
+  });
+
+  it("resets to a fresh dwell on a finish→restart→finish flap", () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
+      { initialProps: { state: "working" as State } }
+    );
+    act(() => rerender({ state: "success" })); // finish #1
+    expect(result.current).toBe(true);
+
+    // Near the first deadline, restart then finish again.
+    act(() => vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 100));
+    act(() => rerender({ state: "working" }));
+    expect(result.current).toBe(false);
+    act(() => rerender({ state: "success" })); // finish #2
+    expect(result.current).toBe(true);
+
+    // The first completion's leftover 100ms must not clear the fresh cue.
+    act(() => vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 1));
+    expect(result.current).toBe(true);
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(false);
+  });
+
+  it("re-baselines on a scope change instead of flashing a completion", () => {
+    // A running tab is removed: the aggregate flips working→success AND the
+    // membership scope key changes. That must NOT read as a finished command.
+    const { result, rerender } = renderHook(
+      ({ state, scope }: { state: State; scope: string }) =>
+        useTransientDockFinishedCue(state, scope),
+      { initialProps: { state: "working" as State, scope: "a|b" } }
+    );
+    act(() => rerender({ state: "success", scope: "b" }));
+    expect(result.current).toBe(false);
+  });
+
+  it("clears its dwell timer on unmount", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
+      { initialProps: { state: "working" as State } }
+    );
+    act(() => rerender({ state: "success" }));
+    expect(result.current).toBe(true);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/Layout/__tests__/useDockActivityState.test.tsx
+++ b/src/components/Layout/__tests__/useDockActivityState.test.tsx
@@ -14,6 +14,7 @@ import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 import {
   getDockDisplayActivityState,
   getGroupDockDisplayActivityState,
+  getGroupActivityScopeKey,
   useTransientDockFinishedCue,
   type DockDisplayActivityState,
 } from "../useDockActivityState";
@@ -91,6 +92,48 @@ describe("getGroupDockDisplayActivityState", () => {
   });
 });
 
+describe("getGroupActivityScopeKey", () => {
+  it("keys on plain contributors, so an agent-detected tab re-baselines", () => {
+    const before = getGroupActivityScopeKey([
+      { id: "a", activityStatus: "success" },
+      { id: "b", activityStatus: "working" },
+    ]);
+    // b's command is detected as an agent — it leaves the plain aggregate.
+    const after = getGroupActivityScopeKey([
+      { id: "a", activityStatus: "success" },
+      { id: "b", activityStatus: "working", launchAgentId: "claude" },
+    ]);
+    expect(before).not.toBe(after);
+  });
+
+  it("stays stable across a working→success transition of the same members", () => {
+    const running = getGroupActivityScopeKey([
+      { id: "a", activityStatus: "working" },
+      { id: "b", activityStatus: "success" },
+    ]);
+    const done = getGroupActivityScopeKey([
+      { id: "a", activityStatus: "success" },
+      { id: "b", activityStatus: "success" },
+    ]);
+    // Membership is unchanged, so a real completion is still detectable.
+    expect(running).toBe(done);
+  });
+
+  it("is order-independent", () => {
+    expect(
+      getGroupActivityScopeKey([
+        { id: "b", activityStatus: "working" },
+        { id: "a", activityStatus: "success" },
+      ])
+    ).toBe(
+      getGroupActivityScopeKey([
+        { id: "a", activityStatus: "success" },
+        { id: "b", activityStatus: "working" },
+      ])
+    );
+  });
+});
+
 describe("useTransientDockFinishedCue", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -104,6 +147,28 @@ describe("useTransientDockFinishedCue", () => {
     expect(result.current).toBe(false);
   });
 
+  it("stays quiet on a late undefined→success (only working→success finishes)", () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
+      { initialProps: { state: undefined as State } }
+    );
+    act(() => {
+      rerender({ state: "success" });
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("stays quiet on success→working with no prior completion", () => {
+    const { result, rerender } = renderHook(
+      ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
+      { initialProps: { state: "success" as State } }
+    );
+    act(() => {
+      rerender({ state: "working" });
+    });
+    expect(result.current).toBe(false);
+  });
+
   it("shows the cue on working→success and clears it after the dwell", () => {
     const { result, rerender } = renderHook(
       ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
@@ -111,15 +176,21 @@ describe("useTransientDockFinishedCue", () => {
     );
     expect(result.current).toBe(false);
 
-    act(() => rerender({ state: "success" }));
+    act(() => {
+      rerender({ state: "success" });
+    });
     expect(result.current).toBe(true);
 
     // Still visible right up to the dwell boundary…
-    act(() => vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 1));
+    act(() => {
+      vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 1);
+    });
     expect(result.current).toBe(true);
 
     // …then gone.
-    act(() => vi.advanceTimersByTime(1));
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
     expect(result.current).toBe(false);
   });
 
@@ -128,10 +199,14 @@ describe("useTransientDockFinishedCue", () => {
       ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
       { initialProps: { state: "working" as State } }
     );
-    act(() => rerender({ state: "success" }));
+    act(() => {
+      rerender({ state: "success" });
+    });
     expect(result.current).toBe(true);
 
-    act(() => rerender({ state: "working" }));
+    act(() => {
+      rerender({ state: "working" });
+    });
     expect(result.current).toBe(false);
   });
 
@@ -140,20 +215,32 @@ describe("useTransientDockFinishedCue", () => {
       ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
       { initialProps: { state: "working" as State } }
     );
-    act(() => rerender({ state: "success" })); // finish #1
+    act(() => {
+      rerender({ state: "success" }); // finish #1
+    });
     expect(result.current).toBe(true);
 
     // Near the first deadline, restart then finish again.
-    act(() => vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 100));
-    act(() => rerender({ state: "working" }));
+    act(() => {
+      vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 100);
+    });
+    act(() => {
+      rerender({ state: "working" });
+    });
     expect(result.current).toBe(false);
-    act(() => rerender({ state: "success" })); // finish #2
+    act(() => {
+      rerender({ state: "success" }); // finish #2
+    });
     expect(result.current).toBe(true);
 
     // The first completion's leftover 100ms must not clear the fresh cue.
-    act(() => vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 1));
+    act(() => {
+      vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS - 1);
+    });
     expect(result.current).toBe(true);
-    act(() => vi.advanceTimersByTime(1));
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
     expect(result.current).toBe(false);
   });
 
@@ -165,7 +252,52 @@ describe("useTransientDockFinishedCue", () => {
         useTransientDockFinishedCue(state, scope),
       { initialProps: { state: "working" as State, scope: "a|b" } }
     );
-    act(() => rerender({ state: "success", scope: "b" }));
+    act(() => {
+      rerender({ state: "success", scope: "b" });
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("clears a visible cue when the scope changes while still on 'success'", () => {
+    // Cue is legitimately showing from a real completion; then an unrelated idle
+    // tab is closed (membership changes, aggregate stays "success"). The cue must
+    // clear — no stale cue lingering under the new subject — and its timer too.
+    const { result, rerender } = renderHook(
+      ({ state, scope }: { state: State; scope: string }) =>
+        useTransientDockFinishedCue(state, scope),
+      { initialProps: { state: "working" as State, scope: "s1" } }
+    );
+    act(() => {
+      rerender({ state: "success", scope: "s1" });
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      rerender({ state: "success", scope: "s2" });
+    });
+    expect(result.current).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("establishes a fresh baseline after a scope change", () => {
+    const { result, rerender } = renderHook(
+      ({ state, scope }: { state: State; scope: string }) =>
+        useTransientDockFinishedCue(state, scope),
+      { initialProps: { state: "working" as State, scope: "s1" } }
+    );
+    act(() => {
+      rerender({ state: "working", scope: "s2" }); // membership changed mid-run
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      rerender({ state: "success", scope: "s2" }); // completes in the new scope
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS);
+    });
     expect(result.current).toBe(false);
   });
 
@@ -174,8 +306,11 @@ describe("useTransientDockFinishedCue", () => {
       ({ state }: { state: State }) => useTransientDockFinishedCue(state, "t-1"),
       { initialProps: { state: "working" as State } }
     );
-    act(() => rerender({ state: "success" }));
+    act(() => {
+      rerender({ state: "success" });
+    });
     expect(result.current).toBe(true);
+    expect(vi.getTimerCount()).toBe(1);
 
     unmount();
     expect(vi.getTimerCount()).toBe(0);

--- a/src/components/Layout/useDockActivityState.ts
+++ b/src/components/Layout/useDockActivityState.ts
@@ -56,6 +56,25 @@ export function getGroupDockDisplayActivityState(
 }
 
 /**
+ * Identity of the plain terminals that FEED the group aggregate — the subject
+ * the transient cue observes. Keyed on the contributing (non-agent) tabs' ids,
+ * NOT the raw membership, so a running plain tab that gets agent-detected
+ * mid-command (it drops out of the aggregate, flipping working→success) changes
+ * this key and re-baselines the cue instead of flashing a false "finished". A
+ * genuine working→success of the same members leaves the key unchanged, so real
+ * completions still register.
+ */
+export function getGroupActivityScopeKey(
+  terminals: ReadonlyArray<{ id: string } & DockActivityStateSource>
+): string {
+  const plainIds: string[] = [];
+  for (const terminal of terminals) {
+    if (getDockDisplayActivityState(terminal) !== undefined) plainIds.push(terminal.id);
+  }
+  return plainIds.sort().join("|");
+}
+
+/**
  * Renderer-local transient "finished" cue. There is no backend timestamp for
  * when `activityStatus` last changed (updateActivity just overwrites the
  * field), so a brief completion flash has to be derived here from a
@@ -78,7 +97,13 @@ export function useTransientDockFinishedCue(
   activityState: DockDisplayActivityState | undefined,
   scopeKey: string
 ): boolean {
-  const [showFinished, setShowFinished] = useState(false);
+  // The cue carries the scope it was raised under so a membership change hides
+  // it synchronously in render — before the passive effect commits — rather than
+  // surfacing a stale cue for one frame under the new scope.
+  const [finished, setFinished] = useState<{ shown: boolean; scope: string }>({
+    shown: false,
+    scope: scopeKey,
+  });
   const prevStateRef = useRef<DockDisplayActivityState | undefined>(activityState);
   const prevScopeRef = useRef(scopeKey);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -102,7 +127,7 @@ export function useTransientDockFinishedCue(
     if (prevScope !== scopeKey) {
       clearTimer();
       generationRef.current++;
-      setShowFinished(false);
+      setFinished({ shown: false, scope: scopeKey });
       return;
     }
 
@@ -110,11 +135,11 @@ export function useTransientDockFinishedCue(
     if (prevState === "working" && activityState === "success") {
       clearTimer();
       const generation = ++generationRef.current;
-      setShowFinished(true);
+      setFinished({ shown: true, scope: scopeKey });
       timerRef.current = setTimeout(() => {
         // Only the newest completion may hide the cue.
         if (generationRef.current === generation) {
-          setShowFinished(false);
+          setFinished({ shown: false, scope: scopeKey });
         }
       }, getPerformanceModeFloor(UI_TRANSIENT_HINT_DWELL_MS));
       return;
@@ -126,17 +151,21 @@ export function useTransientDockFinishedCue(
     if (activityState !== "success") {
       clearTimer();
       generationRef.current++;
-      setShowFinished(false);
+      setFinished({ shown: false, scope: scopeKey });
     }
   }, [activityState, scopeKey]);
 
   useEffect(
     () => () => {
+      // Invalidate any already-queued dwell callback so it can't fire a setter
+      // after unmount, then clear the timer.
+      generationRef.current++;
       if (timerRef.current) clearTimeout(timerRef.current);
     },
     []
   );
 
-  // Working always wins over a lingering cue, even before the effect commits.
-  return showFinished && activityState === "success";
+  // Working always wins over a lingering cue, even before the effect commits;
+  // the scope guard drops a cue raised under a now-stale subject.
+  return finished.shown && finished.scope === scopeKey && activityState === "success";
 }

--- a/src/components/Layout/useDockActivityState.ts
+++ b/src/components/Layout/useDockActivityState.ts
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import type { PanelKind } from "@/types";
+import type { TerminalActivityStatus } from "@shared/types/terminal";
+import { isAgentTerminal, type RuntimeAgentIdentityInput } from "@/utils/terminalType";
+import { UI_TRANSIENT_HINT_DWELL_MS, getPerformanceModeFloor } from "@/lib/animationUtils";
+
+/**
+ * Plain-terminal dock activity — a deliberately SEPARATE resolution path from
+ * `getDockDisplayAgentState` (useDockBlockedState.ts), whose contract is locked
+ * by dockAgentState.test.ts to keep terminal-only process activity out of the
+ * agent dock state. This module surfaces that same activity for non-agent
+ * chips instead of suppressing it.
+ *
+ * For plain shells the backend only ever emits `"working"` (a command is
+ * running) or `"success"` (idle) — never `"waiting"`/`"failure"`, and there is
+ * no exit-code tracking — so the display state is effectively binary. We ignore
+ * the other two `TerminalActivityStatus` members rather than imply a
+ * running/finished distinction the data can't support.
+ */
+export type DockDisplayActivityState = "working" | "success";
+
+export interface DockActivityStateSource extends RuntimeAgentIdentityInput {
+  activityStatus?: TerminalActivityStatus;
+  kind?: PanelKind;
+}
+
+export function getDockDisplayActivityState(
+  terminal: DockActivityStateSource
+): DockDisplayActivityState | undefined {
+  // Agents own the agent-state indicator; never double up on their chips.
+  if (isAgentTerminal(terminal)) return undefined;
+  if (terminal.activityStatus === "working") return "working";
+  if (terminal.activityStatus === "success") return "success";
+  return undefined;
+}
+
+/**
+ * Group aggregate: any plain terminal running → "working"; else if at least one
+ * plain terminal is idle/finished → "success"; else undefined. Agent tabs are
+ * skipped (their state rides the agent path), mirroring how the group's blocked
+ * highlight aggregates only agent-typed values in useDockBlockedState.ts.
+ */
+export function getGroupDockDisplayActivityState(
+  terminals: ReadonlyArray<DockActivityStateSource>
+): DockDisplayActivityState | undefined {
+  let hasWorking = false;
+  let hasSuccess = false;
+  for (const terminal of terminals) {
+    const state = getDockDisplayActivityState(terminal);
+    if (state === "working") hasWorking = true;
+    else if (state === "success") hasSuccess = true;
+  }
+  if (hasWorking) return "working";
+  if (hasSuccess) return "success";
+  return undefined;
+}
+
+/**
+ * Renderer-local transient "finished" cue. There is no backend timestamp for
+ * when `activityStatus` last changed (updateActivity just overwrites the
+ * field), so a brief completion flash has to be derived here from a
+ * `"working" → "success"` transition and held for a fixed dwell.
+ *
+ * `scopeKey` identifies the observed subject (a terminal id, or a group's
+ * sorted membership). When it changes — a group gains/loses a tab, or the chip
+ * is reused for a different terminal — we reset the baseline instead of reading
+ * the membership change as a completion (closing a running tab must not flash
+ * "finished").
+ *
+ * The dwell timeout is guarded by a generation counter (not bare clearTimeout
+ * trust — see the codebase's "queued timer defeats effect cleanup" caution): a
+ * callback the event loop already picked up checks its generation before hiding
+ * the cue, so a rapid working→success→working→success flap can't let a stale
+ * timer hide a newer cue. The render gate additionally requires the current
+ * state to still be `"success"`, so a restart shows the spinner immediately.
+ */
+export function useTransientDockFinishedCue(
+  activityState: DockDisplayActivityState | undefined,
+  scopeKey: string
+): boolean {
+  const [showFinished, setShowFinished] = useState(false);
+  const prevStateRef = useRef<DockDisplayActivityState | undefined>(activityState);
+  const prevScopeRef = useRef(scopeKey);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    const prevScope = prevScopeRef.current;
+    const prevState = prevStateRef.current;
+    prevScopeRef.current = scopeKey;
+    prevStateRef.current = activityState;
+
+    const clearTimer = () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    // Subject changed (group membership / reused chip): re-baseline, never treat
+    // it as a completion.
+    if (prevScope !== scopeKey) {
+      clearTimer();
+      generationRef.current++;
+      setShowFinished(false);
+      return;
+    }
+
+    // A command just finished: flash the cue for one dwell window.
+    if (prevState === "working" && activityState === "success") {
+      clearTimer();
+      const generation = ++generationRef.current;
+      setShowFinished(true);
+      timerRef.current = setTimeout(() => {
+        // Only the newest completion may hide the cue.
+        if (generationRef.current === generation) {
+          setShowFinished(false);
+        }
+      }, getPerformanceModeFloor(UI_TRANSIENT_HINT_DWELL_MS));
+      return;
+    }
+
+    // Any restart (back to working) or unknown state invalidates a pending timer
+    // and hides the cue immediately. A plain re-render that lands on "success"
+    // without a working→success transition leaves the current cue untouched.
+    if (activityState !== "success") {
+      clearTimer();
+      generationRef.current++;
+      setShowFinished(false);
+    }
+  }, [activityState, scopeKey]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  // Working always wins over a lingering cue, even before the effect commits.
+  return showFinished && activityState === "success";
+}


### PR DESCRIPTION
## Summary

- Plain (non-agent) terminal dock chips now show a running/finished cue, matching what agent terminals already get.
- The `activityStatus` field was already being computed for every PTY panel, it was just suppressed for non-agent terminals by `getDockDisplayAgentState`, a locked contract left untouched here.
- Adds a parallel resolution path for plain terminals rather than touching that contract, plus a transient completion flash and group-level aggregation.

Resolves #11187

## Changes

- New `src/components/Layout/useDockActivityState.ts`: `getDockDisplayActivityState` (plain-terminal state), `getGroupDockDisplayActivityState` + `getGroupActivityScopeKey` (group aggregation), and a StrictMode-safe `useTransientDockFinishedCue` hook for a brief working -> success completion flash.
- Wired into `DockedTerminalItem.tsx` and `DockedTabGroup.tsx`: a neutral `SpinnerCircle` while a plain command runs, and a transient `status-success` `CheckCircle2` on completion (1s dwell via `UI_TRANSIENT_HINT_DWELL_MS`). Same icon slot as the agent state icon, `aria-hidden`, with "command running" carried in the accessible name.
- Scoped to working/finished only. Plain shells never emit a failure signal and there's no exit-code tracking, so a red failure cue is out of scope here. No accent tokens, `status-success`/neutral colors only. Extending Watch/notifications to plain terminals is a separate follow-up.
- The group-level transient cue re-baselines whenever plain-terminal membership in a tab group changes (closing a tab, or an agent getting detected on a previously-plain terminal), so it can't flash a false "finished" state.

## Testing

- New `useDockActivityState` unit suite covering the pure helpers and the hook under fake timers, including flap, scope-rebaseline, and unmount cases.
- Extended the `DockedTerminalItem` and `DockedTabGroup` polish suites with component-level tests for the working -> finished wiring.
- All 130 tests across the 7 dock test files pass. Renderer `tsc --noEmit` clean. Prettier/eslint clean on the touched files.
