### PR TITLE
fix(protocols): display images larger than 512 KB in the file viewer

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1658,6 +1658,94 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     expect(fs.open).toHaveBeenCalledTimes(1);
   });
 
+  it("serves an image past the 512 KB text cap (images use the larger ceiling)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 5 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("image/png");
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/big.png", "/project"));
+
+    // 5 MB would 413 under the text cap; an image is decoded as pixels, not a
+    // giant string, so it clears the larger image ceiling and gets read.
+    expect(response.status).toBe(200);
+    expect(fs.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("still rejects an image beyond the image ceiling with 413", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 25 * 1024 * 1024 + 1 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("image/png");
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/huge.png", "/project"));
+
+    expect(response.status).toBe(413);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("serves an image exactly at the image ceiling (cap is exclusive)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 25 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("image/png");
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/edge.png", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(fs.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not extend the raster ceiling to SVG (kept at the text cap)", async () => {
+    // SVG is served through the sanitizing files:read path in the viewer, so the
+    // protocol deliberately keeps it at the tight cap — a 5 MB SVG still 413s.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 5 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("image/svg+xml");
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/big.svg", "/project"));
+
+    expect(response.status).toBe(413);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("rejects a file that grows past the cap between stat and read (413 after open)", async () => {
+    // The pre-open stat is advisory; a writer can grow/swap the file before the
+    // read. The post-read length check is the real ceiling — without it an
+    // oversized buffer would reach the renderer and risk a decode OOM.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 4 } as Awaited<ReturnType<typeof fs.stat>>);
+    const oversized = Buffer.alloc(512 * 1024 + 1);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle(oversized) as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/grew.bin", "/project"));
+
+    expect(response.status).toBe(413);
+    // The open/read did happen — this is the second, post-read guard, not the stat guard.
+    expect(fs.open).toHaveBeenCalledTimes(1);
+  });
+
   it("returns 404 when O_NOFOLLOW rejects a final-component symlink with ELOOP (TOCTOU)", async () => {
     const fs = await import("fs/promises");
     vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
@@ -2660,6 +2748,22 @@ describe("createDaintreeHtmlProtocolHandler — sandboxed HTML preview (#11191)"
 
     const handler = await captureHandler();
     const response = await handler(makeRequest(token, "big.html"));
+    expect(response.status).toBe(413);
+  });
+
+  it("keeps report image assets at the 512 KB cap (raster allowance is file:// only)", async () => {
+    // The larger raster-image ceiling is scoped to the daintree-file:// viewer;
+    // a script-driven preview must not be able to pull multi-MB images through
+    // the shared read core. A 2 MB PNG asset here still 413s.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockResolvedValue({ size: 2 * 1024 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("image/png");
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest(token, "chart.png"));
     expect(response.status).toBe(413);
   });
 });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -159,6 +159,34 @@ function createAppProtocolHandler(distPath: string) {
 // renderer OOM via a malicious or accidental large-file URL.
 const DAINTREE_FILE_MAX_BYTES = 512 * 1024;
 
+// Raster images are decoded as pixels by the <img> element, not turned into a
+// giant JS string the way a text read is, so the 512 KB text cap doesn't apply —
+// a normal screenshot or AI-generated PNG routinely runs to several MB. These
+// MIME types get a much larger ceiling (still bounded, and enforced against the
+// bytes actually read) so the inline file viewer can display them. The set
+// mirrors FileViewerModal's IMAGE_EXTENSIONS; SVG is deliberately excluded — the
+// viewer routes SVG through the sanitizing files:read path (its own 512 KB cap),
+// so serving multi-MB raw SVG here would be inconsistent and pointless.
+const DAINTREE_IMAGE_MAX_BYTES = 25 * 1024 * 1024;
+const LARGE_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  "image/x-icon",
+]);
+
+// The size ceiling for a resolved file. Only the daintree-file:// viewer path
+// opts into the larger raster-image cap (allowLargeImages); daintree-html://
+// report assets stay at the tight cap so a script-driven preview can't turn the
+// allowance into an aggregate-memory DoS.
+function maxBytesForFile(realFile: string, allowLargeImages: boolean): number {
+  return allowLargeImages && LARGE_IMAGE_MIME_TYPES.has(getMimeType(realFile))
+    ? DAINTREE_IMAGE_MAX_BYTES
+    : DAINTREE_FILE_MAX_BYTES;
+}
+
 // Hardened response headers for daintree-file://.
 // CORP must be cross-origin: the app:// renderer and daintree-file:// are
 // different schemes (and therefore different origins/sites), and same-origin
@@ -189,16 +217,20 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
 
 /**
  * Shared read core for daintree-file:// and daintree-html://: realpath
- * containment, 512 KB cap, and O_RDONLY|O_NOFOLLOW open. Returns the file bytes
+ * containment, a size cap (per maxBytesForFile — larger for raster images when
+ * allowLargeImages is set), and O_RDONLY|O_NOFOLLOW open. Returns the file bytes
  * plus the canonical path (for MIME), or an error Response. Callers own the
- * success headers so each scheme sets its own CSP. Extracted verbatim from the
- * original daintree-file:// handler; the flow (realpath → path.relative → stat →
- * O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
+ * success headers so each scheme sets its own CSP. The flow (realpath →
+ * path.relative → stat → O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
  */
 // Return type is inferred, not annotated: annotating `buffer: Buffer` widens it
 // to `Buffer<ArrayBufferLike>`, which `new Response(...)` rejects as a BodyInit.
 // Inference preserves the exact `readFile()` result type the Response accepts.
-async function readContainedDaintreeFile(normalizedRoot: string, normalizedFile: string) {
+async function readContainedDaintreeFile(
+  normalizedRoot: string,
+  normalizedFile: string,
+  allowLargeImages: boolean
+) {
   // Resolve symlinks before containment to block in-root symlinks pointing outside root (CVE-2025-53109 / CVE-2025-54794 class).
   let realRoot: string;
   let realFile: string;
@@ -232,7 +264,8 @@ async function readContainedDaintreeFile(normalizedRoot: string, normalizedFile:
     });
   }
 
-  if (fileStat.size > DAINTREE_FILE_MAX_BYTES) {
+  const maxBytes = maxBytesForFile(realFile, allowLargeImages);
+  if (fileStat.size > maxBytes) {
     return new Response("Payload Too Large", {
       status: 413,
       headers: buildDaintreeFileErrorHeaders(),
@@ -261,6 +294,17 @@ async function readContainedDaintreeFile(normalizedRoot: string, normalizedFile:
 
   try {
     const buffer = await fileHandle.readFile();
+    // The pre-read stat is advisory: a writer can grow or swap the file between
+    // stat and read (O_NOFOLLOW blocks only a final-component symlink swap, not
+    // a regular-file replacement or in-place growth). Re-check the bytes we
+    // actually read so an oversized file can never reach the renderer, where the
+    // decode-OOM risk this cap exists to bound actually lives.
+    if (buffer.length > maxBytes) {
+      return new Response("Payload Too Large", {
+        status: 413,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
     return { buffer, realFile };
   } finally {
     // Swallow close errors so they don't mask a preceding readFile failure.
@@ -308,7 +352,8 @@ function createDaintreeFileProtocolHandler() {
 
       const result = await readContainedDaintreeFile(
         path.normalize(rootPath),
-        path.normalize(filePath)
+        path.normalize(filePath),
+        true
       );
       if (result instanceof Response) return result;
 
@@ -489,7 +534,10 @@ function createDaintreeHtmlProtocolHandler() {
 
     try {
       const candidatePath = path.resolve(root, normalizedPosix);
-      const result = await readContainedDaintreeFile(path.normalize(root), candidatePath);
+      // Report assets keep the tight cap: a preview document can execute scripts
+      // and request the same file many times, so the raster-image allowance is
+      // scoped to the daintree-file:// viewer path only.
+      const result = await readContainedDaintreeFile(path.normalize(root), candidatePath, false);
       if (result instanceof Response) return result;
 
       // Only navigable HTML documents get the loosened, token-scoped CSP;


### PR DESCRIPTION
Clicking an image path in an agent terminal opened the file viewer but just showed "Unable to display image".

The file viewer loads images over our internal `daintree-file://` protocol in `electron/setup/protocols.ts`, and that protocol was rejecting any file over 512 KB with a `413`. So the `<img>` element never got the bytes and dropped straight to the error state.

The 512 KB cap is correct for text reads. A big file becomes a big string and risks an out-of-memory error in the renderer. It's wrong for images though, which decode into pixels. A normal 2.5 MB screenshot or a Codex-generated PNG is perfectly fine to display, it was just being rejected on size.

## The fix

- Raise the cap to 25 MB for raster image types (`png`, `jpeg`, `gif`, `webp`, `bmp`, `ico`), and keep the 512 KB cap for everything else so we don't accidentally pull a huge text file into a string.
- Exclude SVG. The viewer sanitizes SVG through a separate `files:read` path that keeps its own 512 KB cap, so serving multi-MB raw SVG here would be both inconsistent and pointless.
- Scope the larger cap to the `daintree-file://` viewer path only. `daintree-html://` report previews stay at 512 KB. Those previews can execute scripts, and I don't want one requesting the same large image many times over as a cheap denial-of-service. That path was already at 512 KB, so there's no regression there.
- Add a post-read byte-length check, not just the pre-read `stat()`. The `stat` is advisory: a file can grow or be swapped between `stat` and read, and `O_NOFOLLOW` only blocks a final-component symlink swap. The post-read check is the real ceiling, so an oversized file can never reach the renderer where the decode-OOM risk actually lives.

## Tests

Added coverage for the 25 MB ceiling and its exact edge (inclusive max), the SVG exclusion, the `daintree-html://` exclusion, and the grow-after-`stat` guard. Full `npm run check` and the protocol / `files.read` / `FileViewerModal` suites are green.

I left the `HEAD` request path alone. It reads the full body too, but it isn't on the image path (the viewer uses `GET`), so it's out of scope for this fix.
