### PR TITLE
feat(worktree): keep agent terminals alive when their worktree is deleted

### DIFF
--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useMemo } from "react";
+import { FolderX } from "lucide-react";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { cn } from "@/lib/utils";
+import { usePanelStore } from "@/store/panelStore";
+import {
+  getDeletedWorktreeTerminalIds,
+  useWorktreeSelectionStore,
+  type DeletedWorktree,
+} from "@/store/worktreeStore";
+import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
+import {
+  SortableWorktreeTerminal,
+  getAccordionDragId,
+} from "@/components/DragDrop/SortableWorktreeTerminal";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
+import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
+import { isPtyPanel } from "@shared/types/panel";
+import type { PanelInstance } from "@shared/types/panel";
+
+interface DeletedWorktreeCardProps {
+  worktree: DeletedWorktree;
+}
+
+/**
+ * A deleted-worktree terminal row.
+ *
+ * Deliberately *not* `WorktreeTerminalSection`'s `TerminalRow`: that row's
+ * primary affordance is click-to-focus, which cannot work here. Both the grid
+ * and the dock filter panels by `activeWorktreeId`, and a deleted worktree can
+ * never be active — so a deleted-worktree terminal is genuinely unviewable in place. The
+ * row therefore presents identity only, and dragging it to a live worktree is
+ * the single real affordance (hence the card's subtitle).
+ */
+function DeletedWorktreeTerminalRow({ panel }: { panel: PanelInstance }) {
+  const dragHandle = useDragHandle();
+  const chrome = deriveTerminalChrome(panel);
+  const agentState = getTerminalAgentDisplayState(
+    chrome,
+    isPtyPanel(panel) ? panel.agentState : undefined
+  );
+
+  return (
+    <div
+      data-terminal-id={panel.id}
+      data-deleted-worktree-terminal-id={panel.id}
+      data-terminal-runtime-kind={chrome.runtimeKind}
+      data-terminal-agent-id={chrome.agentId || undefined}
+      data-terminal-agent-state={agentState || undefined}
+      ref={dragHandle?.setActivatorNodeRef}
+      {...(dragHandle?.listeners ?? {})}
+      className="group/deletedrow flex items-center gap-2 px-3 py-2 cursor-grab active:cursor-grabbing"
+    >
+      <div className="shrink-0 opacity-60 group-hover/deletedrow:opacity-100 transition-opacity">
+        <TerminalIcon kind={panel.kind} chrome={chrome} className="w-3 h-3" />
+      </div>
+      <span className="truncate text-xs font-medium text-text-secondary" title={panel.title}>
+        {panel.title}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Sidebar row for a worktree whose directory is gone but whose terminals are
+ * still running (#11232).
+ *
+ * Intentionally a separate component rather than a variant of `WorktreeCard`:
+ * a deleted worktree has no git status, no branch operations, and nowhere to open an
+ * editor, so it renders none of that chrome. It also deliberately does *not*
+ * use `SortableWorktreeCard`, which is what registers a card as a drop target
+ * via `type: "worktree"` drag data — a deleted worktree must never accept terminals, and
+ * omitting that wrapper excludes it by construction rather than by a flag
+ * `DndProvider` would have to check.
+ */
+export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
+  const panelsById = usePanelStore((s) => s.panelsById);
+  const panelIdsByWorktreeId = usePanelStore((s) => s.panelIdsByWorktreeId);
+  const requestDestructiveAction = useTerminalPendingDestructiveActionStore((s) => s.request);
+  const dismissDeletedWorktree = useWorktreeSelectionStore((s) => s.dismissDeletedWorktree);
+
+  const panels = useMemo(() => {
+    void panelIdsByWorktreeId;
+    return getDeletedWorktreeTerminalIds(worktree.id)
+      .map((id) => panelsById[id])
+      .filter((panel): panel is PanelInstance => panel != null);
+  }, [worktree.id, panelsById, panelIdsByWorktreeId]);
+
+  const handleDismiss = useCallback(() => {
+    if (panels.length === 0) {
+      // Nothing left to confirm — the pruning subscription is about to drop
+      // this row anyway, but dismissing directly keeps the button honest.
+      dismissDeletedWorktree(worktree.id);
+      return;
+    }
+    requestDestructiveAction({
+      kind: "deletedWorktreeDismiss",
+      targetCount: panels.length,
+      runningAgentCount: panels.filter((panel) => deriveTerminalChrome(panel).isAgent).length,
+      worktreeId: worktree.id,
+    });
+  }, [panels, worktree.id, requestDestructiveAction, dismissDeletedWorktree]);
+
+  // Defensive: the store prunes empty deleted-worktree rows, so an empty row should never
+  // reach render. Bailing keeps a torn frame from showing a zero-terminal card.
+  if (panels.length === 0) return null;
+
+  const noun = panels.length === 1 ? "terminal" : "terminals";
+
+  return (
+    <div
+      data-deleted-worktree-id={worktree.id}
+      // The dashed outline is the load-bearing "this is not a real worktree"
+      // signal — live cards are always solid. Everything else stays neutral and
+      // muted on purpose: a deleted worktree is a resting state the user chose,
+      // not a failure, so no error or warning colour appears anywhere here.
+      className="border-b border-border-default bg-surface-inset/40 border-l-2 border-l-transparent outline-dashed outline-1 -outline-offset-1 outline-border-strong/50"
+    >
+      <div className="flex items-start gap-2 px-4 py-3">
+        <FolderX className="w-4 h-4 text-text-muted mt-0.5 shrink-0" aria-hidden="true" />
+        <div className="flex-1 min-w-0 space-y-0.5">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="truncate text-sm font-medium text-text-muted">{worktree.title}</span>
+            <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] font-medium text-text-muted">
+              Deleted
+            </span>
+          </div>
+          <div className="truncate text-xs text-text-muted line-through" title={worktree.path}>
+            {worktree.path}
+          </div>
+          <div className="text-xs text-text-muted">Drag terminals to another worktree</div>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className={cn(
+            "shrink-0 rounded-sm text-xs text-text-muted transition-colors",
+            "hover:text-daintree-text focus-visible:outline focus-visible:outline-2",
+            "focus-visible:outline-daintree-accent"
+          )}
+        >
+          {`Close ${panels.length} ${noun}`}
+        </button>
+      </div>
+
+      <SortableContext
+        items={panels.map((panel) => getAccordionDragId(panel.id))}
+        strategy={verticalListSortingStrategy}
+      >
+        <div role="list" aria-label={`Terminals from deleted worktree ${worktree.title}`}>
+          {panels.map((panel, index) => (
+            <SortableWorktreeTerminal
+              key={panel.id}
+              terminal={panel}
+              worktreeId={worktree.id}
+              sourceIndex={index}
+            >
+              <DeletedWorktreeTerminalRow panel={panel} />
+            </SortableWorktreeTerminal>
+          ))}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -51,7 +51,9 @@ import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
-import type { PendingCreation } from "@/store/worktreeStore";
+import type { PendingCreation, DeletedWorktree } from "@/store/worktreeStore";
+import { recordSidebarWorktreeOrder } from "@/store/worktreeStore";
+import { DeletedWorktreeCard } from "@/components/Sidebar/DeletedWorktreeCard";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import {
   selectSidebarVisiblePanelIds,
@@ -178,7 +180,14 @@ interface SidebarRowFlatItem {
   mode: "sortable" | "static";
 }
 
-type SidebarFlatItem = SidebarHeaderFlatItem | SidebarRowFlatItem;
+interface SidebarDeletedWorktreeFlatItem {
+  kind: "deletedWorktree";
+  id: string;
+  worktree: DeletedWorktree;
+  ariaRowIndex: number;
+}
+
+type SidebarFlatItem = SidebarHeaderFlatItem | SidebarRowFlatItem | SidebarDeletedWorktreeFlatItem;
 
 interface SidebarVirtuosoContext {
   activeWorktreeId: string | null;
@@ -248,6 +257,15 @@ function renderSidebarFlatItem(
   item: SidebarFlatItem,
   context: SidebarVirtuosoContext
 ) {
+  if (item.kind === "deletedWorktree") {
+    return (
+      <div role="row" aria-rowindex={item.ariaRowIndex}>
+        <div role="gridcell">
+          <DeletedWorktreeCard worktree={item.worktree} />
+        </div>
+      </div>
+    );
+  }
   if (item.kind === "header") {
     return (
       <div
@@ -530,6 +548,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // moment the dialog submits — defer would make the placeholder lag the
   // dialog close by a frame and lose the perceived-responsiveness win.
   const pendingCreations = useWorktreeSelectionStore((s) => s.pendingCreations);
+  const deletedWorktrees = useWorktreeSelectionStore((s) => s.deletedWorktrees);
   const openCreateDialog = useWorktreeSelectionStore((s) => s.openCreateDialog);
   const dismissPendingCreation = useWorktreeSelectionStore((s) => s.dismissPendingCreation);
 
@@ -1196,10 +1215,46 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // grouped path interleaves sticky header sentinels with static rows; the
   // ungrouped path emits sortable rows so dnd-kit's SortableContext can
   // wrap the whole Virtuoso surface.
+  // Publish the visible order so a worktree deleted later can pin its row to
+  // the slot it currently occupies (#11232). Recorded from an effect rather
+  // than during render because it is a write to module state — reading it
+  // happens once, at deletion, well after this has settled.
+  useEffect(() => {
+    recordSidebarWorktreeOrder(filteredWorktrees.map((w) => w.id));
+  }, [filteredWorktrees]);
+
   const sidebarItems = useMemo<SidebarFlatItem[]>(() => {
     const items: SidebarFlatItem[] = [];
     const pinnedSet = new Set(pinnedWorktrees);
     let nextRowIndex = firstScrollableRowIndex;
+
+    // Deleted worktrees hold the slot their row occupied when it was deleted,
+    // so the terminals the user is looking for stay where they left them
+    // instead of jumping to an edge of the list (#11232). Ties and unknown
+    // positions fall back to deletion order for a stable render.
+    const deletedList = Array.from(deletedWorktrees.values()).sort(
+      (a, b) => a.deletedAt - b.deletedAt
+    );
+    const deletedByIndex = new Map<number, DeletedWorktree[]>();
+    const trailingDeleted: DeletedWorktree[] = [];
+    for (const deleted of deletedList) {
+      if (deleted.pinnedIndex >= 0 && deleted.pinnedIndex < filteredWorktrees.length) {
+        const bucket = deletedByIndex.get(deleted.pinnedIndex);
+        if (bucket) bucket.push(deleted);
+        else deletedByIndex.set(deleted.pinnedIndex, [deleted]);
+      } else {
+        trailingDeleted.push(deleted);
+      }
+    }
+    const pushDeleted = (deleted: DeletedWorktree) => {
+      items.push({
+        kind: "deletedWorktree",
+        id: `deleted-${deleted.id}`,
+        worktree: deleted,
+        ariaRowIndex: nextRowIndex++,
+      });
+    };
+
     if (groupedSections) {
       const orderIndex = new Map(dragStartOrder.map((id, i) => [id, i]));
       for (const section of groupedSections) {
@@ -1223,20 +1278,27 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           });
         }
       }
-    } else {
-      for (let i = 0; i < filteredWorktrees.length; i++) {
-        const w = filteredWorktrees[i]!;
-        items.push({
-          kind: "row",
-          id: `row-${w.id}`,
-          worktreeId: w.id,
-          ariaRowIndex: nextRowIndex++,
-          rowIndex: i,
-          isPinned: pinnedSet.has(w.id),
-          mode: "sortable",
-        });
-      }
+      // Type grouping has no slot for a worktree that no longer has a type to
+      // group by, so deleted rows collect at the end rather than inventing a
+      // section for them.
+      for (const deleted of deletedList) pushDeleted(deleted);
+      return items;
     }
+
+    for (let i = 0; i < filteredWorktrees.length; i++) {
+      for (const deleted of deletedByIndex.get(i) ?? []) pushDeleted(deleted);
+      const w = filteredWorktrees[i]!;
+      items.push({
+        kind: "row",
+        id: `row-${w.id}`,
+        worktreeId: w.id,
+        ariaRowIndex: nextRowIndex++,
+        rowIndex: i,
+        isPinned: pinnedSet.has(w.id),
+        mode: "sortable",
+      });
+    }
+    for (const deleted of trailingDeleted) pushDeleted(deleted);
     return items;
   }, [
     groupedSections,
@@ -1244,6 +1306,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     firstScrollableRowIndex,
     pinnedWorktrees,
     dragStartOrder,
+    deletedWorktrees,
   ]);
 
   // Computed after `sidebarItems` because the indicator counts hidden worktree

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    setActivatorNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+import { usePanelStore } from "@/store/panelStore";
+import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
+import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
+import { DeletedWorktreeCard } from "../DeletedWorktreeCard";
+
+function setPanels(
+  entries: Array<{ id: string; worktreeId: string; location?: string; title?: string }>
+): void {
+  const panelsById: Record<string, unknown> = {};
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  for (const entry of entries) {
+    panelsById[entry.id] = {
+      id: entry.id,
+      kind: "terminal",
+      title: entry.title ?? entry.id,
+      worktreeId: entry.worktreeId,
+      location: entry.location ?? "grid",
+    };
+    const bucket = panelIdsByWorktreeId[entry.worktreeId];
+    if (bucket) bucket.push(entry.id);
+    else panelIdsByWorktreeId[entry.worktreeId] = [entry.id];
+  }
+  usePanelStore.setState({
+    panelIds: entries.map((e) => e.id),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    panelsById: panelsById as never,
+    panelIdsByWorktreeId,
+  });
+}
+
+const worktree: DeletedWorktree = {
+  id: "wt-1",
+  title: "feature/login",
+  path: "/repo/feature-login",
+  deletedAt: 1000,
+  pinnedIndex: 2,
+};
+
+beforeEach(() => {
+  cleanup();
+  useTerminalPendingDestructiveActionStore.getState().clear();
+  useWorktreeSelectionStore.getState().reset();
+  setPanels([]);
+});
+
+describe("DeletedWorktreeCard", () => {
+  it("shows the last-known title, struck-through path, and Deleted badge", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    render(<DeletedWorktreeCard worktree={worktree} />);
+
+    expect(screen.getByText("feature/login")).toBeTruthy();
+    expect(screen.getByText("Deleted")).toBeTruthy();
+    const path = screen.getByText("/repo/feature-login");
+    expect(path.className).toContain("line-through");
+  });
+
+  it("tells the user the one thing they can do with the terminals", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    render(<DeletedWorktreeCard worktree={worktree} />);
+
+    expect(screen.getByText("Drag terminals to another worktree")).toBeTruthy();
+  });
+
+  it("renders a row per surviving terminal", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1", title: "claude" },
+      { id: "t2", worktreeId: "wt-1", title: "shell" },
+    ]);
+    render(<DeletedWorktreeCard worktree={worktree} />);
+
+    expect(screen.getByText("claude")).toBeTruthy();
+    expect(screen.getByText("shell")).toBeTruthy();
+  });
+
+  it("omits trashed and overlay panels, matching what dismissing would close", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1", title: "claude" },
+      { id: "t2", worktreeId: "wt-1", title: "binned", location: "trash" },
+      { id: "t3", worktreeId: "wt-1", title: "assistant", location: "overlay" },
+    ]);
+    render(<DeletedWorktreeCard worktree={worktree} />);
+
+    expect(screen.queryByText("binned")).toBeNull();
+    expect(screen.queryByText("assistant")).toBeNull();
+    expect(screen.getByRole("button", { name: "Close 1 terminal" })).toBeTruthy();
+  });
+
+  it("names the live terminal count on the dismiss button", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+      { id: "t3", worktreeId: "wt-1" },
+    ]);
+    render(<DeletedWorktreeCard worktree={worktree} />);
+
+    expect(screen.getByRole("button", { name: "Close 3 terminals" })).toBeTruthy();
+  });
+
+  it("requests a confirmation rather than closing terminals immediately", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+    ]);
+    render(<DeletedWorktreeCard worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close 2 terminals" }));
+
+    // Destructive tier D1: the click must only stage a confirm, never trash.
+    const pending = useTerminalPendingDestructiveActionStore.getState().pending;
+    expect(pending).toMatchObject({
+      kind: "deletedWorktreeDismiss",
+      targetCount: 2,
+      worktreeId: "wt-1",
+    });
+    expect(usePanelStore.getState().panelsById["t1"]).toBeDefined();
+  });
+
+  it("renders nothing once no terminals remain", () => {
+    setPanels([{ id: "t1", worktreeId: "other" }]);
+    const { container } = render(<DeletedWorktreeCard worktree={worktree} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("exposes no drop-target data, so terminals can never be dropped onto it", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const { container } = render(<DeletedWorktreeCard worktree={worktree} />);
+
+    // The card is identified by its own attribute and must not advertise the
+    // worktree drop payload DndProvider gates on.
+    expect(container.querySelector("[data-deleted-worktree-id='wt-1']")).toBeTruthy();
+    expect(container.querySelector("[data-worktree-drop-target]")).toBeNull();
+  });
+});

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -82,6 +82,20 @@ function buildCopy(pending: TerminalPendingDestructiveActionSnapshot): DialogCop
         confirmLabel: `Trash ${pending.targetCount} ${noun}`,
       };
     }
+    case "deletedWorktreeDismiss": {
+      const noun = pending.targetCount === 1 ? "terminal" : "terminals";
+      const agentNote =
+        pending.runningAgentCount === 0
+          ? ""
+          : pending.runningAgentCount === 1
+            ? " 1 still has a running agent."
+            : ` ${pending.runningAgentCount} still have running agents.`;
+      return {
+        title: `Close ${pending.targetCount} ${noun}?`,
+        description: `These terminals outlived their deleted worktree. Closing them moves them to trash and ends their running processes; they can be restored from trash before garbage collection. Drag them to another worktree instead to keep them.${agentNote}`,
+        confirmLabel: `Close ${pending.targetCount} ${noun}`,
+      };
+    }
   }
 }
 
@@ -154,6 +168,21 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
         );
         const noun = pending.targetCount === 1 ? "session" : "sessions";
         announcement = `Trashed ${pending.targetCount} ${noun}`;
+        break;
+      }
+      case "deletedWorktreeDismiss": {
+        if (!pending.worktreeId) break;
+        // Same executor as `worktreeTrashAll` — the panels still carry the
+        // dead worktree's id, so the worktree-scoped trash reaches exactly
+        // the deleted-worktree row's terminals. Trashing the last one prunes the worktree
+        // row itself, so there is nothing else to clean up here (#11232).
+        void actionService.dispatch(
+          "worktree.sessions.trashAll",
+          { worktreeId: pending.worktreeId, confirmed: true },
+          { source: "user" }
+        );
+        const noun = pending.targetCount === 1 ? "terminal" : "terminals";
+        announcement = `Closed ${pending.targetCount} ${noun}`;
         break;
       }
     }

--- a/src/components/Terminal/__tests__/TerminalDestructiveActionConfirmDialog.deletedWorktree.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalDestructiveActionConfirmDialog.deletedWorktree.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+// ConfirmDialog's scroll-shadow hook observes its scroll container, which jsdom
+// does not implement. Declared as a real ResizeObserver so no cast is needed.
+class ResizeObserverStub implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) {}
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub;
+
+// Typed explicitly so asserting on `toHaveBeenCalledWith` needs no cast.
+const dispatch = vi.fn<(id: string, args: unknown, opts: unknown) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (id: string, args: unknown, opts: unknown) => dispatch(id, args, opts),
+  },
+}));
+
+vi.mock("@/lib/accessibility", () => ({
+  closeAndAnnounce: (clear: () => void) => clear(),
+}));
+
+import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
+import { TerminalDestructiveActionConfirmDialog } from "../TerminalDestructiveActionConfirmDialog";
+
+beforeEach(() => {
+  cleanup();
+  dispatch.mockClear();
+  useTerminalPendingDestructiveActionStore.getState().clear();
+});
+
+function stage(targetCount: number, runningAgentCount = 0): void {
+  useTerminalPendingDestructiveActionStore.getState().request({
+    kind: "deletedWorktreeDismiss",
+    targetCount,
+    runningAgentCount,
+    worktreeId: "wt-1",
+  });
+}
+
+describe("TerminalDestructiveActionConfirmDialog — deleted-worktree dismiss", () => {
+  it("names the count in the confirm button", () => {
+    stage(3);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "Close 3 terminals" })).toBeTruthy();
+  });
+
+  it("uses the singular noun for one terminal", () => {
+    stage(1);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "Close 1 terminal" })).toBeTruthy();
+  });
+
+  it("points at dragging as the alternative to closing", () => {
+    stage(2);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByText(/Drag them to another worktree instead/)).toBeTruthy();
+  });
+
+  it("warns when a terminal still has a running agent", () => {
+    stage(2, 1);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByText(/1 still has a running agent/)).toBeTruthy();
+  });
+
+  it("stays silent about agents when none are running", () => {
+    stage(2, 0);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.queryByText(/running agent/)).toBeNull();
+  });
+
+  it("trashes the worktree's sessions on confirm", () => {
+    stage(2);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close 2 terminals" }));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      "worktree.sessions.trashAll",
+      { worktreeId: "wt-1", confirmed: true },
+      { source: "user" }
+    );
+  });
+
+  it("dispatches nothing while the dialog is merely open", () => {
+    stage(2);
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -8,7 +8,11 @@ import {
 import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
 import type { CIStatusState, PR } from "@shared/types/forge";
 import type { PluginWorktreeLinked } from "@shared/types/plugin";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import {
+  useWorktreeSelectionStore,
+  getDeletedWorktreeTerminalIds,
+  getPinnedDeletedWorktreeIndex,
+} from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { usePulseStore } from "@/store/pulseStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -385,18 +389,54 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           selectionStore.setActiveWorktree(null);
         }
 
-        // Side effect: kill associated terminals
-        const terminalStore = usePanelStore.getState();
-        const idsToKill: string[] = [];
-        for (const id of terminalStore.panelIds) {
-          const t = terminalStore.panelsById[id];
-          if (t && (t.worktreeId ?? undefined) === event.worktreeId) {
-            idsToKill.push(id);
-          }
+        // Side effect: hand surviving terminals to a deleted-worktree row (#11232).
+        //
+        // Removing the worktree used to remove every panel that belonged to
+        // it, which destroyed live agent sessions — worst of all when an agent
+        // deleted its own worktree mid-conversation via `worktree.delete` and
+        // killed itself. "Worktree gone" and "PTY dead" are independent facts
+        // with independent owners (#11083), so the panels are left completely
+        // untouched here: their processes keep running, and the deleted-worktree row only
+        // gives them somewhere to live in the sidebar until the user drags
+        // them to another worktree or dismisses the row.
+        //
+        // Metadata is snapshotted from `worktree`, read above *before*
+        // `applyRemove` dropped it from the live map. Both delete entry points
+        // (the delete dialog and the `worktree.delete` action) funnel through
+        // this event, so they get identical behaviour from this one change.
+        if (worktree && getDeletedWorktreeTerminalIds(event.worktreeId).length > 0) {
+          selectionStore.addDeletedWorktree({
+            id: event.worktreeId,
+            // Detached-HEAD worktrees have no branch; fall back to the folder
+            // name so the row always carries a recognisable last-known title.
+            title:
+              worktree.branch ?? worktree.path.split(/[/\\]/).filter(Boolean).pop() ?? "Unknown",
+            path: worktree.path,
+            deletedAt: Date.now(),
+            pinnedIndex: getPinnedDeletedWorktreeIndex(event.worktreeId),
+          });
         }
-        for (const id of idsToKill) {
-          terminalStore.removePanel(id);
+      })
+    );
+
+    // Deleted-worktree rows are derived state: they exist only while at least one panel
+    // still points at the dead worktree. Watching the panel store (rather than
+    // terminal lifecycle events) means every exit route prunes the row —
+    // moved, trashed, killed, or exited alike. `agent:exited` notably never
+    // fires for a killed terminal (#11110), so an event-driven version of this
+    // would strand a deleted-worktree row holding zero terminals.
+    cleanups.push(
+      usePanelStore.subscribe((state, prevState) => {
+        if (
+          state.panelIdsByWorktreeId === prevState.panelIdsByWorktreeId &&
+          state.panelsById === prevState.panelsById
+        ) {
+          return;
         }
+        if (useWorktreeSelectionStore.getState().deletedWorktrees.size === 0) return;
+        useWorktreeSelectionStore
+          .getState()
+          .pruneDeletedWorktrees(new Set(store.getState().worktrees.keys()));
       })
     );
 
@@ -420,6 +460,14 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           if (!state.worktrees.has(id)) {
             usePulseStore.getState().invalidate(id);
           }
+        }
+        // A host restart can re-hydrate a worktree we had already deleted
+        // (#11232). The real row wins — its terminals were never detached, so
+        // the row would otherwise render a duplicate row for the same id.
+        if (useWorktreeSelectionStore.getState().deletedWorktrees.size > 0) {
+          useWorktreeSelectionStore
+            .getState()
+            .pruneDeletedWorktrees(new Set(state.worktrees.keys()));
         }
       })
     );

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -1,0 +1,310 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import { useProjectStore } from "@/store/projectStore";
+import { usePulseStore } from "@/store/pulseStore";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore, recordSidebarWorktreeOrder } from "@/store/worktreeStore";
+import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+const TEST_EPOCH = "test-epoch";
+let _seq = 0;
+function nextV(): WorktreeEventVersion {
+  return { epoch: TEST_EPOCH, seq: ++_seq };
+}
+
+type PortEventName = "worktree-update" | "worktree-removed" | "worktree-activated";
+
+const listeners = new Map<PortEventName, Set<(data: unknown) => void>>();
+
+function emit(name: PortEventName, data: unknown): void {
+  for (const cb of listeners.get(name) ?? []) cb(data);
+}
+
+function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    path: `/repo/${id}`,
+    name: id,
+    isCurrent: false,
+    branch: `branch-${id}`,
+    isMainWorktree: false,
+    ...overrides,
+  } as WorktreeSnapshot;
+}
+
+/**
+ * Install panels directly into the panel store's normalized shape — the
+ * deleted-worktree row derives its membership from `panelIdsByWorktreeId`, so
+ * the index has to be consistent with `panelsById`.
+ */
+function setPanels(entries: Array<{ id: string; worktreeId: string; location?: string }>): void {
+  const panelsById: Record<string, unknown> = {};
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  for (const entry of entries) {
+    panelsById[entry.id] = {
+      id: entry.id,
+      kind: "terminal",
+      title: entry.id,
+      worktreeId: entry.worktreeId,
+      location: entry.location ?? "grid",
+    };
+    const bucket = panelIdsByWorktreeId[entry.worktreeId];
+    if (bucket) bucket.push(entry.id);
+    else panelIdsByWorktreeId[entry.worktreeId] = [entry.id];
+  }
+  usePanelStore.setState({
+    panelIds: entries.map((e) => e.id),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    panelsById: panelsById as never,
+    panelIdsByWorktreeId,
+  });
+}
+
+function setCurrentProject(path: string | null): void {
+  // Only the path is read by the provider; standing up a full Project here
+  // would couple this test to fields it never exercises.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
+  useProjectStore.setState({ currentProject: project });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  setCurrentProject("/repo/proj");
+  _seq = 0;
+  usePulseStore.getState().invalidateAll();
+  useWorktreeSelectionStore.getState().reset();
+  recordSidebarWorktreeOrder([]);
+  setPanels([]);
+
+  // Minimal worktree-port double: the provider only touches these members, so
+  // the bridge is stubbed rather than reconstructed in full.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => true,
+      request: (_name: string) =>
+        Promise.resolve({ states: [] as WorktreeSnapshot[], epoch: TEST_EPOCH, seq: 0 }),
+      onEvent: (name: PortEventName, cb: (data: unknown) => void) => {
+        let set = listeners.get(name);
+        if (!set) {
+          set = new Set();
+          listeners.set(name, set);
+        }
+        set.add(cb);
+        return () => set?.delete(cb);
+      },
+      onReady: (_cb: () => void) => () => {},
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  listeners.clear();
+  setCurrentProject(null);
+  usePulseStore.getState().invalidateAll();
+  useWorktreeSelectionStore.getState().reset();
+  vi.restoreAllMocks();
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const rendered = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!rendered.result.current) throw new Error("WorktreeStoreContext is null");
+  return { store: rendered.result.current, unmount: rendered.unmount };
+}
+
+function removeEvent(worktreeId: string) {
+  return { type: "worktree-removed", worktreeId, ...nextV() };
+}
+
+describe("WorktreeStoreProvider — surviving terminals on worktree removal", () => {
+  it("keeps the panels alive instead of removing them (#11232)", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([
+      { id: "agent-a", worktreeId: "wt-1" },
+      { id: "agent-b", worktreeId: "wt-1" },
+      { id: "other", worktreeId: "wt-2" },
+    ]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    // The whole point of the issue: deleting the worktree must not destroy the
+    // agent sessions that lived in it.
+    expect(usePanelStore.getState().panelsById["agent-a"]).toBeDefined();
+    expect(usePanelStore.getState().panelsById["agent-b"]).toBeDefined();
+    expect(usePanelStore.getState().panelIds).toContain("agent-a");
+  });
+
+  it("records a deleted-worktree row carrying the last-known title and path", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+    expect(row).toMatchObject({ id: "wt-1", title: "branch-wt-1", path: "/repo/wt-1" });
+  });
+
+  it("falls back to the folder name when the worktree had no branch", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1", { branch: undefined })], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.title).toBe("wt-1");
+  });
+
+  it("pins the row to the slot it held in the sidebar", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    recordSidebarWorktreeOrder(["wt-0", "wt-1", "wt-2"]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.pinnedIndex).toBe(1);
+  });
+
+  it("creates no row when the worktree held no terminals", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "other", worktreeId: "wt-2" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
+  });
+
+  it("ignores panels already in the trash when deciding to create a row", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "gone", worktreeId: "wt-1", location: "trash" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
+  });
+
+  it("creates no row for the main worktree, which removal blocks outright", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-main", { isMainWorktree: true })], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-main" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-main"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
+    expect(usePanelStore.getState().panelsById["agent-a"]).toBeDefined();
+  });
+
+  it("drops the row when its last terminal leaves", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+
+    // Dragging the last terminal to a live worktree re-parents the panel, which
+    // must silently retire the row.
+    act(() => {
+      setPanels([{ id: "agent-a", worktreeId: "wt-live" }]);
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
+  it("keeps the row while any terminal remains", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([
+      { id: "agent-a", worktreeId: "wt-1" },
+      { id: "agent-b", worktreeId: "wt-1" },
+    ]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+    act(() => {
+      setPanels([{ id: "agent-b", worktreeId: "wt-1" }]);
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+  });
+
+  it("drops the row when a live worktree reclaims its id", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+
+    // A workspace-host restart re-hydrates the worktree; the real row wins so
+    // the sidebar never shows two rows for one id.
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+});

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const panelState = {
+  panelIdsByWorktreeId: {} as Record<string, string[]>,
+  panelsById: {} as Record<string, { id: string; location: string }>,
+};
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => panelState },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    applyRendererPolicy: vi.fn(),
+    getInstance: vi.fn(),
+  },
+}));
+
+import {
+  useWorktreeSelectionStore,
+  getDeletedWorktreeTerminalIds,
+  getPinnedDeletedWorktreeIndex,
+  recordSidebarWorktreeOrder,
+  type DeletedWorktree,
+} from "@/store/worktreeStore";
+
+function makeDeleted(overrides: Partial<DeletedWorktree> = {}): DeletedWorktree {
+  return {
+    id: "wt-1",
+    title: "feature/x",
+    path: "/repo/wt-1",
+    deletedAt: 1000,
+    pinnedIndex: 0,
+    ...overrides,
+  };
+}
+
+function setPanels(entries: Array<{ id: string; worktreeId: string; location?: string }>): void {
+  panelState.panelIdsByWorktreeId = {};
+  panelState.panelsById = {};
+  for (const entry of entries) {
+    const location = entry.location ?? "grid";
+    panelState.panelsById[entry.id] = { id: entry.id, location };
+    const bucket = panelState.panelIdsByWorktreeId[entry.worktreeId];
+    if (bucket) bucket.push(entry.id);
+    else panelState.panelIdsByWorktreeId[entry.worktreeId] = [entry.id];
+  }
+}
+
+beforeEach(() => {
+  setPanels([]);
+  recordSidebarWorktreeOrder([]);
+  useWorktreeSelectionStore.getState().reset();
+});
+
+describe("getDeletedWorktreeTerminalIds", () => {
+  it("returns only panels that dismissing would actually close", () => {
+    setPanels([
+      { id: "live", worktreeId: "wt-1" },
+      { id: "docked", worktreeId: "wt-1", location: "dock" },
+      { id: "trashed", worktreeId: "wt-1", location: "trash" },
+      { id: "assistant", worktreeId: "wt-1", location: "overlay" },
+      { id: "elsewhere", worktreeId: "wt-2" },
+    ]);
+
+    // Must mirror bulkTrashByWorktree's filter so the confirm's count matches
+    // what confirming closes.
+    expect(getDeletedWorktreeTerminalIds("wt-1")).toEqual(["live", "docked"]);
+  });
+
+  it("returns empty for a worktree with no panels", () => {
+    setPanels([{ id: "a", worktreeId: "other" }]);
+    expect(getDeletedWorktreeTerminalIds("wt-1")).toEqual([]);
+  });
+});
+
+describe("pinned index", () => {
+  it("reports the slot a worktree occupied in the last recorded sidebar order", () => {
+    recordSidebarWorktreeOrder(["a", "b", "c"]);
+    expect(getPinnedDeletedWorktreeIndex("b")).toBe(1);
+  });
+
+  it("reports -1 for a worktree that was not visible", () => {
+    recordSidebarWorktreeOrder(["a", "b"]);
+    expect(getPinnedDeletedWorktreeIndex("hidden")).toBe(-1);
+  });
+});
+
+describe("addDeletedWorktree", () => {
+  it("records the worktree keyed by its former id", () => {
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+    const stored = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+    expect(stored).toMatchObject({ title: "feature/x", path: "/repo/wt-1" });
+  });
+
+  it("keeps the first record when the same id is added twice", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted({ deletedAt: 1000, pinnedIndex: 2 }));
+    store.addDeletedWorktree(makeDeleted({ deletedAt: 9999, pinnedIndex: 7 }));
+
+    const stored = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+    expect(stored?.deletedAt).toBe(1000);
+    expect(stored?.pinnedIndex).toBe(2);
+  });
+});
+
+describe("dismissDeletedWorktree", () => {
+  it("removes the row", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted());
+    store.dismissDeletedWorktree("wt-1");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
+  it("leaves state untouched for an unknown id", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted());
+    const before = useWorktreeSelectionStore.getState().deletedWorktrees;
+    store.dismissDeletedWorktree("nope");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+});
+
+describe("pruneDeletedWorktrees", () => {
+  it("drops a row once its last terminal is gone", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set());
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+
+    setPanels([]);
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set());
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
+  it("treats a terminal moved to another worktree as gone", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+
+    setPanels([{ id: "t1", worktreeId: "wt-live" }]);
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set(["wt-live"]));
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
+  it("treats trashing the last terminal as gone", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+
+    setPanels([{ id: "t1", worktreeId: "wt-1", location: "trash" }]);
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set());
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
+  it("drops a row whose id a live worktree reclaimed", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+
+    // A workspace-host restart re-hydrates the worktree we had already
+    // recorded as deleted; the real row owns the id from here on.
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set(["wt-1"]));
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
+  it("keeps rows that still hold terminals", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted({ id: "wt-1" }));
+    store.addDeletedWorktree(makeDeleted({ id: "wt-2" }));
+
+    setPanels([{ id: "t2", worktreeId: "wt-2" }]);
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set());
+
+    const remaining = useWorktreeSelectionStore.getState().deletedWorktrees;
+    expect(remaining.has("wt-1")).toBe(false);
+    expect(remaining.has("wt-2")).toBe(true);
+  });
+
+  it("returns the same state object when nothing is stale", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+    const before = useWorktreeSelectionStore.getState().deletedWorktrees;
+
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set());
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+});
+
+describe("reset", () => {
+  it("clears deleted worktrees", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(makeDeleted());
+    useWorktreeSelectionStore.getState().reset();
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
+  });
+});

--- a/src/store/terminalPendingDestructiveActionStore.ts
+++ b/src/store/terminalPendingDestructiveActionStore.ts
@@ -18,7 +18,12 @@ export type TerminalPendingDestructiveActionKind =
   | "killAll"
   | "restartAll"
   | "worktreeRestartAll"
-  | "worktreeTrashAll";
+  | "worktreeTrashAll"
+  // Closing the terminals held by a deleted worktree's deleted-worktree row (#11232).
+  // Executes through `worktree.sessions.trashAll` like `worktreeTrashAll`;
+  // it exists as its own kind purely so the copy can speak about a worktree
+  // that no longer exists rather than "this worktree".
+  | "deletedWorktreeDismiss";
 
 export interface TerminalPendingDestructiveActionSnapshot {
   kind: TerminalPendingDestructiveActionKind;

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -29,6 +29,79 @@ export interface PendingCreation {
   error?: string;
 }
 
+/**
+ * A worktree whose directory is gone but whose terminals are still alive
+ * (#11232). Deleting a worktree used to kill every terminal that belonged to
+ * it, which silently destroyed an agent's conversation — most painfully when
+ * the agent deleted its *own* worktree via the `worktree.delete` action.
+ *
+ * The row keeps the sidebar row alive so those terminals have somewhere to
+ * live until the user drags them to another worktree or dismisses the row.
+ * Only display metadata is snapshotted here: membership is *derived* from the
+ * panel store (see `getDeletedWorktreeTerminalIds`), so a terminal leaving by
+ * any route — moved, trashed, killed, or exited — shrinks the row without
+ * this store having to observe terminal lifecycle events at all.
+ */
+export interface DeletedWorktree {
+  id: string;
+  /**
+   * Last known display name — the branch, or the directory name when the
+   * worktree had no branch to speak of (detached HEAD). Snapshotted because
+   * nothing can look it up again: git has forgotten the worktree entirely.
+   */
+  title: string;
+  path: string;
+  deletedAt: number;
+  /**
+   * Index the row occupied in the sidebar's scrollable list when it was
+   * deleted, so the row holds its slot instead of jumping to an edge.
+   *
+   * A deleted worktree cannot re-sort like a live worktree — the git status and activity
+   * timestamps its sort keys derive from froze at deletion — so the position
+   * is pinned once here rather than recomputed. `-1` means the row was not
+   * visible (filtered out, or deleted before the sidebar ever rendered it),
+   * in which case the row appends.
+   */
+  pinnedIndex: number;
+}
+
+/**
+ * The sidebar's most recent visible worktree order, published by
+ * `SidebarContent` so a deleted worktree can be pinned to the slot its row occupied.
+ *
+ * Deliberately a module-level value rather than store state: it changes on
+ * every filter/sort keystroke and is read exactly once (at deletion), so
+ * putting it in the store would re-render every subscriber for data nothing
+ * renders from.
+ */
+let lastSidebarWorktreeOrder: readonly string[] = [];
+
+export function recordSidebarWorktreeOrder(ids: readonly string[]): void {
+  lastSidebarWorktreeOrder = ids;
+}
+
+export function getPinnedDeletedWorktreeIndex(worktreeId: string): number {
+  return lastSidebarWorktreeOrder.indexOf(worktreeId);
+}
+
+/**
+ * Terminals still held by a deleted worktree's row.
+ *
+ * Mirrors `bulkTrashByWorktree`'s filter exactly (trash + overlay excluded) so
+ * the count shown in the dismiss confirm always matches what dismissing
+ * actually closes (#9699). Overlay panels are the Daintree Assistant, not
+ * worktree sessions.
+ */
+export function getDeletedWorktreeTerminalIds(worktreeId: string): string[] {
+  const { panelIdsByWorktreeId, panelsById } = usePanelStore.getState();
+  const ids = panelIdsByWorktreeId[worktreeId];
+  if (!ids || ids.length === 0) return [];
+  return ids.filter((id) => {
+    const panel = panelsById[id];
+    return panel != null && panel.location !== "trash" && panel.location !== "overlay";
+  });
+}
+
 interface QuickCreateState {
   isOpen: boolean;
   issue: Issue | null;
@@ -64,6 +137,13 @@ interface WorktreeSelectionState {
   focusedWorktreeId: string | null;
   pendingWorktreeId: string | null;
   pendingCreations: Map<string, PendingCreation>;
+  /**
+   * Deleted worktrees whose terminals outlived them, keyed by the former
+   * worktree id (#11232). In-memory only — a deleted directory no longer
+   * exists and git has forgotten the worktree, so there is nothing for the
+   * restore pipeline's cwd inference to resolve on the next launch.
+   */
+  deletedWorktrees: Map<string, DeletedWorktree>;
   expandedWorktrees: Set<string>;
   expandedTerminals: Set<string>;
   createDialog: CreateDialogState;
@@ -103,6 +183,9 @@ interface WorktreeSelectionState {
   resolvePendingCreation: (path: string) => void;
   failPendingCreation: (path: string, error: string) => void;
   dismissPendingCreation: (path: string) => void;
+  addDeletedWorktree: (worktree: DeletedWorktree) => void;
+  dismissDeletedWorktree: (worktreeId: string) => void;
+  pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
   toggleWorktreeExpanded: (id: string) => void;
   setWorktreeExpanded: (id: string, expanded: boolean) => void;
   collapseAllWorktrees: () => void;
@@ -450,6 +533,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   focusedWorktreeId: null,
   pendingWorktreeId: null,
   pendingCreations: new Map<string, PendingCreation>(),
+  deletedWorktrees: new Map<string, DeletedWorktree>(),
   expandedWorktrees: new Set<string>(),
   expandedTerminals: new Set<string>(),
   createDialog: {
@@ -697,6 +781,46 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       const next = new Map(state.pendingCreations);
       next.delete(path);
       return { pendingCreations: next };
+    });
+  },
+
+  addDeletedWorktree: (worktree) => {
+    set((state) => {
+      // Re-recording an id already present would reset `deletedAt` and reorder
+      // the row for no user-visible gain; the first record wins.
+      if (state.deletedWorktrees.has(worktree.id)) return state;
+      const next = new Map(state.deletedWorktrees);
+      next.set(worktree.id, worktree);
+      return { deletedWorktrees: next };
+    });
+  },
+
+  dismissDeletedWorktree: (worktreeId) => {
+    set((state) => {
+      if (!state.deletedWorktrees.has(worktreeId)) return state;
+      const next = new Map(state.deletedWorktrees);
+      next.delete(worktreeId);
+      return { deletedWorktrees: next };
+    });
+  },
+
+  pruneDeletedWorktrees: (liveWorktreeIds) => {
+    set((state) => {
+      if (state.deletedWorktrees.size === 0) return state;
+      const stale: string[] = [];
+      for (const id of state.deletedWorktrees.keys()) {
+        // A row dies when its last terminal leaves (silently — the row
+        // simply stops being useful), or when a real worktree reclaims the id,
+        // which happens when the workspace host restarts and re-hydrates a
+        // worktree we had already deleted.
+        if (liveWorktreeIds.has(id) || getDeletedWorktreeTerminalIds(id).length === 0) {
+          stale.push(id);
+        }
+      }
+      if (stale.length === 0) return state;
+      const next = new Map(state.deletedWorktrees);
+      for (const id of stale) next.delete(id);
+      return { deletedWorktrees: next };
     });
   },
 
@@ -1036,6 +1160,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       focusedWorktreeId: null,
       pendingWorktreeId: null,
       pendingCreations: new Map<string, PendingCreation>(),
+      deletedWorktrees: new Map<string, DeletedWorktree>(),
       expandedWorktrees: new Set<string>(),
       expandedTerminals: new Set<string>(),
       createDialog: {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -819,3 +819,54 @@ describe("restorePanelsPhase — savedIdToRestoredId remap (issue #10440)", () =
     expect(savedIdToRestoredId.size).toBe(0);
   });
 });
+
+describe("restorePanelsPhase — panels outliving their worktree (issue #11232)", () => {
+  // Only `id` is read when deciding whether a saved worktreeId still resolves,
+  // so the rest of WorktreeState is left off rather than stubbed per test.
+  const worktreeList = (...ids: string[]) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    Promise.resolve(ids.map((id) => ({ id, path: `/repo/${id}` })) as never);
+
+  it("re-homes a saved panel whose worktree no longer exists", async () => {
+    // Deleting a worktree now leaves its terminals running, and the sidebar row
+    // holding them is in-memory only — so a saved panel can name a worktree
+    // that is gone. Restoring it as-is would strand a live PTY off-screen,
+    // since the grid and dock both filter by the active worktree.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA"),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    await restorePanelsPhase([panel("t1", { worktreeId: "deleted-wt" })], ctx);
+
+    expect(ctx.addPanel).toHaveBeenCalledTimes(1);
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+  });
+
+  it("leaves a saved panel alone when its worktree still exists", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList("wA", "wB"),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    await restorePanelsPhase([panel("t1", { worktreeId: "wB" })], ctx);
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wB" });
+  });
+
+  it("keeps the saved worktree when the worktree list is unavailable", async () => {
+    // Nothing is known about which worktrees exist, so re-homing would be a
+    // guess — the previous behaviour (trust the saved id) is the safe default.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: Promise.resolve(null),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    await restorePanelsPhase([panel("t1", { worktreeId: "wB" })], ctx);
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wB" });
+  });
+});

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -126,6 +126,35 @@ export async function restorePanelsPhase(
   const { batchSize: restoreBatchSize, delayMs: restoreBatchDelayMs } =
     getRestoreBatchParams(resourceProfile);
 
+  // A panel can outlive its worktree (#11232): deleting a worktree leaves its
+  // terminals running, and the sidebar row that holds them is in-memory only.
+  // So a saved panel may point at a worktree that no longer exists, and both
+  // the grid and the dock filter by the active worktree — restoring it as-is
+  // would leave a live PTY on screen nowhere, unreachable even to close.
+  // Re-home those to the active worktree instead.
+  //
+  // The id set is derived once and awaited at each use. `worktreesPromise` is
+  // already in flight (the orphan phase below awaits the same one), so this
+  // costs a microtask per panel once resolved — and unlike sampling a variable
+  // the loader may not have filled yet, it cannot silently skip the re-home.
+  let knownWorktreeIdsPromise: Promise<Set<string> | null> | null = null;
+  const getKnownWorktreeIds = (): Promise<Set<string> | null> => {
+    knownWorktreeIdsPromise ??= worktreesPromise.then((list) =>
+      list ? new Set(list.map((w) => w.id)) : null
+    );
+    return knownWorktreeIdsPromise;
+  };
+  const resolveRestoredWorktreeId = async (
+    worktreeId: string | undefined
+  ): Promise<string | undefined> => {
+    if (!worktreeId) return activeWorktreeId ?? worktreeId;
+    const known = await getKnownWorktreeIds();
+    // With no worktree list there is nothing to check the id against, so
+    // re-homing would be a guess — keep what was saved.
+    if (!known || known.has(worktreeId)) return worktreeId;
+    return activeWorktreeId ?? worktreeId;
+  };
+
   if (savedPanels && savedPanels.length > 0) {
     // Build a single-pass map of worktreeId → highest lastActiveAt across saved
     // panels. The restore predicate uses this to promote each non-active
@@ -208,10 +237,9 @@ export async function restorePanelsPhase(
             logHydrationInfo(`Reconnecting to terminal: ${saved.id}`);
 
             const args = buildArgsForBackendTerminal(backendTerminal, saved, projectRoot || "");
-            // Assign to active worktree if terminal has no worktreeId
-            if (!args.worktreeId && activeWorktreeId) {
-              args.worktreeId = activeWorktreeId;
-            }
+            // Assign to the active worktree when the terminal has no worktree,
+            // or names one that no longer exists.
+            args.worktreeId = await resolveRestoredWorktreeId(args.worktreeId);
             const location = args.location as "grid" | "dock";
 
             logHydrationInfo(`[HYDRATION] Adding terminal from backend:`, {
@@ -284,11 +312,12 @@ export async function restorePanelsPhase(
                   saved,
                   projectRoot || ""
                 );
-                // Assign to active worktree when a legacy saved panel has
-                // no worktreeId (mirrors the matched-backend path).
-                if (!reconnectArgs.worktreeId && activeWorktreeId) {
-                  reconnectArgs.worktreeId = activeWorktreeId;
-                }
+                // Assign to the active worktree when a legacy saved panel has
+                // no worktreeId, or names a deleted one (mirrors the
+                // matched-backend path).
+                reconnectArgs.worktreeId = await resolveRestoredWorktreeId(
+                  reconnectArgs.worktreeId
+                );
                 const restoredTerminalId = await addPanel(reconnectArgs);
                 restoredIdsByIndex.set(capturedIndex, restoredTerminalId);
 
@@ -335,10 +364,10 @@ export async function restorePanelsPhase(
                   projectPresetsByAgent
                 );
 
-                // Assign to active worktree if the saved terminal has no worktreeId
-                if (!respawnArgs.worktreeId && activeWorktreeId) {
-                  respawnArgs.worktreeId = activeWorktreeId;
-                }
+                // Assign to the active worktree when the saved terminal has no
+                // worktreeId, or names a deleted one — which also keeps the
+                // respawn's cwd pointing at a directory that still exists.
+                respawnArgs.worktreeId = await resolveRestoredWorktreeId(respawnArgs.worktreeId);
 
                 logHydrationInfo(
                   `Respawning PTY panel: ${saved.id} (${respawnArgs.launchAgentId ? "agent" : "terminal"})`


### PR DESCRIPTION
## Summary

- Deleting a git worktree was killing every panel with a matching `worktreeId`, which destroyed live agent terminal sessions. Worst case: an agent deletes its own worktree mid-conversation via the `worktree.delete` action and kills itself, losing the whole conversation.
- On `worktree-removed`, panels are now left alone so their PTYs keep running, and a deleted-worktree record is created so a sidebar row can hold them until the user drags the terminals to another worktree or dismisses the row.
- Both delete entry points, the delete dialog and the `worktree.delete` action/MCP path, funnel through this single event, so one renderer-side change covers both. No main-process changes were needed.

Resolves #11232

## What the row does

- Muted, dashed card with the last-known title, a struck-through path, and a neutral "Deleted" badge. No error or warning colors, since this is a resting state the user chose.
- Shows only the surviving terminals and that title. No git status, no branch operations, no open-in-editor.
- Subtitle reads "Drag terminals to another worktree", `FolderX` icon.
- Holds the slot the worktree occupied in the sidebar rather than jumping to an edge.
- Retires itself silently once its last terminal leaves, or when a live worktree reclaims the id after a workspace-host restart.
- Dismissal is a D1 confirm naming the live terminal count ("Close 3 terminals"), executed through the existing `worktree.sessions.trashAll` action, so no new action id was needed and closing is recoverable from trash.

## Design notes

- Membership in the row is derived from `panelIdsByWorktreeId` rather than tracked. A terminal leaving by any route (moved, trashed, killed, exited) shrinks the row without the row ever observing terminal lifecycle events. That sidesteps the trap where `agent:exited` never fires for a killed terminal.
- The card deliberately doesn't use `SortableWorktreeCard`, which is what registers a card as a drop target via `type: "worktree"` drag data. So the deleted-worktree card can never accept terminals, by construction rather than by a flag, while its terminals stay draggable.
- The grid and dock both filter by the active worktree, and a deleted worktree can never be active, so its terminals are genuinely not viewable in place. That's why dragging them out is the real affordance, and why the card says so.
- Second commit handles hydration: since panels can now outlive their worktree, a saved panel could restore pointing at a worktree that no longer exists and land invisible, a live PTY unreachable even to close. Restore now falls back to the active worktree when a saved `worktreeId` no longer resolves.

## Scope

- These rows are in-memory only and clear on app restart. A deleted directory can't be resolved by the restore pipeline's cwd inference, and git has forgotten the worktree entirely. The second commit at least makes those terminals land somewhere reachable instead of invisible.
- Dragging a terminal out only re-parents the panel. Its PTY keeps the now-dead cwd. A full rescue needs restart-with-resume, which the original issue scopes out, so terminal restart in the new worktree remains the available option.
- Platform asymmetry: on Windows, a directory can't be deleted while a ConPTY shell holds it as cwd, so `git worktree remove` hard-fails there and the self-delete scenario usually never reaches this state in the first place. Existing retry/backoff already fails closed, so nothing new was added for it.

## Naming

Called "deleted worktrees" rather than "ghost worktrees" because `ghost` already means the drag preview elsewhere in this codebase (`DRAG_GHOST_OPACITY`), including inside the very component these rows reuse.

## Testing

- 4 new test files: store actions, the `worktree-removed` contract, the card component, and the confirm dialog copy/dispatch.
- 3 regression tests in the restore phase.
- Locally green: 3273 tests / 691 suites across every module the branch touches, plus `typecheck`, `lint:ratchet`, `check:confirm-wiring`, and the accent-guard contract.