### PR TITLE
feat(sidebar): group deleted worktree rows behind one summary row

### DIFF
--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -18,6 +18,12 @@ import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 
 interface DeletedWorktreeCardProps {
   worktree: DeletedWorktree;
+  /**
+   * Grouped cards hide their own trash button (#11260) — the group's single
+   * bulk clear replaces N per-row ones, which is the point of grouping. A
+   * standalone card keeps it.
+   */
+  showDismissAction?: boolean;
 }
 
 /**
@@ -35,7 +41,10 @@ interface DeletedWorktreeCardProps {
  * terminals, and omitting that wrapper excludes it by construction rather than
  * by a flag `DndProvider` would have to check.
  */
-export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
+export function DeletedWorktreeCard({
+  worktree,
+  showDismissAction = true,
+}: DeletedWorktreeCardProps) {
   const panelsById = usePanelStore((s) => s.panelsById);
   const panelIdsByWorktreeId = usePanelStore((s) => s.panelIdsByWorktreeId);
   const setFocused = usePanelStore((s) => s.setFocused);
@@ -211,22 +220,24 @@ export function DeletedWorktreeCard({ worktree }: DeletedWorktreeCardProps) {
                 {remainingSeconds}s
               </span>
             )}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDismiss();
-                  }}
-                  className="sidebar-action-button shrink-0 p-1.5 -my-1.5 text-status-error/70 hover:text-status-error rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                  aria-label={closeLabel}
-                >
-                  <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top">{closeLabel}</TooltipContent>
-            </Tooltip>
+            {showDismissAction && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDismiss();
+                    }}
+                    className="sidebar-action-button shrink-0 p-1.5 -my-1.5 text-status-error/70 hover:text-status-error rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                    aria-label={closeLabel}
+                  >
+                    <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{closeLabel}</TooltipContent>
+              </Tooltip>
+            )}
           </div>
         </div>
         <div className="truncate text-xs text-text-muted line-through mt-0.5" title={worktree.path}>

--- a/src/components/Sidebar/DeletedWorktreeGroup.tsx
+++ b/src/components/Sidebar/DeletedWorktreeGroup.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useMemo, useState } from "react";
+import { ChevronRight, FolderX, GripVertical, Trash2 } from "lucide-react";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { cn } from "@/lib/utils";
+import { usePanelStore } from "@/store/panelStore";
+import {
+  getDeletedWorktreeTerminalIds,
+  useWorktreeSelectionStore,
+  type DeletedWorktree,
+} from "@/store/worktreeStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import {
+  useTerminalPendingDestructiveActionStore,
+  type DeletedWorktreeGroupPreviewWorktree,
+} from "@/store/terminalPendingDestructiveActionStore";
+import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
+import { DeletedWorktreeCard } from "./DeletedWorktreeCard";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  SortableWorktreeTerminal,
+  getAccordionDragId,
+} from "@/components/DragDrop/SortableWorktreeTerminal";
+import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+
+interface GroupMember {
+  worktree: DeletedWorktree;
+  terminals: PtyPanelData[];
+}
+
+interface DeletedWorktreeGroupProps {
+  worktrees: DeletedWorktree[];
+}
+
+/**
+ * Collapsed summary standing in for several deleted-worktree rows at once
+ * (#11260). A burst of deletions used to render one full-height ghost card per
+ * worktree, each with its own countdown and trash button; grouped-by-type mode
+ * piled all of them at the end.
+ *
+ * Collapsed, the group is one row plus a rail of every surviving terminal.
+ * The rail is not decoration: dragging a terminal onto a live worktree is the
+ * only way to rescue an agent session, and a summary that unmounted its
+ * terminals would take that away exactly when the rows are hardest to read.
+ * Each chip is a real `SortableWorktreeTerminal`, so it emits the same
+ * `origin: "accordion"` drag data a card's terminal row does and `DndProvider`
+ * needs no knowledge of this component at all.
+ */
+export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
+  const panelsById = usePanelStore((s) => s.panelsById);
+  const panelIdsByWorktreeId = usePanelStore((s) => s.panelIdsByWorktreeId);
+  const setFocused = usePanelStore((s) => s.setFocused);
+  const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
+  const pingTerminal = usePanelStore((s) => s.pingTerminal);
+  const isExpanded = useWorktreeSelectionStore((s) => s.deletedWorktreeGroupExpanded);
+  const toggleExpanded = useWorktreeSelectionStore((s) => s.toggleDeletedWorktreeGroupExpanded);
+  const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
+  const trackTerminalFocus = useWorktreeSelectionStore((s) => s.trackTerminalFocus);
+  const requestDestructiveAction = useTerminalPendingDestructiveActionStore((s) => s.request);
+
+  // Membership is derived, never snapshotted: a terminal rescued out of the
+  // group shrinks it the same way it shrinks a single card (#11232).
+  const members = useMemo<GroupMember[]>(() => {
+    void panelIdsByWorktreeId;
+    return worktrees.map((worktree) => ({
+      worktree,
+      terminals: getDeletedWorktreeTerminalIds(worktree.id)
+        .map((id) => panelsById[id])
+        .filter((panel): panel is PtyPanelData => panel != null && isPtyPanel(panel)),
+    }));
+  }, [worktrees, panelsById, panelIdsByWorktreeId]);
+
+  const terminalCount = members.reduce((n, m) => n + m.terminals.length, 0);
+
+  const cleanupSeconds = usePreferencesStore((s) => s.deletedWorktreeCleanupSeconds);
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  // The group speaks for whichever member expires first — the deadlines stay
+  // per-row and the cards still show their own once expanded.
+  const soonestExpiresAt = useMemo(() => {
+    let soonest: number | null = null;
+    for (const { worktree } of members) {
+      if (worktree.expiresAt === null) continue;
+      if (soonest === null || worktree.expiresAt < soonest) soonest = worktree.expiresAt;
+    }
+    return soonest;
+  }, [members]);
+  const hasCountdown = soonestExpiresAt !== null && cleanupSeconds > 0 && !isExpanded;
+  useVisibilityAwareInterval(() => setNowTick(Date.now()), 1000, hasCountdown);
+  const cleanupMs = cleanupSeconds * 1000;
+  const rawRemainingMs = soonestExpiresAt !== null ? Math.max(0, soonestExpiresAt - nowTick) : 0;
+  const remainingSeconds = Math.ceil(
+    (cleanupMs > 0 ? Math.min(rawRemainingMs, cleanupMs) : rawRemainingMs) / 1000
+  );
+
+  const handleClearAll = useCallback(() => {
+    const preview: DeletedWorktreeGroupPreviewWorktree[] = members
+      .filter((m) => m.terminals.length > 0)
+      .map((m) => ({
+        worktreeId: m.worktree.id,
+        worktreeTitle: m.worktree.title,
+        terminals: m.terminals.map((terminal) => ({
+          terminalId: terminal.id,
+          // The row's own title, matching what the accordion shows — the
+          // derived chrome label is the terminal's kind, not its name.
+          terminalTitle: terminal.title,
+          hasRunningAgent: deriveTerminalChrome(terminal).isAgent,
+        })),
+      }));
+    if (preview.length === 0) return;
+    const previewedTerminals = preview.reduce((n, entry) => n + entry.terminals.length, 0);
+    requestDestructiveAction({
+      kind: "deletedWorktreeGroupDismiss",
+      targetCount: previewedTerminals,
+      runningAgentCount: preview.reduce(
+        (n, entry) => n + entry.terminals.filter((t) => t.hasRunningAgent).length,
+        0
+      ),
+      preview,
+    });
+  }, [members, requestDestructiveAction]);
+
+  const handleTerminalSelect = useCallback(
+    (terminal: PtyPanelData) => {
+      if (terminal.worktreeId) {
+        trackTerminalFocus(terminal.worktreeId, terminal.id);
+        selectWorktree(terminal.worktreeId, { source: "focus" });
+      }
+      if (terminal.location === "dock") {
+        openDockTerminal(terminal.id);
+      } else {
+        setFocused(terminal.id);
+      }
+      pingTerminal(terminal.id);
+    },
+    [trackTerminalFocus, selectWorktree, openDockTerminal, setFocused, pingTerminal]
+  );
+
+  // Defensive: SidebarContent only builds a group above the threshold, and the
+  // store prunes rows whose last terminal left. Bailing keeps a torn frame from
+  // rendering an empty summary.
+  if (terminalCount === 0) return null;
+
+  const worktreeNoun = members.length === 1 ? "deleted worktree" : "deleted worktrees";
+  const terminalNoun = terminalCount === 1 ? "terminal" : "terminals";
+  const clearLabel = `Clear ${terminalCount} ${terminalNoun}`;
+
+  return (
+    <div className="border-b border-border-default" data-testid="deleted-worktree-group">
+      <div className="flex items-center gap-2 pl-1 pr-4 py-3">
+        <button
+          type="button"
+          onClick={toggleExpanded}
+          aria-expanded={isExpanded}
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded text-left outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
+        >
+          <ChevronRight
+            className={cn(
+              "w-3.5 h-3.5 shrink-0 text-text-muted transition-transform duration-150",
+              isExpanded && "rotate-90"
+            )}
+            aria-hidden="true"
+          />
+          <FolderX
+            className="w-3.5 h-3.5 shrink-0 text-text-muted"
+            strokeWidth={2.5}
+            aria-hidden="true"
+          />
+          <span className="truncate text-[11px] font-medium text-text-muted">
+            {members.length} {worktreeNoun}
+            <span aria-hidden="true"> · </span>
+            <span className="sr-only">, </span>
+            {terminalCount} {terminalNoun}
+          </span>
+        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          {hasCountdown && (
+            <span
+              className="font-mono text-[11px] tabular-nums text-text-muted"
+              title={`Next cleanup in ${remainingSeconds}s`}
+              data-testid="deleted-worktree-group-countdown"
+            >
+              {remainingSeconds}s
+            </span>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleClearAll}
+                className="sidebar-action-button shrink-0 rounded p-1.5 -my-1.5 text-status-error/70 transition-colors hover:text-status-error focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                aria-label={clearLabel}
+              >
+                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">{clearLabel}</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {isExpanded ? (
+        members.map(({ worktree }) => (
+          <DeletedWorktreeCard key={worktree.id} worktree={worktree} showDismissAction={false} />
+        ))
+      ) : (
+        <div className="pb-2 pl-6 pr-4">
+          <SortableContext
+            items={members.flatMap((m) => m.terminals.map((t) => getAccordionDragId(t.id)))}
+            strategy={verticalListSortingStrategy}
+          >
+            <div role="list" className="flex flex-col gap-0.5">
+              {members.map(({ worktree, terminals }) =>
+                terminals.map((terminal, index) => (
+                  <SortableWorktreeTerminal
+                    key={terminal.id}
+                    terminal={terminal}
+                    worktreeId={worktree.id}
+                    sourceIndex={index}
+                  >
+                    <DeletedWorktreeTerminalChip
+                      terminal={terminal}
+                      worktreeTitle={worktree.title}
+                      onSelect={handleTerminalSelect}
+                    />
+                  </SortableWorktreeTerminal>
+                ))
+              )}
+            </div>
+          </SortableContext>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface DeletedWorktreeTerminalChipProps {
+  terminal: PtyPanelData;
+  worktreeTitle: string;
+  onSelect: (terminal: PtyPanelData) => void;
+}
+
+/**
+ * One rescuable terminal in the collapsed rail. Deliberately thinner than
+ * `WorktreeTerminalSection`'s row — no fleet arming, no marquee selection, no
+ * state badges — because the rail exists to keep the drag source reachable and
+ * legible, not to reproduce a live worktree's accordion.
+ */
+function DeletedWorktreeTerminalChip({
+  terminal,
+  worktreeTitle,
+  onSelect,
+}: DeletedWorktreeTerminalChipProps) {
+  const dragHandle = useDragHandle();
+  const chrome = deriveTerminalChrome(terminal);
+  const label = `${terminal.title} in deleted worktree ${worktreeTitle}`;
+
+  return (
+    <div role="listitem" className="group/chip flex items-center gap-1">
+      <button
+        ref={dragHandle?.setActivatorNodeRef}
+        type="button"
+        data-drag-handle
+        className="cursor-grab rounded text-text-primary/25 transition-colors group-hover/chip:text-text-primary/40 hover:text-text-secondary focus-visible:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-daintree-accent active:cursor-grabbing"
+        aria-label={`Drag to rescue ${label}`}
+        {...(dragHandle?.listeners as React.HTMLAttributes<HTMLElement> | undefined)}
+      >
+        <GripVertical className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onSelect(terminal)}
+        className="flex min-w-0 flex-1 items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-daintree-accent"
+        aria-label={label}
+      >
+        <TerminalIcon chrome={chrome} className="w-3 h-3 shrink-0" />
+        <span className="truncate text-[11px] text-text-muted">{terminal.title}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/Sidebar/DeletedWorktreeGroup.tsx
+++ b/src/components/Sidebar/DeletedWorktreeGroup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronRight, FolderX, GripVertical, Trash2 } from "lucide-react";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { cn } from "@/lib/utils";
@@ -23,10 +23,19 @@ import {
 } from "@/components/DragDrop/SortableWorktreeTerminal";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
-import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 
 interface GroupMember {
   worktree: DeletedWorktree;
+  /**
+   * Everything clearing this member would trash. Mirrors
+   * `getDeletedWorktreeTerminalIds` (and so `bulkTrashByWorktree`) without
+   * narrowing by kind — previewing only the PTY panels would under-report what
+   * the confirm is about to close, which is the #9699 mismatch class and a D2
+   * consent violation besides.
+   */
+  panels: PanelInstance[];
+  /** The rescuable subset — only a terminal can ride the accordion drag. */
   terminals: PtyPanelData[];
 }
 
@@ -64,15 +73,15 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
   // group shrinks it the same way it shrinks a single card (#11232).
   const members = useMemo<GroupMember[]>(() => {
     void panelIdsByWorktreeId;
-    return worktrees.map((worktree) => ({
-      worktree,
-      terminals: getDeletedWorktreeTerminalIds(worktree.id)
+    return worktrees.map((worktree) => {
+      const panels = getDeletedWorktreeTerminalIds(worktree.id)
         .map((id) => panelsById[id])
-        .filter((panel): panel is PtyPanelData => panel != null && isPtyPanel(panel)),
-    }));
+        .filter((panel): panel is PanelInstance => panel != null);
+      return { worktree, panels, terminals: panels.filter(isPtyPanel) };
+    });
   }, [worktrees, panelsById, panelIdsByWorktreeId]);
 
-  const terminalCount = members.reduce((n, m) => n + m.terminals.length, 0);
+  const terminalCount = members.reduce((n, m) => n + m.panels.length, 0);
 
   const cleanupSeconds = usePreferencesStore((s) => s.deletedWorktreeCleanupSeconds);
   const [nowTick, setNowTick] = useState(() => Date.now());
@@ -88,6 +97,11 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
   }, [members]);
   const hasCountdown = soonestExpiresAt !== null && cleanupSeconds > 0 && !isExpanded;
   useVisibilityAwareInterval(() => setNowTick(Date.now()), 1000, hasCountdown);
+  // The interval is off while expanded, so `nowTick` is stale on the way back:
+  // collapsing after a minute would flash the full TTL until the first tick.
+  useEffect(() => {
+    if (hasCountdown) setNowTick(Date.now());
+  }, [hasCountdown]);
   const cleanupMs = cleanupSeconds * 1000;
   const rawRemainingMs = soonestExpiresAt !== null ? Math.max(0, soonestExpiresAt - nowTick) : 0;
   const remainingSeconds = Math.ceil(
@@ -96,16 +110,16 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
 
   const handleClearAll = useCallback(() => {
     const preview: DeletedWorktreeGroupPreviewWorktree[] = members
-      .filter((m) => m.terminals.length > 0)
+      .filter((m) => m.panels.length > 0)
       .map((m) => ({
         worktreeId: m.worktree.id,
         worktreeTitle: m.worktree.title,
-        terminals: m.terminals.map((terminal) => ({
-          terminalId: terminal.id,
+        terminals: m.panels.map((panel) => ({
+          terminalId: panel.id,
           // The row's own title, matching what the accordion shows — the
           // derived chrome label is the terminal's kind, not its name.
-          terminalTitle: terminal.title,
-          hasRunningAgent: deriveTerminalChrome(terminal).isAgent,
+          terminalTitle: panel.title,
+          hasRunningAgent: deriveTerminalChrome(panel).isAgent,
         })),
       }));
     if (preview.length === 0) return;
@@ -144,7 +158,8 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
 
   const worktreeNoun = members.length === 1 ? "deleted worktree" : "deleted worktrees";
   const terminalNoun = terminalCount === 1 ? "terminal" : "terminals";
-  const clearLabel = `Clear ${terminalCount} ${terminalNoun}`;
+  // Same verb as a single card's dismiss — the group only changes the scope.
+  const clearLabel = `Close ${terminalCount} ${terminalNoun}`;
 
   return (
     <div className="border-b border-border-default" data-testid="deleted-worktree-group">
@@ -156,8 +171,9 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
           className="flex min-w-0 flex-1 items-center gap-1.5 rounded text-left outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent"
         >
           <ChevronRight
+            data-animated-chevron
             className={cn(
-              "w-3.5 h-3.5 shrink-0 text-text-muted transition-transform duration-150",
+              "w-3.5 h-3.5 shrink-0 text-text-muted transition-transform duration-150 ease-out",
               isExpanded && "rotate-90"
             )}
             aria-hidden="true"
@@ -207,10 +223,11 @@ export function DeletedWorktreeGroup({ worktrees }: DeletedWorktreeGroupProps) {
       ) : (
         <div className="pb-2 pl-6 pr-4">
           <SortableContext
+            id="deleted-worktree-group-rail"
             items={members.flatMap((m) => m.terminals.map((t) => getAccordionDragId(t.id)))}
             strategy={verticalListSortingStrategy}
           >
-            <div role="list" className="flex flex-col gap-0.5">
+            <div role="list" aria-label="Terminals to rescue" className="flex flex-col gap-0.5">
               {members.map(({ worktree, terminals }) =>
                 terminals.map((terminal, index) => (
                   <SortableWorktreeTerminal
@@ -256,8 +273,10 @@ function DeletedWorktreeTerminalChip({
   const chrome = deriveTerminalChrome(terminal);
   const label = `${terminal.title} in deleted worktree ${worktreeTitle}`;
 
+  // No `role="listitem"` here — `SortableWorktreeTerminal` already provides one
+  // around this chip, and nesting a second announces every entry twice.
   return (
-    <div role="listitem" className="group/chip flex items-center gap-1">
+    <div className="group/chip flex items-center gap-1">
       <button
         ref={dragHandle?.setActivatorNodeRef}
         type="button"

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -56,6 +56,7 @@ import {
   recordSidebarWorktreeOrder,
   DELETED_WORKTREE_GROUP_THRESHOLD,
 } from "@/store/worktreeStore";
+import { planDeletedWorktreePlacement } from "@/components/Sidebar/deletedWorktreePlacement";
 import { DeletedWorktreeCard } from "@/components/Sidebar/DeletedWorktreeCard";
 import { DeletedWorktreeGroup } from "@/components/Sidebar/DeletedWorktreeGroup";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -1272,17 +1273,13 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     const deletedList = Array.from(deletedWorktrees.values()).sort(
       (a, b) => a.deletedAt - b.deletedAt
     );
-    const deletedByIndex = new Map<number, DeletedWorktree[]>();
-    const trailingDeleted: DeletedWorktree[] = [];
-    for (const deleted of deletedList) {
-      if (deleted.pinnedIndex >= 0 && deleted.pinnedIndex < filteredWorktrees.length) {
-        const bucket = deletedByIndex.get(deleted.pinnedIndex);
-        if (bucket) bucket.push(deleted);
-        else deletedByIndex.set(deleted.pinnedIndex, [deleted]);
-      } else {
-        trailingDeleted.push(deleted);
-      }
-    }
+    const {
+      isGrouped,
+      groupSlot,
+      byIndex: deletedByIndex,
+      trailing: trailingDeleted,
+    } = planDeletedWorktreePlacement(deletedList, filteredWorktrees.length);
+    const hasGroupSlot = groupSlot >= 0;
     const pushDeleted = (deleted: DeletedWorktree) => {
       items.push({
         kind: "deletedWorktree",
@@ -1291,15 +1288,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         ariaRowIndex: nextRowIndex++,
       });
     };
-    // Above the threshold every deleted row collapses into one summary item,
-    // wherever it would otherwise have gone (#11260). The group takes the
-    // earliest slot any member had pinned so it still lands near where the user
-    // was looking, and falls to the end when none of them were visible.
-    const isGrouped = deletedList.length >= DELETED_WORKTREE_GROUP_THRESHOLD;
-    const groupSlot = isGrouped
-      ? Math.min(...deletedList.map((d) => d.pinnedIndex).filter((i) => i >= 0), Infinity)
-      : Infinity;
-    const hasGroupSlot = isGrouped && Number.isFinite(groupSlot);
     const pushDeletedGroup = () => {
       items.push({
         kind: "deletedWorktreeGroup",

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -52,8 +52,12 @@ import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import type { PendingCreation, DeletedWorktree } from "@/store/worktreeStore";
-import { recordSidebarWorktreeOrder } from "@/store/worktreeStore";
+import {
+  recordSidebarWorktreeOrder,
+  DELETED_WORKTREE_GROUP_THRESHOLD,
+} from "@/store/worktreeStore";
 import { DeletedWorktreeCard } from "@/components/Sidebar/DeletedWorktreeCard";
+import { DeletedWorktreeGroup } from "@/components/Sidebar/DeletedWorktreeGroup";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import {
   selectSidebarVisiblePanelIds,
@@ -187,7 +191,23 @@ interface SidebarDeletedWorktreeFlatItem {
   ariaRowIndex: number;
 }
 
-type SidebarFlatItem = SidebarHeaderFlatItem | SidebarRowFlatItem | SidebarDeletedWorktreeFlatItem;
+/**
+ * Several deleted worktrees collapsed behind one summary row (#11260). One
+ * Virtuoso item regardless of expansion — the member cards render inside it —
+ * so it spans a variable number of ARIA rows while occupying a single index.
+ */
+interface SidebarDeletedWorktreeGroupFlatItem {
+  kind: "deletedWorktreeGroup";
+  id: string;
+  worktrees: DeletedWorktree[];
+  ariaRowIndex: number;
+}
+
+type SidebarFlatItem =
+  | SidebarHeaderFlatItem
+  | SidebarRowFlatItem
+  | SidebarDeletedWorktreeFlatItem
+  | SidebarDeletedWorktreeGroupFlatItem;
 
 interface SidebarVirtuosoContext {
   activeWorktreeId: string | null;
@@ -262,6 +282,18 @@ function renderSidebarFlatItem(
       <div role="row" aria-rowindex={item.ariaRowIndex}>
         <div role="gridcell">
           <DeletedWorktreeCard worktree={item.worktree} />
+        </div>
+      </div>
+    );
+  }
+  if (item.kind === "deletedWorktreeGroup") {
+    // One grid row whether collapsed or expanded: the group is a disclosure
+    // inside its own cell, so expanding changes the row's height rather than
+    // the grid's shape, and `aria-rowindex` stays stable for everything below.
+    return (
+      <div role="row" aria-rowindex={item.ariaRowIndex}>
+        <div role="gridcell">
+          <DeletedWorktreeGroup worktrees={item.worktrees} />
         </div>
       </div>
     );
@@ -1205,11 +1237,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   // Total rows in the grid — pinned rows + group header rows + data rows.
   // Group header rows count toward aria-rowcount because they carry role="row".
+  // Deleted rows carry `role="row"` too, so they count — a collapsed group is
+  // one row no matter how many worktrees it holds.
+  const deletedRowCount =
+    deletedWorktrees.size >= DELETED_WORKTREE_GROUP_THRESHOLD ? 1 : deletedWorktrees.size;
   const ariaRowCount =
     integrationRowIndex +
     (groupedSections
       ? groupedSections.reduce((n, s) => n + 1 + s.worktrees.length, 0)
-      : filteredWorktrees.length);
+      : filteredWorktrees.length) +
+    deletedRowCount;
 
   // Build the flat item array that drives the virtualized scroll region. The
   // grouped path interleaves sticky header sentinels with static rows; the
@@ -1254,6 +1291,23 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         ariaRowIndex: nextRowIndex++,
       });
     };
+    // Above the threshold every deleted row collapses into one summary item,
+    // wherever it would otherwise have gone (#11260). The group takes the
+    // earliest slot any member had pinned so it still lands near where the user
+    // was looking, and falls to the end when none of them were visible.
+    const isGrouped = deletedList.length >= DELETED_WORKTREE_GROUP_THRESHOLD;
+    const groupSlot = isGrouped
+      ? Math.min(...deletedList.map((d) => d.pinnedIndex).filter((i) => i >= 0), Infinity)
+      : Infinity;
+    const hasGroupSlot = isGrouped && Number.isFinite(groupSlot);
+    const pushDeletedGroup = () => {
+      items.push({
+        kind: "deletedWorktreeGroup",
+        id: "deleted-worktree-group",
+        worktrees: deletedList,
+        ariaRowIndex: nextRowIndex++,
+      });
+    };
 
     if (groupedSections) {
       const orderIndex = new Map(dragStartOrder.map((id, i) => [id, i]));
@@ -1280,13 +1334,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       }
       // Type grouping has no slot for a worktree that no longer has a type to
       // group by, so deleted rows collect at the end rather than inventing a
-      // section for them.
-      for (const deleted of deletedList) pushDeleted(deleted);
+      // section for them. Piling up there is exactly what made a burst
+      // unreadable, so the group summary matters most in this path.
+      if (isGrouped) pushDeletedGroup();
+      else for (const deleted of deletedList) pushDeleted(deleted);
       return items;
     }
 
     for (let i = 0; i < filteredWorktrees.length; i++) {
-      for (const deleted of deletedByIndex.get(i) ?? []) pushDeleted(deleted);
+      if (hasGroupSlot && i === groupSlot) pushDeletedGroup();
+      if (!isGrouped) for (const deleted of deletedByIndex.get(i) ?? []) pushDeleted(deleted);
       const w = filteredWorktrees[i]!;
       items.push({
         kind: "row",
@@ -1298,7 +1355,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         mode: "sortable",
       });
     }
-    for (const deleted of trailingDeleted) pushDeleted(deleted);
+    if (isGrouped) {
+      if (!hasGroupSlot) pushDeletedGroup();
+    } else {
+      for (const deleted of trailingDeleted) pushDeleted(deleted);
+    }
     return items;
   }, [
     groupedSections,

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -404,3 +404,28 @@ describe("DeletedWorktreeCard", () => {
     expect(container.querySelector("[data-worktree-drop-target]")).toBeNull();
   });
 });
+
+describe("DeletedWorktreeCard — grouped (#11260)", () => {
+  it("hides its own dismiss button so the group's bulk clear is the only one", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+    ]);
+    render(
+      <TooltipProvider>
+        <DeletedWorktreeCard worktree={worktree} showDismissAction={false} />
+      </TooltipProvider>
+    );
+
+    expect(screen.queryByRole("button", { name: "Close 2 terminals" })).toBeNull();
+    // The rest of the card is unchanged — it still identifies its worktree.
+    expect(screen.getByText("feature/login")).toBeTruthy();
+  });
+
+  it("keeps the dismiss button by default", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    renderCard();
+
+    expect(screen.getByRole("button", { name: "Close 1 terminal" })).toBeTruthy();
+  });
+});

--- a/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    setActivatorNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+// Records what the collapsed rail hands to the real drag source. Rescue-drag is
+// the whole reason the rail exists, so the contract under test is "every
+// surviving terminal gets a drag source, carrying its own worktree id" — not
+// dnd-kit's internals, which the mock above stands in for.
+const sortableProps = vi.fn<(props: { terminalId: string; worktreeId: string }) => void>();
+
+vi.mock("@/components/DragDrop/SortableWorktreeTerminal", () => ({
+  SortableWorktreeTerminal: ({
+    terminal,
+    worktreeId,
+    children,
+  }: {
+    terminal: { id: string };
+    worktreeId: string;
+    children: ReactNode;
+  }) => {
+    sortableProps({ terminalId: terminal.id, worktreeId });
+    return <>{children}</>;
+  },
+  getAccordionDragId: (id: string) => `accordion-${id}`,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="terminal-row-icon" className={className} />
+  ),
+}));
+
+import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
+import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { DeletedWorktreeGroup } from "../DeletedWorktreeGroup";
+
+function setPanels(
+  entries: Array<{ id: string; worktreeId: string; location?: string; title?: string }>
+): void {
+  const panelsById: Record<string, unknown> = {};
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  for (const entry of entries) {
+    panelsById[entry.id] = {
+      id: entry.id,
+      kind: "terminal",
+      title: entry.title ?? entry.id,
+      worktreeId: entry.worktreeId,
+      location: entry.location ?? "grid",
+    };
+    const bucket = panelIdsByWorktreeId[entry.worktreeId];
+    if (bucket) bucket.push(entry.id);
+    else panelIdsByWorktreeId[entry.worktreeId] = [entry.id];
+  }
+  usePanelStore.setState({
+    panelIds: entries.map((e) => e.id),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    panelsById: panelsById as never,
+    panelIdsByWorktreeId,
+  });
+}
+
+function makeDeleted(id: string, title: string, expiresAt: number | null = null): DeletedWorktree {
+  return { id, title, path: `/repo/${id}`, deletedAt: 1000, expiresAt, pinnedIndex: -1 };
+}
+
+const worktrees = [makeDeleted("wt-1", "feature/alpha"), makeDeleted("wt-2", "feature/beta")];
+
+function renderGroup(list: DeletedWorktree[] = worktrees) {
+  return render(
+    <TooltipProvider>
+      <DeletedWorktreeGroup worktrees={list} />
+    </TooltipProvider>
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  sortableProps.mockClear();
+  useTerminalPendingDestructiveActionStore.getState().clear();
+  useWorktreeSelectionStore.getState().reset();
+  usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 60 });
+  setPanels([]);
+});
+
+describe("DeletedWorktreeGroup", () => {
+  it("summarises worktree and terminal counts in one row", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+      { id: "t3", worktreeId: "wt-2" },
+    ]);
+    renderGroup();
+
+    const summary = screen.getByRole("button", { expanded: false });
+    expect(summary.textContent).toContain("2 deleted worktrees");
+    expect(summary.textContent).toContain("3 terminals");
+  });
+
+  it("keeps every surviving terminal mounted as a drag source while collapsed", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1" },
+      { id: "t3", worktreeId: "wt-2" },
+    ]);
+    renderGroup();
+
+    // Rescue-drag must survive collapsing — a summary that unmounted its
+    // terminals would remove the only way to save a live agent session.
+    expect(sortableProps.mock.calls.map((c) => c[0])).toEqual([
+      { terminalId: "t1", worktreeId: "wt-1" },
+      { terminalId: "t2", worktreeId: "wt-1" },
+      { terminalId: "t3", worktreeId: "wt-2" },
+    ]);
+  });
+
+  it("labels each rail chip with its terminal and source worktree", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1", title: "claude" }]);
+    renderGroup();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Drag to rescue claude in deleted worktree feature/alpha",
+      })
+    ).toBeTruthy();
+  });
+
+  it("swaps the rail for the member cards once expanded", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    useWorktreeSelectionStore.setState({ deletedWorktreeGroupExpanded: true });
+    renderGroup();
+
+    expect(screen.getByText("/repo/wt-1")).toBeTruthy();
+    expect(screen.getByText("/repo/wt-2")).toBeTruthy();
+    expect(sortableProps).not.toHaveBeenCalled();
+  });
+
+  it("toggles expansion from the summary row", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    renderGroup();
+
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(true);
+  });
+
+  it("shrinks live when a terminal is rescued out of a member", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    const { rerender } = renderGroup();
+    expect(screen.getByRole("button", { expanded: false }).textContent).toContain("2 terminals");
+
+    // Membership is derived, so re-homing a panel is enough to shrink the group.
+    setPanels([{ id: "t2", worktreeId: "wt-2" }]);
+    rerender(
+      <TooltipProvider>
+        <DeletedWorktreeGroup worktrees={worktrees} />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByRole("button", { expanded: false }).textContent).toContain("1 terminal");
+  });
+
+  it("omits trashed and overlay panels, matching what the clear would close", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-1", location: "trash" },
+      { id: "t3", worktreeId: "wt-2", location: "overlay" },
+    ]);
+    renderGroup();
+
+    expect(screen.getByRole("button", { name: "Clear 1 terminal" })).toBeTruthy();
+  });
+
+  it("shows the soonest member deadline while collapsed", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    const now = Date.now();
+    const { container } = renderGroup([
+      makeDeleted("wt-1", "feature/alpha", now + 50_000),
+      makeDeleted("wt-2", "feature/beta", now + 10_000),
+    ]);
+
+    const readout = container.querySelector("[data-testid='deleted-worktree-group-countdown']");
+    // Soonest wins: ~10s, not the 50s sibling.
+    expect(Number(readout?.textContent?.replace("s", ""))).toBeLessThanOrEqual(11);
+  });
+
+  it("defers the countdown readout to the member cards once expanded", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    useWorktreeSelectionStore.setState({ deletedWorktreeGroupExpanded: true });
+    const { container } = renderGroup([
+      makeDeleted("wt-1", "feature/alpha", Date.now() + 50_000),
+      makeDeleted("wt-2", "feature/beta", Date.now() + 10_000),
+    ]);
+
+    expect(container.querySelector("[data-testid='deleted-worktree-group-countdown']")).toBeNull();
+  });
+
+  it("stages a confirm previewing the actual terminals rather than clearing (D2)", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1", title: "claude" },
+      { id: "t2", worktreeId: "wt-2", title: "shell" },
+    ]);
+    renderGroup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear 2 terminals" }));
+
+    const pending = useTerminalPendingDestructiveActionStore.getState().pending;
+    expect(pending).toMatchObject({ kind: "deletedWorktreeGroupDismiss", targetCount: 2 });
+    expect(pending?.preview).toEqual([
+      {
+        worktreeId: "wt-1",
+        worktreeTitle: "feature/alpha",
+        terminals: [{ terminalId: "t1", terminalTitle: "claude", hasRunningAgent: false }],
+      },
+      {
+        worktreeId: "wt-2",
+        worktreeTitle: "feature/beta",
+        terminals: [{ terminalId: "t2", terminalTitle: "shell", hasRunningAgent: false }],
+      },
+    ]);
+    // Nothing may be trashed before the user confirms.
+    expect(usePanelStore.getState().panelsById["t1"]).toBeDefined();
+  });
+
+  it("leaves a member with no surviving terminals out of the preview", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1", title: "claude" }]);
+    renderGroup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear 1 terminal" }));
+
+    expect(useTerminalPendingDestructiveActionStore.getState().pending?.preview).toHaveLength(1);
+  });
+
+  it("renders nothing once no member has a terminal left", () => {
+    setPanels([{ id: "t1", worktreeId: "other" }]);
+    const { container } = renderGroup();
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
@@ -58,14 +58,20 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { DeletedWorktreeGroup } from "../DeletedWorktreeGroup";
 
 function setPanels(
-  entries: Array<{ id: string; worktreeId: string; location?: string; title?: string }>
+  entries: Array<{
+    id: string;
+    worktreeId: string;
+    location?: string;
+    title?: string;
+    kind?: string;
+  }>
 ): void {
   const panelsById: Record<string, unknown> = {};
   const panelIdsByWorktreeId: Record<string, string[]> = {};
   for (const entry of entries) {
     panelsById[entry.id] = {
       id: entry.id,
-      kind: "terminal",
+      kind: entry.kind ?? "terminal",
       title: entry.title ?? entry.id,
       worktreeId: entry.worktreeId,
       location: entry.location ?? "grid",
@@ -199,7 +205,7 @@ describe("DeletedWorktreeGroup", () => {
     ]);
     renderGroup();
 
-    expect(screen.getByRole("button", { name: "Clear 1 terminal" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close 1 terminal" })).toBeTruthy();
   });
 
   it("shows the soonest member deadline while collapsed", () => {
@@ -239,7 +245,7 @@ describe("DeletedWorktreeGroup", () => {
     ]);
     renderGroup();
 
-    fireEvent.click(screen.getByRole("button", { name: "Clear 2 terminals" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close 2 terminals" }));
 
     const pending = useTerminalPendingDestructiveActionStore.getState().pending;
     expect(pending).toMatchObject({ kind: "deletedWorktreeGroupDismiss", targetCount: 2 });
@@ -263,9 +269,43 @@ describe("DeletedWorktreeGroup", () => {
     setPanels([{ id: "t1", worktreeId: "wt-1", title: "claude" }]);
     renderGroup();
 
-    fireEvent.click(screen.getByRole("button", { name: "Clear 1 terminal" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close 1 terminal" }));
 
     expect(useTerminalPendingDestructiveActionStore.getState().pending?.preview).toHaveLength(1);
+  });
+
+  it("previews every panel the clear would trash, not just the terminals", () => {
+    // `bulkTrashByWorktree` closes every non-trash/overlay/dialog panel, so a
+    // preview narrowed to PTY panels would under-report what confirming ends —
+    // the #9699 mismatch class, and a D2 consent violation besides.
+    setPanels([
+      { id: "t1", worktreeId: "wt-1", title: "claude" },
+      { id: "b1", worktreeId: "wt-1", title: "localhost:3000", kind: "browser" },
+      { id: "t2", worktreeId: "wt-2", title: "shell" },
+    ]);
+    renderGroup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close 3 terminals" }));
+
+    const preview = useTerminalPendingDestructiveActionStore.getState().pending?.preview;
+    expect(preview?.[0]?.terminals.map((t) => t.terminalTitle)).toEqual([
+      "claude",
+      "localhost:3000",
+    ]);
+    expect(useTerminalPendingDestructiveActionStore.getState().pending?.targetCount).toBe(3);
+  });
+
+  it("keeps a non-terminal panel out of the draggable rail", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1", title: "claude" },
+      { id: "b1", worktreeId: "wt-1", title: "localhost:3000", kind: "browser" },
+      { id: "t2", worktreeId: "wt-2", title: "shell" },
+    ]);
+    renderGroup();
+
+    // Only a terminal can ride the accordion drag, so the browser panel counts
+    // toward the clear but must not appear as a rescue chip.
+    expect(sortableProps.mock.calls.map((c) => c[0].terminalId)).toEqual(["t1", "t2"]);
   });
 
   it("renders nothing once no member has a terminal left", () => {

--- a/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
+++ b/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ panelIdsByWorktreeId: {}, panelsById: {} }) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: { applyRendererPolicy: vi.fn(), getInstance: vi.fn() },
+}));
+
+import { planDeletedWorktreePlacement } from "../deletedWorktreePlacement";
+import type { DeletedWorktree } from "@/store/worktreeStore";
+
+function deleted(id: string, pinnedIndex: number): DeletedWorktree {
+  return { id, title: id, path: `/repo/${id}`, deletedAt: 1000, expiresAt: null, pinnedIndex };
+}
+
+describe("planDeletedWorktreePlacement", () => {
+  it("leaves a lone deleted row ungrouped", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", 1)], 5);
+
+    expect(plan.isGrouped).toBe(false);
+    expect(plan.groupSlot).toBe(-1);
+    expect(plan.byIndex.get(1)).toHaveLength(1);
+  });
+
+  it("groups from the second deleted row on", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", 1), deleted("b", 3)], 5);
+
+    expect(plan.isGrouped).toBe(true);
+  });
+
+  it("puts the group at the earliest slot any member held", () => {
+    const plan = planDeletedWorktreePlacement(
+      [deleted("a", 3), deleted("b", 1), deleted("c", 4)],
+      5
+    );
+
+    expect(plan.groupSlot).toBe(1);
+  });
+
+  it("trails the group when no member held a visible slot", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", -1), deleted("b", -1)], 5);
+
+    expect(plan.isGrouped).toBe(true);
+    expect(plan.groupSlot).toBe(-1);
+    expect(plan.trailing).toHaveLength(2);
+  });
+
+  it("never claims a slot past the end of the filtered list", () => {
+    // A pin recorded before a filter narrowed the list points past the end.
+    // Claiming it would strand the group at an index the render loop never
+    // reaches, dropping every deleted row — and its rescuable terminals —
+    // out of the sidebar entirely.
+    const plan = planDeletedWorktreePlacement([deleted("a", 9), deleted("b", 7)], 3);
+
+    expect(plan.groupSlot).toBe(-1);
+    expect(plan.trailing).toHaveLength(2);
+    expect(plan.byIndex.size).toBe(0);
+  });
+
+  it("still uses an in-range slot when only some pins went out of range", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", 9), deleted("b", 2)], 3);
+
+    expect(plan.groupSlot).toBe(2);
+    expect(plan.trailing.map((d) => d.id)).toEqual(["a"]);
+  });
+
+  it("handles an empty list without inventing a group", () => {
+    const plan = planDeletedWorktreePlacement([], 3);
+
+    expect(plan.isGrouped).toBe(false);
+    expect(plan.groupSlot).toBe(-1);
+    expect(plan.trailing).toHaveLength(0);
+  });
+
+  it("trails everything when the filtered list is empty", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", 0), deleted("b", 1)], 0);
+
+    expect(plan.groupSlot).toBe(-1);
+    expect(plan.trailing).toHaveLength(2);
+  });
+
+  it("keeps several rows sharing one slot together in deletion order", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", 2), deleted("b", 2)], 5);
+
+    expect(plan.byIndex.get(2)?.map((d) => d.id)).toEqual(["a", "b"]);
+  });
+});

--- a/src/components/Sidebar/deletedWorktreePlacement.ts
+++ b/src/components/Sidebar/deletedWorktreePlacement.ts
@@ -1,0 +1,55 @@
+import { DELETED_WORKTREE_GROUP_THRESHOLD, type DeletedWorktree } from "@/store/worktreeStore";
+
+export interface DeletedWorktreePlacement {
+  /** Deleted rows collapse behind one summary item instead of rendering a card each. */
+  isGrouped: boolean;
+  /**
+   * Slot in the filtered worktree list the group is inserted before, or `-1`
+   * when no member held a visible slot and the group trails the list.
+   */
+  groupSlot: number;
+  /** Deleted rows keyed by the visible slot they held, for the ungrouped path. */
+  byIndex: Map<number, DeletedWorktree[]>;
+  /** Deleted rows with no visible slot, appended after the live rows. */
+  trailing: DeletedWorktree[];
+}
+
+/**
+ * Where a sidebar's deleted rows go (#11232, #11260).
+ *
+ * A deleted worktree holds the slot its row occupied so the terminals the user
+ * is looking for stay put, but that slot is only meaningful while it still
+ * addresses the current filtered list — a pin recorded before a filter narrowed
+ * the list can point past the end. Both the grouped and ungrouped paths drop
+ * such a pin and fall back to trailing placement; keeping them in agreement is
+ * the whole reason this is one function rather than two call sites.
+ */
+export function planDeletedWorktreePlacement(
+  deletedList: readonly DeletedWorktree[],
+  visibleWorktreeCount: number
+): DeletedWorktreePlacement {
+  const byIndex = new Map<number, DeletedWorktree[]>();
+  const trailing: DeletedWorktree[] = [];
+  for (const deleted of deletedList) {
+    if (deleted.pinnedIndex >= 0 && deleted.pinnedIndex < visibleWorktreeCount) {
+      const bucket = byIndex.get(deleted.pinnedIndex);
+      if (bucket) bucket.push(deleted);
+      else byIndex.set(deleted.pinnedIndex, [deleted]);
+    } else {
+      trailing.push(deleted);
+    }
+  }
+
+  const isGrouped = deletedList.length >= DELETED_WORKTREE_GROUP_THRESHOLD;
+  // Derived from `byIndex` rather than raw `pinnedIndex`, so an out-of-range
+  // pin can never claim a slot the render loop won't reach — that would drop
+  // every deleted row out of the sidebar instead of merely misplacing it.
+  let groupSlot = -1;
+  if (isGrouped) {
+    for (const slot of byIndex.keys()) {
+      if (groupSlot === -1 || slot < groupSlot) groupSlot = slot;
+    }
+  }
+
+  return { isGrouped, groupSlot, byIndex, trailing };
+}

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -99,6 +99,9 @@ function buildCopy(pending: TerminalPendingDestructiveActionSnapshot): DialogCop
     }
     case "deletedWorktreeGroupDismiss": {
       const worktreeCount = pending.preview?.length ?? 0;
+      // A member whose terminals all left is dropped from the preview, so the
+      // group can be clearing a single worktree even though it holds several.
+      const worktreeNoun = worktreeCount === 1 ? "deleted worktree" : "deleted worktrees";
       const noun = pending.targetCount === 1 ? "terminal" : "terminals";
       const agentNote =
         pending.runningAgentCount === 0
@@ -107,7 +110,7 @@ function buildCopy(pending: TerminalPendingDestructiveActionSnapshot): DialogCop
             ? " 1 still has a running agent."
             : ` ${pending.runningAgentCount} still have running agents.`;
       return {
-        title: `Close ${pending.targetCount} ${noun} from ${worktreeCount} deleted worktrees?`,
+        title: `Close ${pending.targetCount} ${noun} from ${worktreeCount} ${worktreeNoun}?`,
         description: `These terminals outlived the worktrees they belonged to. Closing them moves them to trash and ends their running processes; they can be restored from trash before garbage collection. Drag them to another worktree instead to keep them.${agentNote}`,
         confirmLabel: `Close ${pending.targetCount} ${noun}`,
       };
@@ -276,6 +279,9 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
       description={copy.description}
       confirmLabel={copy.confirmLabel}
       variant="destructive"
+      // The grouped clear renders a scrollable preview list, which AppDialog
+      // must expose as a plain dialog rather than an alertdialog.
+      hasPreview={pending.kind === "deletedWorktreeGroupDismiss"}
       onConfirm={handleConfirm}
     >
       {pending.kind === "deletedWorktreeGroupDismiss" && pending.preview && (

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -4,6 +4,7 @@ import { actionService } from "@/services/ActionService";
 import { closeAndAnnounce } from "@/lib/accessibility";
 import {
   useTerminalPendingDestructiveActionStore,
+  type DeletedWorktreeGroupPreviewWorktree,
   type TerminalPendingDestructiveActionSnapshot,
 } from "@/store/terminalPendingDestructiveActionStore";
 
@@ -96,7 +97,57 @@ function buildCopy(pending: TerminalPendingDestructiveActionSnapshot): DialogCop
         confirmLabel: `Close ${pending.targetCount} ${noun}`,
       };
     }
+    case "deletedWorktreeGroupDismiss": {
+      const worktreeCount = pending.preview?.length ?? 0;
+      const noun = pending.targetCount === 1 ? "terminal" : "terminals";
+      const agentNote =
+        pending.runningAgentCount === 0
+          ? ""
+          : pending.runningAgentCount === 1
+            ? " 1 still has a running agent."
+            : ` ${pending.runningAgentCount} still have running agents.`;
+      return {
+        title: `Close ${pending.targetCount} ${noun} from ${worktreeCount} deleted worktrees?`,
+        description: `These terminals outlived the worktrees they belonged to. Closing them moves them to trash and ends their running processes; they can be restored from trash before garbage collection. Drag them to another worktree instead to keep them.${agentNote}`,
+        confirmLabel: `Close ${pending.targetCount} ${noun}`,
+      };
+    }
   }
+}
+
+/**
+ * D2 preview: a bulk clear spanning several worktrees is the one case where a
+ * count tells the user nothing about what they're losing, so the dialog lists
+ * the actual terminals it will trash, grouped under the worktree each came
+ * from (#7880).
+ */
+function GroupDismissPreview({ preview }: { preview: DeletedWorktreeGroupPreviewWorktree[] }) {
+  return (
+    <ul className="mt-3 max-h-56 space-y-3 overflow-y-auto rounded border border-border-default bg-overlay-subtle p-3">
+      {preview.map((entry) => (
+        <li key={entry.worktreeId}>
+          <span className="block truncate font-mono text-[11px] font-medium text-text-secondary">
+            {entry.worktreeTitle}
+          </span>
+          <ul className="mt-1 space-y-0.5">
+            {entry.terminals.map((terminal) => (
+              <li
+                key={terminal.terminalId}
+                className="flex items-center gap-1.5 truncate text-xs text-text-muted"
+              >
+                <span className="truncate">{terminal.terminalTitle}</span>
+                {terminal.hasRunningAgent && (
+                  <span className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] text-text-muted">
+                    Running
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 /**
@@ -185,6 +236,26 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
         announcement = `Closed ${pending.targetCount} ${noun}`;
         break;
       }
+      case "deletedWorktreeGroupDismiss": {
+        if (!pending.preview || pending.preview.length === 0) break;
+        // Fans the single-row executor over each previewed worktree rather than
+        // introducing a multi-worktree one: `worktree.sessions.trashAll`
+        // re-derives its targets, so a terminal rescued while the dialog was
+        // open is simply no longer there. Nothing unpreviewed can appear in the
+        // meantime either — a deleted row never accepts drops (it deliberately
+        // omits `SortableWorktreeCard`), so the live set is always a subset of
+        // what the user just confirmed.
+        for (const entry of pending.preview) {
+          void actionService.dispatch(
+            "worktree.sessions.trashAll",
+            { worktreeId: entry.worktreeId, confirmed: true },
+            { source: "user" }
+          );
+        }
+        const noun = pending.targetCount === 1 ? "terminal" : "terminals";
+        announcement = `Closed ${pending.targetCount} ${noun}`;
+        break;
+      }
     }
     if (announcement) {
       closeAndAnnounce(clear, announcement);
@@ -206,6 +277,10 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
       confirmLabel={copy.confirmLabel}
       variant="destructive"
       onConfirm={handleConfirm}
-    />
+    >
+      {pending.kind === "deletedWorktreeGroupDismiss" && pending.preview && (
+        <GroupDismissPreview preview={pending.preview} />
+      )}
+    </ConfirmDialog>
   );
 }

--- a/src/components/Terminal/__tests__/TerminalDestructiveActionConfirmDialog.deletedWorktree.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalDestructiveActionConfirmDialog.deletedWorktree.test.tsx
@@ -101,3 +101,92 @@ describe("TerminalDestructiveActionConfirmDialog — deleted-worktree dismiss", 
     expect(dispatch).not.toHaveBeenCalled();
   });
 });
+
+function stageGroup(): void {
+  useTerminalPendingDestructiveActionStore.getState().request({
+    kind: "deletedWorktreeGroupDismiss",
+    targetCount: 3,
+    runningAgentCount: 1,
+    preview: [
+      {
+        worktreeId: "wt-1",
+        worktreeTitle: "feature/alpha",
+        terminals: [
+          { terminalId: "t1", terminalTitle: "Claude", hasRunningAgent: true },
+          { terminalId: "t2", terminalTitle: "zsh", hasRunningAgent: false },
+        ],
+      },
+      {
+        worktreeId: "wt-2",
+        worktreeTitle: "feature/beta",
+        terminals: [{ terminalId: "t3", terminalTitle: "Codex", hasRunningAgent: false }],
+      },
+    ],
+  });
+}
+
+describe("TerminalDestructiveActionConfirmDialog — grouped deleted-worktree clear (#11260)", () => {
+  it("previews the actual terminals rather than only a count (D2)", () => {
+    stageGroup();
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByText("Claude")).toBeTruthy();
+    expect(screen.getByText("zsh")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+  });
+
+  it("groups the previewed terminals under the worktree each came from", () => {
+    stageGroup();
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByText("feature/alpha")).toBeTruthy();
+    expect(screen.getByText("feature/beta")).toBeTruthy();
+  });
+
+  it("names both counts in the title", () => {
+    stageGroup();
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByText("Close 3 terminals from 2 deleted worktrees?")).toBeTruthy();
+  });
+
+  it("fans the single-worktree executor over every previewed worktree on confirm", () => {
+    stageGroup();
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close 3 terminals" }));
+
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith(
+      "worktree.sessions.trashAll",
+      { worktreeId: "wt-1", confirmed: true },
+      { source: "user" }
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      "worktree.sessions.trashAll",
+      { worktreeId: "wt-2", confirmed: true },
+      { source: "user" }
+    );
+  });
+
+  it("dispatches nothing when the preview is empty", () => {
+    useTerminalPendingDestructiveActionStore.getState().request({
+      kind: "deletedWorktreeGroupDismiss",
+      targetCount: 0,
+      runningAgentCount: 0,
+      preview: [],
+    });
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close 0 terminals" }));
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("still points at dragging as the alternative", () => {
+    stageGroup();
+    render(<TerminalDestructiveActionConfirmDialog />);
+
+    expect(screen.getByText(/Drag them to another worktree instead/)).toBeTruthy();
+  });
+});

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -261,6 +261,89 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
+  it("collapses a same-tick burst into one inbox entry (#11260)", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+      { id: "t3", worktreeId: "wt-2" },
+      { id: "t4", worktreeId: "wt-3" },
+    ]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ id: "wt-1", title: "feature/a", expiresAt: NOW - 1 });
+    addRow({ id: "wt-2", title: "feature/b", expiresAt: NOW - 1 });
+    addRow({ id: "wt-3", title: "feature/c", expiresAt: NOW - 1 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(3);
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(notify).mock.calls[0]![0];
+    expect(payload.priority).toBe("low");
+    expect(payload.message).toContain("3 deleted worktrees");
+    expect(payload.message).toContain("4 terminals");
+    // No single worktree owns a multi-row sweep, so the entry must not pin one.
+    expect(payload.context?.worktreeId).toBeUndefined();
+  });
+
+  it("counts only the rows that actually expired on this tick", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ id: "wt-1", title: "feature/a", expiresAt: NOW - 1 });
+    // Still counting down — it must not appear in this tick's summary.
+    addRow({ id: "wt-2", title: "feature/b", expiresAt: NOW + 30_000 });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(notify).mock.calls[0]![0].message;
+    expect(message).toContain("feature/a");
+    expect(message).not.toContain("feature/b");
+  });
+
+  it("holds every previewed row while the grouped clear dialog is open", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ id: "wt-1", title: "feature/a", expiresAt: NOW - 1 });
+    addRow({ id: "wt-2", title: "feature/b", expiresAt: NOW - 1 });
+    useTerminalPendingDestructiveActionStore.getState().request({
+      kind: "deletedWorktreeGroupDismiss",
+      targetCount: 2,
+      runningAgentCount: 0,
+      preview: [
+        { worktreeId: "wt-1", worktreeTitle: "feature/a", terminals: [] },
+        { worktreeId: "wt-2", worktreeTitle: "feature/b", terminals: [] },
+      ],
+    });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("only holds rows the grouped clear is actually previewing", () => {
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2" },
+    ]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow({ id: "wt-1", title: "feature/a", expiresAt: NOW - 1 });
+    addRow({ id: "wt-2", title: "feature/b", expiresAt: NOW - 1 });
+    useTerminalPendingDestructiveActionStore.getState().request({
+      kind: "deletedWorktreeGroupDismiss",
+      targetCount: 1,
+      runningAgentCount: 0,
+      preview: [{ worktreeId: "wt-1", worktreeTitle: "feature/a", terminals: [] }],
+    });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+    expect(bulkTrashByWorktree).toHaveBeenCalledWith("wt-2");
+  });
+
   it("re-arms a disarmed row when cleanup is turned back on", () => {
     usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
     addRow({ expiresAt: NOW - 1 });

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 import {
   useWorktreeSelectionStore,
   getDeletedWorktreeTerminalIds,
+  getDeletedWorktreeTerminalIdsForWorktrees,
   getPinnedDeletedWorktreeIndex,
   recordSidebarWorktreeOrder,
   type DeletedWorktree,
@@ -225,5 +226,84 @@ describe("clearRestoreTarget", () => {
     useWorktreeSelectionStore.getState().clearRestoreTarget("wt-1");
 
     expect(useWorktreeSelectionStore.getState()._previousRestoreWorktreeId).toBeNull();
+  });
+});
+
+describe("deleted-worktree group expansion (#11260)", () => {
+  function addRows(count: number): void {
+    setPanels(Array.from({ length: count }, (_, i) => ({ id: `t${i}`, worktreeId: `wt-${i}` })));
+    for (let i = 0; i < count; i++) {
+      useWorktreeSelectionStore
+        .getState()
+        .addDeletedWorktree(makeDeleted({ id: `wt-${i}`, title: `feature/${i}` }));
+    }
+  }
+
+  it("starts collapsed so a burst never opens to a wall of cards", () => {
+    addRows(3);
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(false);
+  });
+
+  it("toggles expansion", () => {
+    addRows(3);
+    useWorktreeSelectionStore.getState().toggleDeletedWorktreeGroupExpanded();
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(true);
+  });
+
+  it("latches shut once dismissals drop the cohort below the threshold", () => {
+    addRows(3);
+    useWorktreeSelectionStore.getState().toggleDeletedWorktreeGroupExpanded();
+
+    useWorktreeSelectionStore.getState().dismissDeletedWorktree("wt-0");
+    // Two rows still form a group, so the expansion the user chose survives.
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(true);
+
+    useWorktreeSelectionStore.getState().dismissDeletedWorktree("wt-1");
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(false);
+  });
+
+  it("latches shut when pruning empties the cohort", () => {
+    addRows(3);
+    useWorktreeSelectionStore.getState().toggleDeletedWorktreeGroupExpanded();
+    setPanels([{ id: "t0", worktreeId: "wt-0" }]);
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set());
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.size).toBe(1);
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(false);
+  });
+
+  it("does not inherit a stale expansion into the next burst", () => {
+    addRows(3);
+    useWorktreeSelectionStore.getState().toggleDeletedWorktreeGroupExpanded();
+    for (let i = 0; i < 3; i++) {
+      useWorktreeSelectionStore.getState().dismissDeletedWorktree(`wt-${i}`);
+    }
+    addRows(3);
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(false);
+  });
+});
+
+describe("getDeletedWorktreeTerminalIdsForWorktrees (#11260)", () => {
+  it("collects every member's terminals in the order the rows were given", () => {
+    setPanels([
+      { id: "a1", worktreeId: "wt-1" },
+      { id: "b1", worktreeId: "wt-2" },
+      { id: "b2", worktreeId: "wt-2" },
+    ]);
+
+    expect(getDeletedWorktreeTerminalIdsForWorktrees(["wt-2", "wt-1"])).toEqual(["b1", "b2", "a1"]);
+  });
+
+  it("applies the same location filter the single-worktree helper does", () => {
+    setPanels([
+      { id: "a1", worktreeId: "wt-1" },
+      { id: "a2", worktreeId: "wt-1", location: "trash" },
+      { id: "b1", worktreeId: "wt-2", location: "overlay" },
+    ]);
+
+    expect(getDeletedWorktreeTerminalIdsForWorktrees(["wt-1", "wt-2"])).toEqual(["a1"]);
   });
 });

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -19,7 +19,6 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 import {
   useWorktreeSelectionStore,
   getDeletedWorktreeTerminalIds,
-  getDeletedWorktreeTerminalIdsForWorktrees,
   getPinnedDeletedWorktreeIndex,
   recordSidebarWorktreeOrder,
   type DeletedWorktree,
@@ -283,27 +282,5 @@ describe("deleted-worktree group expansion (#11260)", () => {
     addRows(3);
 
     expect(useWorktreeSelectionStore.getState().deletedWorktreeGroupExpanded).toBe(false);
-  });
-});
-
-describe("getDeletedWorktreeTerminalIdsForWorktrees (#11260)", () => {
-  it("collects every member's terminals in the order the rows were given", () => {
-    setPanels([
-      { id: "a1", worktreeId: "wt-1" },
-      { id: "b1", worktreeId: "wt-2" },
-      { id: "b2", worktreeId: "wt-2" },
-    ]);
-
-    expect(getDeletedWorktreeTerminalIdsForWorktrees(["wt-2", "wt-1"])).toEqual(["b1", "b2", "a1"]);
-  });
-
-  it("applies the same location filter the single-worktree helper does", () => {
-    setPanels([
-      { id: "a1", worktreeId: "wt-1" },
-      { id: "a2", worktreeId: "wt-1", location: "trash" },
-      { id: "b1", worktreeId: "wt-2", location: "overlay" },
-    ]);
-
-    expect(getDeletedWorktreeTerminalIdsForWorktrees(["wt-1", "wt-2"])).toEqual(["a1"]);
   });
 });

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -69,6 +69,15 @@ function hasWorkingAgent(worktreeId: string): boolean {
 function isCountdownDeferred(worktreeId: string, deps: SweepDeps): boolean {
   const pending = useTerminalPendingDestructiveActionStore.getState().pending;
   if (pending?.kind === "deletedWorktreeDismiss" && pending.worktreeId === worktreeId) return true;
+  // The grouped clear previews several rows at once, so every previewed member
+  // holds while the user reads the dialog — expiring one mid-read would trash
+  // terminals the confirm is still offering to spare (#11260).
+  if (
+    pending?.kind === "deletedWorktreeGroupDismiss" &&
+    pending.preview?.some((entry) => entry.worktreeId === worktreeId)
+  ) {
+    return true;
+  }
   if (deps.isDragActive()) return true;
   return hasWorkingAgent(worktreeId);
 }
@@ -96,19 +105,45 @@ export function resetDeletedWorktreeCleanupState(): void {
  * only inverse (restore from trash). Inbox-only — the event is unattended by
  * definition, so a toast would interrupt whatever the user moved on to.
  */
-function notifySweepTrashed(title: string, count: number, worktreeId: string): void {
+interface SweptRow {
+  worktreeId: string;
+  title: string;
+  count: number;
+}
+
+/**
+ * One inbox entry per sweep pass, not per row (#11260). A burst of deletions is
+ * armed with the same TTL at the same moment, so its rows all expire on one
+ * tick — announcing each of them wrote N entries describing a single event. The
+ * low-priority inbox path skips `notify`'s rate limiter and coalescing
+ * entirely, so collapsing the burst has to happen here, at the call site.
+ */
+function notifySweepTrashed(swept: readonly SweptRow[]): void {
+  if (swept.length === 0) return;
+  const terminalCount = swept.reduce((n, row) => n + row.count, 0);
+  const terminalNoun = terminalCount === 1 ? "terminal" : "terminals";
+  const single = swept.length === 1 ? swept[0]! : null;
+  let message: string;
+  if (single === null) {
+    message = `${swept.length} deleted worktrees still had ${terminalCount} ${terminalNoun} open — they moved to trash and close shortly.`;
+  } else if (single.count === 1) {
+    message = `${single.title} still had 1 terminal open — it moved to trash and closes shortly.`;
+  } else {
+    message = `${single.title} still had ${single.count} terminals open — they moved to trash and close shortly.`;
+  }
   notify({
     type: "info",
-    title: "Deleted worktree cleaned up",
-    message:
-      count === 1
-        ? `${title} still had 1 terminal open — it moved to trash and closes shortly.`
-        : `${title} still had ${count} terminals open — they moved to trash and close shortly.`,
+    title: single ? "Deleted worktree cleaned up" : "Deleted worktrees cleaned up",
+    message,
     // `agent` is the right domain (these are agent sessions) but its policy
     // baseline is active/high; pin low so the unattended record stays a record
     // and never interrupts whatever the user moved on to.
     priority: "low",
-    context: { worktreeId, eventKind: "agent" },
+    // A multi-row sweep has no single worktree to attribute, and pinning one
+    // member's id would make the entry navigate somewhere arbitrary.
+    context: single
+      ? { worktreeId: single.worktreeId, eventKind: "agent" }
+      : { eventKind: "agent" },
   });
 }
 
@@ -126,6 +161,7 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
 
   const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
   const now = deps.now();
+  const swept: SweptRow[] = [];
 
   for (const entry of deletedWorktrees.values()) {
     // An unarmed entry is a fresh (or re-recorded) row — any stale fired flag
@@ -164,9 +200,13 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
       // the panels have already left the row.
       const trashedCount = getDeletedWorktreeTerminalIds(entry.id).length;
       usePanelStore.getState().bulkTrashByWorktree(entry.id);
-      if (trashedCount > 0) notifySweepTrashed(entry.title, trashedCount, entry.id);
+      if (trashedCount > 0) {
+        swept.push({ worktreeId: entry.id, title: entry.title, count: trashedCount });
+      }
     }
   }
+
+  notifySweepTrashed(swept);
 }
 
 /**

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -141,9 +141,7 @@ function notifySweepTrashed(swept: readonly SweptRow[]): void {
     priority: "low",
     // A multi-row sweep has no single worktree to attribute, and pinning one
     // member's id would make the entry navigate somewhere arbitrary.
-    context: single
-      ? { worktreeId: single.worktreeId, eventKind: "agent" }
-      : { eventKind: "agent" },
+    context: { ...(single ? { worktreeId: single.worktreeId } : {}), eventKind: "agent" },
   });
 }
 

--- a/src/store/terminalPendingDestructiveActionStore.ts
+++ b/src/store/terminalPendingDestructiveActionStore.ts
@@ -23,7 +23,26 @@ export type TerminalPendingDestructiveActionKind =
   // Executes through `worktree.sessions.trashAll` like `worktreeTrashAll`;
   // it exists as its own kind purely so the copy can speak about a worktree
   // that no longer exists rather than "this worktree".
-  | "deletedWorktreeDismiss";
+  | "deletedWorktreeDismiss"
+  // Clearing every deleted-worktree row at once from the grouped summary
+  // (#11260). Fans the same `worktree.sessions.trashAll` executor over each
+  // member, and carries `preview` because D2 requires the dialog to list the
+  // terminals it is about to trash rather than just count them.
+  | "deletedWorktreeGroupDismiss";
+
+/** One terminal the group-dismiss confirm is about to trash. */
+export interface DeletedWorktreeGroupPreviewTerminal {
+  terminalId: string;
+  terminalTitle: string;
+  hasRunningAgent: boolean;
+}
+
+/** One deleted worktree in the group-dismiss confirm, with its terminals. */
+export interface DeletedWorktreeGroupPreviewWorktree {
+  worktreeId: string;
+  worktreeTitle: string;
+  terminals: DeletedWorktreeGroupPreviewTerminal[];
+}
 
 export interface TerminalPendingDestructiveActionSnapshot {
   kind: TerminalPendingDestructiveActionKind;
@@ -35,6 +54,13 @@ export interface TerminalPendingDestructiveActionSnapshot {
   worktreeId?: string;
   /** Terminal id for single-terminal actions (kill/restart). */
   terminalId?: string;
+  /**
+   * The actual terminals a `deletedWorktreeGroupDismiss` will trash, grouped by
+   * their deleted worktree. Required for that kind — D2 (#7880) wants the
+   * dialog to preview real content, and a bulk clear spanning several worktrees
+   * is the one case where a count tells the user nothing about what they lose.
+   */
+  preview?: DeletedWorktreeGroupPreviewWorktree[];
 }
 
 interface TerminalPendingDestructiveActionState {

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -135,17 +135,6 @@ function collapseGroupBelowThreshold(
   return state.deletedWorktreeGroupExpanded ? { deletedWorktreeGroupExpanded: false } : {};
 }
 
-/**
- * Terminals held by several deleted rows at once, in the order the rows were
- * given. Delegates per worktree so the `bulkTrashByWorktree` filter mirroring
- * (#9699) holds for the group exactly as it does for a single row.
- */
-export function getDeletedWorktreeTerminalIdsForWorktrees(
-  worktreeIds: readonly string[]
-): string[] {
-  return worktreeIds.flatMap((id) => getDeletedWorktreeTerminalIds(id));
-}
-
 interface QuickCreateState {
   isOpen: boolean;
   issue: Issue | null;

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -115,6 +115,37 @@ export function getDeletedWorktreeTerminalIds(worktreeId: string): string[] {
   });
 }
 
+/**
+ * Deleted rows collapse into a single summary row once this many pile up
+ * (#11260). A lone deleted worktree keeps the familiar full card; the second
+ * one forms the group, because two full-height ghost cards is already the
+ * point where the sidebar stops being readable.
+ */
+export const DELETED_WORKTREE_GROUP_THRESHOLD = 2;
+
+/**
+ * Latch the group shut once the cohort can no longer form one, so the next
+ * burst opens collapsed instead of inheriting an expansion from the last one.
+ */
+function collapseGroupBelowThreshold(
+  state: { deletedWorktreeGroupExpanded: boolean },
+  remaining: number
+): { deletedWorktreeGroupExpanded?: boolean } {
+  if (remaining >= DELETED_WORKTREE_GROUP_THRESHOLD) return {};
+  return state.deletedWorktreeGroupExpanded ? { deletedWorktreeGroupExpanded: false } : {};
+}
+
+/**
+ * Terminals held by several deleted rows at once, in the order the rows were
+ * given. Delegates per worktree so the `bulkTrashByWorktree` filter mirroring
+ * (#9699) holds for the group exactly as it does for a single row.
+ */
+export function getDeletedWorktreeTerminalIdsForWorktrees(
+  worktreeIds: readonly string[]
+): string[] {
+  return worktreeIds.flatMap((id) => getDeletedWorktreeTerminalIds(id));
+}
+
 interface QuickCreateState {
   isOpen: boolean;
   issue: Issue | null;
@@ -157,6 +188,14 @@ interface WorktreeSelectionState {
    * restore pipeline's cwd inference to resolve on the next launch.
    */
   deletedWorktrees: Map<string, DeletedWorktree>;
+  /**
+   * Whether the collapsed deleted-worktree group is showing its member cards
+   * (#11260). Session-only, like `expandedTerminals` — `deletedWorktrees` is
+   * itself in-memory, so persisting this would outlive everything it describes.
+   * Latches back to `false` whenever the cohort drops below the group
+   * threshold, so a later burst never inherits a stale expansion.
+   */
+  deletedWorktreeGroupExpanded: boolean;
   expandedWorktrees: Set<string>;
   expandedTerminals: Set<string>;
   createDialog: CreateDialogState;
@@ -201,6 +240,7 @@ interface WorktreeSelectionState {
   setDeletedWorktreeExpiry: (worktreeId: string, expiresAt: number | null) => void;
   clearRestoreTarget: (worktreeId: string) => void;
   pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
+  toggleDeletedWorktreeGroupExpanded: () => void;
   toggleWorktreeExpanded: (id: string) => void;
   setWorktreeExpanded: (id: string, expanded: boolean) => void;
   collapseAllWorktrees: () => void;
@@ -549,6 +589,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   pendingWorktreeId: null,
   pendingCreations: new Map<string, PendingCreation>(),
   deletedWorktrees: new Map<string, DeletedWorktree>(),
+  deletedWorktreeGroupExpanded: false,
   expandedWorktrees: new Set<string>(),
   expandedTerminals: new Set<string>(),
   createDialog: {
@@ -815,7 +856,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       if (!state.deletedWorktrees.has(worktreeId)) return state;
       const next = new Map(state.deletedWorktrees);
       next.delete(worktreeId);
-      return { deletedWorktrees: next };
+      return { deletedWorktrees: next, ...collapseGroupBelowThreshold(state, next.size) };
     });
   },
 
@@ -861,9 +902,12 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       if (stale.length === 0) return state;
       const next = new Map(state.deletedWorktrees);
       for (const id of stale) next.delete(id);
-      return { deletedWorktrees: next };
+      return { deletedWorktrees: next, ...collapseGroupBelowThreshold(state, next.size) };
     });
   },
+
+  toggleDeletedWorktreeGroupExpanded: () =>
+    set((state) => ({ deletedWorktreeGroupExpanded: !state.deletedWorktreeGroupExpanded })),
 
   toggleWorktreeExpanded: (id) =>
     set((state) => {
@@ -1208,6 +1252,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       pendingWorktreeId: null,
       pendingCreations: new Map<string, PendingCreation>(),
       deletedWorktrees: new Map<string, DeletedWorktree>(),
+      deletedWorktreeGroupExpanded: false,
       expandedWorktrees: new Set<string>(),
       expandedTerminals: new Set<string>(),
       createDialog: {


### PR DESCRIPTION
## Summary

- Deleting several worktrees at once used to flood two surfaces: a full height ghost card per worktree in the sidebar (each with its own countdown and trash button, all piling up at the end in grouped by type mode), plus one inbox entry per worktree from the 1Hz cleanup sweep.
- Two or more deleted rows now collapse into a single summary row, something like "3 deleted worktrees · 7 terminals", that expands to the individual cards. One bulk clear replaces N trash buttons.
- A same tick sweep burst now writes a single inbox entry instead of N.

Resolves #11260

## Key decisions

1. **Rescue drag stays reachable from the collapsed form** via a rail of draggable terminal chips that reuse the existing `SortableWorktreeTerminal` component, so no new dnd-kit surface and zero `DndProvider` changes. This was the load bearing requirement in the issue. Suppressing collapse during an active drag was considered and rejected, since it can't expose a drag source that was already hidden when the drag began.
2. **No new `BUILT_IN_ACTION_IDS` entry.** The bulk clear fans the existing `worktree.sessions.trashAll` action over each member worktree, exactly like the existing single row dismiss already does. That avoids five CI only coupling points: the action snapshot test, the api-surface report, the confirm wiring guard, the destructive action audit, and docs.
3. **The group is exactly one aria row** whose gridcell contains a disclosure control, so expanding it changes the row's height rather than the grid's shape.
4. **Notification aggregation lives at the `deletedWorktreeCleanup` call site**, not inside `notify.ts`. Notify's coalesce logic and its rate limiter are both structurally unreachable for `priority: "low"`, and these notifications have to stay low priority since they're inbox only by design and must never become an auto dismissing toast.

## Bugs caught and fixed during review

- **The group could vanish from the sidebar entirely.** Its slot was derived from the raw `pinnedIndex` without the in-bounds check the per-row placement path applies, so an out-of-range pin could claim a slot the render loop never reached, taking every rescue surface down with it. Fixed by extracting a pure `planDeletedWorktreePlacement` function into its own module, with 9 tests covering out-of-range, mixed, and empty-list pin scenarios.
- **A D2 consent violation in the confirm dialog.** The preview filtered to PTY panels only, but `bulkTrashByWorktree` closes every non-trash, non-overlay, non-dialog panel. A worktree holding a terminal plus a browser panel would preview one item but actually close two. Fixed by mirroring `DeletedWorktreeCard`'s own split: all panel kinds drive the displayed count and preview list, PTY only panels drive the drag rail.

## Notes for reviewers

- Keyboard initiated cross-container drag from the new rail likely can't reach a live worktree drop target, because dnd-kit's `sortableKeyboardCoordinates` is scoped to the currently active sortable container. Not a regression: `WorktreeTerminalSection` already wraps its own terminals in a separate `SortableContext`, so the existing `DeletedWorktreeCard` has identical topology and the same limitation already existed. Pointer drag, the primary rescue path, works fully. Flagging rather than fixing, since it predates this PR and is out of scope.
- The bulk clear fans worktree scoped trash calls rather than executing against the exact confirmed panel ID set from preview time, so a panel arriving in a deleted worktree in the narrow window between preview and confirm gets swept in unpreviewed. The window is narrow (the confirm modal is open and the countdown is deferred during that time), and the already shipped single row dismiss action re-derives its target set identically at confirm time, so diverging from that precedent here was judged riskier than the small hole it leaves open.

## Testing

- `npm run typecheck`: clean
- 1502 tests across 94 files passing
- Prettier and eslint clean on all 14 changed files
