### PR TITLE
fix(terminal): bound the shared WebGL glyph atlas so a streaming view plateaus

### DIFF
--- a/src/services/terminal/TerminalWebGLAtlasCap.ts
+++ b/src/services/terminal/TerminalWebGLAtlasCap.ts
@@ -1,0 +1,96 @@
+// xterm's TextureAtlas is module-global and shared by every terminal whose
+// font/theme config matches, so it outlives any single terminal's dispose
+// (CharAtlasCache only frees it when the last owner goes away). Its glyph cache
+// is keyed by code + bg + fg + ext with no per-entry eviction, so truecolor
+// agent output grows it monotonically.
+//
+// Pages are always created at ATLAS_PAGE_START_SIZE and only grow by merging 4
+// same-size pages into one of double the size, gated on
+// `page.width * 2 <= TextureAtlas.maxTextureSize`. Left at the hardware default
+// (gl.MAX_TEXTURE_SIZE, often 16384) pages ratchet 512 -> 1024 -> ... -> 16384,
+// which is why a busy view never plateaus.
+//
+// Capping maxTextureSize bounds the atlas at maxAtlasPages * cap^2 * 4 bytes and
+// caps merging at a single generation (512 -> 1024). That is strictly less
+// merging than the default, which matters beyond memory: a merge rewrites glyph
+// texturePage indices while each renderer keeps its own model buffers (#8080),
+// whereas the alternative capacity path, _evictAllPages, is a clean reset that
+// fires onRemoveTextureAtlasCanvas for every co-owner and is already handled by
+// scheduleAtlasResync.
+//
+// 1024 rather than the 512 page size: pinning the cap to the page size would bar
+// merging entirely, but it also quarters glyph capacity, and a working set that
+// outgrows the atlas evicts on a loop. 1024 keeps ~4x the slots for the tiled
+// truecolor fleet this bounds, and stays a hard plateau either way.
+export const ATLAS_MAX_TEXTURE_SIZE = 1024;
+
+// Mirrors TextureAtlas's own initial page size. Pages are only ever allocated at
+// this size; anything larger is the product of a merge.
+export const ATLAS_PAGE_START_SIZE = 512;
+
+type AtlasStatics = {
+  maxTextureSize?: number;
+  maxAtlasPages?: number;
+};
+
+function isObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+// The statics live on the class, and a class is a function.
+function isAtlasStatics(value: unknown): value is AtlasStatics {
+  return typeof value === "function";
+}
+
+// The TextureAtlas class is private to the addon bundle: neither the package
+// exports nor the typings expose it, and deep-importing its source would yield a
+// different class than the one closed over by the shipped bundle. A live atlas
+// instance's constructor is that class. Walked defensively so a drifted internal
+// shape degrades to "not capped" instead of throwing.
+function readAtlasStatics(addon: object): AtlasStatics | null {
+  if (!("_renderer" in addon) || !isObject(addon._renderer)) return null;
+  const renderer = addon._renderer;
+  if (!("_charAtlas" in renderer) || !isObject(renderer._charAtlas)) return null;
+  const ctor: unknown = renderer._charAtlas.constructor;
+  return isAtlasStatics(ctor) ? ctor : null;
+}
+
+// Returns whether the atlas is bounded, i.e. capped now or already at/below the
+// cap. False means the statics were unreachable or uninitialized and the caller
+// should retry on a later attach.
+export function applyAtlasPageSizeCap(addon: object): boolean {
+  const statics = readAtlasStatics(addon);
+  if (!statics) return false;
+
+  // GlyphRenderer lazily initializes maxAtlasPages and maxTextureSize together
+  // on its first construction, gated on maxAtlasPages being undefined. Writing
+  // the cap before that runs would be overwritten by the hardware probe, so an
+  // uninitialized atlas is left alone rather than capped early.
+  if (typeof statics.maxTextureSize !== "number") return false;
+  if (statics.maxTextureSize <= ATLAS_MAX_TEXTURE_SIZE) return true;
+
+  try {
+    statics.maxTextureSize = ATLAS_MAX_TEXTURE_SIZE;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Worst-case bytes of atlas pages once every page has merged up to the cap.
+// maxAtlasPages is left at the hardware value because it is baked into the
+// fragment shader and the renderer's texture-unit binding at GlyphRenderer
+// construction; lowering it afterwards would desync the two.
+export function atlasByteCeiling(maxAtlasPages: number, maxTextureSize: number): number {
+  // Mirrors TextureAtlas._createNewPage, which only reclaims once the page count
+  // reaches max(4, maxAtlasPages) — a lower cap cannot shrink the atlas below 4
+  // pages.
+  const pages = Math.max(4, maxAtlasPages);
+  return pages * maxTextureSize * maxTextureSize * 4;
+}
+
+// A page is merge-eligible only while doubling it stays within the cap, so the
+// cap decides how many merge generations exist above the start size.
+export function isPageMergeEligible(pageWidth: number, maxTextureSize: number): boolean {
+  return pageWidth * 2 <= maxTextureSize;
+}

--- a/src/services/terminal/TerminalWebGLAtlasCap.ts
+++ b/src/services/terminal/TerminalWebGLAtlasCap.ts
@@ -2,31 +2,34 @@
 // font/theme config matches, so it outlives any single terminal's dispose
 // (CharAtlasCache only frees it when the last owner goes away). Its glyph cache
 // is keyed by code + bg + fg + ext with no per-entry eviction, so truecolor
-// agent output grows it monotonically.
+// agent output only ever adds to it.
 //
-// Pages are always created at ATLAS_PAGE_START_SIZE and only grow by merging 4
-// same-size pages into one of double the size, gated on
-// `page.width * 2 <= TextureAtlas.maxTextureSize`. Left at the hardware default
-// (gl.MAX_TEXTURE_SIZE, often 16384) pages ratchet 512 -> 1024 -> ... -> 16384,
-// which is why a busy view never plateaus.
+// Pages are allocated at 512px and only grow by merging 4 same-size pages into
+// one of double the size, gated on `page.width * 2 <= maxTextureSize`. Left at
+// the hardware default (gl.MAX_TEXTURE_SIZE, often 16384) pages ratchet
+// 512 -> 1024 -> ... -> 16384, and because a merge always succeeds there is
+// effectively no path to _evictAllPages — which is the only thing that clears
+// the glyph cache maps. That is why a streaming view never plateaus.
 //
-// Capping maxTextureSize bounds the atlas at maxAtlasPages * cap^2 * 4 bytes and
-// caps merging at a single generation (512 -> 1024). That is strictly less
-// merging than the default, which matters beyond memory: a merge rewrites glyph
-// texturePage indices while each renderer keeps its own model buffers (#8080),
-// whereas the alternative capacity path, _evictAllPages, is a clean reset that
-// fires onRemoveTextureAtlasCanvas for every co-owner and is already handled by
-// scheduleAtlasResync.
+// Capping maxTextureSize is what makes eviction reachable: once every page has
+// merged to the cap none are merge-eligible, so the next page demand evicts,
+// dropping the pages AND both cache maps. Empty glyphs (a colored space
+// rasterizes to a shared NULL_RASTERIZED_GLYPH) never consume pixels and so
+// never create page pressure themselves, but they are cached, and the eviction
+// this cap induces is what bounds them too.
 //
 // 1024 rather than the 512 page size: pinning the cap to the page size would bar
 // merging entirely, but it also quarters glyph capacity, and a working set that
-// outgrows the atlas evicts on a loop. 1024 keeps ~4x the slots for the tiled
-// truecolor fleet this bounds, and stays a hard plateau either way.
+// outgrows the atlas evicts on a loop — sustained re-rasterization across every
+// co-owning pane. 1024 keeps ~3.5x the slots for the tiled truecolor fleet this
+// bounds, and both settings plateau.
+//
+// Bound: maxAtlasPages * 1024^2 * 4 bytes of page backing store, i.e. 64MB at 16
+// texture units and 128MB at 32. That covers the regular pages of one atlas
+// config in this renderer — not the single hardware-sized overflow page for
+// glyphs wider than a page (pre-existing, reset by the same eviction), and not
+// the per-context copies each GlyphRenderer uploads to the GPU process.
 export const ATLAS_MAX_TEXTURE_SIZE = 1024;
-
-// Mirrors TextureAtlas's own initial page size. Pages are only ever allocated at
-// this size; anything larger is the product of a merge.
-export const ATLAS_PAGE_START_SIZE = 512;
 
 type AtlasStatics = {
   maxTextureSize?: number;
@@ -42,11 +45,14 @@ function isAtlasStatics(value: unknown): value is AtlasStatics {
   return typeof value === "function";
 }
 
+function isPositiveFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
 // The TextureAtlas class is private to the addon bundle: neither the package
 // exports nor the typings expose it, and deep-importing its source would yield a
 // different class than the one closed over by the shipped bundle. A live atlas
-// instance's constructor is that class. Walked defensively so a drifted internal
-// shape degrades to "not capped" instead of throwing.
+// instance's constructor is that class.
 function readAtlasStatics(addon: object): AtlasStatics | null {
   if (!("_renderer" in addon) || !isObject(addon._renderer)) return null;
   const renderer = addon._renderer;
@@ -55,42 +61,36 @@ function readAtlasStatics(addon: object): AtlasStatics | null {
   return isAtlasStatics(ctor) ? ctor : null;
 }
 
-// Returns whether the atlas is bounded, i.e. capped now or already at/below the
-// cap. False means the statics were unreachable or uninitialized and the caller
-// should retry on a later attach.
+// Returns whether the atlas is bounded. False means the internals were
+// unreachable or the atlas cannot be bounded, and the caller should retry on a
+// later attach. Every read is guarded: an addon whose internal shape has drifted
+// must degrade to "not capped" rather than throw, since this runs inside the
+// attach path and an escaping error would drop the terminal to DOM rendering.
 export function applyAtlasPageSizeCap(addon: object): boolean {
-  const statics = readAtlasStatics(addon);
-  if (!statics) return false;
-
-  // GlyphRenderer lazily initializes maxAtlasPages and maxTextureSize together
-  // on its first construction, gated on maxAtlasPages being undefined. Writing
-  // the cap before that runs would be overwritten by the hardware probe, so an
-  // uninitialized atlas is left alone rather than capped early.
-  if (typeof statics.maxTextureSize !== "number") return false;
-  if (statics.maxTextureSize <= ATLAS_MAX_TEXTURE_SIZE) return true;
-
   try {
-    statics.maxTextureSize = ATLAS_MAX_TEXTURE_SIZE;
-    return true;
+    const statics = readAtlasStatics(addon);
+    if (!statics) return false;
+
+    // A live atlas proves GlyphRenderer's constructor already ran, and with it
+    // the hardware probe that assigns both statics — gated on maxAtlasPages
+    // alone — so it can no longer overwrite the cap. maxAtlasPages also gates
+    // reclaim itself (`if (maxAtlasPages && pages.length >= ...)`), so without a
+    // positive value there is nothing to bound and the cap would be inert.
+    if (!isPositiveFinite(statics.maxAtlasPages)) return false;
+
+    if (
+      !isPositiveFinite(statics.maxTextureSize) ||
+      statics.maxTextureSize > ATLAS_MAX_TEXTURE_SIZE
+    ) {
+      statics.maxTextureSize = ATLAS_MAX_TEXTURE_SIZE;
+    }
+
+    // Read back rather than trust the write: a getter-only or proxied static
+    // swallows it, and reporting success would retire the retry.
+    return (
+      isPositiveFinite(statics.maxTextureSize) && statics.maxTextureSize <= ATLAS_MAX_TEXTURE_SIZE
+    );
   } catch {
     return false;
   }
-}
-
-// Worst-case bytes of atlas pages once every page has merged up to the cap.
-// maxAtlasPages is left at the hardware value because it is baked into the
-// fragment shader and the renderer's texture-unit binding at GlyphRenderer
-// construction; lowering it afterwards would desync the two.
-export function atlasByteCeiling(maxAtlasPages: number, maxTextureSize: number): number {
-  // Mirrors TextureAtlas._createNewPage, which only reclaims once the page count
-  // reaches max(4, maxAtlasPages) — a lower cap cannot shrink the atlas below 4
-  // pages.
-  const pages = Math.max(4, maxAtlasPages);
-  return pages * maxTextureSize * maxTextureSize * 4;
-}
-
-// A page is merge-eligible only while doubling it stays within the cap, so the
-// cap decides how many merge generations exist above the start size.
-export function isPageMergeEligible(pageWidth: number, maxTextureSize: number): boolean {
-  return pageWidth * 2 <= maxTextureSize;
 }

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -1,5 +1,6 @@
 import type { WebglAddon as WebglAddonType } from "@xterm/addon-webgl";
 import type { IDisposable } from "@xterm/xterm";
+import { applyAtlasPageSizeCap } from "./TerminalWebGLAtlasCap";
 import {
   getWebglLowerThreshold,
   getWebglUpperThreshold,
@@ -45,6 +46,11 @@ type WebglAddonConstructor = new () => WebglAddonType;
 // on webglcontextrestored before xterm's onContextLoss fires (see #7467).
 let WebglAddonClass: WebglAddonConstructor | null = null;
 let webglAddonLoadPromise: Promise<WebglAddonConstructor> | null = null;
+
+// Module-scoped to match what it tracks: the atlas cap is a static on the
+// addon's own module-global TextureAtlas, so it is set once per renderer
+// regardless of how many managers or terminals that renderer has.
+let atlasPageSizeCapped = false;
 
 function loadWebglAddon(): Promise<WebglAddonConstructor> {
   if (WebglAddonClass) return Promise.resolve(WebglAddonClass);
@@ -916,6 +922,14 @@ export class TerminalWebGLManager {
         }
       });
       managed.terminal.loadAddon(addon);
+
+      // loadAddon activates the renderer synchronously, which constructs the
+      // first GlyphRenderer and so initializes the atlas statics this bounds.
+      // Retried on later attaches because a drifted internal shape reports false
+      // rather than throwing.
+      if (!atlasPageSizeCapped) {
+        atlasPageSizeCapped = applyAtlasPageSizeCap(addon);
+      }
 
       // Watch the shared TextureAtlas for page merges, and the renderer for
       // atlas-object swaps caused by font/theme/DPR changes. The pinned addon

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -1091,6 +1091,13 @@ export const __testing = {
   resetLoaderState(): void {
     WebglAddonClass = null;
     webglAddonLoadPromise = null;
+    atlasPageSizeCapped = false;
+  },
+  resetAtlasCapState(): void {
+    atlasPageSizeCapped = false;
+  },
+  isAtlasPageSizeCapped(): boolean {
+    return atlasPageSizeCapped;
   },
   isLoaded(): boolean {
     return WebglAddonClass !== null;

--- a/src/services/terminal/__tests__/TerminalWebGLAtlasCap.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLAtlasCap.test.ts
@@ -107,13 +107,17 @@ describe("applyAtlasPageSizeCap", () => {
     expect(writes).toBe(0);
   });
 
-  it("reports failure when the static swallows the write", () => {
-    // A getter-only static accepts the assignment in sloppy mode and keeps the
-    // hardware value; retiring the retry on that would leave the atlas unbounded.
+  it("reports failure when the static accepts the write but ignores it", () => {
+    // An ignoring setter takes the assignment without throwing and keeps the
+    // hardware value. Trusting the write here would retire the retry with the
+    // atlas still unbounded, so only a read-back can tell the two apart.
     class SwallowingAtlas {
       public static maxAtlasPages: number | undefined = HARDWARE_MAX_ATLAS_PAGES;
       public static get maxTextureSize(): number | undefined {
         return HARDWARE_MAX_TEXTURE_SIZE;
+      }
+      public static set maxTextureSize(_value: number | undefined) {
+        // accepted and dropped
       }
     }
 
@@ -155,16 +159,31 @@ describe("applyAtlasPageSizeCap", () => {
   });
 });
 
+// The cap reaches through the addon's private shape and degrades silently by
+// design, so a bump that moved any of this would restore the unbounded growth it
+// fixes with no other signal. These match the surrounding mechanism rather than
+// bare identifiers: `_charAtlas` alone occurs elsewhere in the bundle, so a
+// rename of the one member the cap reaches would slip past a plain search.
 describe("pinned @xterm/addon-webgl contract", () => {
-  // The cap reaches through the addon's private shape and degrades silently by
-  // design, so a rename in a future bump would restore the unbounded growth this
-  // fixes with no other signal. Fail loudly at the bump instead.
-  it("still ships the internals and statics the cap depends on", () => {
-    const require = createRequire(import.meta.url);
-    const bundle = readFileSync(require.resolve("@xterm/addon-webgl/lib/addon-webgl.mjs"), "utf8");
+  const bundle = readFileSync(
+    createRequire(import.meta.url).resolve("@xterm/addon-webgl/lib/addon-webgl.mjs"),
+    "utf8"
+  );
 
-    for (const identifier of ["_renderer", "_charAtlas", "maxAtlasPages", "maxTextureSize"]) {
-      expect(bundle).toContain(identifier);
-    }
+  it("still grows pages only by the merge rule the cap constrains", () => {
+    expect(bundle).toMatch(/canvas\.width\s*\*\s*2\s*<=\s*\(?\s*\w+\.maxTextureSize\s*\|\|/);
+  });
+
+  it("still probes both statics together, which is why the cap has to run after activation", () => {
+    expect(bundle).toMatch(/MAX_TEXTURE_IMAGE_UNITS[\s\S]{0,120}\.maxTextureSize\s*=/);
+  });
+
+  it("still gates page reclaim on the page count the cap leaves at its hardware value", () => {
+    expect(bundle).toMatch(/\w+\.maxAtlasPages\s*&&/);
+  });
+
+  it("still exposes the renderer and atlas the cap reaches through", () => {
+    expect(bundle).toMatch(/this\._renderer\s*=/);
+    expect(bundle).toMatch(/this\._charAtlas\s*=\s*\w+\s*,\s*this\._charAtlas\.warmUp\(\)/);
   });
 });

--- a/src/services/terminal/__tests__/TerminalWebGLAtlasCap.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLAtlasCap.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  ATLAS_MAX_TEXTURE_SIZE,
+  ATLAS_PAGE_START_SIZE,
+  applyAtlasPageSizeCap,
+  atlasByteCeiling,
+  isPageMergeEligible,
+} from "../TerminalWebGLAtlasCap";
+
+// Mirrors the shipped addon: TextureAtlas holds the limits as statics on the
+// class, and the only handle we get on that class is a live atlas instance's
+// constructor.
+function createAtlasClass(statics: { maxTextureSize?: number; maxAtlasPages?: number }) {
+  class FakeTextureAtlas {
+    public static maxTextureSize = statics.maxTextureSize;
+    public static maxAtlasPages = statics.maxAtlasPages;
+  }
+  return FakeTextureAtlas;
+}
+
+function createAddon(atlasClass?: ReturnType<typeof createAtlasClass>): object {
+  return { _renderer: atlasClass ? { _charAtlas: new atlasClass() } : {} };
+}
+
+// GlyphRenderer's hardware probe, which is what runs when the cap is absent.
+const HARDWARE_MAX_TEXTURE_SIZE = 16384;
+const HARDWARE_MAX_ATLAS_PAGES = 16;
+
+describe("applyAtlasPageSizeCap", () => {
+  it("lowers an initialized hardware limit to the cap", () => {
+    const atlasClass = createAtlasClass({
+      maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
+      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
+    });
+
+    expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(true);
+    expect(atlasClass.maxTextureSize).toBeLessThan(HARDWARE_MAX_TEXTURE_SIZE);
+    expect(atlasClass.maxTextureSize).toBe(ATLAS_MAX_TEXTURE_SIZE);
+  });
+
+  it("leaves maxAtlasPages alone, since it is baked into the shader at GlyphRenderer construction", () => {
+    const atlasClass = createAtlasClass({
+      maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
+      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
+    });
+
+    applyAtlasPageSizeCap(createAddon(atlasClass));
+
+    expect(atlasClass.maxAtlasPages).toBe(HARDWARE_MAX_ATLAS_PAGES);
+  });
+
+  it("declines an uninitialized atlas so the hardware probe cannot overwrite the cap", () => {
+    // GlyphRenderer initializes both statics together, gated on maxAtlasPages
+    // being undefined. Capping first would be clobbered moments later.
+    const atlasClass = createAtlasClass({ maxTextureSize: undefined, maxAtlasPages: undefined });
+
+    expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(false);
+    expect(atlasClass.maxTextureSize).toBeUndefined();
+  });
+
+  it("never raises a limit that is already below the cap", () => {
+    const belowCap = ATLAS_MAX_TEXTURE_SIZE / 2;
+    const atlasClass = createAtlasClass({ maxTextureSize: belowCap, maxAtlasPages: 8 });
+
+    expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(true);
+    expect(atlasClass.maxTextureSize).toBe(belowCap);
+  });
+
+  it("is idempotent across repeated attaches", () => {
+    const atlasClass = createAtlasClass({
+      maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
+      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
+    });
+    const addon = createAddon(atlasClass);
+
+    applyAtlasPageSizeCap(addon);
+    const afterFirst = atlasClass.maxTextureSize;
+
+    expect(applyAtlasPageSizeCap(addon)).toBe(true);
+    expect(atlasClass.maxTextureSize).toBe(afterFirst);
+  });
+
+  it("reports failure rather than throwing when the internal shape has drifted", () => {
+    expect(applyAtlasPageSizeCap(createAddon())).toBe(false);
+    expect(applyAtlasPageSizeCap({})).toBe(false);
+    expect(applyAtlasPageSizeCap({ _renderer: { _charAtlas: null } })).toBe(false);
+  });
+});
+
+describe("merge generations under the cap", () => {
+  it("allows a freshly allocated page to merge exactly once", () => {
+    const merged = ATLAS_PAGE_START_SIZE * 2;
+
+    expect(isPageMergeEligible(ATLAS_PAGE_START_SIZE, ATLAS_MAX_TEXTURE_SIZE)).toBe(true);
+    expect(isPageMergeEligible(merged, ATLAS_MAX_TEXTURE_SIZE)).toBe(false);
+  });
+
+  it("permits far more merge generations at the hardware limit than under the cap", () => {
+    const generations = (limit: number): number => {
+      let count = 0;
+      for (let width = ATLAS_PAGE_START_SIZE; isPageMergeEligible(width, limit); width *= 2) {
+        count++;
+      }
+      return count;
+    };
+
+    expect(generations(ATLAS_MAX_TEXTURE_SIZE)).toBeLessThan(
+      generations(HARDWARE_MAX_TEXTURE_SIZE)
+    );
+  });
+
+  it("keeps the cap at or above the size pages are allocated at", () => {
+    // A cap below the start size would bar merging outright and quarter the
+    // glyph capacity, which trades unbounded growth for eviction churn.
+    expect(ATLAS_MAX_TEXTURE_SIZE).toBeGreaterThanOrEqual(ATLAS_PAGE_START_SIZE);
+  });
+});
+
+describe("atlasByteCeiling", () => {
+  it("bounds the atlas far below the uncapped hardware ceiling", () => {
+    const capped = atlasByteCeiling(HARDWARE_MAX_ATLAS_PAGES, ATLAS_MAX_TEXTURE_SIZE);
+    const uncapped = atlasByteCeiling(HARDWARE_MAX_ATLAS_PAGES, HARDWARE_MAX_TEXTURE_SIZE);
+
+    expect(capped).toBeLessThan(uncapped);
+  });
+
+  it("holds the capped ceiling within the renderer's memory budget on the widest hardware", () => {
+    // 32 is the most pages xterm will use (Math.min(32, MAX_TEXTURE_IMAGE_UNITS)).
+    // The issue reports a view climbing past 1GB, so the bound is what makes a
+    // busy view plateau.
+    const widestHardware = atlasByteCeiling(32, ATLAS_MAX_TEXTURE_SIZE);
+
+    expect(widestHardware).toBeLessThanOrEqual(128 * 1024 * 1024);
+  });
+
+  it("cannot shrink the atlas below the four-page floor the atlas enforces", () => {
+    const belowFloor = atlasByteCeiling(1, ATLAS_MAX_TEXTURE_SIZE);
+    const atFloor = atlasByteCeiling(4, ATLAS_MAX_TEXTURE_SIZE);
+
+    expect(belowFloor).toBe(atFloor);
+  });
+
+  it("scales with page count above the floor", () => {
+    expect(atlasByteCeiling(16, ATLAS_MAX_TEXTURE_SIZE)).toBeGreaterThan(
+      atlasByteCeiling(8, ATLAS_MAX_TEXTURE_SIZE)
+    );
+  });
+});

--- a/src/services/terminal/__tests__/TerminalWebGLAtlasCap.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLAtlasCap.test.ts
@@ -1,11 +1,7 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
-import {
-  ATLAS_MAX_TEXTURE_SIZE,
-  ATLAS_PAGE_START_SIZE,
-  applyAtlasPageSizeCap,
-  atlasByteCeiling,
-  isPageMergeEligible,
-} from "../TerminalWebGLAtlasCap";
+import { ATLAS_MAX_TEXTURE_SIZE, applyAtlasPageSizeCap } from "../TerminalWebGLAtlasCap";
 
 // Mirrors the shipped addon: TextureAtlas holds the limits as statics on the
 // class, and the only handle we get on that class is a live atlas instance's
@@ -26,12 +22,16 @@ function createAddon(atlasClass?: ReturnType<typeof createAtlasClass>): object {
 const HARDWARE_MAX_TEXTURE_SIZE = 16384;
 const HARDWARE_MAX_ATLAS_PAGES = 16;
 
+function createProbedAtlasClass() {
+  return createAtlasClass({
+    maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
+    maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
+  });
+}
+
 describe("applyAtlasPageSizeCap", () => {
-  it("lowers an initialized hardware limit to the cap", () => {
-    const atlasClass = createAtlasClass({
-      maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
-      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
-    });
+  it("lowers a probed hardware limit to the cap", () => {
+    const atlasClass = createProbedAtlasClass();
 
     expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(true);
     expect(atlasClass.maxTextureSize).toBeLessThan(HARDWARE_MAX_TEXTURE_SIZE);
@@ -39,23 +39,46 @@ describe("applyAtlasPageSizeCap", () => {
   });
 
   it("leaves maxAtlasPages alone, since it is baked into the shader at GlyphRenderer construction", () => {
-    const atlasClass = createAtlasClass({
-      maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
-      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
-    });
+    const atlasClass = createProbedAtlasClass();
 
-    applyAtlasPageSizeCap(createAddon(atlasClass));
-
+    expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(true);
     expect(atlasClass.maxAtlasPages).toBe(HARDWARE_MAX_ATLAS_PAGES);
   });
 
-  it("declines an uninitialized atlas so the hardware probe cannot overwrite the cap", () => {
-    // GlyphRenderer initializes both statics together, gated on maxAtlasPages
-    // being undefined. Capping first would be clobbered moments later.
+  it("declines an atlas whose probe has not run, so the cap cannot be overwritten", () => {
+    // GlyphRenderer assigns both statics together, gated on maxAtlasPages being
+    // undefined. Capping first would be clobbered moments later.
     const atlasClass = createAtlasClass({ maxTextureSize: undefined, maxAtlasPages: undefined });
 
     expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(false);
     expect(atlasClass.maxTextureSize).toBeUndefined();
+  });
+
+  it("caps a probe that set the page count but left the texture size unusable", () => {
+    // GlyphRenderer assigns maxAtlasPages before querying MAX_TEXTURE_SIZE, so a
+    // throw between the two leaves this state permanently: later renderers skip
+    // the probe entirely and the atlas falls back to its own 4096 default.
+    const atlasClass = createAtlasClass({
+      maxTextureSize: undefined,
+      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
+    });
+
+    expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(true);
+    expect(atlasClass.maxTextureSize).toBe(ATLAS_MAX_TEXTURE_SIZE);
+  });
+
+  it("declines when the page count cannot bound the atlas, leaving the cap inert", () => {
+    // Reclaim is gated on a truthy maxAtlasPages; without one the atlas grows
+    // pages regardless of their size, so reporting success would be a lie.
+    for (const maxAtlasPages of [0, -1, Number.POSITIVE_INFINITY, Number.NaN]) {
+      const atlasClass = createAtlasClass({
+        maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
+        maxAtlasPages,
+      });
+
+      expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(false);
+      expect(atlasClass.maxTextureSize).toBe(HARDWARE_MAX_TEXTURE_SIZE);
+    }
   });
 
   it("never raises a limit that is already below the cap", () => {
@@ -66,83 +89,82 @@ describe("applyAtlasPageSizeCap", () => {
     expect(atlasClass.maxTextureSize).toBe(belowCap);
   });
 
-  it("is idempotent across repeated attaches", () => {
-    const atlasClass = createAtlasClass({
-      maxTextureSize: HARDWARE_MAX_TEXTURE_SIZE,
-      maxAtlasPages: HARDWARE_MAX_ATLAS_PAGES,
-    });
-    const addon = createAddon(atlasClass);
+  it("does not rewrite a static that is already at the cap", () => {
+    let writes = 0;
+    let stored: number | undefined = ATLAS_MAX_TEXTURE_SIZE;
+    class CountingAtlas {
+      public static maxAtlasPages: number | undefined = HARDWARE_MAX_ATLAS_PAGES;
+      public static get maxTextureSize(): number | undefined {
+        return stored;
+      }
+      public static set maxTextureSize(value: number | undefined) {
+        writes++;
+        stored = value;
+      }
+    }
 
-    applyAtlasPageSizeCap(addon);
-    const afterFirst = atlasClass.maxTextureSize;
+    expect(applyAtlasPageSizeCap({ _renderer: { _charAtlas: new CountingAtlas() } })).toBe(true);
+    expect(writes).toBe(0);
+  });
 
-    expect(applyAtlasPageSizeCap(addon)).toBe(true);
-    expect(atlasClass.maxTextureSize).toBe(afterFirst);
+  it("reports failure when the static swallows the write", () => {
+    // A getter-only static accepts the assignment in sloppy mode and keeps the
+    // hardware value; retiring the retry on that would leave the atlas unbounded.
+    class SwallowingAtlas {
+      public static maxAtlasPages: number | undefined = HARDWARE_MAX_ATLAS_PAGES;
+      public static get maxTextureSize(): number | undefined {
+        return HARDWARE_MAX_TEXTURE_SIZE;
+      }
+    }
+
+    expect(applyAtlasPageSizeCap({ _renderer: { _charAtlas: new SwallowingAtlas() } })).toBe(false);
   });
 
   it("reports failure rather than throwing when the internal shape has drifted", () => {
-    expect(applyAtlasPageSizeCap(createAddon())).toBe(false);
-    expect(applyAtlasPageSizeCap({})).toBe(false);
-    expect(applyAtlasPageSizeCap({ _renderer: { _charAtlas: null } })).toBe(false);
-  });
-});
-
-describe("merge generations under the cap", () => {
-  it("allows a freshly allocated page to merge exactly once", () => {
-    const merged = ATLAS_PAGE_START_SIZE * 2;
-
-    expect(isPageMergeEligible(ATLAS_PAGE_START_SIZE, ATLAS_MAX_TEXTURE_SIZE)).toBe(true);
-    expect(isPageMergeEligible(merged, ATLAS_MAX_TEXTURE_SIZE)).toBe(false);
-  });
-
-  it("permits far more merge generations at the hardware limit than under the cap", () => {
-    const generations = (limit: number): number => {
-      let count = 0;
-      for (let width = ATLAS_PAGE_START_SIZE; isPageMergeEligible(width, limit); width *= 2) {
-        count++;
+    class ThrowingAtlas {
+      public static get maxAtlasPages(): number {
+        throw new Error("internal shape drifted");
       }
-      return count;
-    };
+    }
 
-    expect(generations(ATLAS_MAX_TEXTURE_SIZE)).toBeLessThan(
-      generations(HARDWARE_MAX_TEXTURE_SIZE)
-    );
+    const drifted: object[] = [
+      createAddon(),
+      {},
+      { _renderer: null },
+      { _renderer: "not-an-object" },
+      { _renderer: { _charAtlas: null } },
+      { _renderer: { _charAtlas: 42 } },
+      { _renderer: { _charAtlas: { constructor: undefined } } },
+      { _renderer: { _charAtlas: { constructor: "not-a-class" } } },
+      { _renderer: { _charAtlas: new ThrowingAtlas() } },
+    ];
+
+    for (const addon of drifted) {
+      expect(applyAtlasPageSizeCap(addon)).toBe(false);
+    }
   });
 
-  it("keeps the cap at or above the size pages are allocated at", () => {
-    // A cap below the start size would bar merging outright and quarter the
-    // glyph capacity, which trades unbounded growth for eviction churn.
-    expect(ATLAS_MAX_TEXTURE_SIZE).toBeGreaterThanOrEqual(ATLAS_PAGE_START_SIZE);
+  it("caps a frozen class only if the write lands", () => {
+    const atlasClass = createProbedAtlasClass();
+    Object.freeze(atlasClass);
+
+    // Strict mode makes the assignment throw; the guard must swallow it and
+    // report the atlas as unbounded rather than break the attach path.
+    expect(applyAtlasPageSizeCap(createAddon(atlasClass))).toBe(false);
+    expect(atlasClass.maxTextureSize).toBe(HARDWARE_MAX_TEXTURE_SIZE);
   });
 });
 
-describe("atlasByteCeiling", () => {
-  it("bounds the atlas far below the uncapped hardware ceiling", () => {
-    const capped = atlasByteCeiling(HARDWARE_MAX_ATLAS_PAGES, ATLAS_MAX_TEXTURE_SIZE);
-    const uncapped = atlasByteCeiling(HARDWARE_MAX_ATLAS_PAGES, HARDWARE_MAX_TEXTURE_SIZE);
+describe("pinned @xterm/addon-webgl contract", () => {
+  // The cap reaches through the addon's private shape and degrades silently by
+  // design, so a rename in a future bump would restore the unbounded growth this
+  // fixes with no other signal. Fail loudly at the bump instead.
+  it("still ships the internals and statics the cap depends on", () => {
+    const require = createRequire(import.meta.url);
+    const bundle = readFileSync(require.resolve("@xterm/addon-webgl/lib/addon-webgl.mjs"), "utf8");
 
-    expect(capped).toBeLessThan(uncapped);
-  });
-
-  it("holds the capped ceiling within the renderer's memory budget on the widest hardware", () => {
-    // 32 is the most pages xterm will use (Math.min(32, MAX_TEXTURE_IMAGE_UNITS)).
-    // The issue reports a view climbing past 1GB, so the bound is what makes a
-    // busy view plateau.
-    const widestHardware = atlasByteCeiling(32, ATLAS_MAX_TEXTURE_SIZE);
-
-    expect(widestHardware).toBeLessThanOrEqual(128 * 1024 * 1024);
-  });
-
-  it("cannot shrink the atlas below the four-page floor the atlas enforces", () => {
-    const belowFloor = atlasByteCeiling(1, ATLAS_MAX_TEXTURE_SIZE);
-    const atFloor = atlasByteCeiling(4, ATLAS_MAX_TEXTURE_SIZE);
-
-    expect(belowFloor).toBe(atFloor);
-  });
-
-  it("scales with page count above the floor", () => {
-    expect(atlasByteCeiling(16, ATLAS_MAX_TEXTURE_SIZE)).toBeGreaterThan(
-      atlasByteCeiling(8, ATLAS_MAX_TEXTURE_SIZE)
-    );
+    for (const identifier of ["_renderer", "_charAtlas", "maxAtlasPages", "maxTextureSize"]) {
+      expect(bundle).toContain(identifier);
+    }
   });
 });

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -242,18 +242,21 @@ describe("TerminalWebGLManager", () => {
     }
 
     // Mirrors WebglAddon.activate(): the renderer and its atlas are constructed
-    // synchronously, so both exist by the time loadAddon returns.
+    // synchronously, so both exist by the time loadAddon returns. Attaching the
+    // atlas here rather than at addon construction is what pins the ordering —
+    // a cap applied before loadAddon would find nothing to cap.
     function activateOnLoad(
       managed: ManagedTerminal,
       atlasClass: ReturnType<typeof makeAtlasClass> | null
     ): void {
-      (managed.terminal.loadAddon as ReturnType<typeof vi.fn>).mockImplementation(
-        (addon: { _renderer?: { _charAtlas?: object } }) => {
-          if (atlasClass && addon._renderer) {
-            addon._renderer._charAtlas = new atlasClass();
-          }
-        }
-      );
+      vi.mocked(managed.terminal.loadAddon).mockImplementation((addon: unknown) => {
+        if (!atlasClass) return;
+        if (typeof addon !== "object" || addon === null) return;
+        if (!("_renderer" in addon)) return;
+        const renderer = addon._renderer;
+        if (typeof renderer !== "object" || renderer === null) return;
+        Object.assign(renderer, { _charAtlas: new atlasClass() });
+      });
     }
 
     it("caps the atlas once the addon has activated", () => {

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -204,6 +204,9 @@ describe("TerminalWebGLManager", () => {
     // a tight band that's high enough for any single-suite tests to attach
     // freely; the mode-switch describe block raises/lowers them as needed.
     mod.TerminalWebGLManager.setWebglThresholds(32, 28);
+    // Also module-level: once an atlas is capped the manager stops retrying, so
+    // a case that caps would otherwise suppress capping in every later case.
+    mod.__testing.resetAtlasCapState();
     manager = new mod.TerminalWebGLManager();
   });
 
@@ -224,6 +227,84 @@ describe("TerminalWebGLManager", () => {
     expect(WebglAddonMock).toHaveBeenCalledTimes(1);
     expect(managed.terminal.loadAddon).toHaveBeenCalledTimes(1);
     expect(manager.isActive("t1")).toBe(true);
+  });
+
+  describe("shared atlas page-size cap", () => {
+    const HARDWARE_MAX_TEXTURE_SIZE = 16384;
+
+    // One class across every addon, matching the real TextureAtlas: the statics
+    // are module-global to the addon bundle, not per terminal.
+    function makeAtlasClass() {
+      return class FakeTextureAtlas {
+        public static maxTextureSize: number | undefined = HARDWARE_MAX_TEXTURE_SIZE;
+        public static maxAtlasPages: number | undefined = 16;
+      };
+    }
+
+    // Mirrors WebglAddon.activate(): the renderer and its atlas are constructed
+    // synchronously, so both exist by the time loadAddon returns.
+    function activateOnLoad(
+      managed: ManagedTerminal,
+      atlasClass: ReturnType<typeof makeAtlasClass> | null
+    ): void {
+      (managed.terminal.loadAddon as ReturnType<typeof vi.fn>).mockImplementation(
+        (addon: { _renderer?: { _charAtlas?: object } }) => {
+          if (atlasClass && addon._renderer) {
+            addon._renderer._charAtlas = new atlasClass();
+          }
+        }
+      );
+    }
+
+    it("caps the atlas once the addon has activated", () => {
+      const atlasClass = makeAtlasClass();
+      const managed = makeManagedTerminal();
+      activateOnLoad(managed, atlasClass);
+
+      manager.ensureContext("t1", managed);
+
+      expect(atlasClass.maxTextureSize).toBeLessThan(HARDWARE_MAX_TEXTURE_SIZE);
+    });
+
+    it("keeps retrying while the atlas stays unreachable, then caps a later attach", () => {
+      const unreachable = makeManagedTerminal();
+      activateOnLoad(unreachable, null);
+      manager.ensureContext("t1", unreachable);
+
+      const atlasClass = makeAtlasClass();
+      const reachable = makeManagedTerminal();
+      activateOnLoad(reachable, atlasClass);
+      manager.ensureContext("t2", reachable);
+
+      expect(atlasClass.maxTextureSize).toBeLessThan(HARDWARE_MAX_TEXTURE_SIZE);
+    });
+
+    it("stops touching the atlas once it is capped", () => {
+      const atlasClass = makeAtlasClass();
+      const first = makeManagedTerminal();
+      activateOnLoad(first, atlasClass);
+      manager.ensureContext("t1", first);
+
+      const capped = atlasClass.maxTextureSize;
+      // A second atlas class stands in for a shape the cap would reject; it must
+      // never be consulted, because the first attach already retired the retry.
+      const second = makeManagedTerminal();
+      const laterClass = makeAtlasClass();
+      activateOnLoad(second, laterClass);
+      manager.ensureContext("t2", second);
+
+      expect(atlasClass.maxTextureSize).toBe(capped);
+      expect(laterClass.maxTextureSize).toBe(HARDWARE_MAX_TEXTURE_SIZE);
+    });
+
+    it("still attaches WebGL when the atlas cannot be reached", () => {
+      const managed = makeManagedTerminal();
+      activateOnLoad(managed, null);
+
+      manager.ensureContext("t1", managed);
+
+      expect(manager.isActive("t1")).toBe(true);
+    });
   });
 
   it("is a no-op when terminal is not opened", () => {


### PR DESCRIPTION
**Root cause** (verified against the real `@xterm/addon-webgl` 0.20.0-beta.289 source in `node_modules`, which ships readable TS, not inferred):

Two upstream properties compound:

1. `CharAtlasCache.charAtlasCache` is a **module-level array**. `acquireTextureAtlas()` matches entries by `configEquals` and pushes the terminal into `ownedBy: Terminal[]`; `removeTerminalFromCache()` only disposes the atlas when the terminal being disposed was the **last owner**. Every Daintree terminal shares font/theme, so they all share one atlas entry and any surviving sibling keeps the whole thing alive. Upstream even documents the hazard in a comment on that interface: *"N.B. This implementation potentially holds onto copies of the terminal forever, so this may cause memory leaks."* That is why growth never reverses on terminal close.

2. `TextureAtlas`'s glyph cache is a `FourKeyMap` keyed `(code|chars, bg, fg, ext)` with **no per-entry eviction**. Pages are always allocated at 512px and only grow by merging 4 same-size pages into one of double the size, gated on `page.width * 2 <= TextureAtlas.maxTextureSize`. That static is process-global and **Daintree never set it**, so `GlyphRenderer` left it at `gl.MAX_TEXTURE_SIZE` (often 16384). Pages ratchet 512 → 1024 → … → 16384, and because a merge always succeeds, `_evictAllPages` (the only thing that clears the glyph cache maps) is effectively unreachable. Truecolor plus per-token syntax highlighting maximizes distinct keys, which is exactly the reported workload.

**Fix**: cap `maxTextureSize` at 1024 once the atlas statics exist. That makes eviction reachable: once every page has merged to the cap, none are merge-eligible, so the next page demand evicts and drops the pages **and** both cache maps. Bounds the page backing store at `maxAtlasPages * 1024² * 4`, which is 64MB at 16 texture units and 128MB at 32.

Notes on the shape of the fix:
- `maxAtlasPages` is deliberately left at the hardware value: it's baked into the fragment shader and the renderer's texture-unit binding at `GlyphRenderer` construction, so lowering it afterwards would desync the two. `maxTextureSize` has exactly one read in the whole addon (the merge filter), so it's safe to set post-construction.
- The cap must run **after** `loadAddon`: `GlyphRenderer`'s probe assigns both statics gated on `maxAtlasPages === undefined`, so an earlier write is silently clobbered. `loadAddon` → `activate` → `new WebglRenderer` → `_initializeWebGLState` is synchronous, so the atlas is reachable the moment it returns.
- The `TextureAtlas` class is private to the bundle (the package exports and typings expose only `WebglAddon`, and deep-importing its source would yield a *different* class than the one the bundle closed over), so the cap reaches it through a live atlas instance's constructor. Every read is guarded, so a drifted internal shape degrades to "not capped" rather than throwing into the attach path.
- 1024 rather than 512: pinning the cap to the page size would bar merging entirely but also quarters glyph capacity, and a working set that outgrows the atlas evicts on a loop. Today there are five merge generations; at 1024 there's one, so this *reduces* exposure to the #8080 index-rewrite path rather than trading one risk for another.

**Scope**: this is the proactive structural bound only. Reactive reclaim (`clearTextureAtlas()` on invisible terminals, GC nudge after teardown) is #11211's, and hidden-view work reduction is #11212's. Neither is touched here.

**Testing**: 138 tests pass across the atlas-cap, WebGL-manager, and paint-fabric suites. Full project typecheck passes; own-file lint and format are clean with the per-rule warning ratchet flat. The guards are mutation-tested: removing the production call fails 2 tests, removing the page-count guard fails 3, and replacing the write read-back with `return true` fails 1. A contract test matches the pinned bundle's actual mechanism (merge rule, paired hardware probe, reclaim gate, atlas assignment), so a future xterm bump that moves any of it fails loudly instead of silently restoring the leak.

CI forces `--disable-gpu`/`DAINTREE_DISABLE_WEBGL=1`, so this leak class is structurally invisible to the normal suite and to Playwright. Nightly WebGL-gated plateau validation under sustained truecolor streaming is the natural follow-up.

**Known follow-ups, deliberately out of scope** (both pre-existing, unaffected by this change):
- The single `_overflowSizePage` is allocated at hardware `deviceMaxTextureSize` for glyphs wider than a page. Unreachable for normal terminal glyphs and reset by the same eviction.
- `runAtlasResync`'s blanket `suppressAtlasResync` can drop a layout event raised while repairing a co-owner. It self-heals via xterm's `pageLayoutVersion`/`beginFrame` rebuild before the owner's next render, but queueing a trailing pass would be worthwhile hardening.

Resolves #11210
