### PR TITLE
fix(memory): measure tier-2 reclaim and report what each lever freed

### DIFF
--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -277,10 +277,11 @@ export function getEluHighStreaks(): ReadonlyMap<number, number> {
 
 export interface MemoryPressureActions {
   /**
-   * Returns the number of hidden portal tabs actually destroyed. The
-   * `window:destroy-hidden-webviews` push that rides along is fire-and-forget,
-   * so its effect is deliberately NOT counted here — a count is only reported
-   * where the caller can observe the outcome.
+   * Returns the number of hidden portal tabs destroyed. This is a FLOOR, not a
+   * total: the `window:destroy-hidden-webviews` push that rides along is
+   * fire-and-forget, so any webviews the renderers drop in response are not
+   * counted. Reported under a name that says what it measures rather than
+   * implying it covers every webview this action tears down.
    */
   destroyHiddenWebviews: (tier: 1 | 2) => Promise<number>;
   hibernateIdleProjects: () => Promise<void>;
@@ -650,10 +651,12 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               beforeMb: Math.round(beforeMb),
               afterMb: Math.round(afterMb),
               deltaMb: Math.round(deltaMb),
-              // A zero delta with zero evictions means tier 1 had nothing to
-              // reclaim — not that reclaim failed. Without this the two are
-              // indistinguishable in the logs.
-              tabsEvicted: tier1TabsEvicted,
+              // Portal tabs are the only part of this lever whose outcome main
+              // can observe (the webview push is fire-and-forget), so this is a
+              // floor. Even so it separates "tier 1 found tabs to destroy" from
+              // "it found none" when the delta reads zero — previously
+              // indistinguishable.
+              portalTabsDestroyed: tier1TabsEvicted,
               pressureRemains,
               resampleFailed,
             });
@@ -684,7 +687,27 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
             // `afterMb` is this tier's baseline: sampled after tier 1 settled
             // (or with no action taken at all) and before any tier-2 action.
-            const tier2BeforeMb = afterMb;
+            // The exception is a failed re-sample, where it was forced to
+            // `beforeMb` as an escalation sentinel rather than measured. Then
+            // it is either 0 (the pre-sample failed too) or, if tier 1 acted in
+            // this cycle, a pre-tier-1 value that would bill tier 1's reclaim
+            // to tier 2. Re-baseline instead, and report the measurement failed
+            // if even that can't be had.
+            //
+            // The two tiers cannot currently act in one cycle — tier 1 re-fires
+            // on a 5-min clock and tier 2 on a 10-min one, leaving them
+            // permanently out of phase — but that is a consequence of the
+            // cooldown arithmetic, not a guarantee, and this tier's whole job
+            // is to not report numbers it cannot stand behind.
+            let tier2BeforeMb = afterMb;
+            let tier2MeasurementFailed = false;
+            if (resampleFailed) {
+              try {
+                tier2BeforeMb = sumMonitoredMb();
+              } catch {
+                tier2MeasurementFailed = true;
+              }
+            }
 
             // Each action is isolated: one throwing must neither skip the
             // levers after it nor blind the reclaim measurement below, which
@@ -721,25 +744,24 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
             let tier2AfterMb = tier2BeforeMb;
             let tier2PressureRemains = true;
-            let tier2ResampleFailed = false;
             try {
               const measured = measurePressure();
               tier2AfterMb = measured.totalMb;
               tier2PressureRemains = measured.pressureRemains;
             } catch {
-              tier2ResampleFailed = true;
+              tier2MeasurementFailed = true;
             }
 
             logInfo("memory-pressure-tier2-reclaim", {
               beforeMb: Math.round(tier2BeforeMb),
               afterMb: Math.round(tier2AfterMb),
-              deltaMb: tier2ResampleFailed
+              deltaMb: tier2MeasurementFailed
                 ? 0
                 : Math.round(Math.max(0, tier2BeforeMb - tier2AfterMb)),
-              tabsEvicted: tier2TabsEvicted,
+              portalTabsDestroyed: tier2TabsEvicted,
               viewsEvicted: tier2ViewsEvicted,
               pressureRemains: tier2PressureRemains,
-              resampleFailed: tier2ResampleFailed,
+              resampleFailed: tier2MeasurementFailed,
             });
           }
         } catch (err) {

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -276,9 +276,16 @@ export function getEluHighStreaks(): ReadonlyMap<number, number> {
 }
 
 export interface MemoryPressureActions {
-  destroyHiddenWebviews: (tier: 1 | 2) => Promise<void>;
+  /**
+   * Returns the number of hidden portal tabs actually destroyed. The
+   * `window:destroy-hidden-webviews` push that rides along is fire-and-forget,
+   * so its effect is deliberately NOT counted here — a count is only reported
+   * where the caller can observe the outcome.
+   */
+  destroyHiddenWebviews: (tier: 1 | 2) => Promise<number>;
   hibernateIdleProjects: () => Promise<void>;
-  evictCachedProjectViews?: () => Promise<void> | void;
+  /** Returns the number of cached project views evicted. */
+  evictCachedProjectViews?: () => Promise<number> | number;
   trimPtyHostState?: () => void;
   /**
    * Optional Blink memory sampler. If wired, called once per poll BEFORE
@@ -540,20 +547,61 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       mitigationInFlight = true;
       void (async () => {
         try {
-          let beforeMb = 0;
-          try {
-            // Force-refresh: this pair measures a reclaim delta across the
-            // settle window — a TTL-stale read would zero the delta and
-            // change tier-2 escalation behavior.
+          // Force-refresh (never read stale): these samples bracket a reclaim
+          // delta — a TTL-stale read would zero the delta and change tier-2
+          // escalation behavior.
+          const sumMonitoredMb = (): number => {
+            let total = 0;
             for (const proc of refreshAppMetricsSnapshot()) {
               if (!MONITORED_TYPES.has(proc.type)) continue;
-              beforeMb += getProcessMemoryMb(proc);
+              total += getProcessMemoryMb(proc);
             }
+            return total;
+          };
+
+          const measurePressure = (): {
+            totalMb: number;
+            pressureRemains: boolean;
+            systemPressureRemains: boolean;
+          } => {
+            let totalMb = 0;
+            let remains = false;
+            let systemRemains = false;
+            for (const proc of refreshAppMetricsSnapshot()) {
+              if (!MONITORED_TYPES.has(proc.type)) continue;
+              const mb = getProcessMemoryMb(proc);
+              totalMb += mb;
+              const threshold = warnThresholdsMb[proc.type];
+              if (threshold !== undefined && mb > threshold) {
+                remains = true;
+              }
+            }
+            // Aggregate fan-out can hold the combined footprint above the safe
+            // ceiling even when no single process trips its per-type threshold.
+            // Mirror the main poll's aggregate gate here so aggregate-driven
+            // pressure can still escalate to tier 2 when tier 1 under-reclaims —
+            // without this, aggregate-only pressure triggers tier 1 forever but
+            // can never reach tier 2.
+            if (totalMb > aggregateWarnThresholdMb) {
+              remains = true;
+            }
+            const availableMb = readAvailableSystemMemoryMb();
+            if (availableMb !== null && availableMb < systemLowMemoryThresholdMb) {
+              remains = true;
+              systemRemains = true;
+            }
+            return { totalMb, pressureRemains: remains, systemPressureRemains: systemRemains };
+          };
+
+          let beforeMb = 0;
+          try {
+            beforeMb = sumMonitoredMb();
           } catch {
             // If pre-sample fails, beforeMb stays 0; delta will be 0 and we'll
             // err on the side of escalating if pressure persists.
           }
 
+          let tier1TabsEvicted = 0;
           if (shouldRunTier1) {
             lastTier1At = Date.now();
             logInfo("memory-pressure-tier1-mitigation", {
@@ -562,7 +610,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               beforeMb: Math.round(beforeMb),
             });
 
-            await actions.destroyHiddenWebviews(1);
+            tier1TabsEvicted = await actions.destroyHiddenWebviews(1);
 
             try {
               actions.trimPtyHostState?.();
@@ -578,29 +626,10 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           let systemPressureRemains = false;
           let resampleFailed = false;
           try {
-            for (const proc of refreshAppMetricsSnapshot()) {
-              if (!MONITORED_TYPES.has(proc.type)) continue;
-              const mb = getProcessMemoryMb(proc);
-              afterMb += mb;
-              const threshold = warnThresholdsMb[proc.type];
-              if (threshold !== undefined && mb > threshold) {
-                pressureRemains = true;
-              }
-            }
-            // Aggregate fan-out can hold the combined footprint above the safe
-            // ceiling even when no single process trips its per-type threshold.
-            // Mirror the main poll's aggregate gate here so aggregate-driven
-            // pressure can still escalate to tier 2 when tier 1 under-reclaims —
-            // without this, aggregate-only pressure triggers tier 1 forever but
-            // can never reach tier 2.
-            if (afterMb > aggregateWarnThresholdMb) {
-              pressureRemains = true;
-            }
-            const availableAfterMb = readAvailableSystemMemoryMb();
-            if (availableAfterMb !== null && availableAfterMb < systemLowMemoryThresholdMb) {
-              pressureRemains = true;
-              systemPressureRemains = true;
-            }
+            const measured = measurePressure();
+            afterMb = measured.totalMb;
+            pressureRemains = measured.pressureRemains;
+            systemPressureRemains = measured.systemPressureRemains;
           } catch {
             // Re-sample failed — assume pressure persists and treat reclaim
             // as zero so the gate falls through to escalation. Without
@@ -621,6 +650,10 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               beforeMb: Math.round(beforeMb),
               afterMb: Math.round(afterMb),
               deltaMb: Math.round(deltaMb),
+              // A zero delta with zero evictions means tier 1 had nothing to
+              // reclaim — not that reclaim failed. Without this the two are
+              // indistinguishable in the logs.
+              tabsEvicted: tier1TabsEvicted,
               pressureRemains,
               resampleFailed,
             });
@@ -637,14 +670,77 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             // doesn't leave the cooldown unconsumed and let the next poll
             // re-fire destroyHiddenWebviews(2).
             lastTier2At = Date.now();
+            // The escalation inputs, not a reclaim delta: on the common path
+            // tier 1 ran polls earlier and its cooldown blocks a re-run, so
+            // nothing has acted between `beforeMb` and `afterMb` here. This
+            // line previously logged that no-action delta as `deltaMb`, which
+            // is ~0 by construction and read as "tier 2 reclaimed nothing".
             logInfo("memory-pressure-tier2-mitigation", {
               pollCount,
               consecutivePressureCount,
-              deltaMb: Math.round(deltaMb),
+              tier1ReclaimMb: Math.round(lastTier1ReclaimMb),
+              systemPressureRemains,
             });
-            await actions.destroyHiddenWebviews(2);
-            await actions.evictCachedProjectViews?.();
-            await actions.hibernateIdleProjects();
+
+            // `afterMb` is this tier's baseline: sampled after tier 1 settled
+            // (or with no action taken at all) and before any tier-2 action.
+            const tier2BeforeMb = afterMb;
+
+            // Each action is isolated: one throwing must neither skip the
+            // levers after it nor blind the reclaim measurement below, which
+            // is this tier's whole point. Previously a thrown
+            // destroyHiddenWebviews(2) skipped both remaining levers.
+            let tier2TabsEvicted = 0;
+            try {
+              tier2TabsEvicted = await actions.destroyHiddenWebviews(2);
+            } catch (err) {
+              logWarn("memory-pressure-tier2-action-failed", {
+                action: "destroyHiddenWebviews",
+                error: String(err),
+              });
+            }
+            let tier2ViewsEvicted = 0;
+            try {
+              tier2ViewsEvicted = (await actions.evictCachedProjectViews?.()) ?? 0;
+            } catch (err) {
+              logWarn("memory-pressure-tier2-action-failed", {
+                action: "evictCachedProjectViews",
+                error: String(err),
+              });
+            }
+            try {
+              await actions.hibernateIdleProjects();
+            } catch (err) {
+              logWarn("memory-pressure-tier2-action-failed", {
+                action: "hibernateIdleProjects",
+                error: String(err),
+              });
+            }
+
+            await new Promise<void>((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS));
+
+            let tier2AfterMb = tier2BeforeMb;
+            let tier2PressureRemains = true;
+            let tier2ResampleFailed = false;
+            try {
+              const measured = measurePressure();
+              tier2AfterMb = measured.totalMb;
+              tier2PressureRemains = measured.pressureRemains;
+            } catch {
+              tier2ResampleFailed = true;
+            }
+
+            logInfo("memory-pressure-tier2-reclaim", {
+              beforeMb: Math.round(tier2BeforeMb),
+              afterMb: Math.round(tier2AfterMb),
+              deltaMb: tier2ResampleFailed
+                ? 0
+                : Math.round(Math.max(0, tier2BeforeMb - tier2AfterMb)),
+              tabsEvicted: tier2TabsEvicted,
+              viewsEvicted: tier2ViewsEvicted,
+              pressureRemains: tier2PressureRemains,
+              resampleFailed: tier2ResampleFailed,
+            });
           }
         } catch (err) {
           logWarn("memory-pressure-mitigation-failed", { error: String(err) });

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -1122,11 +1122,15 @@ describe("ProcessMemoryMonitor", () => {
 
     it("measures its own reclaim across a settle window that starts after its actions", async () => {
       mockGetAppMetrics.mockReturnValue(underPressure);
-      // Only tier 2's last lever frees anything. A delta can therefore appear
-      // only if tier 2 re-samples after its own actions — the tier-1 sample
-      // taken before them cannot see this drop.
+      // The drop lands midway through the settle window, not when the lever
+      // returns. Only a sample taken after the window can see it: an
+      // implementation that measured straight after the levers and merely
+      // delayed the log would report 0. The tier-1 sample, taken before the
+      // levers, cannot see it either.
       mockActions.hibernateIdleProjects = vi.fn().mockImplementation(async () => {
-        mockGetAppMetrics.mockReturnValue(metricsForMb(100));
+        setTimeout(() => {
+          mockGetAppMetrics.mockReturnValue(metricsForMb(100));
+        }, RECLAIM_SETTLE_MS / 2);
       });
 
       stop = startAppMetricsMonitor(mockActions);
@@ -1161,12 +1165,15 @@ describe("ProcessMemoryMonitor", () => {
       expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier2-reclaim", expect.any(Object));
     });
 
-    it("reports what each tier evicted so a zero delta is attributable", async () => {
-      // Nothing is freed, so both tiers report deltaMb 0 — the eviction counts
-      // are what separate "nothing was eligible" from "levers ran, the metric
-      // could not observe it yet".
+    it("reports what each tier destroyed so a zero delta is attributable", async () => {
+      // Nothing is freed, so both tiers report deltaMb 0 — the counts are what
+      // separate "nothing was eligible" from "levers ran, the metric could not
+      // observe it yet". Each tier returns a distinct count so a tier that
+      // reported its sibling's number would not pass.
       mockGetAppMetrics.mockReturnValue(underPressure);
-      mockActions.destroyHiddenWebviews = vi.fn().mockResolvedValue(2);
+      mockActions.destroyHiddenWebviews = vi
+        .fn()
+        .mockImplementation(async (tier: 1 | 2) => (tier === 1 ? 2 : 4));
       mockActions.evictCachedProjectViews = vi.fn().mockResolvedValue(3);
 
       stop = startAppMetricsMonitor(mockActions);
@@ -1174,11 +1181,11 @@ describe("ProcessMemoryMonitor", () => {
 
       expect(logInfo).toHaveBeenCalledWith(
         "memory-pressure-tier1-reclaim",
-        expect.objectContaining({ deltaMb: 0, tabsEvicted: 2 })
+        expect.objectContaining({ deltaMb: 0, portalTabsDestroyed: 2 })
       );
       expect(logInfo).toHaveBeenCalledWith(
         "memory-pressure-tier2-reclaim",
-        expect.objectContaining({ deltaMb: 0, tabsEvicted: 2, viewsEvicted: 3 })
+        expect.objectContaining({ deltaMb: 0, portalTabsDestroyed: 4, viewsEvicted: 3 })
       );
     });
 
@@ -1221,7 +1228,7 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
       expect(logInfo).toHaveBeenCalledWith(
         "memory-pressure-tier2-reclaim",
-        expect.objectContaining({ deltaMb: 2400, tabsEvicted: 0 })
+        expect.objectContaining({ deltaMb: 2400, portalTabsDestroyed: 0 })
       );
     });
   });

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -497,9 +497,9 @@ describe("ProcessMemoryMonitor", () => {
 
     beforeEach(() => {
       mockActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
-        evictCachedProjectViews: vi.fn().mockResolvedValue(undefined),
+        evictCachedProjectViews: vi.fn().mockResolvedValue(0),
       };
     });
 
@@ -620,9 +620,9 @@ describe("ProcessMemoryMonitor", () => {
 
     beforeEach(() => {
       mockActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
-        evictCachedProjectViews: vi.fn().mockResolvedValue(undefined),
+        evictCachedProjectViews: vi.fn().mockResolvedValue(0),
       };
       originalGetSystemMemoryInfo = (process as { getSystemMemoryInfo?: unknown })
         .getSystemMemoryInfo;
@@ -739,7 +739,7 @@ describe("ProcessMemoryMonitor", () => {
 
     beforeEach(() => {
       mockActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
       };
     });
@@ -760,6 +760,7 @@ describe("ProcessMemoryMonitor", () => {
       });
       mockActions.destroyHiddenWebviews = vi.fn().mockImplementation(async (tier) => {
         if (tier === 1) postMitigation = true;
+        return 0;
       });
     }
 
@@ -1082,6 +1083,149 @@ describe("ProcessMemoryMonitor", () => {
     });
   });
 
+  describe("tier-2 reclaim measurement (issue #11211)", () => {
+    let mockActions: MemoryPressureActions;
+
+    beforeEach(() => {
+      mockActions = {
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        evictCachedProjectViews: vi.fn().mockResolvedValue(0),
+      };
+    });
+
+    // Aggregate-only pressure: 5 × 500 MB Tabs = 2500 MB, over the 2048 MB
+    // (25% of 8 GB) ceiling, with no single Tab over its 768 MB threshold.
+    function metricsForMb(totalMb: number): Electron.ProcessMetric[] {
+      return [makeMetric("Tab", totalMb * 1024, 201)];
+    }
+
+    const underPressure = [
+      makeMetric("Tab", 500 * 1024, 201),
+      makeMetric("Tab", 500 * 1024, 202),
+      makeMetric("Tab", 500 * 1024, 203),
+      makeMetric("Tab", 500 * 1024, 204),
+      makeMetric("Tab", 500 * 1024, 205),
+    ];
+
+    // Tier 1 fires on the first pressure poll; its 5-min cooldown then blocks
+    // a re-run, so when tier 2 escalates two polls later it is the only tier
+    // acting in that cycle and its settle is the only one left to drive. The
+    // aligned poll fires at the very end of each 30s advance, so the loop
+    // leaves the mitigation parked on that settle.
+    async function advanceToTier2(): Promise<void> {
+      for (let i = 0; i < WARMUP_INTERVALS + PRESSURE_COUNT_TIER2; i++) {
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
+    }
+
+    it("measures its own reclaim across a settle window that starts after its actions", async () => {
+      mockGetAppMetrics.mockReturnValue(underPressure);
+      // Only tier 2's last lever frees anything. A delta can therefore appear
+      // only if tier 2 re-samples after its own actions — the tier-1 sample
+      // taken before them cannot see this drop.
+      mockActions.hibernateIdleProjects = vi.fn().mockImplementation(async () => {
+        mockGetAppMetrics.mockReturnValue(metricsForMb(100));
+      });
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advanceToTier2();
+
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier2-reclaim",
+        expect.objectContaining({
+          beforeMb: 2500,
+          afterMb: 100,
+          deltaMb: 2400,
+          pressureRemains: false,
+        })
+      );
+    });
+
+    it("does not emit its reclaim log before the settle window elapses", async () => {
+      mockGetAppMetrics.mockReturnValue(underPressure);
+      stop = startAppMetricsMonitor(mockActions);
+
+      for (let i = 0; i < WARMUP_INTERVALS + PRESSURE_COUNT_TIER2; i++) {
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+
+      // Tier 2's levers have all run, but the reclaim is only measured once
+      // the settle window elapses — reporting before it would sample memory
+      // the levers have not had a chance to release.
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+      expect(logInfo).not.toHaveBeenCalledWith("memory-pressure-tier2-reclaim", expect.any(Object));
+
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
+      expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier2-reclaim", expect.any(Object));
+    });
+
+    it("reports what each tier evicted so a zero delta is attributable", async () => {
+      // Nothing is freed, so both tiers report deltaMb 0 — the eviction counts
+      // are what separate "nothing was eligible" from "levers ran, the metric
+      // could not observe it yet".
+      mockGetAppMetrics.mockReturnValue(underPressure);
+      mockActions.destroyHiddenWebviews = vi.fn().mockResolvedValue(2);
+      mockActions.evictCachedProjectViews = vi.fn().mockResolvedValue(3);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advanceToTier2();
+
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({ deltaMb: 0, tabsEvicted: 2 })
+      );
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier2-reclaim",
+        expect.objectContaining({ deltaMb: 0, tabsEvicted: 2, viewsEvicted: 3 })
+      );
+    });
+
+    it("logs tier-2 escalation inputs instead of a no-action delta", async () => {
+      // The mitigation line used to carry `deltaMb` from a before/after pair
+      // sampled back-to-back with nothing acting between them — ~0 by
+      // construction, and read as "tier 2 reclaimed nothing".
+      mockGetAppMetrics.mockReturnValue(underPressure);
+      stop = startAppMetricsMonitor(mockActions);
+      await advanceToTier2();
+
+      const mitigation = vi
+        .mocked(logInfo)
+        .mock.calls.find(([event]) => event === "memory-pressure-tier2-mitigation");
+
+      expect(mitigation).toBeDefined();
+      expect(mitigation?.[1]).not.toHaveProperty("deltaMb");
+      expect(mitigation?.[1]).toMatchObject({
+        tier1ReclaimMb: 0,
+        systemPressureRemains: false,
+      });
+    });
+
+    it("still measures reclaim when a tier-2 lever throws", async () => {
+      // A failing lever must not skip the levers after it or blind the
+      // measurement — the reclaim log is the point of the tier.
+      mockGetAppMetrics.mockReturnValue(underPressure);
+      mockActions.destroyHiddenWebviews = vi.fn().mockImplementation(async (tier: 1 | 2) => {
+        if (tier === 2) throw new Error("portal manager gone");
+        return 0;
+      });
+      mockActions.hibernateIdleProjects = vi.fn().mockImplementation(async () => {
+        mockGetAppMetrics.mockReturnValue(metricsForMb(100));
+      });
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advanceToTier2();
+
+      expect(mockActions.evictCachedProjectViews).toHaveBeenCalledTimes(1);
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier2-reclaim",
+        expect.objectContaining({ deltaMb: 2400, tabsEvicted: 0 })
+      );
+    });
+  });
+
   describe("blink memory sampling (issue #6272)", () => {
     beforeEach(() => {
       // Sample map is module-scoped; clear per-test so order doesn't matter.
@@ -1137,7 +1281,7 @@ describe("ProcessMemoryMonitor", () => {
     it("startAppMetricsMonitor invokes actions.sampleBlinkMemory once per poll", () => {
       const sampleBlinkMemory = vi.fn();
       const actions: MemoryPressureActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleBlinkMemory,
       };
@@ -1159,7 +1303,7 @@ describe("ProcessMemoryMonitor", () => {
         throw new Error("renderer port closed");
       });
       const actions: MemoryPressureActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleBlinkMemory,
       };
@@ -1178,7 +1322,7 @@ describe("ProcessMemoryMonitor", () => {
 
     it("works without sampleBlinkMemory (optional field, backwards compat)", () => {
       const actions: MemoryPressureActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
       };
 
@@ -1373,7 +1517,7 @@ describe("ProcessMemoryMonitor", () => {
     it("startAppMetricsMonitor invokes actions.sampleRendererElu once per poll", () => {
       const sampleRendererElu = vi.fn();
       const actions: MemoryPressureActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleRendererElu,
       };
@@ -1392,7 +1536,7 @@ describe("ProcessMemoryMonitor", () => {
         throw new Error("renderer port closed");
       });
       const actions: MemoryPressureActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
         sampleRendererElu,
       };
@@ -1722,7 +1866,7 @@ describe("ProcessMemoryMonitor", () => {
 
     it("works without sampleRendererElu (optional, backwards compat)", () => {
       const actions: MemoryPressureActions = {
-        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(0),
         hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
       };
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200 * 1024, 100)]);

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -721,6 +721,7 @@ describe("ProcessMemoryMonitor", () => {
         if (tier === 1) {
           mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 10 * 1024, 100)]);
         }
+        return 0;
       });
 
       stop = startAppMetricsMonitor(mockActions);

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -17,6 +17,16 @@ import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 type EvictionCandidate = [string, ViewEntry, boolean, boolean];
 
 /**
+ * workingSetSize is the only cross-platform field — privateBytes is
+ * Windows-only and reports 0 (not undefined) on macOS/Linux, so a
+ * `privateBytes ?? workingSetSize` fallback never fires there and silently
+ * logs every view as 0 KB (lesson #8646).
+ */
+function readProcessMemoryKb(proc: Electron.ProcessMetric): number {
+  return proc.memory.workingSetSize;
+}
+
+/**
  * Whether destroying `entry` would kill a running Daintree Assistant (#11157).
  *
  * Three conditions, all load-bearing:
@@ -84,11 +94,12 @@ export function evictDeadView(
   });
 }
 
+/** Returns the number of views actually evicted — 0 means nothing was eligible. */
 export function evictStaleViews(
   host: ProjectViewManager,
   reason: EvictionReason,
   forcePressure = false
-): void {
+): number {
   // Override the user-configured cap when system memory is low so we can
   // reclaim Chromium renderers (~100–500 MB each) before the OS hits
   // compressed-RAM throttling. The override is per-pass — `maxCachedViews`
@@ -103,8 +114,8 @@ export function evictStaleViews(
   const effectiveMax = lowMemoryOverride ? 1 : host.maxCachedViews;
   const effectiveReason: EvictionReason = lowMemoryOverride ? "pressure" : reason;
 
-  if (host.views.size <= effectiveMax) return;
-  if (host.activeProjectId === null) return;
+  if (host.views.size <= effectiveMax) return 0;
+  if (host.activeProjectId === null) return 0;
 
   if (lowMemoryOverride) {
     logInfo("projectview.pressure-override", {
@@ -115,7 +126,7 @@ export function evictStaleViews(
     });
   }
 
-  // Build pid → privateBytes index from the synchronous app.getAppMetrics()
+  // Build pid → memory index from the synchronous app.getAppMetrics()
   // snapshot. Joined per-view via `webContents.getOSProcessId()` so the
   // eviction log line can record each evicted view's footprint. Memory size
   // does not drive eviction order — the largest renderer is typically the
@@ -126,8 +137,8 @@ export function evictStaleViews(
     // Shared TTL snapshot: the eviction log line tolerates a few seconds of
     // staleness, so a pass landing near another sampler's sweep reuses it.
     for (const proc of getAppMetricsSnapshot()) {
-      const kb = proc.memory.privateBytes ?? proc.memory.workingSetSize;
-      if (typeof kb === "number" && kb > 0) {
+      const kb = readProcessMemoryKb(proc);
+      if (kb > 0) {
         memoryByPid.set(proc.pid, kb);
       }
     }
@@ -204,6 +215,7 @@ export function evictStaleViews(
     ? [...safeToEvict, ...activeAgentFallback, ...assistantProtected]
     : [...safeToEvict, ...activeAgentFallback];
 
+  let evictedCount = 0;
   while (host.views.size > effectiveMax && candidates.length > 0) {
     const [projectId, entry, activeAgent, liveAssistantBackend] = candidates.shift()!;
     const ageMs = Date.now() - entry.lastUsed;
@@ -222,6 +234,7 @@ export function evictStaleViews(
     logInfo("projectview.eviction", ctx);
     host.evictionTimestamps.set(projectId, Date.now());
     cleanupEntry(host, projectId);
+    evictedCount++;
   }
 
   // The cache is deliberately over its cap because protecting a running
@@ -236,6 +249,8 @@ export function evictStaleViews(
       protectedProjectIds: assistantProtected.map(([projectId]) => projectId),
     });
   }
+
+  return evictedCount;
 }
 
 /**
@@ -255,8 +270,8 @@ export function sampleCachedViewMemory(host: ProjectViewManager): void {
     // samplers near the 30s aligned sweeps reuse them instead of stacking
     // additional full-process-table scans.
     for (const proc of getAppMetricsSnapshot()) {
-      const kb = proc.memory.privateBytes ?? proc.memory.workingSetSize;
-      if (typeof kb === "number" && kb > 0) {
+      const kb = readProcessMemoryKb(proc);
+      if (kb > 0) {
         memoryByPid.set(proc.pid, kb);
       }
     }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -530,8 +530,9 @@ export class ProjectViewManager {
     EvictionController.maybeEvictUnderPressure(this);
   }
 
-  reclaimCachedViewsUnderPressure(): void {
-    EvictionController.evictStaleViews(this, "pressure", true);
+  /** Returns the number of cached views evicted — 0 means nothing was eligible. */
+  reclaimCachedViewsUnderPressure(): number {
+    return EvictionController.evictStaleViews(this, "pressure", true);
   }
 
   /**

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -938,8 +938,8 @@ describe("ProjectViewManager — eviction safety", () => {
     const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
     const wcB = wcBEntry?.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 50 * 1024 } },
-      { pid: wcB.osPid, memory: { privateBytes: 800 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 50 * 1024, privateBytes: 0 } },
+      { pid: wcB.osPid, memory: { workingSetSize: 800 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
@@ -1045,7 +1045,7 @@ describe("ProjectViewManager — eviction safety", () => {
     // not influence the sort — proj-a is the LRU pick and wins eviction
     // priority regardless of which side has metrics.
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 600 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 600 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
@@ -1077,13 +1077,13 @@ describe("ProjectViewManager — eviction safety", () => {
     // proj-a is huge but has an active agent — must not be evicted.
     // proj-b is smaller but evictable.
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 900 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 900 * 1024, privateBytes: 0 } },
       {
         pid: (
           managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
             .webContents as unknown as ReturnType<typeof createMockWebContents>
         ).osPid,
-        memory: { privateBytes: 100 * 1024 },
+        memory: { workingSetSize: 100 * 1024, privateBytes: 0 },
       },
     ] as unknown as Electron.ProcessMetric[]);
     mockGetAllTerminals.mockResolvedValue([
@@ -1118,8 +1118,11 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.switchTo("proj-b", "/path/b");
     await flushImmediates();
 
+    // macOS/Linux shape: privateBytes is reported as 0 (not undefined) off
+    // Windows, so a `privateBytes ?? workingSetSize` read resolves to 0 and
+    // silently drops memoryKb from every eviction line (#8646).
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 250 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     // Sweep fresh: a background sample timer may have cached empty metrics
@@ -1197,9 +1200,9 @@ describe("ProjectViewManager — eviction safety", () => {
     // dropping to 2, the two oldest (a, b) evict and proj-c survives,
     // regardless of their memory footprint.
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 800 * 1024 } },
-      { pid: wcB.osPid, memory: { privateBytes: 100 * 1024 } },
-      { pid: wcC.osPid, memory: { privateBytes: 900 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 800 * 1024, privateBytes: 0 } },
+      { pid: wcB.osPid, memory: { workingSetSize: 100 * 1024, privateBytes: 0 } },
+      { pid: wcC.osPid, memory: { workingSetSize: 900 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     managerWithLimit.setCachedViewLimit(2);
@@ -1588,9 +1591,12 @@ describe("ProjectViewManager — telemetry", () => {
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")?.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
+    // macOS/Linux shape — privateBytes is 0 there, not undefined, so a
+    // `privateBytes ?? workingSetSize` read resolves to 0 and this sampler
+    // emits nothing at all rather than a zero (#8646).
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
-      { pid: wcB.osPid, memory: { privateBytes: 300 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 250 * 1024, privateBytes: 0 } },
+      { pid: wcB.osPid, memory: { workingSetSize: 300 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     // Sweep fresh: a background sample timer may have cached empty metrics
@@ -1640,8 +1646,8 @@ describe("ProjectViewManager — telemetry", () => {
     mockGetAllWebContents.mockReturnValue([guest]);
 
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
-      { pid: guestPid, memory: { privateBytes: 400 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 250 * 1024, privateBytes: 0 } },
+      { pid: guestPid, memory: { workingSetSize: 400 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     // Sweep fresh: a background sample timer may have cached empty metrics
@@ -1678,7 +1684,7 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 250 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     vi.mocked(logInfo).mockClear();
@@ -1751,7 +1757,7 @@ describe("ProjectViewManager — telemetry", () => {
     });
 
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcBPid, memory: { privateBytes: 400 * 1024 } },
+      { pid: wcBPid, memory: { workingSetSize: 400 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     // Sweep fresh: a background sample timer may have cached empty metrics
@@ -1824,7 +1830,7 @@ describe("ProjectViewManager — telemetry", () => {
     await flushImmediates();
 
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
+      { pid: wcA.osPid, memory: { workingSetSize: 250 * 1024, privateBytes: 0 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     manager.dispose();
@@ -2453,10 +2459,27 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
 
-    manager.reclaimCachedViewsUnderPressure();
+    const evicted = manager.reclaimCachedViewsUnderPressure();
 
     expect(manager.getAllViews().map((view) => view.projectId)).toEqual(["proj-c"]);
     expect(wcA.close).toHaveBeenCalled();
+    // The count is what makes a zero reclaim delta attributable upstream
+    // (#11211) — proj-a and proj-b both went.
+    expect(evicted).toBe(2);
+  });
+
+  it("pressure reclaim reports zero when only the active view is cached", async () => {
+    // Nothing is eligible, so the memory-pressure ladder must be able to tell
+    // "nothing to evict" apart from "evicted, but the metric saw no drop".
+    stubSystemMemoryInfo({ free: 2 * 1024 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+    await flushImmediates();
+
+    expect(manager.reclaimCachedViewsUnderPressure()).toBe(0);
+    expect(wcA.close).not.toHaveBeenCalled();
   });
 
   it("periodic pressure check evicts cached views while idle — no project switch needed", async () => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1138,6 +1138,40 @@ describe("ProjectViewManager — eviction safety", () => {
     );
   });
 
+  it("reports the working set, not privateBytes, when both are populated", async () => {
+    // Windows shape: both fields carry distinct non-zero values. The eviction
+    // log standardises on the working set across all three platforms, so the
+    // divergent privateBytes must not win.
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
+
+    mockGetAppMetrics.mockReturnValue([
+      { pid: wcA.osPid, memory: { workingSetSize: 250 * 1024, privateBytes: 900 * 1024 } },
+    ] as unknown as Electron.ProcessMetric[]);
+
+    resetAppMetricsSnapshotForTesting();
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
+
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({ projectId: "proj-a", memoryKb: 250 * 1024 })
+    );
+  });
+
   it("falls back to LRU when app.getAppMetrics() throws", async () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -380,6 +380,7 @@ export async function initGlobalServices(
       setStopAppMetricsMonitor(
         startAppMetricsMonitor({
           destroyHiddenWebviews: async (tier) => {
+            let tabsEvicted = 0;
             if (windowRegistry) {
               for (const wCtx of windowRegistry.all()) {
                 if (wCtx.browserWindow.isDestroyed()) continue;
@@ -387,6 +388,7 @@ export async function initGlobalServices(
                   if (wCtx.services.portalManager) {
                     const evictedTabIds = await wCtx.services.portalManager.destroyHiddenTabs();
                     if (evictedTabIds.length > 0) {
+                      tabsEvicted += evictedTabIds.length;
                       sendToRenderer(wCtx.browserWindow, CHANNELS.PORTAL_TABS_EVICTED, {
                         tabIds: evictedTabIds,
                       });
@@ -405,15 +407,19 @@ export async function initGlobalServices(
                 }
               }
             }
+            return tabsEvicted;
           },
           hibernateIdleProjects: async () => {
             await getHibernationService().hibernateUnderMemoryPressure();
           },
           evictCachedProjectViews: () => {
-            if (!windowRegistry) return;
+            if (!windowRegistry) return 0;
+            let viewsEvicted = 0;
             for (const wCtx of windowRegistry.all()) {
-              wCtx.services.projectViewManager?.reclaimCachedViewsUnderPressure();
+              viewsEvicted +=
+                wCtx.services.projectViewManager?.reclaimCachedViewsUnderPressure() ?? 0;
             }
+            return viewsEvicted;
           },
           trimPtyHostState: () => {
             getPtyClient()?.trimState(SCROLLBACK_BACKGROUND);


### PR DESCRIPTION
## Summary

- Issue #11211 reported memory-pressure reclaim passes freeing almost nothing (deltas of 0, 6, 0, 29, 0, 0, 0, 0, 0 MB across 9 passes) and asked for two new levers plus an `activityBuffer` cleanup.
- A good chunk of that evidence turned out to be a logging bug, not a reclaim failure. Tier 2 was never actually measured.
- This PR fixes the measurement, evaluates and rejects both proposed levers with evidence, and fixes an unrelated eviction telemetry bug it surfaced along the way.

## What the issue reported

The issue reported memory-pressure reclaim passes freeing almost no memory, citing measured deltas of 0, 6, 0, 29, 0, 0, 0, 0, 0 MB across 9 passes, often with `pressureRemains: true` afterward. It asked for two new levers to be evaluated (xterm's `clearTextureAtlas()` for hidden terminals, a GC nudge after terminal teardown) plus a small `activityBuffer` cleanup, and asked that each pass log measured before/after so effectiveness is verifiable.

## The headline finding

A chunk of that evidence is the logging bug, not a reclaim failure.

`memory-pressure-tier2-mitigation` logged a `deltaMb` that's close to zero by construction. On the common escalation path, tier 1 already fired polls earlier and its 5 minute cooldown blocks a rerun, so `beforeMb` and `afterMb` get sampled back to back with nothing acting in between.

And tier 2 itself was never measured at all. `afterMb` was sampled before tier 2's actions ran, and the mitigation block ended right after those actions. So tier 2's effectiveness has never once been recorded.

## What changed

- Tier 2 now takes its own settle window and re-sample, emitting a new `memory-pressure-tier2-reclaim` event with its own before/after/delta.
- `memory-pressure-tier2-mitigation` drops the meaningless delta and instead logs the actual escalation inputs, `tier1ReclaimMb` and `systemPressureRemains`: why tier 2 fired.
- Both tiers now report `portalTabsDestroyed` and `viewsEvicted` counts, so a zero delta is readable as either "nothing was eligible" or "levers ran, the metric couldn't see it yet." That distinction matters because Chromium's PartitionAlloc decommit is idle-driven and lazy, so a 3 second settle window genuinely can't always observe a real win. A zero isn't proof a lever did nothing.
- Each tier-2 lever is now isolated. Previously, an error thrown by `destroyHiddenWebviews(2)` would skip the remaining levers and the measurement entirely.
- `ProjectViewEvictionController` now reads `workingSetSize` unconditionally. `privateBytes` is Windows-only and reports 0, not undefined, off Windows, so the `privateBytes ?? workingSetSize` fallback never fired there: every evicted view logged `memoryKb: 0` on macOS and Linux, and `projectview.cached-memory` telemetry emitted nothing at all, since it skips when `memoryKb <= 0`. This is the same bug #8646 already fixed in `ProcessMemoryMonitor`; this file was the only one missed. The test fixtures mocked a Windows-only metric shape (`privateBytes` with no `workingSetSize`) and so encoded the very bug they hid. Fixed those too, plus a new Windows-shaped case pinning that `workingSetSize` wins.

## On the two proposed levers: evaluated and rejected

`clearTextureAtlas()` for hidden terminals would corrupt visible ones. The atlas is a module-global shared by every terminal with matching font, theme, and DPR, so clearing it blanks sibling terminals until their next resize. The codebase already documents this: first-party comments in `TerminalInstanceService.ts` and `TerminalWebGLManager.ts` note it's deliberately avoided for exactly this reason (#9701), and the behavior persists in the xterm 6.1 betas we're on.

The GC-nudge premise doesn't hold. `global.gc()` returns memory to V8's free list, not the OS, so RSS and `workingSetSize` stay flat. It would measure as roughly zero reclaimed, which is the exact symptom being reported. Worth noting too: the `if (global.gc) global.gc()` call in `pty-host/handlers/stateConfig.ts` is dead code, since the pty-host process has no `--expose-gc` flag.

The `activityBuffer` "leak" isn't one. `flushPanelStatusBuffer` clears all three buffers on every RAF flush, and the fold already skips patches for removed panels, so entries live at most one frame. `cancelTerminalFlowState`'s deletions exist for a correctness reason (#9899, a stale "paused" pill), and its docblock says leaving activity data intact is deliberate.

## Why no new lever ships here

The real gap is architectural. Tier 1 only tears down `<webview>` guest content and trims the pty-host's buffers. Tier 2 only touches stale, cached, and idle content. Nothing in either tier reaches the active foreground view holding the live terminals, which is why full project-view eviction is the only thing that's ever moved the needle.

Two candidate levers exist for that gap: the fully-plumbed-but-unreachable `terminal:reduce-scrollback` channel (landed in 54c1320ec with a renderer listener but no main-side sender), and an active-view purge via the existing safe `purgeMemoryWebContents`. Both are behavioral/UX tradeoffs, and #10948 is the recorded lesson of shipping a reclaim design on an unverified premise and reverting it wholesale. There's no honest metric to evaluate them against today. This PR builds that metric; the levers get their own issue and real data.

Please open a follow-up issue capturing that lever work (the dead `terminal:reduce-scrollback` plumbing, the active-view purge option, and the architectural gap) and reference it from here.

## Testing

- `ProcessMemoryMonitor.test.ts`, `ProjectViewManager.eviction.test.ts`, `globalServicesInit.order.test.ts`, `ResourceProfileService.test.ts`, `HibernationService.test.ts`: 302 tests passing.
- Prettier and ESLint clean on all changed files.

Resolves #11211
