### PR TITLE
refactor(ui): unify dialog headers behind a surface header primitive

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -402,6 +402,15 @@ function SettingsDialogInner({
     return true;
   };
 
+  // AppDialog-mediated closes (Escape, backdrop, the header's close button) have
+  // already flushed via onBeforeClose, so this only dismisses. Flushing again
+  // would re-issue every tab's persistence IPC and the full project save.
+  const handleDialogClose = () => {
+    onClose();
+  };
+
+  // Tab content closes the dialog directly, bypassing onBeforeClose — so this
+  // path owns its own flush.
   const handleClose = async () => {
     await flushDialog();
     onClose();
@@ -557,7 +566,7 @@ function SettingsDialogInner({
   return (
     <AppDialog
       isOpen={isOpen}
-      onClose={handleClose}
+      onClose={handleDialogClose}
       onBeforeClose={handleBeforeClose}
       size="4xl"
       maxHeight="h-[75vh]"

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -373,9 +373,19 @@ function SettingsDialogInner({
   const flushRegistry = useContext(SettingsFlushContext);
   const flushAllTabs = flushRegistry?.flushAll;
 
-  const flushDialog = async () => {
-    if (flushAllTabs) await flushAllTabs();
-    await projectForm.flush();
+  // Coalesced: a visibility change landing mid-close would otherwise re-issue
+  // every registered tab flusher alongside the one already in flight.
+  const flushInFlightRef = useRef<Promise<void> | null>(null);
+  const flushDialog = () => {
+    if (flushInFlightRef.current) return flushInFlightRef.current;
+    const pending = (async () => {
+      if (flushAllTabs) await flushAllTabs();
+      await projectForm.flush();
+    })();
+    flushInFlightRef.current = pending;
+    return pending.finally(() => {
+      flushInFlightRef.current = null;
+    });
   };
 
   // Electron 41 WebContentsView detach (project switch, window close) does not
@@ -409,8 +419,10 @@ function SettingsDialogInner({
     onClose();
   };
 
-  // Tab content closes the dialog directly, bypassing onBeforeClose — so this
-  // path owns its own flush.
+  // Handed to tab content via the registry's `needsOnClose` flag. That route
+  // never passes through onBeforeClose, so it keeps its own flush — no tab
+  // invokes it today (AppThemePicker only tests it for presence), but a caller
+  // that did would otherwise close without persisting.
   const handleClose = async () => {
     await flushDialog();
     onClose();

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -680,28 +680,23 @@ function SettingsDialogInner({
         </div>
 
         <div className="settings-shell flex-1 flex flex-col min-w-0">
-          <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-border-strong shrink-0">
-            <h3 className="text-lg font-semibold text-daintree-text flex items-center gap-2">
-              {isSearching ? (
-                <>
+          <AppDialog.Header>
+            {/* h3, not the default h2: the sidebar's "Settings" h2 is the shell
+                heading and this labels the active section beneath it. */}
+            <AppDialog.Title
+              as="h3"
+              icon={
+                isSearching ? (
                   <Search className="w-5 h-5 text-text-secondary" />
-                  Search Results
-                </>
-              ) : (
-                <>
-                  {tabIcons[activeTab]}
-                  {tabTitles[activeTab]}
-                </>
-              )}
-            </h3>
-            <button
-              onClick={handleClose}
-              className="text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-              aria-label="Close settings"
+                ) : (
+                  tabIcons[activeTab]
+                )
+              }
             >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
+              {isSearching ? "Search Results" : tabTitles[activeTab]}
+            </AppDialog.Title>
+            <AppDialog.CloseButton aria-label="Close settings" />
+          </AppDialog.Header>
 
           <ScrollShadow className="flex-1" scrollClassName="p-6">
             {isSearching ? (

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -32,7 +32,11 @@ import {
   UI_SCRIM_EASING,
   getUiTransitionDuration,
 } from "@/lib/animationUtils";
-import { X } from "lucide-react";
+import {
+  SurfaceHeader,
+  SurfaceHeaderTitle,
+  SurfaceHeaderCloseButton,
+} from "@/components/ui/SurfaceHeader";
 import { Button } from "./button";
 
 type DialogSize = "sm" | "md" | "lg" | "4xl" | "5xl" | "6xl" | "7xl" | "workspace";
@@ -440,56 +444,43 @@ interface AppDialogHeaderProps {
 }
 
 AppDialog.Header = function AppDialogHeader({ children, className }: AppDialogHeaderProps) {
-  return (
-    <div
-      className={cn(
-        "px-6 py-4 border-b border-border-strong dialog-header flex items-center justify-between shrink-0",
-        className
-      )}
-    >
-      {children}
-    </div>
-  );
+  // `density` is deliberately not forwarded: every dialog header is comfortable,
+  // and exposing it would widen AppDialog's public surface for no caller.
+  return <SurfaceHeader className={className}>{children}</SurfaceHeader>;
 };
 
 interface AppDialogTitleProps {
   children: React.ReactNode;
   icon?: React.ReactNode;
   className?: string;
+  as?: "h2" | "h3";
 }
 
-AppDialog.Title = function AppDialogTitle({ children, icon, className }: AppDialogTitleProps) {
+AppDialog.Title = function AppDialogTitle({ children, icon, className, as }: AppDialogTitleProps) {
   const context = useContext(AppDialogContext);
   return (
-    <h2
-      id={context?.titleId}
-      className={cn("text-lg font-semibold text-daintree-text flex items-center gap-2", className)}
-    >
-      {icon}
+    <SurfaceHeaderTitle as={as} id={context?.titleId} icon={icon} className={className}>
       {children}
-    </h2>
+    </SurfaceHeaderTitle>
   );
 };
 
 interface AppDialogCloseButtonProps {
   className?: string;
+  "aria-label"?: string;
 }
 
-AppDialog.CloseButton = function AppDialogCloseButton({ className }: AppDialogCloseButtonProps) {
+AppDialog.CloseButton = function AppDialogCloseButton({
+  className,
+  "aria-label": ariaLabel = "Close dialog",
+}: AppDialogCloseButtonProps) {
   const context = useContext(AppDialogContext);
   return (
-    <button
-      type="button"
+    <SurfaceHeaderCloseButton
       onClick={context?.onClose}
-      className={cn(
-        "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded",
-        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
-        className
-      )}
-      aria-label="Close dialog"
-    >
-      <X className="h-5 w-5" />
-    </button>
+      className={className}
+      aria-label={ariaLabel}
+    />
   );
 };
 

--- a/src/components/ui/SurfaceHeader.tsx
+++ b/src/components/ui/SurfaceHeader.tsx
@@ -72,13 +72,15 @@ const SurfaceHeaderCloseButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <button
     ref={ref}
-    type="button"
     className={cn(
       "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded",
       "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
       className
     )}
     {...props}
+    // After the spread: a cast-through `type: "submit"` would otherwise submit
+    // the surrounding form instead of closing the surface.
+    type="button"
   >
     <X className="h-5 w-5" />
   </button>

--- a/src/components/ui/SurfaceHeader.tsx
+++ b/src/components/ui/SurfaceHeader.tsx
@@ -21,8 +21,7 @@ const surfaceHeaderVariants = cva("", {
 });
 
 export interface SurfaceHeaderProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof surfaceHeaderVariants> {
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof surfaceHeaderVariants> {
   children: React.ReactNode;
 }
 
@@ -59,32 +58,33 @@ const SurfaceHeaderTitle = React.forwardRef<HTMLHeadingElement, SurfaceHeaderTit
 );
 SurfaceHeaderTitle.displayName = "SurfaceHeaderTitle";
 
-export interface SurfaceHeaderCloseButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "type"> {
+export interface SurfaceHeaderCloseButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "type"
+> {
   // Required here, defaulted by the surface that owns the wrapper: a bare
   // "Close" is ambiguous once more than one surface uses this button.
   "aria-label": string;
 }
 
-const SurfaceHeaderCloseButton = React.forwardRef<
-  HTMLButtonElement,
-  SurfaceHeaderCloseButtonProps
->(({ className, ...props }, ref) => (
-  <button
-    ref={ref}
-    className={cn(
-      "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded",
-      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
-      className
-    )}
-    {...props}
-    // After the spread: a cast-through `type: "submit"` would otherwise submit
-    // the surrounding form instead of closing the surface.
-    type="button"
-  >
-    <X className="h-5 w-5" />
-  </button>
-));
+const SurfaceHeaderCloseButton = React.forwardRef<HTMLButtonElement, SurfaceHeaderCloseButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+        className
+      )}
+      {...props}
+      // After the spread: a cast-through `type: "submit"` would otherwise submit
+      // the surrounding form instead of closing the surface.
+      type="button"
+    >
+      <X className="h-5 w-5" />
+    </button>
+  )
+);
 SurfaceHeaderCloseButton.displayName = "SurfaceHeaderCloseButton";
 
 export { SurfaceHeader, SurfaceHeaderTitle, SurfaceHeaderCloseButton, surfaceHeaderVariants };

--- a/src/components/ui/SurfaceHeader.tsx
+++ b/src/components/ui/SurfaceHeader.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// Full literal strings per density rather than a shared base: the comfortable
+// output stays byte-identical to the markup the 35 AppDialog consumers render
+// today, and compact stays free of a `py-*` utility that would fight `h-8`.
+const surfaceHeaderVariants = cva("", {
+  variants: {
+    density: {
+      compact: "h-8 px-3 border-b border-divider flex items-center justify-between shrink-0",
+      comfortable:
+        "px-6 py-4 border-b border-border-strong dialog-header flex items-center justify-between shrink-0",
+    },
+  },
+  defaultVariants: {
+    density: "comfortable",
+  },
+});
+
+export interface SurfaceHeaderProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof surfaceHeaderVariants> {
+  children: React.ReactNode;
+}
+
+// Composition stays open (children, not leading/trailing slots): consumers nest
+// search rows, badge clusters and multi-line title stacks inside the frame.
+const SurfaceHeader = React.forwardRef<HTMLDivElement, SurfaceHeaderProps>(
+  ({ density, className, children, ...props }, ref) => (
+    <div ref={ref} className={cn(surfaceHeaderVariants({ density }), className)} {...props}>
+      {children}
+    </div>
+  )
+);
+SurfaceHeader.displayName = "SurfaceHeader";
+
+export interface SurfaceHeaderTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  children: React.ReactNode;
+  icon?: React.ReactNode;
+  // Restricted rather than fully polymorphic: a surface header is either the
+  // primary label of its dialog (h2) or a section heading inside one (h3).
+  as?: "h2" | "h3";
+}
+
+const SurfaceHeaderTitle = React.forwardRef<HTMLHeadingElement, SurfaceHeaderTitleProps>(
+  ({ as: Heading = "h2", icon, className, children, ...props }, ref) => (
+    <Heading
+      ref={ref}
+      className={cn("text-lg font-semibold text-daintree-text flex items-center gap-2", className)}
+      {...props}
+    >
+      {icon}
+      {children}
+    </Heading>
+  )
+);
+SurfaceHeaderTitle.displayName = "SurfaceHeaderTitle";
+
+export interface SurfaceHeaderCloseButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "children" | "type"> {
+  // Required here, defaulted by the surface that owns the wrapper: a bare
+  // "Close" is ambiguous once more than one surface uses this button.
+  "aria-label": string;
+}
+
+const SurfaceHeaderCloseButton = React.forwardRef<
+  HTMLButtonElement,
+  SurfaceHeaderCloseButtonProps
+>(({ className, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    className={cn(
+      "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded",
+      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+      className
+    )}
+    {...props}
+  >
+    <X className="h-5 w-5" />
+  </button>
+));
+SurfaceHeaderCloseButton.displayName = "SurfaceHeaderCloseButton";
+
+export { SurfaceHeader, SurfaceHeaderTitle, SurfaceHeaderCloseButton, surfaceHeaderVariants };

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -1028,12 +1028,7 @@ describe("AppDialog header composition", () => {
     render(
       <>
         <Dispatcher />
-        <AppDialog
-          isOpen
-          onClose={onClose}
-          onBeforeClose={onBeforeClose}
-          data-testid="test-dialog"
-        >
+        <AppDialog isOpen onClose={onClose} onBeforeClose={onBeforeClose} data-testid="test-dialog">
           <AppDialog.Header>
             <AppDialog.CloseButton />
           </AppDialog.Header>
@@ -1053,12 +1048,7 @@ describe("AppDialog header composition", () => {
     render(
       <>
         <Dispatcher />
-        <AppDialog
-          isOpen
-          onClose={onClose}
-          onBeforeClose={onBeforeClose}
-          data-testid="test-dialog"
-        >
+        <AppDialog isOpen onClose={onClose} onBeforeClose={onBeforeClose} data-testid="test-dialog">
           <AppDialog.Header>
             <AppDialog.CloseButton />
           </AppDialog.Header>

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { AppDialog } from "../AppDialog";
 import { _resetForTests } from "@/lib/escapeStack";
@@ -887,5 +887,149 @@ describe("AppDialog reduced-motion policy", () => {
     const backdrop = screen.getByTestId("test-dialog");
 
     expect(backdrop.style.transitionTimingFunction).not.toBe("");
+  });
+});
+
+describe("AppDialog header composition", () => {
+  beforeEach(() => {
+    mockPrevOpen = false;
+    _resetForTests();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  function labelledBy(): string | null {
+    return screen.getByTestId("test-dialog").getAttribute("aria-labelledby");
+  }
+
+  it("labels the dialog by its title heading", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Header>
+          <AppDialog.Title>Named</AppDialog.Title>
+        </AppDialog.Header>
+      ),
+    });
+
+    expect(screen.getByRole("heading", { level: 2 }).getAttribute("id")).toBe(labelledBy());
+  });
+
+  it("keeps the title wired when rendered as an h3", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Header>
+          <AppDialog.Title as="h3">Section</AppDialog.Title>
+        </AppDialog.Header>
+      ),
+    });
+
+    // Settings renders its section title as an h3; the dialog must still
+    // resolve its accessible name to that heading.
+    expect(screen.getByRole("heading", { level: 3 }).getAttribute("id")).toBe(labelledBy());
+  });
+
+  it("labels the dialog from a title mounted outside the header", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Body>
+          <AppDialog.Title>Standalone</AppDialog.Title>
+        </AppDialog.Body>
+      ),
+    });
+
+    expect(screen.getByRole("heading", { level: 2 }).getAttribute("id")).toBe(labelledBy());
+  });
+
+  it("defaults the close button label", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Header>
+          <AppDialog.CloseButton />
+        </AppDialog.Header>
+      ),
+    });
+
+    expect(screen.queryByRole("button", { name: "Close dialog" })).not.toBeNull();
+  });
+
+  it("lets a surface name its own close button", () => {
+    renderDialog({
+      children: (
+        <AppDialog.Header>
+          <AppDialog.CloseButton aria-label="Close settings" />
+        </AppDialog.Header>
+      ),
+    });
+
+    expect(screen.queryByRole("button", { name: "Close settings" })).not.toBeNull();
+  });
+
+  it("closes through the dialog's own close handler", () => {
+    const onClose = vi.fn();
+    renderDialog({
+      onClose,
+      children: (
+        <AppDialog.Header>
+          <AppDialog.CloseButton />
+        </AppDialog.Header>
+      ),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes the close button through onBeforeClose", async () => {
+    const onClose = vi.fn();
+    const onBeforeClose = vi.fn().mockResolvedValue(true);
+    render(
+      <>
+        <Dispatcher />
+        <AppDialog
+          isOpen
+          onClose={onClose}
+          onBeforeClose={onBeforeClose}
+          data-testid="test-dialog"
+        >
+          <AppDialog.Header>
+            <AppDialog.CloseButton />
+          </AppDialog.Header>
+        </AppDialog>
+      </>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(onBeforeClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog open when onBeforeClose vetoes", async () => {
+    const onClose = vi.fn();
+    const onBeforeClose = vi.fn().mockResolvedValue(false);
+    render(
+      <>
+        <Dispatcher />
+        <AppDialog
+          isOpen
+          onClose={onClose}
+          onBeforeClose={onBeforeClose}
+          data-testid="test-dialog"
+        >
+          <AppDialog.Header>
+            <AppDialog.CloseButton />
+          </AppDialog.Header>
+        </AppDialog>
+      </>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+
+    await waitFor(() => expect(onBeforeClose).toHaveBeenCalledTimes(1));
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -894,6 +894,9 @@ describe("AppDialog header composition", () => {
   beforeEach(() => {
     mockPrevOpen = false;
     _resetForTests();
+    // Earlier describes install fake timers and never restore them, so a
+    // whole-file run would otherwise leak them into `waitFor` below.
+    vi.useRealTimers();
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
   });
 
@@ -901,10 +904,8 @@ describe("AppDialog header composition", () => {
     _resetForTests();
   });
 
-  function labelledBy(): string | null {
-    return screen.getByTestId("test-dialog").getAttribute("aria-labelledby");
-  }
-
+  // Queried by accessible name rather than by comparing two nullable
+  // attributes: dropping the id, or the heading's text, has to fail these.
   it("labels the dialog by its title heading", () => {
     renderDialog({
       children: (
@@ -914,7 +915,7 @@ describe("AppDialog header composition", () => {
       ),
     });
 
-    expect(screen.getByRole("heading", { level: 2 }).getAttribute("id")).toBe(labelledBy());
+    expect(screen.getByRole("dialog", { name: "Named" })).toBe(screen.getByTestId("test-dialog"));
   });
 
   it("keeps the title wired when rendered as an h3", () => {
@@ -928,7 +929,8 @@ describe("AppDialog header composition", () => {
 
     // Settings renders its section title as an h3; the dialog must still
     // resolve its accessible name to that heading.
-    expect(screen.getByRole("heading", { level: 3 }).getAttribute("id")).toBe(labelledBy());
+    expect(screen.getByRole("heading", { level: 3 }).textContent).toBe("Section");
+    expect(screen.getByRole("dialog", { name: "Section" })).toBe(screen.getByTestId("test-dialog"));
   });
 
   it("labels the dialog from a title mounted outside the header", () => {
@@ -940,7 +942,44 @@ describe("AppDialog header composition", () => {
       ),
     });
 
-    expect(screen.getByRole("heading", { level: 2 }).getAttribute("id")).toBe(labelledBy());
+    expect(screen.getByRole("dialog", { name: "Standalone" })).toBe(
+      screen.getByTestId("test-dialog")
+    );
+  });
+
+  it("forwards a header class override to the rendered frame", () => {
+    // CrossWorktreeDiff restyles its header entirely through this prop; the
+    // primitive's own tests would not catch the adapter dropping it.
+    renderDialog({
+      children: (
+        <AppDialog.Header className="px-4 border-border-subtle">
+          <AppDialog.Title>Named</AppDialog.Title>
+        </AppDialog.Header>
+      ),
+    });
+    const header = screen.getByRole("heading").parentElement;
+
+    expect(header?.className).toContain("px-4");
+    expect(header?.className).not.toContain("px-6");
+  });
+
+  it("forwards a title icon and class override", () => {
+    // Nine dialogs pass a leading icon; the file viewers shrink the title.
+    renderDialog({
+      children: (
+        <AppDialog.Header>
+          <AppDialog.Title icon={<span data-testid="icon">*</span>} className="text-sm">
+            Named
+          </AppDialog.Title>
+        </AppDialog.Header>
+      ),
+    });
+    const heading = screen.getByRole("heading");
+
+    expect(screen.queryByTestId("icon")).not.toBeNull();
+    expect(heading.textContent).toBe("*Named");
+    expect(heading.className).toContain("text-sm");
+    expect(heading.className).not.toContain("text-lg");
   });
 
   it("defaults the close button label", () => {

--- a/src/components/ui/__tests__/SurfaceHeader.test.tsx
+++ b/src/components/ui/__tests__/SurfaceHeader.test.tsx
@@ -200,4 +200,17 @@ describe("SurfaceHeaderCloseButton", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it("does not submit a surrounding form", () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <SurfaceHeaderCloseButton aria-label="Close dialog" />
+      </form>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/ui/__tests__/SurfaceHeader.test.tsx
+++ b/src/components/ui/__tests__/SurfaceHeader.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SurfaceHeader,
+  SurfaceHeaderTitle,
+  SurfaceHeaderCloseButton,
+  surfaceHeaderVariants,
+} from "../SurfaceHeader";
+
+// Utility-group helpers: assertions target the *relationships* between the
+// density variants rather than their literal class strings, so restyling the
+// primitive does not force a matching test edit.
+function classesOf(el: HTMLElement): string[] {
+  return el.className.split(/\s+/).filter(Boolean);
+}
+
+function matching(el: HTMLElement, pattern: RegExp): string[] {
+  return classesOf(el).filter((c) => pattern.test(c));
+}
+
+describe("surfaceHeaderVariants", () => {
+  it("defaults to the comfortable density", () => {
+    expect(surfaceHeaderVariants({})).toBe(surfaceHeaderVariants({ density: "comfortable" }));
+  });
+
+  it("emits a distinct class set per density", () => {
+    expect(surfaceHeaderVariants({ density: "compact" })).not.toBe(
+      surfaceHeaderVariants({ density: "comfortable" })
+    );
+  });
+});
+
+describe("SurfaceHeader density geometry", () => {
+  it("sizes compact by a fixed height with no vertical padding", () => {
+    render(
+      <SurfaceHeader density="compact" data-testid="header">
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+    const header = screen.getByTestId("header");
+
+    // A `py-*` alongside `h-8` would fight the fixed panel-chrome height.
+    expect(matching(header, /^py-/)).toHaveLength(0);
+    expect(matching(header, /^h-/)).toHaveLength(1);
+  });
+
+  it("sizes comfortable by vertical padding with no fixed height", () => {
+    render(
+      <SurfaceHeader density="comfortable" data-testid="header">
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+    const header = screen.getByTestId("header");
+
+    expect(matching(header, /^py-/)).toHaveLength(1);
+    expect(matching(header, /^h-/)).toHaveLength(0);
+  });
+
+  it("declares exactly one utility per conflicting group in both densities", () => {
+    for (const density of ["compact", "comfortable"] as const) {
+      const { unmount } = render(
+        <SurfaceHeader density={density} data-testid="header">
+          <span>Title</span>
+        </SurfaceHeader>
+      );
+      const header = screen.getByTestId("header");
+
+      expect(matching(header, /^px-/), `${density} horizontal padding`).toHaveLength(1);
+      expect(matching(header, /^border-b$/), `${density} bottom border`).toHaveLength(1);
+      unmount();
+    }
+  });
+});
+
+describe("SurfaceHeader composition", () => {
+  it("renders arbitrary children in order", () => {
+    render(
+      <SurfaceHeader data-testid="header">
+        <div>
+          <span>Leading</span>
+          <span>Badge</span>
+        </div>
+        <button type="button">Trailing</button>
+      </SurfaceHeader>
+    );
+
+    expect(screen.getByTestId("header").textContent).toBe("LeadingBadgeTrailing");
+  });
+
+  it("forwards a ref to the underlying element", () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(
+      <SurfaceHeader ref={ref}>
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("forwards arbitrary DOM attributes", () => {
+    render(
+      <SurfaceHeader data-testid="header" role="group" aria-label="Panel chrome">
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+
+    expect(screen.getByTestId("header").getAttribute("aria-label")).toBe("Panel chrome");
+  });
+});
+
+describe("SurfaceHeader className merging", () => {
+  it("lets a caller replace same-group density utilities", () => {
+    // Mirrors CrossWorktreeDiff's override shape.
+    render(
+      <SurfaceHeader data-testid="header" className="px-4 py-3 border-b border-border-subtle">
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+    const classes = classesOf(screen.getByTestId("header"));
+
+    expect(classes).toContain("px-4");
+    expect(classes).toContain("py-3");
+    expect(classes).not.toContain("px-6");
+    expect(classes).not.toContain("py-4");
+  });
+
+  it("keeps the plain background class alongside an important override", () => {
+    // The background lives on a bare CSS class, not a Tailwind utility, so
+    // `!bg-transparent` cascades over it instead of being merged away.
+    render(
+      <SurfaceHeader data-testid="header" className="!bg-transparent">
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+    const classes = classesOf(screen.getByTestId("header"));
+
+    expect(classes).toContain("dialog-header");
+    expect(classes).toContain("!bg-transparent");
+  });
+});
+
+describe("SurfaceHeaderTitle", () => {
+  it("renders an h2 by default", () => {
+    render(<SurfaceHeaderTitle>Dialog</SurfaceHeaderTitle>);
+
+    expect(screen.getByRole("heading", { level: 2 }).textContent).toBe("Dialog");
+  });
+
+  it("renders an h3 when asked", () => {
+    render(<SurfaceHeaderTitle as="h3">Section</SurfaceHeaderTitle>);
+
+    expect(screen.getByRole("heading", { level: 3 }).textContent).toBe("Section");
+  });
+
+  it("renders the icon ahead of the children", () => {
+    render(
+      <SurfaceHeaderTitle icon={<span data-testid="icon">*</span>}>Labelled</SurfaceHeaderTitle>
+    );
+
+    expect(screen.getByRole("heading").textContent).toBe("*Labelled");
+  });
+
+  it("lets a caller override the default type scale", () => {
+    render(
+      <SurfaceHeaderTitle className="text-sm">
+        Compact
+      </SurfaceHeaderTitle>
+    );
+    const classes = classesOf(screen.getByRole("heading"));
+
+    expect(classes).toContain("text-sm");
+    expect(classes).not.toContain("text-lg");
+  });
+
+  it("forwards an id so a dialog can point aria-labelledby at it", () => {
+    render(<SurfaceHeaderTitle id="title-1">Titled</SurfaceHeaderTitle>);
+
+    expect(screen.getByRole("heading").getAttribute("id")).toBe("title-1");
+  });
+});
+
+describe("SurfaceHeaderCloseButton", () => {
+  it("renders a non-submitting button carrying the supplied label", () => {
+    render(<SurfaceHeaderCloseButton aria-label="Close settings" />);
+    const button = screen.getByRole("button", { name: "Close settings" });
+
+    // Defaulting to type="submit" inside a form would submit it on close.
+    expect(button.getAttribute("type")).toBe("button");
+  });
+
+  it("invokes its click handler", () => {
+    const onClick = vi.fn();
+    render(<SurfaceHeaderCloseButton aria-label="Close dialog" onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/__tests__/SurfaceHeader.test.tsx
+++ b/src/components/ui/__tests__/SurfaceHeader.test.tsx
@@ -1,12 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import {
-  SurfaceHeader,
-  SurfaceHeaderTitle,
-  SurfaceHeaderCloseButton,
-  surfaceHeaderVariants,
-} from "../SurfaceHeader";
+import { SurfaceHeader, SurfaceHeaderTitle, SurfaceHeaderCloseButton } from "../SurfaceHeader";
 
 // Utility-group helpers: assertions target the *relationships* between the
 // density variants rather than their literal class strings, so restyling the
@@ -19,15 +14,25 @@ function matching(el: HTMLElement, pattern: RegExp): string[] {
   return classesOf(el).filter((c) => pattern.test(c));
 }
 
-describe("surfaceHeaderVariants", () => {
-  it("defaults to the comfortable density", () => {
-    expect(surfaceHeaderVariants({})).toBe(surfaceHeaderVariants({ density: "comfortable" }));
-  });
-
-  it("emits a distinct class set per density", () => {
-    expect(surfaceHeaderVariants({ density: "compact" })).not.toBe(
-      surfaceHeaderVariants({ density: "comfortable" })
+describe("SurfaceHeader default density", () => {
+  it("renders an omitted density identically to an explicit comfortable one", () => {
+    // AppDialog.Header deliberately omits `density`, so the default is what
+    // every dialog in the app actually renders.
+    const { unmount } = render(
+      <SurfaceHeader data-testid="header">
+        <span>Title</span>
+      </SurfaceHeader>
     );
+    const defaulted = screen.getByTestId("header").className;
+    unmount();
+
+    render(
+      <SurfaceHeader density="comfortable" data-testid="header">
+        <span>Title</span>
+      </SurfaceHeader>
+    );
+
+    expect(screen.getByTestId("header").className).toBe(defaulted);
   });
 });
 
@@ -111,24 +116,25 @@ describe("SurfaceHeader composition", () => {
 });
 
 describe("SurfaceHeader className merging", () => {
-  it("lets a caller replace same-group density utilities", () => {
-    // Mirrors CrossWorktreeDiff's override shape.
+  it("leaves the caller as the sole winner in every group it overrides", () => {
+    // Mirrors CrossWorktreeDiff's override shape. Asserting group cardinality
+    // (not just presence) is what catches a merge that concatenates instead of
+    // replacing, leaving both utilities to fight in CSS source order.
     render(
       <SurfaceHeader data-testid="header" className="px-4 py-3 border-b border-border-subtle">
         <span>Title</span>
       </SurfaceHeader>
     );
-    const classes = classesOf(screen.getByTestId("header"));
+    const header = screen.getByTestId("header");
 
-    expect(classes).toContain("px-4");
-    expect(classes).toContain("py-3");
-    expect(classes).not.toContain("px-6");
-    expect(classes).not.toContain("py-4");
+    expect(matching(header, /^px-/)).toEqual(["px-4"]);
+    expect(matching(header, /^py-/)).toEqual(["py-3"]);
+    expect(matching(header, /^border-border-/)).toEqual(["border-border-subtle"]);
   });
 
-  it("keeps the plain background class alongside an important override", () => {
-    // The background lives on a bare CSS class, not a Tailwind utility, so
-    // `!bg-transparent` cascades over it instead of being merged away.
+  it("preserves a non-Tailwind class the caller did not override", () => {
+    // The background lives on a bare CSS class rather than a Tailwind utility,
+    // so twMerge must pass it through untouched for the cascade to reach it.
     render(
       <SurfaceHeader data-testid="header" className="!bg-transparent">
         <span>Title</span>
@@ -163,15 +169,11 @@ describe("SurfaceHeaderTitle", () => {
   });
 
   it("lets a caller override the default type scale", () => {
-    render(
-      <SurfaceHeaderTitle className="text-sm">
-        Compact
-      </SurfaceHeaderTitle>
-    );
-    const classes = classesOf(screen.getByRole("heading"));
+    // The file viewers rely on this to shrink the title; a merge that kept both
+    // sizes would resolve by stylesheet order rather than by the caller.
+    render(<SurfaceHeaderTitle className="text-sm">Compact</SurfaceHeaderTitle>);
 
-    expect(classes).toContain("text-sm");
-    expect(classes).not.toContain("text-lg");
+    expect(matching(screen.getByRole("heading"), /^text-(xs|sm|base|lg|xl)$/)).toEqual(["text-sm"]);
   });
 
   it("forwards an id so a dialog can point aria-labelledby at it", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 @source not "../.lessons/**/*";
 @import "./styles/components/toolbar.css";
 @import "./styles/components/settings.css";
+@import "./styles/components/surface-header.css";
 @import "./styles/components/pulse.css";
 @import "./styles/components/sidebar.css";
 @import "./styles/components/panels.css";

--- a/src/styles/components/settings.css
+++ b/src/styles/components/settings.css
@@ -44,11 +44,6 @@
   color: var(--settings-search-muted, var(--theme-text-muted));
 }
 
-.dialog-header {
-  --_bg: var(--dialog-header-bg, color-mix(in srgb, var(--theme-surface-sidebar) 50%, transparent));
-  background: var(--_bg);
-}
-
 .settings-meta {
   color: var(--settings-meta-fg, var(--theme-text-muted));
   font-size: var(--settings-meta-size, 11px);

--- a/src/styles/components/surface-header.css
+++ b/src/styles/components/surface-header.css
@@ -1,0 +1,7 @@
+/* Comfortable-density surface header background. Single-level var() fallback:
+   Chromium 148 sends multi-layer fallback chains inside color-mix() to
+   invalid-at-computed-value-time, collapsing the declaration to transparent. */
+.dialog-header {
+  --_bg: var(--dialog-header-bg, color-mix(in srgb, var(--theme-surface-sidebar) 50%, transparent));
+  background: var(--_bg);
+}


### PR DESCRIPTION
## Summary

- Adds `src/components/ui/SurfaceHeader.tsx`, a shared surface-header primitive (`SurfaceHeader`, `SurfaceHeaderTitle`, `SurfaceHeaderCloseButton`) with a cva `density` variant (`compact` or `comfortable`, default `comfortable`), following the cva convention already used in `button.tsx`.
- `AppDialog.Header`, `.Title`, and `.CloseButton` become thin context-aware adapters over the new primitive, and `SettingsDialog`'s hand-copied header markup is migrated onto the same primitive.
- The `.dialog-header` background rule moves out of `settings.css` into a new `surface-header.css`. It was never settings-specific in the first place.

Resolves #11238

## API additions (both backward-compatible)

Both exist to preserve markup that was already pinned by tests:

- `AppDialog.CloseButton` gains an optional `aria-label`, defaulting to `"Close dialog"` (a FigureRail test pins this default).
- `AppDialog.Title` gains an optional `as?: "h2" | "h3"`.

Settings' close button has to keep the label `"Close settings"`, and its heading has to stay an `<h3>`, so both props were needed to route Settings through the shared primitive without changing its markup.

## Deliberate scope decisions

**Theme extension keys are untouched.** `--dialog-header-bg`, `--panel-header-bg`, and `--panel-header-focus-bg` are registered in `EXTENSION_KEYS` and policed by a bidirectional drift contract test. `PanelHeader.tsx` is the sole consumer of the panel pair and is explicitly out of scope for this issue, so renaming any of these would either break the contract test or force touching the excluded file. Comfortable density keeps reading `--dialog-header-bg`; compact density uses plain utilities instead. Full token convergence belongs to the deferred `PanelHeader` migration.

**The primitive keeps a `children` + `className` API**, not rigid `leading`/`trailing` slots. Six-plus consumers compose irregular children: `ShortcutReferenceDialog` nests a search input, `CommandBuilder` wraps a step badge, `CrossWorktreeDiff` overrides padding and kills the background with `!bg-transparent`, and `WorktreeDeleteDialog` mounts `Title` standalone with no `Header` at all.

**`compact` density ships with no production consumer.** It's an acceptance criterion and the seam for the deferred `PanelHeader` migration, covered by unit tests rather than a synthetic consumer.

## Fixes found during review

- Settings' close button previously bypassed `AppDialog`'s close gate entirely. Routing it through the shared `CloseButton` surfaced a double flush: both `onBeforeClose` and `onClose` were calling `flushDialog()`. Split into `handleDialogClose` (dismiss-only, for `AppDialog`-mediated closes) and `handleClose` (self-flushing, for the settings registry's `needsOnClose` tab route, which bypasses `onBeforeClose`). `flushDialog` now coalesces behind an in-flight promise so a visibility change landing mid-close can't re-issue every tab's flusher.
- Fixed a latent a11y bug: Settings' `aria-labelledby` pointed at a nonexistent id because its hand-rolled `<h3>` never carried `titleId`. The migrated `Title` carries it correctly now.

## Known follow-ups (not in this PR)

- Settings' accessible name is now the active section title ("Appearance", "Search Results") instead of a stable "Settings". That's a strict improvement over the previous dangling `aria-labelledby` reference, but stabilizing it to a fixed name needs a new `AppDialog` `ariaLabel` prop, which is a separate a11y/API decision.
- Pre-existing and unrelated to this refactor: the "Change theme…" CTA (`useThemeBrowserSettingsBridge.ts:33`) and the plugin-manager transition (`App.tsx:241`) both close Settings via `setIsSettingsOpen(false)` directly, bypassing both close callbacks and flushing zero times. Can lose dirty settings, predates this change, left alone here.

## Testing

New `SurfaceHeader.test.tsx`, and `AppDialog.test.tsx` extended with adapter and context contracts, asserting dialog labelling via accessible name plus className and icon forwarding.

Locally: 343 unit tests across 59 suites pass, composite `npm run typecheck` is clean, prettier/eslint on own changed files are clean with zero errors, and 37 E2E tests pass across `core-settings-tabs.spec.ts` and `core-shell-settings.spec.ts`, the specs that pin the Settings `h3` headings and the `"Close settings"` label.
