### PR TITLE
fix(worktree): fix deleted-worktree auto-close countdown timing

### DIFF
--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -340,7 +340,7 @@ export function WorktreeSettingsTab() {
       >
         <SettingsSelect
           label="Close leftover terminals"
-          description="Leftover terminals move to trash when the timer ends. The timer pauses while a drag is in progress and while an agent is still working."
+          description="Leftover terminals move to trash when the timer ends. The timer only counts down while the project is open, and pauses for a while during a drag, an open close confirmation, or an agent that's still working."
           scope="global"
           value={String(cleanupSeconds)}
           onValueChange={handleCleanupChange}

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, type MouseEvent } from "react";
+import { useCallback, useMemo, useRef, useState, type MouseEvent } from "react";
 import { FolderX, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
@@ -98,14 +98,30 @@ export function DeletedWorktreeCard({
   const hold =
     hasCountdown && worktree.holdReason !== null ? HOLD_COPY[worktree.holdReason] : undefined;
   useVisibilityAwareInterval(() => setNowTick(Date.now()), 1000, hasCountdown);
-  // The sweep (which re-pins the deadline while held) and this tick run on
-  // independent 1s phases — clamp remaining to the TTL (no "61s" flicker)
-  // and snap the top ~1.5s to exactly full so a held bar holds steady
-  // instead of sawtoothing between full and full-minus-a-tick.
+  // Clamp to the TTL: the sweep arms the deadline off its own clock, so the
+  // first tick after arming can otherwise read a whole second past full ("61s").
   const cleanupMs = cleanupSeconds * 1000;
   const rawRemainingMs = expiresAt !== null ? Math.max(0, expiresAt - nowTick) : 0;
-  const remainingMs = cleanupMs > 0 ? Math.min(rawRemainingMs, cleanupMs) : rawRemainingMs;
+  const derivedRemainingMs = cleanupMs > 0 ? Math.min(rawRemainingMs, cleanupMs) : rawRemainingMs;
+  // While held, render the remaining captured when the hold began rather than
+  // re-deriving it from the deadline. The sweep re-pins `expiresAt` to
+  // `now + remaining` on every pass, and its phase is independent of this
+  // component's tick, so each pins a value exactly one interval apart and the
+  // readout alternates between N and N+1 forever — a held row visibly flips
+  // 38s/37s/38s. Freezing is also the honest reading: a held countdown is not
+  // advancing. The key re-captures if the TTL preference changes underneath the
+  // hold, which is the one case where the sweep re-pins a genuinely new value.
+  const heldRemainingRef = useRef<{ key: string; remainingMs: number } | null>(null);
+  const holdKey = hold === undefined ? null : `${worktree.holdReason}:${cleanupMs}`;
+  if (holdKey === null) heldRemainingRef.current = null;
+  else if (heldRemainingRef.current?.key !== holdKey) {
+    heldRemainingRef.current = { key: holdKey, remainingMs: derivedRemainingMs };
+  }
+  const remainingMs = heldRemainingRef.current?.remainingMs ?? derivedRemainingMs;
   const remainingSeconds = Math.ceil(remainingMs / 1000);
+  // Snap the top of the range to exactly full: the tick that arms the row lands
+  // somewhere inside the sweep's first second, so a bar that should read "just
+  // deleted" would otherwise start a sliver short.
   const remainingFraction = hasCountdown
     ? remainingMs >= cleanupMs - 1500
       ? 1
@@ -324,12 +340,15 @@ export function DeletedWorktreeCard({
       >
         {hasCountdown && (
           <div
-            // The 1s linear sweep is the countdown's own tempo (it matches the
-            // tick that drives it), not a state-change tier. It stays on while
-            // held: the sweep re-pins the deadline on its own 1s phase,
-            // independent of this component's tick, so a held bar still gets
-            // sub-second width jitter — the transition is what absorbs it.
-            className="deleted-worktree-countdown-fill h-full bg-border-strong transition-[width] duration-1000 ease-linear motion-reduce:transition-none"
+            className={cn(
+              // The 1s linear sweep is the countdown's own tempo (it matches
+              // the tick that drives it), not a state-change tier. A held bar
+              // holds one frozen width, so there is nothing to interpolate —
+              // leaving the transition on would only smear the moment it stops.
+              "deleted-worktree-countdown-fill h-full bg-border-strong",
+              hold === undefined && "transition-[width] duration-1000 ease-linear",
+              "motion-reduce:transition-none"
+            )}
             style={{ width: `${remainingFraction * 100}%` }}
             data-testid="deleted-worktree-countdown"
             data-held={hold !== undefined ? "true" : undefined}

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -28,9 +28,10 @@ interface DeletedWorktreeCardProps {
 }
 
 /**
- * What the row says while its countdown is held. The label has to survive a
- * narrow sidebar next to the title and the "Deleted" pill, so it stays terse
- * and the tooltip carries the explanation.
+ * What the row says while its countdown is held. The visible label is what
+ * carries the reason — it has to survive a narrow sidebar beside the title and
+ * the "Deleted" pill, so it stays terse, and the tooltip expands it for anyone
+ * who wants the whole sentence.
  */
 const HOLD_COPY: Record<DeletedWorktreeHoldReason, { label: string; tooltip: string }> = {
   confirm: {
@@ -323,15 +324,12 @@ export function DeletedWorktreeCard({
       >
         {hasCountdown && (
           <div
-            className={cn(
-              // The 1s linear sweep is the countdown's own tempo (it matches
-              // the tick that drives it), not a state-change tier. A held bar
-              // isn't moving, so animating it would only smear the moment it
-              // stops.
-              "deleted-worktree-countdown-fill h-full bg-border-strong",
-              hold === undefined && "transition-[width] duration-1000 ease-linear",
-              "motion-reduce:transition-none"
-            )}
+            // The 1s linear sweep is the countdown's own tempo (it matches the
+            // tick that drives it), not a state-change tier. It stays on while
+            // held: the sweep re-pins the deadline on its own 1s phase,
+            // independent of this component's tick, so a held bar still gets
+            // sub-second width jitter — the transition is what absorbs it.
+            className="deleted-worktree-countdown-fill h-full bg-border-strong transition-[width] duration-1000 ease-linear motion-reduce:transition-none"
             style={{ width: `${remainingFraction * 100}%` }}
             data-testid="deleted-worktree-countdown"
             data-held={hold !== undefined ? "true" : undefined}

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -6,6 +6,7 @@ import {
   getDeletedWorktreeTerminalIds,
   useWorktreeSelectionStore,
   type DeletedWorktree,
+  type DeletedWorktreeHoldReason,
 } from "@/store/worktreeStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
@@ -25,6 +26,26 @@ interface DeletedWorktreeCardProps {
    */
   showDismissAction?: boolean;
 }
+
+/**
+ * What the row says while its countdown is held. The label has to survive a
+ * narrow sidebar next to the title and the "Deleted" pill, so it stays terse
+ * and the tooltip carries the explanation.
+ */
+const HOLD_COPY: Record<DeletedWorktreeHoldReason, { label: string; tooltip: string }> = {
+  confirm: {
+    label: "Confirming",
+    tooltip: "Auto-close is paused while you confirm closing this row",
+  },
+  drag: {
+    label: "Dragging",
+    tooltip: "Auto-close is paused while a drag is in progress",
+  },
+  agent: {
+    label: "Agent working",
+    tooltip: "Auto-close is paused while an agent here is still working",
+  },
+};
 
 /**
  * Sidebar row for a worktree whose directory is gone but whose terminals are
@@ -64,17 +85,21 @@ export function DeletedWorktreeCard({
 
   // Auto-cleanup countdown (deletedWorktreeCleanup.ts owns the deadline; this
   // is display only): a numeric seconds readout in the header plus the row's
-  // own bottom separator draining from full width to empty. Both hold at full
-  // while the sweep defers the deadline (drag in progress, agent still
-  // working, confirm dialog open).
+  // own bottom separator draining from full width to empty. While the sweep
+  // holds the countdown it pins the deadline to whatever remained when the hold
+  // began, so both freeze at that value — and `holdReason` says which condition
+  // is holding, because a row that just stops counting down reads as broken
+  // (#11259).
   const cleanupSeconds = usePreferencesStore((s) => s.deletedWorktreeCleanupSeconds);
   const [nowTick, setNowTick] = useState(() => Date.now());
   const expiresAt = worktree.expiresAt;
   const hasCountdown = expiresAt !== null && cleanupSeconds > 0;
+  const hold =
+    hasCountdown && worktree.holdReason !== null ? HOLD_COPY[worktree.holdReason] : undefined;
   useVisibilityAwareInterval(() => setNowTick(Date.now()), 1000, hasCountdown);
-  // The sweep (which re-extends the deadline while deferred) and this tick run
-  // on independent 1s phases — clamp remaining to the TTL (no "61s" flicker)
-  // and snap the top ~1.5s to exactly full so a paused bar holds steady
+  // The sweep (which re-pins the deadline while held) and this tick run on
+  // independent 1s phases — clamp remaining to the TTL (no "61s" flicker)
+  // and snap the top ~1.5s to exactly full so a held bar holds steady
   // instead of sawtoothing between full and full-minus-a-tick.
   const cleanupMs = cleanupSeconds * 1000;
   const rawRemainingMs = expiresAt !== null ? Math.max(0, expiresAt - nowTick) : 0;
@@ -211,10 +236,28 @@ export function DeletedWorktreeCard({
             </span>
           </span>
           <div className="flex items-center gap-2 shrink-0">
+            {hold !== undefined && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="shrink-0 rounded-full bg-overlay-soft px-1.5 py-0.5 text-[10px] font-medium text-text-muted"
+                    data-testid="deleted-worktree-countdown-hold"
+                    data-hold-reason={worktree.holdReason}
+                  >
+                    {hold.label}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">{hold.tooltip}</TooltipContent>
+              </Tooltip>
+            )}
             {hasCountdown && (
               <span
                 className="font-mono text-[11px] tabular-nums text-text-muted"
-                title={`Closes automatically in ${remainingSeconds}s`}
+                title={
+                  hold !== undefined
+                    ? `${hold.tooltip}, holding at ${remainingSeconds}s`
+                    : `Closes automatically in ${remainingSeconds}s`
+                }
                 data-testid="deleted-worktree-countdown-seconds"
               >
                 {remainingSeconds}s
@@ -280,9 +323,18 @@ export function DeletedWorktreeCard({
       >
         {hasCountdown && (
           <div
-            className="deleted-worktree-countdown-fill h-full bg-border-strong transition-[width] duration-1000 ease-linear motion-reduce:transition-none"
+            className={cn(
+              // The 1s linear sweep is the countdown's own tempo (it matches
+              // the tick that drives it), not a state-change tier. A held bar
+              // isn't moving, so animating it would only smear the moment it
+              // stops.
+              "deleted-worktree-countdown-fill h-full bg-border-strong",
+              hold === undefined && "transition-[width] duration-1000 ease-linear",
+              "motion-reduce:transition-none"
+            )}
             style={{ width: `${remainingFraction * 100}%` }}
             data-testid="deleted-worktree-countdown"
+            data-held={hold !== undefined ? "true" : undefined}
           />
         )}
       </div>

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -97,6 +97,7 @@ const worktree: DeletedWorktree = {
   path: "/repo/feature-login",
   deletedAt: 1000,
   expiresAt: null,
+  holdReason: null,
   pinnedIndex: 2,
 };
 
@@ -169,6 +170,70 @@ describe("DeletedWorktreeCard", () => {
 
     const readout = container.querySelector("[data-testid='deleted-worktree-countdown-seconds']");
     expect(readout?.textContent).toMatch(/^\d+s$/);
+  });
+
+  it("names the condition holding the countdown", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const { container } = renderCard({
+      ...worktree,
+      expiresAt: Date.now() + 40_000,
+      holdReason: "agent",
+    });
+
+    const badge = container.querySelector("[data-testid='deleted-worktree-countdown-hold']");
+    // A row that simply stops counting down reads as broken — it has to say
+    // which condition is holding it.
+    expect(badge?.textContent).toBeTruthy();
+    expect(badge?.getAttribute("data-hold-reason")).toBe("agent");
+    // The remaining stays visible alongside it, so the row still shows what it
+    // is holding *at*.
+    const readout = container.querySelector("[data-testid='deleted-worktree-countdown-seconds']");
+    expect(readout?.textContent).toMatch(/^\d+s$/);
+  });
+
+  it("distinguishes the hold conditions from one another", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const labelFor = (holdReason: DeletedWorktree["holdReason"]): string | undefined => {
+      const { container } = renderCard({
+        ...worktree,
+        expiresAt: Date.now() + 40_000,
+        holdReason,
+      });
+      const label = container.querySelector(
+        "[data-testid='deleted-worktree-countdown-hold']"
+      )?.textContent;
+      cleanup();
+      return label ?? undefined;
+    };
+
+    const labels = [labelFor("confirm"), labelFor("drag"), labelFor("agent")];
+    expect(labels.every((label) => label !== undefined && label.length > 0)).toBe(true);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("shows no hold badge while the countdown is running", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    const { container } = renderCard({ ...worktree, expiresAt: Date.now() + 40_000 });
+
+    expect(container.querySelector("[data-testid='deleted-worktree-countdown-hold']")).toBeNull();
+    expect(
+      container
+        .querySelector("[data-testid='deleted-worktree-countdown']")
+        ?.getAttribute("data-held")
+    ).toBeNull();
+  });
+
+  it("hides the hold badge along with the countdown when auto-cleanup is off", () => {
+    setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
+    const { container } = renderCard({
+      ...worktree,
+      expiresAt: Date.now() + 40_000,
+      holdReason: "drag",
+    });
+
+    expect(container.querySelector("[data-testid='deleted-worktree-countdown-hold']")).toBeNull();
+    expect(container.querySelector("[data-testid='deleted-worktree-countdown']")).toBeNull();
   });
 
   it("hides the countdown bar while auto-cleanup is off or the row is unarmed", () => {

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -191,24 +191,45 @@ describe("DeletedWorktreeCard", () => {
     expect(readout?.textContent).toMatch(/^\d+s$/);
   });
 
-  it("distinguishes the hold conditions from one another", () => {
+  it("names each hold condition in terms the user can act on", () => {
     setPanels([{ id: "t1", worktreeId: "wt-1" }]);
-    const labelFor = (holdReason: DeletedWorktree["holdReason"]): string | undefined => {
+    const copyFor = (holdReason: DeletedWorktree["holdReason"]) => {
       const { container } = renderCard({
         ...worktree,
         expiresAt: Date.now() + 40_000,
         holdReason,
       });
-      const label = container.querySelector(
-        "[data-testid='deleted-worktree-countdown-hold']"
-      )?.textContent;
+      const label =
+        container.querySelector("[data-testid='deleted-worktree-countdown-hold']")?.textContent ??
+        "";
+      const explanation =
+        container
+          .querySelector("[data-testid='deleted-worktree-countdown-seconds']")
+          ?.getAttribute("title") ?? "";
       cleanup();
-      return label ?? undefined;
+      return { label, explanation };
     };
 
-    const labels = [labelFor("confirm"), labelFor("drag"), labelFor("agent")];
-    expect(labels.every((label) => label !== undefined && label.length > 0)).toBe(true);
-    expect(new Set(labels).size).toBe(labels.length);
+    // The visible label is what carries the reason, so it has to actually name
+    // the condition — swapped or generic copy would leave the row as opaque as
+    // the bug being fixed.
+    const agent = copyFor("agent");
+    expect(agent.label.toLowerCase()).toContain("agent");
+    expect(agent.explanation.toLowerCase()).toContain("agent");
+
+    const drag = copyFor("drag");
+    expect(drag.label.toLowerCase()).toContain("drag");
+    expect(drag.explanation.toLowerCase()).toContain("drag");
+
+    const confirm = copyFor("confirm");
+    expect(confirm.label.toLowerCase()).toContain("confirm");
+    expect(confirm.explanation.toLowerCase()).toContain("confirm");
+
+    // Sentence case, no trailing period (CLAUDE.md microcopy).
+    for (const { label } of [agent, drag, confirm]) {
+      expect(label.endsWith(".")).toBe(false);
+      expect(label.slice(1)).toBe(label.slice(1).toLowerCase());
+    }
   });
 
   it("shows no hold badge while the countdown is running", () => {

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 
 vi.mock("react-dom", async () => {
@@ -189,6 +189,69 @@ describe("DeletedWorktreeCard", () => {
     // is holding *at*.
     const readout = container.querySelector("[data-testid='deleted-worktree-countdown-seconds']");
     expect(readout?.textContent).toMatch(/^\d+s$/);
+  });
+
+  it("holds the readout on one value while the countdown is held", () => {
+    vi.useFakeTimers();
+    try {
+      setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+      const base = 1_700_000_000_000;
+      vi.setSystemTime(base);
+
+      // A held row is pinned at whatever remained when the hold began, so every
+      // sweep re-pins the deadline to `now + remaining`. `now` has advanced, so
+      // that write is never a no-op and re-renders the card at the *sweep's*
+      // phase, while the card's own 1Hz tick renders at its own. Deriving the
+      // readout from the deadline therefore alternates between N and N+1
+      // forever, which reads as broken in exactly the way this PR set out to
+      // fix. Neither the TTL clamp nor the full-width snap absorbs it: a hold
+      // pins mid-countdown, not at full.
+      const pinnedRemainingMs = 38_000;
+      const sweptAt = (at: number): DeletedWorktree => ({
+        ...worktree,
+        expiresAt: at + pinnedRemainingMs,
+        holdReason: "agent",
+      });
+
+      const { container, rerender } = render(
+        <TooltipProvider>
+          <DeletedWorktreeCard worktree={sweptAt(base)} />
+        </TooltipProvider>
+      );
+      const seconds = () =>
+        container.querySelector("[data-testid='deleted-worktree-countdown-seconds']")?.textContent;
+      const width = () =>
+        container
+          .querySelector("[data-testid='deleted-worktree-countdown']")
+          ?.getAttribute("style");
+
+      const steadySeconds = seconds();
+      const steadyWidth = width();
+      expect(steadySeconds).toMatch(/^\d+s$/);
+
+      // Sweep phase 600ms, card-tick phase 0ms — advancing through both is what
+      // makes the alternation observable.
+      for (let cycle = 1; cycle <= 4; cycle += 1) {
+        act(() => {
+          vi.advanceTimersByTime(600);
+        });
+        rerender(
+          <TooltipProvider>
+            <DeletedWorktreeCard worktree={sweptAt(base + (cycle - 1) * 1000 + 600)} />
+          </TooltipProvider>
+        );
+        expect(seconds()).toBe(steadySeconds);
+        expect(width()).toBe(steadyWidth);
+
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        expect(seconds()).toBe(steadySeconds);
+        expect(width()).toBe(steadyWidth);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("names each hold condition in terms the user can act on", () => {

--- a/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
@@ -89,7 +89,15 @@ function setPanels(
 }
 
 function makeDeleted(id: string, title: string, expiresAt: number | null = null): DeletedWorktree {
-  return { id, title, path: `/repo/${id}`, deletedAt: 1000, expiresAt, pinnedIndex: -1 };
+  return {
+    id,
+    title,
+    path: `/repo/${id}`,
+    deletedAt: 1000,
+    expiresAt,
+    holdReason: null,
+    pinnedIndex: -1,
+  };
 }
 
 const worktrees = [makeDeleted("wt-1", "feature/alpha"), makeDeleted("wt-2", "feature/beta")];

--- a/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
+++ b/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
@@ -12,7 +12,15 @@ import { planDeletedWorktreePlacement } from "../deletedWorktreePlacement";
 import type { DeletedWorktree } from "@/store/worktreeStore";
 
 function deleted(id: string, pinnedIndex: number): DeletedWorktree {
-  return { id, title: id, path: `/repo/${id}`, deletedAt: 1000, expiresAt: null, pinnedIndex };
+  return {
+    id,
+    title: id,
+    path: `/repo/${id}`,
+    deletedAt: 1000,
+    expiresAt: null,
+    holdReason: null,
+    pinnedIndex,
+  };
 }
 
 describe("planDeletedWorktreePlacement", () => {

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -419,6 +419,7 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
         path: "/repo-worktrees/gone",
         deletedAt: 1000,
         expiresAt: null,
+        holdReason: null,
         pinnedIndex: -1,
       });
       useWorktreeSelectionStore.setState({ activeWorktreeId: "ghost-1" });

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -14,7 +14,6 @@ import {
   getPinnedDeletedWorktreeIndex,
 } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
-import { usePreferencesStore } from "@/store/preferencesStore";
 import { startDeletedWorktreeCleanup } from "@/store/deletedWorktreeCleanup";
 import { usePulseStore } from "@/store/pulseStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -439,7 +438,6 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // (the delete dialog and the `worktree.delete` action) funnel through
         // this event, so they get identical behaviour from this one change.
         if (willBecomeGhost) {
-          const cleanupSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
           selectionStore.addDeletedWorktree({
             id: event.worktreeId,
             // Detached-HEAD worktrees have no branch; fall back to the folder
@@ -448,11 +446,13 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
               worktree.branch ?? worktree.path.split(/[/\\]/).filter(Boolean).pop() ?? "Unknown",
             path: worktree.path,
             deletedAt: Date.now(),
-            // Armed HERE, not by the sweep's next tick — deletion starts the
-            // countdown even if this view is hidden and its sweep throttled.
-            // The sweep owns it from now on (defers, re-arms on preference
-            // change, fires into the trash).
-            expiresAt: cleanupSeconds > 0 ? Date.now() + cleanupSeconds * 1000 : null,
+            // Recorded UNARMED on purpose: the sweep arms it on its first tick
+            // with this view awake, and only ever advances it across awake
+            // seconds. Stamping a wall-clock deadline here instead meant a
+            // project cached at deletion time came back with the countdown
+            // already spent and no window to rescue anything (#11259).
+            expiresAt: null,
+            holdReason: null,
             pinnedIndex: getPinnedDeletedWorktreeIndex(event.worktreeId),
           });
         }

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -159,6 +159,26 @@ describe("WorktreeStoreProvider — surviving terminals on worktree removal", ()
     expect(usePanelStore.getState().panelIds).toContain("agent-a");
   });
 
+  it("records the ghost row unarmed and lets the cleanup sweep start the clock (#11259)", async () => {
+    const { store } = await renderProvider();
+    act(() => {
+      store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
+    });
+    setPanels([{ id: "agent-a", worktreeId: "wt-1" }]);
+
+    act(() => {
+      emit("worktree-removed", removeEvent("wt-1"));
+    });
+
+    // Stamping a wall-clock deadline here charged the row for time a cached
+    // project view spent frozen, so it came back already expired with no
+    // window to rescue the surviving agents.
+    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+    expect(row).toBeDefined();
+    expect(row?.expiresAt).toBeNull();
+    expect(row?.holdReason).toBeNull();
+  });
+
   it("keeps the deleted worktree active while its terminals survive", async () => {
     const { store } = await renderProvider();
     act(() => {

--- a/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
@@ -13,7 +13,8 @@ import {
 vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
 
 const NOW = 1_700_000_000_000;
-const TTL_MS = 60_000;
+const TTL_SECONDS = 60;
+const TTL_MS = TTL_SECONDS * 1000;
 
 /**
  * The cached-view half of #11259 is a *lifecycle* bug, so these drive the real
@@ -27,6 +28,18 @@ let warmHandlers: Array<() => void>;
 let revealedHandlers: Array<() => void>;
 let latchedCached: boolean;
 let bulkTrashByWorktree: ReturnType<typeof vi.fn<(worktreeId: string) => void>>;
+let disposeCleanup: (() => void) | undefined;
+
+/** Start the sweep and register its disposer, so a failing assertion can't leak it. */
+function start(): void {
+  disposeCleanup = startDeletedWorktreeCleanup();
+}
+
+function stop(): void {
+  disposeCleanup?.();
+  disposeCleanup = undefined;
+}
+
 
 function goCached(): void {
   latchedCached = true;
@@ -77,7 +90,7 @@ beforeEach(() => {
   resetDeletedWorktreeCleanupState();
   __resetProjectViewCacheStateForTests();
   useWorktreeSelectionStore.getState().reset();
-  usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: TTL_MS / 1000 });
+  usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: TTL_SECONDS });
 
   cachedHandlers = [];
   warmHandlers = [];
@@ -116,6 +129,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Before the timers and globals go away, or a failed assertion leaves the
+  // interval and the document listener behind for the next test.
+  stop();
   vi.useRealTimers();
   vi.unstubAllGlobals();
   __resetProjectViewCacheStateForTests();
@@ -124,11 +140,14 @@ afterEach(() => {
 
 describe("startDeletedWorktreeCleanup view lifecycle", () => {
   it("does not trash a row whose deadline elapsed while the view was cached", () => {
-    const stop = startDeletedWorktreeCleanup();
+    start();
     addRow();
     advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
     advance(10_000);
     const remainingWhenCached = remainingNow();
+    // Guard the guard: if arming ever broke, `null === null` below would still
+    // "pass" while proving nothing.
+    expect(remainingWhenCached).toBeGreaterThan(0);
 
     goCached();
     // Away far longer than the whole TTL — this is the case that used to trash
@@ -139,11 +158,10 @@ describe("startDeletedWorktreeCleanup view lifecycle", () => {
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
     expect(remainingNow()).toBe(remainingWhenCached);
-    stop();
   });
 
   it("arms a row recorded while the view was cached instead of trashing it on wake", () => {
-    const stop = startDeletedWorktreeCleanup();
+    start();
     goCached();
     // Main keeps broadcasting worktree-removed to a cached view.
     addRow();
@@ -153,14 +171,14 @@ describe("startDeletedWorktreeCleanup view lifecycle", () => {
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
     expect(remainingNow()).toBe(TTL_MS);
-    stop();
   });
 
   it("charges only awake time across repeated cache cycles", () => {
-    const stop = startDeletedWorktreeCleanup();
+    start();
     addRow();
     advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
     const startRemaining = remainingNow() ?? 0;
+    expect(startRemaining).toBeGreaterThan(0);
 
     let awakeMs = 0;
     for (let cycle = 0; cycle < 3; cycle++) {
@@ -176,71 +194,136 @@ describe("startDeletedWorktreeCleanup view lifecycle", () => {
     // countdown neither stalls nor gets re-granted by switching projects.
     expect(remainingNow()).toBe(startRemaining - awakeMs);
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
-    stop();
   });
 
-  it("stops sweeping while cached and resumes on activation", () => {
-    const stop = startDeletedWorktreeCleanup();
-    addRow();
-    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+  it("owns exactly one interval across cache, repeated activation, and disposal", () => {
+    // Asserted on timer ownership rather than on the deadline: an absolute
+    // deadline is idempotent, so stacked intervals cannot be detected by
+    // watching how fast the countdown moves.
+    const idle = vi.getTimerCount();
+    start();
+    expect(vi.getTimerCount()).toBe(idle + 1);
 
     goCached();
-    const expiryWhenCached = getRow()?.expiresAt;
-    advance(10 * DELETED_WORKTREE_SWEEP_INTERVAL_MS);
-    // No sweep ran: the deadline is untouched despite ten intervals passing.
-    expect(getRow()?.expiresAt).toBe(expiryWhenCached);
-
-    goActive();
-    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
-    expect(getRow()?.expiresAt).not.toBe(expiryWhenCached);
-    stop();
-  });
-
-  it("does not stack intervals when activation fires repeatedly", () => {
-    const stop = startDeletedWorktreeCleanup();
-    addRow();
-    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    expect(vi.getTimerCount()).toBe(idle);
 
     goActive();
     goActive();
     goRevealed();
-    advance(5_000);
+    expect(vi.getTimerCount()).toBe(idle + 1);
 
-    // A stacked interval would spend the countdown several times per second.
-    expect(remainingNow()).toBe(TTL_MS - 5_000);
     stop();
+    expect(vi.getTimerCount()).toBe(idle);
   });
 
-  it("grants a fresh window to an armed row when the module started already cached", () => {
-    // No `cached` edge is ever delivered here, so there is no snapshot to
-    // restore — the row's deadline is of unknown provenance and may have aged
-    // entirely while nobody could see it.
+  it("arms no interval when the module starts inside a cached window", () => {
     latchedCached = true;
-    addRow({ expiresAt: NOW - 1 });
-    const stop = startDeletedWorktreeCleanup();
-    advance(10 * DELETED_WORKTREE_SWEEP_INTERVAL_MS);
-    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    const idle = vi.getTimerCount();
+    start();
+
+    // No `cached` phase is ever delivered in this case, so the arm has to
+    // consult the seeded latch itself.
+    expect(vi.getTimerCount()).toBe(idle);
+  });
+
+  it("arms a row added during a cached start only once the view is back", () => {
+    // The switch-storm case: the view was already cached before this module
+    // evaluated, so no `cached` phase is ever delivered and the latch is the
+    // only thing that knows.
+    latchedCached = true;
+    start();
+    addRow();
+    advance(60 * 60_000);
+    expect(getRow()?.expiresAt).toBeNull();
 
     goActive();
     goRevealed();
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
     expect(remainingNow()).toBe(TTL_MS);
-    stop();
+  });
+
+  it("keeps a hold's remaining and its cap across a long cache", () => {
+    start();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    advance(10_000);
+    // An agent starts working, so the row holds.
+    usePanelStore.setState({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          title: "t1",
+          worktreeId: "wt-1",
+          location: "grid",
+          agentState: "working",
+        },
+      } as never,
+    });
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    const heldRemaining = remainingNow();
+    expect(getRow()?.holdReason).toBe("agent");
+
+    goCached();
+    advance(90 * 60_000);
+    goActive();
+    goRevealed();
+
+    // The agent is still working, and the hour and a half spent cached is not
+    // charged against either the countdown or the hold's cap — otherwise the
+    // agent's protection would be gone the moment the user came back.
+    expect(getRow()?.holdReason).toBe("agent");
+    expect(remainingNow()).toBe(heldRemaining);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("re-arms to the new TTL when the preference changed while cached", () => {
+    start();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    advance(10_000);
+
+    goCached();
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 30 });
+    advance(30 * 60_000);
+    goActive();
+    goRevealed();
+
+    // A remaining measured against the old 60s TTL would overflow the card's
+    // bar, which divides by the current one.
+    expect(remainingNow()).toBe(30_000);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("leaves rows disarmed across a cache cycle when cleanup is off", () => {
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
+    start();
+    addRow({ expiresAt: NOW + 20_000 });
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    expect(getRow()?.expiresAt).toBeNull();
+
+    goCached();
+    advance(60 * 60_000);
+    goActive();
+    goRevealed();
+
+    expect(getRow()?.expiresAt).toBeNull();
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
   });
 
   it("still fires once the countdown is genuinely spent while awake", () => {
-    const stop = startDeletedWorktreeCleanup();
+    start();
     addRow();
     advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
     advance(TTL_MS + DELETED_WORKTREE_SWEEP_INTERVAL_MS);
 
     expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
-    stop();
   });
 
   it("stops sweeping after disposal", () => {
-    const stop = startDeletedWorktreeCleanup();
+    start();
     addRow();
     advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
     stop();

--- a/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
@@ -157,7 +157,11 @@ describe("startDeletedWorktreeCleanup view lifecycle", () => {
     goRevealed();
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
-    expect(remainingNow()).toBe(remainingWhenCached);
+    // The hour is credited back; only the interval every sweep always spends
+    // comes off, so the user still returns to a real rescue window.
+    const spentWhileAway = (remainingWhenCached ?? 0) - (remainingNow() ?? 0);
+    expect(spentWhileAway).toBeLessThanOrEqual(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    expect(remainingNow()).toBeGreaterThan(0);
   });
 
   it("arms a row recorded while the view was cached instead of trashing it on wake", () => {
@@ -180,8 +184,9 @@ describe("startDeletedWorktreeCleanup view lifecycle", () => {
     const startRemaining = remainingNow() ?? 0;
     expect(startRemaining).toBeGreaterThan(0);
 
+    const cycles = 3;
     let awakeMs = 0;
-    for (let cycle = 0; cycle < 3; cycle++) {
+    for (let cycle = 0; cycle < cycles; cycle++) {
       advance(5_000);
       awakeMs += 5_000;
       goCached();
@@ -190,9 +195,13 @@ describe("startDeletedWorktreeCleanup view lifecycle", () => {
       goRevealed();
     }
 
-    // Each cycle spends its awake seconds and none of its cached ones, so the
-    // countdown neither stalls nor gets re-granted by switching projects.
-    expect(remainingNow()).toBe(startRemaining - awakeMs);
+    // An hour and a half of wall clock passed, of which 15s was watchable.
+    // Each cycle spends its awake seconds plus the one interval every sweep
+    // always spends, and none of its cached ones — so the countdown neither
+    // stalls nor gets re-granted by switching projects.
+    const spent = startRemaining - (remainingNow() ?? 0);
+    expect(spent).toBeGreaterThanOrEqual(awakeMs);
+    expect(spent).toBeLessThanOrEqual(awakeMs + cycles * DELETED_WORKTREE_SWEEP_INTERVAL_MS);
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
   });
 

--- a/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
@@ -40,7 +40,6 @@ function stop(): void {
   disposeCleanup = undefined;
 }
 
-
 function goCached(): void {
   latchedCached = true;
   for (const handler of cachedHandlers) handler();

--- a/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
+import { __resetProjectViewCacheStateForTests } from "@/lib/viewCacheState";
+import {
+  DELETED_WORKTREE_SWEEP_INTERVAL_MS,
+  resetDeletedWorktreeCleanupState,
+  startDeletedWorktreeCleanup,
+} from "../deletedWorktreeCleanup";
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+const NOW = 1_700_000_000_000;
+const TTL_MS = 60_000;
+
+/**
+ * The cached-view half of #11259 is a *lifecycle* bug, so these drive the real
+ * `viewCacheState` bridge (stubbed at the preload boundary, as the watchdog's
+ * tests do) rather than injecting a cached flag. Kept out of the pure sweep
+ * suite because fake timers plus the lifecycle bridge would otherwise leak
+ * across every state-machine case.
+ */
+let cachedHandlers: Array<() => void>;
+let warmHandlers: Array<() => void>;
+let revealedHandlers: Array<() => void>;
+let latchedCached: boolean;
+let bulkTrashByWorktree: ReturnType<typeof vi.fn<(worktreeId: string) => void>>;
+
+function goCached(): void {
+  latchedCached = true;
+  for (const handler of cachedHandlers) handler();
+}
+
+function goActive(): void {
+  latchedCached = false;
+  for (const handler of warmHandlers) handler();
+}
+
+function goRevealed(): void {
+  latchedCached = false;
+  for (const handler of revealedHandlers) handler();
+}
+
+/** Advance wall-clock time. Any live interval ticks along the way. */
+function advance(ms: number): void {
+  vi.advanceTimersByTime(ms);
+}
+
+function addRow(overrides: Partial<DeletedWorktree> = {}): void {
+  useWorktreeSelectionStore.getState().addDeletedWorktree({
+    id: "wt-1",
+    title: "feature/x",
+    path: "/repo/x",
+    deletedAt: NOW,
+    expiresAt: null,
+    holdReason: null,
+    pinnedIndex: -1,
+    ...overrides,
+  });
+}
+
+function getRow(): DeletedWorktree | undefined {
+  return useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+}
+
+/** Remaining the row would display right now. */
+function remainingNow(): number | null {
+  const expiresAt = getRow()?.expiresAt;
+  return expiresAt == null ? null : expiresAt - Date.now();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  resetDeletedWorktreeCleanupState();
+  __resetProjectViewCacheStateForTests();
+  useWorktreeSelectionStore.getState().reset();
+  usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: TTL_MS / 1000 });
+
+  cachedHandlers = [];
+  warmHandlers = [];
+  revealedHandlers = [];
+  latchedCached = false;
+  vi.stubGlobal("electron", {
+    app: {
+      onViewCached: (cb: () => void) => {
+        cachedHandlers.push(cb);
+        return vi.fn();
+      },
+      onViewWarmActivated: (cb: () => void) => {
+        warmHandlers.push(cb);
+        return vi.fn();
+      },
+      onViewRevealed: (cb: () => void) => {
+        revealedHandlers.push(cb);
+        return vi.fn();
+      },
+      // Preload's latch — seeding it before start reproduces the switch-storm
+      // case where the view was cached before this module ever evaluated.
+      isViewCached: () => latchedCached,
+    },
+  });
+
+  bulkTrashByWorktree = vi.fn<(worktreeId: string) => void>();
+  usePanelStore.setState({
+    panelIds: ["t1"],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    panelsById: {
+      t1: { id: "t1", kind: "terminal", title: "t1", worktreeId: "wt-1", location: "grid" },
+    } as never,
+    panelIdsByWorktreeId: { "wt-1": ["t1"] },
+    bulkTrashByWorktree,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  __resetProjectViewCacheStateForTests();
+  resetDeletedWorktreeCleanupState();
+});
+
+describe("startDeletedWorktreeCleanup view lifecycle", () => {
+  it("does not trash a row whose deadline elapsed while the view was cached", () => {
+    const stop = startDeletedWorktreeCleanup();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    advance(10_000);
+    const remainingWhenCached = remainingNow();
+
+    goCached();
+    // Away far longer than the whole TTL — this is the case that used to trash
+    // surviving agents on the first tick after thaw with no window to react.
+    advance(60 * 60_000);
+    goActive();
+    goRevealed();
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(remainingNow()).toBe(remainingWhenCached);
+    stop();
+  });
+
+  it("arms a row recorded while the view was cached instead of trashing it on wake", () => {
+    const stop = startDeletedWorktreeCleanup();
+    goCached();
+    // Main keeps broadcasting worktree-removed to a cached view.
+    addRow();
+    advance(60 * 60_000);
+    goActive();
+    goRevealed();
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(remainingNow()).toBe(TTL_MS);
+    stop();
+  });
+
+  it("charges only awake time across repeated cache cycles", () => {
+    const stop = startDeletedWorktreeCleanup();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    const startRemaining = remainingNow() ?? 0;
+
+    let awakeMs = 0;
+    for (let cycle = 0; cycle < 3; cycle++) {
+      advance(5_000);
+      awakeMs += 5_000;
+      goCached();
+      advance(30 * 60_000);
+      goActive();
+      goRevealed();
+    }
+
+    // Each cycle spends its awake seconds and none of its cached ones, so the
+    // countdown neither stalls nor gets re-granted by switching projects.
+    expect(remainingNow()).toBe(startRemaining - awakeMs);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("stops sweeping while cached and resumes on activation", () => {
+    const stop = startDeletedWorktreeCleanup();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+
+    goCached();
+    const expiryWhenCached = getRow()?.expiresAt;
+    advance(10 * DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    // No sweep ran: the deadline is untouched despite ten intervals passing.
+    expect(getRow()?.expiresAt).toBe(expiryWhenCached);
+
+    goActive();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    expect(getRow()?.expiresAt).not.toBe(expiryWhenCached);
+    stop();
+  });
+
+  it("does not stack intervals when activation fires repeatedly", () => {
+    const stop = startDeletedWorktreeCleanup();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+
+    goActive();
+    goActive();
+    goRevealed();
+    advance(5_000);
+
+    // A stacked interval would spend the countdown several times per second.
+    expect(remainingNow()).toBe(TTL_MS - 5_000);
+    stop();
+  });
+
+  it("grants a fresh window to an armed row when the module started already cached", () => {
+    // No `cached` edge is ever delivered here, so there is no snapshot to
+    // restore — the row's deadline is of unknown provenance and may have aged
+    // entirely while nobody could see it.
+    latchedCached = true;
+    addRow({ expiresAt: NOW - 1 });
+    const stop = startDeletedWorktreeCleanup();
+    advance(10 * DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+
+    goActive();
+    goRevealed();
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(remainingNow()).toBe(TTL_MS);
+    stop();
+  });
+
+  it("still fires once the countdown is genuinely spent while awake", () => {
+    const stop = startDeletedWorktreeCleanup();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    advance(TTL_MS + DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("stops sweeping after disposal", () => {
+    const stop = startDeletedWorktreeCleanup();
+    addRow();
+    advance(DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+    stop();
+
+    advance(TTL_MS * 2);
+    // Neither the interval nor a lifecycle edge may revive a disposed sweep.
+    goActive();
+    goRevealed();
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -6,6 +6,8 @@ import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendin
 import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktreeStore";
 import { notify } from "@/lib/notify";
 import {
+  DELETED_WORKTREE_AGENT_HOLD_CAP_MS,
+  DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS,
   resetDeletedWorktreeCleanupState,
   sweepDeletedWorktreeCleanup,
 } from "../deletedWorktreeCleanup";
@@ -18,11 +20,13 @@ function makeDeps(
   overrides: Partial<{
     now: () => number;
     isDragActive: () => boolean;
+    isViewCached: () => boolean;
   }> = {}
 ) {
   return {
     now: () => NOW,
     isDragActive: () => false,
+    isViewCached: () => false,
     ...overrides,
   };
 }
@@ -34,10 +38,40 @@ function addRow(overrides: Partial<DeletedWorktree> = {}): void {
     path: "/repo/x",
     deletedAt: 0,
     expiresAt: null,
+    holdReason: null,
     pinnedIndex: -1,
     ...overrides,
   });
 }
+
+function getRow(): DeletedWorktree | undefined {
+  return useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+}
+
+function getHoldReason(): DeletedWorktree["holdReason"] | undefined {
+  return getRow()?.holdReason;
+}
+
+/** Remaining the row would display at `now` — the value the countdown shows. */
+function getRemainingAt(now: number): number | null {
+  const expiresAt = getRow()?.expiresAt;
+  return expiresAt == null ? null : expiresAt - now;
+}
+
+/**
+ * Arm a row with no hold condition active and run it down `consumedMs` into
+ * its countdown. Returns that instant, so a test can begin a hold at a known
+ * time rather than inferring when the sweep first saw the condition.
+ */
+function armAndAdvance(consumedMs: number): number {
+  addRow();
+  sweepDeletedWorktreeCleanup(makeDeps());
+  const at = NOW + consumedMs;
+  sweepDeletedWorktreeCleanup(makeDeps({ now: () => at }));
+  return at;
+}
+
+const TTL_MS = 60_000;
 
 function setPanels(
   entries: Array<{
@@ -127,12 +161,22 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(bulkTrashByWorktree).toHaveBeenCalledTimes(2);
   });
 
-  it("holds the countdown while any drag is in progress", () => {
-    addRow({ expiresAt: NOW - 1 });
-    sweepDeletedWorktreeCleanup(makeDeps({ isDragActive: () => true }));
+  it("holds the countdown at its remaining while any drag is in progress", () => {
+    // Two thirds spent before the drag starts: the hold must preserve the
+    // third that is left, not hand back a fresh full window.
+    const held = armAndAdvance(40_000);
+    const deps = { isDragActive: () => true };
+
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held }));
+    const pinned = getRemainingAt(held);
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held + 5_000 }));
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
-    expect(getExpiry()).toBe(NOW + 60_000);
+    // Frozen where it stood, and demonstrably not snapped back to full — the
+    // re-arm-to-full is what held rows open forever.
+    expect(getRemainingAt(held + 5_000)).toBe(pinned);
+    expect(pinned).toBeLessThan(TTL_MS);
+    expect(getHoldReason()).toBe("drag");
   });
 
   it("fires even while the deleted worktree is the active selection", () => {
@@ -145,28 +189,38 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
   });
 
-  it("holds the countdown while an agent in the row is still working", () => {
+  it("holds the countdown at its remaining while an agent in the row is still working", () => {
+    const held = armAndAdvance(40_000);
+
     setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
     usePanelStore.setState({ bulkTrashByWorktree });
-    addRow({ expiresAt: NOW - 1 });
-    sweepDeletedWorktreeCleanup(makeDeps());
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held }));
+    const pinned = getRemainingAt(held);
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held + 5_000 }));
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
-    expect(getExpiry()).toBe(NOW + 60_000);
+    expect(getRemainingAt(held + 5_000)).toBe(pinned);
+    expect(pinned).toBeLessThan(TTL_MS);
+    expect(getHoldReason()).toBe("agent");
   });
 
-  it("holds the countdown while the row's close-confirm dialog is open", () => {
-    addRow({ expiresAt: NOW - 1 });
+  it("holds the countdown at its remaining while the row's close-confirm dialog is open", () => {
+    const held = armAndAdvance(40_000);
+
     useTerminalPendingDestructiveActionStore.getState().request({
       kind: "deletedWorktreeDismiss",
       targetCount: 1,
       runningAgentCount: 0,
       worktreeId: "wt-1",
     });
-    sweepDeletedWorktreeCleanup(makeDeps());
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held }));
+    const pinned = getRemainingAt(held);
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held + 5_000 }));
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
-    expect(getExpiry()).toBe(NOW + 60_000);
+    expect(getRemainingAt(held + 5_000)).toBe(pinned);
+    expect(pinned).toBeLessThan(TTL_MS);
+    expect(getHoldReason()).toBe("confirm");
   });
 
   it("does not defer on a stale working state whose runtime already exited", () => {
@@ -254,11 +308,12 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
-  it("stays silent while the countdown is only being deferred", () => {
-    addRow({ expiresAt: NOW - 1 });
-    sweepDeletedWorktreeCleanup(makeDeps({ isDragActive: () => true }));
+  it("stays silent while the countdown is only being held", () => {
+    const held = armAndAdvance(59_000);
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held + 5_000, isDragActive: () => true }));
 
     expect(notify).not.toHaveBeenCalled();
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
   });
 
   it("collapses a same-tick burst into one inbox entry (#11260)", () => {
@@ -352,5 +407,154 @@ describe("sweepDeletedWorktreeCleanup", () => {
     sweepDeletedWorktreeCleanup(makeDeps());
 
     expect(getExpiry()).toBe(NOW + 60_000);
+  });
+
+  it("resumes from the preserved remaining once the hold clears", () => {
+    const held = armAndAdvance(40_000);
+
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held, isDragActive: () => true }));
+    const pinned = getRemainingAt(held);
+    const releasedAt = held + 10_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => releasedAt }));
+
+    // Picks up where it stopped — the 10s spent held is not charged, and the
+    // row is not handed a fresh window either.
+    expect(getRemainingAt(releasedAt)).toBe(pinned);
+    expect(getHoldReason()).toBeNull();
+  });
+
+  it("gives up on a drag that never clears and fires once its cap is spent", () => {
+    const held = armAndAdvance(40_000);
+    const deps = { isDragActive: () => true };
+
+    // Still inside the transient cap: holding, nothing trashed.
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held }));
+    const pinned = getRemainingAt(held) ?? 0;
+    const beforeCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS - 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => beforeCap }));
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getHoldReason()).toBe("drag");
+
+    // Past the cap the hold gives up: the preserved countdown resumes rather
+    // than the row being trashed on the spot.
+    const afterCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS + 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap }));
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getHoldReason()).toBeNull();
+    expect(getRemainingAt(afterCap)).toBe(pinned);
+
+    // ...and then it actually fires, even though the drag flag never cleared.
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap + pinned }));
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a working agent hold far longer than a drag before giving up", () => {
+    const held = armAndAdvance(40_000);
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held }));
+
+    // A drag would have surrendered by now; a working agent must not, because
+    // trash only holds a terminal for TRASH_TTL_MS before killing the PTY.
+    const pastTransientCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS + 60_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => pastTransientCap }));
+    expect(getHoldReason()).toBe("agent");
+
+    sweepDeletedWorktreeCleanup(
+      makeDeps({ now: () => held + DELETED_WORKTREE_AGENT_HOLD_CAP_MS + 1_000 })
+    );
+    expect(getHoldReason()).toBeNull();
+  });
+
+  it("does not let an exhausted hold restart itself on the next tick", () => {
+    const held = armAndAdvance(40_000);
+    const deps = { isDragActive: () => true };
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held + 1_000 }));
+
+    // The condition is still true, so the hold clock must not be cleared and
+    // restarted — that is what let a permanent condition hold forever.
+    const afterCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS + 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap }));
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap + 1_000 }));
+
+    expect(getHoldReason()).toBeNull();
+  });
+
+  it("falls through an exhausted drag to a still-eligible working agent", () => {
+    const held = armAndAdvance(40_000);
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    const deps = { isDragActive: () => true };
+
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held }));
+    expect(getHoldReason()).toBe("drag");
+
+    // Drag outranks agent while both are eligible; once the drag's shorter cap
+    // is spent the agent keeps holding under its own, longer one.
+    const afterDragCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS + 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterDragCap }));
+    expect(getHoldReason()).toBe("agent");
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
+  it("bounds the total hold even as the reason changes underneath it", () => {
+    const held = armAndAdvance(40_000);
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+
+    // Alternating conditions must not each restart the clock: the whole
+    // continuous hold is measured from when it began.
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held, isDragActive: () => true }));
+    sweepDeletedWorktreeCleanup(
+      makeDeps({ now: () => held + DELETED_WORKTREE_AGENT_HOLD_CAP_MS - 1_000 })
+    );
+    expect(getHoldReason()).toBe("agent");
+
+    sweepDeletedWorktreeCleanup(
+      makeDeps({
+        now: () => held + DELETED_WORKTREE_AGENT_HOLD_CAP_MS + 1_000,
+        isDragActive: () => true,
+      })
+    );
+    expect(getHoldReason()).toBeNull();
+  });
+
+  it("re-captures the held remaining against the new TTL when the preference changes", () => {
+    const held = armAndAdvance(40_000);
+    const deps = { isDragActive: () => true };
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held + 1_000 }));
+
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 30 });
+    const at = held + 2_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => at }));
+
+    // A remaining captured against the old TTL is meaningless under the new
+    // one — and would make the card's bar (which divides by the current TTL)
+    // overflow. The row re-arms to a full window of the new TTL instead.
+    expect(getRemainingAt(at)).toBe(30_000);
+    expect(getHoldReason()).toBe("drag");
+  });
+
+  it("performs no store write and no trash while the project view is cached", () => {
+    addRow({ expiresAt: NOW - 1 });
+    const before = useWorktreeSelectionStore.getState().deletedWorktrees;
+
+    sweepDeletedWorktreeCleanup(makeDeps({ isViewCached: () => true }));
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    // Same map reference — nothing about a view nobody can see was touched.
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+
+  it("clears hold state when cleanup is switched off mid-hold", () => {
+    const held = armAndAdvance(40_000);
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held + 1_000, isDragActive: () => true }));
+    expect(getHoldReason()).toBe("drag");
+
+    usePreferencesStore.setState({ deletedWorktreeCleanupSeconds: 0 });
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held + 2_000, isDragActive: () => true }));
+
+    expect(getExpiry()).toBeNull();
+    expect(getHoldReason()).toBeNull();
   });
 });

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -729,9 +729,9 @@ describe("sweepDeletedWorktreeCleanup", () => {
     sweepDeletedWorktreeCleanup(makeDeps({ now: () => NOW + 61_000 }));
     expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
     expect(bulkTrashByWorktree).toHaveBeenCalledWith("wt-1");
-    expect(
-      useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-2")?.holdReason
-    ).toBe("agent");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-2")?.holdReason).toBe(
+      "agent"
+    );
   });
 
   it("does not let a re-recorded row inherit the previous row's hold", () => {

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -7,6 +7,7 @@ import { useWorktreeSelectionStore, type DeletedWorktree } from "@/store/worktre
 import { notify } from "@/lib/notify";
 import {
   DELETED_WORKTREE_AGENT_HOLD_CAP_MS,
+  DELETED_WORKTREE_SWEEP_INTERVAL_MS,
   DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS,
   resetDeletedWorktreeCleanupState,
   sweepDeletedWorktreeCleanup,
@@ -21,12 +22,17 @@ function makeDeps(
     now: () => number;
     isDragActive: () => boolean;
     isViewCached: () => boolean;
+    maxObservedGapMs: number;
   }> = {}
 ) {
   return {
     now: () => NOW,
     isDragActive: () => false,
     isViewCached: () => false,
+    // These cases step time coarsely to describe the state machine, so every
+    // gap is declared observed — the row was on screen the whole time. The
+    // unobserved-gap credit has its own cases below and in the lifecycle suite.
+    maxObservedGapMs: Number.POSITIVE_INFINITY,
     ...overrides,
   };
 }
@@ -469,15 +475,62 @@ describe("sweepDeletedWorktreeCleanup", () => {
   it("does not let an exhausted hold restart itself on the next tick", () => {
     const held = armAndAdvance(40_000);
     const deps = { isDragActive: () => true };
-    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held + 1_000 }));
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => held }));
+    const pinned = getRemainingAt(held) ?? 0;
+    expect(getHoldReason()).toBe("drag");
 
     // The condition is still true, so the hold clock must not be cleared and
     // restarted — that is what let a permanent condition hold forever.
     const afterCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS + 1_000;
     sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap }));
     sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap + 1_000 }));
-
     expect(getHoldReason()).toBeNull();
+    // Released, not fired: the row still owes its preserved countdown.
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    // And the countdown is genuinely running again, not re-pinned.
+    expect(getRemainingAt(afterCap + 1_000)).toBe(pinned - 1_000);
+
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap + pinned }));
+    sweepDeletedWorktreeCleanup(makeDeps({ ...deps, now: () => afterCap + pinned + 1_000 }));
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("eventually trashes a row an agent held past its cap", () => {
+    const held = armAndAdvance(40_000);
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held }));
+    const pinned = getRemainingAt(held) ?? 0;
+
+    const afterCap = held + DELETED_WORKTREE_AGENT_HOLD_CAP_MS + 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => afterCap }));
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+
+    // The agent never stops working, and the row still goes — that is the
+    // whole "eventually gives up" guarantee.
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => afterCap + pinned }));
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("eventually trashes a row an abandoned close-confirm held past its cap", () => {
+    const held = armAndAdvance(40_000);
+    useTerminalPendingDestructiveActionStore.getState().request({
+      kind: "deletedWorktreeDismiss",
+      targetCount: 1,
+      runningAgentCount: 0,
+      worktreeId: "wt-1",
+    });
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held }));
+    const pinned = getRemainingAt(held) ?? 0;
+    expect(getHoldReason()).toBe("confirm");
+
+    // The dialog is never answered — the sweep must not wait on it forever.
+    const afterCap = held + DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS + 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => afterCap }));
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => afterCap + pinned }));
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
   });
 
   it("falls through an exhausted drag to a still-eligible working agent", () => {
@@ -535,6 +588,53 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(getHoldReason()).toBe("drag");
   });
 
+  it("credits a gap between sweeps back to the deadline instead of spending it", () => {
+    // The sweep runs at 1 Hz, so a gap this large means it did not run: the
+    // window was minimized (Chromium throttles hidden timers to roughly one a
+    // minute), the view was cached, or the machine slept. None of that is time
+    // the user could have watched the countdown in.
+    const observed = { maxObservedGapMs: DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 };
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed }));
+    const at = NOW + 30 * 60_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed, now: () => at }));
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getRemainingAt(at)).toBe(TTL_MS);
+  });
+
+  it("still spends time across the ordinary tick-by-tick cadence", () => {
+    // The mirror of the case above: normal 1 Hz sweeps must not be mistaken for
+    // unobserved gaps, or the countdown would never move at all.
+    const observed = { maxObservedGapMs: DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 };
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed }));
+    let at = NOW;
+    for (let tick = 0; tick < 5; tick++) {
+      at += DELETED_WORKTREE_SWEEP_INTERVAL_MS;
+      sweepDeletedWorktreeCleanup(makeDeps({ ...observed, now: () => at }));
+    }
+
+    expect(getRemainingAt(at)).toBe(TTL_MS - 5 * DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+  });
+
+  it("does not let an unobserved gap spend a hold's cap", () => {
+    const observed = { maxObservedGapMs: DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 };
+    setPanels([{ id: "t1", worktreeId: "wt-1", agentState: "working" }]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed }));
+    expect(getHoldReason()).toBe("agent");
+
+    // Cached for longer than the agent cap. If the cap counted that, the row
+    // would wake with its protection already gone and trash a working agent.
+    const at = NOW + DELETED_WORKTREE_AGENT_HOLD_CAP_MS + 60_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed, now: () => at }));
+
+    expect(getHoldReason()).toBe("agent");
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+  });
+
   it("performs no store write and no trash while the project view is cached", () => {
     addRow({ expiresAt: NOW - 1 });
     const before = useWorktreeSelectionStore.getState().deletedWorktrees;
@@ -544,6 +644,54 @@ describe("sweepDeletedWorktreeCleanup", () => {
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
     // Same map reference — nothing about a view nobody can see was touched.
     expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+
+  it("holds one row without touching another row's countdown", () => {
+    // Everything the sweep remembers lives in module-level maps keyed by row
+    // id, so a leak between rows would be silent — and an app-wide drag holds
+    // every ghost row at once, which is exactly when it would bite.
+    setPanels([
+      { id: "t1", worktreeId: "wt-1" },
+      { id: "t2", worktreeId: "wt-2", agentState: "working" },
+    ]);
+    usePanelStore.setState({ bulkTrashByWorktree });
+    addRow();
+    addRow({ id: "wt-2", title: "feature/y", path: "/repo/y" });
+    sweepDeletedWorktreeCleanup(makeDeps());
+
+    // wt-2 holds on its working agent; wt-1 has nothing holding it.
+    const at = NOW + 30_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => at }));
+    const rows = useWorktreeSelectionStore.getState().deletedWorktrees;
+    expect(rows.get("wt-1")?.holdReason).toBeNull();
+    expect(rows.get("wt-2")?.holdReason).toBe("agent");
+    expect((rows.get("wt-1")?.expiresAt ?? 0) - at).toBeLessThan(
+      (rows.get("wt-2")?.expiresAt ?? 0) - at
+    );
+
+    // The unheld row expires on schedule while the held one stays.
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => NOW + 61_000 }));
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
+    expect(bulkTrashByWorktree).toHaveBeenCalledWith("wt-1");
+    expect(
+      useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-2")?.holdReason
+    ).toBe("agent");
+  });
+
+  it("does not let a re-recorded row inherit the previous row's hold", () => {
+    const held = armAndAdvance(40_000);
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => held, isDragActive: () => true }));
+    expect(getHoldReason()).toBe("drag");
+
+    useWorktreeSelectionStore.getState().dismissDeletedWorktree("wt-1");
+    addRow();
+    const at = held + 1_000;
+    sweepDeletedWorktreeCleanup(makeDeps({ now: () => at }));
+
+    // A fresh row under a reused id starts from a clean full window, not the
+    // remaining its predecessor was holding.
+    expect(getRemainingAt(at)).toBe(TTL_MS);
+    expect(getHoldReason()).toBeNull();
   });
 
   it("clears hold state when cleanup is switched off mid-hold", () => {

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -22,6 +22,7 @@ function makeDeps(
     now: () => number;
     isDragActive: () => boolean;
     isViewCached: () => boolean;
+    isViewHidden: () => boolean;
     maxObservedGapMs: number;
   }> = {}
 ) {
@@ -29,6 +30,7 @@ function makeDeps(
     now: () => NOW,
     isDragActive: () => false,
     isViewCached: () => false,
+    isViewHidden: () => false,
     // These cases step time coarsely to describe the state machine, so every
     // gap is declared observed — the row was on screen the whole time. The
     // unobserved-gap credit has its own cases below and in the lifecycle suite.
@@ -589,10 +591,9 @@ describe("sweepDeletedWorktreeCleanup", () => {
   });
 
   it("credits a gap between sweeps back to the deadline instead of spending it", () => {
-    // The sweep runs at 1 Hz, so a gap this large means it did not run: the
-    // window was minimized (Chromium throttles hidden timers to roughly one a
-    // minute), the view was cached, or the machine slept. None of that is time
-    // the user could have watched the countdown in.
+    // The sweep runs at 1 Hz, so a gap this large means it did not run at all:
+    // the view was cached, the window was hidden, or the machine slept. None
+    // of that is time the user could have watched the countdown in.
     const observed = { maxObservedGapMs: DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 };
     addRow();
     sweepDeletedWorktreeCleanup(makeDeps({ ...observed }));
@@ -600,7 +601,62 @@ describe("sweepDeletedWorktreeCleanup", () => {
     sweepDeletedWorktreeCleanup(makeDeps({ ...observed, now: () => at }));
 
     expect(bulkTrashByWorktree).not.toHaveBeenCalled();
-    expect(getRemainingAt(at)).toBe(TTL_MS);
+    // All but the one interval every sweep always spends.
+    expect(getRemainingAt(at)).toBe(TTL_MS - DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+  });
+
+  it("neither spends nor trashes while the window is hidden", () => {
+    // A minimized window keeps its project ACTIVE — it is never cached — and
+    // Chromium's first background tier throttles timers to 1 Hz, which is this
+    // interval exactly. So the sweep keeps firing on time behind the minimized
+    // window, and without this guard it would burn the countdown down and
+    // trash the terminals where nobody could see it.
+    addRow({ expiresAt: NOW - 1 });
+    const before = useWorktreeSelectionStore.getState().deletedWorktrees;
+
+    sweepDeletedWorktreeCleanup(makeDeps({ isViewHidden: () => true }));
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+
+  it("credits the hidden stretch once the window comes back", () => {
+    const observed = { maxObservedGapMs: DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 };
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed }));
+
+    // Ticks keep arriving at 1 Hz while hidden and are all refused, so the
+    // whole stretch stays in the gap for the first visible sweep to credit.
+    let at = NOW;
+    for (let tick = 0; tick < 120; tick++) {
+      at += DELETED_WORKTREE_SWEEP_INTERVAL_MS;
+      sweepDeletedWorktreeCleanup(
+        makeDeps({ ...observed, now: () => at, isViewHidden: () => true })
+      );
+    }
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed, now: () => at }));
+
+    expect(bulkTrashByWorktree).not.toHaveBeenCalled();
+    expect(getRemainingAt(at)).toBe(TTL_MS - DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+  });
+
+  it("keeps spending the countdown when every gap sits just over the threshold", () => {
+    // Crediting a late gap in full would let a run of these consume exactly
+    // zero countdown forever — a debugger pause, or a renderer pegged under
+    // load, would hold every ghost row open indefinitely. Each sweep must
+    // still spend an interval.
+    const observed = { maxObservedGapMs: DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 };
+    const step = DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2 + 1;
+    addRow();
+    sweepDeletedWorktreeCleanup(makeDeps({ ...observed }));
+
+    let at = NOW;
+    for (let tick = 0; tick < 80; tick++) {
+      at += step;
+      sweepDeletedWorktreeCleanup(makeDeps({ ...observed, now: () => at }));
+    }
+
+    expect(bulkTrashByWorktree).toHaveBeenCalledTimes(1);
   });
 
   it("still spends time across the ordinary tick-by-tick cadence", () => {

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -158,7 +158,9 @@ describe("setDeletedWorktreeCleanupState", () => {
     store.addDeletedWorktree(makeDeleted({ expiresAt: 5_000, holdReason: "drag" }));
     store.setDeletedWorktreeCleanupState("wt-1", { expiresAt: 5_000, holdReason: null });
 
-    expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.holdReason).toBeNull();
+    expect(
+      useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.holdReason
+    ).toBeNull();
   });
 
   it("leaves state untouched for an unknown id", () => {

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -125,14 +125,21 @@ describe("dismissDeletedWorktree", () => {
 });
 
 describe("setDeletedWorktreeCleanupState", () => {
-  it("moves the deadline and the hold reason together", () => {
+  it("moves the deadline and the hold reason in a single update", () => {
     const store = useWorktreeSelectionStore.getState();
     store.addDeletedWorktree(makeDeleted());
-    store.setDeletedWorktreeCleanupState("wt-1", { expiresAt: 5_000, holdReason: "drag" });
 
-    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
-    expect(row?.expiresAt).toBe(5_000);
-    expect(row?.holdReason).toBe("drag");
+    const seen: Array<{ expiresAt: number | null; holdReason: string | null }> = [];
+    const unsubscribe = useWorktreeSelectionStore.subscribe((state) => {
+      const row = state.deletedWorktrees.get("wt-1");
+      if (row) seen.push({ expiresAt: row.expiresAt, holdReason: row.holdReason });
+    });
+    store.setDeletedWorktreeCleanupState("wt-1", { expiresAt: 5_000, holdReason: "drag" });
+    unsubscribe();
+
+    // One emission carrying both fields — two sequential writes would publish a
+    // torn frame (new deadline, stale reason) to every sidebar subscriber.
+    expect(seen).toEqual([{ expiresAt: 5_000, holdReason: "drag" }]);
   });
 
   it("returns the same state when neither field changes", () => {

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -31,6 +31,7 @@ function makeDeleted(overrides: Partial<DeletedWorktree> = {}): DeletedWorktree 
     path: "/repo/wt-1",
     deletedAt: 1000,
     expiresAt: null,
+    holdReason: null,
     pinnedIndex: 0,
     ...overrides,
   };
@@ -119,6 +120,45 @@ describe("dismissDeletedWorktree", () => {
     store.addDeletedWorktree(makeDeleted());
     const before = useWorktreeSelectionStore.getState().deletedWorktrees;
     store.dismissDeletedWorktree("nope");
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+});
+
+describe("setDeletedWorktreeCleanupState", () => {
+  it("moves the deadline and the hold reason together", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted());
+    store.setDeletedWorktreeCleanupState("wt-1", { expiresAt: 5_000, holdReason: "drag" });
+
+    const row = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
+    expect(row?.expiresAt).toBe(5_000);
+    expect(row?.holdReason).toBe("drag");
+  });
+
+  it("returns the same state when neither field changes", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted({ expiresAt: 5_000, holdReason: "agent" }));
+    const before = useWorktreeSelectionStore.getState().deletedWorktrees;
+    store.setDeletedWorktreeCleanupState("wt-1", { expiresAt: 5_000, holdReason: "agent" });
+
+    // The sweep calls this every second; an unconditional clone would re-render
+    // the whole sidebar at 1 Hz.
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
+  });
+
+  it("writes when only the hold reason changes", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted({ expiresAt: 5_000, holdReason: "drag" }));
+    store.setDeletedWorktreeCleanupState("wt-1", { expiresAt: 5_000, holdReason: null });
+
+    expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.holdReason).toBeNull();
+  });
+
+  it("leaves state untouched for an unknown id", () => {
+    const store = useWorktreeSelectionStore.getState();
+    store.addDeletedWorktree(makeDeleted());
+    const before = useWorktreeSelectionStore.getState().deletedWorktrees;
+    store.setDeletedWorktreeCleanupState("nope", { expiresAt: 1, holdReason: null });
     expect(useWorktreeSelectionStore.getState().deletedWorktrees).toBe(before);
   });
 });

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -50,12 +50,11 @@ function holdCapMs(reason: DeletedWorktreeHoldReason): number {
  * - The row is recorded unarmed; this sweep arms it, so a project cached at
  *   deletion time is never charged for the hours it spent frozen before the
  *   countdown could be shown at all.
- * - Any gap between sweeps longer than `MAX_OBSERVED_SWEEP_GAP_MS` is time
- *   nobody could have watched the row — a cached view, a minimized window
- *   (Chromium throttles hidden timers to roughly one per minute), a sleeping
- *   machine — and is credited back to every armed deadline instead of spent.
- *   Repeated project switching still cannot extend a row: only observed
- *   seconds are ever charged, and those only ever accumulate.
+ * - The sweep refuses to run at all while the view is cached or the window is
+ *   hidden, and any gap it then finds on the way back is credited to every
+ *   armed deadline instead of spent. Every sweep still spends at least one
+ *   interval, so the countdown is strictly monotonic — neither project
+ *   switching nor a stalled renderer can hold a row open indefinitely.
  *
  * It holds the countdown (pinned at its current remaining, not reset to full)
  * only while firing would actively break something:
@@ -82,10 +81,10 @@ function holdCapMs(reason: DeletedWorktreeHoldReason): number {
  */
 /**
  * A gap between sweeps longer than this means time passed that the user could
- * not have been watching the countdown — the view was cached, the window was
- * minimized or occluded (Chromium throttles a hidden window's timers to about
- * one per minute), or the machine slept. Two intervals of slack keeps ordinary
- * event-loop jitter from counting as unobserved time.
+ * not have been watching the countdown — the machine slept, the renderer
+ * stalled, or a guarded state (cached / hidden) was left without the sweep
+ * running. Two intervals of slack keeps ordinary event-loop jitter from
+ * counting as unobserved time.
  */
 const MAX_OBSERVED_SWEEP_GAP_MS = DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2;
 
@@ -93,6 +92,7 @@ interface SweepDeps {
   now: () => number;
   isDragActive: () => boolean;
   isViewCached: () => boolean;
+  isViewHidden: () => boolean;
   /**
    * Gap above which the time between two sweeps counts as unobserved. Tests
    * that step time coarsely to describe a state machine pass `Infinity` — "the
@@ -106,10 +106,15 @@ function defaultIsDragActive(): boolean {
   return document.documentElement.dataset.dragging === "true";
 }
 
+function defaultIsViewHidden(): boolean {
+  return typeof document !== "undefined" && document.hidden;
+}
+
 const DEFAULT_DEPS: SweepDeps = {
   now: () => Date.now(),
   isDragActive: defaultIsDragActive,
   isViewCached: isProjectViewCached,
+  isViewHidden: defaultIsViewHidden,
   maxObservedGapMs: MAX_OBSERVED_SWEEP_GAP_MS,
 };
 
@@ -276,11 +281,21 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
     if (!deletedWorktrees.has(id)) forgetRow(id);
   }
 
-  // Guarded in the body, not just by stopping the interval: this is reachable
-  // from the visibility listener, and clearing an interval cannot retract a
-  // callback the event loop has already picked up. Nothing below this line may
-  // write a deadline or trash a terminal on behalf of a view nobody can see.
-  if (deps.isViewCached()) return;
+  // Nothing below this line may write a deadline or trash a terminal on behalf
+  // of a view nobody can see. Both signals are needed and neither implies the
+  // other (`viewCacheState`'s docstring spells this out): a cached view still
+  // reports `visible`, and a minimized window is hidden while its project stays
+  // active. Hidden especially — Chromium's first background tier throttles
+  // timers to 1 Hz, which is this interval exactly, so the sweep keeps firing
+  // on time and would spend the countdown at full speed behind a minimized
+  // window and trash the row where nobody could see it happen.
+  //
+  // Returning BEFORE `lastSweepAt` is updated is what makes this safe: the
+  // whole guarded stretch stays in the gap, so the first sweep back credits it.
+  // Guarded in the body rather than only by stopping the interval, because
+  // clearing an interval cannot retract a callback the event loop has already
+  // picked up, and the visibility listener reaches this too.
+  if (deps.isViewCached() || deps.isViewHidden()) return;
 
   const now = deps.now();
   const swept: SweptRow[] = [];
@@ -289,10 +304,17 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
   // reachable "armed but never swept" state whose deadline would have to be
   // treated as unmeasurable.
   const sinceLastSweep = lastSweepAt === null ? 0 : now - lastSweepAt;
-  // Credit the whole gap, not the gap minus an interval: erring toward a
-  // longer rescue window is the safe direction when the alternative is
-  // trashing a live agent session.
-  const unobservedMs = sinceLastSweep > deps.maxObservedGapMs ? sinceLastSweep : 0;
+  // Credit the gap MINUS one interval, never the whole thing, so every sweep
+  // always spends at least one interval of countdown. Crediting in full would
+  // mean a run of gaps just over the threshold — a debugger pause, a renderer
+  // pegged under load, a project revealed for under a second between longer
+  // cached stretches — consumed exactly zero countdown forever, which is the
+  // never-fires half of this bug arriving by a different road. Against a
+  // genuinely long gap the difference is one second.
+  const unobservedMs =
+    sinceLastSweep > deps.maxObservedGapMs
+      ? sinceLastSweep - DELETED_WORKTREE_SWEEP_INTERVAL_MS
+      : 0;
   lastSweepAt = now;
   if (unobservedMs > 0) {
     // A hold's cap counts observed time too — otherwise a project left cached

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -1,13 +1,40 @@
 import { usePanelStore } from "@/store/panelStore";
-import { getDeletedWorktreeTerminalIds, useWorktreeSelectionStore } from "@/store/worktreeStore";
+import {
+  getDeletedWorktreeTerminalIds,
+  useWorktreeSelectionStore,
+  type DeletedWorktreeHoldReason,
+} from "@/store/worktreeStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useTerminalPendingDestructiveActionStore } from "@/store/terminalPendingDestructiveActionStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 import { notify } from "@/lib/notify";
 
 export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
+
+/**
+ * How long a hold may keep a row open before the countdown resumes anyway.
+ * Two tiers, because the reasons differ by an order of magnitude in how long
+ * they can legitimately last (#11259):
+ * - A confirm dialog or a drag is a gesture measured in seconds. Minutes of it
+ *   means the flag leaked (the drag flag is app-wide and has no owner to clear
+ *   it), so a short cap is a leak recovery, not an interruption.
+ * - A working agent can legitimately work for a long time, and the escape
+ *   hatch is expensive here: trash holds a terminal for only TRASH_TTL_MS
+ *   (20s) before killing the PTY, so force-trashing a live agent is closer to
+ *   termination than to a reversible undo.
+ * Both are measured from the start of one continuous hold — see `holdStartedAt`.
+ */
+export const DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS = 5 * 60_000;
+export const DELETED_WORKTREE_AGENT_HOLD_CAP_MS = 60 * 60_000;
+
+function holdCapMs(reason: DeletedWorktreeHoldReason): number {
+  return reason === "agent"
+    ? DELETED_WORKTREE_AGENT_HOLD_CAP_MS
+    : DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS;
+}
 
 /**
  * Auto-cleanup for deleted-worktree rows (#11232): a row's surviving terminals
@@ -16,10 +43,18 @@ export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
  * ephemeral — they never persist across restarts, and without this sweep a bulk
  * worktree cleanup would leave ghost rows pinned in the sidebar forever.
  *
- * The countdown is armed at deletion time (WorktreeStoreContext's
- * worktree-removed handler stamps `expiresAt`) and runs to zero by default —
- * the row's visible countdown is the user's window to rescue terminals. It
- * defers (holds at full) only while firing would actively break something:
+ * The row is a rescue surface: its visible countdown is the user's window to
+ * drag surviving terminals somewhere else. So the countdown measures time the
+ * user could actually have *seen* it, not wall time (#11259):
+ * - The row is recorded unarmed; this sweep arms it, and the sweep only runs
+ *   while the project view is awake. A view cached at deletion time is never
+ *   charged for the hours it spent frozen.
+ * - Going cached snapshots each row's remaining; coming back restores it. The
+ *   deadline therefore only advances across awake seconds, and repeated
+ *   project switching cannot extend a row (remaining only ever decreases).
+ *
+ * It holds the countdown (pinned at its current remaining, not reset to full)
+ * only while firing would actively break something:
  * - ANY drag is in progress. Dragging a terminal out IS the rescue gesture and
  *   expiring mid-drag would yank the source away, but the drag flag
  *   (`documentElement.dataset.dragging`, set by DndProvider) carries no
@@ -32,6 +67,11 @@ export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
  *   active output resets the idle clock),
  * - the row's own close-confirm dialog is open.
  *
+ * Every hold is capped (see the cap constants). A condition that never clears —
+ * an agent wedged in `working`, a leaked drag flag — used to hold a row open
+ * forever with no clue why; now it holds for at most its cap, the row says
+ * which condition is holding it, and then the preserved countdown resumes.
+ *
  * Terminals go through `bulkTrashByWorktree` — the same executor as the row's
  * manual close button — so auto-cleanup lands in the trash with its usual
  * restore window rather than hard-killing anything immediately.
@@ -39,6 +79,7 @@ export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
 interface SweepDeps {
   now: () => number;
   isDragActive: () => boolean;
+  isViewCached: () => boolean;
 }
 
 function defaultIsDragActive(): boolean {
@@ -48,6 +89,7 @@ function defaultIsDragActive(): boolean {
 const DEFAULT_DEPS: SweepDeps = {
   now: () => Date.now(),
   isDragActive: defaultIsDragActive,
+  isViewCached: isProjectViewCached,
 };
 
 function hasWorkingAgent(worktreeId: string): boolean {
@@ -66,20 +108,26 @@ function hasWorkingAgent(worktreeId: string): boolean {
   });
 }
 
-function isCountdownDeferred(worktreeId: string, deps: SweepDeps): boolean {
+/**
+ * Every hold condition currently true for this row, in precedence order. The
+ * sweep needs the whole set rather than the first match so an exhausted
+ * condition can fall through to a still-eligible one — a leaked drag flag must
+ * not mask (or borrow the short cap of) a genuinely working agent.
+ */
+function activeHoldReasons(worktreeId: string, deps: SweepDeps): DeletedWorktreeHoldReason[] {
+  const reasons: DeletedWorktreeHoldReason[] = [];
   const pending = useTerminalPendingDestructiveActionStore.getState().pending;
-  if (pending?.kind === "deletedWorktreeDismiss" && pending.worktreeId === worktreeId) return true;
   // The grouped clear previews several rows at once, so every previewed member
   // holds while the user reads the dialog — expiring one mid-read would trash
   // terminals the confirm is still offering to spare (#11260).
-  if (
-    pending?.kind === "deletedWorktreeGroupDismiss" &&
-    pending.preview?.some((entry) => entry.worktreeId === worktreeId)
-  ) {
-    return true;
-  }
-  if (deps.isDragActive()) return true;
-  return hasWorkingAgent(worktreeId);
+  const confirmHolds =
+    (pending?.kind === "deletedWorktreeDismiss" && pending.worktreeId === worktreeId) ||
+    (pending?.kind === "deletedWorktreeGroupDismiss" &&
+      (pending.preview?.some((entry) => entry.worktreeId === worktreeId) ?? false));
+  if (confirmHolds) reasons.push("confirm");
+  if (deps.isDragActive()) reasons.push("drag");
+  if (hasWorkingAgent(worktreeId)) reasons.push("agent");
+  return reasons;
 }
 
 // A row whose cleanup has been dispatched must not re-fire on the next tick —
@@ -93,9 +141,75 @@ const firedIds = new Set<string>();
 // the card's progress bar — which divides by the CURRENT TTL — would lie).
 const armedTtlMs = new Map<string, number>();
 
+// Remaining at the moment the countdown stopped advancing, tagged with the TTL
+// it was captured under so a preference change can invalidate it rather than
+// resuming a remaining that no longer means anything.
+interface RemainingSnapshot {
+  remainingMs: number;
+  ttlMs: number;
+}
+
+// Captured once per hold (not per tick) — re-capturing every tick is what made
+// a held row re-arm to full forever.
+const heldRemaining = new Map<string, RemainingSnapshot>();
+
+// Captured when the view goes cached, consumed by the first sweep after it
+// wakes. Separate from `heldRemaining` because a row can be both held and
+// cached, and the two release on different signals.
+const cachedRemaining = new Map<string, RemainingSnapshot>();
+
+// Start of the current *continuous* hold. Cleared only when no hold condition
+// is true at all, which is what latches an exhausted hold: a condition that
+// stays true past its cap can never restart the clock and hold again.
+const holdStartedAt = new Map<string, number>();
+
+// Set on the cached→awake edge. One cache cycle's obligation to restore
+// snapshots, not standing permission to re-grant time.
+let resumeRestorePending = false;
+
+function forgetRow(id: string): void {
+  firedIds.delete(id);
+  armedTtlMs.delete(id);
+  heldRemaining.delete(id);
+  cachedRemaining.delete(id);
+  holdStartedAt.delete(id);
+}
+
 export function resetDeletedWorktreeCleanupState(): void {
   firedIds.clear();
   armedTtlMs.clear();
+  heldRemaining.clear();
+  cachedRemaining.clear();
+  holdStartedAt.clear();
+  resumeRestorePending = false;
+}
+
+/**
+ * Snapshot how much of each row's countdown was left, so the time this view
+ * spends cached is not charged against it. Called on the `cached` edge, while
+ * the renderer is still live (main sends it before throttling/freezing).
+ */
+function captureRemainingForCache(deps: SweepDeps = DEFAULT_DEPS): void {
+  const { deletedWorktrees } = useWorktreeSelectionStore.getState();
+  const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
+  resumeRestorePending = true;
+  if (ttlSeconds === 0) return;
+  const ttlMs = ttlSeconds * 1000;
+  const now = deps.now();
+  for (const entry of deletedWorktrees.values()) {
+    if (entry.expiresAt === null || firedIds.has(entry.id)) continue;
+    // An earlier unconsumed snapshot is the truer one: it predates whatever
+    // aging happened between the two cached edges.
+    if (cachedRemaining.has(entry.id)) continue;
+    cachedRemaining.set(entry.id, {
+      remainingMs: clampRemaining(entry.expiresAt - now, ttlMs),
+      ttlMs,
+    });
+  }
+}
+
+function clampRemaining(remainingMs: number, ttlMs: number): number {
+  return Math.max(0, Math.min(remainingMs, ttlMs));
 }
 
 /**
@@ -147,60 +261,129 @@ function notifySweepTrashed(swept: readonly SweptRow[]): void {
 
 export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): void {
   const selection = useWorktreeSelectionStore.getState();
-  const { deletedWorktrees, setDeletedWorktreeExpiry } = selection;
+  const { deletedWorktrees, setDeletedWorktreeCleanupState } = selection;
 
-  for (const id of firedIds) {
-    if (!deletedWorktrees.has(id)) firedIds.delete(id);
+  // Prune first, and even while cached: a row removed while this view was
+  // frozen must not leave its snapshots behind to be inherited by a later row
+  // reusing the id.
+  for (const id of [
+    ...firedIds,
+    ...armedTtlMs.keys(),
+    ...heldRemaining.keys(),
+    ...cachedRemaining.keys(),
+    ...holdStartedAt.keys(),
+  ]) {
+    if (!deletedWorktrees.has(id)) forgetRow(id);
   }
-  for (const id of armedTtlMs.keys()) {
-    if (!deletedWorktrees.has(id)) armedTtlMs.delete(id);
-  }
-  if (deletedWorktrees.size === 0) return;
 
-  const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
+  // Guarded in the body, not just by stopping the interval: this is reachable
+  // from the visibility listener, and clearing an interval cannot retract a
+  // callback the event loop has already picked up. Nothing below this line may
+  // write a deadline or trash a terminal on behalf of a view nobody can see.
+  if (deps.isViewCached()) return;
+
   const now = deps.now();
   const swept: SweptRow[] = [];
+  const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
+  // Consume the resume obligation for this sweep only. Held to the end so a
+  // row delivered after the cached edge still gets its restore.
+  const isResumeSweep = resumeRestorePending;
+  resumeRestorePending = false;
 
   for (const entry of deletedWorktrees.values()) {
-    // An unarmed entry is a fresh (or re-recorded) row — any stale fired flag
-    // from a previous row under the same id must not suppress its countdown.
-    if (entry.expiresAt === null) firedIds.delete(entry.id);
+    // An unarmed entry is a fresh (or re-recorded) row — any stale state from a
+    // previous row under the same id must not leak into its countdown.
+    if (entry.expiresAt === null) forgetRow(entry.id);
     else if (firedIds.has(entry.id)) continue;
 
     if (ttlSeconds === 0) {
-      if (entry.expiresAt !== null) setDeletedWorktreeExpiry(entry.id, null);
-      armedTtlMs.delete(entry.id);
+      if (entry.expiresAt !== null || entry.holdReason !== null) {
+        setDeletedWorktreeCleanupState(entry.id, { expiresAt: null, holdReason: null });
+      }
+      forgetRow(entry.id);
       continue;
     }
 
     const ttlMs = ttlSeconds * 1000;
     const armedWith = armedTtlMs.get(entry.id);
-    if (
-      entry.expiresAt === null ||
-      (armedWith !== undefined && armedWith !== ttlMs) ||
-      isCountdownDeferred(entry.id, deps)
-    ) {
-      // Arm the countdown (fresh row or TTL preference change), or hold it at
-      // full while activity defers it.
-      setDeletedWorktreeExpiry(entry.id, now + ttlMs);
-      armedTtlMs.set(entry.id, ttlMs);
-      continue;
+    const ttlChanged = armedWith !== undefined && armedWith !== ttlMs;
+    if (ttlChanged) {
+      // Every preserved remaining was measured against the old TTL and means
+      // nothing now. The hold *clock* survives on purpose: toggling the
+      // preference must not reset the cap and re-open an indefinite hold.
+      heldRemaining.delete(entry.id);
+      cachedRemaining.delete(entry.id);
     }
-    // A deadline this sweep didn't arm (unknown provenance) is adopted at the
-    // current TTL so a later preference change still re-arms it.
     armedTtlMs.set(entry.id, ttlMs);
 
-    if (now >= entry.expiresAt) {
-      firedIds.add(entry.id);
-      // Same executor as the row's manual close: terminals land in trash
-      // (restorable until trash GC), and trashing the last one prunes the row.
-      // Count first — the executor mirrors this exact filter, and once it runs
-      // the panels have already left the row.
-      const trashedCount = getDeletedWorktreeTerminalIds(entry.id).length;
-      usePanelStore.getState().bulkTrashByWorktree(entry.id);
-      if (trashedCount > 0) {
-        swept.push({ worktreeId: entry.id, title: entry.title, count: trashedCount });
+    // Resolve this row's deadline before any hold or expiry decision.
+    let expiresAt: number;
+    const restorable = isResumeSweep ? cachedRemaining.get(entry.id) : undefined;
+    cachedRemaining.delete(entry.id);
+    if (entry.expiresAt === null || ttlChanged) {
+      // Fresh row, or one whose TTL just changed: a full window from now.
+      expiresAt = now + ttlMs;
+    } else if (restorable !== undefined && restorable.ttlMs === ttlMs) {
+      expiresAt = now + restorable.remainingMs;
+    } else if (isResumeSweep) {
+      // Armed, but we have no idea how much of its countdown was visible —
+      // the cached edge was missed (this module armed lazily inside a cached
+      // window). Charging it for unobserved time is exactly the bug, so grant
+      // one full window; the snapshot path covers every ordinary cycle.
+      expiresAt = now + ttlMs;
+    } else {
+      expiresAt = entry.expiresAt;
+    }
+
+    const reasons = activeHoldReasons(entry.id, deps);
+    if (reasons.length === 0) {
+      holdStartedAt.delete(entry.id);
+    } else if (!holdStartedAt.has(entry.id)) {
+      holdStartedAt.set(entry.id, now);
+    }
+    const heldSince = holdStartedAt.get(entry.id) ?? now;
+    // First reason still inside its cap. All exhausted (or none active) means
+    // the countdown runs — that is the "eventually gives up" guarantee.
+    const holdReason = reasons.find((reason) => now - heldSince < holdCapMs(reason)) ?? null;
+
+    if (holdReason !== null) {
+      // Capture once per hold, then pin. Re-capturing every tick is what made
+      // the old code re-arm a held row to a fresh full TTL forever.
+      let snapshot = heldRemaining.get(entry.id);
+      if (snapshot === undefined || snapshot.ttlMs !== ttlMs) {
+        snapshot = { remainingMs: clampRemaining(expiresAt - now, ttlMs), ttlMs };
+        heldRemaining.set(entry.id, snapshot);
       }
+      setDeletedWorktreeCleanupState(entry.id, {
+        expiresAt: now + snapshot.remainingMs,
+        holdReason,
+      });
+      continue;
+    }
+
+    // Released: resume from the remaining the hold preserved, so the countdown
+    // picks up where it stopped rather than losing (or re-granting) time.
+    const held = heldRemaining.get(entry.id);
+    if (held !== undefined) {
+      heldRemaining.delete(entry.id);
+      if (held.ttlMs === ttlMs) expiresAt = now + held.remainingMs;
+    }
+
+    if (now < expiresAt) {
+      setDeletedWorktreeCleanupState(entry.id, { expiresAt, holdReason: null });
+      continue;
+    }
+
+    firedIds.add(entry.id);
+    setDeletedWorktreeCleanupState(entry.id, { expiresAt, holdReason: null });
+    // Same executor as the row's manual close: terminals land in trash
+    // (restorable until trash GC), and trashing the last one prunes the row.
+    // Count first — the executor mirrors this exact filter, and once it runs
+    // the panels have already left the row.
+    const trashedCount = getDeletedWorktreeTerminalIds(entry.id).length;
+    usePanelStore.getState().bulkTrashByWorktree(entry.id);
+    if (trashedCount > 0) {
+      swept.push({ worktreeId: entry.id, title: entry.title, count: trashedCount });
     }
   }
 
@@ -208,21 +391,63 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
 }
 
 /**
- * Start the 1 Hz cleanup sweep. The interval is throttled by Chromium while
- * the view is hidden, so a visibility-restore sweep catches up immediately on
- * reveal (mirrors the trash slice's `sweepExpiredTrash`).
+ * Start the 1 Hz cleanup sweep.
+ *
+ * A cached project view keeps reporting `visibilityState === "visible"` while
+ * main has it detached, CPU-throttled and (absent a live agent) frozen, so the
+ * `visibilitychange` catch-up this used to rely on is dead code for exactly the
+ * case that matters (#11212). Main's lifecycle broadcast is the only signal
+ * that tracks it, so the sweep stops while cached and catches up on the way
+ * back — mirroring `TerminalReconciliationWatchdog`. The visibility listener
+ * stays for the case it does still cover: a minimized or occluded window.
  */
 export function startDeletedWorktreeCleanup(): () => void {
-  const interval = setInterval(
-    () => sweepDeletedWorktreeCleanup(),
-    DELETED_WORKTREE_SWEEP_INTERVAL_MS
-  );
+  let interval: ReturnType<typeof setInterval> | undefined;
+
+  /** Idempotent — a rearm while already sweeping keeps the existing timer. */
+  const startSweeping = (): void => {
+    if (interval !== undefined) return;
+    // A controller constructed during a cached window never receives a
+    // `cached` phase, so the arm has to check the seeded state itself.
+    if (isProjectViewCached()) return;
+    interval = setInterval(() => sweepDeletedWorktreeCleanup(), DELETED_WORKTREE_SWEEP_INTERVAL_MS);
+  };
+
+  const stopSweeping = (): void => {
+    if (interval === undefined) return;
+    clearInterval(interval);
+    interval = undefined;
+  };
+
+  startSweeping();
+  if (isProjectViewCached()) {
+    // Armed inside a cached window: rows carry deadlines of unknown provenance
+    // and there was no live edge to snapshot them at, so the first awake sweep
+    // must re-grant rather than trust them.
+    resumeRestorePending = true;
+  }
+
+  const offViewLifecycle = subscribeProjectViewLifecycle((phase) => {
+    if (phase === "cached") {
+      captureRemainingForCache();
+      stopSweeping();
+      return;
+    }
+    startSweeping();
+    // Reveal is when a stale deadline is most likely and most visible — the
+    // restore has to land before the user can see a wrong number, so catch up
+    // now rather than waiting out the rest of the interval.
+    if (phase === "revealed") sweepDeletedWorktreeCleanup();
+  });
+
   const onVisibilityChange = () => {
     if (!document.hidden) sweepDeletedWorktreeCleanup();
   };
   document.addEventListener("visibilitychange", onVisibilityChange);
+
   return () => {
-    clearInterval(interval);
+    stopSweeping();
+    offViewLifecycle();
     document.removeEventListener("visibilitychange", onVisibilityChange);
   };
 }

--- a/src/store/deletedWorktreeCleanup.ts
+++ b/src/store/deletedWorktreeCleanup.ts
@@ -25,7 +25,8 @@ export const DELETED_WORKTREE_SWEEP_INTERVAL_MS = 1000;
  *   hatch is expensive here: trash holds a terminal for only TRASH_TTL_MS
  *   (20s) before killing the PTY, so force-trashing a live agent is closer to
  *   termination than to a reversible undo.
- * Both are measured from the start of one continuous hold — see `holdStartedAt`.
+ * Both are measured across one continuous hold, in observed time — see
+ * `holdStartedAt`, which is credited for unobserved gaps like any deadline.
  */
 export const DELETED_WORKTREE_TRANSIENT_HOLD_CAP_MS = 5 * 60_000;
 export const DELETED_WORKTREE_AGENT_HOLD_CAP_MS = 60 * 60_000;
@@ -46,12 +47,15 @@ function holdCapMs(reason: DeletedWorktreeHoldReason): number {
  * The row is a rescue surface: its visible countdown is the user's window to
  * drag surviving terminals somewhere else. So the countdown measures time the
  * user could actually have *seen* it, not wall time (#11259):
- * - The row is recorded unarmed; this sweep arms it, and the sweep only runs
- *   while the project view is awake. A view cached at deletion time is never
- *   charged for the hours it spent frozen.
- * - Going cached snapshots each row's remaining; coming back restores it. The
- *   deadline therefore only advances across awake seconds, and repeated
- *   project switching cannot extend a row (remaining only ever decreases).
+ * - The row is recorded unarmed; this sweep arms it, so a project cached at
+ *   deletion time is never charged for the hours it spent frozen before the
+ *   countdown could be shown at all.
+ * - Any gap between sweeps longer than `MAX_OBSERVED_SWEEP_GAP_MS` is time
+ *   nobody could have watched the row — a cached view, a minimized window
+ *   (Chromium throttles hidden timers to roughly one per minute), a sleeping
+ *   machine — and is credited back to every armed deadline instead of spent.
+ *   Repeated project switching still cannot extend a row: only observed
+ *   seconds are ever charged, and those only ever accumulate.
  *
  * It holds the countdown (pinned at its current remaining, not reset to full)
  * only while firing would actively break something:
@@ -76,10 +80,26 @@ function holdCapMs(reason: DeletedWorktreeHoldReason): number {
  * manual close button — so auto-cleanup lands in the trash with its usual
  * restore window rather than hard-killing anything immediately.
  */
+/**
+ * A gap between sweeps longer than this means time passed that the user could
+ * not have been watching the countdown — the view was cached, the window was
+ * minimized or occluded (Chromium throttles a hidden window's timers to about
+ * one per minute), or the machine slept. Two intervals of slack keeps ordinary
+ * event-loop jitter from counting as unobserved time.
+ */
+const MAX_OBSERVED_SWEEP_GAP_MS = DELETED_WORKTREE_SWEEP_INTERVAL_MS * 2;
+
 interface SweepDeps {
   now: () => number;
   isDragActive: () => boolean;
   isViewCached: () => boolean;
+  /**
+   * Gap above which the time between two sweeps counts as unobserved. Tests
+   * that step time coarsely to describe a state machine pass `Infinity` — "the
+   * view was awake for all of it" — so the countdown advances the way it does
+   * across the real 1 Hz cadence.
+   */
+  maxObservedGapMs: number;
 }
 
 function defaultIsDragActive(): boolean {
@@ -90,6 +110,7 @@ const DEFAULT_DEPS: SweepDeps = {
   now: () => Date.now(),
   isDragActive: defaultIsDragActive,
   isViewCached: isProjectViewCached,
+  maxObservedGapMs: MAX_OBSERVED_SWEEP_GAP_MS,
 };
 
 function hasWorkingAgent(worktreeId: string): boolean {
@@ -153,25 +174,30 @@ interface RemainingSnapshot {
 // a held row re-arm to full forever.
 const heldRemaining = new Map<string, RemainingSnapshot>();
 
-// Captured when the view goes cached, consumed by the first sweep after it
-// wakes. Separate from `heldRemaining` because a row can be both held and
-// cached, and the two release on different signals.
-const cachedRemaining = new Map<string, RemainingSnapshot>();
-
-// Start of the current *continuous* hold. Cleared only when no hold condition
-// is true at all, which is what latches an exhausted hold: a condition that
-// stays true past its cap can never restart the clock and hold again.
+// Start of the current *continuous* hold, in observed time. Cleared only when
+// no hold condition is true at all, which is what latches an exhausted hold: a
+// condition that stays true past its cap can never restart the clock and hold
+// again.
 const holdStartedAt = new Map<string, number>();
 
-// Set on the cached→awake edge. One cache cycle's obligation to restore
-// snapshots, not standing permission to re-grant time.
-let resumeRestorePending = false;
+/**
+ * When the last sweep actually ran. The gap to the next one is time nobody
+ * could have watched the countdown, and it is credited back to every armed row
+ * rather than spent.
+ *
+ * This is measured rather than driven off lifecycle edges on purpose: an edge
+ * you miss is a row that thaws already expired, and there are several ways to
+ * miss one (a view cached before this module evaluated, a switch superseded
+ * mid-flight, a minimized window that never goes `cached` at all, the machine
+ * sleeping). A gap is impossible to miss — if the sweep did not run, the gap is
+ * there to be seen on the next tick.
+ */
+let lastSweepAt: number | null = null;
 
 function forgetRow(id: string): void {
   firedIds.delete(id);
   armedTtlMs.delete(id);
   heldRemaining.delete(id);
-  cachedRemaining.delete(id);
   holdStartedAt.delete(id);
 }
 
@@ -179,33 +205,8 @@ export function resetDeletedWorktreeCleanupState(): void {
   firedIds.clear();
   armedTtlMs.clear();
   heldRemaining.clear();
-  cachedRemaining.clear();
   holdStartedAt.clear();
-  resumeRestorePending = false;
-}
-
-/**
- * Snapshot how much of each row's countdown was left, so the time this view
- * spends cached is not charged against it. Called on the `cached` edge, while
- * the renderer is still live (main sends it before throttling/freezing).
- */
-function captureRemainingForCache(deps: SweepDeps = DEFAULT_DEPS): void {
-  const { deletedWorktrees } = useWorktreeSelectionStore.getState();
-  const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
-  resumeRestorePending = true;
-  if (ttlSeconds === 0) return;
-  const ttlMs = ttlSeconds * 1000;
-  const now = deps.now();
-  for (const entry of deletedWorktrees.values()) {
-    if (entry.expiresAt === null || firedIds.has(entry.id)) continue;
-    // An earlier unconsumed snapshot is the truer one: it predates whatever
-    // aging happened between the two cached edges.
-    if (cachedRemaining.has(entry.id)) continue;
-    cachedRemaining.set(entry.id, {
-      remainingMs: clampRemaining(entry.expiresAt - now, ttlMs),
-      ttlMs,
-    });
-  }
+  lastSweepAt = null;
 }
 
 function clampRemaining(remainingMs: number, ttlMs: number): number {
@@ -264,13 +265,12 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
   const { deletedWorktrees, setDeletedWorktreeCleanupState } = selection;
 
   // Prune first, and even while cached: a row removed while this view was
-  // frozen must not leave its snapshots behind to be inherited by a later row
-  // reusing the id.
+  // frozen must not leave its bookkeeping behind to be inherited by a later
+  // row reusing the id.
   for (const id of [
     ...firedIds,
     ...armedTtlMs.keys(),
     ...heldRemaining.keys(),
-    ...cachedRemaining.keys(),
     ...holdStartedAt.keys(),
   ]) {
     if (!deletedWorktrees.has(id)) forgetRow(id);
@@ -284,11 +284,24 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
 
   const now = deps.now();
   const swept: SweptRow[] = [];
+  // A row can only be armed by a sweep (they are recorded unarmed), so an
+  // armed row implies a sweep has run and `lastSweepAt` is set. There is no
+  // reachable "armed but never swept" state whose deadline would have to be
+  // treated as unmeasurable.
+  const sinceLastSweep = lastSweepAt === null ? 0 : now - lastSweepAt;
+  // Credit the whole gap, not the gap minus an interval: erring toward a
+  // longer rescue window is the safe direction when the alternative is
+  // trashing a live agent session.
+  const unobservedMs = sinceLastSweep > deps.maxObservedGapMs ? sinceLastSweep : 0;
+  lastSweepAt = now;
+  if (unobservedMs > 0) {
+    // A hold's cap counts observed time too — otherwise a project left cached
+    // overnight comes back with its agent's protection already spent.
+    for (const [id, startedAt] of holdStartedAt) {
+      holdStartedAt.set(id, startedAt + unobservedMs);
+    }
+  }
   const ttlSeconds = usePreferencesStore.getState().deletedWorktreeCleanupSeconds;
-  // Consume the resume obligation for this sweep only. Held to the end so a
-  // row delivered after the cached edge still gets its restore.
-  const isResumeSweep = resumeRestorePending;
-  resumeRestorePending = false;
 
   for (const entry of deletedWorktrees.values()) {
     // An unarmed entry is a fresh (or re-recorded) row — any stale state from a
@@ -308,31 +321,22 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
     const armedWith = armedTtlMs.get(entry.id);
     const ttlChanged = armedWith !== undefined && armedWith !== ttlMs;
     if (ttlChanged) {
-      // Every preserved remaining was measured against the old TTL and means
+      // A preserved remaining was measured against the old TTL and means
       // nothing now. The hold *clock* survives on purpose: toggling the
       // preference must not reset the cap and re-open an indefinite hold.
       heldRemaining.delete(entry.id);
-      cachedRemaining.delete(entry.id);
     }
     armedTtlMs.set(entry.id, ttlMs);
 
     // Resolve this row's deadline before any hold or expiry decision.
     let expiresAt: number;
-    const restorable = isResumeSweep ? cachedRemaining.get(entry.id) : undefined;
-    cachedRemaining.delete(entry.id);
     if (entry.expiresAt === null || ttlChanged) {
       // Fresh row, or one whose TTL just changed: a full window from now.
       expiresAt = now + ttlMs;
-    } else if (restorable !== undefined && restorable.ttlMs === ttlMs) {
-      expiresAt = now + restorable.remainingMs;
-    } else if (isResumeSweep) {
-      // Armed, but we have no idea how much of its countdown was visible —
-      // the cached edge was missed (this module armed lazily inside a cached
-      // window). Charging it for unobserved time is exactly the bug, so grant
-      // one full window; the snapshot path covers every ordinary cycle.
-      expiresAt = now + ttlMs;
     } else {
-      expiresAt = entry.expiresAt;
+      // Push the deadline out by whatever went unobserved, so the countdown
+      // only ever spends time the row was actually on screen.
+      expiresAt = entry.expiresAt + unobservedMs;
     }
 
     const reasons = activeHoldReasons(entry.id, deps);
@@ -396,10 +400,14 @@ export function sweepDeletedWorktreeCleanup(deps: SweepDeps = DEFAULT_DEPS): voi
  * A cached project view keeps reporting `visibilityState === "visible"` while
  * main has it detached, CPU-throttled and (absent a live agent) frozen, so the
  * `visibilitychange` catch-up this used to rely on is dead code for exactly the
- * case that matters (#11212). Main's lifecycle broadcast is the only signal
- * that tracks it, so the sweep stops while cached and catches up on the way
- * back — mirroring `TerminalReconciliationWatchdog`. The visibility listener
- * stays for the case it does still cover: a minimized or occluded window.
+ * case that matters (#11212). The sweep therefore stops while cached and
+ * catches up on the way back, mirroring `TerminalReconciliationWatchdog`; the
+ * visibility listener stays for the case it does still cover, a minimized or
+ * occluded window.
+ *
+ * Neither signal is load-bearing for correctness. Both are prompts to sweep
+ * sooner; the deadline itself is protected by the sweep-gap credit, which
+ * needs no edge to arrive.
  */
 export function startDeletedWorktreeCleanup(): () => void {
   let interval: ReturnType<typeof setInterval> | undefined;
@@ -420,23 +428,18 @@ export function startDeletedWorktreeCleanup(): () => void {
   };
 
   startSweeping();
-  if (isProjectViewCached()) {
-    // Armed inside a cached window: rows carry deadlines of unknown provenance
-    // and there was no live edge to snapshot them at, so the first awake sweep
-    // must re-grant rather than trust them.
-    resumeRestorePending = true;
-  }
 
   const offViewLifecycle = subscribeProjectViewLifecycle((phase) => {
     if (phase === "cached") {
-      captureRemainingForCache();
+      // Purely a cost saving — correctness rides on the sweep-gap measurement,
+      // not on this edge arriving.
       stopSweeping();
       return;
     }
     startSweeping();
-    // Reveal is when a stale deadline is most likely and most visible — the
-    // restore has to land before the user can see a wrong number, so catch up
-    // now rather than waiting out the rest of the interval.
+    // Reveal is when a stale deadline is most likely and most visible: the
+    // credit has to land before the user can read a wrong number off the row,
+    // so catch up now rather than waiting out the rest of the interval.
     if (phase === "revealed") sweepDeletedWorktreeCleanup();
   });
 

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -64,9 +64,10 @@ interface PreferencesState {
   setSkipPushConfirmForWorktree: (worktreePath: string, value: boolean) => void;
   /**
    * How long a deleted worktree's row holds its surviving terminals before
-   * they are moved to trash automatically. The countdown starts at deletion
-   * and defers only while a drag is in progress, an agent is still working,
-   * or the row's close-confirm dialog is open (`deletedWorktreeCleanup.ts`).
+   * they are moved to trash automatically. The countdown measures time the
+   * project view was actually awake, and holds — for a bounded stretch — while
+   * a drag is in progress, an agent is still working, or the row's
+   * close-confirm dialog is open (`deletedWorktreeCleanup.ts`).
    * 0 disables auto-cleanup.
    */
   deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds;

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -42,6 +42,13 @@ export interface PendingCreation {
  * any route — moved, trashed, killed, or exited — shrinks the row without
  * this store having to observe terminal lifecycle events at all.
  */
+/**
+ * Why a deleted-worktree row's auto-cleanup countdown is holding. Ordered by
+ * the precedence the sweep evaluates them in: an open confirm dialog outranks
+ * a drag, which outranks a still-working agent.
+ */
+export type DeletedWorktreeHoldReason = "confirm" | "drag" | "agent";
+
 export interface DeletedWorktree {
   id: string;
   /**
@@ -56,9 +63,20 @@ export interface DeletedWorktree {
    * When the row's auto-cleanup fires (terminals move to trash, row goes).
    * `null` while cleanup is off or the countdown hasn't been armed yet. Owned
    * entirely by the cleanup sweep (`deletedWorktreeCleanup.ts`), which arms,
-   * pauses (by re-extending), and fires it — nothing else writes this.
+   * holds, and fires it — nothing else writes this.
+   *
+   * A row is recorded UNARMED and the sweep arms it on its first tick with the
+   * view awake, so a project cached at deletion time is never charged for the
+   * wall time it spent frozen (#11259).
    */
   expiresAt: number | null;
+  /**
+   * Why the countdown is currently held, or `null` while it is running. The
+   * sweep pins `expiresAt` to the remaining it had when the hold began, so the
+   * row's readout freezes instead of snapping back to full; this field is what
+   * lets the card say *why* rather than just appearing stuck (#11259).
+   */
+  holdReason: DeletedWorktreeHoldReason | null;
   /**
    * Index the row occupied in the sidebar's scrollable list when it was
    * deleted, so the row holds its slot instead of jumping to an edge.
@@ -226,7 +244,10 @@ interface WorktreeSelectionState {
   dismissPendingCreation: (path: string) => void;
   addDeletedWorktree: (worktree: DeletedWorktree) => void;
   dismissDeletedWorktree: (worktreeId: string) => void;
-  setDeletedWorktreeExpiry: (worktreeId: string, expiresAt: number | null) => void;
+  setDeletedWorktreeCleanupState: (
+    worktreeId: string,
+    next: { expiresAt: number | null; holdReason: DeletedWorktreeHoldReason | null }
+  ) => void;
   clearRestoreTarget: (worktreeId: string) => void;
   pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
   toggleDeletedWorktreeGroupExpanded: () => void;
@@ -849,12 +870,16 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     });
   },
 
-  setDeletedWorktreeExpiry: (worktreeId, expiresAt) => {
+  // Deadline and hold reason move together: a held tick rewrites the pinned
+  // expiry every second, and splitting these into two mutators would re-render
+  // the sidebar twice for what is one logical state change.
+  setDeletedWorktreeCleanupState: (worktreeId, { expiresAt, holdReason }) => {
     set((state) => {
       const entry = state.deletedWorktrees.get(worktreeId);
-      if (!entry || entry.expiresAt === expiresAt) return state;
+      if (!entry) return state;
+      if (entry.expiresAt === expiresAt && entry.holdReason === holdReason) return state;
       const next = new Map(state.deletedWorktrees);
-      next.set(worktreeId, { ...entry, expiresAt });
+      next.set(worktreeId, { ...entry, expiresAt, holdReason });
       return { deletedWorktrees: next };
     });
   },


### PR DESCRIPTION
## Summary
- The deleted-worktree ghost row in the sidebar is the only place to drag surviving terminals to another worktree before they're trashed. Its auto-close countdown was broken in two opposite directions: it could hold a row open forever, or it could fire with zero rescue window and silently trash live agent sessions.
- This fixes both by measuring the countdown against actually-observed time instead of a wall-clock deadline, bounding every hold, and showing why a row is holding.

Resolves #11259

## The bug

1. **Never fires.** `isCountdownDeferred` re-armed the deadline to a full TTL on every 1Hz tick instead of pausing it. A stuck `working` agent, or a leaked app-wide drag flag, held a row open indefinitely, with the progress bar snapped to full and nothing in the row explaining why.
2. **Fires with zero window.** The deadline was stamped at deletion time. A backgrounded project view (detached, CPU-throttled, frozen) thawed with an already-expired deadline and trashed live agent sessions on the first tick. This is the worse half: it silently destroys running agents.

## The fix

1. Rows are recorded unarmed; the sweep arms them, and only ever charges the countdown for time the row could actually be seen. Any gap between sweeps longer than two intervals gets credited back rather than spent, one mechanism covering a cached view, a hidden window, a throttled renderer, and a sleeping machine. Every sweep still spends at least one interval, so the countdown stays strictly monotonic and can't be stalled indefinitely.
2. The sweep refuses to run while the project view is cached or the window is hidden. Both checks are needed since neither implies the other: a cached `WebContentsView` still reports `visible` (see `src/lib/viewCacheState.ts`), and a minimized window keeps its project active while Chromium throttles its timers to 1Hz, which is this sweep's exact interval. Skip the check and the sweep burns the countdown down and trashes a row nobody could see.
3. A hold now pauses the countdown at its remaining value instead of resetting it to full, and every hold is bounded: 5 minutes for a confirm dialog or a drag, 60 minutes for a working agent. The longer agent cap is deliberate: `TRASH_TTL_MS` is 20 seconds, so force-trashing a live agent is closer to termination than to a reversible undo. Once a cap is spent, the preserved countdown resumes and the row goes.
4. The row now says why it's holding: a neutral badge naming the condition ("Agent working", "Dragging", "Confirming") with a tooltip, next to the now-steady seconds readout.

The `ttlSeconds === 0` "never" path is untouched, as the issue asked, and the preference options (0/30/60/300, default 60) are unchanged.

## Testing

133 targeted tests pass: a pure sweep suite exercising the state machine with injected dependencies, a new lifecycle suite (`src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts`) driving the real view-cache bridge with fake timers, plus store, card, and context tests. `tsc` is clean, `prettier` is clean, 0 lint errors on changed files.

The implementation went through two adversarial review passes, which caught and fixed two more bugs: a hidden-window path where Chromium's first background throttle tier is 1Hz (not once a minute), so hidden ticks arrived on schedule and spent the countdown anyway; and a liveness hole where crediting a gap in full meant repeated just-over-threshold gaps could consume zero countdown forever.

## Files changed

- `src/store/deletedWorktreeCleanup.ts`
- `src/store/worktreeStore.ts`
- `src/store/preferencesStore.ts`
- `src/contexts/WorktreeStoreContext.tsx`
- `src/components/Sidebar/DeletedWorktreeCard.tsx`
- `src/components/Settings/WorktreeSettingsTab.tsx`
- 6 test files, including the new `src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts`
