### PR TITLE
feat(pulse): populate the Project pulse strip on load and lead with active days

### DIFF
--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -409,8 +409,12 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     wasLoadingRef.current = isLoading;
   }, [isLoading, pulse, error]);
 
+  // Guard on `error === undefined` (never fetched), not `!error`: a settled
+  // null is the deliberate "no commits" outcome, and treating it as falsy would
+  // let this effect refetch in a tight loop. A string error self-retries in the
+  // store; an in-flight request is deduped there too.
   useEffect(() => {
-    if (!pulse && !isLoading && !error) {
+    if (!pulse && !isLoading && error === undefined) {
       fetchPulse(worktreeId);
     }
   }, [worktreeId, pulse, isLoading, error, fetchPulse]);

--- a/src/components/Pulse/ProjectPulseStrip.tsx
+++ b/src/components/Pulse/ProjectPulseStrip.tsx
@@ -46,11 +46,12 @@ function MiniRibbon({ cells }: { cells: HeatCell[] }) {
  * "click to quickly peek", never a permanent dashboard. Expansion is ephemeral
  * (resets to collapsed each mount) by design, so the launcher stays the focus.
  *
- * The collapsed strip renders whatever pulse is already cached but never
- * triggers a fetch itself — the git-log scan only runs when the user expands,
- * so simply landing on an empty grid costs nothing. Expanding kicks a fetch
- * (deduped/TTL-gated in the store) so the peek is fresh and the card opens on a
- * skeleton rather than a blank first frame.
+ * The strip populates itself on load: a cold cache kicks one pulse fetch on
+ * mount so the ribbon/stat/flame peek is there from the first frame instead of
+ * hiding behind a first expand. That fetch is a bounded git-log scan — deduped
+ * in the store while in flight and cheap on repeat (the service caches under a
+ * 60s TTL behind a HEAD probe). Expanding kicks another (deduped) fetch to
+ * refresh the peek and open the card on a skeleton rather than a blank frame.
  */
 export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
   const [expanded, setExpanded] = useState(false);
@@ -58,6 +59,8 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
   // so a plain selector is churn-free — no useShallow needed. fetchPulse is a
   // stable store action.
   const pulse = usePulseStore((state) => state.getPulse(worktreeId));
+  const isLoading = usePulseStore((state) => state.isLoading(worktreeId));
+  const error = usePulseStore((state) => state.getError(worktreeId));
   const fetchPulse = usePulseStore((state) => state.fetchPulse);
 
   const stripButtonRef = useRef<HTMLButtonElement>(null);
@@ -65,6 +68,16 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
   // Only move focus on a user-driven toggle — never grab focus on first mount
   // (the empty grid must not steal focus just by rendering).
   const toggledRef = useRef(false);
+
+  // Populate the collapsed strip on load. A fresh empty grid has no cached
+  // pulse, so kick one fetch on mount — skipped when a pulse is already cached
+  // or a request/error is already in flight (mirrors ProjectPulseCard). The
+  // store dedupes, so a later expand collapses onto the same request.
+  useEffect(() => {
+    if (!pulse && !isLoading && !error) {
+      void fetchPulse(worktreeId);
+    }
+  }, [worktreeId, pulse, isLoading, error, fetchPulse]);
 
   useEffect(() => {
     if (!toggledRef.current) return;
@@ -83,7 +96,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
   const expand = () => {
     toggledRef.current = true;
     // Kick a fetch before mounting the card so it opens on a skeleton (loading
-    // is set synchronously) and the peek reflects the latest commits.
+    // is set synchronously) and the peek reflects the latest activity.
     void fetchPulse(worktreeId);
     setExpanded(true);
   };
@@ -111,11 +124,12 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
   }
 
   const hasStreak = (pulse?.currentStreakDays ?? 0) > 1;
-  // Expose the peeked stats to assistive tech — the visible commit/streak text
-  // lives in aria-hidden decorative spans, so fold it into the button's name.
+  // The button's explicit aria-label overrides its descendant text for the
+  // accessible name, so fold the visible active-days/streak peek into it —
+  // otherwise assistive tech hears only "Show project activity".
   const activityLabel = pulse
-    ? `Show project activity — ${pulse.commitsInRange} commit${
-        pulse.commitsInRange !== 1 ? "s" : ""
+    ? `Show project activity — ${pulse.activeDays} active day${
+        pulse.activeDays !== 1 ? "s" : ""
       }${hasStreak ? `, ${pulse.currentStreakDays} day streak` : ""}`
     : "Show project activity";
 
@@ -135,7 +149,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
         {pulse ? (
           <>
             <span className="font-mono text-xs text-daintree-text/50">
-              {pulse.commitsInRange} commit{pulse.commitsInRange !== 1 ? "s" : ""}
+              {pulse.activeDays} active day{pulse.activeDays !== 1 ? "s" : ""}
             </span>
             {hasStreak && (
               <span className="flex items-center gap-1 font-mono text-xs text-daintree-text/70">

--- a/src/components/Pulse/ProjectPulseStrip.tsx
+++ b/src/components/Pulse/ProjectPulseStrip.tsx
@@ -70,11 +70,15 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
   const toggledRef = useRef(false);
 
   // Populate the collapsed strip on load. A fresh empty grid has no cached
-  // pulse, so kick one fetch on mount — skipped when a pulse is already cached
-  // or a request/error is already in flight (mirrors ProjectPulseCard). The
-  // store dedupes, so a later expand collapses onto the same request.
+  // pulse, so kick one fetch on mount — but only when nothing has been
+  // attempted yet. getError is a tri-state: undefined = never fetched, a
+  // string = a real error (the store self-retries with backoff), and null =
+  // the deliberate "no commits" outcome. Guard on `error === undefined`, not
+  // `!error`: a settled null would otherwise keep passing the guard and, since
+  // this effect is the fetch trigger, spin a tight refetch loop. The store also
+  // dedupes in-flight requests, so a later expand collapses onto this one.
   useEffect(() => {
-    if (!pulse && !isLoading && !error) {
+    if (!pulse && !isLoading && error === undefined) {
       void fetchPulse(worktreeId);
     }
   }, [worktreeId, pulse, isLoading, error, fetchPulse]);

--- a/src/components/Pulse/__tests__/ProjectPulseStrip.test.tsx
+++ b/src/components/Pulse/__tests__/ProjectPulseStrip.test.tsx
@@ -5,11 +5,13 @@ import { render, screen, fireEvent } from "@testing-library/react";
 // Control the cached pulse the strip reads and capture fetch calls. The
 // component reads via usePulseStore((s) => s.getPulse(id)),
 // s.isLoading(id), s.getError(id), and s.fetchPulse; the mock applies each
-// selector to our controllable state.
+// selector to our controllable state. getError is tri-state like the real
+// store: undefined = never fetched (cold), null = settled "no commits", a
+// string = a real error.
 const state = {
   getPulse: (_id: string) => undefined as unknown,
   isLoading: (_id: string) => false,
-  getError: (_id: string) => null as unknown,
+  getError: (_id: string) => undefined as unknown,
   fetchPulse: vi.fn(),
 };
 vi.mock("@/store", () => ({
@@ -50,7 +52,7 @@ function makePulse(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   state.getPulse = () => undefined;
   state.isLoading = () => false;
-  state.getError = () => null;
+  state.getError = () => undefined;
   state.fetchPulse.mockClear();
 });
 
@@ -82,8 +84,18 @@ describe("ProjectPulseStrip", () => {
     expect(state.fetchPulse).not.toHaveBeenCalled();
   });
 
-  it("does not fetch on mount when the last fetch errored", () => {
+  it("does not fetch on mount when the last fetch errored (store handles retry)", () => {
     state.getError = () => "Unable to load activity data";
+    render(<ProjectPulseStrip worktreeId="wt1" />);
+    expect(state.fetchPulse).not.toHaveBeenCalled();
+  });
+
+  it("does not refetch on mount once a fetch settled with no error (no-commits repo)", () => {
+    // A settled null error (distinct from the cold undefined) means a fetch
+    // already ran and classified the repo as commit-less. The mount guard keys
+    // on `error === undefined`, so null counts as "already attempted" — treating
+    // it as falsy would spin a tight refetch loop against git/IPC.
+    state.getError = () => null;
     render(<ProjectPulseStrip worktreeId="wt1" />);
     expect(state.fetchPulse).not.toHaveBeenCalled();
   });
@@ -110,6 +122,15 @@ describe("ProjectPulseStrip", () => {
     render(<ProjectPulseStrip worktreeId="wt1" />);
     expect(
       screen.getByRole("button", { name: /show project activity — 5 active days, 2 day streak/i })
+    ).toBeTruthy();
+  });
+
+  it("uses a singular 'active day' in the accessible name and omits a 1-day streak", () => {
+    state.getPulse = () => makePulse({ activeDays: 1, currentStreakDays: 1 });
+    render(<ProjectPulseStrip worktreeId="wt1" />);
+    // Anchored so "1 active days" (plural bug) or a spurious streak suffix fails.
+    expect(
+      screen.getByRole("button", { name: /^show project activity — 1 active day$/i })
     ).toBeTruthy();
   });
 

--- a/src/components/Pulse/__tests__/ProjectPulseStrip.test.tsx
+++ b/src/components/Pulse/__tests__/ProjectPulseStrip.test.tsx
@@ -2,12 +2,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-// Control the cached pulse the strip reads and capture fetch-on-expand. The
-// component reads via usePulseStore((s) => s.getPulse(id)) and
-// usePulseStore((s) => s.fetchPulse); the mock applies each selector to our
-// controllable state.
+// Control the cached pulse the strip reads and capture fetch calls. The
+// component reads via usePulseStore((s) => s.getPulse(id)),
+// s.isLoading(id), s.getError(id), and s.fetchPulse; the mock applies each
+// selector to our controllable state.
 const state = {
   getPulse: (_id: string) => undefined as unknown,
+  isLoading: (_id: string) => false,
+  getError: (_id: string) => null as unknown,
   fetchPulse: vi.fn(),
 };
 vi.mock("@/store", () => ({
@@ -35,7 +37,11 @@ function cell(date: string, level: number, extra: Record<string, unknown> = {}) 
 function makePulse(overrides: Record<string, unknown> = {}) {
   return {
     heatmap: [cell("2026-06-01", 3), cell("2026-06-02", 0, { isToday: true })],
+    // Deliberately distinct from activeDays so a stat assertion can't pass by
+    // accidentally reading the old commit-count headline.
     commitsInRange: 13,
+    activeDays: 5,
+    projectAgeDays: 60,
     currentStreakDays: 2,
     ...overrides,
   };
@@ -43,36 +49,67 @@ function makePulse(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   state.getPulse = () => undefined;
+  state.isLoading = () => false;
+  state.getError = () => null;
   state.fetchPulse.mockClear();
 });
 
 describe("ProjectPulseStrip", () => {
-  it("renders collapsed by default with no full card mounted and no fetch", () => {
+  it("populates on mount by fetching when nothing is cached, staying collapsed", () => {
     render(<ProjectPulseStrip worktreeId="wt1" />);
     expect(screen.getByRole("button", { name: /show project activity/i })).toBeTruthy();
+    // Populate-on-load: the cold strip kicks a fetch on mount so the peek fills
+    // without needing a first expand — but stays collapsed until clicked.
+    expect(state.fetchPulse).toHaveBeenCalledWith("wt1");
     expect(screen.queryByTestId("pulse-card")).toBeNull();
-    expect(state.fetchPulse).not.toHaveBeenCalled();
   });
 
-  it("shows a 'View activity' hint (no git scan) when nothing is cached", () => {
+  it("shows a 'View activity' fallback while the mount fetch is still resolving", () => {
     render(<ProjectPulseStrip worktreeId="wt1" />);
     expect(screen.getByText(/view activity/i)).toBeTruthy();
     expect(screen.queryByTestId("pulse-mini-ribbon")).toBeNull();
   });
 
-  it("peeks cached stats — commit count, streak, and a mini ribbon", () => {
+  it("does not fetch on mount when a pulse is already cached", () => {
     state.getPulse = () => makePulse();
     render(<ProjectPulseStrip worktreeId="wt1" />);
-    expect(screen.getByText(/13 commits/i)).toBeTruthy();
+    expect(state.fetchPulse).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch on mount while a request is already in flight", () => {
+    state.isLoading = () => true;
+    render(<ProjectPulseStrip worktreeId="wt1" />);
+    expect(state.fetchPulse).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch on mount when the last fetch errored", () => {
+    state.getError = () => "Unable to load activity data";
+    render(<ProjectPulseStrip worktreeId="wt1" />);
+    expect(state.fetchPulse).not.toHaveBeenCalled();
+  });
+
+  it("peeks cached stats — active days (not a raw commit count), streak, and a mini ribbon", () => {
+    state.getPulse = () => makePulse();
+    render(<ProjectPulseStrip worktreeId="wt1" />);
+    expect(screen.getByText(/5 active days/i)).toBeTruthy();
+    // The busyness-flavored commit count is no longer the headline (#11194).
+    expect(screen.queryByText(/13 commits/i)).toBeNull();
     expect(screen.getByTestId("streak-flame")).toBeTruthy();
     expect(screen.getByTestId("pulse-mini-ribbon")).toBeTruthy();
   });
 
+  it("renders a singular 'active day' for a one-day-active pulse", () => {
+    state.getPulse = () => makePulse({ activeDays: 1, currentStreakDays: 1 });
+    render(<ProjectPulseStrip worktreeId="wt1" />);
+    expect(screen.getByText(/1 active day\b/i)).toBeTruthy();
+    expect(screen.queryByText(/active days/i)).toBeNull();
+  });
+
   it("folds the peeked stats into the button's accessible name for screen readers", () => {
-    state.getPulse = () => makePulse({ commitsInRange: 13, currentStreakDays: 2 });
+    state.getPulse = () => makePulse({ activeDays: 5, currentStreakDays: 2 });
     render(<ProjectPulseStrip worktreeId="wt1" />);
     expect(
-      screen.getByRole("button", { name: /show project activity — 13 commits, 2 day streak/i })
+      screen.getByRole("button", { name: /show project activity — 5 active days, 2 day streak/i })
     ).toBeTruthy();
   });
 
@@ -84,11 +121,15 @@ describe("ProjectPulseStrip", () => {
 
   it("expands to the full card on click, fetches fresh data, and collapses again", () => {
     render(<ProjectPulseStrip worktreeId="wt1" />);
+    // The cold-cache mount fetch already fired; clear it so we assert only the
+    // click-triggered fetch (a bare vi.fn() doesn't model the store's dedupe).
+    state.fetchPulse.mockClear();
     fireEvent.click(screen.getByRole("button", { name: /show project activity/i }));
     expect(screen.getByTestId("pulse-card")).toBeTruthy();
     // Expanding kicks a (deduped) fetch so the peek is fresh + the card opens on
     // a skeleton rather than a blank frame.
     expect(state.fetchPulse).toHaveBeenCalledWith("wt1");
+    expect(state.fetchPulse).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: /collapse/i }));
     expect(screen.queryByTestId("pulse-card")).toBeNull();


### PR DESCRIPTION
## Summary
- The collapsed Project pulse strip on the empty grid showed only "View activity" until the user expanded it once. It was rendering cached pulse data but never triggering a fetch itself, only the expand action called `fetchPulse`.
- This PR makes the collapsed strip fetch pulse data on mount when nothing is cached yet, guarded on the pulse being empty, not loading, and `error` being `undefined` (mirroring `ProjectPulseCard`). The mini heatmap ribbon, headline stat, and streak flame now show up on first render instead of hiding behind a first expand.
- It also reframes the headline stat from a raw commit count to an active-days count, in line with the outcomes reframing from #11172 and #11182.

Closes #11194

## Changes
- `ProjectPulseStrip.tsx`: fetch pulse on mount when nothing is cached, guarded the same way `ProjectPulseCard` already is. The strip is a single, always-mounted instance on the empty grid for the active worktree, and the store dedupes in-flight requests, so this adds one bounded git log scan on landing, not polling.
- Swapped the headline stat from a raw `{n} commits` count to an `{n} active day(s)` count, a field already on the pulse data, matching the active-days chip already shown on the expanded card. Left the streak flame untouched. Deliberately kept `useProjectHealth()` and merged-changes data out of the strip: it's always mounted with hooks running unconditionally, so pulling a polling health hook in there would run continuously on the empty grid, working against the strip being cheap to show.
- Fixed a latent bug in the mount-fetch guard, in both the strip and `ProjectPulseCard`: it checked `!error`, but the store's `error` field is tri-state (`undefined` for never-fetched, `null` for a settled no-commits outcome, a string for a real error). Checking falsy treated a settled `null` as not-yet-fetched and would refetch in a loop against git and IPC. It now checks `error === undefined` specifically.
- Updated the button's accessible name and the component doc comment to match, and expanded the unit tests: populate-on-load, cold/cached/loading/error states, the settled-null guard case, an isolated expand-click fetch, and singular/plural wording.

## Testing
- 63 unit tests passing across `ProjectPulseStrip.test.tsx` and `pulseContrast.test.ts`.
- Own changed files are prettier-formatted and lint-clean. The strip uses a void-prefixed `fetchPulse` call; the 4 pre-existing `no-floating-promises` warnings in `ProjectPulseCard` are baseline and untouched.
- `core-pulse.spec.ts` (release-only E2E) is unchanged and still valid, it exercises the click-to-expand flow which this change leaves intact.