### PR TITLE
fix(project): open guided git init for non-repo Dock drops

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -11,7 +11,7 @@ const mockWebContents = vi.hoisted(() => ({
   getZoomLevel: vi.fn(() => 1.0),
   isDestroyed: vi.fn(() => false),
   send: vi.fn(),
-  isLoading: vi.fn(() => false),
+  isLoadingMainFrame: vi.fn(() => false),
   once: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
@@ -180,8 +180,12 @@ vi.mock("../services/pluginMenuRegistry.js", () => ({
   getPluginMenuItems: vi.fn(() => []),
 }));
 
+const getAppWebContentsMock = vi.hoisted(() =>
+  vi.fn((_win: { id: number }): unknown => mockWebContents)
+);
+
 vi.mock("../window/webContentsRegistry.js", () => ({
-  getAppWebContents: vi.fn(() => mockWebContents),
+  getAppWebContents: getAppWebContentsMock,
 }));
 
 const isWindowsStoreBuildMock = vi.hoisted(() => vi.fn(() => true));
@@ -929,8 +933,11 @@ describe("handleDirectoryOpen non-repository folders", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // `clearAllMocks` drops call history but keeps implementations, so restore
+    // the defaults the per-test overrides below replace.
     mockWebContents.isDestroyed.mockReturnValue(false);
-    mockWebContents.isLoading.mockReturnValue(false);
+    mockWebContents.isLoadingMainFrame.mockReturnValue(false);
+    getAppWebContentsMock.mockImplementation(() => mockWebContents);
     windowRefMock.getWindowRegistry.mockReturnValue(undefined);
   });
 
@@ -949,7 +956,7 @@ describe("handleDirectoryOpen non-repository folders", () => {
   });
 
   it("defers the send until the renderer finishes loading", async () => {
-    mockWebContents.isLoading.mockReturnValue(true);
+    mockWebContents.isLoadingMainFrame.mockReturnValue(true);
     projectStoreMock.addProject.mockRejectedValue(
       new AppError({ code: "NOT_A_GIT_REPO", message: "Not a git repository" })
     );
@@ -971,7 +978,7 @@ describe("handleDirectoryOpen non-repository folders", () => {
   });
 
   it("drops the deferred send if the renderer is destroyed before it fires", async () => {
-    mockWebContents.isLoading.mockReturnValue(true);
+    mockWebContents.isLoadingMainFrame.mockReturnValue(true);
     projectStoreMock.addProject.mockRejectedValue(
       new AppError({ code: "NOT_A_GIT_REPO", message: "Not a git repository" })
     );
@@ -986,14 +993,62 @@ describe("handleDirectoryOpen non-repository folders", () => {
   });
 
   it("still shows the native error box for unrelated failures", async () => {
+    projectStoreMock.addProject.mockRejectedValue(new Error("ENOENT: no such file or directory"));
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    expect(mockWebContents.send).not.toHaveBeenCalled();
+    expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hijack unrelated structured errors", async () => {
+    // Guards the `error.code` half of the condition: matching on `isAppError`
+    // alone would route a genuine failure into git-init setup and swallow it.
     projectStoreMock.addProject.mockRejectedValue(
-      new Error("ENOENT: no such file or directory")
+      new AppError({ code: "INTERNAL", message: "Something else broke" })
     );
 
     await handleDirectoryOpen(FOLDER, targetWindowStub());
 
     expect(mockWebContents.send).not.toHaveBeenCalled();
     expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends to the window the open came from, not a global one", async () => {
+    const otherWindowContents = { isDestroyed: () => false, isLoadingMainFrame: () => false, send: vi.fn() };
+    getAppWebContentsMock.mockImplementation((win: { id: number }) =>
+      win.id === 3 ? mockWebContents : otherWindowContents
+    );
+    projectStoreMock.addProject.mockRejectedValue(
+      new AppError({ code: "NOT_A_GIT_REPO", message: "Not a git repository" })
+    );
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    expect(mockWebContents.send).toHaveBeenCalledTimes(1);
+    expect(otherWindowContents.send).not.toHaveBeenCalled();
+  });
+
+  it("gives up if the window closes while the folder is being resolved", async () => {
+    // `addProject` is async, so the user can close the window mid-flight; the
+    // renderer lookup must not run against a dead window.
+    let destroyed = false;
+    projectStoreMock.addProject.mockImplementation(() => {
+      destroyed = true;
+      return Promise.reject(
+        new AppError({ code: "NOT_A_GIT_REPO", message: "Not a git repository" })
+      );
+    });
+    const closingWindow = {
+      id: 3,
+      isDestroyed: () => destroyed,
+    } as unknown as Electron.BrowserWindow;
+
+    await handleDirectoryOpen(FOLDER, closingWindow);
+
+    expect(getAppWebContentsMock).not.toHaveBeenCalled();
+    expect(mockWebContents.send).not.toHaveBeenCalled();
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
   });
 
   it("keys the guided path to the error code, not the message text", async () => {

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -1015,7 +1015,11 @@ describe("handleDirectoryOpen non-repository folders", () => {
   });
 
   it("sends to the window the open came from, not a global one", async () => {
-    const otherWindowContents = { isDestroyed: () => false, isLoadingMainFrame: () => false, send: vi.fn() };
+    const otherWindowContents = {
+      isDestroyed: () => false,
+      isLoadingMainFrame: () => false,
+      send: vi.fn(),
+    };
     getAppWebContentsMock.mockImplementation((win: { id: number }) =>
       win.id === 3 ? mockWebContents : otherWindowContents
     );

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -11,6 +11,8 @@ const mockWebContents = vi.hoisted(() => ({
   getZoomLevel: vi.fn(() => 1.0),
   isDestroyed: vi.fn(() => false),
   send: vi.fn(),
+  isLoading: vi.fn(() => false),
+  once: vi.fn(),
   undo: vi.fn(),
   redo: vi.fn(),
   cut: vi.fn(),
@@ -72,7 +74,10 @@ vi.mock("electron", () => ({
     setApplicationMenu: vi.fn(),
     getApplicationMenu: vi.fn(() => mockApplicationMenu),
   },
-  dialog: { showOpenDialog: vi.fn() },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showMessageBox: vi.fn(() => Promise.resolve({ response: 0, checkboxChecked: false })),
+  },
   BrowserWindow: vi.fn(),
   shell: { openExternal: vi.fn() },
   app: {
@@ -116,7 +121,10 @@ vi.mock("../window/portDistribution.js", () => ({
 }));
 
 vi.mock("../ipc/channels.js", () => ({
-  CHANNELS: { MENU_ACTION: "menu-action" },
+  CHANNELS: {
+    MENU_ACTION: "menu-action",
+    PROJECT_OPEN_GIT_INIT_DIALOG: "project:open-git-init-dialog",
+  },
 }));
 
 vi.mock("../../shared/config/agentRegistry.js", () => ({
@@ -187,7 +195,9 @@ vi.mock("../../shared/config/distribution.js", async (importOriginal) => ({
 
 import { createApplicationMenu, handleDirectoryOpen, buildAboutPanelOptions } from "../menu.js";
 import { getBuildChannelLabel } from "../../shared/config/distribution.js";
-import { webContents, app, Menu } from "electron";
+import { webContents, app, Menu, dialog } from "electron";
+import { CHANNELS } from "../ipc/channels.js";
+import { AppError } from "../utils/errorTypes.js";
 
 function findMenuItem(
   template: Electron.MenuItemConstructorOptions[],
@@ -904,5 +914,97 @@ describe("handleDirectoryOpen window targeting", () => {
 
     expect(targetManager.switchTo).toHaveBeenCalledWith(PROJECT.id, PROJECT.path);
     expect(newestManager.switchTo).not.toHaveBeenCalled();
+  });
+});
+
+// #11281: a folder that isn't a repository yet must route to the renderer's
+// guided GitInitDialog instead of the dead-end native error box, for every entry
+// point that funnels through handleDirectoryOpen (Dock drop, Cmd+O, Recent).
+describe("handleDirectoryOpen non-repository folders", () => {
+  const FOLDER = "/repos/not-a-repo";
+
+  function targetWindowStub(): Electron.BrowserWindow {
+    return { id: 3, isDestroyed: () => false } as unknown as Electron.BrowserWindow;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWebContents.isDestroyed.mockReturnValue(false);
+    mockWebContents.isLoading.mockReturnValue(false);
+    windowRefMock.getWindowRegistry.mockReturnValue(undefined);
+  });
+
+  it("opens the guided dialog instead of the native error box", async () => {
+    projectStoreMock.addProject.mockRejectedValue(
+      new AppError({ code: "NOT_A_GIT_REPO", message: `Not a git repository: ${FOLDER}` })
+    );
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    expect(mockWebContents.send).toHaveBeenCalledTimes(1);
+    expect(mockWebContents.send).toHaveBeenCalledWith(CHANNELS.PROJECT_OPEN_GIT_INIT_DIALOG, {
+      directoryPath: FOLDER,
+    });
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("defers the send until the renderer finishes loading", async () => {
+    mockWebContents.isLoading.mockReturnValue(true);
+    projectStoreMock.addProject.mockRejectedValue(
+      new AppError({ code: "NOT_A_GIT_REPO", message: "Not a git repository" })
+    );
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    // A cold-launch Dock drop opens the folder while the window is still
+    // loading; Electron drops sends made before `did-finish-load` with no queue.
+    expect(mockWebContents.send).not.toHaveBeenCalled();
+    expect(mockWebContents.once).toHaveBeenCalledTimes(1);
+
+    const [event, deferredSend] = mockWebContents.once.mock.calls[0] as [string, () => void];
+    expect(event).toBe("did-finish-load");
+
+    deferredSend();
+    expect(mockWebContents.send).toHaveBeenCalledWith(CHANNELS.PROJECT_OPEN_GIT_INIT_DIALOG, {
+      directoryPath: FOLDER,
+    });
+  });
+
+  it("drops the deferred send if the renderer is destroyed before it fires", async () => {
+    mockWebContents.isLoading.mockReturnValue(true);
+    projectStoreMock.addProject.mockRejectedValue(
+      new AppError({ code: "NOT_A_GIT_REPO", message: "Not a git repository" })
+    );
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    const [, deferredSend] = mockWebContents.once.mock.calls[0] as [string, () => void];
+    mockWebContents.isDestroyed.mockReturnValue(true);
+    deferredSend();
+
+    expect(mockWebContents.send).not.toHaveBeenCalled();
+  });
+
+  it("still shows the native error box for unrelated failures", async () => {
+    projectStoreMock.addProject.mockRejectedValue(
+      new Error("ENOENT: no such file or directory")
+    );
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    expect(mockWebContents.send).not.toHaveBeenCalled();
+    expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys the guided path to the error code, not the message text", async () => {
+    // An untyped error that merely mentions the phrase (e.g. surfaced by some
+    // other git call) must keep the old native-dialog behavior — only the
+    // structured NOT_A_GIT_REPO code means "this folder can be initialized".
+    projectStoreMock.addProject.mockRejectedValue(new Error("Not a git repository: elsewhere"));
+
+    await handleDirectoryOpen(FOLDER, targetWindowStub());
+
+    expect(mockWebContents.send).not.toHaveBeenCalled();
+    expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -235,6 +235,7 @@ export const CHANNELS = {
   PROJECT_INIT_GIT: "project:init-git",
   PROJECT_INIT_GIT_GUIDED: "project:init-git-guided",
   PROJECT_INIT_GIT_PROGRESS: "project:init-git-progress",
+  PROJECT_OPEN_GIT_INIT_DIALOG: "project:open-git-init-dialog",
   PROJECT_CLONE_REPO: "project:clone-repo",
   PROJECT_CLONE_PROGRESS: "project:clone-progress",
   PROJECT_CLONE_CANCEL: "project:clone-cancel",

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -705,8 +705,6 @@ export async function handleDirectoryOpen(
 
     createApplicationMenu(targetWindow, cliAvailabilityService);
   } catch (error) {
-    console.error("Failed to open project:", error);
-
     // A folder that isn't a repository yet is a guided-setup opportunity, not an
     // error: hand it to the renderer's existing GitInitDialog so the user can
     // confirm initializing it. Keyed to the structured AppError code rather than
@@ -724,15 +722,23 @@ export async function handleDirectoryOpen(
 
       // A send before `did-finish-load` is dropped with no queue, which is the
       // cold-launch Dock-drop case (the folder opens while the window is still
-      // loading). Read `isLoading()` here rather than before the await above so
-      // a load that finished during `addProject` isn't waited on forever.
-      if (rendererTarget.isLoading()) {
+      // loading). Gate on `isLoadingMainFrame()`, not `isLoading()`: the latter
+      // is true while *any* frame is loading (an HTML preview iframe, say), but
+      // `did-finish-load` only fires for the main frame — so a bare `isLoading()`
+      // could park the send on an event that never arrives. Read it here rather
+      // than before the await above, so a load that finished while `addProject`
+      // was running isn't waited on forever.
+      if (rendererTarget.isLoadingMainFrame()) {
         rendererTarget.once("did-finish-load", sendOpenGitInitDialog);
       } else {
         sendOpenGitInitDialog();
       }
       return;
     }
+
+    // Logged only after the guided path declines the error — a folder that just
+    // needs initializing is an expected user choice, not a failure.
+    console.error("Failed to open project:", error);
 
     let errorMessage = "An unknown error occurred";
     if (error instanceof Error) {

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -25,6 +25,7 @@ import { getAppWebContents } from "./window/webContentsRegistry.js";
 import { PROJECT_MENU_ITEM_IDS, resolveProjectIdForApplicationMenu } from "./projectMenuState.js";
 import { PRODUCT_NAME, PRODUCT_WEBSITE, PRODUCT_COPYRIGHT_ORG } from "./utils/productBranding.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
+import { isAppError } from "./utils/errorTypes.js";
 import { isWindowsStoreBuild, getBuildChannelLabel } from "../shared/config/distribution.js";
 
 // The About panel's build-version slot shows the release channel for
@@ -705,6 +706,33 @@ export async function handleDirectoryOpen(
     createApplicationMenu(targetWindow, cliAvailabilityService);
   } catch (error) {
     console.error("Failed to open project:", error);
+
+    // A folder that isn't a repository yet is a guided-setup opportunity, not an
+    // error: hand it to the renderer's existing GitInitDialog so the user can
+    // confirm initializing it. Keyed to the structured AppError code rather than
+    // message text — `addProject` is called in-process here, so the thrown
+    // AppError instance survives intact (no structured-clone boundary). Covers
+    // Dock drop, Cmd+O, and Recent Projects alike, since all three land here.
+    if (isAppError(error) && error.code === "NOT_A_GIT_REPO") {
+      if (targetWindow.isDestroyed()) return;
+
+      const rendererTarget = getAppWebContents(targetWindow);
+      const sendOpenGitInitDialog = (): void => {
+        if (rendererTarget.isDestroyed()) return;
+        rendererTarget.send(CHANNELS.PROJECT_OPEN_GIT_INIT_DIALOG, { directoryPath });
+      };
+
+      // A send before `did-finish-load` is dropped with no queue, which is the
+      // cold-launch Dock-drop case (the folder opens while the window is still
+      // loading). Read `isLoading()` here rather than before the await above so
+      // a load that finished during `addProject` isn't waited on forever.
+      if (rendererTarget.isLoading()) {
+        rendererTarget.once("did-finish-load", sendOpenGitInitDialog);
+      } else {
+        sendOpenGitInitDialog();
+      }
+      return;
+    }
 
     let errorMessage = "An unknown error occurred";
     if (error instanceof Error) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1708,6 +1708,9 @@ function buildElectronApi(): ElectronAPI {
         callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
       ) => _typedOn(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, callback),
 
+      onOpenGitInitDialog: (callback: (payload: { directoryPath: string }) => void) =>
+        _typedOn(CHANNELS.PROJECT_OPEN_GIT_INIT_DIALOG, callback),
+
       onFocusOnActivate: (callback: (payload: { intent: "focus-next-waiting" }) => void) =>
         _typedOn(CHANNELS.PROJECT_FOCUS_ON_ACTIVATE, callback),
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -558,6 +558,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onWorktreeLoadStatus(
       callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
     ): () => void;
+    onOpenGitInitDialog(callback: (payload: { directoryPath: string }) => void): () => void;
     onFocusOnActivate(callback: (payload: { intent: "focus-next-waiting" }) => void): () => void;
     onBackgroundResize(callback: (payload: { width: number; height: number }) => void): () => void;
     onUpdated(callback: (project: Project) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1638,6 +1638,10 @@ export interface IpcEventMap {
   "project:stats-updated": ProjectStatusMap;
   "project:updated": Project;
   "project:removed": string;
+  // Main asks the renderer to open the guided git-init dialog for a folder the
+  // user tried to open that isn't a repository yet (Dock drop, Cmd+O, Recent
+  // Projects). Nothing is written to disk until the user confirms in-dialog.
+  "project:open-git-init-dialog": { directoryPath: string };
 
   // Scratch events
   "scratch:on-switch": ScratchSwitchPayload;

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -306,6 +306,12 @@ describe("projectStore adversarial", () => {
     // Nothing is written until the user confirms in-dialog.
     expect(projectClientMock.add).not.toHaveBeenCalled();
 
+    // Dropping a second folder must not swap the path under the open dialog:
+    // mid-initialization that would init the first folder and then add the
+    // second, since the success handler rereads the store.
+    callbacks[0]!({ directoryPath: "/repos/second-folder" });
+    expect(useProjectStore.getState().gitInitDirectoryPath).toBe("/repos/not-a-repo");
+
     useProjectStore.getState().closeGitInitDialog();
     expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
     expect(useProjectStore.getState().gitInitDirectoryPath).toBeNull();

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -20,6 +20,7 @@ type StorageMock = {
 type ProjectApi = {
   onUpdated?: (callback: (project: ProjectShape) => void) => () => void;
   onRemoved?: (callback: (projectId: string) => void) => () => void;
+  onOpenGitInitDialog?: (callback: (payload: { directoryPath: string }) => void) => () => void;
 };
 
 const projectClientMock = vi.hoisted(() => ({
@@ -277,6 +278,38 @@ describe("projectStore adversarial", () => {
 
     updatedCallbacks[0]!(projectB);
     expect(useProjectStore.getState().projects).toEqual([projectB]);
+  });
+
+  // #11281: main pushes this when a folder opened via the Dock/Cmd+O/Recent
+  // isn't a repo yet. Registration lives at module scope so it is wired before
+  // the renderer finishes loading, which is when the cold-launch send arrives.
+  it("opens the git-init dialog when main pushes a non-repository folder", async () => {
+    const callbacks: Array<(payload: { directoryPath: string }) => void> = [];
+    const onOpenGitInitDialog = vi.fn((callback: (payload: { directoryPath: string }) => void) => {
+      callbacks.push(callback);
+      return vi.fn();
+    });
+    installProjectApi({ onOpenGitInitDialog });
+    installLocalStorage(createStorageMock());
+
+    await import("../projectStore");
+    vi.resetModules();
+    const { useProjectStore } = await import("../projectStore");
+
+    expect(onOpenGitInitDialog).toHaveBeenCalledTimes(1);
+    expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+
+    callbacks[0]!({ directoryPath: "/repos/not-a-repo" });
+
+    expect(useProjectStore.getState().gitInitDialogOpen).toBe(true);
+    expect(useProjectStore.getState().gitInitDirectoryPath).toBe("/repos/not-a-repo");
+    // Nothing is written until the user confirms in-dialog.
+    expect(projectClientMock.add).not.toHaveBeenCalled();
+
+    useProjectStore.getState().closeGitInitDialog();
+    expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
+    expect(useProjectStore.getState().gitInitDirectoryPath).toBeNull();
+    expect(projectClientMock.add).not.toHaveBeenCalled();
   });
 
   it("ignores stale switch rejections once a newer switch has started", async () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1006,7 +1006,14 @@ if (typeof window !== "undefined" && window.electron?.project) {
   // Main pushes this when the user tries to open a folder that isn't a repo yet
   // (Dock drop, Cmd+O, Recent Projects). It reuses the same dialog the renderer
   // opens for its own add-project flow, so confirm/cancel behave identically.
+  //
+  // Dropping several folders at once fires one event each, and the dialog holds
+  // a single path. Ignore arrivals while one is already open rather than
+  // swapping the path underneath it: mid-initialization, a swap would init the
+  // first folder but hand the second to `handleGitInitSuccess`, leaving the
+  // first initialized-but-not-added and the second added without being touched.
   listenerState.applyOpenGitInitDialog = ({ directoryPath }) => {
+    if (useProjectStore.getState().gitInitDialogOpen) return;
     useProjectStore.getState().openGitInitDialog(directoryPath);
   };
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -199,9 +199,11 @@ interface ProjectStoreListenerState {
   applyWorktreeLoadStatus:
     | ((payload: { projectId: string; worktreeLoadError: string | null }) => void)
     | null;
+  applyOpenGitInitDialog: ((payload: { directoryPath: string }) => void) | null;
   updatedRegistered: boolean;
   removedRegistered: boolean;
   worktreeLoadStatusRegistered: boolean;
+  openGitInitDialogRegistered: boolean;
 }
 
 const PROJECT_STORE_LISTENER_STATE_KEY = "__daintreeProjectStoreListenerState";
@@ -271,9 +273,11 @@ function getProjectStoreListenerState(): ProjectStoreListenerState {
     applyUpdated: null,
     applyRemoved: null,
     applyWorktreeLoadStatus: null,
+    applyOpenGitInitDialog: null,
     updatedRegistered: false,
     removedRegistered: false,
     worktreeLoadStatusRegistered: false,
+    openGitInitDialogRegistered: false,
   };
   target[PROJECT_STORE_LISTENER_STATE_KEY] = created;
   return created;
@@ -999,6 +1003,13 @@ if (typeof window !== "undefined" && window.electron?.project) {
     });
   };
 
+  // Main pushes this when the user tries to open a folder that isn't a repo yet
+  // (Dock drop, Cmd+O, Recent Projects). It reuses the same dialog the renderer
+  // opens for its own add-project flow, so confirm/cancel behave identically.
+  listenerState.applyOpenGitInitDialog = ({ directoryPath }) => {
+    useProjectStore.getState().openGitInitDialog(directoryPath);
+  };
+
   const projectApi = window.electron.project;
   if (projectApi.onUpdated && !listenerState.updatedRegistered) {
     listenerState.updatedRegistered = true;
@@ -1022,6 +1033,18 @@ if (typeof window !== "undefined" && window.electron?.project) {
     listenerState.worktreeLoadStatusRegistered = true;
     projectClient.onWorktreeLoadStatus((payload) => {
       listenerState.applyWorktreeLoadStatus?.(payload);
+    });
+  }
+  // Registered at module scope (not in a React effect) so it is wired before the
+  // renderer finishes loading — main gates its cold-launch send on
+  // `did-finish-load`, which can fire before any component mounts.
+  if (
+    typeof projectApi.onOpenGitInitDialog === "function" &&
+    !listenerState.openGitInitDialogRegistered
+  ) {
+    listenerState.openGitInitDialogRegistered = true;
+    projectApi.onOpenGitInitDialog((payload) => {
+      listenerState.applyOpenGitInitDialog?.(payload);
     });
   }
 }


### PR DESCRIPTION
## Summary

- Opening a folder that isn't a Git repository (Dock drop, Cmd+O, or Recent Projects) used to dead-end in a native error box. It now opens the existing guided Git init dialog for that folder so the user can confirm initializing it.
- Nothing touches disk until the user confirms. Cancel leaves the folder untouched and adds no project. Confirm initializes the repo, adds it as a project, and opens it.
- All three entry points funnel through `handleDirectoryOpen` in `electron/menu.ts`, so the fix lands there once instead of as a Dock-only special case.

Resolves #11281

## Changes

**`electron/menu.ts`**
- The `catch` block now branches on the structured `AppError` code `NOT_A_GIT_REPO`, not a substring match on the message. On that code we push a new one-way event to the renderer instead of showing the native dialog. Every other error (`ENOENT`, `EACCES`, unknown, and even an untyped `Error` that just mentions "not a git repository") still shows the native dialog and still logs.
- The send targets `getAppWebContents(targetWindow)` so it lands in the window the open came from, and it's gated on `isLoadingMainFrame()` / `once("did-finish-load")` so a cold-launch Dock drop (which opens the folder while the renderer is still loading) doesn't get silently dropped. Electron discards sends made before the renderer finishes loading with no queue to catch them.

**IPC plumbing**
- New one-way main to renderer event `project:open-git-init-dialog` in `channels.ts`, `IpcEventMap`, preload, and `ElectronAPI`. Not an invoke channel, so no codegen and no ratchet baseline change.

**`src/store/projectStore.ts`**
- A module-scope listener, registered before the renderer finishes loading alongside the existing `onUpdated`/`onRemoved`/`onWorktreeLoadStatus` listeners, calls the already-existing `openGitInitDialog(path)`.
- It ignores an arrival while a dialog is already open, so dropping several folders at once can't swap the path out from under an initializing dialog.

**No new UI.** `GitInitDialog`, `addProjectByPath`, and `handleGitInitSuccess` are reused as-is.

## Testing

- `electron/__tests__/menu.test.ts`: new `handleDirectoryOpen non-repository folders` block covering routing to the dialog instead of the native box, deferring the send while the renderer loads, dropping the deferred send if the renderer is destroyed first, sending to the originating window rather than a global one, giving up if the window closes mid-resolve, and still showing the native box for unrelated failures, unrelated structured `AppError`s, and message-only "not a git repository" errors.
- `src/store/__tests__/projectStore.adversarial.test.ts`: the pushed event opens the dialog with the right path, registers once across module reloads, writes nothing until confirmed, and won't let a second folder replace an open dialog's path.
- 222 tests passing across 10 files covering every changed module, including `channelDrift`, `leafPreloadNamespaces`, and `ipcHandleCoverage` IPC guards. ESLint 0 errors on changed files, prettier clean.

**Known gap:** there's no E2E coverage anywhere in the repo for Dock drop, cold launch, or git init, so the native macOS lifecycle here is verified by unit seams and manual testing rather than E2E.

**Out of scope, unchanged:** the pre-existing partial-init-on-failure behavior in the guided git-init handler, where `git init` runs before the gitignore/add/commit steps with no rollback.