### PR TITLE
feat(agents): default grok and opencode to inline mode

### DIFF
--- a/shared/config/agents/grok.ts
+++ b/shared/config/agents/grok.ts
@@ -73,13 +73,14 @@ export const config: AgentConfig = {
   capabilities: {
     scrollback: 10000,
     resizeStrategy: "default",
-    // Rust TUI that takes over the alternate screen. We keep it ON the alt
-    // screen by default: forcing it inline (--no-alt-screen) renders every frame
-    // into the normal-buffer scrollback, so scrolling up shows garbled overdrawn
-    // history and the overlay scrollbar can't be auto-hidden. The flag stays
-    // available as an opt-in via the inline-mode toggle.
+    // Rust TUI that would otherwise take over the alternate screen. We default
+    // it inline (`--no-alt-screen`, grok's scrollback-native mode) so output
+    // flows into Daintree's own WebGL scrollback and stays selectable with our
+    // native text-selection layer instead of grok's mouse-grabbing full-screen
+    // TUI. No `defaultInlineMode` override: inline follows the global
+    // "Use alt-screen mode by default" switch (off ⇒ inline), so users can still
+    // flip back to alt-screen globally or per-agent.
     inlineModeFlag: "--no-alt-screen",
-    defaultInlineMode: false,
     supportsBracketedPaste: true,
     // Rust TUI reads the PTY buffer atomically, so the quit-command body and
     // Enter must be sent as separate writes (same rationale as Codex).

--- a/shared/config/agents/opencode.ts
+++ b/shared/config/agents/opencode.ts
@@ -85,7 +85,15 @@ export const config: AgentConfig = {
   },
   capabilities: {
     scrollback: 10000,
+    // Bubble Tea full-screen TUI — renderer-side `blockAltScreen` garbles it
+    // (same constraint as Crush), so we can't strip the alt-screen escape.
+    // Instead default it inline via OpenCode's own `--mini` (the minimal
+    // scrollback-native interface): verified to emit no alt-screen enter and no
+    // mouse-reporting, so output lands in Daintree's WebGL scrollback and stays
+    // selectable with our native selection layer. Inline follows the global
+    // alt-screen switch (off ⇒ inline); no per-agent `defaultInlineMode`.
     blockAltScreen: false,
+    inlineModeFlag: "--mini",
     resizeStrategy: "default",
     supportsBracketedPaste: true,
     softNewlineSequence: "\n",

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -18,6 +18,8 @@ import {
   DEFAULT_AGENT_SETTINGS,
   DEFAULT_DANGEROUS_ARGS,
 } from "../agentSettings.js";
+import { setUserRegistry } from "../../config/agentRegistry.js";
+import type { AgentConfig } from "../../config/agentRegistry.js";
 
 // Force POSIX shell-escape semantics so the hardcoded single-quote assertions
 // below hold on Windows CI. The Windows double-quote branch is exercised via
@@ -252,18 +254,28 @@ describe("buildAgentLaunchFlags", () => {
     expect(flags).not.toContain("--no-alt-screen");
   });
 
-  it("defaults grok to the alternate screen (defaultInlineMode false → no flag)", () => {
-    // Grok declares defaultInlineMode: false, so an unset inlineMode must NOT add
-    // --no-alt-screen — it should run full-screen on the alt buffer, unlike codex.
+  it("defaults grok to inline like codex (no curated default → global switch, off ⇒ inline)", () => {
+    // Neither grok nor codex pins a curated default now, so an unset inlineMode
+    // follows the global switch (default off ⇒ inline) and both get --no-alt-screen.
     const grok = buildAgentLaunchFlags({}, "grok");
     const codex = buildAgentLaunchFlags({}, "codex");
-    expect(grok).not.toContain("--no-alt-screen");
+    expect(grok).toContain("--no-alt-screen");
     expect(codex).toContain("--no-alt-screen");
   });
 
   it("still lets grok opt into inline mode explicitly", () => {
     const flags = buildAgentLaunchFlags({ inlineMode: true }, "grok");
     expect(flags).toContain("--no-alt-screen");
+  });
+
+  it("injects opencode's --mini on the interactive spawn and drops it when alt-screen is forced", () => {
+    // buildAgentLaunchFlags is the persistent interactive-terminal spawn path,
+    // so opencode's inline flag rides every spawn/restart unless the global
+    // switch (or a per-agent choice) forces alt-screen.
+    expect(buildAgentLaunchFlags({}, "opencode")).toContain("--mini");
+    expect(buildAgentLaunchFlags({}, "opencode", { globalUseAltScreen: true })).not.toContain(
+      "--mini"
+    );
   });
 
   it("does not include clipboard directory", () => {
@@ -383,13 +395,13 @@ describe("generateAgentCommand per-agent prompt injection", () => {
     expect(oneShotCmd).toMatch(/-p\s+'Fix the bug'/);
   });
 
-  it("grok's first-spawn command defaults to the alternate screen, unlike codex", () => {
+  it("grok's and codex's first-spawn commands default to inline (--no-alt-screen)", () => {
     // Covers the generateAgentCommand inline-flag path (separate from
-    // buildAgentLaunchFlags): an unset inlineMode must not add --no-alt-screen
-    // for grok (defaultInlineMode false), while codex still gets it.
+    // buildAgentLaunchFlags): an unset inlineMode follows the global switch
+    // (default off ⇒ inline), so both agents get --no-alt-screen.
     const grok = generateAgentCommand("grok", {}, "grok");
     const codex = generateAgentCommand("codex", {}, "codex");
-    expect(grok).not.toContain("--no-alt-screen");
+    expect(grok).toContain("--no-alt-screen");
     expect(codex).toContain("--no-alt-screen");
   });
 
@@ -407,6 +419,21 @@ describe("generateAgentCommand per-agent prompt injection", () => {
     });
     expect(cmd).toMatch(/run\s+'Fix the bug'/);
     expect(cmd).not.toContain("--prompt");
+  });
+
+  it("opencode injects --mini for the interactive TUI but never the headless run", () => {
+    // `--mini` is opencode's inline (scrollback-native) flag on the default
+    // command. Its `run` subcommand rejects it ("--mini must be used without the
+    // run subcommand"), so the inline flag is interactive-only.
+    const interactiveCmd = generateAgentCommand("opencode", {}, "opencode", {
+      initialPrompt: "Fix the bug",
+    });
+    const headlessCmd = generateAgentCommand("opencode", {}, "opencode", {
+      initialPrompt: "Fix the bug",
+      interactive: false,
+    });
+    expect(interactiveCmd).toContain("--mini");
+    expect(headlessCmd).not.toContain("--mini");
   });
 
   it("aider uses -m in both modes (positionals are filenames)", () => {
@@ -966,6 +993,26 @@ describe("combineInlineModes (#10876)", () => {
 });
 
 describe("resolveEffectiveInlineMode (#10876)", () => {
+  // Synthetic agent exercising the curated registry-default tier. No shipped
+  // agent sets `defaultInlineMode` anymore — they all default inline via the
+  // global switch so it stays user-overridable — so the tier is covered here
+  // with a registered test agent instead of coupling to a real one.
+  const ALT_DEFAULT_AGENT: AgentConfig = {
+    id: "alt-default-agent",
+    name: "Alt Default Agent",
+    command: "alt-default-agent",
+    color: "#ffffff",
+    iconId: "custom",
+    supportsContextInjection: false,
+    capabilities: {
+      scrollback: 1000,
+      inlineModeFlag: "--no-alt-screen",
+      defaultInlineMode: false,
+    },
+  };
+  beforeEach(() => setUserRegistry({ "alt-default-agent": ALT_DEFAULT_AGENT }));
+  afterEach(() => setUserRegistry({}));
+
   it("honours an explicit on/off regardless of the global switch", () => {
     expect(resolveEffectiveInlineMode({ inlineMode: "on" }, "codex", true)).toBe(true);
     expect(resolveEffectiveInlineMode({ inlineMode: "off" }, "codex", false)).toBe(false);
@@ -974,21 +1021,26 @@ describe("resolveEffectiveInlineMode (#10876)", () => {
   });
 
   it("keeps a curated registry default winning over the global switch on inherit", () => {
-    // Grok declares defaultInlineMode: false (alt-screen) — it must stay
+    // The agent declares defaultInlineMode: false (alt-screen) — it must stay
     // alt-screen even when the global "use alt-screen by default" is OFF.
-    expect(resolveEffectiveInlineMode({}, "grok", false)).toBe(false);
-    expect(resolveEffectiveInlineMode({}, "grok", true)).toBe(false);
-    expect(resolveEffectiveInlineMode({ inlineMode: "inherit" }, "grok", false)).toBe(false);
+    expect(resolveEffectiveInlineMode({}, "alt-default-agent", false)).toBe(false);
+    expect(resolveEffectiveInlineMode({}, "alt-default-agent", true)).toBe(false);
+    expect(resolveEffectiveInlineMode({ inlineMode: "inherit" }, "alt-default-agent", false)).toBe(
+      false
+    );
   });
 
   it("falls back to the global switch on inherit when no registry default is declared", () => {
-    // Codex declares no defaultInlineMode → global switch decides.
+    // Codex and Grok declare no defaultInlineMode → the global switch decides,
+    // so both now default inline (global off ⇒ inline).
     expect(resolveEffectiveInlineMode({}, "codex", false)).toBe(true); // global off → inline
     expect(resolveEffectiveInlineMode({}, "codex", true)).toBe(false); // global on → alt-screen
+    expect(resolveEffectiveInlineMode({}, "grok", false)).toBe(true); // grok follows global now
+    expect(resolveEffectiveInlineMode({}, "grok", true)).toBe(false);
   });
 
   it("still lets an agent override its curated registry default explicitly", () => {
-    expect(resolveEffectiveInlineMode({ inlineMode: "on" }, "grok", false)).toBe(true);
+    expect(resolveEffectiveInlineMode({ inlineMode: "on" }, "alt-default-agent", false)).toBe(true);
   });
 });
 
@@ -1046,8 +1098,10 @@ describe("global alt-screen threading through command generation (#10876)", () =
     );
   });
 
-  it("keeps grok on alt-screen regardless of the global switch (curated default)", () => {
-    expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: false })).not.toContain(
+  it("makes grok follow the global switch now that it has no curated default", () => {
+    // Grok no longer pins a curated default, so it threads the global switch
+    // like any other inherit agent: inline when off, alt-screen when on.
+    expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: false })).toContain(
       "--no-alt-screen"
     );
     expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: true })).not.toContain(

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -270,9 +270,9 @@ export function combineInlineModes(agentMode: InlineMode, presetMode?: InlineMod
  * - `"on"`  → inline (inject flag).
  * - `"off"` → alt-screen (no flag); an explicit veto that beats the global switch.
  * - `"inherit"` → a curated per-agent registry `capabilities.defaultInlineMode`
- *   (e.g. Grok's `false`, kept on the alternate screen because inline renders its
- *   Rust TUI as garbled scrollback) wins if declared; otherwise defer to the
- *   global "Use alt-screen mode by default" switch (`globalUseAltScreen` on →
+ *   wins if declared (no shipped agent pins one today — they all follow the
+ *   global switch so it stays user-overridable); otherwise defer to the global
+ *   "Use alt-screen mode by default" switch (`globalUseAltScreen` on →
  *   alt-screen, off → inline).
  *
  * Callers that resolve a launch from a preset must bake the combined mode onto
@@ -572,9 +572,16 @@ export function generateAgentCommand(
     // Add inline mode flag when the resolved tri-state says inline and the agent
     // supports it (#10876). resolveEffectiveInlineMode encodes the full chain:
     // explicit on/off → preset (already baked onto the entry) → curated registry
-    // default → the global `globalUseAltScreen` switch.
+    // default → the global `globalUseAltScreen` switch. Inline rendering only
+    // applies to the interactive TUI, so a headless one-shot (`interactive:
+    // false` — e.g. opencode's `run` subcommand, which rejects `--mini`) must not
+    // carry the flag.
     const inlineModeFlag = agentConfig?.capabilities?.inlineModeFlag;
-    if (inlineModeFlag && resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)) {
+    if (
+      inlineModeFlag &&
+      (options?.interactive ?? true) &&
+      resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)
+    ) {
       parts.push(inlineModeFlag);
     }
   }

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -147,7 +147,7 @@ export interface AgentSettings {
    * and no curated registry default apply. Default off — so `inlineMode`
    * resolves to inline (no alt-screen) globally unless something overrides it,
    * mirroring how `globalSkipPermissions` defaults off. A curated per-agent
-   * registry `defaultInlineMode` (e.g. Grok's alt-screen) still wins over this
+   * registry `defaultInlineMode` (when an agent declares one) still wins over this
    * switch; an explicit per-agent/preset `"on"`/`"off"` always vetoes it. Like
    * the bypass override it is a *live* value OR-ed in at flag-generation time
    * (see {@link resolveEffectiveInlineMode}), never mutating per-agent state.

--- a/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
@@ -1,15 +1,30 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { DEFAULT_AGENT_SETTINGS, type AgentSettingsEntry } from "@shared/types";
+import { setUserRegistry, type AgentConfig } from "@shared/config/agentRegistry";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useAgentScope } from "../useAgentScope";
 
 // The alt-screen "Default (inherit)" hint attributes the resolved value to a
 // source. Its correctness depends on the three-tier precedence in
 // `resolveEffectiveInlineMode` (explicit → curated registry `defaultInlineMode`
-// → global switch). These tests exercise the real agent registry so the
-// registry-default tier (Grok) is genuinely present. #10894.
+// → global switch). No shipped agent sets `defaultInlineMode` (they all default
+// inline via the global switch so it stays user-overridable), so the
+// registry-default tier is supplied here by a registered synthetic agent. #10894.
+const ALT_DEFAULT_AGENT: AgentConfig = {
+  id: "alt-default-agent",
+  name: "Alt Default Agent",
+  command: "alt-default-agent",
+  color: "#ffffff",
+  iconId: "custom",
+  supportsContextInjection: false,
+  capabilities: {
+    scrollback: 1000,
+    inlineModeFlag: "--no-alt-screen",
+    defaultInlineMode: false,
+  },
+};
 
 function makeProps(
   agentId: string,
@@ -41,25 +56,43 @@ function setGlobalAltScreen(globalUseAltScreen: boolean) {
 describe("useAgentScope — inline-mode inherit origin label (#10894)", () => {
   beforeEach(() => {
     useAgentSettingsStore.setState({ settings: DEFAULT_AGENT_SETTINGS });
+    setUserRegistry({ "alt-default-agent": ALT_DEFAULT_AGENT });
+  });
+  afterEach(() => {
+    setUserRegistry({});
   });
 
-  it("attributes an agent with a curated registry default (Grok) to its built-in default, not the global setting", () => {
+  it("attributes an agent with a curated registry default to its built-in default, not the global setting", () => {
     setGlobalAltScreen(false);
-    const { result } = renderHook(() => useAgentScope(makeProps("grok")));
+    const { result } = renderHook(() => useAgentScope(makeProps("alt-default-agent")));
 
     expect(result.current.scopeKind).toBe("default");
     expect(result.current.inlineInheritOriginLabel).toBe("the agent's built-in default");
-    // Grok's registry default is alt-screen (`defaultInlineMode: false`).
+    // The synthetic agent's registry default is alt-screen (`defaultInlineMode: false`).
     expect(result.current.inlineInheritResolvesToInline).toBe(false);
   });
 
   it("keeps attributing to the built-in default even when the global alt-screen switch is on (the registry default shadows it)", () => {
     setGlobalAltScreen(true);
-    const { result } = renderHook(() => useAgentScope(makeProps("grok")));
+    const { result } = renderHook(() => useAgentScope(makeProps("alt-default-agent")));
 
-    // Global toggle flipped, but Grok's built-in default still decides —
+    // Global toggle flipped, but the built-in default still decides —
     // proving the label is not merely echoing the global switch.
     expect(result.current.inlineInheritOriginLabel).toBe("the agent's built-in default");
+    expect(result.current.inlineInheritResolvesToInline).toBe(false);
+  });
+
+  it("attributes Grok (no registry default anymore) to the global setting, defaulting inline", () => {
+    setGlobalAltScreen(false);
+    const { result, rerender } = renderHook(() => useAgentScope(makeProps("grok")));
+
+    // Grok no longer pins a curated default — it follows the global switch, so
+    // it defaults inline (global "use alt-screen" off ⇒ inline).
+    expect(result.current.inlineInheritOriginLabel).toBe("global setting");
+    expect(result.current.inlineInheritResolvesToInline).toBe(true);
+
+    setGlobalAltScreen(true);
+    rerender();
     expect(result.current.inlineInheritResolvesToInline).toBe(false);
   });
 

--- a/src/components/Settings/AgentScopeEditor/useAgentScope.ts
+++ b/src/components/Settings/AgentScopeEditor/useAgentScope.ts
@@ -127,8 +127,9 @@ export function useAgentScope({
     scopeKind === "custom" ? agentResolvedInline : resolveInline("inherit");
   // Mirror the three-tier precedence in `resolveEffectiveInlineMode`: a preset
   // inherits from the agent Default scope; the agent Default scope inherits from
-  // the curated registry default (`capabilities.defaultInlineMode`, currently
-  // only Grok) when one exists, and only otherwise from the global switch.
+  // the curated registry default (`capabilities.defaultInlineMode`) when one is
+  // declared, and only otherwise from the global switch. No shipped agent pins
+  // one today — they all follow the global switch so it stays user-overridable.
   // Attributing a registry-shadowed value to the global setting (#10894) is wrong
   // — the global toggle has no effect while the built-in default decides.
   const hasRegistryInlineDefault = typeof agentCfg?.capabilities?.defaultInlineMode === "boolean";


### PR DESCRIPTION
Makes inline rendering the default for the `grok` and `opencode` agent CLIs. Their output now flows into our own WebGL scrollback and stays selectable with our native text-selection layer, instead of getting locked inside the agent's full-screen alternate-screen TUI.

The global default was already inline for any agent with an inline flag, so this was a small change.

## Grok

Grok had an explicit opt-out, `defaultInlineMode: false`. I removed it, so grok now follows the global switch like everything else. Its `--no-alt-screen` flag was already wired.

## OpenCode

OpenCode is a Bubble Tea TUI, so the renderer-side `blockAltScreen` path would garble it (same constraint as Crush). Instead I wired OpenCode's own `--mini` flag as its inline flag. I verified with a PTY probe that `opencode --mini` emits no alternate-screen enter (`\x1b[?1049h`) and no mouse-reporting, while plain `opencode` emits both.

OpenCode's headless `run` subcommand rejects `--mini` (`--mini must be used without the run subcommand`), so I gated the inline-flag injection in `generateAgentCommand` on interactive mode. `buildAgentLaunchFlags`, the persistent interactive-spawn path, still injects it unconditionally since that path is always interactive.

Both agents stay overridable globally and per-agent.

## Tests

Updated the affected tests. Grok now defaults inline, and the curated-default precedence tier is exercised via a synthetic registered agent since no shipped agent pins `defaultInlineMode` anymore. 143 pass, typecheck and lint clean.

## Follow-up

OpenCode's working-state detection patterns (the braille spinner and `esc to interrupt`) should be validated live under `--mini`. The idle, prompt and boot markers (`Ask anything`, the prompt glyph, `OpenCode`) are already confirmed present in `--mini` output.
