### PR TITLE
fix(plugins): abort stalled plugin archive extraction (#11227)

### DIFF
--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -275,10 +275,27 @@ export async function computeArchiveHash(archivePath: string): Promise<string> {
  */
 function openZip(archivePath: string): Promise<yauzl.ZipFile> {
   return new Promise((resolve, reject) => {
-    yauzl.open(archivePath, { lazyEntries: true }, (err, zipfile) => {
-      if (err) return reject(err);
-      resolve(zipfile);
-    });
+    yauzl.open(
+      archivePath,
+      {
+        lazyEntries: true,
+        // Pin the security-relevant defaults rather than inheriting them, so a
+        // future yauzl bump can't silently weaken a guard. `validateEntrySizes`
+        // enforces each entry's decompressed length against its header — the
+        // cumulative-size zip-bomb guard below trusts it. `strictFileNames`
+        // rejects backslash/invalid-char names at parse time (yauzl otherwise
+        // rewrites `\` to `/` before we ever see the name), enforcing the
+        // `.dntr` POSIX-forward-slash contract at the source. `decodeStrings`
+        // keeps `entry.fileName` a decoded string, not a raw Buffer.
+        strictFileNames: true,
+        decodeStrings: true,
+        validateEntrySizes: true,
+      },
+      (err, zipfile) => {
+        if (err) return reject(err);
+        resolve(zipfile);
+      }
+    );
   });
 }
 
@@ -422,8 +439,10 @@ export async function extractPluginArchive(
         return fail(new Error(`Archive exceeds ${MAX_DNTR_ENTRIES} entry limit`));
       }
 
-      // Reject any raw name that isn't already POSIX-normalized — backslashes,
-      // leading slashes, and drive letters are always invalid in a `.dntr`.
+      // Reject any raw name that isn't already POSIX-normalized. Backslash and
+      // other invalid-char names are already rejected upstream by yauzl's
+      // `strictFileNames` (see openZip), so what this additionally catches is a
+      // leading `/` or `./` prefix that `normalizePath` would otherwise strip.
       if (entry.fileName !== name) {
         return fail(
           new Error(
@@ -463,9 +482,9 @@ export async function extractPluginArchive(
           const out = createWriteStream(resolved, { mode: 0o644 });
 
           // Abort the transfer if the entry stalls. `pipeline` destroys both
-          // streams on abort and rejects with this exact error, which flows to
-          // `fail()` below. The timer is reset on every chunk, so only a truly
-          // dead stream trips it.
+          // streams on abort, then rejects with an AbortError carrying this
+          // error, which flows to `fail()` below. The timer is reset on every
+          // chunk, so only a truly dead stream trips it.
           const controller = new AbortController();
           let timer: ReturnType<typeof setTimeout>;
           const resetTimer = () => {
@@ -502,19 +521,17 @@ export async function extractPluginArchive(
             (pipelineErr: unknown) => {
               clearTimer();
               activeTransfer = null;
-              // On abort, `pipeline` rejects with a generic AbortError that
-              // drops the reason we passed to `controller.abort()`, so recover
-              // it from the signal — that's where the entry-naming stall (or
-              // teardown) error lives. A genuine stream error leaves the signal
-              // un-aborted, so fall through to the pipeline's own error.
+              const err =
+                pipelineErr instanceof Error ? pipelineErr : new Error(String(pipelineErr));
+              // `pipeline` surfaces a genuine stream/fs failure as-is and only
+              // rejects with an AbortError when our abort was the sole cause —
+              // and that AbortError drops the reason we passed, so recover the
+              // entry-naming stall/teardown error from the signal. Discriminate
+              // on the rejection itself (not `signal.aborted`): a real error
+              // that merely raced the inactivity deadline must still win over
+              // the stall message.
               const reason = controller.signal.reason;
-              fail(
-                controller.signal.aborted && reason instanceof Error
-                  ? reason
-                  : pipelineErr instanceof Error
-                    ? pipelineErr
-                    : new Error(String(pipelineErr))
-              );
+              fail(err.name === "AbortError" && reason instanceof Error ? reason : err);
             }
           );
         });

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -2,6 +2,7 @@ import { createHash } from "crypto";
 import fs from "fs/promises";
 import { createWriteStream } from "fs";
 import path from "path";
+import { pipeline } from "node:stream/promises";
 import yauzl from "yauzl";
 import { getPluginManifestSchema } from "../schemas/plugin.js";
 import { MAX_DNTR_BYTES } from "../utils/pluginArchiveConstants.js";
@@ -12,6 +13,19 @@ export const ZIP_EPOCH_DATE = new Date("1980-01-01T00:00:00Z");
 // assets; thousands of entries means an archive padded with tiny/empty members
 // to force unbounded filesystem ops during extraction (zip-bomb-by-count).
 export const MAX_DNTR_ENTRIES = 4096;
+
+// Per-entry inactivity budget during extraction. Extraction is a local disk
+// copy, so a window this wide can only be hit by a genuinely dead stream —
+// never by a slow-but-live one. Without it a stalled read stream leaves
+// `installPlugin` awaiting forever, holding `install.lock` and its
+// `.install-tmp-*` dir until the app is quit (#11227). Per-entry and reset on
+// every chunk, so a large archive isn't penalised for making steady progress.
+export const PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS = 30_000;
+
+export interface ExtractOptions {
+  /** Override the per-entry inactivity abort. Tests only — production uses the default. */
+  inactivityTimeoutMs?: number;
+}
 
 const REQUIRED_EXCLUSIONS: readonly string[] = ["node_modules/", ".git/"];
 
@@ -356,8 +370,17 @@ export async function readArchiveManifest(archivePath: string): Promise<PluginMa
  * rejected via {@link isValidEntryName} before resolution. Directory entries
  * (trailing `/`) only create the directory; file entries stream to disk and
  * the next entry is read only after the write stream closes (`lazyEntries`).
+ *
+ * A file entry that goes quiet for {@link PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS}
+ * aborts the whole extraction with a rejection rather than hanging, so the
+ * caller's cleanup always runs.
  */
-export async function extractPluginArchive(archivePath: string, destDir: string): Promise<void> {
+export async function extractPluginArchive(
+  archivePath: string,
+  destDir: string,
+  opts?: ExtractOptions
+): Promise<void> {
+  const inactivityMs = opts?.inactivityTimeoutMs ?? PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS;
   const stat = await fs.stat(archivePath);
   if (stat.size > MAX_DNTR_BYTES) {
     throw new Error(`Archive size ${stat.size} exceeds ${MAX_DNTR_BYTES} byte limit`);
@@ -379,9 +402,15 @@ export async function extractPluginArchive(archivePath: string, destDir: string)
     let totalUncompressed = 0;
     let entryCount = 0;
     const seen = new Set<string>();
+    // The transfer in flight, if any. `lazyEntries` guarantees at most one at a
+    // time, so a single handle (not a set) is enough. `fail()` aborts it before
+    // closing the zip so a zipfile-level error can't leave a live read stream
+    // dangling on the shared file descriptor.
+    let activeTransfer: { abort: () => void } | null = null;
     const fail = (err: Error) => {
       if (settled) return;
       settled = true;
+      activeTransfer?.abort();
       zipfile.close();
       reject(err);
     };
@@ -432,10 +461,62 @@ export async function extractPluginArchive(archivePath: string, destDir: string)
         zipfile.openReadStream(entry, (err, stream) => {
           if (err) return fail(err);
           const out = createWriteStream(resolved, { mode: 0o644 });
-          stream.on("error", fail);
-          out.on("error", fail);
-          out.on("finish", () => zipfile.readEntry());
-          stream.pipe(out);
+
+          // Abort the transfer if the entry stalls. `pipeline` destroys both
+          // streams on abort and rejects with this exact error, which flows to
+          // `fail()` below. The timer is reset on every chunk, so only a truly
+          // dead stream trips it.
+          const controller = new AbortController();
+          let timer: ReturnType<typeof setTimeout>;
+          const resetTimer = () => {
+            clearTimeout(timer);
+            timer = setTimeout(
+              () =>
+                controller.abort(
+                  new Error(`Extraction of "${name}" stalled: no data for ${inactivityMs}ms`)
+                ),
+              inactivityMs
+            );
+          };
+          const clearTimer = () => clearTimeout(timer);
+          // Attaching this listener flips the stream to flowing mode; `pipeline`
+          // below consumes it. Both must be wired in this same synchronous tick
+          // — `resume()` only schedules the first read on the next tick — or a
+          // chunk could be emitted before `pipeline` starts reading. Do not
+          // split these two statements.
+          stream.on("data", resetTimer);
+          resetTimer();
+          // Reuse the abort as the outer teardown hook: if the zip errors while
+          // this transfer is live, `fail()` aborts the controller, which
+          // destroys both streams and rejects the pipeline below.
+          activeTransfer = {
+            abort: () => controller.abort(new Error(`Extraction of "${name}" was interrupted`)),
+          };
+
+          pipeline(stream, out, { signal: controller.signal }).then(
+            () => {
+              clearTimer();
+              activeTransfer = null;
+              if (!settled) zipfile.readEntry();
+            },
+            (pipelineErr: unknown) => {
+              clearTimer();
+              activeTransfer = null;
+              // On abort, `pipeline` rejects with a generic AbortError that
+              // drops the reason we passed to `controller.abort()`, so recover
+              // it from the signal — that's where the entry-naming stall (or
+              // teardown) error lives. A genuine stream error leaves the signal
+              // un-aborted, so fall through to the pipeline's own error.
+              const reason = controller.signal.reason;
+              fail(
+                controller.signal.aborted && reason instanceof Error
+                  ? reason
+                  : pipelineErr instanceof Error
+                    ? pipelineErr
+                    : new Error(String(pipelineErr))
+              );
+            }
+          );
         });
       }, fail);
     });

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -14,6 +14,10 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Restore any prototype spy even if a test bailed before its own `finally`
+  // ran (e.g. a Vitest timeout), so the mock can't leak into a sibling test on
+  // a reused worker.
+  vi.restoreAllMocks();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -38,7 +42,9 @@ async function createFixture(baseDir: string, files: Record<string, string>): Pr
 // (`deflateOf` raw buffer) so a genuine, internally-consistent zip-bomb can be
 // built — large uncompressedSize, tiny compressed payload, valid CRC — that
 // yauzl accepts and only the installer's own size guard rejects.
-type RawEntry = { name: string; content: string } | { name: string; deflateOf: Buffer };
+type RawEntry =
+  | { name: string; content: string }
+  | { name: string; deflateOf: Buffer; declaredSize?: number };
 
 function buildRawZip(entries: RawEntry[]): Buffer {
   const chunks: Buffer[] = [];
@@ -53,7 +59,9 @@ function buildRawZip(entries: RawEntry[]): Buffer {
     if ("deflateOf" in e) {
       method = 8;
       stored = zlib.deflateRawSync(e.deflateOf);
-      uncompressedSize = e.deflateOf.length;
+      // `declaredSize` forges a header that lies about the uncompressed length,
+      // so a test can prove yauzl's `validateEntrySizes` rejects a mismatch.
+      uncompressedSize = e.declaredSize ?? e.deflateOf.length;
       crc = zlib.crc32(e.deflateOf) >>> 0;
     } else {
       method = 0;
@@ -142,19 +150,17 @@ describe("extractPluginArchive", () => {
     expect(escaped).toBe(false);
   });
 
-  it("rejects a backslash entry name", async () => {
+  it("rejects a backslash entry name even without a traversal segment", async () => {
+    // A benign backslash name (no `..`) must still be rejected: the `.dntr`
+    // contract is POSIX forward slashes, enforced by yauzl's `strictFileNames`.
+    // Without it, yauzl would silently rewrite `dist\index.js` to `dist/index.js`
+    // and extract it, so this proves the guard trips on the backslash itself.
     const archivePath = path.join(tmpDir, "backslash.dntr");
-    await fs.writeFile(
-      archivePath,
-      buildRawZip([
-        { name: "plugin.json", content: JSON.stringify(validManifest()) },
-        { name: "..\\escape.js", content: "pwned" },
-      ])
-    );
+    await fs.writeFile(archivePath, buildRawZip([{ name: "dist\\index.js", content: "x" }]));
     const dest = path.join(tmpDir, "extracted-bs");
     await fs.mkdir(dest, { recursive: true });
 
-    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow();
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow(/invalid characters/i);
   });
 
   it("rejects an absolute entry name", async () => {
@@ -293,11 +299,94 @@ describe("extractPluginArchive", () => {
       ).rejects.toThrow(/dist\/first\.js.*stalled/);
 
       // The abort reached `pipeline`, which destroyed the source stream...
-      expect(stalledStreams).toHaveLength(1);
       expect(stalledStreams[0].destroyed).toBe(true);
-      // ...and extraction never advanced to the second entry (only one
+      // ...and extraction never advanced to the second entry (a single
       // openReadStream call means readEntry() was never issued after the stall).
       expect(openReadStreamSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      openReadStreamSpy.mockRestore();
+    }
+  });
+
+  it("extracts a real entry larger than the 64KiB stream watermark", async () => {
+    // The original #11227 stall only manifested on an entry big enough to cross
+    // the default 64KiB highWaterMark and exert backpressure. A tiny-file happy
+    // path never exercises that; this drives a real >64KiB entry through the
+    // yauzl 3.x + pipeline path and checks the bytes round-trip exactly.
+    const big = Buffer.alloc(100 * 1024);
+    for (let i = 0; i < big.length; i++) {
+      // Knuth multiplicative hash — deterministic, well-distributed, so the
+      // payload barely compresses and genuinely streams many chunks.
+      big[i] = (i * 2654435761) >>> 24;
+    }
+    const archivePath = path.join(tmpDir, "big.dntr");
+    await fs.writeFile(archivePath, buildRawZip([{ name: "dist/big.bin", deflateOf: big }]));
+    const dest = path.join(tmpDir, "extracted-big");
+    await fs.mkdir(dest, { recursive: true });
+
+    await extractPluginArchive(archivePath, dest);
+
+    const written = await fs.readFile(path.join(dest, "dist/big.bin"));
+    expect(written.equals(big)).toBe(true);
+  });
+
+  it("rejects an entry whose data exceeds its declared uncompressed size", async () => {
+    // Declares 1 byte but the payload inflates to 200KB. The cumulative-size
+    // zip-bomb guard trusts the declared size, so its defense rests on yauzl's
+    // `validateEntrySizes` rejecting the mismatch mid-stream — this proves that
+    // option is active after the yauzl 2->3 bump.
+    const archivePath = path.join(tmpDir, "sizelie.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "dist/lie.bin", deflateOf: Buffer.alloc(200 * 1024, 0x41), declaredSize: 1 },
+      ])
+    );
+    const dest = path.join(tmpDir, "extracted-sizelie");
+    await fs.mkdir(dest, { recursive: true });
+
+    await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow(/too many bytes/i);
+  });
+
+  it("resets the inactivity timer on progress so a slow-but-live stream completes", async () => {
+    // A stream that keeps delivering data, just slower than the inactivity
+    // window would allow from a standing start, must NOT be aborted — the timer
+    // has to reset on every chunk. Total activity (10 * 40ms = 400ms) exceeds
+    // the 300ms window, so without a reset the timer would fire mid-stream;
+    // each 40ms gap sits well under 300ms, giving a wide margin against CI
+    // scheduling jitter.
+    const archivePath = path.join(tmpDir, "slow.dntr");
+    await fs.writeFile(archivePath, buildRawZip([{ name: "dist/slow.js", content: "unused" }]));
+    const dest = path.join(tmpDir, "extracted-slow");
+    await fs.mkdir(dest, { recursive: true });
+
+    const CHUNKS = 10;
+    const GAP_MS = 40;
+    const payload = Buffer.from("x".repeat(1024));
+    const openReadStreamSpy = vi
+      .spyOn(yauzl.ZipFile.prototype, "openReadStream")
+      .mockImplementation((_entry, callback) => {
+        const src = new Readable({ read() {} });
+        let n = 0;
+        const step = () => {
+          if (n < CHUNKS) {
+            src.push(payload);
+            n += 1;
+            setTimeout(step, GAP_MS);
+          } else {
+            src.push(null);
+          }
+        };
+        setTimeout(step, GAP_MS);
+        callback(null, src);
+      });
+
+    try {
+      await expect(
+        extractPluginArchive(archivePath, dest, { inactivityTimeoutMs: 300 })
+      ).resolves.toBeUndefined();
+      const written = await fs.readFile(path.join(dest, "dist/slow.js"));
+      expect(written.length).toBe(CHUNKS * payload.length);
     } finally {
       openReadStreamSpy.mockRestore();
     }

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import zlib from "zlib";
+import { Readable } from "stream";
+import yauzl from "yauzl";
 import { packPluginArchive, extractPluginArchive, MAX_DNTR_ENTRIES } from "../PluginArchive.js";
 
 let tmpDir: string;
@@ -251,5 +253,53 @@ describe("extractPluginArchive", () => {
     await fs.mkdir(dest, { recursive: true });
 
     await expect(extractPluginArchive(archivePath, dest)).rejects.toThrow(/exceeds/);
+  });
+
+  // Regression for #11227: a read stream that stops emitting without ever
+  // ending or erroring used to hang extraction forever (the caller's install
+  // lock and temp dir stayed held until the app quit). The inactivity guard now
+  // aborts and rejects instead. We can't reproduce the upstream Node/stream
+  // timing bug deterministically, so we inject a stalled stream via a
+  // prototype spy and drive the guard with a short override — no fake timers,
+  // so the real pipeline/stream machinery runs unmodified.
+  it("aborts and rejects when an entry stream stalls, without advancing to the next entry", async () => {
+    const archivePath = path.join(tmpDir, "stall.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "dist/first.js", content: "a" },
+        { name: "dist/second.js", content: "b" },
+      ])
+    );
+    const dest = path.join(tmpDir, "extracted-stall");
+    await fs.mkdir(dest, { recursive: true });
+
+    const stalledStreams: Readable[] = [];
+    const openReadStreamSpy = vi
+      .spyOn(yauzl.ZipFile.prototype, "openReadStream")
+      .mockImplementation((_entry, callback) => {
+        const stalled = new Readable({ read() {} });
+        stalledStreams.push(stalled);
+        // Emit one chunk, then go silent forever — never end, never error. The
+        // single chunk also exercises the timer's reset-on-data path before the
+        // inactivity window elapses.
+        stalled.push(Buffer.from("partial"));
+        callback(null, stalled);
+      });
+
+    try {
+      await expect(
+        extractPluginArchive(archivePath, dest, { inactivityTimeoutMs: 50 })
+      ).rejects.toThrow(/dist\/first\.js.*stalled/);
+
+      // The abort reached `pipeline`, which destroyed the source stream...
+      expect(stalledStreams).toHaveLength(1);
+      expect(stalledStreams[0].destroyed).toBe(true);
+      // ...and extraction never advanced to the second entry (only one
+      // openReadStream call means readEntry() was never issued after the stall).
+      expect(openReadStreamSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      openReadStreamSpy.mockRestore();
+    }
   });
 });

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -315,8 +315,10 @@ describe("extractPluginArchive", () => {
     // yauzl 3.x + pipeline path and checks the bytes round-trip exactly.
     const big = Buffer.alloc(100 * 1024);
     for (let i = 0; i < big.length; i++) {
-      // Knuth multiplicative hash — deterministic, well-distributed, so the
-      // payload barely compresses and genuinely streams many chunks.
+      // Knuth multiplicative hash — a deterministic, varied fill. What matters
+      // for the repro is the 100KB *decompressed* size: it crosses the write
+      // stream's 64KiB highWaterMark and drives the backpressure the stall
+      // depended on. The bytes are also compared exactly on the way out.
       big[i] = (i * 2654435761) >>> 24;
     }
     const archivePath = path.join(tmpDir, "big.dntr");

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "safe-stable-stringify": "^2.5.0",
         "smol-toml": "^1.6.1",
         "win-job-object": "file:electron/native/win-job-object",
-        "yauzl": "^2.10.0"
+        "yauzl": "^3.4.0"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
@@ -100,7 +100,7 @@
         "@types/stopword": "^2.0.3",
         "@types/trusted-types": "^2.0.7",
         "@types/ws": "^8.18.1",
-        "@types/yauzl": "^2.10.3",
+        "@types/yauzl": "^3.4.0",
         "@uiw/codemirror-themes": "^4.25.8",
         "@uiw/react-codemirror": "^4.25.8",
         "@vitejs/plugin-react": "^6.0.0",
@@ -123,7 +123,7 @@
         "culori": "^4.0.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.1",
-        "electron": "^42.4.0",
+        "electron": "^42.7.0",
         "electron-builder": "^26.8.1",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",
@@ -8182,9 +8182,9 @@
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12012,9 +12012,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
-      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+      "version": "42.7.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.7.0.tgz",
+      "integrity": "sha512-Uu5p03M5o7aqulT8QxFYYg3eJVDfuNEUuasBU1qFl05ghVRRH7UHL7na8S3GhxVScZQ2D7j9DCMsc+qT5FuxtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13132,15 +13132,6 @@
       "license": "MIT",
       "dependencies": {
         "walk-up-path": "^4.0.0"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -23134,22 +23125,15 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
+        "pend": "~1.2.0"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
@@ -23295,7 +23279,7 @@
         "execa": "^9.6.0",
         "globby": "^14.1.0",
         "semver": "^7.8.0",
-        "yauzl": "^2.10.0",
+        "yauzl": "^3.4.0",
         "zod": "^4.4.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "safe-stable-stringify": "^2.5.0",
     "smol-toml": "^1.6.1",
     "win-job-object": "file:electron/native/win-job-object",
-    "yauzl": "^2.10.0"
+    "yauzl": "^3.4.0"
   },
   "optionalDependencies": {
     "ffmpeg-static": "^5.2.0"
@@ -235,7 +235,7 @@
     "@types/stopword": "^2.0.3",
     "@types/trusted-types": "^2.0.7",
     "@types/ws": "^8.18.1",
-    "@types/yauzl": "^2.10.3",
+    "@types/yauzl": "^3.4.0",
     "@uiw/codemirror-themes": "^4.25.8",
     "@uiw/react-codemirror": "^4.25.8",
     "@vitejs/plugin-react": "^6.0.0",
@@ -258,7 +258,7 @@
     "culori": "^4.0.2",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.1",
-    "electron": "^42.4.0",
+    "electron": "^42.7.0",
     "electron-builder": "^26.8.1",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.8.3",

--- a/packages/daintree-plugin/package.json
+++ b/packages/daintree-plugin/package.json
@@ -37,7 +37,7 @@
     "execa": "^9.6.0",
     "globby": "^14.1.0",
     "semver": "^7.8.0",
-    "yauzl": "^2.10.0",
+    "yauzl": "^3.4.0",
     "zod": "^4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Installing a `.dntr` plugin archive whose largest entry crossed the default 64KiB stream `highWaterMark` could hang extraction forever, with no error and no timeout, leaving `install.lock.lock` and a `.install-tmp-*` directory held until the app was quit.
- Root cause is an upstream Node regression (nodejs/node#62557), reverted in nodejs/node#63834 and shipped in Node 24.18.0, interacting with fd-slicer 1.1.0's stream-ending pattern, a dependency of yauzl 2.10.
- Fixes the hang directly with a per-entry inactivity timeout, and picks up the Node revert as defense in depth.

Resolves #11227

## Changes

- Bump `electron` from `^42.4.0` to `^42.7.0` to pick up the Node revert. Chrome stays on the 148 train, so the `chrome148` Vite build target is unchanged.
- Bump `yauzl` from `2.10` to `^3.4.0` and `@types/yauzl` to `^3.4.0`, plus the `yauzl` type declaration in `packages/daintree-plugin`. Yauzl 3.x drops the external `fd-slicer` dependency (confirmed gone from the lockfile) and ships a vendored copy with a proper stream `_destroy`, which the abort path below needs to release the shared zip file descriptor cleanly.
- Rewrite `extractPluginArchive`'s per-entry transfer from `stream.pipe(out)` to `stream.pipeline(stream, out, { signal })`, with a per-entry inactivity `AbortController` (`PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS`, 30 seconds, reset on every chunk). A stalled entry now rejects with an error naming the entry, feeding the installer's existing rollback path (temp directory cleanup, lock release) instead of hanging.
- Harden `openZip` by pinning yauzl's security-relevant options explicitly (`strictFileNames`, `decodeStrings`, `validateEntrySizes`), so the major version bump can't silently weaken a guard.
- Add regression tests: stalled-stream abort, a real archive entry over 64KiB round-tripping successfully, rejection of an entry that lies about its declared size, the inactivity timer resetting on progress, and rejection of a backslash-containing entry name.

Plugin-install progress and cancel UI is out of scope here. Deferring that to a follow-up, per the issue author.

## Testing

- 142 targeted tests pass locally: 13 extraction tests, 97 installer and package tests, 32 integration tests.
- Electron project typechecks clean.
- Changed files pass prettier and eslint.
- Lockfile confirms `electron@42.7.0`, `yauzl@3.4.0`, `@types/yauzl@3.4.0`, and no `fd-slicer` remaining.
