### PR TITLE
feat: render HTML files in the file panel via a sandboxed iframe

### DIFF
--- a/e2e/full/panels/core-file-panel.spec.ts
+++ b/e2e/full/panels/core-file-panel.spec.ts
@@ -316,6 +316,13 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
         "    t.setAttribute('data-has-electron', String(typeof window.electron !== 'undefined'));",
         "    try { void window.parent.document; t.setAttribute('data-parent', 'reachable'); }",
         "    catch (e) { t.setAttribute('data-parent', 'blocked'); }",
+        // connect-src 'none' must hold: a fetch to the legacy daintree-file://
+        // arbitrary-read route must be blocked by the token-scoped preview CSP.
+        // If the trusted app CSP had leaked onto this frame, this would resolve.
+        "    t.setAttribute('data-fetch', 'pending');",
+        "    fetch('daintree-file://load?path=/etc/passwd&root=/')",
+        "      .then(function () { t.setAttribute('data-fetch', 'allowed'); })",
+        "      .catch(function () { t.setAttribute('data-fetch', 'blocked'); });",
         "  </script>",
         "</body>",
         "</html>",
@@ -347,5 +354,9 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
     // Isolation: no app bridge, and the opaque-origin frame can't reach the parent.
     await expect(title).toHaveAttribute("data-has-electron", "false");
     await expect(title).toHaveAttribute("data-parent", "blocked");
+    // The token-scoped preview CSP (connect-src 'none') is authoritative — the
+    // trusted app CSP is NOT overlaid onto the frame, so the legacy daintree-file
+    // arbitrary-read route is unreachable.
+    await expect(title).toHaveAttribute("data-fetch", "blocked", { timeout: T_MEDIUM });
   });
 });

--- a/e2e/full/panels/core-file-panel.spec.ts
+++ b/e2e/full/panels/core-file-panel.spec.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { writeFileSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
 import { test, expect, type Page } from "@playwright/test";
 import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
@@ -287,5 +287,65 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
         { timeout: T_MEDIUM }
       )
       .toEqual({ columnFillsPane: true, backgroundsMatch: true });
+  });
+
+  // #11191: rendered HTML runs the page's own scripts, resolves its relative
+  // assets via daintree-html://, and stays isolated from the app. This is the
+  // only automated proof of the runtime security contract (unit tests can't
+  // exercise Chromium's iframe origin/CSP). Located last, by content not count.
+  test("rendered HTML runs its scripts + relative assets while staying sandboxed", async () => {
+    const assetsDir = path.join(fixtureDir, "html-report", "assets");
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(path.join(assetsDir, "report.css"), "#title { color: rgb(12, 34, 56); }\n");
+    writeFileSync(
+      path.join(assetsDir, "report.js"),
+      "document.getElementById('title').setAttribute('data-external-ran', 'yes');\n"
+    );
+    writeFileSync(
+      path.join(fixtureDir, "html-report", "index.html"),
+      [
+        "<!doctype html>",
+        "<html>",
+        '<head><link rel="stylesheet" href="assets/report.css" /></head>',
+        "<body>",
+        '  <h1 id="title">Report</h1>',
+        '  <script src="assets/report.js"></script>',
+        "  <script>",
+        "    var t = document.getElementById('title');",
+        "    t.setAttribute('data-inline-ran', 'yes');",
+        "    t.setAttribute('data-has-electron', String(typeof window.electron !== 'undefined'));",
+        "    try { void window.parent.document; t.setAttribute('data-parent', 'reachable'); }",
+        "    catch (e) { t.setAttribute('data-parent', 'blocked'); }",
+        "  </script>",
+        "</body>",
+        "</html>",
+      ].join("\n")
+    );
+
+    await dispatchAction(ctx.window, "file.openPanel", {
+      path: path.join(fixtureDir, "html-report", "index.html").replace(/\\/g, "/"),
+      viewMode: "rendered",
+    });
+
+    const frameEl = ctx.window.locator('[data-testid="html-preview-frame"]');
+    await expect(frameEl).toBeVisible({ timeout: T_LONG });
+    // Exactly allow-scripts — never allow-same-origin (that would let the page
+    // escape its opaque origin back into the daintree-html:// partition).
+    await expect(frameEl).toHaveAttribute("sandbox", "allow-scripts");
+
+    const frame = ctx.window.frameLocator('[data-testid="html-preview-frame"]');
+    const title = frame.locator("#title");
+
+    // The page's own inline + relative external scripts execute.
+    await expect(title).toHaveAttribute("data-inline-ran", "yes", { timeout: T_LONG });
+    await expect(title).toHaveAttribute("data-external-ran", "yes", { timeout: T_MEDIUM });
+    // Relative stylesheet resolved via daintree-html:// and applied.
+    await expect
+      .poll(() => title.evaluate((el) => getComputedStyle(el).color), { timeout: T_MEDIUM })
+      .toBe("rgb(12, 34, 56)");
+
+    // Isolation: no app bridge, and the opaque-origin frame can't reach the parent.
+    await expect(title).toHaveAttribute("data-has-electron", "false");
+    await expect(title).toHaveAttribute("data-parent", "blocked");
   });
 });

--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -63,6 +63,7 @@ vi.mock("../../../services/FileSearchService.js", () => ({
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerFilesHandlers, isLfsPointer } from "../files.js";
+import { _resetHtmlPreviewTokensForTests } from "../../../setup/htmlPreviewTokens.js";
 import type { FileReadResult } from "../../../../shared/types/ipc/files.js";
 
 const LFS_HEADER = "version https://git-lfs.github.com/spec/v1\n";
@@ -445,5 +446,74 @@ describe("files:read handler", () => {
       expect(fsMock.realpath).not.toHaveBeenCalled();
       expect(fsMock.open).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("files:read HTML preview mint (#11191)", () => {
+  const root = path.resolve("/tmp/report");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMock.realpath.mockImplementation(async (p: string) => p);
+    fsMock.stat.mockResolvedValue({ size: 11 });
+    _resetHtmlPreviewTokensForTests();
+  });
+
+  async function read(payload: { path: string; rootPath: string; htmlPreview?: boolean }) {
+    fsMock.open.mockResolvedValue(makeFileHandle(Buffer.from("<h1>hi</h1>")));
+    registerFilesHandlers();
+    return getReadHandler()({}, payload);
+  }
+
+  it("mints a daintree-html:// preview URL for an .html file when htmlPreview is true", async () => {
+    const result = await read({
+      path: path.join(root, "index.html"),
+      rootPath: root,
+      htmlPreview: true,
+    });
+    expect(result.content).toBe("<h1>hi</h1>");
+    // Opaque UUID authority + the file's relative path; token is unguessable.
+    expect(result.htmlPreviewUrl).toMatch(/^daintree-html:\/\/[0-9a-f-]{36}\/index\.html$/);
+  });
+
+  it("mints for a .htm file", async () => {
+    const result = await read({
+      path: path.join(root, "page.htm"),
+      rootPath: root,
+      htmlPreview: true,
+    });
+    expect(result.htmlPreviewUrl).toMatch(/\/page\.htm$/);
+  });
+
+  it("mints for an uppercase .HTML file (case-insensitive)", async () => {
+    const result = await read({
+      path: path.join(root, "REPORT.HTML"),
+      rootPath: root,
+      htmlPreview: true,
+    });
+    expect(result.htmlPreviewUrl).toMatch(/^daintree-html:\/\/[0-9a-f-]{36}\/REPORT\.HTML$/);
+  });
+
+  it("does not mint for a non-HTML file even when htmlPreview is true", async () => {
+    const result = await read({
+      path: path.join(root, "data.txt"),
+      rootPath: root,
+      htmlPreview: true,
+    });
+    expect(result.htmlPreviewUrl).toBeUndefined();
+  });
+
+  it("does not mint when htmlPreview is omitted (opt-in)", async () => {
+    const result = await read({ path: path.join(root, "index.html"), rootPath: root });
+    expect(result.htmlPreviewUrl).toBeUndefined();
+  });
+
+  it("does not mint when htmlPreview is false", async () => {
+    const result = await read({
+      path: path.join(root, "index.html"),
+      rootPath: root,
+      htmlPreview: false,
+    });
+    expect(result.htmlPreviewUrl).toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import { CHANNELS } from "../channels.js";
 import { checkRateLimit, typedHandleValidated } from "../utils.js";
 import { fileSearchService } from "../../services/FileSearchService.js";
+import { buildHtmlPreviewUrl } from "../../setup/htmlPreviewTokens.js";
 import {
   FileSearchPayloadSchema,
   FileReadPayloadSchema,
@@ -49,6 +50,7 @@ export function registerFilesHandlers(): () => void {
   const handleRead = async ({
     path: filePath,
     rootPath,
+    htmlPreview,
   }: FileReadPayload): Promise<FileReadResult> => {
     if (!path.isAbsolute(filePath) || !path.isAbsolute(rootPath)) {
       throw new AppError({
@@ -196,7 +198,16 @@ export function registerFilesHandlers(): () => void {
       });
     }
 
-    return { content: buffer.toString("utf-8") };
+    // #11191: on opt-in, mint a sandboxed-iframe preview URL for HTML files. The
+    // token maps to the canonical root; the daintree-html:// handler re-applies
+    // full containment, so this never widens access. realRoot/realFile are
+    // already realpath-resolved and contained above.
+    const htmlPreviewUrl =
+      htmlPreview && /\.html?$/i.test(realFile)
+        ? (buildHtmlPreviewUrl(realRoot, realFile) ?? undefined)
+        : undefined;
+
+    return { content: buffer.toString("utf-8"), htmlPreviewUrl };
   };
 
   handlers.push(typedHandleValidated(CHANNELS.FILES_READ, FileReadPayloadSchema, handleRead));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -24,6 +24,7 @@ import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/sec
 import {
   registerAppProtocol,
   registerDaintreeFileProtocol,
+  registerDaintreeHtmlProtocol,
   registerDeepLinkProtocolClient,
   registerPluginProtocol,
   setupWebviewCSP,
@@ -127,6 +128,20 @@ protocol.registerSchemesAsPrivileged([
     privileges: {
       secure: true,
       supportFetchAPI: true,
+    },
+  },
+  {
+    // Sandboxed HTML file preview (#11191). standard:true gives the scheme
+    // hierarchical URLs + a real origin so the browser natively resolves a
+    // rendered page's relative/root-relative assets against the document URL
+    // (`daintree-html://<token>/<relpath>`). Deliberately kept off the
+    // battle-tested daintree-file:// scheme so its consumers (markdown images,
+    // WebAudio fetch, file viewer) are untouched. No supportFetchAPI/corsEnabled:
+    // preview docs run under `connect-src 'none'` and load assets via tags only.
+    scheme: "daintree-html",
+    privileges: {
+      standard: true,
+      secure: true,
     },
   },
   {
@@ -568,6 +583,7 @@ if (!gotTheLock) {
       registerDeepLinkProtocolClient();
       registerAppProtocol(distPath, { allowDisplayCapture: isDemoMode });
       registerDaintreeFileProtocol();
+      registerDaintreeHtmlProtocol();
       // Register `plugin://` with a placeholder resolver that 404s every
       // request, keeping the heavy ~2900-line PluginService module off the
       // first-paint critical path (#10322). The handler must exist before

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -489,6 +489,8 @@ export const FileReadPayloadSchema = z.object({
     .max(4096)
     // eslint-disable-next-line no-control-regex
     .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+  // Opt-in: mint a sandboxed-iframe preview URL for HTML files (#11191).
+  htmlPreview: z.boolean().optional(),
 });
 
 export const DiffMediaReadFileVersionsPayloadSchema = z.object({

--- a/electron/setup/__tests__/htmlPreviewTokens.test.ts
+++ b/electron/setup/__tests__/htmlPreviewTokens.test.ts
@@ -69,4 +69,9 @@ describe("buildHtmlPreviewUrl", () => {
     expect(buildHtmlPreviewUrl(ROOT, path.resolve("/project/other/x.html"))).toBeNull();
     expect(buildHtmlPreviewUrl(ROOT, path.resolve("/etc/passwd"))).toBeNull();
   });
+
+  it("returns null for a filesystem-root root (no whole-volume capability)", () => {
+    const fsRoot = path.parse(process.cwd()).root;
+    expect(buildHtmlPreviewUrl(fsRoot, path.join(fsRoot, "index.html"))).toBeNull();
+  });
 });

--- a/electron/setup/__tests__/htmlPreviewTokens.test.ts
+++ b/electron/setup/__tests__/htmlPreviewTokens.test.ts
@@ -5,7 +5,7 @@ import {
   mintHtmlPreviewToken,
   resolveHtmlPreviewRoot,
   _resetHtmlPreviewTokensForTests,
-} from "../htmlPreviewTokens";
+} from "../htmlPreviewTokens.js";
 
 afterEach(() => {
   _resetHtmlPreviewTokensForTests();

--- a/electron/setup/__tests__/htmlPreviewTokens.test.ts
+++ b/electron/setup/__tests__/htmlPreviewTokens.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+import path from "path";
+import {
+  buildHtmlPreviewUrl,
+  mintHtmlPreviewToken,
+  resolveHtmlPreviewRoot,
+  _resetHtmlPreviewTokensForTests,
+} from "../htmlPreviewTokens";
+
+afterEach(() => {
+  _resetHtmlPreviewTokensForTests();
+});
+
+const ROOT = path.resolve("/project/report");
+
+describe("mintHtmlPreviewToken", () => {
+  it("mints a stable token per root and reuses it", () => {
+    const a = mintHtmlPreviewToken(ROOT);
+    const b = mintHtmlPreviewToken(ROOT);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("mints distinct tokens for distinct roots", () => {
+    const a = mintHtmlPreviewToken(path.resolve("/project/one"));
+    const b = mintHtmlPreviewToken(path.resolve("/project/two"));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("resolveHtmlPreviewRoot", () => {
+  it("resolves a minted token back to its root", () => {
+    const token = mintHtmlPreviewToken(ROOT);
+    expect(resolveHtmlPreviewRoot(token)).toBe(ROOT);
+  });
+
+  it("returns undefined for an unknown token", () => {
+    expect(resolveHtmlPreviewRoot("not-a-real-token")).toBeUndefined();
+  });
+});
+
+describe("buildHtmlPreviewUrl", () => {
+  it("builds a daintree-html:// URL whose authority resolves back to the root", () => {
+    const url = buildHtmlPreviewUrl(ROOT, path.join(ROOT, "index.html"));
+    expect(url).not.toBeNull();
+    const authority = new URL(url!).hostname;
+    expect(resolveHtmlPreviewRoot(authority)).toBe(ROOT);
+    expect(new URL(url!).pathname).toBe("/index.html");
+  });
+
+  it("percent-encodes nested path segments", () => {
+    const url = buildHtmlPreviewUrl(ROOT, path.join(ROOT, "sub dir", "a b.html"));
+    expect(url).not.toBeNull();
+    // Spaces survive as %20 in each segment; the handler decodes segment-by-segment.
+    expect(url).toContain("/sub%20dir/a%20b.html");
+  });
+
+  it("reuses the same authority for sibling files under one root", () => {
+    const one = buildHtmlPreviewUrl(ROOT, path.join(ROOT, "a.html"));
+    const two = buildHtmlPreviewUrl(ROOT, path.join(ROOT, "b.html"));
+    expect(new URL(one!).hostname).toBe(new URL(two!).hostname);
+  });
+
+  it("returns null when the file is the root itself", () => {
+    expect(buildHtmlPreviewUrl(ROOT, ROOT)).toBeNull();
+  });
+
+  it("returns null when the file escapes the root", () => {
+    expect(buildHtmlPreviewUrl(ROOT, path.resolve("/project/other/x.html"))).toBeNull();
+    expect(buildHtmlPreviewUrl(ROOT, path.resolve("/etc/passwd"))).toBeNull();
+  });
+});

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1155,6 +1155,48 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
     }
   });
 
+  it("passes daintree-html:// preview responses through without overwriting their CSP (#11191)", async () => {
+    const { session } = await import("electron");
+    const { mergeCspHeaders } = await import("../../utils/webviewCsp.js");
+    const fromPartition = vi.mocked(session.fromPartition);
+    vi.mocked(mergeCspHeaders).mockClear();
+
+    let captured:
+      | ((details: unknown, callback: (r: { responseHeaders?: unknown }) => void) => void)
+      | undefined;
+    fromPartition.mockImplementation((partition: string) => {
+      const onHeadersReceived = vi.fn(
+        (
+          _filter: unknown,
+          listener: (details: unknown, callback: (r: { responseHeaders?: unknown }) => void) => void
+        ) => {
+          if (partition === "persist:daintree") captured = listener;
+        }
+      );
+      return { webRequest: { onHeadersReceived } } as unknown as Electron.Session;
+    });
+
+    setupWebviewCSP();
+    expect(captured).toBeDefined();
+
+    // A daintree-html preview iframe already carries its own token-scoped CSP;
+    // the app overlay must NOT replace it (that would break the sandboxed page's
+    // scripts and re-expose connect-src daintree-file:).
+    const previewHeaders = {
+      "Content-Security-Policy": ["sandbox allow-scripts; default-src 'none'"],
+    };
+    let previewResult: { responseHeaders?: unknown } | undefined;
+    captured!({ url: "daintree-html://tok/index.html", responseHeaders: previewHeaders }, (r) => {
+      previewResult = r;
+    });
+    expect(previewResult?.responseHeaders).toBe(previewHeaders);
+    expect(vi.mocked(mergeCspHeaders)).not.toHaveBeenCalled();
+
+    // A normal app response still gets the app CSP overlay applied.
+    captured!({ url: "app://daintree/index.html", responseHeaders: {} }, () => {});
+    expect(vi.mocked(mergeCspHeaders)).toHaveBeenCalledTimes(1);
+  });
+
   it("attaches an onHeadersReceived listener for persist:daintree only (browser is excluded)", async () => {
     const { session } = await import("electron");
     const fromPartition = vi.mocked(session.fromPartition);
@@ -2518,12 +2560,30 @@ describe("createDaintreeHtmlProtocolHandler — sandboxed HTML preview (#11191)"
     expect(csp).toContain("sandbox allow-scripts");
     expect(csp).toContain("connect-src 'none'");
     expect(csp).toContain("default-src 'none'");
+    // WebRTC isn't governed by connect-src, so it's blocked explicitly.
+    expect(csp).toContain("webrtc 'block'");
+    // Egress-limiting response headers.
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(response.headers.get("X-DNS-Prefetch-Control")).toBe("off");
     // Opens the user-derived path with O_NOFOLLOW (TOCTOU defense).
     const fs = await import("fs/promises");
     expect(fs.open).toHaveBeenCalledWith(
       path.resolve(ROOT, "index.html"),
       fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
     );
+  });
+
+  it("404s when the token's root no longer canonically resolves to itself (retarget guard)", async () => {
+    const fs = await import("fs/promises");
+    // The root path was renamed away and now resolves elsewhere (symlink swap).
+    vi.mocked(fs.realpath).mockImplementation((p) =>
+      Promise.resolve(p === ROOT ? (path.resolve("/") as string) : (p as string))
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "index.html"));
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("treats .htm the same as .html", async () => {

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -143,6 +143,7 @@ import {
   setPluginDirResolver,
   setupWebviewCSP,
 } from "../protocols.js";
+import { mintHtmlPreviewToken, _resetHtmlPreviewTokensForTests } from "../htmlPreviewTokens.js";
 import { getWebviewDialogService } from "../../services/WebviewDialogService.js";
 
 const mockedGetWebviewDialogService = vi.mocked(getWebviewDialogService);
@@ -1376,9 +1377,10 @@ describe("protocol registration", () => {
     // plugin:// is skipped here — registerPluginProtocol hasn't been called yet
     // in this test. Production order is the opposite: registerPluginProtocol runs
     // in app.whenReady() before any per-project session is created.
-    expect(handle).toHaveBeenCalledTimes(2);
+    expect(handle).toHaveBeenCalledTimes(3);
     expect(handle).toHaveBeenCalledWith("app", expect.any(Function));
     expect(handle).toHaveBeenCalledWith("daintree-file", expect.any(Function));
+    expect(handle).toHaveBeenCalledWith("daintree-html", expect.any(Function));
   });
 
   it("also registers plugin:// on per-project sessions after the resolver is cached", async () => {
@@ -2458,5 +2460,146 @@ describe("createAppProtocolHandler — direct disk read", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("ok");
     expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createDaintreeHtmlProtocolHandler — sandboxed HTML preview (#11191)", () => {
+  type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
+
+  const ROOT = path.resolve("/project/report");
+  let token: string;
+
+  async function captureHandler(): Promise<ProtocolHandler> {
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+    const call = handle.mock.calls.find((c) => c[0] === "daintree-html");
+    if (!call) throw new Error("handler for daintree-html not registered");
+    return call[1] as ProtocolHandler;
+  }
+
+  function makeRequest(authority: string, relPath: string): GlobalRequest {
+    return new Request(`daintree-html://${authority}/${relPath}`) as GlobalRequest;
+  }
+
+  function makeFileHandle(content: string | Buffer = "<h1>hi</h1>") {
+    const buffer = typeof content === "string" ? Buffer.from(content) : content;
+    return {
+      readFile: vi.fn().mockResolvedValue(buffer),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    _resetHtmlPreviewTokensForTests();
+    token = mintHtmlPreviewToken(ROOT);
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 11 } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("text/css");
+  });
+
+  it("serves an HTML document with a token-scoped preview CSP", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "index.html"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    const csp = response.headers.get("Content-Security-Policy") ?? "";
+    // Scoped to the EXACT token authority — never scheme-wide — so the framed
+    // report can't tag-load through the legacy daintree-file:// route.
+    expect(csp).toContain(`script-src daintree-html://${token} 'unsafe-inline' 'unsafe-eval'`);
+    expect(csp).not.toMatch(/script-src daintree-html:(?!\/\/)/);
+    expect(csp).toContain("sandbox allow-scripts");
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("default-src 'none'");
+    // Opens the user-derived path with O_NOFOLLOW (TOCTOU defense).
+    const fs = await import("fs/promises");
+    expect(fs.open).toHaveBeenCalledWith(
+      path.resolve(ROOT, "index.html"),
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+    );
+  });
+
+  it("treats .htm the same as .html", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "page.htm"));
+    expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("Content-Security-Policy")).toContain("sandbox allow-scripts");
+  });
+
+  it("serves a non-HTML sibling asset with the strict leaf CSP, not the preview CSP", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "assets/app.css"));
+
+    expect(response.status).toBe(200);
+    // Sub-resource: strict leaf headers (browser ignores CSP on sub-resources).
+    expect(response.headers.get("Content-Security-Policy")).toBe("sandbox; default-src 'none'");
+    expect(response.headers.get("Content-Type")).toBe("text/css");
+    const fs = await import("fs/promises");
+    expect(fs.open).toHaveBeenCalledWith(
+      path.resolve(ROOT, "assets/app.css"),
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+    );
+  });
+
+  it("resolves root-relative asset paths within the mapped root", async () => {
+    const handler = await captureHandler();
+    await handler(makeRequest(token, "assets/logo.svg"));
+    const fs = await import("fs/promises");
+    expect(fs.open).toHaveBeenCalledWith(path.resolve(ROOT, "assets/logo.svg"), expect.any(Number));
+  });
+
+  it("404s an unknown or released token without touching the filesystem", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("00000000-dead-beef-0000-000000000000", "index.html")
+    );
+
+    expect(response.status).toBe(404);
+    const fs = await import("fs/promises");
+    expect(fs.open).not.toHaveBeenCalled();
+    expect(fs.realpath).not.toHaveBeenCalled();
+  });
+
+  it("404s a bare token URL with no file path", async () => {
+    const handler = await captureHandler();
+    const response = await handler(new Request(`daintree-html://${token}/`) as GlobalRequest);
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects a symlink that escapes the root (realpath containment)", async () => {
+    const fs = await import("fs/promises");
+    // The requested file realpath-resolves outside the mapped root.
+    vi.mocked(fs.realpath).mockImplementation((p) =>
+      Promise.resolve(p === ROOT ? ROOT : (path.resolve("/etc/passwd") as string))
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "link.html"));
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("rejects an encoded backslash segment", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "sub%5Cfile.html"));
+    expect(response.status).toBe(404);
+  });
+
+  it("enforces the 512 KB size cap with 413", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockResolvedValue({ size: 512 * 1024 + 1 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "big.html"));
+    expect(response.status).toBe(413);
   });
 });

--- a/electron/setup/htmlPreviewTokens.ts
+++ b/electron/setup/htmlPreviewTokens.ts
@@ -49,6 +49,10 @@ export function resolveHtmlPreviewRoot(token: string): string | undefined {
  * absolute paths.
  */
 export function buildHtmlPreviewUrl(canonicalRoot: string, canonicalFile: string): string | null {
+  // Never mint a whole-volume capability: the file panel's parent-directory
+  // fallback can pick a filesystem/drive root for a top-level file, which would
+  // make the entire disk readable inside the preview. Refuse it.
+  if (path.dirname(canonicalRoot) === canonicalRoot) return null;
   const rel = path.relative(canonicalRoot, canonicalFile);
   if (rel === "" || rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
     return null;

--- a/electron/setup/htmlPreviewTokens.ts
+++ b/electron/setup/htmlPreviewTokens.ts
@@ -1,0 +1,68 @@
+// eager-import-allow: pure in-memory capability registry, no side effects on import
+import { randomUUID } from "node:crypto";
+import path from "path";
+
+/**
+ * Capability registry backing the `daintree-html://` sandboxed HTML preview
+ * scheme (issue #11191).
+ *
+ * The renderer never encodes a filesystem root into a preview URL directly.
+ * Doing so would be exploitable: sandboxed HTML controls the URLs it requests
+ * (relative and root-relative refs), so any root it can *name* it can escape to
+ * — e.g. `<img src="/<encoded '/'>/etc/passwd">`. Instead Main mints an opaque,
+ * unguessable token per containment root and puts it in the URL *authority*
+ * (`daintree-html://<token>/<relpath>`). Root-relative (`/x`) and parent (`../x`)
+ * refs resolve against that authority, staying inside the mapped root, and the
+ * sandboxed document cannot forge a token for a root the app never registered.
+ *
+ * Tokens are memoized per canonical root and never released: the set of roots is
+ * bounded (project + worktrees + the file's parent-directory fallback), the map
+ * stays tiny, and a token only ever grants the containment the file panel already
+ * has via `files:read`. The `daintree-html://` protocol handler re-applies full
+ * realpath + `O_NOFOLLOW` containment on every request, so a stale token can
+ * never widen access.
+ */
+
+const rootToToken = new Map<string, string>();
+const tokenToRoot = new Map<string, string>();
+
+/** Mint (or reuse) the opaque preview token for a canonical containment root. */
+export function mintHtmlPreviewToken(canonicalRoot: string): string {
+  const existing = rootToToken.get(canonicalRoot);
+  if (existing) return existing;
+  const token = randomUUID();
+  rootToToken.set(canonicalRoot, token);
+  tokenToRoot.set(token, canonicalRoot);
+  return token;
+}
+
+/** Resolve a preview URL authority (token) back to its canonical root, or undefined. */
+export function resolveHtmlPreviewRoot(token: string): string | undefined {
+  return tokenToRoot.get(token);
+}
+
+/**
+ * Build a `daintree-html://<token>/<encoded-relpath>` URL for a file inside a
+ * root, or null when the file is the root itself or escapes it. Each path
+ * segment is percent-encoded so spaces, `#`, `?`, etc. survive; the handler
+ * decodes segment-by-segment. Both inputs must already be canonical (realpath'd)
+ * absolute paths.
+ */
+export function buildHtmlPreviewUrl(canonicalRoot: string, canonicalFile: string): string | null {
+  const rel = path.relative(canonicalRoot, canonicalFile);
+  if (rel === "" || rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
+    return null;
+  }
+  const token = mintHtmlPreviewToken(canonicalRoot);
+  const encoded = rel
+    .split(path.sep)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `daintree-html://${token}/${encoded}`;
+}
+
+/** Test-only: drop all minted tokens so cases don't leak state into each other. */
+export function _resetHtmlPreviewTokensForTests(): void {
+  rootToToken.clear();
+  tokenToRoot.clear();
+}

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -240,10 +240,11 @@ async function readContainedDaintreeFile(
   }
 
   // Open the user-supplied normalized path (not realFile) with O_NOFOLLOW
-  // so a final-component symlink injected after the realpath check is
-  // rejected with ELOOP. Closes the TOCTOU gap between realpath and the
-  // actual read. On Windows O_NOFOLLOW is 0 (no-op); realpath containment
-  // still applies. Mirrors the files:read IPC handler.
+  // so a *final-component* symlink injected after the realpath check is
+  // rejected with ELOOP — narrowing (not fully closing) the realpath→open
+  // TOCTOU window; an intermediate-directory swap is still theoretically
+  // possible and is an accepted limitation shared with files:read. On Windows
+  // O_NOFOLLOW is 0 (no-op); realpath containment still applies.
   let fileHandle: Awaited<ReturnType<typeof fs.open>>;
   try {
     fileHandle = await fs.open(normalizedFile, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
@@ -327,6 +328,11 @@ function createDaintreeFileProtocolHandler() {
   };
 }
 
+/** True for any `daintree-html://…` request URL (the sandboxed preview scheme). */
+function isDaintreeHtmlPreviewUrl(url: string | undefined): boolean {
+  return typeof url === "string" && url.startsWith("daintree-html://");
+}
+
 /**
  * CSP for a `daintree-html://<token>` sandboxed preview *document* (.html/.htm).
  * Scoped to the exact token authority — NOT the whole `daintree-html:` scheme —
@@ -354,6 +360,9 @@ function buildDaintreeHtmlDocHeaders(token: string, contentLength: number): Reco
     `font-src ${self} data:`,
     `media-src ${self} data: blob:`,
     "connect-src 'none'",
+    // WebRTC is not covered by connect-src, so block it explicitly — otherwise a
+    // rendered report could exfiltrate via an attacker-controlled STUN/TURN host.
+    "webrtc 'block'",
     "worker-src 'none'",
     "frame-src 'none'",
     "object-src 'none'",
@@ -366,6 +375,10 @@ function buildDaintreeHtmlDocHeaders(token: string, contentLength: number): Reco
     "Content-Security-Policy": csp,
     "Cross-Origin-Resource-Policy": "cross-origin",
     "X-Content-Type-Options": "nosniff",
+    // Belt-and-suspenders egress limits: no referrer leakage on any request the
+    // page makes, and no speculative DNS lookups of hostnames in the markup.
+    "Referrer-Policy": "no-referrer",
+    "X-DNS-Prefetch-Control": "off",
     "Cache-Control": "no-store",
   };
 }
@@ -402,6 +415,25 @@ function createDaintreeHtmlProtocolHandler() {
     const root = token ? resolveHtmlPreviewRoot(token) : undefined;
     if (!root) {
       // Unknown or released token — never fall back to a raw filesystem read.
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+
+    // Root-identity binding: the token maps to a canonical (realpath'd) root
+    // captured at mint time. If that path no longer canonically resolves to
+    // itself — e.g. the directory was renamed away and replaced with a symlink
+    // to "/" — the token would otherwise retarget to a different subtree. Reject
+    // it so a stale capability can't be deterministically repointed.
+    try {
+      if ((await fs.realpath(root)) !== root) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
+      }
+    } catch {
       return new Response("Not Found", {
         status: 404,
         headers: buildDaintreeFileErrorHeaders(),
@@ -856,6 +888,10 @@ export function applyDaintreeAppCspToSession(ses: Electron.Session): void {
   ses.webRequest.onHeadersReceived(
     { urls: ["<all_urls>"], types: ["mainFrame", "subFrame", "script"] },
     (details, callback) => {
+      if (isDaintreeHtmlPreviewUrl(details.url)) {
+        callback({ responseHeaders: details.responseHeaders });
+        return;
+      }
       callback({
         responseHeaders: mergeCspHeaders(details, cspPolicy),
       });
@@ -898,6 +934,16 @@ export function setupWebviewCSP(): void {
     ses.webRequest.onHeadersReceived(
       { urls: ["<all_urls>"], types: ["mainFrame", "subFrame", "script"] },
       (details, callback) => {
+        // A daintree-html:// preview iframe carries its own token-scoped CSP
+        // (buildDaintreeHtmlDocHeaders). protocol.handle responses DO flow
+        // through onHeadersReceived (Electron 42 / Chromium 148), so without
+        // this bypass mergeCspHeaders would replace that policy with the trusted
+        // app CSP — breaking the sandboxed page's scripts AND re-exposing
+        // connect-src daintree-file:. Pass it through untouched.
+        if (isDaintreeHtmlPreviewUrl(details.url)) {
+          callback({ responseHeaders: details.responseHeaders });
+          return;
+        }
         callback({
           responseHeaders: mergeCspHeaders(details, cspPolicy),
         });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -195,10 +195,10 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
  * original daintree-file:// handler; the flow (realpath → path.relative → stat →
  * O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
  */
-async function readContainedDaintreeFile(
-  normalizedRoot: string,
-  normalizedFile: string
-): Promise<{ buffer: Buffer; realFile: string } | Response> {
+// Return type is inferred, not annotated: annotating `buffer: Buffer` widens it
+// to `Buffer<ArrayBufferLike>`, which `new Response(...)` rejects as a BodyInit.
+// Inference preserves the exact `readFile()` result type the Response accepts.
+async function readContainedDaintreeFile(normalizedRoot: string, normalizedFile: string) {
   // Resolve symlinks before containment to block in-root symlinks pointing outside root (CVE-2025-53109 / CVE-2025-54794 class).
   let realRoot: string;
   let realFile: string;

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -24,6 +24,7 @@ import {
   mergeCspHeaders,
   isDevPreviewPartition,
 } from "../utils/webviewCsp.js";
+import { resolveHtmlPreviewRoot } from "./htmlPreviewTokens.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import {
   isLocalhostUrl,
@@ -187,6 +188,86 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
 }
 
 /**
+ * Shared read core for daintree-file:// and daintree-html://: realpath
+ * containment, 512 KB cap, and O_RDONLY|O_NOFOLLOW open. Returns the file bytes
+ * plus the canonical path (for MIME), or an error Response. Callers own the
+ * success headers so each scheme sets its own CSP. Extracted verbatim from the
+ * original daintree-file:// handler; the flow (realpath → path.relative → stat →
+ * O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
+ */
+async function readContainedDaintreeFile(
+  normalizedRoot: string,
+  normalizedFile: string
+): Promise<{ buffer: Buffer; realFile: string } | Response> {
+  // Resolve symlinks before containment to block in-root symlinks pointing outside root (CVE-2025-53109 / CVE-2025-54794 class).
+  let realRoot: string;
+  let realFile: string;
+  try {
+    realRoot = await fs.realpath(normalizedRoot);
+    realFile = await fs.realpath(normalizedFile);
+  } catch {
+    return new Response("Not Found", {
+      status: 404,
+      headers: buildDaintreeFileErrorHeaders(),
+    });
+  }
+
+  const rel = path.relative(realRoot, realFile);
+  // Match exact ".." and "../*" — bare startsWith("..") would reject legitimate files like "..hidden/x". isAbsolute catches Windows cross-drive escapes.
+  if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: buildDaintreeFileErrorHeaders(),
+    });
+  }
+
+  // Stat the realpath-resolved path for an accurate size before any read.
+  let fileStat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    fileStat = await fs.stat(realFile);
+  } catch {
+    return new Response("Not Found", {
+      status: 404,
+      headers: buildDaintreeFileErrorHeaders(),
+    });
+  }
+
+  if (fileStat.size > DAINTREE_FILE_MAX_BYTES) {
+    return new Response("Payload Too Large", {
+      status: 413,
+      headers: buildDaintreeFileErrorHeaders(),
+    });
+  }
+
+  // Open the user-supplied normalized path (not realFile) with O_NOFOLLOW
+  // so a final-component symlink injected after the realpath check is
+  // rejected with ELOOP. Closes the TOCTOU gap between realpath and the
+  // actual read. On Windows O_NOFOLLOW is 0 (no-op); realpath containment
+  // still applies. Mirrors the files:read IPC handler.
+  let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    fileHandle = await fs.open(normalizedFile, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  } catch (err) {
+    const errCode = (err as NodeJS.ErrnoException).code;
+    if (errCode === "ELOOP" || errCode === "ENOENT") {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    throw err;
+  }
+
+  try {
+    const buffer = await fileHandle.readFile();
+    return { buffer, realFile };
+  } finally {
+    // Swallow close errors so they don't mask a preceding readFile failure.
+    await fileHandle.close().catch(() => {});
+  }
+}
+
+/**
  * Create the daintree-file:// protocol handler function.
  */
 function createDaintreeFileProtocolHandler() {
@@ -224,84 +305,166 @@ function createDaintreeFileProtocolHandler() {
         });
       }
 
-      const normalizedFile = path.normalize(filePath);
-      const normalizedRoot = path.normalize(rootPath);
+      const result = await readContainedDaintreeFile(
+        path.normalize(rootPath),
+        path.normalize(filePath)
+      );
+      if (result instanceof Response) return result;
 
-      // Resolve symlinks before containment to block in-root symlinks pointing outside root (CVE-2025-53109 / CVE-2025-54794 class).
-      let realRoot: string;
-      let realFile: string;
-      try {
-        realRoot = await fs.realpath(normalizedRoot);
-        realFile = await fs.realpath(normalizedFile);
-      } catch {
-        return new Response("Not Found", {
-          status: 404,
-          headers: buildDaintreeFileErrorHeaders(),
-        });
-      }
-
-      const rel = path.relative(realRoot, realFile);
-      // Match exact ".." and "../*" — bare startsWith("..") would reject legitimate files like "..hidden/x". isAbsolute catches Windows cross-drive escapes.
-      if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
-        return new Response("Not Found", {
-          status: 404,
-          headers: buildDaintreeFileErrorHeaders(),
-        });
-      }
-
-      // Stat the realpath-resolved path for an accurate size before any read.
-      let fileStat: Awaited<ReturnType<typeof fs.stat>>;
-      try {
-        fileStat = await fs.stat(realFile);
-      } catch {
-        return new Response("Not Found", {
-          status: 404,
-          headers: buildDaintreeFileErrorHeaders(),
-        });
-      }
-
-      if (fileStat.size > DAINTREE_FILE_MAX_BYTES) {
-        return new Response("Payload Too Large", {
-          status: 413,
-          headers: buildDaintreeFileErrorHeaders(),
-        });
-      }
-
-      // Open the user-supplied normalized path (not realFile) with O_NOFOLLOW
-      // so a final-component symlink injected after the realpath check is
-      // rejected with ELOOP. Closes the TOCTOU gap between realpath and the
-      // actual read. On Windows O_NOFOLLOW is 0 (no-op); realpath containment
-      // still applies. Mirrors the files:read IPC handler.
-      let fileHandle: Awaited<ReturnType<typeof fs.open>>;
-      try {
-        fileHandle = await fs.open(normalizedFile, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
-      } catch (err) {
-        const errCode = (err as NodeJS.ErrnoException).code;
-        if (errCode === "ELOOP" || errCode === "ENOENT") {
-          return new Response("Not Found", {
-            status: 404,
-            headers: buildDaintreeFileErrorHeaders(),
-          });
-        }
-        throw err;
-      }
-
-      try {
-        const buffer = await fileHandle.readFile();
-        const mimeType = getMimeType(realFile);
-        // Content-Length reflects the bytes actually returned. If the file
-        // grew between stat() and readFile(), buffer.length is the truth;
-        // fileStat.size would be stale.
-        return new Response(buffer, {
-          status: 200,
-          headers: buildDaintreeFileHeaders(mimeType, buffer.length),
-        });
-      } finally {
-        // Swallow close errors so they don't mask a preceding readFile failure.
-        await fileHandle.close().catch(() => {});
-      }
+      // Content-Length reflects the bytes actually returned. If the file
+      // grew between stat() and readFile(), buffer.length is the truth.
+      return new Response(result.buffer, {
+        status: 200,
+        headers: buildDaintreeFileHeaders(getMimeType(result.realFile), result.buffer.length),
+      });
     } catch (err) {
       console.error("[MAIN] daintree-file protocol error:", err);
+      return new Response("Internal Server Error", {
+        status: 500,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+  };
+}
+
+/**
+ * CSP for a `daintree-html://<token>` sandboxed preview *document* (.html/.htm).
+ * Scoped to the exact token authority — NOT the whole `daintree-html:` scheme —
+ * so a rendered report cannot tag-load through a different token's root. Only
+ * navigable-document responses carry an enforced CSP (the browser ignores CSP
+ * on sub-resource responses), so sibling css/js/img assets keep the strict leaf
+ * headers.
+ *
+ * The iframe element also sets sandbox="allow-scripts" (opaque origin, no
+ * allow-same-origin); the `sandbox allow-scripts` directive here is
+ * defense-in-depth if that attribute is ever dropped. `connect-src 'none'`
+ * blocks fetch/XHR/WebSocket back to the scheme; the document can still execute
+ * its own scripts and tag-load its own assets. 'unsafe-inline'/'unsafe-eval'
+ * are harmless inside a fully isolated, network-less opaque origin and let
+ * real-world report/chart pages run.
+ */
+function buildDaintreeHtmlDocHeaders(token: string, contentLength: number): Record<string, string> {
+  const self = `daintree-html://${token}`;
+  const csp = [
+    "sandbox allow-scripts",
+    "default-src 'none'",
+    `script-src ${self} 'unsafe-inline' 'unsafe-eval'`,
+    `style-src ${self} 'unsafe-inline'`,
+    `img-src ${self} data: blob:`,
+    `font-src ${self} data:`,
+    `media-src ${self} data: blob:`,
+    "connect-src 'none'",
+    "worker-src 'none'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+  ].join("; ");
+  return {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Length": String(contentLength),
+    "Content-Security-Policy": csp,
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control": "no-store",
+  };
+}
+
+/**
+ * Create the daintree-html:// protocol handler — sandboxed HTML file preview
+ * (issue #11191). URL shape: `daintree-html://<token>/<relative/path>`, where
+ * <token> is an opaque capability minted by htmlPreviewTokens for exactly one
+ * canonical root. Unknown/stale tokens 404 — a request never falls through to a
+ * filesystem read without a registered root. Security mirrors daintree-file://:
+ * segment `..` rejection, realpath containment, and O_RDONLY|O_NOFOLLOW on the
+ * final open (via the shared read core).
+ */
+function createDaintreeHtmlProtocolHandler() {
+  return async (request: GlobalRequest) => {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+
+    let url: URL;
+    try {
+      url = new URL(request.url);
+    } catch {
+      return new Response("Bad Request", {
+        status: 400,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+
+    const token = url.hostname;
+    const root = token ? resolveHtmlPreviewRoot(token) : undefined;
+    if (!root) {
+      // Unknown or released token — never fall back to a raw filesystem read.
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+
+    // Decode the pathname segment-by-segment; ignore query/fragment so a
+    // cache-busting `?v=N` on the iframe src still maps to the same file.
+    const pathname = url.pathname;
+    if (pathname === "/" || pathname === "") {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(pathname.startsWith("/") ? pathname.slice(1) : pathname);
+    } catch {
+      return new Response("Bad Request", {
+        status: 400,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    if (decodedPath.includes("\0")) {
+      return new Response("Bad Request", {
+        status: 400,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    if (decodedPath.includes("\\")) {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    // Collapse `..` against a leading slash, then reject any residual `..`
+    // segment. Defense-in-depth; realpath/path.relative containment in the
+    // shared read core is the real traversal guard. #4702: segment match, not
+    // substring includes('..').
+    const normalizedPosix = path.posix.normalize("/" + decodedPath).slice(1);
+    if (normalizedPosix === "" || normalizedPosix.split("/").some((seg) => seg === "..")) {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+
+    try {
+      const candidatePath = path.resolve(root, normalizedPosix);
+      const result = await readContainedDaintreeFile(path.normalize(root), candidatePath);
+      if (result instanceof Response) return result;
+
+      // Only navigable HTML documents get the loosened, token-scoped CSP;
+      // sibling assets keep the strict leaf headers (sub-resource CSP is
+      // unenforced by the browser anyway).
+      const isHtmlDoc = /\.html?$/i.test(result.realFile);
+      const headers = isHtmlDoc
+        ? buildDaintreeHtmlDocHeaders(token, result.buffer.length)
+        : buildDaintreeFileHeaders(getMimeType(result.realFile), result.buffer.length);
+      return new Response(result.buffer, { status: 200, headers });
+    } catch (err) {
+      console.error("[MAIN] daintree-html protocol error:", err);
       return new Response("Internal Server Error", {
         status: 500,
         headers: buildDaintreeFileErrorHeaders(),
@@ -553,6 +716,7 @@ export function registerProtocolsForSession(ses: Electron.Session, distPath: str
 
   ses.protocol.handle("app", createAppProtocolHandler(distPath));
   ses.protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
+  ses.protocol.handle("daintree-html", createDaintreeHtmlProtocolHandler());
   if (cachedGetPluginDir) {
     ses.protocol.handle("plugin", createPluginProtocolHandler(resolvePluginDir));
   }
@@ -593,6 +757,10 @@ export function registerDeepLinkProtocolClient(): void {
 
 export function registerDaintreeFileProtocol(): void {
   protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
+}
+
+export function registerDaintreeHtmlProtocol(): void {
+  protocol.handle("daintree-html", createDaintreeHtmlProtocolHandler());
 }
 
 // Stable indirection so the live `plugin://` resolver can be swapped after the

--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -100,6 +100,30 @@ describe("Daintree app CSP", () => {
     });
   });
 
+  describe("daintree-html: preview scheme in frame-src (#11191)", () => {
+    // The file panel mounts a `daintree-html://<token>/…` iframe to render HTML
+    // files. Without the scheme in frame-src the iframe cannot navigate at all;
+    // the framed document's own scripts/assets are governed by the per-document
+    // CSP the protocol handler serves, never this one.
+    it("allows daintree-html: in frame-src in production", () => {
+      const frameSrc = getDaintreeAppProdCSP().match(/frame-src ([^;]*);/)?.[1];
+      expect(frameSrc).toContain("daintree-html:");
+    });
+
+    it("allows daintree-html: in frame-src in development", () => {
+      const frameSrc = getDaintreeAppDevCSP().match(/frame-src ([^;]*);/)?.[1];
+      expect(frameSrc).toContain("daintree-html:");
+    });
+
+    it("does not add daintree-html: to script-src or connect-src", () => {
+      // The scheme is frame-only; the sandboxed document is isolated, so the
+      // trusted shell must never gain script/connect access to it.
+      const csp = getDaintreeAppProdCSP();
+      expect(csp.match(/script-src ([^;]*);/)?.[1]).not.toContain("daintree-html:");
+      expect(csp.match(/connect-src ([^;]*);/)?.[1]).not.toContain("daintree-html:");
+    });
+  });
+
   describe("daintree.org doc images in img-src (#9828)", () => {
     // The `help.displayImage` MCP tool surfaces documentation images served
     // from daintree.org. Chromium 148 does not match the apex against a

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -3,6 +3,12 @@ import { getDevServerOrigins, getDevServerWebSocketOrigins } from "./devServer.j
 // Custom protocol scheme the renderer fetches/loads from.
 const FILE_SCHEMES = "daintree-file:";
 
+// Sandboxed HTML file preview scheme (#11191). Only appears in `frame-src` so
+// the file panel can mount a `daintree-html://<token>/…` iframe; the framed
+// document's own scripts/assets are governed by the per-document CSP the
+// protocol handler serves (scoped to its exact token authority), never this one.
+const HTML_PREVIEW_SCHEME = "daintree-html:";
+
 // Plugin-served renderer modules. `plugin:` is a hardened first-party scheme
 // (`standard: true, secure: true`, no `bypassCSP`) — see
 // `electron/main.ts:120-130` — that resolves to the plugin's installed-on-disk
@@ -101,7 +107,7 @@ export function getDaintreeAppProdCSP(options?: DaintreeCspOptions): string {
     "font-src 'self' data:",
     "media-src 'self'",
     "worker-src 'self' blob:",
-    `frame-src 'self' ${FRAME_LOCALHOST}`,
+    `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'none'",
@@ -135,7 +141,7 @@ export function getDaintreeAppDevCSP(): string {
     `font-src 'self' ${origins} data:`,
     "media-src 'self'",
     "worker-src 'self' blob:",
-    `frame-src 'self' ${FRAME_LOCALHOST}`,
+    `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'none'",

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -241,7 +241,7 @@ export interface FilePanelOptions extends AddPanelOptionsBase {
   kind: "file";
   /** Absolute path of the file to view */
   filePath?: string;
-  /** Initial view mode; defaults to "source" (rendered applies to markdown only) */
+  /** Initial view mode; defaults to "source" (rendered applies to Markdown and HTML) */
   fileViewMode?: FileViewMode;
 }
 

--- a/shared/types/ipc/files.ts
+++ b/shared/types/ipc/files.ts
@@ -13,6 +13,12 @@ export interface FileSearchResult {
 export interface FileReadPayload {
   path: string;
   rootPath: string;
+  /**
+   * When true and the file is HTML (.html/.htm), the result also carries an
+   * `htmlPreviewUrl` for rendering the file in a sandboxed iframe (#11191).
+   * Opt-in so a plain read never mints a preview capability.
+   */
+  htmlPreview?: boolean;
 }
 
 /**
@@ -38,4 +44,10 @@ export type FileReadErrorCode = _AssertSubset<
 
 export interface FileReadResult {
   content: string;
+  /**
+   * `daintree-html://<token>/<relpath>` URL for a sandboxed iframe preview,
+   * present only when the read was requested with `htmlPreview` and the file is
+   * HTML. Absent otherwise (#11191).
+   */
+  htmlPreviewUrl?: string;
 }

--- a/src/components/Html/HtmlViewer.tsx
+++ b/src/components/Html/HtmlViewer.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import { FileWarning } from "lucide-react";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { cn } from "@/lib/utils";
+
+export interface HtmlViewerProps {
+  /**
+   * `daintree-html://<token>/<relpath>` URL minted by the files:read handler.
+   * Null when the read returned no preview URL (e.g. the file moved outside its
+   * root); the viewer shows a fallback rather than a blank frame.
+   */
+  previewUrl: string | null;
+  /**
+   * Bumped by FilePane on every (re)load so a rewritten file re-renders. The
+   * cross-origin sandboxed frame can't be `location.reload()`-ed from here, so a
+   * changing cache-buster query is the only way to force a fresh navigation; the
+   * daintree-html:// handler ignores the query when mapping to disk.
+   */
+  reloadNonce: number;
+  /** Accessible name for the frame (the file name). */
+  title: string;
+  className?: string;
+}
+
+/**
+ * Rendered view of an HTML file (#11191): the page in a sandboxed iframe. The
+ * document is served by the `daintree-html://` protocol with its own
+ * token-scoped CSP; `sandbox="allow-scripts"` WITHOUT `allow-same-origin` gives
+ * it an opaque origin, so its scripts run but it cannot reach the app, the
+ * bridge, storage, or the network. Source mode stays on CodeViewer (owned by
+ * FilePane), so this component is rendered-only — a thin, non-lazy iframe
+ * wrapper with no heavy deps.
+ */
+export function HtmlViewer({ previewUrl, reloadNonce, title, className }: HtmlViewerProps) {
+  const src = useMemo(() => {
+    if (!previewUrl) return null;
+    const separator = previewUrl.includes("?") ? "&" : "?";
+    return `${previewUrl}${separator}v=${reloadNonce}`;
+  }, [previewUrl, reloadNonce]);
+
+  if (!src) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-6">
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          icon={<FileWarning className="h-6 w-6" />}
+          title="Can't render this file"
+          description="Switch to Source to view the markup."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      // Remount on file switch so a stale document never lingers while the new
+      // one loads; the nonce query handles same-file reloads.
+      key={previewUrl}
+      src={src}
+      title={title}
+      // No allow-same-origin: the frame gets an opaque origin and cannot touch
+      // the parent DOM, window.electron, storage, or (with connect-src 'none')
+      // the network. allow-scripts lets the page's own scripts run.
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      className={cn("h-full w-full border-0 bg-white", className)}
+      data-testid="html-preview-frame"
+    />
+  );
+}

--- a/src/components/Html/__tests__/HtmlViewer.test.tsx
+++ b/src/components/Html/__tests__/HtmlViewer.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { HtmlViewer } from "../HtmlViewer";
+
+describe("HtmlViewer", () => {
+  it("renders a sandboxed iframe with allow-scripts and no allow-same-origin", () => {
+    const { getByTestId } = render(
+      <HtmlViewer previewUrl="daintree-html://tok/index.html" reloadNonce={0} title="report.html" />
+    );
+    const frame = getByTestId("html-preview-frame") as HTMLIFrameElement;
+    // Exactly allow-scripts — same-origin would let the frame escape its opaque origin.
+    expect(frame.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(frame.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    expect(frame.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(frame.getAttribute("title")).toBe("report.html");
+  });
+
+  it("appends a cache-busting nonce query so a rewritten file re-navigates", () => {
+    const { getByTestId, rerender } = render(
+      <HtmlViewer previewUrl="daintree-html://tok/index.html" reloadNonce={1} title="r" />
+    );
+    const frame = () => getByTestId("html-preview-frame") as HTMLIFrameElement;
+    expect(frame().getAttribute("src")).toBe("daintree-html://tok/index.html?v=1");
+
+    rerender(<HtmlViewer previewUrl="daintree-html://tok/index.html" reloadNonce={2} title="r" />);
+    expect(frame().getAttribute("src")).toBe("daintree-html://tok/index.html?v=2");
+  });
+
+  it("uses & when the preview URL already has a query", () => {
+    const { getByTestId } = render(
+      <HtmlViewer previewUrl="daintree-html://tok/index.html?a=1" reloadNonce={3} title="r" />
+    );
+    const frame = getByTestId("html-preview-frame") as HTMLIFrameElement;
+    expect(frame.getAttribute("src")).toBe("daintree-html://tok/index.html?a=1&v=3");
+  });
+
+  it("shows a fallback instead of a blank frame when there is no preview URL", () => {
+    const { queryByTestId, getByText } = render(
+      <HtmlViewer previewUrl={null} reloadNonce={0} title="r" />
+    );
+    expect(queryByTestId("html-preview-frame")).toBeNull();
+    expect(getByText("Can't render this file")).toBeTruthy();
+  });
+});

--- a/src/components/Html/__tests__/HtmlViewer.test.tsx
+++ b/src/components/Html/__tests__/HtmlViewer.test.tsx
@@ -8,7 +8,7 @@ describe("HtmlViewer", () => {
     const { getByTestId } = render(
       <HtmlViewer previewUrl="daintree-html://tok/index.html" reloadNonce={0} title="report.html" />
     );
-    const frame = getByTestId("html-preview-frame") as HTMLIFrameElement;
+    const frame = getByTestId("html-preview-frame");
     // Exactly allow-scripts — same-origin would let the frame escape its opaque origin.
     expect(frame.getAttribute("sandbox")).toBe("allow-scripts");
     expect(frame.getAttribute("sandbox")).not.toContain("allow-same-origin");
@@ -20,7 +20,7 @@ describe("HtmlViewer", () => {
     const { getByTestId, rerender } = render(
       <HtmlViewer previewUrl="daintree-html://tok/index.html" reloadNonce={1} title="r" />
     );
-    const frame = () => getByTestId("html-preview-frame") as HTMLIFrameElement;
+    const frame = () => getByTestId("html-preview-frame");
     expect(frame().getAttribute("src")).toBe("daintree-html://tok/index.html?v=1");
 
     rerender(<HtmlViewer previewUrl="daintree-html://tok/index.html" reloadNonce={2} title="r" />);
@@ -31,7 +31,7 @@ describe("HtmlViewer", () => {
     const { getByTestId } = render(
       <HtmlViewer previewUrl="daintree-html://tok/index.html?a=1" reloadNonce={3} title="r" />
     );
-    const frame = getByTestId("html-preview-frame") as HTMLIFrameElement;
+    const frame = getByTestId("html-preview-frame");
     expect(frame.getAttribute("src")).toBe("daintree-html://tok/index.html?a=1&v=3");
   });
 

--- a/src/components/Html/__tests__/isHtmlFile.test.ts
+++ b/src/components/Html/__tests__/isHtmlFile.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isHtmlFilePath } from "../isHtmlFile";
+
+describe("isHtmlFilePath", () => {
+  it("matches .html and .htm regardless of case", () => {
+    expect(isHtmlFilePath("index.html")).toBe(true);
+    expect(isHtmlFilePath("page.htm")).toBe(true);
+    expect(isHtmlFilePath("REPORT.HTML")).toBe(true);
+    expect(isHtmlFilePath("Page.Htm")).toBe(true);
+    expect(isHtmlFilePath("/a/b/dist/report.html")).toBe(true);
+  });
+
+  it("does not match .xhtml, .xml, or non-html extensions", () => {
+    // .xhtml is deliberately excluded (XML parsing/MIME semantics differ).
+    expect(isHtmlFilePath("page.xhtml")).toBe(false);
+    expect(isHtmlFilePath("data.xml")).toBe(false);
+    expect(isHtmlFilePath("styles.css")).toBe(false);
+    expect(isHtmlFilePath("script.js")).toBe(false);
+    expect(isHtmlFilePath("notes.md")).toBe(false);
+  });
+
+  it("does not match when html is not the final extension", () => {
+    expect(isHtmlFilePath("template.html.ts")).toBe(false);
+    expect(isHtmlFilePath("htmlfile")).toBe(false);
+    expect(isHtmlFilePath("")).toBe(false);
+    // NB: a bare "html" (or "htm") matches, since the last dot-segment is the
+    // extension — identical to isMarkdownFilePath("md"). Harmless edge case.
+  });
+});

--- a/src/components/Html/isHtmlFile.ts
+++ b/src/components/Html/isHtmlFile.ts
@@ -1,0 +1,11 @@
+const HTML_EXTENSIONS = new Set(["html", "htm"]);
+
+/**
+ * Extension check for files the file panel can render in a sandboxed iframe.
+ * `.xhtml` is intentionally excluded — its XML parsing/MIME semantics are a
+ * separate concern. Mirrors `isMarkdownFilePath`.
+ */
+export function isHtmlFilePath(filePath: string): boolean {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  return HTML_EXTENSIONS.has(ext);
+}

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -284,10 +284,10 @@ export function FilePane({
   const [pathCopied, setPathCopied] = useState(false);
   // Sandboxed-iframe preview URL for HTML files (#11191), minted by files:read.
   const [htmlPreviewUrl, setHtmlPreviewUrl] = useState<string | null>(null);
-  // Bumped whenever the file's content actually changes so the (cross-origin)
-  // preview frame re-navigates — a rewritten report re-renders on refresh/focus.
+  // Bumped on every successful (re)load so the (cross-origin) preview frame
+  // re-navigates — a rewritten report re-renders on refresh/focus. Bumping on
+  // every load, not just entry-file changes, keeps relative assets fresh too.
   const [reloadNonce, setReloadNonce] = useState(0);
-  const lastContentRef = useRef<string | null>(null);
   const requestRef = useRef(0);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const markdownViewerRef = useRef<MarkdownViewerHandle>(null);
@@ -321,13 +321,13 @@ export function FilePane({
         })
         .then(({ content: fileContent, htmlPreviewUrl: previewUrl }) => {
           if (requestRef.current !== requestId) return;
-          const changed = lastContentRef.current !== fileContent;
-          lastContentRef.current = fileContent;
           setContent((previous) => (previous === fileContent ? previous : fileContent));
           setHtmlPreviewUrl(previewUrl ?? null);
-          // Re-navigate the preview frame only when content actually changed —
-          // avoids a needless reflash on a silent same-content refresh.
-          if (changed) setReloadNonce((nonce) => nonce + 1);
+          // Re-navigate the preview frame on every successful load so a rewritten
+          // report — or an unchanged entry file whose relative asset changed —
+          // always reflects the latest bytes. reloadNonce isn't a loadFile dep,
+          // so this can't re-trigger the load.
+          setReloadNonce((nonce) => nonce + 1);
           setLoadState("loaded");
           setErrorCode(null);
         })

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -8,6 +8,8 @@ import { ContentPanel } from "@/components/Panel/ContentPanel";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { MarkdownViewer, type MarkdownViewerHandle } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+import { HtmlViewer } from "@/components/Html/HtmlViewer";
+import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -251,8 +253,10 @@ export function FilePane({
 
   const filePath = panel?.filePath;
   const isMarkdown = filePath !== undefined && isMarkdownFilePath(filePath);
-  // "rendered" is a markdown-only mode; other files always view as source.
-  const viewMode: FileViewMode = isMarkdown ? (panel?.fileViewMode ?? "source") : "source";
+  const isHtml = filePath !== undefined && isHtmlFilePath(filePath);
+  // Markdown and HTML get a Source/Rendered toggle; every other file is source-only.
+  const isRenderable = isMarkdown || isHtml;
+  const viewMode: FileViewMode = isRenderable ? (panel?.fileViewMode ?? "source") : "source";
 
   const worktreeId = panel?.worktreeId;
   const worktreePath = useWorktreeStore(
@@ -278,6 +282,12 @@ export function FilePane({
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [errorCode, setErrorCode] = useState<FileReadErrorCode | null>(null);
   const [pathCopied, setPathCopied] = useState(false);
+  // Sandboxed-iframe preview URL for HTML files (#11191), minted by files:read.
+  const [htmlPreviewUrl, setHtmlPreviewUrl] = useState<string | null>(null);
+  // Bumped whenever the file's content actually changes so the (cross-origin)
+  // preview frame re-navigates — a rewritten report re-renders on refresh/focus.
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const lastContentRef = useRef<string | null>(null);
   const requestRef = useRef(0);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const markdownViewerRef = useRef<MarkdownViewerHandle>(null);
@@ -304,10 +314,20 @@ export function FilePane({
         setErrorCode(null);
       }
       filesClient
-        .read({ path: filePath, rootPath: effectiveRootPath })
-        .then(({ content: fileContent }) => {
+        .read({
+          path: filePath,
+          rootPath: effectiveRootPath,
+          htmlPreview: isHtmlFilePath(filePath),
+        })
+        .then(({ content: fileContent, htmlPreviewUrl: previewUrl }) => {
           if (requestRef.current !== requestId) return;
+          const changed = lastContentRef.current !== fileContent;
+          lastContentRef.current = fileContent;
           setContent((previous) => (previous === fileContent ? previous : fileContent));
+          setHtmlPreviewUrl(previewUrl ?? null);
+          // Re-navigate the preview frame only when content actually changed —
+          // avoids a needless reflash on a silent same-content refresh.
+          if (changed) setReloadNonce((nonce) => nonce + 1);
           setLoadState("loaded");
           setErrorCode(null);
         })
@@ -434,7 +454,7 @@ export function FilePane({
   const toolbar = filePath ? (
     <>
       <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay">
-        {isMarkdown && (
+        {isRenderable && (
           <SegmentedToggle<FileViewMode>
             options={[
               { value: "source", label: "Source" },
@@ -609,7 +629,7 @@ export function FilePane({
         {filePath &&
           loadState === "loaded" &&
           content !== null &&
-          (isMarkdown && viewMode === "rendered" ? (
+          (viewMode === "rendered" && isMarkdown ? (
             <MarkdownViewer
               ref={markdownViewerRef}
               content={content}
@@ -617,6 +637,15 @@ export function FilePane({
               rootPath={effectiveRootPath}
               viewMode="rendered"
               wrapLines={markdownWrapLines}
+            />
+          ) : viewMode === "rendered" && isHtml ? (
+            // Rendered HTML fills the pane in a sandboxed iframe rather than the
+            // min-h-full source column; the frame owns its own scrolling.
+            <HtmlViewer
+              previewUrl={htmlPreviewUrl}
+              reloadNonce={reloadNonce}
+              title={fileName ?? "HTML preview"}
+              className="min-h-full"
             />
           ) : (
             // min-h-full column (mirrors FileViewerModal): the editor surface

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -48,11 +48,12 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 vi.mock("@/store/accessibilityAnnouncerStore", () => ({
   useAnnouncerStore: { getState: () => ({ announce: vi.fn() }) },
 }));
+const { readMock, searchMock } = vi.hoisted(() => ({
+  readMock: vi.fn(),
+  searchMock: vi.fn(),
+}));
 vi.mock("@/clients/filesClient", () => ({
-  filesClient: {
-    read: vi.fn().mockResolvedValue({ content: "" }),
-    search: vi.fn().mockResolvedValue({ files: [] }),
-  },
+  filesClient: { read: readMock, search: searchMock },
 }));
 // dispatch() resolves an ActionDispatchResult union and never rejects; callers
 // branch on `.ok`, so the mock must honour that shape rather than resolve void.
@@ -71,7 +72,13 @@ vi.mock("@/components/FileViewer/CodeViewer", () => ({
   CodeViewer: () => <div data-testid="code-viewer-mock" />,
 }));
 vi.mock("@/components/Html/HtmlViewer", () => ({
-  HtmlViewer: () => <div data-testid="html-viewer-mock" />,
+  HtmlViewer: (props: { previewUrl: string | null; reloadNonce: number }) => (
+    <div
+      data-testid="html-viewer-mock"
+      data-preview-url={props.previewUrl ?? ""}
+      data-reload-nonce={props.reloadNonce}
+    />
+  ),
 }));
 
 import { FilePane } from "../FilePane";
@@ -86,6 +93,12 @@ function lastContentPanelProps(): Record<string, unknown> {
 beforeEach(() => {
   dispatchMock.mockReset();
   dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+  // Reset per test so a prior test's read call can't satisfy a later
+  // toHaveBeenCalledWith assertion (cross-test contamination).
+  readMock.mockReset();
+  readMock.mockResolvedValue({ content: "" });
+  searchMock.mockReset();
+  searchMock.mockResolvedValue({ files: [] });
   // InlineStatusBanner reads window.matchMedia at render time; jsdom does not
   // implement it, so provide a no-op stub.
   if (typeof window.matchMedia !== "function") {
@@ -350,9 +363,15 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     expect(screen.queryByText("Rendered")).toBeNull();
   });
 
-  it("routes rendered HTML to the sandboxed HtmlViewer", async () => {
+  it("routes rendered HTML to the sandboxed HtmlViewer with the minted preview URL", async () => {
+    readMock.mockResolvedValue({
+      content: "<h1>x</h1>",
+      htmlPreviewUrl: "daintree-html://tok/report.html",
+    });
     renderPane("/repo/dist/report.html", "rendered");
-    expect(await screen.findByTestId("html-viewer-mock")).toBeTruthy();
+    const viewer = await screen.findByTestId("html-viewer-mock");
+    // The URL from files:read must reach HtmlViewer's previewUrl prop.
+    expect(viewer.getAttribute("data-preview-url")).toBe("daintree-html://tok/report.html");
     expect(screen.queryByTestId("code-viewer-mock")).toBeNull();
   });
 
@@ -363,11 +382,19 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
   });
 
   it("passes htmlPreview:true to files:read for HTML files", async () => {
-    const { filesClient } = await import("@/clients/filesClient");
     renderPane("/repo/dist/report.html", "rendered");
     await waitFor(() =>
-      expect(filesClient.read).toHaveBeenCalledWith(
+      expect(readMock).toHaveBeenCalledWith(
         expect.objectContaining({ path: "/repo/dist/report.html", htmlPreview: true })
+      )
+    );
+  });
+
+  it("passes htmlPreview:false to files:read for non-HTML files", async () => {
+    renderPane("/repo/src/index.css");
+    await waitFor(() =>
+      expect(readMock).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/repo/src/index.css", htmlPreview: false })
       )
     );
   });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { ReactNode } from "react";
-import { render, act } from "@testing-library/react";
+import { render, act, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // FilePane forwards a fixed prop list to ContentPanel; #10991 was a dropped
@@ -12,9 +12,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const contentPanelProps: Array<Record<string, unknown>> = [];
 
 vi.mock("@/components/Panel/ContentPanel", () => ({
-  ContentPanel: (props: Record<string, unknown> & { toolbar?: ReactNode }) => {
+  ContentPanel: (
+    props: Record<string, unknown> & { toolbar?: ReactNode; children?: ReactNode }
+  ) => {
     contentPanelProps.push(props);
-    return <>{props.toolbar}</>;
+    // Render children too so the Source/Rendered branch is observable, not just
+    // the toolbar (#11191 HTML preview branch).
+    return (
+      <>
+        {props.toolbar}
+        {props.children}
+      </>
+    );
   },
 }));
 
@@ -55,8 +64,15 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: dispatchMock },
 }));
 vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
-vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
-vi.mock("@/components/FileViewer/CodeViewer", () => ({ CodeViewer: () => null }));
+vi.mock("@/components/Markdown/MarkdownViewer", () => ({
+  MarkdownViewer: () => <div data-testid="markdown-viewer-mock" />,
+}));
+vi.mock("@/components/FileViewer/CodeViewer", () => ({
+  CodeViewer: () => <div data-testid="code-viewer-mock" />,
+}));
+vi.mock("@/components/Html/HtmlViewer", () => ({
+  HtmlViewer: () => <div data-testid="html-viewer-mock" />,
+}));
 
 import { FilePane } from "../FilePane";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -293,5 +309,72 @@ describe("FilePane open-in-editor failure feedback (#11114)", () => {
       { source: "user" }
     );
     expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});
+
+// #11191: HTML files get the same Source/Rendered toggle as Markdown; rendered
+// HTML routes to the sandboxed-iframe HtmlViewer.
+describe("FilePane HTML Source/Rendered (#11191)", () => {
+  function renderPane(filePath: string, fileViewMode?: "source" | "rendered") {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath, fileViewMode };
+    return render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title={filePath.split("/").pop() ?? filePath}
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  it("shows the Source/Rendered toggle for an .html file", async () => {
+    renderPane("/repo/dist/report.html");
+    // SegmentedToggle labels are literal text; both appear only for renderable files.
+    expect(await screen.findByText("Rendered")).toBeTruthy();
+    expect(screen.getByText("Source")).toBeTruthy();
+  });
+
+  it("shows the toggle for a .htm file", async () => {
+    renderPane("/repo/dist/page.htm");
+    expect(await screen.findByText("Rendered")).toBeTruthy();
+  });
+
+  it("does not show the toggle for a non-renderable file (.css)", async () => {
+    renderPane("/repo/src/index.css");
+    // Wait for load to settle so we're not asserting on a pre-render frame.
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByText("Rendered")).toBeNull();
+  });
+
+  it("routes rendered HTML to the sandboxed HtmlViewer", async () => {
+    renderPane("/repo/dist/report.html", "rendered");
+    expect(await screen.findByTestId("html-viewer-mock")).toBeTruthy();
+    expect(screen.queryByTestId("code-viewer-mock")).toBeNull();
+  });
+
+  it("routes source HTML to the CodeViewer, not the HtmlViewer", async () => {
+    renderPane("/repo/dist/report.html", "source");
+    expect(await screen.findByTestId("code-viewer-mock")).toBeTruthy();
+    expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
+  });
+
+  it("passes htmlPreview:true to files:read for HTML files", async () => {
+    const { filesClient } = await import("@/clients/filesClient");
+    renderPane("/repo/dist/report.html", "rendered");
+    await waitFor(() =>
+      expect(filesClient.read).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/repo/dist/report.html", htmlPreview: true })
+      )
+    );
+  });
+
+  it("still routes rendered Markdown to the MarkdownViewer (regression)", async () => {
+    renderPane("/repo/docs/spec.md", "rendered");
+    expect(await screen.findByTestId("markdown-viewer-mock")).toBeTruthy();
+    expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
   });
 });

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -1308,7 +1308,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "files",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Open a file in a read-only file viewer panel in the grid. Markdown files get a Source/Rendered toggle (source is the default view). Args: \`path\` (required) — absolute or repo-relative file path; \`rootPath\` (optional) — root used to resolve a relative \`path\` (defaults to the current project root); \`viewMode\` (optional) — 'source' (default) or 'rendered' (markdown only). Reuses a panel already showing the same file instead of opening a duplicate. Returns { panelId }. Use \`file.read\` to read a file's content without displaying it.",
+    "description": "Open a file in a read-only file viewer panel in the grid. Markdown and HTML files get a Source/Rendered toggle (source is the default view; rendered HTML shows the page in a sandboxed iframe). Args: \`path\` (required) — absolute or repo-relative file path; \`rootPath\` (optional) — root used to resolve a relative \`path\` (defaults to the current project root); \`viewMode\` (optional) — 'source' (default) or 'rendered' (Markdown and HTML only). Reuses a panel already showing the same file instead of opening a duplicate. Returns { panelId }. Use \`file.read\` to read a file's content without displaying it.",
     "examples": [
       {
         "args": {
@@ -1316,6 +1316,13 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
           "viewMode": "rendered",
         },
         "description": "Open a repo-relative markdown file as a rendered document panel",
+      },
+      {
+        "args": {
+          "path": "dist/report.html",
+          "viewMode": "rendered",
+        },
+        "description": "Render a generated HTML report in a sandboxed iframe",
       },
       {
         "args": {
@@ -1330,6 +1337,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
       "viewer",
       "panel",
       "markdown",
+      "html",
       "preview",
       "md",
       "readme",

--- a/src/services/actions/definitions/__tests__/fileActionsOpenPanel.test.ts
+++ b/src/services/actions/definitions/__tests__/fileActionsOpenPanel.test.ts
@@ -109,6 +109,27 @@ describe("file.openPanel", () => {
     expect(addPanelSpy).toHaveBeenCalledWith(expect.objectContaining({ fileViewMode: "rendered" }));
   });
 
+  it("passes rendered through for html files", async () => {
+    const run = setupActions();
+    await run("file.openPanel", { path: "dist/report.html", viewMode: "rendered" });
+
+    expect(addPanelSpy).toHaveBeenCalledWith(expect.objectContaining({ fileViewMode: "rendered" }));
+  });
+
+  it("passes rendered through for .htm files", async () => {
+    const run = setupActions();
+    await run("file.openPanel", { path: "dist/page.htm", viewMode: "rendered" });
+
+    expect(addPanelSpy).toHaveBeenCalledWith(expect.objectContaining({ fileViewMode: "rendered" }));
+  });
+
+  it("clamps a rendered request on a non-renderable file (.xhtml) to source", async () => {
+    const run = setupActions();
+    await run("file.openPanel", { path: "dist/page.xhtml", viewMode: "rendered" });
+
+    expect(addPanelSpy).toHaveBeenCalledWith(expect.objectContaining({ fileViewMode: "source" }));
+  });
+
   it("reuses a panel already showing the same file instead of duplicating", async () => {
     setPanelState({
       "file-1": {

--- a/src/services/actions/definitions/fileActions.ts
+++ b/src/services/actions/definitions/fileActions.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from "@/store";
 import { usePanelStore } from "@/store/panelStore";
 import { isFilePanel } from "@shared/types/panel";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { isAbsolute, isPathInside, join, normalize } from "@shared/utils/path";
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 
@@ -65,7 +66,7 @@ const openPanelArgsSchema = z.object({
     .enum(["rendered", "source"])
     .optional()
     .describe(
-      'Initial view mode. Defaults to "source". "rendered" only applies to markdown files.'
+      'Initial view mode. Defaults to "source". "rendered" applies to Markdown and HTML files.'
     ),
 });
 
@@ -175,17 +176,21 @@ export function registerFileActions(actions: ActionRegistry, callbacks: ActionCa
     id: "file.openPanel",
     title: "Open File Panel",
     description:
-      "Open a file in a read-only file viewer panel in the grid. Markdown files get a Source/Rendered toggle (source is the default view). Args: `path` (required) — absolute or repo-relative file path; `rootPath` (optional) — root used to resolve a relative `path` (defaults to the current project root); `viewMode` (optional) — 'source' (default) or 'rendered' (markdown only). Reuses a panel already showing the same file instead of opening a duplicate. Returns { panelId }. Use `file.read` to read a file's content without displaying it.",
+      "Open a file in a read-only file viewer panel in the grid. Markdown and HTML files get a Source/Rendered toggle (source is the default view; rendered HTML shows the page in a sandboxed iframe). Args: `path` (required) — absolute or repo-relative file path; `rootPath` (optional) — root used to resolve a relative `path` (defaults to the current project root); `viewMode` (optional) — 'source' (default) or 'rendered' (Markdown and HTML only). Reuses a panel already showing the same file instead of opening a duplicate. Returns { panelId }. Use `file.read` to read a file's content without displaying it.",
     category: "files",
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    keywords: ["file", "viewer", "panel", "markdown", "preview", "md", "readme", "spec"],
+    keywords: ["file", "viewer", "panel", "markdown", "html", "preview", "md", "readme", "spec"],
     argsSchema: openPanelArgsSchema,
     examples: [
       {
         args: { path: "docs/spec.md", viewMode: "rendered" },
         description: "Open a repo-relative markdown file as a rendered document panel",
+      },
+      {
+        args: { path: "dist/report.html", viewMode: "rendered" },
+        description: "Render a generated HTML report in a sandboxed iframe",
       },
       {
         args: { path: "src/index.css" },
@@ -195,10 +200,14 @@ export function registerFileActions(actions: ActionRegistry, callbacks: ActionCa
     run: async (args: unknown) => {
       const { path, rootPath, viewMode } = openPanelArgsSchema.parse(args);
       const absolutePath = resolveFilePanelPath(path, rootPath);
-      // "rendered" is a markdown-only mode — clamp so a stray request can't
-      // persist a mode the panel can never display.
+      // "rendered" applies only to Markdown and HTML — clamp so a stray request
+      // can't persist a mode the panel can never display.
       const effectiveViewMode =
-        viewMode === "rendered" && !isMarkdownFilePath(absolutePath) ? "source" : viewMode;
+        viewMode === "rendered" &&
+        !isMarkdownFilePath(absolutePath) &&
+        !isHtmlFilePath(absolutePath)
+          ? "source"
+          : viewMode;
 
       const store = usePanelStore.getState();
       const existing = store.panelIds


### PR DESCRIPTION
## Summary

- HTML files (`.html`/`.htm`) now get the same Source/Rendered toggle Markdown already has in the file panel. Rendered mode shows the page in a sandboxed iframe, its own scripts run, and relative assets (CSS, JS, images, including root-relative references) resolve natively.
- `file.openPanel`'s description, schema, and clamp are updated to accept HTML.
- A critical security finding from review is fixed: the session-wide app CSP overlay was overwriting the iframe's per-document CSP, and both overlay paths now bypass the new scheme so the token-scoped CSP stays authoritative.

Resolves #11191

## Architecture

A dedicated `daintree-html://<token>/<relpath>` protocol scheme (registered standard and secure) serves the page and its sibling assets so relative URLs resolve natively. The main process mints an opaque, unforgeable capability token per root and puts it in the URL authority, the one part of the URL sandboxed content can't forge. The handler re-applies realpath resolution, `O_NOFOLLOW` containment, and a 512KB size cap, same as `daintree-file://`.

The iframe uses `sandbox="allow-scripts"` without `allow-same-origin`, so it gets an opaque origin. The handler serves an exact-authority-scoped per-document CSP (`connect-src 'none'`, WebRTC blocked, `script-src`/`style-src`/`img-src`/`font-src` scoped to the token authority), so the page can run its own scripts but can't reach the app, filesystem, or network.

The existing `daintree-file://` scheme (used by the Markdown viewer) is left untouched, no `standard:true` or CORS changes that could perturb Markdown images, WebAudio, or the file viewer. The preview URL is minted opt-in through the existing `files:read` IPC call via a new `htmlPreviewUrl` field, so no new IPC namespace was needed.

During review, the session-wide app CSP `webRequest` overlay turned out to be overwriting the iframe's per-document CSP, since in Electron 42 `protocol.handle` responses flow through `onHeadersReceived`. Both overlay paths now bypass `daintree-html://` so the token-scoped CSP wins. Verified with a unit test and an E2E probe: a `daintree-file://` fetch from inside the frame is blocked by `connect-src 'none'`.

## Testing

Unit tests cover the protocol handler (containment, CSP by extension, token scoping, unknown-token 404, root-identity and whole-volume rejection, size cap), the token registry, `isHtmlFilePath`, the FilePane toggle and render branch, the `files:read` mint opt-in, the `fileActions` clamp, and the CSP frame-src/bypass behavior.

An E2E case was added to `e2e/full/panels/core-file-panel.spec.ts` proving scripts run, relative assets resolve, and isolation holds (no `window.electron`, parent unreachable, `connect-src` blocks a `daintree-file` fetch). E2E runs in the stabilize/release gate, not PR CI, so it wasn't executed locally.

## Follow-ups (non-blocking)

- Loopback self-navigation and dynamic `<webview>` creation from the preview frame need probing against a live Electron runtime.
- Intermediate-directory TOCTOU and non-regular-file (FIFO) checks are inherited from the existing `daintree-file://` containment.
- Silent-refresh error suppression for `FILE_TOO_LARGE`/`BINARY` is pre-existing FilePane-wide behavior, not new here.
