### PR TITLE
fix(file-panel): hold the pane height across the markdown rendered swap

### DIFF
--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -23,6 +23,11 @@ export interface MarkdownDocumentProps {
   /** Containment root for daintree-file:// image loads */
   rootPath: string;
   className?: string;
+  /**
+   * Fired once the document has committed. Hosts that pinned their height
+   * across the swap into rendered mode use this to release the pin (#11255).
+   */
+  onRendered?: () => void;
 }
 
 /**
@@ -111,7 +116,16 @@ export function MarkdownDocument({
   filePath,
   rootPath,
   className,
+  onRendered,
 }: MarkdownDocumentProps) {
+  // Runs after the first commit, which is the point the host's height pin can
+  // hand the box back to the document. Cold fence grammars land later and swap
+  // plain text for span-wrapped identical text — same characters, same line
+  // count, so they can't shrink the box and don't gate this.
+  useEffect(() => {
+    onRendered?.();
+  }, [onRendered]);
+
   const urlTransform = useMemo(() => {
     return (url: string, key: string): string | null | undefined => {
       if (key === "src") {

--- a/src/components/Markdown/MarkdownViewer.tsx
+++ b/src/components/Markdown/MarkdownViewer.tsx
@@ -27,6 +27,12 @@ export interface MarkdownViewerProps {
   /** Source-mode only: soft-wrap long lines */
   wrapLines?: boolean;
   className?: string;
+  /**
+   * Rendered-mode only: fired once the rendered document has committed. Hosts
+   * that size to their content pin their height across the swap and release it
+   * here, so the lazy chunk's skeleton can't collapse them first (#11255).
+   */
+  onRendered?: () => void;
 }
 
 /**
@@ -36,7 +42,7 @@ export interface MarkdownViewerProps {
  */
 export const MarkdownViewer = forwardRef<MarkdownViewerHandle, MarkdownViewerProps>(
   function MarkdownViewer(
-    { content, filePath, rootPath, viewMode, initialLine, wrapLines, className },
+    { content, filePath, rootPath, viewMode, initialLine, wrapLines, className, onRendered },
     ref
   ) {
     const codeViewerRef = useRef<CodeViewerHandle>(null);
@@ -77,6 +83,7 @@ export const MarkdownViewer = forwardRef<MarkdownViewerHandle, MarkdownViewerPro
           filePath={filePath}
           rootPath={rootPath}
           className={cn("px-6 py-5", className)}
+          onRendered={onRendered}
         />
       </Suspense>
     );

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -69,6 +69,31 @@ describe("MarkdownDocument", () => {
     expect(container.textContent).toContain("plain body");
   });
 
+  it("reports its first commit so a pinned host height can be handed back", () => {
+    const onRendered = vi.fn();
+    render(<MarkdownDocument {...FIXTURE_PROPS} content="# Spec title" onRendered={onRendered} />);
+
+    expect(onRendered).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves fence text verbatim when highlighting, so the token swap can't resize the box", () => {
+    // The cold-grammar path renders the fence as plain text and re-renders with
+    // tokens once ensureLanguage resolves. That second render is only height-safe
+    // because tokenizing wraps the same characters — assert the invariant rather
+    // than the timing.
+    const code = 'const x: string = "hi";';
+    const { container } = render(
+      <MarkdownDocument {...FIXTURE_PROPS} content={`\`\`\`typescript\n${code}\n\`\`\``} />
+    );
+
+    const rendered = container.querySelector("code.language-typescript");
+    expect(rendered!.querySelector(".token")).not.toBeNull();
+    // Byte-identical to the plain fallback, trailing fence newline included —
+    // the `code` mapping strips it before either path renders, so the swap
+    // can't gain or lose a line.
+    expect(rendered!.textContent).toBe(code);
+  });
+
   it("drops raw HTML instead of rendering it", () => {
     const { container } = render(
       <MarkdownDocument

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -69,18 +69,28 @@ describe("MarkdownDocument", () => {
     expect(container.textContent).toContain("plain body");
   });
 
-  it("reports its first commit so a pinned host height can be handed back", () => {
-    const onRendered = vi.fn();
+  it("reports only once the document is in the DOM, so a host can hand back a pinned height", () => {
+    // A host releases a height pin on this signal, so it has to fire after the
+    // commit — reporting during render would release against a box that hasn't
+    // laid out yet. Capture what the DOM looked like at call time rather than
+    // just the call count, which a render-phase call would also satisfy.
+    let headingAtReport: string | null = null;
+    const onRendered = vi.fn(() => {
+      headingAtReport = document.querySelector("h1")?.textContent ?? null;
+    });
+
     render(<MarkdownDocument {...FIXTURE_PROPS} content="# Spec title" onRendered={onRendered} />);
 
     expect(onRendered).toHaveBeenCalledTimes(1);
+    expect(headingAtReport).toBe("Spec title");
   });
 
-  it("preserves fence text verbatim when highlighting, so the token swap can't resize the box", () => {
-    // The cold-grammar path renders the fence as plain text and re-renders with
-    // tokens once ensureLanguage resolves. That second render is only height-safe
-    // because tokenizing wraps the same characters — assert the invariant rather
-    // than the timing.
+  it("keeps fence text byte-identical when highlighting, trailing newline included", () => {
+    // The cold-grammar path renders a fence as plain text and re-renders with
+    // token spans once ensureLanguage resolves. That swap is only height-safe if
+    // it wraps the same characters — this pins the text invariant on the warm
+    // path. It does not prove equal box height: jsdom performs no layout, so
+    // only Chromium can establish that.
     const code = 'const x: string = "hi";';
     const { container } = render(
       <MarkdownDocument {...FIXTURE_PROPS} content={`\`\`\`typescript\n${code}\n\`\`\``} />
@@ -88,9 +98,8 @@ describe("MarkdownDocument", () => {
 
     const rendered = container.querySelector("code.language-typescript");
     expect(rendered!.querySelector(".token")).not.toBeNull();
-    // Byte-identical to the plain fallback, trailing fence newline included —
-    // the `code` mapping strips it before either path renders, so the swap
-    // can't gain or lose a line.
+    // The `code` mapping strips the fence's trailing newline before either path
+    // renders, so neither can gain or lose a line relative to the other.
     expect(rendered!.textContent).toBe(code);
   });
 

--- a/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const dispatchMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+// Source mode mounts CodeMirror, which has nothing to do with what these cover.
+vi.mock("@/components/FileViewer/CodeViewer", () => ({
+  CodeViewer: () => <div data-testid="code-viewer-mock" />,
+}));
+
+import { MarkdownViewer } from "../MarkdownViewer";
+
+const FIXTURE_PROPS = {
+  content: "# Spec title",
+  filePath: "/repo/docs/spec.md",
+  rootPath: "/repo",
+};
+
+describe("MarkdownViewer", () => {
+  // #11255: hosts that size to their content pin their height across the swap
+  // into rendered mode and release it on this signal. If the forwarding breaks,
+  // the pin is never handed back.
+  it("reports the rendered document's commit to its host", async () => {
+    const onRendered = vi.fn();
+    render(<MarkdownViewer {...FIXTURE_PROPS} viewMode="rendered" onRendered={onRendered} />);
+
+    // The document is lazy — nothing to report while the chunk is in flight.
+    expect(onRendered).not.toHaveBeenCalled();
+
+    await screen.findByRole("heading", { level: 1 });
+    expect(onRendered).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent in source mode, which has no chunk to wait on", () => {
+    const onRendered = vi.fn();
+    render(<MarkdownViewer {...FIXTURE_PROPS} viewMode="source" onRendered={onRendered} />);
+
+    expect(screen.getByTestId("code-viewer-mock")).toBeDefined();
+    expect(onRendered).not.toHaveBeenCalled();
+  });
+});

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -33,6 +33,7 @@ import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { isClientAppError } from "@/utils/clientAppError";
 import { logError } from "@/utils/logger";
+import { useHeightHold } from "./useHeightHold";
 
 export interface FilePaneProps extends BasePanelProps {
   tabs?: TabInfo[];
@@ -142,12 +143,39 @@ export function FilePane({
   const markdownWrapLines = usePreferencesStore((state) => state.markdownWrapLines);
   const setMarkdownWrapLines = usePreferencesStore((state) => state.setMarkdownWrapLines);
 
+  const heightHold = useHeightHold();
+
   const filePath = panel?.filePath;
   const isMarkdown = filePath !== undefined && isMarkdownFilePath(filePath);
   const isHtml = filePath !== undefined && isHtmlFilePath(filePath);
   // Markdown and HTML get a Source/Rendered toggle; every other file is source-only.
   const isRenderable = isMarkdown || isHtml;
   const viewMode: FileViewMode = isRenderable ? (panel?.fileViewMode ?? "source") : "source";
+
+  // A dialog host sizes to its content every frame, so swapping markdown source
+  // for the rendered chunk's skeleton collapses the dialog and expands it again
+  // once the document lands. Pin the source height before the swap; the
+  // rendered document releases it on its first commit (#11255). Measured here,
+  // synchronously, because a layout effect only runs once the box has already
+  // shrunk. Only this direction can collapse — source renders at its own height
+  // immediately, so the reverse just drops any stale pin.
+  const handleViewModeChange = useCallback(
+    (mode: FileViewMode) => {
+      if (location === "dialog" && isMarkdown && viewMode === "source" && mode === "rendered") {
+        heightHold.hold();
+      } else {
+        heightHold.cancel();
+      }
+      setFileViewMode(id, mode);
+    },
+    [location, isMarkdown, viewMode, heightHold, setFileViewMode, id]
+  );
+
+  // A file swapped underneath an active pin would hold the new document at the
+  // old one's height.
+  useEffect(() => {
+    heightHold.cancel();
+  }, [filePath, heightHold]);
 
   const worktreeId = panel?.worktreeId;
   const worktreePath = useWorktreeStore(
@@ -413,7 +441,7 @@ export function FilePane({
               { value: "rendered", label: "Rendered" },
             ]}
             value={viewMode}
-            onChange={(mode) => setFileViewMode(id, mode)}
+            onChange={handleViewModeChange}
           />
         )}
         <FileViewerToolbar.Path path={displayPath} copied={pathCopied} onCopy={handleCopyPath} />
@@ -494,7 +522,11 @@ export function FilePane({
       onTabRename={onTabRename}
       onAddTab={onAddTab}
     >
-      <div className="flex-1 min-h-0 overflow-auto bg-daintree-bg" data-testid="file-pane-body">
+      <div
+        ref={heightHold.bodyRef}
+        className="flex-1 min-h-0 overflow-auto bg-daintree-bg"
+        data-testid="file-pane-body"
+      >
         {!filePath && (
           <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-6">
             <EmptyState
@@ -591,6 +623,7 @@ export function FilePane({
               rootPath={effectiveRootPath}
               viewMode="rendered"
               wrapLines={markdownWrapLines}
+              onRendered={heightHold.handleRendered}
             />
           ) : viewMode === "rendered" && isHtml ? (
             // Rendered HTML fills the pane in a sandboxed iframe rather than the

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -172,10 +172,11 @@ export function FilePane({
   );
 
   // A file swapped underneath an active pin would hold the new document at the
-  // old one's height.
+  // old one's height, and a pane promoted out of the dialog would carry a
+  // content-sized floor into a layout-sized host.
   useEffect(() => {
     heightHold.cancel();
-  }, [filePath, heightHold]);
+  }, [filePath, location, heightHold]);
 
   const worktreeId = panel?.worktreeId;
   const worktreePath = useWorktreeStore(

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -480,7 +480,6 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
   });
 });
 
-
 // #11255: a dialog host sizes to its content every frame, so swapping markdown
 // source for the rendered chunk's skeleton collapsed the dialog and expanded it
 // again once the document landed. FilePane pins the body's height across the

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -31,9 +31,19 @@ vi.mock("@/components/Panel/ContentPanel", () => ({
 // therefore a toolbar) without disturbing the prop-forwarding tests.
 const panelsById: Record<string, unknown> = {};
 
+// Stable across selector calls so a test can assert which mode a toggle asked
+// for — a fresh vi.fn() per call records nothing observable.
+const { setFileViewModeMock, setFilePanelPathMock } = vi.hoisted(() => ({
+  setFileViewModeMock: vi.fn(),
+  setFilePanelPathMock: vi.fn(),
+}));
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (state: unknown) => unknown) =>
-    selector({ panelsById, setFileViewMode: vi.fn(), setFilePanelPath: vi.fn() }),
+    selector({
+      panelsById,
+      setFileViewMode: setFileViewModeMock,
+      setFilePanelPath: setFilePanelPathMock,
+    }),
 }));
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
@@ -65,8 +75,17 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: dispatchMock },
 }));
 vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+// Captures the props FilePane hands the rendered viewer so the #11255 release
+// chain (FilePane → MarkdownViewer.onRendered → the height pin) is observable;
+// without this the wiring could be deleted with every test still green.
+const markdownViewerProps = vi.hoisted(() => ({
+  current: null as { onRendered?: () => void } | null,
+}));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
-  MarkdownViewer: () => <div data-testid="markdown-viewer-mock" />,
+  MarkdownViewer: (props: { onRendered?: () => void }) => {
+    markdownViewerProps.current = props;
+    return <div data-testid="markdown-viewer-mock" />;
+  },
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
   CodeViewer: () => <div data-testid="code-viewer-mock" />,
@@ -122,6 +141,9 @@ beforeEach(() => {
 afterEach(() => {
   contentPanelProps.length = 0;
   for (const key of Object.keys(panelsById)) delete panelsById[key];
+  setFileViewModeMock.mockReset();
+  setFilePanelPathMock.mockReset();
+  markdownViewerProps.current = null;
 });
 
 describe("FilePane restore-control wiring", () => {
@@ -458,23 +480,38 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
   });
 });
 
+
 // #11255: a dialog host sizes to its content every frame, so swapping markdown
 // source for the rendered chunk's skeleton collapsed the dialog and expanded it
 // again once the document landed. FilePane pins the body's height across the
-// swap. The MarkdownViewer mock above means the release path never runs here —
-// that lifecycle is covered directly in useHeightHold.test.tsx; these assert the
-// wiring, i.e. which toggles arm a pin at all.
+// swap and the rendered document releases it. The pin's own lifecycle is
+// covered in useHeightHold.test.tsx; these cover FilePane's wiring — which
+// toggles arm a pin, and that the release signal actually reaches it.
 describe("FilePane rendered-swap height hold (#11255)", () => {
   const SOURCE_HEIGHT = 640;
 
-  function renderPaneWithBody(filePath: string, location: "dialog" | "grid") {
-    panelsById["file-1"] = {
-      id: "file-1",
-      kind: "file",
-      filePath,
-      fileViewMode: "source",
-    };
-    const view = render(
+  function stubHeight(node: HTMLElement) {
+    // jsdom lays nothing out; give the pane the height a real source view would
+    // have so the pin has something to measure.
+    node.getBoundingClientRect = vi.fn<() => DOMRect>(() => ({
+      height: SOURCE_HEIGHT,
+      width: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+  }
+
+  function seedPanel(filePath: string, fileViewMode: "source" | "rendered") {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath, fileViewMode };
+  }
+
+  function paneElement(location: "dialog" | "grid") {
+    return (
       <TooltipProvider>
         <FilePane
           id="file-1"
@@ -486,20 +523,19 @@ describe("FilePane rendered-swap height hold (#11255)", () => {
         />
       </TooltipProvider>
     );
-    const body = screen.getByTestId("file-pane-body");
-    // jsdom lays nothing out; give the pane the height a real source view would
-    // have so the pin has something to measure.
-    body.getBoundingClientRect = vi.fn<() => DOMRect>(() => ({
-      height: SOURCE_HEIGHT,
-      width: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    }));
+  }
+
+  async function renderPane(
+    filePath: string,
+    location: "dialog" | "grid",
+    fileViewMode: "source" | "rendered" = "source"
+  ) {
+    seedPanel(filePath, fileViewMode);
+    const view = render(paneElement(location));
+    // Let files:read settle so the viewer branch is actually mounted.
+    await waitFor(() => expect(readMock).toHaveBeenCalled());
+    const body = await screen.findByTestId("file-pane-body");
+    stubHeight(body);
     return { ...view, body };
   }
 
@@ -511,63 +547,80 @@ describe("FilePane rendered-swap height hold (#11255)", () => {
   }
 
   it("pins the source height when a dialog switches markdown to rendered", async () => {
-    const { body } = renderPaneWithBody("/repo/docs/spec.md", "dialog");
+    const { body } = await renderPane("/repo/docs/spec.md", "dialog");
 
     await clickToggle("Rendered");
 
     expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
   });
 
-  it("leaves a grid panel unpinned — its cell height is layout-owned, not content-driven", async () => {
-    const { body } = renderPaneWithBody("/repo/docs/spec.md", "grid");
-
+  it("releases the pin once the rendered document reports its first commit", async () => {
+    const { body, rerender } = await renderPane("/repo/docs/spec.md", "dialog");
     await clickToggle("Rendered");
+    expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
+
+    // The store mock is inert, so drive the mode change the way the real store
+    // would and re-render through the same FilePane instance.
+    seedPanel("/repo/docs/spec.md", "rendered");
+    rerender(paneElement("dialog"));
+    // The pin has to survive the swap itself — that is the whole point.
+    expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
+
+    const onRendered = markdownViewerProps.current?.onRendered;
+    expect(onRendered).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    try {
+      act(() => onRendered!());
+      expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
+      act(() => void vi.advanceTimersToNextFrame());
+      act(() => void vi.advanceTimersToNextFrame());
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(body.style.minHeight).toBe("");
   });
 
-  it("does not pin the reverse switch, which renders at its own height immediately", async () => {
-    panelsById["file-1"] = {
-      id: "file-1",
-      kind: "file",
-      filePath: "/repo/docs/spec.md",
-      fileViewMode: "rendered",
-    };
-    render(
-      <TooltipProvider>
-        <FilePane
-          id="file-1"
-          title="spec.md"
-          isFocused={true}
-          location="dialog"
-          onFocus={() => {}}
-          onClose={() => {}}
-        />
-      </TooltipProvider>
-    );
-    const body = screen.getByTestId("file-pane-body");
-    body.getBoundingClientRect = vi.fn<() => DOMRect>(() => ({
-      height: SOURCE_HEIGHT,
-      width: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    }));
+  it("drops the pin when the pane reverts to source before the document lands", async () => {
+    const { body, rerender } = await renderPane("/repo/docs/spec.md", "dialog");
+    await clickToggle("Rendered");
+    expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
 
+    seedPanel("/repo/docs/spec.md", "rendered");
+    rerender(paneElement("dialog"));
     await clickToggle("Source");
 
+    expect(setFileViewModeMock).toHaveBeenLastCalledWith("file-1", "source");
+    expect(body.style.minHeight).toBe("");
+  });
+
+  it("drops the pin when the pane leaves the dialog for a layout-sized host", async () => {
+    const { body, rerender } = await renderPane("/repo/docs/spec.md", "dialog");
+    await clickToggle("Rendered");
+    expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
+
+    rerender(paneElement("grid"));
+
+    expect(body.style.minHeight).toBe("");
+  });
+
+  it("leaves a grid panel unpinned — its cell height is layout-owned, not content-driven", async () => {
+    const { body } = await renderPane("/repo/docs/spec.md", "grid");
+
+    await clickToggle("Rendered");
+
+    // The toggle still did its job; only the pin is scoped away.
+    expect(setFileViewModeMock).toHaveBeenLastCalledWith("file-1", "rendered");
     expect(body.style.minHeight).toBe("");
   });
 
   it("leaves HTML alone — its preview frame owns its own height", async () => {
-    const { body } = renderPaneWithBody("/repo/dist/report.html", "dialog");
+    const { body } = await renderPane("/repo/dist/report.html", "dialog");
 
     await clickToggle("Rendered");
 
+    expect(setFileViewModeMock).toHaveBeenLastCalledWith("file-1", "rendered");
     expect(body.style.minHeight).toBe("");
   });
 });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -457,3 +457,117 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     );
   });
 });
+
+// #11255: a dialog host sizes to its content every frame, so swapping markdown
+// source for the rendered chunk's skeleton collapsed the dialog and expanded it
+// again once the document landed. FilePane pins the body's height across the
+// swap. The MarkdownViewer mock above means the release path never runs here —
+// that lifecycle is covered directly in useHeightHold.test.tsx; these assert the
+// wiring, i.e. which toggles arm a pin at all.
+describe("FilePane rendered-swap height hold (#11255)", () => {
+  const SOURCE_HEIGHT = 640;
+
+  function renderPaneWithBody(filePath: string, location: "dialog" | "grid") {
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath,
+      fileViewMode: "source",
+    };
+    const view = render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="spec.md"
+          isFocused={true}
+          location={location}
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+    const body = screen.getByTestId("file-pane-body");
+    // jsdom lays nothing out; give the pane the height a real source view would
+    // have so the pin has something to measure.
+    body.getBoundingClientRect = vi.fn<() => DOMRect>(() => ({
+      height: SOURCE_HEIGHT,
+      width: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+    return { ...view, body };
+  }
+
+  async function clickToggle(label: string) {
+    const button = screen.getByRole("button", { name: label });
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  it("pins the source height when a dialog switches markdown to rendered", async () => {
+    const { body } = renderPaneWithBody("/repo/docs/spec.md", "dialog");
+
+    await clickToggle("Rendered");
+
+    expect(body.style.minHeight).toBe(`${SOURCE_HEIGHT}px`);
+  });
+
+  it("leaves a grid panel unpinned — its cell height is layout-owned, not content-driven", async () => {
+    const { body } = renderPaneWithBody("/repo/docs/spec.md", "grid");
+
+    await clickToggle("Rendered");
+
+    expect(body.style.minHeight).toBe("");
+  });
+
+  it("does not pin the reverse switch, which renders at its own height immediately", async () => {
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: "/repo/docs/spec.md",
+      fileViewMode: "rendered",
+    };
+    render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="spec.md"
+          isFocused={true}
+          location="dialog"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+    const body = screen.getByTestId("file-pane-body");
+    body.getBoundingClientRect = vi.fn<() => DOMRect>(() => ({
+      height: SOURCE_HEIGHT,
+      width: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+
+    await clickToggle("Source");
+
+    expect(body.style.minHeight).toBe("");
+  });
+
+  it("leaves HTML alone — its preview frame owns its own height", async () => {
+    const { body } = renderPaneWithBody("/repo/dist/report.html", "dialog");
+
+    await clickToggle("Rendered");
+
+    expect(body.style.minHeight).toBe("");
+  });
+});

--- a/src/panels/file/__tests__/useHeightHold.test.tsx
+++ b/src/panels/file/__tests__/useHeightHold.test.tsx
@@ -4,8 +4,6 @@ import { act, renderHook } from "@testing-library/react";
 import { PANEL_MINIMIZE_DURATION } from "@/lib/animationUtils";
 import { RELEASING_CLASS, useHeightHold } from "../useHeightHold";
 
-/** Two animation frames plus slack — enough for the release to be queued. */
-const TWO_FRAMES_MS = 40;
 /** Past the release transition's fallback timer. */
 const PAST_SETTLE_MS = PANEL_MINIMIZE_DURATION + 200;
 
@@ -23,10 +21,14 @@ function rectOfHeight(height: number): DOMRect {
   };
 }
 
-/** A real, attached node whose measured height the test controls. */
+/** jsdom lays nothing out, so the test supplies the measured height. */
+function measuring(node: HTMLElement, height: number): void {
+  node.getBoundingClientRect = vi.fn<() => DOMRect>(() => rectOfHeight(height));
+}
+
 function mountBody(height: number): HTMLDivElement {
   const node = document.createElement("div");
-  node.getBoundingClientRect = vi.fn<() => DOMRect>(() => rectOfHeight(height));
+  measuring(node, height);
   document.body.appendChild(node);
   return node;
 }
@@ -36,6 +38,27 @@ function setup(height: number) {
   const hook = renderHook(() => useHeightHold());
   hook.result.current.bodyRef.current = node;
   return { node, hook };
+}
+
+/** Steps exactly one animation frame, rather than guessing a frame cadence. */
+function nextFrame(): void {
+  act(() => void vi.advanceTimersToNextFrame());
+}
+
+/** Arms a pin and drives it all the way into its settle transition. */
+function holdAndRelease(height = 500) {
+  const context = setup(height);
+  act(() => context.hook.result.current.hold());
+  act(() => context.hook.result.current.handleRendered());
+  nextFrame();
+  nextFrame();
+  return context;
+}
+
+function transitionEnd(target: EventTarget, propertyName: string): void {
+  const event = new Event("transitionend", { bubbles: true });
+  Object.defineProperty(event, "propertyName", { value: propertyName });
+  act(() => void target.dispatchEvent(event));
 }
 
 beforeEach(() => {
@@ -48,111 +71,222 @@ afterEach(() => {
 });
 
 describe("useHeightHold", () => {
-  it("pins the measured height, rounding up so no sub-pixel shrink slips through", () => {
-    const { node, hook } = setup(421.4);
+  describe("pinning", () => {
+    it("pins the measured height, rounding up so no sub-pixel shrink slips through", () => {
+      const { node, hook } = setup(421.4);
 
-    act(() => hook.result.current.hold());
+      act(() => hook.result.current.hold());
 
-    expect(node.style.minHeight).toBe("422px");
+      expect(node.style.minHeight).toBe("422px");
+    });
+
+    it("applies the pin without the release transition, so it lands in the swap's own frame", () => {
+      const { node, hook } = setup(500);
+
+      act(() => hook.result.current.hold());
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+    });
+
+    it("does not pin a box that has no laid-out height", () => {
+      const { node, hook } = setup(0);
+
+      act(() => hook.result.current.hold());
+
+      expect(node.style.minHeight).toBe("");
+    });
+
+    it("survives with no node to measure", () => {
+      const hook = renderHook(() => useHeightHold());
+
+      act(() => hook.result.current.hold());
+      act(() => hook.result.current.handleRendered());
+      act(() => hook.result.current.cancel());
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 
-  it("applies the pin without the release transition, so it lands in the swap's own frame", () => {
-    const { node, hook } = setup(500);
+  describe("release", () => {
+    it("keeps the pin until the rendered document has both laid out and painted", () => {
+      const { node, hook } = setup(500);
 
-    act(() => hook.result.current.hold());
+      act(() => hook.result.current.hold());
+      act(() => hook.result.current.handleRendered());
+      expect(node.style.minHeight).toBe("500px");
 
-    expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+      // One frame is layout only; releasing here hands the dialog a pre-layout
+      // height, which is the jump this exists to prevent.
+      nextFrame();
+      expect(node.style.minHeight).toBe("500px");
+
+      nextFrame();
+      expect(node.style.minHeight).toBe("");
+    });
+
+    it("animates the settle so a shorter document doesn't snap", () => {
+      const { node } = holdAndRelease();
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
+    });
+
+    it("drops the release transition once it has settled", () => {
+      const { node } = holdAndRelease();
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
+
+      act(() => void vi.advanceTimersByTime(PAST_SETTLE_MS));
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("finishes early when the settle transition reports completion", () => {
+      const { node } = holdAndRelease();
+
+      transitionEnd(node, "min-height");
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+      // The fallback timer is disarmed by the event, not left to fire later.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("ignores a transition that finished on a descendant", () => {
+      const { node } = holdAndRelease();
+      const child = document.createElement("div");
+      node.appendChild(child);
+
+      // transitionend bubbles, so an inner animation must not end the settle.
+      transitionEnd(child, "min-height");
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
+    });
+
+    it("ignores a transition on some other property", () => {
+      const { node } = holdAndRelease();
+
+      transitionEnd(node, "opacity");
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
+    });
+
+    it("holds indefinitely when the rendered signal never arrives", () => {
+      const { node, hook } = setup(500);
+
+      act(() => hook.result.current.hold());
+      act(() => void vi.advanceTimersByTime(60_000));
+
+      // A deadline here would drop the pin mid-load and collapse the dialog to
+      // the skeleton — the original bug, merely delayed.
+      expect(node.style.minHeight).toBe("500px");
+    });
+
+    it("queues one release for a document that reports more than once", () => {
+      const { node, hook } = setup(500);
+
+      act(() => hook.result.current.hold());
+      // StrictMode double-invokes the reporting effect.
+      act(() => hook.result.current.handleRendered());
+      act(() => hook.result.current.handleRendered());
+      nextFrame();
+      nextFrame();
+
+      expect(node.style.minHeight).toBe("");
+      // A second release lifecycle would arm a second settle timer.
+      expect(vi.getTimerCount()).toBe(1);
+    });
+
+    it("ignores a rendered signal that arrives with no pin in flight", () => {
+      const { node, hook } = setup(500);
+
+      act(() => hook.result.current.handleRendered());
+      nextFrame();
+      nextFrame();
+
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 
-  it("does not pin a box that has no laid-out height", () => {
-    const { node, hook } = setup(0);
+  describe("cancellation", () => {
+    it("cancels straight to the content height, with no settle transition", () => {
+      const { node, hook } = setup(500);
 
-    act(() => hook.result.current.hold());
+      act(() => hook.result.current.hold());
+      act(() => hook.result.current.cancel());
 
-    expect(node.style.minHeight).toBe("");
-  });
+      expect(node.style.minHeight).toBe("");
+      // Reverting to source, which supplies its own height immediately — an
+      // animated climb-down would lag behind the content.
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+    });
 
-  it("keeps the pin while the rendered document is still laying out", () => {
-    const { node, hook } = setup(500);
+    it("cancels a pin that is already mid-settle", () => {
+      const { node, hook } = holdAndRelease();
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
 
-    act(() => hook.result.current.hold());
-    act(() => hook.result.current.handleRendered());
+      act(() => hook.result.current.cancel());
 
-    // Queued, not yet run: releasing in the commit's own frame would hand the
-    // dialog a pre-layout height.
-    expect(node.style.minHeight).toBe("500px");
-  });
+      // `release` clears `active` before the transition starts, so a cancel
+      // keyed on `active` would strand the class and its timer here.
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
 
-  it("releases once the rendered document has laid out and painted", () => {
-    const { node, hook } = setup(500);
+    it("does not let a superseded release drop a newer pin", () => {
+      const { node, hook } = setup(500);
 
-    act(() => hook.result.current.hold());
-    act(() => hook.result.current.handleRendered());
-    act(() => void vi.advanceTimersByTime(TWO_FRAMES_MS));
+      act(() => hook.result.current.hold());
+      act(() => hook.result.current.handleRendered());
+      nextFrame();
 
-    expect(node.style.minHeight).toBe("");
-    expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
-  });
+      // A second toggle lands between the two confirmation frames.
+      measuring(node, 800);
+      act(() => hook.result.current.hold());
+      nextFrame();
+      nextFrame();
 
-  it("drops the release transition once it has settled", () => {
-    const { node, hook } = setup(500);
+      expect(node.style.minHeight).toBe("800px");
+    });
 
-    act(() => hook.result.current.hold());
-    act(() => hook.result.current.handleRendered());
-    act(() => void vi.advanceTimersByTime(TWO_FRAMES_MS));
-    act(() => void vi.advanceTimersByTime(PAST_SETTLE_MS));
+    it("re-pins cleanly over a settle that is still running", () => {
+      const { node, hook } = holdAndRelease(500);
 
-    expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
-  });
+      measuring(node, 800);
+      act(() => hook.result.current.hold());
 
-  it("releases a pin that never gets a rendered signal", () => {
-    const { node, hook } = setup(500);
+      expect(node.style.minHeight).toBe("800px");
+      expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
 
-    act(() => hook.result.current.hold());
-    expect(node.style.minHeight).toBe("500px");
+      // The superseded settle must not reach back and clear the new pin.
+      transitionEnd(node, "min-height");
+      act(() => void vi.advanceTimersByTime(PAST_SETTLE_MS));
+      expect(node.style.minHeight).toBe("800px");
+    });
 
-    // A chunk that never resolves must not pin the dialog for the session.
-    act(() => void vi.advanceTimersByTime(10_000));
+    it("takes its listener off the node it attached to, not whichever is current", () => {
+      const { node: first, hook } = holdAndRelease(500);
+      const second = mountBody(800);
 
-    expect(node.style.minHeight).toBe("");
-  });
+      // Swapping the ref mid-settle must not strand the first node's listener.
+      hook.result.current.bodyRef.current = second;
+      act(() => hook.result.current.hold());
 
-  it("cancels straight to the content height, with no settle transition", () => {
-    const { node, hook } = setup(500);
+      transitionEnd(first, "min-height");
 
-    act(() => hook.result.current.hold());
-    act(() => hook.result.current.cancel());
+      expect(second.style.minHeight).toBe("800px");
+      expect(vi.getTimerCount()).toBe(0);
+    });
 
-    expect(node.style.minHeight).toBe("");
-    // Reverting to source, which supplies its own height immediately — an
-    // animated climb-down would lag behind the content.
-    expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
-  });
+    it("stops a pending release from firing after unmount", () => {
+      const { node, hook } = setup(500);
 
-  it("does not let a superseded release drop a newer pin", () => {
-    const node = mountBody(500);
-    const hook = renderHook(() => useHeightHold());
-    hook.result.current.bodyRef.current = node;
+      act(() => hook.result.current.hold());
+      act(() => hook.result.current.handleRendered());
+      hook.unmount();
+      act(() => void vi.advanceTimersByTime(PAST_SETTLE_MS));
 
-    act(() => hook.result.current.hold());
-    act(() => hook.result.current.handleRendered());
-
-    // A second toggle lands between the two confirmation frames.
-    node.getBoundingClientRect = vi.fn<() => DOMRect>(() => rectOfHeight(800));
-    act(() => hook.result.current.hold());
-    act(() => void vi.advanceTimersByTime(TWO_FRAMES_MS));
-
-    expect(node.style.minHeight).toBe("800px");
-  });
-
-  it("stops a pending release from firing after unmount", () => {
-    const { node, hook } = setup(500);
-
-    act(() => hook.result.current.hold());
-    hook.unmount();
-
-    // The cap timer must not survive the panel that armed it.
-    expect(() => act(() => void vi.advanceTimersByTime(10_000))).not.toThrow();
-    expect(node.style.minHeight).toBe("500px");
+      expect(node.style.minHeight).toBe("500px");
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 });

--- a/src/panels/file/__tests__/useHeightHold.test.tsx
+++ b/src/panels/file/__tests__/useHeightHold.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { PANEL_MINIMIZE_DURATION } from "@/lib/animationUtils";
+import { RELEASING_CLASS, useHeightHold } from "../useHeightHold";
+
+/** Two animation frames plus slack — enough for the release to be queued. */
+const TWO_FRAMES_MS = 40;
+/** Past the release transition's fallback timer. */
+const PAST_SETTLE_MS = PANEL_MINIMIZE_DURATION + 200;
+
+function rectOfHeight(height: number): DOMRect {
+  return {
+    height,
+    width: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+}
+
+/** A real, attached node whose measured height the test controls. */
+function mountBody(height: number): HTMLDivElement {
+  const node = document.createElement("div");
+  node.getBoundingClientRect = vi.fn<() => DOMRect>(() => rectOfHeight(height));
+  document.body.appendChild(node);
+  return node;
+}
+
+function setup(height: number) {
+  const node = mountBody(height);
+  const hook = renderHook(() => useHeightHold());
+  hook.result.current.bodyRef.current = node;
+  return { node, hook };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("useHeightHold", () => {
+  it("pins the measured height, rounding up so no sub-pixel shrink slips through", () => {
+    const { node, hook } = setup(421.4);
+
+    act(() => hook.result.current.hold());
+
+    expect(node.style.minHeight).toBe("422px");
+  });
+
+  it("applies the pin without the release transition, so it lands in the swap's own frame", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+
+    expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+  });
+
+  it("does not pin a box that has no laid-out height", () => {
+    const { node, hook } = setup(0);
+
+    act(() => hook.result.current.hold());
+
+    expect(node.style.minHeight).toBe("");
+  });
+
+  it("keeps the pin while the rendered document is still laying out", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+    act(() => hook.result.current.handleRendered());
+
+    // Queued, not yet run: releasing in the commit's own frame would hand the
+    // dialog a pre-layout height.
+    expect(node.style.minHeight).toBe("500px");
+  });
+
+  it("releases once the rendered document has laid out and painted", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+    act(() => hook.result.current.handleRendered());
+    act(() => void vi.advanceTimersByTime(TWO_FRAMES_MS));
+
+    expect(node.style.minHeight).toBe("");
+    expect(node.classList.contains(RELEASING_CLASS)).toBe(true);
+  });
+
+  it("drops the release transition once it has settled", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+    act(() => hook.result.current.handleRendered());
+    act(() => void vi.advanceTimersByTime(TWO_FRAMES_MS));
+    act(() => void vi.advanceTimersByTime(PAST_SETTLE_MS));
+
+    expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+  });
+
+  it("releases a pin that never gets a rendered signal", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+    expect(node.style.minHeight).toBe("500px");
+
+    // A chunk that never resolves must not pin the dialog for the session.
+    act(() => void vi.advanceTimersByTime(10_000));
+
+    expect(node.style.minHeight).toBe("");
+  });
+
+  it("cancels straight to the content height, with no settle transition", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+    act(() => hook.result.current.cancel());
+
+    expect(node.style.minHeight).toBe("");
+    // Reverting to source, which supplies its own height immediately — an
+    // animated climb-down would lag behind the content.
+    expect(node.classList.contains(RELEASING_CLASS)).toBe(false);
+  });
+
+  it("does not let a superseded release drop a newer pin", () => {
+    const node = mountBody(500);
+    const hook = renderHook(() => useHeightHold());
+    hook.result.current.bodyRef.current = node;
+
+    act(() => hook.result.current.hold());
+    act(() => hook.result.current.handleRendered());
+
+    // A second toggle lands between the two confirmation frames.
+    node.getBoundingClientRect = vi.fn<() => DOMRect>(() => rectOfHeight(800));
+    act(() => hook.result.current.hold());
+    act(() => void vi.advanceTimersByTime(TWO_FRAMES_MS));
+
+    expect(node.style.minHeight).toBe("800px");
+  });
+
+  it("stops a pending release from firing after unmount", () => {
+    const { node, hook } = setup(500);
+
+    act(() => hook.result.current.hold());
+    hook.unmount();
+
+    // The cap timer must not survive the panel that armed it.
+    expect(() => act(() => void vi.advanceTimersByTime(10_000))).not.toThrow();
+    expect(node.style.minHeight).toBe("500px");
+  });
+});

--- a/src/panels/file/useHeightHold.ts
+++ b/src/panels/file/useHeightHold.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { PANEL_MINIMIZE_DURATION } from "@/lib/animationUtils";
+
+/**
+ * Longest a hold survives without a release signal. The rendered document
+ * reports its first commit well inside this; the cap exists so a chunk that
+ * never resolves can't pin the dialog at the source height for the rest of the
+ * session.
+ */
+const HOLD_CAP_MS = 4000;
+
+/** Slack over the CSS duration before we stop waiting for `transitionend`. */
+const TRANSITION_GRACE_MS = 50;
+
+/** Carries the release transition; see `.file-pane-body-releasing` in panels.css. */
+export const RELEASING_CLASS = "file-pane-body-releasing";
+
+export interface HeightHoldController {
+  /** Attach to the element whose height should be held across a subtree swap. */
+  bodyRef: React.RefObject<HTMLDivElement | null>;
+  /** Pin the element's measured height. Call before the swap that would shrink it. */
+  hold: () => void;
+  /** The held content committed; release once it has laid out and painted. */
+  handleRendered: () => void;
+  /** Drop the hold immediately, without the settle transition. */
+  cancel: () => void;
+}
+
+/**
+ * Pins an element's height across a subtree swap that would otherwise let it
+ * collapse and re-expand.
+ *
+ * `min-height` is a floor, not a cap: content taller than the hold grows the
+ * box on its own and the release is a no-op, while content shorter than the
+ * hold stays pinned until the release settles it down in one move. That is why
+ * this needs no ResizeObserver — there is no sequence in which a held box
+ * shrinks and then grows again.
+ */
+export function useHeightHold(): HeightHoldController {
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const stateRef = useRef({
+    active: false,
+    /** Bumped by every hold/cancel so a queued release can detect it went stale. */
+    epoch: 0,
+    frames: [] as number[],
+    capTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+    settleTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+    onTransitionEnd: undefined as ((event: TransitionEvent) => void) | undefined,
+  });
+
+  const clearPending = useCallback(() => {
+    const state = stateRef.current;
+    for (const frame of state.frames) cancelAnimationFrame(frame);
+    state.frames = [];
+    if (state.capTimer !== undefined) {
+      clearTimeout(state.capTimer);
+      state.capTimer = undefined;
+    }
+    if (state.settleTimer !== undefined) {
+      clearTimeout(state.settleTimer);
+      state.settleTimer = undefined;
+    }
+    if (state.onTransitionEnd) {
+      bodyRef.current?.removeEventListener("transitionend", state.onTransitionEnd);
+      state.onTransitionEnd = undefined;
+    }
+  }, []);
+
+  const release = useCallback(() => {
+    const state = stateRef.current;
+    if (!state.active) return;
+    clearPending();
+    state.active = false;
+    state.epoch += 1;
+
+    const node = bodyRef.current;
+    if (!node) return;
+
+    node.classList.add(RELEASING_CLASS);
+    node.style.minHeight = "";
+
+    const finish = () => {
+      clearPending();
+      node.classList.remove(RELEASING_CLASS);
+    };
+    // Reduced motion drops the transition entirely and a hold that matched the
+    // rendered height never animates, so `transitionend` is not guaranteed —
+    // the timer, not the event, is what bounds this.
+    const onTransitionEnd = (event: TransitionEvent) => {
+      if (event.target !== node || event.propertyName !== "min-height") return;
+      finish();
+    };
+    state.onTransitionEnd = onTransitionEnd;
+    node.addEventListener("transitionend", onTransitionEnd);
+    state.settleTimer = setTimeout(finish, PANEL_MINIMIZE_DURATION + TRANSITION_GRACE_MS);
+  }, [clearPending]);
+
+  const hold = useCallback(() => {
+    const node = bodyRef.current;
+    if (!node) return;
+    const { height } = node.getBoundingClientRect();
+    // A panel that isn't laid out (hidden host, jsdom default) has nothing
+    // worth pinning, and a 0px floor would be indistinguishable from no hold.
+    if (height <= 0) return;
+
+    clearPending();
+    const state = stateRef.current;
+    state.active = true;
+    state.epoch += 1;
+    // Ceil: a fractional height rounded down lets the box shrink by a sub-pixel
+    // sliver, which is the flicker this exists to prevent. The hold is applied
+    // without the transition class — it has to take effect in the same frame as
+    // the swap, otherwise it animates the collapse instead of preventing it.
+    node.classList.remove(RELEASING_CLASS);
+    node.style.minHeight = `${Math.ceil(height)}px`;
+    state.capTimer = setTimeout(release, HOLD_CAP_MS);
+  }, [clearPending, release]);
+
+  const handleRendered = useCallback(() => {
+    const state = stateRef.current;
+    if (!state.active) return;
+    const epoch = state.epoch;
+    // Two frames: the first lets the rendered commit lay out, the second lets it
+    // paint. Releasing in the commit's own frame hands the dialog a pre-layout
+    // content height, which reintroduces the jump.
+    state.frames.push(
+      requestAnimationFrame(() => {
+        state.frames.push(
+          requestAnimationFrame(() => {
+            if (stateRef.current.epoch !== epoch) return;
+            release();
+          })
+        );
+      })
+    );
+  }, [release]);
+
+  const cancel = useCallback(() => {
+    const state = stateRef.current;
+    if (!state.active) return;
+    clearPending();
+    state.active = false;
+    state.epoch += 1;
+    const node = bodyRef.current;
+    if (!node) return;
+    // No settle transition: the caller is reverting to a view that supplies its
+    // own height immediately, so animating down would lag behind the content.
+    node.classList.remove(RELEASING_CLASS);
+    node.style.minHeight = "";
+  }, [clearPending]);
+
+  useEffect(() => clearPending, [clearPending]);
+
+  return useMemo(
+    () => ({ bodyRef, hold, handleRendered, cancel }),
+    [hold, handleRendered, cancel]
+  );
+}

--- a/src/panels/file/useHeightHold.ts
+++ b/src/panels/file/useHeightHold.ts
@@ -1,14 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { PANEL_MINIMIZE_DURATION } from "@/lib/animationUtils";
 
-/**
- * Longest a hold survives without a release signal. The rendered document
- * reports its first commit well inside this; the cap exists so a chunk that
- * never resolves can't pin the dialog at the source height for the rest of the
- * session.
- */
-const HOLD_CAP_MS = 4000;
-
 /** Slack over the CSS duration before we stop waiting for `transitionend`. */
 const TRANSITION_GRACE_MS = 50;
 
@@ -22,7 +14,7 @@ export interface HeightHoldController {
   hold: () => void;
   /** The held content committed; release once it has laid out and painted. */
   handleRendered: () => void;
-  /** Drop the hold immediately, without the settle transition. */
+  /** Drop the pin immediately, without the settle transition. */
   cancel: () => void;
 }
 
@@ -30,11 +22,17 @@ export interface HeightHoldController {
  * Pins an element's height across a subtree swap that would otherwise let it
  * collapse and re-expand.
  *
- * `min-height` is a floor, not a cap: content taller than the hold grows the
- * box on its own and the release is a no-op, while content shorter than the
- * hold stays pinned until the release settles it down in one move. That is why
- * this needs no ResizeObserver — there is no sequence in which a held box
- * shrinks and then grows again.
+ * `min-height` is a floor, not a cap: content taller than the pin grows the box
+ * on its own and the release is a no-op, while content shorter than the pin
+ * stays held until the release settles it down in one move. That is why this
+ * needs no ResizeObserver — there is no sequence in which a held box shrinks
+ * and then grows again.
+ *
+ * There is deliberately no timeout. A pin that never receives its release
+ * signal holds the box at the height it already had, which is the desired end
+ * state anyway; a deadline would instead drop the pin mid-load and produce
+ * exactly the collapse-then-expand this exists to prevent. The caller cancels
+ * on the real exits — reverting the swap, changing content, unmounting.
  */
 export function useHeightHold(): HeightHoldController {
   const bodyRef = useRef<HTMLDivElement | null>(null);
@@ -43,8 +41,11 @@ export function useHeightHold(): HeightHoldController {
     /** Bumped by every hold/cancel so a queued release can detect it went stale. */
     epoch: 0,
     frames: [] as number[],
-    capTimer: undefined as ReturnType<typeof setTimeout> | undefined,
     settleTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+    /** The pinned node itself — captured, so a reassigned ref can't strand it. */
+    heldNode: null as HTMLElement | null,
+    /** The node the settle listener sits on, so it comes off that same node. */
+    listenerNode: null as HTMLElement | null,
     onTransitionEnd: undefined as ((event: TransitionEvent) => void) | undefined,
   });
 
@@ -52,29 +53,45 @@ export function useHeightHold(): HeightHoldController {
     const state = stateRef.current;
     for (const frame of state.frames) cancelAnimationFrame(frame);
     state.frames = [];
-    if (state.capTimer !== undefined) {
-      clearTimeout(state.capTimer);
-      state.capTimer = undefined;
-    }
     if (state.settleTimer !== undefined) {
       clearTimeout(state.settleTimer);
       state.settleTimer = undefined;
     }
-    if (state.onTransitionEnd) {
-      bodyRef.current?.removeEventListener("transitionend", state.onTransitionEnd);
-      state.onTransitionEnd = undefined;
+    if (state.onTransitionEnd && state.listenerNode) {
+      state.listenerNode.removeEventListener("transitionend", state.onTransitionEnd);
     }
+    state.onTransitionEnd = undefined;
+    state.listenerNode = null;
   }, []);
+
+  const cancel = useCallback(() => {
+    const state = stateRef.current;
+    const node = state.heldNode;
+    clearPending();
+    state.active = false;
+    state.epoch += 1;
+    state.heldNode = null;
+    if (!node) return;
+    // Covers a pin still settling as well as one still held: `release` clears
+    // `active` before the transition starts, so keying this on `active` would
+    // leave a mid-settle node carrying its floor into replacement content.
+    // No settle transition of its own — the caller is switching to content that
+    // supplies its own height immediately, so an animated climb-down lags it.
+    node.classList.remove(RELEASING_CLASS);
+    node.style.minHeight = "";
+  }, [clearPending]);
 
   const release = useCallback(() => {
     const state = stateRef.current;
     if (!state.active) return;
+    const node = state.heldNode;
     clearPending();
     state.active = false;
     state.epoch += 1;
-
-    const node = bodyRef.current;
-    if (!node) return;
+    if (!node) {
+      state.heldNode = null;
+      return;
+    }
 
     node.classList.add(RELEASING_CLASS);
     node.style.minHeight = "";
@@ -82,43 +99,52 @@ export function useHeightHold(): HeightHoldController {
     const finish = () => {
       clearPending();
       node.classList.remove(RELEASING_CLASS);
+      if (stateRef.current.heldNode === node) stateRef.current.heldNode = null;
     };
-    // Reduced motion drops the transition entirely and a hold that matched the
-    // rendered height never animates, so `transitionend` is not guaranteed —
-    // the timer, not the event, is what bounds this.
+    // Reduced motion drops the transition entirely, and a pin that already
+    // matched the rendered height animates nothing, so `transitionend` is not
+    // guaranteed — the timer, not the event, is what bounds this.
     const onTransitionEnd = (event: TransitionEvent) => {
+      // `transitionend` bubbles, so a descendant animating its own min-height
+      // would otherwise cut the settle short.
       if (event.target !== node || event.propertyName !== "min-height") return;
       finish();
     };
     state.onTransitionEnd = onTransitionEnd;
+    state.listenerNode = node;
     node.addEventListener("transitionend", onTransitionEnd);
     state.settleTimer = setTimeout(finish, PANEL_MINIMIZE_DURATION + TRANSITION_GRACE_MS);
   }, [clearPending]);
 
   const hold = useCallback(() => {
     const node = bodyRef.current;
+    // Supersede any in-flight pin or settle up front, so a measurement we end
+    // up rejecting can't leave the previous operation half-armed.
+    cancel();
     if (!node) return;
     const { height } = node.getBoundingClientRect();
-    // A panel that isn't laid out (hidden host, jsdom default) has nothing
-    // worth pinning, and a 0px floor would be indistinguishable from no hold.
+    // A pane that isn't laid out (hidden host, jsdom default) has nothing worth
+    // pinning, and a 0px floor is indistinguishable from no pin at all.
     if (height <= 0) return;
 
-    clearPending();
     const state = stateRef.current;
     state.active = true;
     state.epoch += 1;
+    state.heldNode = node;
     // Ceil: a fractional height rounded down lets the box shrink by a sub-pixel
-    // sliver, which is the flicker this exists to prevent. The hold is applied
-    // without the transition class — it has to take effect in the same frame as
-    // the swap, otherwise it animates the collapse instead of preventing it.
+    // sliver, which is the flicker this exists to prevent. Applied without the
+    // release class — the pin has to land in the swap's own frame, or it
+    // animates the collapse instead of preventing it.
     node.classList.remove(RELEASING_CLASS);
     node.style.minHeight = `${Math.ceil(height)}px`;
-    state.capTimer = setTimeout(release, HOLD_CAP_MS);
-  }, [clearPending, release]);
+  }, [cancel]);
 
   const handleRendered = useCallback(() => {
     const state = stateRef.current;
     if (!state.active) return;
+    // StrictMode double-invokes the reporting effect, and a document may report
+    // more than once; one queued release per pin is enough.
+    if (state.frames.length > 0) return;
     const epoch = state.epoch;
     // Two frames: the first lets the rendered commit lay out, the second lets it
     // paint. Releasing in the commit's own frame hands the dialog a pre-layout
@@ -127,6 +153,8 @@ export function useHeightHold(): HeightHoldController {
       requestAnimationFrame(() => {
         state.frames.push(
           requestAnimationFrame(() => {
+            // `cancelAnimationFrame` can't retract a callback already dequeued
+            // into the running batch, so re-check the generation here.
             if (stateRef.current.epoch !== epoch) return;
             release();
           })
@@ -135,24 +163,7 @@ export function useHeightHold(): HeightHoldController {
     );
   }, [release]);
 
-  const cancel = useCallback(() => {
-    const state = stateRef.current;
-    if (!state.active) return;
-    clearPending();
-    state.active = false;
-    state.epoch += 1;
-    const node = bodyRef.current;
-    if (!node) return;
-    // No settle transition: the caller is reverting to a view that supplies its
-    // own height immediately, so animating down would lag behind the content.
-    node.classList.remove(RELEASING_CLASS);
-    node.style.minHeight = "";
-  }, [clearPending]);
-
   useEffect(() => clearPending, [clearPending]);
 
-  return useMemo(
-    () => ({ bodyRef, hold, handleRendered, cancel }),
-    [hold, handleRendered, cancel]
-  );
+  return useMemo(() => ({ bodyRef, hold, handleRendered, cancel }), [hold, handleRendered, cancel]);
 }

--- a/src/styles/components/panels.css
+++ b/src/styles/components/panels.css
@@ -64,6 +64,24 @@
   opacity: 0.5;
 }
 
+/* Applied to FilePane's body only while it hands back a height it pinned across
+ * the swap into rendered markdown (#11255). The pin itself is deliberately
+ * untransitioned — it has to take effect in the swap's own frame, or it
+ * animates the collapse instead of preventing it. Only the release is motion:
+ * a rendered document shorter than its source settles down rather than
+ * snapping. Panel-minimize tier, since this is a panel-sized box shrinking. */
+.file-pane-body-releasing {
+  transition-property: min-height;
+  transition-duration: var(--duration-120);
+  transition-timing-function: var(--ease-panel-minimize);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .file-pane-body-releasing {
+    transition-property: none;
+  }
+}
+
 /* Users with reduced-transparency preference still see the matched-pane
  * title-bar tint and the fleet ribbon's count — they don't need the dim
  * cue, which would just feel like the app went stale. Mirrors the


### PR DESCRIPTION
## Summary

- The file viewer dialog sizes itself to its content every frame. `AppDialog` has only a `max-h-[85vh]` clamp, no definite height, so switching a markdown file from source to rendered swaps in `MarkdownViewer`'s `lazy()` and `Suspense` fallback, a 10-line skeleton with no height floor. The dialog visibly collapses, then re-expands once the chunk resolves.
- Fix: `FilePane` pins `file-pane-body`'s measured height in the toggle handler, synchronously, before the Zustand action runs (a layout effect only fires after the box has already shrunk). The rendered document reports its first commit through a new optional `onRendered` prop, and the pin releases two frames later, animated on the 120ms panel-minimize tier, so a document shorter than its source settles instead of snapping.
- Also pins a secondary reflow from the issue: `HighlightedCode`'s plain-text to highlighted fence swap.

Resolves #11255

## Changes

- `src/panels/file/useHeightHold.ts` (new): the pin/release lifecycle hook.
- `src/panels/file/FilePane.tsx`: wires the pin into the source/rendered toggle handler and passes `onRendered` through.
- `src/components/Markdown/MarkdownViewer.tsx` / `MarkdownDocument.tsx`: forward the first-commit signal via `onRendered`.
- `src/styles/components/panels.css`: animates the release on the existing 120ms panel-minimize tier.

### Why no `ResizeObserver`

`min-height` is a floor, not a cap. Content taller than the pin grows the box on its own, so releasing the pin is a no-op. Content shorter than the pin stays pinned until release, then settles in one move. There's no sequence where a pinned box shrinks and then grows again, so there's nothing for an observer or a high-water mark to watch for.

### Why no timeout

An earlier revision had a 4 second cap on the pin. It came out during review: releasing mid-load collapses the dialog to the skeleton and re-expands it once the chunk lands, which is the original bug, just delayed. A pin that never gets its release signal just holds the box at the height it already had, which is the state we want anyway. Cancellation happens on the real exits instead: reverting the toggle, changing file, leaving the dialog, unmounting.

### Scope

Dialog markdown source to rendered only. Grid and dock panels are layout-sized, not content-sized, so they never collapsed.

### Relation to #11254

Complementary. #11254 / #11256 make the pane scroll once content exceeds the 85vh cap. This one covers content below the cap flashing smaller then larger. Rebased on top of that work, no conflicts.

## Testing

58 unit tests, including two new files:

- `src/panels/file/__tests__/useHeightHold.test.tsx`: the pin lifecycle. Ceil rounding, two-frame release, the `transitionend` fast path plus its bubbling/property guards, cancel mid-settle, re-pin over a running settle, listener node ownership, duplicate StrictMode signals, unmount.
- `src/components/Markdown/__tests__/MarkdownViewer.test.tsx`: the `onRendered` forwarding seam.

`FilePane.test.tsx` gains a release-chain test, mutation-verified: deleting `onRendered={heightHold.handleRendered}` fails it, and nothing failed before that addition.

The secondary reflow (`HighlightedCode` plain text to highlighted) can't actually change height: the code mapping strips the fence's trailing newline before either path renders, so both draw byte-identical text. Pinned by a test rather than worked around with `startTransition`.

Not run locally: `e2e/full/panels/core-file-viewer.spec.ts` and `core-file-panel.spec.ts` (e2e needs a full build and doesn't run in PR CI). Reviewed their assertions instead: they exercise a file taller than the dialog, where the pin is inert.
