### PR TITLE
refactor(file-viewer): share one toolbar between the dialog and the panel

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -4,6 +4,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import type { RestoreFocusTarget } from "@/components/ui/AppDialog";
 import { DiffViewer } from "@/components/Worktree/DiffViewer";
 import { CodeViewer } from "./CodeViewer";
+import { FileViewerToolbar } from "./FileViewerToolbar";
 import type { CodeViewerHandle } from "./CodeViewer";
 import { MarkdownViewer } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
@@ -227,6 +228,7 @@ export function FileViewerModal({
     return "view";
   });
   const [content, setContent] = useState<string | null>(null);
+  const [reloadRevision, setReloadRevision] = useState(0);
   // Sandboxed-iframe preview URL for HTML files (#11191), minted by files:read.
   const [htmlPreviewUrl, setHtmlPreviewUrl] = useState<string | null>(null);
   // Bumped on each successful load so the cross-origin preview frame re-navigates.
@@ -429,8 +431,11 @@ export function FileViewerModal({
     void isOpen;
     void filePath;
     void effectiveRootPath;
+    // Toolbar Refresh re-reads by bumping this: loadFile is an Effect Event, so
+    // it can only be called from an effect — never straight from an onClick.
+    void reloadRevision;
     loadFile();
-  }, [isOpen, filePath, effectiveRootPath]);
+  }, [isOpen, filePath, effectiveRootPath, reloadRevision]);
 
   // When diff arrives after mount (FileDiffModal async pattern), switch to diff mode once
   useEffect(() => {
@@ -528,6 +533,11 @@ export function FileViewerModal({
 
   const canShowView = loadState === "loaded" && content !== null;
   const isImageMode = loadState === "image" || loadState === "svg";
+
+  // The toolbar pill shows the worktree-relative path where there is one, and
+  // falls back to the absolute path for files outside the root. Either way the
+  // click copies the absolute path — handleCopyPath owns that.
+  const displayPath = workspaceRelPath ?? fwd(filePath);
 
   const metadata = useMemo(() => {
     if (!canShowView || content === null) return null;
@@ -1076,6 +1086,29 @@ export function FileViewerModal({
     };
   }, [isOpen, mode, diff, hunkMarkers.length, searchMarkers.length, collapseRevision]);
 
+  // Mode toggle: markdown and HTML files get Rendered/Source (plus Diff when
+  // available); other files keep the original View/Diff pair. Defined once and
+  // mounted either in the toolbar row or — in diff mode, which has no toolbar
+  // row — in the header.
+  const modeToggle =
+    (hasDiff || renderableFile) && !imageFile && (canShowView || loadState !== "loading") ? (
+      <SegmentedToggle
+        options={[
+          {
+            value: "view" as ViewMode,
+            label: renderableFile ? "Source" : "View",
+            disabled: !canShowView,
+          },
+          ...(renderableFile
+            ? [{ value: "rendered" as ViewMode, label: "Rendered", disabled: !canShowView }]
+            : []),
+          ...(hasDiff ? [{ value: "diff" as ViewMode, label: "Diff" }] : []),
+        ]}
+        value={mode}
+        onChange={setMode}
+      />
+    ) : null;
+
   return (
     <AppDialog
       isOpen={isOpen}
@@ -1122,27 +1155,10 @@ export function FileViewerModal({
               </span>
             )}
 
-          {/* Mode toggle: markdown and HTML files get Rendered/Source (plus Diff
-              when available); other files keep the original View/Diff pair. */}
-          {(hasDiff || renderableFile) &&
-            !imageFile &&
-            (canShowView || loadState !== "loading") && (
-              <SegmentedToggle
-                options={[
-                  {
-                    value: "view" as ViewMode,
-                    label: renderableFile ? "Source" : "View",
-                    disabled: !canShowView,
-                  },
-                  ...(renderableFile
-                    ? [{ value: "rendered" as ViewMode, label: "Rendered", disabled: !canShowView }]
-                    : []),
-                  ...(hasDiff ? [{ value: "diff" as ViewMode, label: "Diff" }] : []),
-                ]}
-                value={mode}
-                onChange={setMode}
-              />
-            )}
+          {/* In diff mode the toolbar row is gone, so the toggle keeps its
+              original header seat; plain viewing hosts it in the toolbar,
+              leading the row exactly as the panel does. */}
+          {mode === "diff" && modeToggle}
         </div>
 
         <div className="flex items-center gap-2 shrink-0 whitespace-nowrap">
@@ -1165,8 +1181,10 @@ export function FileViewerModal({
             </Tooltip>
           )}
 
-          {/* Copy path — agent workflows paste file paths back into prompts */}
-          {!imageFile && (
+          {/* Copy path — agent workflows paste file paths back into prompts.
+              Plain viewing copies from the toolbar's path pill instead, so this
+              is the diff-mode seat only. */}
+          {!imageFile && mode === "diff" && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -1184,7 +1202,7 @@ export function FileViewerModal({
             </Tooltip>
           )}
 
-          {!imageFile && (
+          {!imageFile && mode === "diff" && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -1201,6 +1219,10 @@ export function FileViewerModal({
             </Tooltip>
           )}
 
+          {/* Image files never get a toolbar row (there's no path pill or
+              refresh to hang on it), so their open control stays here. Diff
+              mode keeps the editor button for the same reason — the rendered-
+              HTML branch can't apply, since that mode isn't diff. */}
           {imageFile ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -1215,21 +1237,7 @@ export function FileViewerModal({
               </TooltipTrigger>
               <TooltipContent side="bottom">Open in image viewer</TooltipContent>
             </Tooltip>
-          ) : htmlFile && mode === "rendered" ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleOpenInBrowser}
-                  aria-label="Open in browser"
-                  className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border"
-                >
-                  <Globe className="w-4 h-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open in browser</TooltipContent>
-            </Tooltip>
-          ) : (
+          ) : mode === "diff" ? (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -1243,7 +1251,7 @@ export function FileViewerModal({
               </TooltipTrigger>
               <TooltipContent side="bottom">Open in editor</TooltipContent>
             </Tooltip>
-          )}
+          ) : null}
           <AppDialog.CloseButton />
         </div>
       </AppDialog.Header>
@@ -1262,6 +1270,58 @@ export function FileViewerModal({
           />
         )}
         <div className="relative flex-1 min-w-0 min-h-0 flex flex-col" style={diffFontStyle}>
+          {/* Plain-file-viewing toolbar — the same row the FilePane panel
+              renders, so the two surfaces read identically. Diff mode keeps its
+              own chrome (header toggle + footer controls) and image files have
+              nothing to put here, so both opt out. Refresh living only on this
+              row is what keeps it from colliding with the diff stale banner's
+              own Refresh below. */}
+          {!imageFile && mode !== "diff" && (
+            <FileViewerToolbar.Root>
+              {modeToggle}
+              <FileViewerToolbar.Path
+                path={displayPath}
+                copied={pathCopied}
+                onCopy={handleCopyPath}
+              />
+              <FileViewerToolbar.Actions>
+                {markdownFile && mode === "view" && (
+                  <FileViewerToolbar.IconButton
+                    label="Wrap long lines"
+                    pressed={markdownWrapLines}
+                    onClick={() => setMarkdownWrapLines(!markdownWrapLines)}
+                  >
+                    <WrapText className="w-4 h-4" />
+                  </FileViewerToolbar.IconButton>
+                )}
+                <FileViewerToolbar.IconButton
+                  label="Refresh"
+                  onClick={() => setReloadRevision((revision) => revision + 1)}
+                >
+                  <RefreshCw className="w-4 h-4" />
+                </FileViewerToolbar.IconButton>
+                {htmlFile && mode === "rendered" ? (
+                  <FileViewerToolbar.IconButton
+                    label="Open in browser"
+                    onClick={handleOpenInBrowser}
+                  >
+                    <Globe className="w-4 h-4" />
+                  </FileViewerToolbar.IconButton>
+                ) : (
+                  <FileViewerToolbar.IconButton label="Open in editor" onClick={handleOpenInEditor}>
+                    <ExternalLink className="w-4 h-4" />
+                  </FileViewerToolbar.IconButton>
+                )}
+                <FileViewerToolbar.IconButton
+                  label="Open as panel"
+                  onClick={handleOpenAsPanel}
+                  data-testid="file-viewer-open-as-panel"
+                >
+                  <Grid2x2Plus className="w-4 h-4" />
+                </FileViewerToolbar.IconButton>
+              </FileViewerToolbar.Actions>
+            </FileViewerToolbar.Root>
+          )}
           {!isImageMode &&
             mode === "diff" &&
             diffContentStale &&
@@ -1528,8 +1588,10 @@ export function FileViewerModal({
 
       {/* Slim footer toolbar: navigation + diff display controls (Kaleidoscope-
           style bottom stepper). Rendered whenever there's something to put in
-          it — file stepping in either mode, diff controls in diff mode. */}
-      {(canStepFiles || (mode === "diff" && hasDiff) || (markdownFile && mode === "view")) && (
+          it — file stepping in either mode, diff controls in diff mode. Plain
+          markdown no longer qualifies: its wrap toggle moved to the toolbar
+          row, and keeping the clause would leave an empty bar behind. */}
+      {(canStepFiles || (mode === "diff" && hasDiff)) && (
         <div className="flex items-center justify-between gap-3 px-4 py-1.5 border-t border-border-strong bg-surface-panel shrink-0">
           <div className="flex items-center gap-1 min-w-0">
             {isWorkspace && (
@@ -1654,15 +1716,6 @@ export function FileViewerModal({
           )}
 
           <div className="flex items-center gap-2">
-            {markdownFile && mode === "view" && (
-              <IconToggle
-                pressed={markdownWrapLines}
-                label="Wrap long lines"
-                onToggle={() => setMarkdownWrapLines(!markdownWrapLines)}
-              >
-                <WrapText className="w-4 h-4" />
-              </IconToggle>
-            )}
             {mode === "diff" && hasDiff && (
               <>
                 <IconToggle

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -355,8 +355,17 @@ export function FileViewerModal({
     };
   }, []);
 
+  // The default-to-diff switch below is one-shot per file, so it re-arms on the
+  // dialog opening or the file changing — but deliberately NOT on a manual
+  // refresh, which would otherwise re-fire the default and pull the user out of
+  // a mode they picked themselves.
+  useEffect(() => {
+    hasSwitchedToDiffRef.current = false;
+  }, [isOpen, filePath, effectiveRootPath]);
+
   // Non-reactive: reads defaultMode/hasDiff/initialLine/imageFile/svgFile at call
-  // time so the effect only re-runs on isOpen/filePath/effectiveRootPath changes.
+  // time so the effect only re-runs on isOpen/filePath/effectiveRootPath changes
+  // and on an explicit refresh.
   const loadFile = useEffectEvent(() => {
     if (!isOpen) {
       setContent(null);
@@ -368,7 +377,6 @@ export function FileViewerModal({
       setPathCopied(false);
       setSanitizedSvg(null);
       requestRef.current++;
-      hasSwitchedToDiffRef.current = false;
       currentHunkIndexRef.current = -1;
       pendingHunkTargetRef.current = null;
       setSearchOpen(false);
@@ -382,7 +390,6 @@ export function FileViewerModal({
     setLoadState("loading");
     setErrorCode(null);
     setDisplayErrorMessage(null);
-    hasSwitchedToDiffRef.current = false;
     currentHunkIndexRef.current = -1;
 
     // Stepping between files (onNavigateFile) keeps the modal open, so a mode
@@ -1086,29 +1093,6 @@ export function FileViewerModal({
     };
   }, [isOpen, mode, diff, hunkMarkers.length, searchMarkers.length, collapseRevision]);
 
-  // Mode toggle: markdown and HTML files get Rendered/Source (plus Diff when
-  // available); other files keep the original View/Diff pair. Defined once and
-  // mounted either in the toolbar row or — in diff mode, which has no toolbar
-  // row — in the header.
-  const modeToggle =
-    (hasDiff || renderableFile) && !imageFile && (canShowView || loadState !== "loading") ? (
-      <SegmentedToggle
-        options={[
-          {
-            value: "view" as ViewMode,
-            label: renderableFile ? "Source" : "View",
-            disabled: !canShowView,
-          },
-          ...(renderableFile
-            ? [{ value: "rendered" as ViewMode, label: "Rendered", disabled: !canShowView }]
-            : []),
-          ...(hasDiff ? [{ value: "diff" as ViewMode, label: "Diff" }] : []),
-        ]}
-        value={mode}
-        onChange={setMode}
-      />
-    ) : null;
-
   return (
     <AppDialog
       isOpen={isOpen}
@@ -1155,10 +1139,31 @@ export function FileViewerModal({
               </span>
             )}
 
-          {/* In diff mode the toolbar row is gone, so the toggle keeps its
-              original header seat; plain viewing hosts it in the toolbar,
-              leading the row exactly as the panel does. */}
-          {mode === "diff" && modeToggle}
+          {/* Mode toggle: markdown and HTML files get Rendered/Source (plus Diff
+              when available); other files keep the original View/Diff pair.
+              This stays in the header rather than leading the toolbar row the
+              way the panel's does — the row is gated out of diff mode, so a
+              toggle inside it would unmount on the View→Diff switch and drop
+              the keyboard focus of whoever just activated it. */}
+          {(hasDiff || renderableFile) &&
+            !imageFile &&
+            (canShowView || loadState !== "loading") && (
+              <SegmentedToggle
+                options={[
+                  {
+                    value: "view" as ViewMode,
+                    label: renderableFile ? "Source" : "View",
+                    disabled: !canShowView,
+                  },
+                  ...(renderableFile
+                    ? [{ value: "rendered" as ViewMode, label: "Rendered", disabled: !canShowView }]
+                    : []),
+                  ...(hasDiff ? [{ value: "diff" as ViewMode, label: "Diff" }] : []),
+                ]}
+                value={mode}
+                onChange={setMode}
+              />
+            )}
         </div>
 
         <div className="flex items-center gap-2 shrink-0 whitespace-nowrap">
@@ -1278,7 +1283,6 @@ export function FileViewerModal({
               own Refresh below. */}
           {!imageFile && mode !== "diff" && (
             <FileViewerToolbar.Root>
-              {modeToggle}
               <FileViewerToolbar.Path
                 path={displayPath}
                 copied={pathCopied}
@@ -1587,12 +1591,17 @@ export function FileViewerModal({
       </div>
 
       {/* Slim footer toolbar: navigation + diff display controls (Kaleidoscope-
-          style bottom stepper). Rendered whenever there's something to put in
-          it — file stepping in either mode, diff controls in diff mode. Plain
-          markdown no longer qualifies: its wrap toggle moved to the toolbar
-          row, and keeping the clause would leave an empty bar behind. */}
-      {(canStepFiles || (mode === "diff" && hasDiff)) && (
-        <div className="flex items-center justify-between gap-3 px-4 py-1.5 border-t border-border-strong bg-surface-panel shrink-0">
+          style bottom stepper). One term per control it can hold, so it appears
+          exactly when it has something to show: the file-list toggle, the
+          stepper, the Viewed marker, and the diff controls. Plain markdown no
+          longer keeps it alive on its own — the wrap toggle moved up to the
+          toolbar row — but a lone reviewed file still must, since this bar
+          holds the only control that can UNMARK it (`v` only ever marks). */}
+      {(canStepFiles || isWorkspace || workspaceEntry !== null || (mode === "diff" && hasDiff)) && (
+        <div
+          data-testid="file-viewer-footer"
+          className="flex items-center justify-between gap-3 px-4 py-1.5 border-t border-border-strong bg-surface-panel shrink-0"
+        >
           <div className="flex items-center gap-1 min-w-0">
             {isWorkspace && (
               <IconToggle

--- a/src/components/FileViewer/FileViewerToolbar.tsx
+++ b/src/components/FileViewer/FileViewerToolbar.tsx
@@ -1,0 +1,193 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { Check, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+let measureContext: CanvasRenderingContext2D | null = null;
+
+function measureTextWidth(text: string, font: string): number {
+  measureContext ??= document.createElement("canvas").getContext("2d");
+  if (!measureContext) return text.length * 8;
+  measureContext.font = font;
+  return measureContext.measureText(text).width;
+}
+
+/**
+ * Width-fitted middle truncation: keeps as many characters from the front and
+ * the back as actually fit the element, collapsing the middle with a single
+ * ellipsis. The basename is reserved first so the file name always survives.
+ * Re-fits on resize; measurement uses canvas measureText with the element's
+ * own computed font, so no layout thrash.
+ */
+function useFittedPath(fullText: string | undefined): {
+  spanRef: React.RefObject<HTMLElement | null>;
+  display: string | undefined;
+} {
+  const spanRef = useRef<HTMLElement | null>(null);
+  const [display, setDisplay] = useState<string | undefined>(fullText);
+
+  useLayoutEffect(() => {
+    const el = spanRef.current;
+    if (!el || fullText === undefined) {
+      setDisplay(fullText);
+      return;
+    }
+
+    const fit = () => {
+      const style = getComputedStyle(el);
+      const font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+      const available =
+        el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+      if (available <= 0) {
+        // Not measurable (hidden/zero-width): show the new text rather than a
+        // stale fit of the previous path; CSS truncate is the backstop.
+        setDisplay(fullText);
+        return;
+      }
+      if (measureTextWidth(fullText, font) <= available) {
+        setDisplay(fullText);
+        return;
+      }
+      const slashIdx = fullText.lastIndexOf("/");
+      const basename = slashIdx >= 0 ? fullText.slice(slashIdx) : fullText;
+      const head = fullText.slice(0, fullText.length - basename.length);
+      const build = (kept: number) => {
+        const front = Math.ceil(kept / 2);
+        const back = kept - front;
+        return `${head.slice(0, front)}…${back > 0 ? head.slice(head.length - back) : ""}${basename}`;
+      };
+      // Binary search the most head characters that still fit.
+      let lo = 0;
+      let hi = head.length;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (measureTextWidth(build(mid), font) <= available) lo = mid;
+        else hi = mid - 1;
+      }
+      const candidate = build(lo);
+      if (measureTextWidth(candidate, font) <= available) {
+        setDisplay(candidate);
+        return;
+      }
+      // Very narrow pane: prefer the bare file name over "…/file.md"; if even
+      // that overflows, CSS truncate is the backstop.
+      const bare = basename.startsWith("/") ? basename.slice(1) : basename;
+      setDisplay(measureTextWidth(`…${basename}`, font) <= available ? `…${basename}` : bare);
+    };
+
+    fit();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(fit);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [fullText]);
+
+  return { spanRef, display };
+}
+
+/**
+ * The plain-file-viewing toolbar shared by the FilePane panel and the
+ * FileViewerModal dialog, so the two surfaces can't drift apart again. Both
+ * render the same viewer bodies (CodeViewer/MarkdownViewer/HtmlViewer); this
+ * is the chrome above them.
+ *
+ * Composed rather than config-driven: the two surfaces own materially
+ * different state (the dialog has diff modes and an Open-as-panel action the
+ * panel has no concept of), so they supply their own children and keep their
+ * own handlers. SegmentedToggle stays a separate import for the same reason —
+ * the dialog appends a Diff segment the panel never has.
+ *
+ * None of these primitives take a className. The chrome is deliberately fixed:
+ * `toolbar-icon-button` owns the transition/focus/armed-state contract, and a
+ * caller-supplied `transition-*` utility would silently replace its transition
+ * under tailwind-merge.
+ */
+function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay shrink-0">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Path pill — mirrors the browser toolbar's address field. Click copies the
+ * absolute path; the middle collapses to fit the available width while the
+ * file name always survives. `path` is what's shown (root-relative where the
+ * surface can compute it); what gets copied is the caller's business.
+ */
+function Path({ path, copied, onCopy }: { path?: string; copied: boolean; onCopy: () => void }) {
+  const { spanRef, display } = useFittedPath(path);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onCopy}
+          aria-label="Copy file path"
+          className="relative flex items-center min-w-0 flex-1 group/path"
+        >
+          {copied ? (
+            <Check className="absolute left-2 w-3.5 h-3.5 text-status-success pointer-events-none" />
+          ) : (
+            <FileText
+              aria-hidden="true"
+              className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
+            />
+          )}
+          <span
+            ref={spanRef}
+            className="w-full pl-7 pr-2 py-1 text-left text-xs font-mono rounded bg-daintree-bg border border-overlay text-daintree-text/70 truncate transition-colors group-hover/path:border-border-strong group-hover/path:text-daintree-text"
+          >
+            {display}
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{copied ? "Copied!" : "Click to copy"}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Right-aligned action group; holds the IconButtons. */
+function Actions({ children }: { children: React.ReactNode }) {
+  return <div className="ml-auto flex items-center gap-1.5 shrink-0">{children}</div>;
+}
+
+function IconButton({
+  label,
+  onClick,
+  pressed,
+  children,
+  "data-testid": testId,
+}: {
+  label: string;
+  onClick: () => void;
+  /** Renders the button as a toggle with a pressed state. */
+  pressed?: boolean;
+  children: React.ReactNode;
+  "data-testid"?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={label}
+          aria-pressed={pressed}
+          data-testid={testId}
+          className={cn(
+            "toolbar-icon-button p-1.5 rounded",
+            pressed ? "text-daintree-text" : "text-daintree-text/60"
+          )}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export const FileViewerToolbar = { Root, Path, Actions, IconButton };

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -166,15 +166,19 @@ vi.mock("@/components/Worktree/DiffViewer", () => ({
 const setDiffViewTypeMock = vi.fn();
 const setDiffShowFileListMock = vi.fn();
 const setDiffFontSizeMock = vi.fn();
+const setMarkdownWrapLinesMock = vi.fn();
+const preferencesState = () => ({
+  diffViewType: "split" as const,
+  setDiffViewType: setDiffViewTypeMock,
+  diffShowFileList: true,
+  setDiffShowFileList: setDiffShowFileListMock,
+  diffFontSize: "m" as const,
+  setDiffFontSize: setDiffFontSizeMock,
+  markdownWrapLines: false,
+  setMarkdownWrapLines: setMarkdownWrapLinesMock,
+});
 const usePreferencesStoreMock = vi.fn((selector?: (s: Record<string, unknown>) => unknown) => {
-  const state = {
-    diffViewType: "split" as const,
-    setDiffViewType: setDiffViewTypeMock,
-    diffShowFileList: true,
-    setDiffShowFileList: setDiffShowFileListMock,
-    diffFontSize: "m" as const,
-    setDiffFontSize: setDiffFontSizeMock,
-  };
+  const state = preferencesState();
   return selector ? selector(state) : state;
 });
 vi.mock("@/store/preferencesStore", () => ({
@@ -234,14 +238,7 @@ beforeEach(() => {
   setDiffViewTypeMock.mockReset();
   usePreferencesStoreMock.mockImplementation(
     (selector?: (s: Record<string, unknown>) => unknown) => {
-      const state = {
-        diffViewType: "split" as const,
-        setDiffViewType: setDiffViewTypeMock,
-        diffShowFileList: true,
-        setDiffShowFileList: setDiffShowFileListMock,
-        diffFontSize: "m" as const,
-        setDiffFontSize: setDiffFontSizeMock,
-      };
+      const state = preferencesState();
       return selector ? selector(state) : state;
     }
   );
@@ -605,6 +602,118 @@ describe("FileViewerModal", () => {
     });
   });
 
+  // The dialog and the FilePane panel render the same viewer bodies, so their
+  // chrome is shared too (#11224). These cover the dialog's half of that
+  // contract: the controls it gained, and the ones that must stay put.
+  describe("plain-file toolbar (#11224)", () => {
+    const markdownProps = { ...defaultProps, filePath: "/project/docs/guide.md" };
+
+    it("copies the absolute path from the toolbar pill", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+      });
+      render(<FileViewerModal {...defaultProps} />);
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy file path" }));
+
+      // The pill *shows* the root-relative path but copies the absolute one —
+      // agents paste these back into prompts, where a relative path is useless.
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith("/project/src/index.ts"));
+    });
+
+    it("offers exactly one copy-path control in plain view", async () => {
+      render(<FileViewerModal {...defaultProps} />);
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      // The header's separate copy icon gave way to the pill; two controls with
+      // one name would be a drift regression, not a convenience.
+      expect(screen.getAllByRole("button", { name: "Copy file path" })).toHaveLength(1);
+    });
+
+    it("re-reads the file when Refresh is clicked", async () => {
+      render(<FileViewerModal {...defaultProps} />);
+      await waitFor(() => expect(mockRead).toHaveBeenCalledTimes(1));
+
+      fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+      // Refresh routes through a revision bump rather than calling loadFile
+      // directly (it's an Effect Event), so the re-read is effect-driven.
+      await waitFor(() => expect(mockRead).toHaveBeenCalledTimes(2));
+    });
+
+    it("puts the markdown wrap toggle in the toolbar, above the file body", async () => {
+      render(<FileViewerModal {...markdownProps} />);
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      const wrap = screen.getByRole("button", { name: "Wrap long lines" });
+      const metadata = screen.getByTestId("file-viewer-metadata");
+
+      // Document order is the assertion that the control actually moved out of
+      // the footer: DOCUMENT_POSITION_FOLLOWING means the metadata strip (and
+      // the body under it) comes after the toggle.
+      expect(
+        wrap.compareDocumentPosition(metadata) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+
+      fireEvent.click(wrap);
+      expect(setMarkdownWrapLinesMock).toHaveBeenCalledWith(true);
+    });
+
+    it("drops the footer entirely for a plain markdown file", async () => {
+      render(<FileViewerModal {...markdownProps} />);
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      // The footer used to exist only to host the wrap toggle. With that moved,
+      // a single markdown file has nothing to put down there — and an empty bar
+      // is worse than no bar.
+      expect(screen.queryByRole("button", { name: "Show file list" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Find in diff" })).toBeNull();
+    });
+
+    it("hides the wrap toggle in rendered mode", async () => {
+      render(<FileViewerModal {...markdownProps} />);
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+      expect(screen.getByRole("button", { name: "Wrap long lines" })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Rendered" }));
+
+      // Wrapping is a source-view concern; rendered prose wraps by nature.
+      expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
+    });
+
+    it("keeps Open as panel reachable and carries the mode into the panel", async () => {
+      render(<FileViewerModal {...markdownProps} />);
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      fireEvent.click(screen.getByTestId("file-viewer-open-as-panel"));
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        "file.openPanel",
+        expect.objectContaining({ path: "/project/docs/guide.md", viewMode: "source" }),
+        expect.anything()
+      );
+    });
+
+    it("shows no toolbar Refresh in diff mode", async () => {
+      const diff = "diff --git a/file b/file\n--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new";
+      render(<FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />);
+      await waitFor(() => expect(screen.getByTestId("diff-viewer")).toBeTruthy());
+
+      // Diff mode keeps its own chrome; the toolbar row opts out so its Refresh
+      // can never double up with the stale banner's.
+      expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "View" }));
+
+      await waitFor(() =>
+        expect(screen.getAllByRole("button", { name: "Refresh" })).toHaveLength(1)
+      );
+    });
+  });
+
   describe("diff view type persistence", () => {
     const diff = "diff --git a/file b/file\n--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new";
 
@@ -673,6 +782,11 @@ describe("FileViewerModal", () => {
       });
       // The diff itself stays visible — the banner never replaces content.
       expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+
+      // The banner's Refresh is the only one in diff mode: the toolbar row
+      // (which carries its own Refresh) is gated out of diff mode precisely so
+      // these two can't both answer to the same name.
+      expect(screen.getAllByRole("button", { name: "Refresh" })).toHaveLength(1);
 
       fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
       expect(onRetryDiff).toHaveBeenCalledTimes(1);

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -668,9 +668,39 @@ describe("FileViewerModal", () => {
 
       // The footer used to exist only to host the wrap toggle. With that moved,
       // a single markdown file has nothing to put down there — and an empty bar
-      // is worse than no bar.
-      expect(screen.queryByRole("button", { name: "Show file list" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Find in diff" })).toBeNull();
+      // is worse than no bar. Asserting on the bar itself, not on the controls
+      // it would hold: those are absent either way, so they'd pass on an empty
+      // footer too.
+      expect(screen.queryByTestId("file-viewer-footer")).toBeNull();
+    });
+
+    it("keeps the footer for a lone reviewed file, which owns the only unmark", async () => {
+      // One-entry changeSet: canStepFiles and isWorkspace are both false, so the
+      // wrap clause used to be all that kept this bar alive. The Viewed marker
+      // lives here and `v` only ever MARKS — losing the bar would strand a file
+      // marked viewed with no way back.
+      render(
+        <FileViewerModal
+          {...markdownProps}
+          currentFileIndex={0}
+          totalFileCount={1}
+          onNavigateFile={vi.fn()}
+          onSelectFile={vi.fn()}
+          changeSet={[
+            {
+              path: "docs/guide.md",
+              status: "modified",
+              insertions: 1,
+              deletions: 0,
+              viewedKey: "modified:docs/guide.md",
+            },
+          ]}
+        />
+      );
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      expect(screen.getByTestId("file-viewer-footer")).toBeTruthy();
+      expect(screen.getByTestId("diff-viewed-button")).toBeTruthy();
     });
 
     it("hides the wrap toggle in rendered mode", async () => {
@@ -695,6 +725,30 @@ describe("FileViewerModal", () => {
         expect.objectContaining({ path: "/project/docs/guide.md", viewMode: "source" }),
         expect.anything()
       );
+    });
+
+    it("stays in the mode the user picked when a refresh races a diff refetch", async () => {
+      const diff = "diff --git a/file b/file\n--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new";
+      const { rerender } = render(
+        <FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />
+      );
+      await waitFor(() => expect(screen.getByTestId("diff-viewer")).toBeTruthy());
+
+      // The user leaves the default behind.
+      fireEvent.click(screen.getByRole("button", { name: "View" }));
+      await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+
+      fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+      await waitFor(() => expect(mockRead).toHaveBeenCalledTimes(2));
+
+      // ...and the parent refetches, cycling hasDiff true→false→true. The
+      // default-to-diff switch is one-shot per FILE, so a refresh must not
+      // re-arm it and drag the user back into a mode they left.
+      rerender(<FileViewerModal {...defaultProps} diff={undefined} defaultMode="diff" />);
+      rerender(<FileViewerModal {...defaultProps} diff={diff} defaultMode="diff" />);
+
+      expect(screen.getByTestId("code-viewer")).toBeTruthy();
+      expect(screen.queryByTestId("diff-viewer")).toBeNull();
     });
 
     it("shows no toolbar Refresh in diff mode", async () => {

--- a/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { ReactNode } from "react";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+import { FileViewerToolbar } from "../FileViewerToolbar";
+
+// The fit is pure measurement, and jsdom measures nothing: clientWidth is 0 and
+// there is no canvas. Stub both with a monospace model — every glyph CHAR_PX
+// wide — so the assertions below exercise the truncation algorithm rather than
+// jsdom's CSS engine.
+const CHAR_PX = 10;
+const PAD_X = 36; // pl-7 (28) + pr-2 (8), matching the pill's padding
+
+let containerWidth = 0;
+let resizeCallbacks: ResizeObserverCallback[] = [];
+
+class MockResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallbacks.push(callback);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+/** Re-fit at a new width, the way a real ResizeObserver would. */
+function resizeTo(width: number) {
+  containerWidth = width;
+  act(() => {
+    for (const cb of resizeCallbacks) cb([], {} as ResizeObserver);
+  });
+}
+
+const availableWidth = () => containerWidth - PAD_X;
+
+beforeEach(() => {
+  resizeCallbacks = [];
+  containerWidth = 0;
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  // Override only the five properties the fit reads, delegating the rest to
+  // jsdom: testing-library's accessible-name computation calls
+  // getPropertyValue() on this same object, so a bare literal would break every
+  // getByRole in the file.
+  const FIT_STYLE: Record<string, string> = {
+    fontWeight: "400",
+    fontSize: "12px",
+    fontFamily: "monospace",
+    paddingLeft: "28px",
+    paddingRight: "8px",
+  };
+  const realGetComputedStyle = window.getComputedStyle.bind(window);
+  vi.stubGlobal("getComputedStyle", (el: Element, pseudo?: string | null) => {
+    const real = realGetComputedStyle(el, pseudo ?? undefined);
+    return new Proxy(real, {
+      get(target, prop) {
+        if (typeof prop === "string" && prop in FIT_STYLE) return FIT_STYLE[prop];
+        const value = Reflect.get(target, prop, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+  });
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+    font: "",
+    measureText: (text: string) => ({ width: text.length * CHAR_PX }),
+  } as unknown as CanvasRenderingContext2D);
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => containerWidth,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("FileViewerToolbar.Path", () => {
+  const LONG_PATH = "src/components/deeply/nested/file.tsx";
+  const BASENAME = "/file.tsx";
+
+  function renderPath(path: string, { copied = false, onCopy = vi.fn() } = {}) {
+    render(<FileViewerToolbar.Path path={path} copied={copied} onCopy={onCopy} />);
+    return screen.getByRole("button", { name: "Copy file path" });
+  }
+
+  /** The pill's rendered text, which is what useFittedPath computed. */
+  const fittedText = () => screen.getByRole("button", { name: "Copy file path" }).textContent ?? "";
+
+  it("shows the path untruncated when it fits", () => {
+    containerWidth = LONG_PATH.length * CHAR_PX + PAD_X + 20;
+    renderPath(LONG_PATH);
+
+    expect(fittedText()).toBe(LONG_PATH);
+  });
+
+  it("collapses the middle to fit, always keeping the basename", () => {
+    containerWidth = 200;
+    renderPath(LONG_PATH);
+    const display = fittedText();
+
+    expect(display).not.toBe(LONG_PATH);
+    // The file name is reserved first — it survives at any width.
+    expect(display.endsWith(BASENAME)).toBe(true);
+    // One ellipsis, in the middle — not a chain of them.
+    expect(display.match(/…/g)).toHaveLength(1);
+    // And the result actually fits the space it measured against.
+    expect(display.length * CHAR_PX).toBeLessThanOrEqual(availableWidth());
+  });
+
+  it("keeps as much of the head as fits — one more character would overflow", () => {
+    containerWidth = 200;
+    renderPath(LONG_PATH);
+    const display = fittedText();
+
+    // Maximality: the fit is the *most* head text that fits, so a single extra
+    // character must not. This is what distinguishes a real binary search from
+    // a fixed-length truncation that happens to fit.
+    expect((display.length + 1) * CHAR_PX).toBeGreaterThan(availableWidth());
+  });
+
+  it("restores the full path once the pill is wide enough again", () => {
+    containerWidth = 200;
+    renderPath(LONG_PATH);
+    expect(fittedText()).not.toBe(LONG_PATH);
+
+    resizeTo(LONG_PATH.length * CHAR_PX + PAD_X + 20);
+
+    expect(fittedText()).toBe(LONG_PATH);
+  });
+
+  it("falls back to the bare file name when even an elided head cannot fit", () => {
+    // Narrower than "…/file.tsx" — the pane is too small for any head hint.
+    containerWidth = PAD_X + BASENAME.length * CHAR_PX;
+    renderPath(LONG_PATH);
+
+    expect(fittedText()).toBe("file.tsx");
+  });
+
+  it("shows the full text rather than a stale fit while unmeasurable", () => {
+    // Zero-width (hidden pane): a stale fit of the *previous* path would be
+    // worse than the untruncated text, which CSS truncate still backstops.
+    containerWidth = 0;
+    renderPath(LONG_PATH);
+
+    expect(fittedText()).toBe(LONG_PATH);
+  });
+
+  it("keeps a stable accessible name while showing copied feedback", () => {
+    containerWidth = 400;
+    const { rerender } = render(
+      <FileViewerToolbar.Path path={LONG_PATH} copied={false} onCopy={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: "Copy file path" })).toBeTruthy();
+
+    rerender(<FileViewerToolbar.Path path={LONG_PATH} copied onCopy={vi.fn()} />);
+
+    // The feedback rides the tooltip and the icon, never the accessible name —
+    // a name that flips to "Copied!" would make the control unfindable exactly
+    // when a test or a screen-reader user goes looking for it.
+    expect(screen.getByRole("button", { name: "Copy file path" })).toBeTruthy();
+  });
+
+  it("copies on click", () => {
+    containerWidth = 400;
+    const onCopy = vi.fn();
+    fireEvent.click(renderPath(LONG_PATH, { onCopy }));
+
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("FileViewerToolbar.IconButton", () => {
+  it("forwards clicks and a test id", () => {
+    const onClick = vi.fn();
+    render(
+      <FileViewerToolbar.IconButton label="Refresh" onClick={onClick} data-testid="refresh-btn">
+        <svg />
+      </FileViewerToolbar.IconButton>
+    );
+
+    fireEvent.click(screen.getByTestId("refresh-btn"));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeTruthy();
+  });
+
+  it("is a plain button, not a toggle, when no pressed state is given", () => {
+    render(
+      <FileViewerToolbar.IconButton label="Refresh" onClick={vi.fn()}>
+        <svg />
+      </FileViewerToolbar.IconButton>
+    );
+
+    // aria-pressed must be absent rather than "false": the latter would
+    // announce Refresh as an unpressed toggle.
+    expect(screen.getByRole("button", { name: "Refresh" }).hasAttribute("aria-pressed")).toBe(
+      false
+    );
+  });
+
+  it("reflects the pressed state of a toggle", () => {
+    const { rerender } = render(
+      <FileViewerToolbar.IconButton label="Wrap long lines" onClick={vi.fn()} pressed={false}>
+        <svg />
+      </FileViewerToolbar.IconButton>
+    );
+    expect(
+      screen.getByRole("button", { name: "Wrap long lines" }).getAttribute("aria-pressed")
+    ).toBe("false");
+
+    rerender(
+      <FileViewerToolbar.IconButton label="Wrap long lines" onClick={vi.fn()} pressed>
+        <svg />
+      </FileViewerToolbar.IconButton>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Wrap long lines" }).getAttribute("aria-pressed")
+    ).toBe("true");
+  });
+});

--- a/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
@@ -19,10 +19,13 @@ const CHAR_PX = 10;
 const PAD_X = 36; // pl-7 (28) + pr-2 (8), matching the pill's padding
 
 let containerWidth = 0;
-let resizeCallbacks: ResizeObserverCallback[] = [];
+// The fit callback ignores both ResizeObserver arguments (it re-measures the
+// element it already holds), so the double stores it as the zero-arg function
+// it really is rather than manufacturing entries and an observer to pass it.
+let resizeCallbacks: Array<() => void> = [];
 
 class MockResizeObserver {
-  constructor(callback: ResizeObserverCallback) {
+  constructor(callback: () => void) {
     resizeCallbacks.push(callback);
   }
   observe() {}
@@ -34,7 +37,7 @@ class MockResizeObserver {
 function resizeTo(width: number) {
   containerWidth = width;
   act(() => {
-    for (const cb of resizeCallbacks) cb([], {} as ResizeObserver);
+    for (const cb of resizeCallbacks) cb();
   });
 }
 
@@ -66,6 +69,7 @@ beforeEach(() => {
       },
     });
   });
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the fit only ever touches .font and .measureText().width; a real CanvasRenderingContext2D isn't constructible in jsdom
   vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
     font: "",
     measureText: (text: string) => ({ width: text.length * CHAR_PX }),
@@ -84,6 +88,8 @@ afterEach(() => {
 describe("FileViewerToolbar.Path", () => {
   const LONG_PATH = "src/components/deeply/nested/file.tsx";
   const BASENAME = "/file.tsx";
+  /** The directory part, which is what the fit is allowed to elide. */
+  const HEAD = LONG_PATH.slice(0, LONG_PATH.length - BASENAME.length);
 
   function renderPath(path: string, { copied = false, onCopy = vi.fn() } = {}) {
     render(<FileViewerToolbar.Path path={path} copied={copied} onCopy={onCopy} />);
@@ -112,6 +118,23 @@ describe("FileViewerToolbar.Path", () => {
     expect(display.match(/…/g)).toHaveLength(1);
     // And the result actually fits the space it measured against.
     expect(display.length * CHAR_PX).toBeLessThanOrEqual(availableWidth());
+  });
+
+  it("keeps both ends of the directory head, not just one", () => {
+    containerWidth = 200;
+    renderPath(LONG_PATH);
+    const display = fittedText();
+
+    // Defaulted for noUncheckedIndexedAccess; the non-empty assertions below
+    // are what actually reject a missing side.
+    const [front = "", back = ""] = display.slice(0, display.length - BASENAME.length).split("…");
+    // Spending the whole budget on the prefix would still fit and still keep
+    // the basename — so pin both ends: the kept text must be a genuine prefix
+    // AND suffix of the elided directory head, and neither may be empty.
+    expect(HEAD.startsWith(front)).toBe(true);
+    expect(HEAD.endsWith(back)).toBe(true);
+    expect(front.length).toBeGreaterThan(0);
+    expect(back.length).toBeGreaterThan(0);
   });
 
   it("keeps as much of the head as fits — one more character would overflow", () => {
@@ -143,11 +166,16 @@ describe("FileViewerToolbar.Path", () => {
     expect(fittedText()).toBe("file.tsx");
   });
 
-  it("shows the full text rather than a stale fit while unmeasurable", () => {
-    // Zero-width (hidden pane): a stale fit of the *previous* path would be
-    // worse than the untruncated text, which CSS truncate still backstops.
-    containerWidth = 0;
+  it("shows the full text rather than a stale fit once unmeasurable", () => {
+    // Must start from a real fit: mounting straight into zero width would pass
+    // on the initial state alone, proving nothing about the guard.
+    containerWidth = 200;
     renderPath(LONG_PATH);
+    expect(fittedText()).not.toBe(LONG_PATH);
+
+    // Zero-width (hidden pane): a stale fit of the previous path would be worse
+    // than the untruncated text, which CSS truncate still backstops.
+    resizeTo(0);
 
     expect(fittedText()).toBe(LONG_PATH);
   });

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1,14 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import {
-  Check,
-  ExternalLink,
-  FileText,
-  Globe,
-  RefreshCw,
-  Search,
-  WrapText,
-  XCircle,
-} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ExternalLink, FileText, Globe, RefreshCw, Search, WrapText, XCircle } from "lucide-react";
 import type { FileViewMode } from "@shared/types/panel";
 import { isFilePanel } from "@shared/types/panel";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
@@ -20,10 +11,10 @@ import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
 import { HtmlViewer } from "@/components/Html/HtmlViewer";
 import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
+import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import {
   FILE_READ_ERROR_MESSAGES,
@@ -38,7 +29,6 @@ import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { isClientAppError } from "@/utils/clientAppError";
 import { logError } from "@/utils/logger";
-import { cn } from "@/lib/utils";
 
 export interface FilePaneProps extends BasePanelProps {
   tabs?: TabInfo[];
@@ -60,88 +50,6 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
   if (!rootPath) return false;
   const root = toForwardSlashes(rootPath).replace(/\/$/, "") + "/";
   return toForwardSlashes(filePath).startsWith(root);
-}
-
-let measureContext: CanvasRenderingContext2D | null = null;
-
-function measureTextWidth(text: string, font: string): number {
-  measureContext ??= document.createElement("canvas").getContext("2d");
-  if (!measureContext) return text.length * 8;
-  measureContext.font = font;
-  return measureContext.measureText(text).width;
-}
-
-/**
- * Width-fitted middle truncation: keeps as many characters from the front and
- * the back as actually fit the element, collapsing the middle with a single
- * ellipsis. The basename is reserved first so the file name always survives.
- * Re-fits on resize; measurement uses canvas measureText with the element's
- * own computed font, so no layout thrash.
- */
-function useFittedPath(fullText: string | undefined): {
-  spanRef: React.RefObject<HTMLElement | null>;
-  display: string | undefined;
-} {
-  const spanRef = useRef<HTMLElement | null>(null);
-  const [display, setDisplay] = useState<string | undefined>(fullText);
-
-  useLayoutEffect(() => {
-    const el = spanRef.current;
-    if (!el || fullText === undefined) {
-      setDisplay(fullText);
-      return;
-    }
-
-    const fit = () => {
-      const style = getComputedStyle(el);
-      const font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
-      const available =
-        el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
-      if (available <= 0) {
-        // Not measurable (hidden/zero-width): show the new text rather than a
-        // stale fit of the previous path; CSS truncate is the backstop.
-        setDisplay(fullText);
-        return;
-      }
-      if (measureTextWidth(fullText, font) <= available) {
-        setDisplay(fullText);
-        return;
-      }
-      const slashIdx = fullText.lastIndexOf("/");
-      const basename = slashIdx >= 0 ? fullText.slice(slashIdx) : fullText;
-      const head = fullText.slice(0, fullText.length - basename.length);
-      const build = (kept: number) => {
-        const front = Math.ceil(kept / 2);
-        const back = kept - front;
-        return `${head.slice(0, front)}…${back > 0 ? head.slice(head.length - back) : ""}${basename}`;
-      };
-      // Binary search the most head characters that still fit.
-      let lo = 0;
-      let hi = head.length;
-      while (lo < hi) {
-        const mid = Math.ceil((lo + hi) / 2);
-        if (measureTextWidth(build(mid), font) <= available) lo = mid;
-        else hi = mid - 1;
-      }
-      const candidate = build(lo);
-      if (measureTextWidth(candidate, font) <= available) {
-        setDisplay(candidate);
-        return;
-      }
-      // Very narrow pane: prefer the bare file name over "…/file.md"; if even
-      // that overflows, CSS truncate is the backstop.
-      const bare = basename.startsWith("/") ? basename.slice(1) : basename;
-      setDisplay(measureTextWidth(`…${basename}`, font) <= available ? `…${basename}` : bare);
-    };
-
-    fit();
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(fit);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [fullText]);
-
-  return { spanRef, display };
 }
 
 type LoadState = "idle" | "loading" | "loaded" | "error";
@@ -191,39 +99,6 @@ function useFileSearch(rootPath: string, query: string): PickerResult[] {
   }, [rootPath, query]);
 
   return results;
-}
-
-function ToolbarIconButton({
-  label,
-  onClick,
-  pressed,
-  children,
-}: {
-  label: string;
-  onClick: () => void;
-  /** Renders the button as a toggle with a pressed state. */
-  pressed?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onClick={onClick}
-          aria-label={label}
-          aria-pressed={pressed}
-          className={cn(
-            "toolbar-icon-button p-1.5 rounded",
-            pressed ? "text-daintree-text" : "text-daintree-text/60"
-          )}
-        >
-          {children}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{label}</TooltipContent>
-    </Tooltip>
-  );
 }
 
 export function FilePane({
@@ -473,11 +348,9 @@ export function FilePane({
     filePath && isUnderRoot(filePath, pickerRoot)
       ? toForwardSlashes(filePath).slice(toForwardSlashes(pickerRoot).replace(/\/$/, "").length + 1)
       : filePath && toForwardSlashes(filePath);
-  const { spanRef: pathSpanRef, display: fittedPath } = useFittedPath(displayPath);
-
   const toolbar = filePath ? (
     <>
-      <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay">
+      <FileViewerToolbar.Root>
         {isRenderable && (
           <SegmentedToggle<FileViewMode>
             options={[
@@ -488,49 +361,21 @@ export function FilePane({
             onChange={(mode) => setFileViewMode(id, mode)}
           />
         )}
-        {/* Path pill — mirrors the browser toolbar's address field. Click copies
-          the absolute path; the middle collapses to fit the available width
-          while the file name always survives. */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleCopyPath}
-              aria-label="Copy file path"
-              className="relative flex items-center min-w-0 flex-1 group/path"
-            >
-              {pathCopied ? (
-                <Check className="absolute left-2 w-3.5 h-3.5 text-status-success pointer-events-none" />
-              ) : (
-                <FileText
-                  aria-hidden="true"
-                  className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
-                />
-              )}
-              <span
-                ref={pathSpanRef}
-                className="w-full pl-7 pr-2 py-1 text-left text-xs font-mono rounded bg-daintree-bg border border-overlay text-daintree-text/70 truncate transition-colors group-hover/path:border-border-strong group-hover/path:text-daintree-text"
-              >
-                {fittedPath}
-              </span>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{pathCopied ? "Copied!" : "Click to copy"}</TooltipContent>
-        </Tooltip>
-        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+        <FileViewerToolbar.Path path={displayPath} copied={pathCopied} onCopy={handleCopyPath} />
+        <FileViewerToolbar.Actions>
           {isMarkdown && viewMode === "source" && (
-            <ToolbarIconButton
+            <FileViewerToolbar.IconButton
               label="Wrap long lines"
               pressed={markdownWrapLines}
               onClick={() => setMarkdownWrapLines(!markdownWrapLines)}
             >
               <WrapText className="w-4 h-4" />
-            </ToolbarIconButton>
+            </FileViewerToolbar.IconButton>
           )}
-          <ToolbarIconButton label="Refresh" onClick={() => loadFile(false)}>
+          <FileViewerToolbar.IconButton label="Refresh" onClick={() => loadFile(false)}>
             <RefreshCw className="w-4 h-4" />
-          </ToolbarIconButton>
-          <ToolbarIconButton
+          </FileViewerToolbar.IconButton>
+          <FileViewerToolbar.IconButton
             label={openTarget === "browser" ? "Open in browser" : "Open in editor"}
             onClick={() => void handleOpenExternal(openTarget)}
           >
@@ -539,9 +384,9 @@ export function FilePane({
             ) : (
               <ExternalLink className="w-4 h-4" />
             )}
-          </ToolbarIconButton>
-        </div>
-      </div>
+          </FileViewerToolbar.IconButton>
+        </FileViewerToolbar.Actions>
+      </FileViewerToolbar.Root>
       {openError && (
         <InlineStatusBanner
           icon={XCircle}


### PR DESCRIPTION
## Summary

- The file viewer dialog (`FileViewerModal.tsx`) and the file viewer panel (`FilePane.tsx`) render the same viewer bodies (`CodeViewer`, `MarkdownViewer`, `HtmlViewer`), but their toolbar chrome was built independently and had drifted apart: the panel had a click-to-copy path field, the dialog had a separate copy button and static path text; the panel had Refresh, the dialog didn't; the panel put Wrap in the toolbar, the dialog put it in the footer.
- Extracted a shared compound component, `FileViewerToolbar.tsx` (`Root`, `Path`, `Actions`, `IconButton`, plus a private width-fitted path-truncation hook), and updated both `FilePane.tsx` and `FileViewerModal.tsx` to consume it.

Resolves #11224

## Changes

- New: `src/components/FileViewer/FileViewerToolbar.tsx`.
- `src/panels/file/FilePane.tsx` now consumes the shared toolbar; shrinks by about 150 lines net; rendered output unchanged.
- `src/components/FileViewer/FileViewerModal.tsx` now consumes the shared toolbar. The dialog gains a click-to-copy path pill (replacing its separate copy button), the Wrap toggle moved up from the footer into the toolbar, a Refresh button it never had, and the panel's icon buttons, which carry a focus-visible ring and correct light/dark armed-state polarity the dialog's ad-hoc buttons lacked.
- Diff and workspace mode controls (hunk navigation, split/unified view, font size, ignore whitespace, find-in-diff, the file sidebar) are untouched, per the issue.
- One wrinkle worth flagging: the dialog's `loadFile` is a `useEffectEvent`, which React forbids calling directly from an event handler, so Refresh routes through a revision counter that the load effect consumes instead.

### Review fixes

Three defects turned up in review and got fixed in a second commit:

1. The footer visibility gate only covered two of the four controls it could hold, so a single reviewed file lost its whole footer bar, including the Viewed marker toggle, the only way to unmark a file (`v` only ever marks).
2. Refresh was re-arming a one-shot default-to-diff switch, so a user who'd manually switched to Source and hit Refresh could get yanked back to Diff when the diff refetched. The guard belongs to the file identity, not the read.
3. The mode toggle rendered in different places (toolbar row vs. header) depending on View vs. Diff mode, so switching modes unmounted the button a keyboard user had just pressed and dropped their focus. It now stays fixed in the header.

## Testing

- 265 tests pass across the full covering set: the new/extended toolbar and modal test files, plus every existing suite touching the changed modules.
- Full `npm run typecheck` clean.
- ESLint: 0 errors on the 5 changed files.
- Prettier clean.
- The diff-guard regression test was mutation-tested (reintroducing the bug makes it fail).
- E2E not run locally (CI doesn't run E2E on PRs); the two `data-testid` selectors the existing `core-file-panel` E2E spec asserts (`file-viewer-metadata`, `file-viewer-open-as-panel`) are preserved, so that spec needs no changes.