### PR TITLE
perf(terminal): stop full-rate terminal work in hidden cached project views

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -780,6 +780,31 @@ function _typedOn<K extends Extract<keyof IpcEventMap, string>>(
   return () => ipcRenderer.removeListener(channel, handler);
 }
 
+/**
+ * Latched view-cache state, tracked from preload evaluation onward (#11212).
+ *
+ * The app:view-* signals are non-replaying `ipcRenderer.on` edges, and main
+ * releases a cold switch at the pre-React skeleton — so a switch storm can
+ * cache a view long before its deferred module graph evaluates and subscribes,
+ * and the renderer would never learn it is cached. Preload runs before any page
+ * script, so latching here gives a late subscriber an authoritative snapshot to
+ * seed from instead of defaulting to "not cached" and running the full-rate
+ * terminal work this issue exists to stop.
+ */
+let _viewCached = false;
+ipcRenderer.on(CHANNELS.APP_VIEW_CACHED, () => {
+  _viewCached = true;
+});
+// Warm activation — not reveal — owns the clear: main only sends
+// APP_VIEW_REVEALED while the view is still the active project, so a superseded
+// switch delivers warm-activated alone. Reveal clears too, defensively.
+ipcRenderer.on(CHANNELS.APP_VIEW_WARM_ACTIVATED, () => {
+  _viewCached = false;
+});
+ipcRenderer.on(CHANNELS.APP_VIEW_REVEALED, () => {
+  _viewCached = false;
+});
+
 // Shared multiplexer for the typed event bus. All `window.electron.events.on`
 // subscribers — plus the migrated per-domain helpers below (terminal.onExit,
 // window.onFullscreenChange, etc.) — dispatch through a single ipcRenderer
@@ -1519,6 +1544,7 @@ function buildElectronApi(): ElectronAPI {
       onViewWarmActivated: (callback: () => void) =>
         _typedOn(CHANNELS.APP_VIEW_WARM_ACTIVATED, callback),
       onViewCached: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_CACHED, callback),
+      isViewCached: () => _viewCached,
     },
 
     menu: buildMenuPreloadBindings(_unwrappingInvoke),

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -430,6 +430,19 @@ export async function performSwitch(
       }
       previousEntry.state = "active";
       previousEntry.lastUsed = Date.now();
+      // If the failure landed after deactivateEntry, this view already received
+      // APP_VIEW_CACHED and demoted its periodic terminal work (watchdog sweep,
+      // reflow heartbeat, activity markers — #11212). It is about to be the
+      // visible active view again, so it needs the matching un-gate signal:
+      // without it a rolled-back view stays demoted for the rest of its life,
+      // and an xterm renderer paused while it was occluded would never unpause.
+      // Warm-activated is the right edge — reveal is reserved for the composited
+      // foreground and is skipped when a switch is superseded.
+      try {
+        previousEntry.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED);
+      } catch {
+        // non-critical — a destroyed renderer has nothing to un-gate
+      }
       // Re-fire the view-ready hook so per-view IPC helpers re-bind to the
       // rolled-back active view, matching the load/reload path that normally
       // fires it for the active view.

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -475,7 +475,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * script), making this the authoritative snapshot a late subscriber seeds
      * from (#11212).
      */
-    isViewCached(): boolean;
+    isViewCached?(): boolean;
   };
   // menu is generated — see GeneratedElectronAPI.
   logs: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -466,6 +466,16 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      */
     onViewWarmActivated(callback: () => void): () => void;
     onViewCached(callback: () => void): () => void;
+    /**
+     * Whether main currently has this view cached. The three signals above are
+     * non-replaying `ipcRenderer.on` edges, and a cold switch is released at
+     * the pre-React skeleton — so a switch storm can cache a view before its
+     * module graph evaluates and subscribes, losing the edge entirely. Preload
+     * latches the state from its own evaluation onward (before any page
+     * script), making this the authoritative snapshot a late subscriber seeds
+     * from (#11212).
+     */
+    isViewCached(): boolean;
   };
   // menu is generated — see GeneratedElectronAPI.
   logs: {

--- a/src/lib/__tests__/viewCacheState.node.test.ts
+++ b/src/lib/__tests__/viewCacheState.node.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetProjectViewCacheStateForTests,
+  isProjectViewCached,
+  subscribeProjectViewLifecycle,
+} from "../viewCacheState";
+
+/**
+ * `TerminalInstanceService` builds its controllers at module scope, so every
+ * suite that imports anything downstream of it — action definitions, the panel
+ * registry, worktree stores — evaluates this module too. Many of those run under
+ * the node environment, where `window` is undeclared rather than empty: a bare
+ * read throws a ReferenceError that `?.` cannot catch, and the whole suite fails
+ * to load. jsdom-only coverage cannot see this.
+ */
+describe("viewCacheState without a DOM", () => {
+  afterEach(() => {
+    __resetProjectViewCacheStateForTests();
+  });
+
+  it("does not throw when window is undeclared", () => {
+    expect(typeof window).toBe("undefined");
+    expect(() => isProjectViewCached()).not.toThrow();
+  });
+
+  it("reports not-cached — no window means no view lifecycle", () => {
+    expect(isProjectViewCached()).toBe(false);
+  });
+
+  it("allows subscribing and unsubscribing without a DOM", () => {
+    let off: (() => void) | undefined;
+    expect(() => {
+      off = subscribeProjectViewLifecycle(() => {});
+    }).not.toThrow();
+    expect(() => off?.()).not.toThrow();
+  });
+
+  it("survives a reset with no bridge to detach", () => {
+    subscribeProjectViewLifecycle(() => {});
+    expect(() => __resetProjectViewCacheStateForTests()).not.toThrow();
+    expect(isProjectViewCached()).toBe(false);
+  });
+});

--- a/src/lib/__tests__/viewCacheState.test.ts
+++ b/src/lib/__tests__/viewCacheState.test.ts
@@ -38,7 +38,7 @@ function installElectronStub(latchedCached = false): {
   const offWarmActivated = vi.fn();
   const offRevealed = vi.fn();
 
-  (window as unknown as { electron: unknown }).electron = {
+  vi.stubGlobal("electron", {
     app: {
       onViewCached: (cb: () => void) => {
         counts.cached += 1;
@@ -57,7 +57,7 @@ function installElectronStub(latchedCached = false): {
         return offRevealed;
       },
     },
-  };
+  });
 
   return {
     emit: {
@@ -79,7 +79,7 @@ describe("viewCacheState", () => {
 
   afterEach(() => {
     __resetProjectViewCacheStateForTests();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
   });
 
   it("reports not-cached by default so a cold view is never demoted", () => {
@@ -205,7 +205,7 @@ describe("viewCacheState", () => {
     // so a late first query must report cached — not the false default that
     // would leave the view running full-rate terminal work.
     __resetProjectViewCacheStateForTests();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
     stub = installElectronStub(true);
 
     expect(isProjectViewCached()).toBe(true);
@@ -213,7 +213,7 @@ describe("viewCacheState", () => {
 
   it("still tracks live transitions after seeding from a cached latch", () => {
     __resetProjectViewCacheStateForTests();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
     stub = installElectronStub(true);
     expect(isProjectViewCached()).toBe(true);
 
@@ -226,20 +226,20 @@ describe("viewCacheState", () => {
     // Defensive: an older/partial bridge must degrade to the un-demoted answer
     // rather than throwing on the hot query path.
     __resetProjectViewCacheStateForTests();
-    (window as unknown as { electron: unknown }).electron = {
+    vi.stubGlobal("electron", {
       app: {
         onViewCached: () => vi.fn(),
         onViewWarmActivated: () => vi.fn(),
         onViewRevealed: () => vi.fn(),
       },
-    };
+    });
 
     expect(isProjectViewCached()).toBe(false);
   });
 
   it("answers not-cached when the electron bridge is unavailable", () => {
     __resetProjectViewCacheStateForTests();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
 
     expect(isProjectViewCached()).toBe(false);
     expect(() => subscribeProjectViewLifecycle(vi.fn())).not.toThrow();

--- a/src/lib/__tests__/viewCacheState.test.ts
+++ b/src/lib/__tests__/viewCacheState.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetProjectViewCacheStateForTests,
+  isProjectViewCached,
+  subscribeProjectViewLifecycle,
+  type ProjectViewLifecyclePhase,
+} from "../viewCacheState";
+
+type Emitters = {
+  cached: () => void;
+  warmActivated: () => void;
+  revealed: () => void;
+};
+
+/**
+ * Install a `window.electron.app` stub whose three lifecycle channels can be
+ * fired on demand, mirroring what ProjectViewLifecycleController /
+ * ProjectViewSwitchController send. Returns the emitters plus the per-channel
+ * unsubscribe spies so listener hygiene is assertable.
+ */
+function installElectronStub(): {
+  emit: Emitters;
+  offSpies: { cached: ReturnType<typeof vi.fn> };
+  registrationCounts: () => { cached: number; warmActivated: number; revealed: number };
+} {
+  const handlers: {
+    cached: Array<() => void>;
+    warm: Array<() => void>;
+    revealed: Array<() => void>;
+  } = { cached: [], warm: [], revealed: [] };
+  const counts = { cached: 0, warmActivated: 0, revealed: 0 };
+  const offCached = vi.fn();
+
+  (window as unknown as { electron: unknown }).electron = {
+    app: {
+      onViewCached: (cb: () => void) => {
+        counts.cached += 1;
+        handlers.cached.push(cb);
+        return offCached;
+      },
+      onViewWarmActivated: (cb: () => void) => {
+        counts.warmActivated += 1;
+        handlers.warm.push(cb);
+        return vi.fn();
+      },
+      onViewRevealed: (cb: () => void) => {
+        counts.revealed += 1;
+        handlers.revealed.push(cb);
+        return vi.fn();
+      },
+    },
+  };
+
+  return {
+    emit: {
+      cached: () => handlers.cached.forEach((h) => h()),
+      warmActivated: () => handlers.warm.forEach((h) => h()),
+      revealed: () => handlers.revealed.forEach((h) => h()),
+    },
+    offSpies: { cached: offCached },
+    registrationCounts: () => ({ ...counts }),
+  };
+}
+
+describe("viewCacheState", () => {
+  let stub: ReturnType<typeof installElectronStub>;
+
+  beforeEach(() => {
+    stub = installElectronStub();
+  });
+
+  afterEach(() => {
+    __resetProjectViewCacheStateForTests();
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("reports not-cached by default so a cold view is never demoted", () => {
+    // A cold view never receives warm-activated — defaulting to cached would
+    // permanently demote a view that main never cached.
+    expect(isProjectViewCached()).toBe(false);
+  });
+
+  it("tracks cached -> active -> cached transitions", () => {
+    expect(isProjectViewCached()).toBe(false);
+
+    stub.emit.cached();
+    expect(isProjectViewCached()).toBe(true);
+
+    stub.emit.warmActivated();
+    expect(isProjectViewCached()).toBe(false);
+
+    stub.emit.cached();
+    expect(isProjectViewCached()).toBe(true);
+  });
+
+  it("clears the cached flag on warm-activated, not only on revealed", () => {
+    // Load-bearing: main only sends APP_VIEW_REVEALED while the view is still
+    // the active project, so a superseded switch delivers warm-activated with
+    // no revealed. If revealed owned the clear, that view would stay demoted.
+    stub.emit.cached();
+    stub.emit.warmActivated();
+
+    expect(isProjectViewCached()).toBe(false);
+  });
+
+  it("clears a stale cached flag if revealed arrives without warm-activated", () => {
+    stub.emit.cached();
+    stub.emit.revealed();
+
+    expect(isProjectViewCached()).toBe(false);
+  });
+
+  it("delivers distinct phases to subscribers in order", () => {
+    const phases: ProjectViewLifecyclePhase[] = [];
+    subscribeProjectViewLifecycle((phase) => phases.push(phase));
+
+    stub.emit.cached();
+    stub.emit.warmActivated();
+    stub.emit.revealed();
+
+    expect(phases).toEqual(["cached", "active", "revealed"]);
+  });
+
+  it("exposes the new state to a subscriber reading it during the callback", () => {
+    const seen: boolean[] = [];
+    subscribeProjectViewLifecycle(() => seen.push(isProjectViewCached()));
+
+    stub.emit.cached();
+    stub.emit.warmActivated();
+
+    expect(seen).toEqual([true, false]);
+  });
+
+  it("does not re-emit cached when already cached", () => {
+    const listener = vi.fn();
+    subscribeProjectViewLifecycle(listener);
+
+    stub.emit.cached();
+    stub.emit.cached();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers exactly one underlying listener per channel across many subscribers", () => {
+    subscribeProjectViewLifecycle(vi.fn());
+    subscribeProjectViewLifecycle(vi.fn());
+    subscribeProjectViewLifecycle(vi.fn());
+    void isProjectViewCached();
+
+    expect(stub.registrationCounts()).toEqual({ cached: 1, warmActivated: 1, revealed: 1 });
+  });
+
+  it("stops delivering to an unsubscribed listener without affecting the rest", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const offA = subscribeProjectViewLifecycle(a);
+    subscribeProjectViewLifecycle(b);
+
+    offA();
+    stub.emit.cached();
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledWith("cached");
+  });
+
+  it("keeps notifying the remaining listeners when one throws", () => {
+    const after = vi.fn();
+    subscribeProjectViewLifecycle(() => {
+      throw new Error("bad subscriber");
+    });
+    subscribeProjectViewLifecycle(after);
+
+    expect(() => stub.emit.cached()).not.toThrow();
+    expect(after).toHaveBeenCalledWith("cached");
+  });
+
+  it("still tracks state when queried without any subscriber", () => {
+    // Arming has to happen on the query path too — a query-only consumer of an
+    // unarmed module would silently read "not cached" forever.
+    expect(isProjectViewCached()).toBe(false);
+    stub.emit.cached();
+    expect(isProjectViewCached()).toBe(true);
+  });
+
+  it("answers not-cached when the electron bridge is unavailable", () => {
+    __resetProjectViewCacheStateForTests();
+    delete (window as unknown as { electron?: unknown }).electron;
+
+    expect(isProjectViewCached()).toBe(false);
+    expect(() => subscribeProjectViewLifecycle(vi.fn())).not.toThrow();
+  });
+
+  it("detaches the underlying IPC listeners on reset", () => {
+    subscribeProjectViewLifecycle(vi.fn());
+
+    __resetProjectViewCacheStateForTests();
+
+    expect(stub.offSpies.cached).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/__tests__/viewCacheState.test.ts
+++ b/src/lib/__tests__/viewCacheState.test.ts
@@ -19,9 +19,13 @@ type Emitters = {
  * ProjectViewSwitchController send. Returns the emitters plus the per-channel
  * unsubscribe spies so listener hygiene is assertable.
  */
-function installElectronStub(): {
+function installElectronStub(latchedCached = false): {
   emit: Emitters;
-  offSpies: { cached: ReturnType<typeof vi.fn> };
+  offSpies: {
+    cached: ReturnType<typeof vi.fn>;
+    warmActivated: ReturnType<typeof vi.fn>;
+    revealed: ReturnType<typeof vi.fn>;
+  };
   registrationCounts: () => { cached: number; warmActivated: number; revealed: number };
 } {
   const handlers: {
@@ -31,6 +35,8 @@ function installElectronStub(): {
   } = { cached: [], warm: [], revealed: [] };
   const counts = { cached: 0, warmActivated: 0, revealed: 0 };
   const offCached = vi.fn();
+  const offWarmActivated = vi.fn();
+  const offRevealed = vi.fn();
 
   (window as unknown as { electron: unknown }).electron = {
     app: {
@@ -39,15 +45,16 @@ function installElectronStub(): {
         handlers.cached.push(cb);
         return offCached;
       },
+      isViewCached: () => latchedCached,
       onViewWarmActivated: (cb: () => void) => {
         counts.warmActivated += 1;
         handlers.warm.push(cb);
-        return vi.fn();
+        return offWarmActivated;
       },
       onViewRevealed: (cb: () => void) => {
         counts.revealed += 1;
         handlers.revealed.push(cb);
-        return vi.fn();
+        return offRevealed;
       },
     },
   };
@@ -58,7 +65,7 @@ function installElectronStub(): {
       warmActivated: () => handlers.warm.forEach((h) => h()),
       revealed: () => handlers.revealed.forEach((h) => h()),
     },
-    offSpies: { cached: offCached },
+    offSpies: { cached: offCached, warmActivated: offWarmActivated, revealed: offRevealed },
     registrationCounts: () => ({ ...counts }),
   };
 }
@@ -98,14 +105,22 @@ describe("viewCacheState", () => {
     // Load-bearing: main only sends APP_VIEW_REVEALED while the view is still
     // the active project, so a superseded switch delivers warm-activated with
     // no revealed. If revealed owned the clear, that view would stay demoted.
+    expect(isProjectViewCached()).toBe(false); // arms the module
+
     stub.emit.cached();
+    expect(isProjectViewCached()).toBe(true);
+
     stub.emit.warmActivated();
 
     expect(isProjectViewCached()).toBe(false);
   });
 
   it("clears a stale cached flag if revealed arrives without warm-activated", () => {
+    expect(isProjectViewCached()).toBe(false); // arms the module
+
     stub.emit.cached();
+    expect(isProjectViewCached()).toBe(true);
+
     stub.emit.revealed();
 
     expect(isProjectViewCached()).toBe(false);
@@ -183,6 +198,45 @@ describe("viewCacheState", () => {
     expect(isProjectViewCached()).toBe(true);
   });
 
+  it("seeds from preload's latch when the cached edge landed before arming", () => {
+    // The signals are non-replaying edges and a cold switch is released at the
+    // pre-React skeleton, so a switch storm can cache this view before this
+    // module ever evaluates. Preload has tracked since before any page script,
+    // so a late first query must report cached — not the false default that
+    // would leave the view running full-rate terminal work.
+    __resetProjectViewCacheStateForTests();
+    delete (window as unknown as { electron?: unknown }).electron;
+    stub = installElectronStub(true);
+
+    expect(isProjectViewCached()).toBe(true);
+  });
+
+  it("still tracks live transitions after seeding from a cached latch", () => {
+    __resetProjectViewCacheStateForTests();
+    delete (window as unknown as { electron?: unknown }).electron;
+    stub = installElectronStub(true);
+    expect(isProjectViewCached()).toBe(true);
+
+    stub.emit.warmActivated();
+
+    expect(isProjectViewCached()).toBe(false);
+  });
+
+  it("tolerates a preload without the latch", () => {
+    // Defensive: an older/partial bridge must degrade to the un-demoted answer
+    // rather than throwing on the hot query path.
+    __resetProjectViewCacheStateForTests();
+    (window as unknown as { electron: unknown }).electron = {
+      app: {
+        onViewCached: () => vi.fn(),
+        onViewWarmActivated: () => vi.fn(),
+        onViewRevealed: () => vi.fn(),
+      },
+    };
+
+    expect(isProjectViewCached()).toBe(false);
+  });
+
   it("answers not-cached when the electron bridge is unavailable", () => {
     __resetProjectViewCacheStateForTests();
     delete (window as unknown as { electron?: unknown }).electron;
@@ -196,6 +250,10 @@ describe("viewCacheState", () => {
 
     __resetProjectViewCacheStateForTests();
 
+    // All three, not just cached — a regression that forgot one would leak a
+    // listener per reset.
     expect(stub.offSpies.cached).toHaveBeenCalledTimes(1);
+    expect(stub.offSpies.warmActivated).toHaveBeenCalledTimes(1);
+    expect(stub.offSpies.revealed).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/viewCacheState.ts
+++ b/src/lib/viewCacheState.ts
@@ -1,0 +1,130 @@
+/**
+ * Process-wide signal for whether this project view is currently cached —
+ * backgrounded by `ProjectViewManager` but kept alive for a fast switch back.
+ *
+ * `document.visibilityState` cannot answer this. Caching a view is
+ * `removeChildView` + `setVisible(false)` (see
+ * `ProjectViewLifecycleController.deactivateEntry`), and neither flips page
+ * visibility for a child `WebContentsView` — Chromium tracks occlusion at the
+ * `BrowserWindow` level, so a cached view reports `"visible"` forever and its
+ * `requestAnimationFrame` callbacks keep firing at the full rate. Every gate
+ * written as `document.visibilityState !== "visible"` is therefore dead code
+ * for a cached view, which is how a hidden project ended up at 4.5% CPU and
+ * 3300 idle wakeups/sec (#11212).
+ *
+ * The CPU throttle main applies alongside the cache
+ * (`Emulation.setCPUThrottlingRate`) slows each callback but does not reduce
+ * how often they fire; only a `Page.setWebLifecycleState` freeze does, and
+ * that is deliberately skipped while the cached project has a live agent —
+ * exactly the case that costs the most. So the renderer has to demote its own
+ * periodic work, and main's explicit lifecycle IPC is the only signal that
+ * reliably tracks it.
+ *
+ * Single renderer = single view. Module-level state is safe — each project
+ * view is a distinct WebContentsView with its own V8 context (see
+ * `ProjectViewManager`), so there is exactly one view per module scope. This
+ * mirrors `layoutTransitionLock`.
+ *
+ * Consumers must AND this with the visibility check they already have rather
+ * than replacing it: minimizing the window still legitimately flips
+ * `document.visibilityState`, and that suppression is independent of caching.
+ */
+
+/**
+ * - `cached` — main has detached and hidden this view. Periodic/rAF work
+ *   should stop; nothing can observe this view until it comes back.
+ * - `active` — main has re-attached the view, but it may still sit behind the
+ *   anti-flash bridge where Chromium culls paints. Timers may rearm.
+ * - `revealed` — the view is the presenting foreground surface. Deferred
+ *   catch-up work should run now.
+ */
+export type ProjectViewLifecyclePhase = "cached" | "active" | "revealed";
+
+let cached = false;
+let armed = false;
+let disarm: (() => void) | undefined;
+const listeners = new Set<(phase: ProjectViewLifecyclePhase) => void>();
+
+function emit(phase: ProjectViewLifecyclePhase): void {
+  // Snapshot — a callback may unsubscribe during iteration.
+  for (const listener of Array.from(listeners)) {
+    try {
+      listener(phase);
+    } catch {
+      // Swallow per-listener errors so one bad subscriber can't block others.
+    }
+  }
+}
+
+/**
+ * Attach to main's lifecycle broadcasts once, on first use. Arming lazily (and
+ * from the query as well as the subscribe) keeps this module free of
+ * import-time side effects while making a query-only consumer impossible to
+ * get wrong — an unarmed module would answer "not cached" forever.
+ *
+ * A cold view never receives `warm-activated`, so `cached` must default to
+ * false: the safe answer is the un-demoted one.
+ */
+function ensureArmed(): void {
+  if (armed) return;
+  armed = true;
+
+  const app = window.electron?.app;
+  if (!app) return;
+
+  const offCached = app.onViewCached?.(() => {
+    if (cached) return;
+    cached = true;
+    emit("cached");
+  });
+  // Fires on every reactivation, before the bridge is torn down. This — not
+  // `revealed` — is what clears the cached flag: main only sends `revealed`
+  // when the view is still the active project by the time the swap completes
+  // (`ProjectViewSwitchController`), so a switch superseded mid-flight would
+  // leave a reactivated view demoted forever if `revealed` owned the clear.
+  const offWarmActivated = app.onViewWarmActivated?.(() => {
+    cached = false;
+    emit("active");
+  });
+  const offRevealed = app.onViewRevealed?.(() => {
+    // Defensive: `revealed` implies the view is foreground, so it must never
+    // leave a stale cached flag behind even if `warm-activated` was missed.
+    cached = false;
+    emit("revealed");
+  });
+
+  disarm = () => {
+    offCached?.();
+    offWarmActivated?.();
+    offRevealed?.();
+  };
+}
+
+/** Whether main has this project view cached (detached + hidden). */
+export function isProjectViewCached(): boolean {
+  ensureArmed();
+  return cached;
+}
+
+/**
+ * Subscribe to view lifecycle transitions. Returns an unsubscribe. Listeners
+ * fire after the cached flag is updated, so a handler can read
+ * `isProjectViewCached()` and see the new state.
+ */
+export function subscribeProjectViewLifecycle(
+  listener: (phase: ProjectViewLifecyclePhase) => void
+): () => void {
+  ensureArmed();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function __resetProjectViewCacheStateForTests(): void {
+  disarm?.();
+  disarm = undefined;
+  armed = false;
+  cached = false;
+  listeners.clear();
+}

--- a/src/lib/viewCacheState.ts
+++ b/src/lib/viewCacheState.ts
@@ -73,6 +73,13 @@ function ensureArmed(): void {
   if (armed) return;
   armed = true;
 
+  // `TerminalInstanceService` constructs its controllers at module scope, so
+  // importing anything downstream of it runs this in node-like suites where
+  // `window` is not merely empty but undeclared — a bare read is a
+  // ReferenceError, not something `?.` can catch. No window, no view lifecycle;
+  // not-cached is the right answer.
+  if (typeof window === "undefined") return;
+
   const app = window.electron?.app;
   if (!app) return;
 

--- a/src/lib/viewCacheState.ts
+++ b/src/lib/viewCacheState.ts
@@ -62,8 +62,12 @@ function emit(phase: ProjectViewLifecyclePhase): void {
  * import-time side effects while making a query-only consumer impossible to
  * get wrong — an unarmed module would answer "not cached" forever.
  *
- * A cold view never receives `warm-activated`, so `cached` must default to
- * false: the safe answer is the un-demoted one.
+ * Seeds from preload's latch rather than assuming false. The signals are
+ * non-replaying edges and a cold switch is released at the pre-React skeleton,
+ * so a switch storm can cache this view before this module ever evaluates;
+ * preload has been tracking since before any page script ran, and is the only
+ * thing that can answer for the window we missed. Absent the bridge (or an
+ * older preload), false is the safe default — the un-demoted answer.
  */
 function ensureArmed(): void {
   if (armed) return;
@@ -71,6 +75,8 @@ function ensureArmed(): void {
 
   const app = window.electron?.app;
   if (!app) return;
+
+  cached = app.isViewCached?.() ?? false;
 
   const offCached = app.onViewCached?.(() => {
     if (cached) return;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2497,6 +2497,7 @@ class TerminalInstanceService {
     this.agentStateController.destroy(id);
     this.restoreController.destroy(id);
     this.burstController.destroy(id);
+    this.writeController.forget(id);
 
     managed.scrollbackRestoreState = "none";
 
@@ -2610,6 +2611,7 @@ class TerminalInstanceService {
     this.resizePassScheduler.dispose();
     this.reflowController.dispose();
     this.reconciliationWatchdog.dispose();
+    this.writeController.dispose();
     this.instances.forEach((_, id) => this.destroy(id));
     this.offscreenManager.dispose();
     this.webGLManager.dispose();

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -175,6 +175,10 @@ export class TerminalReconciliationWatchdog {
   /** Idempotent — a rearm while already sweeping keeps the existing timer. */
   private startSweeping(): void {
     if (this.intervalTimer !== undefined) return;
+    // See TerminalReflowController.startHeartbeat: a controller constructed
+    // during a cached window gets no "cached" phase, so the constructor's arm
+    // has to check the seeded state itself.
+    if (isProjectViewCached()) return;
     if (typeof setInterval !== "function") return;
     this.intervalTimer = setInterval(() => this.tick(), WATCHDOG_INTERVAL_MS);
   }

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -1,6 +1,7 @@
 import { Terminal } from "@xterm/xterm";
 import { TerminalRefreshTier } from "@/types";
 import { isSidebarMeasurementLocked } from "@/lib/layoutTransitionLock";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 import { logDebug, logWarn } from "@/utils/logger";
 import { hasStreamingWrites } from "./TerminalResizeController";
 import type { ManagedTerminal } from "./types";
@@ -111,6 +112,7 @@ export interface ReconciliationWatchdogDeps {
 export class TerminalReconciliationWatchdog {
   private deps: ReconciliationWatchdogDeps;
   private intervalTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly offViewLifecycle: () => void;
 
   private readonly _onVisibilityChange = (): void => {
     // The moment the document becomes visible again is when stale state is
@@ -138,9 +140,27 @@ export class TerminalReconciliationWatchdog {
   constructor(deps: ReconciliationWatchdogDeps) {
     this.deps = deps;
 
-    if (typeof setInterval === "function") {
-      this.intervalTimer = setInterval(() => this.tick(), WATCHDOG_INTERVAL_MS);
-    }
+    this.startSweeping();
+
+    // A cached view keeps reporting visibilityState "visible", so `tick`'s own
+    // guard never fires there and every terminal's host still has real,
+    // viewport-passing rect geometry — the sweep classifies panes in a hidden
+    // project as on-screen and issues real repairs against them (#11212).
+    // Stopping the interval removes both the idle wakeups and that whole class
+    // of wasted work; `tick` is gated too, for the callers that aren't this
+    // timer.
+    this.offViewLifecycle = subscribeProjectViewLifecycle((phase) => {
+      if (phase === "cached") {
+        this.stopSweeping();
+        return;
+      }
+      this.startSweeping();
+      // Same reasoning as the visibilitychange sweep: reveal is the moment
+      // stale state is most likely and most visible, so reconcile now rather
+      // than waiting out the rest of the interval.
+      if (phase === "revealed") this.tick();
+    });
+
     if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
       document.addEventListener("visibilitychange", this._onVisibilityChange);
       // Capture phase, registered on document: runs before React's
@@ -152,6 +172,19 @@ export class TerminalReconciliationWatchdog {
     }
   }
 
+  /** Idempotent — a rearm while already sweeping keeps the existing timer. */
+  private startSweeping(): void {
+    if (this.intervalTimer !== undefined) return;
+    if (typeof setInterval !== "function") return;
+    this.intervalTimer = setInterval(() => this.tick(), WATCHDOG_INTERVAL_MS);
+  }
+
+  private stopSweeping(): void {
+    if (this.intervalTimer === undefined) return;
+    clearInterval(this.intervalTimer);
+    this.intervalTimer = undefined;
+  }
+
   /**
    * One reconciliation sweep. Phase 1 batches all DOM geometry reads (rects
    * are pure reads; no repair writes layout until the read pass completes).
@@ -161,6 +194,10 @@ export class TerminalReconciliationWatchdog {
    * re-verification beats issuing several at once.
    */
   tick(): void {
+    // Guarded in the body, not just by stopping the interval: this is reachable
+    // from visibilitychange and the reveal sweep, and clearing an interval
+    // can't retract a callback the event loop has already picked up.
+    if (isProjectViewCached()) return;
     if (typeof document === "undefined" || document.visibilityState !== "visible") return;
     // Mid-drag, mid-layout-animation, and pre-hydration (#10827) geometry is
     // not ground truth, and repairs during any of them would fight legitimate
@@ -582,10 +619,8 @@ export class TerminalReconciliationWatchdog {
   }
 
   dispose(): void {
-    if (this.intervalTimer !== undefined) {
-      clearInterval(this.intervalTimer);
-      this.intervalTimer = undefined;
-    }
+    this.stopSweeping();
+    this.offViewLifecycle();
     if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
       document.removeEventListener("visibilitychange", this._onVisibilityChange);
       document.removeEventListener("pointerdown", this._onPointerDownCapture, { capture: true });

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -1,6 +1,7 @@
 import type { Terminal } from "@xterm/xterm";
 import type { ManagedTerminal } from "./types";
 import { logWarn } from "@/utils/logger";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 
 type XtermCoreRenderPause = {
   _renderService?: {
@@ -68,34 +69,19 @@ export interface ReflowControllerDeps {
 export class TerminalReflowController {
   private deps: ReflowControllerDeps;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly offViewLifecycle: () => void;
   private readonly _onVisibilityChange = (): void => {
     if (typeof document === "undefined" || document.visibilityState !== "visible") return;
-    for (const managed of this.deps.getInstances()) {
-      this.maybeReflow(managed);
-    }
+    this.sweep();
   };
   private readonly _onWindowFocus = (): void => {
-    for (const managed of this.deps.getInstances()) {
-      this.maybeReflow(managed);
-    }
+    this.sweep();
   };
 
   constructor(deps: ReflowControllerDeps) {
     this.deps = deps;
 
-    // Periodic heartbeat: recovers a terminal whose IntersectionObserver has
-    // paused rendering, even while no new writes are arriving. The pause gate
-    // lives in xterm's core RenderService, so WebGL and DOM renderers alike
-    // are affected. Cheap (~1–5ms per visible terminal). Skipped while the
-    // document is hidden — _onVisibilityChange triggers a sweep on regain.
-    if (typeof setInterval === "function") {
-      this.heartbeatTimer = setInterval(() => {
-        if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
-        for (const managed of this.deps.getInstances()) {
-          this.maybeReflow(managed);
-        }
-      }, REFLOW_HEARTBEAT_MS);
-    }
+    this.startHeartbeat();
 
     // App-level recovery: reflow visible terminals whenever the window
     // regains focus or the tab becomes visible. These are the moments a
@@ -106,6 +92,55 @@ export class TerminalReflowController {
     if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
       window.addEventListener("focus", this._onWindowFocus);
     }
+
+    // A cached view never fires visibilitychange, so the heartbeat's own
+    // visibility check can't stop it and it would keep forcing layout on
+    // terminals nobody can see (#11212). Stop the wakeups outright while
+    // cached — `maybeReflow` stays gated regardless, but only stopping the
+    // interval actually removes the idle wakeup.
+    this.offViewLifecycle = subscribeProjectViewLifecycle((phase) => {
+      if (phase === "cached") {
+        this.stopHeartbeat();
+        return;
+      }
+      this.startHeartbeat();
+      // A renderer paused while the view was cached needs the same immediate
+      // recovery visibilitychange gives a backgrounded window — waiting out
+      // the remaining heartbeat would leave the pane blank for up to 3s at the
+      // exact moment the user is looking at it.
+      if (phase === "revealed") this.sweep();
+    });
+  }
+
+  private sweep(): void {
+    for (const managed of this.deps.getInstances()) {
+      this.maybeReflow(managed);
+    }
+  }
+
+  /**
+   * Periodic heartbeat: recovers a terminal whose IntersectionObserver has
+   * paused rendering, even while no new writes are arriving. The pause gate
+   * lives in xterm's core RenderService, so WebGL and DOM renderers alike are
+   * affected. Cheap (~1–5ms per visible terminal). Idempotent — a rearm while
+   * already running keeps the existing timer rather than stacking a second.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer !== undefined) return;
+    if (typeof setInterval !== "function") return;
+    this.heartbeatTimer = setInterval(() => {
+      // maybeReflow re-applies the full gate per terminal; this is the cheap
+      // whole-sweep skip for a hidden window (visibilitychange sweeps on
+      // regain).
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+      this.sweep();
+    }, REFLOW_HEARTBEAT_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer === undefined) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = undefined;
   }
 
   /**
@@ -121,6 +156,13 @@ export class TerminalReflowController {
    * terminal.
    */
   maybeReflow(managed: ManagedTerminal): void {
+    // The decisive gate lives here rather than only on the heartbeat: the
+    // per-write path (`onWriteParsedReflow` → `maybeReflowTerminal`) calls this
+    // directly, so a streaming agent in a cached view would keep forcing layout
+    // no matter what the interval does (#11212). A cached view's
+    // visibilityState is permanently "visible", so this is the only check that
+    // sees it — the document check below still covers window-level occlusion.
+    if (isProjectViewCached()) return;
     if (!managed.isVisible) return;
     if (managed.isAttaching) return;
     if (managed.isAltBuffer) return;
@@ -154,10 +196,8 @@ export class TerminalReflowController {
   }
 
   dispose(): void {
-    if (this.heartbeatTimer !== undefined) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = undefined;
-    }
+    this.stopHeartbeat();
+    this.offViewLifecycle();
     if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
       document.removeEventListener("visibilitychange", this._onVisibilityChange);
     }

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -129,6 +129,10 @@ export class TerminalReflowController {
    */
   private startHeartbeat(): void {
     if (this.heartbeatTimer !== undefined) return;
+    // Construction can happen INSIDE a cached window: the module seeds its state
+    // from preload's latch, so there is no "cached" phase to stop a timer armed
+    // in the constructor, and it would tick unopposed until the view returns.
+    if (isProjectViewCached()) return;
     if (typeof setInterval !== "function") return;
     this.heartbeatTimer = setInterval(() => {
       // maybeReflow re-applies the full gate per terminal; this is the cheap

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -44,8 +44,10 @@ export function forceXtermReflow(element: HTMLElement): void {
 const REFLOW_THROTTLE_MS = 250;
 
 // Periodic heartbeat interval — low frequency is enough to recover a paused
-// renderer that has no writes, without costing measurable CPU.
-const REFLOW_HEARTBEAT_MS = 3000;
+// renderer that has no writes, without costing measurable CPU. Exported for the
+// same reason as the watchdog's WATCHDOG_INTERVAL_MS: tests assert the
+// one-sweep-per-interval invariant and must not hard-code the cadence.
+export const REFLOW_HEARTBEAT_MS = 3000;
 
 export interface ReflowControllerDeps {
   /**

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -1,6 +1,7 @@
 import type { ManagedTerminal } from "./types";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 
 /**
  * UTF-8 byte length of a string chunk — the unit the pty-host's IPC
@@ -129,24 +130,73 @@ export class TerminalWriteController {
   // (user-invoked scrollToLastActivity) needs at most one fresh position per
   // frame and already falls back to scrollToBottom on a disposed marker.
   private pendingMarkerRefresh = new Map<string, ManagedTerminal>();
-  private markerRefreshScheduled = false;
+  private markerRefreshRafId: number | undefined;
+  private readonly offViewLifecycle: () => void;
 
   constructor(deps: WriteControllerDeps) {
     this.deps = deps;
+    this.offViewLifecycle = subscribeProjectViewLifecycle((phase) => {
+      if (phase === "cached") {
+        this.cancelMarkerRefreshFrame();
+        return;
+      }
+      // Back in the foreground: settle the dirty set accumulated while cached.
+      // Runs on `active` (behind the anti-flash bridge) rather than waiting for
+      // `revealed`, because a superseded switch never sends `revealed` — and
+      // this is buffer bookkeeping, not a paint, so the bridge is irrelevant.
+      // The `revealed` pass then finds an empty map and no-ops.
+      this.flushActivityMarkers();
+    });
   }
 
+  /**
+   * Mark a terminal's activity marker stale and settle it on the next frame.
+   *
+   * While the project view is cached the frame is NOT scheduled: rAF still
+   * fires at full rate for a detached view (Chromium only suspends it for
+   * window-level occlusion), and each refresh allocates a Marker plus four
+   * buffer emitter subscriptions, so a streaming agent churns hundreds of
+   * alloc/dispose pairs per second into a view nobody can see. Deferring loses
+   * nothing: `registerMarker(0)` marks the cursor line as of the flush, so one
+   * flush on reveal lands exactly where the last hidden-frame refresh would
+   * have, and the only reader (user-invoked `scrollToLastActivity`) is
+   * unreachable until the view comes back.
+   */
   private scheduleActivityMarkerRefresh(id: string, managed: ManagedTerminal): void {
     this.pendingMarkerRefresh.set(id, managed);
-    if (this.markerRefreshScheduled) return;
+    if (isProjectViewCached()) return;
+    if (this.markerRefreshRafId !== undefined) return;
     if (typeof requestAnimationFrame !== "function") {
       this.flushActivityMarkers();
       return;
     }
-    this.markerRefreshScheduled = true;
-    requestAnimationFrame(() => {
-      this.markerRefreshScheduled = false;
+    this.markerRefreshRafId = requestAnimationFrame(() => {
+      this.markerRefreshRafId = undefined;
+      // The view can be cached between scheduling and the frame, and cancelling
+      // can't retract a callback the event loop has already picked up — so the
+      // gate has to be re-checked in the body, not just at cancel time.
+      if (isProjectViewCached()) return;
       this.flushActivityMarkers();
     });
+  }
+
+  private cancelMarkerRefreshFrame(): void {
+    if (this.markerRefreshRafId === undefined) return;
+    if (typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(this.markerRefreshRafId);
+    }
+    this.markerRefreshRafId = undefined;
+  }
+
+  /**
+   * Drop a destroyed terminal's pending marker obligation. Load-bearing only
+   * because the dirty set is now held for the whole cached window instead of
+   * one frame: without this, a terminal destroyed while the view is hidden
+   * (an agent killed mid-cache) would keep its ManagedTerminal — and with it
+   * the entire xterm buffer — reachable until the next reveal.
+   */
+  forget(id: string): void {
+    this.pendingMarkerRefresh.delete(id);
   }
 
   private flushActivityMarkers(): void {
@@ -272,5 +322,11 @@ export class TerminalWriteController {
         this.scheduleActivityMarkerRefresh(id, managed);
       }
     });
+  }
+
+  dispose(): void {
+    this.cancelMarkerRefreshFrame();
+    this.pendingMarkerRefresh.clear();
+    this.offViewLifecycle();
   }
 }

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -7,6 +7,7 @@ import {
   lockSidebarLayoutTransition,
   unlockSidebarHydration,
 } from "@/lib/layoutTransitionLock";
+import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import {
   TerminalReconciliationWatchdog,
   WATCHDOG_INTERVAL_MS,
@@ -1129,5 +1130,215 @@ describe("isXtermRenderPaused", () => {
     expect(isXtermRenderPaused(managed.terminal)).toBe(true);
     setRenderPaused(managed, false);
     expect(isXtermRenderPaused(managed.terminal)).toBe(false);
+  });
+});
+
+describe("TerminalReconciliationWatchdog — cached project view (#11212)", () => {
+  let watchdog: TerminalReconciliationWatchdog | undefined;
+  let instances: Map<string, ManagedTerminal>;
+  let emitCached: () => void;
+  let emitWarmActivated: () => void;
+  let emitRevealed: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    instances = new Map();
+    // The bug's precondition: a cached view keeps reporting "visible", so the
+    // existing gate never engages and its hosts still have real, on-screen rect
+    // geometry — every pane in a hidden project classifies as on-screen.
+    setDocumentVisibility("visible");
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    unlockSidebarHydration();
+
+    const cachedHandlers: Array<() => void> = [];
+    const warmHandlers: Array<() => void> = [];
+    const revealedHandlers: Array<() => void> = [];
+    (window as unknown as { electron: unknown }).electron = {
+      app: {
+        onViewCached: (cb: () => void) => {
+          cachedHandlers.push(cb);
+          return vi.fn();
+        },
+        onViewWarmActivated: (cb: () => void) => {
+          warmHandlers.push(cb);
+          return vi.fn();
+        },
+        onViewRevealed: (cb: () => void) => {
+          revealedHandlers.push(cb);
+          return vi.fn();
+        },
+      },
+    };
+    emitCached = () => cachedHandlers.forEach((h) => h());
+    emitWarmActivated = () => warmHandlers.forEach((h) => h());
+    emitRevealed = () => revealedHandlers.forEach((h) => h());
+    // viewCacheState arms on first use and persists for the module's life.
+    // Earlier describes in this file construct controllers before the stub
+    // exists, arming it against no bridge — reset so this suite's
+    // subscriptions bind to the emitters above.
+    __resetProjectViewCacheStateForTests();
+  });
+
+  afterEach(() => {
+    watchdog?.dispose();
+    watchdog = undefined;
+    __resetProjectViewCacheStateForTests();
+    delete (window as unknown as { electron?: unknown }).electron;
+    document.body.innerHTML = "";
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("issues no repairs of any kind for a cached view", () => {
+    // Every layer at once: an on-screen-looking pane that is invisible, at
+    // BACKGROUND tier, with a background backend tier and a missing WebGL
+    // context would normally draw a repair from several branches.
+    instances.set(
+      "t1",
+      makeManaged({ isVisible: false, lastAppliedTier: TerminalRefreshTier.BACKGROUND })
+    );
+    const deps = makeDeps(instances, {
+      getBackendTier: vi.fn(() => "background" as const),
+      shouldHaveWebGL: vi.fn(() => true),
+      isWebGLActive: vi.fn(() => false),
+    });
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    expect(deps.setVisible).not.toHaveBeenCalled();
+    expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+    expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
+    expect(deps.forceReflow).not.toHaveBeenCalled();
+    // ensureWebGL on a hidden view would burn a slot from the fleet-wide
+    // context cap that a visible pane needs (cf. #10671).
+    expect(deps.ensureWebGL).not.toHaveBeenCalled();
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+  });
+
+  it("reads no DOM geometry for a cached view", () => {
+    const managed = makeManaged({ isVisible: false });
+    const rectSpy = vi.fn(() => new DOMRect(0, 0, 800, 600));
+    managed.hostElement.getBoundingClientRect = rectSpy;
+    instances.set("t1", managed);
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    // The sweep's forced layout is the cost even when no repair follows.
+    expect(rectSpy).not.toHaveBeenCalled();
+  });
+
+  it("stops the interval while cached", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const getInstances = vi.fn(() => instances.entries());
+    const deps = makeDeps(instances, { getInstances });
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 10);
+
+    expect(getInstances).not.toHaveBeenCalled();
+  });
+
+  it("a direct tick() while cached is a no-op", () => {
+    // tick() is reachable from visibilitychange and the reveal sweep, and a
+    // cleared interval can't retract an already-dispatched callback — so the
+    // guard has to live in the body, not only on the timer.
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    watchdog.tick();
+
+    expect(deps.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("rearms exactly one interval on warm activation", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    emitWarmActivated();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    // Exactly once — a stacked second interval would repair twice per period.
+    expect(deps.setVisible).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not stack intervals when warm activation repeats", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitWarmActivated();
+    emitWarmActivated();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.setVisible).toHaveBeenCalledTimes(1);
+  });
+
+  it("sweeps immediately on reveal instead of waiting out the interval", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    expect(deps.setVisible).not.toHaveBeenCalled();
+
+    emitRevealed();
+
+    // Reveal is when stale state is most likely and most user-visible.
+    expect(deps.setVisible).toHaveBeenCalledWith("t1");
+  });
+
+  it("keeps document-hidden suppression independent of the cache signal", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitWarmActivated();
+    setDocumentVisibility("hidden");
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("resumes normal reconciliation after a cached window ends", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 3);
+    expect(deps.setVisible).not.toHaveBeenCalled();
+
+    emitWarmActivated();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.setVisible).toHaveBeenCalledWith("t1");
+  });
+
+  it("dispose() stops responding to lifecycle events", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    watchdog.dispose();
+    watchdog = undefined;
+    emitWarmActivated();
+    emitRevealed();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    expect(deps.setVisible).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -1156,7 +1156,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     const cachedHandlers: Array<() => void> = [];
     const warmHandlers: Array<() => void> = [];
     const revealedHandlers: Array<() => void> = [];
-    (window as unknown as { electron: unknown }).electron = {
+    vi.stubGlobal("electron", {
       app: {
         onViewCached: (cb: () => void) => {
           cachedHandlers.push(cb);
@@ -1175,7 +1175,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
         // module ever evaluated, so no "cached" phase is ever delivered.
         isViewCached: () => latchedCached,
       },
-    };
+    });
     emitCached = () => cachedHandlers.forEach((h) => h());
     emitWarmActivated = () => warmHandlers.forEach((h) => h());
     emitRevealed = () => revealedHandlers.forEach((h) => h());
@@ -1190,7 +1190,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     watchdog?.dispose();
     watchdog = undefined;
     __resetProjectViewCacheStateForTests();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
     document.body.innerHTML = "";
     __resetSidebarLayoutTransitionLockForTests();
     __resetSidebarHydrationLockForTests();
@@ -1220,7 +1220,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
       makeManaged({
         isVisible: true,
         lastAppliedTier: TerminalRefreshTier.BACKGROUND,
-        getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+        getRefreshTier: () => TerminalRefreshTier.VISIBLE,
       })
     );
     const deps = makeDeps(instances);
@@ -1238,7 +1238,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
       makeManaged({
         isVisible: true,
         lastAppliedTier: TerminalRefreshTier.VISIBLE,
-        getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+        getRefreshTier: () => TerminalRefreshTier.VISIBLE,
       })
     );
     const deps = makeDeps(instances, { getBackendTier: vi.fn(() => "background" as const) });
@@ -1258,7 +1258,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
       makeManaged({
         isVisible: true,
         lastAppliedTier: TerminalRefreshTier.VISIBLE,
-        getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+        getRefreshTier: () => TerminalRefreshTier.VISIBLE,
       })
     );
     const deps = makeDeps(instances, {
@@ -1279,7 +1279,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     const managed = makeManaged({
       isVisible: true,
       lastAppliedTier: TerminalRefreshTier.VISIBLE,
-      getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
       revealPendingRepair: true,
       revealPendingGeneration: 0,
       attachGeneration: 0,
@@ -1303,7 +1303,7 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     const managed = makeManaged({
       isVisible: true,
       lastAppliedTier: TerminalRefreshTier.VISIBLE,
-      getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
       revealPendingRepair: true,
       revealPendingGeneration: 0,
       attachGeneration: 0,

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -1192,16 +1192,70 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     vi.clearAllMocks();
   });
 
-  it("issues no repairs of any kind for a cached view", () => {
-    // Every layer at once: an on-screen-looking pane that is invisible, at
-    // BACKGROUND tier, with a background backend tier and a missing WebGL
-    // context would normally draw a repair from several branches.
+  // One divergence per case. A single terminal carrying every divergence at
+  // once proves nothing about the later branches: reconcile() repairs the first
+  // divergence it finds and returns, so an isVisible=false pane short-circuits
+  // at the visibility branch and the tier/backend/WebGL assertions would hold
+  // even with no gate at all.
+  it("repairs no divergent visibility for a cached view", () => {
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    expect(deps.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("repairs no BACKGROUND tier for a cached view", () => {
     instances.set(
       "t1",
-      makeManaged({ isVisible: false, lastAppliedTier: TerminalRefreshTier.BACKGROUND })
+      makeManaged({
+        isVisible: true,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      })
+    );
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+  });
+
+  it("reasserts no backend tier for a cached view", () => {
+    instances.set(
+      "t1",
+      makeManaged({
+        isVisible: true,
+        lastAppliedTier: TerminalRefreshTier.VISIBLE,
+        getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      })
+    );
+    const deps = makeDeps(instances, { getBackendTier: vi.fn(() => "background" as const) });
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
+
+    expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
+  });
+
+  it("attaches no WebGL context for a cached view", () => {
+    // A hidden view reattaching WebGL burns a slot from the fleet-wide context
+    // cap that a pane the user is actually looking at needs (cf. #10671).
+    instances.set(
+      "t1",
+      makeManaged({
+        isVisible: true,
+        lastAppliedTier: TerminalRefreshTier.VISIBLE,
+        getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      })
     );
     const deps = makeDeps(instances, {
-      getBackendTier: vi.fn(() => "background" as const),
       shouldHaveWebGL: vi.fn(() => true),
       isWebGLActive: vi.fn(() => false),
     });
@@ -1210,14 +1264,53 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     emitCached();
     vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
 
-    expect(deps.setVisible).not.toHaveBeenCalled();
-    expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
-    expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
-    expect(deps.forceReflow).not.toHaveBeenCalled();
-    // ensureWebGL on a hidden view would burn a slot from the fleet-wide
-    // context cap that a visible pane needs (cf. #10671).
     expect(deps.ensureWebGL).not.toHaveBeenCalled();
+  });
+
+  it("keeps a reveal-pending obligation armed across a cached window and discharges it on reveal", () => {
+    // The obligation must survive the cache window intact — neither consumed by
+    // a cached tick nor dropped — and reveal is what discharges it.
+    const managed = makeManaged({
+      isVisible: true,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      revealPendingRepair: true,
+      revealPendingGeneration: 0,
+      attachGeneration: 0,
+    });
+    instances.set("t1", managed);
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 5);
     expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(managed.revealPendingRepair).toBe(true);
+
+    emitRevealed();
+
+    expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
+    expect(managed.revealPendingRepair).toBe(false);
+  });
+
+  it("retains a reveal-pending obligation when the reveal reconcile cannot measure", () => {
+    const managed = makeManaged({
+      isVisible: true,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE as never,
+      revealPendingRepair: true,
+      revealPendingGeneration: 0,
+      attachGeneration: 0,
+    });
+    instances.set("t1", managed);
+    const deps = makeDeps(instances, { reconcileRevealGeometry: vi.fn(() => false) });
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitCached();
+    emitRevealed();
+
+    // An unmeasurable box keeps the obligation for a later tick.
+    expect(managed.revealPendingRepair).toBe(true);
   });
 
   it("reads no DOM geometry for a cached view", () => {

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -1139,8 +1139,10 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
   let emitCached: () => void;
   let emitWarmActivated: () => void;
   let emitRevealed: () => void;
+  let latchedCached = false;
 
   beforeEach(() => {
+    latchedCached = false;
     vi.useFakeTimers();
     instances = new Map();
     // The bug's precondition: a cached view keeps reporting "visible", so the
@@ -1168,6 +1170,10 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
           revealedHandlers.push(cb);
           return vi.fn();
         },
+        // Preload's latch. Setting this before constructing reproduces the
+        // switch-storm case where the view was already cached before this
+        // module ever evaluated, so no "cached" phase is ever delivered.
+        isViewCached: () => latchedCached,
       },
     };
     emitCached = () => cachedHandlers.forEach((h) => h());
@@ -1419,6 +1425,33 @@ describe("TerminalReconciliationWatchdog — cached project view (#11212)", () =
     vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
 
     expect(deps.setVisible).toHaveBeenCalledWith("t1");
+  });
+
+  it("does not arm the interval when constructed during a cached window", () => {
+    // The switch-storm case: cached before this module evaluated, so the state
+    // is seeded from preload's latch and no "cached" phase ever arrives.
+    latchedCached = true;
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const getInstances = vi.fn(() => instances.entries());
+    const deps = makeDeps(instances, { getInstances });
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 10);
+
+    expect(getInstances).not.toHaveBeenCalled();
+    expect(deps.setVisible).not.toHaveBeenCalled();
+  });
+
+  it("arms the interval on activation after being constructed while cached", () => {
+    latchedCached = true;
+    instances.set("t1", makeManaged({ isVisible: false }));
+    const deps = makeDeps(instances);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    emitWarmActivated();
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.setVisible).toHaveBeenCalledTimes(1);
   });
 
   it("dispose() stops responding to lifecycle events", () => {

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalReflowController, forceXtermReflow } from "../TerminalReflowController";
+import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import type { ManagedTerminal } from "../types";
 
 vi.mock("@/utils/logger", () => ({
@@ -411,5 +412,175 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     expect(paddingHistory(managed)).toContain("0.01px");
 
     controller.dispose();
+  });
+});
+
+describe("TerminalReflowController — cached project view (#11212)", () => {
+  let emitCached: () => void;
+  let emitWarmActivated: () => void;
+  let emitRevealed: () => void;
+  let controller: TerminalReflowController | undefined;
+
+  function reflowCount(managed: ManagedTerminal): number {
+    // forceXtermReflow writes paddingTop twice per reflow (jitter + restore).
+    return paddingHistory(managed).length;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const cachedHandlers: Array<() => void> = [];
+    const warmHandlers: Array<() => void> = [];
+    const revealedHandlers: Array<() => void> = [];
+    (window as unknown as { electron: unknown }).electron = {
+      app: {
+        onViewCached: (cb: () => void) => {
+          cachedHandlers.push(cb);
+          return vi.fn();
+        },
+        onViewWarmActivated: (cb: () => void) => {
+          warmHandlers.push(cb);
+          return vi.fn();
+        },
+        onViewRevealed: (cb: () => void) => {
+          revealedHandlers.push(cb);
+          return vi.fn();
+        },
+      },
+    };
+    emitCached = () => cachedHandlers.forEach((h) => h());
+    emitWarmActivated = () => warmHandlers.forEach((h) => h());
+    emitRevealed = () => revealedHandlers.forEach((h) => h());
+    // viewCacheState arms on first use and persists for the module's life.
+    // Earlier describes in this file construct controllers before the stub
+    // exists, arming it against no bridge — reset so this suite's
+    // subscriptions bind to the emitters above.
+    __resetProjectViewCacheStateForTests();
+  });
+
+  afterEach(() => {
+    controller?.dispose();
+    controller = undefined;
+    __resetProjectViewCacheStateForTests();
+    vi.useRealTimers();
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("maybeReflow no-ops while cached even when called directly", () => {
+    // The per-write path (onWriteParsedReflow → maybeReflowTerminal) calls this
+    // directly, so gating only the heartbeat would leave a streaming agent in a
+    // cached view forcing layout on every parsed write.
+    const managed = makeManaged();
+    controller = new TerminalReflowController({ getInstances: () => [managed] });
+
+    emitCached();
+    // Put the throttle window well in the past: under fake timers
+    // performance.now() is 0, so the default lastReflowAt of 0 would suppress
+    // the reflow on its own and this would pass for the wrong reason.
+    managed.lastReflowAt = -10_000;
+    controller.maybeReflow(managed);
+
+    expect(reflowCount(managed)).toBe(0);
+  });
+
+  it("still reflows via the per-write path once the view is active again", () => {
+    const managed = makeManaged();
+    controller = new TerminalReflowController({ getInstances: () => [managed] });
+
+    emitCached();
+    managed.lastReflowAt = -10_000;
+    controller.maybeReflow(managed);
+    expect(reflowCount(managed)).toBe(0);
+
+    emitWarmActivated();
+    managed.lastReflowAt = -10_000;
+    controller.maybeReflow(managed);
+
+    expect(reflowCount(managed)).toBeGreaterThan(0);
+  });
+
+  it("stops the heartbeat while cached", () => {
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    emitCached();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(30_000);
+
+    // A cached view's visibilityState stays "visible", so the heartbeat's own
+    // check can't stop it — only clearing the interval removes the wakeup.
+    expect(getInstances).not.toHaveBeenCalled();
+  });
+
+  it("rearms exactly one heartbeat on warm activation", () => {
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    emitCached();
+    emitWarmActivated();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(3000);
+
+    // Exactly one sweep — a stacked second interval would double it.
+    expect(getInstances).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not stack a second heartbeat when warm activation repeats", () => {
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    emitWarmActivated();
+    emitWarmActivated();
+    emitWarmActivated();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(3000);
+
+    expect(getInstances).toHaveBeenCalledTimes(1);
+  });
+
+  it("sweeps immediately on reveal rather than waiting out the heartbeat", () => {
+    const managed = makeManaged();
+    controller = new TerminalReflowController({ getInstances: () => [managed] });
+
+    emitCached();
+    emitWarmActivated();
+    managed.lastReflowAt = -10_000;
+    emitRevealed();
+
+    // A renderer paused while cached must not stay blank for up to 3s at the
+    // exact moment the user is looking at it.
+    expect(reflowCount(managed)).toBeGreaterThan(0);
+  });
+
+  it("keeps document-hidden suppression independent of the cache signal", () => {
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    const spy = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    emitWarmActivated();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(3000);
+
+    // Window minimize is a separate suppression signal — being un-cached must
+    // not override it.
+    expect(getInstances).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("dispose() stops responding to lifecycle events", () => {
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    controller.dispose();
+    controller = undefined;
+    emitWarmActivated();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(30_000);
+
+    expect(getInstances).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { TerminalReflowController, forceXtermReflow } from "../TerminalReflowController";
+import {
+  REFLOW_HEARTBEAT_MS,
+  TerminalReflowController,
+  forceXtermReflow,
+} from "../TerminalReflowController";
 import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import type { ManagedTerminal } from "../types";
 
@@ -274,7 +278,7 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     // Heartbeat hasn't fired yet.
     expect(paddingHistory(managed).length).toBe(0);
 
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
     expect(paddingHistory(managed)).toContain("0.01px");
 
     controller.dispose();
@@ -290,7 +294,7 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
 
     expect(paddingHistory(managed).length).toBe(0);
 
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
     expect(paddingHistory(managed)).toContain("0.01px");
 
     controller.dispose();
@@ -304,7 +308,7 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     instances = [managed];
     controller = new TerminalReflowController({ getInstances: () => instances });
 
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
     const reflowsAfterFirstTick = paddingHistory(managed).length;
     expect(reflowsAfterFirstTick).toBeGreaterThan(0);
 
@@ -330,7 +334,7 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
       configurable: true,
       get: () => "hidden",
     });
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
     expect(paddingHistory(managed).length).toBe(0);
 
     Object.defineProperty(document, "visibilityState", {
@@ -339,7 +343,7 @@ describe("TerminalReflowController dispose / listener cleanup", () => {
     });
     // Reset throttle in case the visibilitychange listener fired one already.
     managed.lastReflowAt = 0;
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
     expect(paddingHistory(managed)).toContain("0.01px");
 
     controller.dispose();
@@ -428,6 +432,13 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    // Explicit: jsdom does not report "visible" by default, and inheriting it
+    // from an earlier test's stub would make this suite order-dependent (it
+    // would fail under .only or if the file were reordered).
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
     const cachedHandlers: Array<() => void> = [];
     const warmHandlers: Array<() => void> = [];
     const revealedHandlers: Array<() => void> = [];
@@ -463,6 +474,8 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     __resetProjectViewCacheStateForTests();
     vi.useRealTimers();
     delete (window as unknown as { electron?: unknown }).electron;
+    // makeManaged appends to the document on every call.
+    document.body.innerHTML = "";
   });
 
   it("maybeReflow no-ops while cached even when called directly", () => {
@@ -505,7 +518,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
 
     emitCached();
     getInstances.mockClear();
-    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS * 10);
 
     // A cached view's visibilityState stays "visible", so the heartbeat's own
     // check can't stop it — only clearing the interval removes the wakeup.
@@ -520,7 +533,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     emitCached();
     emitWarmActivated();
     getInstances.mockClear();
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
 
     // Exactly one sweep — a stacked second interval would double it.
     expect(getInstances).toHaveBeenCalledTimes(1);
@@ -535,7 +548,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     emitWarmActivated();
     emitWarmActivated();
     getInstances.mockClear();
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
 
     expect(getInstances).toHaveBeenCalledTimes(1);
   });
@@ -562,7 +575,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     const spy = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
     emitWarmActivated();
     getInstances.mockClear();
-    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
 
     // Window minimize is a separate suppression signal — being un-cached must
     // not override it.
@@ -579,7 +592,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     controller = undefined;
     emitWarmActivated();
     getInstances.mockClear();
-    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS * 10);
 
     expect(getInstances).not.toHaveBeenCalled();
   });

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -444,7 +444,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     const cachedHandlers: Array<() => void> = [];
     const warmHandlers: Array<() => void> = [];
     const revealedHandlers: Array<() => void> = [];
-    (window as unknown as { electron: unknown }).electron = {
+    vi.stubGlobal("electron", {
       app: {
         onViewCached: (cb: () => void) => {
           cachedHandlers.push(cb);
@@ -463,7 +463,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
         // module ever evaluated, so no "cached" phase is ever delivered.
         isViewCached: () => latchedCached,
       },
-    };
+    });
     emitCached = () => cachedHandlers.forEach((h) => h());
     emitWarmActivated = () => warmHandlers.forEach((h) => h());
     emitRevealed = () => revealedHandlers.forEach((h) => h());
@@ -479,7 +479,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     controller = undefined;
     __resetProjectViewCacheStateForTests();
     vi.useRealTimers();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
     // makeManaged appends to the document on every call.
     document.body.innerHTML = "";
   });

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -424,6 +424,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
   let emitWarmActivated: () => void;
   let emitRevealed: () => void;
   let controller: TerminalReflowController | undefined;
+  let latchedCached = false;
 
   function reflowCount(managed: ManagedTerminal): number {
     // forceXtermReflow writes paddingTop twice per reflow (jitter + restore).
@@ -431,6 +432,7 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
   }
 
   beforeEach(() => {
+    latchedCached = false;
     vi.useFakeTimers();
     // Explicit: jsdom does not report "visible" by default, and inheriting it
     // from an earlier test's stub would make this suite order-dependent (it
@@ -456,6 +458,10 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
           revealedHandlers.push(cb);
           return vi.fn();
         },
+        // Preload's latch. Setting this before constructing reproduces the
+        // switch-storm case where the view was already cached before this
+        // module ever evaluated, so no "cached" phase is ever delivered.
+        isViewCached: () => latchedCached,
       },
     };
     emitCached = () => cachedHandlers.forEach((h) => h());
@@ -581,6 +587,33 @@ describe("TerminalReflowController — cached project view (#11212)", () => {
     // not override it.
     expect(getInstances).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  it("does not arm the heartbeat when constructed during a cached window", () => {
+    // No "cached" phase arrives here — the module seeds from preload's latch —
+    // so the constructor's arm must consult the seeded state itself or the
+    // interval ticks unopposed until the view returns.
+    latchedCached = true;
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS * 10);
+
+    expect(getInstances).not.toHaveBeenCalled();
+  });
+
+  it("arms the heartbeat on activation after being constructed while cached", () => {
+    latchedCached = true;
+    const managed = makeManaged();
+    const getInstances = vi.fn(() => [managed]);
+    controller = new TerminalReflowController({ getInstances });
+
+    emitWarmActivated();
+    getInstances.mockClear();
+    vi.advanceTimersByTime(REFLOW_HEARTBEAT_MS);
+
+    expect(getInstances).toHaveBeenCalledTimes(1);
   });
 
   it("dispose() stops responding to lifecycle events", () => {

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalWriteController, WriteControllerDeps } from "../TerminalWriteController";
+import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
 import type { ManagedTerminal } from "../types";
 
 vi.mock("@/utils/performance", () => ({
@@ -515,5 +516,251 @@ describe("TerminalWriteController.write", () => {
       expect(term.write).toHaveBeenCalledTimes(1);
       expect(typeof term.write.mock.calls[0]![1]).toBe("function");
     });
+  });
+});
+
+describe("TerminalWriteController — cached project view (#11212)", () => {
+  let store: Map<string, ManagedTerminal>;
+  let deps: WriteControllerDeps;
+  let controller: TerminalWriteController;
+  let managed: ManagedTerminal;
+  let emitCached: () => void;
+  let emitWarmActivated: () => void;
+  let emitRevealed: () => void;
+  let rafQueue: Map<number, FrameRequestCallback>;
+  let rafSpy: ReturnType<typeof vi.fn>;
+  let cancelRafSpy: ReturnType<typeof vi.fn>;
+
+  /** Run every queued frame callback, as one real frame would. */
+  function flushFrames(): void {
+    const pending = [...rafQueue];
+    rafQueue.clear();
+    for (const [, cb] of pending) cb(0);
+  }
+
+  function markerCalls(m: ManagedTerminal): number {
+    return (m.terminal as unknown as MockTerminal).registerMarker.mock.calls.length;
+  }
+
+  beforeEach(() => {
+    const cachedHandlers: Array<() => void> = [];
+    const warmHandlers: Array<() => void> = [];
+    const revealedHandlers: Array<() => void> = [];
+    (window as unknown as { electron: unknown }).electron = {
+      app: {
+        onViewCached: (cb: () => void) => {
+          cachedHandlers.push(cb);
+          return vi.fn();
+        },
+        onViewWarmActivated: (cb: () => void) => {
+          warmHandlers.push(cb);
+          return vi.fn();
+        },
+        onViewRevealed: (cb: () => void) => {
+          revealedHandlers.push(cb);
+          return vi.fn();
+        },
+      },
+    };
+    emitCached = () => cachedHandlers.forEach((h) => h());
+    emitWarmActivated = () => warmHandlers.forEach((h) => h());
+    emitRevealed = () => revealedHandlers.forEach((h) => h());
+    // viewCacheState arms on first use and persists for the module's life.
+    // Earlier describes in this file construct controllers before the stub
+    // exists, arming it against no bridge — reset so this suite's
+    // subscriptions bind to the emitters above.
+    __resetProjectViewCacheStateForTests();
+
+    // Queue-backed rAF with real incrementing ids. Deliberately NOT synchronous:
+    // a sync stub would run the callback before the id is assigned and defeat
+    // the id-based cancel guard this suite exercises.
+    rafQueue = new Map();
+    let nextRafId = 1;
+    rafSpy = vi.fn((cb: FrameRequestCallback) => {
+      const id = nextRafId++;
+      rafQueue.set(id, cb);
+      return id;
+    });
+    cancelRafSpy = vi.fn((id: number) => {
+      rafQueue.delete(id);
+    });
+    vi.stubGlobal("requestAnimationFrame", rafSpy);
+    vi.stubGlobal("cancelAnimationFrame", cancelRafSpy);
+
+    store = new Map<string, ManagedTerminal>();
+    managed = makeManaged();
+    store.set("t1", managed);
+    deps = makeDeps(store);
+    controller = new TerminalWriteController(deps);
+  });
+
+  afterEach(() => {
+    controller.dispose();
+    __resetProjectViewCacheStateForTests();
+    vi.unstubAllGlobals();
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("keeps the byte stream and every ledger live while cached", () => {
+    // The hard constraint from #10811/#4853: demoting a hidden view must never
+    // hold bytes. Ingest stays live, so no backlog exists to detonate on reveal.
+    emitCached();
+    controller.write("t1", "hello");
+
+    const term = managed.terminal as unknown as MockTerminal;
+    expect(term.write).toHaveBeenCalledWith("hello", expect.any(Function));
+    expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 5, 1);
+    expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 5);
+    expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 5);
+    expect(deps.incrementUnseen).toHaveBeenCalledWith("t1", false);
+  });
+
+  it("schedules no frame and allocates no marker for writes while cached", () => {
+    emitCached();
+    for (let i = 0; i < 50; i++) controller.write("t1", `chunk-${i}`);
+
+    expect(rafSpy).not.toHaveBeenCalled();
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("still schedules a frame per write burst while active", () => {
+    controller.write("t1", "a");
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+
+    flushFrames();
+    expect(markerCalls(managed)).toBe(1);
+  });
+
+  it("coalesces a whole cached burst into exactly one refresh on reveal", () => {
+    emitCached();
+    for (let i = 0; i < 25; i++) controller.write("t1", `chunk-${i}`);
+    expect(markerCalls(managed)).toBe(0);
+
+    emitWarmActivated();
+
+    // registerMarker(0) marks the cursor as of the flush, so one settle on
+    // return lands where the last hidden-frame refresh would have.
+    expect(markerCalls(managed)).toBe(1);
+  });
+
+  it("flushes on warm-activated, so a superseded switch still settles", () => {
+    // Main only sends revealed while the view is still the active project;
+    // warm-activated is the signal that always arrives on reactivation.
+    emitCached();
+    controller.write("t1", "a");
+    emitWarmActivated();
+
+    expect(markerCalls(managed)).toBe(1);
+
+    // The later revealed pass finds an empty dirty set.
+    emitRevealed();
+    expect(markerCalls(managed)).toBe(1);
+  });
+
+  it("refreshes each dirty terminal exactly once on reveal", () => {
+    const second = makeManaged();
+    store.set("t2", second);
+
+    emitCached();
+    controller.write("t1", "a");
+    controller.write("t1", "b");
+    controller.write("t2", "c");
+    emitWarmActivated();
+
+    expect(markerCalls(managed)).toBe(1);
+    expect(markerCalls(second)).toBe(1);
+  });
+
+  it("does not refresh a terminal that saw no writes while cached", () => {
+    emitCached();
+    emitWarmActivated();
+
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("cancels an in-flight frame when the view is cached mid-burst", () => {
+    controller.write("t1", "a");
+    expect(rafQueue.size).toBe(1);
+
+    emitCached();
+
+    expect(cancelRafSpy).toHaveBeenCalledTimes(1);
+    expect(rafQueue.size).toBe(0);
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("a frame callback the loop already picked up cannot refresh once cached", () => {
+    // cancelAnimationFrame can't retract a callback already dispatched, so the
+    // gate has to be re-checked in the body.
+    controller.write("t1", "a");
+    const [, queued] = [...rafQueue][0]!;
+    rafQueue.clear();
+
+    emitCached();
+    queued(0);
+
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("re-arms frame scheduling after a cached window ends", () => {
+    controller.write("t1", "a");
+    emitCached();
+    rafSpy.mockClear();
+
+    emitWarmActivated();
+    controller.write("t1", "b");
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    flushFrames();
+    // One flush from the reveal settle, one from the post-reveal write.
+    expect(markerCalls(managed)).toBe(2);
+  });
+
+  it("skips a terminal replaced at the same id while cached", () => {
+    emitCached();
+    controller.write("t1", "a");
+
+    const replacement = makeManaged();
+    store.set("t1", replacement);
+    emitWarmActivated();
+
+    // The stale-identity guard (#4850) still holds across the deferral.
+    expect(markerCalls(managed)).toBe(0);
+    expect(markerCalls(replacement)).toBe(0);
+  });
+
+  it("skips a terminal that entered the alt buffer while cached", () => {
+    emitCached();
+    controller.write("t1", "a");
+    managed.isAltBuffer = true;
+    emitWarmActivated();
+
+    // Alt-buffer panes are excluded from markers by design; the next
+    // normal-buffer write re-dirties them.
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("forget() releases a terminal destroyed during the cached window", () => {
+    // Without this the dirty set — now held for the whole cached window rather
+    // than one frame — keeps a killed agent's xterm buffer reachable until the
+    // next reveal.
+    emitCached();
+    controller.write("t1", "a");
+
+    controller.forget("t1");
+    store.delete("t1");
+    emitWarmActivated();
+
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("dispose() drops the pending set and stops responding to lifecycle events", () => {
+    emitCached();
+    controller.write("t1", "a");
+
+    controller.dispose();
+    emitWarmActivated();
+
+    expect(markerCalls(managed)).toBe(0);
   });
 });

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -101,6 +101,14 @@ describe("TerminalWriteController.write", () => {
     controller = new TerminalWriteController(deps);
   });
 
+  afterEach(() => {
+    // The constructor subscribes to the view-lifecycle singleton, so an
+    // undisposed controller stays reachable from it (along with its deps and
+    // managed terminals) for the rest of the file.
+    controller.dispose();
+    __resetProjectViewCacheStateForTests();
+  });
+
   it("no-ops when the terminal id is unknown", () => {
     controller.write("unknown", "abc");
     expect(deps.acknowledgePortData).not.toHaveBeenCalled();
@@ -671,6 +679,31 @@ describe("TerminalWriteController — cached project view (#11212)", () => {
     expect(markerCalls(second)).toBe(1);
   });
 
+  it("settles a cached burst on a reveal that arrives without warm activation", () => {
+    emitCached();
+    controller.write("t1", "a");
+
+    emitRevealed();
+
+    expect(markerCalls(managed)).toBe(1);
+  });
+
+  it("does not lose or duplicate a write landing between warm activation and reveal", () => {
+    emitCached();
+    controller.write("t1", "a");
+    emitWarmActivated();
+    expect(markerCalls(managed)).toBe(1);
+
+    // Active again: this write takes the ordinary frame-scheduled path.
+    controller.write("t1", "b");
+    emitRevealed();
+    flushFrames();
+
+    // The cached settle, then exactly one more for the post-activation write —
+    // the reveal pass must not double-count it.
+    expect(markerCalls(managed)).toBe(2);
+  });
+
   it("does not refresh a terminal that saw no writes while cached", () => {
     emitCached();
     emitWarmActivated();
@@ -740,25 +773,56 @@ describe("TerminalWriteController — cached project view (#11212)", () => {
     expect(markerCalls(managed)).toBe(0);
   });
 
-  it("forget() releases a terminal destroyed during the cached window", () => {
-    // Without this the dirty set — now held for the whole cached window rather
-    // than one frame — keeps a killed agent's xterm buffer reachable until the
-    // next reveal.
+  it("forget() drops the pending obligation itself, not just via the identity guard", () => {
+    // The instance deliberately STAYS in the store: removing it would let the
+    // stale-identity guard produce this same result whether or not forget()
+    // did anything, and the point is that the dirty set — now held for the
+    // whole cached window rather than one frame — released the reference.
     emitCached();
     controller.write("t1", "a");
 
     controller.forget("t1");
-    store.delete("t1");
     emitWarmActivated();
 
     expect(markerCalls(managed)).toBe(0);
   });
 
-  it("dispose() drops the pending set and stops responding to lifecycle events", () => {
+  it("forget() leaves other terminals' obligations intact", () => {
+    const second = makeManaged();
+    store.set("t2", second);
+
+    emitCached();
+    controller.write("t1", "a");
+    controller.write("t2", "b");
+    controller.forget("t1");
+    emitWarmActivated();
+
+    expect(markerCalls(managed)).toBe(0);
+    expect(markerCalls(second)).toBe(1);
+  });
+
+  it("dispose() drops the pending set", () => {
+    // Proven independently of unsubscription: hold a frame callback the loop
+    // already picked up, dispose, then run it. If dispose only unsubscribed and
+    // left the map populated, this would still register a marker.
+    controller.write("t1", "a");
+    const [, queued] = [...rafQueue][0]!;
+    rafQueue.clear();
+
+    controller.dispose();
+    queued(0);
+
+    expect(markerCalls(managed)).toBe(0);
+  });
+
+  it("dispose() unsubscribes from lifecycle events", () => {
+    // Prove the subscription is gone, not just that the map was cleared: give a
+    // disposed controller a fresh pending obligation, then fire the signal that
+    // would flush it. A still-subscribed controller would register a marker.
+    controller.dispose();
     emitCached();
     controller.write("t1", "a");
 
-    controller.dispose();
     emitWarmActivated();
 
     expect(markerCalls(managed)).toBe(0);

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -162,8 +162,7 @@ describe("TerminalWriteController.write", () => {
   it("normal path: writes to terminal, acks both data and port data, increments unseen", () => {
     controller.write("t1", "hello");
 
-    const term = managed.terminal as unknown as MockTerminal;
-    expect(term.write).toHaveBeenCalledWith("hello", expect.any(Function));
+    expect(vi.mocked(managed.terminal.write)).toHaveBeenCalledWith("hello", expect.any(Function));
     expect(deps.incrementUnseen).toHaveBeenCalledWith("t1", false);
     expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 5, 1);
     expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 5);
@@ -547,14 +546,14 @@ describe("TerminalWriteController — cached project view (#11212)", () => {
   }
 
   function markerCalls(m: ManagedTerminal): number {
-    return (m.terminal as unknown as MockTerminal).registerMarker.mock.calls.length;
+    return vi.mocked(m.terminal.registerMarker).mock.calls.length;
   }
 
   beforeEach(() => {
     const cachedHandlers: Array<() => void> = [];
     const warmHandlers: Array<() => void> = [];
     const revealedHandlers: Array<() => void> = [];
-    (window as unknown as { electron: unknown }).electron = {
+    vi.stubGlobal("electron", {
       app: {
         onViewCached: (cb: () => void) => {
           cachedHandlers.push(cb);
@@ -569,7 +568,7 @@ describe("TerminalWriteController — cached project view (#11212)", () => {
           return vi.fn();
         },
       },
-    };
+    });
     emitCached = () => cachedHandlers.forEach((h) => h());
     emitWarmActivated = () => warmHandlers.forEach((h) => h());
     emitRevealed = () => revealedHandlers.forEach((h) => h());
@@ -606,7 +605,7 @@ describe("TerminalWriteController — cached project view (#11212)", () => {
     controller.dispose();
     __resetProjectViewCacheStateForTests();
     vi.unstubAllGlobals();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.stubGlobal("electron", undefined);
   });
 
   it("keeps the byte stream and every ledger live while cached", () => {
@@ -615,8 +614,7 @@ describe("TerminalWriteController — cached project view (#11212)", () => {
     emitCached();
     controller.write("t1", "hello");
 
-    const term = managed.terminal as unknown as MockTerminal;
-    expect(term.write).toHaveBeenCalledWith("hello", expect.any(Function));
+    expect(vi.mocked(managed.terminal.write)).toHaveBeenCalledWith("hello", expect.any(Function));
     expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 5, 1);
     expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 5);
     expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 5);


### PR DESCRIPTION
## Summary

- A cached (hidden) project view was still doing full terminal work: rAF activity markers, reflow heartbeats and the reconciliation watchdog kept firing at full rate, measured at 4.5% CPU and 3300 wakeups/second for a project you weren't even looking at.
- Root cause: a cached view is `removeChildView` + `setVisible(false)`, and neither one flips `document.visibilityState` on a child `WebContentsView` (Chromium tracks occlusion at the `BrowserWindow` level), so every gate written as `document.visibilityState !== "visible"` was dead code there.
- Fixes it with a new renderer-side cache-state module gating the terminal timers directly, while leaving the byte stream (ingest, `terminal.write`, ledgers) completely untouched so there's nothing to backlog and detonate on reveal.

Resolves #11212

## Root cause

The cached view problem goes deeper than the issue's framing. A cached project view is implemented as `removeChildView` plus `setVisible(false)`, and neither of those changes `document.visibilityState` for a child `WebContentsView`, because Chromium tracks occlusion at the `BrowserWindow` level, not per view. So a cached view reports itself as `visible` forever, and its `requestAnimationFrame` loop just keeps firing.

That makes every gate written as `document.visibilityState !== "visible"` dead code in this scenario: `TerminalReconciliationWatchdog.tick()`, `TerminalReflowController`'s heartbeat, and `revealUntilStable`'s `isDocumentHidden()` check. The CPU throttle we already apply (`Emulation.setCPUThrottlingRate`) slows each callback down but doesn't reduce how often it fires. Only a `Page.setWebLifecycleState` freeze cuts the firing rate, and we deliberately skip that freeze while the cached project has a live agent running, which is exactly the case costing the most. Hence the 4.5% CPU and 3300 wakeups/second.

It's worse than a wasted timer, too. Because a cached view's hosts still carry real, viewport-passing rect geometry, the watchdog was classifying panes in a hidden project as on-screen and issuing real repairs against them: `forceReflow`, `ensureWebGL` (competing for the fleet-wide WebGL context cap, see #10671), and full-scrollback geometry re-wraps.

## The fix

New module: `src/lib/viewCacheState.ts`, a renderer-module singleton over main's existing `app:view-cached` / `warm-activated` / `revealed` broadcasts. These were already being sent, just only ever consumed by `WorktreeStoreContext`.

Three gates hang off it:

- `TerminalWriteController` holds the activity-marker dirty set while cached, instead of allocating a `Marker` plus four buffer subscriptions on every frame, and settles once on return.
- `TerminalReflowController` gates `maybeReflow` itself, not just its heartbeat. The per-write `onWriteParsedReflow` path calls `maybeReflow` directly, so gating only the heartbeat would miss it. It also stops and rearms its interval.
- `TerminalReconciliationWatchdog` stops and rearms its interval and guards `tick()`.

The byte stream is untouched by any of this. Ingest, `terminal.write` and every ledger stay fully live while a view is cached, so there's no backlog to detonate on reveal (that's what the capped-batch coalescing in #4853 already handles) and no suspend/resync of live agent TUIs gets reintroduced (#10811 removed hibernation for exactly that reason). That's the issue's hard constraint, and it's satisfied by construction here, not by tuning a budget.

One detail worth calling out: the gate clears on `warm-activated`, not `revealed`. Main only sends `revealed` while the view is still the active project, so a superseded switch (one view replaced by another mid-flight) only ever delivers `warm-activated`. Keying the clear on `revealed` would strand a reactivated view demoted forever.

## Two holes found in review

Found and closed both of these while reviewing my own first pass:

1. The `app:view-*` signals are non-replaying `ipcRenderer.on` events, and a cold switch is released to the renderer at the pre-React skeleton stage, before the module graph has mounted and subscribed. A rapid switch storm could cache a view before its listener had subscribed and lose the edge for good. Fixed by latching the signal in preload instead, since preload evaluates before any page script runs, and seeding the renderer module's state from that latch.
2. The cold-switch rollback path restored a deactivated view with `setVisible(true)` and `state = "active"`, but sent neither signal. With the new gate in place that left a *visible* view permanently demoted (its paused xterm never unpausing). Fixed by having that rollback path send `warm-activated` too.

## Marker deferral is equivalent, not approximate

Deferring the activity marker while cached isn't just "close enough". `registerMarker(0)` marks the cursor line as of the flush, so one settle on return lands exactly where the last hidden-frame refresh would have. The only reader of that marker, `scrollToLastActivity`, is user-invoked and unreachable while the view is hidden anyway.

## Deliberately out of scope

- **Resize passes**: event-driven, no periodic wakeup cost, so there's nothing to save. Deferring them risks reintroducing the switch-back garble that #10632 and #10909 already fought hard to fix. Pure risk, no wakeup win.
- **`WorkerParseSession`'s 250ms cadence**: this is the issue's cited "250ms cadences", worth stating plainly. It's already flag-gated off by default behind `DAINTREE_PAINT_FABRIC_WORKER_INGEST`, so the issue's wording is addressed without touching it here.

## Known pre-existing gap (not fixed here)

The cold-switch rollback still doesn't reverse `deactivateEntry`'s other main-side effects: the view stays detached from its content view, stays CPU-throttled, and stays marked in `cachedViewWebContents`. That predates this change and is independent of the new gate. Flagging it as a follow-up rather than folding it in here.

## Testing

None of this is E2E-observable. `DAINTREE_DISABLE_WEBGL` forces the DOM renderer in tests, and the DOM renderer paints regardless of whether the gate is doing its job, so an E2E run can't tell the difference. The gate/ungate contract is unit-tested instead, and it was validated red-before-green: with the gate neutered back to its pre-fix behavior, 17 of the new tests fail.

Locally: 376 tests passing across 14 files (including `ProjectViewManager`'s `switchFailure`, `lifecycle`, `eviction` and preload suites), full `npm run typecheck` clean, `check:ipc` / `check:ipc-handwritten` / `check:channels` all clean, and zero new lint warnings on any rule, so the per-rule ratchet stays flat.
