### PR TITLE
fix(github): derive PR dropdown CI status from required checks

### DIFF
--- a/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
@@ -23,6 +23,7 @@ import {
   MAX_REVIEW_THREAD_PAGES,
   REVIEW_THREADS_PER_PAGE,
 } from "../GitHubCaches.js";
+import { buildListCacheKey } from "../GitHubPRs.js";
 import type { Issue, PR, Page } from "../../../../../shared/types/forge.js";
 import type { GitHubIssue, GitHubPR, GitHubListResponse } from "../../shared/types.js";
 
@@ -127,7 +128,12 @@ describe("clearGitHubCaches / clearPRCaches symmetry", () => {
     ["clearPRCaches", clearPRCaches],
   ] as const) {
     it(`${name} clears the PR list and required-status caches together`, () => {
-      forgePRListCache.set("owner/repo:pr:open:created:", {
+      // Key shape must match buildListCacheKey's
+      // `${type}:${owner}/${repo}:${state}:${search}:${sortOrder}:${cursor}` —
+      // a malformed key would still pass under a global clear but would give a
+      // false green if clearing ever became prefix-scoped.
+      const listKey = buildListCacheKey("pr", "owner", "repo", "open", "", "created", "");
+      forgePRListCache.set(listKey, {
         items: [],
         nextCursor: null,
         hasMore: false,
@@ -136,7 +142,7 @@ describe("clearGitHubCaches / clearPRCaches symmetry", () => {
 
       clear();
 
-      expect(forgePRListCache.get("owner/repo:pr:open:created:")).toBeUndefined();
+      expect(forgePRListCache.get(listKey)).toBeUndefined();
       expect(prRequiredStatusCache.get("owner/repo:1")).toBeUndefined();
     });
   }

--- a/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
@@ -13,6 +13,7 @@ import {
   repoStatsAndPageSnapshotCache,
   forgeIssueListCache,
   forgePRListCache,
+  prRequiredStatusCache,
   issueListCache,
   prListCache,
   getRepoListEpoch,
@@ -114,6 +115,31 @@ describe("clearGitHubCaches / clearPRCaches symmetry", () => {
     clearGitHubCaches();
     expect(getETagCacheVersion()).toBeGreaterThan(before);
   });
+
+  // The PR list and the required-status cache jointly back one rendered CI
+  // status: `listPRsImpl` enriches its rows from `prRequiredStatusCache`
+  // before caching the page (#11251). Clearing one without the other would
+  // leave a refreshed list re-enriched from stale required-check entries, or a
+  // cleared status cache shadowed by an already-enriched page — the two-caches-
+  // out-of-step failure mode from #9061.
+  for (const [name, clear] of [
+    ["clearGitHubCaches", clearGitHubCaches],
+    ["clearPRCaches", clearPRCaches],
+  ] as const) {
+    it(`${name} clears the PR list and required-status caches together`, () => {
+      forgePRListCache.set("owner/repo:pr:open:created:", {
+        items: [],
+        nextCursor: null,
+        hasMore: false,
+      } as Page<PR>);
+      prRequiredStatusCache.set("owner/repo:1", { ciStatus: "SUCCESS", ciSummary: undefined });
+
+      clear();
+
+      expect(forgePRListCache.get("owner/repo:pr:open:created:")).toBeUndefined();
+      expect(prRequiredStatusCache.get("owner/repo:1")).toBeUndefined();
+    });
+  }
 });
 
 describe("polling-optimization caches (issues #8757, #9041)", () => {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -701,10 +701,12 @@ describe("listPRs required-check enrichment", () => {
 
   it("falls back to the raw rollup when the PR has no required checks", async () => {
     // "No required checks" is not "all checks passed" (#6240) — a repo without
-    // branch protection must still surface a red rollup as failing.
+    // branch protection must still surface a red rollup as failing. The list
+    // and enrichment rollups differ so the assertion can only pass via the
+    // enrichment path: dropping the merge would leave "pending".
     mockGraphQLClient
       .mockResolvedValueOnce(
-        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("FAILURE"))])
+        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("PENDING"))])
       )
       .mockResolvedValueOnce(
         requiredChecksResponse([
@@ -721,9 +723,10 @@ describe("listPRs required-check enrichment", () => {
     expect(page.items[0].ciStatus).toBe("failure");
   });
 
-  it("does not collapse a no-CI PR into success", async () => {
+  it("derives neutral, not success, for a PR with no CI at all", async () => {
     // A missing rollup derives to `neutral`, which the row renderer draws as
-    // "no badge" — it must never read as passing.
+    // "no badge". Asserting the exact state rather than "not success" keeps the
+    // case from passing on the pre-change `undefined`.
     mockGraphQLClient
       .mockResolvedValueOnce(prListResponse([makePRNode(1, "feature/a")]))
       .mockResolvedValueOnce(
@@ -732,7 +735,58 @@ describe("listPRs required-check enrichment", () => {
 
     const page = await githubForgeProvider.listPRs(repo, {});
 
-    expect(page.items[0].ciStatus).not.toBe("success");
+    expect(page.items[0].ciStatus).toBe("neutral");
+  });
+
+  it("preserves every other mapped field on an enriched row", async () => {
+    // The merge rebuilds each open row, so a partial rebuild would silently
+    // drop fields the enrichment never looks at. The suites covering those
+    // fields run with enrichment suppressed, so this is the only case that
+    // exercises them through the merge.
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([
+          {
+            ...makePRNode(1, "feature/a", "APPROVED", makeCommitsRollup("SUCCESS")),
+            comments: { totalCount: 7 },
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "SUCCESS",
+            contexts: [checkRun("required-e2e", "FAILURE", true)],
+          },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    const pr = page.items[0];
+
+    expect(pr.ciStatus).toBe("failure");
+    expect(pr.reviewDecision).toBe("APPROVED");
+    expect(pr.commentCount).toBe(7);
+    expect(pr.number).toBe(1);
+    expect(pr.title).toBe("PR 1");
+    expect(pr.headRef).toBe("feature/a");
+    expect(pr.state).toBe("open");
+  });
+
+  it("issues no enrichment request when the page has no open rows", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([
+        closedPRNode(1, "feature/a", makeCommitsRollup("SUCCESS")),
+        closedPRNode(2, "feature/b", makeCommitsRollup("FAILURE")),
+      ])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, { state: "closed" });
+
+    expect(page.items[0].ciStatus).toBe("success");
+    expect(page.items[1].ciStatus).toBe("failure");
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
   });
 
   it("reuses the shared required-status cache instead of refetching per surface", async () => {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -101,10 +101,7 @@ function makeCommitsRollup(state: string | null) {
  * itself never consults the gate, so only the enrichment is suppressed.
  */
 function suppressRequiredStatusEnrichment() {
-  mockShouldBlockRequest.mockReturnValue({
-    blocked: true,
-    reason: "test: required-status enrichment suppressed",
-  });
+  mockShouldBlockRequest.mockReturnValue({ blocked: true, reason: "primary" });
 }
 
 /** A `buildBatchRequiredChecksQuery` response for the `pr_<number>` aliases. */
@@ -648,7 +645,7 @@ describe("listPRs required-check enrichment", () => {
   });
 
   it("keeps the coarse value and still resolves when the rate gate blocks", async () => {
-    mockShouldBlockRequest.mockReturnValue({ blocked: true, reason: "graphql budget" });
+    mockShouldBlockRequest.mockReturnValue({ blocked: true, reason: "primary" });
     mockGraphQLClient.mockResolvedValueOnce(
       prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS"))])
     );

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -92,6 +92,64 @@ function makeCommitsRollup(state: string | null) {
   return { nodes: [{ commit: { statusCheckRollup: state === null ? null : { state } } }] };
 }
 
+/**
+ * `listPRs` enriches open rows with required-check status through a second
+ * batched request (#11251). Suites that assert the coarse list mapping or an
+ * exact request count block the rate gate first: `getCIStatusesImpl` then
+ * serves cache-only (empty after `clearGitHubCaches`) and issues no request,
+ * leaving each row's raw `statusCheckRollup` mapping untouched. The list query
+ * itself never consults the gate, so only the enrichment is suppressed.
+ */
+function suppressRequiredStatusEnrichment() {
+  mockShouldBlockRequest.mockReturnValue({
+    blocked: true,
+    reason: "test: required-status enrichment suppressed",
+  });
+}
+
+/** A `buildBatchRequiredChecksQuery` response for the `pr_<number>` aliases. */
+function requiredChecksResponse(
+  entries: Array<{ number: number; contexts: unknown[]; rollupState?: string | null }>
+) {
+  const response: Record<string, unknown> = {
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+  for (const { number, contexts, rollupState } of entries) {
+    response[`pr_${number}`] = {
+      pullRequest: {
+        number,
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup:
+                  rollupState === null
+                    ? null
+                    : {
+                        state: rollupState ?? "SUCCESS",
+                        contexts: { pageInfo: { hasNextPage: false }, nodes: contexts },
+                      },
+              },
+            },
+          ],
+        },
+      },
+    };
+  }
+  return response;
+}
+
+/** A required (or optional) CheckRun context node for the batch response. */
+function checkRun(name: string, conclusion: string | null, isRequired: boolean) {
+  return {
+    __typename: "CheckRun",
+    name,
+    conclusion,
+    status: conclusion === null ? "IN_PROGRESS" : "COMPLETED",
+    isRequired,
+  };
+}
+
 describe("findPRsByBranches", () => {
   beforeEach(() => {
     mockGraphQLClient.mockReset();
@@ -350,6 +408,7 @@ describe("runQuery cache + in-flight dedup", () => {
 describe("listPRs reviewDecision", () => {
   beforeEach(() => {
     mockGraphQLClient.mockReset();
+    suppressRequiredStatusEnrichment();
   });
 
   it("maps GitHub reviewDecision values onto the normalized PR field", async () => {
@@ -396,8 +455,12 @@ describe("listPRs reviewDecision", () => {
 });
 
 describe("listPRs ciStatus", () => {
+  // These cases pin the coarse `statusCheckRollup` -> `ciStatus` mapping in
+  // isolation; the required-check enrichment layered on top has its own suite
+  // below ("listPRs required-check enrichment").
   beforeEach(() => {
     mockGraphQLClient.mockReset();
+    suppressRequiredStatusEnrichment();
   });
 
   function prListResponse(nodes: unknown[]) {
@@ -492,9 +555,245 @@ describe("listPRs ciStatus", () => {
   });
 });
 
+describe("listPRs required-check enrichment", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  function prListResponse(nodes: unknown[]) {
+    return {
+      repository: {
+        pullRequests: {
+          nodes,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalCount: nodes.length,
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+  }
+
+  function closedPRNode(number: number, headRefName: string, commits?: unknown) {
+    return { ...makePRNode(number, headRefName, undefined, commits), state: "CLOSED" };
+  }
+
+  it("overrides a green rollup with the failing required check the sidebar sees", async () => {
+    // The reported bug: an optional check drags the repo-wide rollup to green
+    // (or a required failure hides behind a passing rollup), so the dropdown
+    // showed passing while the sidebar — which derives from required checks
+    // only — showed failing for the same PR.
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS"))])
+      )
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "SUCCESS",
+            contexts: [
+              checkRun("required-e2e", "FAILURE", true),
+              checkRun("optional-lint", "SUCCESS", false),
+            ],
+          },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).toBe("failure");
+  });
+
+  it("enriches an open row that carried no coarse status at all", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(prListResponse([makePRNode(1, "feature/a")]))
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          { number: 1, rollupState: "PENDING", contexts: [checkRun("required-e2e", null, true)] },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).toBe("pending");
+  });
+
+  it("requests required checks for open rows only and leaves closed rows coarse", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([
+          makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS")),
+          closedPRNode(2, "feature/b", makeCommitsRollup("SUCCESS")),
+        ])
+      )
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "SUCCESS",
+            contexts: [checkRun("required-e2e", "FAILURE", true)],
+          },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, { state: "all" });
+
+    expect(page.items[0].ciStatus).toBe("failure");
+    // Closed row keeps the rollup mapping: required-check state is meaningless
+    // once a PR is closed, and enriching it would spend rate-limit budget.
+    expect(page.items[1].ciStatus).toBe("success");
+    const enrichmentQuery = mockGraphQLClient.mock.calls[1]?.[0] as string;
+    expect(enrichmentQuery).toContain("pr_1:");
+    expect(enrichmentQuery).not.toContain("pr_2:");
+  });
+
+  it("keeps the coarse value and still resolves when the rate gate blocks", async () => {
+    mockShouldBlockRequest.mockReturnValue({ blocked: true, reason: "graphql budget" });
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS"))])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).toBe("success");
+    // Only the list query — CI detail degrades silently rather than queueing a
+    // request the budget can't afford.
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the coarse value when the enrichment request rejects", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("FAILURE"))])
+      )
+      .mockRejectedValueOnce(new Error("network down"));
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    // The page must resolve: a CI-detail failure can never blank the dropdown.
+    expect(page.items[0].ciStatus).toBe("failure");
+  });
+
+  it("leaves rows the enrichment response omits untouched", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([
+          makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS")),
+          makePRNode(2, "feature/b", undefined, makeCommitsRollup("PENDING")),
+        ])
+      )
+      .mockResolvedValueOnce(
+        // Only PR 1 comes back; PR 2's alias is absent from the response.
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "SUCCESS",
+            contexts: [checkRun("required-e2e", "FAILURE", true)],
+          },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).toBe("failure");
+    expect(page.items[1].ciStatus).toBe("pending");
+  });
+
+  it("falls back to the raw rollup when the PR has no required checks", async () => {
+    // "No required checks" is not "all checks passed" (#6240) — a repo without
+    // branch protection must still surface a red rollup as failing.
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("FAILURE"))])
+      )
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "FAILURE",
+            contexts: [checkRun("optional-lint", "FAILURE", false)],
+          },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).toBe("failure");
+  });
+
+  it("does not collapse a no-CI PR into success", async () => {
+    // A missing rollup derives to `neutral`, which the row renderer draws as
+    // "no badge" — it must never read as passing.
+    mockGraphQLClient
+      .mockResolvedValueOnce(prListResponse([makePRNode(1, "feature/a")]))
+      .mockResolvedValueOnce(
+        requiredChecksResponse([{ number: 1, rollupState: null, contexts: [] }])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).not.toBe("success");
+  });
+
+  it("reuses the shared required-status cache instead of refetching per surface", async () => {
+    // The sidebar's getCIStatus and the dropdown's listPRs must resolve to one
+    // derivation and one cache entry — that shared entry is what stops the two
+    // surfaces drifting (#11251).
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS"))])
+      )
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "SUCCESS",
+            contexts: [checkRun("required-e2e", "FAILURE", true)],
+          },
+        ])
+      );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect(page.items[0].ciStatus).toBe("failure");
+
+    const callsAfterList = mockGraphQLClient.mock.calls.length;
+    const sidebarStatus = await githubForgeProvider.getCIStatus!(repo, 1);
+
+    expect(sidebarStatus?.state).toBe("failure");
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(callsAfterList);
+  });
+
+  it("writes the enriched value into the list cache, not the coarse one", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS"))])
+      )
+      .mockResolvedValueOnce(
+        requiredChecksResponse([
+          {
+            number: 1,
+            rollupState: "SUCCESS",
+            contexts: [checkRun("required-e2e", "FAILURE", true)],
+          },
+        ])
+      );
+
+    await githubForgeProvider.listPRs(repo, {});
+    const callsAfterFirst = mockGraphQLClient.mock.calls.length;
+
+    // Served from forgePRListCache — must already hold the enriched status, or
+    // the dropdown would render a coarse row for the rest of the 60s TTL.
+    const cached = await githubForgeProvider.listPRs(repo, {});
+
+    expect(cached.items[0].ciStatus).toBe("failure");
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(callsAfterFirst);
+  });
+});
+
 describe("commentCount mapping", () => {
   beforeEach(() => {
     mockGraphQLClient.mockReset();
+    suppressRequiredStatusEnrichment();
   });
 
   function prListWithNodes(nodes: unknown[]) {
@@ -655,7 +954,12 @@ function ciResponse(state = "SUCCESS") {
 }
 
 describe("listPRs caching", () => {
-  beforeEach(() => mockGraphQLClient.mockReset());
+  // Every assertion here counts list queries, so the enrichment request is
+  // suppressed to keep the counts about caching rather than about CI status.
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+    suppressRequiredStatusEnrichment();
+  });
 
   it("serves a warm cache entry without issuing a second query", async () => {
     mockGraphQLClient.mockResolvedValue(prListResponse());

--- a/plugins/builtin/github/main/readOps.ts
+++ b/plugins/builtin/github/main/readOps.ts
@@ -324,6 +324,57 @@ export async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<
   });
 }
 
+/**
+ * Replace each open row's coarse `statusCheckRollup` status with the
+ * required-check-aware value the worktree sidebar already renders.
+ *
+ * `LIST_PRS_QUERY` can only carry the repo-wide rollup (GraphQL can't bind
+ * `isRequired(pullRequestNumber:)` to a sibling node's own number inside a
+ * list connection), so the list path used to disagree with the sidebar on any
+ * PR whose non-required checks and required checks differ — a green rollup
+ * with a failing required check read as passing in the dropdown (#11251). The
+ * enrichment the legacy `GitHubPRs.listPullRequests` path performed was
+ * dropped when the forge provider migration re-homed listing here (#9061).
+ *
+ * Routes through {@link getCIStatusesImpl} rather than re-deriving, so both
+ * surfaces share one derivation *and* one `prRequiredStatusCache` entry per
+ * PR. That call is already cache-first, chunked, rate-gated and single-flighted
+ * — deliberately no "skip PRs that already look green" guard on top of it,
+ * which is what froze a stale green permanently in #6149.
+ *
+ * Best-effort by construction: a rate-limit block, a rejected batch, or a
+ * PR missing from the response leaves that row's coarse value untouched, and
+ * the page still resolves. CI detail degrading must never blank the dropdown.
+ */
+async function enrichPRPageWithRequiredStatus(repo: RepoRef, items: PR[]): Promise<PR[]> {
+  // Closed and merged rows are skipped: required-check state is meaningless
+  // once a PR is no longer open, the row badge only renders for open PRs, and
+  // enriching them would burn rate-limit budget on every `state: "all"` page.
+  const openNumbers = items.filter((pr) => pr.state === "open").map((pr) => pr.number);
+  if (openNumbers.length === 0) return items;
+
+  let statuses: Map<number, CIStatus | null>;
+  try {
+    statuses = await getCIStatusesImpl(repo, openNumbers);
+  } catch {
+    return items;
+  }
+
+  return items.map((pr) => {
+    if (pr.state !== "open") return pr;
+    const derived = statuses.get(pr.number);
+    // A miss (unfetched chunk, blocked request, absent PR node) means "no
+    // required-check answer", not "no CI" — keep whatever the rollup mapped.
+    if (!derived) return pr;
+    // `neutral`/`unknown` overwrite a coarse value on purpose: the sidebar
+    // renders that same derived state, so preserving the rollup here would
+    // recreate exactly the disagreement this fix removes. Both collapse to
+    // "no badge" in the row renderer (see getPRCIStatusVisual), never to
+    // "passing" — "no required checks" is not "all checks passed" (#6240).
+    return { ...pr, ciStatus: derived.state };
+  });
+}
+
 export async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> {
   const state = listCacheState(opts);
   const sortOrder = opts.sort === "updated" ? "updated" : "created";
@@ -378,8 +429,11 @@ export async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Pag
         }
       | undefined;
     const nodes = (prs?.nodes ?? []) as Array<Record<string, unknown>>;
+    // Enrich before the guard below so the value written to `forgePRListCache`
+    // is the required-check-aware one — a warm cache hit returns early and
+    // never reaches this enrichment pass.
     const page: Page<PR> = {
-      items: nodes.filter(Boolean).map(toForgePR),
+      items: await enrichPRPageWithRequiredStatus(repo, nodes.filter(Boolean).map(toForgePR)),
       nextCursor: prs?.pageInfo?.endCursor ?? null,
       hasMore: prs?.pageInfo?.hasNextPage ?? false,
       ...(typeof prs?.totalCount === "number" ? { totalCount: prs.totalCount } : {}),

--- a/plugins/builtin/github/main/readOps.ts
+++ b/plugins/builtin/github/main/readOps.ts
@@ -325,6 +325,17 @@ export async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<
 }
 
 /**
+ * How long a PR page will wait on required-check enrichment before returning
+ * its coarse rows. Enrichment sits on the list's critical path, so an unbounded
+ * await would let a stalled CI query hold the dropdown for the full 15s API
+ * timeout — five sequential chunks on a 100-row page could stall it far longer.
+ * Past the budget the request keeps running and still populates
+ * `prRequiredStatusCache`, so the next read (or the sidebar) picks the derived
+ * status up without a refetch; only this page degrades to coarse.
+ */
+const REQUIRED_STATUS_ENRICHMENT_BUDGET_MS = 4_000;
+
+/**
  * Replace each open row's coarse `statusCheckRollup` status with the
  * required-check-aware value the worktree sidebar already renders.
  *
@@ -342,9 +353,10 @@ export async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<
  * — deliberately no "skip PRs that already look green" guard on top of it,
  * which is what froze a stale green permanently in #6149.
  *
- * Best-effort by construction: a rate-limit block, a rejected batch, or a
- * PR missing from the response leaves that row's coarse value untouched, and
- * the page still resolves. CI detail degrading must never blank the dropdown.
+ * Best-effort by construction: a rate-limit block, a rejected batch, a PR
+ * missing from the response, or enrichment overrunning its time budget leaves
+ * that row's coarse value untouched, and the page still resolves. CI detail
+ * degrading must never blank or stall the dropdown.
  */
 async function enrichPRPageWithRequiredStatus(repo: RepoRef, items: PR[]): Promise<PR[]> {
   // Closed and merged rows are skipped: required-check state is meaningless
@@ -353,12 +365,18 @@ async function enrichPRPageWithRequiredStatus(repo: RepoRef, items: PR[]): Promi
   const openNumbers = items.filter((pr) => pr.state === "open").map((pr) => pr.number);
   if (openNumbers.length === 0) return items;
 
-  let statuses: Map<number, CIStatus | null>;
-  try {
-    statuses = await getCIStatusesImpl(repo, openNumbers);
-  } catch {
-    return items;
-  }
+  // Rejections are handled before the race, not after: past the budget the
+  // request keeps running to warm `prRequiredStatusCache` for the next read,
+  // and an unattached rejection would surface as an unhandled rejection.
+  const pending = getCIStatusesImpl(repo, openNumbers).catch(() => null);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), REQUIRED_STATUS_ENRICHMENT_BUDGET_MS);
+  });
+
+  const statuses = await Promise.race([pending, budget]);
+  clearTimeout(timer);
+  if (!statuses) return items;
 
   return items.map((pr) => {
     if (pr.state !== "open") return pr;

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -6,7 +6,7 @@ import {
   type WorktreeViewStoreApi,
 } from "@/store/createWorktreeStore";
 import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
-import type { CIStatusState, PR } from "@shared/types/forge";
+import type { CIStatusState } from "@shared/types/forge";
 import type { PluginWorktreeLinked } from "@shared/types/plugin";
 import {
   useWorktreeSelectionStore,
@@ -24,7 +24,6 @@ import {
   wakeActiveWorktreeTerminals,
 } from "@/store/wakeActiveWorktreeTerminals";
 import { worktreeClient } from "@/clients/worktreeClient";
-import { mutateCacheEntries } from "@/lib/forgeResourceCache";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 
@@ -595,60 +594,14 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           overlayVersion(store.getState().version)
         );
 
-        // Sync the PR dropdown cache so the sidebar PRBadge and the
-        // dropdown row can't drift. Read the project path at event time —
-        // capturing it in the effect closure would corrupt cache slots after
-        // a project switch (#4670).
-        const projectPath = useProjectStore.getState().currentProject?.path;
-        if (!projectPath) return;
-        // The dropdown cache stores normalized forge rows whose ciStatus is
-        // the same CIStatusState vocabulary as the detection wire. Only the
-        // three render-bearing states are written; neutral/unknown collapse to
-        // undefined ("no checks") to match the row badge's vocabulary.
-        const cacheCiStatus: CIStatusState | undefined =
-          event.prCiStatus === "success" ||
-          event.prCiStatus === "failure" ||
-          event.prCiStatus === "pending"
-            ? event.prCiStatus
-            : undefined;
-        mutateCacheEntries(projectPath, "pr", (entry, keyRemainder) => {
-          // keyRemainder is `${filterState}:${sortOrder}`; filterState values
-          // ("open" | "closed" | "merged" | "all") contain no colons. Unknown
-          // values fall back to "all" semantics (keep the row, only patch CI)
-          // so a malformed key can never silently evict a PR.
-          const filterState = keyRemainder.split(":")[0];
-          const isFilteredSlot =
-            filterState === "open" || filterState === "closed" || filterState === "merged";
-
-          let changed = false;
-          const items: (typeof entry.items)[number][] = [];
-          for (const item of entry.items) {
-            const pr = item as PR;
-            if (pr.number !== event.prNumber) {
-              items.push(item);
-              continue;
-            }
-            // The PR's state no longer matches this filtered slot (e.g. a
-            // closed PR still sitting in the "open" slot). Drop the row so the
-            // sidebar badge and dropdown converge on the next filter switch
-            // instead of waiting out the 45s TTL. This eviction branch must
-            // stay ahead of the CI-only branch below: it sets changed=true on
-            // removal even when ciStatus is unchanged, which is what triggers
-            // the generation bump in mutateCacheEntries.
-            if (isFilteredSlot && pr.state && pr.state !== event.prState) {
-              changed = true;
-              continue;
-            }
-            if (pr.ciStatus === cacheCiStatus) {
-              items.push(item);
-              continue;
-            }
-            changed = true;
-            items.push({ ...pr, ciStatus: cacheCiStatus });
-          }
-          if (!changed) return null;
-          return { ...entry, items };
-        });
+        // No dropdown-cache patch here on purpose. This handler used to
+        // one-way-write the renderer's forgeResourceCache to stop the sidebar
+        // badge and the dropdown row drifting, but it never reached main's
+        // forgePRListCache, so the next revalidate overwrote it with the coarse
+        // rollup and the two surfaces disagreed again. Both now derive CI
+        // status from one place — `listPRsImpl` enriches through the same
+        // `getCIStatusesImpl`/`prRequiredStatusCache` this event's status comes
+        // from — so the dropdown's own fetch already agrees (#11251).
       })
     );
 

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -225,6 +225,42 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(getGeneration(key)).toBe(genBefore);
   });
 
+  it("leaves the cache untouched when only the CI status changes", async () => {
+    // The state-change case above would still pass against a narrower
+    // reintroduction that patched CI only when the row's state still matched
+    // the event. This covers that branch: same state, different CI, and the
+    // cached row must still be untouched.
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    const cachedRow = makePR(42, "pending");
+    setCache(key, {
+      items: [cachedRow],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "failure",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("failure");
+    expect(getCache(key)?.items[0]).toBe(cachedRow);
+    expect(getGeneration(key)).toBe(genBefore);
+  });
+
   it("applies last-write-wins across rapid successive events for the same PR", async () => {
     const store = await renderProvider();
     act(() => {

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -182,105 +182,20 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBeUndefined();
   });
 
-  it("updates the GitHub PR cache so the dropdown stays in sync", async () => {
+  it("leaves the dropdown's PR cache untouched", async () => {
+    // This handler used to one-way-patch the renderer's forge cache to keep the
+    // sidebar badge and the dropdown row aligned. It couldn't: the patch never
+    // reached main's forgePRListCache, so the next revalidate restored the
+    // coarse rollup and the surfaces disagreed again. Both now derive CI status
+    // from one place — listPRsImpl enriches through the same
+    // getCIStatusesImpl/prRequiredStatusCache this event's status comes from —
+    // so the handler owns the worktree store only (#11251). Reinstating a
+    // cache write here would rebuild the drift this test guards against.
     const store = await renderProvider();
     act(() => {
       store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
     });
 
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [makePR(42, "pending"), makePR(43, "success")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-        prCiStatus: "failure",
-      });
-    });
-
-    const entry = getCache(key);
-    const pr42 = entry?.items.find((it) => (it as PR).number === 42) as PR;
-    const pr43 = entry?.items.find((it) => (it as PR).number === 43) as PR;
-    expect(pr42.ciStatus).toBe("failure");
-    expect(pr43.ciStatus).toBe("success");
-    expect(getGeneration(key)).toBe(genBefore + 1);
-  });
-
-  it("does not bump the cache generation when the CI status is unchanged", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [makePR(42, "success")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-        prCiStatus: "success",
-      });
-    });
-
-    expect(getGeneration(key)).toBe(genBefore);
-  });
-
-  it("clears the cached ciStatus when prCiStatus is undefined (full-replace)", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [makePR(42, "success")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-      });
-    });
-
-    expect((getCache(key)?.items[0] as PR).ciStatus).toBeUndefined();
-    expect(getGeneration(key)).toBe(genBefore + 1);
-  });
-
-  it("skips the cache mutation when there is no current project", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    setCurrentProject(null);
     const key = buildCacheKey("/repo/proj", "pr", "open", "created");
     setCache(key, {
       items: [makePR(42, "pending")],
@@ -296,63 +211,24 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
         worktreeId: "wt-1",
         prNumber: 42,
         prUrl: "https://example.test/pr/42",
-        prState: "open",
+        prState: "closed",
         prCiStatus: "failure",
       });
     });
 
+    // The worktree store still takes the update...
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("failure");
+    // ...while the cached row keeps both its CI status and its slot. A stale
+    // row is corrected by the dropdown's own revalidate, not from here.
     expect((getCache(key)?.items[0] as PR).ciStatus).toBe("pending");
+    expect(getCache(key)?.items).toHaveLength(1);
     expect(getGeneration(key)).toBe(genBefore);
-  });
-
-  it("targets the cache slot for the current project, not a sibling", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const sameProj = buildCacheKey("/repo/proj", "pr", "open", "created");
-    const otherProj = buildCacheKey("/repo/other", "pr", "open", "created");
-    setCache(sameProj, {
-      items: [makePR(42, "pending")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    setCache(otherProj, {
-      items: [makePR(42, "pending")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-        prCiStatus: "success",
-      });
-    });
-
-    expect((getCache(sameProj)?.items[0] as PR).ciStatus).toBe("success");
-    expect((getCache(otherProj)?.items[0] as PR).ciStatus).toBe("pending");
   });
 
   it("applies last-write-wins across rapid successive events for the same PR", async () => {
     const store = await renderProvider();
     act(() => {
       store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [makePR(42, "pending")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
     });
 
     act(() => {
@@ -369,7 +245,6 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     });
 
     expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("success");
-    expect((getCache(key)?.items[0] as PR).ciStatus).toBe("success");
   });
 
   it("does nothing when the worktree is not in the store", async () => {
@@ -525,240 +400,6 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     });
 
     expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("success");
-  });
-
-  it("uses the project path read at event time so closures cannot go stale", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    // Project switches AFTER the provider mounts; the handler must read the
-    // new path at fire time, not the path captured at mount.
-    setCurrentProject("/repo/proj-new");
-    const newKey = buildCacheKey("/repo/proj-new", "pr", "open", "created");
-    const oldKey = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(newKey, {
-      items: [makePR(42, "pending")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    setCache(oldKey, {
-      items: [makePR(42, "pending")],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-        prCiStatus: "success",
-      });
-    });
-
-    expect((getCache(newKey)?.items[0] as PR).ciStatus).toBe("success");
-    expect((getCache(oldKey)?.items[0] as PR).ciStatus).toBe("pending");
-  });
-
-  it("evicts a PR from the 'open' slot once it closes", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [
-        { ...makePR(42, "pending"), state: "open" },
-        { ...makePR(43, "success"), state: "open" },
-      ],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "closed",
-        prCiStatus: "failure",
-      });
-    });
-
-    const items = getCache(key)?.items as PR[];
-    expect(items.find((it) => it.number === 42)).toBeUndefined();
-    expect(items.find((it) => it.number === 43)).toBeDefined();
-    expect(getGeneration(key)).toBe(genBefore + 1);
-  });
-
-  it("evicts a closed PR from every 'open' sort slot in one event", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const createdKey = buildCacheKey("/repo/proj", "pr", "open", "created");
-    const updatedKey = buildCacheKey("/repo/proj", "pr", "open", "updated");
-    for (const key of [createdKey, updatedKey]) {
-      setCache(key, {
-        items: [{ ...makePR(42, "pending"), state: "open" }],
-        nextCursor: null,
-        hasMore: false,
-        timestamp: 1,
-      });
-    }
-    const genCreatedBefore = getGeneration(createdKey);
-    const genUpdatedBefore = getGeneration(updatedKey);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "closed",
-        prCiStatus: "failure",
-      });
-    });
-
-    expect((getCache(createdKey)?.items as PR[]).find((it) => it.number === 42)).toBeUndefined();
-    expect((getCache(updatedKey)?.items as PR[]).find((it) => it.number === 42)).toBeUndefined();
-    expect(getGeneration(createdKey)).toBe(genCreatedBefore + 1);
-    expect(getGeneration(updatedKey)).toBe(genUpdatedBefore + 1);
-  });
-
-  it("evicts a PR from the 'open' slot once it merges", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [{ ...makePR(42, "success"), state: "open" }],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "merged",
-        prCiStatus: "success",
-      });
-    });
-
-    expect((getCache(key)?.items as PR[]).find((it) => it.number === 42)).toBeUndefined();
-    expect(getGeneration(key)).toBe(genBefore + 1);
-  });
-
-  it("evicts a PR from the 'closed' slot once it reopens", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "closed", "created");
-    setCache(key, {
-      items: [{ ...makePR(42, "failure"), state: "closed" }],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-        prCiStatus: "pending",
-      });
-    });
-
-    expect((getCache(key)?.items as PR[]).find((it) => it.number === 42)).toBeUndefined();
-    expect(getGeneration(key)).toBe(genBefore + 1);
-  });
-
-  it("keeps the row in a CI-only rollup where the state is unchanged", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
-    setCache(key, {
-      items: [{ ...makePR(42, "pending"), state: "open" }],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "open",
-        prCiStatus: "success",
-      });
-    });
-
-    const pr42 = (getCache(key)?.items as PR[]).find((it) => it.number === 42);
-    expect(pr42).toBeDefined();
-    expect(pr42?.ciStatus).toBe("success");
-    expect(getGeneration(key)).toBe(genBefore + 1);
-  });
-
-  it("keeps a state-changed PR in the 'all' slot, only patching CI", async () => {
-    const store = await renderProvider();
-    act(() => {
-      store.getState().applyUpdate(makeWorktree("wt-1"), nextV());
-    });
-
-    const key = buildCacheKey("/repo/proj", "pr", "all", "created");
-    setCache(key, {
-      items: [{ ...makePR(42, "pending"), state: "open" }],
-      nextCursor: null,
-      hasMore: false,
-      timestamp: 1,
-    });
-    const genBefore = getGeneration(key);
-
-    act(() => {
-      emit("pr-detected", {
-        type: "pr-detected",
-        worktreeId: "wt-1",
-        prNumber: 42,
-        prUrl: "https://example.test/pr/42",
-        prState: "merged",
-        prCiStatus: "success",
-      });
-    });
-
-    const pr42 = (getCache(key)?.items as PR[]).find((it) => it.number === 42);
-    expect(pr42).toBeDefined();
-    expect(pr42?.ciStatus).toBe("success");
-    expect(getGeneration(key)).toBe(genBefore + 1);
   });
 });
 


### PR DESCRIPTION
## The problem

The PR dropdown and the worktree sidebar rendered different CI status for the same PR, and not just as a cache-timing artifact — they derived it from two separate pipelines.

- Dropdown: `LIST_PRS_QUERY` -> `toForgePR` -> `mapListCIStatus`, the coarse repo-wide `statusCheckRollup.state`.
- Sidebar: `PullRequestService` -> `getCIStatusesImpl` -> `buildBatchRequiredChecksQuery` + `deriveRequiredCIStatus`, which is required-check aware.

So a green rollup masking a failing required check read as passing in the dropdown and failing in the sidebar.

The legacy list path (`GitHubPRs.listPullRequests`) did enrich with required-check status. That behavior was dropped when the forge provider migration re-homed listing into `readOps.listPRsImpl` — the same shape as #9061, where a migration silently loses a non-functional behavior of the concrete method it replaced.

## The fix

`listPRsImpl` now enriches open rows through the existing `getCIStatusesImpl`, so both surfaces share one derivation and one `prRequiredStatusCache` entry per PR. No new query, no new cache — `isRequired(pullRequestNumber:)` can't be requested correctly inside a `pullRequests(first:N)` connection anyway, so the per-PR batched aliases already in the codebase are the only sound shape.

- Enrichment runs before the epoch guard, so `forgePRListCache` holds the enriched value for its full TTL.
- Open rows only. Required state is meaningless once a PR closes, and the row badge only renders for open PRs.
- Capped at a 4s budget. It sits on the list's critical path, and a stalled CI query would otherwise hold the dropdown for the full 15s API timeout (far longer across sequential chunks on a large page). Past the budget the request still warms the cache, so only that page degrades to coarse.
- Degrades to the coarse mapping on a rate-limit block, a rejected batch, or an omitted row. CI detail failing never blanks or stalls the dropdown.
- The one-way `pr-detected` cache patch is removed rather than extended, per the issue. It only ever wrote the renderer's cache, never main's `forgePRListCache`, so the next revalidate overwrote it.

## Known gaps

Worth flagging rather than burying — none are regressions this PR introduces except the first, and all deserve their own issues:

1. **Removed state-slot eviction.** The deleted patch also evicted a PR from a filtered cache slot when its state stopped matching (a closed PR sitting in the "open" slot). That's gone. I initially assumed it was bounded by the renderer's 45s TTL; it isn't — stale-while-revalidate keeps rows visible past expiry, a rate-limit block returns before any state change, and a cold mount can re-serve the 60s main page into a fresh renderer lifetime. Restoring it would mean restoring a renderer-side one-way cache write, which this issue explicitly rules out, so it needs a different mechanism (state-aware invalidation with a generation bump).
2. **TTL laundering.** A page written at t=59s copies a 59s-old status into a fresh 60s entry, so a status can effectively live ~119s while the sidebar refetches at 61s. Bounded and short, versus the previous permanent structural disagreement — but real. Fixing it properly means overlaying status at read time instead of baking it into the cached page.
3. **A second coarse writer.** `useRepositoryStats` writes stats-page PR rows, mapped through the coarse `parsePRNode`, into the same `("pr","open","created")` renderer slot the dropdown reads. Since the dropdown bypasses that cache on open, the enriched value wins when the user actually looks, so this is a first-paint transient rather than a persistent conflict.
4. Pre-existing and untouched: `clearPRCaches` doesn't bump the list epoch, so an in-flight page can repopulate after a clear; overlapping `getCIStatusesImpl` batches have no per-PR write ordering; and a required check with an unrecognized conclusion counts toward `requiredTotal` without incrementing any failure counter, which can synthesize SUCCESS (in `prRequiredCIStatus.ts`, deliberately not modified here).

## Testing

423 tests pass across the 11 affected files locally.

New coverage in `forgeProvider.test.ts` (`listPRs required-check enrichment`): a green rollup overridden by a failing required check (the reported bug), enrichment of a row with no coarse status, open-only scoping with the closed row left coarse, rate-gate and rejected-request degradation, partial responses leaving omitted rows untouched, the no-required-checks raw-rollup fallback, neutral for a no-CI PR, shared-cache reuse between the sidebar and dropdown paths, the enriched value landing in the list cache, field preservation through the merge, and a no-open-rows page issuing no request.

`WorktreeStoreContext.prDetected.test.tsx` drops the ~12 tests covering the removed patch and adds two boundary tests asserting the handler leaves the dropdown cache untouched — covering both the state-change and same-state branches, so a narrower reintroduced patch can't slip past.

`GitHubCaches.test.ts` locks in that `clearGitHubCaches` and `clearPRCaches` clear the list and required-status caches together (#9061).

Resolves #11251