### PR TITLE
feat(file-viewer): add a diff option for files with local changes

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -600,17 +600,27 @@ export interface ReviewPanelData extends BasePanelData {
 }
 
 /**
- * View mode shared by the file viewer surfaces (panel + dialog). "rendered"
- * only applies to markdown files; every other file renders as source.
+ * The two modes that render the file's own bytes. Separate from `FileViewMode`
+ * so document viewers can't be handed "diff", which they'd silently treat as
+ * "rendered" (every non-"source" value takes their rendered branch).
  */
-export type FileViewMode = "rendered" | "source";
+export type FileRenderMode = "rendered" | "source";
 
 /**
- * File panel — read-only viewer for a repo file in a grid cell. Markdown
- * files additionally get a rendered-document mode. `filePath` is absolute;
- * the effective read root is resolved at render time (the panel's worktree
- * when the file is inside one, else the file's parent directory) so worktree
- * renames don't strand the panel.
+ * View mode shared by the file viewer surfaces (panel + dialog). "rendered"
+ * only applies to markdown and HTML files; "diff" only to files with local
+ * worktree changes. Every other file is source-only. Availability is derived
+ * per file at render time, so a persisted mode whose capability is gone falls
+ * back to "source" rather than being rewritten.
+ */
+export type FileViewMode = FileRenderMode | "diff";
+
+/**
+ * File panel — read-only viewer for a repo file in a grid cell. Markdown and
+ * HTML files additionally get a rendered-document mode, and locally changed
+ * files get a diff mode. `filePath` is absolute; the effective read root is
+ * resolved at render time (the panel's worktree when the file is inside one,
+ * else the file's parent directory) so worktree renames don't strand the panel.
  */
 export interface FilePanelData extends BasePanelData {
   kind: "file";

--- a/shared/utils/__tests__/path.test.ts
+++ b/shared/utils/__tests__/path.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { isAbsolute, isPathInside, normalize, basename, dirname, resolve, join } from "../path.js";
+import {
+  isAbsolute,
+  isPathInside,
+  normalize,
+  basename,
+  dirname,
+  resolve,
+  join,
+  toWorktreeRelative,
+} from "../path.js";
 
 describe("isAbsolute", () => {
   it("recognizes POSIX absolute paths", () => {
@@ -256,5 +265,47 @@ describe("isPathInside", () => {
   it("rejects relative '.' inputs outright", () => {
     expect(isPathInside(".", "/repo")).toBe(false);
     expect(isPathInside("/repo/file.md", ".")).toBe(false);
+  });
+});
+
+describe("toWorktreeRelative", () => {
+  it("strips the worktree root off a contained POSIX path", () => {
+    expect(toWorktreeRelative("/repo/src/index.ts", "/repo")).toBe("src/index.ts");
+  });
+
+  it("tolerates a trailing separator on the root", () => {
+    expect(toWorktreeRelative("/repo/src/index.ts", "/repo/")).toBe("src/index.ts");
+  });
+
+  it("normalizes Windows separators on both sides", () => {
+    expect(toWorktreeRelative("C:\\repo\\src\\index.ts", "C:\\repo")).toBe("src/index.ts");
+  });
+
+  it("collapses redundant segments before stripping", () => {
+    expect(toWorktreeRelative("/repo/./src/../src/index.ts", "/repo")).toBe("src/index.ts");
+  });
+
+  // The whole reason this uses isPathInside: a raw startsWith would turn
+  // "/repo-other/x.ts" into "-other/x.ts" and hand git a nonsense path.
+  it("passes a sibling root that merely extends the worktree name through untouched", () => {
+    expect(toWorktreeRelative("/repo-other/x.ts", "/repo")).toBe("/repo-other/x.ts");
+  });
+
+  it("passes a path outside the worktree through untouched", () => {
+    expect(toWorktreeRelative("/elsewhere/x.ts", "/repo")).toBe("/elsewhere/x.ts");
+  });
+
+  it("passes through when no root is supplied", () => {
+    expect(toWorktreeRelative("/repo/src/index.ts", undefined)).toBe("/repo/src/index.ts");
+  });
+
+  it("passes the root itself through rather than yielding an empty path", () => {
+    expect(toWorktreeRelative("/repo", "/repo")).toBe("/repo");
+  });
+
+  // Containment is deliberately case-sensitive; a future "fix" that lowercases
+  // would silently change behavior for every other consumer of isPathInside.
+  it("treats a differently-cased root as outside", () => {
+    expect(toWorktreeRelative("/Repo/src/index.ts", "/repo")).toBe("/Repo/src/index.ts");
   });
 });

--- a/shared/utils/path.ts
+++ b/shared/utils/path.ts
@@ -99,6 +99,23 @@ export function isPathInside(child: string, parent: string): boolean {
   return normalizedChild.startsWith(parentWithSlash);
 }
 
+/**
+ * Strip the worktree root off an absolute path. `isPathInside` is what makes
+ * this safe: a raw `startsWith` accepts a sibling whose name merely extends the
+ * root (`/repo-other/x.ts` under `/repo`, which then mangles into `-other/x.ts`)
+ * and ignores separator normalization. A path outside the worktree passes
+ * through untouched — callers reject it downstream with a real error, which
+ * beats inventing a second failure mode here.
+ */
+export function toWorktreeRelative(path: string, worktreeRoot: string | undefined): string {
+  if (!worktreeRoot || !isPathInside(path, worktreeRoot)) return path;
+  const normalizedPath = normalize(path);
+  const normalizedRoot = normalize(worktreeRoot);
+  if (normalizedPath === normalizedRoot) return path;
+  const boundary = normalizedRoot.endsWith("/") ? normalizedRoot : `${normalizedRoot}/`;
+  return normalizedPath.slice(boundary.length);
+}
+
 export function basename(input: string): string {
   const normalized = normalize(input);
   if (

--- a/src/components/Markdown/MarkdownViewer.tsx
+++ b/src/components/Markdown/MarkdownViewer.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, lazy, Suspense, useImperativeHandle, useRef } from "react";
-import type { FileViewMode } from "@shared/types/panel";
+import type { FileRenderMode } from "@shared/types/panel";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
 import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
@@ -21,7 +21,7 @@ export interface MarkdownViewerProps {
   filePath: string;
   /** Containment root for image loads and relative links */
   rootPath: string;
-  viewMode: FileViewMode;
+  viewMode: FileRenderMode;
   /** Source-mode only: line to scroll to and highlight */
   initialLine?: number;
   /** Source-mode only: soft-wrap long lines */

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -15,7 +15,7 @@ function sanitizeViewportPreset(value: string | undefined): ViewportPresetId | u
 
 /** Coerce a persisted file view mode, dropping unknown on-disk values. */
 function sanitizeFileViewMode(value: string | undefined): FileViewMode | undefined {
-  return value === "rendered" || value === "source" ? value : undefined;
+  return value === "rendered" || value === "source" || value === "diff" ? value : undefined;
 }
 
 const GIT_STATUSES: readonly string[] = [

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -604,6 +604,19 @@ describe("panel deserializer field coverage", () => {
     expect(output.filePath).toBe("/home/project/docs/spec.md");
   });
 
+  // #11274: the sanitizer redeclares the mode union at runtime, so widening the
+  // type alone would silently drop a restored diff selection.
+  it("file deserializer restores a persisted diff view mode", () => {
+    const deserializer = getDeserializer("file")!;
+    const output = deserializer({
+      id: "panel-file",
+      kind: "file",
+      filePath: "/home/project/src/index.ts",
+      fileViewMode: "diff",
+    });
+    expect(output.fileViewMode).toBe("diff");
+  });
+
   it("file deserializer reads legacy markdown panel fields", () => {
     const deserializer = getDeserializer("file")!;
     const output = deserializer({

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1,7 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ExternalLink, FileText, Globe, RefreshCw, Search, WrapText, XCircle } from "lucide-react";
-import type { FileViewMode } from "@shared/types/panel";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ExternalLink,
+  FileDiff as FileDiffIcon,
+  FileText,
+  Globe,
+  RefreshCw,
+  Search,
+  WrapText,
+  XCircle,
+} from "lucide-react";
+import type { FileRenderMode, FileViewMode } from "@shared/types/panel";
 import { isFilePanel } from "@shared/types/panel";
+import type { GitStatus } from "@shared/types/git";
+import { isPathInside, normalize, toWorktreeRelative } from "@shared/utils/path";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
@@ -17,6 +28,8 @@ import { isImageFilePath, isSvgFilePath } from "@/components/FileViewer/filePrev
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 import { formatBytes } from "@/lib/formatBytes";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
+import { useDiffContent } from "@/panels/diff/useDiffContent";
+import type { DiffSubject } from "@/panels/diff/diffContentCache";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
@@ -41,6 +54,32 @@ export interface FilePaneProps extends BasePanelProps {
   onTabClose?: (tabId: string) => void;
   onTabRename?: (tabId: string, newTitle: string) => void;
   onAddTab?: () => void;
+}
+
+// Kept out of the file panel's chunk: it pulls react-diff-view, the tokenizer
+// and the diff stylesheet, none of which a plain file view needs. Mirrors how
+// the panel registry splits the panes themselves.
+const LazyDiffViewer = lazy(() =>
+  import("@/components/Worktree/DiffViewer").then((m) => ({ default: m.DiffViewer }))
+);
+
+const MODE_LABELS: Record<FileViewMode, string> = {
+  source: "Source",
+  rendered: "Rendered",
+  diff: "Diff",
+};
+
+// Shared by the fetch wait and the lazy-chunk wait so the two are
+// indistinguishable on screen. `Skeleton` carries the 400ms anti-flicker gate.
+function DiffLoadingSkeleton() {
+  return (
+    <div className="p-4 space-y-3">
+      <Skeleton label="Loading diff">
+        <SkeletonBone className="h-7 w-3/4" />
+        <SkeletonText lines={8} />
+      </Skeleton>
+    </div>
+  );
 }
 
 const toForwardSlashes = (p: string) => p.replace(/\\/g, "/");
@@ -142,15 +181,77 @@ export function FilePane({
   const setFilePanelPath = usePanelStore((state) => state.setFilePanelPath);
   const markdownWrapLines = usePreferencesStore((state) => state.markdownWrapLines);
   const setMarkdownWrapLines = usePreferencesStore((state) => state.setMarkdownWrapLines);
+  // Shared with the diff panel so a user's split/unified and wrap choices carry
+  // across every surface that shows a diff.
+  const diffViewType = usePreferencesStore((state) => state.diffViewType);
+  const diffWrapLines = usePreferencesStore((state) => state.diffWrapLines);
 
   const heightHold = useHeightHold();
 
   const filePath = panel?.filePath;
   const isMarkdown = filePath !== undefined && isMarkdownFilePath(filePath);
   const isHtml = filePath !== undefined && isHtmlFilePath(filePath);
-  // Markdown and HTML get a Source/Rendered toggle; every other file is source-only.
+  // Markdown and HTML get a Rendered mode; every other file is source-only.
   const isRenderable = isMarkdown || isHtml;
-  const viewMode: FileViewMode = isRenderable ? (panel?.fileViewMode ?? "source") : "source";
+
+  const worktreeId = panel?.worktreeId;
+  const worktreePath = useWorktreeStore(
+    useCallback(
+      (state) => (worktreeId ? (state.worktrees.get(worktreeId)?.path ?? "") : ""),
+      [worktreeId]
+    )
+  );
+
+  // Worktree-relative path the diff machinery expects, or "" when the file
+  // isn't inside the panel's worktree — no worktree resolved (worktreeId is
+  // genuinely optional) or a file opened from elsewhere on disk. Both mean
+  // there's no working tree to diff it against.
+  const relativeFilePath = useMemo(
+    () =>
+      filePath && worktreePath && isPathInside(filePath, worktreePath)
+        ? toWorktreeRelative(filePath, worktreePath)
+        : "",
+    [filePath, worktreePath]
+  );
+
+  // Scalar status, never the change entry: `changes` is rebuilt wholesale every
+  // poll tick, so returning the object would re-render the pane on each tick —
+  // the same Object.is bail-out `selectDiffFreshnessKey` relies on (#8635).
+  const localChangeStatus = useWorktreeStore(
+    useCallback(
+      (state): GitStatus | undefined => {
+        if (!worktreeId || !relativeFilePath) return undefined;
+        const worktree = state.worktrees.get(worktreeId);
+        if (!worktree) return undefined;
+        // Stored change paths are absolute today (electron/utils/git.ts keys
+        // changesMap by absolutePath) though the type says relative — fold both
+        // shapes to the same relative form before comparing.
+        return worktree.worktreeChanges?.changes?.find(
+          (change) => normalize(toWorktreeRelative(change.path, worktree.path)) === relativeFilePath
+        )?.status;
+      },
+      [worktreeId, relativeFilePath]
+    )
+  );
+
+  // Rendered and Diff are independent capabilities. One derived list drives
+  // both the toggle and the clamp, so a persisted mode whose capability is gone
+  // falls back to Source — never written back, since a poll that transiently
+  // drops the change must not erase what the user picked.
+  const availableModes = useMemo<FileViewMode[]>(
+    () => [
+      "source",
+      ...(isRenderable ? (["rendered"] as const) : []),
+      ...(localChangeStatus !== undefined ? (["diff"] as const) : []),
+    ],
+    [isRenderable, localChangeStatus]
+  );
+  const requestedMode = panel?.fileViewMode ?? "source";
+  const viewMode: FileViewMode = availableModes.includes(requestedMode) ? requestedMode : "source";
+  const toggleOptions = useMemo(
+    () => availableModes.map((mode) => ({ value: mode, label: MODE_LABELS[mode] })),
+    [availableModes]
+  );
 
   // A dialog host sizes to its content every frame, so swapping markdown source
   // for the rendered chunk's skeleton collapses the dialog and expands it again
@@ -178,13 +279,23 @@ export function FilePane({
     heightHold.cancel();
   }, [filePath, location, heightHold]);
 
-  const worktreeId = panel?.worktreeId;
-  const worktreePath = useWorktreeStore(
-    useCallback(
-      (state) => (worktreeId ? (state.worktrees.get(worktreeId)?.path ?? "") : ""),
-      [worktreeId]
-    )
+  // Only fetch while Diff is the live mode; a null subject also invalidates any
+  // response still in flight from a mode the user has since left.
+  const diffSubject = useMemo<DiffSubject | null>(
+    () =>
+      viewMode === "diff" && worktreePath && relativeFilePath && localChangeStatus !== undefined
+        ? {
+            source: "working-tree",
+            worktreePath,
+            filePath: relativeFilePath,
+            status: localChangeStatus,
+          }
+        : null,
+    [viewMode, worktreePath, relativeFilePath, localChangeStatus]
   );
+  // No `nextSubject`: there's no file to step to from a single-file viewer.
+  const { content: diffContent, stale: diffStale, retry: retryDiff } = useDiffContent(diffSubject);
+
   const projectPath = useProjectStore((state) => state.currentProject?.path ?? "");
 
   // Containment root for files.read / daintree-file://: the worktree or
@@ -435,12 +546,9 @@ export function FilePane({
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
-        {isRenderable && (
+        {availableModes.length > 1 && (
           <SegmentedToggle<FileViewMode>
-            options={[
-              { value: "source", label: "Source" },
-              { value: "rendered", label: "Rendered" },
-            ]}
+            options={toggleOptions}
             value={viewMode}
             onChange={handleViewModeChange}
           />
@@ -456,7 +564,12 @@ export function FilePane({
               <WrapText className="w-4 h-4" />
             </FileViewerToolbar.IconButton>
           )}
-          <FileViewerToolbar.IconButton label="Refresh" onClick={() => loadFile(false)}>
+          {/* Refresh follows what's on screen — re-reading the file wouldn't
+              refetch a diff, and vice versa. */}
+          <FileViewerToolbar.IconButton
+            label="Refresh"
+            onClick={() => (viewMode === "diff" ? retryDiff() : loadFile(false))}
+          >
             <RefreshCw className="w-4 h-4" />
           </FileViewerToolbar.IconButton>
           <FileViewerToolbar.IconButton
@@ -471,6 +584,16 @@ export function FilePane({
           </FileViewerToolbar.IconButton>
         </FileViewerToolbar.Actions>
       </FileViewerToolbar.Root>
+      {viewMode === "diff" && diffStale && diffContent !== undefined && (
+        <InlineStatusBanner
+          severity="info"
+          icon={FileDiffIcon}
+          title="File changed since this diff loaded"
+          role="status"
+          ariaLive="polite"
+          action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: retryDiff }}
+        />
+      )}
       {openError && (
         <InlineStatusBanner
           icon={XCircle}
@@ -525,9 +648,30 @@ export function FilePane({
     >
       <div
         ref={heightHold.bodyRef}
-        className="flex-1 min-h-0 overflow-auto bg-daintree-bg"
+        className={`flex-1 min-h-0 overflow-auto bg-daintree-bg${
+          viewMode === "diff" ? " diff-scroll-root" : ""
+        }`}
         data-testid="file-pane-body"
       >
+        {/* Ahead of every load-state branch on purpose: a deleted file fails
+            files.read, and images/binaries never load as text, yet their diff is
+            exactly what the user asked to see. */}
+        {filePath && viewMode === "diff" && (
+          <Suspense fallback={<DiffLoadingSkeleton />}>
+            {diffContent === undefined ? (
+              <DiffLoadingSkeleton />
+            ) : (
+              <LazyDiffViewer
+                diff={diffContent}
+                viewType={diffViewType}
+                rootPath={worktreePath}
+                wrapLines={diffWrapLines}
+                onRetry={retryDiff}
+              />
+            )}
+          </Suspense>
+        )}
+
         {!filePath && (
           <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-6">
             <EmptyState
@@ -574,7 +718,7 @@ export function FilePane({
           </div>
         )}
 
-        {filePath && loadState === "loading" && (
+        {filePath && viewMode !== "diff" && loadState === "loading" && (
           <div className="p-4 space-y-3">
             <Skeleton label="Loading file">
               <SkeletonBone className="h-5 w-1/3" />
@@ -583,7 +727,7 @@ export function FilePane({
           </div>
         )}
 
-        {filePath && loadState === "error" && errorCode && (
+        {filePath && viewMode !== "diff" && loadState === "error" && errorCode && (
           <div className="flex h-full flex-col items-center justify-center gap-3 p-6">
             <p className="text-sm text-muted-foreground">
               {errorMessage ?? FILE_READ_ERROR_MESSAGES[errorCode]}
@@ -599,7 +743,7 @@ export function FilePane({
           </div>
         )}
 
-        {filePath && (loadState === "image" || loadState === "svg") && (
+        {filePath && viewMode !== "diff" && (loadState === "image" || loadState === "svg") && (
           <FileImagePreview
             filePath={filePath}
             rootPath={effectiveRootPath}
@@ -614,6 +758,7 @@ export function FilePane({
         )}
 
         {filePath &&
+          viewMode !== "diff" &&
           loadState === "loaded" &&
           content !== null &&
           (viewMode === "rendered" && isMarkdown ? (

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -9,7 +9,7 @@ import {
   WrapText,
   XCircle,
 } from "lucide-react";
-import type { FileRenderMode, FileViewMode } from "@shared/types/panel";
+import type { FileViewMode } from "@shared/types/panel";
 import { isFilePanel } from "@shared/types/panel";
 import type { GitStatus } from "@shared/types/git";
 import { isPathInside, normalize, toWorktreeRelative } from "@shared/utils/path";
@@ -31,7 +31,7 @@ import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { useDiffContent } from "@/panels/diff/useDiffContent";
 import type { DiffSubject } from "@/panels/diff/diffContentCache";
 import { EmptyState } from "@/components/ui/EmptyState";
-import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
+import { Skeleton, SkeletonBone, SkeletonHint, SkeletonText } from "@/components/ui/Skeleton";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import {
   FILE_READ_ERROR_MESSAGES,
@@ -78,6 +78,9 @@ function DiffLoadingSkeleton() {
         <SkeletonBone className="h-7 w-3/4" />
         <SkeletonText lines={8} />
       </Skeleton>
+      {/* Sibling, never nested: the wrapper's aria-busy silences mutations
+          inside its own subtree. */}
+      <SkeletonHint />
     </div>
   );
 }
@@ -202,16 +205,34 @@ export function FilePane({
     )
   );
 
-  // Worktree-relative path the diff machinery expects, or "" when the file
-  // isn't inside the panel's worktree — no worktree resolved (worktreeId is
-  // genuinely optional) or a file opened from elsewhere on disk. Both mean
-  // there's no working tree to diff it against.
+  // Whether a file has local changes is a git fact about where it physically
+  // lives, not about the panel's binding: `file.openPanel` resolves an explicit
+  // rootPath but still stamps the *active* worktree id, so `panel.worktreeId`
+  // can name a worktree the file isn't in. Resolve by containment instead, with
+  // the deepest root winning so a nested worktree beats its parent. "" = the
+  // file is in no known worktree, so there's nothing to diff it against.
+  const diffWorktreePath = useWorktreeStore(
+    useCallback(
+      (state): string => {
+        if (!filePath) return "";
+        let best = "";
+        let bestLength = -1;
+        for (const worktree of state.worktrees.values()) {
+          if (!isPathInside(filePath, worktree.path)) continue;
+          const length = normalize(worktree.path).length;
+          if (length <= bestLength) continue;
+          best = worktree.path;
+          bestLength = length;
+        }
+        return best;
+      },
+      [filePath]
+    )
+  );
+
   const relativeFilePath = useMemo(
-    () =>
-      filePath && worktreePath && isPathInside(filePath, worktreePath)
-        ? toWorktreeRelative(filePath, worktreePath)
-        : "",
-    [filePath, worktreePath]
+    () => (filePath && diffWorktreePath ? toWorktreeRelative(filePath, diffWorktreePath) : ""),
+    [filePath, diffWorktreePath]
   );
 
   // Scalar status, never the change entry: `changes` is rebuilt wholesale every
@@ -220,17 +241,20 @@ export function FilePane({
   const localChangeStatus = useWorktreeStore(
     useCallback(
       (state): GitStatus | undefined => {
-        if (!worktreeId || !relativeFilePath) return undefined;
-        const worktree = state.worktrees.get(worktreeId);
-        if (!worktree) return undefined;
-        // Stored change paths are absolute today (electron/utils/git.ts keys
-        // changesMap by absolutePath) though the type says relative — fold both
-        // shapes to the same relative form before comparing.
-        return worktree.worktreeChanges?.changes?.find(
-          (change) => normalize(toWorktreeRelative(change.path, worktree.path)) === relativeFilePath
-        )?.status;
+        if (!diffWorktreePath || !relativeFilePath) return undefined;
+        for (const worktree of state.worktrees.values()) {
+          if (normalize(worktree.path) !== normalize(diffWorktreePath)) continue;
+          // Stored change paths are absolute today (electron/utils/git.ts keys
+          // changesMap by absolutePath) though the type says relative — fold
+          // both shapes to the same relative form before comparing.
+          return worktree.worktreeChanges?.changes?.find(
+            (change) =>
+              normalize(toWorktreeRelative(change.path, worktree.path)) === relativeFilePath
+          )?.status;
+        }
+        return undefined;
       },
-      [worktreeId, relativeFilePath]
+      [diffWorktreePath, relativeFilePath]
     )
   );
 
@@ -262,7 +286,11 @@ export function FilePane({
   // immediately, so the reverse just drops any stale pin.
   const handleViewModeChange = useCallback(
     (mode: FileViewMode) => {
-      if (location === "dialog" && isMarkdown && viewMode === "source" && mode === "rendered") {
+      // Diff collapses the same way: it swaps the document for an async
+      // skeleton. Its first content commit is the release signal, in place of
+      // the rendered document's onRendered.
+      const collapsesOnEntry = mode === "diff" || (mode === "rendered" && isMarkdown);
+      if (location === "dialog" && viewMode === "source" && collapsesOnEntry) {
         heightHold.hold();
       } else {
         heightHold.cancel();
@@ -283,18 +311,24 @@ export function FilePane({
   // response still in flight from a mode the user has since left.
   const diffSubject = useMemo<DiffSubject | null>(
     () =>
-      viewMode === "diff" && worktreePath && relativeFilePath && localChangeStatus !== undefined
+      viewMode === "diff" && diffWorktreePath && relativeFilePath && localChangeStatus !== undefined
         ? {
             source: "working-tree",
-            worktreePath,
+            worktreePath: diffWorktreePath,
             filePath: relativeFilePath,
             status: localChangeStatus,
           }
         : null,
-    [viewMode, worktreePath, relativeFilePath, localChangeStatus]
+    [viewMode, diffWorktreePath, relativeFilePath, localChangeStatus]
   );
   // No `nextSubject`: there's no file to step to from a single-file viewer.
   const { content: diffContent, stale: diffStale, retry: retryDiff } = useDiffContent(diffSubject);
+
+  // The diff has no onRendered of its own; its first content commit (including
+  // the ERROR sentinel) is the equivalent signal for releasing a dialog pin.
+  useEffect(() => {
+    if (viewMode === "diff" && diffContent !== undefined) heightHold.handleRendered();
+  }, [viewMode, diffContent, heightHold]);
 
   const projectPath = useProjectStore((state) => state.currentProject?.path ?? "");
 
@@ -429,6 +463,15 @@ export function FilePane({
   useEffect(() => {
     loadFile(false);
   }, [loadFile]);
+
+  // Leaving Diff — by choice or because the change vanished — lands on source
+  // cached before the edit that prompted the diff in the first place. Re-read it
+  // silently, so a file deleted mid-view can't keep reading as present.
+  const wasDiffModeRef = useRef(viewMode === "diff");
+  useEffect(() => {
+    if (wasDiffModeRef.current && viewMode !== "diff") loadFile(true);
+    wasDiffModeRef.current = viewMode === "diff";
+  }, [viewMode, loadFile]);
 
   // Agents rewrite files while the user reads them: silently re-read when the
   // pane regains focus or the app window returns to the foreground.

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -707,7 +707,11 @@ export function FilePane({
               <LazyDiffViewer
                 diff={diffContent}
                 viewType={diffViewType}
-                rootPath={worktreePath}
+                // The diff's paths are relative to the worktree the file
+                // physically lives in, not the one the panel is stamped with,
+                // so open-in-editor has to join against the same root the
+                // relative paths were derived from.
+                rootPath={diffWorktreePath}
                 wrapLines={diffWrapLines}
                 onRetry={retryDiff}
               />

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -50,10 +50,23 @@ vi.mock("@/store/projectStore", () => ({
 }));
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (state: unknown) => unknown) =>
-    selector({ markdownWrapLines: false, setMarkdownWrapLines: vi.fn() }),
+    selector({
+      markdownWrapLines: false,
+      setMarkdownWrapLines: vi.fn(),
+      diffViewType: "unified",
+      diffWrapLines: false,
+      diffIgnoreWhitespace: false,
+    }),
 }));
+// Mutable so a test can seed a worktree whose change list makes the file
+// locally changed — the Diff option's only trigger (#11274).
+interface WorktreeLike {
+  path: string;
+  worktreeChanges?: { changes: Array<{ path: string; status: string }> } | null;
+}
+const worktreeState = vi.hoisted(() => ({ worktrees: new Map<string, unknown>() }));
 vi.mock("@/hooks/useWorktreeStore", () => ({
-  useWorktreeStore: (selector: (state: unknown) => unknown) => selector({ worktrees: new Map() }),
+  useWorktreeStore: (selector: (state: unknown) => unknown) => selector(worktreeState),
 }));
 vi.mock("@/store/accessibilityAnnouncerStore", () => ({
   useAnnouncerStore: { getState: () => ({ announce: vi.fn() }) },
@@ -90,6 +103,29 @@ vi.mock("@/components/Markdown/MarkdownViewer", () => ({
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
   CodeViewer: () => <div data-testid="code-viewer-mock" />,
 }));
+// Typed rather than bare vi.fn() so reading .mock.calls needs no `as` cast
+// (which would regress the no-unsafe-type-assertion ratchet).
+interface DiffSubjectLike {
+  source: string;
+  worktreePath: string;
+  filePath: string;
+  status: string;
+}
+const { useDiffContentMock } = vi.hoisted(() => ({
+  useDiffContentMock:
+    vi.fn<
+      (
+        subject: DiffSubjectLike | null
+      ) => { content: string | undefined; stale: boolean; retry: () => void }
+    >(),
+}));
+vi.mock("@/panels/diff/useDiffContent", () => ({ useDiffContent: useDiffContentMock }));
+// FilePane lazy-loads the viewer, so assertions on it must await the chunk.
+vi.mock("@/components/Worktree/DiffViewer", () => ({
+  DiffViewer: (props: { diff: string; rootPath?: string }) => (
+    <div data-testid="diff-viewer-mock" data-diff={props.diff} data-root={props.rootPath ?? ""} />
+  ),
+}));
 vi.mock("@/components/Html/HtmlViewer", () => ({
   HtmlViewer: (props: { previewUrl: string | null; reloadNonce: number }) => (
     <div
@@ -112,6 +148,9 @@ function lastContentPanelProps(): Record<string, unknown> {
 beforeEach(() => {
   dispatchMock.mockReset();
   dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+  useDiffContentMock.mockReset();
+  useDiffContentMock.mockReturnValue({ content: undefined, stale: false, retry: vi.fn() });
+  worktreeState.worktrees.clear();
   // Reset per test so a prior test's read call can't satisfy a later
   // toHaveBeenCalledWith assertion (cross-test contamination).
   readMock.mockReset();
@@ -621,5 +660,278 @@ describe("FilePane rendered-swap height hold (#11255)", () => {
 
     expect(setFileViewModeMock).toHaveBeenLastCalledWith("file-1", "rendered");
     expect(body.style.minHeight).toBe("");
+  });
+});
+
+// #11274: a file with local worktree changes gets a third "Diff" option, so the
+// user can see what changed without leaving the viewer. Availability is derived
+// per file — Rendered and Diff are independent capabilities.
+describe("FilePane diff mode (#11274)", () => {
+  const WORKTREE_ID = "wt-1";
+  const WORKTREE_PATH = "/repo";
+
+  function seedWorktree(changes: Array<{ path: string; status: string }> | null) {
+    const worktree: WorktreeLike = {
+      path: WORKTREE_PATH,
+      worktreeChanges: changes === null ? null : { changes },
+    };
+    worktreeState.worktrees.set(WORKTREE_ID, worktree);
+  }
+
+  function paneElement() {
+    return (
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="index.ts"
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  async function renderPane(options: {
+    filePath?: string;
+    worktreeId?: string | undefined;
+    fileViewMode?: string;
+  }) {
+    const filePath = options.filePath ?? "/repo/src/index.ts";
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath,
+      worktreeId: "worktreeId" in options ? options.worktreeId : WORKTREE_ID,
+      fileViewMode: options.fileViewMode,
+    };
+    const view = render(paneElement());
+    // Flush the file read and the lazy diff chunk so no state update lands
+    // outside act(). Can't wait on readMock — an image short-circuits before it.
+    await act(async () => {});
+    return view;
+  }
+
+  function toggleLabels(): string[] {
+    return screen
+      .getAllByRole("button")
+      .map((b) => b.textContent ?? "")
+      .filter((label) => label === "Source" || label === "Rendered" || label === "Diff");
+  }
+
+  function lastSubject(): DiffSubjectLike | null {
+    const call = useDiffContentMock.mock.calls.at(-1);
+    if (!call) throw new Error("useDiffContent was never called");
+    return call[0];
+  }
+
+  describe("capability matrix", () => {
+    it("offers no toggle for a plain unchanged file", async () => {
+      await renderPane({ filePath: "/repo/src/index.ts" });
+      expect(toggleLabels()).toEqual([]);
+    });
+
+    it("offers Source and Diff for a changed non-renderable file", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts" });
+      expect(toggleLabels()).toEqual(["Source", "Diff"]);
+    });
+
+    it("offers Source and Rendered for an unchanged markdown file", async () => {
+      await renderPane({ filePath: "/repo/docs/spec.md" });
+      expect(toggleLabels()).toEqual(["Source", "Rendered"]);
+    });
+
+    it("offers all three, Diff last, for a changed markdown file", async () => {
+      seedWorktree([{ path: "/repo/docs/spec.md", status: "modified" }]);
+      await renderPane({ filePath: "/repo/docs/spec.md" });
+      expect(toggleLabels()).toEqual(["Source", "Rendered", "Diff"]);
+    });
+  });
+
+  describe("change lookup", () => {
+    it("matches a change stored as an absolute path", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts" });
+      expect(toggleLabels()).toContain("Diff");
+    });
+
+    // The type says worktree-relative; the producer emits absolute today.
+    // Both shapes must resolve to the same file.
+    it("matches the same change stored as a worktree-relative path", async () => {
+      seedWorktree([{ path: "src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts" });
+      expect(toggleLabels()).toContain("Diff");
+    });
+
+    it("does not match a different file in the same worktree", async () => {
+      seedWorktree([{ path: "/repo/src/other.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts" });
+      expect(toggleLabels()).toEqual([]);
+    });
+
+    it("offers no Diff when the panel carries no worktree id", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts", worktreeId: undefined });
+      expect(toggleLabels()).toEqual([]);
+    });
+
+    it("offers no Diff when the worktree id resolves to nothing", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts", worktreeId: "wt-gone" });
+      expect(toggleLabels()).toEqual([]);
+    });
+
+    // A sibling root that merely extends the worktree name must not read as
+    // "inside" it — the trap `isPathInside` exists to close.
+    it("offers no Diff for a file in a sibling directory sharing the root prefix", async () => {
+      seedWorktree([{ path: "/repo-other/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo-other/src/index.ts" });
+      expect(toggleLabels()).toEqual([]);
+    });
+
+    it("offers no Diff when the worktree reports a null change list", async () => {
+      seedWorktree(null);
+      await renderPane({ filePath: "/repo/src/index.ts" });
+      expect(toggleLabels()).toEqual([]);
+    });
+  });
+
+  describe("mode clamping", () => {
+    it("falls back to source when a persisted diff mode has no local change", async () => {
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+      expect(await screen.findByTestId("code-viewer-mock")).toBeTruthy();
+      expect(screen.queryByTestId("diff-viewer-mock")).toBeNull();
+    });
+
+    it("falls back to source when a persisted rendered mode has no renderable file", async () => {
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "rendered" });
+      expect(await screen.findByTestId("code-viewer-mock")).toBeTruthy();
+    });
+
+    // The clamp is derived, not written back: a poll that transiently drops the
+    // change must not erase the mode the user picked.
+    it("never writes the fallback back to panel state", async () => {
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+      expect(setFileViewModeMock).not.toHaveBeenCalled();
+    });
+
+    it("honours a persisted diff mode once the file is locally changed", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({
+        content: "@@ -1 +1 @@",
+        stale: false,
+        retry: vi.fn(),
+      });
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+      expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+    });
+  });
+
+  describe("diff subject", () => {
+    it("passes the worktree-relative path and the exact stored status", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "added" }]);
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+
+      expect(lastSubject()).toEqual({
+        source: "working-tree",
+        worktreePath: WORKTREE_PATH,
+        filePath: "src/index.ts",
+        status: "added",
+      });
+    });
+
+    it("passes no subject while Source is the live mode", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "source" });
+      expect(lastSubject()).toBeNull();
+    });
+  });
+
+  // The diff branch deliberately precedes every load-state branch: these files
+  // can never satisfy the source reader, yet their diff is the whole point.
+  describe("rendering ahead of the source read", () => {
+    it("renders the diff for a deleted file whose source read fails", async () => {
+      readMock.mockRejectedValue(
+        Object.assign(new Error("gone"), { code: "NOT_FOUND", isClientAppError: true })
+      );
+      seedWorktree([{ path: "/repo/src/index.ts", status: "deleted" }]);
+      useDiffContentMock.mockReturnValue({
+        content: "@@ -1 +0,0 @@",
+        stale: false,
+        retry: vi.fn(),
+      });
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+
+      expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+    });
+
+    it("renders the diff for an image rather than its preview", async () => {
+      seedWorktree([{ path: "/repo/assets/logo.png", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({
+        content: "Binary files differ",
+        stale: false,
+        retry: vi.fn(),
+      });
+      await renderPane({ filePath: "/repo/assets/logo.png", fileViewMode: "diff" });
+
+      expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+    });
+  });
+
+  describe("toolbar wiring", () => {
+    it("routes Refresh to the diff retry while Diff is live", async () => {
+      const retry = vi.fn();
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({ content: "@@ -1 +1 @@", stale: false, retry });
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+      const readCallsBefore = readMock.mock.calls.length;
+
+      await act(async () => {
+        screen
+          .getByRole("button", { name: "Refresh" })
+          .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(retry).toHaveBeenCalled();
+      // Re-reading the file would not refetch the diff.
+      expect(readMock.mock.calls.length).toBe(readCallsBefore);
+    });
+
+    it("routes Refresh to the file read while Source is live", async () => {
+      const retry = vi.fn();
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({ content: undefined, stale: false, retry });
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "source" });
+      const readCallsBefore = readMock.mock.calls.length;
+
+      await act(async () => {
+        screen
+          .getByRole("button", { name: "Refresh" })
+          .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(retry).not.toHaveBeenCalled();
+      expect(readMock.mock.calls.length).toBeGreaterThan(readCallsBefore);
+    });
+
+    it("surfaces a staleness banner with a refresh action once the file moves under the diff", async () => {
+      const retry = vi.fn();
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({ content: "@@ -1 +1 @@", stale: true, retry });
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+
+      // By text, not role="status" — the loading skeleton carries that role too.
+      expect(await screen.findByText("File changed since this diff loaded")).toBeTruthy();
+    });
+
+    it("shows no staleness banner while the diff is still loading", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({ content: undefined, stale: true, retry: vi.fn() });
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
+
+      expect(screen.queryByText("File changed since this diff loaded")).toBeNull();
+    });
   });
 });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -112,14 +112,13 @@ interface DiffSubjectLike {
   status: string;
 }
 const { useDiffContentMock } = vi.hoisted(() => ({
-  useDiffContentMock:
-    vi.fn<
-      (subject: DiffSubjectLike | null) => {
-        content: string | undefined;
-        stale: boolean;
-        retry: () => void;
-      }
-    >(),
+  useDiffContentMock: vi.fn<
+    (subject: DiffSubjectLike | null) => {
+      content: string | undefined;
+      stale: boolean;
+      retry: () => void;
+    }
+  >(),
 }));
 vi.mock("@/panels/diff/useDiffContent", () => ({ useDiffContent: useDiffContentMock }));
 // FilePane lazy-loads the viewer, so assertions on it must await the chunk.
@@ -938,6 +937,51 @@ describe("FilePane diff mode (#11274)", () => {
       seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
       await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "source" });
       expect(lastSubject()).toBeNull();
+    });
+  });
+
+  // The viewer joins its rootPath with the diff's worktree-relative paths to
+  // build the open-in-editor target, so the root has to be the very worktree the
+  // diff was fetched against — never the one the panel happens to be stamped
+  // with, which containment resolution exists precisely to override.
+  describe("diff viewer root", () => {
+    function viewerRoot(): string | null {
+      return screen.getByTestId("diff-viewer-mock").getAttribute("data-root");
+    }
+
+    async function renderDiff(options: { filePath: string; worktreeId?: string | undefined }) {
+      useDiffContentMock.mockReturnValue({ content: "@@ -1 +1 @@", stale: false, retry: vi.fn() });
+      await renderPane({ ...options, fileViewMode: "diff" });
+      expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+    }
+
+    it("roots the viewer at the resolved worktree, not the panel's stamped one", async () => {
+      // Panel is stamped with the outer worktree; the file lives in the nested
+      // one, so the relative paths in the diff are relative to the nested root.
+      worktreeState.worktrees.set(WORKTREE_ID, {
+        path: WORKTREE_PATH,
+        worktreeChanges: { changes: [] },
+      });
+      worktreeState.worktrees.set("wt-inner", {
+        path: "/repo/nested",
+        worktreeChanges: { changes: [{ path: "src/index.ts", status: "modified" }] },
+      });
+
+      await renderDiff({ filePath: "/repo/nested/src/index.ts" });
+
+      expect(viewerRoot()).toBe(lastSubject()?.worktreePath);
+      expect(viewerRoot()).not.toBe(WORKTREE_PATH);
+    });
+
+    it("roots the viewer by containment when the panel carries no worktree id", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+
+      await renderDiff({ filePath: "/repo/src/index.ts", worktreeId: undefined });
+
+      // Without containment this would be the empty string, leaving the viewer
+      // to join a bare relative path.
+      expect(viewerRoot()).toBe(lastSubject()?.worktreePath);
+      expect(viewerRoot()).toBeTruthy();
     });
   });
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -138,6 +138,7 @@ vi.mock("@/components/Html/HtmlViewer", () => ({
 
 import { FilePane } from "../FilePane";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
 
 function lastContentPanelProps(): Record<string, unknown> {
   const props = contentPanelProps.at(-1);
@@ -771,16 +772,47 @@ describe("FilePane diff mode (#11274)", () => {
       expect(toggleLabels()).toEqual([]);
     });
 
-    it("offers no Diff when the panel carries no worktree id", async () => {
+    // Whether a file has local changes is a fact about where it lives, not
+    // about the panel's binding — which file.openPanel stamps with the *active*
+    // worktree even when it resolved the path against a different root.
+    it("finds the change through containment when the panel carries no worktree id", async () => {
       seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
       await renderPane({ filePath: "/repo/src/index.ts", worktreeId: undefined });
+      expect(toggleLabels()).toContain("Diff");
+    });
+
+    it("finds the change when the panel is bound to a different worktree", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      worktreeState.worktrees.set("wt-other", { path: "/other", worktreeChanges: { changes: [] } });
+      await renderPane({ filePath: "/repo/src/index.ts", worktreeId: "wt-other" });
+      expect(toggleLabels()).toContain("Diff");
+    });
+
+    it("offers no Diff for a file inside no known worktree", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/elsewhere/src/index.ts" });
       expect(toggleLabels()).toEqual([]);
     });
 
-    it("offers no Diff when the worktree id resolves to nothing", async () => {
-      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
-      await renderPane({ filePath: "/repo/src/index.ts", worktreeId: "wt-gone" });
-      expect(toggleLabels()).toEqual([]);
+    // Deepest root wins, so a file in a nested worktree diffs against that
+    // worktree rather than its parent — which may not list it as changed.
+    it("prefers the deepest containing worktree", async () => {
+      worktreeState.worktrees.set("wt-outer", {
+        path: "/repo",
+        worktreeChanges: { changes: [] },
+      });
+      worktreeState.worktrees.set("wt-inner", {
+        path: "/repo/nested",
+        worktreeChanges: { changes: [{ path: "src/index.ts", status: "added" }] },
+      });
+      await renderPane({ filePath: "/repo/nested/src/index.ts", fileViewMode: "diff" });
+
+      expect(lastSubject()).toEqual({
+        source: "working-tree",
+        worktreePath: "/repo/nested",
+        filePath: "src/index.ts",
+        status: "added",
+      });
     });
 
     // A sibling root that merely extends the worktree name must not read as
@@ -810,6 +842,21 @@ describe("FilePane diff mode (#11274)", () => {
       expect(await screen.findByTestId("code-viewer-mock")).toBeTruthy();
     });
 
+    // The two capabilities must not authorize each other: a renderable file is
+    // not thereby diffable, and a changed file is not thereby renderable.
+    it("falls back to source for a persisted diff mode on an unchanged markdown file", async () => {
+      await renderPane({ filePath: "/repo/docs/spec.md", fileViewMode: "diff" });
+      expect(screen.queryByTestId("diff-viewer-mock")).toBeNull();
+      expect(lastSubject()).toBeNull();
+    });
+
+    it("falls back to source for a persisted rendered mode on a changed non-renderable file", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "rendered" });
+      expect(await screen.findByTestId("code-viewer-mock")).toBeTruthy();
+      expect(screen.queryByTestId("markdown-viewer-mock")).toBeNull();
+    });
+
     // The clamp is derived, not written back: a poll that transiently drops the
     // change must not erase the mode the user picked.
     it("never writes the fallback back to panel state", async () => {
@@ -826,6 +873,49 @@ describe("FilePane diff mode (#11274)", () => {
       });
       await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
       expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+    });
+  });
+
+  // Every other diff test seeds the mode directly, so a toggle that never
+  // dispatched "diff" would leave them all green.
+  describe("selecting the option", () => {
+    it("asks the store for diff mode when the Diff segment is clicked", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      await renderPane({ filePath: "/repo/src/index.ts" });
+
+      await act(async () => {
+        screen
+          .getByRole("button", { name: "Diff" })
+          .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(setFileViewModeMock).toHaveBeenLastCalledWith("file-1", "diff");
+    });
+  });
+
+  // Leaving diff lands on source cached before the edit that prompted it.
+  describe("returning to source", () => {
+    it("re-reads the file when the mode leaves diff", async () => {
+      seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({ content: "@@ -1 +1 @@", stale: false, retry: vi.fn() });
+      const { rerender } = await renderPane({
+        filePath: "/repo/src/index.ts",
+        fileViewMode: "diff",
+      });
+      const readCallsBefore = readMock.mock.calls.length;
+
+      panelsById["file-1"] = {
+        id: "file-1",
+        kind: "file",
+        filePath: "/repo/src/index.ts",
+        worktreeId: WORKTREE_ID,
+        fileViewMode: "source",
+      };
+      await act(async () => {
+        rerender(paneElement());
+      });
+
+      expect(readMock.mock.calls.length).toBeGreaterThan(readCallsBefore);
     });
   });
 
@@ -865,6 +955,8 @@ describe("FilePane diff mode (#11274)", () => {
       await renderPane({ filePath: "/repo/src/index.ts", fileViewMode: "diff" });
 
       expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+      // Exclusivity, not just presence: the read error must not render beside it.
+      expect(screen.queryByText(FILE_READ_ERROR_MESSAGES.NOT_FOUND)).toBeNull();
     });
 
     it("renders the diff for an image rather than its preview", async () => {
@@ -874,9 +966,13 @@ describe("FilePane diff mode (#11274)", () => {
         stale: false,
         retry: vi.fn(),
       });
-      await renderPane({ filePath: "/repo/assets/logo.png", fileViewMode: "diff" });
+      const { container } = await renderPane({
+        filePath: "/repo/assets/logo.png",
+        fileViewMode: "diff",
+      });
 
       expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+      expect(container.querySelector("img")).toBeNull();
     });
   });
 
@@ -924,6 +1020,15 @@ describe("FilePane diff mode (#11274)", () => {
 
       // By text, not role="status" — the loading skeleton carries that role too.
       expect(await screen.findByText("File changed since this diff loaded")).toBeTruthy();
+
+      // The banner is only useful if its recovery actually refetches.
+      await act(async () => {
+        screen
+          .getAllByRole("button", { name: "Refresh" })
+          .at(-1)
+          ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(retry).toHaveBeenCalled();
     });
 
     it("shows no staleness banner while the diff is still loading", async () => {

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -114,9 +114,11 @@ interface DiffSubjectLike {
 const { useDiffContentMock } = vi.hoisted(() => ({
   useDiffContentMock:
     vi.fn<
-      (
-        subject: DiffSubjectLike | null
-      ) => { content: string | undefined; stale: boolean; retry: () => void }
+      (subject: DiffSubjectLike | null) => {
+        content: string | undefined;
+        stale: boolean;
+        retry: () => void;
+      }
     >(),
 }));
 vi.mock("@/panels/diff/useDiffContent", () => ({ useDiffContent: useDiffContentMock }));

--- a/src/services/actions/definitions/fileActions.ts
+++ b/src/services/actions/definitions/fileActions.ts
@@ -7,7 +7,7 @@ import { usePanelDialogStore } from "@/store/panelDialogStore";
 import { isFilePanel } from "@shared/types/panel";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
 import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
-import { isAbsolute, isPathInside, join, normalize } from "@shared/utils/path";
+import { isAbsolute, isPathInside, join, normalize, toWorktreeRelative } from "@shared/utils/path";
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 
 const viewArgsSchema = z.object({
@@ -88,23 +88,6 @@ const openImageViewerArgsSchema = z.object({
 const showItemInFolderArgsSchema = z.object({
   path: z.string().min(1),
 });
-
-/**
- * Strip the worktree root off an absolute path. `isPathInside` is what makes
- * this safe: a raw `startsWith` accepts a sibling whose name merely extends the
- * root (`/repo-other/x.ts` under `/repo`, which then mangles into `-other/x.ts`)
- * and ignores separator normalization. A path outside the worktree passes
- * through untouched — GitService rejects it downstream with a real git error,
- * which beats inventing a second failure mode here.
- */
-function toWorktreeRelative(path: string, worktreeRoot: string | undefined): string {
-  if (!worktreeRoot || !isPathInside(path, worktreeRoot)) return path;
-  const normalizedPath = normalize(path);
-  const normalizedRoot = normalize(worktreeRoot);
-  if (normalizedPath === normalizedRoot) return path;
-  const boundary = normalizedRoot.endsWith("/") ? normalizedRoot : `${normalizedRoot}/`;
-  return normalizedPath.slice(boundary.length);
-}
 
 function resolveFilePanelPath(path: string, rootPath: string | undefined): string {
   if (isAbsolute(path)) return normalize(path);


### PR DESCRIPTION
## Summary

- Adds a third Diff option to the file viewer panel's Source/Rendered toggle, shown only when the open file has local worktree changes
- Works for any file type. Source stays the default, and Rendered stays limited to markdown and HTML
- The diff renders inline through the existing `DiffViewer` component rather than a separate panel, so there's no sidebar, stepping, or viewed markers

Resolves #11274

## Design decisions

Rendered and Diff are independent capabilities. One derived capability list drives both the toggle options and the mode clamp, so a persisted mode whose capability has disappeared falls back to Source and is never written back. A poll that transiently drops the change can't erase the user's choice.

The diff branch renders ahead of every load-state branch. A deleted file fails the `files.read` call, and images and other binaries never load as text, but the diff is exactly what the user wants to see in those cases.

The worktree is resolved by path containment rather than by the panel's `worktreeId` field. `file.openPanel` resolves an explicit `rootPath` but still stamps the active worktree id, so the panel's binding can name a worktree the file isn't actually in. The deepest matching root wins, so a nested worktree beats its parent.

Stored change paths are absolute, because `electron/utils/git.ts` keys its `changesMap` by absolute path even though `FileChangeDetail.path` is typed as worktree-relative. The lookup folds both shapes into one relative form.

`sanitizeFileViewMode` redeclares the mode union at runtime, because widening the type alone would have silently dropped a restored diff selection on reload.

`DiffViewer` is lazy-loaded so `react-diff-view`, its tokenizer, and the diff stylesheet stay out of the file panel's chunk. `FilePane` and `DiffPane` remain separate lazy chunks.

Diff mode is deliberately not added to `file.openPanel`'s `viewMode` argument schema, which stays a zod enum of `rendered` and `source`. Diff availability depends on live worktree state that an external or MCP caller can't predict. A separate `file.openDiff` action already exists for that case.

## Not covered

- Case-differing or symlinked worktree roots won't match, since the containment check is lexical and case-sensitive. This is a pre-existing limitation shared with `diffContentCache.ts`; real canonicalization belongs in the Main process as its own change.
- A file renamed while open loses the Diff option, since the change producer only stores the destination path with no old path to match against. Would need an `oldPath` field added to `FileChangeDetail`.

## Testing

- 382 tests across 15 files pass, covering `FilePane`, `useHeightHold`, path utilities, registry field coverage and roundtrip, `panelKindSerialisers`, `filePanelState`, `fileActions` adversarial and openPanel cases, `MarkdownViewer`, `SegmentedToggle`, `Skeleton`, `DiffPane`, and `DiffViewer`
- `tsc --noEmit` is clean
- Prettier and eslint are clean on changed files (5 pre-existing warnings on untouched lines, none added)
- No end-to-end test run locally. `e2e/full/panels/core-file-panel.spec.ts` is the natural home for an end-to-end diff test, but running it needs a full build. The change is additive to existing paths.