### PR TITLE
fix(panel): stop rename fields from starting drags, and a ref written during render

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -764,7 +764,11 @@ function PanelHeaderComponent({
           </span>
 
           {isEditingTitle ? (
+            // [data-no-dnd] opts the rename field out of the header drag
+            // surface: without it, drag-selecting the title text travels past
+            // DRAG_ACTIVATION_DISTANCE and picks the panel up instead.
             <input
+              data-no-dnd
               ref={titleInputRef}
               type="text"
               value={editingValue}

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -209,6 +209,14 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     e.stopPropagation();
   }, []);
 
+  // The tab-reorder DndContext uses a raw TouchSensor, which activates on
+  // touchstart and deliberately ignores the tab strip's [data-no-dnd]. Without
+  // this, a long-press to select text in the rename field starts a tab drag —
+  // the touch twin of the panel-header bug.
+  const handleInputTouchStart = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation();
+  }, []);
+
   // Handle main click - enter edit mode if not already editing, or trigger standard click
   const handleClick = useCallback(() => {
     if (isEditing) return;
@@ -312,6 +320,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               onClick={handleInputClick}
               onDoubleClick={handleInputDoubleClick}
               onPointerDown={handleInputPointerDown}
+              onTouchStart={handleInputTouchStart}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.1 }}

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { PanelHeader } from "../PanelHeader";
 import type { PanelHeaderProps } from "../PanelHeader";
 import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
+import { NoDndMouseSensor, NoDndTouchSensor } from "@/components/DragDrop/DndProvider";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 
@@ -921,6 +922,65 @@ describe("PanelHeader", () => {
       const cls = getRenameInput().className;
       expect(cls).not.toMatch(/(outline|ring|border)-daintree-accent/);
       expect(cls).toContain("focus:outline-hidden");
+    });
+  });
+
+  describe("rename input drag suppression", () => {
+    // Drag-selecting text in the rename input used to travel past the sensor's
+    // 8px activation distance and pick the whole panel up instead of selecting.
+    // These wire the REAL sensor activators as the header's drag listeners,
+    // exactly as DndProvider does, so they assert the actual activation
+    // decision rather than a DOM-shape proxy for it.
+    const renderWithRealSensors = () => {
+      const onActivation = vi.fn();
+      const results: boolean[] = [];
+      const mouseActivator = NoDndMouseSensor.activators[0]!;
+      const touchActivator = NoDndTouchSensor.activators[0]!;
+      mockDragHandle = {
+        listeners: {
+          onMouseDown: (e) =>
+            void results.push(
+              mouseActivator.handler(e as React.MouseEvent, { onActivation } as never)
+            ),
+          onTouchStart: (e) =>
+            void results.push(
+              touchActivator.handler(e as React.TouchEvent, { onActivation } as never)
+            ),
+        },
+      };
+      const utils = render(
+        <PanelHeader
+          {...makeProps({ isEditingTitle: true, editingValue: "Test", location: "grid" })}
+        />
+      );
+      return { ...utils, onActivation, results };
+    };
+
+    afterEach(() => {
+      mockDragHandle = null;
+    });
+
+    it("refuses to arm the panel drag when a mousedown lands in the rename input", () => {
+      const { onActivation, results } = renderWithRealSensors();
+      fireEvent.mouseDown(screen.getByLabelText("Edit terminal title"));
+      expect(results).toEqual([false]);
+      expect(onActivation).not.toHaveBeenCalled();
+    });
+
+    it("refuses to arm the panel drag on a long-press in the rename input", () => {
+      const { onActivation, results } = renderWithRealSensors();
+      fireEvent.touchStart(screen.getByLabelText("Edit terminal title"), {
+        touches: [{ clientX: 0, clientY: 0 }],
+      });
+      expect(results).toEqual([false]);
+      expect(onActivation).not.toHaveBeenCalled();
+    });
+
+    it("still arms the panel drag from the surrounding header while renaming", () => {
+      const { container, onActivation, results } = renderWithRealSensors();
+      fireEvent.mouseDown(container.firstElementChild as HTMLElement);
+      expect(results).toEqual([true]);
+      expect(onActivation).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -606,5 +606,32 @@ describe("TabButton", () => {
       fireEvent.pointerDown(screen.getByRole("tab"));
       expect(parentPointerDown).not.toHaveBeenCalled();
     });
+
+    // Selecting text in the rename field must never pick a tab up. The tab
+    // sortable listens on BOTH pointerdown and touchstart (its DndContext pairs
+    // PointerSensor with a raw TouchSensor that ignores the strip's
+    // [data-no-dnd]), so the input has to stop each one.
+    it.each([
+      ["pointerdown", (el: HTMLElement) => fireEvent.pointerDown(el), "onPointerDown"],
+      ["touchstart", (el: HTMLElement) => fireEvent.touchStart(el), "onTouchStart"],
+    ])("does not arm a tab drag from a %s inside the rename input", (_name, fire, listener) => {
+      const parentHandler = vi.fn();
+      const sensorHandler = vi.fn();
+      render(
+        <div onPointerDown={parentHandler} onTouchStart={parentHandler}>
+          <TabButton
+            {...defaultProps}
+            onRename={vi.fn()}
+            sortableListeners={{ [listener]: sensorHandler }}
+          />
+        </div>
+      );
+
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+      fire(screen.getByTestId("motion-input"));
+
+      expect(sensorHandler).not.toHaveBeenCalled();
+      expect(parentHandler).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Sidebar/DeletedWorktreeCard.tsx
+++ b/src/components/Sidebar/DeletedWorktreeCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type MouseEvent } from "react";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import { FolderX, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
@@ -111,13 +111,27 @@ export function DeletedWorktreeCard({
   // 38s/37s/38s. Freezing is also the honest reading: a held countdown is not
   // advancing. The key re-captures if the TTL preference changes underneath the
   // hold, which is the one case where the sweep re-pins a genuinely new value.
-  const heldRemainingRef = useRef<{ key: string; remainingMs: number } | null>(null);
+  // Captured in state, not a ref: this value IS render output, and refs may not
+  // be read or written during render (React Compiler enforces it). This is the
+  // documented "adjust state when a prop changes" pattern — React re-runs the
+  // component immediately, before paint, so no torn frame is observable.
   const holdKey = hold === undefined ? null : `${worktree.holdReason}:${cleanupMs}`;
-  if (holdKey === null) heldRemainingRef.current = null;
-  else if (heldRemainingRef.current?.key !== holdKey) {
-    heldRemainingRef.current = { key: holdKey, remainingMs: derivedRemainingMs };
+  const [heldRemaining, setHeldRemaining] = useState<{
+    key: string;
+    remainingMs: number;
+  } | null>(null);
+  if (holdKey === null) {
+    if (heldRemaining !== null) setHeldRemaining(null);
+  } else if (heldRemaining?.key !== holdKey) {
+    setHeldRemaining({ key: holdKey, remainingMs: derivedRemainingMs });
   }
-  const remainingMs = heldRemainingRef.current?.remainingMs ?? derivedRemainingMs;
+  // Falls back to the derived value on the capture render, where `heldRemaining`
+  // still holds the previous key — that fallback is the very value being
+  // captured, so the readout never flickers through an underived frame.
+  const remainingMs =
+    heldRemaining !== null && heldRemaining.key === holdKey
+      ? heldRemaining.remainingMs
+      : derivedRemainingMs;
   const remainingSeconds = Math.ceil(remainingMs / 1000);
   // Snap the top of the range to exactly full: the tick that arms the row lands
   // somewhere inside the sweep's first second, so a bar that should read "just

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -254,6 +254,54 @@ describe("DeletedWorktreeCard", () => {
     }
   });
 
+  // The freeze is captured during render, so releasing a hold is where the
+  // capture can linger — the steady-state test above never releases, and a
+  // snapshot that outlived its hold would pin the row forever.
+  it("resumes counting down from the live deadline once the hold is released", () => {
+    vi.useFakeTimers();
+    try {
+      setPanels([{ id: "t1", worktreeId: "wt-1" }]);
+      const base = 1_700_000_000_000;
+      vi.setSystemTime(base);
+      const held: DeletedWorktree = {
+        ...worktree,
+        expiresAt: base + 38_000,
+        holdReason: "agent",
+      };
+
+      const { container, rerender } = renderCard(held);
+      const secondsValue = () =>
+        Number.parseInt(
+          container
+            .querySelector("[data-testid='deleted-worktree-countdown-seconds']")
+            ?.textContent?.replace("s", "") ?? "NaN",
+          10
+        );
+
+      const frozen = secondsValue();
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(secondsValue()).toBe(frozen);
+
+      // Release: the captured snapshot must be dropped, not linger and keep the
+      // row pinned at a value the deadline has long since moved past.
+      rerender(
+        <TooltipProvider>
+          <DeletedWorktreeCard worktree={{ ...held, holdReason: null }} />
+        </TooltipProvider>
+      );
+      expect(secondsValue()).toBeLessThan(frozen);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(secondsValue()).toBeLessThan(frozen - 5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("names each hold condition in terms the user can act on", () => {
     setPanels([{ id: "t1", worktreeId: "wt-1" }]);
     const copyFor = (holdReason: DeletedWorktree["holdReason"]) => {


### PR DESCRIPTION
Fixes two issues.

## Rename fields starting drags

The inline rename field in the panel header sat on the drag surface, so click-dragging to select the title started a panel drag instead of selecting text. Marking the field with `data-no-dnd` is enough: `NoDndMouseSensor` and `NoDndTouchSensor` already check for it, so both the mouse and long-press paths bail before the 8px activation distance. The keyboard path was never affected, since dnd-kit's `KeyboardSensor` requires `event.target === activatorNode` and the activator is the header, not the field.

Reviewing the same area turned up the equivalent field in `TabButton.tsx`. That one only stopped `pointerdown`, but the tab reorder context pairs `PointerSensor` with a raw `TouchSensor` on `touchstart`, and that sensor deliberately ignores the tab strip's `[data-no-dnd]`. A long press to select text in a tab rename field could still pick the tab up. Added a `touchstart` guard there too. Confirmed it was real: with the guard removed, the sortable sensor receives the event.

## Ref written during render

Unrelated, and pre-existing on `develop` (from `e24bf309b`). `DeletedWorktreeCard.tsx` kept the held-countdown value in a `useRef` that was both written and read during render, which produced 9 React Compiler errors. That is also a genuine hazard, not just a lint complaint: a ref write during render schedules nothing, so a frozen readout can fail to repaint.

Replaced it with the standard "adjust state when a prop changes" pattern. On the capture render `heldRemaining` still holds the previous key, so `remainingMs` falls back to `derivedRemainingMs`, which is the value being captured. Output is identical and both branches converge, so there is no render loop.

`compiler-budget:critical` drops from 13 to 4. The file compiles clean rather than merely erroring less (`CompileSuccess`, no bailout), so it is genuinely optimised and needs no baseline change. The remaining 4 errors are pre-existing in `useEditorDomHandlers.ts`, `useColdNumberGap.ts` and `FilePane.tsx`.

## Tests

Every new test was verified to fail without its fix, so none are vacuous. The panel header tests wire the real `NoDndMouseSensor` and `NoDndTouchSensor` activators as the header's drag listeners, the way `DndProvider` does, so they assert the actual activation decision rather than the presence of an attribute.

One thing I deliberately did not pin: the countdown can jump by up to a second when a hold begins, because the capture takes the sweep's re-pinned deadline rather than the value last on screen. That behaviour predates this PR and the ref version did the same, so I left it alone rather than widen the diff.

## Known gaps

- No E2E. The unit tests prove the drag never arms, but only a real browser would prove the text actually selects. Worth adding to `full-panels` if we want belt and braces.
- Several header control buttons stop `pointerdown` while the outer sensors listen on `mousedown` and `touchstart`, so click-dragging them may still arm a panel drag. Pre-existing and out of scope here.
- Two correctness holes in the hold design survive this PR, both pre-existing: a TTL change during a hold can freeze the row on a stale value, and a hold reason change recaptures mid-hold even though the sweep treats it as one continuous hold. Happy to file those separately.
