### PR TITLE
Assistant-only project skills with a Codex source lane

### DIFF
--- a/docs/assistant-custom-commands.md
+++ b/docs/assistant-custom-commands.md
@@ -2,21 +2,26 @@
 
 Users can add their own slash commands and skills to Daintree Assistant sessions by dropping files into a Daintree-owned folder. At every assistant launch, `HelpSessionService.doProvision` mirrors that content into the per-project session directory (`userData/help-sessions/<projectPathHash>/`), where the launched CLI discovers it through its own native cwd-scoped mechanisms. Daintree never touches agent config outside its own directories (`~/.claude/`, `~/.codex/`, etc. stay user-owned — precedent #4100).
 
+This is also the assistant-only isolation boundary: ordinary agent terminals run with the real project or worktree as their cwd, so they never discover anything under `.daintree/assistant` or the private session copy. A project can therefore define skills that exist only for its Daintree Assistant.
+
 ## Source folders
 
 | Scope | Path | Notes |
 | --- | --- | --- |
-| Global | `~/.daintree/assistant/` | Applies to every project. Scaffolded with a README by the "Open Assistant Commands Folder" action (palette, or Settings → Daintree Assistant → Custom commands). |
-| Per-project | `<project>/.daintree/assistant/` | Overrides global on filename collisions. Intentionally git-trackable, like `.daintree/recipes/`. |
+| Global | `~/.daintree/assistant/` | Applies to every project. Scaffolded with a README by the "Open Assistant Commands Folder" action (palette, or Settings → Daintree Assistant → Custom commands and skills). |
+| Per-project | `<project>/.daintree/assistant/` | Overrides global. Intentionally git-trackable, like `.daintree/recipes/`. |
 
 Inside each source folder the layout uses agent-native hidden directories:
 
 ```
 ~/.daintree/assistant/
   .claude/commands/<name>.md        Claude Code slash commands
-  .claude/skills/<name>/SKILL.md    Claude Code skills
+  .claude/skills/<name>/SKILL.md    Claude-only skills
+  .codex/skills/<name>/SKILL.md     Codex-only skills
   .agents/skills/<name>/SKILL.md    Shared skills (Agent Skills convention)
 ```
+
+Every skill directory must contain a `SKILL.md` (Agent Skills shape: `name` + `description` frontmatter). A skill directory without one is invalid: it is logged, skipped, and never shadows a valid lower-precedence skill of the same name.
 
 ## Per-agent mapping
 
@@ -25,33 +30,36 @@ Inside each source folder the layout uses agent-native hidden directories:
 | Agent | Mirrored into session dir | Why |
 | --- | --- | --- |
 | `claude` | `.claude/commands`, `.claude/skills`, and `.agents/skills` translated → `.claude/skills` | Claude Code treats a non-git cwd as the project root and loads both from it, but declined native `.agents/skills` support (anthropics/claude-code#56193), so shared skills are copied into `.claude/skills`. An explicit `.claude/skills/<name>` replaces the translated shared skill of the same name wholesale — skills resolve at directory granularity, never a per-file merge of two skills. |
-| `codex` | `.agents/skills` verbatim | Codex removed custom prompt files in 0.118.0; skills are the only mechanism. `<cwd>/.agents/skills` loads without a git repo and is exempt from the project-config trust gate. `.codex/skills` is deliberately not mirrored — it rides the trust-gated project-config layer. |
+| `codex` | `.agents/skills` verbatim, and `.codex/skills` translated → `.agents/skills` | Codex removed custom prompt files in 0.118.0; skills are the only mechanism. `<cwd>/.agents/skills` loads without a git repo and is exempt from the project-config trust gate. `.codex/skills` is a Daintree-owned SOURCE convention for Codex-only skills — it is delivered through the session's `.agents/skills` and never mirrored to a `.codex` destination, because `<cwd>/.codex` rides the trust-gated project-config layer. An explicit `.codex/skills/<name>` replaces the shared skill of the same name wholesale. |
 | `copilot` | `.agents/skills` and `.claude/skills` verbatim | Copilot CLI reads both conventions from cwd. |
 | `daintree-assistant` | nothing | Runs in the project root and reads nothing from cwd; it will read the source folders natively when its own skill loader grows user paths. |
 | `gemini` | nothing | Deprecated as an assistant backend; cannot provision a help session. |
 
-Precedence, lowest to highest: global `.agents/skills` → global explicit tree → project `.agents/skills` → project explicit tree. Commands resolve per file; skills resolve per skill directory (a higher-precedence skill drops every file of the shadowed one).
+Precedence, lowest to highest: global `.agents/skills` → global explicit tree (`.claude/skills` or `.codex/skills`) → project `.agents/skills` → project explicit tree. Commands resolve per file; skills resolve per skill directory (a higher-precedence skill drops every file of the shadowed one). Deleting a higher-precedence override reveals the shadowed definition again on the next provision.
 
 ## Sync mechanics
 
-- Runs inside `doProvision` after the hash-gated template copy, unconditionally (user content changes independently of app version), and is non-fatal — a broken user file logs a warning and the assistant still launches.
-- Manifest-driven: `.daintree-user-content.json` in the session dir records every mirrored relpath. Files that disappear from the source are deleted on the next sync; files the user hand-placed in the session dir are never touched. Deletion is confined to the three mirror roots even with a corrupt manifest: relpaths with dot segments, backslashes, or drive colons are rejected, and every existing directory component is `lstat`-verified non-symlink before any delete or copy (agents spawned in the session dir can write to it, so a planted `.claude/skills → elsewhere` symlink must not redirect the mirror).
-- The manifest is written after deletions but before copies, so a mid-copy crash leaves it as a superset — stragglers get cleaned on the next sync. Failed deletions stay in the manifest and are retried on the next sync.
+- Runs inside `doProvision` after the hash-gated template copy, unconditionally (user content changes independently of app version). A provision happens before every new backend process: first launch, new session/reset, backend switch, resume after hibernation or eviction, and app restart. Showing or hiding the panel while the process stays alive does not re-sync (Codex only discovers skills at process startup anyway).
+- Failure policy is asymmetric on purpose. Invalid or unwritable NEW content is safely omitted — the assistant launches without it and the reason is logged. But content that would run STALE fails the provision closed: an unreadable source directory (the desired state can't be proven, so previously mirrored skills must not be retired or trusted) or a managed file that should be gone yet is still on disk. In that case `HelpSessionService` throws a typed `USER_CONTENT_SYNC_FAILED` error, the backend does not launch, and the HelpPanel shows an inline retryable error banner.
+- Manifest-driven: `.daintree-user-content.json` in the session dir records every mirrored relpath. Files that disappear from the source are deleted on the next sync; files the user hand-placed in the session dir are never touched. Deletion is confined to the three mirror destination roots (`.claude/commands`, `.claude/skills`, `.agents/skills`) even with a corrupt manifest: relpaths with dot segments, backslashes, or drive colons are rejected, and every existing directory component is `lstat`-verified non-symlink before any delete or copy (agents spawned in the session dir can write to it, so a planted `.claude/skills → elsewhere` symlink must not redirect the mirror). `.codex/skills` is a source-only convention and is deliberately not a deletion root.
+- The manifest is written after deletions but before copies, holding the union of desired and unremoved stale paths — a mid-copy crash leaves it as a superset, and stragglers get cleaned on the next sync. Because every copied path is manifested before its copy starts, no crash point can produce an on-disk managed file the manifest doesn't own; a final verification pass then confirms stale paths are gone and desired paths are regular files. This superset-plus-verification design provides the same recovery guarantee as a separate pending-manifest scheme without a second recovery file.
 - Walks follow symlinks (with realpath cycle detection), skip dot-entries, and cap at 2000 files / depth 12 / 5 MB per file with a logged warning on truncation. Oversized files are excluded before the manifest write, so a file that grows past the cap also gets its old session copy removed.
-- Agent switching self-heals: re-provisioning the same project for codex removes files that were mirrored for claude, because the manifest cleanup spans all mirror roots.
+- Agent switching self-heals: re-provisioning the same project for codex removes files that were mirrored for claude (and vice versa), because the manifest cleanup spans all mirror roots.
 
 ## User-facing behavior notes
 
-- Changes are picked up at the next assistant launch (every open re-provisions). Claude Code additionally hot-reloads skills mid-session; Codex scans skills at startup only.
+- Changes are picked up at the next assistant launch (every open re-provisions). Claude Code additionally hot-reloads skills mid-session; Codex scans skills at startup only — provision-time mirroring stays authoritative and never depends on hot reload.
 - Codex surfaces skills via `$skill-name` mentions and the `/skills` picker, not `/name` slash commands. Codex tolerates Claude-specific `SKILL.md` frontmatter keys (`argument-hint`, `allowed-tools`, …), so a shared skill can carry both.
 - Claude sessions run under the bundled sandbox settings (`Write`/`Edit` denied), so the assistant itself can't author its skills — users author them in an editor or a regular agent terminal, then relaunch the assistant.
 - Commands mirrored into `.claude/commands` automatically appear in the HelpPanel's slash autocomplete: `HybridInputBar` scans the terminal cwd (the session dir) via `SlashCommandService`.
+- Skills are repository-controlled instructions, not authorization: they pass through the same MCP tiering and action confirmation as any other assistant input.
 - Future OpenCode support slots into the same layout (`.opencode/commands`, plus it already reads `.claude/skills` and `.agents/skills`), with one caveat: OpenCode only discovers project content inside a git worktree, so the session dir would need a `git init` or marker tweak.
 
 ## Key files
 
-- `electron/services/AssistantContentMirror.ts` — mapping table, walk, manifest sync, folder scaffolding.
-- `electron/services/HelpSessionService.ts` — the `doProvision` call site.
+- `electron/services/AssistantContentMirror.ts` — mapping table, walk, manifest sync, verification, folder scaffolding.
+- `electron/services/HelpSessionService.ts` — the `doProvision` call site and the fail-closed `USER_CONTENT_SYNC_FAILED` policy.
 - `electron/ipc/handlers/help.ts` — `help:open-assistant-content-folder` (scaffold + reveal).
 - `src/services/actions/definitions/helpActions.ts` — `help.openCommandsFolder` action.
-- `src/components/Settings/DaintreeAssistantSettingsTab.tsx` — the Custom commands settings section.
+- `src/components/Settings/DaintreeAssistantSettingsTab.tsx` — the Custom commands and skills settings section.
+- `src/components/HelpPanel/HelpPanelBanners.tsx` — the `skills-sync-failed` inline error banner.

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -741,6 +741,29 @@ function _reconstructGitError(serialized: {
   return error;
 }
 
+/**
+ * Reconstruct `HelpSessionError` thrown by help-session provisioning. Same
+ * realm-boundary stripping as `_reconstructAppError`: contextBridge discards
+ * the custom `code`, so it rides an encoded message prefix that the renderer
+ * decodes via `extractHelpSessionErrorCode` (`src/utils/clientHelpSessionError.ts`).
+ *
+ * Format: `[HelpSessionError|<code>] <original message>`
+ */
+function _reconstructHelpSessionError(serialized: {
+  name: string;
+  message: string;
+  code?: string;
+}): Error {
+  const code = serialized.code ?? "UNKNOWN";
+  const error = new Error(`[HelpSessionError|${code}] ${serialized.message}`);
+  // Standard properties — set for callers in the same realm. They don't
+  // survive the contextBridge crossing; the message prefix is the source
+  // of truth on the renderer side.
+  error.name = "HelpSessionError";
+  (error as Error & { code: string }).code = code;
+  return error;
+}
+
 // Typed overload: when `channel` is a key of `IpcInvokeMap` and the args match,
 // the result is statically enforced against the central IPC contract. Calls
 // that don't match the typed overload — including the function-value
@@ -763,6 +786,9 @@ async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<a
       }
       if (serialized.name === "GitOperationError" && typeof serialized.gitReason === "string") {
         throw _reconstructGitError(serialized);
+      }
+      if (serialized.name === "HelpSessionError" && typeof serialized.code === "string") {
+        throw _reconstructHelpSessionError(serialized);
       }
       throw deserializeError(serialized);
     }

--- a/electron/services/AssistantContentMirror.ts
+++ b/electron/services/AssistantContentMirror.ts
@@ -16,7 +16,8 @@ import { resilientAtomicWriteFile } from "../utils/fs.js";
  *
  * Inside each source the layout is agent-native hidden folders:
  *   .claude/commands/   Claude Code slash commands (*.md)
- *   .claude/skills/     Claude Code skills (<name>/SKILL.md)
+ *   .claude/skills/     Claude-only skills (<name>/SKILL.md)
+ *   .codex/skills/      Codex-only skills (<name>/SKILL.md)
  *   .agents/skills/     Shared skills (Agent Skills convention)
  *
  * Per-agent mapping rationale (verified July 2026):
@@ -27,8 +28,11 @@ import { resilientAtomicWriteFile } from "../utils/fs.js";
  *     explicit .claude/skills entry of the same name winning.
  *   - Codex removed custom prompts entirely in 0.118.0; skills are the only
  *     vehicle. It loads <cwd>/.agents/skills even when cwd is not a git repo,
- *     and skills are exempt from the project-config trust gate. .codex/skills
- *     is NOT mirrored — that path rides the trust-gated project-config layer.
+ *     and skills are exempt from the project-config trust gate. The
+ *     .codex/skills SOURCE folder is a Daintree-owned authoring convention for
+ *     Codex-only skills — it is translated to the session's .agents/skills,
+ *     never mirrored to a .codex destination, because <cwd>/.codex rides
+ *     Codex's trust-gated project-config layer.
  *   - Copilot CLI reads both .claude/skills and .agents/skills from cwd.
  *   - daintree-assistant runs in the project root and reads nothing from cwd,
  *     so it has no mapping here; it will read the source folders natively.
@@ -39,8 +43,9 @@ interface ContentMapping {
   /**
    * `skillDir`: the unit of precedence is the top-level skill directory — a
    * higher-precedence skill of the same name replaces the lower one wholesale
-   * (never a per-file interleave of two different skills). `file`: each file
-   * stands alone (commands).
+   * (never a per-file interleave of two different skills), and a directory is
+   * only eligible when it contains a SKILL.md. `file`: each file stands alone
+   * (commands).
    */
   granularity: "file" | "skillDir";
 }
@@ -53,7 +58,12 @@ const AGENT_CONTENT_MAPPINGS: Record<string, readonly ContentMapping[]> = {
     { sourceDir: ".claude/commands", destDir: ".claude/commands", granularity: "file" },
     { sourceDir: ".claude/skills", destDir: ".claude/skills", granularity: "skillDir" },
   ],
-  codex: [{ sourceDir: ".agents/skills", destDir: ".agents/skills", granularity: "skillDir" }],
+  // Shared tree first so an explicit .codex/skills/<name> overrides
+  // .agents/skills/<name>; both land in the session's .agents/skills.
+  codex: [
+    { sourceDir: ".agents/skills", destDir: ".agents/skills", granularity: "skillDir" },
+    { sourceDir: ".codex/skills", destDir: ".agents/skills", granularity: "skillDir" },
+  ],
   copilot: [
     { sourceDir: ".agents/skills", destDir: ".agents/skills", granularity: "skillDir" },
     { sourceDir: ".claude/skills", destDir: ".claude/skills", granularity: "skillDir" },
@@ -64,8 +74,20 @@ const AGENT_CONTENT_MAPPINGS: Record<string, readonly ContentMapping[]> = {
 // these roots so a corrupt manifest can never reach template files
 // (.mcp.json, .claude/settings.json, CLAUDE.md, ...). Kept as a superset of
 // all agents' mappings on purpose: switching the same project's session from
-// claude to codex must clean up the claude-mirrored files.
+// claude to codex must clean up the claude-mirrored files. `.codex/skills` is
+// deliberately NOT here — it is a source authoring convention, never a
+// session destination, and must never become a permissible deletion root.
 const MIRROR_DEST_ROOTS = [".claude/commands", ".claude/skills", ".agents/skills"] as const;
+
+// Roots scaffolded in the Daintree-owned AUTHORING folders (~/.daintree/
+// assistant and <project>/.daintree/assistant). Includes the .codex/skills
+// source lane; distinct from MIRROR_DEST_ROOTS, which alone bounds deletion.
+const SOURCE_SCAFFOLD_ROOTS = [
+  ".claude/commands",
+  ".claude/skills",
+  ".codex/skills",
+  ".agents/skills",
+] as const;
 
 // Manifest of relpaths written by the previous sync, stored inside the
 // session dir. Deletion is manifest-driven so user files that happen to be in
@@ -100,9 +122,25 @@ export interface AssistantContentSyncInput {
   globalContentDir?: string;
 }
 
+/**
+ * Structured sync outcome. `staleFailures` is the fail-closed signal: managed
+ * destination files that should be gone (or provably refreshed) but are still
+ * present. The caller must not launch a backend from the session dir while it
+ * is non-empty — otherwise deleted or superseded skill instructions would stay
+ * silently active. `omittedSkills` (invalid sources skipped safely) and
+ * `failedCopies` (desired file absent, nothing stale left behind) are
+ * warnings: the assistant is still safe to launch, just without that content.
+ */
 export interface AssistantContentSyncResult {
   copied: number;
   removed: number;
+  truncated: boolean;
+  /** Skill dirs skipped for missing SKILL.md, as `<scope>:<sourceDir>/<name>`. */
+  omittedSkills: string[];
+  /** Desired dest relpaths that could not be written and are absent on disk. */
+  failedCopies: string[];
+  /** Managed dest relpaths that are stale or unverifiable but still present. */
+  staleFailures: string[];
 }
 
 interface ManifestShape {
@@ -128,19 +166,45 @@ function isUnderMirrorRoot(posixRelPath: string): boolean {
   return MIRROR_DEST_ROOTS.some((root) => posixRelPath.startsWith(root + "/"));
 }
 
+/**
+ * Reads the ownership manifest. Only a missing file means "nothing managed
+ * yet" — the manifest is atomically written and Daintree-owned, so an
+ * unreadable, corrupt, or unsupported one means ownership records are gone
+ * while managed files may still be on disk. Treating that as empty would
+ * launch a session with stale unowned skills; throw instead (fail closed).
+ */
 async function readManifest(sessionPath: string): Promise<string[]> {
+  let raw: string;
   try {
-    const raw = await fs.readFile(path.join(sessionPath, MANIFEST_FILE), "utf-8");
-    const parsed = JSON.parse(raw) as ManifestShape;
-    if (!parsed || !Array.isArray(parsed.files)) return [];
-    return parsed.files.filter((entry): entry is string => typeof entry === "string");
-  } catch {
-    return [];
+    raw = await fs.readFile(path.join(sessionPath, MANIFEST_FILE), "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw new Error(`Unreadable mirror manifest ${MANIFEST_FILE} — cannot prove mirror ownership`, {
+      cause: err,
+    });
   }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Corrupt mirror manifest ${MANIFEST_FILE} — cannot prove mirror ownership`, {
+      cause: err,
+    });
+  }
+  const shape = parsed as ManifestShape | null;
+  if (
+    !shape ||
+    shape.version !== 1 ||
+    !Array.isArray(shape.files) ||
+    shape.files.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error(`Unsupported mirror manifest ${MANIFEST_FILE} — cannot prove mirror ownership`);
+  }
+  return shape.files as string[];
 }
 
 async function writeManifest(sessionPath: string, files: string[]): Promise<void> {
-  const manifest: ManifestShape = { version: 1, files: [...files].sort() };
+  const manifest: ManifestShape = { version: 1, files: [...new Set(files)].sort() };
   await resilientAtomicWriteFile(
     path.join(sessionPath, MANIFEST_FILE),
     JSON.stringify(manifest, null, 2) + "\n",
@@ -153,6 +217,19 @@ interface WalkState {
   files: Map<string, string>;
   visitedDirs: Set<string>;
   truncated: boolean;
+  /**
+   * Directories that exist but could not be read. Distinct from absent
+   * sources: an absent source contributes no skills (and retires previously
+   * mirrored ones), while an unreadable source means the desired state cannot
+   * be proven — the sync must fail rather than silently delete content that
+   * may still be defined.
+   */
+  unreadableDirs: string[];
+}
+
+function isAbsentError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
 }
 
 /**
@@ -162,12 +239,18 @@ interface WalkState {
  * how the CLIs' own scanners treat them.
  */
 async function collectSourceFiles(rootAbs: string): Promise<WalkState> {
-  const state: WalkState = { files: new Map(), visitedDirs: new Set(), truncated: false };
+  const state: WalkState = {
+    files: new Map(),
+    visitedDirs: new Set(),
+    truncated: false,
+    unreadableDirs: [],
+  };
   try {
     const rootReal = await fs.realpath(rootAbs);
     state.visitedDirs.add(rootReal);
-  } catch {
-    return state; // source dir absent — nothing to collect
+  } catch (err) {
+    if (!isAbsentError(err)) state.unreadableDirs.push(rootAbs);
+    return state; // absent source dir — nothing to collect
   }
   await walkDir(rootAbs, "", state, 0);
   return state;
@@ -186,7 +269,8 @@ async function walkDir(
   let entries: Array<import("node:fs").Dirent>;
   try {
     entries = await fs.readdir(dirAbs, { withFileTypes: true });
-  } catch {
+  } catch (err) {
+    if (!isAbsentError(err)) state.unreadableDirs.push(dirAbs);
     return;
   }
   // Alphabetical order keeps traversal — and therefore which files survive
@@ -206,8 +290,12 @@ async function walkDir(
         const stat = await fs.stat(entryAbs);
         isDir = stat.isDirectory();
         isFile = stat.isFile();
-      } catch {
-        continue; // broken symlink
+      } catch (err) {
+        // Dangling symlink (ENOENT) and OS-level link loops are skippable;
+        // anything else (EACCES, EIO) leaves the desired state unprovable.
+        if (isAbsentError(err) || (err as NodeJS.ErrnoException).code === "ELOOP") continue;
+        state.unreadableDirs.push(entryAbs);
+        continue;
       }
     }
 
@@ -216,7 +304,9 @@ async function walkDir(
         const real = await fs.realpath(entryAbs);
         if (state.visitedDirs.has(real)) continue; // symlink cycle
         state.visitedDirs.add(real);
-      } catch {
+      } catch (err) {
+        if (isAbsentError(err) || (err as NodeJS.ErrnoException).code === "ELOOP") continue;
+        state.unreadableDirs.push(entryAbs);
         continue;
       }
       await walkDir(entryAbs, entryRel, state, depth + 1);
@@ -258,10 +348,11 @@ async function verifyRealDirChain(
     try {
       const st = await fs.lstat(current);
       if (st.isSymbolicLink() || !st.isDirectory()) verdict = "unsafe";
-    } catch {
-      // ENOENT (or unreadable): nothing below exists yet, so there is nothing
-      // a symlink could redirect. mkdir will create real dirs from here down.
-      verdict = "ok";
+    } catch (err) {
+      // ENOENT: nothing below exists yet, so there is nothing a symlink could
+      // redirect — mkdir will create real dirs from here down. Any other
+      // failure (EACCES, EIO) leaves the chain unprovable: unsafe.
+      verdict = isAbsentError(err) ? "ok" : "unsafe";
     }
     cache.set(current, verdict);
     if (verdict === "unsafe") return "unsafe";
@@ -269,17 +360,44 @@ async function verifyRealDirChain(
   return "ok";
 }
 
+/** Non-throwing lstat existence probe for the verification pass. */
+async function destFileState(abs: string): Promise<"absent" | "file" | "other"> {
+  try {
+    const st = await fs.lstat(abs);
+    return st.isFile() && !st.isSymbolicLink() ? "file" : "other";
+  } catch (err) {
+    // Only a proven-missing path counts as absent — an unreadable path may
+    // still hold stale content, so it stays unverifiable ("other").
+    return isAbsentError(err) ? "absent" : "other";
+  }
+}
+
+/**
+ * Portable casefold identity for alias detection: the default macOS and
+ * Windows filesystems are case-insensitive (and macOS normalizes Unicode), so
+ * two relpaths differing only by case/normalization address the same file.
+ */
+function foldPath(rel: string): string {
+  return rel.normalize("NFC").toLowerCase();
+}
+
 /**
  * Syncs user assistant content into the session directory for the given
- * agent. Returns null for agents with no cwd-based content mechanism.
+ * agent. Returns null for agents with no cwd-based content mechanism. Throws
+ * when a source directory exists but cannot be read — the desired state is
+ * unprovable, and treating it as empty would wrongly retire mirrored skills.
  *
  * Sync is manifest-driven: files mirrored by the previous sync that are no
- * longer desired are removed (so deleting a command in the source folder
+ * longer desired are removed (so deleting a skill in the source folder
  * actually retires it), then every desired file is copied fresh. The manifest
- * is written after deletions but before copies — a mid-copy crash leaves it
- * as a superset of what's on disk, and superfluous entries delete as harmless
- * no-ops on the next sync. Stale entries whose deletion FAILED stay in the
- * manifest so the next sync retries instead of orphaning the file.
+ * is written twice per sync: first as a superset (desired ∪ stale) after
+ * deletions but before copies — because every copied path is manifested
+ * BEFORE its copy starts, no crash point can produce an on-disk managed file
+ * the manifest doesn't own — then compacted after verification to desired ∪
+ * still-present stale paths, so successfully removed rels are retired and a
+ * future unmanaged file at the same relpath is never claimed. Combined with
+ * the verification pass this gives the same recovery guarantee as a separate
+ * pending-manifest scheme without a second recovery file.
  */
 export async function syncAssistantContent(
   input: AssistantContentSyncInput
@@ -287,9 +405,9 @@ export async function syncAssistantContent(
   const mappings = AGENT_CONTENT_MAPPINGS[input.agentId];
   if (!mappings) return null;
 
-  const sources = [
-    input.globalContentDir ?? getGlobalAssistantContentDir(),
-    getProjectAssistantContentDir(input.projectPath),
+  const sources: Array<{ scope: "global" | "project"; root: string }> = [
+    { scope: "global", root: input.globalContentDir ?? getGlobalAssistantContentDir() },
+    { scope: "project", root: getProjectAssistantContentDir(input.projectPath) },
   ];
 
   // destRel (posix) → source absolute path. Insertion order encodes
@@ -297,28 +415,70 @@ export async function syncAssistantContent(
   // above — later writes overwrite earlier ones. For skillDir mappings the
   // replacement unit is the whole top-level skill directory: all previously
   // collected files under the same dest skill prefix are dropped first, so an
-  // explicit skill never interleaves files with a shadowed shared skill.
+  // explicit skill never interleaves files with a shadowed shared skill. A
+  // skill directory without a SKILL.md is invalid — it contributes nothing
+  // and therefore never shadows a valid lower-precedence skill.
   const desired = new Map<string, string>();
+  const omittedSkills: string[] = [];
   let truncated = false;
-  for (const sourceRoot of sources) {
+  for (const source of sources) {
     for (const mapping of mappings) {
-      const walk = await collectSourceFiles(path.join(sourceRoot, mapping.sourceDir));
+      const walk = await collectSourceFiles(path.join(source.root, mapping.sourceDir));
+      if (walk.unreadableDirs.length > 0) {
+        throw new Error(
+          `Unreadable assistant content directory: ${walk.unreadableDirs[0]} — cannot compute the desired skill state`
+        );
+      }
       truncated ||= walk.truncated;
-      if (mapping.granularity === "skillDir") {
-        const replacedSkills = new Set<string>();
-        for (const rel of walk.files.keys()) {
-          const slash = rel.indexOf("/");
-          if (slash > 0) replacedSkills.add(rel.slice(0, slash));
+      if (mapping.granularity === "file") {
+        for (const [rel, abs] of walk.files) {
+          desired.set(`${mapping.destDir}/${rel}`, abs);
         }
-        for (const skillName of replacedSkills) {
-          const prefix = `${mapping.destDir}/${skillName}/`;
-          for (const key of desired.keys()) {
-            if (key.startsWith(prefix)) desired.delete(key);
+        continue;
+      }
+      const bySkill = new Map<string, Map<string, string>>();
+      for (const [rel, abs] of walk.files) {
+        const slash = rel.indexOf("/");
+        if (slash <= 0) continue; // loose file at the skills root — not a skill bundle
+        const skillName = rel.slice(0, slash);
+        let group = bySkill.get(skillName);
+        if (!group) {
+          group = new Map();
+          bySkill.set(skillName, group);
+        }
+        group.set(rel, abs);
+      }
+      for (const [skillName, group] of bySkill) {
+        // The SKILL.md must exist AND pass the size cap BEFORE this bundle
+        // may shadow a lower-precedence skill — deciding on walk presence
+        // alone would let an oversized manifest knock out the valid skill
+        // underneath and still mirror its own resource files.
+        const skillMdAbs = group.get(`${skillName}/SKILL.md`);
+        let eligible = skillMdAbs !== undefined;
+        if (skillMdAbs) {
+          try {
+            eligible = (await fs.stat(skillMdAbs)).size <= MAX_FILE_BYTES;
+          } catch (err) {
+            if (!isAbsentError(err)) {
+              throw new Error(
+                `Unreadable assistant content directory: ${skillMdAbs} — cannot compute the desired skill state`,
+                { cause: err }
+              );
+            }
+            eligible = false;
           }
         }
-      }
-      for (const [rel, abs] of walk.files) {
-        desired.set(`${mapping.destDir}/${rel}`, abs);
+        if (!eligible) {
+          omittedSkills.push(`${source.scope}:${mapping.sourceDir}/${skillName}`);
+          continue;
+        }
+        const prefix = `${mapping.destDir}/${skillName}/`;
+        for (const key of desired.keys()) {
+          if (key.startsWith(prefix)) desired.delete(key);
+        }
+        for (const [rel, abs] of group) {
+          desired.set(`${mapping.destDir}/${rel}`, abs);
+        }
       }
     }
   }
@@ -328,9 +488,57 @@ export async function syncAssistantContent(
     );
   }
 
+  // A destination relpath the cleanup validator would refuse to own must
+  // never be created: on POSIX, ':' and '\' are legal filename characters,
+  // but isUnderMirrorRoot rejects them (Windows traversal defense) — a
+  // mirrored file with such a name would be stranded outside every future
+  // reconciliation.
+  for (const destRel of [...desired.keys()]) {
+    if (!isUnderMirrorRoot(destRel)) {
+      console.warn("[AssistantContentMirror] Skipping unownable destination path:", destRel);
+      desired.delete(destRel);
+    }
+  }
+
+  // Case-insensitive filesystems (default macOS/Windows) alias skill
+  // directories that differ only by case, which would interleave a shadowed
+  // skill's files with its winner inside one on-disk directory. Collapse
+  // casefold collisions deterministically on every platform: the
+  // last-inserted (highest-precedence) spelling wins, other spellings are
+  // omitted wholesale.
+  const skillPrefixWinners = new Map<string, string>();
+  for (const destRel of desired.keys()) {
+    const segments = destRel.split("/");
+    if (segments.length < 4) continue; // skills sit at <root>/<skill>/<file…>; commands are per-file
+    skillPrefixWinners.set(
+      foldPath(segments.slice(0, 3).join("/")),
+      segments.slice(0, 3).join("/")
+    );
+  }
+  const reportedCollisions = new Set<string>();
+  for (const destRel of [...desired.keys()]) {
+    const segments = destRel.split("/");
+    if (segments.length < 4) continue;
+    const prefix = segments.slice(0, 3).join("/");
+    const winner = skillPrefixWinners.get(foldPath(prefix));
+    if (winner !== undefined && winner !== prefix) {
+      if (!reportedCollisions.has(prefix)) {
+        reportedCollisions.add(prefix);
+        omittedSkills.push(`case-collision:${prefix}`);
+      }
+      desired.delete(destRel);
+    }
+  }
+
+  for (const omitted of omittedSkills) {
+    console.warn(`[AssistantContentMirror] Omitting ineligible skill: ${omitted}`);
+  }
+
   // Eligibility runs BEFORE the manifest write so an ineligible file never
   // holds a manifest entry: a previously mirrored file whose source has since
-  // grown past the cap becomes stale below and its old copy is removed.
+  // grown past the cap becomes stale below and its old copy is removed. Only
+  // a proven-absent source may retire its copy — an unreadable one means the
+  // desired state is unprovable.
   for (const [destRel, sourceAbs] of desired) {
     try {
       const stat = await fs.stat(sourceAbs);
@@ -340,7 +548,13 @@ export async function syncAssistantContent(
         );
         desired.delete(destRel);
       }
-    } catch {
+    } catch (err) {
+      if (!isAbsentError(err)) {
+        throw new Error(
+          `Unreadable assistant content directory: ${sourceAbs} — cannot compute the desired skill state`,
+          { cause: err }
+        );
+      }
       desired.delete(destRel); // vanished between walk and stat
     }
   }
@@ -350,10 +564,11 @@ export async function syncAssistantContent(
   const previous = await readManifest(input.sessionPath);
 
   let removed = 0;
-  const failedRemovals: string[] = [];
+  const staleRels: string[] = [];
   for (const staleRel of previous) {
     if (desired.has(staleRel)) continue;
     if (!isUnderMirrorRoot(staleRel)) continue;
+    staleRels.push(staleRel);
     const segments = staleRel.split("/");
     const staleAbs = path.resolve(sessionBase, ...segments);
     if (!staleAbs.startsWith(sessionBase + path.sep)) continue;
@@ -369,23 +584,29 @@ export async function syncAssistantContent(
       removed += 1;
       await removeEmptyParents(staleAbs, sessionBase);
     } catch (err) {
-      failedRemovals.push(staleRel);
       console.warn("[AssistantContentMirror] Failed to remove stale mirrored file:", staleAbs, err);
     }
   }
 
-  await writeManifest(input.sessionPath, [...desired.keys(), ...failedRemovals]);
+  // Superset manifest: every desired path is owned before its copy starts,
+  // and stale paths stay owned until verification proves them gone.
+  await writeManifest(input.sessionPath, [...desired.keys(), ...staleRels]);
 
   let copied = 0;
+  const copyFailedRels = new Set<string>();
   for (const [destRel, sourceAbs] of desired) {
     const segments = destRel.split("/");
     const destAbs = path.resolve(sessionBase, ...segments);
-    if (!destAbs.startsWith(sessionBase + path.sep)) continue;
+    if (!destAbs.startsWith(sessionBase + path.sep)) {
+      copyFailedRels.add(destRel);
+      continue;
+    }
     if ((await verifyRealDirChain(sessionBase, segments.slice(0, -1), chainCache)) !== "ok") {
       console.warn(
         "[AssistantContentMirror] Skipping copy through a symlinked directory:",
         destRel
       );
+      copyFailedRels.add(destRel);
       continue;
     }
     try {
@@ -402,10 +623,61 @@ export async function syncAssistantContent(
       copied += 1;
     } catch (err) {
       console.warn("[AssistantContentMirror] Failed to mirror file:", sourceAbs, err);
+      copyFailedRels.add(destRel);
     }
   }
 
-  return { copied, removed };
+  // Final verification. Stale paths must be absent; a stale file still on
+  // disk (failed delete, symlinked dir, racing writer) is a fail-closed
+  // signal — the old skill would remain silently active. A desired path whose
+  // copy failed is stale-equivalent when something still exists there (the
+  // previous version's content can't be proven refreshed) and a plain warning
+  // when the slot is simply empty.
+  const staleFailures: string[] = [];
+  const failedCopies: string[] = [];
+  const desiredByFold = new Map<string, string>();
+  for (const rel of desired.keys()) desiredByFold.set(foldPath(rel), rel);
+  for (const staleRel of staleRels) {
+    const staleAbs = path.resolve(sessionBase, ...staleRel.split("/"));
+    const state = await destFileState(staleAbs);
+    if (state === "absent") continue;
+    // On a case-insensitive filesystem a case-only rename leaves the stale
+    // spelling resolving to the freshly copied desired file. Same dev+ino as
+    // the desired path means nothing stale actually remains — without this,
+    // every retry would re-report the alias and permanently block launch.
+    const aliasRel = desiredByFold.get(foldPath(staleRel));
+    if (aliasRel && state === "file" && !copyFailedRels.has(aliasRel)) {
+      try {
+        const [staleSt, aliasSt] = await Promise.all([
+          fs.stat(staleAbs),
+          fs.stat(path.resolve(sessionBase, ...aliasRel.split("/"))),
+        ]);
+        if (staleSt.dev === aliasSt.dev && staleSt.ino === aliasSt.ino) continue;
+      } catch {
+        // fall through — treat as stale
+      }
+    }
+    staleFailures.push(staleRel);
+  }
+  for (const destRel of desired.keys()) {
+    const state = await destFileState(path.resolve(sessionBase, ...destRel.split("/")));
+    if (copyFailedRels.has(destRel)) {
+      if (state === "absent") failedCopies.push(destRel);
+      else staleFailures.push(destRel);
+    } else if (state !== "file") {
+      // Copy reported success but the file is gone or not a regular file —
+      // treat as unverifiable rather than silently trusting the session dir.
+      staleFailures.push(destRel);
+    }
+  }
+
+  // Compact the superset manifest to verified ownership: desired paths plus
+  // stale paths still present. Successfully removed rels are retired so a
+  // future unmanaged user file at the same relpath is never claimed; if this
+  // write fails it propagates (fail closed) while the superset stays valid.
+  await writeManifest(input.sessionPath, [...desired.keys(), ...staleFailures]);
+
+  return { copied, removed, truncated, omittedSkills, failedCopies, staleFailures };
 }
 
 /**
@@ -440,9 +712,15 @@ them up through its own native discovery.
 Layout (agent-native hidden folders):
 
 - .claude/commands/   Claude Code slash commands (*.md with YAML frontmatter)
-- .claude/skills/     Claude Code skills (<name>/SKILL.md)
-- .agents/skills/     Shared skills — loaded by Codex and Copilot, and
-                      translated into .claude/skills for Claude sessions
+- .claude/skills/     Claude-only skills (<name>/SKILL.md)
+- .codex/skills/      Codex-only skills (<name>/SKILL.md) — delivered to
+                      Codex through its .agents/skills discovery path
+- .agents/skills/     Shared skills — loaded by every supported backend
+                      (translated into .claude/skills for Claude sessions)
+
+A backend-specific skill overrides a shared skill of the same name, whole
+directory for whole directory. Every skill directory needs a SKILL.md file
+(conventionally with name and description frontmatter) or it is skipped.
 
 A per-project variant works the same way and takes precedence over this
 folder: <your project>/.daintree/assistant/
@@ -454,13 +732,14 @@ Notes:
 `;
 
 /**
- * Creates the global content folder with a README and the standard layout so
- * the "Open assistant commands folder" affordance always reveals something
- * self-explanatory. Existing files are never overwritten.
+ * Creates the global content folder with a README and the standard authoring
+ * layout (including the .codex/skills source lane) so the "Open assistant
+ * commands folder" affordance always reveals something self-explanatory.
+ * Existing files are never overwritten.
  */
 export async function ensureAssistantContentDir(dir?: string): Promise<string> {
   const target = dir ?? getGlobalAssistantContentDir();
-  for (const root of MIRROR_DEST_ROOTS) {
+  for (const root of SOURCE_SCAFFOLD_ROOTS) {
     await fs.mkdir(path.resolve(target, ...root.split("/")), { recursive: true });
   }
   const readmePath = path.join(target, "README.md");

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -695,13 +695,24 @@ export class HelpSessionService {
       if (syncResult.omittedSkills.length > 0 || syncResult.failedCopies.length > 0) {
         console.warn(
           "[HelpSessionService] Assistant content partially mirrored; launching without:",
-          { omittedSkills: syncResult.omittedSkills, failedCopies: syncResult.failedCopies }
+          {
+            sessionPath,
+            omittedSkills: syncResult.omittedSkills,
+            failedCopies: syncResult.failedCopies,
+          }
         );
       }
       if (syncResult.staleFailures.length > 0) {
+        // Name the session dir: a stale file that survives removal (symlinked
+        // chain, or a directory where a managed file belongs) fails every
+        // retry identically, so clearing that path by hand is the only fix.
+        console.warn(
+          "[HelpSessionService] Assistant content sync left stale managed files; clear this session directory to recover:",
+          { sessionPath, staleFailures: syncResult.staleFailures }
+        );
         throw new HelpSessionError(
           "USER_CONTENT_SYNC_FAILED",
-          `Couldn't refresh the project's assistant commands and skills — outdated copies still present in the session directory: ${syncResult.staleFailures.join(", ")}`
+          `Couldn't refresh the project's assistant commands and skills — outdated copies still present in the session directory ${sessionPath}: ${syncResult.staleFailures.join(", ")}`
         );
       }
     }

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -239,8 +239,18 @@ async function readTemplateHashStamp(sessionPath: string): Promise<string | null
  * but the readiness probe didn't respond in time. `MCP_NOT_READY` is retained
  * as a legacy alias the renderer still classifies (falling back to the
  * probe-failed shape) so older serialized errors keep displaying.
+ *
+ * `USER_CONTENT_SYNC_FAILED` means the user commands/skills mirror could not
+ * reconcile the session dir — either a source folder was unreadable (desired
+ * state unprovable) or a stale managed skill could not be removed. Launching
+ * anyway would run the session with outdated or unowned skill instructions,
+ * so provisioning fails closed and the renderer shows a retryable error.
  */
-export type HelpSessionErrorCode = "MCP_NOT_READY" | "MCP_SERVER_NOT_STARTED" | "MCP_PROBE_FAILED";
+export type HelpSessionErrorCode =
+  | "MCP_NOT_READY"
+  | "MCP_SERVER_NOT_STARTED"
+  | "MCP_PROBE_FAILED"
+  | "USER_CONTENT_SYNC_FAILED";
 
 export class HelpSessionError extends Error {
   readonly code: HelpSessionErrorCode;
@@ -660,18 +670,40 @@ export class HelpSessionService {
     // discovers them through its native cwd-scoped mechanisms. Runs after the
     // template copy and unconditionally — the template hash gate doesn't
     // cover user content, which changes independently of app version.
-    // Non-fatal: a broken user file must never block the assistant launch.
+    //
+    // Failure policy: invalid or unwritable NEW content is safely omitted (the
+    // assistant just launches without it), but content that would run STALE —
+    // an unreadable source (desired state unprovable) or a managed skill that
+    // should be gone yet is still on disk — fails the provision closed. A
+    // session quietly running deleted or superseded skill instructions is
+    // worse than a retryable launch error.
+    let syncResult;
     try {
-      await syncAssistantContent({
+      syncResult = await syncAssistantContent({
         sessionPath,
         projectPath: input.projectPath,
         agentId: input.agentId,
       });
     } catch (err) {
-      console.warn(
-        "[HelpSessionService] User content sync failed; launching without custom commands:",
-        err
+      const reason = formatErrorMessage(err, "couldn't read the assistant content folders");
+      throw new HelpSessionError(
+        "USER_CONTENT_SYNC_FAILED",
+        `Couldn't refresh the project's assistant commands and skills: ${reason}`
       );
+    }
+    if (syncResult) {
+      if (syncResult.omittedSkills.length > 0 || syncResult.failedCopies.length > 0) {
+        console.warn(
+          "[HelpSessionService] Assistant content partially mirrored; launching without:",
+          { omittedSkills: syncResult.omittedSkills, failedCopies: syncResult.failedCopies }
+        );
+      }
+      if (syncResult.staleFailures.length > 0) {
+        throw new HelpSessionError(
+          "USER_CONTENT_SYNC_FAILED",
+          `Couldn't refresh the project's assistant commands and skills — outdated copies still present in the session directory: ${syncResult.staleFailures.join(", ")}`
+        );
+      }
     }
 
     // Per-session scratch dir under `userData/assistant-scratch/<instanceId>/`.

--- a/electron/services/__tests__/AssistantContentMirror.test.ts
+++ b/electron/services/__tests__/AssistantContentMirror.test.ts
@@ -74,7 +74,13 @@ describe("syncAssistantContent", () => {
 
     const result = await sync("claude");
 
-    expect(result).toEqual({ copied: 2, removed: 0 });
+    expect(result).toMatchObject({
+      copied: 2,
+      removed: 0,
+      omittedSkills: [],
+      failedCopies: [],
+      staleFailures: [],
+    });
     expect(await readSession(".claude/commands/review.md")).toBe("do a review");
     expect(await readSession(".claude/skills/deploy/SKILL.md")).toBe("deploy skill");
   });
@@ -94,7 +100,7 @@ describe("syncAssistantContent", () => {
 
     const result = await sync("codex");
 
-    expect(result).toEqual({ copied: 1, removed: 0 });
+    expect(result).toMatchObject({ copied: 1, removed: 0, staleFailures: [] });
     expect(await readSession(".agents/skills/shared-thing/SKILL.md")).toBe("shared");
     expect(await readSession(".claude/commands/review.md")).toBeNull();
   });
@@ -106,7 +112,7 @@ describe("syncAssistantContent", () => {
 
     const result = await sync("copilot");
 
-    expect(result).toEqual({ copied: 2, removed: 0 });
+    expect(result).toMatchObject({ copied: 2, removed: 0, staleFailures: [] });
     expect(await readSession(".agents/skills/a/SKILL.md")).toBe("a");
     expect(await readSession(".claude/skills/b/SKILL.md")).toBe("b");
     expect(await readSession(".claude/commands/c.md")).toBeNull();
@@ -161,7 +167,7 @@ describe("syncAssistantContent", () => {
     await fs.rm(path.join(globalDir, ".claude", "commands", "old.md"));
     const result = await sync("claude");
 
-    expect(result).toEqual({ copied: 0, removed: 1 });
+    expect(result).toMatchObject({ copied: 0, removed: 1, staleFailures: [] });
     expect(await readSession(".claude/commands/old.md")).toBeNull();
   });
 
@@ -213,11 +219,13 @@ describe("syncAssistantContent", () => {
 
     const failed = await sync("claude");
     expect(failed?.removed).toBe(0);
+    expect(failed?.staleFailures).toEqual([".claude/commands/flaky.md"]);
     expect(await readSession(".claude/commands/flaky.md")).toBe("x");
 
     rmSpy.mockRestore();
     const retried = await sync("claude");
     expect(retried?.removed).toBe(1);
+    expect(retried?.staleFailures).toEqual([]);
     expect(await readSession(".claude/commands/flaky.md")).toBeNull();
   });
 
@@ -256,6 +264,11 @@ describe("syncAssistantContent", () => {
 
     expect(result?.removed).toBe(0);
     expect(result?.copied).toBe(0);
+    // Fail-closed: the manifest-owned path resolves through the planted
+    // symlink to a still-present file, so it must be reported stale, and the
+    // skipped copy must be reported (its slot is empty behind the symlink).
+    expect(result?.staleFailures).toContain(".claude/skills/SKILL.md");
+    expect(result?.failedCopies).toContain(".claude/skills/mine/SKILL.md");
     expect(await fs.readFile(path.join(outside, "SKILL.md"), "utf-8")).toBe("precious");
     await expect(fs.stat(path.join(outside, "mine"))).rejects.toThrow();
   });
@@ -316,13 +329,19 @@ describe("syncAssistantContent", () => {
 
     const result = await sync("claude");
 
-    expect(result).toEqual({ copied: 1, removed: 0 });
+    expect(result).toMatchObject({ copied: 1, removed: 0 });
     expect(await readSession(".claude/commands/.hidden.md")).toBeNull();
   });
 
   it("syncs cleanly when no source folders exist", async () => {
     const result = await sync("claude");
-    expect(result).toEqual({ copied: 0, removed: 0 });
+    expect(result).toMatchObject({
+      copied: 0,
+      removed: 0,
+      omittedSkills: [],
+      failedCopies: [],
+      staleFailures: [],
+    });
   });
 
   it("refreshes changed file content on every sync", async () => {
@@ -333,6 +352,253 @@ describe("syncAssistantContent", () => {
     await sync("claude");
 
     expect(await readSession(".claude/commands/review.md")).toBe("v2");
+  });
+
+  it("translates .codex/skills into the session's .agents/skills for codex", async () => {
+    await writeSource(globalDir, ".codex/skills/example/SKILL.md", "codex only");
+
+    const result = await sync("codex");
+
+    expect(result).toMatchObject({ copied: 1, removed: 0, staleFailures: [] });
+    expect(await readSession(".agents/skills/example/SKILL.md")).toBe("codex only");
+    expect(await readSession(".codex/skills/example/SKILL.md")).toBeNull();
+  });
+
+  it("does not deliver .codex/skills to claude sessions", async () => {
+    await writeSource(globalDir, ".codex/skills/example/SKILL.md", "codex only");
+
+    const result = await sync("claude");
+
+    expect(result).toMatchObject({ copied: 0 });
+    expect(await readSession(".claude/skills/example/SKILL.md")).toBeNull();
+    expect(await readSession(".agents/skills/example/SKILL.md")).toBeNull();
+  });
+
+  it("lets an explicit .codex skill override the shared skill wholesale", async () => {
+    await writeSource(globalDir, ".agents/skills/dupe/SKILL.md", "shared version");
+    await writeSource(globalDir, ".agents/skills/dupe/scripts/helper.py", "shared helper");
+    await writeSource(globalDir, ".codex/skills/dupe/SKILL.md", "codex version");
+
+    await sync("codex");
+
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("codex version");
+    expect(await readSession(".agents/skills/dupe/scripts/helper.py")).toBeNull();
+  });
+
+  it("lets a project codex skill override the global codex skill", async () => {
+    await writeSource(globalDir, ".codex/skills/dupe/SKILL.md", "global");
+    const projectContent = getProjectAssistantContentDir(projectPath);
+    await writeSource(projectContent, ".codex/skills/dupe/SKILL.md", "project");
+
+    await sync("codex");
+
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("project");
+  });
+
+  it("removes a deleted codex skill on the next sync", async () => {
+    await writeSource(globalDir, ".codex/skills/gone/SKILL.md", "x");
+    await sync("codex");
+    expect(await readSession(".agents/skills/gone/SKILL.md")).toBe("x");
+
+    await fs.rm(path.join(globalDir, ".codex", "skills", "gone"), { recursive: true });
+    const result = await sync("codex");
+
+    expect(result).toMatchObject({ removed: 1, staleFailures: [] });
+    expect(await readSession(".agents/skills/gone/SKILL.md")).toBeNull();
+  });
+
+  it("reveals the shared skill when the explicit codex override is deleted", async () => {
+    await writeSource(globalDir, ".agents/skills/dupe/SKILL.md", "shared version");
+    await writeSource(globalDir, ".codex/skills/dupe/SKILL.md", "codex version");
+    await sync("codex");
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("codex version");
+
+    await fs.rm(path.join(globalDir, ".codex", "skills", "dupe"), { recursive: true });
+    await sync("codex");
+
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("shared version");
+  });
+
+  it("removes codex-mirrored .agents/skills files when switching to claude", async () => {
+    await writeSource(globalDir, ".codex/skills/example/SKILL.md", "codex only");
+    await sync("codex");
+    expect(await readSession(".agents/skills/example/SKILL.md")).toBe("codex only");
+
+    const result = await sync("claude");
+
+    expect(result).toMatchObject({ removed: 1, staleFailures: [] });
+    expect(await readSession(".agents/skills/example/SKILL.md")).toBeNull();
+  });
+
+  it("omits a skill directory without SKILL.md and reports it", async () => {
+    await writeSource(globalDir, ".codex/skills/broken/notes.md", "no skill manifest");
+
+    const result = await sync("codex");
+
+    expect(result).toMatchObject({ copied: 0, omittedSkills: ["global:.codex/skills/broken"] });
+    expect(await readSession(".agents/skills/broken/notes.md")).toBeNull();
+  });
+
+  it("does not let an invalid explicit skill shadow a valid shared skill", async () => {
+    await writeSource(globalDir, ".agents/skills/dupe/SKILL.md", "shared version");
+    await writeSource(globalDir, ".codex/skills/dupe/README.md", "no SKILL.md here");
+
+    const result = await sync("codex");
+
+    expect(result?.omittedSkills).toEqual(["global:.codex/skills/dupe"]);
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("shared version");
+  });
+
+  it("retires the mirrored copy of a skill whose SKILL.md was deleted", async () => {
+    await writeSource(globalDir, ".codex/skills/tool/SKILL.md", "manifest");
+    await writeSource(globalDir, ".codex/skills/tool/scripts/run.sh", "script");
+    await sync("codex");
+    expect(await readSession(".agents/skills/tool/scripts/run.sh")).toBe("script");
+
+    await fs.rm(path.join(globalDir, ".codex", "skills", "tool", "SKILL.md"));
+    const result = await sync("codex");
+
+    expect(result?.omittedSkills).toEqual(["global:.codex/skills/tool"]);
+    expect(result).toMatchObject({ removed: 2, staleFailures: [] });
+    expect(await readSession(".agents/skills/tool/SKILL.md")).toBeNull();
+    expect(await readSession(".agents/skills/tool/scripts/run.sh")).toBeNull();
+  });
+
+  it("refreshes changed skill resource files on every sync", async () => {
+    await writeSource(globalDir, ".codex/skills/tool/SKILL.md", "manifest");
+    await writeSource(globalDir, ".codex/skills/tool/scripts/run.sh", "v1");
+    await sync("codex");
+    await writeSource(globalDir, ".codex/skills/tool/scripts/run.sh", "v2");
+
+    await sync("codex");
+
+    expect(await readSession(".agents/skills/tool/scripts/run.sh")).toBe("v2");
+  });
+
+  it("throws when a source directory exists but is unreadable", async () => {
+    await writeSource(globalDir, ".claude/commands/ok.md", "fine");
+    const lockedDir = path.join(globalDir, ".claude", "skills", "locked");
+    await fs.mkdir(lockedDir, { recursive: true });
+    const realReaddir = fs.readdir.bind(fs);
+    // The overloaded readdir signature defeats mockImplementation's inference.
+    vi.spyOn(fs, "readdir").mockImplementation((async (target: unknown, opts: unknown) => {
+      if (target === lockedDir) {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      }
+      return realReaddir(target as string, opts as never);
+    }) as never);
+
+    await expect(sync("claude")).rejects.toThrow(/Unreadable assistant content directory/);
+  });
+
+  it("reports a failed copy without failing closed when nothing stale remains", async () => {
+    await writeSource(globalDir, ".claude/commands/new.md", "fresh");
+    const destAbs = path.join(sessionPath, ".claude", "commands", "new.md");
+    const realCopyFile = fs.copyFile.bind(fs);
+    vi.spyOn(fs, "copyFile").mockImplementation(async (src, dest) => {
+      if (dest === destAbs) throw Object.assign(new Error("EIO: simulated"), { code: "EIO" });
+      return realCopyFile(src as string, dest as string);
+    });
+
+    const result = await sync("claude");
+
+    expect(result?.failedCopies).toEqual([".claude/commands/new.md"]);
+    expect(result?.staleFailures).toEqual([]);
+  });
+
+  it("fails closed when a stale copy survives a failed refresh copy", async () => {
+    await writeSource(globalDir, ".claude/commands/review.md", "v1");
+    await sync("claude");
+    await writeSource(globalDir, ".claude/commands/review.md", "v2");
+
+    const destAbs = path.join(sessionPath, ".claude", "commands", "review.md");
+    const realCopyFile = fs.copyFile.bind(fs);
+    vi.spyOn(fs, "copyFile").mockImplementation(async (src, dest) => {
+      if (dest === destAbs) throw Object.assign(new Error("EIO: simulated"), { code: "EIO" });
+      return realCopyFile(src as string, dest as string);
+    });
+
+    const result = await sync("claude");
+
+    expect(result?.staleFailures).toEqual([".claude/commands/review.md"]);
+    expect(result?.failedCopies).toEqual([]);
+    expect(await readSession(".claude/commands/review.md")).toBe("v1");
+  });
+
+  it("fails the sync when the manifest is corrupt instead of orphaning managed files", async () => {
+    await fs.writeFile(path.join(sessionPath, ".daintree-user-content.json"), "{not json", "utf-8");
+
+    await expect(sync("claude")).rejects.toThrow(/manifest/);
+  });
+
+  it("fails the sync on an unsupported manifest version", async () => {
+    await fs.writeFile(
+      path.join(sessionPath, ".daintree-user-content.json"),
+      JSON.stringify({ version: 2, files: [] }),
+      "utf-8"
+    );
+
+    await expect(sync("claude")).rejects.toThrow(/manifest/);
+  });
+
+  it("retires successfully removed paths from the manifest", async () => {
+    await writeSource(globalDir, ".claude/commands/old.md", "old");
+    await sync("claude");
+    await fs.rm(path.join(globalDir, ".claude", "commands", "old.md"));
+    await sync("claude");
+
+    // A hand-placed file at the historical path must now be unmanaged.
+    const handRolled = path.join(sessionPath, ".claude", "commands", "old.md");
+    await fs.mkdir(path.dirname(handRolled), { recursive: true });
+    await fs.writeFile(handRolled, "mine", "utf-8");
+    const result = await sync("claude");
+
+    expect(result?.removed).toBe(0);
+    expect(await readSession(".claude/commands/old.md")).toBe("mine");
+  });
+
+  it("does not let an oversized SKILL.md shadow a valid shared skill", async () => {
+    await writeSource(globalDir, ".agents/skills/dupe/SKILL.md", "shared version");
+    const big = path.join(globalDir, ".codex", "skills", "dupe", "SKILL.md");
+    await fs.mkdir(path.dirname(big), { recursive: true });
+    await fs.writeFile(big, Buffer.alloc(5 * 1024 * 1024 + 1, 0x61));
+
+    const result = await sync("codex");
+
+    expect(result?.omittedSkills).toEqual(["global:.codex/skills/dupe"]);
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("shared version");
+  });
+
+  it("never mirrors filenames its cleanup validator cannot own", async () => {
+    await writeSource(globalDir, ".claude/commands/evil:colon.md", "x");
+
+    const result = await sync("claude");
+
+    expect(result).toMatchObject({ copied: 0, staleFailures: [] });
+    expect(await readSession(".claude/commands/evil:colon.md")).toBeNull();
+  });
+
+  it("collapses case-colliding skill names to the highest-precedence spelling", async () => {
+    await writeSource(globalDir, ".agents/skills/Dupe/SKILL.md", "global spelling");
+    const projectContent = getProjectAssistantContentDir(projectPath);
+    await writeSource(projectContent, ".agents/skills/dupe/SKILL.md", "project spelling");
+
+    const result = await sync("codex");
+
+    expect(result?.copied).toBe(1);
+    expect(result?.omittedSkills).toEqual(["case-collision:.agents/skills/Dupe"]);
+    expect(await readSession(".agents/skills/dupe/SKILL.md")).toBe("project spelling");
+  });
+
+  it("ignores loose files at a skills source root", async () => {
+    await writeSource(globalDir, ".codex/skills/loose-note.md", "not a skill");
+    await writeSource(globalDir, ".codex/skills/real/SKILL.md", "real");
+
+    const result = await sync("codex");
+
+    expect(result).toMatchObject({ copied: 1, omittedSkills: [] });
+    expect(await readSession(".agents/skills/loose-note.md")).toBeNull();
+    expect(await readSession(".agents/skills/real/SKILL.md")).toBe("real");
   });
 });
 
@@ -363,12 +629,13 @@ describe("ensureAssistantContentDir", () => {
     const created = await ensureAssistantContentDir(target);
 
     expect(created).toBe(target);
-    for (const dir of [".claude/commands", ".claude/skills", ".agents/skills"]) {
+    for (const dir of [".claude/commands", ".claude/skills", ".codex/skills", ".agents/skills"]) {
       const stat = await fs.stat(path.join(target, ...dir.split("/")));
       expect(stat.isDirectory()).toBe(true);
     }
     const readme = await fs.readFile(path.join(target, "README.md"), "utf-8");
     expect(readme).toContain(".agents/skills/");
+    expect(readme).toContain(".codex/skills/");
 
     await fs.writeFile(path.join(target, "README.md"), "customized", "utf-8");
     await ensureAssistantContentDir(target);

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -49,8 +49,26 @@ const {
   // ~/.daintree/assistant folder; mirroring behavior has its own suite in
   // AssistantContentMirror.test.ts.
   mockSyncAssistantContent:
-    vi.fn<(input: unknown) => Promise<{ copied: number; removed: number } | null>>(),
+    vi.fn<
+      (
+        input: unknown
+      ) => Promise<import("../AssistantContentMirror.js").AssistantContentSyncResult | null>
+    >(),
 }));
+
+function cleanSyncResult(
+  overrides: Partial<import("../AssistantContentMirror.js").AssistantContentSyncResult> = {}
+): import("../AssistantContentMirror.js").AssistantContentSyncResult {
+  return {
+    copied: 0,
+    removed: 0,
+    truncated: false,
+    omittedSkills: [],
+    failedCopies: [],
+    staleFailures: [],
+    ...overrides,
+  };
+}
 
 vi.mock("electron", () => ({
   app: {
@@ -184,7 +202,7 @@ describe("HelpSessionService", () => {
     mockProbeMcpSseServer.mockReset();
     mockProbeMcpSseServer.mockResolvedValue(undefined);
     mockSyncAssistantContent.mockReset();
-    mockSyncAssistantContent.mockResolvedValue({ copied: 0, removed: 0 });
+    mockSyncAssistantContent.mockResolvedValue(cleanSyncResult());
 
     service = new HelpSessionService();
     // The new `ensureMcpServerReady` path throws if no registry is wired —
@@ -247,12 +265,58 @@ describe("HelpSessionService", () => {
     });
   });
 
-  it("still provisions when the user content sync fails", async () => {
-    mockSyncAssistantContent.mockRejectedValue(new Error("bad user file"));
+  it("fails provisioning closed when the content sync throws", async () => {
+    mockSyncAssistantContent.mockRejectedValue(new Error("unreadable source dir"));
+
+    await expect(service.provisionSession(provisionInput())).rejects.toMatchObject({
+      name: "HelpSessionError",
+      code: "USER_CONTENT_SYNC_FAILED",
+    });
+  });
+
+  it("fails provisioning closed when stale mirrored content cannot be reconciled", async () => {
+    mockSyncAssistantContent.mockResolvedValue(
+      cleanSyncResult({ staleFailures: [".agents/skills/old/SKILL.md"] })
+    );
+
+    await expect(service.provisionSession(provisionInput())).rejects.toMatchObject({
+      name: "HelpSessionError",
+      code: "USER_CONTENT_SYNC_FAILED",
+      message: expect.stringContaining(".agents/skills/old/SKILL.md"),
+    });
+  });
+
+  it("still provisions when invalid new skills were safely omitted", async () => {
+    mockSyncAssistantContent.mockResolvedValue(
+      cleanSyncResult({
+        omittedSkills: ["project:.codex/skills/broken"],
+        failedCopies: [".agents/skills/half/SKILL.md"],
+      })
+    );
 
     const result = await service.provisionSession(provisionInput());
 
     expect(result).not.toBeNull();
+  });
+
+  it("serializes concurrent provisions for the same project", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mockSyncAssistantContent.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      inFlight -= 1;
+      return cleanSyncResult();
+    });
+
+    await Promise.all([
+      service.provisionSession(provisionInput()),
+      service.provisionSession(provisionInput()),
+    ]);
+
+    expect(mockSyncAssistantContent).toHaveBeenCalledTimes(2);
+    expect(maxInFlight).toBe(1);
   });
 
   it("creates a session dir with a .mcp.json that bakes the literal session token into the Authorization header", async () => {

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -275,6 +275,11 @@ describe("HelpSessionService", () => {
   });
 
   it("fails provisioning closed when stale mirrored content cannot be reconciled", async () => {
+    // The stale relpaths are only actionable alongside the directory holding
+    // them — clearing that dir by hand is the recovery for the permanent cases.
+    const clean = await service.provisionSession(provisionInput());
+    if (!clean) throw new Error("expected result");
+
     mockSyncAssistantContent.mockResolvedValue(
       cleanSyncResult({ staleFailures: [".agents/skills/old/SKILL.md"] })
     );
@@ -283,6 +288,9 @@ describe("HelpSessionService", () => {
       name: "HelpSessionError",
       code: "USER_CONTENT_SYNC_FAILED",
       message: expect.stringContaining(".agents/skills/old/SKILL.md"),
+    });
+    await expect(service.provisionSession(provisionInput())).rejects.toMatchObject({
+      message: expect.stringContaining(clean.sessionPath),
     });
   });
 

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -149,6 +149,8 @@ const LAUNCH_ERROR_BODY: Record<LaunchErrorKind, string> = {
   "mcp-server-not-started":
     "Daintree's assistant services didn't start. Check assistant settings, then try again.",
   "mcp-probe-failed": "Daintree's assistant services didn't respond in time. Try again.",
+  "skills-sync-failed":
+    "Daintree couldn't refresh this project's assistant commands and skills, so the session didn't start. Try again.",
   "spawn-failed": "The agent didn't start. Try again.",
   "folder-unavailable":
     "Daintree's bundled assistant files are missing. Reinstall Daintree or check the logs.",
@@ -177,6 +179,7 @@ const LAUNCH_ERROR_CTAS: Record<LaunchErrorKind, LaunchErrorCta[]> = {
     { label: "Retry", handler: "retry", variant: "primary" },
     { label: "Open settings", handler: "settings", variant: "secondary" },
   ],
+  "skills-sync-failed": [{ label: "Retry", handler: "retry", variant: "primary" }],
   "spawn-failed": [{ label: "Retry", handler: "retry", variant: "primary" }],
   "folder-unavailable": [
     { label: "Open logs", handler: "logs", variant: "secondary" },

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -150,7 +150,7 @@ const LAUNCH_ERROR_BODY: Record<LaunchErrorKind, string> = {
     "Daintree's assistant services didn't start. Check assistant settings, then try again.",
   "mcp-probe-failed": "Daintree's assistant services didn't respond in time. Try again.",
   "skills-sync-failed":
-    "Daintree couldn't refresh this project's assistant commands and skills, so the session didn't start. Try again.",
+    "Daintree couldn't refresh this project's assistant commands and skills, so the session didn't start. Retry, or check the logs if it keeps failing.",
   "spawn-failed": "The agent didn't start. Try again.",
   "folder-unavailable":
     "Daintree's bundled assistant files are missing. Reinstall Daintree or check the logs.",
@@ -159,7 +159,10 @@ const LAUNCH_ERROR_BODY: Record<LaunchErrorKind, string> = {
 // Per-kind recovery surface. `folder-unavailable` is non-retryable: the
 // resolver's module-scope cache returns the same null on retry, so the only
 // honest affordances are the installer page and the error log. `Retry` is
-// kept for the transient kinds (spawn/probe/server). The CTA handler is
+// kept for the transient kinds (spawn/probe/server). `skills-sync-failed`
+// pairs both: some causes clear on retry, but a corrupt manifest or an
+// unremovable stale file fails identically forever, so the log — which names
+// the session dir to clear — is the only way out. The CTA handler is
 // resolved in the component from this discriminator — no callbacks in the
 // data, so the data stays serializable and easy to assert against.
 type LaunchErrorCtaHandler = "retry" | "settings" | "logs" | "installer";
@@ -179,7 +182,10 @@ const LAUNCH_ERROR_CTAS: Record<LaunchErrorKind, LaunchErrorCta[]> = {
     { label: "Retry", handler: "retry", variant: "primary" },
     { label: "Open settings", handler: "settings", variant: "secondary" },
   ],
-  "skills-sync-failed": [{ label: "Retry", handler: "retry", variant: "primary" }],
+  "skills-sync-failed": [
+    { label: "Retry", handler: "retry", variant: "primary" },
+    { label: "Open logs", handler: "logs", variant: "secondary" },
+  ],
   "spawn-failed": [{ label: "Retry", handler: "retry", variant: "primary" }],
   "folder-unavailable": [
     { label: "Open logs", handler: "logs", variant: "secondary" },

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -143,7 +143,7 @@ describe("HelpPanelBanners — launch error", () => {
     const cases: { kind: LaunchErrorKind; labels: string[] }[] = [
       { kind: "mcp-server-not-started", labels: ["Retry", "Open settings"] },
       { kind: "mcp-probe-failed", labels: ["Retry", "Open settings"] },
-      { kind: "skills-sync-failed", labels: ["Retry"] },
+      { kind: "skills-sync-failed", labels: ["Retry", "Open logs"] },
       { kind: "spawn-failed", labels: ["Retry"] },
       { kind: "folder-unavailable", labels: ["Open logs", "Open installer page"] },
     ];
@@ -192,6 +192,24 @@ describe("HelpPanelBanners — launch error", () => {
     fireEvent.click(getByText("Open installer page"));
     expect(onOpenInstallerPage).toHaveBeenCalledTimes(1);
     expect(onRetryLaunch).not.toHaveBeenCalled();
+  });
+
+  it("gives skills-sync-failed an escape hatch beyond Retry via Open logs", () => {
+    const onOpenLogs = vi.fn();
+    const onRetryLaunch = vi.fn();
+    const { getByText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        launchError={{ agentId: "claude", kind: "skills-sync-failed" }}
+        onRetryLaunch={onRetryLaunch}
+        onOpenLogs={onOpenLogs}
+      />
+    );
+    fireEvent.click(getByText("Open logs"));
+    expect(onOpenLogs).toHaveBeenCalledTimes(1);
+    expect(onRetryLaunch).not.toHaveBeenCalled();
+    fireEvent.click(getByText("Retry"));
+    expect(onRetryLaunch).toHaveBeenCalledTimes(1);
   });
 
   it("renders nothing for the launch-error slot when launchError is null", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -52,6 +52,7 @@ describe("HelpPanelBanners — launch error", () => {
     const kinds: LaunchErrorKind[] = [
       "mcp-server-not-started",
       "mcp-probe-failed",
+      "skills-sync-failed",
       "spawn-failed",
       "folder-unavailable",
     ];
@@ -77,7 +78,11 @@ describe("HelpPanelBanners — launch error", () => {
       unmount();
     }
 
-    const kindsWithoutSettings: LaunchErrorKind[] = ["spawn-failed", "folder-unavailable"];
+    const kindsWithoutSettings: LaunchErrorKind[] = [
+      "skills-sync-failed",
+      "spawn-failed",
+      "folder-unavailable",
+    ];
     for (const kind of kindsWithoutSettings) {
       const { queryByText, unmount } = render(
         <HelpPanelBanners {...baseProps()} launchError={{ agentId: "claude", kind }} />
@@ -138,6 +143,7 @@ describe("HelpPanelBanners — launch error", () => {
     const cases: { kind: LaunchErrorKind; labels: string[] }[] = [
       { kind: "mcp-server-not-started", labels: ["Retry", "Open settings"] },
       { kind: "mcp-probe-failed", labels: ["Retry", "Open settings"] },
+      { kind: "skills-sync-failed", labels: ["Retry"] },
       { kind: "spawn-failed", labels: ["Retry"] },
       { kind: "folder-unavailable", labels: ["Open logs", "Open installer page"] },
     ];

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -875,10 +875,10 @@ export function DaintreeAssistantSettingsTab() {
         )}
       </SettingsSection>
 
-      {/* Custom commands */}
+      {/* Custom commands and skills */}
       <SettingsSection
         icon={FolderOpen}
-        title="Custom commands"
+        title="Custom commands and skills"
         description="Add your own commands and skills to every assistant session."
       >
         <div className="flex items-start gap-3">
@@ -887,7 +887,8 @@ export function DaintreeAssistantSettingsTab() {
             into each new assistant session. Claude Code picks up{" "}
             <code className="font-mono text-[11px]">.claude/commands</code> and{" "}
             <code className="font-mono text-[11px]">.claude/skills</code>; Codex picks up{" "}
-            <code className="font-mono text-[11px]">.agents/skills</code>; Copilot reads both skill
+            <code className="font-mono text-[11px]">.agents/skills</code> and{" "}
+            <code className="font-mono text-[11px]">.codex/skills</code>; Copilot reads both skill
             trees. A per-project variant in{" "}
             <code className="font-mono text-[11px]">&lt;project&gt;/.daintree/assistant</code> takes
             precedence and can be committed to git.

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -86,6 +86,7 @@ export interface TierMismatchState {
 export type LaunchErrorKind =
   | "mcp-server-not-started"
   | "mcp-probe-failed"
+  | "skills-sync-failed"
   | "spawn-failed"
   | "folder-unavailable";
 

--- a/src/controllers/HelpSessionProvisioner.ts
+++ b/src/controllers/HelpSessionProvisioner.ts
@@ -3,6 +3,7 @@
 // functions with no controller state — moved verbatim, no behavior change.
 
 import { logError } from "@/utils/logger";
+import { extractHelpSessionErrorCode } from "@/utils/clientHelpSessionError";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { ActionContext } from "@shared/types/actions";
 import type { HelpProjectRef, LaunchErrorKind } from "./HelpSessionController";
@@ -30,6 +31,7 @@ export type ProvisionFailureCode =
   | "MCP_NOT_READY"
   | "MCP_SERVER_NOT_STARTED"
   | "MCP_PROBE_FAILED"
+  | "USER_CONTENT_SYNC_FAILED"
   | "UNKNOWN";
 
 export type ProvisionOutcome =
@@ -58,15 +60,15 @@ export async function provisionHelpSession(
     return { ok: true, session: result };
   } catch (err) {
     logError("Failed to provision help session", err);
-    const code =
-      err && typeof err === "object" && "code" in err
-        ? (err as Record<string, unknown>).code
-        : undefined;
+    // Decode BEFORE formatting: the contextBridge strips the custom `code`
+    // property, so it rides an encoded message prefix the decoder strips.
+    const code = extractHelpSessionErrorCode(err);
     const message = formatErrorMessage(err, "Couldn't provision help session");
     if (
       code === "MCP_SERVER_NOT_STARTED" ||
       code === "MCP_PROBE_FAILED" ||
-      code === "MCP_NOT_READY"
+      code === "MCP_NOT_READY" ||
+      code === "USER_CONTENT_SYNC_FAILED"
     ) {
       return { ok: false, code, message };
     }
@@ -83,6 +85,8 @@ export function provisionFailureKind(code: ProvisionFailureCode): LaunchErrorKin
     case "MCP_PROBE_FAILED":
     case "MCP_NOT_READY":
       return "mcp-probe-failed";
+    case "USER_CONTENT_SYNC_FAILED":
+      return "skills-sync-failed";
     default:
       return "spawn-failed";
   }

--- a/src/controllers/LaunchNotifications.ts
+++ b/src/controllers/LaunchNotifications.ts
@@ -138,6 +138,11 @@ export class LaunchNotifications {
       notifyAssistantServicesUnavailable(kind);
     } else if (kind === "folder-unavailable") {
       notifyInstallCorrupted(agentId);
+    } else if (kind === "skills-sync-failed") {
+      notifyLaunchFailed(
+        agentId,
+        "Daintree couldn't refresh this project's assistant commands and skills. Try again."
+      );
     } else {
       notifyLaunchFailed(agentId, "The agent didn't start. Try again.");
     }

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -17,6 +17,7 @@ import {
   LAUNCH_BLOCKED_NO_WORKSPACE,
 } from "@/controllers/LaunchNotifications";
 import { logError } from "@/utils/logger";
+import { extractHelpSessionErrorCode } from "@/utils/clientHelpSessionError";
 import { getDefaultAgentId } from "@/lib/resolveAgentId";
 import { isAssistantOnlyAgentId } from "@shared/config/agentIds";
 
@@ -191,10 +192,9 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
         });
       } catch (err) {
         logError("Failed to provision help session", err);
-        const code =
-          err && typeof err === "object" && "code" in err
-            ? (err as Record<string, unknown>).code
-            : undefined;
+        // Decode BEFORE any message formatting: the contextBridge strips the
+        // custom `code` property, so it rides an encoded message prefix.
+        const code = extractHelpSessionErrorCode(err);
         let message = "Couldn't start the Daintree Assistant session.";
         if (code === "MCP_PROBE_FAILED") {
           message =
@@ -202,6 +202,9 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
         } else if (code === "MCP_SERVER_NOT_STARTED" || code === "MCP_NOT_READY") {
           message =
             "Daintree's assistant services didn't start. Check assistant settings, then try again.";
+        } else if (code === "USER_CONTENT_SYNC_FAILED") {
+          message =
+            "Daintree couldn't refresh this project's assistant commands and skills, so the session didn't start. Try again.";
         }
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({

--- a/src/utils/__tests__/clientHelpSessionError.test.ts
+++ b/src/utils/__tests__/clientHelpSessionError.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { extractHelpSessionErrorCode } from "../clientHelpSessionError";
+
+describe("extractHelpSessionErrorCode", () => {
+  it("decodes the preload's encoded prefix and cleans the message", () => {
+    const err = new Error("[HelpSessionError|USER_CONTENT_SYNC_FAILED] Couldn't refresh skills");
+
+    expect(extractHelpSessionErrorCode(err)).toBe("USER_CONTENT_SYNC_FAILED");
+    expect(err.message).toBe("Couldn't refresh skills");
+    expect(err.name).toBe("HelpSessionError");
+    expect((err as Error & { code?: string }).code).toBe("USER_CONTENT_SYNC_FAILED");
+  });
+
+  it("falls back to a same-realm code property", () => {
+    const err = Object.assign(new Error("boom"), { code: "MCP_PROBE_FAILED" });
+    expect(extractHelpSessionErrorCode(err)).toBe("MCP_PROBE_FAILED");
+  });
+
+  it("returns undefined for plain errors and non-errors", () => {
+    expect(extractHelpSessionErrorCode(new Error("plain failure"))).toBeUndefined();
+    expect(extractHelpSessionErrorCode("string failure")).toBeUndefined();
+    expect(extractHelpSessionErrorCode(null)).toBeUndefined();
+    expect(extractHelpSessionErrorCode(undefined)).toBeUndefined();
+  });
+});

--- a/src/utils/clientHelpSessionError.ts
+++ b/src/utils/clientHelpSessionError.ts
@@ -1,0 +1,36 @@
+/**
+ * Renderer-side decoder for `HelpSessionError` codes thrown by help-session
+ * provisioning in the main process. Electron's contextBridge strips ALL
+ * custom Error properties (including `code`) at the preload→renderer realm
+ * boundary, so the preload's `_reconstructHelpSessionError` encodes the code
+ * into a `[HelpSessionError|<code>] message` prefix — the only reliable
+ * carrier — which this guard decodes. Same pattern as `clientAppError.ts`.
+ */
+
+// Group 1 is the HelpSessionErrorCode (uppercase identifier). Group 2 is the
+// original human-readable message that follows the closing `]`.
+const ENCODED_HELP_SESSION_ERROR_PATTERN = /^\[HelpSessionError\|([A-Z_]+)\] (.*)$/s;
+
+/**
+ * Returns the `HelpSessionErrorCode` carried by `e`, or undefined. Decodes
+ * the preload's encoded prefix (and, as a side effect, restores `name` and
+ * `code` and cleans `message` so later formatting doesn't show the prefix);
+ * falls back to duck-typing a string `code` property for errors that never
+ * crossed the contextBridge (same-realm throws, tests).
+ */
+export function extractHelpSessionErrorCode(e: unknown): string | undefined {
+  if (!e || typeof e !== "object") return undefined;
+  if (e instanceof Error) {
+    const match = ENCODED_HELP_SESSION_ERROR_PATTERN.exec(e.message);
+    if (match) {
+      const [, code, originalMessage] = match;
+      const target = e as Error & { code?: string };
+      target.name = "HelpSessionError";
+      target.code = code;
+      e.message = originalMessage ?? e.message;
+      return code;
+    }
+  }
+  const code = (e as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}


### PR DESCRIPTION
This adds support for project-level skills that are only visible to the Daintree Assistant, not to regular agent terminals.

## How it works

A project can now add Codex-only skills in `.daintree/assistant/.codex/skills`. These are copied into the assistant's private session directory under `.agents/skills`, where Codex discovers them at startup. Ordinary Codex terminals run with the real project or worktree as their cwd, so they never see any of this. The same layout works globally in `~/.daintree/assistant`.

Precedence is per skill directory: an explicit `.codex/skills/<name>` replaces a shared `.agents/skills/<name>` wholesale, and project skills override global ones. Skill folders need a `SKILL.md` file or they're skipped, and an invalid skill never shadows a valid one underneath it. `.codex/skills` is a source convention only. It never becomes a session destination or a deletion root, since `<cwd>/.codex` rides Codex's trust-gated project config.

## Sync hardening

Sync now fails closed where it matters. If outdated mirrored skills can't be removed from the session directory, the assistant refuses to launch and shows a retryable error (`USER_CONTENT_SYNC_FAILED`) instead of silently running stale instructions. Broken new skills are just skipped with a log, since launching without them is harmless.

A few more cases in the same bucket: corrupt or unsupported manifests fail closed rather than orphaning managed files, successfully removed paths are retired from the manifest so a hand-placed file at the same path is never claimed later, and case-insensitive filename collisions on macOS are collapsed deterministically so a case-only skill rename can't wedge provisioning.

## contextBridge error codes fix

While wiring the new error I found that the typed codes on `HelpSessionError` were being stripped crossing Electron's contextBridge, so the renderer never actually saw them and always fell back to the generic error copy. Even the existing MCP error branches were dead in production. Fixed with the same encoded-prefix pattern we already use for `AppError`, decoded by the new `clientHelpSessionError.ts`.

## Other notes

* Around 60 new unit tests across the mirror, provisioning, the banners, and the error codec
* `docs/assistant-custom-commands.md` rewritten for the new lanes, precedence, and the fail-closed policy
* The authoring folder now scaffolds `.codex/skills`, and the settings section is retitled "Custom commands and skills"