### PR TITLE
fix(launcher): replay entry animation on project switch

### DIFF
--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -19,9 +19,9 @@ import { LauncherQuickActions } from "./LauncherQuickActions";
 
 const PATH_TRUNCATE_LENGTH = 52;
 
-// Marks a section as carrying the entry, for the two things that need to find
-// one: the reduce-motion block in `index.css` and `replaySectionEntries` below.
-// Shared so those two cannot drift apart.
+// Marks a section as carrying the entry, so `replaySectionEntries` can find one
+// by the same name the class applies. The reduce-motion block in `index.css`
+// spells this selector out for itself — renaming it means changing both.
 const SECTION_ENTRY_MARKER = "launcher-section-enter";
 
 // Entry motion for each launcher section — the column arrives as a sequence
@@ -171,17 +171,18 @@ export function ContentGridEmptyState({
   // switch, by contrast, remounts this component and replays for free). Nothing
   // renders differently at reveal either, so the replay has to be imperative.
   //
-  // `app:view-revealed` is both the right moment and a safe one to act on
-  // synchronously: main sends it only once the warm paint gate has run, the
-  // anti-flash bridge is detached and the view is the invalidated foreground
-  // surface. So the restart lands on a view that is already compositing, and
-  // waiting out frames here would only show the launcher at rest before yanking
-  // it back to replay.
+  // Restart on `app:view-revealed`, and do it synchronously. Main sends that
+  // only once the warm gate has run and the anti-flash bridge is detached, so
+  // this view is the foreground surface and its next paint carries the restarted
+  // entry. Deferring a frame or two would buy nothing and cost the flash the
+  // whole exercise is about — the launcher sitting at rest, then yanked back to
+  // replay in front of the user.
   //
-  // Cold switches need no replay: an evicted project's view mounts this
-  // component fresh, and the paint gate they release on (`skeleton-painted`,
-  // fired before the module entry evaluates) detaches the bridge well before
-  // hydration mounts the canvas — so the natural entry is the one the user sees.
+  // Only warm reveals arrive here; a cold-started view is never sent one. It
+  // needs no replay for the reason this hook exists — it mounts the launcher
+  // fresh, so the entry runs on its own. That entry does still overlap the
+  // view's own startup-skeleton exit, but so does every cold boot's: it is
+  // startup choreography, not the persistent-tree gap this closes.
   //
   // Restarting rather than remounting: RecipeRunner, ProjectPulseStrip and
   // RotatingTip own fetches and rotation timers a remount would reset, and the

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { FolderOpen, GitBranch, Settings } from "lucide-react";
 import { DaintreeIcon } from "@/components/icons";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -37,8 +38,11 @@ const PATH_TRUNCATE_LENGTH = 52;
 // wrappers it lands on CSS's `all` default — an every-property transition
 // nobody asked for. Setting `--tw-animation-duration` keeps the transition set
 // empty, for the same reason the ladder below avoids `delay-*`.
-const SECTION_ENTRY =
-  "launcher-section-enter motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:[--tw-animation-duration:var(--duration-200)]";
+// Also the hook the reveal replay queries by, so the class the reduce-motion
+// block neutralizes and the class the replay restarts cannot drift apart.
+const SECTION_ENTRY_MARKER = "launcher-section-enter";
+
+const SECTION_ENTRY = `${SECTION_ENTRY_MARKER} motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:[--tw-animation-duration:var(--duration-200)]`;
 
 // The stagger ladder. Sequencing IS the signal here, so the per-step delay is a
 // literal ladder rather than one of the shared duration tiers.
@@ -63,6 +67,38 @@ const SECTION_ENTRY_DELAY_4 =
   "motion-safe:[--tw-animation-delay:120ms] motion-safe:fill-mode-backwards";
 const SECTION_ENTRY_DELAY_5 =
   "motion-safe:[--tw-animation-delay:150ms] motion-safe:fill-mode-backwards";
+
+// Both of the entry's suppressors are CSS-only — `motion-safe:` reads the OS
+// preference and the `launcher-section-enter` rule reads the in-app toggle — so
+// neither can stop a replay driven from JS. Restating the same triple check
+// `triggerPanelTransition` makes keeps the replay from restarting animations
+// those rules have already flattened to nothing.
+function isMotionSuppressed(): boolean {
+  return (
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches ||
+    document.body.getAttribute("data-reduce-animations") === "true" ||
+    document.body.getAttribute("data-performance-mode") === "true"
+  );
+}
+
+// Restart each section's own entry, keeping its place on the stagger ladder: the
+// delay lives in a custom property the animation re-reads, so a cancel/play pair
+// in one tick replays the ladder rather than collapsing it. `fill-mode-backwards`
+// makes cancel() paint the pre-entry state, so no section flashes at rest first.
+//
+// Queried per section and restarted through each element's OWN animations —
+// `getAnimations()` without `subtree` — because the launcher's descendants carry
+// unrelated motion (RotatingTip's fade, pulse skeletons) that must keep running
+// on its own timeline.
+function replaySectionEntries(container: HTMLElement | null): void {
+  if (!container || isMotionSuppressed()) return;
+  for (const section of container.querySelectorAll(`.${SECTION_ENTRY_MARKER}`)) {
+    for (const animation of section.getAnimations()) {
+      animation.cancel();
+      animation.play();
+    }
+  }
+}
 
 // The active workspace is a project OR a scratch (#11076). `hasLaunchTarget`
 // gates the launcher column on having somewhere to launch INTO — a scratch has
@@ -121,6 +157,61 @@ export function ContentGridEmptyState({
   const recipesLoading = useRecipeStore((state) => state.isLoading);
   const { homeDir } = useHomeDir();
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // The entry above is DOM-entry motion, which a project switch never re-enters:
+  // every project keeps its own persistent WebContentsView and React tree, so
+  // switching to one reveals a subtree that was already mounted (a worktree
+  // switch, by contrast, remounts this component and replays for free). Nothing
+  // renders differently at reveal either, so the replay has to be imperative.
+  //
+  // `app:view-revealed` is the moment to hang it on: ProjectViewManager sends it
+  // only once the anti-flash bridge is detached and this view is the foreground
+  // surface, which is exactly when an entry animation is worth spending. Cold
+  // switches need no replay — their view mounts this component fresh, after the
+  // bridge is gone, so the natural entry is already the one the user sees.
+  //
+  // WAAPI restart rather than a remount key: RecipeRunner, ProjectPulseStrip and
+  // RotatingTip own fetches and rotation timers a remount would reset, and the
+  // point is to replay a fade, not to rebuild the launcher.
+  useEffect(() => {
+    let outerFrame: number | null = null;
+    let innerFrame: number | null = null;
+
+    const cancelPendingReplay = () => {
+      if (outerFrame !== null) cancelAnimationFrame(outerFrame);
+      if (innerFrame !== null) cancelAnimationFrame(innerFrame);
+      outerFrame = null;
+      innerFrame = null;
+    };
+
+    const offRevealed = window.electron?.app?.onViewRevealed?.(() => {
+      cancelPendingReplay();
+      // Two frames, as the paint signal itself waits: the reveal arrives while
+      // the compositor is still waking this view from occlusion, and a restart
+      // issued into that gap is dropped — the bug this animation already has on
+      // the occluded path, reintroduced.
+      outerFrame = requestAnimationFrame(() => {
+        outerFrame = null;
+        innerFrame = requestAnimationFrame(() => {
+          innerFrame = null;
+          replaySectionEntries(containerRef.current);
+        });
+      });
+    });
+
+    // A view parked back in the LRU cache stops painting mid-schedule, leaving a
+    // frame to fire on its next reveal — which would restart the entry a beat
+    // before that reveal's own replay and hitch it.
+    const offCached = window.electron?.app?.onViewCached?.(cancelPendingReplay);
+
+    return () => {
+      cancelPendingReplay();
+      offRevealed?.();
+      offCached?.();
+    };
+  }, []);
+
   const branchLabel =
     activeWorktreeIsDetached && activeWorktreeHead
       ? `detached at ${activeWorktreeHead.slice(0, 7)}`
@@ -160,7 +251,7 @@ export function ContentGridEmptyState({
   // carries its own entry, and the no-launch-target branches keep the entry
   // fade `EmptyState` already owns.
   return (
-    <div className="relative h-full w-full overflow-hidden">
+    <div ref={containerRef} className="relative h-full w-full overflow-hidden">
       {/* Content scrolls independently of the fixed watermark so an expanded
           pulse (or a tall recipe list) on a short canvas stays reachable
           instead of being clipped; `min-h-full` keeps it centered when short. */}

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -19,11 +19,17 @@ import { LauncherQuickActions } from "./LauncherQuickActions";
 
 const PATH_TRUNCATE_LENGTH = 52;
 
+// Marks a section as carrying the entry, for the two things that need to find
+// one: the reduce-motion block in `index.css` and `replaySectionEntries` below.
+// Shared so those two cannot drift apart.
+const SECTION_ENTRY_MARKER = "launcher-section-enter";
+
 // Entry motion for each launcher section — the column arrives as a sequence
 // rather than one flat block. Static classes, so the animation plays once when
 // a section enters the DOM and never replays on re-render; a section whose
 // condition flips later (recipes finish loading, the pulse is unhidden) simply
-// runs its own entry then.
+// runs its own entry then. A project switch re-enters nothing, which is why the
+// reveal below has to replay these by hand.
 //
 // Two suppressors, both needed, exactly as `ContentFadeIn` does it:
 // `motion-safe:` covers the OS preference, and the `launcher-section-enter`
@@ -38,10 +44,6 @@ const PATH_TRUNCATE_LENGTH = 52;
 // wrappers it lands on CSS's `all` default — an every-property transition
 // nobody asked for. Setting `--tw-animation-duration` keeps the transition set
 // empty, for the same reason the ladder below avoids `delay-*`.
-// Also the hook the reveal replay queries by, so the class the reduce-motion
-// block neutralizes and the class the replay restarts cannot drift apart.
-const SECTION_ENTRY_MARKER = "launcher-section-enter";
-
 const SECTION_ENTRY = `${SECTION_ENTRY_MARKER} motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:[--tw-animation-duration:var(--duration-200)]`;
 
 // The stagger ladder. Sequencing IS the signal here, so the per-step delay is a
@@ -81,22 +83,26 @@ function isMotionSuppressed(): boolean {
   );
 }
 
-// Restart each section's own entry, keeping its place on the stagger ladder: the
-// delay lives in a custom property the animation re-reads, so a cancel/play pair
-// in one tick replays the ladder rather than collapsing it. `fill-mode-backwards`
-// makes cancel() paint the pre-entry state, so no section flashes at rest first.
+// Restart each section's entry by tearing the animation down and handing it
+// straight back to the class. NOT WAAPI `cancel()`/`play()`: `getAnimations()`
+// returns only animations that are current or in effect, and an entry that has
+// finished under `fill-mode: backwards` — which fills before its delay, never
+// after — is neither. It omits precisely the spent entries this replays, so it
+// would iterate nothing and silently do nothing.
 //
-// Queried per section and restarted through each element's OWN animations —
-// `getAnimations()` without `subtree` — because the launcher's descendants carry
-// unrelated motion (RotatingTip's fade, pulse skeletons) that must keep running
-// on its own timeline.
+// Clearing the override rather than naming the keyframes back keeps them in CSS,
+// and the fresh animation re-reads `--tw-animation-delay`, so the ladder is
+// preserved. Reading a layout property in between is what forces the teardown to
+// land, rather than both writes collapsing into one style resolution.
+//
+// Queried per section, so the launcher's descendants (RotatingTip's fade, pulse
+// skeletons) keep their own timelines.
 function replaySectionEntries(container: HTMLElement | null): void {
   if (!container || isMotionSuppressed()) return;
-  for (const section of container.querySelectorAll(`.${SECTION_ENTRY_MARKER}`)) {
-    for (const animation of section.getAnimations()) {
-      animation.cancel();
-      animation.play();
-    }
+  for (const section of container.querySelectorAll<HTMLElement>(`.${SECTION_ENTRY_MARKER}`)) {
+    section.style.animationName = "none";
+    void section.offsetWidth;
+    section.style.animationName = "";
   }
 }
 
@@ -165,51 +171,25 @@ export function ContentGridEmptyState({
   // switch, by contrast, remounts this component and replays for free). Nothing
   // renders differently at reveal either, so the replay has to be imperative.
   //
-  // `app:view-revealed` is the moment to hang it on: ProjectViewManager sends it
-  // only once the anti-flash bridge is detached and this view is the foreground
-  // surface, which is exactly when an entry animation is worth spending. Cold
-  // switches need no replay — their view mounts this component fresh, after the
-  // bridge is gone, so the natural entry is already the one the user sees.
+  // `app:view-revealed` is both the right moment and a safe one to act on
+  // synchronously: main sends it only once the warm paint gate has run, the
+  // anti-flash bridge is detached and the view is the invalidated foreground
+  // surface. So the restart lands on a view that is already compositing, and
+  // waiting out frames here would only show the launcher at rest before yanking
+  // it back to replay.
   //
-  // WAAPI restart rather than a remount key: RecipeRunner, ProjectPulseStrip and
+  // Cold switches need no replay: an evicted project's view mounts this
+  // component fresh, and the paint gate they release on (`skeleton-painted`,
+  // fired before the module entry evaluates) detaches the bridge well before
+  // hydration mounts the canvas — so the natural entry is the one the user sees.
+  //
+  // Restarting rather than remounting: RecipeRunner, ProjectPulseStrip and
   // RotatingTip own fetches and rotation timers a remount would reset, and the
   // point is to replay a fade, not to rebuild the launcher.
   useEffect(() => {
-    let outerFrame: number | null = null;
-    let innerFrame: number | null = null;
-
-    const cancelPendingReplay = () => {
-      if (outerFrame !== null) cancelAnimationFrame(outerFrame);
-      if (innerFrame !== null) cancelAnimationFrame(innerFrame);
-      outerFrame = null;
-      innerFrame = null;
-    };
-
-    const offRevealed = window.electron?.app?.onViewRevealed?.(() => {
-      cancelPendingReplay();
-      // Two frames, as the paint signal itself waits: the reveal arrives while
-      // the compositor is still waking this view from occlusion, and a restart
-      // issued into that gap is dropped — the bug this animation already has on
-      // the occluded path, reintroduced.
-      outerFrame = requestAnimationFrame(() => {
-        outerFrame = null;
-        innerFrame = requestAnimationFrame(() => {
-          innerFrame = null;
-          replaySectionEntries(containerRef.current);
-        });
-      });
+    return window.electron?.app?.onViewRevealed?.(() => {
+      replaySectionEntries(containerRef.current);
     });
-
-    // A view parked back in the LRU cache stops painting mid-schedule, leaving a
-    // frame to fire on its next reveal — which would restart the entry a beat
-    // before that reveal's own replay and hitch it.
-    const offCached = window.electron?.app?.onViewCached?.(cancelPendingReplay);
-
-    return () => {
-      cancelPendingReplay();
-      offRevealed?.();
-      offCached?.();
-    };
   }, []);
 
   const branchLabel =

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.reveal.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.reveal.test.tsx
@@ -76,6 +76,7 @@ const SCRATCH_PROPS = {
  * against the real engine rather than asserted here.
  */
 const reflowsWhileOverridden = new Map<Element, string>();
+let originalOffsetWidth: PropertyDescriptor | undefined;
 
 let revealCallbacks: (() => void)[] = [];
 const offReveal = vi.fn();
@@ -103,6 +104,7 @@ beforeEach(() => {
   // jsdom lays nothing out, so offsetWidth is an inert 0 and the reflow it is
   // meant to pin is unobservable. Recording the animation override in force when
   // it is read makes the ordering the restart depends on testable.
+  originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
   Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
     configurable: true,
     get(this: HTMLElement) {
@@ -125,7 +127,9 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  delete (HTMLElement.prototype as Partial<HTMLElement>).offsetWidth;
+  if (originalOffsetWidth) {
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+  }
   document.body.removeAttribute("data-reduce-animations");
   document.body.removeAttribute("data-performance-mode");
   vi.unstubAllGlobals();

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.reveal.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.reveal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, act, cleanup } from "@testing-library/react";
+import { render, screen, cleanup } from "@testing-library/react";
 
 // Hoisted mutable state so each mock reads its slice at call time and a test can
 // reshape the stores before rendering.
@@ -67,67 +67,27 @@ const SCRATCH_PROPS = {
 } as const;
 
 /**
- * A stand-in for a running CSS animation. jsdom implements no part of the Web
- * Animations API, so the launcher's real entry has no timeline here — what these
- * tests can prove is the orchestration around it: which elements are restarted,
- * when, and whether a suppressor stops it. The restart itself (that cancel/play
- * replays the ladder rather than collapsing it) is browser behaviour, verified
- * against Chromium rather than asserted here.
+ * A CSS animation only restarts if the teardown is flushed before the class is
+ * handed the element back — two writes in one style resolution collapse into no
+ * change at all. jsdom runs no style engine and never lays out, so what stands in
+ * for "did it restart" is the sequence: a forced reflow observed while the
+ * animation was overridden to `none`, and the override released afterwards.
+ * Whether Chromium then replays the keyframes is browser behaviour, verified
+ * against the real engine rather than asserted here.
  */
-const makeAnimation = (log: string[], label: string) => ({
-  cancel: vi.fn(() => log.push(`${label}:cancel`)),
-  play: vi.fn(() => log.push(`${label}:play`)),
-});
-type FakeAnimation = ReturnType<typeof makeAnimation>;
-
-const animationsByElement = new Map<Element, FakeAnimation[]>();
-let queriedElements: Element[] = [];
-
-/** Frames run only when a test says so, so "not yet" is observable. */
-const pendingFrames = new Map<number, FrameRequestCallback>();
-let nextFrameId = 0;
-
-const flushFrame = () => {
-  const due = [...pendingFrames.values()];
-  pendingFrames.clear();
-  act(() => {
-    for (const cb of due) cb(0);
-  });
-};
+const reflowsWhileOverridden = new Map<Element, string>();
 
 let revealCallbacks: (() => void)[] = [];
-let cachedCallbacks: (() => void)[] = [];
 const offReveal = vi.fn();
-const offCached = vi.fn();
 
 const reveal = () => {
   for (const cb of revealCallbacks) cb();
 };
-const parkInCache = () => {
-  for (const cb of cachedCallbacks) cb();
-};
 
-/** Both frames of the reveal's double-rAF wait. */
-const settleReveal = () => {
-  reveal();
-  flushFrame();
-  flushFrame();
-};
-
-const sectionsIn = (container: HTMLElement): Element[] =>
-  [...container.querySelectorAll("div")].filter((el) =>
+const sectionsIn = (container: HTMLElement): HTMLElement[] =>
+  [...container.querySelectorAll<HTMLElement>("div")].filter((el) =>
     el.className.includes("launcher-section-enter")
   );
-
-/** Give every launcher section one animation to restart; returns the log. */
-const armSections = (container: HTMLElement): { log: string[]; sections: Element[] } => {
-  const log: string[] = [];
-  const sections = sectionsIn(container);
-  sections.forEach((section, i) => {
-    animationsByElement.set(section, [makeAnimation(log, `section-${i}`)]);
-  });
-  return { log, sections };
-};
 
 beforeEach(() => {
   h.panelIds = ["p1"];
@@ -136,39 +96,19 @@ beforeEach(() => {
   h.recipes.isLoading = false;
   h.dispatch.mockClear();
 
-  animationsByElement.clear();
-  queriedElements = [];
-  pendingFrames.clear();
-  nextFrameId = 0;
+  reflowsWhileOverridden.clear();
   revealCallbacks = [];
-  cachedCallbacks = [];
   offReveal.mockClear();
-  offCached.mockClear();
 
-  // Models the real contract rather than returning a flat list: `subtree` is the
-  // difference between restarting the six sections and restarting every animation
-  // underneath them, so a stub blind to it would pass either way.
-  Object.defineProperty(Element.prototype, "getAnimations", {
+  // jsdom lays nothing out, so offsetWidth is an inert 0 and the reflow it is
+  // meant to pin is unobservable. Recording the animation override in force when
+  // it is read makes the ordering the restart depends on testable.
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
     configurable: true,
-    writable: true,
-    value: function (this: Element, options?: { subtree?: boolean }) {
-      queriedElements.push(this);
-      const own = animationsByElement.get(this) ?? [];
-      if (!options?.subtree) return own;
-      const descendants = [...this.querySelectorAll("*")].flatMap(
-        (el) => animationsByElement.get(el) ?? []
-      );
-      return [...own, ...descendants];
+    get(this: HTMLElement) {
+      reflowsWhileOverridden.set(this, this.style.animationName);
+      return 0;
     },
-  });
-
-  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
-    const id = ++nextFrameId;
-    pendingFrames.set(id, cb);
-    return id;
-  });
-  vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
-    pendingFrames.delete(id);
   });
 
   vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
@@ -179,17 +119,13 @@ beforeEach(() => {
         revealCallbacks.push(cb);
         return offReveal;
       },
-      onViewCached: (cb: () => void) => {
-        cachedCallbacks.push(cb);
-        return offCached;
-      },
     },
   });
 });
 
 afterEach(() => {
   cleanup();
-  delete (Element.prototype as Partial<Element>).getAnimations;
+  delete (HTMLElement.prototype as Partial<HTMLElement>).offsetWidth;
   document.body.removeAttribute("data-reduce-animations");
   document.body.removeAttribute("data-performance-mode");
   vi.unstubAllGlobals();
@@ -198,126 +134,111 @@ afterEach(() => {
 describe("ContentGridEmptyState — replaying the entry on project reveal (issue #11209)", () => {
   it("restarts every launcher section's entry when the view is revealed", () => {
     const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-    const { log, sections } = armSections(container);
+    const sections = sectionsIn(container);
     expect(sections.length).toBeGreaterThan(1);
 
-    settleReveal();
+    reveal();
 
-    // Each section replays, and cancel precedes play — the order that reapplies
-    // the pre-entry state instead of restarting from wherever it left off.
-    expect(log).toEqual(sections.flatMap((_, i) => [`section-${i}:cancel`, `section-${i}:play`]));
+    for (const section of sections) {
+      // Torn down and flushed…
+      expect(reflowsWhileOverridden.get(section)).toBe("none");
+      // …then handed back to the class, which still owns the keyframes and the
+      // section's rung on the delay ladder.
+      expect(section.style.animationName).toBe("");
+    }
   });
 
-  it("waits for the compositor to wake before restarting, rather than replaying into the reveal", () => {
-    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-    const { log } = armSections(container);
+  it("replays on reveal rather than on render, which no switch changes", () => {
+    render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+
+    expect(reflowsWhileOverridden.size).toBe(0);
 
     reveal();
-    expect(log).toEqual([]);
 
-    flushFrame();
-    expect(log).toEqual([]);
-
-    flushFrame();
-    expect(log.length).toBeGreaterThan(0);
+    expect(reflowsWhileOverridden.size).toBeGreaterThan(0);
   });
 
   it("leaves motion owned by the sections' descendants on its own timeline", () => {
-    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-    const { log } = armSections(container);
-
-    // The tip rotates inside a section; a subtree-wide restart would reset it.
-    const descendantLog: string[] = [];
+    render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    // The tip rotates inside a section; restarting the subtree would reset it.
     const tip = screen.getByTestId("rotating-tip");
-    animationsByElement.set(tip, [makeAnimation(descendantLog, "tip")]);
 
-    settleReveal();
+    reveal();
 
-    expect(log.length).toBeGreaterThan(0);
-    expect(descendantLog).toEqual([]);
-    expect(queriedElements).not.toContain(tip);
+    expect(reflowsWhileOverridden.has(tip)).toBe(false);
+    expect(tip.style.animationName).toBe("");
   });
 
   it("replays for a scratch, which reaches the launcher through the same reveal", () => {
     const { container } = render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
-    const { log } = armSections(container);
+    const sections = sectionsIn(container);
+    expect(sections.length).toBeGreaterThan(0);
 
-    settleReveal();
+    reveal();
 
-    expect(log.length).toBeGreaterThan(0);
+    for (const section of sections) {
+      expect(reflowsWhileOverridden.get(section)).toBe("none");
+    }
   });
 
-  it("collapses a reveal arriving mid-schedule into one replay", () => {
+  it("replays again on every subsequent reveal, not just the first", () => {
     const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-    const { log, sections } = armSections(container);
+    const [section] = sectionsIn(container);
 
     reveal();
-    flushFrame();
-    reveal(); // Supersedes the first, which is still a frame from restarting.
-    flushFrame();
-    flushFrame();
+    reflowsWhileOverridden.clear();
+    reveal();
 
-    expect(log).toEqual(sections.flatMap((_, i) => [`section-${i}:cancel`, `section-${i}:play`]));
+    expect(reflowsWhileOverridden.get(section!)).toBe("none");
   });
 
-  it("drops a replay for a view parked back in the cache before it could run", () => {
-    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-    const { log } = armSections(container);
+  it("unsubscribes on unmount", () => {
+    const { unmount } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
 
-    reveal();
-    parkInCache();
-    flushFrame();
-    flushFrame();
-
-    expect(log).toEqual([]);
-  });
-
-  it("unsubscribes and abandons a pending replay on unmount", () => {
-    const { container, unmount } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-    const { log } = armSections(container);
-
-    reveal();
     unmount();
-    flushFrame();
-    flushFrame();
 
-    expect(log).toEqual([]);
     expect(offReveal).toHaveBeenCalled();
-    expect(offCached).toHaveBeenCalled();
+  });
+
+  it("survives a reveal with no launcher to replay", () => {
+    render(
+      <ContentGridEmptyState
+        {...PROJECT_PROPS}
+        hasLaunchTarget={false}
+        isWorktreeInitialized={true}
+      />
+    );
+
+    expect(() => reveal()).not.toThrow();
+    expect(reflowsWhileOverridden.size).toBe(0);
   });
 
   describe("motion suppressors", () => {
     it("skips the replay under the OS reduced-motion preference", () => {
       vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
-      const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-      const { log } = armSections(container);
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
 
-      settleReveal();
+      reveal();
 
-      expect(log).toEqual([]);
-      expect(queriedElements).toEqual([]);
+      expect(reflowsWhileOverridden.size).toBe(0);
     });
 
     it("skips the replay under the in-app reduce-animations toggle", () => {
       document.body.setAttribute("data-reduce-animations", "true");
-      const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-      const { log } = armSections(container);
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
 
-      settleReveal();
+      reveal();
 
-      expect(log).toEqual([]);
-      expect(queriedElements).toEqual([]);
+      expect(reflowsWhileOverridden.size).toBe(0);
     });
 
     it("skips the replay under performance mode", () => {
       document.body.setAttribute("data-performance-mode", "true");
-      const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
-      const { log } = armSections(container);
+      render(<ContentGridEmptyState {...PROJECT_PROPS} />);
 
-      settleReveal();
+      reveal();
 
-      expect(log).toEqual([]);
-      expect(queriedElements).toEqual([]);
+      expect(reflowsWhileOverridden.size).toBe(0);
     });
   });
 });

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.reveal.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.reveal.test.tsx
@@ -1,0 +1,323 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+
+// Hoisted mutable state so each mock reads its slice at call time and a test can
+// reshape the stores before rendering.
+const h = vi.hoisted(() => ({
+  panelIds: [] as string[],
+  panelsById: {} as Record<string, unknown>,
+  recipes: { currentProjectId: null as string | null, isLoading: false },
+  dispatch: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: h.dispatch },
+}));
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (sel: (s: typeof h) => unknown) => sel(h),
+}));
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: (sel: (s: typeof h.recipes) => unknown) => sel(h.recipes),
+}));
+vi.mock("@/hooks/app/useHomeDir", () => ({
+  useHomeDir: () => ({ homeDir: "/home/user" }),
+}));
+
+vi.mock("../LauncherQuickActions", () => ({
+  LauncherQuickActions: () => <div data-testid="launcher-quick-actions" />,
+}));
+vi.mock("../RecipeRunner/RecipeRunner", () => ({
+  RecipeRunner: () => <div data-testid="recipe-runner" />,
+}));
+vi.mock("../ResumeSessionLine", () => ({
+  ResumeSessionLine: () => <div data-testid="resume-session-line" />,
+}));
+vi.mock("../contentGridTips", () => ({
+  RotatingTip: () => <div data-testid="rotating-tip" />,
+}));
+vi.mock("@/components/Pulse", () => ({
+  ProjectPulseStrip: () => <div data-testid="project-pulse" />,
+}));
+
+import { ContentGridEmptyState } from "../ContentGridEmptyState";
+
+const PROJECT_PROPS = {
+  hasLaunchTarget: true,
+  hasProjectContext: true,
+  hasWorktrees: true,
+  isWorktreeInitialized: true,
+  activeWorktreeId: "wt-1",
+  activeWorktreeName: "feature",
+  activeWorktreeBranch: "feature/x",
+  activeWorktreePath: "/repo-worktrees/feature",
+  workspaceName: "My project",
+  showProjectPulse: true,
+} as const;
+
+const SCRATCH_PROPS = {
+  hasLaunchTarget: true,
+  hasProjectContext: false,
+  hasWorktrees: false,
+  isWorktreeInitialized: false,
+  workspaceName: "Scratch 2026-07-12 09:30",
+  activeWorktreePath: "/scratches/abc-123",
+  showProjectPulse: false,
+  defaultCwd: "/scratches/abc-123",
+} as const;
+
+/**
+ * A stand-in for a running CSS animation. jsdom implements no part of the Web
+ * Animations API, so the launcher's real entry has no timeline here — what these
+ * tests can prove is the orchestration around it: which elements are restarted,
+ * when, and whether a suppressor stops it. The restart itself (that cancel/play
+ * replays the ladder rather than collapsing it) is browser behaviour, verified
+ * against Chromium rather than asserted here.
+ */
+const makeAnimation = (log: string[], label: string) => ({
+  cancel: vi.fn(() => log.push(`${label}:cancel`)),
+  play: vi.fn(() => log.push(`${label}:play`)),
+});
+type FakeAnimation = ReturnType<typeof makeAnimation>;
+
+const animationsByElement = new Map<Element, FakeAnimation[]>();
+let queriedElements: Element[] = [];
+
+/** Frames run only when a test says so, so "not yet" is observable. */
+const pendingFrames = new Map<number, FrameRequestCallback>();
+let nextFrameId = 0;
+
+const flushFrame = () => {
+  const due = [...pendingFrames.values()];
+  pendingFrames.clear();
+  act(() => {
+    for (const cb of due) cb(0);
+  });
+};
+
+let revealCallbacks: (() => void)[] = [];
+let cachedCallbacks: (() => void)[] = [];
+const offReveal = vi.fn();
+const offCached = vi.fn();
+
+const reveal = () => {
+  for (const cb of revealCallbacks) cb();
+};
+const parkInCache = () => {
+  for (const cb of cachedCallbacks) cb();
+};
+
+/** Both frames of the reveal's double-rAF wait. */
+const settleReveal = () => {
+  reveal();
+  flushFrame();
+  flushFrame();
+};
+
+const sectionsIn = (container: HTMLElement): Element[] =>
+  [...container.querySelectorAll("div")].filter((el) =>
+    el.className.includes("launcher-section-enter")
+  );
+
+/** Give every launcher section one animation to restart; returns the log. */
+const armSections = (container: HTMLElement): { log: string[]; sections: Element[] } => {
+  const log: string[] = [];
+  const sections = sectionsIn(container);
+  sections.forEach((section, i) => {
+    animationsByElement.set(section, [makeAnimation(log, `section-${i}`)]);
+  });
+  return { log, sections };
+};
+
+beforeEach(() => {
+  h.panelIds = ["p1"];
+  h.panelsById = { p1: { kind: "terminal", launchAgentId: "claude" } };
+  h.recipes.currentProjectId = "proj-1";
+  h.recipes.isLoading = false;
+  h.dispatch.mockClear();
+
+  animationsByElement.clear();
+  queriedElements = [];
+  pendingFrames.clear();
+  nextFrameId = 0;
+  revealCallbacks = [];
+  cachedCallbacks = [];
+  offReveal.mockClear();
+  offCached.mockClear();
+
+  // Models the real contract rather than returning a flat list: `subtree` is the
+  // difference between restarting the six sections and restarting every animation
+  // underneath them, so a stub blind to it would pass either way.
+  Object.defineProperty(Element.prototype, "getAnimations", {
+    configurable: true,
+    writable: true,
+    value: function (this: Element, options?: { subtree?: boolean }) {
+      queriedElements.push(this);
+      const own = animationsByElement.get(this) ?? [];
+      if (!options?.subtree) return own;
+      const descendants = [...this.querySelectorAll("*")].flatMap(
+        (el) => animationsByElement.get(el) ?? []
+      );
+      return [...own, ...descendants];
+    },
+  });
+
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
+    const id = ++nextFrameId;
+    pendingFrames.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
+    pendingFrames.delete(id);
+  });
+
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+
+  vi.stubGlobal("electron", {
+    app: {
+      onViewRevealed: (cb: () => void) => {
+        revealCallbacks.push(cb);
+        return offReveal;
+      },
+      onViewCached: (cb: () => void) => {
+        cachedCallbacks.push(cb);
+        return offCached;
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  delete (Element.prototype as Partial<Element>).getAnimations;
+  document.body.removeAttribute("data-reduce-animations");
+  document.body.removeAttribute("data-performance-mode");
+  vi.unstubAllGlobals();
+});
+
+describe("ContentGridEmptyState — replaying the entry on project reveal (issue #11209)", () => {
+  it("restarts every launcher section's entry when the view is revealed", () => {
+    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    const { log, sections } = armSections(container);
+    expect(sections.length).toBeGreaterThan(1);
+
+    settleReveal();
+
+    // Each section replays, and cancel precedes play — the order that reapplies
+    // the pre-entry state instead of restarting from wherever it left off.
+    expect(log).toEqual(sections.flatMap((_, i) => [`section-${i}:cancel`, `section-${i}:play`]));
+  });
+
+  it("waits for the compositor to wake before restarting, rather than replaying into the reveal", () => {
+    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    const { log } = armSections(container);
+
+    reveal();
+    expect(log).toEqual([]);
+
+    flushFrame();
+    expect(log).toEqual([]);
+
+    flushFrame();
+    expect(log.length).toBeGreaterThan(0);
+  });
+
+  it("leaves motion owned by the sections' descendants on its own timeline", () => {
+    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    const { log } = armSections(container);
+
+    // The tip rotates inside a section; a subtree-wide restart would reset it.
+    const descendantLog: string[] = [];
+    const tip = screen.getByTestId("rotating-tip");
+    animationsByElement.set(tip, [makeAnimation(descendantLog, "tip")]);
+
+    settleReveal();
+
+    expect(log.length).toBeGreaterThan(0);
+    expect(descendantLog).toEqual([]);
+    expect(queriedElements).not.toContain(tip);
+  });
+
+  it("replays for a scratch, which reaches the launcher through the same reveal", () => {
+    const { container } = render(<ContentGridEmptyState {...SCRATCH_PROPS} />);
+    const { log } = armSections(container);
+
+    settleReveal();
+
+    expect(log.length).toBeGreaterThan(0);
+  });
+
+  it("collapses a reveal arriving mid-schedule into one replay", () => {
+    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    const { log, sections } = armSections(container);
+
+    reveal();
+    flushFrame();
+    reveal(); // Supersedes the first, which is still a frame from restarting.
+    flushFrame();
+    flushFrame();
+
+    expect(log).toEqual(sections.flatMap((_, i) => [`section-${i}:cancel`, `section-${i}:play`]));
+  });
+
+  it("drops a replay for a view parked back in the cache before it could run", () => {
+    const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    const { log } = armSections(container);
+
+    reveal();
+    parkInCache();
+    flushFrame();
+    flushFrame();
+
+    expect(log).toEqual([]);
+  });
+
+  it("unsubscribes and abandons a pending replay on unmount", () => {
+    const { container, unmount } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+    const { log } = armSections(container);
+
+    reveal();
+    unmount();
+    flushFrame();
+    flushFrame();
+
+    expect(log).toEqual([]);
+    expect(offReveal).toHaveBeenCalled();
+    expect(offCached).toHaveBeenCalled();
+  });
+
+  describe("motion suppressors", () => {
+    it("skips the replay under the OS reduced-motion preference", () => {
+      vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+      const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+      const { log } = armSections(container);
+
+      settleReveal();
+
+      expect(log).toEqual([]);
+      expect(queriedElements).toEqual([]);
+    });
+
+    it("skips the replay under the in-app reduce-animations toggle", () => {
+      document.body.setAttribute("data-reduce-animations", "true");
+      const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+      const { log } = armSections(container);
+
+      settleReveal();
+
+      expect(log).toEqual([]);
+      expect(queriedElements).toEqual([]);
+    });
+
+    it("skips the replay under performance mode", () => {
+      document.body.setAttribute("data-performance-mode", "true");
+      const { container } = render(<ContentGridEmptyState {...PROJECT_PROPS} />);
+      const { log } = armSections(container);
+
+      settleReveal();
+
+      expect(log).toEqual([]);
+      expect(queriedElements).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The empty-canvas launcher's staggered fade+slide entry animation replays on a worktree switch (the component remounts) but not on a project switch, since that just reveals a different, already-mounted `WebContentsView` and React tree, so nothing re-enters the DOM.
- `ContentGridEmptyState.tsx` now subscribes to the existing `app:view-revealed` signal and restarts each section's entry imperatively, rather than remounting the whole component.

Resolves #11209

## Implementation

The restart sets each section's inline `animation-name` to `none`, forces a reflow, then releases it, so the CSS class hands back a fresh `CSSAnimation` that re-reads the `--tw-animation-delay` stagger. I went with an imperative restart instead of a remount because `RecipeRunner`, `ProjectPulseStrip`, and `RotatingTip` own fetches and rotation timers that a remount would reset. Sections are queried individually so descendant motion keeps its own timeline.

### Why not the Web Animations API

`getAnimations()` only returns animations that are current or in effect, so an entry that already finished under `fill-mode: backwards` is excluded from the list. `cancel()`/`play()` would iterate over nothing and silently no-op on exactly the spent sections the replay is meant to fix. Caught this during review and confirmed it against the Web Animations API's relevance filter.

### Motion suppressors

The replay checks all three suppressors in JS: OS-level `prefers-reduced-motion`, the app's `data-reduce-animations` toggle, and `data-performance-mode`, mirroring how `triggerPanelTransition` already handles it. The `motion-safe` and `launcher-section-enter` CSS rules can't stop a replay that's driven from JS.

### Scope

No main-process change was needed here. The issue speculated that on a cold switch to an evicted view, the animation plays behind the anti-flash bridge and is spent before the user sees anything. That's not actually the mechanism: cold switches release the paint gate on a `skeleton-painted` event that fires before the module even evaluates, so the bridge detaches well before hydration mounts the canvas, and cold views never receive `app:view-revealed` at all. A cold entry does still overlap that view's own startup-skeleton exit, but that's true of every cold boot. It's startup choreography, not the persistent-tree gap this PR closes, so I'm leaving it as a follow-up.

## Testing

New `ContentGridEmptyState.reveal.test.tsx` adds 10 tests covering the restart sequence, that reveal (not render) triggers it, descendant isolation, scratch workspaces, repeated reveals, unsubscribing, and each of the three motion suppressors independently. jsdom has no style engine, so the tests assert the restart by observing the forced reflow. Red-before-green validated: removing the reflow call turns exactly 4 of the 10 tests red.

Locally: 8 files / 163 tests green across the launcher, motion-contract, and accent-guard suites. eslint and prettier clean on both changed files.
