### PR TITLE
refactor(ui): move PanelHeader onto the shared surface header frame

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -52,6 +52,7 @@ import { cn } from "@/lib/utils";
 import { formatShortcutForTooltip } from "@/lib/platform";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { STATE_COLORS, STATE_ICONS } from "@/components/Worktree/terminalStateConfig";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -626,7 +627,13 @@ function PanelHeaderComponent({
   const headerActivatorRef = headerHasDrag ? dragHandle?.setActivatorNodeRef : undefined;
 
   return (
-    <div
+    // Compact density supplies the shared frame (h-8, px-3, border-b
+    // border-divider, flex alignment, shrink-0); everything panel-only —
+    // drag surface, state backgrounds, follower stripe, tab strip, badges,
+    // control cluster — stays composed here rather than folded into the
+    // primitive.
+    <SurfaceHeader
+      density="compact"
       ref={headerActivatorRef}
       {...dragListeners}
       tabIndex={headerHasDrag ? 0 : undefined}
@@ -641,8 +648,7 @@ function PanelHeaderComponent({
       data-fleet-previewed={isFleetPreviewed || undefined}
       data-pane-chrome=""
       className={cn(
-        "flex items-center justify-between px-3 shrink-0 text-xs transition-colors relative overflow-hidden group select-none",
-        "h-8 border-b border-divider",
+        "text-xs transition-colors relative overflow-hidden group select-none",
         isMaximized
           ? "h-10 bg-daintree-sidebar border-daintree-border"
           : location === "dock"
@@ -1258,7 +1264,7 @@ function PanelHeaderComponent({
           data-testid="fleet-preview-enter-overlay"
         />
       ) : null}
-    </div>
+    </SurfaceHeader>
   );
 }
 

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { PanelHeader } from "../PanelHeader";
 import type { PanelHeaderProps } from "../PanelHeader";
+import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 
 vi.mock("react-dom", async () => {
@@ -987,6 +988,155 @@ describe("PanelHeader", () => {
 
       rerender(<PanelHeader {...makeProps({ isFleetPreviewed: false })} />);
       expect(header?.hasAttribute("data-fleet-previewed")).toBe(false);
+    });
+  });
+
+  describe("shared surface header frame (#11241)", () => {
+    // Classes are read off a live SurfaceHeader rather than copied here: this
+    // asserts the consumer/primitive relationship, so an intentional restyle of
+    // the frame follows automatically while a wrong density or a clobbered
+    // frame utility still fails.
+    function frameClassesOf(density: "compact" | "comfortable"): string[] {
+      const { container, unmount } = render(<SurfaceHeader density={density}>x</SurfaceHeader>);
+      const classes = classListOf(container.firstElementChild as HTMLElement);
+      unmount();
+      return classes;
+    }
+
+    function classListOf(el: HTMLElement): string[] {
+      return el.className.split(/\s+/).filter(Boolean);
+    }
+
+    it("renders the header on the shared compact frame", () => {
+      const frame = frameClassesOf("compact");
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const header = classListOf(container.firstElementChild as HTMLElement);
+      for (const cls of frame) {
+        expect(header, `missing shared frame class ${cls}`).toContain(cls);
+      }
+    });
+
+    it("adopts compact density rather than the dialog's comfortable frame", () => {
+      const compact = new Set(frameClassesOf("compact"));
+      const comfortableOnly = frameClassesOf("comfortable").filter((c) => !compact.has(c));
+      // Sanity: the two densities must actually differ, else the assertion below
+      // would pass vacuously.
+      expect(comfortableOnly.length).toBeGreaterThan(0);
+
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const header = new Set(classListOf(container.firstElementChild as HTMLElement));
+      for (const cls of comfortableOnly) {
+        expect(header.has(cls), `leaked comfortable-density class ${cls}`).toBe(false);
+      }
+    });
+
+    it("collapses the maximized height override against the frame height", () => {
+      // The frame supplies a height and the maximized branch overrides it. If
+      // the merge ever stops resolving them, both survive and the taller one
+      // silently wins by source order instead of by intent.
+      const heightsOf = (el: HTMLElement) => classListOf(el).filter((c) => /^h-/.test(c));
+
+      const { container: normal } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const { container: maximized } = render(
+        <PanelHeader {...makeProps({ location: "grid", isMaximized: true })} />
+      );
+      const normalHeight = heightsOf(normal.firstElementChild as HTMLElement);
+      const maximizedHeight = heightsOf(maximized.firstElementChild as HTMLElement);
+
+      expect(normalHeight).toHaveLength(1);
+      expect(maximizedHeight).toHaveLength(1);
+      expect(maximizedHeight[0]).not.toBe(normalHeight[0]);
+    });
+
+    it("collapses the maximized border colour against the frame divider", () => {
+      const borderColorsOf = (el: HTMLElement) =>
+        classListOf(el).filter((c) => c.startsWith("border-") && !/^border-[trbl]$/.test(c));
+
+      const { container: normal } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const { container: maximized } = render(
+        <PanelHeader {...makeProps({ location: "grid", isMaximized: true })} />
+      );
+      const normalBorder = borderColorsOf(normal.firstElementChild as HTMLElement);
+      const maximizedBorder = borderColorsOf(maximized.firstElementChild as HTMLElement);
+
+      expect(normalBorder).toHaveLength(1);
+      expect(maximizedBorder).toHaveLength(1);
+      expect(maximizedBorder[0]).not.toBe(normalBorder[0]);
+    });
+
+    it("keeps inline controls from arming the panel drag (#6928 guard)", () => {
+      // The whole header is the drag surface, so every inline control opts out
+      // via a pointerdown guard. Losing one makes that button intermittently
+      // register as a drag pickup instead of a click.
+      const controls: { name: string; find: () => HTMLElement | null }[] = [
+        { name: "tabs overflow", find: () => screen.queryByTestId("panel-tabs-overflow") },
+        { name: "fleet failure dot", find: () => screen.queryByTestId("panel-fleet-failure-dot") },
+        {
+          name: "duplicate as tab",
+          find: () => screen.queryByLabelText("Duplicate panel as new tab"),
+        },
+        { name: "overflow menu", find: () => screen.queryByLabelText("More panel actions") },
+        { name: "move to dock", find: () => screen.queryByTestId("panel-move-to-dock") },
+        { name: "move to grid", find: () => screen.queryByTestId("panel-move-to-grid") },
+        { name: "restore", find: () => screen.queryByLabelText("Restore grid view") },
+        { name: "maximize", find: () => screen.queryByLabelText("Maximize") },
+        { name: "close", find: () => screen.queryByTestId("panel-close") },
+      ];
+      const configs: Partial<PanelHeaderProps>[] = [
+        {
+          location: "grid",
+          onToggleMaximize: vi.fn(),
+          onMoveToDock: vi.fn(),
+          onAddTab: vi.fn(),
+          onRestore: vi.fn(),
+        },
+        { location: "dock", onMoveToGrid: vi.fn(), onRestore: vi.fn() },
+        { location: "grid", isMaximized: true, onToggleMaximize: vi.fn(), onRestore: vi.fn() },
+      ];
+
+      const dragPointerDown = vi.fn();
+      mockDragHandle = {
+        listeners: { onPointerDown: dragPointerDown },
+        setActivatorNodeRef: vi.fn(),
+      };
+      const covered = new Set<string>();
+      try {
+        for (const config of configs) {
+          const { unmount } = render(<PanelHeader {...makeProps(config)} />);
+          for (const control of controls) {
+            const el = control.find();
+            if (!el) continue;
+            covered.add(control.name);
+            dragPointerDown.mockClear();
+            fireEvent.pointerDown(el);
+            expect(dragPointerDown, `${control.name} armed the panel drag`).not.toHaveBeenCalled();
+          }
+          unmount();
+        }
+      } finally {
+        mockDragHandle = null;
+      }
+
+      // Floor guard: without it the loop passes vacuously if the render configs
+      // stop surfacing any control.
+      expect(covered.size).toBeGreaterThanOrEqual(5);
+    });
+
+    it("still forwards pointerdown on the header itself to the drag listener", () => {
+      // Counterpart to the guard test: proves the exclusions above are scoped to
+      // the controls and the frame swap did not sever the root drag wiring.
+      const dragPointerDown = vi.fn();
+      mockDragHandle = {
+        listeners: { onPointerDown: dragPointerDown },
+        setActivatorNodeRef: vi.fn(),
+      };
+      try {
+        const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+        fireEvent.pointerDown(container.firstElementChild as HTMLElement);
+        expect(dragPointerDown).toHaveBeenCalledTimes(1);
+      } finally {
+        mockDragHandle = null;
+      }
     });
   });
 });

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -1010,12 +1010,20 @@ describe("PanelHeader", () => {
     // frame utility still fails.
     function frameClassesOf(density: "compact" | "comfortable"): string[] {
       const { container, unmount } = render(<SurfaceHeader density={density}>x</SurfaceHeader>);
-      const classes = classListOf(container.firstElementChild as HTMLElement);
+      const classes = classListOf(rootOf(container));
       unmount();
       return classes;
     }
 
-    function classListOf(el: HTMLElement): string[] {
+    // Element, not HTMLElement: className is declared on Element, so the whole
+    // block stays cast-free.
+    function rootOf(container: HTMLElement): Element {
+      const root = container.firstElementChild;
+      if (!root) throw new Error("expected a rendered root element");
+      return root;
+    }
+
+    function classListOf(el: Element): string[] {
       return el.className.split(/\s+/).filter(Boolean);
     }
 
@@ -1026,7 +1034,7 @@ describe("PanelHeader", () => {
     it("matches the shared compact frame", () => {
       const frame = frameClassesOf("compact");
       const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
-      const header = classListOf(container.firstElementChild as HTMLElement);
+      const header = classListOf(rootOf(container));
       for (const cls of frame) {
         expect(header, `missing shared frame class ${cls}`).toContain(cls);
       }
@@ -1037,9 +1045,7 @@ describe("PanelHeader", () => {
       // fixed height. A subset check alone would still pass if the panel
       // layered padding back on, so assert the absence directly.
       const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
-      const verticalPadding = classListOf(container.firstElementChild as HTMLElement).filter((c) =>
-        /^(py|pt|pb)-/.test(c)
-      );
+      const verticalPadding = classListOf(rootOf(container)).filter((c) => /^(py|pt|pb)-/.test(c));
       expect(verticalPadding).toEqual([]);
     });
 
@@ -1051,7 +1057,7 @@ describe("PanelHeader", () => {
       expect(comfortableOnly.length).toBeGreaterThan(0);
 
       const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
-      const header = new Set(classListOf(container.firstElementChild as HTMLElement));
+      const header = new Set(classListOf(rootOf(container)));
       for (const cls of comfortableOnly) {
         expect(header.has(cls), `leaked comfortable-density class ${cls}`).toBe(false);
       }
@@ -1061,14 +1067,14 @@ describe("PanelHeader", () => {
       // The frame supplies a height and the maximized branch overrides it. If
       // the merge ever stops resolving them, both survive and the taller one
       // silently wins by source order instead of by intent.
-      const heightsOf = (el: HTMLElement) => classListOf(el).filter((c) => /^h-/.test(c));
+      const heightsOf = (el: Element) => classListOf(el).filter((c) => /^h-/.test(c));
 
       const { container: normal } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
       const { container: maximized } = render(
         <PanelHeader {...makeProps({ location: "grid", isMaximized: true })} />
       );
-      const normalHeight = heightsOf(normal.firstElementChild as HTMLElement);
-      const maximizedHeight = heightsOf(maximized.firstElementChild as HTMLElement);
+      const normalHeight = heightsOf(rootOf(normal));
+      const maximizedHeight = heightsOf(rootOf(maximized));
 
       expect(normalHeight).toHaveLength(1);
       expect(maximizedHeight).toHaveLength(1);
@@ -1078,7 +1084,7 @@ describe("PanelHeader", () => {
     it("collapses the maximized border colour against the frame divider", () => {
       // Colour only: border-b/-2/-dashed and friends are width/style utilities,
       // and counting them would fail this test for an unrelated border change.
-      const borderColorsOf = (el: HTMLElement) =>
+      const borderColorsOf = (el: Element) =>
         classListOf(el).filter(
           (c) =>
             c.startsWith("border-") &&
@@ -1091,8 +1097,8 @@ describe("PanelHeader", () => {
       const { container: maximized } = render(
         <PanelHeader {...makeProps({ location: "grid", isMaximized: true })} />
       );
-      const normalBorder = borderColorsOf(normal.firstElementChild as HTMLElement);
-      const maximizedBorder = borderColorsOf(maximized.firstElementChild as HTMLElement);
+      const normalBorder = borderColorsOf(rootOf(normal));
+      const maximizedBorder = borderColorsOf(rootOf(maximized));
 
       expect(normalBorder).toHaveLength(1);
       expect(maximizedBorder).toHaveLength(1);
@@ -1206,7 +1212,7 @@ describe("PanelHeader", () => {
       };
       try {
         const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
-        fireEvent.pointerDown(container.firstElementChild as HTMLElement);
+        fireEvent.pointerDown(rootOf(container));
         expect(dragPointerDown).toHaveBeenCalledTimes(1);
       } finally {
         mockDragHandle = null;

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { PanelHeader } from "../PanelHeader";
 import type { PanelHeaderProps } from "../PanelHeader";
 import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
+import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 
 vi.mock("react-dom", async () => {
@@ -80,10 +81,12 @@ vi.mock("@/store/panelStore", () => {
 });
 
 let mockHasPty = false;
+let mockIsDockable = true;
 
 vi.mock("@shared/config/panelKindRegistry", () => ({
   panelKindCanRestart: () => false,
   panelKindHasPty: () => mockHasPty,
+  panelKindIsDockable: () => mockIsDockable,
   getPanelKindConfig: (kind: string) =>
     kind === "browser"
       ? { id: "browser", name: "Browser", iconId: "globe", color: "#38bdf8" }
@@ -192,6 +195,7 @@ describe("PanelHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockHasPty = false;
+    mockIsDockable = true;
     mockHiddenTabIds = new Set();
     mockStoreState = {
       watchedPanels: new Set<string>(),
@@ -992,6 +996,14 @@ describe("PanelHeader", () => {
   });
 
   describe("shared surface header frame (#11241)", () => {
+    const overflowTabs = ["t1", "t2", "t3"].map((id, i) => ({
+      id,
+      title: `Tab ${i + 1}`,
+      kind: "terminal" as const,
+      chrome: deriveTerminalChrome(),
+      isActive: i === 0,
+    }));
+
     // Classes are read off a live SurfaceHeader rather than copied here: this
     // asserts the consumer/primitive relationship, so an intentional restyle of
     // the frame follows automatically while a wrong density or a clobbered
@@ -1007,13 +1019,28 @@ describe("PanelHeader", () => {
       return el.className.split(/\s+/).filter(Boolean);
     }
 
-    it("renders the header on the shared compact frame", () => {
+    // Names what this proves: the rendered frame matches the primitive's
+    // compact output. It does not prove the component *delegates* to
+    // SurfaceHeader — a hand-copied div would satisfy it too. Its job is
+    // holding parity once ownership moved.
+    it("matches the shared compact frame", () => {
       const frame = frameClassesOf("compact");
       const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
       const header = classListOf(container.firstElementChild as HTMLElement);
       for (const cls of frame) {
         expect(header, `missing shared frame class ${cls}`).toContain(cls);
       }
+    });
+
+    it("keeps vertical padding off the fixed-height frame", () => {
+      // Compact density is deliberately free of py-* so nothing fights the
+      // fixed height. A subset check alone would still pass if the panel
+      // layered padding back on, so assert the absence directly.
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const verticalPadding = classListOf(container.firstElementChild as HTMLElement).filter((c) =>
+        /^(py|pt|pb)-/.test(c)
+      );
+      expect(verticalPadding).toEqual([]);
     });
 
     it("adopts compact density rather than the dialog's comfortable frame", () => {
@@ -1049,8 +1076,16 @@ describe("PanelHeader", () => {
     });
 
     it("collapses the maximized border colour against the frame divider", () => {
+      // Colour only: border-b/-2/-dashed and friends are width/style utilities,
+      // and counting them would fail this test for an unrelated border change.
       const borderColorsOf = (el: HTMLElement) =>
-        classListOf(el).filter((c) => c.startsWith("border-") && !/^border-[trbl]$/.test(c));
+        classListOf(el).filter(
+          (c) =>
+            c.startsWith("border-") &&
+            !/^border-[trblxy]$/.test(c) &&
+            !/^border-(\d+|solid|dashed|dotted|double|hidden|none)$/.test(c) &&
+            !/^border-[trblxy]-/.test(c)
+        );
 
       const { container: normal } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
       const { container: maximized } = render(
@@ -1064,34 +1099,57 @@ describe("PanelHeader", () => {
       expect(maximizedBorder[0]).not.toBe(normalBorder[0]);
     });
 
-    it("keeps inline controls from arming the panel drag (#6928 guard)", () => {
+    it("keeps every inline control from arming the panel drag (#6928 guard)", () => {
       // The whole header is the drag surface, so every inline control opts out
       // via a pointerdown guard. Losing one makes that button intermittently
       // register as a drag pickup instead of a click.
-      const controls: { name: string; find: () => HTMLElement | null }[] = [
-        { name: "tabs overflow", find: () => screen.queryByTestId("panel-tabs-overflow") },
-        { name: "fleet failure dot", find: () => screen.queryByTestId("panel-fleet-failure-dot") },
+      //
+      // Each scenario names the controls it must surface and looks them up with
+      // getBy* — a control that stops rendering fails loudly here instead of
+      // being silently skipped. The union is asserted against the full
+      // inventory below so a newly guarded control can't slip in uncovered.
+      const scenarios: {
+        props: Partial<PanelHeaderProps>;
+        setup?: () => void;
+        controls: Record<string, () => HTMLElement>;
+      }[] = [
         {
-          name: "duplicate as tab",
-          find: () => screen.queryByLabelText("Duplicate panel as new tab"),
+          props: { location: "grid", onToggleMaximize: vi.fn(), onMinimize: vi.fn() },
+          controls: {
+            "overflow menu": () => screen.getByLabelText("More panel actions"),
+            "move to dock": () => screen.getByTestId("panel-move-to-dock"),
+            maximize: () => screen.getByLabelText("Maximize"),
+            close: () => screen.getByTestId("panel-close"),
+          },
         },
-        { name: "overflow menu", find: () => screen.queryByLabelText("More panel actions") },
-        { name: "move to dock", find: () => screen.queryByTestId("panel-move-to-dock") },
-        { name: "move to grid", find: () => screen.queryByTestId("panel-move-to-grid") },
-        { name: "restore", find: () => screen.queryByLabelText("Restore grid view") },
-        { name: "maximize", find: () => screen.queryByLabelText("Maximize") },
-        { name: "close", find: () => screen.queryByTestId("panel-close") },
-      ];
-      const configs: Partial<PanelHeaderProps>[] = [
         {
-          location: "grid",
-          onToggleMaximize: vi.fn(),
-          onMoveToDock: vi.fn(),
-          onAddTab: vi.fn(),
-          onRestore: vi.fn(),
+          props: { location: "grid", isMaximized: true, onToggleMaximize: vi.fn() },
+          controls: { restore: () => screen.getByLabelText("Restore grid view") },
         },
-        { location: "dock", onMoveToGrid: vi.fn(), onRestore: vi.fn() },
-        { location: "grid", isMaximized: true, onToggleMaximize: vi.fn(), onRestore: vi.fn() },
+        {
+          props: { location: "dock", onRestore: vi.fn(), showRestoreControl: true },
+          controls: { "move to grid": () => screen.getByTestId("panel-move-to-grid") },
+        },
+        {
+          props: { location: "grid", onAddTab: vi.fn() },
+          controls: {
+            "duplicate as tab": () => screen.getByLabelText("Duplicate panel as new tab"),
+          },
+        },
+        {
+          props: { location: "grid", tabs: overflowTabs, onTabClick: vi.fn() },
+          setup: () => {
+            mockHiddenTabIds = new Set(["t2"]);
+          },
+          controls: { "tabs overflow": () => screen.getByTestId("panel-tabs-overflow") },
+        },
+        {
+          props: { location: "grid" },
+          setup: () => {
+            useFleetFailureStore.getState().recordFailure("x", ["test-panel"]);
+          },
+          controls: { "fleet failure dot": () => screen.getByTestId("panel-fleet-failure-dot") },
+        },
       ];
 
       const dragPointerDown = vi.fn();
@@ -1101,25 +1159,41 @@ describe("PanelHeader", () => {
       };
       const covered = new Set<string>();
       try {
-        for (const config of configs) {
-          const { unmount } = render(<PanelHeader {...makeProps(config)} />);
-          for (const control of controls) {
-            const el = control.find();
-            if (!el) continue;
-            covered.add(control.name);
+        for (const scenario of scenarios) {
+          scenario.setup?.();
+          const { unmount } = render(<PanelHeader {...makeProps(scenario.props)} />);
+          for (const [name, find] of Object.entries(scenario.controls)) {
+            const el = find();
+            covered.add(name);
             dragPointerDown.mockClear();
             fireEvent.pointerDown(el);
-            expect(dragPointerDown, `${control.name} armed the panel drag`).not.toHaveBeenCalled();
+            expect(dragPointerDown, `${name} armed the panel drag`).not.toHaveBeenCalled();
           }
           unmount();
+          mockHiddenTabIds = new Set();
+          useFleetFailureStore.getState().clear();
         }
       } finally {
         mockDragHandle = null;
+        mockHiddenTabIds = new Set();
+        useFleetFailureStore.getState().clear();
       }
 
-      // Floor guard: without it the loop passes vacuously if the render configs
-      // stop surfacing any control.
-      expect(covered.size).toBeGreaterThanOrEqual(5);
+      // Pins coverage to the guard inventory in PanelHeader.tsx: adding a
+      // guarded control without covering it here fails on the mismatch.
+      expect([...covered].sort()).toEqual(
+        [
+          "close",
+          "duplicate as tab",
+          "fleet failure dot",
+          "maximize",
+          "move to dock",
+          "move to grid",
+          "overflow menu",
+          "restore",
+          "tabs overflow",
+        ].sort()
+      );
     });
 
     it("still forwards pointerdown on the header itself to the drag listener", () => {


### PR DESCRIPTION
## Summary

- Wave 2 of the panel-as-dialog header consolidation. Depends on #11238, merged as #11246.
- Moves `PanelHeader`'s hand-rolled root `div` onto `<SurfaceHeader density="compact">`, so panels and dialogs share one header frame with density as the only axis of difference.
- `SurfaceHeader.tsx` itself is unchanged.

Resolves #11241

## Changes

- `src/components/Panel/PanelHeader.tsx`: root element swap plus the import change.
- `src/components/Panel/__tests__/PanelHeader.test.tsx`: new "shared surface header frame (#11241)" `describe` block.

The compact variant now owns `h-8`, `px-3`, `border-b border-divider`, `flex items-center justify-between`, and `shrink-0`. Everything panel-specific stays composed as slots: the whole-header dnd-kit drag surface, tab-strip substitution, agent/fleet badges, inline title editing, the colored kind icon, and the control cluster.

**Out of scope:** unifying `--panel-header-bg` / `--panel-header-focus-bg` into `--dialog-header-bg`. #11246 already deferred this and this issue's acceptance bar doesn't call for it. It would touch `extensionRegistry.ts`, 8+ built-in theme files, and the drift-detection test for no behavioral gain here.

No `AppDialog`-style wrapper sub-components were added. `PanelHeader`'s title slot alternates between a plain span, an inline-edit input, and a full tab strip, and `SurfaceHeaderTitle`'s `h2`/`h3` semantics would pollute the document outline with dozens of per-panel headings.

## Visual parity

Rendered class sets were dumped across grid-focused, grid-unfocused, grid-maximized, and dock, and they're identical to the pre-change output. A separate adversarial pass checked all 512 combinations of the boolean state flags against `tailwind-merge` and found zero token-set differences. `tailwind-merge` still collapses `h-8` to `h-10` and `border-divider` to `border-daintree-border` when maximized, while keeping `border-b`.

## Testing

All 992 pre-existing lines in `PanelHeader.test.tsx` pass unmodified. New coverage adds:

- A consumer/primitive frame contract, deriving expected classes from a live `SurfaceHeader` at runtime rather than hardcoding them, so intentional primitive restyles don't force test edits.
- A compact-vs-comfortable density guard.
- Exactly-one-height and exactly-one-border-color merge invariants.
- A no-vertical-padding invariant.
- A drag-exclusion test covering all nine inline pointer guards against the full control inventory.

Verified locally: 191 tests pass, `npm run typecheck` is clean, `prettier` is clean, and eslint warning counts are identical to `develop` for the changed files (the per-rule lint ratchet stays flat).

Mutation-tested: removing the panel-close guard, and separately the tabs-overflow guard, each turn the drag-exclusion test red and name the offending control.

**Note for reviewers:** E2E wasn't run locally (it needs a full app build) and this repo doesn't run E2E on PRs, so unit coverage is the gate here. It pins every selector the panel E2E specs rely on: `[data-pane-chrome]`, `panel-close`, root element identity, and drag forwarding.