### PR TITLE
fix(terminal): track WebGL fleet-flip thresholds to the raised context cap

### DIFF
--- a/electron/ipc/handlers/__tests__/resourceProfile.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/resourceProfile.handlers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ResourceProfileSnapshot } from "../../../../shared/types/resourceProfile.js";
+import type {
+  ResourceProfile,
+  ResourceProfilePayload,
+  ResourceProfileSnapshot,
+} from "../../../../shared/types/resourceProfile.js";
+import { resolveResourceProfileConfig } from "../../../utils/resourceProfileConfig.js";
 
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),
@@ -85,6 +90,43 @@ describe("registerResourceProfileHandlers — getResourceProfileSnapshot", () =>
       speedLimit: 100,
       lagPressureActive: false,
     });
+  });
+});
+
+describe("registerResourceProfileHandlers — getResourceProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves the live profile's config through the shared resolver (pull == push)", async () => {
+    serviceRefsMock.getResourceProfileService.mockReturnValue({
+      getProfile: (): ResourceProfile => "performance",
+    });
+
+    registerResourceProfileHandlers({} as never);
+    const result = (await getHandler("system:get-resource-profile")()) as ResourceProfilePayload;
+
+    expect(result.profile).toBe("performance");
+    // The pulled config must match the resolver exactly — the same helper the
+    // broadcast path uses — so a late-created renderer gets identical WebGL flip
+    // thresholds. Comparing against the resolver (not literal numbers) keeps this
+    // deterministic on any host RAM.
+    expect(result.config).toEqual(resolveResourceProfileConfig("performance"));
+    // The resolved config must actually carry the WebGL flip thresholds (they
+    // were removed from the static table) with a valid hysteresis band.
+    expect(result.config.webglLowerThreshold).toBeLessThanOrEqual(
+      result.config.webglUpperThreshold
+    );
+  });
+
+  it("falls back to the balanced profile's resolved config when the service is unavailable", async () => {
+    serviceRefsMock.getResourceProfileService.mockReturnValue(null);
+
+    registerResourceProfileHandlers({} as never);
+    const result = (await getHandler("system:get-resource-profile")()) as ResourceProfilePayload;
+
+    expect(result.profile).toBe("balanced");
+    expect(result.config).toEqual(resolveResourceProfileConfig("balanced"));
   });
 });
 

--- a/electron/ipc/handlers/resourceProfile.ts
+++ b/electron/ipc/handlers/resourceProfile.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 import { defineIpcNamespace, op, opValidated } from "../define.js";
 import {
-  RESOURCE_PROFILE_CONFIGS,
   type ResourceProfilePayload,
   type ResourceProfileSnapshot,
 } from "../../../shared/types/resourceProfile.js";
 import { getResourceProfileService } from "../../window/serviceRefs.js";
+import { resolveResourceProfileConfig } from "../../utils/resourceProfileConfig.js";
 import type { HandlerDependencies } from "../types.js";
 import { RESOURCE_PROFILE_METHOD_CHANNELS } from "./resourceProfile.preload.js";
 
@@ -23,7 +23,9 @@ export function registerResourceProfileHandlers(_deps: HandlerDependencies): () 
         RESOURCE_PROFILE_METHOD_CHANNELS.getResourceProfile,
         async (): Promise<ResourceProfilePayload> => {
           const profile = getResourceProfileService()?.getProfile() ?? "balanced";
-          return { profile, config: RESOURCE_PROFILE_CONFIGS[profile] };
+          // Resolve through the same helper the broadcast path uses so the
+          // pulled WebGL flip thresholds match the pushed ones (#11192).
+          return { profile, config: resolveResourceProfileConfig(profile) };
         }
       ),
       // Read-only host-pressure projection (profile + thermal/battery/CPU/lag

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -27,6 +27,7 @@ import {
 import type { WhySlowResourceReason, WhySlowResourceSnapshot } from "../../shared/types/whySlow.js";
 import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.js";
 import { getSystemMemoryThresholds, readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
+import { resolveResourceProfileConfig } from "../utils/resourceProfileConfig.js";
 
 /** Map an additive pressure score to a profile. Efficiency latches at ≥ 3; a
  *  zero score (no pressure signals) unlocks performance; anything else is
@@ -1225,9 +1226,14 @@ export class ResourceProfileService {
       }
     }
 
-    // Broadcast to renderer
+    // Broadcast to renderer. Resolve the full config (base table + RAM-derived
+    // WebGL flip thresholds) so the push carries the same thresholds the pull
+    // path builds — see resolveResourceProfileConfig (#11192).
     try {
-      const payload: ResourceProfilePayload = { profile, config };
+      const payload: ResourceProfilePayload = {
+        profile,
+        config: resolveResourceProfileConfig(profile),
+      };
       broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "resource:profile-changed", payload });
     } catch {
       // non-critical — window may be closing

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -49,6 +49,8 @@ import { app, powerMonitor } from "electron";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 import { ResourceProfileService, type ResourceProfileDeps } from "../ResourceProfileService.js";
 import { RESOURCE_PROFILE_CONFIGS } from "../../../shared/types/resourceProfile.js";
+import { resolveResourceProfileConfig } from "../../utils/resourceProfileConfig.js";
+import { resolveWebglThresholds } from "../../utils/webglContextBudget.js";
 import { resetAppMetricsSnapshotForTesting } from "../../utils/appMetricsSnapshot.js";
 import { resetMemoryAccountingForTesting } from "../memoryAccounting.js";
 import type { MemoryRollup } from "../../../shared/types/pty-host.js";
@@ -342,13 +344,17 @@ describe("ResourceProfileService", () => {
     // Past warmup + hysteresis
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
 
+    // The broadcast config must be the RESOLVED config (base table + RAM-derived
+    // WebGL thresholds), routed through the same resolver the pull path uses.
+    // os.totalmem is pinned to 8 GB (ceiling 24) in beforeEach, so this stays
+    // deterministic without echoing literal threshold numbers.
     expect(broadcastToRenderer).toHaveBeenCalledWith(
       "events:push",
       expect.objectContaining({
         name: "resource:profile-changed",
         payload: expect.objectContaining({
           profile: "efficiency",
-          config: RESOURCE_PROFILE_CONFIGS.efficiency,
+          config: resolveResourceProfileConfig("efficiency"),
         }),
       })
     );
@@ -939,26 +945,34 @@ describe("ResourceProfileService", () => {
     expect(balanced.pollIntervalBackground).toBe(10000);
     expect(balanced.processTreePollInterval).toBe(2500);
     expect(balanced.projectStatsPollInterval).toBe(5000);
-    expect(balanced.webglUpperThreshold).toBe(12);
-    expect(balanced.webglLowerThreshold).toBe(10);
     expect(balanced.memoryPressureInactiveMs).toBe(30 * 60 * 1000);
     expect(balanced.lowMemoryFreeThresholdMb).toBe(768);
   });
 
-  it("performance and efficiency WebGL thresholds stay pinned", () => {
-    // Performance pushes closer to Chromium's 16-context cap.
-    expect(RESOURCE_PROFILE_CONFIGS.performance.webglUpperThreshold).toBe(14);
-    expect(RESOURCE_PROFILE_CONFIGS.performance.webglLowerThreshold).toBe(12);
-    // Efficiency kicks to DOM-mode sooner on constrained hardware.
-    expect(RESOURCE_PROFILE_CONFIGS.efficiency.webglUpperThreshold).toBe(8);
-    expect(RESOURCE_PROFILE_CONFIGS.efficiency.webglLowerThreshold).toBe(6);
+  it("resolves per-profile WebGL thresholds off the RAM-tiered ceiling", () => {
+    // WebGL thresholds are no longer stored in the static table — they are
+    // resolved from the effective ceiling so they track the raised cap and
+    // never drift from environment.ts's switch. Assert the profile ordering
+    // that the resolver must preserve rather than any literal number.
+    const eff = resolveResourceProfileConfig("efficiency");
+    const bal = resolveResourceProfileConfig("balanced");
+    const perf = resolveResourceProfileConfig("performance");
+    expect(eff.webglUpperThreshold).toBeLessThan(bal.webglUpperThreshold);
+    expect(bal.webglUpperThreshold).toBeLessThan(perf.webglUpperThreshold);
+    // On the pinned 8 GB test host the ceiling is 24; every profile must leave
+    // headroom below it for non-terminal WebGL consumers.
+    for (const config of [eff, bal, perf]) {
+      expect(config.webglUpperThreshold).toBeLessThan(24);
+    }
   });
 
-  it("every profile keeps webglLowerThreshold <= webglUpperThreshold", () => {
+  it("every resolved profile keeps webglLowerThreshold <= webglUpperThreshold", () => {
     // The mode-switch hysteresis assumes lower <= upper. A profile that
     // inverted them would oscillate forever at the boundary.
-    for (const config of Object.values(RESOURCE_PROFILE_CONFIGS)) {
-      expect(config.webglLowerThreshold).toBeLessThanOrEqual(config.webglUpperThreshold);
+    for (const profile of ["performance", "balanced", "efficiency"] as const) {
+      const { webglUpperThreshold: upper, webglLowerThreshold: lower } =
+        resolveWebglThresholds(profile);
+      expect(lower).toBeLessThanOrEqual(upper);
     }
   });
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -25,6 +25,7 @@ import fs from "fs";
 import { existsSync } from "fs";
 import os from "os";
 import { isLinuxWaylandHybridGpu } from "../utils/gpuDetection.js";
+import { getMaxWebGLContextCeiling } from "../utils/webglContextBudget.js";
 // Deliberately the tiny pure-fs module, NOT GpuCrashMonitorService — importing
 // the service here would evaluate its logger/telemetry/store import chain at
 // module load, before this file's body re-paths userData for dev instances.
@@ -192,21 +193,19 @@ function getGpuTileMemoryCapMb(): string {
 
 app.commandLine.appendSwitch("force-gpu-mem-available-mb", getGpuTileMemoryCapMb());
 
-// Lift Chromium's 16-active-WebGL-context per-renderer ceiling so the terminal pool
-// can keep more xterm panes on the WebGL renderer before LRU eviction drops them to
-// DOM. Scales with system RAM on the same tiers as the tile-memory budget above.
-// Each xterm WebGL context is small (no 3D geometry, no MSAA) so headroom for 24-32
-// is safe within the raised tile budget. Memory-pressure context loss is still
-// possible at the OS/GPU-budget level (Chromium 465176577) — the existing
-// TerminalWebGLManager circuit breaker handles that path independently.
-function getMaxWebGLContexts(): string {
-  const totalMem = os.totalmem();
-  if (totalMem <= 8 * 1024 ** 3) return "24";
-  if (totalMem <= 16 * 1024 ** 3) return "28";
-  return "32";
-}
-
-app.commandLine.appendSwitch("max-active-webgl-contexts", getMaxWebGLContexts());
+// Lift Chromium's default 16-active-WebGL-context per-renderer ceiling so the
+// terminal pool can keep more xterm panes on the WebGL renderer before the
+// whole-fleet flip drops them to DOM. Scales with system RAM on the same tiers
+// as the tile-memory budget above (24/28/32). Each xterm WebGL context is small
+// (no 3D geometry, no MSAA) so this headroom is safe within the raised tile
+// budget. Memory-pressure context loss is still possible at the OS/GPU-budget
+// level (Chromium 465176577) — the existing TerminalWebGLManager circuit breaker
+// handles that path independently.
+//
+// getMaxWebGLContextCeiling is the single source of truth: the resource-profile
+// fleet-flip thresholds derive from the same function so the raised cap and the
+// thresholds guarding it can never drift apart (#11192).
+app.commandLine.appendSwitch("max-active-webgl-contexts", String(getMaxWebGLContextCeiling()));
 
 if (process.platform === "win32") {
   const extraPaths = getWindowsExtraPaths();

--- a/electron/utils/__tests__/resourceProfileConfig.test.ts
+++ b/electron/utils/__tests__/resourceProfileConfig.test.ts
@@ -30,10 +30,9 @@ describe("resolveResourceProfileConfig", () => {
     for (const profile of PROFILES) {
       const base = RESOURCE_PROFILE_CONFIGS[profile];
       const resolved = resolveResourceProfileConfig(profile, 28);
-      for (const key of Object.keys(base) as (keyof typeof base)[]) {
-        expect(resolved[key]).toBe(base[key]);
-      }
-      // …and adds exactly the two resolved WebGL fields on top of the base keys.
+      // Every base field is carried through unchanged…
+      expect(resolved).toMatchObject(base);
+      // …and the resolved config adds exactly the two WebGL fields on top.
       expect(new Set(Object.keys(resolved))).toEqual(
         new Set([...Object.keys(base), "webglUpperThreshold", "webglLowerThreshold"])
       );

--- a/electron/utils/__tests__/resourceProfileConfig.test.ts
+++ b/electron/utils/__tests__/resourceProfileConfig.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  RESOURCE_PROFILE_CONFIGS,
+  type ResourceProfile,
+} from "../../../shared/types/resourceProfile.js";
+import { resolveResourceProfileConfig } from "../resourceProfileConfig.js";
+
+const PROFILES: ResourceProfile[] = ["performance", "balanced", "efficiency"];
+
+describe("resolveResourceProfileConfig", () => {
+  it("forwards the ceiling so WebGL thresholds scale (not pinned to one tier)", () => {
+    // Concrete anchors independent of resolveWebglThresholds: a wrapper that
+    // ignored its ceiling argument (e.g. hardcoded 24) would return the 24-tier
+    // pair for both calls and fail the 32-tier expectation.
+    expect(resolveResourceProfileConfig("balanced", 24)).toMatchObject({
+      webglUpperThreshold: 18,
+      webglLowerThreshold: 15,
+    });
+    expect(resolveResourceProfileConfig("balanced", 32)).toMatchObject({
+      webglUpperThreshold: 24,
+      webglLowerThreshold: 20,
+    });
+    expect(resolveResourceProfileConfig("performance", 32)).toMatchObject({
+      webglUpperThreshold: 28,
+      webglLowerThreshold: 24,
+    });
+  });
+
+  it("preserves every base field from the static table verbatim", () => {
+    for (const profile of PROFILES) {
+      const base = RESOURCE_PROFILE_CONFIGS[profile];
+      const resolved = resolveResourceProfileConfig(profile, 28);
+      for (const key of Object.keys(base) as (keyof typeof base)[]) {
+        expect(resolved[key]).toBe(base[key]);
+      }
+      // …and adds exactly the two resolved WebGL fields on top of the base keys.
+      expect(new Set(Object.keys(resolved))).toEqual(
+        new Set([...Object.keys(base), "webglUpperThreshold", "webglLowerThreshold"])
+      );
+    }
+  });
+
+  it("does not mutate the shared RESOURCE_PROFILE_CONFIGS table", () => {
+    const balancedBefore = { ...RESOURCE_PROFILE_CONFIGS.balanced };
+    resolveResourceProfileConfig("balanced", 32);
+    expect(RESOURCE_PROFILE_CONFIGS.balanced).toEqual(balancedBefore);
+    // The WebGL fields must never leak back onto the static table.
+    expect("webglUpperThreshold" in RESOURCE_PROFILE_CONFIGS.balanced).toBe(false);
+    expect("webglLowerThreshold" in RESOURCE_PROFILE_CONFIGS.balanced).toBe(false);
+  });
+});

--- a/electron/utils/__tests__/webglContextBudget.test.ts
+++ b/electron/utils/__tests__/webglContextBudget.test.ts
@@ -76,16 +76,30 @@ describe("resolveWebglThresholds — invariants", () => {
     }
   });
 
-  it("derives from the exported ratios (upper ≈ round(ceiling × ratio.upper))", () => {
-    // Guards against the derivation silently decoupling from WEBGL_THRESHOLD_RATIOS.
-    // (Loose: the defensive clamps may pull a value in, but never push it out.)
+  it("derives exactly from the exported ratios at supported ceilings (clamps do not bind)", () => {
+    // Ties the output to WEBGL_THRESHOLD_RATIOS: at 24/28/32 the defensive clamps
+    // never engage, so both thresholds are exactly round(ceiling × ratio).
     for (const ceiling of SUPPORTED_CEILINGS) {
       for (const profile of PROFILES) {
-        const { webglUpperThreshold: upper } = resolveWebglThresholds(profile, ceiling);
-        expect(upper).toBeLessThanOrEqual(
-          Math.round(ceiling * WEBGL_THRESHOLD_RATIOS[profile].upper)
+        const { webglUpperThreshold: upper, webglLowerThreshold: lower } = resolveWebglThresholds(
+          profile,
+          ceiling
         );
+        expect(upper).toBe(Math.round(ceiling * WEBGL_THRESHOLD_RATIOS[profile].upper));
+        expect(lower).toBe(Math.round(ceiling * WEBGL_THRESHOLD_RATIOS[profile].lower));
       }
+    }
+  });
+
+  it("clamps a degenerate ceiling to a valid (non-inverted, non-negative) pair", () => {
+    // At ceiling 4 the raw ratio-derived values would violate the headroom /
+    // hysteresis floors, so the clamps engage. Every profile resolves to the
+    // same clamped {2, 0}: upper pulled to ceiling-2, lower to upper-2.
+    for (const profile of PROFILES) {
+      expect(resolveWebglThresholds(profile, 4)).toEqual({
+        webglUpperThreshold: 2,
+        webglLowerThreshold: 0,
+      });
     }
   });
 });

--- a/electron/utils/__tests__/webglContextBudget.test.ts
+++ b/electron/utils/__tests__/webglContextBudget.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import type { ResourceProfile } from "../../../shared/types/resourceProfile.js";
+import {
+  getMaxWebGLContextCeiling,
+  resolveWebglThresholds,
+  WEBGL_THRESHOLD_RATIOS,
+} from "../webglContextBudget.js";
+
+const GIB = 1024 ** 3;
+const PROFILES: ResourceProfile[] = ["performance", "balanced", "efficiency"];
+const SUPPORTED_CEILINGS = [24, 28, 32];
+
+describe("getMaxWebGLContextCeiling", () => {
+  it("returns 24 at or below the 8 GiB tier", () => {
+    expect(getMaxWebGLContextCeiling(4 * GIB)).toBe(24);
+    expect(getMaxWebGLContextCeiling(8 * GIB)).toBe(24);
+  });
+
+  it("returns 28 above 8 GiB up to and including 16 GiB", () => {
+    expect(getMaxWebGLContextCeiling(8 * GIB + 1)).toBe(28);
+    expect(getMaxWebGLContextCeiling(16 * GIB)).toBe(28);
+  });
+
+  it("returns 32 above 16 GiB", () => {
+    expect(getMaxWebGLContextCeiling(16 * GIB + 1)).toBe(32);
+    expect(getMaxWebGLContextCeiling(64 * GIB)).toBe(32);
+  });
+
+  it("is monotonic non-decreasing across the tiers", () => {
+    const c1 = getMaxWebGLContextCeiling(4 * GIB);
+    const c2 = getMaxWebGLContextCeiling(12 * GIB);
+    const c3 = getMaxWebGLContextCeiling(32 * GIB);
+    expect(c1).toBeLessThan(c2);
+    expect(c2).toBeLessThan(c3);
+  });
+});
+
+describe("resolveWebglThresholds — invariants", () => {
+  for (const ceiling of SUPPORTED_CEILINGS) {
+    it(`leaves headroom below the ceiling and a hysteresis gap at ceiling ${ceiling}`, () => {
+      for (const profile of PROFILES) {
+        const { webglUpperThreshold: upper, webglLowerThreshold: lower } = resolveWebglThresholds(
+          profile,
+          ceiling
+        );
+        // Headroom for non-terminal WebGL consumers: never claim the whole cap.
+        expect(upper).toBeLessThan(ceiling);
+        expect(ceiling - upper).toBeGreaterThanOrEqual(2);
+        // Real hysteresis band so a single toggling panel cannot flap the fleet.
+        expect(lower).toBeLessThan(upper);
+        expect(upper - lower).toBeGreaterThanOrEqual(2);
+        // Whole, non-negative context counts.
+        expect(Number.isInteger(upper)).toBe(true);
+        expect(Number.isInteger(lower)).toBe(true);
+        expect(lower).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it(`preserves profile ordering efficiency < balanced < performance at ceiling ${ceiling}`, () => {
+      const eff = resolveWebglThresholds("efficiency", ceiling);
+      const bal = resolveWebglThresholds("balanced", ceiling);
+      const perf = resolveWebglThresholds("performance", ceiling);
+      expect(eff.webglUpperThreshold).toBeLessThan(bal.webglUpperThreshold);
+      expect(bal.webglUpperThreshold).toBeLessThan(perf.webglUpperThreshold);
+      expect(eff.webglLowerThreshold).toBeLessThan(bal.webglLowerThreshold);
+      expect(bal.webglLowerThreshold).toBeLessThan(perf.webglLowerThreshold);
+    });
+  }
+
+  it("scales thresholds up as the ceiling grows", () => {
+    for (const profile of PROFILES) {
+      const small = resolveWebglThresholds(profile, 24);
+      const large = resolveWebglThresholds(profile, 32);
+      expect(large.webglUpperThreshold).toBeGreaterThan(small.webglUpperThreshold);
+      expect(large.webglLowerThreshold).toBeGreaterThan(small.webglLowerThreshold);
+    }
+  });
+
+  it("derives from the exported ratios (upper ≈ round(ceiling × ratio.upper))", () => {
+    // Guards against the derivation silently decoupling from WEBGL_THRESHOLD_RATIOS.
+    // (Loose: the defensive clamps may pull a value in, but never push it out.)
+    for (const ceiling of SUPPORTED_CEILINGS) {
+      for (const profile of PROFILES) {
+        const { webglUpperThreshold: upper } = resolveWebglThresholds(profile, ceiling);
+        expect(upper).toBeLessThanOrEqual(
+          Math.round(ceiling * WEBGL_THRESHOLD_RATIOS[profile].upper)
+        );
+      }
+    }
+  });
+});
+
+describe("resolveWebglThresholds — rounding anchors", () => {
+  // Concrete computed outputs that pin the round-half-up behavior at each tier
+  // (e.g. ceiling 28 balanced lower = round(17.5) = 18). Not copied constants —
+  // each is ceiling × ratio, rounded, then clamped.
+  it("ceiling 24", () => {
+    expect(resolveWebglThresholds("performance", 24)).toEqual({
+      webglUpperThreshold: 21,
+      webglLowerThreshold: 18,
+    });
+    expect(resolveWebglThresholds("balanced", 24)).toEqual({
+      webglUpperThreshold: 18,
+      webglLowerThreshold: 15,
+    });
+    expect(resolveWebglThresholds("efficiency", 24)).toEqual({
+      webglUpperThreshold: 12,
+      webglLowerThreshold: 9,
+    });
+  });
+
+  it("ceiling 28 (round-half-up boundaries)", () => {
+    expect(resolveWebglThresholds("performance", 28)).toEqual({
+      webglUpperThreshold: 25, // round(24.5)
+      webglLowerThreshold: 21,
+    });
+    expect(resolveWebglThresholds("balanced", 28)).toEqual({
+      webglUpperThreshold: 21,
+      webglLowerThreshold: 18, // round(17.5)
+    });
+    expect(resolveWebglThresholds("efficiency", 28)).toEqual({
+      webglUpperThreshold: 14,
+      webglLowerThreshold: 11, // round(10.5)
+    });
+  });
+
+  it("ceiling 32", () => {
+    expect(resolveWebglThresholds("performance", 32)).toEqual({
+      webglUpperThreshold: 28,
+      webglLowerThreshold: 24,
+    });
+    expect(resolveWebglThresholds("balanced", 32)).toEqual({
+      webglUpperThreshold: 24,
+      webglLowerThreshold: 20,
+    });
+    expect(resolveWebglThresholds("efficiency", 32)).toEqual({
+      webglUpperThreshold: 16,
+      webglLowerThreshold: 12,
+    });
+  });
+});

--- a/electron/utils/resourceProfileConfig.ts
+++ b/electron/utils/resourceProfileConfig.ts
@@ -1,0 +1,27 @@
+import {
+  RESOURCE_PROFILE_CONFIGS,
+  type ResourceProfile,
+  type ResourceProfileConfig,
+} from "../../shared/types/resourceProfile.js";
+import { getMaxWebGLContextCeiling, resolveWebglThresholds } from "./webglContextBudget.js";
+
+/**
+ * Assemble the full ResourceProfileConfig that is broadcast (on transition) and
+ * pulled (by late-created renderers) to drive per-profile settings.
+ *
+ * RESOURCE_PROFILE_CONFIGS holds only the host-independent knobs; the
+ * RAM-dependent WebGL flip thresholds are resolved here so the push path
+ * (ResourceProfileService.applyProfile) and the pull path (the
+ * getResourceProfile IPC handler) share one derivation and can never diverge
+ * (#11192). Callers on the main process must build the renderer payload through
+ * this function rather than reading the static table directly.
+ */
+export function resolveResourceProfileConfig(
+  profile: ResourceProfile,
+  ceiling: number = getMaxWebGLContextCeiling()
+): ResourceProfileConfig {
+  return {
+    ...RESOURCE_PROFILE_CONFIGS[profile],
+    ...resolveWebglThresholds(profile, ceiling),
+  };
+}

--- a/electron/utils/webglContextBudget.ts
+++ b/electron/utils/webglContextBudget.ts
@@ -1,0 +1,82 @@
+import os from "os";
+import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
+
+// Single source of truth for the WebGL-context budget (#11192).
+//
+// Chromium hard-caps active WebGL contexts per renderer process (default 16),
+// silently evicting the oldest on overflow (webglcontextlost). Daintree raises
+// that ceiling via the `max-active-webgl-contexts` command-line switch in
+// electron/setup/environment.ts, scaled by system RAM. The whole-fleet
+// WebGL->DOM flip thresholds (per resource profile) must track that raised
+// ceiling — otherwise the fleet force-flips to the slower DOM renderer while
+// the GPU still has room. Deriving both the switch value and the per-profile
+// thresholds from this module keeps them from drifting apart.
+//
+// This module depends only on `node:os` (plus a type-only import) so
+// environment.ts can pull `getMaxWebGLContextCeiling` into its early-boot path
+// without dragging in the shared resource-profile table or anything heavier.
+
+const EIGHT_GIB = 8 * 1024 ** 3;
+const SIXTEEN_GIB = 16 * 1024 ** 3;
+
+/**
+ * Effective per-renderer active-WebGL-context ceiling, RAM-tiered on the same
+ * breakpoints as the GPU tile-memory budget in environment.ts:
+ * ≤8 GiB → 24, >8 and ≤16 GiB → 28, >16 GiB → 32. Each xterm WebGL context is
+ * small (no 3D geometry, no MSAA) so this headroom is safe within the raised
+ * tile budget. `totalMemBytes` defaults to `os.totalmem()` at call time (never
+ * at module load) and is injectable for deterministic tests.
+ */
+export function getMaxWebGLContextCeiling(totalMemBytes: number = os.totalmem()): number {
+  if (totalMemBytes <= EIGHT_GIB) return 24;
+  if (totalMemBytes <= SIXTEEN_GIB) return 28;
+  return 32;
+}
+
+/**
+ * Per-profile fractions of the ceiling for the whole-fleet WebGL→DOM flip.
+ * These reproduce the ratios the old flat thresholds already encoded against
+ * the previous 16-context cap (performance 14/16 upper·12/16 lower, balanced
+ * 12/16·10/16, efficiency 8/16·6/16), so the tuned headroom shape and the
+ * profile ordering (efficiency < balanced < performance) are preserved as the
+ * ceiling scales. The gap between upper and lower is the hysteresis band and
+ * grows proportionally with the ceiling.
+ */
+export const WEBGL_THRESHOLD_RATIOS: Record<ResourceProfile, { upper: number; lower: number }> = {
+  performance: { upper: 14 / 16, lower: 12 / 16 },
+  balanced: { upper: 12 / 16, lower: 10 / 16 },
+  efficiency: { upper: 8 / 16, lower: 6 / 16 },
+};
+
+// Minimum slots kept free below the ceiling for non-terminal in-renderer WebGL
+// consumers (browser / dev-preview panels, devtools). Matches the tightest
+// headroom the old policy left (performance held 14 of 16).
+const MIN_HEADROOM = 2;
+// Minimum hysteresis gap so a single panel toggling at the boundary cannot flap
+// the whole fleet. Matches the old flat gap of 2.
+const MIN_HYSTERESIS_GAP = 2;
+
+export interface WebglThresholds {
+  webglUpperThreshold: number;
+  webglLowerThreshold: number;
+}
+
+/**
+ * Resolve the whole-fleet flip thresholds for a profile against the effective
+ * RAM-tiered ceiling. The ratio-derived values are rounded, then clamped
+ * defensively so the result always leaves headroom below the ceiling and a
+ * real hysteresis gap. The clamps never bind at the supported 24/28/32
+ * ceilings — they only guard against a degenerate (very small) ceiling.
+ */
+export function resolveWebglThresholds(
+  profile: ResourceProfile,
+  ceiling: number = getMaxWebGLContextCeiling()
+): WebglThresholds {
+  const ratios = WEBGL_THRESHOLD_RATIOS[profile];
+  const upper = Math.max(1, Math.min(Math.round(ceiling * ratios.upper), ceiling - MIN_HEADROOM));
+  const lower = Math.max(
+    0,
+    Math.min(Math.round(ceiling * ratios.lower), upper - MIN_HYSTERESIS_GAP)
+  );
+  return { webglUpperThreshold: upper, webglLowerThreshold: lower };
+}

--- a/electron/utils/webglContextBudget.ts
+++ b/electron/utils/webglContextBudget.ts
@@ -64,9 +64,12 @@ export interface WebglThresholds {
 /**
  * Resolve the whole-fleet flip thresholds for a profile against the effective
  * RAM-tiered ceiling. The ratio-derived values are rounded, then clamped
- * defensively so the result always leaves headroom below the ceiling and a
- * real hysteresis gap. The clamps never bind at the supported 24/28/32
- * ceilings — they only guard against a degenerate (very small) ceiling.
+ * defensively so the result leaves headroom below the ceiling and a real
+ * hysteresis gap. The clamps never bind at the supported 24/28/32 ceilings;
+ * they only guard a degenerate ceiling from producing an inverted or negative
+ * pair. The full MIN_HEADROOM / MIN_HYSTERESIS_GAP invariants (2 slots each)
+ * are only guaranteed for a ceiling ≥ 4 — the supported inputs are always well
+ * above that.
  */
 export function resolveWebglThresholds(
   profile: ResourceProfile,

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -22,8 +22,12 @@ export interface ResourceProfileConfig {
   /**
    * Upper threshold for the WebGL mode switch. When the count of terminals
    * wanting WebGL exceeds this value, every active context is released and
-   * the manager flips to DOM-mode. Must stay below 16 to leave headroom for
-   * Chromium's per-renderer WebGL-context cap.
+   * the manager flips to DOM-mode. Kept a headroom margin below the effective
+   * per-renderer WebGL-context ceiling (RAM-tiered via the
+   * `max-active-webgl-contexts` switch) so devtools and other in-renderer
+   * WebGL consumers still have room. Not stored in RESOURCE_PROFILE_CONFIGS —
+   * resolved from the ceiling on the main process (see
+   * electron/utils/resourceProfileConfig.ts, #11192).
    */
   webglUpperThreshold: number;
   /**
@@ -31,7 +35,8 @@ export interface ResourceProfileConfig {
    * value or below, the manager flips back to WebGL-mode and re-attaches an
    * addon to every want via a rAF-staggered drain. The gap between upper and
    * lower is the hysteresis band — opening/closing one panel at the boundary
-   * will not flap the fleet.
+   * will not flap the fleet. Resolved from the ceiling alongside
+   * webglUpperThreshold (see webglUpperThreshold).
    */
   webglLowerThreshold: number;
   /**
@@ -102,6 +107,19 @@ export interface ResourceProfileConfig {
   warmPaintGateHardTimeoutMs: number;
 }
 
+/**
+ * Host-independent slice of ResourceProfileConfig — everything except the
+ * WebGL flip thresholds, which are RAM-dependent and resolved on the main
+ * process (electron/utils/resourceProfileConfig.ts). RESOURCE_PROFILE_CONFIGS
+ * is typed as this so a stale literal WebGL threshold can never be read off the
+ * static table again; the full config is only ever assembled by the resolver
+ * (#11192).
+ */
+export type BaseResourceProfileConfig = Omit<
+  ResourceProfileConfig,
+  "webglUpperThreshold" | "webglLowerThreshold"
+>;
+
 export interface ResourceProfilePayload {
   profile: ResourceProfile;
   config: ResourceProfileConfig;
@@ -137,22 +155,22 @@ export interface ResourceProfileSnapshot {
  * - pollIntervalBackground: 10000 (WorkspaceService DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS)
  * - processTreePollInterval: 2500 (ProcessTreeCache constructor default)
  * - projectStatsPollInterval: 5000 (ProjectStatsService DEFAULT_POLL_INTERVAL_MS)
- * - webglUpperThreshold: 12 (TerminalWebGLConfig initial value)
- * - webglLowerThreshold: 10 (TerminalWebGLConfig initial value)
  * - memoryPressureInactiveMs: 1800000 (HibernationService MEMORY_PRESSURE_INACTIVE_MS = 30min)
+ *
+ * The WebGL flip thresholds (webglUpperThreshold / webglLowerThreshold) are NOT
+ * stored here: they are RAM-dependent and resolved from the effective
+ * per-renderer WebGL-context ceiling on the main process
+ * (electron/utils/resourceProfileConfig.ts). The table is therefore typed
+ * `BaseResourceProfileConfig` and the full config is only ever assembled by the
+ * resolver (#11192).
  */
-export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileConfig> = {
+export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfileConfig> = {
   performance: {
     pollIntervalActive: 1500,
     pollIntervalBackground: 5000,
     backgroundGitWatcherCap: 20,
     processTreePollInterval: 2000,
     projectStatsPollInterval: 5000,
-    // Performance pushes closer to Chromium's 16-context cap. Higher upper +
-    // 2-slot hysteresis still leaves room for devtools / OffscreenCanvas while
-    // letting more agents render through WebGL simultaneously.
-    webglUpperThreshold: 14,
-    webglLowerThreshold: 12,
     memoryPressureInactiveMs: 60 * 60 * 1000, // 60 min
     lowMemoryFreeThresholdMb: null,
     agentScrollbackMaxLines: 5000,
@@ -170,8 +188,6 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     backgroundGitWatcherCap: 12,
     processTreePollInterval: 2500,
     projectStatsPollInterval: 5000,
-    webglUpperThreshold: 12,
-    webglLowerThreshold: 10,
     memoryPressureInactiveMs: 30 * 60 * 1000, // 30 min
     lowMemoryFreeThresholdMb: 768,
     agentScrollbackMaxLines: 5000,
@@ -195,10 +211,6 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     backgroundGitWatcherCap: 6,
     processTreePollInterval: 5000,
     projectStatsPollInterval: 25000,
-    // Efficiency kicks to DOM-mode sooner on constrained hardware where each
-    // active WebGL context is comparatively more expensive.
-    webglUpperThreshold: 8,
-    webglLowerThreshold: 6,
     memoryPressureInactiveMs: 15 * 60 * 1000, // 15 min
     lowMemoryFreeThresholdMb: 1024,
     // Half the agent history ceiling on constrained hardware — ~3MB less

--- a/src/services/terminal/TerminalWebGLConfig.ts
+++ b/src/services/terminal/TerminalWebGLConfig.ts
@@ -9,11 +9,17 @@
 // The gap between the two values is hysteresis: opening/closing a single panel
 // at the boundary will not flap the whole fleet.
 //
-// Chromium hard-caps active WebGL contexts at 16 per renderer process and
-// silently evicts the oldest on overflow (webglcontextlost), so the upper
-// threshold must stay comfortably below 16 to leave headroom for devtools,
-// OffscreenCanvas, and any future non-terminal WebGL consumer.
-// Initial values match the balanced resource profile.
+// Chromium silently evicts the oldest active WebGL context on overflow
+// (webglcontextlost), so the upper threshold must stay a headroom margin below
+// the effective per-renderer ceiling to leave room for devtools, OffscreenCanvas,
+// and any non-terminal WebGL consumer. That ceiling is raised above Chromium's
+// default 16 and RAM-tiered (see electron/setup/environment.ts), and the live
+// thresholds are resolved from it and pushed in via useResourceProfile (#11192).
+//
+// These are conservative bootstrap defaults only — used until the first
+// resource-profile push/pull resolves the real RAM-tiered values on mount. They
+// are intentionally low so a slow or failed pull can't briefly over-attach
+// contexts; they are NOT the balanced profile's source of truth.
 
 let upperThreshold = 12;
 let lowerThreshold = 10;

--- a/src/services/terminal/TerminalWebGLConfig.ts
+++ b/src/services/terminal/TerminalWebGLConfig.ts
@@ -16,13 +16,20 @@
 // default 16 and RAM-tiered (see electron/setup/environment.ts), and the live
 // thresholds are resolved from it and pushed in via useResourceProfile (#11192).
 //
-// These are conservative bootstrap defaults only — used until the first
-// resource-profile push/pull resolves the real RAM-tiered values on mount. They
-// are intentionally low so a slow or failed pull can't briefly over-attach
-// contexts; they are NOT the balanced profile's source of truth.
+// Bootstrap defaults only — used until the first resource-profile push/pull
+// resolves the real RAM-tiered values on mount. They are NOT the balanced
+// profile's source of truth. Sized to the balanced profile at the guaranteed
+// minimum ceiling of 24 (resolveWebglThresholds("balanced", 24) → 18/15,
+// electron/utils/webglContextBudget.ts): cold start is always balanced (the
+// efficiency profile only latches after sustained runtime pressure), and every
+// machine gets a ceiling ≥ 24 from the max-active-webgl-contexts switch, so 18
+// is always within budget. Keeping these in step with the resolved cold-start
+// value stops a large restored fleet from flipping to DOM under the old stale
+// 12-upper and then being stranded there — DOM→WebGL only re-flips once the
+// count falls back to the lower threshold (#11192).
 
-let upperThreshold = 12;
-let lowerThreshold = 10;
+let upperThreshold = 18;
+let lowerThreshold = 15;
 
 export function getWebglUpperThreshold(): number {
   return upperThreshold;

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -442,8 +442,9 @@ export class TerminalWebGLManager {
 
   // External re-evaluation hook. Threshold changes pushed from the main
   // process via useResourceProfile arrive between consumer events; without
-  // this, a profile downgrade from balanced (12/10) to efficiency (8/6) would
-  // leave 9+ wants on WebGL until the next ensure/release happens to land.
+  // this, a profile downgrade (which lowers both thresholds, e.g. balanced →
+  // efficiency) would leave over-budget wants on WebGL until the next
+  // ensure/release happens to land.
   refreshMode(): void {
     this.evaluateMode();
   }

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -23,8 +23,10 @@ import { type ManagedTerminal } from "./types";
 // DAINTREE_* env vars to import.meta.env via envPrefix in vite.config.ts.
 //
 // Why this shape instead of an LRU pool:
-// Chromium hard-caps active WebGL contexts at 16 per renderer and silently
-// evicts the oldest on overflow (webglcontextlost — see crbug 40939743). An
+// Chromium caps active WebGL contexts per renderer (default 16, raised and
+// RAM-tiered to 24/28/32 here via the max-active-webgl-contexts switch — see
+// electron/setup/environment.ts) and silently evicts the oldest on overflow
+// (webglcontextlost — see crbug 40939743). An
 // LRU pool inside our renderer was making the same eviction decisions
 // Chromium was already making one layer below, producing visible churn at
 // 12-20 visible agent terminals: contexts cycled out, fell back to DOM,
@@ -38,7 +40,7 @@ type WebglAddonConstructor = new () => WebglAddonType;
 // eager critical path. ensureContext() routes every new request through a
 // requestAnimationFrame drain queue (one attach per frame): without that
 // stagger, a burst of synchronous attaches during bulk worktree creation or a
-// DOM→WebGL mode flip over-subscribes Chromium's 16-context-per-renderer cap,
+// DOM→WebGL mode flip over-subscribes Chromium's per-renderer context cap,
 // causing silent eviction of older contexts that then sit blank for 3s waiting
 // on webglcontextrestored before xterm's onContextLoss fires (see #7467).
 let WebglAddonClass: WebglAddonConstructor | null = null;
@@ -63,7 +65,7 @@ function loadWebglAddon(): Promise<WebglAddonConstructor> {
 
 // Force synchronous GPU-side context release. Reaches into @xterm/addon-webgl
 // 0.20's renderer internals to get the WebGL context and call loseContext()
-// before addon.dispose() — without this, Chromium's 16-context budget is not
+// before addon.dispose() — without this, Chromium's per-renderer context budget is not
 // freed until garbage collection runs the WebGL teardown. Wrapped in try/catch
 // so a future addon shape change degrades gracefully rather than throwing.
 function forceGpuSlotRelease(addon: WebglAddonType): void {
@@ -210,7 +212,7 @@ export class TerminalWebGLManager {
   // Focus pin: in DOM mode, exactly one WebGL context stays attached to the
   // focused terminal so the pane the user is reading keeps fast, glyph-correct
   // rendering above the mode-switch threshold. One context is far below
-  // Chromium's 16-cap, and its churn is bounded by user focus clicks — not the
+  // Chromium's per-renderer cap, and its churn is bounded by user focus clicks — not the
   // N-terminal output/visibility cycling the wholesale mode switch replaced
   // (see header comment). In WebGL mode the pin is bookkeeping only; it takes
   // effect when the fleet flips to DOM.
@@ -232,7 +234,7 @@ export class TerminalWebGLManager {
   // identically by isPinned() at every DOM-mode exemption site; they are kept
   // separate only because their lifecycles differ (focus events vs buffer-mode
   // changes). Each alt-buffer pin still holds one WebGL context against
-  // Chromium's 16-cap, so this is bounded by how many alt-buffer panes are
+  // Chromium's per-renderer cap, so this is bounded by how many alt-buffer panes are
   // visible — far below the cap in practice, and the breaker trip clears them
   // all (see setHardwareAvailable).
   private altBufferPinnedIds = new Set<string>();
@@ -526,8 +528,8 @@ export class TerminalWebGLManager {
       }
       // terminal.dispose() handles addon cleanup, so we skip addon.dispose()
       // here — but we still need to force the synchronous GPU-slot release so
-      // a hibernation-then-bulk-recreate cycle does not stall on the 16-slot
-      // Chromium budget the same way #7467 stalled the attach path.
+      // a hibernation-then-bulk-recreate cycle does not stall on the
+      // per-renderer Chromium context budget the same way #7467 stalled the attach path.
       forceGpuSlotRelease(entry.addon);
       this.pool.delete(id);
     }
@@ -644,7 +646,7 @@ export class TerminalWebGLManager {
     // (per-session, but recoverable across the cycle).
     this.hasLoggedModeFlip = false;
     // Queue every still-wanting terminal for attach. The rAF drain serialises
-    // them so the bulk attach never over-subscribes the 16-context budget.
+    // them so the bulk attach never over-subscribes the per-renderer context budget.
     for (const [id, managed] of this.wants) {
       if (!this.pool.has(id)) {
         this.queueAttach(id, managed);
@@ -1038,7 +1040,7 @@ export class TerminalWebGLManager {
       // ignore
     }
     // Force synchronous GPU-side context release before addon.dispose() so the
-    // 16-context Chromium budget actually frees this slot before the next
+    // per-renderer Chromium context budget actually frees this slot before the next
     // getContext() call.
     forceGpuSlotRelease(entry.addon);
     try {

--- a/src/services/terminal/__tests__/TerminalInstanceService.paintFabricGpu.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.paintFabricGpu.test.ts
@@ -66,6 +66,14 @@ async function importFresh() {
   const compositorModule = await import("../paintFabric/PaintFabricCompositor");
   const configModule = await import("../paintFabric/paintFabricConfig");
   const clientsModule = await import("@/clients");
+  // Pin the whole-fleet WebGL flip thresholds so this test's count logic — the
+  // 13th want crosses a single surface's threshold; a round-robin split keeps
+  // each surface under it — is independent of the RAM-tiered bootstrap default.
+  // resetModules() re-seeds that default from system memory (now 18/15), which
+  // would otherwise let all 13 wants stay in WebGL. 12/10 restores the "13th
+  // flips" boundary this scenario was written around.
+  const webglConfigModule = await import("../TerminalWebGLConfig");
+  webglConfigModule.setWebglThresholds(12, 10);
   return {
     terminalInstanceService: serviceModule.terminalInstanceService,
     PaintFabricCompositor: compositorModule.PaintFabricCompositor,

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -1154,8 +1154,9 @@ describe("TerminalWebGLManager", () => {
 
   describe("mode switch", () => {
     // Tight thresholds so the count manipulation here is small enough to
-    // follow. Real defaults are 12/10 (balanced profile); the test layer
-    // controls them directly.
+    // follow. The live thresholds are resolved per resource profile from the
+    // RAM-tiered ceiling (the module carries conservative bootstrap defaults
+    // until the first profile push); the test layer controls them directly.
     beforeEach(async () => {
       const mod = await import("../TerminalWebGLManager");
       mod.TerminalWebGLManager.setWebglThresholds(3, 2);


### PR DESCRIPTION
## Summary

- Chromium's per-renderer active WebGL context cap was already raised from the default 16 to a RAM-tiered 24/28/32 via the `max-active-webgl-contexts` switch in `electron/setup/environment.ts`, but the whole-fleet WebGL-to-DOM flip thresholds (`TerminalWebGLConfig` defaults, plus the per-resource-profile variants in `shared/types/resourceProfile.ts`) were still sized for the old 16 cap.
- Result: the terminal fleet force-flipped to the slower DOM renderer while the GPU still had plenty of context headroom, and the two guards could silently drift apart from each other.
- Fix: both guards now derive from one source of truth for the raised ceiling, so they can't drift again.

Resolves #11192.

## Changes

- Added `electron/utils/webglContextBudget.ts` as the single source of truth for the RAM-tiered ceiling (`getMaxWebGLContextCeiling`) and derives the per-profile flip thresholds from it (`resolveWebglThresholds`), using ratios that reproduce the old policy's shape against the raised cap: `efficiency < balanced < performance` ordering, with proportional headroom and hysteresis preserved.
- Added `electron/utils/resourceProfileConfig.ts` (`resolveResourceProfileConfig`) so the broadcast (push) and `getResourceProfile` (pull) IPC paths derive identical thresholds instead of computing them separately.
- `environment.ts`'s `max-active-webgl-contexts` switch now sources the same ceiling function.
- Removed the stale WebGL literals from `RESOURCE_PROFILE_CONFIGS` and typed the table as `BaseResourceProfileConfig` (an `Omit` type), so a stale threshold can no longer be read off the static table. This is a compile-time drift guard, not just a runtime one.
- Raised the `TerminalWebGLConfig` bootstrap defaults from 12/10 to 18/15 (balanced profile at the minimum ceiling of 24), so a large restored terminal fleet doesn't flip to DOM under the old stale upper bound of 12 and get stranded there before the resource profile pull resolves.
- Corrected the stale "must stay below 16" comments across `TerminalWebGLConfig`, the resource profile types, and `TerminalWebGLManager`. Comments only, no behavior change.
- Left untouched, per the issue: the per-terminal `onContextLoss` to DOM fallback, the eager `WEBGL_lose_context` disposal, and `TerminalWebGLManager`'s hardware-availability circuit breaker. The whole-fleet flip stays in place as a safety valve, not the primary mechanism.
- Flagged out of scope for a follow-up: `src/services/terminal/paintFabric/webglBudget.ts` (dormant, flag-gated Phase-2 scaffolding with zero live callers) and `docs/architecture/resource-governance.md` (docs) still carry the old constants.

## Testing

- New unit suites for `webglContextBudget` and `resourceProfileConfig` covering tier boundaries, ordering, headroom/hysteresis invariants, computed rounding anchors, degenerate-ceiling clamps, base-field preservation, and non-mutation.
- New `getResourceProfile` handler coverage asserting the pull path matches the push path.
- Rewrote the previously tautological threshold assertions into computed/invariant checks.
- 341 targeted tests pass locally across 8 files.
