### PR TITLE
feat(diagnostics): label renderer processes with project names in memory popover

### DIFF
--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -316,7 +316,9 @@ describe("registerDiagnosticsHandlers", () => {
           type: "Tab",
           name: "Tab",
           memory: { privateBytes: 0, workingSetSize: 102400 },
-          cpu: { percentCPUUsage: 1 },
+          // Deliberately not a round number, so the row exercises the handler's
+          // rounding rather than passing a value straight through.
+          cpu: { percentCPUUsage: 1.26 },
         })),
       ]);
       resetAppMetricsSnapshotForTesting();
@@ -366,6 +368,18 @@ describe("registerDiagnosticsHandlers", () => {
       getProjectByIdMock.mockReturnValue({ name: "RuinWeave" });
 
       expect(rowForPid(getProcessRows(), 400).projectNames).toEqual(["RuinWeave"]);
+    });
+
+    it("counts same-named projects separately, since names are not unique", () => {
+      withTabPids(400);
+      getRegisteredProjectViewsMock.mockReturnValue([
+        createProjectView("project-a", 400),
+        createProjectView("project-b", 400),
+      ]);
+      // Two distinct repos can carry the same name; they are still two owners.
+      getProjectByIdMock.mockReturnValue({ name: "api" });
+
+      expect(rowForPid(getProcessRows(), 400).projectNames).toEqual(["api", "api"]);
     });
 
     it("keeps each renderer's label to the projects actually running in it", () => {
@@ -435,7 +449,6 @@ describe("registerDiagnosticsHandlers", () => {
 
       const rows = getProcessRows();
       // The throwing view neither blanks the table nor suppresses its siblings.
-      expect(rows.length).toBeGreaterThan(0);
       expect(rowForPid(rows, 400).projectNames).toBeUndefined();
       expect(rowForPid(rows, 401).projectNames).toEqual(["Cedar Forge"]);
     });
@@ -449,7 +462,8 @@ describe("registerDiagnosticsHandlers", () => {
       const tab = rowForPid(rows, 400) as ProcessRow & { memoryMB: number; cpuPercent: number };
       // workingSetSize 102400 KB / 1024 = 100 MB, from workingSetSize not privateBytes.
       expect(tab.memoryMB).toBe(100);
-      expect(tab.cpuPercent).toBe(1);
+      // 1.26 rounded to one decimal.
+      expect(tab.cpuPercent).toBe(1.3);
       const memory = rows.map((r) => r.memoryMB);
       expect(memory).toEqual([...memory].sort((a, b) => b - a));
     });

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -352,7 +352,8 @@ describe("registerDiagnosticsHandlers", () => {
         createProjectView("project-b", 400),
       ]);
       getProjectByIdMock.mockImplementation(
-        (id) => ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id]
+        (id) =>
+          ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id] ?? null
       );
 
       // Sorted, so the label stays stable across polls regardless of view order.
@@ -389,7 +390,8 @@ describe("registerDiagnosticsHandlers", () => {
         createProjectView("project-b", 401),
       ]);
       getProjectByIdMock.mockImplementation(
-        (id) => ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id]
+        (id) =>
+          ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id] ?? null
       );
 
       const rows = getProcessRows();
@@ -444,7 +446,8 @@ describe("registerDiagnosticsHandlers", () => {
         createProjectView("project-b", 401),
       ]);
       getProjectByIdMock.mockImplementation(
-        (id) => ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id]
+        (id) =>
+          ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id] ?? null
       );
 
       const rows = getProcessRows();

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -100,6 +100,10 @@ vi.mock("electron", () => ({
   BrowserWindow: {
     fromWebContents: vi.fn(() => null),
   },
+  // The real webContentsRegistry loads through importOriginal below, so the
+  // electron surface it imports at module scope has to exist here.
+  WebContentsView: vi.fn(),
+  webContents: { fromId: vi.fn(() => null) },
 }));
 
 const chmodMock = vi.hoisted(() =>
@@ -174,6 +178,25 @@ vi.mock("../../../services/ProcessMemoryMonitor.js", () => ({
   recordEluSample: recordEluSampleMock,
 }));
 
+const getRegisteredProjectViewsMock = vi.hoisted(() =>
+  vi.fn<() => Array<{ webContents: unknown; projectId: string }>>(() => [])
+);
+
+// Spread the real module: buildIpcContext imports seven other members from it,
+// and a bare factory would shadow them all away.
+vi.mock("../../../window/webContentsRegistry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../window/webContentsRegistry.js")>()),
+  getRegisteredProjectViews: getRegisteredProjectViewsMock,
+}));
+
+const getProjectByIdMock = vi.hoisted(() =>
+  vi.fn<(projectId: string) => { name: string } | null>(() => null)
+);
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: getProjectByIdMock },
+}));
+
 import { registerDiagnosticsHandlers } from "../diagnostics.js";
 import { resetAppMetricsSnapshotForTesting } from "../../../utils/appMetricsSnapshot.js";
 
@@ -196,6 +219,8 @@ describe("registerDiagnosticsHandlers", () => {
     // The metrics handlers read through a 5s shared cache; clear it so each
     // test's mocked getAppMetrics (incl. per-test throw overrides) actually runs.
     resetAppMetricsSnapshotForTesting();
+    getRegisteredProjectViewsMock.mockReturnValue([]);
+    getProjectByIdMock.mockReturnValue(null);
   });
 
   it("registers all expected IPC handlers", () => {
@@ -265,6 +290,168 @@ describe("registerDiagnosticsHandlers", () => {
       registerDiagnosticsHandlers(deps);
       const handler = getHandlerFn("diagnostics:get-process-metrics");
       expect(handler()).toEqual([]);
+    });
+
+    type ProcessRow = { pid: number; type: string; name: string; projectNames?: string[] };
+
+    function createProjectView(projectId: string, osProcessId: number | (() => number)) {
+      return {
+        projectId,
+        webContents: {
+          isDestroyed: vi.fn(() => false),
+          getOSProcessId: vi.fn(
+            typeof osProcessId === "function" ? osProcessId : () => osProcessId
+          ),
+        },
+      };
+    }
+
+    /** Adds Tab processes to the fixture without disturbing the shared non-Tab rows. */
+    function withTabPids(...pids: number[]): void {
+      const base = appMock.getAppMetrics();
+      appMock.getAppMetrics.mockReturnValueOnce([
+        ...base,
+        ...pids.map((pid) => ({
+          pid,
+          type: "Tab",
+          name: "Tab",
+          memory: { privateBytes: 0, workingSetSize: 102400 },
+          cpu: { percentCPUUsage: 1 },
+        })),
+      ]);
+      resetAppMetricsSnapshotForTesting();
+    }
+
+    function getProcessRows(): ProcessRow[] {
+      registerDiagnosticsHandlers(deps);
+      return getHandlerFn("diagnostics:get-process-metrics")() as ProcessRow[];
+    }
+
+    function rowForPid(rows: ProcessRow[], pid: number): ProcessRow {
+      const row = rows.find((r) => r.pid === pid);
+      if (!row) throw new Error(`No process row for pid ${pid}`);
+      return row;
+    }
+
+    it("labels a Tab process with the project rendering in it", () => {
+      withTabPids(400);
+      getRegisteredProjectViewsMock.mockReturnValue([createProjectView("project-a", 400)]);
+      getProjectByIdMock.mockImplementation((id) =>
+        id === "project-a" ? { name: "RuinWeave" } : null
+      );
+
+      expect(rowForPid(getProcessRows(), 400).projectNames).toEqual(["RuinWeave"]);
+    });
+
+    it("reports every project when Chromium consolidates views into one renderer", () => {
+      withTabPids(400);
+      getRegisteredProjectViewsMock.mockReturnValue([
+        createProjectView("project-a", 400),
+        createProjectView("project-b", 400),
+      ]);
+      getProjectByIdMock.mockImplementation(
+        (id) => ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id]
+      );
+
+      // Sorted, so the label stays stable across polls regardless of view order.
+      expect(rowForPid(getProcessRows(), 400).projectNames).toEqual(["Cedar Forge", "RuinWeave"]);
+    });
+
+    it("dedupes a project whose views share one renderer", () => {
+      withTabPids(400);
+      getRegisteredProjectViewsMock.mockReturnValue([
+        createProjectView("project-a", 400),
+        createProjectView("project-a", 400),
+      ]);
+      getProjectByIdMock.mockReturnValue({ name: "RuinWeave" });
+
+      expect(rowForPid(getProcessRows(), 400).projectNames).toEqual(["RuinWeave"]);
+    });
+
+    it("keeps each renderer's label to the projects actually running in it", () => {
+      withTabPids(400, 401);
+      getRegisteredProjectViewsMock.mockReturnValue([
+        createProjectView("project-a", 400),
+        createProjectView("project-b", 401),
+      ]);
+      getProjectByIdMock.mockImplementation(
+        (id) => ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id]
+      );
+
+      const rows = getProcessRows();
+      expect(rowForPid(rows, 400).projectNames).toEqual(["RuinWeave"]);
+      expect(rowForPid(rows, 401).projectNames).toEqual(["Cedar Forge"]);
+    });
+
+    it("leaves non-Tab processes generic even when a project view reports their pid", () => {
+      // pid 200 is the GPU process in the shared fixture.
+      getRegisteredProjectViewsMock.mockReturnValue([createProjectView("project-a", 200)]);
+      getProjectByIdMock.mockReturnValue({ name: "RuinWeave" });
+
+      const gpu = rowForPid(getProcessRows(), 200);
+      expect(gpu.projectNames).toBeUndefined();
+      expect(gpu.name).toBe("GPU Process");
+    });
+
+    it("never reads the pid of a destroyed view", () => {
+      withTabPids(400);
+      const view = createProjectView("project-a", 400);
+      view.webContents.isDestroyed.mockReturnValue(true);
+      getRegisteredProjectViewsMock.mockReturnValue([view]);
+      getProjectByIdMock.mockReturnValue({ name: "RuinWeave" });
+
+      // getOSProcessId() throws on a destroyed webContents, so it must not be called.
+      expect(rowForPid(getProcessRows(), 400).projectNames).toBeUndefined();
+      expect(view.webContents.getOSProcessId).not.toHaveBeenCalled();
+    });
+
+    it("ignores pid 0, which means the renderer has not spawned or has crashed", () => {
+      withTabPids(0);
+      getRegisteredProjectViewsMock.mockReturnValue([createProjectView("project-a", 0)]);
+      getProjectByIdMock.mockReturnValue({ name: "RuinWeave" });
+
+      expect(rowForPid(getProcessRows(), 0).projectNames).toBeUndefined();
+    });
+
+    it("skips views whose project record is gone", () => {
+      withTabPids(400);
+      getRegisteredProjectViewsMock.mockReturnValue([createProjectView("project-a", 400)]);
+      getProjectByIdMock.mockReturnValue(null);
+
+      expect(rowForPid(getProcessRows(), 400).projectNames).toBeUndefined();
+    });
+
+    it("keeps labelling the other projects when one view is torn down mid-read", () => {
+      withTabPids(400, 401);
+      getRegisteredProjectViewsMock.mockReturnValue([
+        createProjectView("project-a", () => {
+          throw new Error("Object has been destroyed");
+        }),
+        createProjectView("project-b", 401),
+      ]);
+      getProjectByIdMock.mockImplementation(
+        (id) => ({ "project-a": { name: "RuinWeave" }, "project-b": { name: "Cedar Forge" } })[id]
+      );
+
+      const rows = getProcessRows();
+      // The throwing view neither blanks the table nor suppresses its siblings.
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rowForPid(rows, 400).projectNames).toBeUndefined();
+      expect(rowForPid(rows, 401).projectNames).toEqual(["Cedar Forge"]);
+    });
+
+    it("preserves memory, cpu and sort order while labelling", () => {
+      withTabPids(400);
+      getRegisteredProjectViewsMock.mockReturnValue([createProjectView("project-a", 400)]);
+      getProjectByIdMock.mockReturnValue({ name: "RuinWeave" });
+
+      const rows = getProcessRows() as Array<ProcessRow & { memoryMB: number; cpuPercent: number }>;
+      const tab = rowForPid(rows, 400) as ProcessRow & { memoryMB: number; cpuPercent: number };
+      // workingSetSize 102400 KB / 1024 = 100 MB, from workingSetSize not privateBytes.
+      expect(tab.memoryMB).toBe(100);
+      expect(tab.cpuPercent).toBe(1);
+      const memory = rows.map((r) => r.memoryMB);
+      expect(memory).toEqual([...memory].sort((a, b) => b - a));
     });
   });
 

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -28,6 +28,8 @@ import { getActionBreadcrumbService } from "../../services/ActionBreadcrumbServi
 import type * as DiagnosticsCollectorModule from "../../services/DiagnosticsCollector.js";
 import { recordBlinkSample, recordEluSample } from "../../services/ProcessMemoryMonitor.js";
 import { getAppMetricsSnapshot } from "../../utils/appMetricsSnapshot.js";
+import { getRegisteredProjectViews } from "../../window/webContentsRegistry.js";
+import { projectStore } from "../../services/ProjectStore.js";
 
 let cachedDiagnosticsCollector: typeof DiagnosticsCollectorModule | null = null;
 async function getDiagnosticsCollector(): Promise<typeof DiagnosticsCollectorModule> {
@@ -240,19 +242,55 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_APP_METRICS, handleGetAppMetrics));
 
+  // OS pid → names of the projects rendering in it. A Set because project views
+  // share one partition and URL, so Chromium may collapse several into one
+  // renderer process; each view is resolved independently so a teardown race on
+  // one cannot blank the whole process table.
+  const collectProjectNamesByPid = (): Map<number, Set<string>> => {
+    const byPid = new Map<number, Set<string>>();
+    for (const { webContents, projectId } of getRegisteredProjectViews()) {
+      try {
+        // Re-checked here, not just in the registry: getOSProcessId() throws
+        // once the webContents is destroyed, and destruction can race the
+        // enumeration above.
+        if (webContents.isDestroyed()) continue;
+        // 0 means "no renderer process yet" (pre-spawn) or "crashed" — never a
+        // real pid, so it must not group views together.
+        const pid = webContents.getOSProcessId();
+        if (!Number.isInteger(pid) || pid <= 0) continue;
+        const name = projectStore.getProjectById(projectId)?.name;
+        if (!name) continue;
+        const names = byPid.get(pid) ?? new Set<string>();
+        names.add(name);
+        byPid.set(pid, names);
+      } catch {
+        // Torn down mid-read: leave this view unlabelled.
+      }
+    }
+    return byPid;
+  };
+
   const handleGetProcessMetrics = (): ProcessMetricEntry[] => {
     try {
       const metrics = getAppMetricsSnapshot();
+      const projectNamesByPid = collectProjectNamesByPid();
       return metrics
-        .map((proc) => ({
-          pid: proc.pid,
-          type: proc.type,
-          name: proc.name ?? proc.type,
-          // workingSetSize only — privateBytes is Windows-only and reports 0
-          // on macOS/Linux (lesson #8646).
-          memoryMB: Math.round(proc.memory.workingSetSize / 1024),
-          cpuPercent: Math.round((proc.cpu?.percentCPUUsage ?? 0) * 10) / 10,
-        }))
+        .map((proc) => {
+          const entry: ProcessMetricEntry = {
+            pid: proc.pid,
+            type: proc.type,
+            name: proc.name ?? proc.type,
+            // workingSetSize only — privateBytes is Windows-only and reports 0
+            // on macOS/Linux (lesson #8646).
+            memoryMB: Math.round(proc.memory.workingSetSize / 1024),
+            cpuPercent: Math.round((proc.cpu?.percentCPUUsage ?? 0) * 10) / 10,
+          };
+          const names = proc.type === "Tab" ? projectNamesByPid.get(proc.pid) : undefined;
+          if (names?.size) {
+            entry.projectNames = [...names].sort((a, b) => a.localeCompare(b));
+          }
+          return entry;
+        })
         .sort((a, b) => b.memoryMB - a.memoryMB);
     } catch {
       return [];

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -242,12 +242,13 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_APP_METRICS, handleGetAppMetrics));
 
-  // OS pid → names of the projects rendering in it. A Set because project views
-  // share one partition and URL, so Chromium may collapse several into one
-  // renderer process; each view is resolved independently so a teardown race on
-  // one cannot blank the whole process table.
-  const collectProjectNamesByPid = (): Map<number, Set<string>> => {
-    const byPid = new Map<number, Set<string>>();
+  // OS pid → the projects rendering in it, keyed by project id: views share one
+  // partition and URL, so Chromium may collapse several projects into one
+  // renderer process. Keyed by id rather than name because names are not unique
+  // — two projects both called "api" are two owners, not one. Each view is
+  // resolved independently so a teardown race on one cannot blank the table.
+  const collectProjectNamesByPid = (): Map<number, string[]> => {
+    const byPid = new Map<number, Map<string, string>>();
     for (const { webContents, projectId } of getRegisteredProjectViews()) {
       try {
         // Re-checked here, not just in the registry: getOSProcessId() throws
@@ -260,14 +261,21 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
         if (!Number.isInteger(pid) || pid <= 0) continue;
         const name = projectStore.getProjectById(projectId)?.name;
         if (!name) continue;
-        const names = byPid.get(pid) ?? new Set<string>();
-        names.add(name);
-        byPid.set(pid, names);
+        const projects = byPid.get(pid) ?? new Map<string, string>();
+        projects.set(projectId, name);
+        byPid.set(pid, projects);
       } catch {
         // Torn down mid-read: leave this view unlabelled.
       }
     }
-    return byPid;
+    // Plain lexical order, not localeCompare: the label must not reshuffle
+    // between polls on a different OS locale or ICU build.
+    return new Map(
+      [...byPid].map(([pid, projects]) => [
+        pid,
+        [...projects.values()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+      ])
+    );
   };
 
   const handleGetProcessMetrics = (): ProcessMetricEntry[] => {
@@ -286,8 +294,8 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
             cpuPercent: Math.round((proc.cpu?.percentCPUUsage ?? 0) * 10) / 10,
           };
           const names = proc.type === "Tab" ? projectNamesByPid.get(proc.pid) : undefined;
-          if (names?.size) {
-            entry.projectNames = [...names].sort((a, b) => a.localeCompare(b));
+          if (names?.length) {
+            entry.projectNames = names;
           }
           return entry;
         })

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -256,6 +256,10 @@ describe("webContentsRegistry", () => {
     expect(getProjectForWebContents(staleWc.id)).toBeNull();
     expect(isCachedViewWebContents(staleWc.id)).toBe(false);
     expect(getProjectForWebContents(liveWc.id)).toBe("project-b");
+    // Pruning a view that never fired "destroyed" must release its listener too,
+    // or the registration keeps the WebContents and its closure alive.
+    expect(staleWc.listenerCount("destroyed")).toBe(0);
+    expect(liveWc.listenerCount("destroyed")).toBe(1);
   });
 
   it("getRegisteredProjectViews prunes views whose webContents no longer resolves", async () => {

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -5,7 +5,9 @@ import type { BrowserWindow, WebContents, WebContentsView } from "electron";
 const electronMock = vi.hoisted(() => ({
   fromWebContents: vi.fn(() => null),
   getAllWindows: vi.fn(() => []),
-  fromId: vi.fn(() => null),
+  // Typed at the source: the enumeration tests resolve ids to real mock
+  // webContents, which a `() => null` inference would reject.
+  fromId: vi.fn<(id: number) => WebContents | null>(() => null),
 }));
 
 vi.mock("electron", () => ({

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -199,6 +199,78 @@ describe("webContentsRegistry", () => {
     expect(getAppWebContents(win)).toBe(win.webContents);
   });
 
+  it("getRegisteredProjectViews pairs every live view with its project across windows", async () => {
+    const { getRegisteredProjectViews, registerProjectView } = await loadRegistry();
+    const wcA = createWebContents(301);
+    const wcB = createWebContents(302);
+    electronMock.fromId.mockImplementation(
+      (id: number) => ({ 301: wcA, 302: wcB })[id] as unknown as WebContents
+    );
+
+    registerProjectView("project-a", wcA as unknown as WebContents);
+    registerProjectView("project-b", wcB as unknown as WebContents);
+
+    expect(getRegisteredProjectViews()).toEqual([
+      { webContents: wcA, projectId: "project-a" },
+      { webContents: wcB, projectId: "project-b" },
+    ]);
+  });
+
+  it("getRegisteredProjectViews includes cached (deactivated) views", async () => {
+    const { getRegisteredProjectViews, registerCachedViewWebContents, registerProjectView } =
+      await loadRegistry();
+    const wc = createWebContents(303);
+    electronMock.fromId.mockImplementation((id: number) =>
+      id === 303 ? (wc as unknown as WebContents) : null
+    );
+
+    registerProjectView("project-a", wc as unknown as WebContents);
+    // Deactivation only marks the view; its renderer process stays alive.
+    registerCachedViewWebContents(wc as unknown as WebContents);
+
+    expect(getRegisteredProjectViews()).toEqual([{ webContents: wc, projectId: "project-a" }]);
+  });
+
+  it("getRegisteredProjectViews prunes only the stale view, keeping live ones", async () => {
+    const {
+      getProjectForWebContents,
+      getRegisteredProjectViews,
+      isCachedViewWebContents,
+      registerCachedViewWebContents,
+      registerProjectView,
+    } = await loadRegistry();
+    const staleWc = createWebContents(304);
+    const liveWc = createWebContents(305);
+    electronMock.fromId.mockImplementation(
+      (id: number) => ({ 304: staleWc, 305: liveWc })[id] as unknown as WebContents
+    );
+
+    registerProjectView("project-a", staleWc as unknown as WebContents);
+    registerCachedViewWebContents(staleWc as unknown as WebContents);
+    registerProjectView("project-b", liveWc as unknown as WebContents);
+
+    // Destroyed without firing "destroyed", so only the read-time prune can clear it.
+    staleWc.setDestroyed(true);
+
+    expect(getRegisteredProjectViews()).toEqual([{ webContents: liveWc, projectId: "project-b" }]);
+    expect(getProjectForWebContents(staleWc.id)).toBeNull();
+    expect(isCachedViewWebContents(staleWc.id)).toBe(false);
+    expect(getProjectForWebContents(liveWc.id)).toBe("project-b");
+  });
+
+  it("getRegisteredProjectViews prunes views whose webContents no longer resolves", async () => {
+    const { getProjectForWebContents, getRegisteredProjectViews, registerProjectView } =
+      await loadRegistry();
+    const wc = createWebContents(306);
+    registerProjectView("project-a", wc as unknown as WebContents);
+
+    // fromId returns null once Electron has torn the webContents down entirely.
+    electronMock.fromId.mockReturnValue(null);
+
+    expect(getRegisteredProjectViews()).toEqual([]);
+    expect(getProjectForWebContents(wc.id)).toBeNull();
+  });
+
   it("marks a webContents cached and clears the mark on unregister", async () => {
     const {
       isCachedViewWebContents,

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -369,9 +369,9 @@ export function getRegisteredProjectViews(): Array<{
     if (wc && !wc.isDestroyed()) {
       result.push({ webContents: wc, projectId });
     } else {
-      viewToProject.delete(wcId);
-      cachedViewWebContents.delete(wcId);
-      invalidateAllAppWebContentsCache();
+      // Full unregister, not a bare map delete: a view pruned here never fired
+      // "destroyed", so its listener registration would retain the WebContents.
+      unregisterProjectView(wcId);
     }
   }
   return result;

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -353,3 +353,26 @@ export function getWebContentsForProject(projectId: string): WebContents[] {
   }
   return result;
 }
+
+/**
+ * Every live project view paired with the project that owns it, across all
+ * windows. Cached (deactivated) views are included — they keep a live renderer
+ * process. Prunes stale entries like getWebContentsForProject().
+ */
+export function getRegisteredProjectViews(): Array<{
+  webContents: WebContents;
+  projectId: string;
+}> {
+  const result: Array<{ webContents: WebContents; projectId: string }> = [];
+  for (const [wcId, projectId] of viewToProject) {
+    const wc = webContentsModule.fromId(wcId);
+    if (wc && !wc.isDestroyed()) {
+      result.push({ webContents: wc, projectId });
+    } else {
+      viewToProject.delete(wcId);
+      cachedViewWebContents.delete(wcId);
+      invalidateAllAppWebContentsCache();
+    }
+  }
+  return result;
+}

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -224,6 +224,14 @@ export interface ProcessMetricEntry {
   name: string;
   memoryMB: number;
   cpuPercent: number;
+  /**
+   * Names of the projects whose views run in this renderer, for "Tab" processes
+   * only. Absent when no project owns the process (GPU/utility/browser, portal
+   * views, an unbound welcome view) — an array because project views share one
+   * session partition and URL, so Chromium can collapse several into a single
+   * renderer process. Sorted, deduped, and never empty when present.
+   */
+  projectNames?: string[];
 }
 
 /** V8 heap statistics from the main process */

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -20,6 +20,7 @@ import {
   getMemoryState,
   getTrendDirection,
   formatMemory,
+  formatProcessLabel,
 } from "./ProjectResourceBadge.utils";
 
 const MAX_SAMPLES = 12;
@@ -170,20 +171,26 @@ function ProcessTable({ metrics }: { metrics: ProcessMetricEntry[] }) {
     <div className="space-y-1">
       <div className="text-[10px] text-daintree-text/50 font-medium">Daintree processes</div>
       <div className="space-y-px">
-        {metrics.map((proc) => (
-          <div
-            key={proc.pid}
-            className="flex items-center justify-between text-[10px] font-mono py-0.5"
-          >
-            <span className="text-daintree-text/60 truncate max-w-[140px]">
-              {proc.name} <span className="text-daintree-text/25">({proc.pid})</span>
-            </span>
-            <div className="flex gap-2 text-daintree-text/40 shrink-0">
-              <span>{proc.memoryMB}MB</span>
-              <span className="w-10 text-right">{proc.cpuPercent}%</span>
+        {metrics.map((proc) => {
+          const label = formatProcessLabel(proc);
+          return (
+            <div
+              key={proc.pid}
+              className="flex items-center justify-between text-[10px] font-mono py-0.5"
+            >
+              <span
+                className="text-daintree-text/60 truncate max-w-[140px]"
+                title={`${label} (${proc.pid})`}
+              >
+                {label} <span className="text-daintree-text/25">({proc.pid})</span>
+              </span>
+              <div className="flex gap-2 text-daintree-text/40 shrink-0">
+                <span>{proc.memoryMB}MB</span>
+                <span className="w-10 text-right">{proc.cpuPercent}%</span>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Project/ProjectResourceBadge.utils.ts
+++ b/src/components/Project/ProjectResourceBadge.utils.ts
@@ -63,3 +63,17 @@ export function formatMemory(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)}GB`;
   return `${mb}MB`;
 }
+
+/**
+ * Name a process row by the projects rendering in it, falling back to Electron's
+ * own label when none own it. The count leads the multi-project form because the
+ * row truncates at ~23 characters: "2 views · Cedar Forg…" still reports the
+ * sharing honestly, where a bare name list would ellipsize into what reads as a
+ * single oddly-named project.
+ */
+export function formatProcessLabel(proc: { name: string; projectNames?: string[] }): string {
+  const names = proc.projectNames;
+  if (!names?.length) return proc.name;
+  if (names.length === 1) return `${names[0]} view`;
+  return `${names.length} views · ${names.join(", ")}`;
+}

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -298,13 +298,19 @@ describe("ProjectResourceBadge — process ownership", () => {
     return { pid: 400, type: "Tab", name: "Tab", memoryMB: 100, cpuPercent: 1, ...overrides };
   }
 
+  /** The process row's label cell, located by the pid it renders. */
+  function processRowLabel(container: HTMLElement, pid: number): string {
+    const row = container.querySelector(`[title$="(${pid})"]`);
+    if (!row) throw new Error(`No process row for pid ${pid}`);
+    return row.textContent ?? "";
+  }
+
   it("names the owning project instead of the generic renderer label", async () => {
     mockGetProcessMetrics.mockResolvedValue([makeProcess({ projectNames: ["RuinWeave"] })]);
 
     const container = await renderOpenBadge();
 
-    expect(container.textContent).toContain("RuinWeave view");
-    expect(container.textContent).toContain("(400)");
+    expect(processRowLabel(container, 400)).toBe("RuinWeave view (400)");
   });
 
   it("leaves an unowned process on its generic label", async () => {
@@ -314,8 +320,8 @@ describe("ProjectResourceBadge — process ownership", () => {
 
     const container = await renderOpenBadge();
 
-    expect(container.textContent).toContain("GPU Process");
-    expect(container.textContent).not.toContain("view");
+    // Scoped to the row: unrelated popover copy may legitimately say "view".
+    expect(processRowLabel(container, 200)).toBe("GPU Process (200)");
   });
 
   it("surfaces the full label on hover when the row truncates", async () => {

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -55,6 +55,7 @@ import type {
   CompositeMemorySnapshot,
   TerminalWorkloadSlice,
 } from "@shared/types/memoryAccounting";
+import type { ProcessMetricEntry } from "@shared/types/ipc/system";
 import { ProjectResourceBadge } from "../ProjectResourceBadge";
 
 const mockGetAll = vi.mocked(projectClient.getAll);
@@ -142,36 +143,40 @@ async function renderOpenBadge(): Promise<HTMLElement> {
   return container;
 }
 
-describe("ProjectResourceBadge — popover memory honesty", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    mockGetAll.mockReset().mockResolvedValue([makeProject()]);
-    mockGetBulkStats.mockReset().mockResolvedValue({
-      p1: makeBulkStatsEntry({
-        terminalMemoryMB: 750,
-        topProcess: { name: "node", memoryMB: 400 },
-      }),
-    });
-    mockGetAppMetrics.mockReset().mockResolvedValue({ totalMemoryMB: 290 });
-    mockGetHardwareInfo.mockReset().mockResolvedValue({
-      totalMemoryBytes: 8 * 1024 * 1024 * 1024,
-      logicalCpuCount: 8,
-    });
-    mockGetProcessMetrics.mockReset().mockResolvedValue([]);
-    mockGetHeapStats
-      .mockReset()
-      .mockResolvedValue({ usedMB: 100, limitMB: 200, percent: 50, externalMB: 10 });
-    mockGetDiagnosticsInfo
-      .mockReset()
-      .mockResolvedValue({ uptimeSeconds: 60, eventLoopP99Ms: 10, systemAvailableMB: 4096 });
-    mockGetMemorySnapshot.mockReset().mockResolvedValue(makeMemorySnapshot());
-    statsStoreState.stats = { p1: { processCount: 1 } };
+function setupDefaultMocks(): void {
+  vi.useFakeTimers();
+  mockGetAll.mockReset().mockResolvedValue([makeProject()]);
+  mockGetBulkStats.mockReset().mockResolvedValue({
+    p1: makeBulkStatsEntry({
+      terminalMemoryMB: 750,
+      topProcess: { name: "node", memoryMB: 400 },
+    }),
   });
+  mockGetAppMetrics.mockReset().mockResolvedValue({ totalMemoryMB: 290 });
+  mockGetHardwareInfo.mockReset().mockResolvedValue({
+    totalMemoryBytes: 8 * 1024 * 1024 * 1024,
+    logicalCpuCount: 8,
+  });
+  mockGetProcessMetrics.mockReset().mockResolvedValue([]);
+  mockGetHeapStats
+    .mockReset()
+    .mockResolvedValue({ usedMB: 100, limitMB: 200, percent: 50, externalMB: 10 });
+  mockGetDiagnosticsInfo
+    .mockReset()
+    .mockResolvedValue({ uptimeSeconds: 60, eventLoopP99Ms: 10, systemAvailableMB: 4096 });
+  mockGetMemorySnapshot.mockReset().mockResolvedValue(makeMemorySnapshot());
+  statsStoreState.stats = { p1: { processCount: 1 } };
+}
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-  });
+function restoreTimersAndMocks(): void {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+}
+
+describe("ProjectResourceBadge — popover memory honesty", () => {
+  beforeEach(setupDefaultMocks);
+
+  afterEach(restoreTimersAndMocks);
 
   it("labels measured app and workload memory from the composite snapshot", async () => {
     const container = await renderOpenBadge();
@@ -281,5 +286,46 @@ describe("ProjectResourceBadge — popover memory honesty", () => {
 
     expect(container.textContent).toContain("~150MB");
     expect(container.textContent).toContain("estimated from terminal count, not measured");
+  });
+});
+
+describe("ProjectResourceBadge — process ownership", () => {
+  beforeEach(setupDefaultMocks);
+
+  afterEach(restoreTimersAndMocks);
+
+  function makeProcess(overrides: Partial<ProcessMetricEntry> = {}): ProcessMetricEntry {
+    return { pid: 400, type: "Tab", name: "Tab", memoryMB: 100, cpuPercent: 1, ...overrides };
+  }
+
+  it("names the owning project instead of the generic renderer label", async () => {
+    mockGetProcessMetrics.mockResolvedValue([makeProcess({ projectNames: ["RuinWeave"] })]);
+
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("RuinWeave view");
+    expect(container.textContent).toContain("(400)");
+  });
+
+  it("leaves an unowned process on its generic label", async () => {
+    mockGetProcessMetrics.mockResolvedValue([
+      makeProcess({ pid: 200, type: "GPU", name: "GPU Process" }),
+    ]);
+
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("GPU Process");
+    expect(container.textContent).not.toContain("view");
+  });
+
+  it("surfaces the full label on hover when the row truncates", async () => {
+    mockGetProcessMetrics.mockResolvedValue([
+      makeProcess({ projectNames: ["Cedar Forge", "RuinWeave"] }),
+    ]);
+
+    const container = await renderOpenBadge();
+
+    const row = container.querySelector('[title*="RuinWeave"]');
+    expect(row?.getAttribute("title")).toBe("2 views · Cedar Forge, RuinWeave (400)");
   });
 });

--- a/src/components/Project/__tests__/ProjectResourceBadge.utils.test.ts
+++ b/src/components/Project/__tests__/ProjectResourceBadge.utils.test.ts
@@ -5,6 +5,7 @@ import {
   computeSlope,
   getTrendDirection,
   formatMemory,
+  formatProcessLabel,
   FALLBACK_THRESHOLDS,
 } from "../ProjectResourceBadge.utils";
 
@@ -120,5 +121,41 @@ describe("formatMemory", () => {
     expect(formatMemory(1024)).toBe("1.0GB");
     expect(formatMemory(1536)).toBe("1.5GB");
     expect(formatMemory(2048)).toBe("2.0GB");
+  });
+});
+
+describe("formatProcessLabel", () => {
+  it("falls back to the process name when no project owns the process", () => {
+    expect(formatProcessLabel({ name: "GPU Process" })).toBe("GPU Process");
+    expect(formatProcessLabel({ name: "Tab", projectNames: [] })).toBe("Tab");
+  });
+
+  it("names the owning project instead of the generic process name", () => {
+    const label = formatProcessLabel({ name: "Tab", projectNames: ["RuinWeave"] });
+    expect(label).toBe("RuinWeave view");
+    expect(label).not.toContain("Tab");
+  });
+
+  it("reports every project sharing a consolidated renderer, counted first", () => {
+    const label = formatProcessLabel({
+      name: "Tab",
+      projectNames: ["Cedar Forge", "RuinWeave"],
+    });
+    expect(label).toBe("2 views · Cedar Forge, RuinWeave");
+    // The count leads so it survives the row's ~23-char truncation.
+    expect(label.slice(0, 23)).toContain("2 views");
+  });
+
+  it("counts each additional project sharing the renderer", () => {
+    const names = ["Alpha", "Cedar Forge", "RuinWeave"];
+    expect(formatProcessLabel({ name: "Tab", projectNames: names })).toBe(
+      `${names.length} views · ${names.join(", ")}`
+    );
+  });
+
+  it("keeps the label free of trailing punctuation", () => {
+    for (const projectNames of [undefined, ["RuinWeave"], ["Cedar Forge", "RuinWeave"]]) {
+      expect(formatProcessLabel({ name: "Tab", projectNames })).not.toMatch(/\.$/);
+    }
   });
 });

--- a/src/components/Project/__tests__/ProjectResourceBadge.utils.test.ts
+++ b/src/components/Project/__tests__/ProjectResourceBadge.utils.test.ts
@@ -131,9 +131,7 @@ describe("formatProcessLabel", () => {
   });
 
   it("names the owning project instead of the generic process name", () => {
-    const label = formatProcessLabel({ name: "Tab", projectNames: ["RuinWeave"] });
-    expect(label).toBe("RuinWeave view");
-    expect(label).not.toContain("Tab");
+    expect(formatProcessLabel({ name: "Tab", projectNames: ["RuinWeave"] })).toBe("RuinWeave view");
   });
 
   it("reports every project sharing a consolidated renderer, counted first", () => {
@@ -142,14 +140,23 @@ describe("formatProcessLabel", () => {
       projectNames: ["Cedar Forge", "RuinWeave"],
     });
     expect(label).toBe("2 views · Cedar Forge, RuinWeave");
-    // The count leads so it survives the row's ~23-char truncation.
-    expect(label.slice(0, 23)).toContain("2 views");
   });
 
-  it("counts each additional project sharing the renderer", () => {
+  it("scales the count with the projects sharing the renderer, listing them in order", () => {
     const names = ["Alpha", "Cedar Forge", "RuinWeave"];
-    expect(formatProcessLabel({ name: "Tab", projectNames: names })).toBe(
-      `${names.length} views · ${names.join(", ")}`
+    const label = formatProcessLabel({ name: "Tab", projectNames: names });
+
+    // The count leads, so it survives the row's truncation.
+    expect(label.startsWith("3 views")).toBe(true);
+    // Every project stays named, in the order given.
+    expect(names.every((name) => label.includes(name))).toBe(true);
+    expect(label.indexOf("Alpha")).toBeLessThan(label.indexOf("RuinWeave"));
+  });
+
+  it("keeps same-named projects distinct rather than collapsing them", () => {
+    // Names are not unique across projects; two owners must still read as two.
+    expect(formatProcessLabel({ name: "Tab", projectNames: ["api", "api"] })).toBe(
+      "2 views · api, api"
     );
   });
 


### PR DESCRIPTION
## Summary

- The memory badge popover's "Daintree processes" list showed renderer rows generically, like `Tab (92227) 1192MB`, with no indication of which project each renderer belonged to.
- Renderer rows are now labeled with the names of the projects rendering in them.
- Project views all share a single session partition (`persist:daintree`) and a single URL, so Chromium can sometimes fold several projects' views into one renderer process. That's a risk already documented in `SurfaceViewManager.ts`, and it's why ownership is modeled as a list rather than a single name.

Resolves #11213

## Changes

- `shared/types/ipc/system.ts`: `ProcessMetricEntry` gains an optional `projectNames?: string[]`.
- `electron/window/webContentsRegistry.ts`: new `getRegisteredProjectViews()` enumerating live project views across windows.
- `electron/ipc/handlers/diagnostics.ts`: `handleGetProcessMetrics` enriches Tab rows with the project names that own them.
- `src/components/Project/ProjectResourceBadge.utils.ts`: new pure `formatProcessLabel()`.
- `src/components/Project/ProjectResourceBadge.tsx`: `ProcessTable` renders the label and puts the full text in a `title` for hover.
- Label reads `{Name} view` for a single owner, or `{count} views, {Name}, {Name}` for a shared renderer (e.g. `2 views, Cedar Forge, RuinWeave`). The count leads because the row truncates at around 23 characters, so the shared case stays honest under truncation, and the full label is still there on hover.
- Owners are keyed by project id, not project name. Two distinct repos can both be named `api`, and a name-keyed set would have silently merged them into one owner.
- Guards: `getOSProcessId()` throws once the webContents is destroyed, so it's re-checked immediately before the read. A pid of `0` (pre-spawn or crashed) is never treated as real. Each view resolves in its own try/catch so one teardown race can't blank the whole process table.
- No new IPC channel or polling loop: this rides the existing popover-gated 4 second poll and the existing `DIAGNOSTICS_GET_PROCESS_METRICS` channel.
- Non-project renderers (portal views, the unbound welcome view) and non-renderer processes (Browser, GPU, Utility) keep their existing generic labels.

## Testing

- 225 tests pass across 10 files locally, covering this branch's own tests plus consumers of the handlers barrel and the registry.
- Prettier clean on all 9 changed files.
- ESLint reports 0 errors, with 11 pre-existing `no-restricted-syntax` `typedHandle` warnings, unchanged versus base, so the lint ratchet is untouched.