### PR TITLE
fix(sidebar): merge the deleted-worktree separator and countdown into one rule

### DIFF
--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -242,17 +242,24 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
         />
       </div>
       {/* The row separator and the countdown are one element, not two stacked
-          ones (#11262). A `border-b` on this card would paint at the border-box
-          edge while an absolutely positioned bar resolves `bottom-0` against
-          the *padding* edge — offset by exactly the border width, which read as
-          a doubled rule. So the track below owns the bottom edge outright: it
-          is the separator when unarmed, and the fill drains along it when
-          armed. Nudging the bar by a negative offset instead would only line up
+          ones (#11262). A `border-b` on this card paints at the border-box edge
+          while an absolutely positioned bar resolves `bottom-0` against the
+          *padding* edge — offset by exactly the border width, which read as a
+          doubled rule. So this track owns the bottom edge outright: it is the
+          separator when unarmed, and the fill drains along it when armed.
+          Nudging the bar by a negative offset instead would only line up
           coincidentally, and re-break under sub-pixel rounding at fractional
-          DPR. */}
+          DPR.
+
+          It sits behind the interaction plane (`-z-10`, contained by the root's
+          `isolate`) so it can't clip the overlay button's inset focus ring the
+          way a `z-10` track did along the bottom edge; it still paints above
+          the card's own background, and the content div carries none of its
+          own. No `title` either: a 1px decorative strip is an unhittable hover
+          target, and the seconds readout in the header already owns that
+          tooltip. */}
       <div
-        className="deleted-worktree-separator absolute inset-x-0 bottom-0 z-10 h-px bg-border-default"
-        title={hasCountdown ? `Closes automatically in ${remainingSeconds}s` : undefined}
+        className="deleted-worktree-separator pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-px bg-border-default"
         data-testid="deleted-worktree-separator"
         aria-hidden="true"
       >

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -251,15 +251,19 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
           coincidentally, and re-break under sub-pixel rounding at fractional
           DPR.
 
-          It sits behind the interaction plane (`-z-10`, contained by the root's
-          `isolate`) so it can't clip the overlay button's inset focus ring the
-          way a `z-10` track did along the bottom edge; it still paints above
-          the card's own background, and the content div carries none of its
-          own. No `title` either: a 1px decorative strip is an unhittable hover
-          target, and the seconds readout in the header already owns that
+          It stays above the interaction plane on purpose. Behind it (`-z-10`)
+          the overlay button's bottom edge would cover it in contrast modes,
+          where every button picks up a 1px/2px border (`src/index.css`
+          forced-colors and prefers-contrast blocks) — the separator would
+          disappear for exactly the users the forced-colors fallback below is
+          meant to serve. The cost is that it clips the outermost pixel of that
+          button's inset focus ring along the bottom; the ring stays visible on
+          all four sides, and the armed countdown already did this before
+          #11262. No `title` either: a 1px decorative strip is an unhittable
+          hover target, and the seconds readout in the header already owns that
           tooltip. */}
       <div
-        className="deleted-worktree-separator pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-px bg-border-default"
+        className="deleted-worktree-separator pointer-events-none absolute inset-x-0 bottom-0 z-10 h-px bg-border-default"
         data-testid="deleted-worktree-separator"
         aria-hidden="true"
       >

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -54,9 +54,10 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
   const { counts, terminals } = useWorktreeTerminals(worktree.id);
 
   // Auto-cleanup countdown (deletedWorktreeCleanup.ts owns the deadline; this
-  // is display only): a numeric seconds readout in the header plus a depleting
-  // bar along the bottom edge. Both hold at full while the sweep defers the
-  // deadline (drag in progress, agent still working, confirm dialog open).
+  // is display only): a numeric seconds readout in the header plus the row's
+  // own bottom separator draining from full width to empty. Both hold at full
+  // while the sweep defers the deadline (drag in progress, agent still
+  // working, confirm dialog open).
   const cleanupSeconds = usePreferencesStore((s) => s.deletedWorktreeCleanupSeconds);
   const [nowTick, setNowTick] = useState(() => Date.now());
   const expiresAt = worktree.expiresAt;
@@ -154,7 +155,7 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
   return (
     <div
       data-deleted-worktree-id={worktree.id}
-      className="sidebar-worktree-card group/card relative isolate transition-colors duration-150 border-b border-border-default"
+      className="sidebar-worktree-card group/card relative isolate transition-colors duration-150"
       data-active={isActive ? "true" : undefined}
       data-hoverable={!isActive ? "true" : undefined}
       aria-label={`Deleted worktree: ${worktree.title}`}
@@ -240,19 +241,29 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
           onTerminalSelect={handleTerminalSelect}
         />
       </div>
-      {hasCountdown && (
-        <div
-          className="absolute inset-x-0 bottom-0 z-10 h-[2px]"
-          title={`Closes automatically in ${remainingSeconds}s`}
-          data-testid="deleted-worktree-countdown"
-          aria-hidden="true"
-        >
+      {/* The row separator and the countdown are one element, not two stacked
+          ones (#11262). A `border-b` on this card would paint at the border-box
+          edge while an absolutely positioned bar resolves `bottom-0` against
+          the *padding* edge — offset by exactly the border width, which read as
+          a doubled rule. So the track below owns the bottom edge outright: it
+          is the separator when unarmed, and the fill drains along it when
+          armed. Nudging the bar by a negative offset instead would only line up
+          coincidentally, and re-break under sub-pixel rounding at fractional
+          DPR. */}
+      <div
+        className="deleted-worktree-separator absolute inset-x-0 bottom-0 z-10 h-px bg-border-default"
+        title={hasCountdown ? `Closes automatically in ${remainingSeconds}s` : undefined}
+        data-testid="deleted-worktree-separator"
+        aria-hidden="true"
+      >
+        {hasCountdown && (
           <div
-            className="h-full bg-border-strong transition-[width] duration-1000 ease-linear motion-reduce:transition-none"
+            className="deleted-worktree-countdown-fill h-full bg-border-strong transition-[width] duration-1000 ease-linear motion-reduce:transition-none"
             style={{ width: `${remainingFraction * 100}%` }}
+            data-testid="deleted-worktree-countdown"
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -65,13 +65,18 @@ function setPanels(
   });
 }
 
-// Classifies Tailwind bottom-border utilities (`border-b`, `border-b-2`, and
-// any variant-prefixed form like `hover:border-b`) rather than matching the
+// Classifies Tailwind bottom-border *width* utilities (`border-b`, `border-b-2`,
+// and variant-prefixed forms like `hover:border-b`) rather than matching the
 // class string, so the check keeps working as unrelated classes come and go.
+// `border-b-0` is excluded because it removes the border rather than painting
+// one, as are colour-only utilities like `border-b-border-default`.
 function hasBottomBorderUtility(element: Element): boolean {
   return [...element.classList].some((className) => {
     const utility = className.split(":").at(-1);
-    return utility === "border-b" || utility?.startsWith("border-b-") === true;
+    if (utility === "border-b") return true;
+    const width =
+      utility?.startsWith("border-b-") === true ? utility.slice("border-b-".length) : "";
+    return /^\d+$/.test(width) && width !== "0";
   });
 }
 
@@ -152,12 +157,8 @@ describe("DeletedWorktreeCard", () => {
     expect(selectWorktree).toHaveBeenCalledWith("wt-1", { source: "focus" });
   });
 
-  it("shows the auto-cleanup countdown bar when a deadline is armed", () => {
-    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
-    const { container } = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
-
-    expect(container.querySelector("[data-testid='deleted-worktree-countdown']")).toBeTruthy();
-  });
+  // Armed presence is owned by the bottom-edge-ownership block below, which
+  // asserts the same thing plus where the fill sits in the tree.
 
   it("shows the seconds readout next to the close button while armed", () => {
     setPanels([{ id: "t1", worktreeId: "wt-1" }]);
@@ -237,29 +238,66 @@ describe("DeletedWorktreeCard", () => {
       });
     }
 
-    it("exposes the countdown tooltip on the full-width track only while armed", () => {
+    it("keeps the track decorative rather than a second tooltip target", () => {
       setPanels([{ id: "t1", worktreeId: "wt-1" }]);
-      const armed = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
-      const armedSeparator = armed.container.querySelector(
-        "[data-testid='deleted-worktree-separator']"
-      );
-      // The tooltip belongs to the track, not the fill — on the fill the hover
-      // target would shrink as the countdown drains.
-      expect(armedSeparator?.getAttribute("title")).toMatch(/^Closes automatically in \d+s$/);
-      expect(
-        armed.container
-          .querySelector("[data-testid='deleted-worktree-countdown']")
-          ?.hasAttribute("title")
-      ).toBe(false);
-      cleanup();
+      const { container } = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
 
-      const unarmed = renderCard();
-      // Unarmed the track is just a separator, so it must not claim a tooltip.
+      const separator = container.querySelector("[data-testid='deleted-worktree-separator']");
+      // A 1px strip is an unhittable hover target, and the seconds readout in
+      // the header already carries the tooltip — a title here would be dead
+      // weight that screen readers skip anyway.
+      expect(separator?.getAttribute("aria-hidden")).toBe("true");
+      expect(separator?.hasAttribute("title")).toBe(false);
       expect(
-        unarmed.container
-          .querySelector("[data-testid='deleted-worktree-separator']")
-          ?.hasAttribute("title")
+        container.querySelector("[data-testid='deleted-worktree-countdown']")?.hasAttribute("title")
       ).toBe(false);
+      // The readout keeps its own tooltip, so the information is not lost.
+      expect(
+        container
+          .querySelector("[data-testid='deleted-worktree-countdown-seconds']")
+          ?.getAttribute("title")
+      ).toContain("Closes automatically");
+    });
+  });
+
+  // The fill's width is the only thing that makes the separator read as a
+  // countdown, and `remainingFraction` is not a straight ratio: it clamps to
+  // the configured TTL (the sweep re-extends the deadline out of phase with
+  // this component's tick) and snaps the top ~1.5s to exactly full so a
+  // deferred countdown holds steady instead of sawtoothing. Assert the
+  // computed width, since every structural test above passes even if the fill
+  // is permanently stuck at 0% or 100%.
+  describe("countdown fill width", () => {
+    function fillWidth(expiresAt: number, cleanupSeconds = 60): string | undefined {
+      setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+      usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: cleanupSeconds });
+      const { container } = renderCard({ ...worktree, expiresAt });
+      const fill = container.querySelector<HTMLElement>(
+        "[data-testid='deleted-worktree-countdown']"
+      );
+      return fill?.style.width;
+    }
+
+    it("holds at full while the sweep defers the deadline past the TTL", () => {
+      // Deadline beyond the TTL: the clamp must cap this at 100%, not overflow.
+      expect(fillWidth(Date.now() + 90_000)).toBe("100%");
+    });
+
+    it("snaps the opening moments to exactly full so a paused bar holds steady", () => {
+      // Inside the ~1.5s snap window — a raw ratio would render just under 100%.
+      expect(fillWidth(Date.now() + 59_200)).toBe("100%");
+    });
+
+    it("tracks the remaining fraction once the countdown is clear of the snap", () => {
+      const width = fillWidth(Date.now() + 30_000);
+      const percent = Number.parseFloat(width ?? "");
+      // Tolerance absorbs the ms that elapse between arming and asserting.
+      expect(percent).toBeGreaterThan(48);
+      expect(percent).toBeLessThan(52);
+    });
+
+    it("drains to empty once the deadline has passed", () => {
+      expect(fillWidth(Date.now() - 5_000)).toBe("0%");
     });
   });
 

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -74,9 +74,12 @@ function hasBottomBorderUtility(element: Element): boolean {
   return [...element.classList].some((className) => {
     const utility = className.split(":").at(-1);
     if (utility === "border-b") return true;
-    const width =
-      utility?.startsWith("border-b-") === true ? utility.slice("border-b-".length) : "";
-    return /^\d+$/.test(width) && width !== "0";
+    if (utility?.startsWith("border-b-") !== true) return false;
+    const value = utility.slice("border-b-".length);
+    // Arbitrary widths (`border-b-[1px]`) paint a rule of their own; arbitrary
+    // colours (`border-b-[#fff]`) only tint one some width utility declared.
+    if (value.startsWith("[")) return !value.startsWith("[#");
+    return /^\d+$/.test(value) && value !== "0";
   });
 }
 
@@ -268,19 +271,30 @@ describe("DeletedWorktreeCard", () => {
   // computed width, since every structural test above passes even if the fill
   // is permanently stuck at 0% or 100%.
   describe("countdown fill width", () => {
-    function fillWidth(expiresAt: number, cleanupSeconds = 60): string | undefined {
+    function renderArmed(expiresAt: number, cleanupSeconds = 60) {
       setPanels([{ id: "t1", worktreeId: "wt-1" }]);
       usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: cleanupSeconds });
       const { container } = renderCard({ ...worktree, expiresAt });
-      const fill = container.querySelector<HTMLElement>(
-        "[data-testid='deleted-worktree-countdown']"
-      );
-      return fill?.style.width;
+      return {
+        width: container.querySelector<HTMLElement>("[data-testid='deleted-worktree-countdown']")
+          ?.style.width,
+        readout: container.querySelector("[data-testid='deleted-worktree-countdown-seconds']")
+          ?.textContent,
+      };
+    }
+
+    function fillWidth(expiresAt: number, cleanupSeconds = 60): string | undefined {
+      return renderArmed(expiresAt, cleanupSeconds).width;
     }
 
     it("holds at full while the sweep defers the deadline past the TTL", () => {
-      // Deadline beyond the TTL: the clamp must cap this at 100%, not overflow.
-      expect(fillWidth(Date.now() + 90_000)).toBe("100%");
+      // The sweep re-extends the deadline out of phase with this component's
+      // tick, so a deadline beyond the TTL is normal and must read as full.
+      // Assert the readout too: the width alone can't distinguish the clamp
+      // from the snap-to-full branch, which would also yield 100% here.
+      const { width, readout } = renderArmed(Date.now() + 90_000);
+      expect(width).toBe("100%");
+      expect(readout).toBe("60s");
     });
 
     it("snaps the opening moments to exactly full so a paused bar holds steady", () => {

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@/components/Terminal/TerminalIcon", () => ({
 }));
 
 import { usePanelStore } from "@/store/panelStore";
-import { usePreferencesStore } from "@/store/preferencesStore";
+import { usePreferencesStore, type DeletedWorktreeCleanupSeconds } from "@/store/preferencesStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
 import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -192,7 +192,12 @@ describe("DeletedWorktreeCard", () => {
   // it rather than beside it. jsdom can't measure the overlap that caused the
   // bug, so we assert the arrangement that makes it unrepresentable.
   describe("bottom-edge ownership (#11262)", () => {
-    const bottomEdgeStates = [
+    const bottomEdgeStates: Array<{
+      name: string;
+      wt: DeletedWorktree;
+      cleanupSeconds: DeletedWorktreeCleanupSeconds;
+      armed: boolean;
+    }> = [
       { name: "unarmed", wt: worktree, cleanupSeconds: 60, armed: false },
       {
         name: "armed",
@@ -271,7 +276,7 @@ describe("DeletedWorktreeCard", () => {
   // computed width, since every structural test above passes even if the fill
   // is permanently stuck at 0% or 100%.
   describe("countdown fill width", () => {
-    function renderArmed(expiresAt: number, cleanupSeconds = 60) {
+    function renderArmed(expiresAt: number, cleanupSeconds: DeletedWorktreeCleanupSeconds = 60) {
       setPanels([{ id: "t1", worktreeId: "wt-1" }]);
       usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: cleanupSeconds });
       const { container } = renderCard({ ...worktree, expiresAt });
@@ -283,7 +288,10 @@ describe("DeletedWorktreeCard", () => {
       };
     }
 
-    function fillWidth(expiresAt: number, cleanupSeconds = 60): string | undefined {
+    function fillWidth(
+      expiresAt: number,
+      cleanupSeconds: DeletedWorktreeCleanupSeconds = 60
+    ): string | undefined {
       return renderArmed(expiresAt, cleanupSeconds).width;
     }
 

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -65,6 +65,16 @@ function setPanels(
   });
 }
 
+// Classifies Tailwind bottom-border utilities (`border-b`, `border-b-2`, and
+// any variant-prefixed form like `hover:border-b`) rather than matching the
+// class string, so the check keeps working as unrelated classes come and go.
+function hasBottomBorderUtility(element: Element): boolean {
+  return [...element.classList].some((className) => {
+    const utility = className.split(":").at(-1);
+    return utility === "border-b" || utility?.startsWith("border-b-") === true;
+  });
+}
+
 function renderCard(wt: DeletedWorktree = worktree) {
   return render(
     <TooltipProvider>
@@ -168,6 +178,89 @@ describe("DeletedWorktreeCard", () => {
     usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
     const off = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
     expect(off.container.querySelector("[data-testid='deleted-worktree-countdown']")).toBeNull();
+  });
+
+  // #11262: the card used to carry a `border-b` *and* an absolutely positioned
+  // countdown bar. `bottom-0` resolves against the padding edge, so the bar
+  // landed one border-width above the border and the two painted as a doubled
+  // rule. The invariant these lock is structural, not cosmetic: exactly one
+  // element owns the bottom edge in every state, and the countdown lives inside
+  // it rather than beside it. jsdom can't measure the overlap that caused the
+  // bug, so we assert the arrangement that makes it unrepresentable.
+  describe("bottom-edge ownership (#11262)", () => {
+    const bottomEdgeStates = [
+      { name: "unarmed", wt: worktree, cleanupSeconds: 60, armed: false },
+      {
+        name: "armed",
+        wt: { ...worktree, expiresAt: Date.now() + 60_000 },
+        cleanupSeconds: 60,
+        armed: true,
+      },
+      {
+        name: "deadline set but auto-cleanup disabled",
+        wt: { ...worktree, expiresAt: Date.now() + 60_000 },
+        cleanupSeconds: 0,
+        armed: false,
+      },
+    ];
+
+    for (const { name, wt, cleanupSeconds, armed } of bottomEdgeStates) {
+      it(`keeps a single bottom rule while ${name}`, () => {
+        setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+        usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: cleanupSeconds });
+        const { container } = renderCard(wt);
+
+        const card = container.querySelector("[data-deleted-worktree-id='wt-1']");
+        if (!card) throw new Error("card did not render");
+
+        // The card must not paint a border of its own — that border plus the
+        // positioned track is precisely the doubling this fixes.
+        expect(hasBottomBorderUtility(card)).toBe(false);
+
+        const separators = card.querySelectorAll(
+          ":scope > [data-testid='deleted-worktree-separator']"
+        );
+        expect(separators).toHaveLength(1);
+
+        // The countdown must be nested in the separator. A regression that
+        // reintroduces it as a sibling would still satisfy a naive
+        // presence check, so assert the containment and the absence of a
+        // second top-level bar separately.
+        const separator = separators[0];
+        if (!separator) throw new Error("separator did not render");
+        expect(
+          separator.querySelectorAll(":scope > [data-testid='deleted-worktree-countdown']")
+        ).toHaveLength(armed ? 1 : 0);
+        expect(
+          card.querySelectorAll(":scope > [data-testid='deleted-worktree-countdown']")
+        ).toHaveLength(0);
+      });
+    }
+
+    it("exposes the countdown tooltip on the full-width track only while armed", () => {
+      setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+      const armed = renderCard({ ...worktree, expiresAt: Date.now() + 60_000 });
+      const armedSeparator = armed.container.querySelector(
+        "[data-testid='deleted-worktree-separator']"
+      );
+      // The tooltip belongs to the track, not the fill — on the fill the hover
+      // target would shrink as the countdown drains.
+      expect(armedSeparator?.getAttribute("title")).toMatch(/^Closes automatically in \d+s$/);
+      expect(
+        armed.container
+          .querySelector("[data-testid='deleted-worktree-countdown']")
+          ?.hasAttribute("title")
+      ).toBe(false);
+      cleanup();
+
+      const unarmed = renderCard();
+      // Unarmed the track is just a separator, so it must not claim a tooltip.
+      expect(
+        unarmed.container
+          .querySelector("[data-testid='deleted-worktree-separator']")
+          ?.hasAttribute("title")
+      ).toBe(false);
+    });
   });
 
   it("marks the card active when it is the active worktree", () => {

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -7,6 +7,7 @@ const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
 const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
 const TOOLBAR_CSS = path.join(REPO_ROOT, "src/styles/components/toolbar.css");
+const SIDEBAR_CSS = path.join(REPO_ROOT, "src/styles/components/sidebar.css");
 
 // Issue #8936: status indicators (toolbar pips, ActivityLight) and the
 // SettingsSwitch toggle lose all state in forced-colors / Windows High Contrast
@@ -70,6 +71,19 @@ describe("forced-colors status-indicator contract (#8936)", () => {
     const block = readForcedColorsBlocks(INDEX_CSS);
     expect(block).toMatch(/span\[data-state="checked"\]\s*\{[^}]*HighlightText/);
     expect(block).toMatch(/span\[data-state="unchecked"\]\s*\{[^}]*ButtonText/);
+  });
+
+  // #11262: the deleted-worktree row's separator moved from a `border-b` to a
+  // painted element so the countdown could drain along the same 1px rule.
+  // Borders survive forced-colors; backgrounds are forced to Canvas — so
+  // without an explicit repaint the separator disappears for HC users, a
+  // regression the old border didn't have.
+  it("sidebar.css repaints the deleted-row separator and its countdown fill", () => {
+    const block = readForcedColorsBlocks(SIDEBAR_CSS);
+    expect(block).toMatch(/\.deleted-worktree-separator\s*\{[^}]*background-color:\s*CanvasText/);
+    expect(block).toMatch(
+      /\.deleted-worktree-countdown-fill\s*\{[^}]*background-color:\s*Highlight/
+    );
   });
 
   it("toolbar.css repaints every pip type with CanvasText", () => {

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -178,4 +178,18 @@ html[data-dragging="true"]
     outline: 2px dashed Highlight;
     outline-offset: -2px;
   }
+
+  /* The deleted row's bottom separator is a painted 1px element rather than a
+     `border-b` (#11262 — a real border and the countdown bar rendered as two
+     stacked rules). Backgrounds are forced to Canvas here, so without these the
+     separator would vanish for HC users where the old border survived. Repaint
+     the track as CanvasText and the draining fill as Highlight so the two stay
+     distinguishable. */
+  .deleted-worktree-separator {
+    background-color: CanvasText;
+  }
+
+  .deleted-worktree-countdown-fill {
+    background-color: Highlight;
+  }
 }


### PR DESCRIPTION
## Summary

- Deleted (ghost) worktree cards were drawing two stacked horizontal lines at the bottom edge instead of one. The card root had `border-b border-border-default`, and the auto-cleanup countdown bar was an absolutely positioned `inset-x-0 bottom-0 h-[2px]` child of that same element.
- Per the CSS Positioned Layout Level 3 spec, `bottom: 0` resolves against the containing block's padding edge, not its border box. The card has no bottom padding, so the bar landed exactly one border width above the painted border. Two non-overlapping boxes, which is why no `z-index` change could have fixed it.
- The fix makes one element own the bottom edge in every state: the root's `border-b` is gone, replaced by an always-rendered 1px track that acts as the row separator when unarmed, with the countdown fill draining along that same rule when armed. A negative-offset compensation (`-bottom-px`) was considered and rejected as brittle under Chromium's independent per-element sub-pixel rounding at fractional device pixel ratios.

Resolves #11262

## Changes

- `src/components/Sidebar/DeletedWorktreeCard.tsx`: removed the root `border-b`, added the always-rendered 1px separator/countdown track.
- `src/styles/components/sidebar.css`: forced-colors handling for the new track (`CanvasText`) and fill (`Highlight`).
- `src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx`: structural coverage for the merged rule, plus width assertions for `remainingFraction` across the TTL clamp, the snap-to-full window, mid-drain, and drained states.
- `forcedColorsStatusIndicators.contract.test.ts`: extended to cover the new track and fill repaint.

Two things came up in review worth flagging:

1. Replacing a real `border-b` with a painted element is a regression risk in forced-colors mode / Windows High Contrast, where the user agent strips `background-color` but keeps borders. The separator would have silently vanished for exactly those users. `sidebar.css` now repaints the track as `CanvasText` and the fill as `Highlight` inside its existing `@media (forced-colors: active)` block, and the contract test was extended to match.
2. The track deliberately stays at `z-10`, above the select-overlay button. Moving it behind (`-z-10`) would protect the overlay's inset focus ring, but every `button` picks up a border in both contrast blocks of `src/index.css`, and the overlay is `inset-0`, so its bottom border would cover the separator in exactly the modes point 1 addresses. The trade is that the track clips the outermost pixel of that ring's bottom edge; the ring stays visible on all four sides, and the armed countdown already did this before this change.

Deliberate non-changes: `duration-1000` stays (semantic decay exemption, precedent `ActivityLight.tsx:65`); the fill stays on `bg-border-strong` rather than an accent token (accent restraint, `accentGuard` contract); no `variant` prop was added to mirror `WorktreeCard`, since that component is genuinely sidebar-vs-grid multi-context while this one is sidebar-only by construction.

## Testing

- `npm run typecheck` clean.
- 345 tests green across `src/components/Sidebar/__tests__/`, the forced-colors and accent-guard contract tests, and `WorktreeCardInteraction.test.tsx`.
- Prettier and eslint clean on all four changed files.

Known limitation: jsdom can't measure paint order, so the single-rule rendering and the forced-colors fallback both still need a real Chromium check. The tests lock the structural arrangement that makes the doubled rule unrepresentable, not the pixels themselves.
