### PR TITLE
fix(github): open-in-GitHub button links to plain list, not search

### DIFF
--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -2036,10 +2036,38 @@ describe("buildIssuesUrl", () => {
     expect(q).toBeNull();
   });
 
-  it("passes a query through to q without a state qualifier", () => {
+  // #11201: the default open filter with no search should link to the bare
+  // /issues list (GitHub already scopes it to `is:issue is:open`), not a raw
+  // `?q=is:open` search view.
+  it("returns the bare /issues path with no q param for the default open filter", () => {
+    const { path, q } = parseBuiltUrl(githubForgeProvider.buildIssuesUrl(repo, { state: "open" }));
+    expect(path).toBe("/owner/repo/issues");
+    expect(q).toBeNull();
+  });
+
+  it("treats an empty-string query with state 'open' as the default open filter", () => {
+    const { path, q } = parseBuiltUrl(
+      githubForgeProvider.buildIssuesUrl(repo, { query: "", state: "open" })
+    );
+    expect(path).toBe("/owner/repo/issues");
+    expect(q).toBeNull();
+  });
+
+  // #11201: once a search query is present the `is:issue` type qualifier is
+  // required so results stay scoped to issues and don't leak PRs (GitHub's
+  // issue/PR search is unified).
+  it("prefixes the is:issue type qualifier when a query is given", () => {
     const { path, q } = parseBuiltUrl(githubForgeProvider.buildIssuesUrl(repo, { query: "bug" }));
     expect(path).toBe("/owner/repo/issues");
-    expect(q).toBe("bug");
+    expect(q).toBe("is:issue bug");
+  });
+
+  it("keeps the is:open state qualifier alongside a query on the open filter", () => {
+    const { path, q } = parseBuiltUrl(
+      githubForgeProvider.buildIssuesUrl(repo, { query: "bug", state: "open" })
+    );
+    expect(path).toBe("/owner/repo/issues");
+    expect(q).toBe("is:issue bug is:open");
   });
 
   // Regression for #9986: the previous implementation gated the `is:<state>`
@@ -2065,7 +2093,7 @@ describe("buildIssuesUrl", () => {
       githubForgeProvider.buildIssuesUrl(repo, { query: "bug", state: "closed" })
     );
     expect(path).toBe("/owner/repo/issues");
-    expect(q).toBe("bug is:closed");
+    expect(q).toBe("is:issue bug is:closed");
   });
 
   it("treats state: 'all' as a no-op when given alone", () => {
@@ -2078,7 +2106,7 @@ describe("buildIssuesUrl", () => {
     const { q } = parseBuiltUrl(
       githubForgeProvider.buildIssuesUrl(repo, { query: "bug", state: "all" })
     );
-    expect(q).toBe("bug");
+    expect(q).toBe("is:issue bug");
   });
 });
 
@@ -2095,10 +2123,36 @@ describe("buildPRsUrl", () => {
     expect(q).toBeNull();
   });
 
-  it("passes a query through to q without a state qualifier", () => {
+  // #11201: the default open filter → bare /pulls list (GitHub already scopes
+  // it to `is:pr is:open`), not a raw `?q=is:open` search view.
+  it("returns the bare /pulls path with no q param for the default open filter", () => {
+    const { path, q } = parseBuiltUrl(githubForgeProvider.buildPRsUrl(repo, { state: "open" }));
+    expect(path).toBe("/owner/repo/pulls");
+    expect(q).toBeNull();
+  });
+
+  it("treats an empty-string query with state 'open' as the default open filter", () => {
+    const { path, q } = parseBuiltUrl(
+      githubForgeProvider.buildPRsUrl(repo, { query: "", state: "open" })
+    );
+    expect(path).toBe("/owner/repo/pulls");
+    expect(q).toBeNull();
+  });
+
+  // #11201: once a search query is present the `is:pr` type qualifier is
+  // required so results stay scoped to PRs.
+  it("prefixes the is:pr type qualifier when a query is given", () => {
     const { path, q } = parseBuiltUrl(githubForgeProvider.buildPRsUrl(repo, { query: "bug" }));
     expect(path).toBe("/owner/repo/pulls");
-    expect(q).toBe("bug");
+    expect(q).toBe("is:pr bug");
+  });
+
+  it("keeps the is:open state qualifier alongside a query on the open filter", () => {
+    const { path, q } = parseBuiltUrl(
+      githubForgeProvider.buildPRsUrl(repo, { query: "bug", state: "open" })
+    );
+    expect(path).toBe("/owner/repo/pulls");
+    expect(q).toBe("is:pr bug is:open");
   });
 
   // Regression for #9986: see buildIssuesUrl counterpart.
@@ -2128,7 +2182,7 @@ describe("buildPRsUrl", () => {
       githubForgeProvider.buildPRsUrl(repo, { query: "bug", state: "closed" })
     );
     expect(path).toBe("/owner/repo/pulls");
-    expect(q).toBe("bug is:closed");
+    expect(q).toBe("is:pr bug is:closed");
   });
 
   it("treats state: 'all' as a no-op when given alone", () => {
@@ -2141,7 +2195,7 @@ describe("buildPRsUrl", () => {
     const { q } = parseBuiltUrl(
       githubForgeProvider.buildPRsUrl(repo, { query: "bug", state: "all" })
     );
-    expect(q).toBe("bug");
+    expect(q).toBe("is:pr bug");
   });
 });
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -341,21 +341,34 @@ export const githubForgeProvider: ForgeProviderImpl = {
     return `https://github.com/${repo.owner}/${repo.repo}/pull/${number}`;
   },
 
+  // GitHub's bare `/issues` list already scopes to `is:issue is:open`, so the
+  // default open filter with no search should link there directly rather than a
+  // raw `?q=is:open` search view (#11201). Once a search query is present the
+  // `is:issue` type qualifier is required to keep results scoped to issues and
+  // not leak PRs (GitHub's issue/PR search is unified). `is:closed`/`is:merged`
+  // have no bare-URL equivalent, so they stay as `q` qualifiers even without a
+  // query (#9986).
   buildIssuesUrl(repo: RepoRef, options?: { query?: string; state?: string }): string {
     const base = `https://github.com/${repo.owner}/${repo.repo}/issues`;
+    const query = options?.query;
+    const state = options?.state;
     const qParts: string[] = [];
-    if (options?.query) qParts.push(options.query);
-    if (options?.state && options.state !== "all") qParts.push(`is:${options.state}`);
+    if (query) qParts.push("is:issue", query);
+    if (state && state !== "all" && (state !== "open" || query)) qParts.push(`is:${state}`);
     const params = new URLSearchParams();
     if (qParts.length > 0) params.set("q", qParts.join(" "));
     return params.toString() ? `${base}?${params.toString()}` : base;
   },
 
+  // Mirrors buildIssuesUrl with the `is:pr` type qualifier; bare `/pulls`
+  // already scopes to `is:pr is:open`. See buildIssuesUrl for the rationale.
   buildPRsUrl(repo: RepoRef, options?: { query?: string; state?: string }): string {
     const base = `https://github.com/${repo.owner}/${repo.repo}/pulls`;
+    const query = options?.query;
+    const state = options?.state;
     const qParts: string[] = [];
-    if (options?.query) qParts.push(options.query);
-    if (options?.state && options.state !== "all") qParts.push(`is:${options.state}`);
+    if (query) qParts.push("is:pr", query);
+    if (state && state !== "all" && (state !== "open" || query)) qParts.push(`is:${state}`);
     const params = new URLSearchParams();
     if (qParts.length > 0) params.set("q", qParts.join(" "));
     return params.toString() ? `${base}?${params.toString()}` : base;


### PR DESCRIPTION
## Summary

- The forge toolbar's open-in-GitHub button built a raw search URL for the default open filter (e.g. `github.com/owner/repo/issues?q=is%3Aopen`) instead of the plain issues/PRs list.
- GitHub already scopes the bare `/issues` URL to open issues and the bare `/pulls` URL to open PRs, so the default open case now returns the bare URL with no search query.
- When there's an actual search query, `is:issue` / `is:pr` is now added as a type qualifier so results stay scoped to the right kind, since GitHub's issue and PR search is unified.

Resolves #11201

## Changes

- `buildIssuesUrl` / `buildPRsUrl` in `plugins/builtin/github/main/forgeProvider.ts`: return the bare `/issues` or `/pulls` URL for the default open filter with no search query, and add the `is:issue`/`is:pr` type qualifier whenever a query is present.
- Non-open states without a query (`is:closed`, `is:merged`) still keep their `q` qualifier, so the #9986 fix stays intact.
- Body-only change, no public API signature touched.

## Testing

- Updated and added cases in `plugins/builtin/github/main/__tests__/forgeProvider.test.ts`: bare-URL for the open filter, empty query + open state, and the type-qualifier addition on query cases.
- 146 tests pass.