### PR TITLE
fix(system-shell): allow open/reveal for files in tracked worktrees

### DIFF
--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -42,12 +42,26 @@ vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,
 }));
 
-const storeMock = vi.hoisted(() => ({
-  get: vi.fn<(key: string) => unknown>(() => undefined),
+type WorktreeRecord = {
+  path: string;
+  branch: string;
+  bare: boolean;
+  isMainWorktree: boolean;
+};
+
+const gitServiceMock = vi.hoisted(() => ({
+  listWorktrees:
+    vi.fn<
+      () => Promise<Array<{ path: string; branch: string; bare: boolean; isMainWorktree: boolean }>>
+    >(),
 }));
 
-vi.mock("../../../store.js", () => ({
-  store: storeMock,
+const gitServiceCacheMock = vi.hoisted(() => ({
+  getGitService: vi.fn<(root: string) => { listWorktrees: () => Promise<unknown[]> }>(),
+}));
+
+vi.mock("../../../services/GitServiceCache.js", () => ({
+  gitServiceCache: gitServiceCacheMock,
 }));
 
 const openFileMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
@@ -94,13 +108,33 @@ function getHandler(channel: string): Handler {
 const fakeEvent = {};
 const TEST_ROOT = path.parse(process.cwd()).root;
 const PROJECT_ROOT = path.join(TEST_ROOT, "Users", "me", "project");
-// Derived from the default pattern `{parent-dir}/{base-folder}-worktrees/{branch-slug}`
-// applied to PROJECT_ROOT.
-const WORKTREE_PARENT = path.join(
+// The parent dir the retired path-pattern heuristic used to predict from
+// PROJECT_ROOT (`{parent-dir}/{base-folder}-worktrees/{branch-slug}`). Kept
+// only as a negative fixture: living under it earns a path nothing anymore —
+// containment now follows what `git worktree list` actually reports.
+const LEGACY_PATTERN_PARENT = path.join(
   path.dirname(PROJECT_ROOT),
   `${path.basename(PROJECT_ROOT)}-worktrees`
 );
 const USERDATA_PARENT = path.join(TEST_ROOT, "userdata");
+
+function worktreeRecord(worktreePath: string, overrides: Partial<WorktreeRecord> = {}) {
+  return {
+    path: worktreePath,
+    branch: "feature",
+    bare: false,
+    isMainWorktree: false,
+    ...overrides,
+  };
+}
+
+// `vi.clearAllMocks()` wipes call history but leaves implementations set by a
+// previous test in place, so every suite re-establishes the default of "this
+// project tracks no linked worktrees".
+function resetGitMocks() {
+  gitServiceMock.listWorktrees.mockResolvedValue([]);
+  gitServiceCacheMock.getGitService.mockReturnValue(gitServiceMock);
+}
 const deniedLauncherName =
   process.platform === "win32"
     ? "launcher.exe"
@@ -117,7 +151,7 @@ describe("system:open-path containment", () => {
     fsMock.promises.realpath.mockImplementation(realpathEcho);
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
     appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
-    storeMock.get.mockReturnValue(undefined);
+    resetGitMocks();
     cleanup = registerSystemShellHandlers({} as HandlerDependencies);
   });
 
@@ -214,7 +248,7 @@ describe("system:open-in-editor containment", () => {
     fsMock.promises.realpath.mockImplementation(realpathEcho);
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
     appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
-    storeMock.get.mockReturnValue(undefined);
+    resetGitMocks();
     cleanup = registerSystemShellHandlers({} as HandlerDependencies);
   });
 
@@ -261,7 +295,7 @@ describe("system:show-item-in-folder containment", () => {
     fsMock.promises.realpath.mockImplementation(realpathEcho);
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
     appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
-    storeMock.get.mockReturnValue(undefined);
+    resetGitMocks();
     cleanup = registerSystemShellHandlers({} as HandlerDependencies);
   });
 
@@ -333,7 +367,7 @@ describe("system:show-item-in-folder containment", () => {
   });
 });
 
-describe("system path-allowlist: worktree parent dirs", () => {
+describe("system path-allowlist: tracked worktree roots", () => {
   let cleanup: () => void;
 
   beforeEach(() => {
@@ -341,7 +375,7 @@ describe("system path-allowlist: worktree parent dirs", () => {
     fsMock.promises.realpath.mockImplementation(realpathEcho);
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
     appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
-    storeMock.get.mockReturnValue(undefined);
+    resetGitMocks();
     cleanup = registerSystemShellHandlers({} as HandlerDependencies);
   });
 
@@ -349,57 +383,142 @@ describe("system path-allowlist: worktree parent dirs", () => {
     cleanup();
   });
 
-  it("opens a path inside the default worktree parent dir (Reveal in Finder on worktree card)", async () => {
+  it("opens a worktree root that git reports (Reveal in Finder on worktree card)", async () => {
+    const worktreePath = path.join(LEGACY_PATTERN_PARENT, "feature-issue-9149");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(PROJECT_ROOT, { isMainWorktree: true, branch: "develop" }),
+      worktreeRecord(worktreePath),
+    ]);
+
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
-    const worktreePath = path.join(WORKTREE_PARENT, "feature-issue-9149");
     await handler(fakeEvent, { path: worktreePath });
     expect(shellMock.openPath).toHaveBeenCalledWith(worktreePath);
   });
 
-  it("opens a file inside a worktree (ReviewHub file-open click)", async () => {
+  // The per-project `worktreePathPattern` override was invisible to the old
+  // global-pattern heuristic, so worktrees created under it were rejected.
+  // Git reports the real path regardless of which pattern produced it.
+  it("opens a file inside a worktree created under a custom per-project pattern", async () => {
+    const customWorktree = path.join(
+      path.dirname(PROJECT_ROOT),
+      `${path.basename(PROJECT_ROOT)}.wt`,
+      "feature-x"
+    );
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(PROJECT_ROOT, { isMainWorktree: true }),
+      worktreeRecord(customWorktree),
+    ]);
+
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
-    const filePath = path.join(WORKTREE_PARENT, "feature-issue-9149", "src", "index.ts");
+    const filePath = path.join(customWorktree, "src", "index.ts");
     await handler(fakeEvent, { path: filePath, line: 1, col: 1 });
     expect(openFileMock).toHaveBeenCalledWith(filePath, 1, 1, null);
   });
 
-  it("honors a globally-configured worktree pattern in addition to the default", async () => {
-    // Configure an alternative pattern. Both the configured and the default
-    // parent should be admitted (so changing the pattern doesn't lock the
-    // user out of previously-created worktrees).
-    storeMock.get.mockImplementation((key: string) =>
-      key === "worktreeConfig.pathPattern"
-        ? "{parent-dir}/{base-folder}.wt/{branch-slug}"
-        : undefined
-    );
-    // Re-register so the handler picks up the mock (the handler itself reads
-    // the store on each call, so this is technically unnecessary — but kept
-    // explicit to mirror the production startup order).
-    cleanup();
-    cleanup = registerSystemShellHandlers({} as HandlerDependencies);
+  // `git worktree add ~/scratch/hotfix` puts the worktree somewhere no pattern
+  // predicts. Enumerating instead of predicting is what makes this case work.
+  it("reveals a file inside a manually-created worktree outside any pattern", async () => {
+    const manualWorktree = path.join(TEST_ROOT, "tmp", "scratch", "hotfix");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(PROJECT_ROOT, { isMainWorktree: true }),
+      worktreeRecord(manualWorktree),
+    ]);
 
-    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
-    const customParent = path.join(path.dirname(PROJECT_ROOT), `${path.basename(PROJECT_ROOT)}.wt`);
-    const customWorktree = path.join(customParent, "feature-x");
-    await handler(fakeEvent, { path: customWorktree });
-    expect(shellMock.openPath).toHaveBeenCalledWith(customWorktree);
-
-    // The default parent stays admitted too.
-    shellMock.openPath.mockClear();
-    const legacyWorktree = path.join(WORKTREE_PARENT, "legacy-branch");
-    await handler(fakeEvent, { path: legacyWorktree });
-    expect(shellMock.openPath).toHaveBeenCalledWith(legacyWorktree);
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    const filePath = path.join(manualWorktree, "src", "app.ts");
+    await handler(fakeEvent, { path: filePath });
+    expect(shellMock.showItemInFolder).toHaveBeenCalledWith(filePath);
   });
 
-  it("still rejects sibling-prefix paths that share a worktree-parent prefix", async () => {
+  // The deliberate tightening: the pattern-derived parent used to admit every
+  // child wholesale, including directories that were never worktrees.
+  it("rejects a predicted-pattern sibling that git does not track", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(PROJECT_ROOT, { isMainWorktree: true }),
+      worktreeRecord(path.join(LEGACY_PATTERN_PARENT, "real-worktree")),
+    ]);
+
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
-    // `/Users/me/project-worktrees-evil/...` shares a string prefix with the
-    // worktree parent dir but isn't actually contained — the realpath +
-    // separator check in pathGuard must still reject it.
     await expect(
-      handler(fakeEvent, { path: `${WORKTREE_PARENT}-evil${path.sep}secret.txt` })
+      handler(fakeEvent, {
+        path: path.join(LEGACY_PATTERN_PARENT, "never-a-worktree", "src", "index.ts"),
+      })
     ).rejects.toMatchObject({ code: "OUTSIDE_ROOT" });
     expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  it("rejects a sibling-prefix path that shares a tracked worktree's prefix", async () => {
+    const worktreePath = path.join(LEGACY_PATTERN_PARENT, "feature-x");
+    gitServiceMock.listWorktrees.mockResolvedValue([worktreeRecord(worktreePath)]);
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    // Shares a string prefix with the tracked root but isn't contained — the
+    // realpath + separator check in pathGuard must still reject it.
+    await expect(
+      handler(fakeEvent, { path: `${worktreePath}-evil${path.sep}secret.txt` })
+    ).rejects.toMatchObject({ code: "OUTSIDE_ROOT" });
+    expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  // Git keeps externally-deleted worktrees listed as "prunable" until someone
+  // runs `git worktree prune`. Containment must tolerate them rather than
+  // mutate repository state to tidy up, so the stale root is simply skipped.
+  it("skips an orphaned worktree root and still admits a healthy one", async () => {
+    const orphaned = path.join(LEGACY_PATTERN_PARENT, "deleted-branch");
+    const healthy = path.join(LEGACY_PATTERN_PARENT, "live-branch");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(PROJECT_ROOT, { isMainWorktree: true }),
+      worktreeRecord(orphaned),
+      worktreeRecord(healthy),
+    ]);
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      path.normalize(p) === path.normalize(orphaned)
+        ? Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+        : realpathEcho(p)
+    );
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    const filePath = path.join(healthy, "src", "index.ts");
+    await handler(fakeEvent, { path: filePath });
+    expect(shellMock.openPath).toHaveBeenCalledWith(filePath);
+  });
+
+  // One unreadable repository must not suppress the others — each enumeration
+  // fails independently to an empty list.
+  it("isolates a failing project's enumeration from a healthy project", async () => {
+    const otherRoot = path.join(TEST_ROOT, "Users", "me", "other-project");
+    const otherWorktree = path.join(TEST_ROOT, "Users", "me", "other-worktrees", "feature-y");
+    projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }, { path: otherRoot }]);
+    gitServiceCacheMock.getGitService.mockImplementation((root: string) =>
+      root === PROJECT_ROOT
+        ? { listWorktrees: () => Promise.reject(new Error("not a git repository")) }
+        : { listWorktrees: () => Promise.resolve([worktreeRecord(otherWorktree)]) }
+    );
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    const filePath = path.join(otherWorktree, "src", "index.ts");
+    await handler(fakeEvent, { path: filePath });
+    expect(shellMock.openPath).toHaveBeenCalledWith(filePath);
+  });
+
+  // Enumeration shells out to git, so it must stay off the common path where
+  // the target already sits inside a registered project root.
+  it("does not enumerate worktrees when the target is inside a project root", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    await handler(fakeEvent, { path: path.join(PROJECT_ROOT, "src", "index.ts") });
+    expect(shellMock.openPath).toHaveBeenCalled();
+    expect(gitServiceCacheMock.getGitService).not.toHaveBeenCalled();
+    expect(gitServiceMock.listWorktrees).not.toHaveBeenCalled();
+  });
+
+  // A path that can't be resolved at all fails identically against every root
+  // set, so it must short-circuit before paying for enumeration.
+  it("does not enumerate worktrees for a non-absolute path", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    await expect(handler(fakeEvent, { path: "relative/file.txt" })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(gitServiceMock.listWorktrees).not.toHaveBeenCalled();
   });
 });
 
@@ -412,7 +531,7 @@ describe("system:show-item-in-folder-unconfined (out-of-root reveal recovery)", 
     fsMock.promises.stat.mockResolvedValue({ isFile: () => true, isDirectory: () => false });
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
     appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
-    storeMock.get.mockReturnValue(undefined);
+    resetGitMocks();
     cleanup = registerSystemShellHandlers({} as HandlerDependencies);
   });
 

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -28,6 +28,7 @@ const fsMock = vi.hoisted(() => ({
     stat: vi.fn<(p: string) => Promise<{ isFile: () => boolean; isDirectory: () => boolean }>>(() =>
       Promise.resolve({ isFile: () => true, isDirectory: () => false })
     ),
+    access: vi.fn<(p: string) => Promise<void>>(() => Promise.resolve()),
   },
 }));
 
@@ -128,12 +129,28 @@ function worktreeRecord(worktreePath: string, overrides: Partial<WorktreeRecord>
   };
 }
 
+// A tracked worktree in a location no path pattern would ever predict, so
+// admitting it can only be the result of asking git.
+const UNPREDICTED_WORKTREE = path.join(TEST_ROOT, "Volumes", "scratch", "hotfix");
+
 // `vi.clearAllMocks()` wipes call history but leaves implementations set by a
-// previous test in place, so every suite re-establishes the default of "this
-// project tracks no linked worktrees".
+// previous test in place, so every suite re-establishes the defaults: this
+// project tracks no linked worktrees, and any candidate that is consulted
+// looks like a live working tree.
 function resetGitMocks() {
   gitServiceMock.listWorktrees.mockResolvedValue([]);
   gitServiceCacheMock.getGitService.mockReturnValue(gitServiceMock);
+  fsMock.promises.access.mockResolvedValue(undefined);
+}
+
+// Rejects the `.git` probe for the given roots, marking them as no longer
+// live working trees (deleted-and-recreated directories, bare repos).
+function denyGitProbeFor(...roots: string[]) {
+  fsMock.promises.access.mockImplementation((p: string) =>
+    roots.some((root) => path.normalize(p) === path.join(root, ".git"))
+      ? Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+      : Promise.resolve()
+  );
 }
 const deniedLauncherName =
   process.platform === "win32"
@@ -384,15 +401,14 @@ describe("system path-allowlist: tracked worktree roots", () => {
   });
 
   it("opens a worktree root that git reports (Reveal in Finder on worktree card)", async () => {
-    const worktreePath = path.join(LEGACY_PATTERN_PARENT, "feature-issue-9149");
     gitServiceMock.listWorktrees.mockResolvedValue([
       worktreeRecord(PROJECT_ROOT, { isMainWorktree: true, branch: "develop" }),
-      worktreeRecord(worktreePath),
+      worktreeRecord(UNPREDICTED_WORKTREE),
     ]);
 
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
-    await handler(fakeEvent, { path: worktreePath });
-    expect(shellMock.openPath).toHaveBeenCalledWith(worktreePath);
+    await handler(fakeEvent, { path: UNPREDICTED_WORKTREE });
+    expect(shellMock.openPath).toHaveBeenCalledWith(UNPREDICTED_WORKTREE);
   });
 
   // The per-project `worktreePathPattern` override was invisible to the old
@@ -463,41 +479,119 @@ describe("system path-allowlist: tracked worktree roots", () => {
   // Git keeps externally-deleted worktrees listed as "prunable" until someone
   // runs `git worktree prune`. Containment must tolerate them rather than
   // mutate repository state to tidy up, so the stale root is simply skipped.
-  it("skips an orphaned worktree root and still admits a healthy one", async () => {
-    const orphaned = path.join(LEGACY_PATTERN_PARENT, "deleted-branch");
-    const healthy = path.join(LEGACY_PATTERN_PARENT, "live-branch");
+  it("skips a worktree root that has since been deleted and admits a healthy one", async () => {
+    const orphaned = path.join(TEST_ROOT, "Volumes", "scratch", "deleted-branch");
     gitServiceMock.listWorktrees.mockResolvedValue([
       worktreeRecord(PROJECT_ROOT, { isMainWorktree: true }),
       worktreeRecord(orphaned),
-      worktreeRecord(healthy),
+      worktreeRecord(UNPREDICTED_WORKTREE),
     ]);
     fsMock.promises.realpath.mockImplementation((p: string) =>
       path.normalize(p) === path.normalize(orphaned)
         ? Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
         : realpathEcho(p)
     );
+    denyGitProbeFor(orphaned);
 
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
-    const filePath = path.join(healthy, "src", "index.ts");
+    const filePath = path.join(UNPREDICTED_WORKTREE, "src", "index.ts");
     await handler(fakeEvent, { path: filePath });
     expect(shellMock.openPath).toHaveBeenCalledWith(filePath);
+  });
+
+  // Git keeps reporting a worktree the user deleted behind its back. If that
+  // path is later reused by something unrelated, it realpaths fine — only the
+  // missing `.git` keeps it from becoming a launch root.
+  it("rejects a stale worktree path that was recreated as an unrelated directory", async () => {
+    const recreated = path.join(TEST_ROOT, "Volumes", "scratch", "reused");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(PROJECT_ROOT, { isMainWorktree: true }),
+      worktreeRecord(recreated),
+    ]);
+    denyGitProbeFor(recreated);
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    await expect(handler(fakeEvent, { path: path.join(recreated, "runme") })).rejects.toMatchObject(
+      { code: "OUTSIDE_ROOT" }
+    );
+    expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  // A linked checkout backed by a bare repository reports that repository.
+  // Granting it would hand out the object store, refs, config and hooks.
+  it("rejects the bare repository backing a linked worktree", async () => {
+    const bareRepo = path.join(TEST_ROOT, "srv", "repo.git");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      worktreeRecord(bareRepo, { bare: true, isMainWorktree: true, branch: "" }),
+      worktreeRecord(UNPREDICTED_WORKTREE),
+    ]);
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+    await expect(handler(fakeEvent, { path: path.join(bareRepo, "config") })).rejects.toMatchObject(
+      {
+        code: "OUTSIDE_ROOT",
+      }
+    );
+    expect(openFileMock).not.toHaveBeenCalled();
+
+    // The healthy linked worktree alongside it is still admitted.
+    const filePath = path.join(UNPREDICTED_WORKTREE, "src", "index.ts");
+    await handler(fakeEvent, { path: filePath });
+    expect(openFileMock).toHaveBeenCalledWith(filePath, undefined, undefined, null);
+  });
+
+  // The escalated branch must hand the sink the canonical target, not the
+  // renderer-supplied path — same TOCTOU-narrowing property as the base path.
+  it("forwards the realpath-resolved target when admitted via a worktree root", async () => {
+    const link = path.join(UNPREDICTED_WORKTREE, "link.txt");
+    const resolved = path.join(UNPREDICTED_WORKTREE, "real.txt");
+    gitServiceMock.listWorktrees.mockResolvedValue([worktreeRecord(UNPREDICTED_WORKTREE)]);
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      Promise.resolve(path.normalize(p) === path.normalize(link) ? resolved : path.normalize(p))
+    );
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    await handler(fakeEvent, { path: link });
+    expect(shellMock.openPath).toHaveBeenCalledWith(resolved);
+  });
+
+  // The deny-list runs again on the resolved target, so a safe-named symlink
+  // inside a worktree can't smuggle an executable past the launcher.
+  it("rejects a safe-named symlink inside a worktree that resolves to an executable", async () => {
+    const link = path.join(UNPREDICTED_WORKTREE, "notes.txt");
+    const payload = path.join(UNPREDICTED_WORKTREE, deniedLauncherName);
+    gitServiceMock.listWorktrees.mockResolvedValue([worktreeRecord(UNPREDICTED_WORKTREE)]);
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      Promise.resolve(path.normalize(p) === path.normalize(link) ? payload : path.normalize(p))
+    );
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    await expect(handler(fakeEvent, { path: link })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.openPath).not.toHaveBeenCalled();
   });
 
   // One unreadable repository must not suppress the others — each enumeration
   // fails independently to an empty list.
   it("isolates a failing project's enumeration from a healthy project", async () => {
     const otherRoot = path.join(TEST_ROOT, "Users", "me", "other-project");
-    const otherWorktree = path.join(TEST_ROOT, "Users", "me", "other-worktrees", "feature-y");
+    const failing = vi.fn(() => Promise.reject(new Error("not a git repository")));
+    const healthy = vi.fn(() => Promise.resolve([worktreeRecord(UNPREDICTED_WORKTREE)]));
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }, { path: otherRoot }]);
-    gitServiceCacheMock.getGitService.mockImplementation((root: string) =>
-      root === PROJECT_ROOT
-        ? { listWorktrees: () => Promise.reject(new Error("not a git repository")) }
-        : { listWorktrees: () => Promise.resolve([worktreeRecord(otherWorktree)]) }
-    );
+    gitServiceCacheMock.getGitService.mockImplementation((root: string) => {
+      if (root === PROJECT_ROOT) return { listWorktrees: failing };
+      if (root === otherRoot) return { listWorktrees: healthy };
+      throw new Error(`unexpected project root: ${root}`);
+    });
 
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
-    const filePath = path.join(otherWorktree, "src", "index.ts");
+    const filePath = path.join(UNPREDICTED_WORKTREE, "src", "index.ts");
     await handler(fakeEvent, { path: filePath });
+
+    // Both repositories were consulted, and the rejection didn't abort the batch.
+    expect(failing).toHaveBeenCalled();
+    expect(healthy).toHaveBeenCalled();
     expect(shellMock.openPath).toHaveBeenCalledWith(filePath);
   });
 

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -517,6 +517,32 @@ describe("system path-allowlist: tracked worktree roots", () => {
     expect(shellMock.openPath).not.toHaveBeenCalled();
   });
 
+  // pathGuard treats the filesystem root as containing every absolute path, so
+  // a record pointing there would hand out the whole disk.
+  it("rejects a worktree record pointing at the filesystem root", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([worktreeRecord(TEST_ROOT)]);
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    await expect(handler(fakeEvent, { path: "/etc/passwd" })).rejects.toMatchObject({
+      code: "OUTSIDE_ROOT",
+    });
+    expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  // Git reported this worktree; a permission or I/O failure while probing says
+  // nothing about whether it is one, so it must not lock the user out.
+  it("still admits a worktree whose .git probe fails for a non-existence reason", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([worktreeRecord(UNPREDICTED_WORKTREE)]);
+    fsMock.promises.access.mockImplementation(() =>
+      Promise.reject(Object.assign(new Error("EACCES"), { code: "EACCES" }))
+    );
+
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_PATH);
+    const filePath = path.join(UNPREDICTED_WORKTREE, "src", "index.ts");
+    await handler(fakeEvent, { path: filePath });
+    expect(shellMock.openPath).toHaveBeenCalledWith(filePath);
+  });
+
   // A linked checkout backed by a bare repository reports that repository.
   // Granting it would hand out the object store, refs, config and hooks.
   it("rejects the bare repository backing a linked worktree", async () => {

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -1,4 +1,3 @@
-// eager-import-allow: reads worktree config via store.get synchronously to derive worktree parent dirs for path-guard checks
 import { app, shell } from "electron";
 import os from "os";
 import * as nodePath from "path";
@@ -6,15 +5,9 @@ import * as nodeFs from "fs";
 import { CHANNELS } from "../channels.js";
 import { openExternalUrl } from "../../utils/openExternal.js";
 import { projectStore } from "../../services/ProjectStore.js";
-import { store } from "../../store.js";
+import { gitServiceCache } from "../../services/GitServiceCache.js";
 import { AppError } from "../../utils/errorTypes.js";
 import { resolveContainedPath } from "./pathGuard.js";
-import {
-  DEFAULT_WORKTREE_PATH_PATTERN,
-  buildPathPatternVariables,
-  resolvePathPattern,
-  validatePathPattern,
-} from "../../../shared/utils/pathPattern.js";
 import {
   SystemOpenExternalPayloadSchema,
   SystemOpenPathPayloadSchema,
@@ -72,62 +65,55 @@ function assertExtensionAllowed(candidate: string): void {
   }
 }
 
-// A placeholder branch slug used purely to resolve a worktree path pattern down
-// to its parent directory. Worktrees for a project all share the parent of the
-// resolved pattern; the slug value itself is discarded after `dirname()`.
-const WORKTREE_PARENT_PROBE_SLUG = "__daintree_probe__";
-
 /**
- * Compute the set of "worktree parent" directories implied by the configured
- * worktree path pattern(s) and the global default. Worktrees aren't tracked
- * in `projectStore` (they live in workspace-host state), but they always sit
- * under a deterministic parent derived from the project root + pattern. We
- * include both the global-configured pattern and the built-in default so a
- * stale or temporarily-changed pattern doesn't lock the user out of the
- * "Reveal in Finder" / "Open in Editor" flows on existing worktrees.
+ * Collect the worktree roots git actually tracks for each project.
+ *
+ * This replaces an earlier heuristic that reconstructed a worktree *parent*
+ * directory from the configured path pattern. That approach admitted the whole
+ * predicted parent (including directories that were never worktrees) yet still
+ * missed real ones: it only consulted the global pattern, so a per-project
+ * `worktreePathPattern` override was invisible to it, and a worktree created
+ * by hand via `git worktree add` lands wherever the user chose — no pattern
+ * predicts it. Asking git is both narrower and complete.
+ *
+ * Each returned path is a root in its own right; the parent is never admitted.
+ * Enumeration runs concurrently and per-project failures degrade to an empty
+ * list, so one broken or deleted repository can't suppress healthy ones — the
+ * project root itself stays allowed regardless. Stale ("prunable") entries are
+ * harmless: `resolveContainedPath` skips any root whose realpath fails, so we
+ * never mutate repository state to tidy them.
  */
-function collectWorktreeParentDirs(projectRoots: readonly string[]): string[] {
-  const patterns = new Set<string>([DEFAULT_WORKTREE_PATH_PATTERN]);
-  try {
-    const configured = store.get("worktreeConfig.pathPattern");
-    if (typeof configured === "string" && configured.trim()) {
-      const validation = validatePathPattern(configured);
-      if (validation.valid) {
-        patterns.add(configured);
-      }
-    }
-  } catch {
-    // Store read failures fall through to the default-only set.
-  }
+async function collectTrackedWorktreeRoots(projectRoots: readonly string[]): Promise<string[]> {
+  const perProject = await Promise.all(
+    projectRoots.map((root) =>
+      gitServiceCache
+        .getGitService(root)
+        .listWorktrees()
+        .catch(() => [])
+    )
+  );
 
-  const parents = new Set<string>();
-  for (const root of projectRoots) {
-    for (const pattern of patterns) {
-      try {
-        const variables = buildPathPatternVariables(root, WORKTREE_PARENT_PROBE_SLUG);
-        const resolved = resolvePathPattern(pattern, variables, root);
-        const parent = nodePath.dirname(resolved);
-        if (parent && parent !== "." && parent !== nodePath.sep) {
-          parents.add(parent);
-        }
-      } catch {
-        // Skip patterns that fail to resolve for a given root.
-      }
-    }
-  }
-  return [...parents];
+  return perProject.flatMap((worktrees) => worktrees.map((worktree) => worktree.path));
 }
 
 /**
  * Guard a renderer-supplied path before forwarding it to a system sink
  * (shell.openPath / EditorService.openFile). Rejects non-absolute paths,
  * executable extensions, and any path not contained within a known project
- * root, a known worktree parent directory, or the app's userData dir (where
- * crash logs live). The extension is checked twice — on the raw input and on
- * the realpath-resolved target — so a benignly-named symlink (`notes.txt` →
- * `Evil.app`) inside a root can't smuggle an executable past the deny-list.
- * Returns the resolved path so the caller hands the canonical target to the
- * sink, shrinking the TOCTOU window.
+ * root, a git-tracked worktree of one of those projects, or the app's userData
+ * dir (where crash logs live). The extension is checked twice — on the raw
+ * input and on the realpath-resolved target — so a benignly-named symlink
+ * (`notes.txt` → `Evil.app`) inside a root can't smuggle an executable past
+ * the deny-list. Returns the resolved path so the caller hands the canonical
+ * target to the sink, shrinking the TOCTOU window.
+ *
+ * Worktree enumeration shells out to git, so it is deferred until a path is
+ * otherwise about to be rejected. Containment against a union is the same
+ * question as containment against any one member, so escalating only after an
+ * OUTSIDE_ROOT miss decides identical cases while keeping the common
+ * inside-the-project case free of subprocess work. A path that fails for any
+ * other reason (non-absolute, unresolvable) would fail against every root set,
+ * so it propagates immediately rather than paying for enumeration.
  *
  * `flavor` controls the executable deny-list. The OS launcher (`shell.openPath`)
  * runs scripts and binaries, so it gets the full deny-list. Editors only read
@@ -143,12 +129,24 @@ async function assertPathAllowed(
     assertExtensionAllowed(targetPath);
   }
 
-  const projectRoots = projectStore.getAllProjects().map((p) => p.path);
-  const roots: string[] = [...projectRoots];
-  roots.push(...collectWorktreeParentDirs(projectRoots));
-  roots.push(app.getPath("userData"));
+  const projectRoots = [...new Set(projectStore.getAllProjects().map((p) => p.path))];
+  const baseRoots = [...projectRoots, app.getPath("userData")];
 
-  const realTarget = await resolveContainedPath(targetPath, roots);
+  let realTarget: string;
+  try {
+    realTarget = await resolveContainedPath(targetPath, baseRoots);
+  } catch (error) {
+    if (!(error instanceof AppError) || error.code !== "OUTSIDE_ROOT") {
+      throw error;
+    }
+    const worktreeRoots = await collectTrackedWorktreeRoots(projectRoots);
+    if (worktreeRoots.length === 0) {
+      throw error;
+    }
+    realTarget = await resolveContainedPath(targetPath, [
+      ...new Set([...baseRoots, ...worktreeRoots]),
+    ]);
+  }
 
   // shell.openPath / openFile follow symlinks, so re-check the resolved
   // extension to defeat a safe-named symlink pointing at an executable.

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -106,7 +106,7 @@ async function collectTrackedWorktreeRoots(projectRoots: readonly string[]): Pro
   const candidates = [
     ...new Set(
       perProject.flatMap((worktrees) =>
-        worktrees.filter((worktree) => !worktree.bare).map((worktree) => worktree.path)
+        worktrees.filter(isAdmissibleRecord).map((worktree) => worktree.path)
       )
     ),
   ];
@@ -115,13 +115,29 @@ async function collectTrackedWorktreeRoots(projectRoots: readonly string[]): Pro
   return candidates.filter((_, index) => live[index]);
 }
 
-/** True when `candidate` still looks like a git working tree we can trust. */
+function isAdmissibleRecord(worktree: { path: string; bare: boolean }): boolean {
+  if (worktree.bare) return false;
+  // pathGuard treats the filesystem root as containing every absolute path, so
+  // a record pointing there would silently grant the whole disk.
+  return nodePath.parse(worktree.path).root !== worktree.path;
+}
+
+/**
+ * True when `candidate` still looks like a working tree worth trusting.
+ *
+ * Only a definitively absent `.git` disqualifies it. Any other error — a
+ * permission failure while traversing, an unreachable network volume, a
+ * transient I/O fault — says nothing about whether this is a worktree, and git
+ * just told us it is; rejecting on those would lock a user out of a perfectly
+ * good worktree for an unrelated reason.
+ */
 async function isLiveWorkingTree(candidate: string): Promise<boolean> {
   try {
     await nodeFs.promises.access(nodePath.join(candidate, ".git"));
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code !== "ENOENT" && code !== "ENOTDIR";
   }
 }
 

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -79,9 +79,19 @@ function assertExtensionAllowed(candidate: string): void {
  * Each returned path is a root in its own right; the parent is never admitted.
  * Enumeration runs concurrently and per-project failures degrade to an empty
  * list, so one broken or deleted repository can't suppress healthy ones — the
- * project root itself stays allowed regardless. Stale ("prunable") entries are
- * harmless: `resolveContainedPath` skips any root whose realpath fails, so we
- * never mutate repository state to tidy them.
+ * project root itself stays allowed regardless.
+ *
+ * Git reports more than live working trees, so every candidate is confirmed to
+ * still be one before it earns containment. Bare entries are excluded outright:
+ * a linked checkout backed by a bare repository reports that repository, and
+ * granting it would hand out its object store and hooks. The rest are checked
+ * for a `.git` entry, which every working tree has (a directory in the main
+ * one, a gitdir pointer file in linked ones). That check is what makes stale
+ * "prunable" records safe — git keeps reporting a worktree directory the user
+ * deleted behind its back, and if that path is later reused by something
+ * unrelated, the absent `.git` is the only thing separating it from a granted
+ * root. Recreation is exactly the case a realpath-only test misses. We never
+ * prune: this is a read-time authorization check, not worktree lifecycle code.
  */
 async function collectTrackedWorktreeRoots(projectRoots: readonly string[]): Promise<string[]> {
   const perProject = await Promise.all(
@@ -93,7 +103,26 @@ async function collectTrackedWorktreeRoots(projectRoots: readonly string[]): Pro
     )
   );
 
-  return perProject.flatMap((worktrees) => worktrees.map((worktree) => worktree.path));
+  const candidates = [
+    ...new Set(
+      perProject.flatMap((worktrees) =>
+        worktrees.filter((worktree) => !worktree.bare).map((worktree) => worktree.path)
+      )
+    ),
+  ];
+  const live = await Promise.all(candidates.map((candidate) => isLiveWorkingTree(candidate)));
+
+  return candidates.filter((_, index) => live[index]);
+}
+
+/** True when `candidate` still looks like a git working tree we can trust. */
+async function isLiveWorkingTree(candidate: string): Promise<boolean> {
+  try {
+    await nodeFs.promises.access(nodePath.join(candidate, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/scripts/baselines/eager-import-baseline.json
+++ b/scripts/baselines/eager-import-baseline.json
@@ -23,7 +23,6 @@
     "electron/ipc/handlers/pluginMcp.ts",
     "electron/ipc/handlers/privacy.ts",
     "electron/ipc/handlers/shortcutHints.ts",
-    "electron/ipc/handlers/systemShell.ts",
     "electron/ipc/handlers/terminalConfig.ts",
     "electron/ipc/handlers/voiceInput.ts",
     "electron/ipc/handlers/worktree/lifecycle.ts",
@@ -320,11 +319,6 @@
     {
       "file": "electron/ipc/handlers/shortcutHints.ts",
       "line": 14,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/systemShell.ts",
-      "line": 88,
       "pattern": "sync-store-get"
     },
     {


### PR DESCRIPTION
## Summary

- Open in Editor and Reveal in Finder rejected files inside a git worktree with `OUTSIDE_ROOT`, even though the file viewer read the same file fine.
- `assertPathAllowed` in `electron/ipc/handlers/systemShell.ts` built its containment allow-list by predicting worktree parent directories from a path pattern, reading only the global `worktreeConfig.pathPattern`. That over-admitted (every child of the predicted parent, worktree or not) and under-admitted (per-project `worktreePathPattern` overrides were invisible, and no pattern predicts a manual `git worktree add`).
- Fix: stop predicting, ask git. Enumerate the real worktree roots per project via `gitServiceCache.getGitService(root).listWorktrees()` and admit each tracked root exactly, never its parent. `pathGuard.ts` and the executable deny-list are untouched; only how `roots` is built changed.

Resolves #11277

## Changes

- Git enumeration is deferred until a path would otherwise be rejected. Checking a path against a union of roots is equivalent to checking it against whichever root actually contains it, so escalating only after an `OUTSIDE_ROOT` miss keeps the common case (a file inside the main project) free of subprocess overhead. A non-absolute or unresolvable path short-circuits before any git subprocess is spawned.
- Enumerated worktree records are vetted before they earn containment: `bare` entries are excluded (a linked checkout backed by something like `/srv/repo.git` would otherwise grant its object store, refs, config, and hooks), records pointing at the filesystem root are dropped (the containment check treats `/` as containing everything), and each remaining candidate needs a `.git` entry present on disk.
- That last check is what makes stale "prunable" records safe. Git keeps reporting a worktree directory as tracked after it's been deleted on disk, and if that path is later reused by something unrelated, the missing `.git` entry is the only thing standing between it and a granted root. Only a definitive `ENOENT`/`ENOTDIR` disqualifies a candidate; a permission or I/O error doesn't, since git already confirmed it's a worktree.
- Net effect is a tightening, not just a fix: the old predicted-parent-directory approach was strictly broader than the new exact-root approach.
- Dropped the now-stale `systemShell.ts` entry from `scripts/baselines/eager-import-baseline.json`. Removing a synchronous `store.get` call left that allowlist entry unused, which `check-import-budget` treats as a hard error.

## Testing

`systemShell.handlers.test.ts` was rewritten around a mocked `gitServiceCache`. It covers the two scenarios from the issue (a custom per-project pattern, and a manual `git worktree add` outside any pattern), the deliberate tightening (a sibling directory matching the old predicted pattern that git doesn't actually track is now rejected), bare-repo exclusion, stale-path reuse, filesystem-root records, permission-failing probes, per-project enumeration failure isolation, canonical target path forwarding through the escalated branch, and confirms the executable deny-list still fires on a safe-named symlink inside a worktree.

153 tests green locally across `systemShell`, `handlers.registry`, `files.read`, `forgeResolution`, and import-budget suites. Prettier clean, eslint 0 errors.