### PR TITLE
fix(terminal): keep WebGL context on visible standard terminals

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -233,22 +233,18 @@ class TerminalInstanceService {
           // gap, and VISIBLE is an eligible tier for both. Release only happens
           // once a pane is off-screen (an ineligible tier while still visible,
           // e.g. a visible-BACKGROUND handoff, retains the live context until the
-          // hide path releases it). Tier demotion is an authoritative signal —
-          // cancel any pending hide-dwell and release. The webGLHideTimer guard
-          // keeps the dwell window intact for a hidden terminal still streaming at
-          // BURST: wantsWebGLAtTier returns false for off-screen panes (#10671),
-          // so without it the next write's tier-apply would release on frame 1
-          // instead of after WEBGL_HIDE_DWELL_MS — defeating the hide→show
-          // anti-churn dwell. Once the dwell timer fires (or never armed), the
-          // guard is undefined and the release proceeds.
+          // hide path releases it). No refresh on release: the pane is off-screen
+          // here, and repainting an offscreen DOM produces a stale frame that
+          // flashes on next show (#6802). Tier demotion is an authoritative
+          // signal — cancel any pending hide-dwell and release. The webGLHideTimer
+          // guard keeps the dwell window intact for a hidden terminal still
+          // streaming at BURST: wantsWebGLAtTier returns false for off-screen
+          // panes (#10671), so without it the next write's tier-apply would
+          // release on frame 1 instead of after WEBGL_HIDE_DWELL_MS — defeating
+          // the hide→show anti-churn dwell. Once the dwell timer fires (or never
+          // armed), the guard is undefined and the release proceeds.
           this.cancelWebGLHideTimer(managed);
-          const hadWebGL = this.webGLManager.isActive(id);
           this.webGLManager.releaseContext(id);
-          // Only refresh for a visible terminal — repainting an offscreen
-          // DOM produces a stale frame that flashes on next show (#6802).
-          if (hadWebGL && managed.isVisible && managed.terminal.rows > 0) {
-            managed.terminal.refresh(0, managed.terminal.rows - 1);
-          }
         }
 
         // Cursor blink is policy-driven: plain terminals run the blink timer

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -227,21 +227,17 @@ class TerminalInstanceService {
 
         if (this.webGLPolicy.wantsWebGLAtTier(managed, tier)) {
           this.webGLManager.ensureContext(id, managed);
-        } else if (
-          (managed.webGLHideTimer === undefined && !managed.isVisible) ||
-          !managed.runtimeAgentId
-        ) {
-          // Agent terminals keep WebGL while visible — releasing causes a
-          // one-frame renderer gap, and VISIBLE is an eligible tier for them
-          // anyway. Plain terminals release as soon as they stop being
-          // focused (even while visible): the DOM renderer is their
-          // status-quo at VISIBLE, and a lingering want per previously
-          // focused shell would accumulate toward the mode-switch threshold.
-          // Tier demotion is an authoritative signal — cancel any pending
-          // hide-dwell and release immediately. The webGLHideTimer guard keeps
-          // the dwell window intact for a hidden agent still streaming at BURST:
-          // wantsWebGLAtTier now returns false for off-screen panes (#10671), so
-          // without it the next write's tier-apply would release on frame 1
+        } else if (managed.webGLHideTimer === undefined && !managed.isVisible) {
+          // Standard and agent terminals are treated identically now (#11193):
+          // both keep WebGL while visible — releasing causes a one-frame renderer
+          // gap, and VISIBLE is an eligible tier for both. Release only happens
+          // once a pane is off-screen (an ineligible tier while still visible,
+          // e.g. a visible-BACKGROUND handoff, retains the live context until the
+          // hide path releases it). Tier demotion is an authoritative signal —
+          // cancel any pending hide-dwell and release. The webGLHideTimer guard
+          // keeps the dwell window intact for a hidden terminal still streaming at
+          // BURST: wantsWebGLAtTier returns false for off-screen panes (#10671),
+          // so without it the next write's tier-apply would release on frame 1
           // instead of after WEBGL_HIDE_DWELL_MS — defeating the hide→show
           // anti-churn dwell. Once the dwell timer fires (or never armed), the
           // guard is undefined and the release proceeds.
@@ -2440,9 +2436,9 @@ class TerminalInstanceService {
     this.applyCursorBlinkPolicy(managed);
     restoreScrollback(managed);
     // Agent demotion is authoritative — cancel any pending hide-dwell so the
-    // timer can't fire later and call releaseContext on a stale slot. A
-    // focused pane stays WebGL-eligible as a plain terminal, so keep (or
-    // acquire) its context instead of churning it through a release.
+    // timer can't fire later and call releaseContext on a stale slot. Any
+    // visible pane stays WebGL-eligible as a plain terminal now (#11193), so
+    // keep (or acquire) its context instead of churning it through a release.
     this.cancelWebGLHideTimer(managed);
     if (managed.isOpened && this.webGLPolicy.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);

--- a/src/services/terminal/TerminalWebGLPolicy.ts
+++ b/src/services/terminal/TerminalWebGLPolicy.ts
@@ -20,15 +20,15 @@ export class TerminalWebGLPolicy {
   constructor(private deps: TerminalWebGLPolicyDeps) {}
 
   /**
-   * Whether a terminal wants a WebGL context at the given tier. Agent
-   * terminals are eligible at every WebGL-eligible tier (FOCUSED/BURST/
-   * VISIBLE) — the DOM renderer mangles the block glyphs agent headers use
-   * (see isWebGLEligibleTier in types.ts). Plain terminals are eligible only
-   * while focused: FOCUSED, or a BURST on the focused pane (input bursts and
-   * streaming output must not drop the context mid-use). BURST alone is
-   * write-driven for every terminal, so granting it to unfocused plain shells
-   * would add a want per streaming build/log pane and trip the count-based
-   * mode switch; VISIBLE is excluded for the same budget reason.
+   * Whether a terminal wants a WebGL context at the given tier. Eligibility is
+   * identity-neutral: standard and agent terminals are treated identically and
+   * both want WebGL at every WebGL-eligible tier (FOCUSED/BURST/VISIBLE). The
+   * DOM renderer falls back to the configured font, mangling block/box-drawing/
+   * Powerline glyphs (see isWebGLEligibleTier in types.ts) — so a visible-but-
+   * unfocused plain pane must keep its context instead of visibly shifting to
+   * DOM on blur (#11193). Only two things veto a want: an ineligible tier
+   * (BACKGROUND/undefined) and off-screen visibility. Headroom for the wider
+   * want-set is tracked by the fleet-flip threshold retune in #11192.
    */
   wantsWebGLAtTier(
     managed: ManagedTerminal,
@@ -37,20 +37,18 @@ export class TerminalWebGLPolicy {
   ): boolean {
     if (!isWebGLEligibleTier(tier)) return false;
     // Visibility gates every case: an off-screen pane never wants WebGL, even
-    // an agent streaming at BURST. The want set is fleet-wide per project view,
-    // so hidden streaming agents would otherwise accumulate wants and trip the
-    // count-based mode switch, dropping the whole visible fleet to DOM
-    // (#10671). The reveal path (setVisible(true) → debounced shouldRestoreWebGL
-    // → ensureContext) re-acquires the want once the pane is on-screen again —
-    // and on a warm WebContentsView resume it passes trustDomVisibility because
-    // it has already proven the pane on-screen from DOM truth, so the stale
+    // an agent (or plain shell) streaming at BURST. The want set is fleet-wide
+    // per project view, so hidden streaming terminals would otherwise accumulate
+    // wants and trip the count-based mode switch, dropping the whole visible
+    // fleet to DOM (#10671). This gate must stay first, before the unconditional
+    // return, so identity-neutral eligibility never resurrects that bug. The
+    // reveal path (setVisible(true) → debounced shouldRestoreWebGL →
+    // ensureContext) re-acquires the want once the pane is on-screen again — and
+    // on a warm WebContentsView resume it passes trustDomVisibility because it
+    // has already proven the pane on-screen from DOM truth, so the stale
     // reactive isVisible flag must not veto the want there.
     if (!opts?.trustDomVisibility && !managed.isVisible) return false;
-    if (managed.runtimeAgentId) return true;
-    return (
-      tier === TerminalRefreshTier.FOCUSED ||
-      (tier === TerminalRefreshTier.BURST && managed.isFocused)
-    );
+    return true;
   }
 
   /**

--- a/src/services/terminal/TerminalWebGLPolicy.ts
+++ b/src/services/terminal/TerminalWebGLPolicy.ts
@@ -53,9 +53,9 @@ export class TerminalWebGLPolicy {
 
   /**
    * Eligibility for visibility-driven WebGL restore. Mirrors the gates in
-   * onTierApplied (agent identity / focus + tier) plus liveness checks
-   * (opened, not attaching). Used by the debounced timer in setVisible()
-   * before re-acquiring a context.
+   * onTierApplied (identity-neutral tier eligibility via wantsWebGLAtTier) plus
+   * liveness checks (opened, not attaching). Used by the debounced timer in
+   * setVisible() before re-acquiring a context.
    */
   shouldRestoreWebGL(managed: ManagedTerminal, opts?: { trustDomVisibility?: boolean }): boolean {
     if (!managed.isOpened) return false;

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -206,12 +206,14 @@ describe("WebGL lease through tier transitions", () => {
 
 describe("onTierApplied handler — WebGL manager integration", () => {
   let webGLManager: import("../TerminalWebGLManager").TerminalWebGLManager;
+  let webGLPolicy: import("../TerminalWebGLPolicy").TerminalWebGLPolicy;
   let managed: ManagedTerminal;
 
   function makeManagedTerminal(agentId?: string | null): ManagedTerminal {
-    // Agent identity lives on `runtimeAgentId`. WebGL reservation gates on it.
-    // Tests that want a plain (non-agent) terminal pass `null` (or omit — but
-    // `null` is more explicit and avoids the default-param trap when callers
+    // Agent identity lives on `runtimeAgentId`. Eligibility is identity-neutral
+    // now (#11193): standard and agent terminals both want WebGL at visible
+    // tiers. Tests that want a plain (non-agent) terminal pass `null` (or omit —
+    // but `null` is more explicit and avoids the default-param trap when callers
     // pass `undefined`).
     return {
       terminal: { loadAddon: vi.fn(), refresh: vi.fn(), rows: 24 },
@@ -228,28 +230,27 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     vi.resetModules();
 
     const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+    const { TerminalWebGLPolicy } = await import("../TerminalWebGLPolicy");
     webGLManager = new TerminalWebGLManager();
+    webGLPolicy = new TerminalWebGLPolicy({
+      getMode: () => webGLManager.getMode(),
+      getPinnedId: () => webGLManager.getPinnedId(),
+      isAltBufferPinned: (id) => webGLManager.isAltBufferPinned(id),
+    });
     managed = makeManagedTerminal();
     await preloadMockWebglAddon();
   });
 
+  // Drives the real TerminalWebGLPolicy for the acquire decision so this suite
+  // can't drift from production eligibility (it previously hand-rolled an
+  // agent-only rule that already contradicted production for standard FOCUSED
+  // terminals). The release branch is deliberately the simplified tier→WebGL
+  // model — the production webGLHideTimer dwell + isVisible-gated refresh are
+  // covered by webglVisibility.test.ts, which drives the real service.
   function simulateOnTierApplied(id: string, tier: TerminalRefreshTier, m: ManagedTerminal) {
-    if (!m.runtimeAgentId) return;
-
-    // Mirrors wantsWebGLAtTier: an off-screen pane never wants WebGL, even an
-    // agent at an eligible tier (#10671).
-    if (
-      m.isVisible &&
-      (tier === TerminalRefreshTier.FOCUSED ||
-        tier === TerminalRefreshTier.BURST ||
-        tier === TerminalRefreshTier.VISIBLE)
-    ) {
+    if (webGLPolicy.wantsWebGLAtTier(m, tier)) {
       webGLManager.ensureContext(id, m);
     } else if (!m.isVisible) {
-      // This model intentionally omits the production webGLHideTimer dwell
-      // guard (TerminalInstanceService.onTierApplied) — the lease suite covers
-      // pure tier→WebGL mapping; hide-dwell timing lives in
-      // webglVisibility.test.ts, which drives the real service.
       const hadWebGL = webGLManager.isActive(id);
       webGLManager.releaseContext(id);
       if (hadWebGL && m.terminal.rows > 0) {
@@ -329,21 +330,24 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     expect(webGLManager.isActive("t1")).toBe(true);
   });
 
-  it("standard terminal at FOCUSED never acquires WebGL context", () => {
+  it("standard terminal at FOCUSED acquires WebGL context (#11193)", () => {
     const stdManaged = makeManagedTerminal(null);
     simulateOnTierApplied("t-std", TerminalRefreshTier.FOCUSED, stdManaged);
-    expect(webGLManager.isActive("t-std")).toBe(false);
+    expect(webGLManager.isActive("t-std")).toBe(true);
   });
 
-  it("standard terminal at BURST/VISIBLE never acquires WebGL context", () => {
+  it("standard terminal at BURST/VISIBLE acquires WebGL context (#11193)", () => {
     const stdManaged = makeManagedTerminal(null);
     simulateOnTierApplied("t-std", TerminalRefreshTier.BURST, stdManaged);
-    expect(webGLManager.isActive("t-std")).toBe(false);
+    expect(webGLManager.isActive("t-std")).toBe(true);
     simulateOnTierApplied("t-std", TerminalRefreshTier.VISIBLE, stdManaged);
-    expect(webGLManager.isActive("t-std")).toBe(false);
+    expect(webGLManager.isActive("t-std")).toBe(true);
   });
 
-  it("rapid tier churn on standard terminal does not create pool entries", () => {
+  it("visible standard terminal retains its context across tier churn (#11193)", () => {
+    // FOCUSED→BURST→FOCUSED keep the context; a visible BACKGROUND retains it
+    // (ineligible tier while visible is a no-op, not a release); VISIBLE
+    // re-ensures. The pane stays visible throughout, so it never releases.
     const stdManaged = makeManagedTerminal(null);
     const tiers = [
       TerminalRefreshTier.FOCUSED,
@@ -355,10 +359,10 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     for (const tier of tiers) {
       simulateOnTierApplied("t-std", tier, stdManaged);
     }
-    expect(webGLManager.isActive("t-std")).toBe(false);
+    expect(webGLManager.isActive("t-std")).toBe(true);
   });
 
-  it("mixed pool: standard terminals don't consume agent WebGL slots", () => {
+  it("mixed pool: standard and agent terminals both acquire WebGL uniformly (#11193)", () => {
     const agents = Array.from({ length: 3 }, (_, i) => ({
       id: `agent-${i}`,
       m: makeManagedTerminal("claude"),
@@ -373,7 +377,7 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     for (const { id } of agents) {
       expect(webGLManager.isActive(id)).toBe(true);
     }
-    expect(webGLManager.isActive("t-std")).toBe(false);
+    expect(webGLManager.isActive("t-std")).toBe(true);
   });
 
   it("agent terminal refresh is called after WebGL release", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -251,11 +251,10 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     if (webGLPolicy.wantsWebGLAtTier(m, tier)) {
       webGLManager.ensureContext(id, m);
     } else if (!m.isVisible) {
-      const hadWebGL = webGLManager.isActive(id);
+      // Production guards the DOM-swap refresh on isVisible, so a hidden pane is
+      // released WITHOUT a repaint (#6802). Mirror that here — the branch only
+      // runs when hidden, so no refresh is invoked.
       webGLManager.releaseContext(id);
-      if (hadWebGL && m.terminal.rows > 0) {
-        m.terminal.refresh(0, m.terminal.rows - 1);
-      }
     }
   }
 
@@ -380,14 +379,21 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     expect(webGLManager.isActive("t-std")).toBe(true);
   });
 
-  it("agent terminal refresh is called after WebGL release", () => {
+  it("hidden release does not repaint the DOM (#6802)", () => {
+    // Release only happens once a pane is off-screen. Repainting an offscreen
+    // DOM produces a stale frame that flashes on next show, so production guards
+    // the refresh on isVisible — a hidden release never repaints.
     simulateOnTierApplied("t1", TerminalRefreshTier.FOCUSED, managed);
     expect(webGLManager.isActive("t1")).toBe(true);
+
+    // The DOM→WebGL attach on the FOCUSED ensure repaints once; clear that so
+    // the assertion isolates the release path itself.
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
 
     managed.isVisible = false;
     simulateOnTierApplied("t1", TerminalRefreshTier.BACKGROUND, managed);
     expect(webGLManager.isActive("t1")).toBe(false);
-    expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
   it("agent terminal refresh is NOT called when no WebGL was active", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -56,6 +56,7 @@ type WebGLVisibilityService = {
   destroy: (id: string) => void;
   applyRendererPolicy: (id: string, tier: TerminalRefreshTier) => void;
   applyAgentPromotion: (id: string, agentId: string) => void;
+  clearAgentPromotion: (id: string) => void;
   webGLManager: {
     isActive: (id: string) => boolean;
     ensureContext: (id: string, managed: unknown) => void;
@@ -410,6 +411,31 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
+  it("standard terminal tier demotion while visible keeps WebGL active (#11193)", () => {
+    // Identity parity: a visible standard pane demoted to an ineligible tier
+    // must not release its context — an ineligible tier while still on-screen is
+    // a no-op, not a release. Guards against a reintroduced !runtimeAgentId
+    // release exception, which the agent-only test above would not catch.
+    const managed = makeMockManaged({
+      isVisible: true,
+      isFocused: false,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+    vi.advanceTimersByTime(500);
+
+    expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BACKGROUND);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
+  });
+
   it("standard terminal blur (FOCUSED → VISIBLE) keeps WebGL, no DOM swap (#11193)", () => {
     // The core fix: a standard pane that loses focus but stays visible drops
     // from FOCUSED to VISIBLE. Pre-#11193 this released the context and forced a
@@ -433,8 +459,47 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     service.applyRendererPolicy("t1", TerminalRefreshTier.VISIBLE);
     vi.advanceTimersByTime(500);
 
+    // Prove the downgrade actually fired (otherwise active/no-refresh would pass
+    // vacuously if the hysteresis callback never ran).
+    expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.VISIBLE);
     expect(service.webGLManager.isActive("t1")).toBe(true);
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("a grid of visible standard terminals all hold WebGL; hiding one releases only it (#11193)", () => {
+    // Issue-shaped multi-pane check: a focused standard pane plus two visible-
+    // but-unfocused standard siblings all hold WebGL at once (no unfocused pane
+    // stranded on the DOM renderer). Hiding one sibling releases only it, after
+    // the dwell, while the visible panes keep their contexts.
+    const mk = (tier: TerminalRefreshTier, isFocused: boolean) =>
+      makeMockManaged({
+        isVisible: true,
+        isFocused,
+        runtimeAgentId: undefined,
+        launchAgentId: undefined,
+        lastAppliedTier: tier,
+        getRefreshTier: () => tier,
+      });
+    const focused = mk(TerminalRefreshTier.FOCUSED, true);
+    const sibA = mk(TerminalRefreshTier.VISIBLE, false);
+    const sibB = mk(TerminalRefreshTier.VISIBLE, false);
+    service.instances.set("focused", focused as unknown as Record<string, unknown>);
+    service.instances.set("sibA", sibA as unknown as Record<string, unknown>);
+    service.instances.set("sibB", sibB as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("focused", focused);
+    service.webGLManager.ensureContext("sibA", sibA);
+    service.webGLManager.ensureContext("sibB", sibB);
+
+    expect(service.webGLManager.isActive("focused")).toBe(true);
+    expect(service.webGLManager.isActive("sibA")).toBe(true);
+    expect(service.webGLManager.isActive("sibB")).toBe(true);
+
+    service.setVisible("sibA", false);
+    vi.advanceTimersByTime(500);
+
+    expect(service.webGLManager.isActive("sibA")).toBe(false);
+    expect(service.webGLManager.isActive("focused")).toBe(true);
+    expect(service.webGLManager.isActive("sibB")).toBe(true);
   });
 
   it("destroy cancels the pending WebGL hide-dwell timer", () => {
@@ -477,7 +542,7 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(managed.webGLHideTimer).toBeUndefined();
   });
 
-  it("agent demotion during debounce window does not cancel WebGL restore for a visible pane (#11193)", () => {
+  it("runtimeAgentId cleared during the restore debounce does not cancel WebGL restore for a visible pane (#11193)", () => {
     const managed = makeMockManaged({
       isVisible: false,
       lastAppliedTier: TerminalRefreshTier.VISIBLE,
@@ -488,16 +553,37 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     service.setVisible("t1", true);
     expect(service.webGLManager.isActive("t1")).toBe(false);
 
-    // Demotion happens inside the debounce window — runtimeAgentId clears.
-    // Eligibility is identity-neutral now: VISIBLE keeps both an agent and a
-    // plain terminal eligible, so demotion must NOT revoke the pending restore.
+    // The agent identity clears inside the restore debounce window (e.g. the
+    // agent exits mid-reveal). Eligibility is identity-neutral now: VISIBLE
+    // keeps both an agent and a plain terminal eligible, so the restore timer's
+    // shouldRestoreWebGL re-check must NOT revoke the pending restore.
     managed.runtimeAgentId = undefined;
 
     vi.advanceTimersByTime(100);
 
-    // shouldRestoreWebGL re-checks eligibility in the timer callback and a
-    // visible plain terminal at VISIBLE still wants WebGL, so the deferred
-    // restore fires.
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+  });
+
+  it("clearAgentPromotion keeps WebGL for a visible unfocused (VISIBLE) pane (#11193)", () => {
+    // The real demotion path: agent→plain on a visible-but-unfocused pane.
+    // Pre-#11193 a plain terminal was ineligible at VISIBLE, so demotion
+    // released the context; now it stays WebGL-eligible, so the method must
+    // keep (re-ensure) the context rather than churn it through a release.
+    const managed = makeMockManaged({
+      isVisible: true,
+      isFocused: false,
+      runtimeAgentId: "claude",
+      launchAgentId: "claude",
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    service.clearAgentPromotion("t1");
+
+    expect(managed.runtimeAgentId).toBeUndefined();
     expect(service.webGLManager.isActive("t1")).toBe(true);
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -280,9 +280,13 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 
-  it("standard (non-agent) unfocused terminal does not acquire WebGL on show", () => {
+  it("standard (non-agent) unfocused visible terminal acquires WebGL on show (#11193)", () => {
+    // Parity with agents: a visible-but-unfocused standard terminal at VISIBLE
+    // tier keeps a WebGL context so blur no longer visibly shifts it to the DOM
+    // renderer (mangled block/box-drawing glyphs).
     const managed = makeMockManaged({
       isVisible: false,
+      isFocused: false,
       runtimeAgentId: undefined,
       launchAgentId: undefined,
       lastAppliedTier: TerminalRefreshTier.VISIBLE,
@@ -293,7 +297,7 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     service.setVisible("t1", true);
     vi.advanceTimersByTime(100);
 
-    expect(service.webGLManager.isActive("t1")).toBe(false);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
   });
 
   it("standard (non-agent) focused terminal acquires WebGL on show", () => {
@@ -406,6 +410,33 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
+  it("standard terminal blur (FOCUSED → VISIBLE) keeps WebGL, no DOM swap (#11193)", () => {
+    // The core fix: a standard pane that loses focus but stays visible drops
+    // from FOCUSED to VISIBLE. Pre-#11193 this released the context and forced a
+    // full-buffer refresh onto the DOM renderer (the visible glyph shift). Now
+    // VISIBLE is eligible for standard terminals, so the context is retained and
+    // no refresh runs.
+    const managed = makeMockManaged({
+      isVisible: true,
+      isFocused: false,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    // FOCUSED → VISIBLE is a downgrade, applied through the tier hysteresis.
+    service.applyRendererPolicy("t1", TerminalRefreshTier.VISIBLE);
+    vi.advanceTimersByTime(500);
+
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
+  });
+
   it("destroy cancels the pending WebGL hide-dwell timer", () => {
     const managed = makeMockManaged();
     service.instances.set("t1", managed as unknown as Record<string, unknown>);
@@ -446,7 +477,7 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(managed.webGLHideTimer).toBeUndefined();
   });
 
-  it("agent demotion during debounce window cancels WebGL restore for an unfocused pane", () => {
+  it("agent demotion during debounce window does not cancel WebGL restore for a visible pane (#11193)", () => {
     const managed = makeMockManaged({
       isVisible: false,
       lastAppliedTier: TerminalRefreshTier.VISIBLE,
@@ -458,14 +489,16 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(service.webGLManager.isActive("t1")).toBe(false);
 
     // Demotion happens inside the debounce window — runtimeAgentId clears.
-    // VISIBLE keeps an agent eligible but not a plain terminal.
+    // Eligibility is identity-neutral now: VISIBLE keeps both an agent and a
+    // plain terminal eligible, so demotion must NOT revoke the pending restore.
     managed.runtimeAgentId = undefined;
 
     vi.advanceTimersByTime(100);
 
-    // shouldRestoreWebGL re-checks eligibility in the timer callback,
-    // so the deferred restore must not fire after demotion.
-    expect(service.webGLManager.isActive("t1")).toBe(false);
+    // shouldRestoreWebGL re-checks eligibility in the timer callback and a
+    // visible plain terminal at VISIBLE still wants WebGL, so the deferred
+    // restore fires.
+    expect(service.webGLManager.isActive("t1")).toBe(true);
   });
 
   // #10671: off-screen agent terminals must not register a fleet-wide WebGL
@@ -481,6 +514,25 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     // A PTY write while off-screen drives the pane to BURST. The tier still
     // applies (backpressure cadence), but the want must not be registered.
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+    expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+  });
+
+  // #10671 is now identity-neutral (#11193): the off-screen guard must reject a
+  // hidden standard terminal at BURST exactly as it does a hidden agent, so a
+  // streaming background build/log pane can't inflate the fleet-wide want set.
+  it("hidden standard terminal at BURST tier does not acquire WebGL (#10671, #11193)", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
     service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
 
     expect(service.webGLManager.isActive("t1")).toBe(false);

--- a/src/services/terminal/__tests__/TerminalWebGLPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLPolicy.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/panel";
+import type { ManagedTerminal } from "../types";
+import { TerminalWebGLPolicy, type TerminalWebGLPolicyDeps } from "../TerminalWebGLPolicy";
+
+// Direct coverage for the pure eligibility policy. This file changed three times
+// under production incidents (#10671 want-set accumulation, the DOM-mode pinned
+// context circuit breaker, bulk-attach staggering), so its decisions are worth
+// pinning in isolation rather than only through the service integration suites.
+
+function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
+  return {
+    id: "t1",
+    isOpened: true,
+    isVisible: true,
+    isFocused: false,
+    isAttaching: false,
+    runtimeAgentId: undefined,
+    launchAgentId: undefined,
+    lastAppliedTier: undefined,
+    getRefreshTier: undefined,
+    ...overrides,
+  } as unknown as ManagedTerminal;
+}
+
+function makePolicy(deps: Partial<TerminalWebGLPolicyDeps> = {}): TerminalWebGLPolicy {
+  return new TerminalWebGLPolicy({
+    getMode: () => "webgl",
+    getPinnedId: () => null,
+    isAltBufferPinned: () => false,
+    ...deps,
+  });
+}
+
+const ELIGIBLE_TIERS = [
+  TerminalRefreshTier.FOCUSED,
+  TerminalRefreshTier.BURST,
+  TerminalRefreshTier.VISIBLE,
+] as const;
+
+describe("TerminalWebGLPolicy.wantsWebGLAtTier", () => {
+  it("is identity-neutral: standard and agent terminals both want WebGL at every eligible tier (#11193)", () => {
+    const policy = makePolicy();
+    for (const tier of ELIGIBLE_TIERS) {
+      for (const runtimeAgentId of [undefined, "claude"]) {
+        for (const isFocused of [true, false]) {
+          const managed = makeManaged({ isVisible: true, runtimeAgentId, isFocused });
+          expect(policy.wantsWebGLAtTier(managed, tier)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("focus does not change the result — an unfocused visible standard terminal still wants WebGL", () => {
+    const policy = makePolicy();
+    const unfocusedStandard = makeManaged({
+      isVisible: true,
+      isFocused: false,
+      runtimeAgentId: undefined,
+    });
+    expect(policy.wantsWebGLAtTier(unfocusedStandard, TerminalRefreshTier.VISIBLE)).toBe(true);
+  });
+
+  it("ineligible tiers (BACKGROUND, undefined) never want WebGL, even visible + focused + agent", () => {
+    const policy = makePolicy();
+    const managed = makeManaged({ isVisible: true, isFocused: true, runtimeAgentId: "claude" });
+    expect(policy.wantsWebGLAtTier(managed, TerminalRefreshTier.BACKGROUND)).toBe(false);
+    expect(policy.wantsWebGLAtTier(managed, undefined)).toBe(false);
+  });
+
+  it("off-screen terminals never want WebGL at any eligible tier — agent or standard (#10671)", () => {
+    const policy = makePolicy();
+    for (const tier of ELIGIBLE_TIERS) {
+      for (const runtimeAgentId of [undefined, "claude"]) {
+        const hidden = makeManaged({ isVisible: false, runtimeAgentId });
+        expect(policy.wantsWebGLAtTier(hidden, tier)).toBe(false);
+      }
+    }
+  });
+
+  it("trustDomVisibility bypasses only the reactive visibility gate, not the tier gate", () => {
+    const policy = makePolicy();
+    const hidden = makeManaged({ isVisible: false, runtimeAgentId: undefined });
+
+    // Warm-resume reveal proved visibility from DOM truth: an eligible tier wants WebGL.
+    expect(
+      policy.wantsWebGLAtTier(hidden, TerminalRefreshTier.VISIBLE, { trustDomVisibility: true })
+    ).toBe(true);
+
+    // But an ineligible tier is still rejected — trustDomVisibility is not a blanket override.
+    expect(
+      policy.wantsWebGLAtTier(hidden, TerminalRefreshTier.BACKGROUND, { trustDomVisibility: true })
+    ).toBe(false);
+  });
+});
+
+describe("TerminalWebGLPolicy.shouldHaveActiveWebGL — DOM-mode pin safety net", () => {
+  // The watchdog must not treat a missing context as a fault for a non-pinned
+  // pane while the fleet is in DOM-mode fallback (only pinned contexts stay
+  // active). This safety net is identity-neutral and must survive #11193.
+  const baseManaged = () =>
+    makeManaged({
+      id: "t1",
+      isOpened: true,
+      isVisible: true,
+      isAttaching: false,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      runtimeAgentId: undefined,
+    });
+
+  it("returns false for a non-pinned visible terminal while in DOM mode", () => {
+    const policy = makePolicy({ getMode: () => "dom", getPinnedId: () => "other" });
+    expect(policy.shouldHaveActiveWebGL(baseManaged())).toBe(false);
+  });
+
+  it("returns true for the focus-pinned terminal while in DOM mode", () => {
+    const policy = makePolicy({ getMode: () => "dom", getPinnedId: () => "t1" });
+    expect(policy.shouldHaveActiveWebGL(baseManaged())).toBe(true);
+  });
+
+  it("returns true for a visible eligible terminal in WebGL mode", () => {
+    const policy = makePolicy({ getMode: () => "webgl" });
+    expect(policy.shouldHaveActiveWebGL(baseManaged())).toBe(true);
+  });
+});

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -308,9 +308,10 @@ export const GRID_RESIZE_COALESCE_MS = 120;
  * VISIBLE is included because xterm's pixel-perfect block / box-drawing /
  * Powerline glyph rendering only works under the WebGL or canvas renderer —
  * the DOM renderer always falls back to the configured font, which
- * mangles glyphs like U+2584 used in agent ASCII-art headers. Limiting WebGL
- * to FOCUSED|BURST visibly degraded rendering on every unfocused-but-visible
- * agent pane in tiled fleets.
+ * mangles glyphs like U+2584 (agent ASCII-art headers, TUI box-drawing).
+ * Limiting WebGL to FOCUSED|BURST visibly degraded rendering on every
+ * unfocused-but-visible pane in tiled fleets — for standard terminals as much
+ * as agents (#11193), which is why eligibility is identity-neutral.
  */
 export function isWebGLEligibleTier(tier: TerminalRefreshTier | undefined): boolean {
   return (


### PR DESCRIPTION
## Summary
- Makes WebGL eligibility identity-neutral: standard (non-agent) terminals now keep their WebGL context at any visible tier (`FOCUSED`, `BURST`, `VISIBLE`), not only while focused.
- Fixes a visible glyph-rendering shift that happened whenever a plain terminal pane lost focus and fell back to the DOM renderer.
- Collapses `wantsWebGLAtTier` in `TerminalWebGLPolicy.ts` so standard and agent terminals are treated the same, and removes a leftover `!runtimeAgentId` release exception in `TerminalInstanceService`'s tier-apply path.

Resolves #11193

## Changes
- `src/services/terminal/TerminalWebGLPolicy.ts`: single identity-neutral path through `wantsWebGLAtTier` for both standard and agent terminals.
- `src/services/terminal/TerminalInstanceService.ts`: drops the residual `!runtimeAgentId` release exception in the tier-apply path.
- `src/services/terminal/types.ts`: supporting type changes for the above.
- All existing safety nets stay in place: the off-screen want gate from #10671 (still first in the check order), the DOM-mode pinned-context circuit breaker, the rAF-staggered drain, and the per-terminal `onContextLoss` fallback.
- The fleet-flip threshold retune is intentionally out of scope here, tracked separately in #11192. Shipping this alone is a fair tradeoff: busier terminal grids may trip the coordinated DOM fallback somewhat sooner, which isn't a regression.

## Testing
- New direct unit test file for `TerminalWebGLPolicy`.
- Expanded visibility and lease test coverage, 187 targeted tests passing.
- New multi-pane grid retention test.
- New identity-neutral companion test for the original #10671 scenario.
