### PR TITLE
feat(files): view selected file paths from composer and terminal context menus

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -966,6 +966,17 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
                     ref={(node) => {
                       editorHostRef.current = node;
                       compactEditorHostRef.current = node;
+                      // The Radix trigger swaps element type (Slot → Trigger)
+                      // when its lazy chunk resolves, remounting this host node
+                      // and orphaning CodeMirror's imperatively-attached DOM.
+                      // Re-adopt the editor only when it is genuinely detached
+                      // (isConnected === false) so the normal expand/collapse
+                      // reparent in useHostReparent is left untouched. The modal
+                      // host carries the mirror-image guard.
+                      const view = editorViewRef.current;
+                      if (node && view && !isExpanded && !view.dom.isConnected) {
+                        node.appendChild(view.dom);
+                      }
                     }}
                     className={cn("w-full min-h-[20px]", disabled && "pointer-events-none")}
                     style={{ color: inputBarColors.foreground }}
@@ -1054,7 +1065,20 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             <ContextMenu>
               <ContextMenuTrigger asChild onContextMenu={handleEditorContextMenu}>
                 <div
-                  ref={modalEditorHostRef}
+                  ref={(node) => {
+                    modalEditorHostRef.current = node;
+                    // Mirror of the compact host's guard: AppDialog is not a
+                    // Radix consumer, so this trigger can also mount in the
+                    // Slot state and remount (orphaning the editor) when the
+                    // chunk resolves. Re-adopt only when detached so the normal
+                    // reparent is untouched; this also closes the AppDialog
+                    // mount-order gap where the reparent effect could run
+                    // before this host exists.
+                    const view = editorViewRef.current;
+                    if (node && view && isExpanded && !view.dom.isConnected) {
+                      node.appendChild(view.dom);
+                    }
+                  }}
                   className="flex-1 min-h-[200px] overflow-auto text-daintree-text p-4"
                 />
               </ContextMenuTrigger>

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { EditorView } from "@codemirror/view";
 import { EditorSelection } from "@codemirror/state";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
@@ -58,6 +66,13 @@ import { useFleetMirror } from "./hooks/useFleetMirror";
 import { useEditorDomHandlers } from "./hooks/useEditorDomHandlers";
 import { useEditorFactory } from "./hooks/useEditorFactory";
 import { useHostReparent } from "./hooks/useHostReparent";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { SelectedFileMenuItems } from "./SelectedFileMenuItems";
+import { resolveSelectedFilePath } from "@/services/terminal/filePathDetection";
 
 export interface HybridInputBarHandle {
   focus: () => void;
@@ -188,6 +203,9 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const [isExpanded, setIsExpanded] = useState(false);
     const modalEditorHostRef = useRef<HTMLDivElement | null>(null);
     const compactEditorHostRef = useRef<HTMLDivElement | null>(null);
+    // Absolute path the current selection resolves to, captured on right-click.
+    // Gates the "View file" / "Open folder" context-menu section.
+    const [selectionFilePath, setSelectionFilePath] = useState<string | null>(null);
     const lastEnterKeydownNewlineRef = useRef(false);
     const handledEnterRef = useRef(false);
     const historyPaletteOpenRef = useRef<(() => void) | null>(null);
@@ -710,6 +728,29 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       setActiveCompletionContext,
     });
 
+    // Right-click gate for the composer's file-path menu. Read the selection
+    // synchronously from the live EditorView, resolve it against the terminal's
+    // cwd, and only let Radix open its menu when it resolves to a path —
+    // otherwise preventDefault so no empty menu appears. When not prevented,
+    // the batched setState lands before Radix renders the (portalled) content,
+    // so the items are present the moment the menu opens.
+    const handleEditorContextMenu = useCallback(
+      (event: React.MouseEvent) => {
+        const view = editorViewRef.current;
+        let resolvedPath: string | null = null;
+        if (view) {
+          const { from, to } = view.state.selection.main;
+          if (from !== to) {
+            resolvedPath =
+              resolveSelectedFilePath(view.state.sliceDoc(from, to), cwd)?.absolutePath ?? null;
+          }
+        }
+        setSelectionFilePath(resolvedPath);
+        if (!resolvedPath) event.preventDefault();
+      },
+      [cwd]
+    );
+
     useEditorFactory({
       terminalId,
       editorHostRef,
@@ -918,16 +959,23 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             >
               ❯
             </button>
-            <div className="relative flex-1">
-              <div
-                ref={(node) => {
-                  editorHostRef.current = node;
-                  compactEditorHostRef.current = node;
-                }}
-                className={cn("w-full min-h-[20px]", disabled && "pointer-events-none")}
-                style={{ color: inputBarColors.foreground }}
-              />
-            </div>
+            <ContextMenu>
+              <ContextMenuTrigger asChild onContextMenu={handleEditorContextMenu}>
+                <div className="relative flex-1">
+                  <div
+                    ref={(node) => {
+                      editorHostRef.current = node;
+                      compactEditorHostRef.current = node;
+                    }}
+                    className={cn("w-full min-h-[20px]", disabled && "pointer-events-none")}
+                    style={{ color: inputBarColors.foreground }}
+                  />
+                </div>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                {selectionFilePath && <SelectedFileMenuItems absolutePath={selectionFilePath} />}
+              </ContextMenuContent>
+            </ContextMenu>
             <div className="flex items-center pr-1.5">
               {hasStash && (
                 <Tooltip>
@@ -1003,10 +1051,17 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             <AppDialog.CloseButton />
           </AppDialog.Header>
           <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-            <div
-              ref={modalEditorHostRef}
-              className="flex-1 min-h-[200px] overflow-auto text-daintree-text p-4"
-            />
+            <ContextMenu>
+              <ContextMenuTrigger asChild onContextMenu={handleEditorContextMenu}>
+                <div
+                  ref={modalEditorHostRef}
+                  className="flex-1 min-h-[200px] overflow-auto text-daintree-text p-4"
+                />
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                {selectionFilePath && <SelectedFileMenuItems absolutePath={selectionFilePath} />}
+              </ContextMenuContent>
+            </ContextMenu>
           </div>
         </AppDialog>
         {isFocusedTerminal && (

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -66,11 +66,7 @@ import { useFleetMirror } from "./hooks/useFleetMirror";
 import { useEditorDomHandlers } from "./hooks/useEditorDomHandlers";
 import { useEditorFactory } from "./hooks/useEditorFactory";
 import { useHostReparent } from "./hooks/useHostReparent";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { SelectedFileMenuItems } from "./SelectedFileMenuItems";
 import { resolveSelectedFilePath } from "@/services/terminal/filePathDetection";
 

--- a/src/components/Terminal/SelectedFileMenuItems.tsx
+++ b/src/components/Terminal/SelectedFileMenuItems.tsx
@@ -1,0 +1,60 @@
+import { FileText, FolderOpen } from "@/components/icons";
+import { ContextMenuItem } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
+import { actionService } from "@/services/ActionService";
+import { reportFileLinkFailure } from "@/services/terminal/FileLinksAddon";
+
+const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
+
+interface SelectedFileMenuItemsProps {
+  /** Absolute path the selected text resolved to. */
+  absolutePath: string;
+}
+
+/**
+ * "View file" + "Open folder" pair shown when the user right-clicks a selection
+ * that resolves to a file path — in the terminal and the composer. Callers own
+ * the leading separator so the section can sit flush at the top of the composer
+ * menu but below the terminal menu's other items. Dispatch failures (a path
+ * outside project roots, a since-deleted file) surface through the same
+ * coalesced toast as terminal file links rather than failing silently.
+ */
+export function SelectedFileMenuItems({ absolutePath }: SelectedFileMenuItemsProps) {
+  const source = useMenuActionSource();
+  return (
+    <>
+      <ContextMenuItem
+        onSelect={() => {
+          void actionService
+            .dispatch("file.openPanel", { path: absolutePath }, { source })
+            .then((result) => {
+              if (!result.ok) {
+                reportFileLinkFailure("Failed to open file panel", result.error.details, absolutePath);
+              }
+            });
+        }}
+      >
+        <FileText className={ICON_CLASS} aria-hidden="true" />
+        View file
+      </ContextMenuItem>
+      <ContextMenuItem
+        onSelect={() => {
+          void actionService
+            .dispatch("file.showItemInFolder", { path: absolutePath }, { source })
+            .then((result) => {
+              if (!result.ok) {
+                reportFileLinkFailure(
+                  "Failed to reveal in file manager",
+                  result.error.details,
+                  absolutePath
+                );
+              }
+            });
+        }}
+      >
+        <FolderOpen className={ICON_CLASS} aria-hidden="true" />
+        Open folder
+      </ContextMenuItem>
+    </>
+  );
+}

--- a/src/components/Terminal/SelectedFileMenuItems.tsx
+++ b/src/components/Terminal/SelectedFileMenuItems.tsx
@@ -29,7 +29,11 @@ export function SelectedFileMenuItems({ absolutePath }: SelectedFileMenuItemsPro
             .dispatch("file.openPanel", { path: absolutePath }, { source })
             .then((result) => {
               if (!result.ok) {
-                reportFileLinkFailure("Failed to open file panel", result.error.details, absolutePath);
+                reportFileLinkFailure(
+                  "Failed to open file panel",
+                  result.error.details,
+                  absolutePath
+                );
               }
             });
         }}

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -19,6 +19,8 @@ import {
 } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { reportFileLinkFailure } from "@/services/terminal/FileLinksAddon";
+import { resolveSelectedFilePath } from "@/services/terminal/filePathDetection";
+import { SelectedFileMenuItems } from "./SelectedFileMenuItems";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
 import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
@@ -127,6 +129,7 @@ export function TerminalContextMenu({
   const [hasSelection, setHasSelection] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
   const [hoveredFilePath, setHoveredFilePath] = useState<string | null>(null);
+  const [selectedText, setSelectedText] = useState<string | null>(null);
   const suppressNextCloseAutoFocusRef = useRef(false);
   // Local confirm dialog for single-terminal kill/restart when an agent
   // session is mid-work. Bare PTY terminals skip this gate and run
@@ -186,10 +189,14 @@ export function TerminalContextMenu({
         setHasSelection(false);
         setHoveredUrl(null);
         setHoveredFilePath(null);
+        setSelectedText(null);
         return;
       }
+      // Read the selection synchronously here — xterm clears it on the next
+      // forwarded keystroke (#7649), so a deferred read would see nothing.
       const selection = managed.terminal.getSelection();
       setHasSelection(!!selection);
+      setSelectedText(selection || null);
       setHoveredUrl(terminalInstanceService.getHoveredLinkText(terminalId));
       setHoveredFilePath(terminalInstanceService.getHoveredFilePath(terminalId));
     },
@@ -198,6 +205,17 @@ export function TerminalContextMenu({
 
   const terminalPty = terminal && isPtyPanel(terminal) ? terminal : undefined;
   const terminalBrowser = terminal && isBrowserPanel(terminal) ? terminal : undefined;
+
+  // A selection that resolves to a file path unlocks the "View file" / "Open
+  // folder" section. Relative paths resolve against the terminal's cwd;
+  // absolute selections resolve without one (empty cwd is fine for those).
+  const selectionFilePath = useMemo(
+    () =>
+      selectedText
+        ? (resolveSelectedFilePath(selectedText, terminalPty?.cwd ?? "")?.absolutePath ?? null)
+        : null,
+    [selectedText, terminalPty?.cwd]
+  );
   const isPaused =
     terminalPty?.flowStatus === "paused-backpressure" ||
     terminalPty?.flowStatus === "paused-resource-governor";
@@ -833,6 +851,12 @@ export function TerminalContextMenu({
                     <FolderOpen className={ICON_CLASS} aria-hidden="true" />
                     {mac ? "Reveal in Finder" : isWindows() ? "Show in Explorer" : "Show in folder"}
                   </ContextMenuItem>
+                </>
+              )}
+              {selectionFilePath && (
+                <>
+                  <ContextMenuSeparator />
+                  <SelectedFileMenuItems absolutePath={selectionFilePath} />
                 </>
               )}
               <ContextMenuSeparator />

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -10,6 +10,7 @@ export * from "./brands";
 export {
   Activity, // project pulse / live activity heartbeat
   BellDot, // watch alert / notify on completion
+  FileText, // view selected file path in the read-only file viewer
   FolderGit2, // git worktree (single)
   FolderOpen, // reveal in file manager (Finder / Explorer / file manager)
   Folders, // copy tree / file hierarchy capture (two overlapping folders)

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -1,23 +1,13 @@
 import type { Terminal, ILinkProvider, ILink, IBufferRange } from "@xterm/xterm";
 import { systemClient } from "@/clients";
-import { basename, isAbsolute, resolve } from "@shared/utils/path";
+import { basename } from "@shared/utils/path";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { isClientAppError } from "@/utils/clientAppError";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { FILE_PATH_REGEX, isPathExcluded, resolveFilePathCandidate } from "./filePathDetection";
 import type { TerminalLink } from "./types";
-
-interface ResolvedFilePath {
-  absolutePath: string;
-  line?: number;
-  col?: number;
-}
-
-const FILE_PATH_REGEX =
-  /(?:^|[\s(])((?:\\\\wsl(?:\$|\.localhost)\\[^\\]+(?:\\[\w.-]+)+|\/[\w./-]+|[a-zA-Z]:[\\/][\w./\\-]+|(?:\.\.?[\\/])+[\w./\\-]+|[\w-]+[\\/][\w./\\-]+)\.[\w]+(?::\d+(?::\d+)?)?)/g;
-
-const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
 
 // Coalesce key for file-link activation failures. A user who scrolls a stack
 // trace and clicks 10 bad links shouldn't see 10 toasts; collapse the burst
@@ -174,11 +164,11 @@ export class FileLinksAddon implements ILinkProvider {
     for (const match of lineText.matchAll(FILE_PATH_REGEX)) {
       const fullMatch = match[1];
       if (fullMatch === undefined) continue;
-      if (this._isExcluded(fullMatch)) {
+      if (isPathExcluded(fullMatch)) {
         continue;
       }
 
-      const resolved = this._resolveFilePath(fullMatch);
+      const resolved = resolveFilePathCandidate(fullMatch, this._getCwd());
       if (!resolved) {
         continue;
       }
@@ -204,48 +194,6 @@ export class FileLinksAddon implements ILinkProvider {
     }
 
     callback(links.length > 0 ? links : undefined);
-  }
-
-  private _isExcluded(text: string): boolean {
-    if (text.includes("://")) {
-      return true;
-    }
-    if (text.includes("\x1b")) {
-      return true;
-    }
-    return false;
-  }
-
-  private _resolveFilePath(text: string): ResolvedFilePath | null {
-    const match = /^(.*\.[^\s:]+?)(?::(\d+)(?::(\d+))?)?$/.exec(text);
-    if (!match) return null;
-    const pathPart = match[1];
-    if (pathPart === undefined) return null;
-    const linePart = match[2] ? Number(match[2]) : undefined;
-    const colPart = match[3] ? Number(match[3]) : undefined;
-
-    let absolutePath: string;
-
-    if (isAbsolute(pathPart)) {
-      absolutePath = pathPart;
-    } else {
-      const cwd = this._getCwd();
-      if (!cwd) {
-        return null;
-      }
-      if (WINDOWS_ABS.test(cwd)) {
-        const sep = cwd.includes("\\") ? "\\" : "/";
-        absolutePath = `${cwd.replace(/[\\/]+$/, "")}${sep}${pathPart.replace(/[\\/]+/g, sep)}`;
-      } else {
-        absolutePath = resolve(cwd, pathPart);
-      }
-    }
-
-    return {
-      absolutePath,
-      line: linePart,
-      col: colPart,
-    };
   }
 
   dispose(): void {}

--- a/src/services/terminal/__tests__/filePathDetection.test.ts
+++ b/src/services/terminal/__tests__/filePathDetection.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  FILE_PATH_REGEX,
+  isPathExcluded,
+  resolveFilePathCandidate,
+  resolveSelectedFilePath,
+} from "../filePathDetection";
+
+describe("resolveFilePathCandidate", () => {
+  it("returns an absolute POSIX path unchanged", () => {
+    expect(resolveFilePathCandidate("/usr/local/app.log", "/home/u")).toEqual({
+      absolutePath: "/usr/local/app.log",
+      line: undefined,
+      col: undefined,
+    });
+  });
+
+  it("resolves a relative path against the cwd", () => {
+    expect(resolveFilePathCandidate("src/foo.ts", "/home/u/proj")?.absolutePath).toBe(
+      "/home/u/proj/src/foo.ts"
+    );
+  });
+
+  it("collapses ./ and ../ segments during resolution", () => {
+    expect(resolveFilePathCandidate("./foo.ts", "/home/u/proj")?.absolutePath).toBe(
+      "/home/u/proj/foo.ts"
+    );
+    expect(resolveFilePathCandidate("../a/b.ts", "/home/u/proj")?.absolutePath).toBe(
+      "/home/u/a/b.ts"
+    );
+  });
+
+  it("strips a :line:col suffix and reports the numbers", () => {
+    expect(resolveFilePathCandidate("src/foo.ts:42:7", "/p")).toEqual({
+      absolutePath: "/p/src/foo.ts",
+      line: 42,
+      col: 7,
+    });
+    expect(resolveFilePathCandidate("src/foo.ts:42", "/p")).toEqual({
+      absolutePath: "/p/src/foo.ts",
+      line: 42,
+      col: undefined,
+    });
+  });
+
+  it("keeps a Windows drive-absolute path verbatim", () => {
+    expect(resolveFilePathCandidate("C:\\Users\\me\\file.txt", "/ignored")?.absolutePath).toBe(
+      "C:\\Users\\me\\file.txt"
+    );
+  });
+
+  it("joins a relative path under a Windows cwd with backslashes", () => {
+    expect(resolveFilePathCandidate("src/foo.ts", "C:\\proj")?.absolutePath).toBe(
+      "C:\\proj\\src\\foo.ts"
+    );
+  });
+
+  it("cannot resolve a relative path without a cwd", () => {
+    expect(resolveFilePathCandidate("src/foo.ts", "")).toBeNull();
+  });
+
+  it("rejects text with no file extension", () => {
+    expect(resolveFilePathCandidate("/etc/hosts", "/p")).toBeNull();
+  });
+});
+
+describe("resolveSelectedFilePath", () => {
+  it("accepts a selection that is exactly one path token", () => {
+    expect(resolveSelectedFilePath("src/foo.ts", "/home/u/proj")?.absolutePath).toBe(
+      "/home/u/proj/src/foo.ts"
+    );
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(resolveSelectedFilePath("  src/foo.ts \n", "/p")?.absolutePath).toBe("/p/src/foo.ts");
+  });
+
+  it("resolves a WSL absolute path verbatim", () => {
+    const wsl = "\\\\wsl$\\Ubuntu\\home\\me\\file.txt";
+    expect(resolveSelectedFilePath(wsl, "/ignored")?.absolutePath).toBe(wsl);
+  });
+
+  it("rejects a path embedded in surrounding prose", () => {
+    expect(resolveSelectedFilePath("see src/foo.ts for details", "/p")).toBeNull();
+  });
+
+  it("rejects a selection spanning two paths", () => {
+    expect(resolveSelectedFilePath("a/one.ts b/two.ts", "/p")).toBeNull();
+  });
+
+  it("rejects a URL that looks path-like", () => {
+    expect(resolveSelectedFilePath("https://example.com/a/b.ts", "/p")).toBeNull();
+  });
+
+  it("rejects slash-commands with no extension", () => {
+    expect(resolveSelectedFilePath("/help", "/p")).toBeNull();
+    expect(resolveSelectedFilePath("/api/v1", "/p")).toBeNull();
+  });
+
+  it("rejects an empty or whitespace-only selection", () => {
+    expect(resolveSelectedFilePath("", "/p")).toBeNull();
+    expect(resolveSelectedFilePath("   ", "/p")).toBeNull();
+  });
+
+  it("rejects a bare filename with no separator", () => {
+    expect(resolveSelectedFilePath("foo.ts", "/p")).toBeNull();
+  });
+});
+
+describe("isPathExcluded", () => {
+  it("excludes URLs and text carrying escape sequences", () => {
+    expect(isPathExcluded("https://x/a.ts")).toBe(true);
+    expect(isPathExcluded("a\x1b[0m/b.ts")).toBe(true);
+    expect(isPathExcluded("src/foo.ts")).toBe(false);
+  });
+});
+
+describe("FILE_PATH_REGEX (terminal line scanning)", () => {
+  it("finds a path token embedded in a log line", () => {
+    const matches = [..." at /home/app.js:10:5 threw".matchAll(FILE_PATH_REGEX)];
+    expect(matches.map((m) => m[1])).toEqual(["/home/app.js:10:5"]);
+  });
+});

--- a/src/services/terminal/filePathDetection.ts
+++ b/src/services/terminal/filePathDetection.ts
@@ -62,6 +62,7 @@ export function resolveSelectedFilePath(selection: string, cwd: string): Resolve
   if (!trimmed || isPathExcluded(trimmed)) return null;
   const matches = [...trimmed.matchAll(FILE_PATH_REGEX)];
   if (matches.length !== 1) return null;
-  if (matches[0][1] !== trimmed) return null;
+  const [match] = matches;
+  if (!match || match[1] !== trimmed) return null;
   return resolveFilePathCandidate(trimmed, cwd);
 }

--- a/src/services/terminal/filePathDetection.ts
+++ b/src/services/terminal/filePathDetection.ts
@@ -1,0 +1,67 @@
+import { isAbsolute, resolve } from "@shared/utils/path";
+
+export interface ResolvedFilePath {
+  absolutePath: string;
+  line?: number;
+  col?: number;
+}
+
+// Matches a file-path-like token inside arbitrary text. Every alternative
+// requires a path separator ('/' or '\') and a trailing `.ext`, so bare words
+// and slash-commands (`/help`, `/api/v1`) never match. Global so the terminal
+// link scanner can walk every match on a line. Kept byte-for-byte identical to
+// the historical FileLinksAddon regex so link-scanning behavior is unchanged.
+export const FILE_PATH_REGEX =
+  /(?:^|[\s(])((?:\\\\wsl(?:\$|\.localhost)\\[^\\]+(?:\\[\w.-]+)+|\/[\w./-]+|[a-zA-Z]:[\\/][\w./\\-]+|(?:\.\.?[\\/])+[\w./\\-]+|[\w-]+[\\/][\w./\\-]+)\.[\w]+(?::\d+(?::\d+)?)?)/g;
+
+const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
+
+/** URLs and embedded escape sequences look path-ish but aren't files. */
+export function isPathExcluded(text: string): boolean {
+  return text.includes("://") || text.includes("\x1b");
+}
+
+/**
+ * Turn a path-like token into an absolute path, stripping any `:line[:col]`
+ * suffix. Relative tokens resolve against `cwd`; when `cwd` is empty a relative
+ * token can't be resolved and returns null. Windows cwds join with the drive's
+ * separator so a POSIX-style relative token still lands under the drive root.
+ */
+export function resolveFilePathCandidate(text: string, cwd: string): ResolvedFilePath | null {
+  const match = /^(.*\.[^\s:]+?)(?::(\d+)(?::(\d+))?)?$/.exec(text);
+  if (!match) return null;
+  const pathPart = match[1];
+  if (pathPart === undefined) return null;
+  const line = match[2] ? Number(match[2]) : undefined;
+  const col = match[3] ? Number(match[3]) : undefined;
+
+  let absolutePath: string;
+  if (isAbsolute(pathPart)) {
+    absolutePath = pathPart;
+  } else {
+    if (!cwd) return null;
+    if (WINDOWS_ABS.test(cwd)) {
+      const sep = cwd.includes("\\") ? "\\" : "/";
+      absolutePath = `${cwd.replace(/[\\/]+$/, "")}${sep}${pathPart.replace(/[\\/]+/g, sep)}`;
+    } else {
+      absolutePath = resolve(cwd, pathPart);
+    }
+  }
+
+  return { absolutePath, line, col };
+}
+
+/**
+ * Detect a file path from a user's text *selection* (terminal or composer). The
+ * whole trimmed selection must be a single path token — a path embedded in
+ * prose ("see src/foo.ts for details") is intentionally rejected so the "View
+ * file" menu section only appears when the user selected exactly a path.
+ */
+export function resolveSelectedFilePath(selection: string, cwd: string): ResolvedFilePath | null {
+  const trimmed = selection.trim();
+  if (!trimmed || isPathExcluded(trimmed)) return null;
+  const matches = [...trimmed.matchAll(FILE_PATH_REGEX)];
+  if (matches.length !== 1) return null;
+  if (matches[0][1] !== trimmed) return null;
+  return resolveFilePathCandidate(trimmed, cwd);
+}


### PR DESCRIPTION
## Summary

- Adds a `View file` + `Open folder` context menu section that appears when the user right-clicks a text selection that resolves to a file path, in the agent terminal and in the composer (both compact and expanded editor).
- `View file` opens the read-only file viewer panel via the existing `file.openPanel` action; `Open folder` reveals it in the OS file manager via the existing `file.showItemInFolder` action.
- Agent response text is covered too: agent output renders through the terminal (xterm), there's no separate chat renderer, so the terminal implementation handles that case for free.

Resolves #11204

## Changes

- Extracted the path-detection and resolution logic out of `FileLinksAddon` into a new pure module, `src/services/terminal/filePathDetection.ts`, which `FileLinksAddon` now consumes. Hovered-link behavior is unchanged.
- `resolveSelectedFilePath` requires the whole trimmed selection to be a single path token, and resolves relative paths against the terminal's cwd.
- Validity is a client-side heuristic that matches the existing hovered-file-link feature, which also doesn't check the filesystem for existence. Dispatch failures surface through the existing `reportFileLinkFailure` coalesced toast.
- Reuses existing actions (`file.openPanel`, `file.showItemInFolder`). No new action IDs, no new IPC channels.
- Terminal: new section added to `TerminalContextMenu`, next to the existing hovered-path reveal.
- Composer: a Radix `ContextMenu` wraps the CodeMirror host, gated by a conditional `preventDefault` on `menu-open` so the section only appears when the selection resolves to a path. Both editor hosts re-adopt CodeMirror's imperative DOM if Radix's lazy-loaded trigger remounts the host node (found during review).

## Testing

- Added unit tests in `src/services/terminal/__tests__/filePathDetection.test.ts` covering path detection edge cases, plus the existing `FileLinksAddon` suite as a regression check. 49 tests pass locally.
- Known limitation: touch/pen long-press opens the context menu without firing `onContextMenu`, so it can show a stale or empty section. This is a desktop app, and it's consistent with the existing terminal menu's long-press behavior.
