### PR TITLE
Deleted worktree cards: working drag-out, live-card design, and auto-cleanup countdown

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -951,6 +951,29 @@ export function DndProvider({ children }: DndProviderProps) {
         const actualOverId = parseAccordionDragId(overId) ?? overId;
         const overTerminal = freshTerminalsById[actualOverId];
 
+        // Cross-worktree drop: an accordion drag released over another
+        // worktree's card (either of its two stacked droppable ids) or over a
+        // terminal row inside another worktree's accordion moves the terminal
+        // there instead of reordering. This is the only exit path for
+        // terminals stranded on a deleted worktree's row. The target must be a
+        // LIVE worktree — a terminal row can also belong to a deleted-worktree
+        // row, and moving a terminal INTO a dead worktree would just strand it
+        // on another ghost.
+        const overCardWorktreeId =
+          overData?.type === "worktree" && overData.worktreeId
+            ? overData.worktreeId
+            : parseWorktreeSortDragId(overId);
+        const targetWorktreeId = overCardWorktreeId ?? overTerminal?.worktreeId ?? null;
+        if (targetWorktreeId && targetWorktreeId !== (accordionWorktreeId ?? null)) {
+          const draggedTerminal = freshTerminalsById[actualDraggedId];
+          const isLiveTarget = getCurrentViewStore().getState().worktrees.has(targetWorktreeId);
+          if (isLiveTarget && draggedTerminal && draggedTerminal.worktreeId !== targetWorktreeId) {
+            moveTerminalToWorktree(actualDraggedId, targetWorktreeId);
+            setFocused(null);
+          }
+          return;
+        }
+
         if (overTerminal && actualDraggedId !== actualOverId) {
           const containerTerminals: CarrierPanel[] = [];
           for (const tid of freshTerminalIds) {

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { AlertCircle, Check, RotateCcw } from "lucide-react";
+import { AlertCircle, Check, FolderX, RotateCcw } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -9,7 +9,13 @@ import {
   DEFAULT_WORKTREE_PATH_PATTERN,
 } from "@shared/utils/pathPattern";
 import { actionService } from "@/services/ActionService";
+import {
+  usePreferencesStore,
+  isDeletedWorktreeCleanupSeconds,
+  DELETED_WORKTREE_CLEANUP_DEFAULT,
+} from "@/store/preferencesStore";
 import { SettingsSection } from "./SettingsSection";
+import { SettingsSelect } from "./SettingsSelect";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { useSettingsTabFlush } from "./SettingsFlushRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -34,6 +40,13 @@ const PATTERN_PRESETS = [
 
 const SAMPLE_BRANCH = "feature/example-branch";
 
+const DELETED_WORKTREE_CLEANUP_OPTIONS = [
+  { value: "30", label: "After 30 seconds" },
+  { value: "60", label: "After 1 minute (default)" },
+  { value: "300", label: "After 5 minutes" },
+  { value: "0", label: "Never — close manually" },
+];
+
 export function WorktreeSettingsTab() {
   const [pattern, setPattern] = useState("");
   const [originalPattern, setOriginalPattern] = useState("");
@@ -44,6 +57,13 @@ export function WorktreeSettingsTab() {
   const [savedMessageTimeout, setSavedMessageTimeout] = useState<NodeJS.Timeout | null>(null);
 
   const sampleRootPath = "/Users/name/Projects/my-project";
+
+  const cleanupSeconds = usePreferencesStore((s) => s.deletedWorktreeCleanupSeconds);
+  const setCleanupSeconds = usePreferencesStore((s) => s.setDeletedWorktreeCleanupSeconds);
+  const handleCleanupChange = (value: string) => {
+    const parsed = Number(value);
+    if (isDeletedWorktreeCleanupSeconds(parsed)) setCleanupSeconds(parsed);
+  };
 
   useEffect(() => {
     return () => {
@@ -311,6 +331,23 @@ export function WorktreeSettingsTab() {
             root.
           </p>
         </div>
+      </SettingsSection>
+
+      <SettingsSection
+        icon={FolderX}
+        title="Deleted worktrees"
+        description="When a worktree is deleted while terminals are still running, its terminals stay in a temporary sidebar row until you move or close them."
+      >
+        <SettingsSelect
+          label="Close leftover terminals"
+          description="Leftover terminals move to trash when the timer ends. The timer pauses while a drag is in progress and while an agent is still working."
+          scope="global"
+          value={String(cleanupSeconds)}
+          onValueChange={handleCleanupChange}
+          options={DELETED_WORKTREE_CLEANUP_OPTIONS}
+          isModified={cleanupSeconds !== DELETED_WORKTREE_CLEANUP_DEFAULT}
+          onReset={() => setCleanupSeconds(DELETED_WORKTREE_CLEANUP_DEFAULT)}
+        />
       </SettingsSection>
     </div>
   );

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useMemo } from "react";
-import { FolderX } from "lucide-react";
-import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
+import { FolderX, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
 import {
@@ -8,78 +7,74 @@ import {
   useWorktreeSelectionStore,
   type DeletedWorktree,
 } from "@/store/worktreeStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
-import {
-  SortableWorktreeTerminal,
-  getAccordionDragId,
-} from "@/components/DragDrop/SortableWorktreeTerminal";
-import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
+import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
+import { WorktreeTerminalSection } from "@/components/Worktree/WorktreeCard/WorktreeTerminalSection";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
-import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
-import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
-import { isPtyPanel } from "@shared/types/panel";
-import type { PanelInstance } from "@shared/types/panel";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 
 interface DeletedWorktreeCardProps {
   worktree: DeletedWorktree;
 }
 
 /**
- * A deleted-worktree terminal row.
- *
- * Deliberately *not* `WorktreeTerminalSection`'s `TerminalRow`: that row's
- * primary affordance is click-to-focus, which cannot work here. Both the grid
- * and the dock filter panels by `activeWorktreeId`, and a deleted worktree can
- * never be active — so a deleted-worktree terminal is genuinely unviewable in place. The
- * row therefore presents identity only, and dragging it to a live worktree is
- * the single real affordance (hence the card's subtitle).
- */
-function DeletedWorktreeTerminalRow({ panel }: { panel: PanelInstance }) {
-  const dragHandle = useDragHandle();
-  const chrome = deriveTerminalChrome(panel);
-  const agentState = getTerminalAgentDisplayState(
-    chrome,
-    isPtyPanel(panel) ? panel.agentState : undefined
-  );
-
-  return (
-    <div
-      data-terminal-id={panel.id}
-      data-deleted-worktree-terminal-id={panel.id}
-      data-terminal-runtime-kind={chrome.runtimeKind}
-      data-terminal-agent-id={chrome.agentId || undefined}
-      data-terminal-agent-state={agentState || undefined}
-      ref={dragHandle?.setActivatorNodeRef}
-      {...(dragHandle?.listeners ?? {})}
-      className="group/deletedrow flex items-center gap-2 px-3 py-2 cursor-grab active:cursor-grabbing"
-    >
-      <div className="shrink-0 opacity-60 group-hover/deletedrow:opacity-100 transition-opacity">
-        <TerminalIcon kind={panel.kind} chrome={chrome} className="w-3 h-3" />
-      </div>
-      <span className="truncate text-xs font-medium text-text-secondary" title={panel.title}>
-        {panel.title}
-      </span>
-    </div>
-  );
-}
-
-/**
  * Sidebar row for a worktree whose directory is gone but whose terminals are
  * still running (#11232).
  *
- * Intentionally a separate component rather than a variant of `WorktreeCard`:
- * a deleted worktree has no git status, no branch operations, and nowhere to open an
- * editor, so it renders none of that chrome. It also deliberately does *not*
- * use `SortableWorktreeCard`, which is what registers a card as a drop target
- * via `type: "worktree"` drag data — a deleted worktree must never accept terminals, and
- * omitting that wrapper excludes it by construction rather than by a flag
- * `DndProvider` would have to check.
+ * Shares the live card's design language on purpose: same header scale, the
+ * same `WorktreeTerminalSection` (collapsed "N active" bar with waiting
+ * indicators, expandable rows, drag handles), and the same select-on-click
+ * behaviour — activating it shows its surviving terminals in the grid/dock.
+ * What marks it as deleted is the `FolderX` icon, the badge, the struck-through
+ * path, and a slight fade. It deliberately does *not* use
+ * `SortableWorktreeCard`, which is what registers a card as a drop target via
+ * `type: "worktree"` drag data — a deleted worktree must never accept
+ * terminals, and omitting that wrapper excludes it by construction rather than
+ * by a flag `DndProvider` would have to check.
  */
 export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
   const panelsById = usePanelStore((s) => s.panelsById);
   const panelIdsByWorktreeId = usePanelStore((s) => s.panelIdsByWorktreeId);
+  const setFocused = usePanelStore((s) => s.setFocused);
+  const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
+  const pingTerminal = usePanelStore((s) => s.pingTerminal);
   const requestDestructiveAction = useTerminalPendingDestructiveActionStore((s) => s.request);
   const dismissDeletedWorktree = useWorktreeSelectionStore((s) => s.dismissDeletedWorktree);
+  const isActive = useWorktreeSelectionStore((s) => s.activeWorktreeId === worktree.id);
+  const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
+  const trackTerminalFocus = useWorktreeSelectionStore((s) => s.trackTerminalFocus);
+  const isTerminalsExpanded = useWorktreeSelectionStore((s) =>
+    s.expandedTerminals.has(worktree.id)
+  );
+  const toggleTerminalsExpanded = useWorktreeSelectionStore((s) => s.toggleTerminalsExpanded);
+
+  const { counts, terminals } = useWorktreeTerminals(worktree.id);
+
+  // Auto-cleanup countdown (deletedWorktreeCleanup.ts owns the deadline; this
+  // is display only): a numeric seconds readout in the header plus a depleting
+  // bar along the bottom edge. Both hold at full while the sweep defers the
+  // deadline (drag in progress, agent still working, confirm dialog open).
+  const cleanupSeconds = usePreferencesStore((s) => s.deletedWorktreeCleanupSeconds);
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  const expiresAt = worktree.expiresAt;
+  const hasCountdown = expiresAt !== null && cleanupSeconds > 0;
+  useVisibilityAwareInterval(() => setNowTick(Date.now()), 1000, hasCountdown);
+  // The sweep (which re-extends the deadline while deferred) and this tick run
+  // on independent 1s phases — clamp remaining to the TTL (no "61s" flicker)
+  // and snap the top ~1.5s to exactly full so a paused bar holds steady
+  // instead of sawtoothing between full and full-minus-a-tick.
+  const cleanupMs = cleanupSeconds * 1000;
+  const rawRemainingMs = expiresAt !== null ? Math.max(0, expiresAt - nowTick) : 0;
+  const remainingMs = cleanupMs > 0 ? Math.min(rawRemainingMs, cleanupMs) : rawRemainingMs;
+  const remainingSeconds = Math.ceil(remainingMs / 1000);
+  const remainingFraction = hasCountdown
+    ? remainingMs >= cleanupMs - 1500
+      ? 1
+      : Math.min(1, remainingMs / cleanupMs)
+    : 0;
 
   const panels = useMemo(() => {
     void panelIdsByWorktreeId;
@@ -103,65 +98,157 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
     });
   }, [panels, worktree.id, requestDestructiveAction, dismissDeletedWorktree]);
 
+  // `source: "focus"` — viewing a ghost row is an incidental, session-only
+  // selection. The user-source path would persist the deleted id as the
+  // durable restore target, and after a restart (deletedWorktrees is
+  // in-memory only) panel restoration would re-home surviving sessions onto
+  // an id with neither a live worktree nor a ghost row.
+  const handleSelect = useCallback(() => {
+    selectWorktree(worktree.id, { source: "focus" });
+  }, [selectWorktree, worktree.id]);
+
+  // Mirrors WorktreeCard's handleTerminalSelect: activate this worktree first
+  // so the grid/dock (both filtered by activeWorktreeId) can actually show the
+  // terminal, then focus and ping it.
+  const handleTerminalSelect = useCallback(
+    (terminal: PtyPanelData) => {
+      if (!isActive) {
+        if (terminal.worktreeId) {
+          trackTerminalFocus(terminal.worktreeId, terminal.id);
+        }
+        selectWorktree(worktree.id, { source: "focus" });
+      }
+      if (terminal.location === "dock") {
+        openDockTerminal(terminal.id);
+      } else {
+        setFocused(terminal.id);
+      }
+      pingTerminal(terminal.id);
+    },
+    [
+      isActive,
+      trackTerminalFocus,
+      selectWorktree,
+      worktree.id,
+      openDockTerminal,
+      setFocused,
+      pingTerminal,
+    ]
+  );
+
+  const handleToggleTerminals = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      toggleTerminalsExpanded(worktree.id);
+    },
+    [toggleTerminalsExpanded, worktree.id]
+  );
+
   // Defensive: the store prunes empty deleted-worktree rows, so an empty row should never
   // reach render. Bailing keeps a torn frame from showing a zero-terminal card.
   if (panels.length === 0) return null;
 
   const noun = panels.length === 1 ? "terminal" : "terminals";
+  const closeLabel = `Close ${panels.length} ${noun}`;
 
   return (
     <div
       data-deleted-worktree-id={worktree.id}
-      // The dashed outline is the load-bearing "this is not a real worktree"
-      // signal — live cards are always solid. Everything else stays neutral and
-      // muted on purpose: a deleted worktree is a resting state the user chose,
-      // not a failure, so no error or warning colour appears anywhere here.
-      className="border-b border-border-default bg-surface-inset/40 border-l-2 border-l-transparent outline-dashed outline-1 -outline-offset-1 outline-border-strong/50"
+      className="sidebar-worktree-card group/card relative isolate transition-colors duration-150 border-b border-border-default"
+      data-active={isActive ? "true" : undefined}
+      data-hoverable={!isActive ? "true" : undefined}
+      aria-label={`Deleted worktree: ${worktree.title}`}
+      onClick={handleSelect}
     >
-      <div className="flex items-start gap-2 px-4 py-3">
-        <FolderX className="w-4 h-4 text-text-muted mt-0.5 shrink-0" aria-hidden="true" />
-        <div className="flex-1 min-w-0 space-y-0.5">
-          <div className="flex items-center gap-2 min-w-0">
-            <span className="truncate text-sm font-medium text-text-muted">{worktree.title}</span>
+      <button
+        type="button"
+        data-card-select-overlay=""
+        className="absolute inset-0 z-0 outline-hidden"
+        aria-label={`Select deleted worktree: ${worktree.title}`}
+      />
+      <div
+        className={cn(
+          // The fade is the "this worktree is gone" signal; it lifts on hover,
+          // focus, and while active so the card stays fully usable. Left
+          // padding matches live sidebar rows' drag-handle gutter (w-4 + pl-1)
+          // so the icon sits exactly in line with live branch icons.
+          "relative z-10 pl-5 pr-4 py-3 transition-opacity duration-150",
+          !isActive && "opacity-70 group-hover/card:opacity-100 group-focus-within/card:opacity-100"
+        )}
+      >
+        {/* Mirrors WorktreeHeader's title row: same row height, and the same
+            icon size/stroke/gap/typography as BranchLabel, with FolderX in
+            the branch-type icon's slot. */}
+        <div className="flex items-center gap-2 min-h-[22px]">
+          <span className="flex items-center gap-1.5 min-w-0 flex-1">
+            <FolderX
+              className="w-3.5 h-3.5 text-text-muted shrink-0"
+              strokeWidth={2.5}
+              aria-hidden="true"
+            />
+            <span
+              className="truncate font-mono text-[11px] font-medium text-text-muted"
+              title={worktree.title}
+            >
+              {worktree.title}
+            </span>
             <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] font-medium text-text-muted">
               Deleted
             </span>
+          </span>
+          <div className="flex items-center gap-2 shrink-0">
+            {hasCountdown && (
+              <span
+                className="font-mono text-[11px] tabular-nums text-text-muted"
+                title={`Closes automatically in ${remainingSeconds}s`}
+                data-testid="deleted-worktree-countdown-seconds"
+              >
+                {remainingSeconds}s
+              </span>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDismiss();
+                  }}
+                  className="sidebar-action-button shrink-0 p-1.5 -my-1.5 text-status-error/70 hover:text-status-error rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                  aria-label={closeLabel}
+                >
+                  <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{closeLabel}</TooltipContent>
+            </Tooltip>
           </div>
-          <div className="truncate text-xs text-text-muted line-through" title={worktree.path}>
-            {worktree.path}
-          </div>
-          <div className="text-xs text-text-muted">Drag terminals to another worktree</div>
         </div>
-        <button
-          type="button"
-          onClick={handleDismiss}
-          className={cn(
-            "shrink-0 rounded-sm text-xs text-text-muted transition-colors",
-            "hover:text-daintree-text focus-visible:outline focus-visible:outline-2",
-            "focus-visible:outline-daintree-accent"
-          )}
-        >
-          {`Close ${panels.length} ${noun}`}
-        </button>
+        <div className="truncate text-xs text-text-muted line-through mt-0.5" title={worktree.path}>
+          {worktree.path}
+        </div>
+        <WorktreeTerminalSection
+          worktreeId={worktree.id}
+          isExpanded={isTerminalsExpanded}
+          counts={counts}
+          terminals={terminals}
+          onToggle={handleToggleTerminals}
+          onTerminalSelect={handleTerminalSelect}
+        />
       </div>
-
-      <SortableContext
-        items={panels.map((panel) => getAccordionDragId(panel.id))}
-        strategy={verticalListSortingStrategy}
-      >
-        <div role="list" aria-label={`Terminals from deleted worktree ${worktree.title}`}>
-          {panels.map((panel, index) => (
-            <SortableWorktreeTerminal
-              key={panel.id}
-              terminal={panel}
-              worktreeId={worktree.id}
-              sourceIndex={index}
-            >
-              <DeletedWorktreeTerminalRow panel={panel} />
-            </SortableWorktreeTerminal>
-          ))}
+      {hasCountdown && (
+        <div
+          className="absolute inset-x-0 bottom-0 z-10 h-[2px]"
+          title={`Closes automatically in ${remainingSeconds}s`}
+          data-testid="deleted-worktree-countdown"
+          aria-hidden="true"
+        >
+          <div
+            className="h-full bg-border-strong transition-[width] duration-1000 ease-linear motion-reduce:transition-none"
+            style={{ width: `${remainingFraction * 100}%` }}
+          />
         </div>
-      </SortableContext>
+      )}
     </div>
   );
 }

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -163,7 +163,11 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
       <button
         type="button"
         data-card-select-overlay=""
-        className="absolute inset-0 z-0 outline-hidden"
+        // Unlike the live card's overlay (allowlisted in the focus-ring
+        // contract), this card has no focusable parent row owning keyboard
+        // nav — the overlay button IS the keyboard path, so it carries its
+        // own inset focus ring.
+        className="absolute inset-0 z-0 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
         aria-label={`Select deleted worktree: ${worktree.title}`}
       />
       <div

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
 
 vi.mock("@dnd-kit/sortable", () => ({
-  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SortableContext: ({ children }: { children: ReactNode }) => <>{children}</>,
   verticalListSortingStrategy: {},
   useSortable: () => ({
     attributes: {},
@@ -16,9 +22,22 @@ vi.mock("@dnd-kit/sortable", () => ({
   }),
 }));
 
+vi.mock("@/components/DragDrop/SortableWorktreeTerminal", () => ({
+  SortableWorktreeTerminal: ({ children }: { children: ReactNode }) => <>{children}</>,
+  getAccordionDragId: (id: string) => `accordion-${id}`,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="terminal-row-icon" className={className} />
+  ),
+}));
+
 import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
 import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { DeletedWorktreeCard } from "../DeletedWorktreeCard";
 
 function setPanels(
@@ -46,48 +65,119 @@ function setPanels(
   });
 }
 
+function renderCard(wt: DeletedWorktree = worktree) {
+  return render(
+    <TooltipProvider>
+      <DeletedWorktreeCard worktree={wt} />
+    </TooltipProvider>
+  );
+}
+
 const worktree: DeletedWorktree = {
   id: "wt-1",
   title: "feature/login",
   path: "/repo/feature-login",
   deletedAt: 1000,
+  expiresAt: null,
   pinnedIndex: 2,
 };
+
+const originalSelectWorktree = useWorktreeSelectionStore.getState().selectWorktree;
 
 beforeEach(() => {
   cleanup();
   useTerminalPendingDestructiveActionStore.getState().clear();
   useWorktreeSelectionStore.getState().reset();
+  // reset() restores data fields only — undo any per-test action override.
+  useWorktreeSelectionStore.setState({ selectWorktree: originalSelectWorktree });
+  usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 60 });
   setPanels([]);
 });
 
 describe("DeletedWorktreeCard", () => {
-  it("shows the last-known title, struck-through path, and Deleted badge", () => {
+  it("shows the last-known title, path, and Deleted badge", () => {
     setPanels([{ id: "t1", worktreeId: "wt-1" }]);
-    render(<DeletedWorktreeCard worktree={worktree} />);
+    renderCard();
 
     expect(screen.getByText("feature/login")).toBeTruthy();
     expect(screen.getByText("Deleted")).toBeTruthy();
-    const path = screen.getByText("/repo/feature-login");
-    expect(path.className).toContain("line-through");
+    expect(screen.getByText("/repo/feature-login")).toBeTruthy();
   });
 
-  it("tells the user the one thing they can do with the terminals", () => {
-    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
-    render(<DeletedWorktreeCard worktree={worktree} />);
+  it("shows the live-card terminal summary bar instead of instructional copy", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+    ]);
+    renderCard();
 
-    expect(screen.getByText("Drag terminals to another worktree")).toBeTruthy();
+    expect(screen.queryByText("Drag terminals to another worktree")).toBeNull();
+    // Collapsed WorktreeTerminalSection: count + "active" label, same as live cards.
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("active")).toBeTruthy();
   });
 
-  it("renders a row per surviving terminal", () => {
+  it("lists surviving terminals when the sessions section is expanded", () => {
     setPanels([
       { id: "t1", worktreeId: "wt-1", title: "claude" },
       { id: "t2", worktreeId: "wt-1", title: "shell" },
     ]);
-    render(<DeletedWorktreeCard worktree={worktree} />);
+    useWorktreeSelectionStore.getState().toggleTerminalsExpanded("wt-1");
+    renderCard();
 
     expect(screen.getByText("claude")).toBeTruthy();
     expect(screen.getByText("shell")).toBeTruthy();
+  });
+
+  it("selects the deleted worktree when the card is clicked", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const selectWorktree = vi.fn();
+    useWorktreeSelectionStore.setState({ selectWorktree });
+    renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select deleted worktree: feature/login" }));
+
+    // Session-only selection: a ghost id must never become the persisted
+    // restore target (deletedWorktrees does not survive restarts).
+    expect(selectWorktree).toHaveBeenCalledWith("wt-1", { source: "focus" });
+  });
+
+  it("shows the auto-cleanup countdown bar when a deadline is armed", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const { container } = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
+
+    expect(container.querySelector("[data-testid='deleted-worktree-countdown']")).toBeTruthy();
+  });
+
+  it("shows the seconds readout next to the close button while armed", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const { container } = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
+
+    const readout = container.querySelector("[data-testid='deleted-worktree-countdown-seconds']");
+    expect(readout?.textContent).toMatch(/^\d+s$/);
+  });
+
+  it("hides the countdown bar while auto-cleanup is off or the row is unarmed", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const unarmed = renderCard();
+    expect(
+      unarmed.container.querySelector("[data-testid='deleted-worktree-countdown']")
+    ).toBeNull();
+    cleanup();
+
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
+    const off = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
+    expect(off.container.querySelector("[data-testid='deleted-worktree-countdown']")).toBeNull();
+  });
+
+  it("marks the card active when it is the active worktree", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    const { container } = renderCard();
+
+    expect(
+      container.querySelector("[data-deleted-worktree-id='wt-1']")?.getAttribute("data-active")
+    ).toBe("true");
   });
 
   it("omits trashed and overlay panels, matching what dismissing would close", () => {
@@ -96,7 +186,7 @@ describe("DeletedWorktreeCard", () => {
       { id: "t2", worktreeId: "wt-1", title: "binned", location: "trash" },
       { id: "t3", worktreeId: "wt-1", title: "assistant", location: "overlay" },
     ]);
-    render(<DeletedWorktreeCard worktree={worktree} />);
+    renderCard();
 
     expect(screen.queryByText("binned")).toBeNull();
     expect(screen.queryByText("assistant")).toBeNull();
@@ -109,7 +199,7 @@ describe("DeletedWorktreeCard", () => {
       { id: "t2", worktreeId: "wt-1" },
       { id: "t3", worktreeId: "wt-1" },
     ]);
-    render(<DeletedWorktreeCard worktree={worktree} />);
+    renderCard();
 
     expect(screen.getByRole("button", { name: "Close 3 terminals" })).toBeTruthy();
   });
@@ -119,7 +209,7 @@ describe("DeletedWorktreeCard", () => {
       { id: "t1", worktreeId: "wt-1" },
       { id: "t2", worktreeId: "wt-1" },
     ]);
-    render(<DeletedWorktreeCard worktree={worktree} />);
+    renderCard();
 
     fireEvent.click(screen.getByRole("button", { name: "Close 2 terminals" }));
 
@@ -133,16 +223,27 @@ describe("DeletedWorktreeCard", () => {
     expect(usePanelStore.getState().panelsById["t1"]).toBeDefined();
   });
 
+  it("does not select the worktree when the dismiss button is clicked", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const selectWorktree = vi.fn();
+    useWorktreeSelectionStore.setState({ selectWorktree });
+    renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close 1 terminal" }));
+
+    expect(selectWorktree).not.toHaveBeenCalled();
+  });
+
   it("renders nothing once no terminals remain", () => {
     setPanels([{ id: "t1", worktreeId: "other" }]);
-    const { container } = render(<DeletedWorktreeCard worktree={worktree} />);
+    const { container } = renderCard();
 
     expect(container.firstChild).toBeNull();
   });
 
   it("exposes no drop-target data, so terminals can never be dropped onto it", () => {
     setPanels([{ id: "t1", worktreeId: "wt-1" }]);
-    const { container } = render(<DeletedWorktreeCard worktree={worktree} />);
+    const { container } = renderCard();
 
     // The card is identified by its own attribute and must not advertise the
     // worktree drop payload DndProvider gates on.

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { FolderOpen, GitBranch, Settings } from "lucide-react";
+import { FolderOpen, FolderX, GitBranch, Settings } from "lucide-react";
 import { DaintreeIcon } from "@/components/icons";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Button } from "@/components/ui/button";
@@ -9,6 +9,8 @@ import { cn } from "@/lib/utils";
 import { svgToDataUrl, sanitizeSvg } from "@/lib/svg";
 import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { useRecipeStore } from "@/store/recipeStore";
 import { formatPath, middleTruncate } from "@/utils/textParsing";
@@ -163,6 +165,31 @@ export function ContentGridEmptyState({
   const recipesLoading = useRecipeStore((state) => state.isLoading);
   const { homeDir } = useHomeDir();
 
+  // A deleted worktree can be the active selection (its ghost row is
+  // clickable), and `hasLaunchTarget` is rightly false for it — but the
+  // generic "Select a worktree" copy would gaslight the user who just
+  // selected one. Give the ghost its own state naming the way out.
+  const isDeletedWorktreeActive = useWorktreeSelectionStore(
+    (s) => s.activeWorktreeId !== null && s.deletedWorktrees.has(s.activeWorktreeId)
+  );
+  // Resolved at click time via the view store accessor rather than a hook —
+  // this component also renders in provider-less contexts (tests, scratches),
+  // and the id is only needed once the button is pressed.
+  const handleGoToMainWorktree = () => {
+    const { worktrees } = getCurrentViewStore().getState();
+    let mainId: string | null = null;
+    for (const w of worktrees.values()) {
+      if (w.isMainWorktree) {
+        mainId = w.id;
+        break;
+      }
+      mainId ??= w.id;
+    }
+    if (mainId !== null) {
+      useWorktreeSelectionStore.getState().selectWorktree(mainId);
+    }
+  };
+
   const containerRef = useRef<HTMLDivElement>(null);
 
   // The entry above is DOM-entry motion, which a project switch never re-enters:
@@ -297,15 +324,35 @@ export function ContentGridEmptyState({
             )}
 
             {!hasLaunchTarget && !isWorktreeInitialized && null}
-            {!hasLaunchTarget && isWorktreeInitialized && hasWorktrees && (
-              <EmptyState
-                variant="zero-data"
-                scale="canvas"
-                icon={<FolderOpen />}
-                title="Select a worktree"
-                description="Choose a worktree from the sidebar to open it in the canvas"
-              />
-            )}
+            {!hasLaunchTarget &&
+              isWorktreeInitialized &&
+              hasWorktrees &&
+              isDeletedWorktreeActive && (
+                <EmptyState
+                  variant="zero-data"
+                  scale="canvas"
+                  icon={<FolderX />}
+                  title="Worktree deleted"
+                  description="Its leftover terminals stay in the sidebar row until they close — drag them to another worktree to keep them"
+                  action={
+                    <Button variant="outline" size="sm" onClick={handleGoToMainWorktree}>
+                      Go to main worktree
+                    </Button>
+                  }
+                />
+              )}
+            {!hasLaunchTarget &&
+              isWorktreeInitialized &&
+              hasWorktrees &&
+              !isDeletedWorktreeActive && (
+                <EmptyState
+                  variant="zero-data"
+                  scale="canvas"
+                  icon={<FolderOpen />}
+                  title="Select a worktree"
+                  description="Choose a worktree from the sidebar to open it in the canvas"
+                />
+              )}
             {!hasLaunchTarget && isWorktreeInitialized && !hasWorktrees && (
               <EmptyState
                 variant="zero-data"

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { reduceMotionSelectors } from "./launcherMotionContract";
 
@@ -44,6 +44,7 @@ vi.mock("@/components/Pulse", () => ({
 }));
 
 import { ContentGridEmptyState } from "../ContentGridEmptyState";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 const PROJECT_PROPS = {
   hasLaunchTarget: true,
@@ -407,5 +408,40 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
         expect(screen.queryByText("Select a worktree")).toBeNull();
       }
     );
+  });
+
+  describe("an active deleted worktree", () => {
+    beforeEach(() => {
+      useWorktreeSelectionStore.getState().reset();
+      useWorktreeSelectionStore.getState().addDeletedWorktree({
+        id: "ghost-1",
+        title: "feature/gone",
+        path: "/repo-worktrees/gone",
+        deletedAt: 1000,
+        expiresAt: null,
+        pinnedIndex: -1,
+      });
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "ghost-1" });
+    });
+
+    afterEach(() => {
+      useWorktreeSelectionStore.getState().reset();
+    });
+
+    it("names the deleted worktree instead of claiming nothing is selected", () => {
+      render(
+        <ContentGridEmptyState
+          hasLaunchTarget={false}
+          hasProjectContext
+          hasWorktrees
+          isWorktreeInitialized
+          showProjectPulse={false}
+        />
+      );
+
+      expect(screen.getByText("Worktree deleted")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Go to main worktree" })).toBeTruthy();
+      expect(screen.queryByText("Select a worktree")).toBeNull();
+    });
   });
 });

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -8,7 +8,11 @@ import { useWorktreeTerminals } from "../../hooks/useWorktreeTerminals";
 
 import { useDroppable } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
-import { useIsWorktreeSortDragging, type WorktreeDragData } from "../DragDrop/DndProvider";
+import {
+  useDndPlaceholder,
+  useIsWorktreeSortDragging,
+  type WorktreeDragData,
+} from "../DragDrop/DndProvider";
 import { getWorktreeSortDragId } from "../DragDrop/SortableWorktreeCard";
 import { GripVertical } from "lucide-react";
 import { useErrorStore, usePanelStore, type RetryAction } from "../../store";
@@ -608,33 +612,47 @@ export function WorktreeCard({
     hasActiveAgent: terminalCounts.byState.working > 0,
   });
 
+  // The active card used to opt out of being a drop target entirely — every
+  // panel drag originated from the active worktree, so it could only ever be a
+  // no-op self-drop. Accordion drags broke that assumption: dragging a
+  // terminal out of an inactive (or deleted) worktree's sidebar row onto the
+  // ACTIVE card is the most common rescue flow, so the droppable stays
+  // registered and only disables when the dragged panel already lives here.
+  const { activeTerminal: draggedPanel } = useDndPlaceholder();
+  const isCrossWorktreePanelDrag =
+    draggedPanel !== null && (draggedPanel.worktreeId ?? null) !== worktree.id;
+
   const { setNodeRef, isOver, over, active } = useDroppable({
     id: `worktree-drop-${worktree.id}`,
     data: {
       type: "worktree",
       worktreeId: worktree.id,
     },
-    disabled: isActive || isWorktreeSortDragging,
+    disabled: (isActive && !isCrossWorktreePanelDrag) || isWorktreeSortDragging,
   });
 
   const droppableRef = (node: HTMLElement | null) => {
-    if (!isActive) setNodeRef(node);
+    setNodeRef(node);
   };
 
   const activeDragData = active?.data.current as Partial<WorktreeDragData> | undefined;
   // Only drops handleDragEnd will actually accept: a single-panel drag —
-  // group drags are rejected by cancelDrop, accordion drags never reach the
-  // worktree-drop branch, and worktree-sort drags carry no terminal.
+  // group drags are rejected by cancelDrop, and worktree-sort drags carry no
+  // terminal. Accordion drags count only when they come from a *different*
+  // worktree (a cross-worktree move); within their own worktree they are
+  // reorders and the card must not light up as a drop target.
   const isMovablePanelDrag =
     activeDragData?.terminal !== undefined &&
-    activeDragData.origin !== "accordion" &&
+    (activeDragData.origin !== "accordion" || activeDragData.worktreeId !== worktree.id) &&
     !(activeDragData.groupId && (activeDragData.groupPanelIds?.length ?? 0) > 1);
   // The sidebar row stacks two same-size droppables (this drop target inside
   // the SortableWorktreeCard sortable), and pointerWithin resolves their tie
   // by registration order — `over` can be either id, so match both. Mirrors
   // the dual-id handling in DndProvider's handleDragEnd.
   const isPanelDropTarget =
-    !isActive && isMovablePanelDrag && (isOver || over?.id === getWorktreeSortDragId(worktree.id));
+    (!isActive || isCrossWorktreePanelDrag) &&
+    isMovablePanelDrag &&
+    (isOver || over?.id === getWorktreeSortDragId(worktree.id));
 
   const isMuted =
     (isIdleCard || isStaleCard) && !isWaitingCard && !isActive && !isFocused && !isPanelDropTarget;

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -410,7 +410,10 @@ export function WorktreeTerminalSection({
                   type="button"
                   className="ml-2 rounded-sm text-text-muted hover:text-text-secondary transition-colors"
                   aria-label="Dismiss hint"
-                  onClick={() => {
+                  onClick={(e) => {
+                    // Dismissing the hint must not double as selecting the
+                    // card the section happens to live in.
+                    e.stopPropagation();
                     localStorage.setItem(FLEET_HINT_DISMISSED_KEY, "1");
                     setHintDismissed(true);
                   }}

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -382,12 +382,44 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         store.getState().applyRemove(event.worktreeId, { epoch: event.epoch, seq: event.seq });
         if (epochChanged) fetchInitialState();
 
+        // applyRemove version-gates internally but returns void: a stale
+        // same-epoch replay leaves the worktree in the map. Selection and
+        // ghost side effects must not run on a rejected event — a replay
+        // would otherwise demote the restore target or clear the selection
+        // for a worktree that still exists. Cross-epoch events keep the old
+        // behavior: the refetch reconciles the map, and the ghost row must
+        // still be recorded for survivors of a removal across a host restart.
+        if (!epochChanged && store.getState().worktrees.has(event.worktreeId)) {
+          return;
+        }
+
         // Side effect: invalidate pulse cache
         usePulseStore.getState().invalidate(event.worktreeId);
 
-        // Side effect: clear active selection if removed
+        // Side effect: selection handling for the removed worktree. When
+        // terminals survive, the id lives on as a ghost row and the user may
+        // be mid-cleanup on it — deleting must NOT yank them away, so the
+        // selection stays put and useActiveWorktreeSync falls back to main
+        // only once the ghost row itself is gone (last terminal closed, row
+        // dismissed, or auto-cleanup fired). Only the durable restore target
+        // is demoted (below) — a deleted id must never persist across
+        // restarts. With no survivors there is nothing left to look at, so
+        // the selection clears immediately as before.
         const selectionStore = useWorktreeSelectionStore.getState();
-        if (selectionStore.activeWorktreeId === event.worktreeId) {
+        const willBecomeGhost =
+          !!worktree && getDeletedWorktreeTerminalIds(event.worktreeId).length > 0;
+        // A removed id must never remain the durable restore target — ghost
+        // or not, it can't be restored after a restart. No-ops unless the id
+        // IS the restore target (or its fleet-parked snapshot).
+        selectionStore.clearRestoreTarget(event.worktreeId);
+        // `deletedWorktrees.has` guards a duplicate removal event for an id
+        // that is already a ghost (snapshot lookup misses → willBecomeGhost
+        // false): the live ghost row must not lose the selection to a replay.
+        if (
+          selectionStore.activeWorktreeId === event.worktreeId &&
+          !willBecomeGhost &&
+          !selectionStore.deletedWorktrees.has(event.worktreeId)
+        ) {
           selectionStore.setActiveWorktree(null);
         }
 
@@ -407,7 +439,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // `applyRemove` dropped it from the live map. Both delete entry points
         // (the delete dialog and the `worktree.delete` action) funnel through
         // this event, so they get identical behaviour from this one change.
-        if (worktree && getDeletedWorktreeTerminalIds(event.worktreeId).length > 0) {
+        if (willBecomeGhost) {
           const cleanupSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
           selectionStore.addDeletedWorktree({
             id: event.worktreeId,
@@ -502,6 +534,26 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // preceding `worktree-removed` event.
         if (selectionStore.activeWorktreeId === event.worktreeId) {
           return;
+        }
+        // Deleting the active worktree makes the host auto-switch to main and
+        // echo that switch here — but a user standing on a worktree whose
+        // terminals survive must stay on its ghost row, not get yanked to
+        // main mid-cleanup. Two orderings exist: UI deletes emit
+        // activated(main) BEFORE worktree-removed (the active worktree is
+        // then mid-delete: `deletingIds`); external removals emit it AFTER
+        // (the active id is then already a ghost row). Both suppress only
+        // while terminals actually survive — a deletion with nothing left
+        // follows the auto-switch as before.
+        const activeId = selectionStore.activeWorktreeId;
+        if (activeId !== null) {
+          const isActiveGhost = selectionStore.deletedWorktrees.has(activeId);
+          const isActiveDeleting = store.getState().deletingIds.has(activeId);
+          if (
+            (isActiveGhost || isActiveDeleting) &&
+            getDeletedWorktreeTerminalIds(activeId).length > 0
+          ) {
+            return;
+          }
         }
         selectionStore.setPendingWorktree(event.worktreeId);
         selectionStore.selectWorktree(event.worktreeId);

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -14,6 +14,8 @@ import {
   getPinnedDeletedWorktreeIndex,
 } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { startDeletedWorktreeCleanup } from "@/store/deletedWorktreeCleanup";
 import { usePulseStore } from "@/store/pulseStore";
 import { useProjectStore } from "@/store/projectStore";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
@@ -398,13 +400,15 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // with independent owners (#11083), so the panels are left completely
         // untouched here: their processes keep running, and the deleted-worktree row only
         // gives them somewhere to live in the sidebar until the user drags
-        // them to another worktree or dismisses the row.
+        // them to another worktree, dismisses the row, or its auto-cleanup
+        // countdown moves them to trash (deletedWorktreeCleanup.ts).
         //
         // Metadata is snapshotted from `worktree`, read above *before*
         // `applyRemove` dropped it from the live map. Both delete entry points
         // (the delete dialog and the `worktree.delete` action) funnel through
         // this event, so they get identical behaviour from this one change.
         if (worktree && getDeletedWorktreeTerminalIds(event.worktreeId).length > 0) {
+          const cleanupSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
           selectionStore.addDeletedWorktree({
             id: event.worktreeId,
             // Detached-HEAD worktrees have no branch; fall back to the folder
@@ -413,6 +417,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
               worktree.branch ?? worktree.path.split(/[/\\]/).filter(Boolean).pop() ?? "Unknown",
             path: worktree.path,
             deletedAt: Date.now(),
+            // Armed HERE, not by the sweep's next tick — deletion starts the
+            // countdown even if this view is hidden and its sweep throttled.
+            // The sweep owns it from now on (defers, re-arms on preference
+            // change, fires into the trash).
+            expiresAt: cleanupSeconds > 0 ? Date.now() + cleanupSeconds * 1000 : null,
             pinnedIndex: getPinnedDeletedWorktreeIndex(event.worktreeId),
           });
         }
@@ -439,6 +448,10 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           .pruneDeletedWorktrees(new Set(store.getState().worktrees.keys()));
       })
     );
+
+    // Age-based auto-cleanup for deleted-worktree rows: arms/defers/fires each
+    // row's countdown per the user's preference (see deletedWorktreeCleanup.ts).
+    cleanups.push(startDeletedWorktreeCleanup());
 
     // Pulse-cache pruning backstop: the `worktree-removed` event invalidates a
     // single worktree, but `applySnapshot` on a host restart can replace the

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -159,6 +159,141 @@ describe("WorktreeStoreProvider — surviving terminals on worktree removal", ()
     expect(usePanelStore.getState().panelIds).toContain("agent-a");
   });
 
+  it("keeps the deleted worktree active while its terminals survive", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-1" });
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    const selection = useWorktreeSelectionStore.getState();
+    // The user may be mid-cleanup on the ghost — deletion must not yank them
+    // away; the fallback to main happens only when the ghost row itself goes.
+    expect(selection.activeWorktreeId).toBe("wt-1");
+    // But a deleted id must never remain the durable restore target — the
+    // ghost row is in-memory only and resolves to nothing after a restart.
+    expect(selection.restoreWorktreeId).toBeNull();
+  });
+
+  it("clears the active selection when the removed worktree has no surviving terminals", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-1" });
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBeNull();
+  });
+
+  it("suppresses the host's auto-switch echo that precedes a UI delete (activated → removed)", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("main")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    act(() => {
+      store.setState({ deletingIds: new Set(["wt-1"]) });
+    });
+
+    // The host switches itself to main before removing the worktree and
+    // echoes that switch; the user mid-delete must not be yanked off wt-1.
+    act(() => {
+      emit("worktree-activated", { type: "worktree-activated", worktreeId: "main", ...nextV() });
+    });
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+  });
+
+  it("suppresses the host's auto-switch echo that follows an external removal (removed → activated)", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("main")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+      emit("worktree-activated", { type: "worktree-activated", worktreeId: "main", ...nextV() });
+    });
+
+    // The active id is a ghost row with survivors — the echo must not win.
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+  });
+
+  it("still follows the host's switch when the deletion left no surviving terminals", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1"), makeWorktree("main")], nextV());
+    });
+    setPanels([]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+      emit("worktree-activated", { type: "worktree-activated", worktreeId: "main", ...nextV() });
+    });
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("main");
+  });
+
+  it("keeps the ghost selection through a duplicate removal event", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(true);
+  });
+
+  it("ignores a stale same-epoch removal replay entirely", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-1" });
+
+    act(() => {
+      // seq 0 is older than the snapshot's version — applyRemove rejects it,
+      // and none of the selection/ghost side effects may run either.
+      emit("worktree-removed", {
+        type: "worktree-removed",
+        worktreeId: "wt-1",
+        epoch: TEST_EPOCH,
+        seq: 0,
+      });
+    });
+
+    expect(store.getState().worktrees.has("wt-1")).toBe(true);
+    expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-1");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.has("wt-1")).toBe(false);
+  });
+
   it("records a deleted-worktree row carrying the last-known title and path", async () => {
     const { store } = await renderProvider();
     act(() => {

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -10,6 +10,7 @@ export function useActiveWorktreeSync() {
   const { worktrees, isInitialized } = useWorktrees();
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
+  const deletedWorktrees = useWorktreeSelectionStore((s) => s.deletedWorktrees);
   const currentProject = useProjectStore((s) => s.currentProject);
   const currentScratch = useScratchStore((s) => s.currentScratch);
   const { homeDir } = useHomeDir();
@@ -27,12 +28,18 @@ export function useActiveWorktreeSync() {
   useEffect(() => {
     if (!isInitialized || worktrees.length === 0) return;
 
-    const worktreeExists = activeWorktreeId && worktrees.some((w) => w.id === activeWorktreeId);
+    // A deleted-worktree row (directory gone, terminals surviving) is a valid
+    // active selection — the user clicked it to view its terminals. Only snap
+    // back to main once the id is neither live nor a deleted row (e.g. its
+    // last terminal closed and the row was pruned).
+    const worktreeExists =
+      activeWorktreeId &&
+      (worktrees.some((w) => w.id === activeWorktreeId) || deletedWorktrees.has(activeWorktreeId));
     if (!worktreeExists) {
       const mainWorktree = worktrees.find((w) => w.isMainWorktree) ?? worktrees[0]!;
       selectWorktree(mainWorktree.id);
     }
-  }, [worktrees, activeWorktreeId, isInitialized, selectWorktree]);
+  }, [worktrees, activeWorktreeId, isInitialized, selectWorktree, deletedWorktrees]);
 
   useEffect(() => {
     const projectId = currentProject?.id ?? null;

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -4,10 +4,13 @@ import { usePanelStore } from "@/store/panelStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
 import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
+import { notify } from "@/lib/notify";
 import {
   resetDeletedWorktreeCleanupState,
   sweepDeletedWorktreeCleanup,
 } from "../deletedWorktreeCleanup";
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
 
 const NOW = 100_000;
 
@@ -74,6 +77,7 @@ function getExpiry(): number | null | undefined {
 let bulkTrashByWorktree: ReturnType<typeof vi.fn<(worktreeId: string) => void>>;
 
 beforeEach(() => {
+  vi.mocked(notify).mockClear();
   resetDeletedWorktreeCleanupState();
   useWorktreeSelectionStore.getState().reset();
   useTerminalPendingDestructiveActionStore.getState().clear();
@@ -206,6 +210,50 @@ describe("sweepDeletedWorktreeCleanup", () => {
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
     expect(getExpiry()).toBeNull();
+  });
+
+  it("records an inbox-only notification naming the terminals it trashed", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+    ]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(notify).mock.calls[0][0];
+    // Inbox-only: the sweep fires unattended, so it must never toast.
+    expect(payload.priority).toBe("low");
+    expect(payload.message).toContain("2 terminals");
+    expect(payload.message).toContain("feature/x");
+    expect(payload.context?.worktreeId).toBe("wt-1");
+  });
+
+  it("uses singular phrasing for a single surviving terminal", () => {
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    const message = vi.mocked(notify).mock.calls[0][0].message;
+    expect(message).toContain("1 terminal ");
+    expect(message).not.toContain("terminals");
+  });
+
+  it("stays silent when the sweep had no surviving terminals to trash", () => {
+    setPanels([]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("stays silent while the countdown is only being deferred", () => {
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps({ isDragActive: () => true }));
+
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it("re-arms a disarmed row when cleanup is turned back on", () => {

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -222,7 +222,9 @@ describe("sweepDeletedWorktreeCleanup", () => {
     sweepDeletedWorktreeCleanup(makeDeps());
 
     expect(notify).toHaveBeenCalledTimes(1);
-    const payload = vi.mocked(notify).mock.calls[0][0];
+    const call = vi.mocked(notify).mock.calls[0];
+    expect(call).toBeDefined();
+    const payload = call![0];
     // Inbox-only: the sweep fires unattended, so it must never toast.
     expect(payload.priority).toBe("low");
     expect(payload.message).toContain("2 terminals");
@@ -234,7 +236,10 @@ describe("sweepDeletedWorktreeCleanup", () => {
     addRow({ expiresAt: NOW - 1 });
     sweepDeletedWorktreeCleanup(makeDeps());
 
-    const message = vi.mocked(notify).mock.calls[0][0].message;
+    expect(notify).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(notify).mock.calls[0];
+    expect(call).toBeDefined();
+    const message = call![0].message;
     expect(message).toContain("1 terminal ");
     expect(message).not.toContain("terminals");
   });

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
+import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
+import {
+  resetDeletedWorktreeCleanupState,
+  sweepDeletedWorktreeCleanup,
+} from "../deletedWorktreeCleanup";
+
+const NOW = 100_000;
+
+function makeDeps(
+  overrides: Partial<{
+    now: () => number;
+    isDragActive: () => boolean;
+  }> = {}
+) {
+  return {
+    now: () => NOW,
+    isDragActive: () => false,
+    ...overrides,
+  };
+}
+
+function addRow(overrides: Partial<DeletedWorktree> = {}): void {
+  useWorktreeSelectionStore.getState().addDeletedWorktree({
+    id: "wt-1",
+    title: "feature/x",
+    path: "/repo/x",
+    deletedAt: 0,
+    expiresAt: null,
+    pinnedIndex: -1,
+    ...overrides,
+  });
+}
+
+function setPanels(
+  entries: Array<{
+    id: string;
+    worktreeId: string;
+    agentState?: string;
+    location?: string;
+    runtimeStatus?: string;
+  }>
+): void {
+  const panelsById: Record<string, unknown> = {};
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  for (const entry of entries) {
+    panelsById[entry.id] = {
+      id: entry.id,
+      kind: "terminal",
+      title: entry.id,
+      worktreeId: entry.worktreeId,
+      location: entry.location ?? "grid",
+      agentState: entry.agentState,
+      runtimeStatus: entry.runtimeStatus,
+    };
+    (panelIdsByWorktreeId[entry.worktreeId] ??= []).push(entry.id);
+  }
+  usePanelStore.setState({
+    panelIds: entries.map((e) => e.id),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    panelsById: panelsById as never,
+    panelIdsByWorktreeId,
+  });
+}
+
+function getExpiry(): number | null | undefined {
+  return useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.expiresAt;
+}
+
+let bulkTrashByWorktree: ReturnType<typeof vi.fn<(worktreeId: string) => void>>;
+
+beforeEach(() => {
+  resetDeletedWorktreeCleanupState();
+  useWorktreeSelectionStore.getState().reset();
+  useTerminalPendingDestructiveActionStore.getState().clear();
+  usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 60 });
+  bulkTrashByWorktree = vi.fn<(worktreeId: string) => void>();
+  usePanelStore.setState({ bulkTrashByWorktree });
+  setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+});
+
+describe("sweepDeletedWorktreeCleanup", () => {
+  it("arms an unarmed row with the full configured TTL", () => {
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(getExpiry()).toBe(NOW + 60_000);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("trashes the row's terminals once the deadline passes", () => {
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+    expect(bulkTrashByWorktree).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("fires only once even if the row lingers across further sweeps", () => {
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+    sweepDeletedWorktreeCleanup(makeDeps());
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fires for a fresh row after the original was pruned and re-recorded", () => {
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+    useWorktreeSelectionStore.getState().dismissDeletedWorktree("wt-1");
+    // Fresh rows always start unarmed; the sweep arms them, then fires once
+    // the deadline passes.
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps());
+    expect(getExpiry()).toBe(NOW + 60_000);
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => NOW + 60_001 }));
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds the countdown while any drag is in progress", () => {
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps({ isDragActive: () => true }));
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getExpiry()).toBe(NOW + 60_000);
+  });
+
+  it("fires even while the deleted worktree is the active selection", () => {
+    // Viewing the ghost's terminals must not suppress cleanup — the visible
+    // countdown is the rescue window, and deletion is the default outcome.
+    addRow({ expiresAt: NOW - 1 });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the countdown while an agent in the row is still working", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getExpiry()).toBe(NOW + 60_000);
+  });
+
+  it("holds the countdown while the row's close-confirm dialog is open", () => {
+    addRow({ expiresAt: NOW - 1 });
+    useTerminalPendingDestructiveActionStore.getState().request({
+      kind: "deletedWorktreeDismiss",
+      targetCount: 1,
+      runningAgentCount: 0,
+      worktreeId: "wt-1",
+    });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getExpiry()).toBe(NOW + 60_000);
+  });
+
+  it("does not defer on a stale working state whose runtime already exited", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working", runtimeStatus: "exited" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms an armed row when the TTL preference lengthens", () => {
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps());
+    expect(getExpiry()).toBe(NOW + 60_000);
+
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 300 });
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => NOW + 10_000 }));
+
+    expect(getExpiry()).toBe(NOW + 10_000 + 300_000);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("re-arms to the shorter TTL rather than honoring the old longer deadline", () => {
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 300 });
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps());
+    expect(getExpiry()).toBe(NOW + 300_000);
+
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 30 });
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => NOW + 1_000 }));
+
+    expect(getExpiry()).toBe(NOW + 1_000 + 30_000);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("disarms rows and never fires when cleanup is off", () => {
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getExpiry()).toBeNull();
+  });
+
+  it("re-arms a disarmed row when cleanup is turned back on", () => {
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
+    addRow({ expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 60 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(getExpiry()).toBe(NOW + 60_000);
+  });
+});

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -61,6 +61,7 @@ describe("getDeletedWorktreeTerminalIds", () => {
       { id: "docked", worktreeId: "wt-1", location: "dock" },
       { id: "trashed", worktreeId: "wt-1", location: "trash" },
       { id: "assistant", worktreeId: "wt-1", location: "overlay" },
+      { id: "dialog", worktreeId: "wt-1", location: "dialog" },
       { id: "elsewhere", worktreeId: "wt-2" },
     ]);
 

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -202,3 +202,27 @@ describe("reset", () => {
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(0);
   });
 });
+
+describe("clearRestoreTarget", () => {
+  it("demotes a matching durable restore target without touching the active selection", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-1" });
+    useWorktreeSelectionStore.getState().clearRestoreTarget("wt-1");
+
+    expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBeNull();
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+  });
+
+  it("no-ops when a different worktree is the restore target", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-2" });
+    useWorktreeSelectionStore.getState().clearRestoreTarget("wt-1");
+
+    expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-2");
+  });
+
+  it("scrubs a matching fleet-parked restore snapshot so scope exit can't resurrect it", () => {
+    useWorktreeSelectionStore.setState({ _previousRestoreWorktreeId: "wt-1" });
+    useWorktreeSelectionStore.getState().clearRestoreTarget("wt-1");
+
+    expect(useWorktreeSelectionStore.getState()._previousRestoreWorktreeId).toBeNull();
+  });
+});

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -30,6 +30,7 @@ function makeDeleted(overrides: Partial<DeletedWorktree> = {}): DeletedWorktree 
     title: "feature/x",
     path: "/repo/wt-1",
     deletedAt: 1000,
+    expiresAt: null,
     pinnedIndex: 0,
     ...overrides,
   };

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -1,0 +1,156 @@
+import { usePanelStore } from "@/store/panelStore";
+import { getDeletedWorktreeTerminalIds, useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
+import { isPtyPanel } from "@shared/types/panel";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
+
+export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
+
+/**
+ * Auto-cleanup for deleted-worktree rows (#11232): a row's surviving terminals
+ * are moved to trash after `deletedWorktreeCleanupSeconds` (default 60s, 0 =
+ * never), after which the row prunes itself. Deleted worktrees are deliberately
+ * ephemeral — they never persist across restarts, and without this sweep a bulk
+ * worktree cleanup would leave ghost rows pinned in the sidebar forever.
+ *
+ * The countdown is armed at deletion time (WorktreeStoreContext's
+ * worktree-removed handler stamps `expiresAt`) and runs to zero by default —
+ * the row's visible countdown is the user's window to rescue terminals. It
+ * defers (holds at full) only while firing would actively break something:
+ * - a drag is in progress (dragging a terminal out IS the rescue gesture —
+ *   expiring mid-drag would yank the source away),
+ * - any surviving terminal's agent is still `working` (the Codespaces model:
+ *   active output resets the idle clock),
+ * - the row's own close-confirm dialog is open.
+ *
+ * Terminals go through `bulkTrashByWorktree` — the same executor as the row's
+ * manual close button — so auto-cleanup lands in the trash with its usual
+ * restore window rather than hard-killing anything immediately.
+ */
+interface SweepDeps {
+  now: () => number;
+  isDragActive: () => boolean;
+}
+
+function defaultIsDragActive(): boolean {
+  return document.documentElement.dataset.dragging === "true";
+}
+
+const DEFAULT_DEPS: SweepDeps = {
+  now: () => Date.now(),
+  isDragActive: defaultIsDragActive,
+};
+
+function hasWorkingAgent(worktreeId: string): boolean {
+  const { panelsById } = usePanelStore.getState();
+  return getDeletedWorktreeTerminalIds(worktreeId).some((id) => {
+    const panel = panelsById[id];
+    if (panel == null || !isPtyPanel(panel)) return false;
+    // Same display-state coercion as the sidebar badges: a panel whose chrome
+    // no longer renders an agent (exited, errored, plain shell) must not defer
+    // cleanup forever on a stale `working` heuristic.
+    const displayState = getTerminalAgentDisplayState(
+      deriveTerminalChrome(panel),
+      panel.agentState
+    );
+    return displayState === "working";
+  });
+}
+
+function isCountdownDeferred(worktreeId: string, deps: SweepDeps): boolean {
+  const pending = useTerminalPendingDestructiveActionStore.getState().pending;
+  if (pending?.kind === "deletedWorktreeDismiss" && pending.worktreeId === worktreeId) return true;
+  if (deps.isDragActive()) return true;
+  return hasWorkingAgent(worktreeId);
+}
+
+// A row whose cleanup has been dispatched must not re-fire on the next tick —
+// the trash commit and the row prune land asynchronously. Entries clear when
+// the row leaves the map (or the sweep resets, in tests).
+const firedIds = new Set<string>();
+
+// TTL each row's deadline was armed with, so changing the preference mid-
+// countdown re-arms the row to `now + newTTL` instead of honoring a deadline
+// computed from the old value (30→300 would otherwise still fire at 30s, and
+// the card's progress bar — which divides by the CURRENT TTL — would lie).
+const armedTtlMs = new Map<string, number>();
+
+export function resetDeletedWorktreeCleanupState(): void {
+  firedIds.clear();
+  armedTtlMs.clear();
+}
+
+export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): void {
+  const selection = useWorktreeSelectionStore.getState();
+  const { deletedWorktrees, setDeletedWorktreeExpiry } = selection;
+
+  for (const id of firedIds) {
+    if (!deletedWorktrees.has(id)) firedIds.delete(id);
+  }
+  for (const id of armedTtlMs.keys()) {
+    if (!deletedWorktrees.has(id)) armedTtlMs.delete(id);
+  }
+  if (deletedWorktrees.size === 0) return;
+
+  const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
+  const now = deps.now();
+
+  for (const entry of deletedWorktrees.values()) {
+    // An unarmed entry is a fresh (or re-recorded) row — any stale fired flag
+    // from a previous row under the same id must not suppress its countdown.
+    if (entry.expiresAt === null) firedIds.delete(entry.id);
+    else if (firedIds.has(entry.id)) continue;
+
+    if (ttlSeconds === 0) {
+      if (entry.expiresAt !== null) setDeletedWorktreeExpiry(entry.id, null);
+      armedTtlMs.delete(entry.id);
+      continue;
+    }
+
+    const ttlMs = ttlSeconds * 1000;
+    const armedWith = armedTtlMs.get(entry.id);
+    if (
+      entry.expiresAt === null ||
+      (armedWith !== undefined && armedWith !== ttlMs) ||
+      isCountdownDeferred(entry.id, deps)
+    ) {
+      // Arm the countdown (fresh row or TTL preference change), or hold it at
+      // full while activity defers it.
+      setDeletedWorktreeExpiry(entry.id, now + ttlMs);
+      armedTtlMs.set(entry.id, ttlMs);
+      continue;
+    }
+    // A deadline this sweep didn't arm (unknown provenance) is adopted at the
+    // current TTL so a later preference change still re-arms it.
+    armedTtlMs.set(entry.id, ttlMs);
+
+    if (now >= entry.expiresAt) {
+      firedIds.add(entry.id);
+      // Same executor as the row's manual close: terminals land in trash
+      // (restorable until trash GC), and trashing the last one prunes the row.
+      usePanelStore.getState().bulkTrashByWorktree(entry.id);
+    }
+  }
+}
+
+/**
+ * Start the 1 Hz cleanup sweep. The interval is throttled by Chromium while
+ * the view is hidden, so a visibility-restore sweep catches up immediately on
+ * reveal (mirrors the trash slice's `sweepExpiredTrash`).
+ */
+export function startDeletedWorktreeCleanup(): () => void {
+  const interval = setInterval(
+    () => sweepDeletedWorktreeCleanup(),
+    DELETED_WORKTREE_SWEEP_INTERVAL_MS
+  );
+  const onVisibilityChange = () => {
+    if (!document.hidden) sweepDeletedWorktreeCleanup();
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  return () => {
+    clearInterval(interval);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  };
+}

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -5,6 +5,7 @@ import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendin
 import { isPtyPanel } from "@shared/types/panel";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
+import { notify } from "@/lib/notify";
 
 export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
 
@@ -19,8 +20,14 @@ export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
  * worktree-removed handler stamps `expiresAt`) and runs to zero by default —
  * the row's visible countdown is the user's window to rescue terminals. It
  * defers (holds at full) only while firing would actively break something:
- * - a drag is in progress (dragging a terminal out IS the rescue gesture —
- *   expiring mid-drag would yank the source away),
+ * - ANY drag is in progress. Dragging a terminal out IS the rescue gesture and
+ *   expiring mid-drag would yank the source away, but the drag flag
+ *   (`documentElement.dataset.dragging`, set by DndProvider) carries no
+ *   identity — the dragged panel's owning row is React state inside the
+ *   provider, not something this module-level sweep can read. So every ghost
+ *   row holds for the duration of any drag anywhere. Drags are short and
+ *   deliberate, so the over-broad hold is cheap; the alternative (plumbing the
+ *   active drag's worktree out of DndProvider) buys nothing at this cost.
  * - any surviving terminal's agent is still `working` (the Codespaces model:
  *   active output resets the idle clock),
  * - the row's own close-confirm dialog is open.
@@ -82,6 +89,29 @@ export function resetDeletedWorktreeCleanupState(): void {
   armedTtlMs.clear();
 }
 
+/**
+ * The sweep is the one path that closes terminals with nobody watching: the
+ * row vanishes and the trash TTL kills the PTYs shortly after, so a user who
+ * stepped away would otherwise have no record it happened and no chance at the
+ * only inverse (restore from trash). Inbox-only — the event is unattended by
+ * definition, so a toast would interrupt whatever the user moved on to.
+ */
+function notifySweepTrashed(title: string, count: number, worktreeId: string): void {
+  notify({
+    type: "info",
+    title: "Deleted worktree cleaned up",
+    message:
+      count === 1
+        ? `${title} still had 1 terminal open — it moved to trash and closes shortly.`
+        : `${title} still had ${count} terminals open — they moved to trash and close shortly.`,
+    // `agent` is the right domain (these are agent sessions) but its policy
+    // baseline is active/high; pin low so the unattended record stays a record
+    // and never interrupts whatever the user moved on to.
+    priority: "low",
+    context: { worktreeId, eventKind: "agent" },
+  });
+}
+
 export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): void {
   const selection = useWorktreeSelectionStore.getState();
   const { deletedWorktrees, setDeletedWorktreeExpiry } = selection;
@@ -130,7 +160,11 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
       firedIds.add(entry.id);
       // Same executor as the row's manual close: terminals land in trash
       // (restorable until trash GC), and trashing the last one prunes the row.
+      // Count first — the executor mirrors this exact filter, and once it runs
+      // the panels have already left the row.
+      const trashedCount = getDeletedWorktreeTerminalIds(entry.id).length;
       usePanelStore.getState().bulkTrashByWorktree(entry.id);
+      if (trashedCount > 0) notifySweepTrashed(entry.title, trashedCount, entry.id);
     }
   }
 }

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -11,6 +11,11 @@ export type DiffViewType = "split" | "unified";
 
 export type DiffFontSize = "s" | "m" | "l";
 
+/** Seconds before a deleted worktree's surviving terminals auto-close (0 = never). */
+export type DeletedWorktreeCleanupSeconds = 0 | 30 | 60 | 300;
+
+export const DELETED_WORKTREE_CLEANUP_DEFAULT: DeletedWorktreeCleanupSeconds = 60;
+
 interface PreferencesState {
   showProjectPulse: boolean;
   setShowProjectPulse: (show: boolean) => void;
@@ -50,6 +55,15 @@ interface PreferencesState {
   ) => void;
   skipPushConfirmByWorktreePath: Record<string, boolean>;
   setSkipPushConfirmForWorktree: (worktreePath: string, value: boolean) => void;
+  /**
+   * How long a deleted worktree's row holds its surviving terminals before
+   * they are moved to trash automatically. The countdown starts at deletion
+   * and defers only while a drag is in progress, an agent is still working,
+   * or the row's close-confirm dialog is open (`deletedWorktreeCleanup.ts`).
+   * 0 disables auto-cleanup.
+   */
+  deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds;
+  setDeletedWorktreeCleanupSeconds: (value: DeletedWorktreeCleanupSeconds) => void;
 }
 
 function isDockDensity(value: unknown): value is DockDensity {
@@ -66,6 +80,12 @@ function isDiffFontSize(value: unknown): value is DiffFontSize {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
+}
+
+export function isDeletedWorktreeCleanupSeconds(
+  value: unknown
+): value is DeletedWorktreeCleanupSeconds {
+  return value === 0 || value === 30 || value === 60 || value === 300;
 }
 
 /**
@@ -90,6 +110,9 @@ function sanitizePersistedPreferences(
   if (!isDiffFontSize(sanitized.diffFontSize)) sanitized.diffFontSize = "m";
   if (typeof sanitized.markdownWrapLines !== "boolean") sanitized.markdownWrapLines = true;
   if (typeof sanitized.showAgentTaskTitles !== "boolean") sanitized.showAgentTaskTitles = true;
+  if (!isDeletedWorktreeCleanupSeconds(sanitized.deletedWorktreeCleanupSeconds)) {
+    sanitized.deletedWorktreeCleanupSeconds = DELETED_WORKTREE_CLEANUP_DEFAULT;
+  }
 
   // A truthy non-record value here would otherwise bypass the push-confirm gate.
   const skip = sanitized.skipPushConfirmByWorktreePath;
@@ -162,11 +185,13 @@ export const usePreferencesStore = create<PreferencesState>()(
           const { [worktreePath]: _removed, ...rest } = state.skipPushConfirmByWorktreePath;
           return { skipPushConfirmByWorktreePath: rest };
         }),
+      deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
+      setDeletedWorktreeCleanupSeconds: (value) => set({ deletedWorktreeCleanupSeconds: value }),
     }),
     {
       name: "daintree-preferences",
       storage: createSafeJSONStorage(),
-      version: 12,
+      version: 13,
       // Runs on every hydration (unlike `migrate`, which Zustand skips when the
       // persisted version matches). Closed-set normalisation lives here so a
       // corrupt-but-parseable value is clamped even at the current version.
@@ -269,6 +294,11 @@ export const usePreferencesStore = create<PreferencesState>()(
           if (typeof persisted.diffShowFileList !== "boolean") persisted.diffShowFileList = true;
           if (!isDiffFontSize(persisted.diffFontSize)) persisted.diffFontSize = "m";
         }
+        if (version < 13 && isRecord(persisted)) {
+          if (!isDeletedWorktreeCleanupSeconds(persisted.deletedWorktreeCleanupSeconds)) {
+            persisted.deletedWorktreeCleanupSeconds = DELETED_WORKTREE_CLEANUP_DEFAULT;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -279,5 +309,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds }",
 });

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -53,6 +53,13 @@ export interface DeletedWorktree {
   path: string;
   deletedAt: number;
   /**
+   * When the row's auto-cleanup fires (terminals move to trash, row goes).
+   * `null` while cleanup is off or the countdown hasn't been armed yet. Owned
+   * entirely by the cleanup sweep (`deletedWorktreeCleanup.ts`), which arms,
+   * pauses (by re-extending), and fires it — nothing else writes this.
+   */
+  expiresAt: number | null;
+  /**
    * Index the row occupied in the sidebar's scrollable list when it was
    * deleted, so the row holds its slot instead of jumping to an edge.
    *
@@ -190,6 +197,7 @@ interface WorktreeSelectionState {
   dismissPendingCreation: (path: string) => void;
   addDeletedWorktree: (worktree: DeletedWorktree) => void;
   dismissDeletedWorktree: (worktreeId: string) => void;
+  setDeletedWorktreeExpiry: (worktreeId: string, expiresAt: number | null) => void;
   pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
   toggleWorktreeExpanded: (id: string) => void;
   setWorktreeExpanded: (id: string, expanded: boolean) => void;
@@ -805,6 +813,16 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       if (!state.deletedWorktrees.has(worktreeId)) return state;
       const next = new Map(state.deletedWorktrees);
       next.delete(worktreeId);
+      return { deletedWorktrees: next };
+    });
+  },
+
+  setDeletedWorktreeExpiry: (worktreeId, expiresAt) => {
+    set((state) => {
+      const entry = state.deletedWorktrees.get(worktreeId);
+      if (!entry || entry.expiresAt === expiresAt) return state;
+      const next = new Map(state.deletedWorktrees);
+      next.set(worktreeId, { ...entry, expiresAt });
       return { deletedWorktrees: next };
     });
   },

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -94,7 +94,8 @@ export function getPinnedDeletedWorktreeIndex(worktreeId: string): number {
 /**
  * Terminals still held by a deleted worktree's row.
  *
- * Mirrors `bulkTrashByWorktree`'s filter exactly (trash + overlay excluded) so
+ * Mirrors `bulkTrashByWorktree`'s filter exactly (trash + overlay + dialog
+ * excluded) so
  * the count shown in the dismiss confirm always matches what dismissing
  * actually closes (#9699). Overlay panels are the Daintree Assistant, not
  * worktree sessions.

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -198,6 +198,7 @@ interface WorktreeSelectionState {
   addDeletedWorktree: (worktree: DeletedWorktree) => void;
   dismissDeletedWorktree: (worktreeId: string) => void;
   setDeletedWorktreeExpiry: (worktreeId: string, expiresAt: number | null) => void;
+  clearRestoreTarget: (worktreeId: string) => void;
   pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
   toggleWorktreeExpanded: (id: string) => void;
   setWorktreeExpanded: (id: string, expanded: boolean) => void;
@@ -827,6 +828,22 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     });
   },
 
+  // Demote a worktree from the durable restore target without touching the
+  // session-active selection. Used when a deleted worktree lives on as a ghost
+  // row: it may stay ACTIVE (the user is mid-cleanup on it), but a deleted id
+  // must never persist as the restore point — deletedWorktrees is in-memory
+  // only, so after a restart the id would resolve to nothing. The fleet-parked
+  // snapshot is scrubbed too: exitFleetScope restores `_previousRestoreWorktreeId`
+  // into the durable slot, which would resurrect the deleted id.
+  clearRestoreTarget: (worktreeId) => {
+    const updates: Partial<WorktreeSelectionState> = {};
+    if (get().restoreWorktreeId === worktreeId) updates.restoreWorktreeId = null;
+    if (get()._previousRestoreWorktreeId === worktreeId) updates._previousRestoreWorktreeId = null;
+    if (Object.keys(updates).length === 0) return;
+    set(updates);
+    persistActiveWorktree(null);
+  },
+
   pruneDeletedWorktrees: (liveWorktreeIds) => {
     set((state) => {
       if (state.deletedWorktrees.size === 0) return state;
@@ -1139,7 +1156,13 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       focusedWorktreeId: restoreId,
       _policyGeneration: generation,
     });
-    persistActiveWorktree(restoreId);
+    // The parked active id can have become a ghost row while scope was open
+    // (its worktree deleted with surviving terminals). Restoring the session
+    // selection to it is fine — persisting it is not: deletedWorktrees is
+    // in-memory only, so the id resolves to nothing after a restart.
+    persistActiveWorktree(
+      restoreId !== null && get().deletedWorktrees.has(restoreId) ? null : restoreId
+    );
     // Hand the restored worktree its own maximize back, or clear the trio
     // outright. Either way `preMaximizeLayout` is replaced, so a snapshot that
     // survived scope entry can no longer restore a foreign column count.


### PR DESCRIPTION
This PR reworks the deleted worktree card in the sidebar. It used to just tell users to drag terminals to another worktree, but the drop never actually worked. It also looked nothing like the cards for live worktrees.

### Making drags work

Sidebar terminal drags (`origin: "accordion"`) could never move a terminal across worktrees. The drop handler only knew how to reorder within the same worktree and returned early before the move logic. Now dropping a sidebar terminal onto another worktree's card, or onto one of its terminal rows, moves it there, just like a drag from the grid. Targets are gated on the live worktree map so a terminal can't be moved into another dead worktree, and the active worktree's card now accepts and highlights for cross-worktree drags too, since that's the most common rescue flow.

### Matching the design

The deleted card now looks almost identical to a live worktree card. Same icon alignment and typography as `BranchLabel`, slightly faded, with a `Deleted` badge and the struck-through path underneath. It reuses `WorktreeTerminalSection`, so you get the same active count bar with the waiting indicators, and the card is clickable to view its terminals in the grid. Selection is session-only (`source: "focus"`), so a deleted id can never become the persisted restore target.

### Closing leftover terminals

There's a clearly visible delete button behind a confirm dialog, with a ticking seconds readout next to it.

### Auto-cleanup countdown

Deleted worktrees clean themselves up after 60 seconds, moving any leftover terminals into the trash (so they still get the trash's own restore window). The countdown is armed at deletion time and shown as the seconds readout plus a thin progress bar along the bottom of the card. It pauses while a drag is in progress, while an agent is still working, or while the confirm dialog is open. There's a new setting under Settings → Worktree for the duration: 30 seconds, 1 minute (default), 5 minutes, or never. These rows never persist across restarts.

### Staying put on delete

Deleting the worktree you're currently standing in no longer jumps the view to main. The selection stays on the ghost row until it's fully gone (terminals closed, moved, or auto-cleaned), then falls back to main. This also suppresses the host's auto-switch echo in both event orderings, ignores stale removal replays, and scrubs the fleet-parked restore snapshot so a deleted id can't be resurrected on scope exit.

### Minor fixes

* A dedicated empty state when viewing a deleted worktree with an empty grid, with a button back to the main worktree, instead of the misleading "Select a worktree" copy.
* Dismissing the fleet selection hint no longer also selects the card it lives in.

Unit coverage across the sweep, card, store lifecycle, and both host event orderings. `npm run check` is clean.
