### PR TITLE
fix(panels): let dialog-hosted panels scroll long content

### DIFF
--- a/e2e/full/panels/core-file-viewer.spec.ts
+++ b/e2e/full/panels/core-file-viewer.spec.ts
@@ -58,22 +58,36 @@ async function expectScrollsWithinDialog(pane: Locator) {
   await expect
     .poll(
       () =>
-        pane.evaluate((el) => ({
-          scrollsInternally: el.scrollHeight > el.clientHeight,
-          paneBounded: el.clientHeight <= window.innerHeight,
-        })),
+        pane.evaluate((el) => {
+          const dialogRect = el.closest('[data-testid="panel-dialog"]')?.getBoundingClientRect();
+          return {
+            scrollsInternally: el.scrollHeight > el.clientHeight,
+            // A real scrollbar, not merely programmatic scrollability: an
+            // `overflow: hidden` element still accepts a `scrollTop` write, so
+            // the scroll check below would pass on a clipped pane.
+            scrollable: ["auto", "scroll"].includes(getComputedStyle(el).overflowY),
+            // Bounded by the dialog surface rather than the window: a pane
+            // taller than the 85vh dialog still fits the viewport while having
+            // its bottom edge — and its scrollbar — clipped away.
+            withinDialog:
+              dialogRect !== undefined &&
+              el.getBoundingClientRect().bottom <= dialogRect.bottom + 1,
+          };
+        }),
       { timeout: T_MEDIUM }
     )
-    .toEqual({ scrollsInternally: true, paneBounded: true });
+    .toEqual({ scrollsInternally: true, scrollable: true, withinDialog: true });
 
-  // Content past the first screen is actually reachable, not just measurable.
-  const scrolled = await pane.evaluate((el) => {
+  // Content past the first screen is reachable, and scrolling lands on the real
+  // bottom rather than some intermediate clamp.
+  const scroll = await pane.evaluate((el) => {
     el.scrollTop = el.scrollHeight;
     const reached = el.scrollTop;
     el.scrollTop = 0;
-    return reached;
+    return { reached, max: el.scrollHeight - el.clientHeight };
   });
-  expect(scrolled).toBeGreaterThan(0);
+  expect(scroll.reached).toBeGreaterThan(0);
+  expect(scroll.reached).toBeGreaterThanOrEqual(scroll.max - 2);
 }
 
 async function closeDialog(ctx: AppContext) {
@@ -153,6 +167,15 @@ test.describe.serial("Core: File Viewer Modal", () => {
       timeout: T_LONG,
     });
     await expectScrollsWithinDialog(pane);
+
+    // The symptom in the issue was the tail of the document being unreachable,
+    // so prove the last node actually comes into view. Rendered mode only:
+    // CodeMirror virtualizes its line list, so the source-mode tail is not in
+    // the DOM to assert against.
+    await pane.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await expect(dialog.locator(".markdown-document h2")).toBeInViewport({ timeout: T_SHORT });
 
     await closeDialog(ctx);
   });

--- a/e2e/full/panels/core-file-viewer.spec.ts
+++ b/e2e/full/panels/core-file-viewer.spec.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import { test, expect } from "@playwright/test";
+import { writeFileSync } from "fs";
+import { test, expect, type Locator } from "@playwright/test";
 import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
 import { createFixtureRepo } from "../../helpers/fixtures";
 import { openAndOnboardProject } from "../../helpers/project";
@@ -9,6 +10,17 @@ import { T_SHORT, T_MEDIUM, T_LONG } from "../../helpers/timeouts";
 let ctx: AppContext;
 let fixtureDir: string;
 let fixtureCleanup: (() => void) | undefined;
+
+// Long enough to overflow the dialog's 85vh cap in both source and rendered
+// mode. Blank-line separated so the rendered document is a tall stack of real
+// <p> elements rather than one wrapped paragraph.
+const TALL_MARKDOWN =
+  "# Tall document\n\n" +
+  Array.from(
+    { length: 300 },
+    (_, i) => `Paragraph ${String(i + 1).padStart(3, "0")} lorem ipsum dolor sit amet.`
+  ).join("\n\n") +
+  "\n\n## tall-doc-end\n";
 
 async function dispatchViewFile(ctx: AppContext, filePath: string, rootPath?: string) {
   // Normalize to forward slashes so the renderer's containment check works on Windows
@@ -35,6 +47,35 @@ async function waitForDialog(ctx: AppContext) {
   return dialog;
 }
 
+/**
+ * #11254: the pane body owns the scroll inside the dialog too. Without the
+ * flex-item sizing contract on the panel root, the panel sizes to the file's
+ * intrinsic height instead of the dialog body's, so the pane never overflows
+ * internally (no scrollbar) and everything past the first screen is clipped.
+ * Mirrors the grid-side proof in core-file-panel.spec.ts (#11024).
+ */
+async function expectScrollsWithinDialog(pane: Locator) {
+  await expect
+    .poll(
+      () =>
+        pane.evaluate((el) => ({
+          scrollsInternally: el.scrollHeight > el.clientHeight,
+          paneBounded: el.clientHeight <= window.innerHeight,
+        })),
+      { timeout: T_MEDIUM }
+    )
+    .toEqual({ scrollsInternally: true, paneBounded: true });
+
+  // Content past the first screen is actually reachable, not just measurable.
+  const scrolled = await pane.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+    const reached = el.scrollTop;
+    el.scrollTop = 0;
+    return reached;
+  });
+  expect(scrolled).toBeGreaterThan(0);
+}
+
 async function closeDialog(ctx: AppContext) {
   await ctx.window.locator(SEL.fileViewer.closeButton).click();
   await expect(ctx.window.locator(SEL.fileViewer.dialog)).not.toBeVisible({
@@ -52,6 +93,7 @@ test.describe.serial("Core: File Viewer Modal", () => {
     });
     fixtureDir = dir;
     fixtureCleanup = cleanup;
+    writeFileSync(path.join(dir, "tall.md"), TALL_MARKDOWN);
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "File Viewer Test");
   });
@@ -88,6 +130,29 @@ test.describe.serial("Core: File Viewer Modal", () => {
     await expect(metadataBar).toBeVisible({ timeout: T_MEDIUM });
     await expect(metadataBar).toContainText("lines", { timeout: T_SHORT });
     await expect(metadataBar).toContainText("UTF-8", { timeout: T_SHORT });
+
+    await closeDialog(ctx);
+  });
+
+  test("a file taller than the dialog scrolls internally in source and rendered mode", async () => {
+    await dispatchViewFile(ctx, path.join(fixtureDir, "tall.md"));
+
+    const dialog = await waitForDialog(ctx);
+    const pane = dialog.locator('[data-testid="file-pane-body"]');
+
+    // Markdown opens as source first.
+    await expect(dialog.locator(".cm-content")).toContainText("# Tall document", {
+      timeout: T_LONG,
+    });
+    await expectScrollsWithinDialog(pane);
+
+    // The issue reports both modes clipping, and rendered markdown is a
+    // different content subtree, so it needs its own proof.
+    await dialog.getByRole("button", { name: "Rendered", exact: true }).click();
+    await expect(dialog.locator(".markdown-document h1")).toHaveText("Tall document", {
+      timeout: T_LONG,
+    });
+    await expectScrollsWithinDialog(pane);
 
     await closeDialog(ctx);
   });

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -510,14 +510,14 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           : undefined),
       }}
       className={cn(
-        // Three host contexts, one class set. Grid and maximized parents are
-        // block-level `h-full` wrappers, so the percentage height is what fills
-        // the cell there and `flex-1` is inert. The dialog body is a flex
-        // column, where `h-full` resolves against an indefinite parent and
-        // collapses to `auto` — the panel then sizes to its content and the
-        // pane's own scroller never overflows, so a long file just clips
-        // (#11254). `flex-1` sizes it from the flex line instead, and `min-h-0`
-        // releases the automatic minimum size so it can actually shrink.
+        // Dual sizing contract, because the panel root is hosted under both
+        // block-level and flex parents. `h-full` fills the block wrappers the
+        // grid layouts use. `flex-1 min-h-0` covers the flex columns (dialog
+        // body, dock slot, the registry's fade wrapper): there `h-full`
+        // resolves against an indefinite parent and collapses to `auto`, so the
+        // panel sizes to its content, the pane's own scroller never overflows,
+        // and a long file just clips (#11254). Every wrapper between a host and
+        // a pane root has to carry this same pair — see panels/registry.tsx.
         "flex flex-col h-full flex-1 min-h-0 overflow-hidden group/panel",
         location === "grid" && !isMaximized && "bg-surface",
         // Dialog joins the dock/maximized bucket: AppDialog already draws the

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -510,7 +510,15 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           : undefined),
       }}
       className={cn(
-        "flex flex-col h-full overflow-hidden group/panel",
+        // Three host contexts, one class set. Grid and maximized parents are
+        // block-level `h-full` wrappers, so the percentage height is what fills
+        // the cell there and `flex-1` is inert. The dialog body is a flex
+        // column, where `h-full` resolves against an indefinite parent and
+        // collapses to `auto` — the panel then sizes to its content and the
+        // pane's own scroller never overflows, so a long file just clips
+        // (#11254). `flex-1` sizes it from the flex line instead, and `min-h-0`
+        // releases the automatic minimum size so it can actually shrink.
+        "flex flex-col h-full flex-1 min-h-0 overflow-hidden group/panel",
         location === "grid" && !isMaximized && "bg-surface",
         // Dialog joins the dock/maximized bucket: AppDialog already draws the
         // surface, border, radius, and shadow, so a second set here would

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -86,6 +86,11 @@ const LazyDiffPane = lazy(() => import("./diff/DiffPane").then((m) => ({ default
 // TerminalPane is intentionally NOT lazy/wrapped: it is the hottest panel kind,
 // open/close must feel instant, and a Suspense skeleton + 150ms fade on every
 // mount is a visible regression for a live text surface.
+// The fade wrapper is a real div, so for every lazy kind it — not the pane it
+// wraps — is the direct child of whatever hosts the panel. It therefore has to
+// carry the same sizing contract the pane roots do: `h-full` for the
+// block-level grid wrappers, `flex-1 min-h-0` so it can shrink inside the
+// dialog body's flex column instead of growing to fit a long file (#11254).
 // Browser/review/file fallbacks mirror their kind's content silhouette and all
 // bones pulse immediately — React's ~300ms fallback throttle already serves the
 // anti-flicker gate (#9040 note in useDeferredLoading.ts). Dev preview uses the
@@ -95,7 +100,7 @@ function BrowserPaneWrapper(props: ComponentProps<typeof LazyBrowserPane>) {
   return (
     <ErrorBoundary variant="component" componentName="BrowserPane">
       <Suspense fallback={<BrowserPaneSkeleton />}>
-        <ContentFadeIn className="flex flex-col h-full w-full">
+        <ContentFadeIn className="flex flex-col h-full w-full flex-1 min-h-0">
           <LazyBrowserPane {...props} />
         </ContentFadeIn>
       </Suspense>
@@ -117,7 +122,7 @@ function ReviewPaneWrapper(props: ComponentProps<typeof LazyReviewPane>) {
   return (
     <ErrorBoundary variant="component" componentName="ReviewPane">
       <Suspense fallback={<ReviewPaneSkeleton />}>
-        <ContentFadeIn className="flex flex-col h-full w-full">
+        <ContentFadeIn className="flex flex-col h-full w-full flex-1 min-h-0">
           <LazyReviewPane {...props} />
         </ContentFadeIn>
       </Suspense>
@@ -129,7 +134,7 @@ function FilePaneWrapper(props: ComponentProps<typeof LazyFilePane>) {
   return (
     <ErrorBoundary variant="component" componentName="FilePane">
       <Suspense fallback={<BrowserPaneSkeleton label="Loading file panel" />}>
-        <ContentFadeIn className="flex flex-col h-full w-full">
+        <ContentFadeIn className="flex flex-col h-full w-full flex-1 min-h-0">
           <LazyFilePane {...props} />
         </ContentFadeIn>
       </Suspense>
@@ -141,7 +146,7 @@ function DiffPaneWrapper(props: ComponentProps<typeof LazyDiffPane>) {
   return (
     <ErrorBoundary variant="component" componentName="DiffPane">
       <Suspense fallback={<BrowserPaneSkeleton label="Loading diff panel" />}>
-        <ContentFadeIn className="flex flex-col h-full w-full">
+        <ContentFadeIn className="flex flex-col h-full w-full flex-1 min-h-0">
           <LazyDiffPane {...props} />
         </ContentFadeIn>
       </Suspense>

--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -98,7 +98,15 @@ export function ReviewPane({
   }
 
   return (
-    <div ref={setContainerEl} tabIndex={-1} className="flex h-full w-full flex-col bg-daintree-bg">
+    // Review is the one built-in kind that renders no ContentPanel, so it
+    // carries that root's sizing contract itself: `h-full` for the block-level
+    // grid/dock wrappers, `flex-1 min-h-0` for the dialog body's flex column
+    // (see the same pairing in ContentPanel, #11254).
+    <div
+      ref={setContainerEl}
+      tabIndex={-1}
+      className="flex h-full min-h-0 w-full flex-1 flex-col bg-daintree-bg"
+    >
       <ReviewHubContent
         isOpen={true}
         panelId={id}

--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -99,9 +99,9 @@ export function ReviewPane({
 
   return (
     // Review is the one built-in kind that renders no ContentPanel, so it
-    // carries that root's sizing contract itself: `h-full` for the block-level
-    // grid/dock wrappers, `flex-1 min-h-0` for the dialog body's flex column
-    // (see the same pairing in ContentPanel, #11254).
+    // carries that root's dual sizing contract itself — `h-full` for block
+    // wrappers, `flex-1 min-h-0` for flex ones (#11254). ReviewHubContent's own
+    // `flex-1 min-h-0` only bounds its scroller once this root is bounded too.
     <div
       ref={setContainerEl}
       tabIndex={-1}


### PR DESCRIPTION
## Summary

- Opening a long file through the file viewer dialog clipped it: no scrollbar in either Source or Rendered mode, and everything past the first screen was unreachable. The same file scrolled fine as a docked grid panel.
- Root cause was a dual sizing contract that was only half declared. Panel roots carried `h-full` but no flex item contract, so the dialog's flex column resolved `h-full` to `auto` and the panel just sized to the file's intrinsic height instead of overflowing.
- Fix adds `flex-1 min-h-0` alongside `h-full` at each level in the panel chain, so the same class set works under both the grid's block wrappers and the dialog's flex column.

Resolves #11254

## Root cause

Under the grid layouts' block level wrappers, `h-full` is what fills the cell, so grid worked. Under the dialog body's flex column (`AppDialog.BodyScroll`, `PanelDialogHost.tsx:124`), `h-full` resolves against an indefinite parent and collapses to `auto`. The panel then sized to the file's intrinsic height, so `FilePane`'s own `overflow-auto` scroller never overflowed (hence no scrollbar), and the oversized box got clipped by the dialog's `overflow-hidden`.

## Changes

`flex-1` sizes from the flex line instead of a percentage; `min-h-0` releases the flexbox automatic minimum size so the box can actually shrink. Applied in three places:

- `ContentPanel` root: the shared panel surface.
- `panels/registry.tsx`: the `ContentFadeIn` fade wrapper is a real div, so for every lazy kind (file, review, browser, diff) it, not the pane root, is the direct child of the dialog body. This was the substantive catch from review; without it the fix is incomplete.
- `ReviewPane`: the one built-in kind that renders no `ContentPanel` and so carries the contract itself. This is preventive hardening. A review-hub failure wasn't reproduced, but the shape is identical.

`PanelDialogHost`'s `overflow-hidden` was deliberately left alone. Commit `edc850cf1` added it to fix a padding inset bug, and reverting it would risk double scrollbars for panel kinds that own their internal scroll surface.

## Testing

E2E doesn't run in PR CI, so this was verified locally:

- Added a regression test in `e2e/full/panels/core-file-viewer.spec.ts` asserting, for both Source and Rendered mode, that the pane overflows internally (`scrollHeight > clientHeight`), has a real `overflow-y: auto`/`scroll` (an `overflow: hidden` element still accepts a `scrollTop` write, so that check alone would false pass), stays bounded by the dialog rect rather than merely the window, scrolls to its true bottom, and brings the document's last node into view.
- Verified red before green: with the source fix reverted, the new test fails with `scrollsInternally: false, withinDialog: false`, exactly the reported symptom. With the fix, green.
- 18/18 passed across `core-file-viewer.spec.ts` plus `core-file-panel.spec.ts`. The latter's existing grid tall file test (#11024) is the guard proving that keeping `h-full` didn't regress the grid/dock presentation.
- 175 targeted unit tests pass, `tsc` is clean, `eslint`/`prettier` are clean on all four changed files.
- No unit test was added for the CSS fix itself by design: jsdom computes no layout so it can't express the invariant, and a `toHaveClass("min-h-0")` assertion would just be a source literal tautology.
