### PR TITLE
fix(hydration): stop agent terminals collapsing into the active worktree on cold restart

### DIFF
--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -869,4 +869,28 @@ describe("restorePanelsPhase — panels outliving their worktree (issue #11232)"
 
     expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wB" });
   });
+
+  it("keeps saved worktrees when the list is empty (#11234)", async () => {
+    // Hydration races backend init, so `worktree.getAll()` answers [] while the
+    // workspace host is still registering. Reading that as "every worktree is
+    // gone" collapsed every panel into the active worktree, and the save loop
+    // persisted the result — so the damage compounded on each restart. An
+    // active worktree must be set here, otherwise `activeWorktreeId ?? saved`
+    // returns the saved id anyway and the regression hides.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: Promise.resolve([]),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    ctx.backendTerminalMap.set("t2", backend("t2"));
+
+    await restorePanelsPhase(
+      [panel("t1", { worktreeId: "wB" }), panel("t2", { worktreeId: "wC" })],
+      ctx
+    );
+
+    // Distinct homes surviving is the invariant: the bug funnelled both into "wA".
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wB" });
+    expect(ctx.addPanel.mock.calls[1]![0]).toMatchObject({ worktreeId: "wC" });
+  });
 });

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -589,13 +589,20 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     // panelRestorePhase for why a cold boot can answer [] while the workspace
     // host is still registering.
     const worktreesAreKnown = worktrees !== null && worktrees.length > 0;
+    // Restore re-homes a stranded panel onto the saved active worktree, so a
+    // saved selection that is itself gone re-homes onto a dead id. Cleanup
+    // would then kill that panel's PTY before the fallback below repairs the
+    // selection. Skipping cleanup for one boot lets the repaired selection
+    // persist, and the next boot re-homes onto a live worktree.
+    const activeWorktreeIsLive =
+      !savedActiveId || (worktrees?.some((wt) => wt.id === savedActiveId) ?? false);
 
     // Runs after terminals are restored so it sees the full list. Destructive —
-    // removePanel kills the PTY — so it only runs against a list we can trust:
-    // restore keeps a saved worktreeId when the list is unknown (#11234), and
-    // cleanup would read that survivor as a deleted worktree and kill a live
-    // agent terminal, the exact outcome #11232 ruled out.
-    if (worktreesAreKnown) {
+    // removePanel kills the PTY — so it only runs on a coherent worktree
+    // picture: restore keeps a saved worktreeId when the list is unknown
+    // (#11234), and cleanup would read that survivor as a deleted worktree and
+    // kill a live agent terminal, the exact outcome #11232 ruled out.
+    if (worktreesAreKnown && activeWorktreeIsLive) {
       try {
         const { cleanupOrphanedTerminals } = await import("@/store/createWorktreeStore");
         cleanupOrphanedTerminals();

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -596,11 +596,14 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     const worktrees = await worktreesPromise;
     const savedActiveId = appState.activeWorktreeId;
 
-    if (worktrees === null) {
+    // An empty list means the worktree set is unknown, not that none exist
+    // (#11234) — see `getKnownWorktreeIds` in panelRestorePhase for why. Both
+    // cases keep the saved selection rather than dropping it on the floor.
+    if (worktrees === null || worktrees.length === 0) {
       if (savedActiveId) {
         setActiveWorktree(savedActiveId);
       }
-    } else if (worktrees.length > 0) {
+    } else {
       // Check if the saved active worktree still exists
       const worktreeExists = savedActiveId && worktrees.some((wt) => wt.id === savedActiveId);
 
@@ -617,7 +620,6 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         setActiveWorktree(fallbackWorktree.id);
       }
     }
-    // If no worktrees exist, we don't set any active worktree (handled gracefully)
 
     // Recipe load starts earlier to overlap with hydration work.
     // Recipes are non-critical for first paint; fire-and-forget on both initial load and project switch.

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -582,24 +582,31 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
       }
     }
 
-    // Cleanup orphaned terminals after terminal hydration completes
-    // This must run after terminals are restored to ensure we're checking the full terminal list
-    try {
-      const { cleanupOrphanedTerminals } = await import("@/store/createWorktreeStore");
-      cleanupOrphanedTerminals();
-    } catch (error) {
-      logWarn("Failed to cleanup orphaned terminals", { error });
-    }
-
-    // Restore active worktree with validation.
     // Worktree fetch starts earlier to overlap with terminal restoration.
     const worktrees = await worktreesPromise;
     const savedActiveId = appState.activeWorktreeId;
+    // An empty list means "unknown", not "none" — see `getKnownWorktreeIds` in
+    // panelRestorePhase for why a cold boot can answer [] while the workspace
+    // host is still registering.
+    const worktreesAreKnown = worktrees !== null && worktrees.length > 0;
 
-    // An empty list means the worktree set is unknown, not that none exist
-    // (#11234) — see `getKnownWorktreeIds` in panelRestorePhase for why. Both
-    // cases keep the saved selection rather than dropping it on the floor.
-    if (worktrees === null || worktrees.length === 0) {
+    // Runs after terminals are restored so it sees the full list. Destructive —
+    // removePanel kills the PTY — so it only runs against a list we can trust:
+    // restore keeps a saved worktreeId when the list is unknown (#11234), and
+    // cleanup would read that survivor as a deleted worktree and kill a live
+    // agent terminal, the exact outcome #11232 ruled out.
+    if (worktreesAreKnown) {
+      try {
+        const { cleanupOrphanedTerminals } = await import("@/store/createWorktreeStore");
+        cleanupOrphanedTerminals();
+      } catch (error) {
+        logWarn("Failed to cleanup orphaned terminals", { error });
+      }
+    }
+
+    // An unknown worktree set keeps the saved selection rather than dropping it
+    // on the floor (#11234).
+    if (!worktreesAreKnown) {
       if (savedActiveId) {
         setActiveWorktree(savedActiveId);
       }

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -137,10 +137,18 @@ export async function restorePanelsPhase(
   // already in flight (the orphan phase below awaits the same one), so this
   // costs a microtask per panel once resolved — and unlike sampling a variable
   // the loader may not have filled yet, it cannot silently skip the re-home.
+  //
+  // An empty list counts as unknown, not as "every worktree is gone" (#11234).
+  // Hydration races backend init by design, and `worktree.getAll()` answers []
+  // while the window's workspace host is still registering — indistinguishable
+  // from a real empty list. Empty is never legitimate anyway: `git worktree
+  // list` always reports the main worktree. Treating it as authoritative
+  // re-homed every panel to the active worktree, and the save loop then
+  // persisted that, compounding across restarts.
   let knownWorktreeIdsPromise: Promise<Set<string> | null> | null = null;
   const getKnownWorktreeIds = (): Promise<Set<string> | null> => {
     knownWorktreeIdsPromise ??= worktreesPromise.then((list) =>
-      list ? new Set(list.map((w) => w.id)) : null
+      list && list.length > 0 ? new Set(list.map((w) => w.id)) : null
     );
     return knownWorktreeIdsPromise;
   };

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -140,11 +140,11 @@ export async function restorePanelsPhase(
   //
   // An empty list counts as unknown, not as "every worktree is gone" (#11234).
   // Hydration races backend init by design, and `worktree.getAll()` answers []
-  // while the window's workspace host is still registering — indistinguishable
-  // from a real empty list. Empty is never legitimate anyway: `git worktree
-  // list` always reports the main worktree. Treating it as authoritative
-  // re-homed every panel to the active worktree, and the save loop then
-  // persisted that, compounding across restarts.
+  // while the window's workspace host is still registering. A successful git
+  // enumeration never yields zero — `git worktree list` always reports the main
+  // worktree — so [] only ever means "not ready", never a real count. Treating
+  // it as authoritative re-homed every panel to the active worktree, and the
+  // save loop then persisted that, compounding across restarts.
   let knownWorktreeIdsPromise: Promise<Set<string> | null> | null = null;
   const getKnownWorktreeIds = (): Promise<Set<string> | null> => {
     knownWorktreeIdsPromise ??= worktreesPromise.then((list) =>


### PR DESCRIPTION
## Summary

On a cold restart, agent terminals were collapsing into a single active worktree instead of staying where they were saved. This was a regression from `2a7374d6c` (PR #11233, for #11232).

Resolves #11234

## Root cause

`getKnownWorktreeIds()` in `panelRestorePhase.ts` built its known-id Set with `list ? new Set(...) : null`. An empty array is truthy in JavaScript, so a resolved but empty worktree list turned into an empty Set instead of being treated as unknown. `resolveRestoredWorktreeId()` then read that empty Set as proof that every saved worktree was gone, and re-homed every restored panel onto the active worktree. The normal panel-save loop persisted that result, so the damage compounded on every restart.

## Why the list comes back empty

Hydration is designed to race backend initialization (#8827). `worktree.getAll()` resolves to `[]` while the window's workspace host is still registering: `WorkspaceClient._doGetAllStates` returns `[]` when the per-window host isn't in the pool yet, and `WorkspaceHostPool` only maps `windowId` to project after `load-project` finishes. Over the wire, "host not ready" is indistinguishable from "loaded, zero worktrees." A successful git enumeration never yields zero, since `git worktree list` always reports the main worktree, so `[]` only ever means "not ready."

## The fix

1. An empty list now resolves to null/unknown, so restored panels keep their saved worktree id instead of collapsing onto the active one.
2. The active-worktree restore path shares that same signal. An empty list used to silently restore no active worktree at all, a second latent bug from the same race.
3. Orphan cleanup is now gated on a coherent worktree picture. This one matters on its own: `cleanupOrphanedTerminals` calls `removePanel`, which kills the underlying PTY. The old re-home behavior was accidentally masking that path. With panels no longer re-homed onto the active worktree, a panel whose worktree really was deleted would keep its dead id, and cleanup would kill a live agent terminal, exactly the failure mode #11232 established must never happen. Cleanup now runs only when the list is authoritative and the saved active worktree still exists: a stale saved selection means restore would re-home onto a dead id, so skipping cleanup for one boot lets the fallback logic repair the selection, and the next boot re-homes onto a worktree that's actually alive.

## Testing

- New regression test for the empty-list case in `panelRestorePhase.test.ts`, verified red before green (reverting the guard fails it, with both panels collapsing onto the active worktree).
- 412 tests pass across every module this branch touches, including `stateHydration.recoveryAndOrphans.test.ts`, which covers the cleanup path.
- Full project typecheck is clean.

## Known follow-up

`resolveRestoredWorktreeId` still re-homes to `activeWorktreeId` without validating that it's live. The cleanup gate above stops that from killing a PTY, but the proper fix is to re-home onto a live fallback worktree, which needs `selectFallbackWorktree` extracted out of `index.ts` to avoid a circular import. Worth its own issue.

## Changes

- `src/utils/stateHydration/panelRestorePhase.ts`
- `src/utils/stateHydration/index.ts`
- `src/utils/stateHydration/__tests__/panelRestorePhase.test.ts`
