### PR TITLE
fix(git): point core.hooksPath at an app-owned directory

### DIFF
--- a/electron/utils/__tests__/gitCheckIgnore.test.ts
+++ b/electron/utils/__tests__/gitCheckIgnore.test.ts
@@ -2,28 +2,33 @@ import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSpawn, mockHardenedGitConfig, mockBuildHardenedGitEnv } = vi.hoisted(() => ({
-  mockSpawn: vi.fn(),
-  mockHardenedGitConfig: [
-    "core.fsmonitor=false",
-    "protocol.ext.allow=never",
-    "credential.helper=",
-    "core.hooksPath=/mock/user/data/git-hooks",
-  ] as const,
-  mockBuildHardenedGitEnv: vi.fn(() => ({
-    LC_ALL: "",
-    LC_CTYPE: "C.UTF-8",
-    GIT_TERMINAL_PROMPT: "0",
-    GIT_OPTIONAL_LOCKS: "0",
-  })),
-}));
+const { mockSpawn, mockGetHardenedGitConfig, mockHardenedGitConfig, mockBuildHardenedGitEnv } =
+  vi.hoisted(() => {
+    const config = [
+      "core.fsmonitor=false",
+      "protocol.ext.allow=never",
+      "credential.helper=",
+      "core.hooksPath=/mock/user/data/git-hooks",
+    ] as const;
+    return {
+      mockSpawn: vi.fn(),
+      mockHardenedGitConfig: config,
+      mockGetHardenedGitConfig: vi.fn((_platform?: NodeJS.Platform) => config),
+      mockBuildHardenedGitEnv: vi.fn(() => ({
+        LC_ALL: "",
+        LC_CTYPE: "C.UTF-8",
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_OPTIONAL_LOCKS: "0",
+      })),
+    };
+  });
 
 vi.mock("node:child_process", () => ({
   spawn: mockSpawn,
 }));
 
 vi.mock("../hardenedGit.js", () => ({
-  getHardenedGitConfig: () => mockHardenedGitConfig,
+  getHardenedGitConfig: mockGetHardenedGitConfig,
   buildHardenedGitEnv: mockBuildHardenedGitEnv,
   // Mocked to a tiny value so the hang-timeout test (which sleeps past this
   // constant to observe the kill) runs in milliseconds, not the real 30s.
@@ -131,9 +136,11 @@ describe("checkIgnoredPaths", () => {
 
     await checkIgnoredPaths("/repo", ["src/a.txt"]);
 
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args.slice(-3)).toEqual(["check-ignore", "--stdin", "-z"]);
     expect(mockSpawn).toHaveBeenCalledWith(
       "git",
-      [...mockHardenedGitConfig.flatMap((entry) => ["-c", entry]), "check-ignore", "--stdin", "-z"],
+      expect.anything(),
       expect.objectContaining({
         cwd: "/repo",
         stdio: ["pipe", "pipe", "pipe"],
@@ -149,14 +156,27 @@ describe("checkIgnoredPaths", () => {
 
     await checkIgnoredPaths("/repo", ["src/a.txt"]);
 
+    // Every config entry must be carried as its own `-c <entry>` pair, in order
+    // and ahead of the command — asserted structurally rather than by rebuilding
+    // the expected argv with the same flatMap the implementation uses.
     const args = mockSpawn.mock.calls[0][1] as string[];
-    const configFlags: string[] = [];
-    for (let i = 0; i < args.length - 1; i++) {
-      if (args[i] === "-c") configFlags.push(args[i + 1] as string);
+    const prefix = args.slice(0, args.length - 3);
+    expect(prefix).toHaveLength(mockHardenedGitConfig.length * 2);
+    for (let i = 0; i < prefix.length; i += 2) {
+      expect(prefix[i]).toBe("-c");
+      expect(prefix[i + 1]).toBe(mockHardenedGitConfig[i / 2]);
     }
-    for (const entry of mockHardenedGitConfig) {
-      expect(configFlags).toContain(entry);
-    }
+  });
+
+  it("PROPAGATES_PLATFORM_TO_CONFIG_GETTER", async () => {
+    const child = makeFakeProcess({ exitCode: 0 });
+    mockSpawn.mockReturnValue(child);
+
+    await checkIgnoredPaths("/repo", ["src/a.txt"], { platform: "win32" });
+
+    // The getter converts Windows separators for git's -c parser, so it has to
+    // see the same platform the env builder does.
+    expect(mockGetHardenedGitConfig).toHaveBeenCalledWith("win32");
   });
 
   it("FORWARDS_HARDENED_ENV_TO_SPAWN", async () => {

--- a/electron/utils/__tests__/gitCheckIgnore.test.ts
+++ b/electron/utils/__tests__/gitCheckIgnore.test.ts
@@ -8,6 +8,7 @@ const { mockSpawn, mockHardenedGitConfig, mockBuildHardenedGitEnv } = vi.hoisted
     "core.fsmonitor=false",
     "protocol.ext.allow=never",
     "credential.helper=",
+    "core.hooksPath=/mock/user/data/git-hooks",
   ] as const,
   mockBuildHardenedGitEnv: vi.fn(() => ({
     LC_ALL: "",
@@ -22,7 +23,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 vi.mock("../hardenedGit.js", () => ({
-  HARDENED_GIT_CONFIG: mockHardenedGitConfig,
+  getHardenedGitConfig: () => mockHardenedGitConfig,
   buildHardenedGitEnv: mockBuildHardenedGitEnv,
   // Mocked to a tiny value so the hang-timeout test (which sleeps past this
   // constant to observe the kill) runs in milliseconds, not the real 30s.
@@ -132,17 +133,7 @@ describe("checkIgnoredPaths", () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "git",
-      [
-        "-c",
-        "core.fsmonitor=false",
-        "-c",
-        "protocol.ext.allow=never",
-        "-c",
-        "credential.helper=",
-        "check-ignore",
-        "--stdin",
-        "-z",
-      ],
+      [...mockHardenedGitConfig.flatMap((entry) => ["-c", entry]), "check-ignore", "--stdin", "-z"],
       expect.objectContaining({
         cwd: "/repo",
         stdio: ["pipe", "pipe", "pipe"],

--- a/electron/utils/__tests__/hardenedGit.hooks.test.ts
+++ b/electron/utils/__tests__/hardenedGit.hooks.test.ts
@@ -22,13 +22,29 @@ const TEST_USER_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-hooks-use
 process.env.DAINTREE_USER_DATA = TEST_USER_DATA;
 
 const HOOKS_DIR = path.join(TEST_USER_DATA, "git-hooks");
-const HOOK_NAMES = ["post-checkout", "post-commit", "post-merge", "pre-push"];
 
 let repoDir: string;
 let scratchDir: string;
 
+/**
+ * Fixture git, isolated from the developer's own config: an inherited
+ * `commit.gpgSign=true` would hang the setup commit on a passphrase prompt, and
+ * an inherited `core.hooksPath` would run their hooks against these temp repos.
+ * The timeout keeps a wedged git from blocking the suite — vitest cannot
+ * interrupt a synchronous native call.
+ */
 function git(cwd: string, args: string[]): void {
-  execFileSync("git", args, { cwd, stdio: "pipe" });
+  execFileSync("git", args, {
+    cwd,
+    stdio: "pipe",
+    timeout: 10_000,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+  });
 }
 
 function writeHook(dir: string, name: string, body: string): void {
@@ -36,6 +52,12 @@ function writeHook(dir: string, name: string, body: string): void {
   const file = path.join(dir, name);
   fs.writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
 }
+
+// Registered outside the suite below: a skipped suite never runs its hooks, so
+// cleanup declared inside it would leak the temp root on Windows.
+afterAll(() => {
+  fs.rmSync(TEST_USER_DATA, { recursive: true, force: true });
+});
 
 // Hooks are shell scripts; Windows git has no /bin/sh on the default PATH, and
 // the WSL route carries its own POSIX hooks path that this suite cannot reach.
@@ -57,7 +79,6 @@ describePosix("hardened git core.hooksPath (real git)", () => {
 
   afterAll(() => {
     fs.rmSync(scratchDir, { recursive: true, force: true });
-    fs.rmSync(TEST_USER_DATA, { recursive: true, force: true });
   });
 
   it("does not execute a repo-supplied hook", async () => {
@@ -84,10 +105,14 @@ describePosix("hardened git core.hooksPath (real git)", () => {
     expect(fs.existsSync(sentinel)).toBe(true);
   });
 
-  // The reported symptom: during `git worktree add` the CWD at checkout-hook
-  // dispatch is the new worktree root, so anything resolving hooks relatively
-  // lands its files there.
-  it("resolves hooks from the app-owned directory during worktree add, not the worktree root", async () => {
+  // `git worktree add` is the operation from the issue report: the CWD at
+  // checkout-hook dispatch is the new worktree root, which is what git-lfs
+  // resolved its relative hooks path against.
+  //
+  // Asserting the four hook files are absent from the worktree root would be
+  // vacuous — nothing here installs them, so it passes against the empty value
+  // too. Only git-lfs writes them, and it is not available in CI.
+  it("dispatches hooks from the app-owned directory during worktree add", async () => {
     const { createHardenedGit } = await import("../hardenedGit.js");
     const sentinel = path.join(scratchDir, "worktree-hook-fired");
     const worktreeDir = path.join(scratchDir, "wt");
@@ -98,9 +123,6 @@ describePosix("hardened git core.hooksPath (real git)", () => {
     await client.raw(["worktree", "add", "-q", worktreeDir, "-b", "wt-branch"]);
 
     expect(fs.existsSync(sentinel)).toBe(true);
-    for (const name of HOOK_NAMES) {
-      expect(fs.existsSync(path.join(worktreeDir, name))).toBe(false);
-    }
   });
 
   it("reports the app-owned directory as the effective hooksPath", async () => {

--- a/electron/utils/__tests__/hardenedGit.hooks.test.ts
+++ b/electron/utils/__tests__/hardenedGit.hooks.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Real-git coverage for the `core.hooksPath` override (issue #11226).
+ *
+ * Deliberately no `simple-git` mock: the value under test is what actual git
+ * does with the config we emit, which a mock cannot tell us.
+ *
+ * Not covered here: reproducing the original litter. That is git-lfs resolving
+ * a relative `core.hooksPath` against its own CWD while self-installing, so it
+ * needs a git-lfs binary. What is provable without one is the pair of
+ * invariants that fix has to preserve — repo hooks stay blocked (#3742), and
+ * hooks in the app-owned directory still dispatch (so git-lfs's `pre-push`
+ * upload keeps working once it installs there).
+ */
+
+const TEST_USER_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-hooks-userdata-"));
+process.env.DAINTREE_USER_DATA = TEST_USER_DATA;
+
+const HOOKS_DIR = path.join(TEST_USER_DATA, "git-hooks");
+const HOOK_NAMES = ["post-checkout", "post-commit", "post-merge", "pre-push"];
+
+let repoDir: string;
+let scratchDir: string;
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+function writeHook(dir: string, name: string, body: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+}
+
+// Hooks are shell scripts; Windows git has no /bin/sh on the default PATH, and
+// the WSL route carries its own POSIX hooks path that this suite cannot reach.
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+describePosix("hardened git core.hooksPath (real git)", () => {
+  beforeAll(async () => {
+    scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-hooks-repo-"));
+    repoDir = path.join(scratchDir, "repo");
+    fs.mkdirSync(repoDir);
+
+    git(repoDir, ["init", "-q"]);
+    git(repoDir, ["config", "user.email", "test@example.com"]);
+    git(repoDir, ["config", "user.name", "Test"]);
+    fs.writeFileSync(path.join(repoDir, "file.txt"), "contents\n");
+    git(repoDir, ["add", "file.txt"]);
+    git(repoDir, ["commit", "-qm", "init"]);
+  });
+
+  afterAll(() => {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+    fs.rmSync(TEST_USER_DATA, { recursive: true, force: true });
+  });
+
+  it("does not execute a repo-supplied hook", async () => {
+    const { createHardenedGit } = await import("../hardenedGit.js");
+    const sentinel = path.join(scratchDir, "repo-hook-fired");
+
+    writeHook(path.join(repoDir, ".git", "hooks"), "post-checkout", `echo fired > "${sentinel}"`);
+
+    const client = await createHardenedGit(repoDir);
+    await client.raw(["checkout", "-q", "-b", "blocked-branch"]);
+
+    expect(fs.existsSync(sentinel)).toBe(false);
+  });
+
+  it("executes a hook from the app-owned directory, keeping git-lfs pre-push viable", async () => {
+    const { createHardenedGit } = await import("../hardenedGit.js");
+    const sentinel = path.join(scratchDir, "app-hook-fired");
+
+    writeHook(HOOKS_DIR, "post-checkout", `echo fired > "${sentinel}"`);
+
+    const client = await createHardenedGit(repoDir);
+    await client.raw(["checkout", "-q", "-b", "app-hook-branch"]);
+
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+
+  // The reported symptom: during `git worktree add` the CWD at checkout-hook
+  // dispatch is the new worktree root, so anything resolving hooks relatively
+  // lands its files there.
+  it("resolves hooks from the app-owned directory during worktree add, not the worktree root", async () => {
+    const { createHardenedGit } = await import("../hardenedGit.js");
+    const sentinel = path.join(scratchDir, "worktree-hook-fired");
+    const worktreeDir = path.join(scratchDir, "wt");
+
+    writeHook(HOOKS_DIR, "post-checkout", `echo fired > "${sentinel}"`);
+
+    const client = await createHardenedGit(repoDir);
+    await client.raw(["worktree", "add", "-q", worktreeDir, "-b", "wt-branch"]);
+
+    expect(fs.existsSync(sentinel)).toBe(true);
+    for (const name of HOOK_NAMES) {
+      expect(fs.existsSync(path.join(worktreeDir, name))).toBe(false);
+    }
+  });
+
+  it("reports the app-owned directory as the effective hooksPath", async () => {
+    const { createHardenedGit } = await import("../hardenedGit.js");
+
+    const client = await createHardenedGit(repoDir);
+    const effective = (await client.raw(["config", "--get", "core.hooksPath"])).trim();
+
+    expect(effective).toBe(HOOKS_DIR);
+    expect(path.isAbsolute(effective)).toBe(true);
+  });
+});

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -1,4 +1,18 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The hooks-path resolver reads DAINTREE_USER_DATA first (the workspace-host
+// route), so pointing it at a temp dir keeps the suite off the real userData
+// path. Set before any factory call — the resolved directory is memoized on
+// first use.
+const TEST_USER_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-hardened-git-"));
+process.env.DAINTREE_USER_DATA = TEST_USER_DATA;
+
+afterAll(() => {
+  fs.rmSync(TEST_USER_DATA, { recursive: true, force: true });
+});
 
 const mockGitInstance: Record<string, ReturnType<typeof vi.fn>> = {
   raw: vi.fn(),
@@ -23,10 +37,31 @@ import {
   getGitLocaleEnv,
   buildHardenedGitEnv,
   buildContinueEnv,
-  HARDENED_GIT_CONFIG,
-  AUTHENTICATED_GIT_CONFIG,
+  getHardenedGitConfig,
+  toGitConfigPath,
 } from "../hardenedGit.js";
 import { simpleGit } from "simple-git";
+
+/**
+ * Pull the generated `core.hooksPath` value out of a captured config array.
+ * Tests assert invariants on this (absolute, non-empty, app-owned) rather than
+ * pinning the literal, which would just restate the implementation.
+ */
+function hooksPathValues(config: readonly string[]): string[] {
+  return config
+    .filter((entry) => entry.startsWith("core.hooksPath="))
+    .map((entry) => entry.slice("core.hooksPath=".length));
+}
+
+function soleHooksPath(config: readonly string[]): string {
+  const values = hooksPathValues(config);
+  expect(values).toHaveLength(1);
+  return values[0];
+}
+
+function capturedConfig(callIndex = 0): string[] {
+  return (simpleGit as ReturnType<typeof vi.fn>).mock.calls[callIndex][0].config;
+}
 
 describe("validateCwd", () => {
   it("throws for empty string", async () => {
@@ -144,14 +179,14 @@ describe("createHardenedGit", () => {
       "protocol.ext.allow=never",
       "core.sshCommand=",
       "core.gitProxy=",
-      "core.hooksPath=",
       "core.quotepath=false",
       "core.precomposeunicode=true",
     ];
     for (const key of expectedKeys) {
       expect(options.config).toContain(key);
     }
-    expect(options.config).toHaveLength(expectedKeys.length);
+    // +1 for the generated core.hooksPath entry, asserted by value below.
+    expect(options.config).toHaveLength(expectedKeys.length + 1);
   });
 
   it("passes abort signal when provided", async () => {
@@ -364,9 +399,9 @@ describe("createAuthenticatedGit", () => {
     expect(options.config).toContain("core.pager=cat");
     expect(options.config).toContain("protocol.ext.allow=never");
     expect(options.config).toContain("core.gitProxy=");
-    expect(options.config).toContain("core.hooksPath=");
     expect(options.config).toContain("core.quotepath=false");
     expect(options.config).toContain("core.precomposeunicode=true");
+    expect(path.isAbsolute(soleHooksPath(options.config))).toBe(true);
   });
 
   it("sets GIT_TERMINAL_PROMPT, hardened GIT_SSH_COMMAND, and GIT_OPTIONAL_LOCKS=0 via .env()", async () => {
@@ -783,18 +818,35 @@ describe("createWslHardenedGit", () => {
     expect(options.binary).toEqual(["wsl.exe", "git"]);
   });
 
-  it("carries the full HARDENED_GIT_CONFIG", async () => {
+  it("carries the same non-path hardening as the native hardened profile", async () => {
     await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
     });
 
-    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    for (const entry of HARDENED_GIT_CONFIG) {
-      expect(options.config).toContain(entry);
-    }
-    expect(options.config).toHaveLength(HARDENED_GIT_CONFIG.length);
+    // Compare with the hooks entry stripped: WSL intentionally diverges there
+    // (its git runs inside the distro), but every other override must match.
+    const withoutHooks = (config: readonly string[]) =>
+      config.filter((entry) => !entry.startsWith("core.hooksPath="));
+
+    expect(withoutHooks(capturedConfig())).toEqual(withoutHooks(getHardenedGitConfig()));
+  });
+
+  it("points core.hooksPath at a POSIX path inside the distro, not the Windows host", async () => {
+    await createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
+
+    const hooksPath = soleHooksPath(capturedConfig());
+    // Linux git resolves anything without a leading `/` (or an expandable `~`)
+    // against the CWD — which during a checkout is the worktree root. That is
+    // the #11226 defect, so the WSL value must be neither.
+    expect(hooksPath.startsWith("/") || hooksPath.startsWith("~/")).toBe(true);
+    expect(hooksPath).not.toMatch(/^[A-Za-z]:/);
+    expect(hooksPath).not.toContain("\\");
   });
 
   it("sets WSL_DISTRO_NAME, GIT_OPTIONAL_LOCKS=0, and locale in env for diagnostics", async () => {
@@ -893,34 +945,122 @@ describe("getGitLocaleEnv", () => {
   });
 });
 
-describe("config constants", () => {
-  it("HARDENED_GIT_CONFIG includes credential-blocking entries", async () => {
-    expect(HARDENED_GIT_CONFIG).toContain("credential.helper=");
-    expect(HARDENED_GIT_CONFIG).toContain("core.sshCommand=");
-    expect(HARDENED_GIT_CONFIG).toContain("core.askpass=");
+describe("config profiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("AUTHENTICATED_GIT_CONFIG excludes credential-blocking entries", async () => {
-    expect(AUTHENTICATED_GIT_CONFIG).not.toContain("credential.helper=");
-    expect(AUTHENTICATED_GIT_CONFIG).not.toContain("core.sshCommand=");
-    expect(AUTHENTICATED_GIT_CONFIG).not.toContain("core.askpass=");
+  it("hardened profile includes credential-blocking entries", async () => {
+    expect(getHardenedGitConfig()).toContain("credential.helper=");
+    expect(getHardenedGitConfig()).toContain("core.sshCommand=");
+    expect(getHardenedGitConfig()).toContain("core.askpass=");
   });
 
-  it("both configs share the same security base entries", async () => {
+  it("authenticated profile excludes credential-blocking entries", async () => {
+    await createAuthenticatedGit("/test/repo");
+
+    const config = capturedConfig();
+    expect(config).not.toContain("credential.helper=");
+    expect(config).not.toContain("core.sshCommand=");
+    expect(config).not.toContain("core.askpass=");
+  });
+
+  it("both profiles share the same security base entries", async () => {
     const securityEntries = [
       "core.fsmonitor=false",
       "core.untrackedCache=keep",
       "core.pager=cat",
       "protocol.ext.allow=never",
       "core.gitProxy=",
-      "core.hooksPath=",
       "core.quotepath=false",
       "core.precomposeunicode=true",
     ];
+    await createAuthenticatedGit("/test/repo");
+    const authenticated = capturedConfig();
+
     for (const entry of securityEntries) {
-      expect(HARDENED_GIT_CONFIG).toContain(entry);
-      expect(AUTHENTICATED_GIT_CONFIG).toContain(entry);
+      expect(getHardenedGitConfig()).toContain(entry);
+      expect(authenticated).toContain(entry);
     }
+  });
+
+  it("both profiles resolve the same app-owned hooks directory", async () => {
+    await createAuthenticatedGit("/test/repo");
+
+    expect(soleHooksPath(capturedConfig())).toBe(soleHooksPath(getHardenedGitConfig()));
+  });
+});
+
+describe("core.hooksPath enforcement (issue #11226)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // An empty or otherwise relative value is resolved against the process CWD,
+  // which during `git worktree add` is the new worktree root — that is how
+  // git-lfs came to self-install four hook files there.
+  it("is absolute and non-empty, so it can never resolve against the CWD", async () => {
+    await createHardenedGit("/test/repo");
+
+    const hooksPath = soleHooksPath(capturedConfig());
+    expect(hooksPath).not.toBe("");
+    expect(path.isAbsolute(hooksPath)).toBe(true);
+  });
+
+  it("points inside the resolved userData directory", async () => {
+    await createHardenedGit("/test/repo");
+
+    const hooksPath = soleHooksPath(capturedConfig());
+    const relative = path.relative(process.env.DAINTREE_USER_DATA as string, hooksPath);
+    expect(relative).not.toBe("");
+    expect(relative.startsWith("..")).toBe(false);
+    expect(path.isAbsolute(relative)).toBe(false);
+  });
+
+  it("creates the hooks directory so git-lfs has somewhere to install", async () => {
+    await createHardenedGit("/test/repo");
+
+    expect(fs.existsSync(soleHooksPath(capturedConfig()))).toBe(true);
+  });
+
+  it("appears exactly once per profile", async () => {
+    await createHardenedGit("/test/repo");
+    expect(hooksPathValues(capturedConfig())).toHaveLength(1);
+  });
+
+  // git takes the last -c for a single-valued key, so a caller-supplied
+  // override must not be able to displace the enforcement value.
+  it("wins over a conflicting core.hooksPath passed via extraConfig", async () => {
+    await createAuthenticatedGit("/test/repo", {
+      extraConfig: ["core.hooksPath=/tmp/attacker-controlled"],
+    });
+
+    const effective = hooksPathValues(capturedConfig()).at(-1);
+    expect(effective).not.toBe("/tmp/attacker-controlled");
+    expect(effective).toBe(soleHooksPath(getHardenedGitConfig()));
+  });
+
+  it("background fetch inherits the enforced hooks path", async () => {
+    const controller = new AbortController();
+    await createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+
+    expect(path.isAbsolute(soleHooksPath(capturedConfig()))).toBe(true);
+  });
+});
+
+describe("toGitConfigPath", () => {
+  // git parses -c values with backslash escapes; forward slashes are accepted
+  // on every platform and sidestep the question entirely.
+  it("converts Windows separators to forward slashes", () => {
+    const converted = toGitConfigPath("C:\\Users\\Alice\\AppData\\Daintree\\git-hooks", "win32");
+    expect(converted).not.toContain("\\");
+    expect(path.win32.isAbsolute(converted)).toBe(true);
+  });
+
+  it("leaves POSIX paths untouched, where a backslash is a legal filename char", () => {
+    expect(toGitConfigPath("/home/alice/odd\\name/git-hooks", "linux")).toBe(
+      "/home/alice/odd\\name/git-hooks"
+    );
   });
 });
 

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -1033,8 +1033,8 @@ describe("core.hooksPath enforcement (issue #11226)", () => {
     expect(fs.existsSync(soleHooksPath(capturedConfig()))).toBe(true);
   });
 
-  // Guards against double-emission: the entry is appended by three separate
-  // builders (hardened, authenticated, WSL).
+  // Guards against double-emission. The WSL profile is covered by its own suite,
+  // whose soleHooksPath call enforces the same cardinality.
   it("appears exactly once in every profile", async () => {
     await createHardenedGit("/test/repo");
     expect(hooksPathValues(capturedConfig())).toHaveLength(1);
@@ -1148,18 +1148,26 @@ describe("hooks directory resolution", () => {
  */
 describe("selectUserDataDir", () => {
   const HOME = "/home/alice";
+  const home = () => HOME;
 
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.DAINTREE_UTILITY_PROCESS_KIND;
   });
 
+  // Every workspace host would otherwise attempt a require("electron") it can
+  // never satisfy, on its first git call.
   it("prefers an absolute env value, without consulting electron", () => {
-    expect(selectUserDataDir("/env/userdata", "/electron/userdata", HOME)).toBe("/env/userdata");
+    const electron = vi.fn(() => "/electron/userdata");
+
+    expect(selectUserDataDir("/env/userdata", electron, home)).toBe("/env/userdata");
+    expect(electron).not.toHaveBeenCalled();
   });
 
   it("uses electron's userData when no env value is set — the main-process path", () => {
-    expect(selectUserDataDir(undefined, "/electron/userdata", HOME)).toBe("/electron/userdata");
+    expect(selectUserDataDir(undefined, () => "/electron/userdata", home)).toBe(
+      "/electron/userdata"
+    );
   });
 
   // A relative value would be resolved against the cwd, which is the defect
@@ -1167,20 +1175,20 @@ describe("selectUserDataDir", () => {
   it("skips a relative env value and reports it", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    expect(selectUserDataDir("relative/userdata", "/electron/userdata", HOME)).toBe(
+    expect(selectUserDataDir("relative/userdata", () => "/electron/userdata", home)).toBe(
       "/electron/userdata"
     );
     expect(errorSpy).toHaveBeenCalled();
   });
 
   it("skips a relative electron value too", () => {
-    expect(selectUserDataDir(undefined, "relative/userdata", HOME)).toBe(
+    expect(selectUserDataDir(undefined, () => "relative/userdata", home)).toBe(
       path.join(HOME, ".daintree")
     );
   });
 
   it("falls back to the home directory when neither source is usable", () => {
-    expect(selectUserDataDir(undefined, undefined, HOME)).toBe(path.join(HOME, ".daintree"));
+    expect(selectUserDataDir(undefined, () => undefined, home)).toBe(path.join(HOME, ".daintree"));
   });
 
   // In a utility process the env var is supplied by the fork; missing it means
@@ -1189,7 +1197,7 @@ describe("selectUserDataDir", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     process.env.DAINTREE_UTILITY_PROCESS_KIND = "workspace-host";
 
-    selectUserDataDir(undefined, undefined, HOME);
+    selectUserDataDir(undefined, () => undefined, home);
 
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("workspace-host"));
   });
@@ -1197,13 +1205,19 @@ describe("selectUserDataDir", () => {
   it("stays quiet on the ordinary main-process path", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    selectUserDataDir(undefined, "/electron/userdata", HOME);
+    selectUserDataDir(undefined, () => "/electron/userdata", home);
 
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it("throws rather than ever resolving against the cwd", () => {
-    expect(() => selectUserDataDir(undefined, undefined, "")).toThrow(/absolute userData/);
+    expect(() =>
+      selectUserDataDir(
+        undefined,
+        () => undefined,
+        () => ""
+      )
+    ).toThrow(/absolute userData/);
   });
 });
 

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -38,6 +38,7 @@ import {
   buildHardenedGitEnv,
   buildContinueEnv,
   getHardenedGitConfig,
+  selectUserDataDir,
   toGitConfigPath,
 } from "../hardenedGit.js";
 import { simpleGit } from "simple-git";
@@ -185,8 +186,13 @@ describe("createHardenedGit", () => {
     for (const key of expectedKeys) {
       expect(options.config).toContain(key);
     }
-    // +1 for the generated core.hooksPath entry, asserted by value below.
-    expect(options.config).toHaveLength(expectedKeys.length + 1);
+    // Count the static entries on their own; the generated hooks entry has its
+    // own coverage below, and folding it into this total would hide a change to
+    // either half behind one number.
+    const staticEntries = options.config.filter(
+      (entry: string) => !entry.startsWith("core.hooksPath=")
+    );
+    expect(staticEntries).toHaveLength(expectedKeys.length);
   });
 
   it("passes abort signal when provided", async () => {
@@ -987,7 +993,11 @@ describe("config profiles", () => {
   it("both profiles resolve the same app-owned hooks directory", async () => {
     await createAuthenticatedGit("/test/repo");
 
-    expect(soleHooksPath(capturedConfig())).toBe(soleHooksPath(getHardenedGitConfig()));
+    const shared = soleHooksPath(capturedConfig());
+    expect(shared).toBe(soleHooksPath(getHardenedGitConfig()));
+    // Without this the assertion would hold for two empty strings, which is
+    // precisely the state being fixed.
+    expect(path.isAbsolute(shared)).toBe(true);
   });
 });
 
@@ -1023,9 +1033,16 @@ describe("core.hooksPath enforcement (issue #11226)", () => {
     expect(fs.existsSync(soleHooksPath(capturedConfig()))).toBe(true);
   });
 
-  it("appears exactly once per profile", async () => {
+  // Guards against double-emission: the entry is appended by three separate
+  // builders (hardened, authenticated, WSL).
+  it("appears exactly once in every profile", async () => {
     await createHardenedGit("/test/repo");
     expect(hooksPathValues(capturedConfig())).toHaveLength(1);
+
+    await createAuthenticatedGit("/test/repo");
+    expect(hooksPathValues(capturedConfig(1))).toHaveLength(1);
+
+    expect(hooksPathValues(getHardenedGitConfig())).toHaveLength(1);
   });
 
   // git takes the last -c for a single-valued key, so a caller-supplied
@@ -1048,12 +1065,165 @@ describe("core.hooksPath enforcement (issue #11226)", () => {
   });
 });
 
+// The hooks directory is resolved and memoized on first use, so these need a
+// fresh module registry per case rather than the file-wide instance.
+describe("hooks directory resolution", () => {
+  const originalUserData = process.env.DAINTREE_USER_DATA;
+
+  afterEach(() => {
+    process.env.DAINTREE_USER_DATA = originalUserData;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function importFresh(userData: string | undefined) {
+    vi.resetModules();
+    if (userData === undefined) delete process.env.DAINTREE_USER_DATA;
+    else process.env.DAINTREE_USER_DATA = userData;
+    return import("../hardenedGit.js");
+  }
+
+  it("does not touch the filesystem at import time", async () => {
+    const userData = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-lazy-"));
+    const mod = await importFresh(userData);
+
+    // Importing hardenedGit.ts must stay inert: it is pulled in very early and
+    // very broadly, before dev overrides userData.
+    expect(fs.existsSync(path.join(userData, "git-hooks"))).toBe(false);
+
+    mod.getHardenedGitConfig();
+    expect(fs.existsSync(path.join(userData, "git-hooks"))).toBe(true);
+
+    fs.rmSync(userData, { recursive: true, force: true });
+  });
+
+  it("resolves once and reuses the result", async () => {
+    const userData = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-memo-"));
+    const mod = await importFresh(userData);
+
+    const first = mod.getHardenedGitConfig().find((e) => e.startsWith("core.hooksPath="));
+    process.env.DAINTREE_USER_DATA = path.join(os.tmpdir(), "daintree-moved-elsewhere");
+    const second = mod.getHardenedGitConfig().find((e) => e.startsWith("core.hooksPath="));
+
+    expect(second).toBe(first);
+
+    fs.rmSync(userData, { recursive: true, force: true });
+  });
+
+  it("keeps a directory-creation failure non-fatal, still emitting an absolute path", async () => {
+    // A path *under a regular file* makes the real mkdir fail with ENOTDIR — no
+    // fs mocking needed to reach the failure branch.
+    const blocker = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "daintree-enotdir-")), "afile");
+    fs.writeFileSync(blocker, "not a directory");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const mod = await importFresh(blocker);
+    const hooksPath = mod
+      .getHardenedGitConfig()
+      .find((e) => e.startsWith("core.hooksPath="))
+      ?.slice("core.hooksPath=".length);
+
+    // git blocks repo-supplied hooks against a path that does not exist, so the
+    // security invariant survives a creation failure — only git-lfs's install
+    // target is lost, which must not take git down with it.
+    expect(hooksPath).toBeDefined();
+    expect(path.isAbsolute(hooksPath as string)).toBe(true);
+    expect(fs.existsSync(hooksPath as string)).toBe(false);
+
+    mod.getHardenedGitConfig();
+    mod.getHardenedGitConfig();
+    // Warned once, not once per git invocation — this rides the status-polling path.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    fs.rmSync(path.dirname(blocker), { recursive: true, force: true });
+  });
+});
+
+/**
+ * The `require("electron")` read cannot be reached under vitest — the bundled
+ * main gets `require` from an esbuild banner that vitest has no equivalent for,
+ * and stubbing the global does not rebind the module's identifier. Its
+ * precedence logic is therefore tested through `selectUserDataDir`, which takes
+ * the candidates as arguments.
+ */
+describe("selectUserDataDir", () => {
+  const HOME = "/home/alice";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.DAINTREE_UTILITY_PROCESS_KIND;
+  });
+
+  it("prefers an absolute env value, without consulting electron", () => {
+    expect(selectUserDataDir("/env/userdata", "/electron/userdata", HOME)).toBe("/env/userdata");
+  });
+
+  it("uses electron's userData when no env value is set — the main-process path", () => {
+    expect(selectUserDataDir(undefined, "/electron/userdata", HOME)).toBe("/electron/userdata");
+  });
+
+  // A relative value would be resolved against the cwd, which is the defect
+  // this override exists to prevent.
+  it("skips a relative env value and reports it", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(selectUserDataDir("relative/userdata", "/electron/userdata", HOME)).toBe(
+      "/electron/userdata"
+    );
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("skips a relative electron value too", () => {
+    expect(selectUserDataDir(undefined, "relative/userdata", HOME)).toBe(
+      path.join(HOME, ".daintree")
+    );
+  });
+
+  it("falls back to the home directory when neither source is usable", () => {
+    expect(selectUserDataDir(undefined, undefined, HOME)).toBe(path.join(HOME, ".daintree"));
+  });
+
+  // In a utility process the env var is supplied by the fork; missing it means
+  // main and the host have split onto different hook roots.
+  it("reports a fallback inside a utility process, where it is never expected", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.DAINTREE_UTILITY_PROCESS_KIND = "workspace-host";
+
+    selectUserDataDir(undefined, undefined, HOME);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("workspace-host"));
+  });
+
+  it("stays quiet on the ordinary main-process path", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    selectUserDataDir(undefined, "/electron/userdata", HOME);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws rather than ever resolving against the cwd", () => {
+    expect(() => selectUserDataDir(undefined, undefined, "")).toThrow(/absolute userData/);
+  });
+});
+
 describe("toGitConfigPath", () => {
   // git parses -c values with backslash escapes; forward slashes are accepted
   // on every platform and sidestep the question entirely.
-  it("converts Windows separators to forward slashes", () => {
-    const converted = toGitConfigPath("C:\\Users\\Alice\\AppData\\Daintree\\git-hooks", "win32");
+  it("converts Windows separators to forward slashes, preserving every segment", () => {
+    const segments = ["C:", "Users", "Alice", "AppData", "Daintree", "git-hooks"];
+    const converted = toGitConfigPath(segments.join("\\"), "win32");
+
     expect(converted).not.toContain("\\");
+    expect(path.win32.isAbsolute(converted)).toBe(true);
+    // Absoluteness alone would accept a value truncated to "C:/".
+    expect(converted.split("/")).toEqual(segments);
+  });
+
+  it("preserves a UNC root, which stays absolute for git-for-windows", () => {
+    const converted = toGitConfigPath("\\\\server\\share\\Daintree\\git-hooks", "win32");
+
+    expect(converted).toBe("//server/share/Daintree/git-hooks");
     expect(path.win32.isAbsolute(converted)).toBe(true);
   });
 

--- a/electron/utils/gitCheckIgnore.ts
+++ b/electron/utils/gitCheckIgnore.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { HARDENED_GIT_CONFIG, buildHardenedGitEnv, GIT_BLOCK_TIMEOUT_MS } from "./hardenedGit.js";
+import { getHardenedGitConfig, buildHardenedGitEnv, GIT_BLOCK_TIMEOUT_MS } from "./hardenedGit.js";
 
 /**
  * Direct-spawn wrapper around `git check-ignore --stdin -z`.
@@ -11,12 +11,12 @@ import { HARDENED_GIT_CONFIG, buildHardenedGitEnv, GIT_BLOCK_TIMEOUT_MS } from "
  * makes the argv constant-size and safe up to the OS pipe-buffer limit
  * (typically 64 KB) per spawn.
  *
- * The hardened `-c` config flags from `HARDENED_GIT_CONFIG` are spread into
+ * The hardened `-c` config flags from `getHardenedGitConfig()` are spread into
  * the argv so the call inherits every security-relevant git override the
  * simple-git factory applies (`core.fsmonitor=false`,
- * `protocol.ext.allow=never`, credential-blocking entries, …). Env comes
- * from `buildHardenedGitEnv` so locale and lock-suppression are identical
- * to the simple-git path.
+ * `protocol.ext.allow=never`, credential-blocking entries, an app-owned
+ * `core.hooksPath`, …). Env comes from `buildHardenedGitEnv` so locale and
+ * lock-suppression are identical to the simple-git path.
  *
  * The wrapper applies the same `GIT_BLOCK_TIMEOUT_MS` ceiling that
  * `createHardenedGit` passes to simple-git's `block` knob: a hung git
@@ -48,7 +48,7 @@ export async function checkIgnoredPaths(
   // data follows (matches the output convention of `-z`).
   const body = gitRelativePaths.join("\0") + "\0";
 
-  const configArgs = HARDENED_GIT_CONFIG.flatMap((entry) => ["-c", entry]);
+  const configArgs = getHardenedGitConfig(platform).flatMap((entry) => ["-c", entry]);
   const args = [...configArgs, "check-ignore", "--stdin", "-z"];
 
   return new Promise<Set<string>>((resolve, reject) => {

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "path";
 import type { SimpleGit, SimpleGitProgressEvent } from "simple-git";
+import { tightenDirPermissionsSync } from "./fs.js";
 import { detectWslPath } from "./wsl.js";
 
 // Deferred import keeps simple-git out of the eager pre-paint main bundle —
@@ -87,27 +88,62 @@ let hooksDirWarned = false;
  * Never falls back to `process.cwd()`: a CWD-relative hooks path is exactly the
  * defect being fixed.
  */
-function resolveUserDataDir(): string {
-  const fromEnv = process.env.DAINTREE_USER_DATA;
-  if (fromEnv && path.isAbsolute(fromEnv)) return fromEnv;
-  if (fromEnv) {
-    console.warn(`[hardenedGit] DAINTREE_USER_DATA is not absolute: ${fromEnv}, falling back`);
-  }
-
+function getElectronUserDataPath(): string | undefined {
   try {
-    // Dynamic require to avoid breaking tests that mock electron
+    // Dynamic require to avoid breaking tests that mock electron. `require`
+    // exists in the bundled main via esbuild's createRequire banner; under
+    // vitest it does not, and the throw is swallowed on purpose.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const electron = require("electron");
     const userData: unknown = electron.app?.getPath("userData");
-    if (typeof userData === "string" && path.isAbsolute(userData)) return userData;
+    return typeof userData === "string" ? userData : undefined;
   } catch {
-    // Not the main process (or no electron at all) — fall through.
+    return undefined;
+  }
+}
+
+/**
+ * Precedence for the userData root, split out from how the candidates are
+ * obtained so it can be tested directly — the `require("electron")` read above
+ * is unreachable under vitest.
+ *
+ * Every candidate must be absolute; a relative one is reported and skipped
+ * rather than honoured, because a relative hooks path is the defect itself.
+ */
+export function selectUserDataDir(
+  fromEnv: string | undefined,
+  fromElectron: string | undefined,
+  homeDir: string
+): string {
+  if (fromEnv && path.isAbsolute(fromEnv)) return fromEnv;
+  if (fromEnv) {
+    // console.error, not warn: esbuild strips console.warn from production
+    // builds, and a misconfigured hooks root must not fail silently.
+    console.error(`[hardenedGit] DAINTREE_USER_DATA is not absolute: ${fromEnv}, falling back`);
   }
 
-  const home = os.homedir();
-  if (home && path.isAbsolute(home)) return path.join(home, ".daintree");
+  if (fromElectron && path.isAbsolute(fromElectron)) return fromElectron;
+
+  if (homeDir && path.isAbsolute(homeDir)) {
+    // Only expected in tests: the main process resolves via electron, and every
+    // utility process is forked with DAINTREE_USER_DATA. Reaching this in a real
+    // process means main and the workspace-host have split onto different hook
+    // roots, silently costing git-lfs its pre-push hook — so say so loudly.
+    if (process.env.DAINTREE_UTILITY_PROCESS_KIND) {
+      console.error(
+        "[hardenedGit] No usable DAINTREE_USER_DATA in utility process " +
+          `"${process.env.DAINTREE_UTILITY_PROCESS_KIND}" — falling back to the home directory, ` +
+          "which will not match the main process's hooks directory"
+      );
+    }
+    return path.join(homeDir, ".daintree");
+  }
 
   throw new Error("[hardenedGit] Cannot resolve an absolute userData directory for core.hooksPath");
+}
+
+function resolveUserDataDir(): string {
+  return selectUserDataDir(process.env.DAINTREE_USER_DATA, getElectronUserDataPath(), os.homedir());
 }
 
 /**
@@ -127,13 +163,19 @@ function getGitHooksDir(): string {
 
   const dir = path.join(resolveUserDataDir(), "git-hooks");
   try {
-    // 0o700: git dispatches whatever lives here for every repo Daintree
-    // touches, so it must not be writable by other local users.
+    // git dispatches whatever lives here for every repo Daintree touches, so it
+    // must not be writable by other local users. mkdir's `mode` only applies to
+    // segments it newly creates, so tighten unconditionally afterwards — a
+    // directory left at 0o755 by an earlier version would otherwise stay there.
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    tightenDirPermissionsSync(dir);
   } catch (e) {
     if (!hooksDirWarned) {
       hooksDirWarned = true;
-      console.warn(`[hardenedGit] Could not create git hooks directory: ${dir}`, e);
+      // console.error, not warn: esbuild strips console.warn from production
+      // builds, which would make this failure invisible exactly where it costs
+      // git-lfs its install target.
+      console.error(`[hardenedGit] Could not create git hooks directory: ${dir}`, e);
     }
   }
   cachedGitHooksDir = dir;

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "path";
 import type { SimpleGit, SimpleGitProgressEvent } from "simple-git";
 import { detectWslPath } from "./wsl.js";
@@ -11,7 +13,7 @@ import { detectWslPath } from "./wsl.js";
 const simpleGitModule = import("simple-git");
 void simpleGitModule.catch(() => {});
 
-const SAFE_GIT_CONFIG = [
+const SAFE_GIT_CONFIG_BASE = [
   "core.fsmonitor=false",
   // keep reads an existing untracked-cache without creating one and without
   // stripping the extension on the next index write. fsmonitor (the daemon/
@@ -22,7 +24,6 @@ const SAFE_GIT_CONFIG = [
   "core.pager=cat",
   "protocol.ext.allow=never",
   "core.gitProxy=",
-  "core.hooksPath=",
   // Emit literal UTF-8 paths in porcelain/status output so non-ASCII filenames
   // flow through to IPC consumers unquoted (e.g. conflict detection on
   // `café.txt` would otherwise be returned as `"caf\303\251.txt"`).
@@ -36,17 +37,155 @@ const SAFE_GIT_CONFIG = [
 ] as const;
 
 /**
- * Git config overrides that neutralize dangerous .git/config directives.
- * Passed as -c flags to every git command, taking precedence over repo config.
+ * Path-independent half of the hardened profile. `core.hooksPath` is appended
+ * per call by `getHardenedGitConfig()` — it resolves an app-owned absolute
+ * directory that cannot be captured at module evaluation (see
+ * `resolveUserDataDir`).
  */
-export const HARDENED_GIT_CONFIG = [
-  ...SAFE_GIT_CONFIG,
+const HARDENED_GIT_CONFIG_BASE = [
+  ...SAFE_GIT_CONFIG_BASE,
   "core.askpass=",
   "credential.helper=",
   "core.sshCommand=",
 ] as const;
 
-export const AUTHENTICATED_GIT_CONFIG = [...SAFE_GIT_CONFIG] as const;
+const AUTHENTICATED_GIT_CONFIG_BASE = [...SAFE_GIT_CONFIG_BASE] as const;
+
+/**
+ * Hook directory for git running *inside* a WSL distro. `createWslHardenedGit`
+ * spawns `wsl.exe git`, so the Windows-side userData path is meaningless there:
+ * without a leading `/` Linux git would treat it as relative, which is the very
+ * bug this override exists to prevent (issue #11226). Git expands a leading `~`
+ * in `core.hooksPath` against the distro user's home at hook-dispatch time, so
+ * this resolves to an absolute, user-owned directory inside the distro without
+ * the Windows host having to probe for it.
+ *
+ * Not created eagerly: the WSL route only serves read-only status/divergence
+ * polling, and git blocks repo hooks against a missing directory just as well
+ * as an existing one.
+ */
+const WSL_GIT_HOOKS_PATH = "~/.daintree/git-hooks";
+
+let cachedGitHooksDir: string | null = null;
+let hooksDirWarned = false;
+
+/**
+ * Resolve the app-owned directory that holds the git hooks Daintree is willing
+ * to execute. Deliberately lazy — `hardenedGit.ts` is imported very early and
+ * very broadly, and `electron/setup/environment.ts` rewrites `userData` in dev
+ * *after* those imports, so a module-scope capture would pin the wrong path.
+ *
+ * Resolution order, each candidate rejected unless absolute:
+ *   1. `DAINTREE_USER_DATA` — the workspace-host UtilityProcess has no usable
+ *      `app` API and receives this from its fork env (`WorkspaceHostProcess`).
+ *   2. Electron's `userData` — the main process. `require` exists in the
+ *      bundled main (esbuild injects `createRequire`) but not under vitest,
+ *      where this throws and is intentionally swallowed.
+ *   3. The user's home directory — reachable only when neither of the above is
+ *      available (i.e. tests).
+ *
+ * Never falls back to `process.cwd()`: a CWD-relative hooks path is exactly the
+ * defect being fixed.
+ */
+function resolveUserDataDir(): string {
+  const fromEnv = process.env.DAINTREE_USER_DATA;
+  if (fromEnv && path.isAbsolute(fromEnv)) return fromEnv;
+  if (fromEnv) {
+    console.warn(`[hardenedGit] DAINTREE_USER_DATA is not absolute: ${fromEnv}, falling back`);
+  }
+
+  try {
+    // Dynamic require to avoid breaking tests that mock electron
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require("electron");
+    const userData: unknown = electron.app?.getPath("userData");
+    if (typeof userData === "string" && path.isAbsolute(userData)) return userData;
+  } catch {
+    // Not the main process (or no electron at all) — fall through.
+  }
+
+  const home = os.homedir();
+  if (home && path.isAbsolute(home)) return path.join(home, ".daintree");
+
+  throw new Error("[hardenedGit] Cannot resolve an absolute userData directory for core.hooksPath");
+}
+
+/**
+ * Absolute hooks directory, resolved and created once per process.
+ *
+ * `WorktreeMonitor` polls git status continuously, so the `mkdirSync` must not
+ * ride the hot path — the resolved value is memoized on first use.
+ *
+ * A creation failure is logged once and otherwise ignored: git blocks
+ * repo-supplied hooks against a non-existent absolute path (the security
+ * invariant holds regardless), and the directory only needs to exist so
+ * git-lfs can install its hooks somewhere other than a worktree root. Failing
+ * hard here would take every git operation down over a permissions hiccup.
+ */
+function getGitHooksDir(): string {
+  if (cachedGitHooksDir !== null) return cachedGitHooksDir;
+
+  const dir = path.join(resolveUserDataDir(), "git-hooks");
+  try {
+    // 0o700: git dispatches whatever lives here for every repo Daintree
+    // touches, so it must not be writable by other local users.
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch (e) {
+    if (!hooksDirWarned) {
+      hooksDirWarned = true;
+      console.warn(`[hardenedGit] Could not create git hooks directory: ${dir}`, e);
+    }
+  }
+  cachedGitHooksDir = dir;
+  return dir;
+}
+
+/**
+ * Git parses `-c key=value` values with backslash escape sequences, so a raw
+ * Windows path risks mangling (`C:\Users` → `C:Users`). Git accepts forward
+ * slashes on every platform. POSIX paths pass through untouched — a backslash
+ * there is a legal filename character, not a separator.
+ */
+export function toGitConfigPath(dir: string, platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? dir.replace(/\\/g, "/") : dir;
+}
+
+function hooksPathEntry(hooksPath: string, platform?: NodeJS.Platform): string {
+  return `core.hooksPath=${toGitConfigPath(hooksPath, platform)}`;
+}
+
+/**
+ * Git config overrides that neutralize dangerous .git/config directives.
+ * Passed as -c flags to every git command, taking precedence over repo config.
+ *
+ * `core.hooksPath` points at an app-owned absolute directory rather than being
+ * blanked. An empty value is relative, and git-lfs resolves it against its own
+ * CWD when self-installing its hooks — during `git worktree add` that CWD is
+ * the new worktree root, so four hook files landed there as untracked litter
+ * (issue #11226). An absolute path still overrides (and therefore blocks) any
+ * repo-supplied `.git/hooks` — the invariant from #3742 — while giving git-lfs
+ * a stable home so its `pre-push` object upload keeps working.
+ *
+ * The directory is shared across every repo Daintree touches: git-lfs installs
+ * its hooks there once, and they run (as no-ops) for non-LFS repos too. That is
+ * the deliberate tradeoff recorded in #11226.
+ */
+export function getHardenedGitConfig(platform?: NodeJS.Platform): readonly string[] {
+  return [...HARDENED_GIT_CONFIG_BASE, hooksPathEntry(getGitHooksDir(), platform)];
+}
+
+/**
+ * Authenticated profile. `extraConfig` is placed *before* the hooks entry: git
+ * takes the last `-c` for a single-valued key, so a caller cannot override the
+ * hook enforcement path, accidentally or otherwise.
+ */
+function getAuthenticatedGitConfig(extraConfig?: string[], platform?: NodeJS.Platform): string[] {
+  return [
+    ...AUTHENTICATED_GIT_CONFIG_BASE,
+    ...(extraConfig ?? []),
+    hooksPathEntry(getGitHooksDir(), platform),
+  ];
+}
 
 const UNSAFE_FLAGS = {
   allowUnsafeAskPass: true,
@@ -198,7 +337,7 @@ export async function createHardenedGit(
   const { simpleGit } = await simpleGitModule;
   return simpleGit({
     baseDir: cwd,
-    config: [...HARDENED_GIT_CONFIG],
+    config: [...getHardenedGitConfig(platform)],
     timeout: { block: GIT_BLOCK_TIMEOUT_MS },
     ...(signal ? { abort: signal } : {}),
     unsafe: UNSAFE_FLAGS,
@@ -278,7 +417,11 @@ export async function createWslHardenedGit(
   return simpleGit({
     baseDir: uncPath,
     binary: ["wsl.exe", "git"],
-    config: [...HARDENED_GIT_CONFIG],
+    // The Windows-side hooks directory is not addressable from inside the
+    // distro, so this route carries its own POSIX path (see
+    // WSL_GIT_HOOKS_PATH). Non-path hardening is shared with the native
+    // profile.
+    config: [...HARDENED_GIT_CONFIG_BASE, `core.hooksPath=${WSL_GIT_HOOKS_PATH}`],
     timeout: { block: GIT_BLOCK_TIMEOUT_MS },
     ...(signal ? { abort: signal } : {}),
     unsafe: UNSAFE_FLAGS,
@@ -319,7 +462,7 @@ export async function createAuthenticatedGit(
   const { simpleGit } = await simpleGitModule;
   return simpleGit({
     baseDir: cwd,
-    config: [...AUTHENTICATED_GIT_CONFIG, ...(extraConfig ?? [])],
+    config: getAuthenticatedGitConfig(extraConfig),
     timeout: { block: 0 },
     ...(signal ? { abort: signal } : {}),
     ...(progress ? { progress } : {}),

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -70,24 +70,7 @@ const WSL_GIT_HOOKS_PATH = "~/.daintree/git-hooks";
 let cachedGitHooksDir: string | null = null;
 let hooksDirWarned = false;
 
-/**
- * Resolve the app-owned directory that holds the git hooks Daintree is willing
- * to execute. Deliberately lazy — `hardenedGit.ts` is imported very early and
- * very broadly, and `electron/setup/environment.ts` rewrites `userData` in dev
- * *after* those imports, so a module-scope capture would pin the wrong path.
- *
- * Resolution order, each candidate rejected unless absolute:
- *   1. `DAINTREE_USER_DATA` — the workspace-host UtilityProcess has no usable
- *      `app` API and receives this from its fork env (`WorkspaceHostProcess`).
- *   2. Electron's `userData` — the main process. `require` exists in the
- *      bundled main (esbuild injects `createRequire`) but not under vitest,
- *      where this throws and is intentionally swallowed.
- *   3. The user's home directory — reachable only when neither of the above is
- *      available (i.e. tests).
- *
- * Never falls back to `process.cwd()`: a CWD-relative hooks path is exactly the
- * defect being fixed.
- */
+/** Electron's `userData`, or undefined outside the main process. */
 function getElectronUserDataPath(): string | undefined {
   try {
     // Dynamic require to avoid breaking tests that mock electron. `require`
@@ -107,13 +90,17 @@ function getElectronUserDataPath(): string | undefined {
  * obtained so it can be tested directly — the `require("electron")` read above
  * is unreachable under vitest.
  *
+ * The later candidates are suppliers, not values, so a valid env var still
+ * short-circuits before Electron is touched — every workspace host would
+ * otherwise attempt (and fail) a `require("electron")` it never needs.
+ *
  * Every candidate must be absolute; a relative one is reported and skipped
  * rather than honoured, because a relative hooks path is the defect itself.
  */
 export function selectUserDataDir(
   fromEnv: string | undefined,
-  fromElectron: string | undefined,
-  homeDir: string
+  fromElectron: () => string | undefined,
+  homeDir: () => string
 ): string {
   if (fromEnv && path.isAbsolute(fromEnv)) return fromEnv;
   if (fromEnv) {
@@ -122,9 +109,11 @@ export function selectUserDataDir(
     console.error(`[hardenedGit] DAINTREE_USER_DATA is not absolute: ${fromEnv}, falling back`);
   }
 
-  if (fromElectron && path.isAbsolute(fromElectron)) return fromElectron;
+  const electronUserData = fromElectron();
+  if (electronUserData && path.isAbsolute(electronUserData)) return electronUserData;
 
-  if (homeDir && path.isAbsolute(homeDir)) {
+  const home = homeDir();
+  if (home && path.isAbsolute(home)) {
     // Only expected in tests: the main process resolves via electron, and every
     // utility process is forked with DAINTREE_USER_DATA. Reaching this in a real
     // process means main and the workspace-host have split onto different hook
@@ -136,14 +125,30 @@ export function selectUserDataDir(
           "which will not match the main process's hooks directory"
       );
     }
-    return path.join(homeDir, ".daintree");
+    return path.join(home, ".daintree");
   }
 
   throw new Error("[hardenedGit] Cannot resolve an absolute userData directory for core.hooksPath");
 }
 
+/**
+ * Resolve the userData root holding the git hooks Daintree is willing to run.
+ *
+ * Deliberately lazy — `hardenedGit.ts` is imported very early and very broadly,
+ * and `electron/setup/environment.ts` rewrites `userData` in dev *after* those
+ * imports, so a module-scope capture would pin the wrong path.
+ *
+ * Candidates, in the order `selectUserDataDir` considers them:
+ *   1. `DAINTREE_USER_DATA` — the workspace-host UtilityProcess has no usable
+ *      `app` API and receives this from its fork env (`WorkspaceHostProcess`).
+ *   2. Electron's `userData` — the main process.
+ *   3. The user's home directory — expected only in tests; in a real process it
+ *      means something is broken, and `selectUserDataDir` says so.
+ */
 function resolveUserDataDir(): string {
-  return selectUserDataDir(process.env.DAINTREE_USER_DATA, getElectronUserDataPath(), os.homedir());
+  return selectUserDataDir(process.env.DAINTREE_USER_DATA, getElectronUserDataPath, () =>
+    os.homedir()
+  );
 }
 
 /**

--- a/scripts/eval/__tests__/turnOutcome.test.ts
+++ b/scripts/eval/__tests__/turnOutcome.test.ts
@@ -52,9 +52,17 @@ describe("resolveStorePath", () => {
 
   it("uses Daintree capitalization on macOS", () => {
     const platformSpy = vi.spyOn(os, "platform").mockReturnValue("darwin");
+    // The platform default only applies with no env override, which the test
+    // setup now always provides — unset it explicitly rather than relying on
+    // it being absent from the ambient environment.
+    const prev = process.env.DAINTREE_USER_DATA;
+    delete process.env.DAINTREE_USER_DATA;
+
     // Can't easily mock os.homedir() but check the path ends correctly
     const result = resolveStorePath();
     expect(normalize(result)).toContain("Library/Application Support/Daintree/config.json");
+
+    if (prev) process.env.DAINTREE_USER_DATA = prev;
     platformSpy.mockRestore();
   });
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,11 +4,21 @@
 // that need to verify the throwing behavior (e.g. `ipcGuard.test.ts`) reset
 // the flag explicitly via `_resetIpcGuardForTesting()`.
 
+import os from "node:os";
+import path from "node:path";
 import { vi } from "vitest";
 import { markIpcSecurityReady } from "./electron/ipc/ipcGuard.js";
 import { primeRadix } from "./src/components/ui/radix-loader";
 
 markIpcSecurityReady();
+
+// `hardenedGit` resolves an app-owned `core.hooksPath` from DAINTREE_USER_DATA,
+// falling back to the real home directory when nothing else is available. Any
+// test that builds a git factory would otherwise create `~/.daintree/git-hooks`
+// on the developer's machine. Point it at a temp root instead; suites that
+// inspect the directory (hardenedGit's own) override this with their own
+// mkdtemp before their first factory call.
+process.env.DAINTREE_USER_DATA ??= path.join(os.tmpdir(), "daintree-vitest-userdata");
 
 // Tests render Radix wrappers synchronously, but our production wrappers
 // dynamic-import the Radix primitive chunk on demand. Prime the loader once

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -18,7 +18,13 @@ markIpcSecurityReady();
 // on the developer's machine. Point it at a temp root instead; suites that
 // inspect the directory (hardenedGit's own) override this with their own
 // mkdtemp before their first factory call.
-process.env.DAINTREE_USER_DATA ??= path.join(os.tmpdir(), "daintree-vitest-userdata");
+//
+// Assigned unconditionally: an inherited empty or relative value would survive
+// `??=` and land right back on the home directory, and an inherited real
+// userData path would let a test suite write into the developer's own app data.
+// Keyed by pid so a stale hook file from an earlier run can't be dispatched by
+// a later one.
+process.env.DAINTREE_USER_DATA = path.join(os.tmpdir(), `daintree-vitest-userdata-${process.pid}`);
 
 // Tests render Radix wrappers synchronously, but our production wrappers
 // dynamic-import the Radix primitive chunk on demand. Prime the loader once


### PR DESCRIPTION
## Summary

- `SAFE_GIT_CONFIG` in `electron/utils/hardenedGit.ts` was setting `core.hooksPath=` (empty) as a `-c` flag on every git invocation, to block repo-supplied hooks (the security fix from #3742).
- An empty value is a relative path. git-lfs resolves it against its own working directory when self-installing hooks, and during `git worktree add` that directory is the new worktree root, so `post-checkout`, `post-commit`, `post-merge` and `pre-push` landed as untracked files in every new worktree in LFS repos.
- Fix: point `core.hooksPath` at an absolute, app-owned directory (`userData/git-hooks`). It still overrides and blocks any repo-supplied `.git/hooks`, so the #3742 invariant holds, but it gives git-lfs somewhere stable to install so `pre-push` object upload keeps working. `/dev/null` was ruled out in the issue because it kills that upload path entirely.

Resolves #11226

## Implementation notes

- Resolution is lazy, never at module eval time. `hardenedGit.ts` is imported before `environment.ts` rewrites `userData` in dev, and the workspace-host `UtilityProcess` has no `app` API at all, it reads `DAINTREE_USER_DATA` from its forked process env instead. Ordering mirrors `store.ts`. There's intentionally no fallback to `process.cwd()`, since that would just recreate this bug.
- The resolve-and-mkdir step is memoized once per process. `WorktreeMonitor` polls git status continuously and shouldn't carry a synchronous filesystem syscall on every poll.
- The hooks config entry is emitted last in the config list, so a later `extraConfig` option can never displace it (git takes the last `-c` for a single-valued key).
- On WSL, git runs inside the distro, where a Windows-style path like `C:\...` has no leading slash and would resolve as relative, reproducing the same bug. That path uses `~/.daintree/git-hooks` instead, which git tilde-expands at dispatch time.
- A failed `mkdir` is non-fatal. An absolute path blocks repo hooks whether or not the directory exists, so a permissions hiccup shouldn't take git operations down.

## Verified against real git 2.55.0

Worth stating since it corrected a couple of assumptions in the original issue:

- An absolute, nonexistent `hooksPath` still blocks repo hooks and exits 0. Git doesn't create the directory itself.
- The last `-c` wins for a single-valued config key.
- Git tilde-expands `core.hooksPath` at dispatch time.
- `core.hooksPath=` (empty) doesn't dispatch any hook from the working directory at all. Git's own dispatch logic treats empty as "no hooks configured." The litter is entirely git-lfs's own install-side behavior, not git's, which also means it can't be reproduced in an automated test without a real git-lfs binary, and CI doesn't have one.

## Honest tradeoffs

- The app-owned hooks directory is shared across every repo Daintree touches, so git-lfs installs its hooks there once, and they no-op on non-LFS repos. That's a deliberate call, the one the issue author flagged directly as worth making on purpose.
- If a user pushes before any checkout has triggered git-lfs's self-install, `pre-push` is still absent for that push. That's pre-existing and strictly improved here, since the old empty value meant no hook ever dispatched, so Daintree's own pushes never ran `pre-push` at all. Proactively provisioning `git lfs install` would be a separate change.

## Testing

- Replaced literal-coupled assertions in the existing suites with invariant-based ones (the repo's testing policy forbids tautological assertions that just restate a source-of-truth constant).
- Added `hardenedGit.hooks.test.ts`, which runs against real git and proves both halves of the security property: a planted `.git/hooks/post-checkout` does not execute under the hardened config, and a hook placed in the app-owned directory does.
- Locally: 556 tests passing across 22 files, `tsc -b electron/tsconfig.json` clean.
