### PR TITLE
feat(diff): add reveal and open-in-editor to the Diff Viewer toolbar

### DIFF
--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -328,9 +328,7 @@ export function DiffPane({
       if (externalInFlightRef.current.has(target)) return;
       externalInFlightRef.current.add(target);
       const generation = externalGenerationRef.current;
-      setPendingTargets((current) =>
-        current.includes(target) ? current : [...current, target]
-      );
+      setPendingTargets((current) => (current.includes(target) ? current : [...current, target]));
       try {
         const result = await actionService.dispatch(
           target === "reveal" ? "file.showItemInFolder" : "file.openInEditor",
@@ -363,7 +361,8 @@ export function DiffPane({
     [absolutePath]
   );
 
-  const isErrorTargetPending = externalError !== null && pendingTargets.includes(externalError.target);
+  const isErrorTargetPending =
+    externalError !== null && pendingTargets.includes(externalError.target);
   // Below the Doherty threshold a spinner is just a flash; `disabled` still
   // blocks a double submit from the first millisecond.
   const showRetrySpinner = useDohertyGate(isErrorTargetPending);
@@ -598,9 +597,7 @@ export function DiffPane({
             disabled: isErrorTargetPending,
             onClick: () => void handleExternalAction(externalError.target),
             ariaLabel:
-              externalError.target === "reveal"
-                ? reveal.retryAriaLabel
-                : "Retry opening in editor",
+              externalError.target === "reveal" ? reveal.retryAriaLabel : "Retry opening in editor",
           }}
           onClose={() => setExternalError(null)}
           closeAriaLabel={
@@ -618,7 +615,12 @@ export function DiffPane({
               title="File changed since this diff loaded"
               role="status"
               ariaLive="polite"
-              action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: refreshAll }}
+              action={{
+                id: "refresh-diff",
+                label: "Refresh",
+                icon: RefreshCw,
+                onClick: refreshAll,
+              }}
             />
           )}
           {/* Suppressed while the staleness banner is up: both would be pointing
@@ -633,7 +635,12 @@ export function DiffPane({
               ariaLive="polite"
               action={
                 fullFileNotice.recoverable
-                  ? { id: "refresh-full-file", label: "Retry", icon: RefreshCw, onClick: refreshAll }
+                  ? {
+                      id: "refresh-full-file",
+                      label: "Retry",
+                      icon: RefreshCw,
+                      onClick: refreshAll,
+                    }
                   : undefined
               }
             />

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -33,6 +33,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { usePanelStore } from "@/store/panelStore";
 import { usePreferencesStore, type DiffFontSize } from "@/store/preferencesStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import { useDiffContent } from "./useDiffContent";
 import { useDiffFileSource } from "./useDiffFileSource";
@@ -302,55 +303,70 @@ export function DiffPane({
     message: string;
     target: ExternalTarget;
   } | null>(null);
-  const [isExternalPending, setIsExternalPending] = useState(false);
-  const externalAttemptRef = useRef(0);
+  // Tracked per target, not as one flag: revealing successfully says nothing
+  // about a missing editor, so the two must not clear or spin for each other.
+  const [pendingTargets, setPendingTargets] = useState<readonly ExternalTarget[]>([]);
+  // Bumped only by the reset below, so a still-running action is invalidated by
+  // the file moving out from under it — never by the sibling button starting.
+  const externalGenerationRef = useRef(0);
   // Synchronous re-entry guard: state can't stop a double-click in one tick.
-  const externalInFlightRef = useRef(false);
+  const externalInFlightRef = useRef<Set<ExternalTarget>>(new Set());
 
   // Keyed on the resolved absolute path, not the relative one — a worktree move
   // re-aims these buttons without changing `filePath`, and a result landing
   // after that belongs to the old location.
   useEffect(() => {
-    externalAttemptRef.current += 1;
-    externalInFlightRef.current = false;
+    externalGenerationRef.current += 1;
+    externalInFlightRef.current.clear();
     setExternalError(null);
-    setIsExternalPending(false);
+    setPendingTargets([]);
   }, [id, absolutePath]);
 
   const handleExternalAction = useCallback(
     async (target: ExternalTarget) => {
       if (!absolutePath) return;
-      if (externalInFlightRef.current) return;
-      externalInFlightRef.current = true;
-      const attempt = ++externalAttemptRef.current;
-      // Both buttons share one pending flag, so a banner left by the *other*
-      // target has to go: keeping it would light its Retry spinner for work
-      // that isn't its own. A retry of the same target keeps its banner so the
-      // spinner has somewhere to show.
-      setExternalError((current) => (current?.target === target ? current : null));
-      setIsExternalPending(true);
-      const result = await actionService.dispatch(
-        target === "reveal" ? "file.showItemInFolder" : "file.openInEditor",
-        { path: absolutePath },
-        { source: "user" }
+      if (externalInFlightRef.current.has(target)) return;
+      externalInFlightRef.current.add(target);
+      const generation = externalGenerationRef.current;
+      setPendingTargets((current) =>
+        current.includes(target) ? current : [...current, target]
       );
-      // A newer attempt (or a file/worktree switch) already reset the guard and
-      // owns the banner — an obsolete completion must not unlock it.
-      if (externalAttemptRef.current !== attempt) return;
-      externalInFlightRef.current = false;
-      setIsExternalPending(false);
-      if (result.ok) {
-        setExternalError(null);
-        return;
+      try {
+        const result = await actionService.dispatch(
+          target === "reveal" ? "file.showItemInFolder" : "file.openInEditor",
+          { path: absolutePath },
+          { source: "user" }
+        );
+        // The file (or its worktree) moved while this was in flight: the result
+        // describes a location the pane no longer shows.
+        if (externalGenerationRef.current !== generation) return;
+        if (result.ok) {
+          // Clears only its own failure — the other button's banner stands
+          // until that button's own retry succeeds.
+          setExternalError((current) => (current?.target === target ? null : current));
+          return;
+        }
+        logError(
+          `[DiffPane] ${target === "reveal" ? "showItemInFolder" : "openInEditor"} failed`,
+          result.error
+        );
+        setExternalError({ message: result.error.message, target });
+      } finally {
+        // Releasing in `finally` keeps a rejection from wedging the button for
+        // good; the generation check leaves a reset's clean slate alone.
+        if (externalGenerationRef.current === generation) {
+          externalInFlightRef.current.delete(target);
+          setPendingTargets((current) => current.filter((t) => t !== target));
+        }
       }
-      logError(
-        `[DiffPane] ${target === "reveal" ? "showItemInFolder" : "openInEditor"} failed`,
-        result.error
-      );
-      setExternalError({ message: result.error.message, target });
     },
     [absolutePath]
   );
+
+  const isErrorTargetPending = externalError !== null && pendingTargets.includes(externalError.target);
+  // Below the Doherty threshold a spinner is just a flash; `disabled` still
+  // blocks a double submit from the first millisecond.
+  const showRetrySpinner = useDohertyGate(isErrorTargetPending);
 
   const hasPrevFile = isWorkspace && currentIndex > 0;
   const hasNextFile =
@@ -578,7 +594,8 @@ export function DiffPane({
             label: "Retry",
             icon: RefreshCw,
             variant: "dangerFilled",
-            loading: isExternalPending,
+            loading: showRetrySpinner,
+            disabled: isErrorTargetPending,
             onClick: () => void handleExternalAction(externalError.target),
             ariaLabel:
               externalError.target === "reveal"

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -1,8 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
-import { ChevronLeft, ChevronRight, Check, PanelLeft, RefreshCw, WrapText } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  ExternalLink,
+  PanelLeft,
+  RefreshCw,
+  WrapText,
+  XCircle,
+} from "lucide-react";
 import { FileDiff as FileDiffIcon } from "lucide-react";
 import type { GitStatus } from "@shared/types/git";
 import type { DiffPanelData } from "@shared/types/panel";
+import { isAbsolute, join } from "@shared/utils/path";
+import { FolderOpen } from "@/components/icons";
+import { isMac, isWindows } from "@/lib/platform";
+import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
@@ -36,6 +50,9 @@ type DiffViewType = "split" | "unified";
  */
 type DiffContentScope = "changes" | "full-file";
 
+/** Which external surface a toolbar action aims the current file at. */
+type ExternalTarget = "reveal" | "editor";
+
 const FULL_FILE_FALLBACK_MESSAGES: Record<FullFileUnavailableReason, string> = {
   "source-mismatch": "The file changed after this diff loaded, so only changed lines are shown",
   "too-large": `Files over ${FULL_FILE_MAX_LINES.toLocaleString()} lines stay on changed lines to keep the diff responsive`,
@@ -45,6 +62,33 @@ const FULL_FILE_FALLBACK_MESSAGES: Record<FullFileUnavailableReason, string> = {
 // Mirrors the ladder the modal used, so the preference keeps meaning the same
 // sizes it always did.
 const DIFF_FONT_SIZE_PX: Record<DiffFontSize, string> = { s: "11px", m: "12px", l: "14px" };
+
+/**
+ * The file manager is named differently on every platform, and the button, its
+ * failure title and the retry's accessible name all have to agree — so the three
+ * strings are resolved together rather than as three ternaries that could drift.
+ */
+function revealCopy(): { label: string; errorTitle: string; retryAriaLabel: string } {
+  if (isMac()) {
+    return {
+      label: "Reveal in Finder",
+      errorTitle: "Couldn't reveal in Finder",
+      retryAriaLabel: "Retry revealing in Finder",
+    };
+  }
+  if (isWindows()) {
+    return {
+      label: "Show in Explorer",
+      errorTitle: "Couldn't show in Explorer",
+      retryAriaLabel: "Retry showing in Explorer",
+    };
+  }
+  return {
+    label: "Show in folder",
+    errorTitle: "Couldn't show in folder",
+    retryAriaLabel: "Retry showing in folder",
+  };
+}
 
 export interface DiffPaneProps extends BasePanelProps {
   tabs?: TabInfo[];
@@ -144,6 +188,17 @@ export function DiffPane({
   const setDiffShowFileList = usePreferencesStore((s) => s.setDiffShowFileList);
 
   const filePath = panel?.filePath;
+  // `filePath` is worktree-relative (unlike FilePanelData's), but both file
+  // actions want an absolute path. Null means there is nothing to aim them at:
+  // a relative path with no resolved worktree can't be made absolute, and
+  // dispatching the relative one would just fail inside the action.
+  const absolutePath = !filePath
+    ? null
+    : isAbsolute(filePath)
+      ? filePath
+      : worktreePath
+        ? join(worktreePath, filePath)
+        : null;
   const fileStatus = panel?.fileStatus;
   const changeSet = panel?.changeSet;
   const diffSource = panel?.diffSource;
@@ -238,6 +293,64 @@ export function DiffPane({
       window.setTimeout(() => setPathCopied(false), 1500);
     });
   }, [filePath]);
+
+  // dispatch() resolves an ActionDispatchResult and never rejects, so a failed
+  // open would otherwise vanish entirely (the #11114 bug FilePane already hit).
+  // Surface it on the pane that owns the button rather than through a toast.
+  // `target` rides along so Retry re-aims at what actually failed.
+  const [externalError, setExternalError] = useState<{
+    message: string;
+    target: ExternalTarget;
+  } | null>(null);
+  const [isExternalPending, setIsExternalPending] = useState(false);
+  const externalAttemptRef = useRef(0);
+  // Synchronous re-entry guard: state can't stop a double-click in one tick.
+  const externalInFlightRef = useRef(false);
+
+  // Keyed on the resolved absolute path, not the relative one — a worktree move
+  // re-aims these buttons without changing `filePath`, and a result landing
+  // after that belongs to the old location.
+  useEffect(() => {
+    externalAttemptRef.current += 1;
+    externalInFlightRef.current = false;
+    setExternalError(null);
+    setIsExternalPending(false);
+  }, [id, absolutePath]);
+
+  const handleExternalAction = useCallback(
+    async (target: ExternalTarget) => {
+      if (!absolutePath) return;
+      if (externalInFlightRef.current) return;
+      externalInFlightRef.current = true;
+      const attempt = ++externalAttemptRef.current;
+      // Both buttons share one pending flag, so a banner left by the *other*
+      // target has to go: keeping it would light its Retry spinner for work
+      // that isn't its own. A retry of the same target keeps its banner so the
+      // spinner has somewhere to show.
+      setExternalError((current) => (current?.target === target ? current : null));
+      setIsExternalPending(true);
+      const result = await actionService.dispatch(
+        target === "reveal" ? "file.showItemInFolder" : "file.openInEditor",
+        { path: absolutePath },
+        { source: "user" }
+      );
+      // A newer attempt (or a file/worktree switch) already reset the guard and
+      // owns the banner — an obsolete completion must not unlock it.
+      if (externalAttemptRef.current !== attempt) return;
+      externalInFlightRef.current = false;
+      setIsExternalPending(false);
+      if (result.ok) {
+        setExternalError(null);
+        return;
+      }
+      logError(
+        `[DiffPane] ${target === "reveal" ? "showItemInFolder" : "openInEditor"} failed`,
+        result.error
+      );
+      setExternalError({ message: result.error.message, target });
+    },
+    [absolutePath]
+  );
 
   const hasPrevFile = isWorkspace && currentIndex > 0;
   const hasNextFile =
@@ -392,6 +505,7 @@ export function DiffPane({
   const fileName = filePath?.split(/[/\\]/).filter(Boolean).pop();
   const displayTitle = panel?.titleMode === "user" ? title : (fileName ?? title);
 
+  const reveal = revealCopy();
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
@@ -431,34 +545,83 @@ export function DiffPane({
           <FileViewerToolbar.IconButton label="Refresh" onClick={retry}>
             <RefreshCw className="w-4 h-4" />
           </FileViewerToolbar.IconButton>
+          {absolutePath && (
+            <>
+              <FileViewerToolbar.IconButton
+                label={reveal.label}
+                onClick={() => void handleExternalAction("reveal")}
+              >
+                <FolderOpen className="w-4 h-4" />
+              </FileViewerToolbar.IconButton>
+              <FileViewerToolbar.IconButton
+                label="Open in editor"
+                onClick={() => void handleExternalAction("editor")}
+              >
+                <ExternalLink className="w-4 h-4" />
+              </FileViewerToolbar.IconButton>
+            </>
+          )}
         </FileViewerToolbar.Actions>
       </FileViewerToolbar.Root>
-      {stale && hasDiff && (
+      {/* A failed action carries a recovery the user just asked for, so it
+          outranks both ambient notices; they return once it is dismissed or a
+          retry succeeds. Below it, the existing stale-over-full-file order
+          stands. */}
+      {externalError ? (
         <InlineStatusBanner
-          severity="info"
-          icon={FileDiffIcon}
-          title="File changed since this diff loaded"
-          role="status"
-          ariaLive="polite"
-          action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: refreshAll }}
-        />
-      )}
-      {/* Suppressed while the staleness banner is up: both would be pointing at
-          the same underlying change and offering the same refresh. */}
-      {fullFileNotice && !stale && (
-        <InlineStatusBanner
-          severity="warning"
-          icon={FileDiffIcon}
-          title="Showing changed lines only"
-          description={fullFileNotice.message}
-          role="status"
-          ariaLive="polite"
-          action={
-            fullFileNotice.recoverable
-              ? { id: "refresh-full-file", label: "Retry", icon: RefreshCw, onClick: refreshAll }
-              : undefined
+          icon={XCircle}
+          severity="error"
+          title={externalError.target === "reveal" ? reveal.errorTitle : "Couldn't open in editor"}
+          description={externalError.message}
+          action={{
+            id: "retry-external-action",
+            label: "Retry",
+            icon: RefreshCw,
+            variant: "dangerFilled",
+            loading: isExternalPending,
+            onClick: () => void handleExternalAction(externalError.target),
+            ariaLabel:
+              externalError.target === "reveal"
+                ? reveal.retryAriaLabel
+                : "Retry opening in editor",
+          }}
+          onClose={() => setExternalError(null)}
+          closeAriaLabel={
+            externalError.target === "reveal"
+              ? "Dismiss file manager error"
+              : "Dismiss editor error"
           }
         />
+      ) : (
+        <>
+          {stale && hasDiff && (
+            <InlineStatusBanner
+              severity="info"
+              icon={FileDiffIcon}
+              title="File changed since this diff loaded"
+              role="status"
+              ariaLive="polite"
+              action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: refreshAll }}
+            />
+          )}
+          {/* Suppressed while the staleness banner is up: both would be pointing
+              at the same underlying change and offering the same refresh. */}
+          {fullFileNotice && !stale && (
+            <InlineStatusBanner
+              severity="warning"
+              icon={FileDiffIcon}
+              title="Showing changed lines only"
+              description={fullFileNotice.message}
+              role="status"
+              ariaLive="polite"
+              action={
+                fullFileNotice.recoverable
+                  ? { id: "refresh-full-file", label: "Retry", icon: RefreshCw, onClick: refreshAll }
+                  : undefined
+              }
+            />
+          )}
+        </>
       )}
     </>
   ) : undefined;

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -21,6 +21,13 @@ vi.mock("@/components/ui/tooltip", () => ({
 
 vi.mock("@/components/Worktree/DiffViewer", () => ({
   DiffViewer: () => null,
+  FULL_FILE_MAX_LINES: 5000,
+}));
+
+// The full-file read is a real IPC call; the toolbar tests never exercise the
+// scope, so it stays inert rather than reaching for `window.electron`.
+vi.mock("../useDiffFileSource", () => ({
+  useDiffFileSource: () => ({ source: undefined, errorCode: null }),
 }));
 vi.mock("@/components/FileViewer/ImageDiffViewer", () => ({
   ImageDiffViewer: () => null,
@@ -72,6 +79,8 @@ vi.mock("@/store/preferencesStore", () => ({
       diffShowFileList: false,
       setDiffShowFileList: vi.fn(),
       diffFontSize: "m",
+      diffFullFile: false,
+      setDiffFullFile: vi.fn(),
     }),
 }));
 
@@ -159,7 +168,11 @@ beforeEach(() => {
   isWindowsMock.mockReturnValue(false);
   logErrorMock.mockReset();
   useDiffContentMock.mockReset();
-  useDiffContentMock.mockReturnValue({ content: "diff --git a/a.ts b/a.ts", stale: false, retry: vi.fn() });
+  useDiffContentMock.mockReturnValue({
+    content: "diff --git a/a.ts b/a.ts",
+    stale: false,
+    retry: vi.fn(),
+  });
   worktrees.clear();
   worktrees.set(WORKTREE_ID, { path: WORKTREE_ROOT, branch: "feature/x" });
   vi.stubGlobal(
@@ -295,9 +308,10 @@ describe("DiffPane toolbar — platform naming", () => {
       isMacMock.mockReturnValue(mac);
       isWindowsMock.mockReturnValue(windows);
       const { unmount } = renderPane();
-      const label = screen
-        .getByLabelText("Open in editor")
-        .previousElementSibling?.getAttribute("aria-label") ?? null;
+      const label =
+        screen
+          .getByLabelText("Open in editor")
+          .previousElementSibling?.getAttribute("aria-label") ?? null;
       unmount();
       return label;
     };

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -532,7 +532,7 @@ describe("DiffPane toolbar — concurrency", () => {
     expect(dispatchMock.mock.calls[1][1]).toEqual({ path: "/repo-moved/src/index.ts" });
   });
 
-  it("lets one button run while the other is still in flight", async () => {
+  it("lets one button run while the other is still in flight, and still reports its result", async () => {
     const gate = deferred();
     dispatchMock.mockReturnValueOnce(gate.promise).mockResolvedValue(ok());
     seedPanel("src/index.ts");
@@ -548,6 +548,77 @@ describe("DiffPane toolbar — concurrency", () => {
       "file.showItemInFolder",
       "file.openInEditor",
     ]);
+
+    // The sibling starting must not invalidate this one: a per-dispatch counter
+    // would have marked the reveal stale here and eaten its failure silently.
+    await act(async () => {
+      gate.resolve(fail("reveal came back after the editor started"));
+      await gate.promise;
+    });
+    expect(screen.getByText("reveal came back after the editor started")).toBeTruthy();
+  });
+
+  it("won't let a superseded result unlock the attempt that replaced it", async () => {
+    const stale = deferred();
+    const live = deferred();
+    dispatchMock.mockReturnValueOnce(stale.promise).mockReturnValueOnce(live.promise);
+    seedPanel("src/index.ts");
+    const { rerender } = renderPane();
+
+    act(() => {
+      fireEvent.click(editorButton());
+    });
+
+    seedPanel("src/other.ts");
+    rerender(
+      <DiffPane
+        id={PANEL_ID}
+        title="pane"
+        isFocused
+        location="dialog"
+        worktreeId={WORKTREE_ID}
+        onFocus={() => {}}
+        onClose={() => {}}
+      />
+    );
+    act(() => {
+      fireEvent.click(editorButton());
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    // The first file's result lands last. Releasing the guard on its way out
+    // would hand the second file's in-flight attempt a free slot.
+    await act(async () => {
+      stale.resolve(ok());
+      await stale.promise;
+    });
+    await click(editorButton());
+
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      live.resolve(ok());
+      await live.promise;
+    });
+  });
+
+  it("leaves a retry usable while only the other target is pending", async () => {
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("no editor configured"));
+    renderPane();
+    await click(editorButton());
+
+    const gate = deferred();
+    dispatchMock.mockReturnValue(gate.promise);
+    act(() => {
+      fireEvent.click(revealButton());
+    });
+
+    // Pending is per target: a slow reveal says nothing about the editor, so
+    // the editor's own Retry must stay live.
+    expect(
+      screen.getByRole("button", { name: "Retry opening in editor" }).hasAttribute("disabled")
+    ).toBe(false);
 
     await act(async () => {
       gate.resolve(ok());

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -142,6 +142,21 @@ function editorButton(): HTMLElement {
   return screen.getByLabelText("Open in editor");
 }
 
+/**
+ * The nth dispatch, failing loudly if it never happened — `mock.calls[n]` is
+ * `T | undefined` under noUncheckedIndexedAccess, and a bare `!` would turn a
+ * missing dispatch into a confusing destructure error instead of this message.
+ */
+function dispatchCall(index: number): [string, unknown, unknown] {
+  const call = dispatchMock.mock.calls[index];
+  if (!call) {
+    throw new Error(
+      `expected a dispatch at index ${index}, but only ${dispatchMock.mock.calls.length} were made`
+    );
+  }
+  return call;
+}
+
 /** Click and let the dispatch promise settle. */
 async function click(el: HTMLElement): Promise<void> {
   await act(async () => {
@@ -197,7 +212,7 @@ describe("DiffPane toolbar — path resolution", () => {
 
     await click(editorButton());
 
-    const [, args] = dispatchMock.mock.calls[0];
+    const [, args] = dispatchCall(0);
     // Neither input alone is the answer: the root and the relative path combine.
     expect(args).toEqual({ path: `${WORKTREE_ROOT}/src/index.ts` });
   });
@@ -208,7 +223,7 @@ describe("DiffPane toolbar — path resolution", () => {
 
     await click(editorButton());
 
-    expect(dispatchMock.mock.calls[0][1]).toEqual({ path: "/elsewhere/vendored.ts" });
+    expect(dispatchCall(0)[1]).toEqual({ path: "/elsewhere/vendored.ts" });
   });
 
   it("recognises a Windows drive path as absolute rather than joining it to the root", async () => {
@@ -218,7 +233,7 @@ describe("DiffPane toolbar — path resolution", () => {
 
     await click(editorButton());
 
-    expect(dispatchMock.mock.calls[0][1]).not.toEqual({
+    expect(dispatchCall(0)[1]).not.toEqual({
       path: `${WORKTREE_ROOT}/C:\\vendor\\lib.ts`,
     });
   });
@@ -294,7 +309,7 @@ describe("DiffPane toolbar — action routing", () => {
 
     await click(editorButton());
 
-    expect(dispatchMock.mock.calls[0][2]).toEqual({ source: "user" });
+    expect(dispatchCall(0)[2]).toEqual({ source: "user" });
   });
 });
 
@@ -359,7 +374,7 @@ describe("DiffPane toolbar — failure and recovery", () => {
     dispatchMock.mockClear();
     await click(screen.getByRole("button", { name: "Retry revealing in Finder" }));
 
-    expect(dispatchMock.mock.calls[0][0]).toBe("file.showItemInFolder");
+    expect(dispatchCall(0)[0]).toBe("file.showItemInFolder");
   });
 
   it("holds the banner open across a retry and clears it only once that retry succeeds", async () => {
@@ -378,7 +393,7 @@ describe("DiffPane toolbar — failure and recovery", () => {
     });
 
     expect(screen.getByText("transient")).toBeTruthy();
-    expect(dispatchMock.mock.calls[0]).toEqual([
+    expect(dispatchCall(0)).toEqual([
       "file.openInEditor",
       { path: `${WORKTREE_ROOT}/src/index.ts` },
       { source: "user" },
@@ -543,7 +558,7 @@ describe("DiffPane toolbar — concurrency", () => {
 
     // The move also released the guard, so the button works against the new root.
     await click(editorButton());
-    expect(dispatchMock.mock.calls[1][1]).toEqual({ path: "/repo-moved/src/index.ts" });
+    expect(dispatchCall(1)[1]).toEqual({ path: "/repo-moved/src/index.ts" });
   });
 
   it("lets one button run while the other is still in flight, and still reports its result", async () => {

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -1,0 +1,466 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { act, render, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitStatus } from "@shared/types/git";
+import type { ActionDispatchResult } from "@shared/types/actions";
+
+// The sibling DiffPane.test.tsx stubs `toolbar` away on purpose. These tests are
+// the opposite: the toolbar IS the subject, so ContentPanel renders it and the
+// body is dropped instead. Radix stays mocked out either way.
+vi.mock("@/components/Panel/ContentPanel", () => ({
+  ContentPanel: (props: { toolbar?: ReactNode }) => <>{props.toolbar}</>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Worktree/DiffViewer", () => ({
+  DiffViewer: () => null,
+}));
+vi.mock("@/components/FileViewer/ImageDiffViewer", () => ({
+  ImageDiffViewer: () => null,
+  isImageDiffCandidate: () => false,
+}));
+vi.mock("@/components/ui/EmptyState", () => ({ EmptyState: () => null }));
+vi.mock("@/components/FileViewer/DiffFileSidebar", () => ({ DiffFileSidebar: () => null }));
+
+const { dispatchMock, isMacMock, isWindowsMock, logErrorMock, useDiffContentMock } = vi.hoisted(
+  () => ({
+    dispatchMock:
+      vi.fn<(id: string, args: unknown, opts: unknown) => Promise<ActionDispatchResult<unknown>>>(),
+    isMacMock: vi.fn<() => boolean>(),
+    isWindowsMock: vi.fn<() => boolean>(),
+    logErrorMock: vi.fn(),
+    useDiffContentMock: vi.fn(),
+  })
+);
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+vi.mock("@/lib/platform", () => ({
+  isMac: isMacMock,
+  isWindows: isWindowsMock,
+  isLinux: () => false,
+}));
+vi.mock("@/utils/logger", () => ({ logError: logErrorMock }));
+vi.mock("../useDiffContent", () => ({ useDiffContent: useDiffContentMock }));
+
+const panelsById: Record<string, unknown> = {};
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (selector: (state: unknown) => unknown) =>
+    selector({ panelsById, setDiffPanelFile: vi.fn() }),
+}));
+
+const worktrees = new Map<string, { path: string; branch: string }>();
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (state: unknown) => unknown) => selector({ worktrees }),
+}));
+
+vi.mock("@/store/preferencesStore", () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      diffViewType: "unified",
+      setDiffViewType: vi.fn(),
+      diffWrapLines: false,
+      setDiffWrapLines: vi.fn(),
+      diffShowFileList: false,
+      setDiffShowFileList: vi.fn(),
+      diffFontSize: "m",
+    }),
+}));
+
+vi.mock("@/store/diffViewedStore", () => ({
+  useDiffViewedStore: (selector: (state: unknown) => unknown) =>
+    selector({ toggleViewed: vi.fn() }),
+  selectViewedSet: () => new Set<string>(),
+}));
+
+import { DiffPane } from "../DiffPane";
+
+const PANEL_ID = "diff-1";
+const WORKTREE_ID = "wt-1";
+const WORKTREE_ROOT = "/repo";
+
+function ok(): ActionDispatchResult<unknown> {
+  return { ok: true, result: undefined };
+}
+
+function fail(message: string): ActionDispatchResult<unknown> {
+  return { ok: false, error: { code: "EXECUTION_ERROR", message } };
+}
+
+function seedPanel(filePath: string | undefined, fileStatus: GitStatus = "modified"): void {
+  panelsById[PANEL_ID] = {
+    id: PANEL_ID,
+    kind: "diff",
+    diffSource: "working-tree",
+    filePath,
+    fileStatus,
+  };
+}
+
+function renderPane() {
+  return render(
+    <DiffPane
+      id={PANEL_ID}
+      title="pane"
+      isFocused
+      location="dialog"
+      worktreeId={WORKTREE_ID}
+      onFocus={() => {}}
+      onClose={() => {}}
+    />
+  );
+}
+
+/** The reveal button's accessible name is platform-derived, so find it by icon-free elimination. */
+function revealButton(): HTMLElement {
+  const label = isMacMock()
+    ? "Reveal in Finder"
+    : isWindowsMock()
+      ? "Show in Explorer"
+      : "Show in folder";
+  return screen.getByLabelText(label);
+}
+
+function editorButton(): HTMLElement {
+  return screen.getByLabelText("Open in editor");
+}
+
+/** Click and let the dispatch promise settle. */
+async function click(el: HTMLElement): Promise<void> {
+  await act(async () => {
+    fireEvent.click(el);
+  });
+}
+
+/** A promise the test resolves by hand, for in-flight/stale-completion cases. */
+function deferred(): {
+  promise: Promise<ActionDispatchResult<unknown>>;
+  resolve: (v: ActionDispatchResult<unknown>) => void;
+} {
+  let resolve!: (v: ActionDispatchResult<unknown>) => void;
+  const promise = new Promise<ActionDispatchResult<unknown>>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  dispatchMock.mockReset();
+  dispatchMock.mockResolvedValue(ok());
+  isMacMock.mockReturnValue(true);
+  isWindowsMock.mockReturnValue(false);
+  logErrorMock.mockReset();
+  useDiffContentMock.mockReset();
+  useDiffContentMock.mockReturnValue({ content: "diff --git a/a.ts b/a.ts", stale: false, retry: vi.fn() });
+  worktrees.clear();
+  worktrees.set(WORKTREE_ID, { path: WORKTREE_ROOT, branch: "feature/x" });
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  );
+});
+
+afterEach(() => {
+  for (const key of Object.keys(panelsById)) delete panelsById[key];
+  vi.unstubAllGlobals();
+});
+
+describe("DiffPane toolbar — path resolution", () => {
+  it("resolves the panel's worktree-relative path against the worktree root before dispatching", async () => {
+    seedPanel("src/index.ts");
+    renderPane();
+
+    await click(editorButton());
+
+    const [, args] = dispatchMock.mock.calls[0];
+    // Neither input alone is the answer: the root and the relative path combine.
+    expect(args).toEqual({ path: `${WORKTREE_ROOT}/src/index.ts` });
+  });
+
+  it("passes an already-absolute path through untouched", async () => {
+    seedPanel("/elsewhere/vendored.ts");
+    renderPane();
+
+    await click(editorButton());
+
+    expect(dispatchMock.mock.calls[0][1]).toEqual({ path: "/elsewhere/vendored.ts" });
+  });
+
+  it("still offers the actions for an absolute path when the worktree no longer resolves", async () => {
+    worktrees.clear();
+    seedPanel("/elsewhere/vendored.ts");
+    renderPane();
+
+    await click(editorButton());
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides both actions when a relative path has no worktree root to resolve against", () => {
+    worktrees.clear();
+    seedPanel("src/index.ts");
+    renderPane();
+
+    // Refresh proves the toolbar itself rendered — only the two path-dependent
+    // buttons dropped out, rather than the whole toolbar being absent.
+    expect(screen.getByLabelText("Refresh")).toBeTruthy();
+    expect(screen.queryByLabelText("Open in editor")).toBeNull();
+    expect(screen.queryByLabelText("Reveal in Finder")).toBeNull();
+  });
+
+  it("keeps offering the actions when the diff itself is unavailable", async () => {
+    // A base-branch panel with no base ref can't build a diff subject, but the
+    // file on disk is still perfectly revealable.
+    panelsById[PANEL_ID] = {
+      id: PANEL_ID,
+      kind: "diff",
+      diffSource: "base-branch",
+      filePath: "src/index.ts",
+      fileStatus: "modified",
+    };
+    renderPane();
+
+    await click(revealButton());
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers the actions for a deleted file so the action itself reports what went wrong", async () => {
+    seedPanel("src/gone.ts", "deleted");
+    dispatchMock.mockResolvedValue(fail("File no longer exists"));
+    renderPane();
+
+    await click(revealButton());
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("File no longer exists")).toBeTruthy();
+  });
+});
+
+describe("DiffPane toolbar — action routing", () => {
+  it("routes each button to its own action", async () => {
+    seedPanel("src/index.ts");
+    renderPane();
+
+    await click(revealButton());
+    await click(editorButton());
+
+    expect(dispatchMock.mock.calls.map(([id]) => id)).toEqual([
+      "file.showItemInFolder",
+      "file.openInEditor",
+    ]);
+  });
+
+  it("attributes the dispatch to the user", async () => {
+    seedPanel("src/index.ts");
+    renderPane();
+
+    await click(editorButton());
+
+    expect(dispatchMock.mock.calls[0][2]).toEqual({ source: "user" });
+  });
+});
+
+describe("DiffPane toolbar — platform naming", () => {
+  it("names the file manager differently on each platform", () => {
+    seedPanel("src/index.ts");
+
+    isMacMock.mockReturnValue(true);
+    isWindowsMock.mockReturnValue(false);
+    const { unmount: unmountMac } = renderPane();
+    const macLabel = revealButton().getAttribute("aria-label");
+    unmountMac();
+
+    isMacMock.mockReturnValue(false);
+    isWindowsMock.mockReturnValue(true);
+    const { unmount: unmountWin } = renderPane();
+    const winLabel = revealButton().getAttribute("aria-label");
+    unmountWin();
+
+    isMacMock.mockReturnValue(false);
+    isWindowsMock.mockReturnValue(false);
+    renderPane();
+    const linuxLabel = revealButton().getAttribute("aria-label");
+
+    expect(new Set([macLabel, winLabel, linuxLabel]).size).toBe(3);
+  });
+
+  it("keeps the failure title on the same platform as the button that failed", async () => {
+    isMacMock.mockReturnValue(false);
+    isWindowsMock.mockReturnValue(true);
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("nope"));
+    renderPane();
+
+    const buttonLabel = revealButton().getAttribute("aria-label") ?? "";
+    await click(revealButton());
+
+    // "Show in Explorer" → "Couldn't show in Explorer": the platform noun has to
+    // survive into the error, not fall back to the macOS wording.
+    const platformNoun = buttonLabel.split(" ").slice(-1)[0];
+    expect(screen.getByText(new RegExp(`Couldn't.*${platformNoun}`))).toBeTruthy();
+  });
+});
+
+describe("DiffPane toolbar — failure and recovery", () => {
+  it("surfaces the action's own message rather than a generic one", async () => {
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("Editor binary not found on PATH"));
+    renderPane();
+
+    await click(editorButton());
+
+    expect(screen.getByText("Editor binary not found on PATH")).toBeTruthy();
+    expect(logErrorMock).toHaveBeenCalled();
+  });
+
+  it("re-aims Retry at the target that actually failed", async () => {
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("nope"));
+    renderPane();
+
+    await click(revealButton());
+    dispatchMock.mockClear();
+    await click(screen.getByRole("button", { name: "Retry revealing in Finder" }));
+
+    expect(dispatchMock.mock.calls[0][0]).toBe("file.showItemInFolder");
+  });
+
+  it("clears the banner once a retry succeeds", async () => {
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("transient"));
+    renderPane();
+    await click(editorButton());
+
+    dispatchMock.mockResolvedValue(ok());
+    await click(screen.getByRole("button", { name: "Retry opening in editor" }));
+
+    expect(screen.queryByText("transient")).toBeNull();
+  });
+
+  it("drops the other target's banner rather than lighting its retry spinner", async () => {
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("editor is down"));
+    renderPane();
+    await click(editorButton());
+
+    // Both buttons share one pending flag, so the stale editor banner must not
+    // survive into a reveal attempt and claim that work as its own.
+    dispatchMock.mockResolvedValue(ok());
+    await click(revealButton());
+
+    expect(screen.queryByText("editor is down")).toBeNull();
+  });
+});
+
+describe("DiffPane toolbar — banner precedence", () => {
+  it("lets a failed action displace the stale-diff notice, and restores it on dismiss", async () => {
+    useDiffContentMock.mockReturnValue({
+      content: "diff --git a/a.ts b/a.ts",
+      stale: true,
+      retry: vi.fn(),
+    });
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("boom"));
+    renderPane();
+
+    expect(screen.getByText("File changed since this diff loaded")).toBeTruthy();
+
+    await click(editorButton());
+    expect(screen.queryByText("File changed since this diff loaded")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss editor error" }));
+    });
+    expect(screen.getByText("File changed since this diff loaded")).toBeTruthy();
+  });
+});
+
+describe("DiffPane toolbar — concurrency", () => {
+  it("collapses a double-click into one dispatch", async () => {
+    const gate = deferred();
+    dispatchMock.mockReturnValue(gate.promise);
+    seedPanel("src/index.ts");
+    renderPane();
+
+    act(() => {
+      fireEvent.click(editorButton());
+      fireEvent.click(editorButton());
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      gate.resolve(ok());
+      await gate.promise;
+    });
+
+    // The guard releases once the first attempt settles.
+    await click(editorButton());
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a result that lands after the panel moved to another file", async () => {
+    const gate = deferred();
+    dispatchMock.mockReturnValue(gate.promise);
+    seedPanel("src/index.ts");
+    const { rerender } = renderPane();
+
+    act(() => {
+      fireEvent.click(editorButton());
+    });
+
+    seedPanel("src/other.ts");
+    rerender(
+      <DiffPane
+        id={PANEL_ID}
+        title="pane"
+        isFocused
+        location="dialog"
+        worktreeId={WORKTREE_ID}
+        onFocus={() => {}}
+        onClose={() => {}}
+      />
+    );
+
+    await act(async () => {
+      gate.resolve(fail("stale failure"));
+      await gate.promise;
+    });
+
+    // The failure belonged to the file that is no longer open.
+    expect(screen.queryByText("stale failure")).toBeNull();
+  });
+
+  it("re-aims at the new location when the worktree moves under an open file", async () => {
+    seedPanel("src/index.ts");
+    const { rerender } = renderPane();
+
+    worktrees.set(WORKTREE_ID, { path: "/repo-moved", branch: "feature/x" });
+    rerender(
+      <DiffPane
+        id={PANEL_ID}
+        title="pane"
+        isFocused
+        location="dialog"
+        worktreeId={WORKTREE_ID}
+        onFocus={() => {}}
+        onClose={() => {}}
+      />
+    );
+    await click(editorButton());
+
+    expect(dispatchMock.mock.calls[0][1]).toEqual({ path: "/repo-moved/src/index.ts" });
+  });
+});

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -198,6 +198,18 @@ describe("DiffPane toolbar — path resolution", () => {
     expect(dispatchMock.mock.calls[0][1]).toEqual({ path: "/elsewhere/vendored.ts" });
   });
 
+  it("recognises a Windows drive path as absolute rather than joining it to the root", async () => {
+    // A POSIX-only "starts with /" check would join this onto the worktree root.
+    seedPanel("C:\\vendor\\lib.ts");
+    renderPane();
+
+    await click(editorButton());
+
+    expect(dispatchMock.mock.calls[0][1]).not.toEqual({
+      path: `${WORKTREE_ROOT}/C:\\vendor\\lib.ts`,
+    });
+  });
+
   it("still offers the actions for an absolute path when the worktree no longer resolves", async () => {
     worktrees.clear();
     seedPanel("/elsewhere/vendored.ts");
@@ -274,27 +286,25 @@ describe("DiffPane toolbar — action routing", () => {
 });
 
 describe("DiffPane toolbar — platform naming", () => {
-  it("names the file manager differently on each platform", () => {
+  it("names the file manager for the platform it is actually running on", () => {
     seedPanel("src/index.ts");
 
-    isMacMock.mockReturnValue(true);
-    isWindowsMock.mockReturnValue(false);
-    const { unmount: unmountMac } = renderPane();
-    const macLabel = revealButton().getAttribute("aria-label");
-    unmountMac();
+    // Located by position rather than by name, so the name itself stays an
+    // assertion instead of being smuggled into the query.
+    const revealLabelFor = (mac: boolean, windows: boolean): string | null => {
+      isMacMock.mockReturnValue(mac);
+      isWindowsMock.mockReturnValue(windows);
+      const { unmount } = renderPane();
+      const label = screen
+        .getByLabelText("Open in editor")
+        .previousElementSibling?.getAttribute("aria-label") ?? null;
+      unmount();
+      return label;
+    };
 
-    isMacMock.mockReturnValue(false);
-    isWindowsMock.mockReturnValue(true);
-    const { unmount: unmountWin } = renderPane();
-    const winLabel = revealButton().getAttribute("aria-label");
-    unmountWin();
-
-    isMacMock.mockReturnValue(false);
-    isWindowsMock.mockReturnValue(false);
-    renderPane();
-    const linuxLabel = revealButton().getAttribute("aria-label");
-
-    expect(new Set([macLabel, winLabel, linuxLabel]).size).toBe(3);
+    expect(revealLabelFor(true, false)).toBe("Reveal in Finder");
+    expect(revealLabelFor(false, true)).toBe("Show in Explorer");
+    expect(revealLabelFor(false, false)).toBe("Show in folder");
   });
 
   it("keeps the failure title on the same platform as the button that failed", async () => {
@@ -338,30 +348,71 @@ describe("DiffPane toolbar — failure and recovery", () => {
     expect(dispatchMock.mock.calls[0][0]).toBe("file.showItemInFolder");
   });
 
-  it("clears the banner once a retry succeeds", async () => {
+  it("holds the banner open across a retry and clears it only once that retry succeeds", async () => {
     seedPanel("src/index.ts");
     dispatchMock.mockResolvedValue(fail("transient"));
     renderPane();
     await click(editorButton());
 
-    dispatchMock.mockResolvedValue(ok());
-    await click(screen.getByRole("button", { name: "Retry opening in editor" }));
+    // Deferred, so the in-between state is observable: clearing the banner up
+    // front would "pass" this test's end state while losing the retry's spinner.
+    const gate = deferred();
+    dispatchMock.mockReset();
+    dispatchMock.mockReturnValue(gate.promise);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry opening in editor" }));
+    });
 
+    expect(screen.getByText("transient")).toBeTruthy();
+    expect(dispatchMock.mock.calls[0]).toEqual([
+      "file.openInEditor",
+      { path: `${WORKTREE_ROOT}/src/index.ts` },
+      { source: "user" },
+    ]);
+
+    await act(async () => {
+      gate.resolve(ok());
+      await gate.promise;
+    });
     expect(screen.queryByText("transient")).toBeNull();
   });
 
-  it("drops the other target's banner rather than lighting its retry spinner", async () => {
+  it("keeps a failed target's banner when the other target succeeds", async () => {
     seedPanel("src/index.ts");
-    dispatchMock.mockResolvedValue(fail("editor is down"));
+    dispatchMock.mockResolvedValue(fail("no editor configured"));
     renderPane();
     await click(editorButton());
 
-    // Both buttons share one pending flag, so the stale editor banner must not
-    // survive into a reveal attempt and claim that work as its own.
+    // Revealing the file did nothing to configure an editor, so the editor's
+    // failure is still true and still needs its Retry.
     dispatchMock.mockResolvedValue(ok());
     await click(revealButton());
 
-    expect(screen.queryByText("editor is down")).toBeNull();
+    expect(screen.getByText("no editor configured")).toBeTruthy();
+  });
+
+  it("disables Retry while its own attempt is in flight", async () => {
+    seedPanel("src/index.ts");
+    dispatchMock.mockResolvedValue(fail("boom"));
+    renderPane();
+    await click(editorButton());
+
+    const gate = deferred();
+    dispatchMock.mockReturnValue(gate.promise);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry opening in editor" }));
+    });
+
+    const retry = screen.getByRole("button", { name: "Retry opening in editor" });
+    expect(retry.hasAttribute("disabled")).toBe(true);
+
+    await act(async () => {
+      gate.resolve(fail("boom"));
+      await gate.promise;
+    });
+    expect(
+      screen.getByRole("button", { name: "Retry opening in editor" }).hasAttribute("disabled")
+    ).toBe(false);
   });
 });
 
@@ -391,7 +442,9 @@ describe("DiffPane toolbar — banner precedence", () => {
 describe("DiffPane toolbar — concurrency", () => {
   it("collapses a double-click into one dispatch", async () => {
     const gate = deferred();
-    dispatchMock.mockReturnValue(gate.promise);
+    // Once-then-default, so the post-settlement click is a genuinely new
+    // operation rather than a replay of the already-resolved promise.
+    dispatchMock.mockReturnValueOnce(gate.promise).mockResolvedValue(ok());
     seedPanel("src/index.ts");
     renderPane();
 
@@ -443,10 +496,18 @@ describe("DiffPane toolbar — concurrency", () => {
     expect(screen.queryByText("stale failure")).toBeNull();
   });
 
-  it("re-aims at the new location when the worktree moves under an open file", async () => {
+  it("discards an in-flight result when the worktree moves, and re-aims at the new root", async () => {
+    const gate = deferred();
+    dispatchMock.mockReturnValueOnce(gate.promise).mockResolvedValue(ok());
     seedPanel("src/index.ts");
     const { rerender } = renderPane();
 
+    act(() => {
+      fireEvent.click(editorButton());
+    });
+
+    // A worktree move re-aims the buttons without `filePath` changing at all —
+    // which is why the reset keys on the resolved path, not the relative one.
     worktrees.set(WORKTREE_ID, { path: "/repo-moved", branch: "feature/x" });
     rerender(
       <DiffPane
@@ -459,8 +520,38 @@ describe("DiffPane toolbar — concurrency", () => {
         onClose={() => {}}
       />
     );
+
+    await act(async () => {
+      gate.resolve(fail("failed against the old root"));
+      await gate.promise;
+    });
+    expect(screen.queryByText("failed against the old root")).toBeNull();
+
+    // The move also released the guard, so the button works against the new root.
+    await click(editorButton());
+    expect(dispatchMock.mock.calls[1][1]).toEqual({ path: "/repo-moved/src/index.ts" });
+  });
+
+  it("lets one button run while the other is still in flight", async () => {
+    const gate = deferred();
+    dispatchMock.mockReturnValueOnce(gate.promise).mockResolvedValue(ok());
+    seedPanel("src/index.ts");
+    renderPane();
+
+    act(() => {
+      fireEvent.click(revealButton());
+    });
+    // A slow reveal must not swallow a click on the other button.
     await click(editorButton());
 
-    expect(dispatchMock.mock.calls[0][1]).toEqual({ path: "/repo-moved/src/index.ts" });
+    expect(dispatchMock.mock.calls.map(([id]) => id)).toEqual([
+      "file.showItemInFolder",
+      "file.openInEditor",
+    ]);
+
+    await act(async () => {
+      gate.resolve(ok());
+      await gate.promise;
+    });
   });
 });


### PR DESCRIPTION
## Summary

- The Diff Viewer toolbar had a copyable path, a wrap toggle, and Refresh, but no way to get from a viewed diff to the file itself.
- Adds two buttons after Refresh: a platform-labeled reveal-in-file-manager button ("Reveal in Finder" on macOS, "Show in Explorer" on Windows, "Show in folder" on Linux, mirroring the existing ternary in `TerminalContextMenu.tsx`) and an "Open in editor" button.
- Both reuse the existing `file.showItemInFolder` and `file.openInEditor` actions. No new IPC surface, no new action IDs.

Resolves #11269

## Changes

- `DiffPanelData.filePath` is worktree-relative, unlike `FilePanelData`'s absolute path, but both actions need an absolute path. Resolved via `isAbsolute`/`join` from `@shared/utils/path`, the same convention `FileChangeList` already uses. The buttons hide themselves when a relative path has no resolved worktree root to join against.
- Dispatch goes through `ActionService` rather than `systemClient` directly, since `dispatch()` resolves an `ActionDispatchResult` and never rejects. Calling the client directly would let a failed open vanish silently, the same bug `FilePane` fixed in #11114. Failures now surface in an inline banner with a Retry aimed at whichever button failed.
- Pending state and the in-flight guard are tracked per target, so revealing a file doesn't clear an unresolved "no editor configured" failure, and a slow reveal can't silently discard a click on open-in-editor.
- Staleness uses a generation counter that only bumps when the selected file changes, so the sibling button can't invalidate a running action.
- The error banner takes the top slot of the existing precedence chain (error, then stale-diff, then full-file), preserving the stale-over-full-file order already on `develop`.
- Retry's spinner sits behind the 400ms Doherty gate while `disabled` applies immediately, so a fast retry doesn't flash.

## Testing

Added `src/panels/diff/__tests__/DiffPane.externalActions.test.tsx` (22 tests). The sibling `DiffPane.test.tsx` deliberately mocks the toolbar away, so this one does the inverse and renders only the toolbar: path resolution (relative join, absolute pass-through, Windows drive paths), action routing, platform naming, failure/retry/dismiss, banner precedence, and concurrency (double-click collapse, cross-target independence, superseded results). 101 tests pass across the 7 affected files.

## Not in scope

- Adding the same two entries to `FileChangeList`'s per-row context menu. That menu only renders when a plugin contributes items today, so adding built-ins means restructuring the gate and wrapping every row of a hot list in a Radix `ContextMenu`. Worth a follow-up.
- `WorktreeMenuItems.tsx:484-486` hardcodes "Reveal in Finder" with no platform check, a pre-existing bug on Windows/Linux. Noted but out of scope here.
