### PR TITLE
fix(worktree): follow rescued terminal after deleted-row drag

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -90,6 +90,7 @@ import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalDragPreview, TERMINAL_DRAG_PREVIEW_WIDTH } from "./TerminalDragPreview";
 import { WorktreeDragPreview } from "./WorktreeDragPreview";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { moveTerminalToWorktreeAndFollowRescue } from "@/services/terminal/crossWorktreeMove";
 import { parseAccordionDragId } from "./SortableWorktreeTerminal";
 import { isWorktreeSortDragData, parseWorktreeSortDragId } from "./SortableWorktreeCard";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
@@ -664,7 +665,6 @@ export function DndProvider({ children }: DndProviderProps) {
   const reorderTabGroups = usePanelStore((s) => s.reorderTabGroups);
   const moveTerminalToPosition = usePanelStore((s) => s.moveTerminalToPosition);
   const moveTabGroupToLocation = usePanelStore((s) => s.moveTabGroupToLocation);
-  const moveTerminalToWorktree = usePanelStore((s) => s.moveTerminalToWorktree);
   const setFocused = usePanelStore((s) => s.setFocused);
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
@@ -968,8 +968,7 @@ export function DndProvider({ children }: DndProviderProps) {
           const draggedTerminal = freshTerminalsById[actualDraggedId];
           const isLiveTarget = getCurrentViewStore().getState().worktrees.has(targetWorktreeId);
           if (isLiveTarget && draggedTerminal && draggedTerminal.worktreeId !== targetWorktreeId) {
-            moveTerminalToWorktree(actualDraggedId, targetWorktreeId);
-            setFocused(null);
+            moveTerminalToWorktreeAndFollowRescue(actualDraggedId, targetWorktreeId);
           }
           return;
         }
@@ -1006,8 +1005,7 @@ export function DndProvider({ children }: DndProviderProps) {
         if (isGroupDrag) return; // Defensive: cancelDrop should catch this
         const currentTerminal = freshTerminalsById[draggedId];
         if (currentTerminal && currentTerminal.worktreeId !== overData.worktreeId) {
-          moveTerminalToWorktree(draggedId, overData.worktreeId!);
-          setFocused(null);
+          moveTerminalToWorktreeAndFollowRescue(draggedId, overData.worktreeId!);
         }
         // Don't return - fall through to stabilization
       }
@@ -1268,7 +1266,6 @@ export function DndProvider({ children }: DndProviderProps) {
       reorderTabGroups,
       moveTerminalToPosition,
       moveTabGroupToLocation,
-      moveTerminalToWorktree,
       setFocused,
       activeWorktreeId,
     ]

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   selectionState: {
     activeWorktreeId: null as string | null,
     selectWorktree: vi.fn(),
+    deletedWorktrees: new Map<string, unknown>(),
   },
   projectState: {
     currentProject: { id: "project-1", path: "/repo" } as { id: string; path: string } | null,
@@ -60,6 +61,7 @@ describe("useActiveWorktreeSync initialization", () => {
   beforeEach(() => {
     mocks.selectionState.activeWorktreeId = null;
     mocks.selectionState.selectWorktree.mockReset();
+    mocks.selectionState.deletedWorktrees = new Map();
     mocks.useWorktrees.mockReset();
     mocks.projectState.currentProject = { id: "project-1", path: "/repo" };
     mocks.scratchState.currentScratch = null;
@@ -82,6 +84,29 @@ describe("useActiveWorktreeSync initialization", () => {
     rerender();
 
     expect(mocks.selectionState.selectWorktree).toHaveBeenCalledOnce();
+    expect(mocks.selectionState.selectWorktree).toHaveBeenCalledWith(mainWorktree.id);
+  });
+
+  // The rescue-follow (#11273) lands the user on the destination before the row
+  // is pruned, so this generic fallback must keep owning every other way a
+  // deleted row can die — last terminal closed or trashed, dismissed, or
+  // auto-cleanup. The hook cannot tell those causes apart, so one case covers
+  // all of them.
+  it("holds the selection on a deleted row and snaps to main only once it is gone", () => {
+    mocks.selectionState.activeWorktreeId = "ghost";
+    mocks.selectionState.deletedWorktrees = new Map([["ghost", {}]]);
+    mocks.useWorktrees.mockReturnValue({
+      worktrees: [mainWorktree, featureWorktree],
+      isInitialized: true,
+    });
+
+    const { rerender } = renderHook(() => useActiveWorktreeSync());
+
+    expect(mocks.selectionState.selectWorktree).not.toHaveBeenCalled();
+
+    mocks.selectionState.deletedWorktrees = new Map();
+    rerender();
+
     expect(mocks.selectionState.selectWorktree).toHaveBeenCalledWith(mainWorktree.id);
   });
 });

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.initialization.test.ts
@@ -87,16 +87,18 @@ describe("useActiveWorktreeSync initialization", () => {
     expect(mocks.selectionState.selectWorktree).toHaveBeenCalledWith(mainWorktree.id);
   });
 
-  // The rescue-follow (#11273) lands the user on the destination before the row
-  // is pruned, so this generic fallback must keep owning every other way a
-  // deleted row can die — last terminal closed or trashed, dismissed, or
-  // auto-cleanup. The hook cannot tell those causes apart, so one case covers
-  // all of them.
+  // The rescue-follow (#11273) selects the destination after the row is pruned
+  // but before this effect runs, so it never reaches the branch below. Every
+  // other way a deleted row can die — last terminal closed or trashed, row
+  // dismissed, auto-cleanup — still lands here. The hook cannot tell those
+  // causes apart, so one case covers all of them.
   it("holds the selection on a deleted row and snaps to main only once it is gone", () => {
     mocks.selectionState.activeWorktreeId = "ghost";
     mocks.selectionState.deletedWorktrees = new Map([["ghost", {}]]);
+    // Feature first, so the assertion proves the fallback picks the designated
+    // main worktree rather than whatever happens to sit at index zero.
     mocks.useWorktrees.mockReturnValue({
-      worktrees: [mainWorktree, featureWorktree],
+      worktrees: [featureWorktree, mainWorktree],
       isInitialized: true,
     });
 
@@ -107,6 +109,6 @@ describe("useActiveWorktreeSync initialization", () => {
     mocks.selectionState.deletedWorktrees = new Map();
     rerender();
 
-    expect(mocks.selectionState.selectWorktree).toHaveBeenCalledWith(mainWorktree.id);
+    expect(mocks.selectionState.selectWorktree).toHaveBeenCalledExactlyOnceWith(mainWorktree.id);
   });
 });

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -9,6 +9,10 @@ const mocks = vi.hoisted(() => ({
   selectionState: {
     activeWorktreeId: null as string | null,
     selectWorktree: vi.fn(),
+    // Only unread today because every active id here is also a live worktree,
+    // which short-circuits the `||`. One absent-worktree fixture away from a
+    // TypeError without it.
+    deletedWorktrees: new Map<string, unknown>(),
   },
   projectState: {
     currentProject: null as { id: string; path: string } | null,
@@ -69,6 +73,7 @@ const cwdOf = () => renderHook(() => useActiveWorktreeSync()).result.current.def
 describe("useActiveWorktreeSync defaultTerminalCwd", () => {
   beforeEach(() => {
     mocks.selectionState.activeWorktreeId = worktree.id;
+    mocks.selectionState.deletedWorktrees = new Map();
     mocks.projectState.currentProject = null;
     mocks.scratchState.currentScratch = null;
     mocks.homeDir.homeDir = "/home/user";

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -605,7 +605,7 @@ describe("terminal.moveToWorktree", () => {
 
     await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-2" });
 
-    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledWith("p1", "wt-2");
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith("p1", "wt-2");
   });
 
   it("falls back to the focused panel when no terminal id is supplied", async () => {
@@ -617,7 +617,7 @@ describe("terminal.moveToWorktree", () => {
 
     await run("terminal.moveToWorktree", { worktreeId: "wt-2" });
 
-    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledWith("p-focused", "wt-2");
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith("p-focused", "wt-2");
   });
 
   it("captures the undo snapshot before moving so the undo restores the origin", async () => {
@@ -626,6 +626,8 @@ describe("terminal.moveToWorktree", () => {
 
     await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-2" });
 
+    expect(pushLayoutSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledTimes(1);
     expect(pushLayoutSnapshotMock.mock.invocationCallOrder[0]).toBeLessThan(
       moveTerminalToWorktreeAndFollowRescueMock.mock.invocationCallOrder[0]!
     );

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -3,9 +3,11 @@ import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../..
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 
 const panelStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const pushLayoutSnapshotMock = vi.hoisted(() => vi.fn());
 const layoutUndoMock = vi.hoisted(() => ({
-  getState: vi.fn(() => ({ pushLayoutSnapshot: vi.fn() })),
+  getState: vi.fn(() => ({ pushLayoutSnapshot: pushLayoutSnapshotMock })),
 }));
+const moveTerminalToWorktreeAndFollowRescueMock = vi.hoisted(() => vi.fn());
 const buildPanelDuplicateOptionsMock = vi.hoisted(() => vi.fn());
 const flushOptimisticClosesMock = vi.hoisted(() => vi.fn());
 const buildResumePanelOptionsMock = vi.hoisted(() => vi.fn());
@@ -18,6 +20,9 @@ vi.mock("@/services/terminal/panelDuplicationService", () => ({
 }));
 vi.mock("@/services/terminal/optimisticPanelClose", () => ({
   flushOptimisticCloses: flushOptimisticClosesMock,
+}));
+vi.mock("@/services/terminal/crossWorktreeMove", () => ({
+  moveTerminalToWorktreeAndFollowRescue: moveTerminalToWorktreeAndFollowRescueMock,
 }));
 vi.mock("@/services/agentResume", () => ({
   buildResumePanelOptions: buildResumePanelOptionsMock,
@@ -590,5 +595,59 @@ describe("terminal.reopenLast journal fallback", () => {
 
     expect(activateTerminal).not.toHaveBeenCalled();
     expect(addPanel).toHaveBeenCalledWith(resumeOptions);
+  });
+});
+
+describe("terminal.moveToWorktree", () => {
+  it("delegates the move to the rescue-aware helper", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    const run = setupActions();
+
+    await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-2" });
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledWith("p1", "wt-2");
+  });
+
+  it("falls back to the focused panel when no terminal id is supplied", async () => {
+    setPanelState({
+      focusedId: "p-focused",
+      panels: [{ id: "p-focused", location: "grid", worktreeId: "wt-1" }],
+    });
+    const run = setupActions();
+
+    await run("terminal.moveToWorktree", { worktreeId: "wt-2" });
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledWith("p-focused", "wt-2");
+  });
+
+  it("captures the undo snapshot before moving so the undo restores the origin", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-1" }] });
+    const run = setupActions();
+
+    await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-2" });
+
+    expect(pushLayoutSnapshotMock.mock.invocationCallOrder[0]).toBeLessThan(
+      moveTerminalToWorktreeAndFollowRescueMock.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("does nothing when the panel is already in the target worktree", async () => {
+    setPanelState({ panels: [{ id: "p1", location: "grid", worktreeId: "wt-2" }] });
+    const run = setupActions();
+
+    await run("terminal.moveToWorktree", { terminalId: "p1", worktreeId: "wt-2" });
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+    expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the panel does not exist", async () => {
+    setPanelState({ panels: [] });
+    const run = setupActions();
+
+    await run("terminal.moveToWorktree", { terminalId: "ghost", worktreeId: "wt-2" });
+
+    expect(moveTerminalToWorktreeAndFollowRescueMock).not.toHaveBeenCalled();
+    expect(pushLayoutSnapshotMock).not.toHaveBeenCalled();
   });
 });

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -617,7 +617,10 @@ describe("terminal.moveToWorktree", () => {
 
     await run("terminal.moveToWorktree", { worktreeId: "wt-2" });
 
-    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith("p-focused", "wt-2");
+    expect(moveTerminalToWorktreeAndFollowRescueMock).toHaveBeenCalledExactlyOnceWith(
+      "p-focused",
+      "wt-2"
+    );
   });
 
   it("captures the undo snapshot before moving so the undo restores the origin", async () => {

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -4,6 +4,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { flushOptimisticCloses } from "@/services/terminal/optimisticPanelClose";
+import { moveTerminalToWorktreeAndFollowRescue } from "@/services/terminal/crossWorktreeMove";
 import { buildResumePanelOptions } from "@/services/agentResume";
 import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
@@ -259,8 +260,7 @@ export function registerTerminalSpawnActions(
         }
 
         useLayoutUndoStore.getState().pushLayoutSnapshot();
-        state.setFocused(null);
-        state.moveTerminalToWorktree(targetId, worktreeId);
+        moveTerminalToWorktreeAndFollowRescue(targetId, worktreeId);
       }
     },
   }));

--- a/src/services/terminal/__tests__/crossWorktreeMove.test.ts
+++ b/src/services/terminal/__tests__/crossWorktreeMove.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { DeletedWorktree } from "@/store/worktreeStore";
+
+vi.mock("@/clients", () => ({
+  terminalClient: { resize: vi.fn() },
+  agentSettingsClient: { get: vi.fn().mockResolvedValue(null) },
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    resize: vi.fn().mockReturnValue(null),
+    wake: vi.fn(),
+    wakeForFocus: vi.fn(),
+    getInstance: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    saveTabGroups: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+const { usePanelStore } = await import("@/store/panelStore");
+const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+const { moveTerminalToWorktreeAndFollowRescue } = await import("../crossWorktreeMove");
+
+function panel(id: string, worktreeId: string, location: "grid" | "dock" = "grid"): PtyPanelData {
+  return {
+    id,
+    title: id,
+    kind: "terminal" as const,
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    worktreeId,
+    location,
+    isVisible: location === "grid",
+  };
+}
+
+function seedPanels(panels: PtyPanelData[]): void {
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  for (const p of panels) {
+    const bucket = panelIdsByWorktreeId[p.worktreeId!];
+    if (bucket) bucket.push(p.id);
+    else panelIdsByWorktreeId[p.worktreeId!] = [p.id];
+  }
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+    panelIds: panels.map((p) => p.id),
+    panelIdsByWorktreeId,
+  });
+}
+
+function deletedRow(id: string): DeletedWorktree {
+  return {
+    id,
+    title: id,
+    path: `/repo/${id}`,
+    deletedAt: 1000,
+    expiresAt: null,
+    holdReason: null,
+    pinnedIndex: 0,
+  };
+}
+
+/**
+ * Mirrors the panel-store subscriber `WorktreeStoreContext` installs in
+ * production — the thing that makes an emptied deleted row prune itself
+ * synchronously during the move. Without it the helper is being tested against
+ * a world where rows never die.
+ */
+function wirePruneSubscriber(liveWorktreeIds: string[]): () => void {
+  return usePanelStore.subscribe((state, prevState) => {
+    if (
+      state.panelIdsByWorktreeId === prevState.panelIdsByWorktreeId &&
+      state.panelsById === prevState.panelsById
+    ) {
+      return;
+    }
+    if (useWorktreeSelectionStore.getState().deletedWorktrees.size === 0) return;
+    useWorktreeSelectionStore.getState().pruneDeletedWorktrees(new Set(liveWorktreeIds));
+  });
+}
+
+let unsubscribe: (() => void) | null = null;
+
+beforeEach(() => {
+  usePanelStore.getState().reset();
+  usePanelStore.setState({
+    panelsById: {},
+    panelIds: [],
+    panelIdsByWorktreeId: {},
+    tabGroups: new Map(),
+    focusedId: null,
+    maximizedId: null,
+    commandQueue: [],
+  });
+  useWorktreeSelectionStore.getState().reset();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  unsubscribe?.();
+  unsubscribe = null;
+});
+
+describe("moveTerminalToWorktreeAndFollowRescue", () => {
+  it("follows the rescued terminal when the drag empties the active deleted row", () => {
+    seedPanels([panel("t1", "wt-dead")]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead" });
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    const selection = useWorktreeSelectionStore.getState();
+    expect(selection.activeWorktreeId).toBe("wt-live");
+    expect(selection.deletedWorktrees.has("wt-dead")).toBe(false);
+    // `source: "user"` is what makes the destination durable — a "focus"
+    // promotion would move the active id but leave the restore target behind.
+    expect(selection.restoreWorktreeId).toBe("wt-live");
+  });
+
+  it("stays put when the emptied row is not the one the user is standing on", () => {
+    seedPanels([panel("t1", "wt-dead"), panel("other", "wt-elsewhere")]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-elsewhere" });
+    unsubscribe = wirePruneSubscriber(["wt-live", "wt-elsewhere"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    const selection = useWorktreeSelectionStore.getState();
+    expect(selection.deletedWorktrees.has("wt-dead")).toBe(false);
+    expect(selection.activeWorktreeId).toBe("wt-elsewhere");
+  });
+
+  it("stays put when the deleted row still holds another terminal", () => {
+    seedPanels([panel("t1", "wt-dead"), panel("t2", "wt-dead")]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead" });
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    const selection = useWorktreeSelectionStore.getState();
+    expect(selection.deletedWorktrees.has("wt-dead")).toBe(true);
+    expect(selection.activeWorktreeId).toBe("wt-dead");
+  });
+
+  it("never changes selection for a move between two live worktrees", () => {
+    seedPanels([panel("t1", "wt-a")]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
+    unsubscribe = wirePruneSubscriber(["wt-a", "wt-b"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-b");
+
+    expect(usePanelStore.getState().panelsById["t1"]?.worktreeId).toBe("wt-b");
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-a");
+  });
+
+  it("follows when a grouped move carries the row's last terminals away", () => {
+    seedPanels([panel("t1", "wt-dead"), panel("t2", "wt-dead")]);
+    usePanelStore.setState({
+      tabGroups: new Map([
+        [
+          "g1",
+          {
+            id: "g1",
+            location: "grid" as const,
+            worktreeId: "wt-dead",
+            activeTabId: "t1",
+            panelIds: ["t1", "t2"],
+          },
+        ],
+      ]),
+    });
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead" });
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+
+    // Moving one grouped panel relocates the whole group, so the row empties in
+    // a single move — the follow decision must come from the row's actual
+    // disappearance, not from counting the panels named in the call.
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    const panels = usePanelStore.getState().panelsById;
+    expect(panels["t1"]?.worktreeId).toBe("wt-live");
+    expect(panels["t2"]?.worktreeId).toBe("wt-live");
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-live");
+  });
+
+  it("hands focus to the destination's last-focused terminal on a rescue", () => {
+    seedPanels([panel("t1", "wt-dead"), panel("resident", "wt-live")]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: "wt-dead",
+      lastFocusedTerminalByWorktree: new Map([["wt-live", "resident"]]),
+    });
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    // The pre-fix path cleared focus and then let the fallback select main,
+    // which restored main's last-focused terminal. Landing on the destination
+    // has to behave the same way — only the worktree changes.
+    expect(usePanelStore.getState().focusedId).toBe("resident");
+  });
+
+  it("clears focus without selecting anything when no rescue is involved", () => {
+    seedPanels([panel("t1", "wt-a")]);
+    usePanelStore.getState().setFocused("t1");
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-b");
+
+    expect(usePanelStore.getState().focusedId).toBeNull();
+  });
+
+  it("leaves focus alone when the panel is already in the target worktree", () => {
+    seedPanels([panel("t1", "wt-a")]);
+    usePanelStore.getState().setFocused("t1");
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-a");
+
+    expect(usePanelStore.getState().focusedId).toBe("t1");
+  });
+
+  it("leaves focus alone when the panel does not exist", () => {
+    seedPanels([panel("t1", "wt-a")]);
+    usePanelStore.getState().setFocused("t1");
+
+    moveTerminalToWorktreeAndFollowRescue("ghost", "wt-b");
+
+    expect(usePanelStore.getState().focusedId).toBe("t1");
+  });
+});

--- a/src/services/terminal/__tests__/crossWorktreeMove.test.ts
+++ b/src/services/terminal/__tests__/crossWorktreeMove.test.ts
@@ -28,6 +28,14 @@ vi.mock("@/store/persistence/panelPersistence", () => ({
   },
 }));
 
+// The helper confirms the destination is live before following. Only that one
+// export is stubbed so the rest of the view-store module keeps its real shape.
+const liveWorktrees = new Map<string, unknown>();
+vi.mock("@/store/createWorktreeStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/createWorktreeStore")>()),
+  getCurrentViewStoreOrNull: () => ({ getState: () => ({ worktrees: liveWorktrees }) }),
+}));
+
 const { usePanelStore } = await import("@/store/panelStore");
 const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
 const { moveTerminalToWorktreeAndFollowRescue } = await import("../crossWorktreeMove");
@@ -78,7 +86,13 @@ function deletedRow(id: string): DeletedWorktree {
  * synchronously during the move. Without it the helper is being tested against
  * a world where rows never die.
  */
+function setLiveWorktrees(ids: string[]): void {
+  liveWorktrees.clear();
+  for (const id of ids) liveWorktrees.set(id, { id });
+}
+
 function wirePruneSubscriber(liveWorktreeIds: string[]): () => void {
+  setLiveWorktrees(liveWorktreeIds);
   return usePanelStore.subscribe((state, prevState) => {
     if (
       state.panelIdsByWorktreeId === prevState.panelIdsByWorktreeId &&
@@ -105,6 +119,7 @@ beforeEach(() => {
     commandQueue: [],
   });
   useWorktreeSelectionStore.getState().reset();
+  setLiveWorktrees([]);
   vi.clearAllMocks();
 });
 
@@ -146,14 +161,85 @@ describe("moveTerminalToWorktreeAndFollowRescue", () => {
   it("stays put when the deleted row still holds another terminal", () => {
     seedPanels([panel("t1", "wt-dead"), panel("t2", "wt-dead")]);
     useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead", restoreWorktreeId: "wt-keep" });
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    const panels = usePanelStore.getState().panelsById;
+    expect(panels["t1"]?.worktreeId).toBe("wt-live");
+    expect(panels["t2"]?.worktreeId).toBe("wt-dead");
+    const selection = useWorktreeSelectionStore.getState();
+    expect(selection.deletedWorktrees.has("wt-dead")).toBe(true);
+    expect(selection.activeWorktreeId).toBe("wt-dead");
+    expect(selection.restoreWorktreeId).toBe("wt-keep");
+  });
+
+  it("follows once the row's only survivors are panels a dismiss would not close", () => {
+    // `getDeletedWorktreeTerminalIds` excludes trash/overlay/dialog, so a row
+    // holding only those is already empty as far as the prune is concerned.
+    seedPanels([
+      panel("t1", "wt-dead"),
+      panel("binned", "wt-dead", "trash"),
+      panel("assistant", "wt-dead", "overlay"),
+    ]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
     useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead" });
     unsubscribe = wirePruneSubscriber(["wt-live"]);
 
     moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
 
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-live");
+  });
+
+  it("keeps the follow alive across a fleet-scope cycle", () => {
+    seedPanels([panel("t1", "wt-dead")]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead" });
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+    const token = useWorktreeSelectionStore.getState().enterFleetScope();
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+    useWorktreeSelectionStore.getState().exitFleetScope(token);
+
+    // Exiting scope restores the parked pre-scope selection verbatim. Without
+    // retargeting it, that would hand the user back the pruned row and the
+    // fallback would strand the rescued session on main all over again.
     const selection = useWorktreeSelectionStore.getState();
-    expect(selection.deletedWorktrees.has("wt-dead")).toBe(true);
+    expect(selection.activeWorktreeId).toBe("wt-live");
+    expect(selection.restoreWorktreeId).toBe("wt-live");
+  });
+
+  it("does not follow to a destination the view store cannot vouch for", () => {
+    seedPanels([panel("t1", "wt-dead")]);
+    useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead" });
+    // The row still empties, but "wt-ghost" is absent from the live map — the
+    // action layer accepts any string, and a bogus id must never become the
+    // durable restore target.
+    unsubscribe = wirePruneSubscriber(["wt-live"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-ghost");
+
+    const selection = useWorktreeSelectionStore.getState();
     expect(selection.activeWorktreeId).toBe("wt-dead");
+    expect(selection.restoreWorktreeId).toBeNull();
+  });
+
+  it("moves a panel with no worktree of its own without touching selection", () => {
+    const orphan = { ...panel("t1", "wt-a"), worktreeId: undefined } as PtyPanelData;
+    usePanelStore.setState({
+      panelsById: { t1: orphan },
+      panelIds: ["t1"],
+      panelIdsByWorktreeId: {},
+    });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
+    unsubscribe = wirePruneSubscriber(["wt-a", "wt-live"]);
+
+    moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
+
+    expect(usePanelStore.getState().panelsById["t1"]?.worktreeId).toBe("wt-live");
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-a");
   });
 
   it("never changes selection for a move between two live worktrees", () => {
@@ -195,7 +281,9 @@ describe("moveTerminalToWorktreeAndFollowRescue", () => {
     const panels = usePanelStore.getState().panelsById;
     expect(panels["t1"]?.worktreeId).toBe("wt-live");
     expect(panels["t2"]?.worktreeId).toBe("wt-live");
-    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-live");
+    const selection = useWorktreeSelectionStore.getState();
+    expect(selection.deletedWorktrees.has("wt-dead")).toBe(false);
+    expect(selection.activeWorktreeId).toBe("wt-live");
   });
 
   it("hands focus to the destination's last-focused terminal on a rescue", () => {
@@ -218,11 +306,15 @@ describe("moveTerminalToWorktreeAndFollowRescue", () => {
   it("clears focus without selecting anything when no rescue is involved", () => {
     seedPanels([panel("t1", "wt-a")]);
     usePanelStore.getState().setFocused("t1");
-    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a", restoreWorktreeId: "wt-a" });
+    setLiveWorktrees(["wt-a", "wt-b"]);
 
     moveTerminalToWorktreeAndFollowRescue("t1", "wt-b");
 
     expect(usePanelStore.getState().focusedId).toBeNull();
+    const selection = useWorktreeSelectionStore.getState();
+    expect(selection.activeWorktreeId).toBe("wt-a");
+    expect(selection.restoreWorktreeId).toBe("wt-a");
   });
 
   it("leaves focus alone when the panel is already in the target worktree", () => {

--- a/src/services/terminal/__tests__/crossWorktreeMove.test.ts
+++ b/src/services/terminal/__tests__/crossWorktreeMove.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import type { PtyPanelData } from "@shared/types/panel";
+import type { PanelLocation, PtyPanelData } from "@shared/types/panel";
 import type { DeletedWorktree } from "@/store/worktreeStore";
 
 vi.mock("@/clients", () => ({
@@ -40,7 +40,7 @@ const { usePanelStore } = await import("@/store/panelStore");
 const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
 const { moveTerminalToWorktreeAndFollowRescue } = await import("../crossWorktreeMove");
 
-function panel(id: string, worktreeId: string, location: "grid" | "dock" = "grid"): PtyPanelData {
+function panel(id: string, worktreeId: string, location: PanelLocation = "grid"): PtyPanelData {
   return {
     id,
     title: id,
@@ -80,17 +80,17 @@ function deletedRow(id: string): DeletedWorktree {
   };
 }
 
+function setLiveWorktrees(ids: string[]): void {
+  liveWorktrees.clear();
+  for (const id of ids) liveWorktrees.set(id, { id });
+}
+
 /**
  * Mirrors the panel-store subscriber `WorktreeStoreContext` installs in
  * production — the thing that makes an emptied deleted row prune itself
  * synchronously during the move. Without it the helper is being tested against
  * a world where rows never die.
  */
-function setLiveWorktrees(ids: string[]): void {
-  liveWorktrees.clear();
-  for (const id of ids) liveWorktrees.set(id, { id });
-}
-
 function wirePruneSubscriber(liveWorktreeIds: string[]): () => void {
   setLiveWorktrees(liveWorktreeIds);
   return usePanelStore.subscribe((state, prevState) => {
@@ -161,7 +161,10 @@ describe("moveTerminalToWorktreeAndFollowRescue", () => {
   it("stays put when the deleted row still holds another terminal", () => {
     seedPanels([panel("t1", "wt-dead"), panel("t2", "wt-dead")]);
     useWorktreeSelectionStore.getState().addDeletedWorktree(deletedRow("wt-dead"));
-    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-dead", restoreWorktreeId: "wt-keep" });
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: "wt-dead",
+      restoreWorktreeId: "wt-keep",
+    });
     unsubscribe = wirePruneSubscriber(["wt-live"]);
 
     moveTerminalToWorktreeAndFollowRescue("t1", "wt-live");
@@ -227,7 +230,7 @@ describe("moveTerminalToWorktreeAndFollowRescue", () => {
   });
 
   it("moves a panel with no worktree of its own without touching selection", () => {
-    const orphan = { ...panel("t1", "wt-a"), worktreeId: undefined } as PtyPanelData;
+    const orphan: PtyPanelData = { ...panel("t1", "wt-a"), worktreeId: undefined };
     usePanelStore.setState({
       panelsById: { t1: orphan },
       panelIds: ["t1"],

--- a/src/services/terminal/crossWorktreeMove.ts
+++ b/src/services/terminal/crossWorktreeMove.ts
@@ -1,0 +1,51 @@
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+
+/**
+ * Cross-worktree move that follows the terminal when the gesture rescues the
+ * last survivor off a deleted-worktree row (#11273).
+ *
+ * A deleted-worktree row is derived state: it lives only while a panel still
+ * points at the dead worktree, and `WorktreeStoreContext`'s panel-store
+ * subscriber prunes it synchronously during the move below. Without a follow,
+ * the row vanishes under the user's own selection and `useActiveWorktreeSync`
+ * snaps to main, stranding the rescued session off-screen.
+ *
+ * The follow decision is a before/after membership diff rather than a
+ * "was this the last terminal" prediction, so it cannot drift from the prune's
+ * own rule and it covers grouped moves (which relocate the whole tab group)
+ * for free. Every other row-death route — closed, trashed, dismissed,
+ * auto-cleanup — never reaches here and keeps falling back to main.
+ */
+export function moveTerminalToWorktreeAndFollowRescue(
+  terminalId: string,
+  targetWorktreeId: string
+): void {
+  const panel = usePanelStore.getState().panelsById[terminalId];
+  if (!panel || panel.worktreeId === targetWorktreeId) return;
+
+  const sourceWorktreeId = panel.worktreeId;
+  const before = useWorktreeSelectionStore.getState();
+  const wasRescuingActiveDeletedRow =
+    sourceWorktreeId != null &&
+    before.activeWorktreeId === sourceWorktreeId &&
+    before.deletedWorktrees.has(sourceWorktreeId);
+
+  usePanelStore.getState().moveTerminalToWorktree(terminalId, targetWorktreeId);
+  usePanelStore.getState().setFocused(null);
+
+  if (!wasRescuingActiveDeletedRow) return;
+
+  // Re-read: the prune replaced the selection state and its `deletedWorktrees`
+  // map, so the pre-move snapshot is stale. The active-id check keeps a nested
+  // selection change (something else already moved the user) from being undone.
+  const after = useWorktreeSelectionStore.getState();
+  if (after.activeWorktreeId !== sourceWorktreeId) return;
+  if (after.deletedWorktrees.has(sourceWorktreeId)) return;
+
+  // `"user"`, not `"focus"`: the rescue is a deliberate gesture, so the
+  // destination should become the durable restore target and land in the MRU
+  // (#9512). This also restores the destination's last-focused terminal, which
+  // is what the fallback-to-main path already did — only the target changes.
+  after.selectWorktree(targetWorktreeId);
+}

--- a/src/services/terminal/crossWorktreeMove.ts
+++ b/src/services/terminal/crossWorktreeMove.ts
@@ -1,5 +1,6 @@
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
 
 /**
  * Cross-worktree move that follows the terminal when the gesture rescues the
@@ -37,15 +38,20 @@ export function moveTerminalToWorktreeAndFollowRescue(
   if (!wasRescuingActiveDeletedRow) return;
 
   // Re-read: the prune replaced the selection state and its `deletedWorktrees`
-  // map, so the pre-move snapshot is stale. The active-id check keeps a nested
-  // selection change (something else already moved the user) from being undone.
+  // map, so the pre-move snapshot is stale.
   const after = useWorktreeSelectionStore.getState();
-  if (after.activeWorktreeId !== sourceWorktreeId) return;
   if (after.deletedWorktrees.has(sourceWorktreeId)) return;
+
+  // The drag paths already reject a dead destination, but `terminal.moveToWorktree`
+  // takes any string from the action layer. Following an unverified id would make
+  // it the durable restore target, so confirm liveness rather than trusting the
+  // caller — and skip the follow entirely if no view store can answer.
+  if (!getCurrentViewStoreOrNull()?.getState().worktrees.has(targetWorktreeId)) return;
 
   // `"user"`, not `"focus"`: the rescue is a deliberate gesture, so the
   // destination should become the durable restore target and land in the MRU
   // (#9512). This also restores the destination's last-focused terminal, which
   // is what the fallback-to-main path already did — only the target changes.
   after.selectWorktree(targetWorktreeId);
+  after.retargetParkedFleetSelection(targetWorktreeId);
 }

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -249,6 +249,7 @@ interface WorktreeSelectionState {
     next: { expiresAt: number | null; holdReason: DeletedWorktreeHoldReason | null }
   ) => void;
   clearRestoreTarget: (worktreeId: string) => void;
+  retargetParkedFleetSelection: (worktreeId: string) => void;
   pruneDeletedWorktrees: (liveWorktreeIds: ReadonlySet<string>) => void;
   toggleDeletedWorktreeGroupExpanded: () => void;
   toggleWorktreeExpanded: (id: string) => void;
@@ -898,6 +899,16 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     if (Object.keys(updates).length === 0) return;
     set(updates);
     persistActiveWorktree(null);
+  },
+
+  // Fleet scope parks the pre-scope selection and restores it verbatim on exit.
+  // A rescue performed while scoped (#11273) retires the parked id — its row is
+  // pruned the moment the last terminal leaves — so exiting would restore a
+  // worktree that no longer exists and hand the user back to main, undoing the
+  // follow. Retarget both slots so the destination survives the scope cycle.
+  retargetParkedFleetSelection: (worktreeId) => {
+    if (!get().isFleetScopeActive) return;
+    set({ _previousActiveWorktreeId: worktreeId, _previousRestoreWorktreeId: worktreeId });
   },
 
   pruneDeletedWorktrees: (liveWorktreeIds) => {


### PR DESCRIPTION
## Summary

- When a user was standing on a deleted worktree's sidebar row (the row that keeps live agent terminals alive after the worktree itself is deleted) and dragged the last surviving terminal out of that row into a live worktree, selection snapped to the main worktree instead of following the terminal. The rescued agent session ended up off-screen and unselected.
- Fix: a new renderer service, `src/services/terminal/crossWorktreeMove.ts`, exporting `moveTerminalToWorktreeAndFollowRescue(terminalId, targetWorktreeId)`. It snapshots the current selection, performs the move, clears focus, and only when the source was a deleted row the user was standing on and that row is now pruned, selects the destination worktree with the default `user` selection source, so it becomes the durable restore target and lands in the MRU list per the provenance contract from #9512.
- All three entry points now route through this service: both cross-worktree drop branches in `DndProvider.tsx`, and the `terminal.moveToWorktree` action.

Resolves #11273

## Changes

- Added `src/services/terminal/crossWorktreeMove.ts` with `moveTerminalToWorktreeAndFollowRescue`.
- Wired both cross-worktree drop branches in `src/components/DragDrop/DndProvider.tsx` and the `terminal.moveToWorktree` action (`terminalSpawnActions.ts`) through the new service.
- Added `retargetParkedFleetSelection` to `src/store/worktreeStore.ts` (see design notes below).
- New/updated tests: `crossWorktreeMove.test.ts`, `terminalSpawnActions.test.ts`, both `useActiveWorktreeSync` suites.

## Design notes

- The follow decision is made by diffing `deletedWorktrees` membership before and after the move, not by predicting whether the moved terminal was the last one. The prune happens synchronously in the same call stack (panel-store mutation, `WorktreeStoreContext`'s subscriber, `pruneDeletedWorktrees`), so the diff can't drift from the prune's own rule, and it covers grouped moves (relocating a whole tab group) for free.
- `useActiveWorktreeSync`'s generic fallback to main is untouched, so every other way a row can die (last terminal closed or trashed, row dismissed, auto-cleanup) still falls back to main as before.
- Review surfaced that exiting fleet scope was restoring the parked pre-scope worktree verbatim, which reintroduced the same bug for a rescue performed while scoped. Added a narrow `retargetParkedFleetSelection` selection-store action so the destination survives the scope cycle.
- The follow is gated on the destination being a verified live worktree. `terminal.moveToWorktree` accepts any string ID from the action and MCP layer, and following an unverified ID would have made it the durable restore target.
- Verified by tests: moves between two live worktrees never change selection, a move while standing on a different worktree changes nothing, and a move that leaves the row occupied changes nothing.

## Not covered

- Undoing a last-survivor rescue restores the panel to the dead worktree ID without recreating its ghost row. This is pre-existing (`LayoutSnapshot` never carried deleted-row metadata) and orthogonal to this change.
- If the destination worktree has a parked maximize, the rescued terminal stays behind it. Consistent with every other worktree selection; a separate product decision.

## Testing

243 tests passing across 11 suites: `crossWorktreeMove`, `terminalSpawnActions`, both `useActiveWorktreeSync` suites, `moveTerminalToWorktree`, `worktreeStore` + `deletedWorktrees` + `circularInit`, `WorktreeStoreContext.deletedWorktree`, both `deletedWorktreeCleanup` suites. Full composite `npm run typecheck` is clean. ESLint is clean on all changed files. Prettier is clean.

New test coverage: the rescue follow itself, the grouped-move rescue, focus landing on the destination's last-focused terminal, a row whose only survivors are trash or overlay panels, a full fleet-scope enter/rescue/exit cycle, an unverified destination, a panel with no worktree, plus regression guards for the three must-not-change cases and the generic fallback.
