### PR TITLE
feat(terminal): raise agent scrollback ceiling to 10k lines

### DIFF
--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -277,12 +277,17 @@ export const WRITE_MAX_CHUNK_SIZE = 50;
 export const WRITE_INTERVAL_MS = 5;
 
 // Scrollback configuration
-// All PTY panels get the same scrollback; there is no "agent tier" scrollback
-// decision any more. Capped at the renderer's hard display ceiling (AGENT_POLICY
-// maxLines in src/utils/scrollbackConfig.ts — 5000 even for "unlimited") so the
-// headless analysis mirror never retains lines no renderer can show and no
-// consumer can read (terminal.getOutput caps at 1000). At ~12 bytes/cell this
-// halves the worst-case mirror cost per terminal versus the previous 10000.
+// All PTY panels get the same headless-mirror scrollback; there is no "agent
+// tier" scrollback decision any more. This is the pty-host analysis mirror, NOT
+// the renderer's display buffer — the two are sized independently on purpose.
+// The renderer agent ceiling is AGENT_POLICY maxLines (10000, in
+// src/utils/scrollbackConfig.ts); this mirror is deliberately kept lower to bound
+// pty-host heap (at ~12 bytes/cell, 5000 vs 10000 halves the worst-case mirror
+// cost per terminal). The mirror only feeds analysis (terminal.getOutput caps at
+// 1000) and serialize/restore, so the trade is: a live renderer scrolls back the
+// full 10000 lines, but a session restored after project-view eviction recovers
+// only the most recent ~5000. Raise this to match the renderer ceiling only with
+// a pty-host memory review (and a re-check of the persisted-snapshot size limit).
 export const DEFAULT_SCROLLBACK = 5000;
 
 // Preserved-snapshot eviction (issue #10839)

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -43,8 +43,9 @@ export interface ResourceProfileConfig {
    * Ceiling on the agent-terminal scrollback policy (lines). Caps the
    * AGENT_POLICY maxLines in src/utils/scrollbackConfig.ts — at xterm's
    * ~1.2KB/line each agent terminal holds up to ~maxLines×1.2KB of buffer
-   * once filled, so constrained hardware (efficiency) trades history depth
-   * for ~3MB per visible agent terminal. Applied live on profile change via
+   * once filled (~12MB at the 10k perf/balanced ceiling), so constrained
+   * hardware (efficiency) trades history depth for ~7MB per visible agent
+   * terminal by dropping to 4k. Applied live on profile change via
    * useResourceProfile → restoreScrollbackAllForeground.
    */
   agentScrollbackMaxLines: number;
@@ -173,7 +174,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfi
     projectStatsPollInterval: 5000,
     memoryPressureInactiveMs: 60 * 60 * 1000, // 60 min
     lowMemoryFreeThresholdMb: null,
-    agentScrollbackMaxLines: 5000,
+    agentScrollbackMaxLines: 10000,
     fetchIntervalActiveMs: 20_000,
     fetchIntervalBackgroundMs: 3 * 60_000,
     portBatchThroughputDelayMs: 16,
@@ -190,7 +191,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfi
     projectStatsPollInterval: 5000,
     memoryPressureInactiveMs: 30 * 60 * 1000, // 30 min
     lowMemoryFreeThresholdMb: 768,
-    agentScrollbackMaxLines: 5000,
+    agentScrollbackMaxLines: 10000,
     fetchIntervalActiveMs: 30_000,
     fetchIntervalBackgroundMs: 5 * 60_000,
     // Must match PORT_BATCH_THROUGHPUT_DELAY_MS — the pty-host's fallback
@@ -213,10 +214,12 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, BaseResourceProfi
     projectStatsPollInterval: 25000,
     memoryPressureInactiveMs: 15 * 60 * 1000, // 15 min
     lowMemoryFreeThresholdMb: 1024,
-    // Half the agent history ceiling on constrained hardware — ~3MB less
-    // buffer headroom per filled agent terminal, consistent with the
-    // efficiency profile's other fidelity trades.
-    agentScrollbackMaxLines: 2500,
+    // Lower agent history ceiling on constrained hardware — ~7MB less buffer
+    // headroom per filled agent terminal versus the 10k perf/balanced ceiling,
+    // consistent with the efficiency profile's other fidelity trades. Still
+    // well above the previous 2.5k efficiency ceiling so a filled session stays
+    // scrollable.
+    agentScrollbackMaxLines: 4000,
     fetchIntervalActiveMs: 45_000,
     fetchIntervalBackgroundMs: 10 * 60_000,
     // ~2.5x fewer flush wakeups and MessagePort posts per busy terminal; the

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -257,8 +257,8 @@ describe("TerminalInstanceService - Scrollback", () => {
 
       service.restoreScrollback("t1");
 
-      // getScrollbackForType(true, 5000) = min(5000, max(500, floor(5000*1.5))) = 5000
-      expect(managed.terminal.options.scrollback).toBe(5000);
+      // getScrollbackForType(true, 5000) = min(10000, max(500, floor(5000*10))) = 10000
+      expect(managed.terminal.options.scrollback).toBe(10000);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
@@ -92,7 +92,7 @@ describe("TerminalScrollbackController adversarial", () => {
     restoreScrollback(agentManaged);
 
     expect(terminalManaged.terminal.options.scrollback).toBe(2000);
-    expect(agentManaged.terminal.options.scrollback).toBe(5000);
+    expect(agentManaged.terminal.options.scrollback).toBe(10000);
   });
 
   it("NEGATIVE_SCROLLBACK_USED_NO_WARN", () => {

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -268,7 +268,8 @@ describe("TerminalScrollbackController", () => {
       managed.terminal.options.scrollback = 100;
 
       restoreScrollback(managed);
-      expect(managed.terminal.options.scrollback).toBe(5000);
+      // getScrollbackForType(true, 5000) = min(10000, floor(5000*10)) = 10000
+      expect(managed.terminal.options.scrollback).toBe(10000);
     });
 
     // #10911 — a demotion flap (agent→plain) calls restoreScrollback with a

--- a/src/utils/__tests__/scrollbackConfig.test.ts
+++ b/src/utils/__tests__/scrollbackConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { RESOURCE_PROFILE_CONFIGS } from "@shared/types/resourceProfile";
 import {
   estimateMemoryUsage,
   getAgentScrollbackMaxLines,
@@ -15,16 +16,19 @@ afterEach(() => {
 describe("estimateMemoryUsage", () => {
   it("computes per-type and total bytes for a typical 8-agent + 8-shell session", () => {
     const result = estimateMemoryUsage({ agent: 8, plain: 8 }, 1000);
-    // agent: 1000 * 5 = 5000 lines/term, 5000 * 1200 * 8 = 48,000,000
+    // agent: 1000 * 10 = 10000 lines/term (at cap), 10000 * 1200 * 8 = 96,000,000
     // plain: 1000 * 0.3 = 300 lines/term, 300 * 1200 * 8 =  2,880,000
-    // total = 50,880,000
-    expect(result.agent).toBe(48_000_000);
+    // total = 98,880,000
+    expect(result.agent).toBe(96_000_000);
     expect(result.plain).toBe(2_880_000);
-    expect(result.total).toBe(50_880_000);
+    expect(result.total).toBe(98_880_000);
   });
 
-  it("computes a single agent terminal at default scrollback", () => {
-    const result = estimateMemoryUsage({ agent: 1, plain: 0 }, 1000);
+  it("computes a single agent terminal below the cap so the multiplier is exercised", () => {
+    // base=500 keeps the agent value (5000) under the 10k cap, so this proves
+    // the estimate flows the multiplier through rather than always using maxLines.
+    const result = estimateMemoryUsage({ agent: 1, plain: 0 }, 500);
+    // 500 * 10 = 5000 lines, 5000 * 1200 = 6,000,000
     expect(result.agent).toBe(6_000_000);
     expect(result.plain).toBe(0);
     expect(result.total).toBe(6_000_000);
@@ -39,10 +43,10 @@ describe("estimateMemoryUsage", () => {
 
   it("uses maxLines for unlimited scrollback (base=0)", () => {
     const result = estimateMemoryUsage({ agent: 8, plain: 8 }, 0);
-    // agent: 5000 lines/term, plain: 2000 lines/term
-    expect(result.agent).toBe(5000 * 1200 * 8); // 48,000,000
+    // agent: 10000 lines/term, plain: 2000 lines/term
+    expect(result.agent).toBe(10000 * 1200 * 8); // 96,000,000
     expect(result.plain).toBe(2000 * 1200 * 8); // 19,200,000
-    expect(result.total).toBe(67_200_000);
+    expect(result.total).toBe(115_200_000);
   });
 
   it("returns zeros when there are no terminals", () => {
@@ -63,10 +67,14 @@ describe("getScrollbackForType", () => {
   });
 
   it("scales agent scrollback proportionally below the cap and clamps above it", () => {
-    // base=500 is the realistic memory-pressure restore base (SCROLLBACK_BACKGROUND)
-    expect(getScrollbackForType(true, 500)).toBe(2500);
-    expect(getScrollbackForType(true, 1000)).toBe(5000);
-    expect(getScrollbackForType(true, 5000)).toBe(5000);
+    // Sub-cap: the ×10 multiplier is applied verbatim (500 is also the realistic
+    // memory-pressure restore base, SCROLLBACK_BACKGROUND). 999 sits just below
+    // saturation so it proves scaling rather than clamping.
+    expect(getScrollbackForType(true, 500)).toBe(5000);
+    expect(getScrollbackForType(true, 999)).toBe(9990);
+    // At/above saturation (base ≥ 1000): clamped to the 10k policy ceiling.
+    expect(getScrollbackForType(true, 1001)).toBe(10000);
+    expect(getScrollbackForType(true, 5000)).toBe(10000);
   });
 
   it("keeps plain terminals on the small policy at the default base", () => {
@@ -89,8 +97,33 @@ describe("getScrollbackForType", () => {
     });
 
     it("never raises the ceiling above the policy max", () => {
+      // Invariant, not a copied literal: a profile ceiling above the policy max
+      // cannot push the effective cap past what the policy already allows.
+      const capBefore = getScrollbackForType(true, 0);
       setAgentScrollbackMaxLines(50_000);
-      expect(getScrollbackForType(true, 0)).toBe(5000);
+      expect(getScrollbackForType(true, 0)).toBe(capBefore);
+    });
+
+    it("binds the effective agent cap to the configured efficiency ceiling", () => {
+      // Feed the real efficiency ceiling in rather than a copied literal: whatever
+      // the profile table configures becomes the binding cap, and a sub-ceiling
+      // base still scales by the multiplier beneath it.
+      const efficiencyCeiling = RESOURCE_PROFILE_CONFIGS.efficiency.agentScrollbackMaxLines;
+      setAgentScrollbackMaxLines(efficiencyCeiling);
+
+      expect(getScrollbackForType(true, 0)).toBe(efficiencyCeiling);
+      expect(getScrollbackForType(true, 100_000)).toBe(efficiencyCeiling);
+      // A base whose ×10 result is under the efficiency ceiling scales freely.
+      const subCeilingBase = Math.floor(efficiencyCeiling / 10) - 1;
+      expect(getScrollbackForType(true, subCeilingBase)).toBe(subCeilingBase * 10);
+    });
+
+    it("keeps performance and balanced ceilings equal and above efficiency", () => {
+      // Ordering invariant across the profile table — no per-value literals, so
+      // the assertion survives any future retuning that preserves the ordering.
+      const { performance, balanced, efficiency } = RESOURCE_PROFILE_CONFIGS;
+      expect(performance.agentScrollbackMaxLines).toBe(balanced.agentScrollbackMaxLines);
+      expect(efficiency.agentScrollbackMaxLines).toBeLessThan(balanced.agentScrollbackMaxLines);
     });
 
     it("clamps the ceiling to the policy floor and ignores non-finite input", () => {

--- a/src/utils/scrollbackConfig.ts
+++ b/src/utils/scrollbackConfig.ts
@@ -6,7 +6,7 @@ interface ScrollbackPolicy {
   minLines: number;
 }
 
-const AGENT_POLICY: ScrollbackPolicy = { multiplier: 5, maxLines: 5000, minLines: 500 };
+const AGENT_POLICY: ScrollbackPolicy = { multiplier: 10, maxLines: 10000, minLines: 500 };
 const PLAIN_POLICY: ScrollbackPolicy = { multiplier: 0.3, maxLines: 2000, minLines: 200 };
 
 // Resource-profile ceiling on the agent policy. Pushed by useResourceProfile
@@ -28,7 +28,8 @@ export function getAgentScrollbackMaxLines(): number {
  * Get appropriate scrollback lines based on whether an agent is live in the
  * terminal. Agent terminals (or terminals launched to run an agent) get the
  * larger scrollback policy; plain shells get the smaller one. The agent
- * ceiling scales with the resource profile (efficiency halves it).
+ * ceiling scales with the resource profile (efficiency lowers it to 4k, ~40%
+ * of the 10k perf/balanced ceiling).
  */
 export function getScrollbackForType(isAgent: boolean, baseScrollback: number): number {
   const policy = isAgent ? AGENT_POLICY : PLAIN_POLICY;


### PR DESCRIPTION
Raises the agent-terminal scrollback ceiling from an effective 5000 lines to 10000. 5000 was too shallow to scroll back through a full agent session.

The core change is `AGENT_POLICY` in `src/utils/scrollbackConfig.ts`: multiplier 5 to 10, `maxLines` 5000 to 10000. The resource-profile ceilings in `shared/types/resourceProfile.ts` move with it: `performance` and `balanced` from 5000 to 10000, `efficiency` from 2500 to 4000. Efficiency stays lower on purpose, it's the pressure valve.

10000 is where the native terminals sit (GNOME, Alacritty), it's already our `SCROLLBACK_MAX`, and it's already the Codex per-agent cap, so there's no new magic number in play.

## Caveats

Two limitations I left out of this PR. Neither is a regression (the old 5k had the same shape), both are worth a follow-up.

1. The pty-host analysis mirror (`DEFAULT_SCROLLBACK` in `electron/services/pty/types.ts`) stays at 5000, deliberately, to bound pty-host heap. A live renderer scrolls the full 10000, but a session restored after project-view eviction only recovers the most recent ~5000. Raising the mirror needs a pty-host memory review and a re-check of the persisted-snapshot size limit.

2. The renderer buffers aren't trimmed by the memory-pressure governor. The `terminal:reduce-scrollback` path is wired but has no main-process emitter, so the governor only trims the pty-host mirrors. On the renderer, the efficiency profile is the only relief. Wiring that emitter would make the higher ceiling properly governed, and that's the fix that would let us push the mirror up safely too.

## Tests

Updated the scrollback unit tests for the new policy, de-tautologised the proportional-vs-clamp cases (`999` sub-cap, `1001` clamp, instead of a bare `1000` at the boundary), and added coverage for the efficiency ceiling and the profile ordering. Full `npm run check` passes.
