### PR TITLE
fix(plugins): serve React's public API from the host import map

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,11 @@ yarn.lock
 *.min.js
 *.min.css
 
+# Generated plugin view — `npm run build:sample-rich-view` output, committed and
+# shipped verbatim (#11208). Formatting it here would make every regeneration
+# fail format:check. Its hand-authored sibling (rich-panel-view.js) IS formatted.
+plugins/sample/rich-daintree/view/hook-panel-view.js
+
 # Generated API-surface snapshots (raw tsup .d.ts output — see scripts/ci/check-api-surface.mjs)
 packages/*/api-report/
 

--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -73,6 +73,11 @@ test.describe.serial("Core: Plugin panels contribution", () => {
   // the grid membership selectors dropped non-built-in kinds. This opens the
   // panel and asserts its React component actually MOUNTS over `plugin://`,
   // which is the coverage gap that let the bug ship.
+  //
+  // This view imports nothing, which is deliberate: it isolates a `plugin://`
+  // protocol failure from a React-contract failure (covered below). If both
+  // tests go red the loader broke; if only the hook test does, the import map
+  // did.
   test("mounts the contributed view's React component in the grid", async () => {
     await dispatchAction(ctx.window, "panel.openPluginPanel", {
       kind: "daintree.rich.rich-panel",
@@ -83,5 +88,109 @@ test.describe.serial("Core: Plugin panels contribution", () => {
     await expect(ctx.window.getByText("Rich panel view mounted")).toBeVisible({
       timeout: T_LONG,
     });
+  });
+
+  // Regression for #11208: every packaged build since v0.15.0 mapped all five
+  // React specifiers to the `vendor-react` code-split chunk, whose exports are
+  // Rolldown's private cross-chunk interface — so a plugin doing `import
+  // { useState } from "react"` died at load with "does not provide an export
+  // named 'useState'". Nothing caught it because the only plugin:// view in the
+  // repo imported no React, and dev mode used a different (working) mechanism.
+  //
+  // `hook-panel-view` is built by the public @daintreehq/plugin-vite preset, so
+  // this exercises the same externalize→import-map path a third-party plugin
+  // takes. Waiting on the post-effect "ready" is the whole assertion: reaching
+  // it requires the named `react` imports to have resolved, JSX to have resolved
+  // `react/jsx-runtime`, AND the hooks to dispatch through the HOST's React —
+  // a duplicated React would throw "Invalid hook call" before ever getting here.
+  test("mounts a hook-based view that imports React through the host import map", async () => {
+    await dispatchAction(ctx.window, "panel.openPluginPanel", {
+      kind: "daintree.rich.hook-panel",
+    });
+
+    await expect(ctx.window.getByText("Hook panel view ready")).toBeVisible({
+      timeout: T_LONG,
+    });
+  });
+
+  // The build-time guard (hostReactFacadePlugin in vite.config.ts) proves the
+  // facade CHUNKS carry the right export names. This proves the other half the
+  // build can't see: that the import map in the shipped index.html actually
+  // RESOLVES those specifiers at runtime, under the real app:// protocol and CSP.
+  test("resolves every mapped specifier to its public export surface", async () => {
+    // Passed as a string on purpose: Playwright transpiles this TS spec, which
+    // rewrites `await import(...)` inside a callback into a `require()` the
+    // renderer can't run. A string literal reaches the page verbatim.
+    const probe = `(async () => {
+      const CONTRACT = {
+        "react": ["useState", "useEffect", "useMemo", "useCallback", "useRef",
+                  "useContext", "useReducer", "createElement", "forwardRef",
+                  "memo", "createContext", "lazy"],
+        "react/jsx-runtime": ["jsx", "jsxs"],
+        "react/jsx-dev-runtime": [],
+        "react-dom": ["createPortal", "flushSync"],
+        "react-dom/client": ["createRoot", "hydrateRoot"]
+      };
+      const rows = [];
+      for (const specifier of Object.keys(CONTRACT)) {
+        const row = { specifier, error: null, missing: [], notFunctions: [],
+                      hasFragment: false, hasOwnJsxDEV: false };
+        try {
+          const ns = await import(specifier);
+          for (const name of CONTRACT[specifier]) {
+            if (!Object.hasOwn(ns, name)) row.missing.push(name);
+            else if (typeof ns[name] !== "function") {
+              row.notFunctions.push(name + ":" + typeof ns[name]);
+            }
+          }
+          row.hasFragment = Object.hasOwn(ns, "Fragment");
+          row.hasOwnJsxDEV = Object.hasOwn(ns, "jsxDEV");
+        } catch (err) {
+          row.error = String((err && err.message) || err);
+        }
+        rows.push(row);
+      }
+      return rows;
+    })()`;
+
+    const rows = await ctx.window.evaluate<
+      Array<{
+        specifier: string;
+        error: string | null;
+        missing: string[];
+        notFunctions: string[];
+        hasFragment: boolean;
+        hasOwnJsxDEV: boolean;
+      }>
+    >(probe);
+
+    // Assert on the whole shape at once so a failure names every broken
+    // specifier, not just the first.
+    expect(
+      rows.map((r) => ({
+        specifier: r.specifier,
+        error: r.error,
+        missing: r.missing,
+        notFunctions: r.notFunctions,
+      }))
+    ).toEqual([
+      { specifier: "react", error: null, missing: [], notFunctions: [] },
+      { specifier: "react/jsx-runtime", error: null, missing: [], notFunctions: [] },
+      { specifier: "react/jsx-dev-runtime", error: null, missing: [], notFunctions: [] },
+      { specifier: "react-dom", error: null, missing: [], notFunctions: [] },
+      { specifier: "react-dom/client", error: null, missing: [], notFunctions: [] },
+    ]);
+
+    // Fragment rides on the three specifiers that document it.
+    const fragmentOwners = rows.filter((r) => r.hasFragment).map((r) => r.specifier);
+    expect(fragmentOwners).toEqual(["react", "react/jsx-runtime", "react/jsx-dev-runtime"]);
+
+    // React's PRODUCTION jsx-dev-runtime exports `jsxDEV` as `undefined` — the
+    // name is there, the value isn't. `hasOwn` is the only honest check: reading
+    // `ns.jsxDEV` yields `undefined` whether the export exists or not, so a
+    // truthiness/`toBeUndefined` assertion would pass on a map that serves
+    // nothing at all — exactly the #11208 bug.
+    const jsxDev = rows.find((r) => r.specifier === "react/jsx-dev-runtime");
+    expect(jsxDev?.hasOwnJsxDEV).toBe(true);
   });
 });

--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -75,9 +75,10 @@ test.describe.serial("Core: Plugin panels contribution", () => {
   // which is the coverage gap that let the bug ship.
   //
   // This view imports nothing, which is deliberate: it isolates a `plugin://`
-  // protocol failure from a React-contract failure (covered below). If both
-  // tests go red the loader broke; if only the hook test does, the import map
-  // did.
+  // protocol failure from a React-contract failure (covered below). Read the two
+  // together — this one passing while the hook view fails means the loader is
+  // fine and the React contract broke. (The suite is `serial`, so a failure here
+  // skips the rest rather than reporting them red.)
   test("mounts the contributed view's React component in the grid", async () => {
     await dispatchAction(ctx.window, "panel.openPluginPanel", {
       kind: "daintree.rich.rich-panel",
@@ -97,30 +98,19 @@ test.describe.serial("Core: Plugin panels contribution", () => {
   // named 'useState'". Nothing caught it because the only plugin:// view in the
   // repo imported no React, and dev mode used a different (working) mechanism.
   //
-  // `hook-panel-view` is built by the public @daintreehq/plugin-vite preset, so
-  // this exercises the same externalize→import-map path a third-party plugin
-  // takes. Waiting on the post-effect "ready" is the whole assertion: reaching
-  // it requires the named `react` imports to have resolved, JSX to have resolved
-  // `react/jsx-runtime`, AND the hooks to dispatch through the HOST's React —
-  // a duplicated React would throw "Invalid hook call" before ever getting here.
-  test("mounts a hook-based view that imports React through the host import map", async () => {
-    await dispatchAction(ctx.window, "panel.openPluginPanel", {
-      kind: "daintree.rich.hook-panel",
-    });
-
-    await expect(ctx.window.getByText("Hook panel view ready")).toBeVisible({
-      timeout: T_LONG,
-    });
-  });
-
   // The build-time guard (hostReactFacadePlugin in vite.config.ts) proves the
-  // facade CHUNKS carry the right export names. This proves the other half the
-  // build can't see: that the import map in the shipped index.html actually
-  // RESOLVES those specifiers at runtime, under the real app:// protocol and CSP.
+  // facade CHUNKS carry the right export names. This proves the half the build
+  // can't see: that the shipped index.html's import map actually RESOLVES those
+  // specifiers at runtime, under the real app:// protocol and CSP.
+  //
+  // Ordered before the hook-panel test on purpose — the suite is `serial`, so on
+  // a #11208-style regression this reports exactly which specifiers lost which
+  // exports instead of just "the panel never mounted".
   test("resolves every mapped specifier to its public export surface", async () => {
-    // Passed as a string on purpose: Playwright transpiles this TS spec, which
-    // rewrites `await import(...)` inside a callback into a `require()` the
-    // renderer can't run. A string literal reaches the page verbatim.
+    // Passed as a string rather than a callback so the probe reaches the page
+    // verbatim. A callback's `await import(...)` has to survive Playwright's TS
+    // transform intact, which is a version-dependent detail this test has no
+    // reason to depend on; a string can't be rewritten.
     const probe = `(async () => {
       const CONTRACT = {
         "react": ["useState", "useEffect", "useMemo", "useCallback", "useRef",
@@ -132,9 +122,10 @@ test.describe.serial("Core: Plugin panels contribution", () => {
         "react-dom/client": ["createRoot", "hydrateRoot"]
       };
       const rows = [];
+      const fragments = new Map();
       for (const specifier of Object.keys(CONTRACT)) {
         const row = { specifier, error: null, missing: [], notFunctions: [],
-                      hasFragment: false, hasOwnJsxDEV: false };
+                      fragmentType: "absent", hasOwnJsxDEV: false, versionType: "absent" };
         try {
           const ns = await import(specifier);
           for (const name of CONTRACT[specifier]) {
@@ -143,26 +134,38 @@ test.describe.serial("Core: Plugin panels contribution", () => {
               row.notFunctions.push(name + ":" + typeof ns[name]);
             }
           }
-          row.hasFragment = Object.hasOwn(ns, "Fragment");
+          if (Object.hasOwn(ns, "Fragment")) {
+            row.fragmentType = typeof ns.Fragment;
+            fragments.set(specifier, ns.Fragment);
+          }
+          if (Object.hasOwn(ns, "version")) row.versionType = typeof ns.version;
           row.hasOwnJsxDEV = Object.hasOwn(ns, "jsxDEV");
         } catch (err) {
           row.error = String((err && err.message) || err);
         }
         rows.push(row);
       }
-      return rows;
+      // Identity, not just presence: every specifier that exposes Fragment must
+      // expose the SAME symbol. Distinct symbols mean the facades resolved to
+      // different React copies, which is the "Invalid hook call" failure.
+      const fragmentValues = [...fragments.values()];
+      const distinctFragments = new Set(fragmentValues).size;
+      return { rows, fragmentOwners: [...fragments.keys()], distinctFragments };
     })()`;
 
-    const rows = await ctx.window.evaluate<
-      Array<{
+    const { rows, fragmentOwners, distinctFragments } = await ctx.window.evaluate<{
+      rows: Array<{
         specifier: string;
         error: string | null;
         missing: string[];
         notFunctions: string[];
-        hasFragment: boolean;
+        fragmentType: string;
         hasOwnJsxDEV: boolean;
-      }>
-    >(probe);
+        versionType: string;
+      }>;
+      fragmentOwners: string[];
+      distinctFragments: number;
+    }>(probe);
 
     // Assert on the whole shape at once so a failure names every broken
     // specifier, not just the first.
@@ -181,16 +184,57 @@ test.describe.serial("Core: Plugin panels contribution", () => {
       { specifier: "react-dom/client", error: null, missing: [], notFunctions: [] },
     ]);
 
-    // Fragment rides on the three specifiers that document it.
-    const fragmentOwners = rows.filter((r) => r.hasFragment).map((r) => r.specifier);
+    // Fragment rides on the three specifiers that document it, is a real symbol
+    // (not an own-but-undefined binding), and agrees across all three.
+    //
+    // NOT a single-instance proof, despite the temptation to read it as one:
+    // React builds Fragment with `Symbol.for("react.fragment")`, a REGISTERED
+    // symbol, so two duplicated React copies in one realm still hand back the
+    // identical symbol. This only proves the facades expose a live, canonical
+    // marker rather than a hollow binding. Single-instance is proven by the
+    // hook-panel test below (a second copy throws "Invalid hook call") and, at
+    // build time, by the guard asserting all five facades import the one shared
+    // vendor-react chunk.
     expect(fragmentOwners).toEqual(["react", "react/jsx-runtime", "react/jsx-dev-runtime"]);
+    expect(rows.filter((r) => r.fragmentType === "symbol").map((r) => r.specifier)).toEqual(
+      fragmentOwners
+    );
+    expect(distinctFragments).toBe(1);
+
+    // `version` is a string wherever React documents it — catches a facade whose
+    // names resolve but whose bindings are hollow.
+    expect(rows.filter((r) => r.versionType === "string").map((r) => r.specifier)).toEqual([
+      "react",
+      "react-dom",
+      "react-dom/client",
+    ]);
 
     // React's PRODUCTION jsx-dev-runtime exports `jsxDEV` as `undefined` — the
     // name is there, the value isn't. `hasOwn` is the only honest check: reading
     // `ns.jsxDEV` yields `undefined` whether the export exists or not, so a
     // truthiness/`toBeUndefined` assertion would pass on a map that serves
-    // nothing at all — exactly the #11208 bug.
+    // nothing at all — exactly the #11208 bug. The value itself is deliberately
+    // not asserted: it's React's to define, and differs between dev and prod.
     const jsxDev = rows.find((r) => r.specifier === "react/jsx-dev-runtime");
     expect(jsxDev?.hasOwnJsxDEV).toBe(true);
+  });
+
+  // `hook-panel-view` is built by the public @daintreehq/plugin-vite preset, so
+  // this exercises the same externalize→import-map path a third-party plugin
+  // takes — the probe above proves the specifiers resolve; this proves a real
+  // component built the real way actually renders.
+  //
+  // Waiting on the post-effect "ready" is the whole assertion: reaching it
+  // requires the named `react` imports to have resolved, JSX to have resolved
+  // `react/jsx-runtime`, AND the hooks to dispatch through the HOST's React —
+  // a duplicated React would throw "Invalid hook call" before ever getting here.
+  test("mounts a hook-based view that imports React through the host import map", async () => {
+    await dispatchAction(ctx.window, "panel.openPluginPanel", {
+      kind: "daintree.rich.hook-panel",
+    });
+
+    await expect(ctx.window.getByText("Hook panel view ready")).toBeVisible({
+      timeout: T_LONG,
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "typecheck": "cross-env NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck:projects",
     "typecheck:projects": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json && tsc --noEmit -p packages/daintree-plugin/tsconfig.json && tsc --noEmit -p packages/create-daintree-plugin/tsconfig.json && tsc --noEmit -p packages/plugin-sdk/tsconfig.json && tsc --noEmit -p packages/plugin-testing/tsconfig.json && tsc --noEmit -p packages/plugin-vite/tsconfig.json && tsc --noEmit -p tsconfig.plugins.json",
     "packages:build": "npm run build --workspace=packages/plugin-sdk --workspace=packages/plugin-testing --workspace=packages/plugin-vite --workspace=packages/daintree-plugin --workspace=packages/create-daintree-plugin",
+    "build:sample-rich-view": "npm run build --workspace=packages/plugin-vite && vite build plugins/sample/rich-daintree --config plugins/sample/rich-daintree/vite.config.ts",
     "check:channels": "node scripts/ci/check-channel-drift.mjs",
     "check:preload-backdoors": "node scripts/ci/check-preload-backdoors.mjs",
     "check:crash-loop-constants": "node scripts/ci/check-crash-loop-constants.mjs",

--- a/packages/plugin-vite/src/index.ts
+++ b/packages/plugin-vite/src/index.ts
@@ -4,11 +4,16 @@ import type { Plugin } from "vite";
 /**
  * The exact React specifiers the Daintree host import map serves. This is the
  * single source of truth for the host/plugin contract: `vite.config.ts` imports
- * this list to build the `<script type="importmap">` it injects, and the plugin
- * build (below) errors at build time on any React subpath outside it. Keeping
- * the two sides on one constant is what stops the "externalized but unresolved
- * at runtime" drift (e.g. `react-dom/server`) that this list previously had to
- * be hand-synced against.
+ * this list to emit one facade chunk per specifier and to build the `<script
+ * type="importmap">` it injects, and the plugin build (below) errors at build
+ * time on any React subpath outside it. Keeping the two sides on one constant is
+ * what stops the "externalized but unresolved at runtime" drift (e.g.
+ * `react-dom/server`) that this list previously had to be hand-synced against.
+ *
+ * Adding an entry here is a real change on the host side: it must also declare
+ * the specifier's expected public exports in `HOST_REACT_REQUIRED_EXPORTS`
+ * (vite.config.ts), which is typed against this list and will fail typecheck
+ * until it does.
  */
 export const HOST_IMPORTMAP_SPECIFIERS = [
   "react",
@@ -27,8 +32,13 @@ export const HOST_IMPORTMAP_SPECIFIERS = [
  * matches only the literal string and would bundle `react/jsx-runtime`).
  *
  * Paired with the host import map (injected into Daintree's index.html), the
- * stripped imports resolve at load time to Daintree's single `vendor-react`
- * chunk, sharing one React instance across the host and every loaded plugin.
+ * stripped imports resolve at load time to a per-specifier facade module that
+ * re-exports that specifier's public API. All the facades are backed by
+ * Daintree's single `vendor-react` chunk, so the host and every loaded plugin
+ * share one React instance. The map deliberately does NOT point at that chunk
+ * directly: a code-split chunk only exports the private cross-chunk interface
+ * other chunks import from it, so `import { useState } from "react"` failed to
+ * load in every packaged build until #11208.
  *
  * Breadth here is safe only because {@link daintreePlugin} also runs a
  * `resolveId` guard that fails the build on any React subpath the host import

--- a/plugins/sample/rich-daintree/plugin.json
+++ b/plugins/sample/rich-daintree/plugin.json
@@ -24,12 +24,27 @@
         "canRestart": false,
         "canConvert": false,
         "showInPalette": true
+      },
+      {
+        "id": "hook-panel",
+        "name": "Hook Panel",
+        "iconId": "layout-panel-top",
+        "color": "#22d3ee",
+        "hasPty": false,
+        "canRestart": false,
+        "canConvert": false,
+        "showInPalette": true
       }
     ],
     "views": [
       {
         "id": "rich-panel",
         "componentPath": "./view/rich-panel-view.js",
+        "location": "panel"
+      },
+      {
+        "id": "hook-panel",
+        "componentPath": "./view/hook-panel-view.js",
         "location": "panel"
       }
     ],

--- a/plugins/sample/rich-daintree/renderer/hook-panel-view.tsx
+++ b/plugins/sample/rich-daintree/renderer/hook-panel-view.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook-based panel view for the `hook-panel` contribution (#11208).
+ *
+ * Authoring source — NOT what ships. `renderer/` is in
+ * PLUGIN_EXTRA_ASSET_SKIP_DIRS, so the build never copies this file; the
+ * committed bundle at `../view/hook-panel-view.js` is what `plugin://` loads.
+ * Regenerate it with `npm run build:sample-rich-view` after changing this.
+ *
+ * This is the only view in the repo that exercises the host/plugin React
+ * contract, and it is deliberately built by the PUBLIC `@daintreehq/plugin-vite`
+ * preset — the same entry a third-party author uses — so the import map's
+ * production ABI is proven by the same path real plugins take. Its sibling
+ * `rich-panel-view.js` imports nothing and stays that way: it isolates
+ * "`plugin://` is broken" from "the React contract is broken", which are
+ * different bugs with different fixes.
+ *
+ * The mounting → ready transition is the assertion target, and it proves three
+ * things at once: the named imports below resolved (a bad map fails at module
+ * load), JSX resolved `react/jsx-runtime`, and the hooks dispatched through the
+ * HOST's React — a second React copy would throw "Invalid hook call" here
+ * rather than ever reaching "ready".
+ */
+export default function HookPanelView() {
+  const [phase, setPhase] = useState<"mounting" | "ready">("mounting");
+
+  useEffect(() => {
+    setPhase("ready");
+  }, []);
+
+  // One interpolated child, so the assertion matches a single text node.
+  return <div data-testid="hook-panel-view">{`Hook panel view ${phase}`}</div>;
+}

--- a/plugins/sample/rich-daintree/view/hook-panel-view.js
+++ b/plugins/sample/rich-daintree/view/hook-panel-view.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { jsx } from "react/jsx-runtime";
+//#region plugins/sample/rich-daintree/renderer/hook-panel-view.tsx
+/**
+* Hook-based panel view for the `hook-panel` contribution (#11208).
+*
+* Authoring source — NOT what ships. `renderer/` is in
+* PLUGIN_EXTRA_ASSET_SKIP_DIRS, so the build never copies this file; the
+* committed bundle at `../view/hook-panel-view.js` is what `plugin://` loads.
+* Regenerate it with `npm run build:sample-rich-view` after changing this.
+*
+* This is the only view in the repo that exercises the host/plugin React
+* contract, and it is deliberately built by the PUBLIC `@daintreehq/plugin-vite`
+* preset — the same entry a third-party author uses — so the import map's
+* production ABI is proven by the same path real plugins take. Its sibling
+* `rich-panel-view.js` imports nothing and stays that way: it isolates
+* "`plugin://` is broken" from "the React contract is broken", which are
+* different bugs with different fixes.
+*
+* The mounting → ready transition is the assertion target, and it proves three
+* things at once: the named imports below resolved (a bad map fails at module
+* load), JSX resolved `react/jsx-runtime`, and the hooks dispatched through the
+* HOST's React — a second React copy would throw "Invalid hook call" here
+* rather than ever reaching "ready".
+*/
+function HookPanelView() {
+	const [phase, setPhase] = useState("mounting");
+	useEffect(() => {
+		setPhase("ready");
+	}, []);
+	return /* @__PURE__ */ jsx("div", {
+		"data-testid": "hook-panel-view",
+		children: `Hook panel view ${phase}`
+	});
+}
+//#endregion
+export { HookPanelView as default };

--- a/plugins/sample/rich-daintree/vite.config.ts
+++ b/plugins/sample/rich-daintree/vite.config.ts
@@ -1,0 +1,41 @@
+import { daintreePlugin } from "@daintreehq/plugin-vite";
+import { defineConfig } from "vite";
+
+/**
+ * Builds the hook-based panel view (#11208) with the PUBLIC plugin preset —
+ * `daintreePlugin()` from `@daintreehq/plugin-vite`, byte-for-byte the entry a
+ * third-party author uses. That is the point: the preset externalizes React so
+ * the bundle resolves it through the host import map at load time, which is the
+ * exact contract that shipped broken. Hand-writing browser-ready ESM here would
+ * exercise a path no real plugin takes.
+ *
+ * Not wired into `npm run build`. The output is committed and copied verbatim by
+ * `build-main.mjs` (which must NOT process `view/`, or it would bundle a second
+ * React and break the single-instance guarantee). Building it on every app build
+ * would also force a `packages:build` into the main chain for one sample.
+ *
+ * Regenerate with `npm run build:sample-rich-view` from the repo root; that
+ * script builds the workspace preset first and passes this directory as the
+ * positional root arg, which is what makes the relative paths below resolve
+ * against it rather than the repo root.
+ */
+export default defineConfig({
+  plugins: [daintreePlugin()],
+  // Explicit rather than inherited from a discovered tsconfig: the automatic
+  // runtime is what routes JSX through `react/jsx-runtime`, one of the five
+  // mapped specifiers under test.
+  esbuild: { jsx: "automatic" },
+  build: {
+    outDir: "view",
+    // `view/` also holds the hand-authored rich-panel-view.js — emptying it
+    // would delete that sibling.
+    emptyOutDir: false,
+    // Committed artifact: readable diffs matter more than bytes for a sample.
+    minify: false,
+    lib: {
+      entry: "renderer/hook-panel-view.tsx",
+      formats: ["es"],
+      fileName: () => "hook-panel-view.js",
+    },
+  },
+});

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -166,9 +166,22 @@ export function collectClosure(manifest, seedKeys, { followDynamic = true } = {}
   });
 }
 
-function findEntryKey(manifest) {
+// The React facade chunks (`host-react-*`) that vite.config.ts emits for the
+// plugin import map (#11208) are entry chunks, but they are NOT the app entry —
+// they're re-export shims third-party plugin bundles resolve against. Manifest
+// order is not specified, so without this a facade could be picked as the entry
+// and the gate would silently measure a ~1KB shim instead of the app.
+// Matches on `name` when the manifest carries one and falls back to the emitted
+// `file` path, so the check holds regardless of which field Vite populates.
+function isHostReactFacadeChunk(chunk) {
+  const name = typeof chunk?.name === "string" ? chunk.name : "";
+  const file = typeof chunk?.file === "string" ? chunk.file : "";
+  return name.startsWith("host-react-") || /(^|\/)host-react-/.test(file);
+}
+
+export function findEntryKey(manifest) {
   for (const [key, chunk] of Object.entries(manifest)) {
-    if (chunk?.isEntry) return key;
+    if (chunk?.isEntry && !isHostReactFacadeChunk(chunk)) return key;
   }
   return null;
 }

--- a/scripts/check-first-render-chunk-budget.test.mjs
+++ b/scripts/check-first-render-chunk-budget.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   collectClosure,
+  findEntryKey,
   shrinkageGuardError,
   classifyFirstRenderBudget,
 } from "./check-first-render-chunk-budget.mjs";
@@ -66,6 +67,43 @@ function makeManifest(extra = {}) {
     ...extra,
   };
 }
+
+// vite.config.ts emits five `host-react-*` React facade entry chunks for the
+// plugin import map (#11208). They are `isEntry: true` but are not the app, and
+// manifest key order is not specified — so the gate must identify the app entry
+// by more than "first entry wins" or it silently measures a re-export shim.
+describe("findEntryKey", () => {
+  it("skips host-react facade entries that precede the app entry", () => {
+    const manifest = {
+      "\0virtual:daintree-host-react/react": {
+        file: "assets/host-react-react-aaa.js",
+        name: "host-react-react",
+        isEntry: true,
+        imports: ["_vendor-react.js"],
+        dynamicImports: [],
+      },
+      ...makeManifest(),
+    };
+    expect(findEntryKey(manifest)).toBe("index.html");
+  });
+
+  it("identifies a facade by its file path when the manifest carries no name", () => {
+    const manifest = {
+      "\0virtual:daintree-host-react/react/jsx-runtime": {
+        file: "assets/host-react-react-jsx-runtime-bbb.js",
+        isEntry: true,
+        imports: ["_vendor-react.js"],
+        dynamicImports: [],
+      },
+      ...makeManifest(),
+    };
+    expect(findEntryKey(manifest)).toBe("index.html");
+  });
+
+  it("does not mistake a real chunk for a facade just because it imports react", () => {
+    expect(findEntryKey(makeManifest())).toBe("index.html");
+  });
+});
 
 describe("collectClosure — eager walk (followDynamic: false)", () => {
   it("follows imports[] only, excluding the dynamic domMax boundary", () => {

--- a/scripts/check-renderer-import-budget.mjs
+++ b/scripts/check-renderer-import-budget.mjs
@@ -113,9 +113,22 @@ function readManifest() {
   }
 }
 
-function findEntryKey(manifest) {
+// The React facade chunks (`host-react-*`) that vite.config.ts emits for the
+// plugin import map (#11208) are entry chunks, but they are NOT the app entry —
+// they're re-export shims third-party plugin bundles resolve against. Manifest
+// order is not specified, so without this a facade could be picked as the entry
+// and the gate would silently measure a ~1KB shim instead of the app.
+// Matches on `name` when the manifest carries one and falls back to the emitted
+// `file` path, so the check holds regardless of which field Vite populates.
+function isHostReactFacadeChunk(chunk) {
+  const name = typeof chunk?.name === "string" ? chunk.name : "";
+  const file = typeof chunk?.file === "string" ? chunk.file : "";
+  return name.startsWith("host-react-") || /(^|\/)host-react-/.test(file);
+}
+
+export function findEntryKey(manifest) {
   for (const [key, chunk] of Object.entries(manifest)) {
-    if (chunk?.isEntry) return key;
+    if (chunk?.isEntry && !isHostReactFacadeChunk(chunk)) return key;
   }
   return null;
 }

--- a/scripts/check-renderer-import-budget.test.mjs
+++ b/scripts/check-renderer-import-budget.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   collectEagerChunks,
   compareReport,
+  findEntryKey,
   parseArgs,
   shrinkageGuardError,
   stableChunkId,
@@ -42,6 +43,56 @@ function makeManifest(extra = {}) {
     ...extra,
   };
 }
+
+// vite.config.ts emits five `host-react-*` React facade entry chunks for the
+// plugin import map (#11208). They are `isEntry: true` but are not the app, and
+// manifest key order is not specified — so the gate must identify the app entry
+// by more than "first entry wins" or it silently measures a re-export shim.
+describe("findEntryKey", () => {
+  it("skips host-react facade entries that precede the app entry", () => {
+    const manifest = {
+      "\0virtual:daintree-host-react/react": {
+        file: "assets/host-react-react-aaa.js",
+        name: "host-react-react",
+        isEntry: true,
+        imports: ["_vendor-react.js"],
+        dynamicImports: [],
+      },
+      ...makeManifest(),
+    };
+    expect(findEntryKey(manifest)).toBe("src/main.tsx");
+  });
+
+  it("identifies a facade by its file path when the manifest carries no name", () => {
+    const manifest = {
+      "\0virtual:daintree-host-react/react-dom/client": {
+        file: "assets/host-react-react-dom-client-bbb.js",
+        isEntry: true,
+        imports: ["_vendor-react.js"],
+        dynamicImports: [],
+      },
+      ...makeManifest(),
+    };
+    expect(findEntryKey(manifest)).toBe("src/main.tsx");
+  });
+
+  it("does not mistake a real chunk for a facade just because it imports react", () => {
+    expect(findEntryKey(makeManifest())).toBe("src/main.tsx");
+  });
+
+  it("returns null when the manifest has only facade entries", () => {
+    const manifest = {
+      "\0virtual:daintree-host-react/react": {
+        file: "assets/host-react-react-aaa.js",
+        name: "host-react-react",
+        isEntry: true,
+        imports: [],
+        dynamicImports: [],
+      },
+    };
+    expect(findEntryKey(manifest)).toBeNull();
+  });
+});
 
 describe("collectEagerChunks", () => {
   it("walks imports[] from the entry key", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,12 @@
       "@shared/*": ["./shared/*"]
     }
   },
-  "include": ["src", "shared", "plugins/builtin/*/renderer", "packages/plugin-vite/src"],
+  "include": [
+    "src",
+    "shared",
+    "plugins/builtin/*/renderer",
+    "plugins/sample/*/renderer",
+    "packages/plugin-vite/src"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -423,13 +423,24 @@ const requireFromRoot = createRequire(path.join(process.cwd(), "vite.config.ts")
 // React export has ever needed it.
 const SAFE_EXPORT_NAME = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
+const hostReactExportNameCache = new Map<string, string[]>();
+
 // The public names a specifier actually exports, read from the installed
 // package. Generating from the real surface (rather than a hand-kept list)
-// keeps the facades correct across React upgrades, and matches per mode: `vite
-// build` runs with NODE_ENV=production so this sees React's production build,
-// exactly the one the browser bundle resolves to; `vite dev` likewise sees the
-// development build the dev server serves.
+// keeps the facades correct across React upgrades, and matches per mode: Vite
+// defaults NODE_ENV to production for `build` (and preserves an explicit one)
+// and uses that same value for the browser's `process.env.NODE_ENV` define, so
+// this Node process and the bundle always select the same branch of React's
+// `if (process.env.NODE_ENV === 'production')` CJS switch. `vite dev` likewise
+// sees the development build the dev server serves.
+//
+// Memoized: the generator and the build guard both need this list, and the
+// guard's whole job is to compare what the generator ASKED for against what
+// Rolldown emitted — so both must read exactly the same set.
 function hostReactExportNames(specifier: string): string[] {
+  const cached = hostReactExportNameCache.get(specifier);
+  if (cached) return cached;
+
   let ns: Record<string, unknown>;
   try {
     ns = requireFromRoot(specifier) as Record<string, unknown>;
@@ -441,9 +452,11 @@ function hostReactExportNames(specifier: string): string[] {
   }
   // `default` is excluded here and re-exported explicitly below; emitting it in
   // the named clause too would be a duplicate-binding syntax error.
-  return Object.keys(ns)
+  const names = Object.keys(ns)
     .filter((name) => name !== "default" && SAFE_EXPORT_NAME.test(name))
     .sort();
+  hostReactExportNameCache.set(specifier, names);
+  return names;
 }
 
 // The single source of the facade module body, shared by the production emitter
@@ -472,26 +485,49 @@ function renderHostReactFacade(specifier: string): string {
 }
 
 // Emitted-chunk name for a specifier. Slashes are flattened to hyphens so the
-// name can't be read as a directory path; the results are asserted unique at
-// emit time. The hashed `.fileName` is resolved from the bundle by this name —
-// never predicted — because only Rolldown knows the final hash.
+// name can't be read as a directory path. The hashed `.fileName` is resolved
+// from the bundle by this name — never predicted — because only Rolldown knows
+// the final hash.
 function hostReactFacadeChunkName(specifier: string): string {
   return `host-react-${specifier.replaceAll("/", "-")}`;
 }
 
-function isHostReactFacadeChunkName(name: string): boolean {
-  return name.startsWith("host-react-");
+// Exact name -> specifier, not a `startsWith("host-react-")` prefix test: this
+// set decides which chunks are excluded from entry selection and compile hints,
+// and a real app chunk that happened to share the prefix would be silently
+// dropped from those gates.
+const HOST_REACT_FACADE_CHUNK_NAMES: ReadonlyMap<string, HostReactSpecifier> = new Map(
+  HOST_IMPORTMAP_SPECIFIERS.map((specifier) => [hostReactFacadeChunkName(specifier), specifier])
+);
+
+// Flattening `/` to `-` is not injective, so prove the derived names are
+// distinct. Throwing at module scope fails config load — loud and immediate —
+// rather than letting two specifiers collide onto one chunk.
+if (HOST_REACT_FACADE_CHUNK_NAMES.size !== HOST_IMPORTMAP_SPECIFIERS.length) {
+  throw new Error(
+    "[host-react-facade] two HOST_IMPORTMAP_SPECIFIERS entries flatten to the same chunk name: " +
+      HOST_IMPORTMAP_SPECIFIERS.map((s) => `${s} -> ${hostReactFacadeChunkName(s)}`).join(", ")
+  );
 }
 
-// The public API each facade must expose, verified against the built chunk's
-// real export list (see hostReactFacadePlugin's generateBundle). This is an
-// independent statement of the host/plugin contract — the names third-party
-// plugins are promised — not a copy of React's export table: the build compares
-// it against what Rolldown ACTUALLY emitted, which is what catches a
-// tree-shaking regression (`experimental.lazyBarrel` prunes barrel-shaped
-// `export *` re-exports; #8850 shows this repo has been bitten by it before).
-// Keyed by HostReactSpecifier so adding a specifier to the shared constant
-// fails typecheck until its contract is declared here.
+function isHostReactFacadeChunkName(name: string): boolean {
+  return HOST_REACT_FACADE_CHUNK_NAMES.has(name);
+}
+
+// A MINIMUM public API per specifier, verified against the built chunk's real
+// export list (see hostReactFacadePlugin's generateBundle).
+//
+// This is the second of two independent checks, and it exists to catch what the
+// first one structurally cannot. The first check asserts every name
+// `hostReactExportNames` asked for survived into the chunk — that catches
+// tree-shaking/elision (`experimental.lazyBarrel` prunes barrel-shaped
+// re-exports; #8850 shows this repo has been bitten before). But it compares the
+// generator against itself: if the generator regressed to emit a handful of
+// names, the built chunk would still match what it asked for and the check would
+// pass vacuously. This hand-written list is the fixed point that catches that —
+// the names third-party plugins are promised, independent of what any code
+// derives. Keyed by HostReactSpecifier so adding a specifier to the shared
+// constant fails typecheck until its contract is declared here.
 const HOST_REACT_REQUIRED_EXPORTS: Record<HostReactSpecifier, readonly string[]> = {
   react: [
     "default",
@@ -577,16 +613,7 @@ function hostReactFacadePlugin(): Plugin {
     name: "host-react-facade",
     apply: "build",
     buildStart() {
-      const seen = new Set<string>();
-      for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
-        const name = hostReactFacadeChunkName(specifier);
-        if (seen.has(name)) {
-          throw new Error(
-            `[host-react-facade] duplicate facade chunk name "${name}". Two entries in ` +
-              "HOST_IMPORTMAP_SPECIFIERS flatten to the same name; give one a distinct name."
-          );
-        }
-        seen.add(name);
+      for (const [name, specifier] of HOST_REACT_FACADE_CHUNK_NAMES) {
         this.emitFile({
           type: "chunk",
           id: `${HOST_REACT_VIRTUAL_PREFIX}${specifier}`,
@@ -626,14 +653,38 @@ function hostReactFacadePlugin(): Plugin {
       }
 
       const problems: string[] = [];
-      for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
-        const name = hostReactFacadeChunkName(specifier);
+
+      // Fail closed. If the named group ever stops emitting, every per-facade
+      // single-instance check below would silently no-op while React quietly
+      // duplicated across entries — the exact failure this guard exists to catch.
+      if (!vendorReactFileName) {
+        problems.push(
+          "no chunk named `vendor-react` in the build output — the codeSplitting group in " +
+            "vite.config.ts is the only thing keeping React a single shared instance."
+        );
+      }
+
+      for (const [name, specifier] of HOST_REACT_FACADE_CHUNK_NAMES) {
         const chunk = chunksByName.get(name);
         if (!chunk) {
           problems.push(`"${specifier}": no facade chunk named "${name}" in the bundle`);
           continue;
         }
         const actual = new Set(chunk.exports);
+
+        // Check 1 — nothing the generator asked for got tree-shaken away.
+        const elided = [...hostReactExportNames(specifier), "default"].filter(
+          (n) => !actual.has(n)
+        );
+        if (elided.length > 0) {
+          problems.push(
+            `"${specifier}" (${chunk.fileName}) lost ${elided.length} export(s) the facade ` +
+              `re-exported: ${elided.join(", ")}`
+          );
+        }
+
+        // Check 2 — the promised minimum is present regardless of what the
+        // generator derived (see HOST_REACT_REQUIRED_EXPORTS).
         const missing = HOST_REACT_REQUIRED_EXPORTS[specifier].filter((n) => !actual.has(n));
         if (missing.length > 0) {
           problems.push(
@@ -641,6 +692,7 @@ function hostReactFacadePlugin(): Plugin {
               `Emitted exports: ${chunk.exports.join(", ") || "(none)"}`
           );
         }
+
         // Every facade must reach React through the one shared chunk. If a
         // facade stopped importing vendor-react, React got inlined into it —
         // i.e. a second copy — which breaks hooks at the first render.
@@ -708,6 +760,21 @@ function hostImportMapPlugin(state: ImportMapBuildState): Plugin {
           ])
         ),
       };
+
+      // Pin the shape of the map itself, not just the facades it points at.
+      // The facade guard proves the CHUNKS are good; it cannot see this HTML, so
+      // a refactor that collapsed every specifier back onto one target (#11208's
+      // original shape) would leave five valid-but-unused facades and still
+      // build clean. This is the assertion that makes that regression loud.
+      const targets = Object.values(importMapPayload.imports);
+      if (new Set(targets).size !== HOST_IMPORTMAP_SPECIFIERS.length) {
+        throw new Error(
+          "[host-import-map] every specifier must map to its own facade; got " +
+            `${new Set(targets).size} distinct target(s) for ${HOST_IMPORTMAP_SPECIFIERS.length} ` +
+            "specifiers. Mapping several specifiers at one file is #11208: a shared chunk only " +
+            "exports the private cross-chunk interface, never React's public API."
+        );
+      }
       // Compact JSON without trailing whitespace — the byte sequence here is
       // exactly what the browser receives, and the SHA-256 must match.
       const serialized = JSON.stringify(importMapPayload);
@@ -1045,6 +1112,7 @@ function compileHintsPlugin(): Plugin {
 // the native handle, so they're read lazily, never structured-cloned.
 interface BundleChunkLike {
   type: string;
+  name?: string;
   fileName: string;
   isEntry?: boolean;
   facadeModuleId?: string | null;
@@ -1089,7 +1157,15 @@ function firstRenderModulePreloadPlugin(): Plugin {
       // Populated only for production builds — the dev server has no bundle.
       if (!ctx.bundle) return;
 
-      const chunks = Object.values(ctx.bundle as unknown as Record<string, BundleChunkLike>);
+      // Drop the React facades before the closure math. computeFirstRenderPreloadFiles
+      // subtracts every `isEntry` chunk's closure as "what Vite already
+      // auto-preloads" — true for the HTML entry, false for the facades, which
+      // index.html never references (a plugin imports them at runtime through
+      // the import map). Leaving them in would subtract a closure the browser
+      // was never given, silently dropping preload tags a first-render seed needs.
+      const chunks = Object.values(ctx.bundle as unknown as Record<string, BundleChunkLike>).filter(
+        (chunk) => !isHostReactFacadeChunkName(chunk.name ?? "")
+      );
       const { files, matchedSeedCount } = computeFirstRenderPreloadFiles(
         chunks,
         seedSourcePaths,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "path";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
 import { getDevServerConfig } from "./shared/config/devServer";
@@ -385,11 +386,15 @@ function renderFanoutProbePlugin(state: ImportMapBuildState): Plugin {
 }
 
 // `HOST_IMPORTMAP_SPECIFIERS` (imported from @daintreehq/plugin-vite above) is
-// the set of specifiers exposed to externalized plugin bundles. In production
-// each bare specifier points at the same `vendor-react` chunk because Rolldown
-// bundles `react`, `react-dom`, `scheduler`, and `use-sync-external-store` into
-// one file (see the `vendor-react` codeSplitting group below). Trailing-slash
-// mappings ("react/") can't substitute — a single chunk file has no subpath
+// the set of specifiers exposed to externalized plugin bundles. Each one gets
+// its OWN facade module re-exporting that specifier's public API; the import
+// map points at the facades, never at `vendor-react` directly. Pointing every
+// specifier at the shared `vendor-react` chunk is what broke the contract in
+// #11208: a code-split chunk is not an entry, so its exports are Rolldown's
+// private cross-chunk interface (`export{n as a,i,...}`), not React's public
+// API — `import { useEffect } from "react"` threw "does not provide an export
+// named 'useEffect'" in every packaged build since v0.15.0. Trailing-slash
+// mappings ("react/") can't substitute either — a chunk file has no subpath
 // structure to concatenate against — so every JSX/React entrypoint plugins
 // might import is listed explicitly in the shared constant. `scheduler` is
 // internal to React and not exposed because no documented plugin path imports
@@ -398,19 +403,264 @@ function renderFanoutProbePlugin(state: ImportMapBuildState): Plugin {
 
 const HOST_APP_ORIGIN = "app://daintree";
 
-// Locate the vendor-react chunk by its codeSplitting `name`, which Rolldown
-// preserves as `OutputChunk.name`. The hashed `.fileName` is what plugins (and
-// the browser) must load, so the import map resolves bare React specifiers to
-// that exact filename.
-function findVendorReactChunkPath(
-  bundle: Record<string, { type: string; name?: string; fileName?: string }>
-): string | null {
+type HostReactSpecifier = (typeof HOST_IMPORTMAP_SPECIFIERS)[number];
+
+// Prefix for the virtual facade modules that re-export the host's React. Shared
+// by the production emitter (hostReactFacadePlugin) and the dev server
+// (hostImportMapDevPlugin) — the two apply to disjoint modes but must generate
+// byte-identical module source, which is the whole point of #11208: dev built a
+// real facade while production mapped to a raw chunk, so the ABI plugins compile
+// against silently differed between `npm run dev` and a packaged build.
+const HOST_REACT_VIRTUAL_PREFIX = "virtual:daintree-host-react/";
+
+// Resolution anchor for reading the installed React packages. Anchored on cwd
+// rather than `import.meta.url` because Vite may load this config as either ESM
+// or CJS, and `import.meta` is absent in the CJS path.
+const requireFromRoot = createRequire(path.join(process.cwd(), "vite.config.ts"));
+
+// A conservative "safe to write in an export clause" identifier test. Anything
+// exotic is dropped rather than risking a syntax error in generated code; no
+// React export has ever needed it.
+const SAFE_EXPORT_NAME = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// The public names a specifier actually exports, read from the installed
+// package. Generating from the real surface (rather than a hand-kept list)
+// keeps the facades correct across React upgrades, and matches per mode: `vite
+// build` runs with NODE_ENV=production so this sees React's production build,
+// exactly the one the browser bundle resolves to; `vite dev` likewise sees the
+// development build the dev server serves.
+function hostReactExportNames(specifier: string): string[] {
+  let ns: Record<string, unknown>;
+  try {
+    ns = requireFromRoot(specifier) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `[host-react-facade] cannot resolve "${specifier}" to read its export surface: ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  // `default` is excluded here and re-exported explicitly below; emitting it in
+  // the named clause too would be a duplicate-binding syntax error.
+  return Object.keys(ns)
+    .filter((name) => name !== "default" && SAFE_EXPORT_NAME.test(name))
+    .sort();
+}
+
+// The single source of the facade module body, shared by the production emitter
+// and the dev server.
+//
+// The named re-exports are enumerated EXPLICITLY. `export * from "react"` looks
+// equivalent and is not: React ships CJS, and a star re-export from CJS has no
+// statically-known name set, so Rolldown emits a facade exporting nothing but
+// `default` — silently, with a clean build. (Dev got away with `export *` only
+// because Vite pre-bundles React into real ESM first, which is precisely the
+// dev/prod divergence behind #11208.) Naming each export is what makes the
+// production chunk's signature real; hostReactFacadePlugin's generateBundle
+// then proves it against the built output.
+//
+// The star form also never re-exports `default` (ESM semantics), so the
+// computed default below keeps `import React from "react"` working without a
+// direct `export { default }`, which would throw for subpaths (e.g.
+// jsx-runtime) that have no own default export.
+function renderHostReactFacade(specifier: string): string {
+  const target = JSON.stringify(specifier);
+  const named = hostReactExportNames(specifier);
+  const lines = [`import * as m from ${target};`];
+  if (named.length > 0) lines.push(`export { ${named.join(", ")} } from ${target};`);
+  lines.push(`export default m.default ?? m;`);
+  return `${lines.join("\n")}\n`;
+}
+
+// Emitted-chunk name for a specifier. Slashes are flattened to hyphens so the
+// name can't be read as a directory path; the results are asserted unique at
+// emit time. The hashed `.fileName` is resolved from the bundle by this name —
+// never predicted — because only Rolldown knows the final hash.
+function hostReactFacadeChunkName(specifier: string): string {
+  return `host-react-${specifier.replaceAll("/", "-")}`;
+}
+
+function isHostReactFacadeChunkName(name: string): boolean {
+  return name.startsWith("host-react-");
+}
+
+// The public API each facade must expose, verified against the built chunk's
+// real export list (see hostReactFacadePlugin's generateBundle). This is an
+// independent statement of the host/plugin contract — the names third-party
+// plugins are promised — not a copy of React's export table: the build compares
+// it against what Rolldown ACTUALLY emitted, which is what catches a
+// tree-shaking regression (`experimental.lazyBarrel` prunes barrel-shaped
+// `export *` re-exports; #8850 shows this repo has been bitten by it before).
+// Keyed by HostReactSpecifier so adding a specifier to the shared constant
+// fails typecheck until its contract is declared here.
+const HOST_REACT_REQUIRED_EXPORTS: Record<HostReactSpecifier, readonly string[]> = {
+  react: [
+    "default",
+    "Fragment",
+    "Suspense",
+    "createContext",
+    "createElement",
+    "forwardRef",
+    "lazy",
+    "memo",
+    "useCallback",
+    "useContext",
+    "useEffect",
+    "useMemo",
+    "useReducer",
+    "useRef",
+    "useState",
+    "version",
+  ],
+  "react/jsx-runtime": ["Fragment", "jsx", "jsxs"],
+  // `jsxDEV` is exported as `undefined` by React's PRODUCTION jsx-dev-runtime
+  // build — the name exists, the value doesn't. Asserting the name here is
+  // exactly right for a chunk export list; the runtime E2E uses `Object.hasOwn`
+  // rather than a truthiness check, since an ABSENT export also reads
+  // `undefined` and would otherwise pass.
+  "react/jsx-dev-runtime": ["Fragment", "jsxDEV"],
+  "react-dom": ["createPortal", "flushSync", "version"],
+  "react-dom/client": ["createRoot", "hydrateRoot", "version"],
+};
+
+interface FacadeLookupChunk {
+  type: string;
+  name?: string;
+  fileName?: string;
+}
+
+// Resolve each specifier's facade chunk to its hashed `.fileName`, which
+// Rolldown assigns and the browser must load. Throws rather than falling back:
+// a missing facade means the emitter didn't run, and silently mapping to
+// something else is how #11208 shipped in the first place.
+function findHostReactFacadePaths(
+  bundle: Record<string, FacadeLookupChunk>
+): Record<string, string> {
+  const byName = new Map<string, string>();
   for (const output of Object.values(bundle)) {
-    if (output.type === "chunk" && output.name === "vendor-react" && output.fileName) {
-      return output.fileName;
+    if (output.type === "chunk" && output.name && output.fileName) {
+      if (isHostReactFacadeChunkName(output.name)) byName.set(output.name, output.fileName);
     }
   }
-  return null;
+
+  const paths: Record<string, string> = {};
+  const missing: string[] = [];
+  for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
+    const fileName = byName.get(hostReactFacadeChunkName(specifier));
+    if (fileName) paths[specifier] = fileName;
+    else missing.push(specifier);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `[host-import-map] no facade chunk emitted for: ${missing.join(", ")}. ` +
+        "Check hostReactFacadePlugin's buildStart emitFile calls in vite.config.ts."
+    );
+  }
+  return paths;
+}
+
+// Emits one facade entry chunk per host specifier and verifies the built result
+// actually carries React's public API (#11208).
+//
+// Why entry chunks: only an ENTRY has a preserved, meaningful export signature.
+// `vendor-react` is a code-split chunk, so its exports are whatever other chunks
+// happen to import from it — the private cross-chunk interface the import map
+// used to point at. Emitting `import * as m from "react"; export * from "react"`
+// as its own entry (`preserveSignature: "exports-only"`) makes Rolldown emit a
+// chunk whose export list IS react's public surface, while the actual runtime
+// modules stay captured by the untouched `vendor-react` group (priority 80) —
+// so all five facades import that same one chunk and the single-React-instance
+// guarantee holds. Do NOT add `entriesAware` to the vendor-react group to
+// "help": it fragments a group per unique importing-entry-set, which would give
+// each facade its own React copy and reintroduce `Invalid hook call`.
+function hostReactFacadePlugin(): Plugin {
+  return {
+    name: "host-react-facade",
+    apply: "build",
+    buildStart() {
+      const seen = new Set<string>();
+      for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
+        const name = hostReactFacadeChunkName(specifier);
+        if (seen.has(name)) {
+          throw new Error(
+            `[host-react-facade] duplicate facade chunk name "${name}". Two entries in ` +
+              "HOST_IMPORTMAP_SPECIFIERS flatten to the same name; give one a distinct name."
+          );
+        }
+        seen.add(name);
+        this.emitFile({
+          type: "chunk",
+          id: `${HOST_REACT_VIRTUAL_PREFIX}${specifier}`,
+          name,
+          // Explicit rather than relying on the `'exports-only'` global default:
+          // this is the property the whole contract rests on, and Vite's
+          // RollupOptions type doesn't surface `preserveEntrySignatures`, so the
+          // per-chunk override is the only place it can be stated in config.
+          preserveSignature: "exports-only",
+        });
+      }
+    },
+    resolveId(id) {
+      if (id.startsWith(HOST_REACT_VIRTUAL_PREFIX)) return `\0${id}`;
+      return null;
+    },
+    load(id) {
+      const resolvedPrefix = `\0${HOST_REACT_VIRTUAL_PREFIX}`;
+      if (!id.startsWith(resolvedPrefix)) return null;
+      return renderHostReactFacade(id.slice(resolvedPrefix.length));
+    },
+    // Runs against the FINAL bundle, so `chunk.exports` is the post-tree-shake
+    // export list — the only thing that proves the facade survived. Source-level
+    // `export *` and `preserveSignature` are both necessary but neither is
+    // sufficient evidence: lazyBarrel prunes silently.
+    generateBundle(_options, bundle) {
+      const chunksByName = new Map<string, { fileName: string; exports: string[] }>();
+      let vendorReactFileName: string | null = null;
+      const facadeImports = new Map<string, readonly string[]>();
+
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk") continue;
+        if (output.name === "vendor-react") vendorReactFileName = output.fileName;
+        if (!output.name || !isHostReactFacadeChunkName(output.name)) continue;
+        chunksByName.set(output.name, { fileName: output.fileName, exports: output.exports });
+        facadeImports.set(output.name, output.imports);
+      }
+
+      const problems: string[] = [];
+      for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
+        const name = hostReactFacadeChunkName(specifier);
+        const chunk = chunksByName.get(name);
+        if (!chunk) {
+          problems.push(`"${specifier}": no facade chunk named "${name}" in the bundle`);
+          continue;
+        }
+        const actual = new Set(chunk.exports);
+        const missing = HOST_REACT_REQUIRED_EXPORTS[specifier].filter((n) => !actual.has(n));
+        if (missing.length > 0) {
+          problems.push(
+            `"${specifier}" (${chunk.fileName}) is missing: ${missing.join(", ")}. ` +
+              `Emitted exports: ${chunk.exports.join(", ") || "(none)"}`
+          );
+        }
+        // Every facade must reach React through the one shared chunk. If a
+        // facade stopped importing vendor-react, React got inlined into it —
+        // i.e. a second copy — which breaks hooks at the first render.
+        if (vendorReactFileName && !facadeImports.get(name)?.includes(vendorReactFileName)) {
+          problems.push(
+            `"${specifier}" (${chunk.fileName}) does not import the shared vendor-react chunk ` +
+              `(${vendorReactFileName}) — React may have been duplicated into the facade.`
+          );
+        }
+      }
+
+      if (problems.length > 0) {
+        throw new Error(
+          "[host-react-facade] the production import map would serve modules that do not " +
+            "expose React's public API — third-party plugins would fail to load (#11208):\n" +
+            problems.map((p) => `  - ${p}`).join("\n")
+        );
+      }
+    },
+  };
 }
 
 // Injects `<script type="importmap">` into the production index.html and emits
@@ -442,20 +692,20 @@ function hostImportMapPlugin(state: ImportMapBuildState): Plugin {
       // that won't be emitted would be a runtime 404.
       if (!ctx.bundle) return;
 
-      const vendorReactPath = findVendorReactChunkPath(
-        ctx.bundle as Record<string, { type: string; name?: string; fileName?: string }>
+      const facadePaths = findHostReactFacadePaths(
+        ctx.bundle as Record<string, FacadeLookupChunk>
       );
-      if (!vendorReactPath) {
-        throw new Error(
-          "[host-import-map] vendor-react chunk not found in build output. " +
-            "Check the codeSplitting group with `name: 'vendor-react'` in vite.config.ts."
-        );
-      }
 
-      const targetUrl = `${HOST_APP_ORIGIN}/${vendorReactPath}`;
+      // One distinct target per specifier — each facade exposes only that
+      // specifier's public surface. hostReactFacadePlugin has already verified
+      // those surfaces against the built chunks, so a map emitted here is a map
+      // that actually resolves.
       const importMapPayload = {
         imports: Object.fromEntries(
-          HOST_IMPORTMAP_SPECIFIERS.map((specifier) => [specifier, targetUrl])
+          HOST_IMPORTMAP_SPECIFIERS.map((specifier) => [
+            specifier,
+            `${HOST_APP_ORIGIN}/${facadePaths[specifier]}`,
+          ])
         ),
       };
       // Compact JSON without trailing whitespace — the byte sequence here is
@@ -492,46 +742,36 @@ function hostImportMapPlugin(state: ImportMapBuildState): Plugin {
   };
 }
 
-// Prefix for the dev-only virtual modules that re-export the host's React. Each
-// `HOST_IMPORTMAP_SPECIFIERS` entry gets one (`…/react`, `…/react-dom/client`,
-// …). Vite serves a resolved virtual id at `/@id/<id>` in dev, so that URL is
-// stable across runs — unlike the optimized-dep path (`/node_modules/.vite/
-// deps/react.js?v=<hash>`), whose hash changes per optimize pass and can't be
-// referenced statically from an import map.
-const DEV_HOST_REACT_PREFIX = "virtual:daintree-host-react/";
-
-// Dev counterpart to hostImportMapPlugin. In production the import map points
-// plugin bundles at the hashed `vendor-react` chunk; in dev that chunk doesn't
-// exist (Vite serves React from the module graph), so a sideloaded plugin view
-// that externalizes React has nothing to resolve `react` against and fails to
-// mount (#10514). This plugin closes that gap: it injects an import map into the
-// dev index.html mapping each host specifier to a stable virtual module that
+// Dev counterpart to hostImportMapPlugin. Production maps each specifier to a
+// hashed facade chunk emitted by hostReactFacadePlugin; in dev those chunks
+// don't exist (Vite serves React from the module graph), so a sideloaded plugin
+// view that externalizes React has nothing to resolve `react` against and fails
+// to mount (#10514). This plugin closes that gap: it injects an import map into
+// the dev index.html mapping each host specifier to a stable virtual module that
 // re-exports the host's React. Because the virtual module's own `import` is
 // resolved by Vite server-side (not via the browser import map), it lands on the
 // exact React instance the host uses — one instance shared with every plugin,
 // same guarantee as production. Serve-only; the dev CSP carries `'unsafe-inline'`
 // so the inline `<script type="importmap">` needs no hash.
+//
+// Vite serves a resolved virtual id at `/@id/<id>`, so that URL is stable across
+// runs — unlike the optimized-dep path (`/node_modules/.vite/deps/react.js?v=
+// <hash>`), whose hash changes per optimize pass and can't be referenced
+// statically from an import map. The id is left un-prefixed here for that
+// reason; the production emitter `\0`-prefixes the same id, which is why these
+// two plugins resolve alike but not identically.
 function hostImportMapDevPlugin(): Plugin {
   return {
     name: "host-import-map-dev",
     apply: "serve",
     resolveId(id) {
-      if (id.startsWith(DEV_HOST_REACT_PREFIX)) return id;
+      if (id.startsWith(HOST_REACT_VIRTUAL_PREFIX)) return id;
       return null;
     },
     load(id) {
-      if (!id.startsWith(DEV_HOST_REACT_PREFIX)) return null;
-      const specifier = id.slice(DEV_HOST_REACT_PREFIX.length);
-      const target = JSON.stringify(specifier);
-      // `export *` carries the named exports (`useState`, `jsx`, …); the
-      // computed default keeps `import React from "react"` working without a
-      // direct `export { default }` that would throw for subpaths (e.g.
-      // jsx-runtime) that have no own default export.
-      return (
-        `import * as m from ${target};\n` +
-        `export * from ${target};\n` +
-        `export default m.default ?? m;\n`
-      );
+      if (!id.startsWith(HOST_REACT_VIRTUAL_PREFIX)) return null;
+      // Same generator as production — dev/prod ABI parity by construction.
+      return renderHostReactFacade(id.slice(HOST_REACT_VIRTUAL_PREFIX.length));
     },
     transformIndexHtml(_html, ctx) {
       if (!ctx.server) return;
@@ -539,7 +779,7 @@ function hostImportMapDevPlugin(): Plugin {
         imports: Object.fromEntries(
           HOST_IMPORTMAP_SPECIFIERS.map((specifier) => [
             specifier,
-            `/@id/${DEV_HOST_REACT_PREFIX}${specifier}`,
+            `/@id/${HOST_REACT_VIRTUAL_PREFIX}${specifier}`,
           ])
         ),
       };
@@ -603,8 +843,11 @@ function rendererBundleSizePlugin(): Plugin {
           chunks[name] = { raw, gzip: gz };
           totalJsRaw += raw;
           totalJsGzip += gz;
-          if (output.isEntry && !entryChunkName) {
-            entryChunkName = name;
+          // The app entry specifically, not merely the first `isEntry` chunk:
+          // hostReactFacadePlugin emits five React facades as additional
+          // entries, and bundle order does not guarantee the app comes first.
+          if (output.isEntry && !isHostReactFacadeChunkName(name)) {
+            entryChunkName ??= name;
           }
         } else if (output.type === "asset" && output.fileName.endsWith(".css")) {
           const src = output.source;
@@ -755,6 +998,10 @@ function compileHintsPlugin(): Plugin {
     facadeModuleId?: string | null;
   }): boolean => {
     const facade = chunk.facadeModuleId?.split(path.sep).join("/");
+    // The React facades are entries but not boot-hot: they're re-export shims a
+    // plugin pulls in on demand, so eager-compiling them costs startup time for
+    // code the app itself never calls.
+    if (isHostReactFacadeChunkName(chunk.name)) return false;
     return (
       chunk.isEntry ||
       hintedChunkNames.has(chunk.name) ||
@@ -954,6 +1201,9 @@ export default defineConfig(({ command, mode }) => {
         ],
       }),
       tailwindcss(),
+      // Must precede hostImportMapPlugin: it emits (and validates) the facade
+      // chunks that plugin's transformIndexHtml resolves the map targets from.
+      hostReactFacadePlugin(),
       hostImportMapPlugin(importMapState),
       hostImportMapDevPlugin(),
       // Must precede cspTransformPlugin: both use default-order

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ import { getDaintreeAppDevCSP, getDaintreeAppProdCSP } from "./shared/config/csp
 // way this config already imports from `./shared/*`.
 import { HOST_IMPORTMAP_SPECIFIERS } from "./packages/plugin-vite/src/index";
 import { getFirstRenderPreloadSeeds } from "./shared/config/panelKindRegistry";
+import { formatErrorMessage } from "./shared/utils/errorMessage";
 import { computeFirstRenderPreloadFiles } from "./scripts/first-render-closure-lib.mjs";
 
 const devServerConfig = getDevServerConfig();
@@ -447,7 +448,8 @@ function hostReactExportNames(specifier: string): string[] {
   } catch (err) {
     throw new Error(
       `[host-react-facade] cannot resolve "${specifier}" to read its export surface: ` +
-        `${err instanceof Error ? err.message : String(err)}`
+        formatErrorMessage(err, "module resolution failed"),
+      { cause: err }
     );
   }
   // `default` is excluded here and re-exported explicitly below; emitting it in
@@ -744,9 +746,7 @@ function hostImportMapPlugin(state: ImportMapBuildState): Plugin {
       // that won't be emitted would be a runtime 404.
       if (!ctx.bundle) return;
 
-      const facadePaths = findHostReactFacadePaths(
-        ctx.bundle as Record<string, FacadeLookupChunk>
-      );
+      const facadePaths = findHostReactFacadePaths(ctx.bundle as Record<string, FacadeLookupChunk>);
 
       // One distinct target per specifier — each facade exposes only that
       // specifier's public surface. hostReactFacadePlugin has already verified


### PR DESCRIPTION
## Summary

- The production import map pointed all five React specifiers (`react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-dom`, `react-dom/client`) at the internal `vendor-react` code-split chunk. A code-split chunk isn't an entry, so its exports are Rolldown's private cross-chunk interface, literally `export{n as a,i,c as n,o as r,f as t}`, not React's public API.
- Any third-party plugin doing `import { useState } from "react"` died at load with "does not provide an export named 'useState'". This has been broken in every packaged build since v0.15.0. An external plugin developer hit it and had to ship a text-only panel instead of the interactive one they wanted.
- Fixes it by emitting a real facade chunk per specifier and hardening a build guard so it can't silently regress again.

Resolves #11208

## The fix

`hostReactFacadePlugin` emits one facade entry chunk per specifier via `emitFile({ type: "chunk", preserveSignature: "exports-only" })`, and each specifier in the import map now points at its own facade. The `vendor-react` codeSplitting group is untouched, so all five facades import that same runtime chunk. Still one React instance.

Worth calling out: the first pass at this reused dev mode's approach, `export * from "react"`. The new build guard caught it immediately, it was emitting only a `default` export, every named export elided. React ships CJS, and a star re-export from CJS has no statically known name set, so Rolldown emits nothing for it. Dev mode only ever worked because Vite pre-bundles React into real ESM first. That dev/prod divergence is the actual root cause of this issue, so the fix enumerates named exports explicitly, read from the installed package at build time, and dev and prod now share one generator instead of diverging.

## Why it can't silently regress again

A `generateBundle` guard checks the built chunks two independent ways:

1. Every name the generator re-exported survived into the chunk. This catches tree-shaking (`lazyBarrel` is on and prunes barrel-shaped re-exports).
2. A hand-written, per-specifier minimum contract is present. This catches the generator itself regressing, which check 1 would pass vacuously.

It also fails closed if `vendor-react` ever stops emitting, and asserts that each facade imports that one shared chunk. This runs in `npm run build`, which CI runs on every PR.

## Sample plugin

`rich-daintree` gains a hook-based panel view (`useState`/`useEffect` plus JSX) built with the public `@daintreehq/plugin-vite` preset, the same path a third-party author takes. Its mounting -> ready transition proves named imports, the JSX runtime, and hooks dispatching through the host's React all at once. The existing import-free `rich-panel-view.js` stays as a control, it isolates a `plugin://` loader failure from a React-contract failure.

## Also

Emitted facades are entry chunks, so a few "first entry = app entry" assumptions needed hardening: the bundle-size report, compile hints, both budget scripts' `findEntryKey`, and the first-render preload closure (which was subtracting every `isEntry` chunk as already auto-preloaded, not true for facades that `index.html` never references).

## Testing

- `vite build` passes with the guard active, and the built facades now export the real surface. For example, `jsx-runtime` exports `Fragment, default, jsx, jsxs`, and `react-dom/client` exports `createRoot, default, hydrateRoot, version`. All five import the same `vendor-react` file.
- Typecheck, 301 targeted unit tests, plugin-manifest validation, and scoped lint/format all pass.
- Added two new E2E tests to `e2e/full/plugins/core-plugin-panels.spec.ts`. That bucket gates releases, not PRs, so they didn't run as part of this change.

## Follow-up worth its own issue

Found during review: `@daintreehq/plugin-vite`'s `resolveId` guard for unmapped React subpaths (e.g. `react-dom/server`) never fires, because Rolldown marks `external` regex matches before `resolveId` runs. An unsupported subpath currently builds clean and fails at runtime instead of at build time. This is pre-existing and out of scope here, fixing it would change public preset behavior for every plugin build, but it should get its own issue.
