### PR TITLE
fix(diff): hide the text-diff controls when the pane shows an image

### DIFF
--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -395,16 +395,18 @@ export function DiffPane({
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
-        <div role="group" aria-label="Diff layout">
-          <SegmentedToggle<DiffViewType>
-            options={[
-              { value: "unified", label: "Unified" },
-              { value: "split", label: "Split" },
-            ]}
-            value={diffViewType}
-            onChange={setDiffViewType}
-          />
-        </div>
+        {!isImageMode && (
+          <div role="group" aria-label="Diff layout">
+            <SegmentedToggle<DiffViewType>
+              options={[
+                { value: "unified", label: "Unified" },
+                { value: "split", label: "Split" },
+              ]}
+              value={diffViewType}
+              onChange={setDiffViewType}
+            />
+          </div>
+        )}
         {fullFileAvailability.available ? (
           scopeToggle
         ) : (
@@ -417,13 +419,15 @@ export function DiffPane({
         )}
         <FileViewerToolbar.Path path={filePath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
-          <FileViewerToolbar.IconButton
-            label="Wrap long lines"
-            pressed={diffWrapLines}
-            onClick={() => setDiffWrapLines(!diffWrapLines)}
-          >
-            <WrapText className="w-4 h-4" />
-          </FileViewerToolbar.IconButton>
+          {!isImageMode && (
+            <FileViewerToolbar.IconButton
+              label="Wrap long lines"
+              pressed={diffWrapLines}
+              onClick={() => setDiffWrapLines(!diffWrapLines)}
+            >
+              <WrapText className="w-4 h-4" />
+            </FileViewerToolbar.IconButton>
+          )}
           <FileViewerToolbar.IconButton label="Refresh" onClick={retry}>
             <RefreshCw className="w-4 h-4" />
           </FileViewerToolbar.IconButton>

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -10,10 +10,15 @@ import type { DiffChangeSetEntry } from "@shared/types/git";
 // itself. These tests target that logic only, so the diff renderer, the
 // sidebar and the content fetch are all stubbed out.
 
-// The stub deliberately drops `toolbar` — nothing here asserts on it, and
-// leaving it unrendered keeps the toolbar's Radix/observer tree out of jsdom.
+// A fragment, so the toolbar stays a sibling of the keydown host rather than
+// wrapping it — the stepping shortcuts bubble through the same subtree as before.
 vi.mock("@/components/Panel/ContentPanel", () => ({
-  ContentPanel: (props: { children?: ReactNode }) => <>{props.children}</>,
+  ContentPanel: (props: { toolbar?: ReactNode; children?: ReactNode }) => (
+    <>
+      {props.toolbar}
+      {props.children}
+    </>
+  ),
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -27,9 +32,16 @@ vi.mock("@/components/Worktree/DiffViewer", () => ({
   DiffViewer: () => <div data-testid="diff-viewer-mock" />,
   FULL_FILE_MAX_LINES: 5000,
 }));
+
+// Controllable so a test can put the pane in image mode; `beforeEach` returns it
+// to text mode, which is what every other test in this file assumes.
+const { isImageDiffCandidateMock } = vi.hoisted(() => ({
+  isImageDiffCandidateMock:
+    vi.fn<typeof import("@/components/FileViewer/ImageDiffViewer").isImageDiffCandidate>(),
+}));
 vi.mock("@/components/FileViewer/ImageDiffViewer", () => ({
   ImageDiffViewer: () => <div data-testid="image-diff-mock" />,
-  isImageDiffCandidate: () => false,
+  isImageDiffCandidate: isImageDiffCandidateMock,
 }));
 vi.mock("@/components/ui/EmptyState", () => ({
   EmptyState: (props: { title: string }) => (
@@ -152,6 +164,8 @@ beforeEach(() => {
     retry: vi.fn(),
   });
   viewedKeys.clear();
+  isImageDiffCandidateMock.mockReset();
+  isImageDiffCandidateMock.mockReturnValue(false);
   preferences.diffShowFileList = true;
   worktrees.clear();
   worktrees.set(WORKTREE_ID, { path: WORKTREE_PATH, branch: "feature/x" });
@@ -421,6 +435,58 @@ describe("DiffPane — workspace chrome", () => {
     fireEvent.click(screen.getByLabelText("Viewed"));
 
     expect(toggleViewedMock).toHaveBeenCalledWith(WORKTREE_PATH, changeSet[1]!.viewedKey);
+  });
+});
+
+describe("DiffPane — content-aware toolbar", () => {
+  it("drops the text-diff controls for an image, keeping the ones that still act", () => {
+    isImageDiffCandidateMock.mockReturnValue(true);
+    seedPanel({ filePath: "assets/logo.png", fileStatus: "modified" });
+    renderPane();
+
+    // The image branch is the one under test, not just any non-text render —
+    // and it is this file's path that classified it, not a blanket true.
+    expect(screen.getByTestId("image-diff-mock")).toBeTruthy();
+    expect(isImageDiffCandidateMock).toHaveBeenCalledWith("assets/logo.png");
+
+    // Nothing to lay out side by side, and no lines to wrap.
+    expect(screen.queryByText("Unified")).toBeNull();
+    expect(screen.queryByText("Split")).toBeNull();
+    expect(screen.queryByLabelText("Wrap long lines")).toBeNull();
+
+    // Refresh and the path pill act on any file kind, so they stay.
+    expect(screen.getByLabelText("Copy file path")).toBeTruthy();
+    expect(screen.getByLabelText("Refresh")).toBeTruthy();
+  });
+
+  it("keeps the text-diff controls for a text file", () => {
+    seedPanel({ filePath: "src/a.ts", fileStatus: "modified" });
+    renderPane();
+
+    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
+    expect(screen.getByText("Unified")).toBeTruthy();
+    expect(screen.getByText("Split")).toBeTruthy();
+    expect(screen.getByLabelText("Wrap long lines")).toBeTruthy();
+  });
+
+  it("keeps them for a base-branch image, which the text viewer still handles", () => {
+    // ImageDiffViewer compares the working tree against HEAD, so it has nothing
+    // to show for a base-branch comparison — those stay on DiffViewer whatever
+    // the extension. Gating the toolbar on candidacy alone would strip the
+    // controls off a body that is still the text viewer.
+    isImageDiffCandidateMock.mockReturnValue(true);
+    seedPanel({
+      filePath: "assets/logo.png",
+      fileStatus: "modified",
+      diffSource: "base-branch",
+      baseBranch: "main",
+    });
+    renderPane();
+
+    expect(screen.queryByTestId("image-diff-mock")).toBeNull();
+    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
+    expect(screen.getByText("Unified")).toBeTruthy();
+    expect(screen.getByLabelText("Wrap long lines")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

- Image mode in the diff viewer still showed the Unified/Split toggle and the "Wrap long lines" button, and neither one can act on an image: there are no lines to wrap and no unified/split text rendering to switch between.
- Both controls now render only when the pane isn't in image mode. The file path pill and Refresh stay, since they apply to any file kind.
- Mirrors how `FilePane.tsx` already gates its Source/Rendered toggle on `isRenderable` and its wrap button on `isMarkdown`.

Resolves #11270

## Why this shape

`DiffPane.tsx` already computed `isImageMode` and the body already branched on it to pick `ImageDiffViewer` over `DiffViewer`. The toolbar just never read the flag, so the fix is small: gate the two controls on it.

I did try a named `showsTextDiff` predicate first, to carry the issue's point about covering other file kinds later. I dropped it. The name asserts a text diff is rendering, but it would have read true for base-branch binaries, images with a missing status, and error states, none of which render a text diff. `FilePane.tsx`, the pattern the issue points at, uses inline conditions too. A real capability predicate is worth building once there's an actual second non-text kind to design it against, not before.

## Testing

`DiffPane.test.tsx` previously mocked `ContentPanel` in a way that dropped the toolbar entirely, so the diff toolbar had zero coverage. The stub now renders it as a fragment, keeping the toolbar a sibling of the keydown host so the file-stepping shortcut tests keep the same event path, and `isImageDiffCandidate` became a controllable hoisted mock. Three cases:

- Image mode drops both controls but keeps the path pill and Refresh.
- A text file keeps both controls.
- A base-branch image keeps them too. `ImageDiffViewer` compares the working tree against HEAD and has no base-branch mode, so those stay on the text viewer regardless of extension. This case pins the boundary so the gate can't later get "simplified" down to raw image candidacy.

Locally: 95 tests pass across 7 files (all of `src/panels/diff`, including the newer full-file-view suites, plus `FileViewerToolbar`, `SegmentedToggle`, `FilePane`). Prettier is clean on both changed files. ESLint reports 2 errors in `DiffPane.tsx` (lines 238, 253); they're byte-identical on `develop` at the same lines and untouched by this change, so they're pre-existing and already in the ratchet baseline.

## Note on the rebase

This rebased onto the full-file-scope feature that landed on `develop` mid-flight. It adds a Changes/Full file toggle to the same toolbar, and handles image mode differently on purpose: visible but disabled, with copy explaining "This view already shows the whole image." I left that as written. It's a defensible distinction: Unified/Split and wrap are meaningless for an image, while a disabled Full file toggle actively teaches that the image view is already complete. Worth a look if you'd rather the two behaved the same way.

## Found while here (pre-existing, not fixed here)

- Refresh is inert for images. `retry()` only refetches the textual git diff; `ImageDiffViewer` only reloads when `worktreePath`/`relPath`/its private fetch nonce change. Edit a PNG on disk, hit Refresh, and the stale banner can clear while the old image stays on screen.
- `buildSubject` normalizes status with `?? "modified"`, but `isImageMode` requires a raw truthy `fileStatus`, so a restored `.png` panel with no status falls back to the text viewer.
- Focus gets lost when `[`/`]` steps across an image/text boundary while a body control holds focus. Nothing reclaims it, so later scoped shortcuts stop reaching the pane.

Each is probably its own issue rather than something to fold into this one.
