### PR TITLE
feat(plugins): give plugin render errors real diagnostics

### DIFF
--- a/src/components/Plugin/PluginViewDiagnosticsFallback.tsx
+++ b/src/components/Plugin/PluginViewDiagnosticsFallback.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { TriangleAlert } from "lucide-react";
+import { scrubReportText } from "@shared/utils/reportScrubbers";
+import { cn } from "@/lib/utils";
+import { actionService } from "@/services/ActionService";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+
+export interface PluginViewDiagnosticsFallbackProps {
+  error: Error;
+  errorInfo?: React.ErrorInfo;
+  resetError: () => void;
+  incidentId?: string | null;
+  /** Plugin id — `manifest.name`, e.g. `acme`. */
+  pluginId: string;
+  /** Manifest display name, or the plugin id when the manifest omits one. */
+  pluginDisplayName: string;
+  /** Panel kind id — already prefixed, i.e. `${pluginId}.${panel.id}`. */
+  kindId: string;
+  /** The panel's own name, e.g. `Dashboard`. */
+  panelDisplayName: string;
+  /** Resolved `plugin://` URL of the view module that threw. */
+  componentPath: string;
+  /** The owning plugin loads from a dir outside the managed plugins dir. */
+  devMode: boolean;
+}
+
+const BUTTON_BASE = "rounded px-3 py-1.5 text-xs transition-colors";
+const NEUTRAL_BUTTON = "bg-daintree-border text-daintree-text hover:bg-daintree-border/80";
+
+function buildTrace(error: Error, errorInfo: React.ErrorInfo | undefined): string {
+  return [
+    "Stack:",
+    error.stack || "No stack trace available",
+    "",
+    "Component stack:",
+    errorInfo?.componentStack || "No component stack available",
+  ].join("\n");
+}
+
+/**
+ * Diagnostics pane for a plugin view that threw during render. Replaces the
+ * shared `component` ErrorFallback at the plugin boundary only — that variant
+ * stays lean for BrowserPane/FilePane/ReviewPane, which have no author to
+ * inform (#11207).
+ *
+ * Detail depth keys off the plugin's own `devMode`, never `import.meta.env.DEV`:
+ * plugin authors build against a *production* Daintree, so a build-mode gate
+ * blinds the exact audience the trace exists for. The trace is redacted rather
+ * than hidden for installed plugins — visibility isn't the risk, leaking the
+ * user's paths and secrets into a pasted report is (#9427).
+ */
+export function PluginViewDiagnosticsFallback({
+  error,
+  errorInfo,
+  resetError,
+  incidentId,
+  pluginId,
+  pluginDisplayName,
+  kindId,
+  panelDisplayName,
+  componentPath,
+  devMode,
+}: PluginViewDiagnosticsFallbackProps) {
+  const { copied, copy } = useCopyWithFeedback({ announcement: "Diagnostics copied" });
+  const message = error.message || "Unknown render error";
+
+  const announcedRef = useRef(false);
+  useEffect(() => {
+    if (announcedRef.current) return;
+    announcedRef.current = true;
+    useAnnouncerStore.getState().announce(`${panelDisplayName} error`, "polite");
+  }, [panelDisplayName]);
+
+  // Scrubbed once, here, so the rendered trace and the copied report can never
+  // diverge. A dev-mode plugin's paths are the author's own — redacting them
+  // would strip the file references they need to find the throw.
+  const trace = useMemo(() => {
+    const raw = buildTrace(error, errorInfo);
+    return devMode ? raw : scrubReportText(raw);
+  }, [error, errorInfo, devMode]);
+
+  // Identity and message stay raw in both surfaces: they name the plugin, not
+  // the user, and redacting them costs signal for no leak benefit.
+  const report = useMemo(
+    () =>
+      [
+        `Plugin: ${pluginDisplayName} (${pluginId})`,
+        `Panel: ${panelDisplayName} (${kindId})`,
+        `Module: ${componentPath}`,
+        ...(incidentId ? [`Error ID: ${incidentId}`] : []),
+        `Trace: ${devMode ? "raw (dev mode)" : "redacted"}`,
+        "",
+        `Message: ${message}`,
+        "",
+        trace,
+      ].join("\n"),
+    [
+      pluginDisplayName,
+      pluginId,
+      panelDisplayName,
+      kindId,
+      componentPath,
+      incidentId,
+      devMode,
+      message,
+      trace,
+    ]
+  );
+
+  const handleCopy = useCallback(() => {
+    void copy(report);
+  }, [copy, report]);
+
+  const handleOpenLogs = useCallback(() => {
+    void actionService.dispatch("logs.openFile", undefined, { source: "user" });
+  }, []);
+
+  return (
+    <div
+      role="region"
+      aria-label={`${panelDisplayName} render error`}
+      data-testid="plugin-view-diagnostics"
+      className="flex h-full min-h-0 w-full flex-col gap-4 overflow-auto bg-surface-panel p-6"
+    >
+      <div className="flex items-center gap-2">
+        <TriangleAlert className="size-5 shrink-0 text-status-error" />
+        <h2
+          className="text-sm font-semibold text-status-error"
+          data-testid="plugin-view-diagnostics-title"
+        >
+          Couldn&apos;t render {panelDisplayName}
+        </h2>
+      </div>
+
+      <p className="text-xs text-text-primary" data-testid="plugin-view-diagnostics-message">
+        {message}
+      </p>
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt className="text-text-muted">Plugin</dt>
+        <dd className="font-mono break-all text-text-primary">
+          {pluginDisplayName} ({pluginId})
+        </dd>
+        <dt className="text-text-muted">Panel</dt>
+        <dd className="font-mono break-all text-text-primary">
+          {panelDisplayName} ({kindId})
+        </dd>
+        <dt className="text-text-muted">Module</dt>
+        <dd className="font-mono break-all text-text-primary">{componentPath}</dd>
+        {incidentId && (
+          <>
+            <dt className="text-text-muted">Error ID</dt>
+            <dd className="font-mono break-all text-text-primary">{incidentId}</dd>
+          </>
+        )}
+      </dl>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={resetError}
+          data-testid="plugin-view-diagnostics-retry"
+          className={cn(
+            BUTTON_BASE,
+            "bg-status-error text-daintree-bg hover:bg-[color-mix(in_oklab,var(--color-status-error)_85%,transparent)]"
+          )}
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy diagnostics"
+          data-testid="plugin-view-diagnostics-copy"
+          className={cn(BUTTON_BASE, NEUTRAL_BUTTON)}
+        >
+          {copied ? "Copied" : "Copy diagnostics"}
+        </button>
+        <button
+          type="button"
+          onClick={handleOpenLogs}
+          data-testid="plugin-view-diagnostics-logs"
+          className={cn(BUTTON_BASE, NEUTRAL_BUTTON)}
+        >
+          View logs
+        </button>
+      </div>
+
+      <pre
+        data-testid="plugin-view-diagnostics-trace"
+        className="rounded bg-scrim-soft p-3 text-xs break-words whitespace-pre-wrap text-status-error/80 select-text"
+      >
+        {trace}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -99,6 +99,16 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
       (s) => s.pluginMetaById.get(pluginId!)?.displayName ?? pluginId!
     );
 
+    // Re-pull here rather than at host mount, because at host mount the plugin
+    // may not be listable yet: `loadPlugin` registers the panel kind (which is
+    // what mounts this host) before awaiting skill loading and entering the
+    // plugins map, and `daintree-plugin dev` never fires provenance at all.
+    // Reaching this component means the view rendered and threw, so its plugin
+    // is certainly loaded by now and this pull can see it. The pane fails
+    // closed meanwhile and upgrades in place when the snapshot lands.
+    const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
+    useEffect(() => refreshPluginRuntime(), [refreshPluginRuntime]);
+
     return (
       <PluginViewDiagnosticsFallback
         error={error}
@@ -179,22 +189,11 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     // in its own slot.
     const [retryCount, setRetryCount] = useState(0);
 
-    // Warm the plugin runtime mirror from the host rather than the fallback:
-    // the pull is async, and starting it at mount means the dev-mode flag has
-    // landed long before a view can resolve and then throw. The fallback still
-    // subscribes, so a late snapshot upgrades a redacted trace in place.
-    //
-    // `refresh` on top of `init` because `init` is one-shot: a store some other
-    // consumer initialized at startup would never see a plugin that attached
-    // later via `daintree-plugin dev` (that path broadcasts panel kinds but not
-    // provenance), leaving the author's own stack redacted forever. This host
-    // only exists because a plugin view is about to render, so pull for it.
+    // Warm the plugin runtime mirror at mount so the dev-mode flag is usually
+    // already there if this view later throws. The fallback re-pulls for the
+    // cases this can't cover; see PluginViewFallback.
     const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
-    const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
-    useEffect(() => {
-      initPluginRuntime();
-      refreshPluginRuntime();
-    }, [initPluginRuntime, refreshPluginRuntime]);
+    useEffect(() => initPluginRuntime(), [initPluginRuntime]);
 
     const rootRef = useRef<HTMLDivElement | null>(null);
     const panelId = props.id;

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -11,9 +11,12 @@ import {
 import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
 import type { PanelViewProps } from "@shared/types/plugin";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import type { ErrorFallbackProps } from "@/components/ErrorBoundary/ErrorFallback";
 import { BrowserPaneSkeleton } from "@/components/Browser/BrowserPaneSkeleton";
 import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
 import { usePanelRootFocus } from "@/components/Panel/usePanelRootFocus";
+import { PluginViewDiagnosticsFallback } from "@/components/Plugin/PluginViewDiagnosticsFallback";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 import type { PanelComponentProps } from "@/panels/registry";
 import { logWarn } from "@/utils/logger";
 
@@ -83,6 +86,35 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     };
   }
 
+  // Defined once per host, not inline in render: the boundary swaps its
+  // fallback subtree whenever this component *type* changes identity, which
+  // would remount the diagnostics pane (and drop its copy feedback) on every
+  // host render.
+  function PluginViewFallback({ error, errorInfo, resetError, incidentId }: ErrorFallbackProps) {
+    // Two primitive selectors rather than one object selector: the meta record
+    // is rebuilt on every provenance pull, so selecting it whole would re-render
+    // the pane on pulls that changed nothing about this plugin.
+    const devMode = usePluginRuntimeStore((s) => s.pluginMetaById.get(pluginId!)?.devMode === true);
+    const pluginDisplayName = usePluginRuntimeStore(
+      (s) => s.pluginMetaById.get(pluginId!)?.displayName ?? pluginId!
+    );
+
+    return (
+      <PluginViewDiagnosticsFallback
+        error={error}
+        errorInfo={errorInfo}
+        resetError={resetError}
+        incidentId={incidentId}
+        pluginId={pluginId!}
+        pluginDisplayName={pluginDisplayName}
+        kindId={kindId}
+        panelDisplayName={displayName}
+        componentPath={componentPath!}
+        devMode={devMode}
+      />
+    );
+  }
+
   const createLazyView = (): LazyExoticComponent<ComponentType<PanelViewProps>> =>
     lazy<ComponentType<PanelViewProps>>(async () => {
       // Race the `plugin://` import against a timeout. A wedged protocol load
@@ -146,6 +178,13 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     // counter is observable to the boundary even though the lazy ref lives
     // in its own slot.
     const [retryCount, setRetryCount] = useState(0);
+
+    // Warm the plugin runtime mirror from the host rather than the fallback:
+    // the pull is async, and starting it at mount means the dev-mode flag has
+    // landed long before a view can resolve and then throw. The fallback still
+    // subscribes, so a late snapshot upgrades a redacted trace in place.
+    const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
+    useEffect(() => initPluginRuntime(), [initPluginRuntime]);
 
     const rootRef = useRef<HTMLDivElement | null>(null);
     const panelId = props.id;
@@ -215,7 +254,10 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
       <div ref={rootRef} tabIndex={-1} className="flex flex-col h-full w-full">
         <ErrorBoundary
           variant="component"
-          componentName={`PluginView:${pluginId}.${kindId}`}
+          // `kindId` is already `${pluginId}.${panel.id}` (PluginService builds
+          // it that way), so prefixing pluginId again doubled it.
+          componentName={`PluginView:${kindId}`}
+          fallback={PluginViewFallback}
           onReset={handleReset}
           resetKeys={[retryCount]}
         >

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -183,8 +183,18 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     // the pull is async, and starting it at mount means the dev-mode flag has
     // landed long before a view can resolve and then throw. The fallback still
     // subscribes, so a late snapshot upgrades a redacted trace in place.
+    //
+    // `refresh` on top of `init` because `init` is one-shot: a store some other
+    // consumer initialized at startup would never see a plugin that attached
+    // later via `daintree-plugin dev` (that path broadcasts panel kinds but not
+    // provenance), leaving the author's own stack redacted forever. This host
+    // only exists because a plugin view is about to render, so pull for it.
     const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
-    useEffect(() => initPluginRuntime(), [initPluginRuntime]);
+    const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
+    useEffect(() => {
+      initPluginRuntime();
+      refreshPluginRuntime();
+    }, [initPluginRuntime, refreshPluginRuntime]);
 
     const rootRef = useRef<HTMLDivElement | null>(null);
     const panelId = props.id;

--- a/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PluginViewDiagnosticsFallback,
+  type PluginViewDiagnosticsFallbackProps,
+} from "../PluginViewDiagnosticsFallback";
+
+const dispatchMock = vi.hoisted(() => vi.fn(() => Promise.resolve({ ok: true })));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+const announceMock = vi.hoisted(() => vi.fn());
+vi.mock("@/store/accessibilityAnnouncerStore", () => ({
+  useAnnouncerStore: { getState: () => ({ announce: announceMock }) },
+}));
+
+const writeTextMock = vi.fn<(text: string) => Promise<void>>();
+
+// A stack and a component stack that carry *different* usernames: a scrub that
+// only reached the stack would leave `bob` behind, which a single-path fixture
+// could never catch.
+const STACK = "Error: boom\n    at Widget (/Users/alice/plugins/acme/dashboard.js:10:5)";
+const COMPONENT_STACK = "\n    at Widget (/Users/bob/plugins/acme/dashboard.js:10:5)";
+
+function makeError(message: string, stack?: string): Error {
+  const error = new Error(message);
+  error.stack = stack;
+  return error;
+}
+
+function renderFallback(overrides: Partial<PluginViewDiagnosticsFallbackProps> = {}) {
+  const props: PluginViewDiagnosticsFallbackProps = {
+    error: makeError("Cannot read properties of undefined", STACK),
+    errorInfo: { componentStack: COMPONENT_STACK },
+    resetError: vi.fn(),
+    incidentId: null,
+    pluginId: "acme",
+    pluginDisplayName: "Acme Tools",
+    kindId: "acme.dashboard",
+    panelDisplayName: "Dashboard",
+    componentPath: "plugin://acme/dashboard.js",
+    devMode: false,
+    ...overrides,
+  };
+  return { props, ...render(<PluginViewDiagnosticsFallback {...props} />) };
+}
+
+const trace = () => screen.getByTestId("plugin-view-diagnostics-trace").textContent ?? "";
+
+beforeEach(() => {
+  dispatchMock.mockClear();
+  announceMock.mockClear();
+  writeTextMock.mockReset();
+  writeTextMock.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: writeTextMock },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("PluginViewDiagnosticsFallback", () => {
+  it("shows the plugin identity, module path and message", () => {
+    renderFallback();
+
+    const pane = screen.getByTestId("plugin-view-diagnostics").textContent ?? "";
+    expect(pane).toContain("Acme Tools");
+    expect(pane).toContain("acme.dashboard");
+    expect(pane).toContain("plugin://acme/dashboard.js");
+    expect(screen.getByTestId("plugin-view-diagnostics-message").textContent).toBe(
+      "Cannot read properties of undefined"
+    );
+  });
+
+  it("renders the stack and the component stack", () => {
+    renderFallback({ devMode: true });
+
+    expect(trace()).toContain("at Widget");
+    expect(trace()).toContain("Component stack:");
+  });
+
+  // The bug this component exists to fix: a plugin author runs a *production*
+  // Daintree, so a build-mode gate hides the trace from the one person who can
+  // act on it. Vitest runs with DEV=true, so a `import.meta.env.DEV` gate would
+  // wrongly unlock raw output here and fail this case.
+  it("redacts an installed plugin's stacks even though the app build is DEV", () => {
+    renderFallback({ devMode: false });
+
+    expect(trace()).toContain("/Users/USER/plugins");
+    expect(trace()).not.toContain("/Users/alice");
+    expect(trace()).not.toContain("/Users/bob");
+  });
+
+  it("leaves a dev-mode plugin's stacks raw even though the app build is not DEV", () => {
+    vi.stubEnv("DEV", false);
+
+    renderFallback({ devMode: true });
+
+    expect(trace()).toContain("/Users/alice");
+    expect(trace()).toContain("/Users/bob");
+  });
+
+  // Redaction is about the user's data, not the plugin's. Scrubbing the message
+  // would cost diagnostic signal for no leak benefit (#9427).
+  it("never redacts the message or the plugin identity", () => {
+    renderFallback({
+      devMode: false,
+      error: makeError("Failed to load /Users/alice/config.json", STACK),
+    });
+
+    expect(screen.getByTestId("plugin-view-diagnostics-message").textContent).toBe(
+      "Failed to load /Users/alice/config.json"
+    );
+  });
+
+  it("copies the same trace it renders, so the two can never diverge", async () => {
+    renderFallback({ devMode: false });
+
+    fireEvent.click(screen.getByTestId("plugin-view-diagnostics-copy"));
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    const copied = writeTextMock.mock.calls[0]![0];
+    expect(copied).toContain(trace());
+    expect(copied).not.toContain("/Users/alice");
+    expect(copied).toContain("plugin://acme/dashboard.js");
+  });
+
+  it("includes the error id in the pane and the copied report only when there is one", async () => {
+    const { unmount } = renderFallback({ incidentId: "abc-123" });
+    expect(screen.getByTestId("plugin-view-diagnostics").textContent).toContain("abc-123");
+    fireEvent.click(screen.getByTestId("plugin-view-diagnostics-copy"));
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    expect(writeTextMock.mock.calls[0]![0]).toContain("Error ID: abc-123");
+    unmount();
+
+    writeTextMock.mockClear();
+    renderFallback({ incidentId: null });
+    fireEvent.click(screen.getByTestId("plugin-view-diagnostics-copy"));
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    expect(writeTextMock.mock.calls[0]![0]).not.toContain("Error ID:");
+  });
+
+  it("flips the copy button label without changing its accessible name", async () => {
+    renderFallback();
+    const button = screen.getByTestId("plugin-view-diagnostics-copy");
+    expect(button.textContent).toBe("Copy diagnostics");
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button.textContent).toBe("Copied"));
+    expect(button.getAttribute("aria-label")).toBe("Copy diagnostics");
+  });
+
+  it("opens the log file from View logs", () => {
+    renderFallback();
+
+    fireEvent.click(screen.getByTestId("plugin-view-diagnostics-logs"));
+
+    expect(dispatchMock).toHaveBeenCalledWith("logs.openFile", undefined, { source: "user" });
+  });
+
+  it("routes Try again to the boundary's reset", () => {
+    const resetError = vi.fn();
+    renderFallback({ resetError });
+
+    fireEvent.click(screen.getByTestId("plugin-view-diagnostics-retry"));
+
+    expect(resetError).toHaveBeenCalledTimes(1);
+  });
+
+  it("substitutes placeholders when the error carries no stacks", () => {
+    renderFallback({ error: makeError("boom", undefined), errorInfo: undefined });
+
+    expect(trace()).toContain("No stack trace available");
+    expect(trace()).toContain("No component stack available");
+  });
+
+  it("falls back to a generic message when the error has none", () => {
+    renderFallback({ error: makeError("", STACK) });
+
+    expect(screen.getByTestId("plugin-view-diagnostics-message").textContent).toBe(
+      "Unknown render error"
+    );
+  });
+
+  it("announces the failure once for screen readers", () => {
+    renderFallback();
+
+    expect(announceMock).toHaveBeenCalledWith("Dashboard error", "polite");
+  });
+});

--- a/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
@@ -18,11 +18,16 @@ vi.mock("@/store/accessibilityAnnouncerStore", () => ({
 
 const writeTextMock = vi.fn<(text: string) => Promise<void>>();
 
-// A stack and a component stack that carry *different* usernames: a scrub that
-// only reached the stack would leave `bob` behind, which a single-path fixture
-// could never catch.
-const STACK = "Error: boom\n    at Widget (/Users/alice/plugins/acme/dashboard.js:10:5)";
-const COMPONENT_STACK = "\n    at Widget (/Users/bob/plugins/acme/dashboard.js:10:5)";
+// Both stacks carry a *distinct* username and a *distinct* secret sigil. The
+// usernames catch a scrub that reaches only one of the two stacks; the tokens
+// catch a downgrade from `scrubReportText` to path-only `scrubReportPath`,
+// which would keep every path assertion green while leaking credentials.
+const ALICE_TOKEN = `ghp_${"a".repeat(36)}`;
+const BOB_TOKEN = `ghp_${"b".repeat(36)}`;
+const STACK = `Error: boom (${ALICE_TOKEN})\n    at Widget (/Users/alice/plugins/acme/dashboard.js:10:5)`;
+const COMPONENT_STACK = `\n    at Widget (/Users/bob/plugins/acme/dashboard.js:10:5) ${BOB_TOKEN}`;
+/** Everything that must never survive redaction for an installed plugin. */
+const SENSITIVE = ["/Users/alice", "/Users/bob", ALICE_TOKEN, BOB_TOKEN];
 
 function makeError(message: string, stack?: string): Error {
   const error = new Error(message);
@@ -77,37 +82,39 @@ describe("PluginViewDiagnosticsFallback", () => {
     );
   });
 
-  it("renders the stack and the component stack", () => {
+  it("renders frames from both the stack and the component stack", () => {
     renderFallback({ devMode: true });
 
-    expect(trace()).toContain("at Widget");
-    expect(trace()).toContain("Component stack:");
+    // Assert the frames themselves, not the headings — a heading proves only
+    // that the label was printed, not that any stack reached the pane.
+    expect(trace()).toContain("dashboard.js:10:5");
+    expect(trace()).toContain("/Users/bob");
   });
 
   // The bug this component exists to fix: a plugin author runs a *production*
   // Daintree, so a build-mode gate hides the trace from the one person who can
-  // act on it. Vitest runs with DEV=true, so a `import.meta.env.DEV` gate would
+  // act on it. Vitest runs with DEV=true, so an `import.meta.env.DEV` gate would
   // wrongly unlock raw output here and fail this case.
-  it("redacts an installed plugin's stacks even though the app build is DEV", () => {
+  it("redacts an installed plugin's paths and secrets even though the app build is DEV", () => {
     renderFallback({ devMode: false });
 
-    expect(trace()).toContain("/Users/USER/plugins");
-    expect(trace()).not.toContain("/Users/alice");
-    expect(trace()).not.toContain("/Users/bob");
+    for (const secret of SENSITIVE) expect(trace()).not.toContain(secret);
+    // Redaction must not cost the frame itself — the author still needs to see
+    // which module and line threw.
+    expect(trace()).toContain("dashboard.js:10:5");
   });
 
-  it("leaves a dev-mode plugin's stacks raw even though the app build is not DEV", () => {
+  it("leaves a dev-mode plugin's paths and secrets raw even though the app build is not DEV", () => {
     vi.stubEnv("DEV", false);
 
     renderFallback({ devMode: true });
 
-    expect(trace()).toContain("/Users/alice");
-    expect(trace()).toContain("/Users/bob");
+    for (const secret of SENSITIVE) expect(trace()).toContain(secret);
   });
 
   // Redaction is about the user's data, not the plugin's. Scrubbing the message
   // would cost diagnostic signal for no leak benefit (#9427).
-  it("never redacts the message or the plugin identity", () => {
+  it("never redacts the message", () => {
     renderFallback({
       devMode: false,
       error: makeError("Failed to load /Users/alice/config.json", STACK),
@@ -118,7 +125,7 @@ describe("PluginViewDiagnosticsFallback", () => {
     );
   });
 
-  it("copies the same trace it renders, so the two can never diverge", async () => {
+  it("copies the trace it renders and nothing sensitive beyond it", async () => {
     renderFallback({ devMode: false });
 
     fireEvent.click(screen.getByTestId("plugin-view-diagnostics-copy"));
@@ -126,7 +133,9 @@ describe("PluginViewDiagnosticsFallback", () => {
     await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
     const copied = writeTextMock.mock.calls[0]![0];
     expect(copied).toContain(trace());
-    expect(copied).not.toContain("/Users/alice");
+    // Containment alone would still pass if the report appended a *raw* second
+    // copy of either stack, so assert every sensitive value is absent outright.
+    for (const secret of SENSITIVE) expect(copied).not.toContain(secret);
     expect(copied).toContain("plugin://acme/dashboard.js");
   });
 
@@ -189,8 +198,10 @@ describe("PluginViewDiagnosticsFallback", () => {
   });
 
   it("announces the failure once for screen readers", () => {
-    renderFallback();
+    const { rerender, props } = renderFallback();
+    rerender(<PluginViewDiagnosticsFallback {...props} />);
 
+    expect(announceMock).toHaveBeenCalledTimes(1);
     expect(announceMock).toHaveBeenCalledWith("Dashboard error", "polite");
   });
 });

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -497,6 +497,46 @@ describe("makePluginViewHost", () => {
     );
   });
 
+  // The metadata the pane needs may not exist at host-mount time: `loadPlugin`
+  // registers the panel kind before the plugin is listable, and dev attach
+  // never fires provenance. Reaching the fallback means the view already threw,
+  // so the plugin is loaded — the pane must pull for itself at that point
+  // rather than trust whatever the store happened to hold earlier (#11207).
+  it("pulls a fresh plugin snapshot when the diagnostics pane mounts (#11207)", async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: {
+        plugin: {
+          onPanelKindsChanged: onPanelKindsChangedMock,
+          onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
+          list,
+        },
+      },
+    });
+
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    render(
+      <Host
+        id="panel-refresh"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+    const callsBeforeCrash = list.mock.calls.length;
+
+    const Fallback = boundaryProps.last!.fallback!;
+    render(<Fallback error={new Error("view exploded")} resetError={(): void => {}} />);
+
+    await waitFor(() => expect(list.mock.calls.length).toBeGreaterThan(callsBeforeCrash));
+  });
+
   // The dev-plugin snapshot can land *after* the view has already crashed (the
   // pull is async, and `daintree-plugin dev` never fires provenance). The pane
   // must upgrade in place rather than stay redacted until the user retries.

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -12,6 +12,11 @@ vi.mock("@/components/ui/ContentFadeIn", () => ({
   ContentFadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// The fake records the props it was handed. Fallback *rendering* is covered by
+// PluginViewDiagnosticsFallback.test.tsx against the real component — asserting
+// pane content through this stub would pass without exercising any of it.
+const boundaryProps = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
+
 // Stub the real ErrorBoundary with a minimal class — exercising the entire
 // reporting pipeline (Sentry, errorStore, notify) is out of scope for the
 // host's unit tests. The stub honors `resetKeys` and `onReset` so the reload
@@ -24,6 +29,7 @@ vi.mock("@/components/ErrorBoundary", async () => {
       onReset?: () => void;
       resetKeys?: Array<string | number>;
       componentName?: string;
+      fallback?: React.ComponentType<unknown>;
     },
     { hasError: boolean; lastKey: string | number | undefined }
   > {
@@ -42,6 +48,7 @@ vi.mock("@/components/ErrorBoundary", async () => {
       void prev;
     }
     render(): React.ReactNode {
+      boundaryProps.last = this.props;
       if (this.state.hasError) {
         return (
           <button
@@ -79,6 +86,7 @@ function makeConfig(overrides: Partial<PanelKindConfig> = {}): PanelKindConfig {
 const onPanelKindsChangedMock = vi.fn();
 
 beforeEach(() => {
+  boundaryProps.last = null;
   onPanelKindsChangedMock.mockReset();
   onPanelKindsChangedMock.mockReturnValue(() => {});
   vi.stubGlobal("electron", undefined);
@@ -413,6 +421,27 @@ describe("makePluginViewHost", () => {
     expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
 
     unmount();
+  });
+
+  it("hands the boundary a plugin-specific fallback and an undoubled component name (#11207)", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    render(
+      <Host
+        id="panel-fallback"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+    // `kindId` already carries the plugin prefix, so re-prefixing it produced
+    // `PluginView:acme.acme.dashboard` in the title and every log field.
+    expect(boundaryProps.last!.componentName).toBe("PluginView:acme.dashboard");
+    expect(typeof boundaryProps.last!.fallback).toBe("function");
   });
 });
 

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -12,10 +12,27 @@ vi.mock("@/components/ui/ContentFadeIn", () => ({
   ContentFadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-// The fake records the props it was handed. Fallback *rendering* is covered by
-// PluginViewDiagnosticsFallback.test.tsx against the real component — asserting
-// pane content through this stub would pass without exercising any of it.
-const boundaryProps = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
+// The subset of ErrorBoundary's contract the host relies on. Typed here rather
+// than cast at each read site — a cast would regress the per-rule
+// no-unsafe-type-assertion lint baseline.
+interface CapturedFallbackProps {
+  error: Error;
+  errorInfo?: React.ErrorInfo;
+  resetError: () => void;
+  incidentId?: string | null;
+}
+interface CapturedBoundaryProps {
+  children: React.ReactNode;
+  onReset?: () => void;
+  resetKeys?: Array<string | number>;
+  componentName?: string;
+  fallback?: React.ComponentType<CapturedFallbackProps>;
+}
+
+// The fake records the props it was handed, so the tests can render the very
+// fallback the host supplied. Asserting only that `fallback` is *a function*
+// would be satisfied by `() => null`.
+const boundaryProps = vi.hoisted(() => ({ last: null as CapturedBoundaryProps | null }));
 
 // Stub the real ErrorBoundary with a minimal class — exercising the entire
 // reporting pipeline (Sentry, errorStore, notify) is out of scope for the
@@ -24,13 +41,7 @@ const boundaryProps = vi.hoisted(() => ({ last: null as Record<string, unknown> 
 vi.mock("@/components/ErrorBoundary", async () => {
   const { Component } = await import("react");
   class FakeBoundary extends Component<
-    {
-      children: React.ReactNode;
-      onReset?: () => void;
-      resetKeys?: Array<string | number>;
-      componentName?: string;
-      fallback?: React.ComponentType<unknown>;
-    },
+    CapturedBoundaryProps,
     { hasError: boolean; lastKey: string | number | undefined }
   > {
     state = { hasError: false, lastKey: this.props.resetKeys?.[0] };
@@ -441,7 +452,90 @@ describe("makePluginViewHost", () => {
     // `kindId` already carries the plugin prefix, so re-prefixing it produced
     // `PluginView:acme.acme.dashboard` in the title and every log field.
     expect(boundaryProps.last!.componentName).toBe("PluginView:acme.dashboard");
-    expect(typeof boundaryProps.last!.fallback).toBe("function");
+  });
+
+  // Closes the seam the fake boundary would otherwise hide: asserting that
+  // `fallback` is merely a function is satisfied by `() => null`. Rendering the
+  // very component the host handed the boundary proves the wiring reaches the
+  // real diagnostics pane, carries this plugin's identity, and fails closed
+  // when the runtime store holds no metadata for it.
+  it("hands the boundary a fallback that renders this plugin's diagnostics (#11207)", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    render(
+      <Host
+        id="panel-fallback-render"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+
+    const Fallback = boundaryProps.last!.fallback!;
+    const error = new Error("view exploded");
+    error.stack = "Error: view exploded\n    at View (/Users/alice/acme/dashboard.js:3:1)";
+
+    render(
+      <Fallback
+        error={error}
+        errorInfo={{ componentStack: "\n    at View" }}
+        resetError={(): void => {}}
+        incidentId={null}
+      />
+    );
+
+    const pane = screen.getByTestId("plugin-view-diagnostics").textContent ?? "";
+    expect(pane).toContain("view exploded");
+    expect(pane).toContain("plugin://acme/dashboard.js");
+    expect(pane).toContain("acme.dashboard");
+    // This suite never seeds a runtime snapshot ⇒ unknown devMode ⇒ redacted.
+    expect(screen.getByTestId("plugin-view-diagnostics-trace").textContent).not.toContain(
+      "/Users/alice"
+    );
+  });
+
+  // The dev-plugin snapshot can land *after* the view has already crashed (the
+  // pull is async, and `daintree-plugin dev` never fires provenance). The pane
+  // must upgrade in place rather than stay redacted until the user retries.
+  it("upgrades a redacted trace to raw when the plugin's dev-mode snapshot lands late (#11207)", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    // Resolved from the same module graph as the host — the suite resets
+    // modules between cases, so a static import would seed a different store.
+    const { usePluginRuntimeStore } = await import("@/store/pluginRuntimeStore");
+    const Host = makePluginViewHost(makeConfig());
+
+    render(
+      <Host
+        id="panel-late-snapshot"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+
+    const Fallback = boundaryProps.last!.fallback!;
+    const error = new Error("view exploded");
+    error.stack = "Error: view exploded\n    at View (/Users/alice/acme/dashboard.js:3:1)";
+    render(<Fallback error={error} resetError={(): void => {}} />);
+
+    const trace = () => screen.getByTestId("plugin-view-diagnostics-trace").textContent ?? "";
+    expect(trace()).not.toContain("/Users/alice");
+
+    act(() => {
+      usePluginRuntimeStore.setState({
+        pluginMetaById: new Map([["acme", { devMode: true, displayName: "Acme Tools" }]]),
+      });
+    });
+
+    expect(trace()).toContain("/Users/alice");
+    // The same snapshot carries the manifest display name, which the panel's
+    // own `config.name` ("Dashboard") can't supply.
+    expect(screen.getByTestId("plugin-view-diagnostics").textContent).toContain("Acme Tools");
   });
 });
 

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -162,13 +162,16 @@ describe("usePluginRuntimeStore", () => {
     );
 
     // The superseded pull lands last; its snapshot must not roll the store back.
-    resolveFirst?.([makePlugin({ id: "acme.stale" })]);
+    resolveFirst?.([makePlugin({ id: "acme.stale", disabled: true })]);
     await Promise.resolve();
     await Promise.resolve();
 
     const state = usePluginRuntimeStore.getState();
     expect(state.pluginMetaById.has("acme.stale")).toBe(false);
     expect(state.pluginMetaById.has("acme.fresh")).toBe(true);
+    // Both collections ride the same guard — checking only the metadata map
+    // would still pass if a stale response could commit the disabled set.
+    expect(state.disabledPluginIds.has("acme.stale")).toBe(false);
   });
 
   it("pulls and subscribes once across repeated init calls", async () => {
@@ -186,19 +189,58 @@ describe("usePluginRuntimeStore", () => {
     installBridge({});
 
     expect(() => usePluginRuntimeStore.getState().init()).not.toThrow();
+    expect(() => usePluginRuntimeStore.getState().refresh()).not.toThrow();
     expect(listMock).not.toHaveBeenCalled();
     expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(0);
   });
 
-  it("leaves both collections intact when the list pull rejects", async () => {
-    listMock.mockRejectedValue(new Error("bridge down"));
+  // `daintree-plugin dev` attaches a plugin without broadcasting provenance, so
+  // a store already initialized by some earlier consumer would never learn the
+  // dev plugin's devMode and would redact its author's own stack forever. This
+  // is the escape hatch for exactly that (#11207) — it must pull even though
+  // the one-shot init() has already run.
+  it("pulls on refresh even once initialized, picking up a plugin that never announced itself", async () => {
+    listMock.mockResolvedValueOnce([makePlugin({ id: "acme.installed" })]);
 
     usePluginRuntimeStore.getState().init();
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(1));
+
+    // The dev plugin attaches now — no provenance event fires for it.
+    listMock.mockResolvedValueOnce([
+      makePlugin({ id: "acme.installed" }),
+      makePlugin({ id: "acme.dev", displayName: "Acme Dev", devMode: true }),
+    ]);
+    usePluginRuntimeStore.getState().refresh();
+
+    await vi.waitFor(() =>
+      expect(usePluginRuntimeStore.getState().pluginMetaById.get("acme.dev")?.devMode).toBe(true)
+    );
+    expect(listMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the last good snapshot when a later pull rejects", async () => {
+    let fire: (() => void) | undefined;
+    onProvenanceChangedMock.mockImplementation((cb) => {
+      fire = cb;
+      return () => {};
+    });
+    listMock.mockResolvedValueOnce([
+      makePlugin({ id: "acme.a", displayName: "Acme A", disabled: true, devMode: true }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(1));
+
+    // Starting from a populated store, not an empty one: asserting "still
+    // empty" after a rejection would also pass if a transient failure wiped a
+    // good snapshot.
+    listMock.mockRejectedValueOnce(new Error("bridge down"));
+    fire?.();
 
     await vi.waitFor(() => expect(logErrorMock).toHaveBeenCalled());
     const state = usePluginRuntimeStore.getState();
-    expect(state.pluginMetaById.size).toBe(0);
-    expect(state.disabledPluginIds.size).toBe(0);
+    expect(state.pluginMetaById.get("acme.a")).toEqual({ devMode: true, displayName: "Acme A" });
+    expect(state.disabledPluginIds.has("acme.a")).toBe(true);
   });
 
   it("unsubscribes and clears every collection on test reset", async () => {

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LoadedPluginInfo } from "@shared/types/plugin";
+import { _resetPluginRuntimeStoreForTest, usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+
+const logErrorMock = vi.hoisted(() => vi.fn());
+vi.mock("@/utils/logger", () => ({
+  logError: logErrorMock,
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+function makePlugin(opts: {
+  id: string;
+  displayName?: string;
+  devMode?: boolean;
+  disabled?: boolean;
+}): LoadedPluginInfo {
+  return {
+    manifest: {
+      name: opts.id,
+      version: "1.0.0",
+      ...(opts.displayName === undefined ? {} : { displayName: opts.displayName }),
+      contributes: {
+        panels: [],
+        toolbarButtons: [],
+        menuItems: [],
+        commands: [],
+        views: [],
+        mcpServers: [],
+        skills: [],
+        keybindings: [],
+        contextMenus: [],
+        forgeProviders: [],
+        fileDecorationProviders: [],
+        agents: [],
+      },
+    },
+    dir: `/plugins/${opts.id}`,
+    loadedAt: 1,
+    isBuiltin: false,
+    disabled: opts.disabled ?? false,
+    pendingRestart: false,
+    source: "sideload",
+    installedAt: 1,
+    archiveHash: null,
+    originalUrl: null,
+    loadError: null,
+    updateAvailable: null,
+    devMode: opts.devMode ?? false,
+    pluginDanger: "safe",
+    blocklisted: false,
+  };
+}
+
+const listMock = vi.fn<() => Promise<LoadedPluginInfo[]>>();
+const onProvenanceChangedMock = vi.fn<(cb: () => void) => () => void>();
+
+function installBridge(plugin: Record<string, unknown>): void {
+  Object.defineProperty(window, "electron", {
+    configurable: true,
+    writable: true,
+    value: { plugin },
+  });
+}
+
+beforeEach(() => {
+  _resetPluginRuntimeStoreForTest();
+  logErrorMock.mockReset();
+  listMock.mockReset();
+  onProvenanceChangedMock.mockReset();
+  onProvenanceChangedMock.mockReturnValue(() => {});
+  installBridge({ list: listMock, onProvenanceChanged: onProvenanceChangedMock });
+});
+
+afterEach(() => {
+  // Reset in afterEach too: a failed case would otherwise leak its provenance
+  // listener into the next one.
+  _resetPluginRuntimeStoreForTest();
+});
+
+describe("usePluginRuntimeStore", () => {
+  it("derives the disabled set and per-plugin metadata from one snapshot", async () => {
+    listMock.mockResolvedValue([
+      makePlugin({ id: "acme.dev", displayName: "Acme Dev", devMode: true }),
+      makePlugin({ id: "acme.off", displayName: "Acme Off", disabled: true }),
+      makePlugin({ id: "acme.plain", displayName: "Acme Plain" }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(3));
+    const state = usePluginRuntimeStore.getState();
+    expect([...state.disabledPluginIds]).toEqual(["acme.off"]);
+    expect(state.pluginMetaById.get("acme.dev")).toEqual({
+      devMode: true,
+      displayName: "Acme Dev",
+    });
+    expect(state.pluginMetaById.get("acme.plain")?.devMode).toBe(false);
+  });
+
+  it("falls back to the plugin id when the manifest declares no display name", async () => {
+    listMock.mockResolvedValue([makePlugin({ id: "acme.nameless" })]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() =>
+      expect(usePluginRuntimeStore.getState().pluginMetaById.get("acme.nameless")).toBeDefined()
+    );
+    expect(usePluginRuntimeStore.getState().pluginMetaById.get("acme.nameless")?.displayName).toBe(
+      "acme.nameless"
+    );
+  });
+
+  it("re-pulls on a provenance change and drops metadata for removed plugins", async () => {
+    let fire: (() => void) | undefined;
+    onProvenanceChangedMock.mockImplementation((cb) => {
+      fire = cb;
+      return () => {};
+    });
+    listMock.mockResolvedValueOnce([makePlugin({ id: "acme.a" }), makePlugin({ id: "acme.b" })]);
+
+    usePluginRuntimeStore.getState().init();
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(2));
+
+    listMock.mockResolvedValueOnce([makePlugin({ id: "acme.a", devMode: true })]);
+    fire?.();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(1));
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.has("acme.b")).toBe(false);
+    expect(state.pluginMetaById.get("acme.a")?.devMode).toBe(true);
+  });
+
+  it("ignores a stale in-flight response that resolves after a newer pull", async () => {
+    let resolveFirst: ((v: LoadedPluginInfo[]) => void) | undefined;
+    let resolveSecond: ((v: LoadedPluginInfo[]) => void) | undefined;
+    listMock
+      .mockReturnValueOnce(
+        new Promise<LoadedPluginInfo[]>((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise<LoadedPluginInfo[]>((r) => {
+          resolveSecond = r;
+        })
+      );
+    let fire: (() => void) | undefined;
+    onProvenanceChangedMock.mockImplementation((cb) => {
+      fire = cb;
+      return () => {};
+    });
+
+    usePluginRuntimeStore.getState().init(); // pull 1
+    fire?.(); // pull 2 — supersedes pull 1
+
+    resolveSecond?.([makePlugin({ id: "acme.fresh", devMode: true })]);
+    await vi.waitFor(() =>
+      expect(usePluginRuntimeStore.getState().pluginMetaById.has("acme.fresh")).toBe(true)
+    );
+
+    // The superseded pull lands last; its snapshot must not roll the store back.
+    resolveFirst?.([makePlugin({ id: "acme.stale" })]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.has("acme.stale")).toBe(false);
+    expect(state.pluginMetaById.has("acme.fresh")).toBe(true);
+  });
+
+  it("pulls and subscribes once across repeated init calls", async () => {
+    listMock.mockResolvedValue([]);
+
+    usePluginRuntimeStore.getState().init();
+    usePluginRuntimeStore.getState().init();
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(listMock).toHaveBeenCalledTimes(1));
+    expect(onProvenanceChangedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when the plugin bridge is only partially stubbed", () => {
+    installBridge({});
+
+    expect(() => usePluginRuntimeStore.getState().init()).not.toThrow();
+    expect(listMock).not.toHaveBeenCalled();
+    expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(0);
+  });
+
+  it("leaves both collections intact when the list pull rejects", async () => {
+    listMock.mockRejectedValue(new Error("bridge down"));
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(logErrorMock).toHaveBeenCalled());
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.size).toBe(0);
+    expect(state.disabledPluginIds.size).toBe(0);
+  });
+
+  it("unsubscribes and clears every collection on test reset", async () => {
+    const unsub = vi.fn();
+    onProvenanceChangedMock.mockReturnValue(unsub);
+    listMock.mockResolvedValue([makePlugin({ id: "acme.a", disabled: true, devMode: true })]);
+
+    usePluginRuntimeStore.getState().init();
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(1));
+
+    _resetPluginRuntimeStoreForTest();
+
+    expect(unsub).toHaveBeenCalledTimes(1);
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.size).toBe(0);
+    expect(state.disabledPluginIds.size).toBe(0);
+  });
+});

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -218,6 +218,26 @@ describe("usePluginRuntimeStore", () => {
     expect(listMock).toHaveBeenCalledTimes(2);
   });
 
+  // refresh() subscribes on its own rather than leaning on a separate init()
+  // call: two pulls in one tick would make `pullSeq` discard the first, so a
+  // rejected second pull would throw away the only successful snapshot.
+  it("subscribes and pulls exactly once when refresh is the first caller", async () => {
+    listMock.mockResolvedValue([makePlugin({ id: "acme.a", devMode: true })]);
+
+    usePluginRuntimeStore.getState().refresh();
+
+    await vi.waitFor(() =>
+      expect(usePluginRuntimeStore.getState().pluginMetaById.get("acme.a")?.devMode).toBe(true)
+    );
+    expect(listMock).toHaveBeenCalledTimes(1);
+    expect(onProvenanceChangedMock).toHaveBeenCalledTimes(1);
+
+    // A later init() must not re-subscribe or re-pull on top of it.
+    usePluginRuntimeStore.getState().init();
+    expect(listMock).toHaveBeenCalledTimes(1);
+    expect(onProvenanceChangedMock).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the last good snapshot when a later pull rejects", async () => {
     let fire: (() => void) | undefined;
     onProvenanceChangedMock.mockImplementation((cb) => {

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -174,6 +174,30 @@ describe("usePluginRuntimeStore", () => {
     expect(state.disabledPluginIds.has("acme.stale")).toBe(false);
   });
 
+  // Staleness is judged on what committed, not what started. React Strict Mode
+  // replays mount effects, so same-tick pull pairs are routine — if the second
+  // rejects, the first must still be allowed to land.
+  it("keeps an in-flight snapshot that resolves after a newer pull rejected", async () => {
+    let resolveFirst: ((v: LoadedPluginInfo[]) => void) | undefined;
+    listMock
+      .mockReturnValueOnce(
+        new Promise<LoadedPluginInfo[]>((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockRejectedValueOnce(new Error("bridge down"));
+
+    usePluginRuntimeStore.getState().refresh(); // pull 1 — succeeds, but slowly
+    usePluginRuntimeStore.getState().refresh(); // pull 2 — supersedes, then fails
+
+    await vi.waitFor(() => expect(logErrorMock).toHaveBeenCalled());
+    resolveFirst?.([makePlugin({ id: "acme.a", devMode: true })]);
+
+    await vi.waitFor(() =>
+      expect(usePluginRuntimeStore.getState().pluginMetaById.get("acme.a")?.devMode).toBe(true)
+    );
+  });
+
   it("pulls and subscribes once across repeated init calls", async () => {
     listMock.mockResolvedValue([]);
 

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -56,6 +56,13 @@ let unsubscribe: (() => void) | null = null;
 // Monotonic pull sequence: rapid provenance events can interleave list()
 // round-trips, and a slow older response must not overwrite a newer set.
 let pullSeq = 0;
+// Sequence of the newest response that actually *committed*. Staleness is
+// judged against what landed, not against what merely started: keying off the
+// latest started pull would let a rejected newer request discard an older
+// successful one, leaving the store empty when a good snapshot was in hand
+// (React Strict Mode double-invokes mount effects, so same-tick pull pairs are
+// routine in dev).
+let committedSeq = 0;
 
 async function pullPluginRuntimeSnapshot(
   set: (state: Partial<PluginRuntimeState>) => void
@@ -63,7 +70,8 @@ async function pullPluginRuntimeSnapshot(
   const seq = ++pullSeq;
   try {
     const list = await window.electron.plugin.list();
-    if (seq !== pullSeq) return;
+    if (seq <= committedSeq) return;
+    committedSeq = seq;
     const disabledPluginIds = new Set<string>();
     const pluginMetaById = new Map<string, PluginRuntimeMeta>();
     for (const p of list) {
@@ -129,6 +137,7 @@ export function _resetPluginRuntimeStoreForTest(): void {
   unsubscribe = null;
   initialized = false;
   pullSeq = 0;
+  committedSeq = 0;
   usePluginRuntimeStore.setState({
     disabledPluginIds: new Set<string>(),
     pluginMetaById: new Map<string, PluginRuntimeMeta>(),

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -37,6 +37,15 @@ interface PluginRuntimeState {
   pluginMetaById: ReadonlyMap<string, PluginRuntimeMeta>;
   /** Idempotent: pulls the current snapshot and subscribes to live updates. */
   init: () => void;
+  /**
+   * Pull a fresh snapshot now. Unlike `init()` this runs even once initialized,
+   * because not every plugin that appears announces itself: `daintree-plugin
+   * dev` attaches one through `PluginService.loadDevPlugin`, which broadcasts
+   * `plugin:panel-kinds-changed` but never `plugin:provenance-changed`. A store
+   * that initialized before the dev plugin attached would otherwise never learn
+   * its `devMode` and would redact its author's own stack forever (#11207).
+   */
+  refresh: () => void;
 }
 
 let initialized = false;
@@ -90,6 +99,10 @@ export const usePluginRuntimeStore = create<PluginRuntimeState>((set) => ({
     unsubscribe = plugin.onProvenanceChanged(() => {
       void pullPluginRuntimeSnapshot(set);
     });
+    void pullPluginRuntimeSnapshot(set);
+  },
+  refresh: () => {
+    if (typeof window.electron?.plugin?.list !== "function") return;
     void pullPluginRuntimeSnapshot(set);
   },
 }));

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -38,12 +38,15 @@ interface PluginRuntimeState {
   /** Idempotent: pulls the current snapshot and subscribes to live updates. */
   init: () => void;
   /**
-   * Pull a fresh snapshot now. Unlike `init()` this runs even once initialized,
-   * because not every plugin that appears announces itself: `daintree-plugin
-   * dev` attaches one through `PluginService.loadDevPlugin`, which broadcasts
-   * `plugin:panel-kinds-changed` but never `plugin:provenance-changed`. A store
-   * that initialized before the dev plugin attached would otherwise never learn
-   * its `devMode` and would redact its author's own stack forever (#11207).
+   * Pull a fresh snapshot now, subscribing first if nobody has yet. Unlike
+   * `init()` this pulls even once initialized, because not every plugin that
+   * appears announces itself: `daintree-plugin dev` attaches one through
+   * `PluginService.loadDevPlugin`, which broadcasts `plugin:panel-kinds-changed`
+   * but never `plugin:provenance-changed`. A store that initialized before the
+   * dev plugin attached would otherwise never learn its `devMode` and would
+   * redact its author's own stack forever (#11207).
+   *
+   * Call it where the answer has to be current — not on a hot path.
    */
   refresh: () => void;
 }
@@ -79,29 +82,42 @@ async function pullPluginRuntimeSnapshot(
   }
 }
 
+/**
+ * Subscribe to provenance updates once. Returns true when this call is what
+ * established the subscription, i.e. the caller still owes the first pull.
+ *
+ * Consumed from many leaf components (toolbar pills, banners, tooltips, slot
+ * hooks), so tolerate a partially-stubbed bridge instead of pushing a
+ * plugin-namespace mock into every component test. Absent bridge ⇒ the disabled
+ * set stays empty (plugins read as enabled), matching prod optimism before the
+ * first snapshot.
+ */
+function ensureSubscribed(set: (state: Partial<PluginRuntimeState>) => void): boolean {
+  if (initialized) return false;
+  initialized = true;
+
+  const plugin = window.electron?.plugin;
+  if (typeof plugin?.onProvenanceChanged !== "function" || typeof plugin.list !== "function") {
+    return false;
+  }
+
+  unsubscribe = plugin.onProvenanceChanged(() => {
+    void pullPluginRuntimeSnapshot(set);
+  });
+  return true;
+}
+
 export const usePluginRuntimeStore = create<PluginRuntimeState>((set) => ({
   disabledPluginIds: new Set<string>(),
   pluginMetaById: new Map<string, PluginRuntimeMeta>(),
   init: () => {
-    if (initialized) return;
-    initialized = true;
-
-    // Consumed from many leaf components (toolbar pills, banners, tooltips,
-    // slot hooks), so tolerate a partially-stubbed bridge instead of pushing
-    // a plugin-namespace mock into every component test. Absent bridge ⇒ the
-    // disabled set stays empty (plugins read as enabled), matching prod
-    // optimism before the first snapshot.
-    const plugin = window.electron?.plugin;
-    if (typeof plugin?.onProvenanceChanged !== "function" || typeof plugin.list !== "function") {
-      return;
-    }
-
-    unsubscribe = plugin.onProvenanceChanged(() => {
-      void pullPluginRuntimeSnapshot(set);
-    });
-    void pullPluginRuntimeSnapshot(set);
+    if (ensureSubscribed(set)) void pullPluginRuntimeSnapshot(set);
   },
   refresh: () => {
+    // Subscribes without pulling twice — `pullSeq` would discard the first of
+    // two same-tick pulls, so a rejected second one could throw away the only
+    // successful snapshot.
+    ensureSubscribed(set);
     if (typeof window.electron?.plugin?.list !== "function") return;
     void pullPluginRuntimeSnapshot(set);
   },

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -2,19 +2,39 @@ import { create } from "zustand";
 import { logError } from "@/utils/logger";
 
 /**
- * Renderer mirror of which plugins are currently disabled, so plugin-gated UI
- * (builtin view slots, plugin-owned settings panels) can drop out live when a
- * plugin is toggled in Preferences. Source of truth is `plugin.list()` in
- * main; refreshed on every `plugin:provenance-changed` broadcast — the same
- * signal PluginsTab/usePluginManager follow. Not persisted.
+ * Renderer mirror of live plugin runtime state: which plugins are disabled, so
+ * plugin-gated UI (builtin view slots, plugin-owned settings panels) can drop
+ * out live when a plugin is toggled in Preferences, plus the per-plugin
+ * metadata diagnostics surfaces need synchronously (`pluginMetaById`). Source
+ * of truth is `plugin.list()` in main; refreshed on every
+ * `plugin:provenance-changed` broadcast — the same signal
+ * PluginsTab/usePluginManager follow. Not persisted.
  *
  * Until the first snapshot lands, the disabled set is empty — unknown state
  * treats plugins as enabled, matching the pre-gating behavior (and the main
  * process independently gates plugin-backed IPC, so a brief optimistic render
- * cannot reach a disabled plugin's data).
+ * cannot reach a disabled plugin's data). Metadata reads fail the other way:
+ * an absent entry reads as non-dev, so a plugin's diagnostics are redacted
+ * until its dev-mode flag is positively known (#11207).
  */
+/** Per-plugin facts diagnostics surfaces need at render time. */
+export interface PluginRuntimeMeta {
+  /**
+   * The plugin loads from a directory outside the managed plugins dir — i.e.
+   * whoever is looking at it is looking at their own build.
+   */
+  devMode: boolean;
+  /** `manifest.displayName` when the manifest declares one, else the plugin id. */
+  displayName: string;
+}
+
 interface PluginRuntimeState {
   disabledPluginIds: ReadonlySet<string>;
+  /**
+   * Keyed by plugin id (`manifest.name`). An absent entry means "no snapshot
+   * yet", not "no such plugin" — read it as non-dev, the conservative default.
+   */
+  pluginMetaById: ReadonlyMap<string, PluginRuntimeMeta>;
   /** Idempotent: pulls the current snapshot and subscribes to live updates. */
   init: () => void;
 }
@@ -25,21 +45,34 @@ let unsubscribe: (() => void) | null = null;
 // round-trips, and a slow older response must not overwrite a newer set.
 let pullSeq = 0;
 
-async function pullDisabledSet(set: (state: Partial<PluginRuntimeState>) => void): Promise<void> {
+async function pullPluginRuntimeSnapshot(
+  set: (state: Partial<PluginRuntimeState>) => void
+): Promise<void> {
   const seq = ++pullSeq;
   try {
     const list = await window.electron.plugin.list();
     if (seq !== pullSeq) return;
-    set({
-      disabledPluginIds: new Set(list.filter((p) => p.disabled).map((p) => p.manifest.name)),
-    });
+    const disabledPluginIds = new Set<string>();
+    const pluginMetaById = new Map<string, PluginRuntimeMeta>();
+    for (const p of list) {
+      const id = p.manifest.name;
+      if (p.disabled) disabledPluginIds.add(id);
+      pluginMetaById.set(id, {
+        devMode: p.devMode,
+        displayName: p.manifest.displayName ?? id,
+      });
+    }
+    // One commit: a consumer must never read a plugin's dev-mode flag from a
+    // different snapshot than the disabled set it renders against.
+    set({ disabledPluginIds, pluginMetaById });
   } catch (err) {
-    logError("Failed to load plugin disabled state", err);
+    logError("Failed to load plugin runtime state", err);
   }
 }
 
 export const usePluginRuntimeStore = create<PluginRuntimeState>((set) => ({
   disabledPluginIds: new Set<string>(),
+  pluginMetaById: new Map<string, PluginRuntimeMeta>(),
   init: () => {
     if (initialized) return;
     initialized = true;
@@ -55,9 +88,9 @@ export const usePluginRuntimeStore = create<PluginRuntimeState>((set) => ({
     }
 
     unsubscribe = plugin.onProvenanceChanged(() => {
-      void pullDisabledSet(set);
+      void pullPluginRuntimeSnapshot(set);
     });
-    void pullDisabledSet(set);
+    void pullPluginRuntimeSnapshot(set);
   },
 }));
 
@@ -67,5 +100,8 @@ export function _resetPluginRuntimeStoreForTest(): void {
   unsubscribe = null;
   initialized = false;
   pullSeq = 0;
-  usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
+  usePluginRuntimeStore.setState({
+    disabledPluginIds: new Set<string>(),
+    pluginMetaById: new Map<string, PluginRuntimeMeta>(),
+  });
 }


### PR DESCRIPTION
## Summary

- Plugin views that threw during render fell back to the shared error card, which only shows detail when the app itself is a development build. Plugin authors build against production Daintree installs, so that flag is always false for them, meaning the one audience that could actually act on a plugin error saw nothing useful.
- Adds a dedicated diagnostics fallback for plugin view errors: plugin identity, panel name and kind id, the failing `plugin://` module path, error message, stack, and component stack, plus buttons to copy the full diagnostic block, view logs, and try again.
- Detail depth is now keyed off the plugin's own `devMode` flag instead of the app's build mode. Installed (non-dev) plugins aren't hidden from their errors, they're redacted: stack and component stack pass through the existing `scrubReportText` once, so the rendered trace and the copied report can never diverge. The error message and plugin identity stay unredacted since scrubbing those loses diagnostic value for no real privacy gain.

Resolves #11207

## Changes

- `src/components/Plugin/PluginViewDiagnosticsFallback.tsx` (new): pane-filling diagnostics surface wired into the existing `ErrorBoundary variant="component"` via its `fallback` prop.
- `src/components/Plugin/PluginViewHost.tsx`: passes the new fallback through; also fixes a secondary bug where `componentName` doubled the plugin id in the title (`PluginView:acme.acme.dashboard` → `PluginView:acme.dashboard`), since `kindId` already carries the `pluginId` prefix.
- `src/store/pluginRuntimeStore.ts`: adds `pluginMetaById` (devMode + display name) fed by the existing `plugin.list()` pull, a `refresh()` escape hatch, and commit-order staleness guarding.
- 3 new/updated test files (~650 lines).

While reviewing this, I found that `daintree-plugin dev` attaches a plugin via `loadDevPlugin`, which broadcasts `plugin:panel-kinds-changed` but never `plugin:provenance-changed`. A plugin runtime store initialized before that dev attach never learns the dev plugin's `devMode`, so it would have redacted its own author's stack forever, defeating the point of this feature for its primary audience. Fixed by having the diagnostics pane pull a fresh plugin metadata snapshot on mount: reaching that pane means the view already rendered and threw, so the plugin is certainly loaded by then.

### Follow-ups

- `PluginService.loadDevPlugin` not broadcasting provenance is a main-process bug worth fixing at the source separately. It also leaves the Plugin Manager UI stale after a dev attach.
- `.dev-marker` isn't in `PluginArchive`'s exclusion list, so a crafted `.dntr` could self-report `devMode: true`. Pre-existing trust boundary issue, low impact since the stack only ever renders in the user's own UI.

## Testing

78 targeted tests pass locally (3 new suites plus 3 existing suites that import the changed store). Prettier and eslint are clean on all changed files, aside from one pre-existing `no-unsafe-type-assertion` warning left untouched.
