### PR TITLE
fix(plugins): route plugin panels through ContentPanel for focus and pane controls

### DIFF
--- a/src/components/Panel/__tests__/ContentPanel.focus.test.tsx
+++ b/src/components/Panel/__tests__/ContentPanel.focus.test.tsx
@@ -68,13 +68,19 @@ vi.mock("@/components/ui/tooltip", () => ({
 import { ContentPanel } from "../ContentPanel";
 import { focusPanelInput } from "../panelFocusRegistry";
 
-type PanelKind = "terminal" | "browser" | "dev-preview" | "review" | "file";
+// `acme.dashboard` stands in for a plugin-contributed kind: unregistered in this
+// suite, so it also pins `panelKindHasPty`'s `?? false` fallback — an unknown
+// kind must still get a focus target rather than being mistaken for a PTY (#11228).
+type PanelKind = "terminal" | "browser" | "dev-preview" | "review" | "file" | "acme.dashboard";
+
+const NON_PTY_KINDS: PanelKind[] = ["browser", "dev-preview", "review", "file", "acme.dashboard"];
 
 interface RenderExtras {
   tabIndex?: number;
   ref?: React.Ref<HTMLDivElement>;
   isFocused?: boolean;
   children?: React.ReactNode;
+  onFocus?: () => void;
 }
 
 function panelElement(id: string, kind: PanelKind, extra?: RenderExtras) {
@@ -84,7 +90,7 @@ function panelElement(id: string, kind: PanelKind, extra?: RenderExtras) {
       title={`Panel ${id}`}
       kind={kind}
       isFocused={extra?.isFocused ?? false}
-      onFocus={() => {}}
+      onFocus={extra?.onFocus ?? (() => {})}
       onClose={() => {}}
       tabIndex={extra?.tabIndex}
       ref={extra?.ref}
@@ -114,7 +120,7 @@ function panelRoot(container: HTMLElement, id: string): HTMLElement {
 describe("ContentPanel focus target (#11109)", () => {
   afterEach(cleanup);
 
-  it.each<PanelKind>(["browser", "dev-preview", "review", "file"])(
+  it.each<PanelKind>(NON_PTY_KINDS)(
     "moves focus to the panel root and confirms the handoff for %s panels",
     (kind) => {
       const { container } = renderPanel("p-1", kind);
@@ -187,6 +193,54 @@ describe("ContentPanel focus target (#11109)", () => {
 });
 
 /**
+ * Focus *selection*, as distinct from the focus *delivery* covered above:
+ * clicking a pane has to write `focusedId`, or panel-scoped actions keep
+ * resolving `terminalId ?? focusedId` to whatever was selected before — which
+ * is how Cmd+W ended up closing the previously focused agent (#11228).
+ */
+describe("ContentPanel click-to-select (#11228)", () => {
+  afterEach(cleanup);
+
+  it.each<PanelKind>(NON_PTY_KINDS)(
+    "selects a %s panel when a click bubbles out of its content",
+    (kind) => {
+      const onFocus = vi.fn<() => void>();
+      const { container } = renderPanel("p-1", kind, {
+        onFocus,
+        children: <button data-testid="plugin-child">Inside the plugin</button>,
+      });
+
+      // Click the deepest child, not the root: the bug was that content clicks
+      // never reached any focus wiring at all.
+      container.querySelector<HTMLElement>('[data-testid="plugin-child"]')!.click();
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("lets content opt out of selection by preventing the click", () => {
+    const onFocus = vi.fn<() => void>();
+    const { container } = renderPanel("p-1", "acme.dashboard", {
+      onFocus,
+      children: (
+        <button
+          data-testid="plugin-child"
+          onClick={(e) => {
+            e.preventDefault();
+          }}
+        >
+          Handled by the plugin
+        </button>
+      ),
+    });
+
+    container.querySelector<HTMLElement>('[data-testid="plugin-child"]')!.click();
+
+    expect(onFocus).not.toHaveBeenCalled();
+  });
+});
+
+/**
  * The registry alone only covers macro-grid Enter and in-group tab switches.
  * Arrow navigation, Cmd+1..9, focusNext/Previous and agent-state cycling all
  * just write `focusedId` — so becoming the focused pane has to move DOM focus
@@ -196,7 +250,7 @@ describe("ContentPanel focus target (#11109)", () => {
 describe("ContentPanel reactive focus (#11133)", () => {
   afterEach(cleanup);
 
-  it.each<PanelKind>(["browser", "dev-preview", "review", "file"])(
+  it.each<PanelKind>(NON_PTY_KINDS)(
     "claims DOM focus for a %s panel that becomes focused without the registry",
     (kind) => {
       const outside = document.createElement("button");

--- a/src/components/Panel/__tests__/ContentPanel.focus.test.tsx
+++ b/src/components/Panel/__tests__/ContentPanel.focus.test.tsx
@@ -201,22 +201,23 @@ describe("ContentPanel focus target (#11109)", () => {
 describe("ContentPanel click-to-select (#11228)", () => {
   afterEach(cleanup);
 
-  it.each<PanelKind>(NON_PTY_KINDS)(
-    "selects a %s panel when a click bubbles out of its content",
-    (kind) => {
-      const onFocus = vi.fn<() => void>();
-      const { container } = renderPanel("p-1", kind, {
-        onFocus,
-        children: <button data-testid="plugin-child">Inside the plugin</button>,
-      });
+  // handleClick doesn't branch on kind, so one representative kind covers the
+  // path; the plugin kind is the issue's subject. (The per-kind variation that
+  // matters — panelKindHasPty's unknown-kind fallback — is exercised by the
+  // focus-registration matrices above, not here.)
+  it("selects the panel when a click bubbles out of its content", () => {
+    const onFocus = vi.fn<() => void>();
+    const { container } = renderPanel("p-1", "acme.dashboard", {
+      onFocus,
+      children: <button data-testid="plugin-child">Inside the plugin</button>,
+    });
 
-      // Click the deepest child, not the root: the bug was that content clicks
-      // never reached any focus wiring at all.
-      container.querySelector<HTMLElement>('[data-testid="plugin-child"]')!.click();
+    // Click the deepest child, not the root: the bug was that content clicks
+    // never reached any focus wiring at all.
+    container.querySelector<HTMLElement>('[data-testid="plugin-child"]')!.click();
 
-      expect(onFocus).toHaveBeenCalledTimes(1);
-    }
-  );
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
 
   it("lets content opt out of selection by preventing the click", () => {
     const onFocus = vi.fn<() => void>();

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -1,7 +1,6 @@
 import {
   Suspense,
   lazy,
-  useCallback,
   useEffect,
   useRef,
   useState,
@@ -12,13 +11,31 @@ import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
 import type { PanelViewProps } from "@shared/types/plugin";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import type { ErrorFallbackProps } from "@/components/ErrorBoundary/ErrorFallback";
-import { BrowserPaneSkeleton } from "@/components/Browser/BrowserPaneSkeleton";
+import { ContentPanel, type BasePanelProps } from "@/components/Panel";
+import type { TabInfo } from "@/components/Panel/TabButton";
+import { Skeleton, SkeletonHint } from "@/components/ui/Skeleton";
 import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
-import { usePanelRootFocus } from "@/components/Panel/usePanelRootFocus";
 import { PluginViewDiagnosticsFallback } from "@/components/Plugin/PluginViewDiagnosticsFallback";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
-import type { PanelComponentProps } from "@/panels/registry";
 import { logWarn } from "@/utils/logger";
+
+/**
+ * Plugin panels are ordinary grid panels: `ContentPanel` owns their chrome and
+ * their focus-registry entry, so the host's props mirror what every other
+ * non-PTY pane declares (`FilePaneProps`) rather than the registry's untyped
+ * `PanelComponentProps` bag — spreading `unknown`-valued tab props into
+ * `ContentPanel` would not typecheck. `GridPanel` supplies every field here.
+ */
+export interface PluginViewHostProps extends BasePanelProps {
+  extensionState?: Record<string, unknown>;
+  tabs?: TabInfo[];
+  groupId?: string;
+  onTabClick?: (tabId: string) => void;
+  onTabClose?: (tabId: string) => void;
+  onTabRename?: (tabId: string, newTitle: string) => void;
+  onAddTab?: () => void;
+  onTabReorder?: (newOrder: string[]) => void;
+}
 
 /**
  * Upper bound on a single `plugin://` view import before the host gives up and
@@ -64,7 +81,7 @@ function isPluginViewModule(mod: unknown): mod is { default: ComponentType<Panel
  * unresolved as of 2026), so every dev iteration permanently expands the
  * renderer's module map. Acceptable for dev; never for production.
  */
-export function makePluginViewHost(config: PanelKindConfig): ComponentType<PanelComponentProps> {
+export function makePluginViewHost(config: PanelKindConfig): ComponentType<PluginViewHostProps> {
   const componentPath = config.componentPath;
   const pluginId = config.extensionId;
   const kindId = config.id;
@@ -174,7 +191,7 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
       return { default: mod.default };
     });
 
-  function PluginViewHost(props: PanelComponentProps) {
+  function PluginViewHost({ extensionState, ...panelProps }: PluginViewHostProps) {
     // Store the lazy component in state so retries can swap in a fresh ref
     // without a useMemo dependency array — `lazy()` memoizes the import
     // promise by factory-function identity, so retrying after a chunk-load
@@ -194,14 +211,6 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     // cases this can't cover; see PluginViewFallback.
     const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
     useEffect(() => initPluginRuntime(), [initPluginRuntime]);
-
-    const rootRef = useRef<HTMLDivElement | null>(null);
-    const panelId = props.id;
-    // Focusing the host root establishes ownership in the parent document; it
-    // does not push focus into the plugin's guest frame. Focus already inside
-    // the host (a plugin input, an iframe) is left where it is.
-    const getRootNode = useCallback(() => rootRef.current, []);
-    usePanelRootFocus({ id: panelId, isFocused: props.isFocused, getNode: getRootNode });
 
     // The dispose controller lives in state because its signal is consumed
     // during render (passed to the plugin view as `disposeSignal`), and refs
@@ -257,10 +266,13 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     };
 
     return (
-      // Plugin views render no ContentPanel, so the host owns the panel's focus
-      // target. Sitting outside the boundary keeps macro-grid Enter working
-      // while the view is still loading and after it has failed.
-      <div ref={rootRef} tabIndex={-1} className="flex flex-col h-full w-full">
+      // ContentPanel owns click-to-focus, the focus-registry entry, and the pane
+      // chrome, exactly as it does for every other non-PTY kind (#11228). It sits
+      // outside the boundary and Suspense on purpose: a loading or crashed view
+      // keeps its header, context menu, and close control, so the panel is never
+      // stranded open. `kind` comes from the closure — `buildPanelProps` doesn't
+      // supply one, and the closure value is authoritative anyway.
+      <ContentPanel {...panelProps} kind={kindId}>
         <ErrorBoundary
           variant="component"
           // `kindId` is already `${pluginId}.${panel.id}` (PluginService builds
@@ -270,18 +282,32 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
           onReset={handleReset}
           resetKeys={[retryCount]}
         >
-          <Suspense fallback={<BrowserPaneSkeleton label={`Loading ${displayName}`} />}>
-            <ContentFadeIn className="flex flex-col h-full w-full">
+          <Suspense
+            fallback={
+              // Content-only bones: ContentPanel already paints the real header,
+              // so a skeleton carrying its own (BrowserPaneSkeleton) would double
+              // it. Mirrors DevPreviewPaneFallback's quiet canvas — a plugin's
+              // content shape is unknowable, so bones must not imply one.
+              <div className="relative h-full">
+                <Skeleton
+                  label={`Loading ${displayName}`}
+                  className="h-full bg-surface-canvas"
+                />
+                <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+              </div>
+            }
+          >
+            <ContentFadeIn className="flex flex-col flex-1 min-h-0 w-full">
               <LazyView
-                panelId={props.id}
+                panelId={panelProps.id}
                 pluginId={pluginId!}
                 disposeSignal={controller.signal}
-                initialArgs={props.extensionState}
+                initialArgs={extensionState}
               />
             </ContentFadeIn>
           </Suspense>
         </ErrorBoundary>
-      </div>
+      </ContentPanel>
     );
   }
 

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -272,7 +272,14 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Plugi
       // keeps its header, context menu, and close control, so the panel is never
       // stranded open. `kind` comes from the closure — `buildPanelProps` doesn't
       // supply one, and the closure value is authoritative anyway.
-      <ContentPanel {...panelProps} kind={kindId}>
+      //
+      // `chrome={undefined}` forces ContentPanel to derive the descriptor from
+      // `kind`, matching FilePane/Browser/DevPreview (none of which forward one).
+      // buildPanelProps precomputes a `chrome` and GridPanel spreads it in
+      // untyped; forwarding it would pin a stale descriptor when a disabled
+      // plugin's persisted panel re-enables (the panelProps memo doesn't depend
+      // on the kind registry).
+      <ContentPanel {...panelProps} kind={kindId} chrome={undefined}>
         <ErrorBoundary
           variant="component"
           // `kindId` is already `${pluginId}.${panel.id}` (PluginService builds

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -296,10 +296,7 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Plugi
               // it. Mirrors DevPreviewPaneFallback's quiet canvas — a plugin's
               // content shape is unknowable, so bones must not imply one.
               <div className="relative h-full">
-                <Skeleton
-                  label={`Loading ${displayName}`}
-                  className="h-full bg-surface-canvas"
-                />
+                <Skeleton label={`Loading ${displayName}`} className="h-full bg-surface-canvas" />
                 <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
               </div>
             }

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -852,9 +852,8 @@ describe("PluginViewHost panel integration (#11228)", () => {
     // above). Register the kind so the real chrome derivation resolves it to the
     // panel branch, proving `kindId` (not a default or `props.kind`) reached
     // ContentPanel end-to-end, via `data-runtime-*` on the panel root.
-    const { registerPanelKind, unregisterPanelKind } = await import(
-      "@shared/config/panelKindRegistry"
-    );
+    const { registerPanelKind, unregisterPanelKind } =
+      await import("@shared/config/panelKindRegistry");
     registerPanelKind({
       id: "acme.dashboard",
       name: "Dashboard",

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -784,47 +784,110 @@ describe("PluginViewHost panel integration (#11228)", () => {
     const Host = makePluginViewHost(makeConfig());
     const onFocus = vi.fn<() => void>();
 
-    const { container } = render(<Host {...hostProps} onFocus={onFocus} />);
+    render(<Host {...hostProps} onFocus={onFocus} />);
 
     // The skeleton stands in for plugin content here — the point is that a click
-    // anywhere inside the panel's body reaches ContentPanel's handler, which is
-    // exactly what the bare host div swallowed.
+    // inside the panel's body reaches ContentPanel's handler, which is exactly
+    // what the bare host div swallowed.
     await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
     screen.getByTestId("skeleton").click();
 
     expect(onFocus).toHaveBeenCalledTimes(1);
-    expect(panelRoot(container)).toBeTruthy();
   });
 
-  it("keeps the pane chrome mounted while the plugin view is still loading", async () => {
+  it("keeps the pane chrome mounted and closable while the plugin view is still loading", async () => {
     const { makePluginViewHost } = await import("../PluginViewHost");
     const Host = makePluginViewHost(makeConfig());
+    const onClose = vi.fn<() => void>();
 
-    const { container } = render(<Host {...hostProps} onFocus={(): void => {}} />);
+    const { container } = render(<Host {...hostProps} onClose={onClose} onFocus={() => {}} />);
 
     await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
     expect(panelRoot(container)).toBeTruthy();
     expect(container.querySelector("[data-pane-chrome]")).toBeTruthy();
-    expect(screen.getByTestId("panel-close")).toBeTruthy();
+
+    // Not just present — operable. A loading view must stay dismissable.
+    act(() => screen.getByTestId("panel-close").click());
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps the pane chrome mounted and closable after the plugin view crashes", async () => {
+    // The structural claim of the fix: ContentPanel sits OUTSIDE the error
+    // boundary, so a thrown plugin view swaps only the content slot for the
+    // boundary fallback while the header and close control stay live. Without
+    // that, a crashed plugin view would be stranded open (#11228).
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CrashingView(): never {
+            throw new Error("plugin view exploded on render");
+          },
+      };
+    });
+
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+    const onClose = vi.fn<() => void>();
+
+    const { container } = render(<Host {...hostProps} onClose={onClose} onFocus={() => {}} />);
+
+    // The mocked ErrorBoundary renders its reset sentinel once it catches.
+    await waitFor(() => expect(screen.getByTestId("reset")).toBeTruthy());
+    // Chrome coexists with the fallback rather than being replaced by it.
+    expect(panelRoot(container)).toBeTruthy();
+    expect(container.querySelector("[data-pane-chrome]")).toBeTruthy();
+
+    act(() => screen.getByTestId("panel-close").click());
+    expect(onClose).toHaveBeenCalled();
+    vi.doUnmock("react");
   });
 
   it("passes the plugin's own kind and the live panel title to the shell", async () => {
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    // `buildPanelProps` supplies no `kind`, so the host must source it from its
-    // closure; the title has to be the instance's, not the kind's config name.
-    const { container } = render(
-      <Host {...hostProps} title="Renamed by the user" onFocus={() => {}} />
+    // Resolve the registry from the SAME post-reset module graph as the host —
+    // the suite calls vi.resetModules() between tests, so a statically imported
+    // registerPanelKind would write to a different instance than the one the
+    // dynamically imported ContentPanel reads (mirrors the focusPanelInput note
+    // above). Register the kind so the real chrome derivation resolves it to the
+    // panel branch, proving `kindId` (not a default or `props.kind`) reached
+    // ContentPanel end-to-end, via `data-runtime-*` on the panel root.
+    const { registerPanelKind, unregisterPanelKind } = await import(
+      "@shared/config/panelKindRegistry"
     );
+    registerPanelKind({
+      id: "acme.dashboard",
+      name: "Dashboard",
+      iconId: "gauge",
+      color: "#abcdef",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "acme",
+    });
+    try {
+      const { makePluginViewHost } = await import("../PluginViewHost");
+      const Host = makePluginViewHost(makeConfig());
 
-    await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
-    expect(panelRoot(container).getAttribute("data-panel-id")).toBe("panel-1");
-    // The header renders the title in more than one node (visible label plus the
-    // rename editor's prefill), so match within the chrome rather than globally.
-    const chrome = container.querySelector<HTMLElement>("[data-pane-chrome]");
-    expect(chrome).toBeTruthy();
-    expect(within(chrome!).getAllByText("Renamed by the user").length).toBeGreaterThan(0);
-    expect(screen.queryByText("Dashboard")).toBeNull();
+      // `buildPanelProps` supplies no `kind`, so the host must source it from its
+      // closure; the title has to be the instance's, not the kind's config name.
+      const { container } = render(
+        <Host {...hostProps} title="Renamed by the user" onFocus={() => {}} />
+      );
+
+      await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
+      const root = panelRoot(container);
+      // Non-PTY panel chrome, keyed off the plugin kind's registry entry — a
+      // wrong or defaulted kind would derive a different runtime kind/icon.
+      expect(root.getAttribute("data-runtime-kind")).toBe("panel");
+      expect(root.getAttribute("data-runtime-icon-id")).toBe("gauge");
+      // The header renders the title in more than one node (visible label plus
+      // the rename editor's prefill), so match within the chrome, not globally.
+      const chrome = container.querySelector<HTMLElement>("[data-pane-chrome]");
+      expect(chrome).toBeTruthy();
+      expect(within(chrome!).getAllByText("Renamed by the user").length).toBeGreaterThan(0);
+    } finally {
+      unregisterPanelKind("acme.dashboard");
+    }
   });
 });

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -1,16 +1,87 @@
 // @vitest-environment jsdom
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
 
 // Stub presentational deps — the host's behavioral contract is the lazy
 // import + AbortController wiring, not the skeleton or fade-in chrome.
-vi.mock("@/components/Browser/BrowserPaneSkeleton", () => ({
-  BrowserPaneSkeleton: ({ label }: { label?: string }) => <div data-testid="skeleton">{label}</div>,
+vi.mock("@/components/ui/Skeleton", () => ({
+  Skeleton: ({ label }: { label?: string }) => <div data-testid="skeleton">{label}</div>,
+  SkeletonHint: () => null,
 }));
 vi.mock("@/components/ui/ContentFadeIn", () => ({
   ContentFadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+
+// ContentPanel renders for real: it owns the click-to-focus wiring and the
+// chrome this suite asserts on, so a stand-in would make those behaviors
+// properties of the double instead of the host. Only its store/context graph is
+// stubbed — the same scaffold ContentPanel.focus.test.tsx uses. `panelKindHasPty`
+// and PanelHeader stay real so the focus gate and the close control are genuine.
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (s: { worktrees: Map<string, unknown> }) => unknown) =>
+    selector({ worktrees: new Map() }),
+}));
+vi.mock("@/hooks/useWorktreeColorMap", () => ({
+  useWorktreeColorMap: () => undefined,
+}));
+vi.mock("@/components/DragDrop", () => ({
+  useIsDragging: () => false,
+}));
+vi.mock("@/components/Layout/useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+}));
+vi.mock("@/utils/terminalAgentDisplayState", () => ({
+  getTerminalAgentDisplayState: () => undefined,
+}));
+vi.mock("@/components/Terminal/TerminalHeaderContent", () => ({
+  TerminalHeaderContent: () => null,
+}));
+vi.mock("@/store", () => ({
+  usePreferencesStore: (
+    selector: (s: { showGridAgentHighlights: boolean; showAgentTaskTitles: boolean }) => unknown
+  ) => selector({ showGridAgentHighlights: false, showAgentTaskTitles: true }),
+  usePanelStore: (selector: (s: { panelsById: Record<string, never> }) => unknown) =>
+    selector({ panelsById: {} }),
+}));
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Count live focus-registry owners per panel id while delegating to the real
+// registry — the duplicate-registration regression is invisible to the registry's
+// own API (last writer just wins), so it can only be caught at the seam.
+// `importOriginal` is spread back in: a bare factory would drop `focusPanelInput`
+// and every other export the panel graph imports from here.
+const focusRegistry = vi.hoisted(() => {
+  const live = new Map<string, number>();
+  return {
+    live,
+    liveCount: (id: string) => live.get(id) ?? 0,
+    reset: () => live.clear(),
+  };
+});
+
+vi.mock("@/components/Panel/panelFocusRegistry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/Panel/panelFocusRegistry")>();
+  return {
+    ...actual,
+    registerPanelFocusHandler: (id: string, handler: () => boolean) => {
+      focusRegistry.live.set(id, (focusRegistry.live.get(id) ?? 0) + 1);
+      const release = actual.registerPanelFocusHandler(id, handler);
+      return () => {
+        focusRegistry.live.set(id, Math.max(0, (focusRegistry.live.get(id) ?? 0) - 1));
+        release();
+      };
+    },
+  };
+});
 
 // The subset of ErrorBoundary's contract the host relies on. Typed here rather
 // than cast at each read site — a cast would regress the per-rule
@@ -98,6 +169,7 @@ const onPanelKindsChangedMock = vi.fn();
 
 beforeEach(() => {
   boundaryProps.last = null;
+  focusRegistry.reset();
   onPanelKindsChangedMock.mockReset();
   onPanelKindsChangedMock.mockReturnValue(() => {});
   vi.stubGlobal("electron", undefined);
@@ -579,11 +651,20 @@ describe("makePluginViewHost", () => {
   });
 });
 
+/** The panel root ContentPanel renders — the host no longer owns one (#11228). */
+function panelRoot(container: HTMLElement): HTMLElement {
+  const root = container.querySelector<HTMLElement>('[data-panel-id="panel-1"]');
+  if (!root) throw new Error("panel root not rendered");
+  return root;
+}
+
 /**
- * The plugin host bypasses ContentPanel, so it owns its focus target. Focusing
- * the host root claims the keyboard in the parent document; it does not push
- * focus into the plugin's guest frame, and it must never pull focus out of a
- * plugin input the user is already typing in (#11133).
+ * Focus *delivery*: becoming the focused pane must move DOM focus, or the pane
+ * paints as selected while keystrokes land wherever they were before (#11133).
+ * ContentPanel now owns the focus target, so these assert against its root
+ * rather than a host-owned div. Focusing that root claims the keyboard in the
+ * parent document; it never pushes focus into the plugin's guest frame, and it
+ * must never pull focus out of a plugin input the user is already typing in.
  */
 describe("PluginViewHost reactive focus (#11133)", () => {
   it("claims DOM focus when the host becomes the focused pane", async () => {
@@ -617,7 +698,7 @@ describe("PluginViewHost reactive focus (#11133)", () => {
       );
     });
 
-    expect(document.activeElement).toBe(container.firstElementChild);
+    expect(document.activeElement).toBe(panelRoot(container));
     outside.remove();
   });
 
@@ -639,9 +720,8 @@ describe("PluginViewHost reactive focus (#11133)", () => {
       />
     );
 
-    const root = container.firstElementChild as HTMLElement;
     const guestInput = document.createElement("input");
-    root.appendChild(guestInput);
+    panelRoot(container).appendChild(guestInput);
     act(() => guestInput.focus());
 
     let accepted = false;
@@ -651,5 +731,100 @@ describe("PluginViewHost reactive focus (#11133)", () => {
 
     expect(accepted).toBe(true);
     expect(document.activeElement).toBe(guestInput);
+  });
+
+  it("registers exactly one focus handler for the panel id", async () => {
+    // The host used to call usePanelRootFocus itself. Now that ContentPanel
+    // wraps it, a surviving host-side call would be a second registration under
+    // one id — and the registry is last-writer-wins, so the two would silently
+    // clobber each other rather than fail loudly (#11132/#11150).
+    const { focusPanelInput } = await import("@/components/Panel/panelFocusRegistry");
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    const { unmount } = render(
+      <Host
+        id="panel-1"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+
+    // Count live registrations, not calls: a registration that is added and
+    // released still nets to one owner, and counting this way stays correct if
+    // Strict Mode ever double-invokes the effect.
+    expect(focusRegistry.liveCount("panel-1")).toBe(1);
+    expect(focusPanelInput("panel-1")).toBe(true);
+
+    unmount();
+    expect(focusRegistry.liveCount("panel-1")).toBe(0);
+    expect(focusPanelInput("panel-1")).toBe(false);
+  });
+});
+
+/**
+ * The bug itself (#11228): a plugin panel rendered fine but never took part in
+ * click-based selection, so `focusedId` stayed on the previously focused agent
+ * and Cmd+W closed *that* instead. The chrome cases pin the other half — the
+ * shell has to outlive the plugin's own loading and crash states, or a wedged
+ * view is unclosable.
+ */
+describe("PluginViewHost panel integration (#11228)", () => {
+  const hostProps = {
+    id: "panel-1",
+    title: "Dashboard",
+    isFocused: false,
+    onClose: (): void => {},
+  };
+
+  it("selects the panel when a click bubbles out of the plugin's content", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+    const onFocus = vi.fn<() => void>();
+
+    const { container } = render(<Host {...hostProps} onFocus={onFocus} />);
+
+    // The skeleton stands in for plugin content here — the point is that a click
+    // anywhere inside the panel's body reaches ContentPanel's handler, which is
+    // exactly what the bare host div swallowed.
+    await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
+    screen.getByTestId("skeleton").click();
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(panelRoot(container)).toBeTruthy();
+  });
+
+  it("keeps the pane chrome mounted while the plugin view is still loading", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    const { container } = render(<Host {...hostProps} onFocus={(): void => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
+    expect(panelRoot(container)).toBeTruthy();
+    expect(container.querySelector("[data-pane-chrome]")).toBeTruthy();
+    expect(screen.getByTestId("panel-close")).toBeTruthy();
+  });
+
+  it("passes the plugin's own kind and the live panel title to the shell", async () => {
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    // `buildPanelProps` supplies no `kind`, so the host must source it from its
+    // closure; the title has to be the instance's, not the kind's config name.
+    const { container } = render(
+      <Host {...hostProps} title="Renamed by the user" onFocus={() => {}} />
+    );
+
+    await waitFor(() => expect(screen.getByTestId("skeleton")).toBeTruthy());
+    expect(panelRoot(container).getAttribute("data-panel-id")).toBe("panel-1");
+    // The header renders the title in more than one node (visible label plus the
+    // rename editor's prefill), so match within the chrome rather than globally.
+    const chrome = container.querySelector<HTMLElement>("[data-pane-chrome]");
+    expect(chrome).toBeTruthy();
+    expect(within(chrome!).getAllByText("Renamed by the user").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Dashboard")).toBeNull();
   });
 });

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -517,14 +517,16 @@ export function TerminalContextMenu({
   const isDevPreview = isDevPreviewPanel(terminal);
   const isReview = isReviewPanel(terminal);
   const isFile = isFilePanel(terminal);
-  // Plugin-contributed kinds match none of the built-in guards, so without this
-  // they fall through to the terminal menu and are offered "Duplicate terminal",
+  const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
+  // A non-PTY plugin kind matches none of the built-in guards, so without this
+  // it falls through to the terminal menu and is offered "Duplicate terminal",
   // "Kill terminal", and friends — none of which apply (#11228). `pluginId` is
   // stamped at creation and survives the plugin going missing, which is why it
-  // beats a registry lookup here. The generic panel menu below is exactly the
-  // right item set, so plugin panels share it rather than duplicating it.
-  const isPlugin = Boolean(terminal.pluginId);
-  const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
+  // beats a registry lookup here. The `!hasPty` half is load-bearing: plugins
+  // may also contribute PTY-backed kinds that render through TerminalPane and
+  // are stamped with pluginId too (addPanel.ts) — those are genuine terminals
+  // and must keep copy/paste, redraw, restart, and the rest of the PTY menu.
+  const isPlugin = Boolean(terminal.pluginId) && !hasPty;
 
   const layoutSection = (
     <>

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -517,6 +517,13 @@ export function TerminalContextMenu({
   const isDevPreview = isDevPreviewPanel(terminal);
   const isReview = isReviewPanel(terminal);
   const isFile = isFilePanel(terminal);
+  // Plugin-contributed kinds match none of the built-in guards, so without this
+  // they fall through to the terminal menu and are offered "Duplicate terminal",
+  // "Kill terminal", and friends — none of which apply (#11228). `pluginId` is
+  // stamped at creation and survives the plugin going missing, which is why it
+  // beats a registry lookup here. The generic panel menu below is exactly the
+  // right item set, so plugin panels share it rather than duplicating it.
+  const isPlugin = Boolean(terminal.pluginId);
   const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
 
   const layoutSection = (
@@ -744,7 +751,7 @@ export function TerminalContextMenu({
     );
   }
 
-  if (isFile) {
+  if (isFile || isPlugin) {
     return (
       <ContextMenu>
         <MenuActionSourceContext.Consumer>

--- a/src/components/Terminal/__tests__/TerminalContextMenu.plugin.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.plugin.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+/**
+ * Plugin panels get the generic panel menu, not the terminal one (#11228).
+ *
+ * A plugin-contributed kind matches none of the built-in panel type guards, so
+ * before this it fell through to the terminal-flavored default branch and was
+ * offered "Duplicate terminal", "Kill terminal" and friends — none of which mean
+ * anything for a plugin view. `hasPty` gated only some of those items, so the
+ * mislabeled ones survived.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+// Render menu content synchronously. Radix only mounts it behind a real
+// right-click into a portal, which tells us nothing about which branch ran —
+// the branch choice is the whole contract under test here.
+vi.mock("@/components/ui/context-menu", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  const Item = ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
+    <button onClick={() => onSelect?.()}>{children}</button>
+  );
+  return {
+    ContextMenu: Passthrough,
+    ContextMenuTrigger: Passthrough,
+    ContextMenuContent: Passthrough,
+    ContextMenuItem: Item,
+    ContextMenuActionItem: Item,
+    ContextMenuCheckboxItem: Item,
+    ContextMenuRadioGroup: Passthrough,
+    ContextMenuRadioItem: Item,
+    ContextMenuSeparator: () => null,
+    ContextMenuLabel: Passthrough,
+    ContextMenuShortcut: Passthrough,
+    ContextMenuGroup: Passthrough,
+    ContextMenuPortal: Passthrough,
+    ContextMenuSub: Passthrough,
+    ContextMenuSubContent: Passthrough,
+    ContextMenuSubTrigger: Passthrough,
+  };
+});
+
+const dispatch = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch,
+    get: () => undefined,
+    list: () => [],
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    getTerminal: () => undefined,
+    getSelection: () => "",
+  },
+}));
+
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({ worktrees: [] }),
+}));
+
+vi.mock("@/hooks/useIsHibernated", () => ({
+  useIsHibernated: () => false,
+}));
+
+vi.mock("@/hooks/usePluginContextMenuItems", () => ({
+  usePluginContextMenuItems: () => [],
+}));
+
+vi.mock("@/store/voiceRecordingStore", () => ({
+  useVoiceRecordingStore: (selector: (s: unknown) => unknown) =>
+    selector({ lockedTarget: null, recentTargets: [] }),
+}));
+
+vi.mock("@/store/fleetArmingStore", () => ({
+  useFleetArmingStore: (selector: (s: { armedIds: Set<string> }) => unknown) =>
+    selector({ armedIds: new Set<string>() }),
+  isFleetArmEligible: () => false,
+}));
+
+const panelsById = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+
+vi.mock("@/store", () => ({
+  usePanelStore: (
+    selector: (s: {
+      panelsById: Record<string, unknown>;
+      maximizeTarget: null;
+      getPanelGroup: () => undefined;
+      watchedPanels: Set<string>;
+    }) => unknown
+  ) =>
+    selector({
+      panelsById: panelsById.current,
+      maximizeTarget: null,
+      getPanelGroup: () => undefined,
+      watchedPanels: new Set<string>(),
+    }),
+}));
+
+import { TerminalContextMenu } from "../TerminalContextMenu";
+
+// Terminal-only labels that must never reach a plugin panel. "Rename terminal"
+// and "Trash terminal" are the sharp ones: the generic branch offers its own
+// "Rename panel"/"Trash panel", so a regression here shows up as the wrong noun
+// rather than a missing item.
+const TERMINAL_ONLY_LABELS = [
+  "Duplicate terminal",
+  "Rename terminal",
+  "Trash terminal",
+  "Kill terminal",
+  "View terminal info",
+];
+
+const GENERIC_PANEL_LABELS = ["Rename panel", "Send to background", "Trash panel", "Remove panel"];
+
+function renderMenuFor(panel: Record<string, unknown>) {
+  panelsById.current = { "panel-1": panel };
+  return render(
+    <TerminalContextMenu terminalId="panel-1">
+      <div>Panel body</div>
+    </TerminalContextMenu>
+  );
+}
+
+const pluginPanel = {
+  id: "panel-1",
+  title: "Dashboard",
+  kind: "acme.dashboard",
+  pluginId: "acme",
+  worktreeId: "wt-1",
+};
+
+describe("TerminalContextMenu — plugin panels (#11228)", () => {
+  afterEach(() => {
+    cleanup();
+    dispatch.mockReset();
+  });
+
+  it.each(GENERIC_PANEL_LABELS)("offers %s on a plugin panel", (label) => {
+    renderMenuFor(pluginPanel);
+
+    expect(screen.getByText(label)).toBeTruthy();
+  });
+
+  it.each(TERMINAL_ONLY_LABELS)("never offers %s on a plugin panel", (label) => {
+    renderMenuFor(pluginPanel);
+
+    expect(screen.queryByText(label)).toBeNull();
+  });
+
+  it("routes a generic item to the panel the menu was opened on", () => {
+    renderMenuFor(pluginPanel);
+
+    screen.getByText("Trash panel").click();
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    // The explicit id matters: panel-scoped actions otherwise fall back to
+    // `focusedId`, which is the exact misrouting this issue is about.
+    const [, args] = dispatch.mock.calls[0]!;
+    expect(args).toMatchObject({ terminalId: "panel-1" });
+  });
+
+  it("still gives a PTY panel the terminal menu", () => {
+    // Guards the discriminator itself: keying off `pluginId` must not drag any
+    // ordinary terminal into the generic branch.
+    renderMenuFor({
+      id: "panel-1",
+      title: "Agent",
+      kind: "terminal",
+      worktreeId: "wt-1",
+    });
+
+    expect(screen.queryByText("Rename panel")).toBeNull();
+    expect(screen.getByText("Rename terminal")).toBeTruthy();
+  });
+});

--- a/src/components/Terminal/__tests__/TerminalContextMenu.plugin.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.plugin.test.tsx
@@ -98,7 +98,13 @@ vi.mock("@/store", () => ({
     }),
 }));
 
+import { registerPanelKind, unregisterPanelKind } from "@shared/config/panelKindRegistry";
 import { TerminalContextMenu } from "../TerminalContextMenu";
+
+// A PTY-backed plugin kind. Registered so the real `panelKindHasPty` reports
+// `hasPty: true` for it, which is what keeps such a panel on the terminal menu
+// despite carrying a `pluginId`.
+const PTY_PLUGIN_KIND = "acme.shell";
 
 // Terminal-only labels that must never reach a plugin panel. "Rename terminal"
 // and "Trash terminal" are the sharp ones: the generic branch offers its own
@@ -149,21 +155,23 @@ describe("TerminalContextMenu — plugin panels (#11228)", () => {
     expect(screen.queryByText(label)).toBeNull();
   });
 
-  it("routes a generic item to the panel the menu was opened on", () => {
+  it("routes a generic item to the panel the menu was opened on with the panel action", () => {
     renderMenuFor(pluginPanel);
 
     screen.getByText("Trash panel").click();
 
     expect(dispatch).toHaveBeenCalledTimes(1);
-    // The explicit id matters: panel-scoped actions otherwise fall back to
-    // `focusedId`, which is the exact misrouting this issue is about.
-    const [, args] = dispatch.mock.calls[0]!;
+    // Assert BOTH halves: the action id proves it's the panel action, not a
+    // mislabeled terminal one, and the explicit id proves it doesn't fall back
+    // to `focusedId` — the exact misrouting this issue is about.
+    const [actionId, args] = dispatch.mock.calls[0]!;
+    expect(actionId).toBe("terminal.trash");
     expect(args).toMatchObject({ terminalId: "panel-1" });
   });
 
-  it("still gives a PTY panel the terminal menu", () => {
-    // Guards the discriminator itself: keying off `pluginId` must not drag any
-    // ordinary terminal into the generic branch.
+  it("still gives a built-in terminal the terminal menu", () => {
+    // Guards the discriminator: keying off `pluginId` must not drag an ordinary
+    // terminal into the generic branch.
     renderMenuFor({
       id: "panel-1",
       title: "Agent",
@@ -173,5 +181,36 @@ describe("TerminalContextMenu — plugin panels (#11228)", () => {
 
     expect(screen.queryByText("Rename panel")).toBeNull();
     expect(screen.getByText("Rename terminal")).toBeTruthy();
+  });
+
+  it("gives a PTY-backed plugin panel the terminal menu, not the generic one", () => {
+    // The load-bearing case behind `&& !hasPty`: a plugin can contribute a
+    // PTY-backed kind that renders through TerminalPane and is stamped with
+    // pluginId. It's a genuine terminal, so keying off pluginId alone would
+    // strip its copy/paste/redraw/restart — the regression this guards.
+    registerPanelKind({
+      id: PTY_PLUGIN_KIND,
+      name: "Acme Shell",
+      iconId: "terminal",
+      color: "#abcdef",
+      hasPty: true,
+      canRestart: true,
+      canConvert: false,
+      extensionId: "acme",
+    });
+    try {
+      renderMenuFor({
+        id: "panel-1",
+        title: "Acme Shell",
+        kind: PTY_PLUGIN_KIND,
+        pluginId: "acme",
+        worktreeId: "wt-1",
+      });
+
+      expect(screen.queryByText("Rename panel")).toBeNull();
+      expect(screen.getByText("Rename terminal")).toBeTruthy();
+    } finally {
+      unregisterPanelKind(PTY_PLUGIN_KIND);
+    }
   });
 });

--- a/src/utils/__tests__/terminalChrome.test.ts
+++ b/src/utils/__tests__/terminalChrome.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerPanelKind, unregisterPanelKind } from "@shared/config/panelKindRegistry";
 import {
   deriveTerminalChrome,
   deriveTerminalRuntimeIdentity,
@@ -100,6 +101,66 @@ describe("deriveTerminalChrome", () => {
       processId: null,
       runtimeKind: "panel",
       hasExited: false,
+    });
+  });
+
+  describe("registered plugin kinds (#11228)", () => {
+    afterEach(() => {
+      unregisterPanelKind("acme.dashboard");
+      unregisterPanelKind("acme.shell");
+    });
+
+    it("takes the panel branch for a registered non-PTY plugin kind, keeping its manifest icon", () => {
+      // The generalized allowlist (`!hasPty`) must cover plugin kinds, not just
+      // the four built-ins — otherwise a plugin panel's new header renders with
+      // no icon and a "Terminal" label from the fall-through branch.
+      registerPanelKind({
+        id: "acme.dashboard",
+        name: "Acme Dashboard",
+        iconId: "gauge",
+        color: "#abcdef",
+        hasPty: false,
+        canRestart: false,
+        canConvert: false,
+        extensionId: "acme",
+      });
+
+      expect(deriveTerminalChrome({ kind: "acme.dashboard" })).toMatchObject({
+        iconId: "gauge",
+        label: "Acme Dashboard",
+        isAgent: false,
+        runtimeKind: "panel",
+        hasExited: false,
+      });
+    });
+
+    it("does NOT take the panel branch for a registered PTY plugin kind", () => {
+      // A PTY-backed plugin kind is a real terminal — it must fall through to
+      // the agent/process/none derivation, not the panel branch.
+      registerPanelKind({
+        id: "acme.shell",
+        name: "Acme Shell",
+        iconId: "terminal",
+        color: "#abcdef",
+        hasPty: true,
+        canRestart: true,
+        canConvert: false,
+        extensionId: "acme",
+      });
+
+      expect(deriveTerminalChrome({ kind: "acme.shell" })).toMatchObject({
+        runtimeKind: "none",
+      });
+    });
+
+    it("falls through to generic chrome for an unknown (unregistered) kind", () => {
+      // The `?? false` safety property: a plugin that has gone missing leaves an
+      // unregistered kind, which must not be mistaken for a panel and must stay
+      // on the safe fall-through path.
+      expect(deriveTerminalChrome({ kind: "gone.missing" })).toMatchObject({
+        iconId: null,
+        runtimeKind: "none",
+      });
     });
   });
 

--- a/src/utils/terminalChrome.ts
+++ b/src/utils/terminalChrome.ts
@@ -187,14 +187,18 @@ export function terminalChromeDescriptorsEqual(
 
 export function deriveTerminalChrome(input: TerminalChromeInput = {}): TerminalChromeDescriptor {
   const kind = input.kind ?? "terminal";
-  // Any registered non-PTY kind is a panel, not a process: take its identity
-  // straight from the registry entry. This was a hardcoded list of the built-in
-  // non-PTY kinds (browser/dev-preview/review/file), which is exactly the set
-  // `!hasPty` selects — but it silently excluded plugin-contributed kinds, so a
-  // plugin panel fell through to the agent path and lost the `iconId` its
-  // manifest declares (#11228). An unregistered kind still falls through below.
+  // Any registered kind EXPLICITLY declared non-PTY is a panel, not a process:
+  // take its identity straight from the registry entry. This was a hardcoded
+  // list of the built-in non-PTY kinds (browser/dev-preview/review/file), which
+  // is exactly the `hasPty: false` set — but it silently excluded plugin
+  // contributed kinds, so a plugin panel fell through to the agent path and lost
+  // the `iconId` its manifest declares (#11228). Test `hasPty === false`, not
+  // `!hasPty`: a config with the field absent (a loose mock, a malformed entry)
+  // must NOT be treated as a panel — it falls through to the agent/process path
+  // below, matching the old allowlist behavior for anything but the four kinds.
+  // An unregistered kind falls through too (getPanelKindConfig → undefined).
   const panelConfig = getPanelKindConfig(kind);
-  if (panelConfig && !panelConfig.hasPty) {
+  if (panelConfig && panelConfig.hasPty === false) {
     return {
       iconId: panelConfig.iconId ?? null,
       color: panelConfig.color ?? getPanelKindColor(kind),

--- a/src/utils/terminalChrome.ts
+++ b/src/utils/terminalChrome.ts
@@ -187,12 +187,18 @@ export function terminalChromeDescriptorsEqual(
 
 export function deriveTerminalChrome(input: TerminalChromeInput = {}): TerminalChromeDescriptor {
   const kind = input.kind ?? "terminal";
-  if (kind === "browser" || kind === "dev-preview" || kind === "review" || kind === "file") {
-    const config = getPanelKindConfig(kind);
+  // Any registered non-PTY kind is a panel, not a process: take its identity
+  // straight from the registry entry. This was a hardcoded list of the built-in
+  // non-PTY kinds (browser/dev-preview/review/file), which is exactly the set
+  // `!hasPty` selects — but it silently excluded plugin-contributed kinds, so a
+  // plugin panel fell through to the agent path and lost the `iconId` its
+  // manifest declares (#11228). An unregistered kind still falls through below.
+  const panelConfig = getPanelKindConfig(kind);
+  if (panelConfig && !panelConfig.hasPty) {
     return {
-      iconId: config?.iconId ?? null,
-      color: config?.color ?? getPanelKindColor(kind),
-      label: config?.name ?? kind,
+      iconId: panelConfig.iconId ?? null,
+      color: panelConfig.color ?? getPanelKindColor(kind),
+      label: panelConfig.name ?? kind,
       isAgent: false,
       agentId: null,
       processId: null,


### PR DESCRIPTION
## Summary
- Fixes #11228: a non-PTY plugin-contributed grid panel rendered fine but never took focus on click and had no pane chrome (header, drag, context menu, close, trash). Clicking inside it left the previously focused agent panel focused, so `Cmd+W` closed the wrong panel.
- Root cause: `PluginViewHost` mounted the plugin view inside a bare `div` instead of a `ContentPanel`. Every other grid panel kind wraps itself in `ContentPanel`, which owns both the click-to-focus wiring (`handleClick` calling `onFocus`) and the chrome.
- The fix wraps the plugin view in `ContentPanel` at the outermost level, so focus and chrome now work the same way they do for every other panel kind, including while loading or after a crash.

Resolves #11228

## Changes
- `PluginViewHost` now wraps its `ErrorBoundary > Suspense > ContentFadeIn > LazyView` tree in `ContentPanel`, placed outside the boundary and Suspense so a loading or crashed view still keeps its chrome and stays closable.
- Deleted `PluginViewHost`'s own `usePanelRootFocus`/`rootRef` registration. `ContentPanel` already registers non-PTY kinds, and a duplicate registration under the same panel id clobbers the first in `panelFocusRegistry` (last-writer-wins), which would have regressed #11132 and #11150.
- `ContentPanel` now derives its chrome fresh from `kind` instead of the host forwarding a precomputed value.
- Added an `isPlugin` branch to `TerminalContextMenu` (guarded on `pluginId` being set and `hasPty` being false) so non-PTY plugin panels get the generic panel menu instead of terminal-only items; PTY-backed plugin panels keep the full terminal menu.
- Generalized `deriveTerminalChrome`'s non-PTY allowlist so plugin kinds keep their manifest icon in the new header.

## Testing
- Click-to-select behavior, chrome surviving loading and crash states, exactly one focus registration per panel, PTY-backed plugin panels keeping the terminal menu, and `deriveTerminalChrome`'s panel/agent/none branches.
- 115 targeted tests pass, typecheck clean.

## Follow-ups (out of scope)
- `ReviewPane` has the same click-to-focus gap but already renders its own header.
- `PanelHeader` announces the new plugin title control as "Agent title", and `TerminalIcon` falls back to the terminal glyph for arbitrary manifest icons. Both are pre-existing behaviors already shared by `file` panels.