### PR TITLE
refactor(plugins): decouple the plugin view host from ContentPanel chrome

### DIFF
--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -1,0 +1,295 @@
+import {
+  Suspense,
+  lazy,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type LazyExoticComponent,
+} from "react";
+import type { PanelViewProps } from "@shared/types/plugin";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import type { ErrorFallbackProps } from "@/components/ErrorBoundary/ErrorFallback";
+import { Skeleton, SkeletonHint } from "@/components/ui/Skeleton";
+import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
+import { PluginViewDiagnosticsFallback } from "@/components/Plugin/PluginViewDiagnosticsFallback";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+
+/**
+ * The resolved subset of `PanelKindConfig` a plugin view actually needs. Both
+ * `componentPath` and `extensionId` are non-optional here: the misconfiguration
+ * check lives in the caller (`makePluginViewHost`), so everything downstream of
+ * it works with proven-present values rather than non-null assertions.
+ */
+export interface PluginViewContentConfig {
+  id: string;
+  name: string;
+  componentPath: string;
+  extensionId: string;
+}
+
+/**
+ * What a presentation host must supply. Deliberately presentation-neutral — no
+ * title, focus, tabs, or close handlers — so a dialog host can mount the same
+ * content without inheriting grid-pane chrome (#11240). `initialArgs` mirrors
+ * the SDK-facing `PanelViewProps` name rather than the panel-persistence term
+ * (`extensionState`) the grid adapter stores it under.
+ */
+export interface PluginViewContentProps {
+  panelId: string;
+  initialArgs?: Record<string, unknown>;
+}
+
+/**
+ * Upper bound on a single `plugin://` view import before the host gives up and
+ * surfaces the ErrorBoundary's retry. Generous enough to cover a cold protocol
+ * handler start; short enough that a genuinely wedged load doesn't strand the
+ * user on an indefinite skeleton (#10512).
+ */
+const PLUGIN_VIEW_IMPORT_TIMEOUT_MS = 10_000;
+
+function isPluginViewModule(mod: unknown): mod is { default: ComponentType<PanelViewProps> } {
+  if (mod === null || typeof mod !== "object") return false;
+  const candidate = (mod as { default?: unknown }).default;
+  // Accept any React element type — function components, `memo(...)`,
+  // `forwardRef(...)`, and lazy/class wrappers are all valid defaults.
+  // `memo` and `forwardRef` return objects (typeof === "object"), not
+  // functions, so a `typeof === "function"`-only check would reject common
+  // optimization patterns.
+  return typeof candidate === "function" || (typeof candidate === "object" && candidate !== null);
+}
+
+/**
+ * Build the chrome-free half of a plugin panel: activation, lazy `plugin://`
+ * import, error boundary, and dispose-signal lifecycle, with no presentation
+ * concerns at all. The surrounding host supplies the chrome — `ContentPanel`
+ * for grid/dock panes today, a dialog shell later (#11240 / #11239).
+ *
+ * Call this ONCE per kind, at factory-construction scope — never inside a
+ * render. `lazy()` and every piece of state below are keyed to the returned
+ * component's identity, so re-invoking the factory while rendering would remount
+ * the plugin view (and restart its import) on every parent render. Callers must
+ * cache the result per `(kindId, componentPath)`, as `usePluginPanelKinds` does.
+ *
+ * Lifetime contract:
+ *   - On mount the content creates an `AbortController` and passes its signal as
+ *     `disposeSignal` to the plugin view.
+ *   - The signal aborts when this React subtree unmounts AND when the plugin's
+ *     kind disappears from a `plugin:panel-kinds-changed` broadcast (the
+ *     broadcast fires before the main process tears down plugin IPC handlers, so
+ *     signal-driven cleanup runs while host APIs are still live).
+ *   - On render error the boundary's "Try again" button reloads the module — a
+ *     fresh state-held ref produces a new `lazy()` call so `import()` is
+ *     re-evaluated rather than returning the cached failed promise.
+ *
+ * The dev-mode hot-reload mechanism (a versioned query-string) is intentionally
+ * scoped to `import.meta.env.DEV`. V8 caches ESM module records by URL string
+ * and Chromium has no way to evict an entry (Vite #14438 / Chromium #350426234,
+ * unresolved as of 2026), so every dev iteration permanently expands the
+ * renderer's module map. Acceptable for dev; never for production.
+ */
+export function makePluginViewContent(
+  config: PluginViewContentConfig
+): ComponentType<PluginViewContentProps> {
+  const { componentPath, extensionId: pluginId, id: kindId, name: displayName } = config;
+
+  // Defined once per content factory, not inline in render: the boundary swaps
+  // its fallback subtree whenever this component *type* changes identity, which
+  // would remount the diagnostics pane (and drop its copy feedback) on every
+  // render.
+  function PluginViewFallback({ error, errorInfo, resetError, incidentId }: ErrorFallbackProps) {
+    // Two primitive selectors rather than one object selector: the meta record
+    // is rebuilt on every provenance pull, so selecting it whole would re-render
+    // the pane on pulls that changed nothing about this plugin.
+    const devMode = usePluginRuntimeStore((s) => s.pluginMetaById.get(pluginId)?.devMode === true);
+    const pluginDisplayName = usePluginRuntimeStore(
+      (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginId
+    );
+
+    // Re-pull here rather than at mount, because at mount the plugin may not be
+    // listable yet: `loadPlugin` registers the panel kind (which is what mounts
+    // this content) before awaiting skill loading and entering the plugins map,
+    // and `daintree-plugin dev` never fires provenance at all. Reaching this
+    // component means the view rendered and threw, so its plugin is certainly
+    // loaded by now and this pull can see it. The pane fails closed meanwhile
+    // and upgrades in place when the snapshot lands.
+    const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
+    useEffect(() => refreshPluginRuntime(), [refreshPluginRuntime]);
+
+    return (
+      <PluginViewDiagnosticsFallback
+        error={error}
+        errorInfo={errorInfo}
+        resetError={resetError}
+        incidentId={incidentId}
+        pluginId={pluginId}
+        pluginDisplayName={pluginDisplayName}
+        kindId={kindId}
+        panelDisplayName={displayName}
+        componentPath={componentPath}
+        devMode={devMode}
+      />
+    );
+  }
+
+  const createLazyView = (): LazyExoticComponent<ComponentType<PanelViewProps>> =>
+    lazy<ComponentType<PanelViewProps>>(async () => {
+      // Race the `plugin://` import against a timeout. A wedged protocol load
+      // (handler hang, never-resolving fetch) would otherwise sit behind
+      // Suspense forever — the ErrorBoundary only catches rejections, never a
+      // pending promise. Rejecting on timeout routes through Suspense to the
+      // boundary's "Try again", and because the race lives inside the factory a
+      // retry (a fresh `createLazyView()`) restarts the timer cleanly (#10512).
+      // The activation + import sequence shares one timeout so a stalled
+      // `activate()` surfaces the same recovery path as a stalled import.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const mod: unknown = await Promise.race([
+        (async () => {
+          // Implicit lazy activation (#10523): force the owning plugin to
+          // `activate()` before importing its module, so handlers it registers
+          // during activate() are live when the view first renders. Optional
+          // chaining keeps this working in test environments without
+          // `window.electron`. `activateForView` is a no-op once the plugin is
+          // already activated.
+          //
+          // On activation failure the IPC call now REJECTS with the real cause
+          // (#10618: the handler throws an AppError) — the `await` rethrows it
+          // here, before `import()`, so the ErrorBoundary shows why activation
+          // failed (e.g. a manifest collision or an activate() throw) instead of
+          // the generic import timeout the module load would otherwise produce
+          // once its handlers never bound.
+          await window.electron?.plugin?.activateForView?.(kindId);
+          return import(/* @vite-ignore */ componentPath);
+        })().finally(() => {
+          if (timeoutId !== undefined) clearTimeout(timeoutId);
+        }),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(
+              new Error(
+                `Plugin "${pluginId}" view module at ${componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
+              )
+            );
+          }, PLUGIN_VIEW_IMPORT_TIMEOUT_MS);
+        }),
+      ]);
+      if (!isPluginViewModule(mod)) {
+        throw new Error(
+          `Plugin "${pluginId}" view module at ${componentPath} did not export a default React component`
+        );
+      }
+      return { default: mod.default };
+    });
+
+  function PluginViewContent({ panelId, initialArgs }: PluginViewContentProps) {
+    // Store the lazy component in state so retries can swap in a fresh ref
+    // without a useMemo dependency array — `lazy()` memoizes the import
+    // promise by factory-function identity, so retrying after a chunk-load
+    // failure requires a genuinely new factory reference. Using a state
+    // initializer (and `setLazyView(() => createLazyView())` on reset) keeps
+    // exhaustive-deps happy and lets the React Compiler optimize this component.
+    const [LazyView, setLazyView] = useState<LazyExoticComponent<ComponentType<PanelViewProps>>>(
+      () => createLazyView()
+    );
+    // Drive the ErrorBoundary's `resetKeys` independently — the reset
+    // counter is observable to the boundary even though the lazy ref lives
+    // in its own slot.
+    const [retryCount, setRetryCount] = useState(0);
+
+    // Warm the plugin runtime mirror at mount so the dev-mode flag is usually
+    // already there if this view later throws. The fallback re-pulls for the
+    // cases this can't cover; see PluginViewFallback.
+    const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
+    useEffect(() => initPluginRuntime(), [initPluginRuntime]);
+
+    // The dispose controller lives in state because its signal is consumed
+    // during render (passed to the plugin view as `disposeSignal`), and refs
+    // must not be read during render. A retry swaps in a fresh controller via
+    // handleReset so the new lazy import sees an unaborted signal.
+    const [controller, setController] = useState<AbortController>(() => new AbortController());
+
+    // Mirror the current controller into a ref so the long-lived (deps: [])
+    // teardown effect below reads the *latest* controller at call time — i.e.
+    // the post-retry one — without having to re-subscribe to the
+    // panel-kinds-changed broadcast on every retry.
+    const controllerRef = useRef(controller);
+    useEffect(() => {
+      controllerRef.current = controller;
+    }, [controller]);
+
+    useEffect(() => {
+      let disposed = false;
+      const electron = typeof window !== "undefined" ? window.electron : undefined;
+      const onChanged = electron?.plugin?.onPanelKindsChanged;
+      let cleanup: (() => void) | undefined;
+      if (onChanged) {
+        cleanup = onChanged((payload) => {
+          if (disposed) return;
+          const stillRegistered = payload.kinds.some((k) => k.id === kindId);
+          if (!stillRegistered) {
+            // Read the controller through the ref so a retry that swapped in a
+            // fresh AbortController is the one that gets aborted. Capturing
+            // `controllerRef.current` into a const at effect setup would leave
+            // post-retry signals permanently un-aborted on plugin removal.
+            controllerRef.current?.abort();
+          }
+        });
+      }
+      return () => {
+        disposed = true;
+        cleanup?.();
+        controllerRef.current?.abort();
+      };
+    }, []);
+
+    const handleReset = (): void => {
+      // Abort the outgoing view's signal before swapping in a fresh controller —
+      // the prior view instance is being discarded on retry, so any fetches or
+      // subscriptions it tied to `disposeSignal` must cancel now rather than
+      // linger until the whole subtree unmounts (#10512 review).
+      controller.abort();
+      // Fresh controller for the retry so the new lazy import sees an unaborted
+      // signal; the mirror effect propagates it to controllerRef for teardown.
+      setController(new AbortController());
+      setLazyView(() => createLazyView());
+      setRetryCount((c) => c + 1);
+    };
+
+    return (
+      <ErrorBoundary
+        variant="component"
+        // `kindId` is already `${pluginId}.${panel.id}` (PluginService builds
+        // it that way), so prefixing pluginId again doubled it.
+        componentName={`PluginView:${kindId}`}
+        fallback={PluginViewFallback}
+        onReset={handleReset}
+        resetKeys={[retryCount]}
+      >
+        <Suspense
+          fallback={
+            // Content-only bones: the presentation host already paints the real
+            // header, so a skeleton carrying its own (BrowserPaneSkeleton) would
+            // double it. Mirrors DevPreviewPaneFallback's quiet canvas — a
+            // plugin's content shape is unknowable, so bones must not imply one.
+            <div className="relative h-full">
+              <Skeleton label={`Loading ${displayName}`} className="h-full bg-surface-canvas" />
+              <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+            </div>
+          }
+        >
+          <ContentFadeIn className="flex flex-col flex-1 min-h-0 w-full">
+            <LazyView
+              panelId={panelId}
+              pluginId={pluginId}
+              disposeSignal={controller.signal}
+              initialArgs={initialArgs}
+            />
+          </ContentFadeIn>
+        </Suspense>
+      </ErrorBoundary>
+    );
+  }
+
+  PluginViewContent.displayName = `PluginViewContent(${kindId})`;
+  return PluginViewContent;
+}

--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -186,11 +186,12 @@ export function makePluginViewContent(
 
   function PluginViewContent({ panelId, initialArgs }: PluginViewContentProps) {
     // Store the lazy component in state so retries can swap in a fresh ref
-    // without a useMemo dependency array — `lazy()` memoizes the import
-    // promise by factory-function identity, so retrying after a chunk-load
-    // failure requires a genuinely new factory reference. Using a state
-    // initializer (and `setLazyView(() => createLazyView())` on reset) keeps
-    // exhaustive-deps happy and lets the React Compiler optimize this component.
+    // without a useMemo dependency array. Each `lazy()` wrapper caches its
+    // import result on its own payload, so a chunk-load failure is sticky for
+    // that wrapper — recovering requires constructing a genuinely new one, not
+    // re-invoking the old one. Using a state initializer (and
+    // `setLazyView(() => createLazyView())` on reset) keeps exhaustive-deps
+    // happy and lets the React Compiler optimize this component.
     const [LazyView, setLazyView] = useState<LazyExoticComponent<ComponentType<PanelViewProps>>>(
       () => createLazyView()
     );

--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -61,8 +61,10 @@ function isPluginViewModule(mod: unknown): mod is { default: ComponentType<Panel
 
 /**
  * Build the chrome-free half of a plugin panel: activation, lazy `plugin://`
- * import, error boundary, and dispose-signal lifecycle, with no presentation
- * concerns at all. The surrounding host supplies the chrome — `ContentPanel`
+ * import, error boundary, and dispose-signal lifecycle. It still owns the UI
+ * those duties imply — the loading skeleton, the fade-in, and the diagnostics
+ * fallback — but none of the surrounding panel shell: no header, no focus
+ * target, no close control. The presentation host supplies that — `ContentPanel`
  * for grid/dock panes today, a dialog shell later (#11240 / #11239).
  *
  * Call this ONCE per kind, at factory-construction scope — never inside a
@@ -82,11 +84,12 @@ function isPluginViewModule(mod: unknown): mod is { default: ComponentType<Panel
  *     fresh state-held ref produces a new `lazy()` call so `import()` is
  *     re-evaluated rather than returning the cached failed promise.
  *
- * The dev-mode hot-reload mechanism (a versioned query-string) is intentionally
- * scoped to `import.meta.env.DEV`. V8 caches ESM module records by URL string
- * and Chromium has no way to evict an entry (Vite #14438 / Chromium #350426234,
- * unresolved as of 2026), so every dev iteration permanently expands the
- * renderer's module map. Acceptable for dev; never for production.
+ * `componentPath` is imported verbatim — there is deliberately no cache-busting
+ * query string. V8 caches ESM module records by URL and Chromium has no way to
+ * evict an entry (Vite #14438 / Chromium #350426234, unresolved as of 2026), so
+ * a per-load version parameter would permanently expand the renderer's module
+ * map. If dev-mode hot reload ever needs one, gate it on `import.meta.env.DEV`;
+ * it must never ship to production.
  */
 export function makePluginViewContent(
   config: PluginViewContentConfig

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -28,7 +28,7 @@ export interface PluginViewHostProps extends BasePanelProps {
  * panel. This is the *presentation adapter* only: it maps panel props onto
  * `ContentPanel` and delegates every plugin concern — activation, the lazy
  * `plugin://` import, the error boundary, and dispose-signal teardown — to
- * `PluginViewContent`, which carries no presentation of its own (#11240).
+ * `PluginViewContent`, which carries no panel chrome of its own (#11240).
  *
  * One host instance is created per plugin panel kind during
  * `usePluginPanelKinds` reconciliation, which caches it per

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -1,22 +1,8 @@
-import {
-  Suspense,
-  lazy,
-  useEffect,
-  useRef,
-  useState,
-  type ComponentType,
-  type LazyExoticComponent,
-} from "react";
+import { useEffect, type ComponentType } from "react";
 import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
-import type { PanelViewProps } from "@shared/types/plugin";
-import { ErrorBoundary } from "@/components/ErrorBoundary";
-import type { ErrorFallbackProps } from "@/components/ErrorBoundary/ErrorFallback";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import type { TabInfo } from "@/components/Panel/TabButton";
-import { Skeleton, SkeletonHint } from "@/components/ui/Skeleton";
-import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
-import { PluginViewDiagnosticsFallback } from "@/components/Plugin/PluginViewDiagnosticsFallback";
-import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { makePluginViewContent } from "@/components/Plugin/PluginViewContent";
 import { logWarn } from "@/utils/logger";
 
 /**
@@ -38,48 +24,17 @@ export interface PluginViewHostProps extends BasePanelProps {
 }
 
 /**
- * Upper bound on a single `plugin://` view import before the host gives up and
- * surfaces the ErrorBoundary's retry. Generous enough to cover a cold protocol
- * handler start; short enough that a genuinely wedged load doesn't strand the
- * user on an indefinite skeleton (#10512).
- */
-const PLUGIN_VIEW_IMPORT_TIMEOUT_MS = 10_000;
-
-function isPluginViewModule(mod: unknown): mod is { default: ComponentType<PanelViewProps> } {
-  if (mod === null || typeof mod !== "object") return false;
-  const candidate = (mod as { default?: unknown }).default;
-  // Accept any React element type — function components, `memo(...)`,
-  // `forwardRef(...)`, and lazy/class wrappers are all valid defaults.
-  // `memo` and `forwardRef` return objects (typeof === "object"), not
-  // functions, so a `typeof === "function"`-only check would reject common
-  // optimization patterns.
-  return typeof candidate === "function" || (typeof candidate === "object" && candidate !== null);
-}
-
-/**
- * Build a per-kind renderer host that lazy-imports the plugin's React module
- * over the `plugin://` protocol and mounts it under an `ErrorBoundary` +
- * `Suspense`. One host instance is created per plugin panel kind during
- * `usePluginPanelKinds` reconciliation — the closure captures the
- * already-resolved `plugin://{pluginId}/{path}` URL stored on the kind's
- * `PanelKindConfig.componentPath`.
+ * Build a per-kind renderer host that presents a plugin view as a grid/dock
+ * panel. This is the *presentation adapter* only: it maps panel props onto
+ * `ContentPanel` and delegates every plugin concern — activation, the lazy
+ * `plugin://` import, the error boundary, and dispose-signal teardown — to
+ * `PluginViewContent`, which carries no presentation of its own (#11240).
  *
- * Lifetime contract:
- *   - On mount the host creates an `AbortController` and passes its signal as
- *     `disposeSignal` to the plugin view.
- *   - The signal aborts when the host React subtree unmounts AND when the
- *     plugin's kind disappears from a `plugin:panel-kinds-changed` broadcast
- *     (the broadcast fires before the main process tears down plugin IPC
- *     handlers, so signal-driven cleanup runs while host APIs are still live).
- *   - On render error the boundary's "Try again" button reloads the module —
- *     a fresh `useMemo` ref produces a new `lazy()` call so `import()` is
- *     re-evaluated rather than returning the cached failed promise.
- *
- * The dev-mode hot-reload mechanism (a versioned query-string) is intentionally
- * scoped to `import.meta.env.DEV`. V8 caches ESM module records by URL string
- * and Chromium has no way to evict an entry (Vite #14438 / Chromium #350426234,
- * unresolved as of 2026), so every dev iteration permanently expands the
- * renderer's module map. Acceptable for dev; never for production.
+ * One host instance is created per plugin panel kind during
+ * `usePluginPanelKinds` reconciliation, which caches it per
+ * `(kindId, componentPath)`. That cache is what keeps both this component and
+ * the content component it creates stable across broadcast replays; see
+ * `makePluginViewContent` for why the inner factory must not run during render.
  */
 export function makePluginViewHost(config: PanelKindConfig): ComponentType<PluginViewHostProps> {
   const componentPath = config.componentPath;
@@ -103,175 +58,26 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Plugi
     };
   }
 
-  // Defined once per host, not inline in render: the boundary swaps its
-  // fallback subtree whenever this component *type* changes identity, which
-  // would remount the diagnostics pane (and drop its copy feedback) on every
-  // host render.
-  function PluginViewFallback({ error, errorInfo, resetError, incidentId }: ErrorFallbackProps) {
-    // Two primitive selectors rather than one object selector: the meta record
-    // is rebuilt on every provenance pull, so selecting it whole would re-render
-    // the pane on pulls that changed nothing about this plugin.
-    const devMode = usePluginRuntimeStore((s) => s.pluginMetaById.get(pluginId!)?.devMode === true);
-    const pluginDisplayName = usePluginRuntimeStore(
-      (s) => s.pluginMetaById.get(pluginId!)?.displayName ?? pluginId!
-    );
-
-    // Re-pull here rather than at host mount, because at host mount the plugin
-    // may not be listable yet: `loadPlugin` registers the panel kind (which is
-    // what mounts this host) before awaiting skill loading and entering the
-    // plugins map, and `daintree-plugin dev` never fires provenance at all.
-    // Reaching this component means the view rendered and threw, so its plugin
-    // is certainly loaded by now and this pull can see it. The pane fails
-    // closed meanwhile and upgrades in place when the snapshot lands.
-    const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
-    useEffect(() => refreshPluginRuntime(), [refreshPluginRuntime]);
-
-    return (
-      <PluginViewDiagnosticsFallback
-        error={error}
-        errorInfo={errorInfo}
-        resetError={resetError}
-        incidentId={incidentId}
-        pluginId={pluginId!}
-        pluginDisplayName={pluginDisplayName}
-        kindId={kindId}
-        panelDisplayName={displayName}
-        componentPath={componentPath!}
-        devMode={devMode}
-      />
-    );
-  }
-
-  const createLazyView = (): LazyExoticComponent<ComponentType<PanelViewProps>> =>
-    lazy<ComponentType<PanelViewProps>>(async () => {
-      // Race the `plugin://` import against a timeout. A wedged protocol load
-      // (handler hang, never-resolving fetch) would otherwise sit behind
-      // Suspense forever — the ErrorBoundary only catches rejections, never a
-      // pending promise. Rejecting on timeout routes through Suspense to the
-      // boundary's "Try again", and because the race lives inside the factory a
-      // retry (a fresh `createLazyView()`) restarts the timer cleanly (#10512).
-      // The activation + import sequence shares one timeout so a stalled
-      // `activate()` surfaces the same recovery path as a stalled import.
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const mod: unknown = await Promise.race([
-        (async () => {
-          // Implicit lazy activation (#10523): force the owning plugin to
-          // `activate()` before importing its module, so handlers it registers
-          // during activate() are live when the view first renders. Optional
-          // chaining keeps the host working in test environments without
-          // `window.electron`. `activateForView` is a no-op once the plugin is
-          // already activated.
-          //
-          // On activation failure the IPC call now REJECTS with the real cause
-          // (#10618: the handler throws an AppError) — the `await` rethrows it
-          // here, before `import()`, so the ErrorBoundary shows why activation
-          // failed (e.g. a manifest collision or an activate() throw) instead of
-          // the generic import timeout the module load would otherwise produce
-          // once its handlers never bound.
-          await window.electron?.plugin?.activateForView?.(kindId);
-          return import(/* @vite-ignore */ componentPath!);
-        })().finally(() => {
-          if (timeoutId !== undefined) clearTimeout(timeoutId);
-        }),
-        new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => {
-            reject(
-              new Error(
-                `Plugin "${pluginId}" view module at ${componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
-              )
-            );
-          }, PLUGIN_VIEW_IMPORT_TIMEOUT_MS);
-        }),
-      ]);
-      if (!isPluginViewModule(mod)) {
-        throw new Error(
-          `Plugin "${pluginId}" view module at ${componentPath} did not export a default React component`
-        );
-      }
-      return { default: mod.default };
-    });
+  // Created once per host, at factory-construction scope. Calling this inside
+  // `PluginViewHost` — even behind `useMemo` — would produce a new component
+  // type per render, remounting the plugin view and restarting its import every
+  // time a panel prop changed.
+  const PluginViewContent = makePluginViewContent({
+    id: kindId,
+    name: displayName,
+    componentPath,
+    extensionId: pluginId,
+  });
 
   function PluginViewHost({ extensionState, ...panelProps }: PluginViewHostProps) {
-    // Store the lazy component in state so retries can swap in a fresh ref
-    // without a useMemo dependency array — `lazy()` memoizes the import
-    // promise by factory-function identity, so retrying after a chunk-load
-    // failure requires a genuinely new factory reference. Using a state
-    // initializer (and `setLazyView(() => createLazyView())` on reset) keeps
-    // exhaustive-deps happy and lets the React Compiler optimize the host.
-    const [LazyView, setLazyView] = useState<LazyExoticComponent<ComponentType<PanelViewProps>>>(
-      () => createLazyView()
-    );
-    // Drive the ErrorBoundary's `resetKeys` independently — the reset
-    // counter is observable to the boundary even though the lazy ref lives
-    // in its own slot.
-    const [retryCount, setRetryCount] = useState(0);
-
-    // Warm the plugin runtime mirror at mount so the dev-mode flag is usually
-    // already there if this view later throws. The fallback re-pulls for the
-    // cases this can't cover; see PluginViewFallback.
-    const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
-    useEffect(() => initPluginRuntime(), [initPluginRuntime]);
-
-    // The dispose controller lives in state because its signal is consumed
-    // during render (passed to the plugin view as `disposeSignal`), and refs
-    // must not be read during render. A retry swaps in a fresh controller via
-    // handleReset so the new lazy import sees an unaborted signal.
-    const [controller, setController] = useState<AbortController>(() => new AbortController());
-
-    // Mirror the current controller into a ref so the long-lived (deps: [])
-    // teardown effect below reads the *latest* controller at call time — i.e.
-    // the post-retry one — without having to re-subscribe to the
-    // panel-kinds-changed broadcast on every retry.
-    const controllerRef = useRef(controller);
-    useEffect(() => {
-      controllerRef.current = controller;
-    }, [controller]);
-
-    useEffect(() => {
-      let disposed = false;
-      const electron = typeof window !== "undefined" ? window.electron : undefined;
-      const onChanged = electron?.plugin?.onPanelKindsChanged;
-      let cleanup: (() => void) | undefined;
-      if (onChanged) {
-        cleanup = onChanged((payload) => {
-          if (disposed) return;
-          const stillRegistered = payload.kinds.some((k) => k.id === kindId);
-          if (!stillRegistered) {
-            // Read the controller through the ref so a retry that swapped in a
-            // fresh AbortController is the one that gets aborted. Capturing
-            // `controllerRef.current` into a const at effect setup would leave
-            // post-retry signals permanently un-aborted on plugin removal.
-            controllerRef.current?.abort();
-          }
-        });
-      }
-      return () => {
-        disposed = true;
-        cleanup?.();
-        controllerRef.current?.abort();
-      };
-    }, []);
-
-    const handleReset = (): void => {
-      // Abort the outgoing view's signal before swapping in a fresh controller —
-      // the prior view instance is being discarded on retry, so any fetches or
-      // subscriptions it tied to `disposeSignal` must cancel now rather than
-      // linger until the whole host unmounts (#10512 review).
-      controller.abort();
-      // Fresh controller for the retry so the new lazy import sees an unaborted
-      // signal; the mirror effect propagates it to controllerRef for teardown.
-      setController(new AbortController());
-      setLazyView(() => createLazyView());
-      setRetryCount((c) => c + 1);
-    };
-
     return (
       // ContentPanel owns click-to-focus, the focus-registry entry, and the pane
       // chrome, exactly as it does for every other non-PTY kind (#11228). It sits
-      // outside the boundary and Suspense on purpose: a loading or crashed view
-      // keeps its header, context menu, and close control, so the panel is never
-      // stranded open. `kind` comes from the closure — `buildPanelProps` doesn't
-      // supply one, and the closure value is authoritative anyway.
+      // outside the content's boundary and Suspense on purpose: a loading or
+      // crashed view keeps its header, context menu, and close control, so the
+      // panel is never stranded open. `kind` comes from the closure —
+      // `buildPanelProps` doesn't supply one, and the closure value is
+      // authoritative anyway.
       //
       // `chrome={undefined}` forces ContentPanel to derive the descriptor from
       // `kind`, matching FilePane/Browser/DevPreview (none of which forward one).
@@ -280,37 +86,10 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Plugi
       // plugin's persisted panel re-enables (the panelProps memo doesn't depend
       // on the kind registry).
       <ContentPanel {...panelProps} kind={kindId} chrome={undefined}>
-        <ErrorBoundary
-          variant="component"
-          // `kindId` is already `${pluginId}.${panel.id}` (PluginService builds
-          // it that way), so prefixing pluginId again doubled it.
-          componentName={`PluginView:${kindId}`}
-          fallback={PluginViewFallback}
-          onReset={handleReset}
-          resetKeys={[retryCount]}
-        >
-          <Suspense
-            fallback={
-              // Content-only bones: ContentPanel already paints the real header,
-              // so a skeleton carrying its own (BrowserPaneSkeleton) would double
-              // it. Mirrors DevPreviewPaneFallback's quiet canvas — a plugin's
-              // content shape is unknowable, so bones must not imply one.
-              <div className="relative h-full">
-                <Skeleton label={`Loading ${displayName}`} className="h-full bg-surface-canvas" />
-                <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
-              </div>
-            }
-          >
-            <ContentFadeIn className="flex flex-col flex-1 min-h-0 w-full">
-              <LazyView
-                panelId={panelProps.id}
-                pluginId={pluginId!}
-                disposeSignal={controller.signal}
-                initialArgs={extensionState}
-              />
-            </ContentFadeIn>
-          </Suspense>
-        </ErrorBoundary>
+        {/* `extensionState` is how the panel store persists a view's spawn
+            arguments; the content layer speaks the SDK's presentation-neutral
+            `initialArgs` instead, so the mapping happens here at the seam. */}
+        <PluginViewContent panelId={panelProps.id} initialArgs={extensionState} />
       </ContentPanel>
     );
   }

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -58,10 +58,12 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Plugi
     };
   }
 
-  // Created once per host, at factory-construction scope. Calling this inside
-  // `PluginViewHost` — even behind `useMemo` — would produce a new component
-  // type per render, remounting the plugin view and restarting its import every
-  // time a panel prop changed.
+  // Created once per host, at factory-construction scope. Constructing it inside
+  // `PluginViewHost` would produce a new component type per render, remounting
+  // the plugin view and restarting its import every time a panel prop changed.
+  // (`useMemo` with a stable dep array would survive ordinary rerenders, but it
+  // ties the view's identity to a hook that remounts it whenever a dep changes;
+  // the construction belongs outside the component entirely.)
   const PluginViewContent = makePluginViewContent({
     id: kindId,
     name: displayName,

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -1,0 +1,576 @@
+// @vitest-environment jsdom
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
+import type { PluginViewContentConfig } from "../PluginViewContent";
+
+// Stub presentational deps — the content's behavioral contract is the lazy
+// import + AbortController wiring, not the skeleton or fade-in.
+vi.mock("@/components/ui/Skeleton", () => ({
+  Skeleton: ({ label }: { label?: string }) => <div data-testid="skeleton">{label}</div>,
+  SkeletonHint: () => null,
+}));
+vi.mock("@/components/ui/ContentFadeIn", () => ({
+  ContentFadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Note what is absent: this suite mocks none of the worktree/preferences/tooltip
+// graph that ContentPanel needs, because the content layer renders no chrome at
+// all. If a future change reintroduces a ContentPanel dependency here, this file
+// stops resolving — which is the point (#11240).
+
+// The subset of ErrorBoundary's contract the content relies on. Typed here
+// rather than cast at each read site — a cast would regress the per-rule
+// no-unsafe-type-assertion lint baseline.
+interface CapturedFallbackProps {
+  error: Error;
+  errorInfo?: React.ErrorInfo;
+  resetError: () => void;
+  incidentId?: string | null;
+}
+interface CapturedBoundaryProps {
+  children: React.ReactNode;
+  onReset?: () => void;
+  resetKeys?: Array<string | number>;
+  componentName?: string;
+  fallback?: React.ComponentType<CapturedFallbackProps>;
+}
+
+// The fake records the props it was handed, so the tests can render the very
+// fallback the content supplied. Asserting only that `fallback` is *a function*
+// would be satisfied by `() => null`.
+const boundaryProps = vi.hoisted(() => ({ last: null as CapturedBoundaryProps | null }));
+
+// Stub the real ErrorBoundary with a minimal class — exercising the entire
+// reporting pipeline (Sentry, errorStore, notify) is out of scope for these
+// unit tests. The stub honors `resetKeys` and `onReset` so the reload path can
+// be tested.
+vi.mock("@/components/ErrorBoundary", async () => {
+  const { Component } = await import("react");
+  class FakeBoundary extends Component<
+    CapturedBoundaryProps,
+    { hasError: boolean; lastKey: string | number | undefined }
+  > {
+    state = { hasError: false, lastKey: this.props.resetKeys?.[0] };
+    static getDerivedStateFromError(): { hasError: true } {
+      return { hasError: true };
+    }
+    componentDidCatch(): void {}
+    componentDidUpdate(prev: { resetKeys?: Array<string | number> }): void {
+      const next = this.props.resetKeys?.[0];
+      if (this.state.hasError && next !== this.state.lastKey) {
+        this.setState({ hasError: false, lastKey: next });
+      } else if (next !== this.state.lastKey) {
+        this.setState({ lastKey: next });
+      }
+      void prev;
+    }
+    render(): React.ReactNode {
+      boundaryProps.last = this.props;
+      if (this.state.hasError) {
+        return (
+          <button
+            data-testid="reset"
+            onClick={(): void => {
+              this.setState({ hasError: false });
+              this.props.onReset?.();
+            }}
+          >
+            Try again
+          </button>
+        );
+      }
+      return this.props.children;
+    }
+  }
+  return { ErrorBoundary: FakeBoundary };
+});
+
+function makeContentConfig(
+  overrides: Partial<PluginViewContentConfig> = {}
+): PluginViewContentConfig {
+  return {
+    id: "acme.dashboard",
+    name: "Dashboard",
+    componentPath: "plugin://acme/dashboard.js",
+    extensionId: "acme",
+    ...overrides,
+  };
+}
+
+const onPanelKindsChangedMock = vi.fn();
+
+beforeEach(() => {
+  boundaryProps.last = null;
+  onPanelKindsChangedMock.mockReset();
+  onPanelKindsChangedMock.mockReturnValue(() => {});
+  vi.stubGlobal("electron", undefined);
+  Object.defineProperty(window, "electron", {
+    configurable: true,
+    writable: true,
+    value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock } },
+  });
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+describe("makePluginViewContent", () => {
+  it("renders the plugin view with no panel chrome around it (#11240)", async () => {
+    // The decoupling contract itself: whatever presentation a host chooses, the
+    // content layer contributes none of it. A dialog host (#11239) mounting this
+    // must not inherit a grid pane's root, chrome, or close control.
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function StubView() {
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      const { container } = render(<Content panelId="panel-1" />);
+
+      await waitFor(() => expect(screen.getByTestId("plugin-view")).toBeTruthy());
+      expect(container.querySelector("[data-panel-id]")).toBeNull();
+      expect(container.querySelector("[data-pane-chrome]")).toBeNull();
+      expect(screen.queryByTestId("panel-close")).toBeNull();
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("hands the plugin view its panel id, plugin id, dispose signal, and initial args", async () => {
+    const capturedProps: Array<Record<string, unknown>> = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CapturingView(props: Record<string, unknown>) {
+            capturedProps.push(props);
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      const initialArgs = { path: "/repo/src/index.ts", line: 12 };
+      render(<Content panelId="panel-args" initialArgs={initialArgs} />);
+
+      await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
+      const props = capturedProps[capturedProps.length - 1]!;
+      expect(props.panelId).toBe("panel-args");
+      expect(props.pluginId).toBe("acme");
+      // The bag is forwarded by reference, not reconstructed.
+      expect(props.initialArgs).toBe(initialArgs);
+      expect(props.disposeSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("subscribes to plugin:panel-kinds-changed on mount and unsubscribes on unmount", async () => {
+    const cleanupSpy = vi.fn();
+    onPanelKindsChangedMock.mockReturnValue(cleanupSpy);
+
+    const { makePluginViewContent } = await import("../PluginViewContent");
+    const Content = makePluginViewContent(makeContentConfig());
+
+    const { unmount } = render(<Content panelId="panel-1" />);
+
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalledTimes(1));
+    unmount();
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a panel-kinds-changed push that omits its kind without throwing", async () => {
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation((cb) => {
+      emit = cb;
+      return () => {};
+    });
+
+    const { makePluginViewContent } = await import("../PluginViewContent");
+    const Content = makePluginViewContent(makeContentConfig());
+
+    render(<Content panelId="panel-7" />);
+
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+
+    const registered: PanelKindConfig[] = [
+      {
+        id: "acme.dashboard",
+        name: "Dashboard",
+        iconId: "gauge",
+        color: "#abcdef",
+        hasPty: false,
+        canRestart: false,
+        canConvert: false,
+        extensionId: "acme",
+      },
+    ];
+
+    // Live push that still contains the kind: nothing observable changes.
+    expect(() => act(() => emit!({ kinds: registered }))).not.toThrow();
+    // Push without the kind: the content aborts its controller — this branch
+    // must complete without throwing even though the dynamic import never
+    // resolved in jsdom (Suspense is still showing the skeleton).
+    expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
+  });
+
+  it("awaits plugin.activateForView with the kind id before importing the view module (#10523)", async () => {
+    // Reject activation with a sentinel so we can prove the import is *gated*
+    // on activation, not merely fired alongside it: if the `await` were dropped
+    // the factory would reject with the `plugin://` import error (module not
+    // found) instead of this sentinel.
+    const activateForView = vi.fn().mockRejectedValue(new Error("ACTIVATION_FAILED"));
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
+    });
+
+    // Capture the lazy factory so we can drive it directly — the real
+    // `plugin://` import never resolves in jsdom.
+    let capturedFactory: (() => Promise<unknown>) | undefined;
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          capturedFactory = factory;
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      render(<Content panelId="panel-act" />);
+
+      await waitFor(() => expect(capturedFactory).toBeDefined());
+      // Activation rejects, so the awaited call short-circuits before `import()`.
+      // Awaiting to settlement also lets the factory's `finally` clear the 10s
+      // timeout rather than leaking an open timer into the next test.
+      await expect(capturedFactory!()).rejects.toThrow("ACTIVATION_FAILED");
+      expect(activateForView).toHaveBeenCalledWith("acme.dashboard");
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("surfaces the real activation cause when activateForView rejects, before import (#10618)", async () => {
+    // The #10618 contract: on activation failure the activate-for-view IPC call
+    // REJECTS with the real cause (the handler throws an AppError), carrying the
+    // plugin's own message. The `await` rethrows it before `import()`, so the
+    // ErrorBoundary surfaces why activation failed instead of a generic import
+    // timeout. (Distinct from the #10523 gating test above, which only proves
+    // the await ordering with a sentinel.)
+    const activateForView = vi
+      .fn()
+      .mockRejectedValue(new Error('Plugin failed to activate for view "acme.dashboard": boom'));
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
+    });
+
+    let capturedFactory: (() => Promise<unknown>) | undefined;
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          capturedFactory = factory;
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      render(<Content panelId="panel-act-fail" />);
+
+      await waitFor(() => expect(capturedFactory).toBeDefined());
+      // The factory rejects with the real activation error and never reaches the
+      // `plugin://` import.
+      await expect(capturedFactory!()).rejects.toThrow(/boom/);
+      expect(activateForView).toHaveBeenCalledWith("acme.dashboard");
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("tolerates a missing activateForView binding without throwing (#10523)", async () => {
+    // beforeEach installs window.electron.plugin without activateForView, so the
+    // optional-chained call must no-op and the import must still proceed.
+    let capturedFactory: (() => Promise<unknown>) | undefined;
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          capturedFactory = factory;
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      render(<Content panelId="panel-noact" />);
+
+      await waitFor(() => expect(capturedFactory).toBeDefined());
+      // No activateForView present — the factory must not throw synchronously.
+      let threw = false;
+      const settled = (async () => {
+        try {
+          await capturedFactory!();
+        } catch {
+          // jsdom can't resolve the plugin:// import; that's expected here.
+        }
+      })().catch(() => {
+        threw = true;
+      });
+      await settled;
+      expect(threw).toBe(false);
+      // The content still mounted its (stubbed) view rather than crashing.
+      expect(screen.getByTestId("plugin-view")).toBeTruthy();
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("aborts the outgoing signal on retry and the post-retry signal on kind removal", async () => {
+    // Regression guard for the renderer-first teardown contract (#9501/#10512).
+    // Two failure modes, both invisible to a "doesn't throw" assertion: (1) a
+    // retry that swaps controllers without aborting the outgoing one leaks the
+    // discarded view's fetches and subscriptions; (2) an effect that captured
+    // `controllerRef.current` at setup would abort the *prior* controller on a
+    // kind-removed push, leaving the live signal armed forever. Capturing both
+    // generations' signals and asserting each aborts at its own moment is the
+    // only way to see either.
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation((cb) => {
+      emit = cb;
+      return () => {};
+    });
+
+    // Collect distinct controllers rather than counting renders: React may
+    // render a given generation more than once, and only the identity of the
+    // signal handed to the view is contractual.
+    const signals: AbortSignal[] = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CapturingView(props: { disposeSignal: AbortSignal }) {
+            if (!signals.includes(props.disposeSignal)) signals.push(props.disposeSignal);
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      render(<Content panelId="panel-9" />);
+
+      await waitFor(() => expect(signals).not.toHaveLength(0));
+      const first = signals[0]!;
+      expect(first.aborted).toBe(false);
+
+      // Drive the very callback the boundary's "Try again" invokes. Going
+      // through `onReset` rather than a thrown render keeps this deterministic:
+      // React's error-recovery re-render semantics are not the contract under
+      // test here, and the #11228 host suite already proves the boundary is
+      // wired to this handler.
+      const onReset = boundaryProps.last!.onReset;
+      expect(onReset).toBeTypeOf("function");
+      act(() => onReset!());
+
+      // The retry mints a genuinely fresh controller for the replacement view.
+      await waitFor(() => expect(signals.length).toBeGreaterThan(1));
+      const second = signals[1]!;
+      expect(second).not.toBe(first);
+      // The discarded view's signal aborted at swap time, not at unmount.
+      expect(first.aborted).toBe(true);
+      expect(second.aborted).toBe(false);
+
+      // Kind removal must abort the CURRENT controller, resolved through the ref
+      // at call time rather than the one captured when the effect was set up.
+      act(() => emit!({ kinds: [] }));
+      expect(second.aborted).toBe(true);
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("aborts the dispose signal when the content unmounts", async () => {
+    const signals: AbortSignal[] = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CapturingView(props: { disposeSignal: AbortSignal }) {
+            signals.push(props.disposeSignal);
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      const { unmount } = render(<Content panelId="panel-unmount" />);
+      await waitFor(() => expect(signals).not.toHaveLength(0));
+      const signal = signals[signals.length - 1]!;
+      expect(signal.aborted).toBe(false);
+
+      unmount();
+      expect(signal.aborted).toBe(true);
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("hands the boundary a plugin-specific fallback and an undoubled component name (#11207)", async () => {
+    const { makePluginViewContent } = await import("../PluginViewContent");
+    const Content = makePluginViewContent(makeContentConfig());
+
+    render(<Content panelId="panel-fallback" />);
+
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+    // `kindId` already carries the plugin prefix, so re-prefixing it produced
+    // `PluginView:acme.acme.dashboard` in the title and every log field.
+    expect(boundaryProps.last!.componentName).toBe("PluginView:acme.dashboard");
+  });
+
+  // Closes the seam the fake boundary would otherwise hide: asserting that
+  // `fallback` is merely a function is satisfied by `() => null`. Rendering the
+  // very component the content handed the boundary proves the wiring reaches the
+  // real diagnostics pane, carries this plugin's identity, and fails closed
+  // when the runtime store holds no metadata for it.
+  it("hands the boundary a fallback that renders this plugin's diagnostics (#11207)", async () => {
+    const { makePluginViewContent } = await import("../PluginViewContent");
+    const Content = makePluginViewContent(makeContentConfig());
+
+    render(<Content panelId="panel-fallback-render" />);
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+
+    const Fallback = boundaryProps.last!.fallback!;
+    const error = new Error("view exploded");
+    error.stack = "Error: view exploded\n    at View (/Users/alice/acme/dashboard.js:3:1)";
+
+    render(
+      <Fallback
+        error={error}
+        errorInfo={{ componentStack: "\n    at View" }}
+        resetError={(): void => {}}
+        incidentId={null}
+      />
+    );
+
+    const pane = screen.getByTestId("plugin-view-diagnostics").textContent ?? "";
+    expect(pane).toContain("view exploded");
+    expect(pane).toContain("plugin://acme/dashboard.js");
+    expect(pane).toContain("acme.dashboard");
+    // This suite never seeds a runtime snapshot ⇒ unknown devMode ⇒ redacted.
+    expect(screen.getByTestId("plugin-view-diagnostics-trace").textContent).not.toContain(
+      "/Users/alice"
+    );
+  });
+
+  // The metadata the pane needs may not exist at mount time: `loadPlugin`
+  // registers the panel kind before the plugin is listable, and dev attach
+  // never fires provenance. Reaching the fallback means the view already threw,
+  // so the plugin is loaded — the pane must pull for itself at that point
+  // rather than trust whatever the store happened to hold earlier (#11207).
+  it("pulls a fresh plugin snapshot when the diagnostics pane mounts (#11207)", async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: {
+        plugin: {
+          onPanelKindsChanged: onPanelKindsChangedMock,
+          onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
+          list,
+        },
+      },
+    });
+
+    const { makePluginViewContent } = await import("../PluginViewContent");
+    const Content = makePluginViewContent(makeContentConfig());
+
+    render(<Content panelId="panel-refresh" />);
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+    const callsBeforeCrash = list.mock.calls.length;
+
+    const Fallback = boundaryProps.last!.fallback!;
+    render(<Fallback error={new Error("view exploded")} resetError={(): void => {}} />);
+
+    await waitFor(() => expect(list.mock.calls.length).toBeGreaterThan(callsBeforeCrash));
+  });
+
+  // The dev-plugin snapshot can land *after* the view has already crashed (the
+  // pull is async, and `daintree-plugin dev` never fires provenance). The pane
+  // must upgrade in place rather than stay redacted until the user retries.
+  it("upgrades a redacted trace to raw when the plugin's dev-mode snapshot lands late (#11207)", async () => {
+    const { makePluginViewContent } = await import("../PluginViewContent");
+    // Resolved from the same module graph as the content — the suite resets
+    // modules between cases, so a static import would seed a different store.
+    const { usePluginRuntimeStore } = await import("@/store/pluginRuntimeStore");
+    const Content = makePluginViewContent(makeContentConfig());
+
+    render(<Content panelId="panel-late-snapshot" />);
+    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
+
+    const Fallback = boundaryProps.last!.fallback!;
+    const error = new Error("view exploded");
+    error.stack = "Error: view exploded\n    at View (/Users/alice/acme/dashboard.js:3:1)";
+    render(<Fallback error={error} resetError={(): void => {}} />);
+
+    const trace = () => screen.getByTestId("plugin-view-diagnostics-trace").textContent ?? "";
+    expect(trace()).not.toContain("/Users/alice");
+
+    act(() => {
+      usePluginRuntimeStore.setState({
+        pluginMetaById: new Map([["acme", { devMode: true, displayName: "Acme Tools" }]]),
+      });
+    });
+
+    expect(trace()).toContain("/Users/alice");
+    // The same snapshot carries the manifest display name, which the panel's
+    // own `config.name` ("Dashboard") can't supply.
+    expect(screen.getByTestId("plugin-view-diagnostics").textContent).toContain("Acme Tools");
+  });
+});

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -273,7 +273,7 @@ describe("makePluginViewContent", () => {
     });
 
     // Capture the lazy factory so we can drive it directly — the real
-    // `plugin://` import never resolves in jsdom.
+    // `plugin://` import rejects in jsdom with an unsupported-scheme error.
     let capturedFactory: (() => Promise<unknown>) | undefined;
     vi.doMock("react", async () => {
       const actual = await vi.importActual<typeof import("react")>("react");
@@ -414,10 +414,10 @@ describe("makePluginViewContent", () => {
     // render a given generation more than once, and only the identity of the
     // signal handed to the view is contractual.
     const signals: AbortSignal[] = [];
-    // Count factory constructions: `lazy()` memoizes its import promise by
-    // factory identity, so a retry that reuses the old ref would replay the
-    // cached *failed* promise and never re-import. Only a fresh construction
-    // proves the reload actually happens (#9501).
+    // Count wrapper constructions: each `lazy()` caches its import result on its
+    // own payload, so a retry that reuses the old wrapper replays the cached
+    // *failed* result and never re-imports. Only a fresh construction proves the
+    // reload actually happens (#9501).
     const lazyCalls = { count: 0 };
     vi.doMock("react", async () => {
       const actual = await vi.importActual<typeof import("react")>("react");

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -15,9 +15,10 @@ vi.mock("@/components/ui/ContentFadeIn", () => ({
 }));
 
 // Note what is absent: this suite mocks none of the worktree/preferences/tooltip
-// graph that ContentPanel needs, because the content layer renders no chrome at
-// all. If a future change reintroduces a ContentPanel dependency here, this file
-// stops resolving — which is the point (#11240).
+// graph that ContentPanel needs, because the content layer renders no panel
+// chrome at all. Reintroducing a ContentPanel wrap here would throw on render
+// (it reaches useWorktreeStore with no provider) rather than quietly pass —
+// which is the point (#11240).
 
 // The subset of ErrorBoundary's contract the content relies on. Typed here
 // rather than cast at each read site — a cast would regress the per-rule
@@ -195,39 +196,68 @@ describe("makePluginViewContent", () => {
     expect(cleanupSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("tolerates a panel-kinds-changed push that omits its kind without throwing", async () => {
+  it("aborts only when a panel-kinds push drops its kind, not on every push", async () => {
+    // The disposeSignal is the observable, not "didn't throw": an implementation
+    // that aborted on *every* broadcast would tear down a healthy plugin view
+    // whenever any unrelated plugin was installed, enabled, or removed — and a
+    // no-throw assertion would happily pass while it did.
     let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
     onPanelKindsChangedMock.mockImplementation((cb) => {
       emit = cb;
       return () => {};
     });
 
-    const { makePluginViewContent } = await import("../PluginViewContent");
-    const Content = makePluginViewContent(makeContentConfig());
+    const signals: AbortSignal[] = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CapturingView(props: { disposeSignal: AbortSignal }) {
+            if (!signals.includes(props.disposeSignal)) signals.push(props.disposeSignal);
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
 
-    render(<Content panelId="panel-7" />);
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
 
-    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+      render(<Content panelId="panel-7" />);
 
-    const registered: PanelKindConfig[] = [
-      {
-        id: "acme.dashboard",
-        name: "Dashboard",
-        iconId: "gauge",
-        color: "#abcdef",
-        hasPty: false,
-        canRestart: false,
-        canConvert: false,
-        extensionId: "acme",
-      },
-    ];
+      await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+      await waitFor(() => expect(signals).not.toHaveLength(0));
+      const signal = signals[0]!;
 
-    // Live push that still contains the kind: nothing observable changes.
-    expect(() => act(() => emit!({ kinds: registered }))).not.toThrow();
-    // Push without the kind: the content aborts its controller — this branch
-    // must complete without throwing even though the dynamic import never
-    // resolved in jsdom (Suspense is still showing the skeleton).
-    expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
+      const registered: PanelKindConfig[] = [
+        {
+          id: "acme.dashboard",
+          name: "Dashboard",
+          iconId: "gauge",
+          color: "#abcdef",
+          hasPty: false,
+          canRestart: false,
+          canConvert: false,
+          extensionId: "acme",
+        },
+      ];
+
+      // A push that still lists this kind must leave the live view untouched.
+      act(() => emit!({ kinds: registered }));
+      expect(signal.aborted).toBe(false);
+
+      // Dropping the kind is what disposes it.
+      act(() => emit!({ kinds: [] }));
+      expect(signal.aborted).toBe(true);
+
+      // A duplicate removal is idempotent — the broadcast can repeat, and
+      // aborting an already-aborted controller must stay a no-op.
+      expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
+      expect(signal.aborted).toBe(true);
+    } finally {
+      vi.doUnmock("react");
+    }
   });
 
   it("awaits plugin.activateForView with the kind id before importing the view module (#10523)", async () => {
@@ -345,19 +375,19 @@ describe("makePluginViewContent", () => {
       render(<Content panelId="panel-noact" />);
 
       await waitFor(() => expect(capturedFactory).toBeDefined());
-      // No activateForView present — the factory must not throw synchronously.
-      let threw = false;
-      const settled = (async () => {
-        try {
-          await capturedFactory!();
-        } catch {
-          // jsdom can't resolve the plugin:// import; that's expected here.
-        }
-      })().catch(() => {
-        threw = true;
-      });
-      await settled;
-      expect(threw).toBe(false);
+
+      // The factory still rejects here — jsdom can't resolve a `plugin://` URL —
+      // so "did it reject" proves nothing. What matters is the *cause*: with the
+      // optional chaining intact the missing binding is skipped and the failure
+      // comes from the import. Drop the `?.` and the factory instead dies on
+      // "activateForView is not a function" before reaching `import()`.
+      // Awaiting to settlement also lets the factory's `finally` clear the
+      // import timeout instead of leaking a live timer into the next test.
+      const cause: unknown = await capturedFactory!().then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect(String(cause)).not.toMatch(/is not a function/);
       // The content still mounted its (stubbed) view rather than crashing.
       expect(screen.getByTestId("plugin-view")).toBeTruthy();
     } finally {
@@ -384,15 +414,22 @@ describe("makePluginViewContent", () => {
     // render a given generation more than once, and only the identity of the
     // signal handed to the view is contractual.
     const signals: AbortSignal[] = [];
+    // Count factory constructions: `lazy()` memoizes its import promise by
+    // factory identity, so a retry that reuses the old ref would replay the
+    // cached *failed* promise and never re-import. Only a fresh construction
+    // proves the reload actually happens (#9501).
+    const lazyCalls = { count: 0 };
     vi.doMock("react", async () => {
       const actual = await vi.importActual<typeof import("react")>("react");
       return {
         ...actual,
-        lazy: () =>
-          function CapturingView(props: { disposeSignal: AbortSignal }) {
+        lazy: () => {
+          lazyCalls.count += 1;
+          return function CapturingView(props: { disposeSignal: AbortSignal }) {
             if (!signals.includes(props.disposeSignal)) signals.push(props.disposeSignal);
             return <div data-testid="plugin-view" />;
-          },
+          };
+        },
       };
     });
 
@@ -405,12 +442,17 @@ describe("makePluginViewContent", () => {
       await waitFor(() => expect(signals).not.toHaveLength(0));
       const first = signals[0]!;
       expect(first.aborted).toBe(false);
+      const callsBeforeReset = lazyCalls.count;
+      const resetKeyBeforeReset = boundaryProps.last!.resetKeys?.[0];
 
       // Drive the very callback the boundary's "Try again" invokes. Going
       // through `onReset` rather than a thrown render keeps this deterministic:
-      // React's error-recovery re-render semantics are not the contract under
-      // test here, and the #11228 host suite already proves the boundary is
-      // wired to this handler.
+      // a synchronously throwing view double is incompatible with React's
+      // concurrent initial-mount recovery, which discards the uncommitted tree
+      // and re-runs the `useState` initializer, so a call-count-keyed double
+      // ends up mounting the generation it meant to skip. The wiring from the
+      // boundary to this handler is asserted separately, where the boundary's
+      // captured props are checked.
       const onReset = boundaryProps.last!.onReset;
       expect(onReset).toBeTypeOf("function");
       act(() => onReset!());
@@ -422,6 +464,11 @@ describe("makePluginViewContent", () => {
       // The discarded view's signal aborted at swap time, not at unmount.
       expect(first.aborted).toBe(true);
       expect(second.aborted).toBe(false);
+      // ...and the module is genuinely re-imported rather than the controller
+      // merely being swapped: a fresh `lazy()` ref, and a bumped reset key so
+      // the boundary clears its error state.
+      expect(lazyCalls.count).toBeGreaterThan(callsBeforeReset);
+      expect(boundaryProps.last!.resetKeys?.[0]).not.toBe(resetKeyBeforeReset);
 
       // Kind removal must abort the CURRENT controller, resolved through the ref
       // at call time rather than the one captured when the effect was set up.

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -223,59 +223,6 @@ describe("makePluginViewHost", () => {
     expect(screen.getByText(/Dashboard unavailable/i)).toBeTruthy();
   });
 
-  it("subscribes to plugin:panel-kinds-changed on mount and unsubscribes on unmount", async () => {
-    const cleanupSpy = vi.fn();
-    onPanelKindsChangedMock.mockReturnValue(cleanupSpy);
-
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    const { unmount } = render(
-      <Host
-        id="panel-1"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-
-    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalledTimes(1));
-    unmount();
-    expect(cleanupSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("tolerates a panel-kinds-changed push that omits its kind without throwing", async () => {
-    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
-    onPanelKindsChangedMock.mockImplementation((cb) => {
-      emit = cb;
-      return () => {};
-    });
-
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const config = makeConfig();
-    const Host = makePluginViewHost(config);
-
-    render(
-      <Host
-        id="panel-7"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-
-    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
-
-    // Live push that still contains the kind: nothing observable changes.
-    expect(() => act(() => emit!({ kinds: [config] }))).not.toThrow();
-    // Push without the kind: the host aborts its controller — this branch
-    // must complete without throwing even though the dynamic import never
-    // resolved in jsdom (Suspense is still showing the skeleton).
-    expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
-  });
-
   it("passes the panel's extensionState to the mounted view as initialArgs", async () => {
     const capturedProps: Array<Record<string, unknown>> = [];
     // Replace React.lazy so the plugin view renders synchronously (the real
@@ -320,334 +267,62 @@ describe("makePluginViewHost", () => {
     vi.doUnmock("react");
   });
 
-  it("awaits plugin.activateForView with the kind id before importing the view module (#10523)", async () => {
-    // Reject activation with a sentinel so we can prove the import is *gated*
-    // on activation, not merely fired alongside it: if the `await` were dropped
-    // the factory would reject with the `plugin://` import error (module not
-    // found) instead of this sentinel.
-    const activateForView = vi.fn().mockRejectedValue(new Error("ACTIVATION_FAILED"));
-    Object.defineProperty(window, "electron", {
-      configurable: true,
-      writable: true,
-      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
-    });
-
-    // Capture the lazy factory so we can drive it directly — the real
-    // `plugin://` import never resolves in jsdom.
-    let capturedFactory: (() => Promise<unknown>) | undefined;
+  it("keeps the plugin view mounted across panel prop changes (#11240)", async () => {
+    // The content component type must be created once, at factory-construction
+    // scope. Building it inside the host's render — even behind useMemo — mints
+    // a new type per render, so React unmounts and remounts the plugin view (and
+    // restarts its `plugin://` import, and aborts its disposeSignal) every time
+    // a title or focus prop changes. The signal identity is the observable:
+    // a remount would hand the view a fresh, distinct controller.
+    const signals: AbortSignal[] = [];
     vi.doMock("react", async () => {
       const actual = await vi.importActual<typeof import("react")>("react");
       return {
         ...actual,
-        lazy: (factory: () => Promise<unknown>) => {
-          capturedFactory = factory;
-          return function StubView() {
+        lazy: () =>
+          function CapturingView(props: { disposeSignal: AbortSignal }) {
+            signals.push(props.disposeSignal);
             return <div data-testid="plugin-view" />;
-          };
-        },
+          },
       };
     });
 
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
+    try {
+      const { makePluginViewHost } = await import("../PluginViewHost");
+      const Host = makePluginViewHost(makeConfig());
 
-    render(
-      <Host
-        id="panel-act"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
+      const { rerender } = render(
+        <Host
+          id="panel-identity"
+          title="Dashboard"
+          isFocused={false}
+          onFocus={(): void => {}}
+          onClose={(): void => {}}
+        />
+      );
 
-    await waitFor(() => expect(capturedFactory).toBeDefined());
-    // Activation rejects, so the awaited call short-circuits before `import()`.
-    await expect(capturedFactory!()).rejects.toThrow("ACTIVATION_FAILED");
-    expect(activateForView).toHaveBeenCalledWith("acme.dashboard");
-    vi.doUnmock("react");
-  });
+      await waitFor(() => expect(signals).not.toHaveLength(0));
+      const first = signals[0]!;
 
-  it("surfaces the real activation cause when activateForView rejects, before import (#10618)", async () => {
-    // The #10618 contract: on activation failure the activate-for-view IPC call
-    // REJECTS with the real cause (the handler throws an AppError), carrying the
-    // plugin's own message. The host's `await` rethrows it before `import()`, so
-    // the ErrorBoundary surfaces why activation failed instead of a generic
-    // import timeout. (Distinct from the #10523 gating test below, which only
-    // proves the await ordering with a sentinel.)
-    const activateForView = vi
-      .fn()
-      .mockRejectedValue(new Error('Plugin failed to activate for view "acme.dashboard": boom'));
-    Object.defineProperty(window, "electron", {
-      configurable: true,
-      writable: true,
-      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
-    });
-
-    let capturedFactory: (() => Promise<unknown>) | undefined;
-    vi.doMock("react", async () => {
-      const actual = await vi.importActual<typeof import("react")>("react");
-      return {
-        ...actual,
-        lazy: (factory: () => Promise<unknown>) => {
-          capturedFactory = factory;
-          return function StubView() {
-            return <div data-testid="plugin-view" />;
-          };
-        },
-      };
-    });
-
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    render(
-      <Host
-        id="panel-act-fail"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-
-    await waitFor(() => expect(capturedFactory).toBeDefined());
-    // The factory rejects with the real activation error and never reaches the
-    // `plugin://` import.
-    await expect(capturedFactory!()).rejects.toThrow(/boom/);
-    expect(activateForView).toHaveBeenCalledWith("acme.dashboard");
-    vi.doUnmock("react");
-  });
-
-  it("tolerates a missing activateForView binding without throwing (#10523)", async () => {
-    // beforeEach installs window.electron.plugin without activateForView, so the
-    // optional-chained call must no-op and the import must still proceed.
-    let capturedFactory: (() => Promise<unknown>) | undefined;
-    vi.doMock("react", async () => {
-      const actual = await vi.importActual<typeof import("react")>("react");
-      return {
-        ...actual,
-        lazy: (factory: () => Promise<unknown>) => {
-          capturedFactory = factory;
-          return function StubView() {
-            return <div data-testid="plugin-view" />;
-          };
-        },
-      };
-    });
-
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    render(
-      <Host
-        id="panel-noact"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-
-    await waitFor(() => expect(capturedFactory).toBeDefined());
-    // No activateForView present — the factory must not throw synchronously.
-    let threw = false;
-    const settled = (async () => {
-      try {
-        await capturedFactory!();
-      } catch {
-        // jsdom can't resolve the plugin:// import; that's expected here.
-      }
-    })().catch(() => {
-      threw = true;
-    });
-    await settled;
-    expect(threw).toBe(false);
-    // The host still mounted its (stubbed) view rather than crashing.
-    expect(screen.getByTestId("plugin-view")).toBeTruthy();
-    vi.doUnmock("react");
-  });
-
-  it("reads the AbortController through a ref so post-retry removals abort the current signal", async () => {
-    // Regression guard for the renderer-first teardown contract: if the
-    // useEffect captured controllerRef.current into a const at setup time,
-    // a kind-removed push after a retry would abort the prior (already
-    // aborted) controller and leave the live signal armed. Capturing
-    // controllerRef.current and asserting it changes across two pushes
-    // proves the ref-through-callback pattern.
-    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
-    onPanelKindsChangedMock.mockImplementation((cb) => {
-      emit = cb;
-      return () => {};
-    });
-
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const config = makeConfig();
-    const Host = makePluginViewHost(config);
-
-    const { unmount } = render(
-      <Host
-        id="panel-9"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-
-    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
-
-    // Removing the kind from the broadcast must abort. Doing this twice and
-    // unmounting in between still must not throw — the callback resolves the
-    // controller through the ref at call time, not via a stale closure.
-    expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
-    expect(() => act(() => emit!({ kinds: [] }))).not.toThrow();
-
-    unmount();
-  });
-
-  it("hands the boundary a plugin-specific fallback and an undoubled component name (#11207)", async () => {
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    render(
-      <Host
-        id="panel-fallback"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-
-    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
-    // `kindId` already carries the plugin prefix, so re-prefixing it produced
-    // `PluginView:acme.acme.dashboard` in the title and every log field.
-    expect(boundaryProps.last!.componentName).toBe("PluginView:acme.dashboard");
-  });
-
-  // Closes the seam the fake boundary would otherwise hide: asserting that
-  // `fallback` is merely a function is satisfied by `() => null`. Rendering the
-  // very component the host handed the boundary proves the wiring reaches the
-  // real diagnostics pane, carries this plugin's identity, and fails closed
-  // when the runtime store holds no metadata for it.
-  it("hands the boundary a fallback that renders this plugin's diagnostics (#11207)", async () => {
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    render(
-      <Host
-        id="panel-fallback-render"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
-
-    const Fallback = boundaryProps.last!.fallback!;
-    const error = new Error("view exploded");
-    error.stack = "Error: view exploded\n    at View (/Users/alice/acme/dashboard.js:3:1)";
-
-    render(
-      <Fallback
-        error={error}
-        errorInfo={{ componentStack: "\n    at View" }}
-        resetError={(): void => {}}
-        incidentId={null}
-      />
-    );
-
-    const pane = screen.getByTestId("plugin-view-diagnostics").textContent ?? "";
-    expect(pane).toContain("view exploded");
-    expect(pane).toContain("plugin://acme/dashboard.js");
-    expect(pane).toContain("acme.dashboard");
-    // This suite never seeds a runtime snapshot ⇒ unknown devMode ⇒ redacted.
-    expect(screen.getByTestId("plugin-view-diagnostics-trace").textContent).not.toContain(
-      "/Users/alice"
-    );
-  });
-
-  // The metadata the pane needs may not exist at host-mount time: `loadPlugin`
-  // registers the panel kind before the plugin is listable, and dev attach
-  // never fires provenance. Reaching the fallback means the view already threw,
-  // so the plugin is loaded — the pane must pull for itself at that point
-  // rather than trust whatever the store happened to hold earlier (#11207).
-  it("pulls a fresh plugin snapshot when the diagnostics pane mounts (#11207)", async () => {
-    const list = vi.fn().mockResolvedValue([]);
-    Object.defineProperty(window, "electron", {
-      configurable: true,
-      writable: true,
-      value: {
-        plugin: {
-          onPanelKindsChanged: onPanelKindsChangedMock,
-          onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
-          list,
-        },
-      },
-    });
-
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-
-    render(
-      <Host
-        id="panel-refresh"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
-    const callsBeforeCrash = list.mock.calls.length;
-
-    const Fallback = boundaryProps.last!.fallback!;
-    render(<Fallback error={new Error("view exploded")} resetError={(): void => {}} />);
-
-    await waitFor(() => expect(list.mock.calls.length).toBeGreaterThan(callsBeforeCrash));
-  });
-
-  // The dev-plugin snapshot can land *after* the view has already crashed (the
-  // pull is async, and `daintree-plugin dev` never fires provenance). The pane
-  // must upgrade in place rather than stay redacted until the user retries.
-  it("upgrades a redacted trace to raw when the plugin's dev-mode snapshot lands late (#11207)", async () => {
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    // Resolved from the same module graph as the host — the suite resets
-    // modules between cases, so a static import would seed a different store.
-    const { usePluginRuntimeStore } = await import("@/store/pluginRuntimeStore");
-    const Host = makePluginViewHost(makeConfig());
-
-    render(
-      <Host
-        id="panel-late-snapshot"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-      />
-    );
-    await waitFor(() => expect(boundaryProps.last).not.toBeNull());
-
-    const Fallback = boundaryProps.last!.fallback!;
-    const error = new Error("view exploded");
-    error.stack = "Error: view exploded\n    at View (/Users/alice/acme/dashboard.js:3:1)";
-    render(<Fallback error={error} resetError={(): void => {}} />);
-
-    const trace = () => screen.getByTestId("plugin-view-diagnostics-trace").textContent ?? "";
-    expect(trace()).not.toContain("/Users/alice");
-
-    act(() => {
-      usePluginRuntimeStore.setState({
-        pluginMetaById: new Map([["acme", { devMode: true, displayName: "Acme Tools" }]]),
+      act(() => {
+        rerender(
+          <Host
+            id="panel-identity"
+            title="Renamed by the user"
+            isFocused
+            onFocus={(): void => {}}
+            onClose={(): void => {}}
+          />
+        );
       });
-    });
 
-    expect(trace()).toContain("/Users/alice");
-    // The same snapshot carries the manifest display name, which the panel's
-    // own `config.name` ("Dashboard") can't supply.
-    expect(screen.getByTestId("plugin-view-diagnostics").textContent).toContain("Acme Tools");
+      // Same controller instance, still live: the view was re-rendered, not
+      // re-created.
+      expect(signals[signals.length - 1]).toBe(first);
+      expect(first.aborted).toBe(false);
+    } finally {
+      vi.doUnmock("react");
+    }
   });
 });
 

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -85,9 +85,11 @@ vi.mock("@/components/Panel/panelFocusRegistry", async (importOriginal) => {
   };
 });
 
-// The subset of ErrorBoundary's contract the host relies on. Typed here rather
-// than cast at each read site — a cast would regress the per-rule
-// no-unsafe-type-assertion lint baseline.
+// The subset of ErrorBoundary's contract this suite observes. The boundary now
+// lives inside PluginViewContent; what the host cares about is only that a
+// crashed view still sits inside the chrome. Typed here rather than cast at each
+// read site — a cast would regress the per-rule no-unsafe-type-assertion lint
+// baseline.
 interface CapturedFallbackProps {
   error: Error;
   errorInfo?: React.ErrorInfo;
@@ -102,9 +104,10 @@ interface CapturedBoundaryProps {
   fallback?: React.ComponentType<CapturedFallbackProps>;
 }
 
-// The fake records the props it was handed, so the tests can render the very
-// fallback the host supplied. Asserting only that `fallback` is *a function*
-// would be satisfied by `() => null`.
+// The fake records the props it was handed and renders a reset sentinel once it
+// catches, which is how the chrome tests below observe a crashed view. The
+// fallback's own wiring is asserted in the PluginViewContent suite, which owns
+// the boundary.
 const boundaryProps = vi.hoisted(() => ({ last: null as CapturedBoundaryProps | null }));
 
 // Stub the real ErrorBoundary with a minimal class — exercising the entire
@@ -228,7 +231,8 @@ describe("makePluginViewHost", () => {
   it("passes the panel's extensionState to the mounted view as initialArgs", async () => {
     const capturedProps: Array<Record<string, unknown>> = [];
     // Replace React.lazy so the plugin view renders synchronously (the real
-    // `plugin://` dynamic import never resolves in jsdom). The stub renders a
+    // `plugin://` dynamic import rejects in jsdom — unsupported URL scheme —
+    // so the real view could never mount here). The stub renders a
     // capturing component that records the props the host hands it — proving the
     // spawn-time `extensionState` reaches the view as `initialArgs`.
     vi.doMock("react", async () => {

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -3,8 +3,10 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
 
-// Stub presentational deps — the host's behavioral contract is the lazy
-// import + AbortController wiring, not the skeleton or fade-in chrome.
+// Stub presentational deps — the skeleton and fade-in are incidental here. The
+// host's contract is panel adaptation: mapping panel props onto ContentPanel and
+// mounting the content component inside it. The lazy import and AbortController
+// wiring moved to PluginViewContent and are covered by its own suite (#11240).
 vi.mock("@/components/ui/Skeleton", () => ({
   Skeleton: ({ label }: { label?: string }) => <div data-testid="skeleton">{label}</div>,
   SkeletonHint: () => null,
@@ -241,38 +243,45 @@ describe("makePluginViewHost", () => {
       };
     });
 
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
+    try {
+      const { makePluginViewHost } = await import("../PluginViewHost");
+      const Host = makePluginViewHost(makeConfig());
 
-    const initialArgs = { path: "/repo/src/index.ts", line: 12 };
-    render(
-      <Host
-        id="panel-args"
-        title="Dashboard"
-        isFocused={false}
-        onFocus={(): void => {}}
-        onClose={(): void => {}}
-        extensionState={initialArgs}
-      />
-    );
+      const initialArgs = { path: "/repo/src/index.ts", line: 12 };
+      render(
+        <Host
+          id="panel-args"
+          title="Dashboard"
+          isFocused={false}
+          onFocus={(): void => {}}
+          onClose={(): void => {}}
+          extensionState={initialArgs}
+        />
+      );
 
-    await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
-    expect(capturedProps).not.toHaveLength(0);
-    const props = capturedProps[capturedProps.length - 1]!;
-    expect(props.panelId).toBe("panel-args");
-    expect(props.pluginId).toBe("acme");
-    expect(props.initialArgs).toEqual(initialArgs);
-    // The bag is forwarded by reference from extensionState, not reconstructed.
-    expect(props.initialArgs).toBe(initialArgs);
-    vi.doUnmock("react");
+      await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
+      const props = capturedProps[capturedProps.length - 1]!;
+      expect(props.panelId).toBe("panel-args");
+      expect(props.pluginId).toBe("acme");
+      // The bag is forwarded by reference from extensionState, not reconstructed.
+      expect(props.initialArgs).toBe(initialArgs);
+    } finally {
+      // Unmock in `finally`: a failed assertion above would otherwise leak the
+      // capturing `lazy` into every later test in this file (`vi.resetModules`
+      // clears the module cache but not the registered mock).
+      vi.doUnmock("react");
+    }
   });
 
   it("keeps the plugin view mounted across panel prop changes (#11240)", async () => {
     // The content component type must be created once, at factory-construction
-    // scope. Building it inside the host's render — even behind useMemo — mints
-    // a new type per render, so React unmounts and remounts the plugin view (and
-    // restarts its `plugin://` import, and aborts its disposeSignal) every time
-    // a title or focus prop changes. The signal identity is the observable:
+    // scope. Constructing it during the host's render mints a new type per
+    // render, so React unmounts and remounts the plugin view — restarting its
+    // `plugin://` import and aborting its disposeSignal — every time a title or
+    // focus prop changes. (A `useMemo` with a stable dep array would survive
+    // ordinary rerenders, but it ties the component's identity to a hook that
+    // silently remounts the view the moment a dep changes; construction belongs
+    // outside the component entirely.) The signal identity is the observable:
     // a remount would hand the view a fresh, distinct controller.
     const signals: AbortSignal[] = [];
     vi.doMock("react", async () => {
@@ -502,21 +511,26 @@ describe("PluginViewHost panel integration (#11228)", () => {
       };
     });
 
-    const { makePluginViewHost } = await import("../PluginViewHost");
-    const Host = makePluginViewHost(makeConfig());
-    const onClose = vi.fn<() => void>();
+    try {
+      const { makePluginViewHost } = await import("../PluginViewHost");
+      const Host = makePluginViewHost(makeConfig());
+      const onClose = vi.fn<() => void>();
 
-    const { container } = render(<Host {...hostProps} onClose={onClose} onFocus={() => {}} />);
+      const { container } = render(<Host {...hostProps} onClose={onClose} onFocus={() => {}} />);
 
-    // The mocked ErrorBoundary renders its reset sentinel once it catches.
-    await waitFor(() => expect(screen.getByTestId("reset")).toBeTruthy());
-    // Chrome coexists with the fallback rather than being replaced by it.
-    expect(panelRoot(container)).toBeTruthy();
-    expect(container.querySelector("[data-pane-chrome]")).toBeTruthy();
+      // The mocked ErrorBoundary renders its reset sentinel once it catches.
+      await waitFor(() => expect(screen.getByTestId("reset")).toBeTruthy());
+      // Chrome coexists with the fallback rather than being replaced by it.
+      expect(panelRoot(container)).toBeTruthy();
+      expect(container.querySelector("[data-pane-chrome]")).toBeTruthy();
 
-    act(() => screen.getByTestId("panel-close").click());
-    expect(onClose).toHaveBeenCalled();
-    vi.doUnmock("react");
+      act(() => screen.getByTestId("panel-close").click());
+      expect(onClose).toHaveBeenCalled();
+    } finally {
+      // A failed assertion above would otherwise leak the crashing `lazy` into
+      // every later test in this file.
+      vi.doUnmock("react");
+    }
   });
 
   it("passes the plugin's own kind and the live panel title to the shell", async () => {


### PR DESCRIPTION
## Summary

`makePluginViewHost` was doing two unrelated jobs at once: the plugin work (implicit activation, a lazy `plugin://` import racing a 10s timeout, `ErrorBoundary`, `Suspense`, `disposeSignal`/`AbortController` lifecycle) and grid pane presentation (a hardcoded `ContentPanel` wrap). This splits them apart.

Resolves #11240

## Changes

- New file `src/components/Plugin/PluginViewContent.tsx` exports `makePluginViewContent(config)`, returning a component that owns the entire plugin lifecycle and contributes no panel chrome: no header, no focus target, no close control.
- `makePluginViewHost` is now a thin panel adapter. It maps panel props onto `ContentPanel` and mounts the content component inside it. Its exported signature and registration contract are unchanged, so `usePluginPanelKinds.ts` is untouched.
- The content contract narrows to `{ panelId, initialArgs }`. `initialArgs` matches the SDK-facing `PanelViewProps` name; the panel store's `extensionState` is mapped onto it at the seam. Making `componentPath`/`extensionId` required on the new config also removed every `pluginId!` / `componentPath!` non-null assertion from the moved code.
- The content component is constructed at factory-construction scope, never during render, so panel prop changes trigger a re-render rather than a remount of the plugin view.

This is Wave 1 groundwork so a future dialog host (#11239) can mount plugin views without dragging grid chrome into a modal. `shared/types/plugin.ts`'s `PanelViewProps` is unchanged; nothing on the SDK side needed to move.

### Design notes

- The `ContentPanel` wrap was deliberately not hoisted into `GridPanel` or `DockedPanel`. Both render `PanelComponent` directly, and every registered kind (`TerminalPane`, `BrowserPane`, `DevPreviewPane`, `FilePane`) owns its own wrap. Hoisting it would have special-cased plugin kinds against a uniform contract.
- `PluginViewHostMisconfigured` keeps its existing chrome-free behavior. Changing it is out of scope for this issue.

## Testing

The 892-line test suite split to match the code: plugin lifecycle tests moved to `PluginViewContent.test.tsx`; panel adaptation, focus (#11133), and chrome (#11228) tests stay on the host. Every original assertion survives or was strengthened.

Two new regression tests lock in the decoupling, and three guards were mutation-tested, each mutation kills exactly its intended test and nothing else:

- content renders with no `data-panel-id`, `data-pane-chrome`, or close control (verified by forcing a `ContentPanel` wrap back in)
- host rerenders preserve the view's `disposeSignal` identity (verified by moving the content factory inside render)
- the panel-kinds broadcast aborts only when the kind is dropped (verified by forcing abort on every push)

Review also fixed pre-existing test weaknesses inherited by the split: a vacuous assertion in the missing-`activateForView` test (an inner try/catch swallowed every rejection so it could never fail), a retry test that proved the controller swap but not the module reload, a broadcast test that would have passed while tearing down healthy views, and two React mocks that leaked on assertion failure.

Locally verified: 122 unit tests across 27 files pass; Prettier and ESLint are clean on all 4 changed files; `tsc --noEmit` passes.

I haven't run `e2e/full/plugins/core-plugin-panels.spec.ts` locally. It needs a full app build, and the local E2E launch helper kills Electron machine-wide, which would disrupt an active sibling worktree. PR CI doesn't run E2E, so I'll trigger the full-plugins bucket on GitHub separately.