### PR TITLE
feat(update): link the release notes from the Update ready toast

### DIFF
--- a/src/hooks/__tests__/useUpdateListener.test.tsx
+++ b/src/hooks/__tests__/useUpdateListener.test.tsx
@@ -304,10 +304,9 @@ describe("useUpdateListener", () => {
     });
 
     const patch = updateNotificationMock.mock.calls[0]![1];
-    // Restart stays the single primary CTA in the singular `action` slot; the
-    // release-notes link rides `actions[]`, which the toaster renders to its
-    // left as muted secondary text.
-    expect(patch.action).toEqual(expect.objectContaining({ label: "Restart to update" }));
+    // Restart stays the single primary CTA in the singular `action` slot (asserted
+    // by the preceding test); the release-notes link rides `actions[]`, which the
+    // toaster renders to its left as muted secondary text.
     expect(patch.actions).toHaveLength(1);
 
     const notes = patch.actions![0]!;
@@ -325,6 +324,30 @@ describe("useUpdateListener", () => {
     expect(openExternalMock).toHaveBeenCalledWith(
       "https://github.com/daintreehq/daintree/releases/tag/v2.5.0"
     );
+  });
+
+  it("strips both update controls when progress lands on a ready toast", () => {
+    renderHook(() => useUpdateListener());
+
+    act(() => {
+      capturedAvailable!({ version: "2.5.0" });
+    });
+    act(() => {
+      capturedDownloaded!({ version: "2.5.0" });
+    });
+
+    // A newer build starts downloading. surfaceAvailable() would normally clear
+    // both controls, but notify() drops the payload while suppressed, so the
+    // progress patch is the backstop: a download in flight means there is
+    // nothing ready to install and no notes worth linking.
+    act(() => {
+      capturedProgress!({ percent: 12 });
+    });
+
+    const progressPatch = updateNotificationMock.mock.calls.at(-1)![1];
+    expect(progressPatch.title).toBe("Downloading update");
+    expect(progressPatch).toHaveProperty("action", undefined);
+    expect(progressPatch).toHaveProperty("actions", undefined);
   });
 
   it("skips progress when toast was not created (quiet period)", () => {

--- a/src/hooks/__tests__/useUpdateListener.test.tsx
+++ b/src/hooks/__tests__/useUpdateListener.test.tsx
@@ -79,6 +79,7 @@ const cleanupAvailable = vi.fn();
 const cleanupProgress = vi.fn();
 const cleanupDownloaded = vi.fn();
 const notifyDismissMock = vi.fn().mockResolvedValue(undefined);
+const openExternalMock = vi.fn<(url: string) => Promise<void>>().mockResolvedValue(undefined);
 
 type UpdateStage = { version: string; downloaded: boolean };
 
@@ -148,6 +149,7 @@ describe("useUpdateListener", () => {
       return id;
     });
     notifyDismissMock.mockClear();
+    openExternalMock.mockClear();
     // Nothing pending is the default; the hydration tests opt in.
     getLatestMock.mockReset().mockResolvedValue(null);
 
@@ -169,6 +171,9 @@ describe("useUpdateListener", () => {
         checkForUpdates: vi.fn(),
         notifyDismiss: notifyDismissMock,
         getLatest: getLatestMock,
+      },
+      system: {
+        openExternal: openExternalMock,
       },
     } as unknown as typeof window.electron;
   });
@@ -287,6 +292,41 @@ describe("useUpdateListener", () => {
     expect(window.electron.update.quitAndInstall).toHaveBeenCalledTimes(1);
   });
 
+  it("offers release notes for the downloaded version alongside the restart action", () => {
+    renderHook(() => useUpdateListener());
+
+    act(() => {
+      capturedAvailable!({ version: "2.5.0" });
+    });
+
+    act(() => {
+      capturedDownloaded!({ version: "2.5.0" });
+    });
+
+    const patch = updateNotificationMock.mock.calls[0]![1];
+    // Restart stays the single primary CTA in the singular `action` slot; the
+    // release-notes link rides `actions[]`, which the toaster renders to its
+    // left as muted secondary text.
+    expect(patch.action).toEqual(expect.objectContaining({ label: "Restart to update" }));
+    expect(patch.actions).toHaveLength(1);
+
+    const notes = patch.actions![0]!;
+    expect(notes.label).toBe("View release notes");
+    expect(notes.variant).toBe("secondary");
+    // actionId + actionArgs are what keep the button alive in inbox history —
+    // notify.ts drops actions that carry no actionId.
+    expect(notes.actionId).toBe("system.openExternal");
+    // The updater reports bare semver; the GitHub tag carries a leading `v`.
+    expect(notes.actionArgs).toEqual({
+      url: "https://github.com/daintreehq/daintree/releases/tag/v2.5.0",
+    });
+
+    notes.onClick();
+    expect(openExternalMock).toHaveBeenCalledWith(
+      "https://github.com/daintreehq/daintree/releases/tag/v2.5.0"
+    );
+  });
+
   it("skips progress when toast was not created (quiet period)", () => {
     // Simulate quiet hours — non-urgent notify() calls are suppressed.
     notifyMock.mockImplementation((payload) => {
@@ -349,6 +389,19 @@ describe("useUpdateListener", () => {
         urgent: true,
         duration: 0,
         action: expect.objectContaining({ label: "Restart to update" }),
+        // The fresh-toast branch is the one that writes an inbox entry, so the
+        // release-notes link has to ride this payload too — not just the
+        // in-place update path.
+        actions: [
+          expect.objectContaining({
+            label: "View release notes",
+            variant: "secondary",
+            actionId: "system.openExternal",
+            actionArgs: {
+              url: "https://github.com/daintreehq/daintree/releases/tag/v2.5.0",
+            },
+          }),
+        ],
       })
     );
   });
@@ -492,7 +545,7 @@ describe("useUpdateListener", () => {
     expect(notifyDismissMock).not.toHaveBeenCalled();
   });
 
-  it("clears the restart action when update-available fires after update-ready (stage regression)", () => {
+  it("clears both update controls when update-available fires after update-ready (stage regression)", () => {
     renderHook(() => useUpdateListener());
 
     // Notify calls pass `action: undefined` explicitly so the store's
@@ -503,6 +556,9 @@ describe("useUpdateListener", () => {
       capturedAvailable!({ version: "2.5.0" });
     });
     expect(notifyMock.mock.calls[0]![0]).toHaveProperty("action", undefined);
+    // Same reasoning for the release-notes link: left in place it would point
+    // at the superseded version's tag while a newer build downloads.
+    expect(notifyMock.mock.calls[0]![0]).toHaveProperty("actions", undefined);
   });
 
   it("pending ref upgrades to downloaded but never downgrades back to available", () => {

--- a/src/hooks/useUpdateListener.tsx
+++ b/src/hooks/useUpdateListener.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useNotificationStore } from "@/store/notificationStore";
+import { useNotificationStore, type NotificationAction } from "@/store/notificationStore";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -7,6 +7,7 @@ import { useDistributionStore } from "@/store/distributionStore";
 
 const AVAILABLE_HINT = 'Use "Check for Updates..." to check again.';
 const UPDATE_CORRELATION_ID = "app-update";
+const RELEASE_NOTES_BASE_URL = "https://github.com/daintreehq/daintree/releases/tag";
 
 /** The stage of the update the user is currently being told about. */
 type UpdateStage = { version: string; downloaded: boolean };
@@ -45,6 +46,29 @@ function restartAction() {
   };
 }
 
+function releaseNotesAction(version: string): NotificationAction {
+  // `version` arrives as bare semver from the updater (AutoUpdaterService
+  // normalizes via semver.valid), while GitHub tags carry a leading `v`.
+  const url = `${RELEASE_NOTES_BASE_URL}/v${version}`;
+  return {
+    label: "View release notes",
+    // Secondary keeps "Restart to update" the single load-bearing CTA — this is
+    // an informational escape hatch, not a competing decision.
+    variant: "secondary",
+    // actionId + actionArgs (not bare onClick) so the button survives the
+    // inbox-history filter in notify.ts — actions without an actionId are
+    // silently dropped, leaving history text with no way to act on it.
+    actionId: "system.openExternal",
+    actionArgs: { url },
+    onClick: () => {
+      const promise = window.electron?.system?.openExternal(url);
+      if (promise) {
+        safeFireAndForget(promise, { context: "Open release notes" });
+      }
+    },
+  };
+}
+
 function surfaceAvailable(version: string): void {
   // Repeats and re-checks collapse onto the same toast via correlationId; no
   // bespoke dedup ref needed. The store's collapse path resets the auto-dismiss
@@ -60,8 +84,10 @@ function surfaceAvailable(version: string): void {
     // Explicit undefined: if a prior "Update ready" toast is live (stage
     // regression), clear its "Restart to update" action so the user does not
     // accidentally restart into a stale build while a newer one is still
-    // downloading.
+    // downloading, and clear its "View release notes" link so it cannot point
+    // at the superseded version's tag.
     action: undefined,
+    actions: undefined,
     // Forwarded to main only when the user explicitly closes the toast —
     // MAX_VISIBLE_TOASTS eviction and programmatic dismissals bypass this.
     onDismiss: () => {
@@ -88,6 +114,7 @@ function surfaceDownloaded(version: string): void {
       dismissed: false,
       onDismiss: undefined,
       action: restartAction(),
+      actions: [releaseNotesAction(version)],
     });
     return;
   }
@@ -108,6 +135,7 @@ function surfaceDownloaded(version: string): void {
     duration: 0,
     correlationId: UPDATE_CORRELATION_ID,
     action: restartAction(),
+    actions: [releaseNotesAction(version)],
   });
 }
 

--- a/src/hooks/useUpdateListener.tsx
+++ b/src/hooks/useUpdateListener.tsx
@@ -47,9 +47,12 @@ function restartAction() {
 }
 
 function releaseNotesAction(version: string): NotificationAction {
-  // `version` arrives as bare semver from the updater (AutoUpdaterService
-  // normalizes via semver.valid), while GitHub tags carry a leading `v`.
-  const url = `${RELEASE_NOTES_BASE_URL}/v${version}`;
+  // `version` arrives as bare semver from the updater while GitHub tags carry a
+  // leading `v`. It is NOT pre-validated: AutoUpdaterService runs semver.valid
+  // only to gate the persisted pendingUpdateVersion and broadcasts the raw
+  // string, so encode it as a single path segment — a stray `/`, `?` or `#`
+  // would otherwise retarget the URL elsewhere on github.com.
+  const url = `${RELEASE_NOTES_BASE_URL}/v${encodeURIComponent(version)}`;
   return {
     label: "View release notes",
     // Secondary keeps "Restart to update" the single load-bearing CTA — this is
@@ -205,6 +208,14 @@ export function useUpdateListener(suppressToasts = false): void {
         title: "Downloading update",
         message: <DownloadProgress percent={info.percent} />,
         inboxMessage: `Downloading update: ${Math.round(info.percent)}%`,
+        // A download in flight means there is nothing ready to install, so
+        // neither control can be valid here. surfaceAvailable() normally clears
+        // them on the stage regression, but it routes through notify(), which
+        // drops the payload entirely while suppressed (quiet hours, blurred,
+        // rate-limited). Without this the previous version's restart button and
+        // release-notes link ride along onto the downloading toast.
+        action: undefined,
+        actions: undefined,
       });
     });
 

--- a/src/lib/__tests__/notify.routing-and-defaults.test.ts
+++ b/src/lib/__tests__/notify.routing-and-defaults.test.ts
@@ -372,32 +372,6 @@ describe("notify()", () => {
       expect(entry!.actions![0]!.actionArgs).toEqual({ panelId: "p2" });
       expect(entry!.actions![1]!.actionArgs).toEqual({ panelId: "p1" });
     });
-  });
-
-  describe("transient — toast only, no inbox entry", () => {
-    it("skips history entry when transient is true", () => {
-      vi.spyOn(document, "hasFocus").mockReturnValue(true);
-      notify({
-        type: "info",
-        title: "Path copied",
-        message: "/Users/me/project",
-        transient: true,
-      });
-      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
-      expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
-    });
-
-    it("still shows the toast when transient is true", () => {
-      vi.spyOn(document, "hasFocus").mockReturnValue(true);
-      notify({
-        type: "success",
-        title: "Shortcuts exported",
-        message: "Saved.",
-        transient: true,
-      });
-      expect(useNotificationStore.getState().notifications).toHaveLength(1);
-      expect(useNotificationStore.getState().notifications[0]!.historyEntryId).toBeUndefined();
-    });
 
     it("forwards an explicit `actions: undefined` through to the store's collapse clear", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
@@ -425,6 +399,32 @@ describe("notify()", () => {
       const live = useNotificationStore.getState().notifications;
       expect(live).toHaveLength(1);
       expect(live[0]!.actions).toBeUndefined();
+    });
+  });
+
+  describe("transient — toast only, no inbox entry", () => {
+    it("skips history entry when transient is true", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        title: "Path copied",
+        message: "/Users/me/project",
+        transient: true,
+      });
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+    });
+
+    it("still shows the toast when transient is true", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "success",
+        title: "Shortcuts exported",
+        message: "Saved.",
+        transient: true,
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationStore.getState().notifications[0]!.historyEntryId).toBeUndefined();
     });
 
     it("skips history for grid-bar placement when transient", () => {

--- a/src/lib/__tests__/notify.routing-and-defaults.test.ts
+++ b/src/lib/__tests__/notify.routing-and-defaults.test.ts
@@ -375,6 +375,7 @@ describe("notify()", () => {
 
     it("forwards an explicit `actions: undefined` through to the store's collapse clear", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      // eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok
       notify({
         type: "success",
         title: "Update ready",
@@ -383,6 +384,7 @@ describe("notify()", () => {
         duration: 0,
         actions: [{ label: "View release notes", onClick: () => {} }],
       });
+      // eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok
       notify({
         type: "info",
         title: "Update available",

--- a/src/lib/__tests__/notify.routing-and-defaults.test.ts
+++ b/src/lib/__tests__/notify.routing-and-defaults.test.ts
@@ -399,6 +399,34 @@ describe("notify()", () => {
       expect(useNotificationStore.getState().notifications[0]!.historyEntryId).toBeUndefined();
     });
 
+    it("forwards an explicit `actions: undefined` through to the store's collapse clear", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "success",
+        title: "Update ready",
+        message: "Version 2.5.0 is ready to install.",
+        correlationId: "collapse-clear",
+        duration: 0,
+        actions: [{ label: "View release notes", onClick: () => {} }],
+      });
+      notify({
+        type: "info",
+        title: "Update available",
+        message: "Version 2.5.1 is downloading...",
+        correlationId: "collapse-clear",
+        duration: 0,
+        actions: undefined,
+      });
+
+      // The store's clear branch keys off `"actions" in payload`, so this only
+      // works if notify() forwards an own key whose value is undefined. A future
+      // normalization that strips undefined fields would silently resurrect
+      // stale actions while the hook and store unit tests both stayed green.
+      const live = useNotificationStore.getState().notifications;
+      expect(live).toHaveLength(1);
+      expect(live[0]!.actions).toBeUndefined();
+    });
+
     it("skips history for grid-bar placement when transient", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       notify({

--- a/src/store/__tests__/notificationStore.adversarial.test.ts
+++ b/src/store/__tests__/notificationStore.adversarial.test.ts
@@ -329,20 +329,6 @@ describe("notificationStore adversarial", () => {
     expect(n.actions).toBeUndefined();
   });
 
-  it("omitting `actions` entirely preserves the existing array", () => {
-    const id = addToast({
-      correlationId: "entity-a",
-      message: "m",
-      actions: [{ label: "Retry", onClick: () => {} }],
-    });
-
-    addToast({ correlationId: "entity-a", message: "m2" });
-
-    const n = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
-    expect(n.actions).toHaveLength(1);
-    expect(n.actions![0]!.label).toBe("Retry");
-  });
-
   it("collapse does not re-trigger FIFO even when the cap is at the edge", () => {
     // Fill the cap with three distinct entities
     addToast({ correlationId: "entity-a", message: "a" });

--- a/src/store/__tests__/notificationStore.adversarial.test.ts
+++ b/src/store/__tests__/notificationStore.adversarial.test.ts
@@ -312,6 +312,37 @@ describe("notificationStore adversarial", () => {
     expect(n.actions![0]!.label).toBe("Retry");
   });
 
+  it("explicit `actions: undefined` clears the array (stage-regression escape hatch)", () => {
+    const id = addToast({
+      correlationId: "entity-a",
+      message: "m",
+      actions: [{ label: "View release notes", onClick: () => {} }],
+    });
+
+    // Distinct from the empty-array case above: passing the key with an
+    // explicit undefined is the caller saying "wipe what's there", mirroring
+    // the singular `action` slot. Update Ready → Update Available relies on
+    // this so a superseded version's link cannot linger.
+    addToast({ correlationId: "entity-a", message: "m2", actions: undefined });
+
+    const n = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(n.actions).toBeUndefined();
+  });
+
+  it("omitting `actions` entirely preserves the existing array", () => {
+    const id = addToast({
+      correlationId: "entity-a",
+      message: "m",
+      actions: [{ label: "Retry", onClick: () => {} }],
+    });
+
+    addToast({ correlationId: "entity-a", message: "m2" });
+
+    const n = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(n.actions).toHaveLength(1);
+    expect(n.actions![0]!.label).toBe("Retry");
+  });
+
   it("collapse does not re-trigger FIFO even when the cap is at the edge", () => {
     // Fill the cap with three distinct entities
     addToast({ correlationId: "entity-a", message: "a" });

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -208,6 +208,17 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
           // onto a downloading-again state. Unset keys still preserve the
           // existing action (the default "missing = preserve" semantic).
           const actionResolved = "action" in notification ? notification.action : liveMatch.action;
+          // `actions` is tri-state, mirroring `action`'s explicit-clear escape
+          // hatch: an explicit `actions: undefined` clears the slot (same stage
+          // regression rationale as above), while an omitted key or an empty
+          // array still preserves the existing array — callers that pass `[]`
+          // mean "I have no actions to contribute", not "wipe the ones there".
+          const actionsResolved =
+            "actions" in notification && notification.actions === undefined
+              ? undefined
+              : incomingHasActions
+                ? notification.actions
+                : liveMatch.actions;
           const messageChanged = !messagesEqual(notification.message, liveMatch.message);
           return {
             notifications: state.notifications.map((n) =>
@@ -221,7 +232,7 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
                     inboxMessage: notification.inboxMessage ?? n.inboxMessage,
                     duration: notification.duration ?? n.duration,
                     action: actionResolved,
-                    actions: incomingHasActions ? notification.actions : n.actions,
+                    actions: actionsResolved,
                     onDismiss: notification.onDismiss ?? n.onDismiss,
                     historyEntryId: notification.historyEntryId ?? n.historyEntryId,
                     count: (n.count ?? 1) + 1,


### PR DESCRIPTION
## Summary

- The "Update ready" toast only offered `Restart to update`, with no way to see what changed first. It now carries a secondary `View release notes` action linking to the GitHub release page for the downloaded version's tag.
- `Restart to update` stays in the notification's singular `action` slot as the one primary CTA. The release notes link rides `actions[]`, which the toaster renders to its left as muted secondary text.
- Supporting change in `notificationStore.ts` so a stage regression can't strand a stale release notes link on the toast.

Resolves #11261

## Changes

The split between `action` and `actions[]` isn't stylistic. `surfaceAvailable()` in `src/hooks/useUpdateListener.tsx` clears the singular `action` on a stage regression, so a user is never offered a restart into a superseded build. Moving restart into `actions[]` would quietly break that guard, so it stays put and the release notes link goes in the secondary array instead.

The link reuses the existing `system.openExternal` action, so it routes through the existing protocol allowlist and no new IPC surface gets added. It carries `actionId` and `actionArgs` (not a bare `onClick`) because `notify.ts` drops actions without an `actionId` from inbox history.

In `src/store/notificationStore.ts`, the correlated-collapse merge now treats `actions` as tri-state, mirroring the escape hatch `action` already had: an explicit `actions: undefined` clears the slot, while an omitted key or an empty array still preserves the existing array. Without this, a stage regression could leave a release notes link pointing at a version that's no longer the one downloaded. No existing caller passes an empty or undefined `actions` on a correlated payload, so this doesn't change behaviour anywhere else, and the `[]`-preserves case was already pinned by an existing adversarial test.

Two things worth flagging honestly:

1. The release notes link assumes a published GitHub Release exists for the tag. That's a manual step in the release process (`gh release create`), not something CI enforces since the release workflows only publish build artifacts to R2. It's held for the last 15 releases, but skip that step and the link 404s.
2. There's a pre-existing gap this doesn't fully close. `surfaceAvailable()` clears stale controls through `notify()`, which drops the payload entirely when the app is quiet, blurred, or rate-limited. The download-progress handler now clears both slots as a backstop, covering any regression that actually starts downloading, but a stage regression whose download fails before emitting a single progress event can still leave stale controls on the toast. That path already stranded the restart button before this change. Closing it properly means restructuring the update stage state machine, which is out of scope here.

## Testing

484 targeted tests pass across 13 files: update listener, notification store plus adversarial, all five notify suites, toaster, grid notification bar, forge recommendation, agent waiting nudge.

New coverage: the release notes action on both `surfaceDownloaded` branches including the `openExternal` fallback and the v-prefixed tag URL, the progress patch stripping both controls, the explicit-undefined clear at the store level and through the real `notify()` boundary, and the stage regression clearing both slots. Removed two assertions that passed before this change (one duplicated an existing store test, one duplicated the adjacent restart test).

Prettier is clean and eslint shows 0 errors on all 5 changed files, with 0 per-rule ratchet delta.
