### PR TITLE
fix: blank HTML preview iframe caused by missing COEP header

### DIFF
--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -374,6 +374,11 @@ function buildDaintreeHtmlDocHeaders(token: string, contentLength: number): Reco
     "Content-Length": String(contentLength),
     "Content-Security-Policy": csp,
     "Cross-Origin-Resource-Policy": "cross-origin",
+    // The trusted renderer document is COEP `credentialless` (app:// headers +
+    // vite dev server), and a COEP document may only embed frames whose own
+    // document response carries a compatible COEP. Without this the iframe
+    // navigation dies with ERR_BLOCKED_BY_RESPONSE — a blank white frame.
+    "Cross-Origin-Embedder-Policy": "credentialless",
     "X-Content-Type-Options": "nosniff",
     // Belt-and-suspenders egress limits: no referrer leakage on any request the
     // page makes, and no speculative DNS lookups of hostnames in the markup.


### PR DESCRIPTION
The rendered HTML preview from #11198 was showing a blank white iframe for every file, in both development and production.

The app's renderer document sets `Cross-Origin-Embedder-Policy: credentialless`, and a document with COEP set can only embed frames whose own response carries a compatible COEP header. The `daintree-html://` preview document wasn't sending one, so Chromium blocked the frame navigation with `ERR_BLOCKED_BY_RESPONSE`. The white screen is just the empty iframe element.

The fix is one line: add `Cross-Origin-Embedder-Policy: credentialless` to the preview document headers in `electron/setup/protocols.ts`.

We do have an end-to-end test covering exactly this case ("rendered HTML runs its scripts + relative assets while staying sandboxed" in `e2e/full/panels/core-file-panel.spec.ts`). It fails on `develop` and passes with this fix. It didn't catch the regression at merge time because PR CI doesn't run end-to-end tests.

Note: this re-lands `1bfe074da`, which briefly landed directly on `develop` by mistake and was reverted in `e44ac6b21` so the change could go through a proper PR.