### PR TITLE
test(plugins): guard the builtin forge slot view seam against drift

### DIFF
--- a/src/registry/__tests__/builtinViewRegistrations.test.ts
+++ b/src/registry/__tests__/builtinViewRegistrations.test.ts
@@ -40,12 +40,35 @@ interface Registration {
   pluginId: string | null;
 }
 
-/** Manifest shape this test reads — deliberately narrow. */
-interface ManifestShape {
-  name?: string;
-  contributes?: {
-    forgeProviders?: Array<{ slots?: Record<string, string> }>;
-  };
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Narrow the parsed manifest by hand rather than asserting a shape onto it: the
+ * file is read off disk, so a wrong assumption here would surface as a confusing
+ * runtime error inside an assertion instead of a plain "no slot refs found".
+ */
+function readSlotRefs(manifest: unknown): string[] {
+  if (!isRecord(manifest)) return [];
+  const contributes = manifest.contributes;
+  if (!isRecord(contributes)) return [];
+  const providers = contributes.forgeProviders;
+  if (!Array.isArray(providers)) return [];
+
+  return providers.flatMap((provider) => {
+    if (!isRecord(provider)) return [];
+    const slots = provider.slots;
+    if (!isRecord(slots)) return [];
+    return Object.values(slots).filter(
+      (ref): ref is string => typeof ref === "string" && ref !== ""
+    );
+  });
+}
+
+function readManifestName(manifest: unknown, fallback: string): string {
+  if (!isRecord(manifest)) return fallback;
+  return typeof manifest.name === "string" ? manifest.name : fallback;
 }
 
 function readRendererSource(dir: string): string | null {
@@ -67,7 +90,8 @@ function parseRegistrations(source: string): Registration[] {
   return calls.map((call, index) => {
     const id = call[1] ?? "";
     const start = call.index ?? 0;
-    const end = index + 1 < calls.length ? (calls[index + 1]?.index ?? source.length) : source.length;
+    const end =
+      index + 1 < calls.length ? (calls[index + 1]?.index ?? source.length) : source.length;
     const owner = /pluginId:\s*"([^"]+)"/.exec(source.slice(start, end));
     return { id, pluginId: owner?.[1] ?? null };
   });
@@ -84,11 +108,15 @@ function loadBuiltinPlugins(): BuiltinPlugin[] {
       const rendererSource = readRendererSource(dir);
       if (!fs.existsSync(manifestPath) || rendererSource === null) return [];
 
-      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as ManifestShape;
-      const slotRefs = (manifest.contributes?.forgeProviders ?? []).flatMap((provider) =>
-        Object.values(provider.slots ?? {}).filter((ref) => typeof ref === "string" && ref.length > 0)
-      );
-      return [{ name: manifest.name ?? entry.name, dir, rendererSource, slotRefs }];
+      const manifest: unknown = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      return [
+        {
+          name: readManifestName(manifest, entry.name),
+          dir,
+          rendererSource,
+          slotRefs: readSlotRefs(manifest),
+        },
+      ];
     });
 }
 

--- a/src/registry/__tests__/builtinViewRegistrations.test.ts
+++ b/src/registry/__tests__/builtinViewRegistrations.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Keeps the two halves of the built-in view seam honest: every
+ * `forgeProviders.slots` ref in a built-in plugin's manifest must have a
+ * matching `registerBuiltinView` call in that plugin's renderer entry, under the
+ * declaring plugin's own id.
+ *
+ * Nothing else checks this. The main process validates `slots` for shape only —
+ * it cannot see the renderer bundle the ids resolve against (see
+ * `builtinRendererRegistry.ts` for why that bundle is host-linked rather than
+ * `plugin://`-loadable). A typo'd or dropped ref therefore reaches production as
+ * silently missing UI, caught only by a dev-mode console warning nobody is
+ * watching. The `pluginId` half matters just as much: a registration whose owner
+ * doesn't match the manifest slips the enable-aware gate, so disabling the
+ * plugin in Preferences leaves its UI on screen.
+ *
+ * Scope: this is a source scan, not an execution trace. It proves a matching
+ * registration *call* is written, not that it runs — a call that is commented
+ * out, tree-shaken, or written with a non-literal id is outside what a regex can
+ * see. That is a deliberate trade: importing the entries would pull the whole
+ * host renderer graph into a dependency-free node test, and the failure this
+ * guards (hand-editing one side of the pair) is textual in practice.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const BUILTIN_PLUGINS_DIR = path.resolve(HERE, "../../../plugins/builtin");
+
+interface BuiltinPlugin {
+  name: string;
+  dir: string;
+  rendererSource: string;
+  slotRefs: string[];
+}
+
+interface Registration {
+  id: string;
+  pluginId: string | null;
+}
+
+/** Manifest shape this test reads — deliberately narrow. */
+interface ManifestShape {
+  name?: string;
+  contributes?: {
+    forgeProviders?: Array<{ slots?: Record<string, string> }>;
+  };
+}
+
+function readRendererSource(dir: string): string | null {
+  for (const entry of ["renderer/index.tsx", "renderer/index.ts"]) {
+    const candidate = path.join(dir, entry);
+    if (fs.existsSync(candidate)) return fs.readFileSync(candidate, "utf8");
+  }
+  return null;
+}
+
+/**
+ * Every `registerBuiltinView("<id>", Component, { pluginId: "<owner>" })` in the
+ * entry. `pluginId` is read from the text between this call's id and the next
+ * call, so a multi-line options object is matched but a neighbouring call's
+ * owner can't leak into it.
+ */
+function parseRegistrations(source: string): Registration[] {
+  const calls = [...source.matchAll(/registerBuiltinView\(\s*"([^"]+)"/g)];
+  return calls.map((call, index) => {
+    const id = call[1] ?? "";
+    const start = call.index ?? 0;
+    const end = index + 1 < calls.length ? (calls[index + 1]?.index ?? source.length) : source.length;
+    const owner = /pluginId:\s*"([^"]+)"/.exec(source.slice(start, end));
+    return { id, pluginId: owner?.[1] ?? null };
+  });
+}
+
+function loadBuiltinPlugins(): BuiltinPlugin[] {
+  if (!fs.existsSync(BUILTIN_PLUGINS_DIR)) return [];
+  return fs
+    .readdirSync(BUILTIN_PLUGINS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const dir = path.join(BUILTIN_PLUGINS_DIR, entry.name);
+      const manifestPath = path.join(dir, "plugin.json");
+      const rendererSource = readRendererSource(dir);
+      if (!fs.existsSync(manifestPath) || rendererSource === null) return [];
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as ManifestShape;
+      const slotRefs = (manifest.contributes?.forgeProviders ?? []).flatMap((provider) =>
+        Object.values(provider.slots ?? {}).filter((ref) => typeof ref === "string" && ref.length > 0)
+      );
+      return [{ name: manifest.name ?? entry.name, dir, rendererSource, slotRefs }];
+    });
+}
+
+const builtinPlugins = loadBuiltinPlugins();
+
+describe("built-in plugin view registrations", () => {
+  it("finds at least one built-in plugin to check", () => {
+    // Guards the whole suite against silently passing on an empty discovery —
+    // a moved plugins/builtin path would otherwise make every case vacuous.
+    expect(builtinPlugins.length).toBeGreaterThan(0);
+  });
+
+  describe.each(builtinPlugins.map((plugin) => [plugin.name, plugin] as const))(
+    "%s",
+    (_name, plugin) => {
+      const registrations = parseRegistrations(plugin.rendererSource);
+      const registeredIds = registrations.map((registration) => registration.id);
+
+      it("registers a view for every forge provider slot ref", () => {
+        const missing = plugin.slotRefs.filter((ref) => !registeredIds.includes(ref));
+        expect(missing).toEqual([]);
+      });
+
+      it("registers each view under the declaring plugin's own id", () => {
+        const referenced = registrations.filter((registration) =>
+          plugin.slotRefs.includes(registration.id)
+        );
+        const misowned = referenced
+          .filter((registration) => registration.pluginId !== plugin.name)
+          .map((registration) => `${registration.id} -> ${registration.pluginId ?? "(ungated)"}`);
+        expect(misowned).toEqual([]);
+      });
+    }
+  );
+});

--- a/src/registry/builtinRendererRegistry.ts
+++ b/src/registry/builtinRendererRegistry.ts
@@ -3,18 +3,35 @@ import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 
 /**
  * Slot registry for renderer-side views contributed by built-in plugins. The
- * registry exists so host-owned dialogs (NewWorktreeDialog, SidebarContent)
- * can render plugin-contributed components without importing them directly,
- * preserving the plugin boundary while `contributes.views` from the plugin
- * manifest is unimplemented. Slot ids are dot-namespaced by plugin
- * (`github.bulkCreateWorktreeDialog`) so the host can grep the seam.
+ * registry exists so host-owned surfaces (NewWorktreeDialog, SidebarContent,
+ * CodeForgeSettingsTab, ForgeStatsToolbarButton) can render plugin-contributed
+ * components without importing them directly, preserving the plugin boundary.
+ * Slot ids are dot-namespaced by plugin (`github.bulkCreateWorktreeDialog`) so
+ * the host can grep the seam.
  *
- * Registration is unconditional (plugin renderer bundles are imported eagerly
- * at app start), but resolution is enable-aware: a slot registered with an
- * owning `pluginId` resolves to `null` while that plugin is disabled, so host
- * UI drops plugin-contributed views live with the Preferences toggle. React
- * consumers must use {@link useBuiltinView}; {@link getBuiltinView} reads the
- * same gate non-reactively and won't re-render on toggle.
+ * Why this is separate from `contributes.views` / `PluginViewContent` rather
+ * than folded into them (#11244): that path resolves a view's `componentPath`
+ * to a `plugin://{id}/{path}` URL and lazy-imports it, which requires the
+ * plugin to ship its renderer as a separately built bundle. Built-in renderer
+ * entries are compiled into the *host* bundle — `builtinPluginRenderers.ts`
+ * eagerly globs them for their registration side effects, and they import host
+ * modules directly (`@/components/...`, `@/store/...`). There is no
+ * `plugin://` module to import, so the standard loader cannot reach them.
+ *
+ * Folding the two together therefore needs more than a manifest change: either
+ * the built-ins get a standalone build boundary (severing those host imports
+ * through the SDK/import map), or the view-resolution path learns to resolve
+ * host-bundled components in-process. Until one of those lands, this registry
+ * is the seam, and `forgeProviders.slots` refs stay unvalidated against it —
+ * the main process cannot see the renderer bundle. The
+ * `builtinViewRegistrations` test is what keeps the two halves honest.
+ *
+ * Registration is unconditional, but resolution is enable-aware: a slot
+ * registered with an owning `pluginId` resolves to `null` while that plugin is
+ * disabled, so host UI drops plugin-contributed views live with the Preferences
+ * toggle. React consumers must use {@link useBuiltinView};
+ * {@link getBuiltinView} reads the same gate non-reactively and won't re-render
+ * on toggle.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- slot props vary per consumer; the cast site at getBuiltinView() preserves type safety
@@ -52,16 +69,19 @@ function resolveSlot<P>(
 ): ComponentType<P> | null {
   const entry = REGISTRY.get(slotId);
   if (!entry) {
-    // A non-empty ref that was never registered is most likely a plugin-author
-    // typo in a `forgeProviders.slots` value — the main process can't validate
-    // these against this renderer registry, so surface it here. Dev-only and
-    // warn-not-throw: an empty ref is the documented "no slot" sentinel, and a
-    // null resolution is defined contract, not an error.
+    // A dangling `forgeProviders.slots` ref is a manifest parse error since
+    // #11244, so reaching here means the declaration and the host bundle
+    // disagree: an id is declared in `contributes.builtinViews` but its
+    // `registerBuiltinView` call is missing (or the renderer entry was
+    // tree-shaken out — see the package.json `sideEffects` coupling in
+    // builtinPluginRenderers.ts). Dev-only and warn-not-throw: an empty ref is
+    // the documented "no slot" sentinel, and a null resolution is defined
+    // contract, not an error.
     if (import.meta.env.DEV && slotId.length > 0 && !warnedMissingSlots.has(slotId)) {
       warnedMissingSlots.add(slotId);
       console.warn(
-        `[builtinRendererRegistry] No view registered for slot "${slotId}" — ` +
-          `check the plugin's forgeProviders.slots ref and registerBuiltinView call`
+        `[builtinRendererRegistry] No view registered for declared slot "${slotId}" — ` +
+          `the plugin's contributes.builtinViews and its registerBuiltinView calls disagree`
       );
     }
     return null;

--- a/src/registry/builtinRendererRegistry.ts
+++ b/src/registry/builtinRendererRegistry.ts
@@ -69,19 +69,18 @@ function resolveSlot<P>(
 ): ComponentType<P> | null {
   const entry = REGISTRY.get(slotId);
   if (!entry) {
-    // A dangling `forgeProviders.slots` ref is a manifest parse error since
-    // #11244, so reaching here means the declaration and the host bundle
-    // disagree: an id is declared in `contributes.builtinViews` but its
-    // `registerBuiltinView` call is missing (or the renderer entry was
-    // tree-shaken out — see the package.json `sideEffects` coupling in
-    // builtinPluginRenderers.ts). Dev-only and warn-not-throw: an empty ref is
-    // the documented "no slot" sentinel, and a null resolution is defined
-    // contract, not an error.
+    // The main process can't validate slot refs against this registry, so
+    // reaching here means the manifest and the host bundle disagree: an id is
+    // declared in `forgeProviders.slots` but its `registerBuiltinView` call is
+    // missing (or the renderer entry was tree-shaken out — see the
+    // package.json `sideEffects` coupling in builtinPluginRenderers.ts).
+    // Dev-only and warn-not-throw: an empty ref is the documented "no slot"
+    // sentinel, and a null resolution is defined contract, not an error.
     if (import.meta.env.DEV && slotId.length > 0 && !warnedMissingSlots.has(slotId)) {
       warnedMissingSlots.add(slotId);
       console.warn(
         `[builtinRendererRegistry] No view registered for declared slot "${slotId}" — ` +
-          `the plugin's contributes.builtinViews and its registerBuiltinView calls disagree`
+          `the plugin's forgeProviders.slots and its registerBuiltinView calls disagree`
       );
     }
     return null;


### PR DESCRIPTION
Refs #11244

## What this does

Adds a CI-visible guard over the built-in forge slot view seam, and documents why that seam cannot currently fold into the standard `contributes.views` path.

The test asserts, for every built-in plugin, that each `forgeProviders.slots` ref in the manifest has a matching `registerBuiltinView` call in that plugin's renderer entry, registered under the declaring plugin's own id. Neither half was checked before. The main process validates `slots` for shape only, it cannot see the renderer bundle the ids resolve against, so a dropped or typo'd ref reached production as silently missing UI, caught only by a dev-mode console warning. The `pluginId` half matters just as much: a registration whose owner does not match the manifest slips the enable-aware gate, so disabling the plugin in Preferences would leave its UI on screen.

Verified the guard is not vacuous by mutating a registration id and confirming the test fails, then restoring it.

## What this deliberately does NOT do

It does not fold the forge slots into `contributes.panels` + `contributes.views`, and it does not delete `builtinRendererRegistry`. #11244 stays open.

Investigating the issue turned up a blocker in its premise. `contributes.views` resolves a view's `componentPath` to a `plugin://{id}/{path}` URL and lazy-imports it, which requires the plugin to ship a separately built renderer bundle. Built-in renderer entries are compiled into the **host** bundle: `src/registry/builtinPluginRenderers.ts` eagerly globs them for their registration side effects, `package.json` `sideEffects` keeps rolldown from dropping the chain, and the components import host modules directly (`BulkCreateWorktreeDialog.tsx` alone pulls in ~20 `@/` modules). There is no `plugin://` module for the loader to reach. GitHub is currently the only built-in, and it ships no `plugin://`-loadable renderer asset.

Folding therefore needs one of two real architectural changes, either of which deserves its own issue: give built-ins a standalone build boundary (severing those host imports through the SDK/import map), or teach the view-resolution path to resolve host-bundled components in-process. Separately, the bulk-create wizard is a poor fit for `PanelViewProps` regardless of the loader, it is driven by transient selection state (`mode`, `selectedIssues`, `selectedPRs`) rather than the `panelId` + `initialArgs` contract panel views receive.

An earlier draft of this PR tried a middle path, a new `contributes.builtinViews` contribution kind cross-validated against `slots`. It was reverted: it made `builtinViews` a required field on the public `PluginManifest` (breaking `npm run typecheck` in 7 existing fixtures), it broke external forge plugins that use `slots` (they could satisfy neither the ref check nor the builtin-only gate), and it was circular, `slots` already names the ids, so declaring them twice only checked two strings against each other while leaving the relationship that matters (declared id to registered component) unproven.

## Testing

`npx vitest run src/registry/__tests__/` (17 tests), `npm run typecheck`, and scoped prettier/eslint on the changed files all pass.
