### PR TITLE
feat(diff): add full file view option to the diff panel

### DIFF
--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -98,17 +98,20 @@ export interface DiffViewerProps {
   /**
    * Expand every gap so the rendered diff covers the whole file. Requires
    * `source`; without a usable one the diff renders unexpanded and
-   * `onFullFileUnavailable` fires so the host can explain why.
+   * `onFullFileVerdict` fires so the host can explain why.
    */
   fullFile?: boolean;
   /**
-   * Fired when `fullFile` was requested but can't be honoured, with the reason
-   * and the `source` it was judged against. Lets the host surface one
-   * explanation in its own chrome instead of the viewer growing a second banner
-   * system, and lets it tell a current verdict from a superseded one.
+   * The verdict on a requested `fullFile`, with the `source` it was judged
+   * against. Lets the host surface one explanation in its own chrome instead of
+   * the viewer growing a second banner system.
+   *
+   * Fires with `null` on success too: a host that only heard about failures
+   * couldn't tell a current verdict from a superseded one, and would keep
+   * showing the last refusal after a refresh made the expansion work.
    */
-  onFullFileUnavailable?: (
-    reason: FullFileUnavailableReason,
+  onFullFileVerdict?: (
+    reason: FullFileUnavailableReason | null,
     forSource: string | null | undefined
   ) => void;
   /** Soft-wrap long lines instead of horizontal scrolling */
@@ -312,6 +315,9 @@ function estimateLineColumns(text: string): number {
  * count used for the size ceiling.
  */
 function toSourceLines(source: string): string[] {
+  // A zero-byte file has no lines; splitting it would claim one empty line and
+  // push the reconstructed old side one line long.
+  if (source === "") return [];
   const lines = source.split("\n");
   if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
   // A CRLF checkout leaves a carriage return on every line of the disk read
@@ -380,7 +386,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
     rootPath,
     source,
     fullFile = false,
-    onFullFileUnavailable,
+    onFullFileVerdict,
     wrapLines = false,
     searchQuery,
     onRetry,
@@ -462,8 +468,8 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   const effectiveFullFile = fullFile && !fullFileBlocked;
 
   useEffect(() => {
-    if (fullFile && expansion.reason !== null) onFullFileUnavailable?.(expansion.reason, source);
-  }, [fullFile, expansion.reason, onFullFileUnavailable, source]);
+    if (fullFile) onFullFileVerdict?.(expansion.reason, source);
+  }, [fullFile, expansion.reason, onFullFileVerdict, source]);
 
   if (!diff || diff === "NO_CHANGES") {
     return (

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -298,17 +298,6 @@ function estimateLineColumns(text: string): number {
 }
 
 /**
- * Confirm the supplied source really is the diff's new side before any of it is
- * shown as context.
- *
- * `buildSyntheticOldSource` trusts the source completely — it reconstructs the
- * old side by indexing into it at hunk offsets, so a source that has drifted
- * from the diff (the file edited between the two reads, or a revision the diff
- * was never generated against) yields believable-looking context lines that
- * belong to different code. Every hunk already carries its own new-side lines,
- * which gives a cheap way to check: they must appear verbatim at `newStart`.
- */
-/**
  * Split file content into its lines. A file ending in a newline splits with a
  * trailing empty element that is not a line of the file — left in, it renders
  * as a phantom blank row at the end of every expanded file and shifts the line
@@ -326,6 +315,17 @@ function toSourceLines(source: string): string[] {
   return lines.map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line));
 }
 
+/**
+ * Confirm the supplied source really is the diff's new side before any of it is
+ * shown as context.
+ *
+ * `buildSyntheticOldSource` trusts the source completely — it reconstructs the
+ * old side by indexing into it at hunk offsets, so a source that has drifted
+ * from the diff (the file edited between the two reads, or a revision the diff
+ * was never generated against) yields believable-looking context lines that
+ * belong to different code. Every hunk already carries its own new-side lines,
+ * which gives a cheap way to check: they must appear verbatim at `newStart`.
+ */
 function sourceMatchesHunks(newLines: string[], hunks: HunkData[]): boolean {
   if (!hunks.length) return false;
   for (const hunk of hunks) {

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -55,6 +55,7 @@ import {
   getFilePath,
   shouldCollapseByDefault,
   estimateFileDiffBytes,
+  estimateHunksBytes,
 } from "./diffCollapseUtils";
 import { detectMovedLines } from "./diffMovedUtils";
 import { computeSearchRanges, computeTrailingWsRanges } from "./diffTokenRanges";
@@ -64,6 +65,24 @@ import { diffTokenizeClient } from "@/services/DiffTokenizeService";
 import { formatBytes } from "@/lib/formatBytes";
 
 export { _resetLangStateForTests, _flushLangLoadsForTests } from "./diffRefractor";
+
+/**
+ * Why a requested full-file view fell back to the plain diff.
+ * - `source-mismatch`: the supplied source isn't the diff's new side, so its
+ *   lines would be context from different code.
+ * - `too-large`: expanding would commit more rows than the un-virtualized
+ *   table can render responsively.
+ * - `unsupported`: the diff has no expandable single-file modify shape.
+ */
+export type FullFileUnavailableReason = "source-mismatch" | "too-large" | "unsupported";
+
+/**
+ * Row ceiling for full-file expansion. `expandFromRawCode` merges adjacent
+ * hunks, so a fully expanded file becomes one hunk that the per-hunk
+ * progressive reveal can no longer stage — every row commits in a single
+ * layout pass. Until the table is virtualized this is the backstop.
+ */
+export const FULL_FILE_MAX_LINES = 5000;
 
 export interface DiffViewerProps {
   diff: string;
@@ -76,6 +95,18 @@ export interface DiffViewerProps {
    * loaded file may not match the diff's new side.
    */
   source?: string | null;
+  /**
+   * Expand every gap so the rendered diff covers the whole file. Requires
+   * `source`; without a usable one the diff renders unexpanded and
+   * `onFullFileUnavailable` fires so the host can explain why.
+   */
+  fullFile?: boolean;
+  /**
+   * Fired when `fullFile` was requested but can't be honoured, with the reason.
+   * Lets the host surface one explanation in its own chrome instead of the
+   * viewer growing a second banner system.
+   */
+  onFullFileUnavailable?: (reason: FullFileUnavailableReason) => void;
   /** Soft-wrap long lines instead of horizontal scrolling */
   wrapLines?: boolean;
   /** Case-insensitive plain-text query; matches render as .diff-search-match spans */
@@ -260,6 +291,35 @@ function estimateLineColumns(text: string): number {
 }
 
 /**
+ * Confirm the supplied source really is the diff's new side before any of it is
+ * shown as context.
+ *
+ * `buildSyntheticOldSource` trusts the source completely — it reconstructs the
+ * old side by indexing into it at hunk offsets, so a source that has drifted
+ * from the diff (the file edited between the two reads, or a revision the diff
+ * was never generated against) yields believable-looking context lines that
+ * belong to different code. Every hunk already carries its own new-side lines,
+ * which gives a cheap way to check: they must appear verbatim at `newStart`.
+ */
+function sourceMatchesHunks(newSource: string, hunks: HunkData[]): boolean {
+  if (!hunks.length) return false;
+  const newLines = newSource.split("\n");
+  for (const hunk of hunks) {
+    let lineNumber = hunk.newStart;
+    for (const change of hunk.changes) {
+      // Deletes exist only on the old side and occupy no new-side line.
+      if (change.type === "delete") continue;
+      if (newLines[lineNumber - 1] !== change.content) return false;
+      lineNumber++;
+    }
+    // A hunk claiming more new-side lines than it listed means the diff and the
+    // source disagree about the file's shape.
+    if (lineNumber !== hunk.newStart + hunk.newLines) return false;
+  }
+  return true;
+}
+
+/**
  * Build an old-side source (indexed by old line numbers, as
  * `expandFromRawCode` expects) from the new-side file content. Unchanged
  * regions are byte-identical between revisions, differing only by the running
@@ -302,6 +362,8 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
     viewType = "split",
     rootPath,
     source,
+    fullFile = false,
+    onFullFileUnavailable,
     wrapLines = false,
     searchQuery,
     onRetry,
@@ -341,13 +403,41 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   }, [diff, files]);
 
   // Context expansion is only sound when the supplied source is the diff's
-  // new side, which callers guarantee only for single-file diffs.
-  const oldSource = useMemo(() => {
-    if (!source || files.length !== 1) return null;
+  // new side, which callers guarantee only for single-file diffs — and which
+  // `sourceMatchesHunks` then verifies, since a caller's guarantee can still be
+  // defeated by the file changing between the diff and the source read.
+  //
+  // The rejection reason is carried alongside so a requested full-file view can
+  // say why it fell back rather than silently rendering the plain diff.
+  const expansion = useMemo<{
+    oldSource: string[] | null;
+    reason: FullFileUnavailableReason | null;
+  }>(() => {
+    if (source == null) return { oldSource: null, reason: null };
+    if (files.length !== 1) return { oldSource: null, reason: "unsupported" };
     const file = files[0];
-    if (file.type !== "modify" && file.type !== "rename" && file.type !== "copy") return null;
-    return buildSyntheticOldSource(source, file.hunks ?? []);
+    if (file.type !== "modify" && file.type !== "rename" && file.type !== "copy") {
+      return { oldSource: null, reason: "unsupported" };
+    }
+    const hunks = file.hunks ?? [];
+    if (!sourceMatchesHunks(source, hunks)) {
+      return { oldSource: null, reason: "source-mismatch" };
+    }
+    const built = buildSyntheticOldSource(source, hunks);
+    if (built === null) return { oldSource: null, reason: "unsupported" };
+    if (built.length > FULL_FILE_MAX_LINES) return { oldSource: built, reason: "too-large" };
+    return { oldSource: built, reason: null };
   }, [source, files]);
+  const oldSource = expansion.oldSource;
+
+  // A file past the row ceiling keeps its per-gap expanders (the user can still
+  // reveal context deliberately) but never auto-expands wholesale.
+  const fullFileBlocked = expansion.reason !== null;
+  const effectiveFullFile = fullFile && !fullFileBlocked;
+
+  useEffect(() => {
+    if (fullFile && expansion.reason !== null) onFullFileUnavailable?.(expansion.reason);
+  }, [fullFile, expansion.reason, onFullFileUnavailable]);
 
   if (!diff || diff === "NO_CHANGES") {
     return (
@@ -444,6 +534,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
           searchQuery={deferredSearchQuery}
           rootPath={rootPath}
           oldSource={files.length === 1 ? oldSource : null}
+          fullFile={effectiveFullFile}
           onToggleCollapse={onToggleCollapse}
           onTokensRendered={onTokensRendered}
         />
@@ -562,6 +653,8 @@ interface FileDiffProps {
   rootPath?: string;
   /** Synthetic old-side source enabling context expansion (single-file diffs only) */
   oldSource: string[] | null;
+  /** Render every line of the file rather than the changed regions and their context */
+  fullFile: boolean;
   /** Fired whenever this file's rendered hunk rows change (collapse, expansion, reveal) */
   onToggleCollapse?: () => void;
   /** Fired after this file's token pass commits */
@@ -576,6 +669,7 @@ function FileDiff({
   searchQuery,
   rootPath,
   oldSource,
+  fullFile,
   onToggleCollapse,
   onTokensRendered,
 }: FileDiffProps) {
@@ -587,7 +681,10 @@ function FileDiff({
   const diffType: DiffType = file.type as DiffType;
 
   const fileBytes = useMemo(() => estimateFileDiffBytes(file), [file]);
-  const isLargeFile = fileBytes > DIFF_SOFT_COLLAPSE_BYTES;
+  // Whether the diff *as authored* is large. Drives the collapse-by-default and
+  // progressive-reveal decisions, which are statements about the change itself
+  // and must not shift when the user expands context.
+  const isLargeDiff = fileBytes > DIFF_SOFT_COLLAPSE_BYTES;
 
   const collapseDecision = useMemo(() => shouldCollapseByDefault(file), [file]);
   const [isCollapsed, setIsCollapsed] = useState(collapseDecision.collapse);
@@ -596,33 +693,60 @@ function FileDiff({
     setIsCollapsed(collapseDecision.collapse);
   }, [collapseDecision.collapse]);
 
-  // Context expansion mutates the rendered hunk set; reset when the file changes.
+  // Manual per-gap expansion. Reset when the file changes, and when the source
+  // changes under it — context revealed from a previous revision must not
+  // survive into a newly loaded one.
   const [hunks, setHunks] = useState<HunkData[]>(file.hunks ?? []);
   useEffect(() => {
     setHunks(file.hunks ?? []);
-  }, [file]);
+  }, [file, oldSource]);
+
+  // Full file is derived from the file's own hunks rather than folded into
+  // `hunks`, so toggling it off restores whatever the user had manually
+  // expanded instead of discarding it.
+  const renderedHunks = useMemo(() => {
+    if (!fullFile || !oldSource) return hunks;
+    try {
+      // `end` is exclusive, so the last line needs length + 1.
+      return expandFromRawCode(file.hunks ?? [], oldSource, 1, oldSource.length + 1);
+    } catch {
+      return hunks;
+    }
+  }, [fullFile, oldSource, file, hunks]);
 
   // Progressive reveal for very large expanded files: committing tens of
   // thousands of table cells at once forces a full-table layout pass under
   // width: max-content.
   const [visibleHunkCount, setVisibleHunkCount] = useState(() =>
-    isLargeFile ? INITIAL_VISIBLE_HUNKS : Number.POSITIVE_INFINITY
+    isLargeDiff ? INITIAL_VISIBLE_HUNKS : Number.POSITIVE_INFINITY
   );
   useEffect(() => {
-    setVisibleHunkCount(isLargeFile ? INITIAL_VISIBLE_HUNKS : Number.POSITIVE_INFINITY);
-  }, [file, isLargeFile]);
+    setVisibleHunkCount(isLargeDiff ? INITIAL_VISIBLE_HUNKS : Number.POSITIVE_INFINITY);
+  }, [file, isLargeDiff]);
 
   const visibleHunks = useMemo(
-    () => (hunks.length > visibleHunkCount ? hunks.slice(0, visibleHunkCount) : hunks),
-    [hunks, visibleHunkCount]
+    () =>
+      renderedHunks.length > visibleHunkCount
+        ? renderedHunks.slice(0, visibleHunkCount)
+        : renderedHunks,
+    [renderedHunks, visibleHunkCount]
   );
-  const hiddenHunkCount = hunks.length - visibleHunks.length;
+  const hiddenHunkCount = renderedHunks.length - visibleHunks.length;
+
+  // Measured from what is actually being rendered, not from the parsed diff:
+  // expansion merges hunks and grows them without end, so a small diff in a
+  // large file would otherwise keep the cheap-to-highlight verdict it earned
+  // while collapsed.
+  const isLargeRender = useMemo(
+    () => estimateHunksBytes(visibleHunks) > DIFF_SOFT_COLLAPSE_BYTES,
+    [visibleHunks]
+  );
 
   // Moved-block detection shares the large-file gate with syntax highlighting:
   // past the soft-collapse threshold the diff is churn, not review material.
   const movedKeys = useMemo(
-    () => (isCollapsed || isLargeFile ? null : detectMovedLines(visibleHunks)),
-    [visibleHunks, isCollapsed, isLargeFile]
+    () => (isCollapsed || isLargeRender ? null : detectMovedLines(visibleHunks)),
+    [visibleHunks, isCollapsed, isLargeRender]
   );
 
   const renderGutter = useMemo(
@@ -664,13 +788,26 @@ function FileDiff({
     visibleHunks,
     language,
     !isCollapsed,
-    !isLargeFile,
+    !isLargeRender,
     extraRanges
   );
 
   useEffect(() => {
     onTokensRendered?.();
   }, [tokens, onTokensRendered]);
+
+  // Single notification point for the rendered row set changing — manual gap
+  // expansion, progressive reveal, the full-file scope, and a source arriving
+  // after the diff all land here, so each fires exactly once and none can be
+  // forgotten. Collapse/expand is separate: it changes visibility, not rows,
+  // and notifies from its own handler. The first commit is the initial render
+  // rather than a transition, so the ref starts already-notified.
+  const lastNotifiedHunksRef = useRef(visibleHunks);
+  useEffect(() => {
+    if (lastNotifiedHunksRef.current === visibleHunks) return;
+    lastNotifiedHunksRef.current = visibleHunks;
+    onToggleCollapse?.();
+  }, [visibleHunks, onToggleCollapse]);
 
   // Gutter columns get an explicit width sized to the widest line number plus
   // the +/- marker, published as a CSS var that also positions the second
@@ -862,6 +999,9 @@ function FileDiff({
     setIsCollapsed((prev) => !prev);
   };
 
+  // Both of these change the rendered row set, so the effect above issues the
+  // `onToggleCollapse` notification — notifying here too would double-fire, and
+  // would also fire when an expansion failed and changed nothing.
   const handleExpandContext = useCallback(
     (start: number, end: number) => {
       if (!oldSource) return;
@@ -872,14 +1012,12 @@ function FileDiff({
           return prev;
         }
       });
-      onToggleCollapse?.();
     },
-    [oldSource, onToggleCollapse]
+    [oldSource]
   );
 
   const handleShowMoreHunks = () => {
     setVisibleHunkCount((count) => count + SHOW_MORE_HUNKS_STEP);
-    onToggleCollapse?.();
   };
 
   const fileStyle: CSSProperties & Record<"--diff-gutter-width" | "--diff-max-line", string> = {
@@ -989,9 +1127,9 @@ function FileDiff({
               Plain text
             </span>
           )}
-          {!langLoadFailed && isLargeFile && !isCollapsed && (
+          {!langLoadFailed && isLargeRender && !isCollapsed && (
             <span className="text-xs text-text-muted" data-testid="diff-highlight-off-badge">
-              Highlighting off for large diff
+              {fullFile ? "Highlighting off for large file" : "Highlighting off for large diff"}
             </span>
           )}
           <div className="flex items-center gap-2 shrink-0 text-daintree-text/60">

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -102,11 +102,15 @@ export interface DiffViewerProps {
    */
   fullFile?: boolean;
   /**
-   * Fired when `fullFile` was requested but can't be honoured, with the reason.
-   * Lets the host surface one explanation in its own chrome instead of the
-   * viewer growing a second banner system.
+   * Fired when `fullFile` was requested but can't be honoured, with the reason
+   * and the `source` it was judged against. Lets the host surface one
+   * explanation in its own chrome instead of the viewer growing a second banner
+   * system, and lets it tell a current verdict from a superseded one.
    */
-  onFullFileUnavailable?: (reason: FullFileUnavailableReason) => void;
+  onFullFileUnavailable?: (
+    reason: FullFileUnavailableReason,
+    forSource: string | null | undefined
+  ) => void;
   /** Soft-wrap long lines instead of horizontal scrolling */
   wrapLines?: boolean;
   /** Case-insensitive plain-text query; matches render as .diff-search-match spans */
@@ -301,9 +305,23 @@ function estimateLineColumns(text: string): number {
  * belong to different code. Every hunk already carries its own new-side lines,
  * which gives a cheap way to check: they must appear verbatim at `newStart`.
  */
-function sourceMatchesHunks(newSource: string, hunks: HunkData[]): boolean {
+/**
+ * Split file content into its lines. A file ending in a newline splits with a
+ * trailing empty element that is not a line of the file — left in, it renders
+ * as a phantom blank row at the end of every expanded file and shifts the line
+ * count used for the size ceiling.
+ */
+function toSourceLines(source: string): string[] {
+  const lines = source.split("\n");
+  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
+  // A CRLF checkout leaves a carriage return on every line of the disk read
+  // that git's diff output doesn't carry. Left in, every line compares unequal
+  // and the whole feature reads as a permanent mismatch on Windows.
+  return lines.map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line));
+}
+
+function sourceMatchesHunks(newLines: string[], hunks: HunkData[]): boolean {
   if (!hunks.length) return false;
-  const newLines = newSource.split("\n");
   for (const hunk of hunks) {
     let lineNumber = hunk.newStart;
     for (const change of hunk.changes) {
@@ -326,9 +344,8 @@ function sourceMatchesHunks(newSource: string, hunks: HunkData[]): boolean {
  * insert/delete offset — and expansion only ever reads unchanged regions, so
  * positions inside hunks can stay empty.
  */
-function buildSyntheticOldSource(newSource: string, hunks: HunkData[]): string[] | null {
+function buildSyntheticOldSource(newLines: string[], hunks: HunkData[]): string[] | null {
   if (!hunks.length) return null;
-  const newLines = newSource.split("\n");
   let inserts = 0;
   let deletes = 0;
   for (const hunk of hunks) {
@@ -420,12 +437,21 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
       return { oldSource: null, reason: "unsupported" };
     }
     const hunks = file.hunks ?? [];
-    if (!sourceMatchesHunks(source, hunks)) {
+    // A diff with no hunks (a pure rename, a mode change) has no gaps to fill.
+    // Reporting that as a mismatch would tell the user their file changed.
+    if (!hunks.length) return { oldSource: null, reason: "unsupported" };
+    const newLines = toSourceLines(source);
+    if (!sourceMatchesHunks(newLines, hunks)) {
       return { oldSource: null, reason: "source-mismatch" };
     }
-    const built = buildSyntheticOldSource(source, hunks);
+    const built = buildSyntheticOldSource(newLines, hunks);
     if (built === null) return { oldSource: null, reason: "unsupported" };
-    if (built.length > FULL_FILE_MAX_LINES) return { oldSource: built, reason: "too-large" };
+    // Both sides are rendered, and they diverge: inserting 2,000 lines into a
+    // 4,000-line file leaves the old side under the ceiling while the new side
+    // is well past it. The larger side is what the table has to carry.
+    if (Math.max(built.length, newLines.length) > FULL_FILE_MAX_LINES) {
+      return { oldSource: built, reason: "too-large" };
+    }
     return { oldSource: built, reason: null };
   }, [source, files]);
   const oldSource = expansion.oldSource;
@@ -436,8 +462,8 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   const effectiveFullFile = fullFile && !fullFileBlocked;
 
   useEffect(() => {
-    if (fullFile && expansion.reason !== null) onFullFileUnavailable?.(expansion.reason);
-  }, [fullFile, expansion.reason, onFullFileUnavailable]);
+    if (fullFile && expansion.reason !== null) onFullFileUnavailable?.(expansion.reason, source);
+  }, [fullFile, expansion.reason, onFullFileUnavailable, source]);
 
   if (!diff || diff === "NO_CHANGES") {
     return (

--- a/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
@@ -114,9 +114,11 @@ describe("DiffViewer full file scope", () => {
     renderViewer({ diff, source, fullFile: true });
 
     const hunks = capturedDiffProps.hunks ?? [];
-    expect(hunks.length).toBeGreaterThan(0);
-    const first = hunks[0];
-    const last = hunks[hunks.length - 1];
+    const first = hunks.at(0);
+    const last = hunks.at(-1);
+    expect(first).toBeDefined();
+    expect(last).toBeDefined();
+    if (!first || !last) return;
     expect(first.oldStart).toBe(1);
     // Old and new sides are the same length here (one line replaced one line),
     // so full coverage means the last hunk reaches the final line.
@@ -342,7 +344,7 @@ describe("DiffViewer full file scope", () => {
 
     renderViewer({ diff, source: drifted, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onVerdict.mock.calls[0][1]).toBe(drifted);
+    expect(onVerdict).toHaveBeenLastCalledWith("source-mismatch", drifted);
   });
 
   it("notifies once when the scope changes the rendered rows, and not on mount", () => {

--- a/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
@@ -141,38 +141,44 @@ describe("DiffViewer full file scope", () => {
     // Same shape, different content — exactly what a file edited between the
     // diff and the source read looks like.
     const drifted = Array.from({ length: 12 }, (_, i) => `unrelated${i + 1}`).join("\n");
-    const onUnavailable =
-      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+    const onVerdict =
+      vi.fn<
+        (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => void
+      >();
 
-    renderViewer({ diff, source: drifted, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source: drifted, fullFile: true, onFullFileVerdict: onVerdict });
 
     const content = renderedContent();
     // None of the drifted file's lines may leak in as context.
     expect(content.some((line) => line.startsWith("unrelated"))).toBe(false);
     expect(content).toContain("CHANGED");
-    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch", expect.any(String));
+    expect(onVerdict).toHaveBeenCalledWith("source-mismatch", expect.any(String));
   });
 
   it("reports a truncated source as a mismatch rather than expanding past its end", () => {
     const { diff } = makeFixture(12, 5);
     const truncated = ["line1", "line2", "line3"].join("\n");
-    const onUnavailable =
-      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+    const onVerdict =
+      vi.fn<
+        (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => void
+      >();
 
-    renderViewer({ diff, source: truncated, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source: truncated, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch", expect.any(String));
+    expect(onVerdict).toHaveBeenCalledWith("source-mismatch", expect.any(String));
   });
 
   it("falls back rather than committing more rows than the table can carry", () => {
     const totalLines = FULL_FILE_MAX_LINES + 1;
     const { diff, source } = makeFixture(totalLines, 100);
-    const onUnavailable =
-      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+    const onVerdict =
+      vi.fn<
+        (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => void
+      >();
 
-    renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onUnavailable).toHaveBeenCalledWith("too-large", expect.any(String));
+    expect(onVerdict).toHaveBeenCalledWith("too-large", expect.any(String));
     // The diff itself still renders — the fallback is to changed lines, never
     // to an empty pane.
     expect(renderedContent()).toContain("CHANGED");
@@ -180,25 +186,29 @@ describe("DiffViewer full file scope", () => {
 
   it("expands a file sitting exactly on the row ceiling", () => {
     const { diff, source } = makeFixture(FULL_FILE_MAX_LINES, 100);
-    const onUnavailable =
-      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+    const onVerdict =
+      vi.fn<
+        (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => void
+      >();
 
-    renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onUnavailable).not.toHaveBeenCalled();
+    expect(onVerdict).toHaveBeenLastCalledWith(null, expect.any(String));
     expect(renderedContent()).toContain("line1");
   });
 
   it("stays on the plain diff when no source is supplied", () => {
     const { diff } = makeFixture(12, 5);
-    const onUnavailable =
-      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+    const onVerdict =
+      vi.fn<
+        (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => void
+      >();
 
-    renderViewer({ diff, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, fullFile: true, onFullFileVerdict: onVerdict });
 
     expect(renderedContent()).not.toContain("line1");
-    // No source is a pending read, not a refusal — nothing to explain yet.
-    expect(onUnavailable).not.toHaveBeenCalled();
+    // No source is a pending read, not a refusal — there's nothing to explain.
+    expect(onVerdict).toHaveBeenLastCalledWith(null, undefined);
   });
 
   // Files on disk almost always end in a newline; a fixture built by joining
@@ -218,27 +228,30 @@ describe("DiffViewer full file scope", () => {
     // Exactly at the ceiling once the trailing newline is discounted — a naive
     // split would read this as one line over and refuse to expand.
     const { diff, source } = makeFixture(FULL_FILE_MAX_LINES, 100);
-    const onUnavailable =
-      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+    const onVerdict =
+      vi.fn<
+        (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => void
+      >();
 
     renderViewer({
       diff,
       source: `${source}\n`,
       fullFile: true,
-      onFullFileUnavailable: onUnavailable,
+      onFullFileVerdict: onVerdict,
     });
 
-    expect(onUnavailable).not.toHaveBeenCalled();
+    expect(onVerdict).toHaveBeenLastCalledWith(null, expect.any(String));
   });
 
   it("tolerates a CRLF checkout, where disk lines carry a return the diff doesn't", () => {
     const { diff, source } = makeFixture(12, 5);
     const crlf = source.split("\n").join("\r\n");
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+    const onVerdict =
+      vi.fn<(reason: FullFileUnavailableReason | null, forSource: unknown) => void>();
 
-    renderViewer({ diff, source: crlf, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source: crlf, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onUnavailable).not.toHaveBeenCalled();
+    expect(onVerdict).toHaveBeenLastCalledWith(null, expect.any(String));
     expect(renderedContent()).toContain("line1");
   });
 
@@ -266,11 +279,12 @@ describe("DiffViewer full file scope", () => {
       "line2",
       ...Array.from({ length: oldLines - 2 }, (_, i) => `tail${i + 1}`),
     ].join("\n");
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+    const onVerdict =
+      vi.fn<(reason: FullFileUnavailableReason | null, forSource: unknown) => void>();
 
-    renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onUnavailable).toHaveBeenCalledWith("too-large", expect.any(String));
+    expect(onVerdict).toHaveBeenCalledWith("too-large", expect.any(String));
   });
 
   it("calls a hunkless diff unsupported rather than claiming the file changed", () => {
@@ -282,28 +296,53 @@ describe("DiffViewer full file scope", () => {
       "rename from old.ts",
       "rename to new.ts",
     ].join("\n");
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+    const onVerdict =
+      vi.fn<(reason: FullFileUnavailableReason | null, forSource: unknown) => void>();
 
     renderViewer({
       diff: renameDiff,
       source: "line1\nline2\n",
       fullFile: true,
-      onFullFileUnavailable: onUnavailable,
+      onFullFileVerdict: onVerdict,
     });
 
-    if (onUnavailable.mock.calls.length > 0) {
-      expect(onUnavailable).toHaveBeenCalledWith("unsupported", expect.anything());
-    }
+    expect(onVerdict).toHaveBeenLastCalledWith("unsupported", expect.any(String));
+  });
+
+  it("clears a fallback verdict once a refreshed diff makes the same source usable", () => {
+    // A host that only heard about failures would keep the explanation up while
+    // the file below it silently rendered fully expanded.
+    const { diff, source } = makeFixture(12, 5);
+    const staleDiff = makeFixture(12, 9).diff;
+    const onVerdict =
+      vi.fn<(reason: FullFileUnavailableReason | null, forSource: unknown) => void>();
+
+    const { rerender } = render(
+      <TooltipProvider>
+        <DiffViewer diff={staleDiff} source={source} fullFile onFullFileVerdict={onVerdict} />
+      </TooltipProvider>
+    );
+    expect(onVerdict).toHaveBeenLastCalledWith("source-mismatch", source);
+
+    // The diff is refreshed and now matches, while the source string is
+    // unchanged — so the verdict, not the source, is what has to move.
+    rerender(
+      <TooltipProvider>
+        <DiffViewer diff={diff} source={source} fullFile onFullFileVerdict={onVerdict} />
+      </TooltipProvider>
+    );
+    expect(onVerdict).toHaveBeenLastCalledWith(null, source);
   });
 
   it("reports the reason against the source it judged, so a host can tell verdicts apart", () => {
     const { diff } = makeFixture(12, 5);
     const drifted = Array.from({ length: 12 }, (_, i) => `unrelated${i + 1}`).join("\n");
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+    const onVerdict =
+      vi.fn<(reason: FullFileUnavailableReason | null, forSource: unknown) => void>();
 
-    renderViewer({ diff, source: drifted, fullFile: true, onFullFileUnavailable: onUnavailable });
+    renderViewer({ diff, source: drifted, fullFile: true, onFullFileVerdict: onVerdict });
 
-    expect(onUnavailable.mock.calls[0][1]).toBe(drifted);
+    expect(onVerdict.mock.calls[0][1]).toBe(drifted);
   });
 
   it("notifies once when the scope changes the rendered rows, and not on mount", () => {

--- a/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
@@ -141,7 +141,8 @@ describe("DiffViewer full file scope", () => {
     // Same shape, different content — exactly what a file edited between the
     // diff and the source read looks like.
     const drifted = Array.from({ length: 12 }, (_, i) => `unrelated${i + 1}`).join("\n");
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+    const onUnavailable =
+      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
 
     renderViewer({ diff, source: drifted, fullFile: true, onFullFileUnavailable: onUnavailable });
 
@@ -149,27 +150,29 @@ describe("DiffViewer full file scope", () => {
     // None of the drifted file's lines may leak in as context.
     expect(content.some((line) => line.startsWith("unrelated"))).toBe(false);
     expect(content).toContain("CHANGED");
-    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch");
+    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch", expect.any(String));
   });
 
   it("reports a truncated source as a mismatch rather than expanding past its end", () => {
     const { diff } = makeFixture(12, 5);
     const truncated = ["line1", "line2", "line3"].join("\n");
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+    const onUnavailable =
+      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
 
     renderViewer({ diff, source: truncated, fullFile: true, onFullFileUnavailable: onUnavailable });
 
-    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch");
+    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch", expect.any(String));
   });
 
   it("falls back rather than committing more rows than the table can carry", () => {
     const totalLines = FULL_FILE_MAX_LINES + 1;
     const { diff, source } = makeFixture(totalLines, 100);
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+    const onUnavailable =
+      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
 
     renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
 
-    expect(onUnavailable).toHaveBeenCalledWith("too-large");
+    expect(onUnavailable).toHaveBeenCalledWith("too-large", expect.any(String));
     // The diff itself still renders — the fallback is to changed lines, never
     // to an empty pane.
     expect(renderedContent()).toContain("CHANGED");
@@ -177,7 +180,8 @@ describe("DiffViewer full file scope", () => {
 
   it("expands a file sitting exactly on the row ceiling", () => {
     const { diff, source } = makeFixture(FULL_FILE_MAX_LINES, 100);
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+    const onUnavailable =
+      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
 
     renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
 
@@ -187,13 +191,119 @@ describe("DiffViewer full file scope", () => {
 
   it("stays on the plain diff when no source is supplied", () => {
     const { diff } = makeFixture(12, 5);
-    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+    const onUnavailable =
+      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
 
     renderViewer({ diff, fullFile: true, onFullFileUnavailable: onUnavailable });
 
     expect(renderedContent()).not.toContain("line1");
     // No source is a pending read, not a refusal — nothing to explain yet.
     expect(onUnavailable).not.toHaveBeenCalled();
+  });
+
+  // Files on disk almost always end in a newline; a fixture built by joining
+  // lines does not. The difference is invisible until it renders.
+  it("doesn't invent a trailing blank line for a file that ends in a newline", () => {
+    const totalLines = 12;
+    const { diff, source } = makeFixture(totalLines, 5);
+    renderViewer({ diff, source: `${source}\n`, fullFile: true });
+
+    const content = renderedContent();
+    expect(content).toContain("line12");
+    expect(content[content.length - 1]).toBe("line12");
+    expect(content.length).toBe(totalLines + 1); // +1 for the replaced line's delete row
+  });
+
+  it("counts lines for the size ceiling without the trailing newline's empty split", () => {
+    // Exactly at the ceiling once the trailing newline is discounted — a naive
+    // split would read this as one line over and refuse to expand.
+    const { diff, source } = makeFixture(FULL_FILE_MAX_LINES, 100);
+    const onUnavailable =
+      vi.fn<(reason: FullFileUnavailableReason, forSource: string | null | undefined) => void>();
+
+    renderViewer({
+      diff,
+      source: `${source}\n`,
+      fullFile: true,
+      onFullFileUnavailable: onUnavailable,
+    });
+
+    expect(onUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a CRLF checkout, where disk lines carry a return the diff doesn't", () => {
+    const { diff, source } = makeFixture(12, 5);
+    const crlf = source.split("\n").join("\r\n");
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+
+    renderViewer({ diff, source: crlf, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(onUnavailable).not.toHaveBeenCalled();
+    expect(renderedContent()).toContain("line1");
+  });
+
+  it("measures the ceiling against the larger side, not just the old one", () => {
+    // A big insertion leaves the old side small while the new side — which is
+    // rendered too — blows past the ceiling.
+    const oldLines = 10;
+    const inserted = FULL_FILE_MAX_LINES + 1 - oldLines;
+    const body = [
+      " line1",
+      ...Array.from({ length: inserted }, (_, i) => `+new${i + 1}`),
+      " line2",
+    ];
+    const diff = [
+      "diff --git a/f.ts b/f.ts",
+      "index 1111111..2222222 100644",
+      "--- a/f.ts",
+      "+++ b/f.ts",
+      `@@ -1,2 +1,${inserted + 2} @@`,
+      ...body,
+    ].join("\n");
+    const source = [
+      "line1",
+      ...Array.from({ length: inserted }, (_, i) => `new${i + 1}`),
+      "line2",
+      ...Array.from({ length: oldLines - 2 }, (_, i) => `tail${i + 1}`),
+    ].join("\n");
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+
+    renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(onUnavailable).toHaveBeenCalledWith("too-large", expect.any(String));
+  });
+
+  it("calls a hunkless diff unsupported rather than claiming the file changed", () => {
+    // A pure rename carries no hunks; reporting a mismatch would tell the user
+    // their file changed when nothing did.
+    const renameDiff = [
+      "diff --git a/old.ts b/new.ts",
+      "similarity index 100%",
+      "rename from old.ts",
+      "rename to new.ts",
+    ].join("\n");
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+
+    renderViewer({
+      diff: renameDiff,
+      source: "line1\nline2\n",
+      fullFile: true,
+      onFullFileUnavailable: onUnavailable,
+    });
+
+    if (onUnavailable.mock.calls.length > 0) {
+      expect(onUnavailable).toHaveBeenCalledWith("unsupported", expect.anything());
+    }
+  });
+
+  it("reports the reason against the source it judged, so a host can tell verdicts apart", () => {
+    const { diff } = makeFixture(12, 5);
+    const drifted = Array.from({ length: 12 }, (_, i) => `unrelated${i + 1}`).join("\n");
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason, forSource: unknown) => void>();
+
+    renderViewer({ diff, source: drifted, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(onUnavailable.mock.calls[0][1]).toBe(drifted);
   });
 
   it("notifies once when the scope changes the rendered rows, and not on mount", () => {

--- a/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.fullFile.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { HunkData } from "react-diff-view";
+import { DiffViewer, FULL_FILE_MAX_LINES, _resetLangStateForTests } from "../DiffViewer";
+import type { FullFileUnavailableReason } from "../DiffViewer";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const { capturedDiffProps } = vi.hoisted(() => ({
+  capturedDiffProps: {} as { hunks?: HunkData[] },
+}));
+
+vi.mock("react-diff-view", async () => {
+  const actual = await vi.importActual<typeof import("react-diff-view")>("react-diff-view");
+  return {
+    ...actual,
+    Diff: (props: { children: (hunks: unknown[]) => React.ReactNode; hunks: HunkData[] }) => {
+      capturedDiffProps.hunks = props.hunks;
+      return <div data-testid="diff-element">{props.children(props.hunks)}</div>;
+    },
+    Hunk: () => <div data-testid="hunk" />,
+    tokenize: vi.fn(),
+    markEdits: vi.fn(() => vi.fn()),
+  };
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn().mockResolvedValue({ ok: true }) },
+}));
+
+/**
+ * A single-hunk modification of one line, with three lines of context, plus the
+ * exact new-side file content it was generated from. Keeping the two in one
+ * factory is the point: the source-consistency check only means something if
+ * the "good" fixture is genuinely consistent.
+ */
+function makeFixture(totalLines: number, changedLine: number) {
+  const originalLine = (n: number) => `line${n}`;
+  const contextStart = changedLine - 3;
+  const hunkLines: string[] = [];
+  for (let n = contextStart; n < changedLine; n++) hunkLines.push(` ${originalLine(n)}`);
+  hunkLines.push(`-${originalLine(changedLine)}`);
+  hunkLines.push(`+CHANGED`);
+  for (let n = changedLine + 1; n <= changedLine + 3; n++) hunkLines.push(` ${originalLine(n)}`);
+
+  const diff = [
+    "diff --git a/f.ts b/f.ts",
+    "index 1111111..2222222 100644",
+    "--- a/f.ts",
+    "+++ b/f.ts",
+    `@@ -${contextStart},7 +${contextStart},7 @@`,
+    ...hunkLines,
+  ].join("\n");
+
+  const source = Array.from({ length: totalLines }, (_, i) =>
+    i + 1 === changedLine ? "CHANGED" : originalLine(i + 1)
+  ).join("\n");
+
+  return { diff, source };
+}
+
+/** Every line of content the viewer handed to the diff table. */
+function renderedContent(): string[] {
+  const lines: string[] = [];
+  for (const hunk of capturedDiffProps.hunks ?? []) {
+    for (const change of hunk.changes) lines.push(change.content);
+  }
+  return lines;
+}
+
+function renderViewer(props: Partial<React.ComponentProps<typeof DiffViewer>> & { diff: string }) {
+  return render(
+    <TooltipProvider>
+      <DiffViewer {...props} />
+    </TooltipProvider>
+  );
+}
+
+beforeEach(() => {
+  capturedDiffProps.hunks = undefined;
+  _resetLangStateForTests();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DiffViewer full file scope", () => {
+  it("renders only the changed region and its context when scope is off", () => {
+    const { diff, source } = makeFixture(12, 5);
+    renderViewer({ diff, source, fullFile: false });
+
+    const content = renderedContent();
+    // The first and last lines of the file sit outside the hunk's context.
+    expect(content).not.toContain("line1");
+    expect(content).not.toContain("line12");
+    expect(content).toContain("CHANGED");
+  });
+
+  it("renders every line of the file when scope is on", () => {
+    const { diff, source } = makeFixture(12, 5);
+    renderViewer({ diff, source, fullFile: true });
+
+    const content = renderedContent();
+    expect(content).toContain("line1");
+    expect(content).toContain("line12");
+    expect(content).toContain("CHANGED");
+  });
+
+  it("covers the file end to end without gaps once expanded", () => {
+    const totalLines = 12;
+    const { diff, source } = makeFixture(totalLines, 5);
+    renderViewer({ diff, source, fullFile: true });
+
+    const hunks = capturedDiffProps.hunks ?? [];
+    expect(hunks.length).toBeGreaterThan(0);
+    const first = hunks[0];
+    const last = hunks[hunks.length - 1];
+    expect(first.oldStart).toBe(1);
+    // Old and new sides are the same length here (one line replaced one line),
+    // so full coverage means the last hunk reaches the final line.
+    expect(last.oldStart + last.oldLines - 1).toBe(totalLines);
+  });
+
+  it("restores the unexpanded view when scope is switched back off", () => {
+    const { diff, source } = makeFixture(12, 5);
+    const { rerender } = renderViewer({ diff, source, fullFile: true });
+    expect(renderedContent()).toContain("line1");
+
+    rerender(
+      <TooltipProvider>
+        <DiffViewer diff={diff} source={source} fullFile={false} />
+      </TooltipProvider>
+    );
+    expect(renderedContent()).not.toContain("line1");
+  });
+
+  it("refuses to expand against a source that isn't the diff's new side", () => {
+    const { diff } = makeFixture(12, 5);
+    // Same shape, different content — exactly what a file edited between the
+    // diff and the source read looks like.
+    const drifted = Array.from({ length: 12 }, (_, i) => `unrelated${i + 1}`).join("\n");
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+
+    renderViewer({ diff, source: drifted, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    const content = renderedContent();
+    // None of the drifted file's lines may leak in as context.
+    expect(content.some((line) => line.startsWith("unrelated"))).toBe(false);
+    expect(content).toContain("CHANGED");
+    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch");
+  });
+
+  it("reports a truncated source as a mismatch rather than expanding past its end", () => {
+    const { diff } = makeFixture(12, 5);
+    const truncated = ["line1", "line2", "line3"].join("\n");
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+
+    renderViewer({ diff, source: truncated, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(onUnavailable).toHaveBeenCalledWith("source-mismatch");
+  });
+
+  it("falls back rather than committing more rows than the table can carry", () => {
+    const totalLines = FULL_FILE_MAX_LINES + 1;
+    const { diff, source } = makeFixture(totalLines, 100);
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+
+    renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(onUnavailable).toHaveBeenCalledWith("too-large");
+    // The diff itself still renders — the fallback is to changed lines, never
+    // to an empty pane.
+    expect(renderedContent()).toContain("CHANGED");
+  });
+
+  it("expands a file sitting exactly on the row ceiling", () => {
+    const { diff, source } = makeFixture(FULL_FILE_MAX_LINES, 100);
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+
+    renderViewer({ diff, source, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(onUnavailable).not.toHaveBeenCalled();
+    expect(renderedContent()).toContain("line1");
+  });
+
+  it("stays on the plain diff when no source is supplied", () => {
+    const { diff } = makeFixture(12, 5);
+    const onUnavailable = vi.fn<(reason: FullFileUnavailableReason) => void>();
+
+    renderViewer({ diff, fullFile: true, onFullFileUnavailable: onUnavailable });
+
+    expect(renderedContent()).not.toContain("line1");
+    // No source is a pending read, not a refusal — nothing to explain yet.
+    expect(onUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("notifies once when the scope changes the rendered rows, and not on mount", () => {
+    const { diff, source } = makeFixture(12, 5);
+    const onToggleCollapse = vi.fn();
+    const { rerender } = render(
+      <TooltipProvider>
+        <DiffViewer
+          diff={diff}
+          source={source}
+          fullFile={false}
+          onToggleCollapse={onToggleCollapse}
+        />
+      </TooltipProvider>
+    );
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    rerender(
+      <TooltipProvider>
+        <DiffViewer diff={diff} source={source} fullFile onToggleCollapse={onToggleCollapse} />
+      </TooltipProvider>
+    );
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies when a late-arriving source expands the rows", () => {
+    const { diff, source } = makeFixture(12, 5);
+    const onToggleCollapse = vi.fn();
+    // Scope is on before the read resolves — the common ordering, since the
+    // diff renders first and the file content follows.
+    const { rerender } = render(
+      <TooltipProvider>
+        <DiffViewer diff={diff} fullFile onToggleCollapse={onToggleCollapse} />
+      </TooltipProvider>
+    );
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    rerender(
+      <TooltipProvider>
+        <DiffViewer diff={diff} source={source} fullFile onToggleCollapse={onToggleCollapse} />
+      </TooltipProvider>
+    );
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards expanded context when the source is replaced", async () => {
+    const { diff, source } = makeFixture(12, 5);
+    const { rerender } = renderViewer({ diff, source, fullFile: true });
+    expect(renderedContent()).toContain("line1");
+
+    const drifted = Array.from({ length: 12 }, (_, i) => `unrelated${i + 1}`).join("\n");
+    await act(async () => {
+      rerender(
+        <TooltipProvider>
+          <DiffViewer diff={diff} source={drifted} fullFile />
+        </TooltipProvider>
+      );
+    });
+
+    const content = renderedContent();
+    expect(content).not.toContain("line1");
+    expect(content.some((line) => line.startsWith("unrelated"))).toBe(false);
+  });
+});

--- a/src/components/Worktree/diffCollapseUtils.ts
+++ b/src/components/Worktree/diffCollapseUtils.ts
@@ -10,12 +10,23 @@ export function getFilePath(file: File): string {
 }
 
 /**
+ * Only what a byte estimate reads. Typed structurally because the parsed diff
+ * and the rendered hunks come from different packages — gitdiff-parser's
+ * `Hunk` and react-diff-view's `HunkData` differ in their change shapes, and
+ * this measure applies to both.
+ */
+interface MeasurableHunk {
+  content: string;
+  changes: readonly { content: string }[];
+}
+
+/**
  * Byte estimate for an arbitrary hunk set. Split out from
  * `estimateFileDiffBytes` so the same measure can be taken of the hunks
  * actually being rendered, which context expansion grows well past the parsed
  * diff's own size.
  */
-export function estimateHunksBytes(hunks: readonly File["hunks"][number][]): number {
+export function estimateHunksBytes(hunks: readonly MeasurableHunk[]): number {
   let bytes = 0;
   for (const hunk of hunks) {
     bytes += hunk.content.length;

--- a/src/components/Worktree/diffCollapseUtils.ts
+++ b/src/components/Worktree/diffCollapseUtils.ts
@@ -9,15 +9,25 @@ export function getFilePath(file: File): string {
   return "";
 }
 
-export function estimateFileDiffBytes(file: File): number {
+/**
+ * Byte estimate for an arbitrary hunk set. Split out from
+ * `estimateFileDiffBytes` so the same measure can be taken of the hunks
+ * actually being rendered, which context expansion grows well past the parsed
+ * diff's own size.
+ */
+export function estimateHunksBytes(hunks: readonly File["hunks"][number][]): number {
   let bytes = 0;
-  for (const hunk of file.hunks ?? []) {
+  for (const hunk of hunks) {
     bytes += hunk.content.length;
     for (const change of hunk.changes) {
       bytes += change.content.length;
     }
   }
   return bytes;
+}
+
+export function estimateFileDiffBytes(file: File): number {
+  return estimateHunksBytes(file.hunks ?? []);
 }
 
 export function shouldCollapseByDefault(file: File): {

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -345,12 +345,17 @@ export function DiffPane({
 
   // One line explaining why a requested whole-file view isn't on screen. The
   // read failure wins over the viewer's verdict: without content the viewer
-  // never got far enough to have one.
-  const fullFileNotice = wantsFullFile
+  // never got far enough to have one. `recoverable` marks the notices a refresh
+  // can actually clear — a hunkless rename never grows hunks and an over-size
+  // file never shrinks, so those get no action rather than one that can't work.
+  const fullFileNotice: { message: string; recoverable: boolean } | null = wantsFullFile
     ? sourceErrorCode
-      ? FILE_READ_ERROR_MESSAGES[sourceErrorCode]
+      ? { message: FILE_READ_ERROR_MESSAGES[sourceErrorCode], recoverable: true }
       : activeViewerFallback
-        ? FULL_FILE_FALLBACK_MESSAGES[activeViewerFallback]
+        ? {
+            message: FULL_FILE_FALLBACK_MESSAGES[activeViewerFallback],
+            recoverable: activeViewerFallback === "source-mismatch",
+          }
         : null
     : null;
 
@@ -441,10 +446,14 @@ export function DiffPane({
           severity="warning"
           icon={FileDiffIcon}
           title="Showing changed lines only"
-          description={fullFileNotice}
+          description={fullFileNotice.message}
           role="status"
           ariaLive="polite"
-          action={{ id: "refresh-full-file", label: "Retry", icon: RefreshCw, onClick: refreshAll }}
+          action={
+            fullFileNotice.recoverable
+              ? { id: "refresh-full-file", label: "Retry", icon: RefreshCw, onClick: refreshAll }
+              : undefined
+          }
         />
       )}
     </>

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -276,9 +276,16 @@ export function DiffPane({
   const isImageMode = Boolean(
     filePath && fileStatus && isImageDiffCandidate(filePath) && panel?.diffSource !== "base-branch"
   );
-  const hasDiff = Boolean(
-    content && content.trim() && content !== "NO_CHANGES" && content !== "ERROR"
-  );
+  // Sentinels the viewer turns into empty states rather than a rendered diff.
+  // `NO_CHANGES`/`ERROR` gate the pane's own branches below; the binary and
+  // oversized ones matter to the full-file scope, which has nothing to expand
+  // when no hunks were rendered in the first place.
+  const isDiffSentinel =
+    content === "NO_CHANGES" ||
+    content === "ERROR" ||
+    content === "BINARY_FILE" ||
+    content === "FILE_TOO_LARGE";
+  const hasDiff = Boolean(content && content.trim() && !isDiffSentinel);
 
   // Whether this file *can* show its whole contents, independent of whether the
   // user currently wants to — the toggle stays visible either way so the option
@@ -308,11 +315,7 @@ export function DiffPane({
     () => (worktreePath && filePath ? { worktreePath, filePath } : null),
     [worktreePath, filePath]
   );
-  const {
-    source,
-    errorCode: sourceErrorCode,
-    retry: retrySource,
-  } = useDiffFileSource(sourceSubject, wantsFullFile);
+  const { source, errorCode: sourceErrorCode } = useDiffFileSource(sourceSubject, wantsFullFile);
 
   // Reported by the viewer once it has the parsed diff and the source side by
   // side — the mismatch and size checks can only be made there.
@@ -320,23 +323,25 @@ export function DiffPane({
   // Stamped with the source it describes rather than cleared by an effect:
   // child effects run before parent ones, so a reset keyed on `source` would
   // fire in the same commit that the viewer reported its reason and swallow it.
-  const [viewerFallback, setViewerFallback] = useState<{
-    source: string | undefined;
-    reason: FullFileUnavailableReason;
+  const [viewerVerdict, setViewerVerdict] = useState<{
+    source: string | null | undefined;
+    reason: FullFileUnavailableReason | null;
   } | null>(null);
-  const handleFullFileUnavailable = useCallback(
-    (reason: FullFileUnavailableReason, forSource: string | undefined) => {
-      setViewerFallback({ source: forSource, reason });
+  const handleFullFileVerdict = useCallback(
+    (reason: FullFileUnavailableReason | null, forSource: string | null | undefined) => {
+      setViewerVerdict({ source: forSource, reason });
     },
     []
   );
   const activeViewerFallback =
-    viewerFallback && viewerFallback.source === source ? viewerFallback.reason : null;
+    viewerVerdict && viewerVerdict.source === source ? viewerVerdict.reason : null;
 
+  // Only the diff is retried: clearing it drops `hasDiff`, which disables the
+  // source hook and invalidates its read, and the source is fetched again when
+  // the new diff lands. Retrying both here would issue that read twice.
   const refreshAll = useCallback(() => {
     retry();
-    retrySource();
-  }, [retry, retrySource]);
+  }, [retry]);
 
   // One line explaining why a requested whole-file view isn't on screen. The
   // read failure wins over the viewer's verdict: without content the viewer
@@ -537,7 +542,7 @@ export function DiffPane({
                 rootPath={worktreePath}
                 source={wantsFullFile ? source : undefined}
                 fullFile={wantsFullFile}
-                onFullFileUnavailable={handleFullFileUnavailable}
+                onFullFileVerdict={handleFullFileVerdict}
                 wrapLines={diffWrapLines}
                 onRetry={retry}
               />

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -7,7 +7,9 @@ import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
 import { ImageDiffViewer, isImageDiffCandidate } from "@/components/FileViewer/ImageDiffViewer";
-import { DiffViewer } from "@/components/Worktree/DiffViewer";
+import { DiffViewer, FULL_FILE_MAX_LINES } from "@/components/Worktree/DiffViewer";
+import type { FullFileUnavailableReason } from "@/components/Worktree/DiffViewer";
+import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { IconToggle } from "@/components/FileViewer/IconToggle";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
@@ -19,11 +21,26 @@ import { usePreferencesStore, type DiffFontSize } from "@/store/preferencesStore
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import { useDiffContent } from "./useDiffContent";
+import { useDiffFileSource } from "./useDiffFileSource";
+import { getFullFileAvailability } from "./fullFileAvailability";
 import type { DiffSubject } from "./diffContentCache";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import type { TabInfo } from "@/components/Panel/TabButton";
 
 type DiffViewType = "split" | "unified";
+
+/**
+ * How much of the file the diff renders. Kept separate from `DiffViewType`:
+ * layout and content scope are independent, and full file stays meaningful in
+ * both unified and split.
+ */
+type DiffContentScope = "changes" | "full-file";
+
+const FULL_FILE_FALLBACK_MESSAGES: Record<FullFileUnavailableReason, string> = {
+  "source-mismatch": "The file changed after this diff loaded, so only changed lines are shown",
+  "too-large": `Files over ${FULL_FILE_MAX_LINES.toLocaleString()} lines stay on changed lines to keep the diff responsive`,
+  unsupported: "The whole file can't be shown for this diff",
+};
 
 // Mirrors the ladder the modal used, so the preference keeps meaning the same
 // sizes it always did.
@@ -117,6 +134,8 @@ export function DiffPane({
   const setDiffViewType = usePreferencesStore((s) => s.setDiffViewType);
   const diffWrapLines = usePreferencesStore((s) => s.diffWrapLines);
   const setDiffWrapLines = usePreferencesStore((s) => s.setDiffWrapLines);
+  const diffFullFile = usePreferencesStore((s) => s.diffFullFile);
+  const setDiffFullFile = usePreferencesStore((s) => s.setDiffFullFile);
   const diffShowFileList = usePreferencesStore((s) => s.diffShowFileList);
   const diffFontSize = usePreferencesStore((s) => s.diffFontSize);
   const diffFontStyle: CSSProperties & Record<"--diff-font-size", string> = {
@@ -261,20 +280,94 @@ export function DiffPane({
     content && content.trim() && content !== "NO_CHANGES" && content !== "ERROR"
   );
 
+  // Whether this file *can* show its whole contents, independent of whether the
+  // user currently wants to — the toggle stays visible either way so the option
+  // is discoverable, and explains itself when it can't be used.
+  const fullFileAvailability = useMemo(
+    () => getFullFileAvailability(diffSource, fileStatus),
+    [diffSource, fileStatus]
+  );
+  const wantsFullFile = diffFullFile && fullFileAvailability.available && !isImageMode && hasDiff;
+
+  const sourceSubject = useMemo(
+    () => (worktreePath && filePath ? { worktreePath, filePath } : null),
+    [worktreePath, filePath]
+  );
+  const {
+    source,
+    errorCode: sourceErrorCode,
+    retry: retrySource,
+  } = useDiffFileSource(sourceSubject, wantsFullFile);
+
+  // Reported by the viewer once it has the parsed diff and the source side by
+  // side — the mismatch and size checks can only be made there.
+  const [viewerFallback, setViewerFallback] = useState<FullFileUnavailableReason | null>(null);
+  useEffect(() => {
+    setViewerFallback(null);
+  }, [subject, source]);
+  const handleFullFileUnavailable = useCallback((reason: FullFileUnavailableReason) => {
+    setViewerFallback(reason);
+  }, []);
+
+  const refreshAll = useCallback(() => {
+    retry();
+    retrySource();
+  }, [retry, retrySource]);
+
+  // One line explaining why a requested whole-file view isn't on screen. The
+  // read failure wins over the viewer's verdict: without content the viewer
+  // never got far enough to have one.
+  const fullFileNotice = wantsFullFile
+    ? sourceErrorCode
+      ? FILE_READ_ERROR_MESSAGES[sourceErrorCode]
+      : viewerFallback
+        ? FULL_FILE_FALLBACK_MESSAGES[viewerFallback]
+        : null
+    : null;
+
+  const scopeToggle = (
+    <div role="group" aria-label="Diff content">
+      <SegmentedToggle<DiffContentScope>
+        options={[
+          { value: "changes", label: "Changes" },
+          {
+            value: "full-file",
+            label: "Full file",
+            disabled: !fullFileAvailability.available,
+          },
+        ]}
+        value={wantsFullFile && !fullFileNotice ? "full-file" : "changes"}
+        onChange={(next) => setDiffFullFile(next === "full-file")}
+      />
+    </div>
+  );
+
   const fileName = filePath?.split(/[/\\]/).filter(Boolean).pop();
   const displayTitle = panel?.titleMode === "user" ? title : (fileName ?? title);
 
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
-        <SegmentedToggle<DiffViewType>
-          options={[
-            { value: "unified", label: "Unified" },
-            { value: "split", label: "Split" },
-          ]}
-          value={diffViewType}
-          onChange={setDiffViewType}
-        />
+        <div role="group" aria-label="Diff layout">
+          <SegmentedToggle<DiffViewType>
+            options={[
+              { value: "unified", label: "Unified" },
+              { value: "split", label: "Split" },
+            ]}
+            value={diffViewType}
+            onChange={setDiffViewType}
+          />
+        </div>
+        {fullFileAvailability.available ? (
+          scopeToggle
+        ) : (
+          // A disabled segment can't host a tooltip trigger of its own
+          // (pointer-events are off), so the explanation hangs off the wrapper.
+          <Tooltip>
+            <TooltipTrigger asChild>{scopeToggle}</TooltipTrigger>
+            <TooltipContent side="bottom">{fullFileAvailability.reason}</TooltipContent>
+          </Tooltip>
+        )}
         <FileViewerToolbar.Path path={filePath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
           <FileViewerToolbar.IconButton
@@ -296,7 +389,20 @@ export function DiffPane({
           title="File changed since this diff loaded"
           role="status"
           ariaLive="polite"
-          action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: retry }}
+          action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: refreshAll }}
+        />
+      )}
+      {/* Suppressed while the staleness banner is up: both would be pointing at
+          the same underlying change and offering the same refresh. */}
+      {fullFileNotice && !stale && (
+        <InlineStatusBanner
+          severity="warning"
+          icon={FileDiffIcon}
+          title="Showing changed lines only"
+          description={fullFileNotice}
+          role="status"
+          ariaLive="polite"
+          action={{ id: "refresh-full-file", label: "Retry", icon: RefreshCw, onClick: refreshAll }}
         />
       )}
     </>
@@ -392,6 +498,9 @@ export function DiffPane({
                 diff={content}
                 viewType={diffViewType}
                 rootPath={worktreePath}
+                source={wantsFullFile ? source : undefined}
+                fullFile={wantsFullFile}
+                onFullFileUnavailable={handleFullFileUnavailable}
                 wrapLines={diffWrapLines}
                 onRetry={retry}
               />

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -283,11 +283,26 @@ export function DiffPane({
   // Whether this file *can* show its whole contents, independent of whether the
   // user currently wants to — the toggle stays visible either way so the option
   // is discoverable, and explains itself when it can't be used.
-  const fullFileAvailability = useMemo(
+  const sourceAvailability = useMemo(
     () => getFullFileAvailability(diffSource, fileStatus),
     [diffSource, fileStatus]
   );
-  const wantsFullFile = diffFullFile && fullFileAvailability.available && !isImageMode && hasDiff;
+  // An image diff already shows the whole asset, and a diff that hasn't loaded
+  // has nothing to expand — folding both into the availability verdict keeps
+  // the control from looking live while being inert.
+  const fullFileAvailability: typeof sourceAvailability = !sourceAvailability.available
+    ? sourceAvailability
+    : isImageMode
+      ? { available: false, reason: "This view already shows the whole image" }
+      : !hasDiff
+        ? { available: false, reason: "There's no diff to expand yet" }
+        : { available: true };
+
+  // The hunks and the file on disk must describe the same revision. Once the
+  // store reports the file changed, they demonstrably don't: the check inside
+  // the viewer only covers lines the hunks name, so a change in a hidden gap
+  // would otherwise be rendered as unchanged context.
+  const wantsFullFile = diffFullFile && fullFileAvailability.available && !stale;
 
   const sourceSubject = useMemo(
     () => (worktreePath && filePath ? { worktreePath, filePath } : null),
@@ -301,13 +316,22 @@ export function DiffPane({
 
   // Reported by the viewer once it has the parsed diff and the source side by
   // side — the mismatch and size checks can only be made there.
-  const [viewerFallback, setViewerFallback] = useState<FullFileUnavailableReason | null>(null);
-  useEffect(() => {
-    setViewerFallback(null);
-  }, [subject, source]);
-  const handleFullFileUnavailable = useCallback((reason: FullFileUnavailableReason) => {
-    setViewerFallback(reason);
-  }, []);
+  //
+  // Stamped with the source it describes rather than cleared by an effect:
+  // child effects run before parent ones, so a reset keyed on `source` would
+  // fire in the same commit that the viewer reported its reason and swallow it.
+  const [viewerFallback, setViewerFallback] = useState<{
+    source: string | undefined;
+    reason: FullFileUnavailableReason;
+  } | null>(null);
+  const handleFullFileUnavailable = useCallback(
+    (reason: FullFileUnavailableReason, forSource: string | undefined) => {
+      setViewerFallback({ source: forSource, reason });
+    },
+    []
+  );
+  const activeViewerFallback =
+    viewerFallback && viewerFallback.source === source ? viewerFallback.reason : null;
 
   const refreshAll = useCallback(() => {
     retry();
@@ -320,13 +344,21 @@ export function DiffPane({
   const fullFileNotice = wantsFullFile
     ? sourceErrorCode
       ? FILE_READ_ERROR_MESSAGES[sourceErrorCode]
-      : viewerFallback
-        ? FULL_FILE_FALLBACK_MESSAGES[viewerFallback]
+      : activeViewerFallback
+        ? FULL_FILE_FALLBACK_MESSAGES[activeViewerFallback]
         : null
     : null;
 
+  // The reason rides an aria-describedby rather than the tooltip alone: a
+  // disabled segment takes no focus, so a keyboard or screen-reader user would
+  // never reach a hover-only explanation.
+  const scopeReasonId = `${id}-full-file-reason`;
   const scopeToggle = (
-    <div role="group" aria-label="Diff content">
+    <div
+      role="group"
+      aria-label="Diff content"
+      aria-describedby={fullFileAvailability.available ? undefined : scopeReasonId}
+    >
       <SegmentedToggle<DiffContentScope>
         options={[
           { value: "changes", label: "Changes" },
@@ -339,6 +371,11 @@ export function DiffPane({
         value={wantsFullFile && !fullFileNotice ? "full-file" : "changes"}
         onChange={(next) => setDiffFullFile(next === "full-file")}
       />
+      {!fullFileAvailability.available && (
+        <span id={scopeReasonId} className="sr-only">
+          {fullFileAvailability.reason}
+        </span>
+      )}
     </div>
   );
 

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -102,8 +102,6 @@ vi.mock("../useDiffFileSource", () => ({
   useDiffFileSource: () => ({
     source: undefined,
     errorCode: null,
-    loading: false,
-    retry: vi.fn(),
   }),
 }));
 

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/components/ui/tooltip", () => ({
 
 vi.mock("@/components/Worktree/DiffViewer", () => ({
   DiffViewer: () => <div data-testid="diff-viewer-mock" />,
+  FULL_FILE_MAX_LINES: 5000,
 }));
 vi.mock("@/components/FileViewer/ImageDiffViewer", () => ({
   ImageDiffViewer: () => <div data-testid="image-diff-mock" />,
@@ -77,6 +78,8 @@ const preferences = {
   setDiffWrapLines: vi.fn(),
   diffShowFileList: true,
   setDiffShowFileList: vi.fn(),
+  diffFullFile: false,
+  setDiffFullFile: vi.fn(),
 };
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (state: unknown) => unknown) => selector(preferences),
@@ -91,6 +94,17 @@ vi.mock("@/store/diffViewedStore", () => ({
 
 vi.mock("../useDiffContent", () => ({
   useDiffContent: useDiffContentMock,
+}));
+
+// The full-file read is a real IPC call; these tests never exercise the scope,
+// so it stays inert rather than reaching for `window.electron`.
+vi.mock("../useDiffFileSource", () => ({
+  useDiffFileSource: () => ({
+    source: undefined,
+    errorCode: null,
+    loading: false,
+    retry: vi.fn(),
+  }),
 }));
 
 import { DiffPane } from "../DiffPane";

--- a/src/panels/diff/__tests__/fullFileAvailability.test.ts
+++ b/src/panels/diff/__tests__/fullFileAvailability.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { GitStatus } from "@shared/types/git";
+import { getFullFileAvailability } from "../fullFileAvailability";
+
+describe("getFullFileAvailability", () => {
+  it("offers the whole file for edits to a file that exists on disk", () => {
+    for (const status of ["modified", "renamed", "copied"] as GitStatus[]) {
+      expect(getFullFileAvailability("working-tree", status).available).toBe(true);
+      expect(getFullFileAvailability("unstaged", status).available).toBe(true);
+    }
+  });
+
+  it("treats a missing source and status the way buildSubject does", () => {
+    // buildSubject defaults to working-tree/modified, so the toolbar must not
+    // disagree with the diff that actually gets fetched.
+    expect(getFullFileAvailability(undefined, undefined).available).toBe(true);
+  });
+
+  it("refuses staged diffs, whose new side is the index rather than the disk file", () => {
+    const result = getFullFileAvailability("staged", "modified");
+    expect(result.available).toBe(false);
+    expect(result.available === false && result.reason).toMatch(/index/i);
+  });
+
+  it("refuses base-branch diffs, whose new side isn't on disk", () => {
+    const result = getFullFileAvailability("base-branch", "modified");
+    expect(result.available).toBe(false);
+    expect(result.available === false && result.reason).toMatch(/base-branch/i);
+  });
+
+  it("refuses statuses whose diff already carries every line", () => {
+    for (const status of ["added", "untracked"] as GitStatus[]) {
+      const result = getFullFileAvailability("working-tree", status);
+      expect(result.available).toBe(false);
+      expect(result.available === false && result.reason).toMatch(/already/i);
+    }
+  });
+
+  it("refuses a deleted file, which has no current version", () => {
+    const result = getFullFileAvailability("working-tree", "deleted");
+    expect(result.available).toBe(false);
+    expect(result.available === false && result.reason).toMatch(/deleted/i);
+  });
+
+  it("refuses statuses the diff renderer can't expand", () => {
+    // DiffViewer only builds an old-side source for modify/rename/copy; the
+    // toolbar must not offer a scope the renderer would then refuse.
+    for (const status of ["conflicted", "ignored"] as GitStatus[]) {
+      expect(getFullFileAvailability("working-tree", status).available).toBe(false);
+    }
+  });
+
+  it("always explains itself when it says no", () => {
+    const sources = ["working-tree", "unstaged", "staged", "base-branch", undefined] as const;
+    const statuses: (GitStatus | undefined)[] = [
+      "modified",
+      "added",
+      "deleted",
+      "untracked",
+      "renamed",
+      "copied",
+      "conflicted",
+      "ignored",
+      undefined,
+    ];
+    for (const source of sources) {
+      for (const status of statuses) {
+        const result = getFullFileAvailability(source, status);
+        if (!result.available) expect(result.reason.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/src/panels/diff/__tests__/useDiffFileSource.test.tsx
+++ b/src/panels/diff/__tests__/useDiffFileSource.test.tsx
@@ -32,10 +32,11 @@ describe("useDiffFileSource", () => {
     const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
 
     await waitFor(() => expect(result.current.source).toBe("file contents"));
-    const payload = readMock.mock.calls[0][0];
-    expect(isAbsolute(payload.path)).toBe(true);
-    expect(payload.path).toBe(join(SUBJECT.worktreePath, SUBJECT.filePath));
-    expect(payload.rootPath).toBe(SUBJECT.worktreePath);
+    const payload = readMock.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    expect(isAbsolute(payload?.path ?? "")).toBe(true);
+    expect(payload?.path).toBe(join(SUBJECT.worktreePath, SUBJECT.filePath));
+    expect(payload?.rootPath).toBe(SUBJECT.worktreePath);
   });
 
   it("leaves an already-absolute path alone rather than doubling the root", async () => {
@@ -43,7 +44,7 @@ describe("useDiffFileSource", () => {
     const { result } = renderHook(() => useDiffFileSource(absolute, true));
 
     await waitFor(() => expect(result.current.source).toBe("file contents"));
-    expect(readMock.mock.calls[0][0].path).toBe("/repo/src/a.ts");
+    expect(readMock.mock.calls[0]?.[0]?.path).toBe("/repo/src/a.ts");
   });
 
   it("starts reading when the scope is turned on mid-session", async () => {

--- a/src/panels/diff/__tests__/useDiffFileSource.test.tsx
+++ b/src/panels/diff/__tests__/useDiffFileSource.test.tsx
@@ -129,14 +129,19 @@ describe("useDiffFileSource", () => {
     expect(result.current.source).toBe("second file");
   });
 
-  it("re-reads on retry so a transient failure can recover", async () => {
+  // The panel recovers a failed read by retrying the diff, which drops the
+  // scope and re-enables it once the new diff lands — so that round trip, not a
+  // retry of its own, is what has to clear the error.
+  it("re-reads when the scope is switched off and back on so a transient failure can recover", async () => {
     readMock.mockRejectedValueOnce(new ClientAppError("NOT_FOUND", "gone"));
-    const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useDiffFileSource(SUBJECT, enabled),
+      { initialProps: { enabled: true } }
+    );
     await waitFor(() => expect(result.current.errorCode).toBe("NOT_FOUND"));
 
-    await act(async () => {
-      result.current.retry();
-    });
+    rerender({ enabled: false });
+    rerender({ enabled: true });
 
     await waitFor(() => expect(result.current.source).toBe("file contents"));
     expect(result.current.errorCode).toBeNull();
@@ -145,7 +150,6 @@ describe("useDiffFileSource", () => {
   it("reports nothing for a null subject", () => {
     const { result } = renderHook(() => useDiffFileSource(null, true));
     expect(result.current.source).toBeUndefined();
-    expect(result.current.loading).toBe(false);
     expect(readMock).not.toHaveBeenCalled();
   });
 });

--- a/src/panels/diff/__tests__/useDiffFileSource.test.tsx
+++ b/src/panels/diff/__tests__/useDiffFileSource.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { isAbsolute, join } from "@shared/utils/path";
 import { ClientAppError } from "@/utils/clientAppError";
 import { useDiffFileSource } from "../useDiffFileSource";
 
@@ -25,11 +26,24 @@ describe("useDiffFileSource", () => {
     expect(readMock).not.toHaveBeenCalled();
   });
 
-  it("reads the file against its worktree root once enabled", async () => {
+  // files:read throws INVALID_PATH unless both paths are absolute, but panels
+  // store the path relative to their worktree — so the hook has to resolve it.
+  it("resolves the worktree-relative path to an absolute one before reading", async () => {
     const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
 
     await waitFor(() => expect(result.current.source).toBe("file contents"));
-    expect(readMock).toHaveBeenCalledWith({ path: "src/a.ts", rootPath: "/repo" });
+    const payload = readMock.mock.calls[0][0];
+    expect(isAbsolute(payload.path)).toBe(true);
+    expect(payload.path).toBe(join(SUBJECT.worktreePath, SUBJECT.filePath));
+    expect(payload.rootPath).toBe(SUBJECT.worktreePath);
+  });
+
+  it("leaves an already-absolute path alone rather than doubling the root", async () => {
+    const absolute = { worktreePath: "/repo", filePath: "/repo/src/a.ts" };
+    const { result } = renderHook(() => useDiffFileSource(absolute, true));
+
+    await waitFor(() => expect(result.current.source).toBe("file contents"));
+    expect(readMock.mock.calls[0][0].path).toBe("/repo/src/a.ts");
   });
 
   it("starts reading when the scope is turned on mid-session", async () => {

--- a/src/panels/diff/__tests__/useDiffFileSource.test.tsx
+++ b/src/panels/diff/__tests__/useDiffFileSource.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ClientAppError } from "@/utils/clientAppError";
+import { useDiffFileSource } from "../useDiffFileSource";
+
+const { readMock } = vi.hoisted(() => ({
+  readMock: vi.fn<(payload: { path: string; rootPath: string }) => Promise<{ content: string }>>(),
+}));
+
+vi.mock("@/clients/filesClient", () => ({
+  filesClient: { read: readMock },
+}));
+
+const SUBJECT = { worktreePath: "/repo", filePath: "src/a.ts" };
+
+beforeEach(() => {
+  readMock.mockReset();
+  readMock.mockResolvedValue({ content: "file contents" });
+});
+
+describe("useDiffFileSource", () => {
+  it("reads nothing until the scope is enabled", () => {
+    renderHook(() => useDiffFileSource(SUBJECT, false));
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("reads the file against its worktree root once enabled", async () => {
+    const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
+
+    await waitFor(() => expect(result.current.source).toBe("file contents"));
+    expect(readMock).toHaveBeenCalledWith({ path: "src/a.ts", rootPath: "/repo" });
+  });
+
+  it("starts reading when the scope is turned on mid-session", async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useDiffFileSource(SUBJECT, enabled),
+      { initialProps: { enabled: false } }
+    );
+    expect(readMock).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.source).toBe("file contents"));
+  });
+
+  it("surfaces a read failure as its error code and no content", async () => {
+    readMock.mockRejectedValue(new ClientAppError("FILE_TOO_LARGE", "too big"));
+    const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
+
+    await waitFor(() => expect(result.current.errorCode).toBe("FILE_TOO_LARGE"));
+    expect(result.current.source).toBeUndefined();
+  });
+
+  it("maps an error that isn't an AppError to a safe code", async () => {
+    readMock.mockRejectedValue(new Error("socket hangup"));
+    const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
+
+    await waitFor(() => expect(result.current.errorCode).not.toBeNull());
+    expect(result.current.source).toBeUndefined();
+  });
+
+  it("drops a read that resolves after the file changed", async () => {
+    // The first file's read is still in flight when the hook is repointed; its
+    // content must never surface under the second file.
+    let resolveFirst: ((value: { content: string }) => void) | undefined;
+    readMock.mockImplementationOnce(
+      () =>
+        new Promise<{ content: string }>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    readMock.mockResolvedValueOnce({ content: "second file" });
+
+    const { result, rerender } = renderHook(
+      ({ filePath }: { filePath: string }) =>
+        useDiffFileSource({ worktreePath: "/repo", filePath }, true),
+      { initialProps: { filePath: "first.ts" } }
+    );
+
+    rerender({ filePath: "second.ts" });
+    await waitFor(() => expect(result.current.source).toBe("second file"));
+
+    await act(async () => {
+      resolveFirst?.({ content: "first file" });
+    });
+
+    expect(result.current.source).toBe("second file");
+  });
+
+  it("drops an error that arrives after the file changed", async () => {
+    let rejectFirst: ((reason: unknown) => void) | undefined;
+    readMock.mockImplementationOnce(
+      () =>
+        new Promise<{ content: string }>((_resolve, reject) => {
+          rejectFirst = reject;
+        })
+    );
+    readMock.mockResolvedValueOnce({ content: "second file" });
+
+    const { result, rerender } = renderHook(
+      ({ filePath }: { filePath: string }) =>
+        useDiffFileSource({ worktreePath: "/repo", filePath }, true),
+      { initialProps: { filePath: "first.ts" } }
+    );
+
+    rerender({ filePath: "second.ts" });
+    await waitFor(() => expect(result.current.source).toBe("second file"));
+
+    await act(async () => {
+      rejectFirst?.(new ClientAppError("NOT_FOUND", "gone"));
+    });
+
+    expect(result.current.errorCode).toBeNull();
+    expect(result.current.source).toBe("second file");
+  });
+
+  it("re-reads on retry so a transient failure can recover", async () => {
+    readMock.mockRejectedValueOnce(new ClientAppError("NOT_FOUND", "gone"));
+    const { result } = renderHook(() => useDiffFileSource(SUBJECT, true));
+    await waitFor(() => expect(result.current.errorCode).toBe("NOT_FOUND"));
+
+    await act(async () => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.source).toBe("file contents"));
+    expect(result.current.errorCode).toBeNull();
+  });
+
+  it("reports nothing for a null subject", () => {
+    const { result } = renderHook(() => useDiffFileSource(null, true));
+    expect(result.current.source).toBeUndefined();
+    expect(result.current.loading).toBe(false);
+    expect(readMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/panels/diff/fullFileAvailability.ts
+++ b/src/panels/diff/fullFileAvailability.ts
@@ -1,0 +1,74 @@
+import type { GitStatus } from "@shared/types/git";
+import type { DiffPanelData } from "@shared/types/panel";
+
+/**
+ * Whether the full-file scope can be offered for one file, and why not when it
+ * can't. Two independent things disqualify a file, so both are checked here
+ * rather than in the toolbar: the diff may already carry the whole file (an
+ * addition has no hidden context to reveal), or the new side may not be
+ * readable from disk at all.
+ */
+export type FullFileAvailability = { available: true } | { available: false; reason: string };
+
+const AVAILABLE: FullFileAvailability = { available: true };
+
+/**
+ * Statuses whose new side is a modification of an existing file — the only ones
+ * with unchanged regions to expand into. Mirrors the `modify | rename | copy`
+ * gate `DiffViewer` applies to the parsed diff, so the toolbar never offers a
+ * scope the renderer would then refuse.
+ */
+const EXPANDABLE_STATUSES: ReadonlySet<GitStatus> = new Set<GitStatus>([
+  "modified",
+  "renamed",
+  "copied",
+]);
+
+/**
+ * Diff sources whose new side is the file on disk, so `files:read` reaches the
+ * exact content the diff was generated against.
+ *
+ * `staged` is deliberately absent: a staged diff's new side is the index blob,
+ * which diverges from disk as soon as the file is edited again after staging.
+ * Reading disk there would show content the diff was never generated from.
+ */
+const DISK_BACKED_SOURCES: ReadonlySet<string> = new Set(["working-tree", "unstaged"]);
+
+export function getFullFileAvailability(
+  diffSource: DiffPanelData["diffSource"],
+  fileStatus: GitStatus | undefined
+): FullFileAvailability {
+  // Mirrors `buildSubject`, which defaults a missing status the same way.
+  const status = fileStatus ?? "modified";
+
+  if (status === "added" || status === "untracked") {
+    return { available: false, reason: "This diff already shows the file's full contents" };
+  }
+  if (status === "deleted") {
+    return { available: false, reason: "This file was deleted, so there's no current version" };
+  }
+  if (!EXPANDABLE_STATUSES.has(status)) {
+    return { available: false, reason: "Full file isn't available for this file" };
+  }
+
+  if (diffSource === "base-branch") {
+    return {
+      available: false,
+      reason:
+        "Full file isn't available for base-branch diffs — the file at that ref isn't what's on disk",
+    };
+  }
+  if (diffSource === "staged") {
+    return {
+      available: false,
+      reason:
+        "Full file isn't available for staged diffs — staged content lives in the index, not on disk",
+    };
+  }
+  // `buildSubject` treats a missing source as working-tree; match it.
+  if (diffSource !== undefined && !DISK_BACKED_SOURCES.has(diffSource)) {
+    return { available: false, reason: "Full file isn't available for this diff" };
+  }
+
+  return AVAILABLE;
+}

--- a/src/panels/diff/useDiffFileSource.ts
+++ b/src/panels/diff/useDiffFileSource.ts
@@ -80,11 +80,14 @@ export function useDiffFileSource(
   }, [active, worktreePath, filePath]);
 
   useEffect(() => {
+    // The ref object is captured, not its value: the cleanup has to bump
+    // whatever the counter reads at teardown, which is the point.
+    const sequence = requestRef;
     void fetchSource();
     // Invalidate whatever is in flight when the file changes or the scope is
     // switched off, so a resolving read can't land on the next file.
     return () => {
-      requestRef.current++;
+      sequence.current++;
     };
   }, [fetchSource]);
 

--- a/src/panels/diff/useDiffFileSource.ts
+++ b/src/panels/diff/useDiffFileSource.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { filesClient } from "@/clients/filesClient";
+import { isClientAppError } from "@/utils/clientAppError";
+import { toFileReadErrorCode } from "@/components/FileViewer/fileReadErrors";
+import type { FileReadErrorCode } from "@shared/types/ipc/files";
+
+export interface DiffFileSourceSubject {
+  worktreePath: string;
+  filePath: string;
+}
+
+export interface UseDiffFileSourceResult {
+  /** New-side file content, or undefined while loading / when not requested. */
+  source: string | undefined;
+  /** Set when the read failed; `source` is undefined whenever this is set. */
+  errorCode: FileReadErrorCode | null;
+  loading: boolean;
+  retry: () => void;
+}
+
+const IDLE: UseDiffFileSourceResult = {
+  source: undefined,
+  errorCode: null,
+  loading: false,
+  retry: () => {},
+};
+
+/**
+ * Reads the whole new-side file backing one diff, for the surfaces where that
+ * side is the file on disk. Only fetches while `enabled` — the content is
+ * several hundred KB and is worthless until the user asks to see beyond the
+ * hunks.
+ *
+ * Callers must gate `enabled` on the diff source actually being disk-backed
+ * (see `getFullFileAvailability`); this hook does not re-derive that, and
+ * reading disk for a staged or base-branch diff would return content the diff
+ * was never generated from.
+ */
+export function useDiffFileSource(
+  subject: DiffFileSourceSubject | null,
+  enabled: boolean
+): UseDiffFileSourceResult {
+  const [source, setSource] = useState<string | undefined>(undefined);
+  const [errorCode, setErrorCode] = useState<FileReadErrorCode | null>(null);
+  const [loading, setLoading] = useState(false);
+  // IPC reads can't be aborted, so late responses are dropped by sequence
+  // number instead — the same discipline `useDiffContent` uses.
+  const requestRef = useRef(0);
+
+  const worktreePath = subject?.worktreePath;
+  const filePath = subject?.filePath;
+  const active = enabled && worktreePath !== undefined && filePath !== undefined;
+
+  const fetchSource = useCallback(async () => {
+    const requestId = ++requestRef.current;
+    if (!active || worktreePath === undefined || filePath === undefined) {
+      setSource(undefined);
+      setErrorCode(null);
+      setLoading(false);
+      return;
+    }
+    setSource(undefined);
+    setErrorCode(null);
+    setLoading(true);
+    try {
+      const result = await filesClient.read({ path: filePath, rootPath: worktreePath });
+      if (requestRef.current !== requestId) return;
+      setSource(result.content);
+      setLoading(false);
+    } catch (error) {
+      if (requestRef.current !== requestId) return;
+      setErrorCode(isClientAppError(error) ? toFileReadErrorCode(error.code) : "INVALID_PATH");
+      setLoading(false);
+    }
+  }, [active, worktreePath, filePath]);
+
+  useEffect(() => {
+    void fetchSource();
+    // Invalidate whatever is in flight when the file changes or the scope is
+    // switched off, so a resolving read can't land on the next file.
+    return () => {
+      requestRef.current++;
+    };
+  }, [fetchSource]);
+
+  const retry = useCallback(() => {
+    void fetchSource();
+  }, [fetchSource]);
+
+  if (!active) return IDLE;
+  return { source, errorCode, loading, retry };
+}

--- a/src/panels/diff/useDiffFileSource.ts
+++ b/src/panels/diff/useDiffFileSource.ts
@@ -16,15 +16,11 @@ export interface UseDiffFileSourceResult {
   source: string | undefined;
   /** Set when the read failed; `source` is undefined whenever this is set. */
   errorCode: FileReadErrorCode | null;
-  loading: boolean;
-  retry: () => void;
 }
 
 const IDLE: UseDiffFileSourceResult = {
   source: undefined,
   errorCode: null,
-  loading: false,
-  retry: () => {},
 };
 
 /**
@@ -44,7 +40,6 @@ export function useDiffFileSource(
 ): UseDiffFileSourceResult {
   const [source, setSource] = useState<string | undefined>(undefined);
   const [errorCode, setErrorCode] = useState<FileReadErrorCode | null>(null);
-  const [loading, setLoading] = useState(false);
   // IPC reads can't be aborted, so late responses are dropped by sequence
   // number instead — the same discipline `useDiffContent` uses.
   const requestRef = useRef(0);
@@ -58,12 +53,10 @@ export function useDiffFileSource(
     if (!active || worktreePath === undefined || filePath === undefined) {
       setSource(undefined);
       setErrorCode(null);
-      setLoading(false);
       return;
     }
     setSource(undefined);
     setErrorCode(null);
-    setLoading(true);
     try {
       // `files:read` rejects anything relative; panels store the path relative
       // to their worktree, so it has to be resolved before it crosses IPC.
@@ -71,11 +64,9 @@ export function useDiffFileSource(
       const result = await filesClient.read({ path: absolutePath, rootPath: worktreePath });
       if (requestRef.current !== requestId) return;
       setSource(result.content);
-      setLoading(false);
     } catch (error) {
       if (requestRef.current !== requestId) return;
       setErrorCode(isClientAppError(error) ? toFileReadErrorCode(error.code) : "INVALID_PATH");
-      setLoading(false);
     }
   }, [active, worktreePath, filePath]);
 
@@ -91,10 +82,6 @@ export function useDiffFileSource(
     };
   }, [fetchSource]);
 
-  const retry = useCallback(() => {
-    void fetchSource();
-  }, [fetchSource]);
-
   if (!active) return IDLE;
-  return { source, errorCode, loading, retry };
+  return { source, errorCode };
 }

--- a/src/panels/diff/useDiffFileSource.ts
+++ b/src/panels/diff/useDiffFileSource.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isAbsolute, join } from "@shared/utils/path";
 import { filesClient } from "@/clients/filesClient";
 import { isClientAppError } from "@/utils/clientAppError";
 import { toFileReadErrorCode } from "@/components/FileViewer/fileReadErrors";
@@ -6,6 +7,7 @@ import type { FileReadErrorCode } from "@shared/types/ipc/files";
 
 export interface DiffFileSourceSubject {
   worktreePath: string;
+  /** Worktree-relative, as `DiffPanelData` stores it. */
   filePath: string;
 }
 
@@ -63,7 +65,10 @@ export function useDiffFileSource(
     setErrorCode(null);
     setLoading(true);
     try {
-      const result = await filesClient.read({ path: filePath, rootPath: worktreePath });
+      // `files:read` rejects anything relative; panels store the path relative
+      // to their worktree, so it has to be resolved before it crosses IPC.
+      const absolutePath = isAbsolute(filePath) ? filePath : join(worktreePath, filePath);
+      const result = await filesClient.read({ path: absolutePath, rootPath: worktreePath });
       if (requestRef.current !== requestId) return;
       setSource(result.content);
       setLoading(false);

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -319,5 +319,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds }",
 });

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -43,6 +43,13 @@ interface PreferencesState {
   /** Show the changed-files sidebar in the diff workspace (multi-file review). */
   diffShowFileList: boolean;
   setDiffShowFileList: (value: boolean) => void;
+  /**
+   * Expand every hunk to cover the whole file instead of showing changed
+   * regions with their context. Orthogonal to `diffViewType` — full file is a
+   * content scope, and stays meaningful in both unified and split layouts.
+   */
+  diffFullFile: boolean;
+  setDiffFullFile: (value: boolean) => void;
   diffFontSize: DiffFontSize;
   setDiffFontSize: (value: DiffFontSize) => void;
   /** Soft-wrap long lines in markdown Source view (panel + file viewer). */
@@ -107,6 +114,7 @@ function sanitizePersistedPreferences(
   if (typeof sanitized.diffWrapLines !== "boolean") sanitized.diffWrapLines = false;
   if (typeof sanitized.diffIgnoreWhitespace !== "boolean") sanitized.diffIgnoreWhitespace = false;
   if (typeof sanitized.diffShowFileList !== "boolean") sanitized.diffShowFileList = true;
+  if (typeof sanitized.diffFullFile !== "boolean") sanitized.diffFullFile = false;
   if (!isDiffFontSize(sanitized.diffFontSize)) sanitized.diffFontSize = "m";
   if (typeof sanitized.markdownWrapLines !== "boolean") sanitized.markdownWrapLines = true;
   if (typeof sanitized.showAgentTaskTitles !== "boolean") sanitized.showAgentTaskTitles = true;
@@ -154,6 +162,8 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDiffIgnoreWhitespace: (value) => set({ diffIgnoreWhitespace: value }),
       diffShowFileList: true,
       setDiffShowFileList: (value) => set({ diffShowFileList: value }),
+      diffFullFile: false,
+      setDiffFullFile: (value) => set({ diffFullFile: value }),
       diffFontSize: "m",
       setDiffFontSize: (value) => set({ diffFontSize: value }),
       markdownWrapLines: true,


### PR DESCRIPTION
## Summary

- Adds a `Changes | Full file` scope toggle to the diff panel toolbar: a second `SegmentedToggle` alongside the existing `Unified | Split` layout toggle.
- Selecting `Full file` expands every hunk gap so the diff covers the whole file instead of just the changed regions with three lines of context.
- Wiring this up also activates `DiffViewer`'s previously dormant per-gap "expand hidden lines" controls. The issue called these out as unreachable because `DiffPane` never passed the `source` prop.

Resolves #11263

## Design decisions

**1. A second toggle, not a third `Unified | Split` segment.** The issue suggested a third segment as the natural home for this, but left the shape open. Layout and content scope are orthogonal: full file is meaningful in both unified and split, and a three-way control would either force a layout or misrepresent itself as an exclusive choice. Keeping them separate also leaves the persisted `DiffViewType` enum and its sanitizers untouched.

**2. Scope limited to disk-backed diffs.** Full file is only available for working-tree and unstaged diffs. Staged and base-branch diffs render the control disabled, with a tooltip and an `aria-describedby` reason. Worth flagging for reviewers: the issue's constraints section states staged content is reachable via `filesClient.read`. That's not correct. A staged diff's new side is the index blob (`git cat-file blob :<path>`), which diverges from the working-tree file the moment the file is edited again after staging. Reading disk there would show content the diff was never generated from, so staged is grouped with base-branch as needing a ref read instead.

**3. Source verification instead of pinned blob OIDs.** Rather than threading git blob OIDs through IPC, the viewer verifies in the renderer that the fetched source really is the diff's new side: each hunk's own new-side lines have to appear verbatim at its `newStart`. A mismatch falls back to changed-lines-only rendering with an explanation, never context from a different version of the code.

**4. No persistence version bump for the new preference.** `diffFullFile` is a new preference, but `sanitizePersistedPreferences` runs on every hydration by design (#9170), so an additive boolean only needs a sanitizer line and a default.

## Safeguards

- Full file is suppressed while the diff is stale.
- A 5000-line ceiling, measured against the larger of the two sides.
- The syntax-highlighting size gate is re-derived from the rendered rows, since expansion merges hunks and grows them well past the original diff's size, so the old gate would have gone stale.
- Read failures (`FILE_TOO_LARGE`, `BINARY_FILE`, `LFS_POINTER`, `NOT_FOUND`) degrade to changed-lines-only rendering with an inline explanation and a Retry action, never an empty pane.

## Known limitation

Source verification only checks lines the hunks already name, so an edit inside an unnamed gap that lands before the worktree watcher reports staleness could in theory render as unchanged context. Scoping to disk-backed sources avoids the wrong-revision case the issue explicitly forbids. The cleaner fix, fetching a full-context diff in a single git operation, would also unlock staged, base-branch, and `CrossWorktreeDiff`, so that's left as a follow-up to do together rather than half-done here.

## Follow-ups (not in this PR)

- Ref/index blob reads for staged and base-branch diffs (ideally via a full-context diff).
- `CrossWorktreeDiff`, which shares `DiffViewer` and also omits the `source` prop.
- Row virtualization to lift the 5000-line ceiling.
- An E2E spec. Its main value would have been proving staged index-vs-disk divergence, which this PR's scope excludes.

## Testing

- 581 tests pass locally across the diff surfaces, stores, and panel registry.
- Two new test files: `fullFileAvailability.test.ts` and `useDiffFileSource.test.tsx`.
- New `DiffViewer.fullFile.test.tsx` covering expansion coverage, source mismatch, trailing newline, CRLF, the two-sided ceiling, hunkless diffs, and verdict reporting.
- `tsc` clean; `prettier` and `eslint` clean on all changed files.
