### PR TITLE
feat(project): preserve project identity across folder moves

### DIFF
--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -127,6 +127,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     ) {
       projectStore
         .writeInRepoProjectIdentity(updated.path, {
+          id: updated.id,
           name: updated.name,
           emoji: updated.emoji,
           color: updated.color,

--- a/electron/ipc/handlers/projectInRepoSettings.ts
+++ b/electron/ipc/handlers/projectInRepoSettings.ts
@@ -96,6 +96,7 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
     }
     const settings = await projectStore.getProjectSettings(projectId);
     await projectStore.writeInRepoProjectIdentity(project.path, {
+      id: project.id,
       name: project.name,
       emoji: project.emoji,
       color: project.color,

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -614,6 +614,34 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     }, "removeWorktree");
   }
 
+  /**
+   * Re-links this repository with its linked worktrees after the main worktree
+   * has moved on disk (#11282).
+   *
+   * A move breaks a pointer *pair*: each linked worktree's `.git` file still
+   * names the old main location, and `.git/worktrees/<id>/gitdir` still names
+   * the old linked location. Run from the main worktree's new path, `git
+   * worktree repair` fixes the linked worktrees git can still find on its own,
+   * which covers the common case where only the main folder moved. When the
+   * linked worktrees moved too, git has no anchor to infer them from and their
+   * new paths must be passed explicitly.
+   *
+   * Note this does not repair nested submodule gitlinks — those need
+   * `git submodule absorbgitdirs` and are not handled here.
+   */
+  async repairWorktrees(worktreePaths: string[] = []): Promise<void> {
+    logDebug("Repairing worktrees", { rootPath: this.rootPath, worktreePaths });
+
+    const args = ["worktree", "repair"];
+    if (worktreePaths.length > 0) {
+      args.push("--end-of-options", ...worktreePaths);
+    }
+
+    return this.handleGitOperation(async () => {
+      await (await this.getGit()).raw(args);
+    }, "repairWorktrees");
+  }
+
   async findAvailableBranchName(baseName: string): Promise<string> {
     const branches = await this.listBranches();
     // Only check local branches for conflicts (remote branches don't prevent local creation)

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -10,7 +10,7 @@ import fs from "fs/promises";
 import { createHash } from "crypto";
 import { z } from "zod";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
-import { UTF8_BOM } from "./projectStorePaths.js";
+import { UTF8_BOM, isValidProjectId } from "./projectStorePaths.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
 import { TerminalRecipeSchema } from "../schemas/ipc.js";
 import {
@@ -97,7 +97,7 @@ function buildShareableTerminalSettings(
 export class ProjectIdentityFiles {
   async readInRepoProjectIdentity(
     projectPath: string
-  ): Promise<{ name?: string; emoji?: string; color?: string; found: boolean }> {
+  ): Promise<{ id?: string; name?: string; emoji?: string; color?: string; found: boolean }> {
     const filePath = path.join(projectPath, DAINTREE_PROJECT_JSON);
     try {
       let content = await fs.readFile(filePath, "utf-8");
@@ -114,9 +114,17 @@ export class ProjectIdentityFiles {
         return { found: false };
       }
 
-      const result: { name?: string; emoji?: string; color?: string; found: boolean } = {
-        found: true,
-      };
+      const result: { id?: string; name?: string; emoji?: string; color?: string; found: boolean } =
+        {
+          found: true,
+        };
+
+      // The move anchor (#11282). A malformed id is dropped without discarding
+      // the rest of the identity — a hand-edited or truncated value must not
+      // cost the user their project name/emoji/color.
+      if (typeof parsed.id === "string" && isValidProjectId(parsed.id)) {
+        result.id = parsed.id;
+      }
 
       if (typeof parsed.name === "string" && parsed.name.trim().length > 0) {
         result.name = parsed.name.trim().slice(0, MAX_PROJECT_NAME_LENGTH);
@@ -153,13 +161,26 @@ export class ProjectIdentityFiles {
 
   async writeInRepoProjectIdentity(
     projectPath: string,
-    data: { name?: string; emoji?: string; color?: string }
+    data: { id?: string; name?: string; emoji?: string; color?: string }
   ): Promise<void> {
     await this.assertDaintreeDirNotSymlink(projectPath);
     const daintreeDir = path.join(projectPath, DAINTREE_DIR);
     const filePath = path.join(projectPath, DAINTREE_PROJECT_JSON);
 
-    const payload: { version: 1; name?: string; emoji?: string; color?: string } = { version: 1 };
+    // This function rebuilds the envelope from scratch, so an `id` the caller
+    // does not supply would be *erased* by any ordinary name/emoji/color edit —
+    // silently disarming move detection (#11282). Carry the on-disk value
+    // forward whenever the caller doesn't name one.
+    let id = data.id !== undefined && isValidProjectId(data.id) ? data.id : undefined;
+    if (id === undefined) {
+      const existing = await this.readInRepoProjectIdentity(projectPath);
+      id = existing.id;
+    }
+
+    const payload: { version: 1; id?: string; name?: string; emoji?: string; color?: string } = {
+      version: 1,
+    };
+    if (id !== undefined) payload.id = id;
     if (data.name !== undefined) payload.name = data.name;
     if (data.emoji !== undefined) payload.emoji = data.emoji;
     if (data.color !== undefined) payload.color = data.color;

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -182,7 +182,11 @@ export class ProjectStateManager {
       }
     }
 
-    this.setProjectStateCache(projectId, validatedState);
+    // Stamp the id we actually saved under, so a cached read and a fresh disk
+    // read agree. The disk path treats the state directory as authoritative, and
+    // a caller passing a stale embedded id must not get a different answer just
+    // because the cache happened to be warm.
+    this.setProjectStateCache(projectId, { ...validatedState, projectId });
   }
 
   async getProjectState(projectId: string): Promise<ProjectState | null> {

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -243,7 +243,12 @@ export class ProjectStateManager {
       );
 
       const state: ProjectState = {
-        projectId: parsed.projectId || projectId,
+        // The state directory this was read from is the authority. An embedded
+        // id can be stale — older builds copied the state dir wholesale when a
+        // relocation minted a new id, leaving the previous id inside the file
+        // (#11282) — and trusting it hands callers an id that no longer names
+        // any project.
+        projectId,
         activeWorktreeId: parsed.activeWorktreeId,
         sidebarWidth: typeof parsed.sidebarWidth === "number" ? parsed.sidebarWidth : 350,
         terminals: validTerminals,

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -26,7 +26,12 @@ import {
   type ProjectRow,
 } from "./persistence/schema.js";
 import { eq, desc } from "drizzle-orm";
-import { generateProjectId, getProjectStateDir } from "./projectStorePaths.js";
+import {
+  generateProjectId,
+  mintProjectId,
+  isValidProjectId,
+  getProjectStateDir,
+} from "./projectStorePaths.js";
 import { ProjectSettingsManager } from "./ProjectSettingsManager.js";
 import { ProjectStateManager, type ProjectStateReadResult } from "./ProjectStateManager.js";
 import { invalidatePrefetchCache } from "./prefetchHydrateCache.js";
@@ -45,6 +50,37 @@ import { computeFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
 
 export const DEFAULT_PROJECT_EMOJI = "🌲";
+
+/**
+ * The single spelling of a project path used for identity comparisons. Separator
+ * normalization and Unicode normalization are independent problems: a
+ * Finder-dragged NFD path and a typed NFC path denote the same folder on macOS
+ * but are different strings, so both operands of any path comparison have to go
+ * through here.
+ */
+export function normalizeProjectPath(projectPath: string): string {
+  return path.normalize(projectPath).normalize("NFC");
+}
+
+function isEnoent(error: unknown): boolean {
+  return (
+    typeof error === "object" && error !== null && (error as { code?: string }).code === "ENOENT"
+  );
+}
+
+/**
+ * Best-effort re-link of a moved project's linked worktrees. Deliberately never
+ * throws: a project whose folder moved is still perfectly usable on its own, so
+ * a repair failure must not fail the relocation and strand the user with an
+ * unregistered project.
+ */
+async function repairLinkedWorktrees(projectPath: string): Promise<void> {
+  try {
+    await new GitService(projectPath).repairWorktrees();
+  } catch (error) {
+    logError(`Failed to repair linked worktrees for ${projectPath}`, error);
+  }
+}
 
 /**
  * Read a persisted count back, rejecting anything a corrupt row could hold.
@@ -173,13 +209,13 @@ export class ProjectStore {
 
   async readInRepoProjectIdentity(
     projectPath: string
-  ): Promise<{ name?: string; emoji?: string; color?: string; found: boolean }> {
+  ): Promise<{ id?: string; name?: string; emoji?: string; color?: string; found: boolean }> {
     return this.identityFiles.readInRepoProjectIdentity(projectPath);
   }
 
   async writeInRepoProjectIdentity(
     projectPath: string,
-    data: { name?: string; emoji?: string; color?: string }
+    data: { id?: string; name?: string; emoji?: string; color?: string }
   ): Promise<void> {
     return this.identityFiles.writeInRepoProjectIdentity(projectPath, data);
   }
@@ -375,9 +411,17 @@ export class ProjectStore {
 
     const inRepo = await this.readInRepoProjectIdentity(normalizedPath);
 
+    // The folder may be a project we already know that simply moved. `inRepo.id`
+    // is the anchor written into `.daintree/project.json`; if it names a row
+    // whose registered path is gone, this is that project at its new home and
+    // its identity — and therefore every id-keyed piece of state — is preserved
+    // in place (#11282).
+    const relocated = await this.tryAdoptMovedProject(inRepo.id, normalizedPath);
+    if (relocated) return relocated;
+
     const now = Date.now();
     const project: Project = {
-      id: generateProjectId(normalizedPath),
+      id: mintProjectId(normalizedPath, (candidate) => this.getProjectById(candidate) !== null),
       path: normalizedPath,
       name: inRepo.name ?? path.basename(normalizedPath),
       emoji: inRepo.emoji ?? DEFAULT_PROJECT_EMOJI,
@@ -407,6 +451,55 @@ export class ProjectStore {
       .run();
 
     return project;
+  }
+
+  /**
+   * Decides whether the folder now at `normalizedPath` is an already-registered
+   * project that moved, and if so repoints it in place.
+   *
+   * `.daintree/project.json` is git-tracked, so a clone or fork inherits the
+   * anchor of the repository it was copied from. The discriminator is whether
+   * the anchored project's registered path is *still there*: if it is, this
+   * folder is a copy living alongside the original and must get its own
+   * identity; only a vanished original means "the same project moved here".
+   *
+   * Every uncertain case returns `null`, which falls through to registering a
+   * brand-new project — today's behavior. Failing that direction costs the user
+   * a re-link; the opposite failure would silently hand one project's panels,
+   * settings and Assistant history to a different repository.
+   */
+  private async tryAdoptMovedProject(
+    anchorId: string | undefined,
+    normalizedPath: string
+  ): Promise<Project | null> {
+    if (!anchorId || !isValidProjectId(anchorId)) return null;
+
+    const anchored = this.getProjectById(anchorId);
+    if (!anchored) return null;
+
+    // Already registered here; the caller's path lookup should have caught it.
+    if (normalizeProjectPath(anchored.path) === normalizedPath) return null;
+
+    let originalIsGone: boolean;
+    try {
+      await fs.access(anchored.path);
+      originalIsGone = false;
+    } catch (error) {
+      // Only a genuinely absent original proves a move. A permissions or I/O
+      // failure tells us nothing, so it must not be read as "gone".
+      originalIsGone = isEnoent(error);
+    }
+    if (!originalIsGone) return null;
+
+    const adopted = this.updateProject(anchorId, {
+      path: normalizedPath,
+      status: "closed",
+    });
+
+    this.pruneInRepoRecipeHashes(anchored.path);
+    await repairLinkedWorktrees(normalizedPath);
+
+    return adopted;
   }
 
   async removeProject(projectId: string): Promise<void> {
@@ -681,6 +774,23 @@ export class ProjectStore {
     return row ? rowToProject(row) : null;
   }
 
+  /**
+   * Resolves the id of the project registered at `projectPath`.
+   *
+   * Prefer this over `generateProjectId(path)` anywhere the answer is used to
+   * look something up: ids survive a folder move, so a relocated project's id
+   * no longer equals the hash of its current path and hashing would silently
+   * resolve to a project that does not exist (#11282). Falls back to the hash
+   * for paths that were never registered, preserving the previous behavior for
+   * callers that run before/without a project row.
+   */
+  resolveProjectIdForPath(projectPath: string): string {
+    const normalizedPath = normalizeProjectPath(projectPath);
+    const db = getSharedDb();
+    const row = db.select().from(projectsTable).where(eq(projectsTable.path, normalizedPath)).get();
+    return row?.id ?? generateProjectId(normalizedPath);
+  }
+
   getProjectById(projectId: string): Project | null {
     const db = getSharedDb();
     const row = db.select().from(projectsTable).where(eq(projectsTable.id, projectId)).get();
@@ -730,96 +840,29 @@ export class ProjectStore {
     }
 
     const canonicalNewPath = await this.getGitRoot(newPath);
-    const newProjectId = generateProjectId(canonicalNewPath);
 
-    if (newProjectId === projectId) {
-      return this.updateProject(projectId, { path: canonicalNewPath, status: "closed" });
-    }
-
-    const existingAtNewPath = this.getProjectById(newProjectId);
-    if (existingAtNewPath) {
+    // A project id is immutable once registered, so reattaching a folder is a
+    // path update on the existing row — not a new identity (#11282). Everything
+    // keyed by the id (state dir, settings, secure env, panel/terminal ids,
+    // Assistant hibernation, session journal) therefore stays reachable with no
+    // copying, re-keying or cleanup at all, and there is no half-migrated state
+    // for a failure to strand.
+    const existingAtNewPath = await this.getProjectByPath(canonicalNewPath);
+    if (existingAtNewPath && existingAtNewPath.id !== projectId) {
       throw new Error(`A project already exists at that location: ${existingAtNewPath.name}`);
     }
 
-    const oldStateDir = getProjectStateDir(this.projectsConfigDir, projectId);
-    const newStateDir = getProjectStateDir(this.projectsConfigDir, newProjectId);
-
-    if (oldStateDir && newStateDir && existsSync(oldStateDir)) {
-      await fs.cp(oldStateDir, newStateDir, { recursive: true });
-    }
-
-    const projects = this.getAllProjects();
-    const index = projects.findIndex((p) => p.id === projectId);
-    if (index === -1) {
-      if (newStateDir && existsSync(newStateDir)) {
-        await fs.rm(newStateDir, { recursive: true, force: true }).catch(() => {});
-      }
-      throw new Error(`Project not found: ${projectId}`);
-    }
-
-    const oldProject = projects[index];
-    const updatedProject: Project = {
-      ...oldProject,
-      id: newProjectId,
+    const oldPath = project.path;
+    const updatedProject = this.updateProject(projectId, {
       path: canonicalNewPath,
       status: "closed",
-    };
+    });
 
-    const db = getSharedDb();
-    try {
-      db.delete(projectsTable).where(eq(projectsTable.id, projectId)).run();
-      db.insert(projectsTable)
-        .values({
-          id: updatedProject.id,
-          path: updatedProject.path,
-          name: updatedProject.name,
-          emoji: updatedProject.emoji,
-          lastOpened: updatedProject.lastOpened,
-          color: updatedProject.color ?? null,
-          status: updatedProject.status ?? null,
-          daintreeConfigPresent: updatedProject.daintreeConfigPresent ?? null,
-          inRepoSettings: updatedProject.inRepoSettings ?? null,
-          pinned: updatedProject.pinned ? 1 : 0,
-          frecencyScore: updatedProject.frecencyScore ?? FRECENCY_COLD_START,
-          lastAccessedAt: updatedProject.lastAccessedAt ?? 0,
-          ...repoStatsToColumns(updatedProject.lastKnownStats),
-        })
-        .run();
-      this.settingsManager.migrateEnvForProject(projectId, newProjectId);
-      this.stateManager.invalidateProjectStateCache(projectId);
-      this.stateManager.invalidateProjectStateCache(newProjectId);
-    } catch (error) {
-      db.delete(projectsTable).where(eq(projectsTable.id, newProjectId)).run();
-      db.insert(projectsTable)
-        .values({
-          id: oldProject.id,
-          path: oldProject.path,
-          name: oldProject.name,
-          emoji: oldProject.emoji,
-          lastOpened: oldProject.lastOpened,
-          color: oldProject.color ?? null,
-          status: oldProject.status ?? null,
-          daintreeConfigPresent: oldProject.daintreeConfigPresent ?? null,
-          inRepoSettings: oldProject.inRepoSettings ?? null,
-          pinned: oldProject.pinned ? 1 : 0,
-          frecencyScore: oldProject.frecencyScore ?? FRECENCY_COLD_START,
-          lastAccessedAt: oldProject.lastAccessedAt ?? 0,
-          ...repoStatsToColumns(oldProject.lastKnownStats),
-        })
-        .run();
-      if (newStateDir && existsSync(newStateDir)) {
-        await fs.rm(newStateDir, { recursive: true, force: true }).catch(() => {});
-      }
-      throw error;
-    }
-
-    // The old path is gone — drop its cached recipe hashes so they don't linger.
-    this.pruneInRepoRecipeHashes(oldProject.path);
-
-    if (oldStateDir && existsSync(oldStateDir)) {
-      await fs.rm(oldStateDir, { recursive: true, force: true }).catch((err) => {
-        logError(`Failed to clean up old state dir for project ${projectId}`, err);
-      });
+    if (normalizeProjectPath(oldPath) !== normalizeProjectPath(canonicalNewPath)) {
+      // The old path no longer backs this project — drop its cached recipe
+      // hashes so they don't linger.
+      this.pruneInRepoRecipeHashes(oldPath);
+      await repairLinkedWorktrees(canonicalNewPath);
     }
 
     return updatedProject;

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -109,27 +109,6 @@ function rowToRepoStats(row: ProjectRow): ProjectRepoStats | null {
   };
 }
 
-/**
- * Inverse of {@link rowToRepoStats}, for the insert paths that rebuild a row
- * from a `Project` (relocation). Without this the last-known counts would be
- * dropped on the floor and the toolbar would shift once after every relocate.
- */
-function repoStatsToColumns(stats: ProjectRepoStats | undefined): {
-  statsCommitCount: number | null;
-  statsIssueCount: number | null;
-  statsPrCount: number | null;
-  statsProviderId: string | null;
-  statsLastUpdated: number | null;
-} {
-  return {
-    statsCommitCount: stats ? readPersistedCount(stats.commitCount) : null,
-    statsIssueCount: stats ? readPersistedCount(stats.issueCount) : null,
-    statsPrCount: stats ? readPersistedCount(stats.prCount) : null,
-    statsProviderId: stats?.providerId ?? null,
-    statsLastUpdated: stats ? readPersistedCount(stats.lastUpdated) : null,
-  };
-}
-
 function rowToProject(row: ProjectRow): Project {
   const project: Project = {
     id: row.id,
@@ -419,9 +398,17 @@ export class ProjectStore {
     const relocated = await this.tryAdoptMovedProject(inRepo.id, normalizedPath);
     if (relocated) return relocated;
 
+    // Re-check under the same tick as the insert. Several awaits have happened
+    // since the lookup above, and a concurrent `addProject` for this same folder
+    // would otherwise get past that stale check, find the path-derived id taken,
+    // mint a *random* one and insert a second row for one directory — the path
+    // column has no unique index to catch it.
+    const raced = await this.getProjectByPath(normalizedPath);
+    if (raced) return raced;
+
     const now = Date.now();
     const project: Project = {
-      id: mintProjectId(normalizedPath, (candidate) => this.getProjectById(candidate) !== null),
+      id: mintProjectId(normalizedPath, (candidate) => this.isProjectIdTaken(candidate)),
       path: normalizedPath,
       name: inRepo.name ?? path.basename(normalizedPath),
       emoji: inRepo.emoji ?? DEFAULT_PROJECT_EMOJI,
@@ -454,6 +441,21 @@ export class ProjectStore {
   }
 
   /**
+   * True if `candidate` may not be handed to a new project.
+   *
+   * A registered row is the obvious case, but a leftover *state directory* is
+   * just as disqualifying: cleanup after a removed project is best-effort, so an
+   * orphaned directory can outlive its row. Reusing its id would silently serve
+   * a dead project's panels, settings and secure-env keys to an unrelated
+   * repository.
+   */
+  private isProjectIdTaken(candidate: string): boolean {
+    if (this.getProjectById(candidate) !== null) return true;
+    const stateDir = getProjectStateDir(this.projectsConfigDir, candidate);
+    return stateDir !== null && existsSync(stateDir);
+  }
+
+  /**
    * Decides whether the folder now at `normalizedPath` is an already-registered
    * project that moved, and if so repoints it in place.
    *
@@ -479,6 +481,13 @@ export class ProjectStore {
 
     // Already registered here; the caller's path lookup should have caught it.
     if (normalizeProjectPath(anchored.path) === normalizedPath) return null;
+
+    // Repointing the project a window is currently displaying would strand that
+    // view, its workspace host and its PTYs on the old path — the same reason
+    // `relocateProject` refuses it. Rebinding a live project needs the
+    // quiesce/rebind sequence that doesn't exist yet, so decline the adoption
+    // and let this register as an ordinary new project.
+    if (anchorId === this.getCurrentProjectId()) return null;
 
     let originalIsGone: boolean;
     try {

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -86,7 +86,7 @@ vi.mock("../projectQuarantineCleanup.js", () => ({
 }));
 
 import { ProjectStore } from "../ProjectStore.js";
-import { mintProjectId, isValidProjectId } from "../projectStorePaths.js";
+import { mintProjectId, isValidProjectId, generateProjectId } from "../projectStorePaths.js";
 import { ProjectIdentityFiles } from "../ProjectIdentityFiles.js";
 
 /** Creates a real directory and returns its canonicalized path. */
@@ -183,12 +183,64 @@ describe("project identity across folder moves", () => {
 
     it("registers a new project when the anchor names nothing known", async () => {
       const dir = await makeDir("unknown-anchor");
-      await writeAnchor(dir, "a".repeat(64));
+      const unknownAnchor = "a".repeat(64);
+      await writeAnchor(dir, unknownAnchor);
 
       const added = await store.addProject(dir);
 
+      // An anchor with no local row must not be trusted as this project's id.
+      expect(added.id).not.toBe(unknownAnchor);
       expect(added.path).toBe(dir);
       expect(store.getAllProjects()).toHaveLength(1);
+    });
+
+    it.each([
+      ["EACCES", "EACCES"],
+      ["EIO", "EIO"],
+    ])("does not treat an unreadable original (%s) as a move", async (_label, code) => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+
+      const candidate = await makeDir("candidate");
+      await writeAnchor(candidate, registered.id);
+
+      // The original may still be sitting there behind a permissions or I/O
+      // failure. Only a provably absent original means "moved".
+      const accessSpy = vi.spyOn(fs.promises, "access").mockImplementation(async (target) => {
+        if (target === original) {
+          throw Object.assign(new Error(`${code}: cannot read`), { code });
+        }
+      });
+
+      try {
+        const added = await store.addProject(candidate);
+
+        expect(added.id).not.toBe(registered.id);
+        expect(store.getProjectById(registered.id)?.path).toBe(original);
+        expect(store.getAllProjects()).toHaveLength(2);
+        expect(repairWorktrees).not.toHaveBeenCalled();
+      } finally {
+        accessSpy.mockRestore();
+      }
+    });
+
+    it("declines to adopt the currently active project", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+      db.insert(schema.appState).values({ key: "currentProjectId", value: registered.id }).run();
+
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      const canonicalMoved = await fs.promises.realpath(moved);
+
+      const added = await store.addProject(canonicalMoved);
+
+      // Repointing a live project would strand its view and PTYs on the old
+      // path, so it registers separately instead.
+      expect(added.id).not.toBe(registered.id);
+      expect(store.getProjectById(registered.id)?.path).toBe(original);
     });
 
     it("ignores a malformed anchor without losing the rest of the identity", async () => {
@@ -250,6 +302,28 @@ describe("project identity across folder moves", () => {
       expect(store.getProjectById(projectA.id)?.path).toBe(a);
     });
 
+    it("gives a new repository at a vacated path its own identity", async () => {
+      // The end-to-end shape of the collision mintProjectId guards against: a
+      // project keeps sha256(oldPath) after moving away, so a different repo
+      // created at that same path must not inherit its row.
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      const preferredForOriginal = generateProjectId(original);
+      expect(registered.id).toBe(preferredForOriginal);
+
+      const moved = path.join(tmpRoot, "elsewhere");
+      await fs.promises.rename(original, moved);
+      await store.relocateProject(registered.id, await fs.promises.realpath(moved));
+
+      // A brand-new repository now occupies the vacated path.
+      const reborn = await makeDir("original");
+      const added = await store.addProject(reborn);
+
+      expect(added.id).not.toBe(registered.id);
+      expect(isValidProjectId(added.id)).toBe(true);
+      expect(store.getProjectById(registered.id)?.id).toBe(preferredForOriginal);
+    });
+
     it("skips worktree repair when the path did not actually change", async () => {
       const dir = await makeDir("unchanged");
       const registered = await store.addProject(dir);
@@ -263,18 +337,22 @@ describe("project identity across folder moves", () => {
 
   describe("mintProjectId", () => {
     it("prefers the path-derived id when it is free", () => {
-      const id = mintProjectId("/some/path", () => false);
-      expect(id).toBe(mintProjectId("/some/path", () => false));
-      expect(isValidProjectId(id)).toBe(true);
+      const isTaken = vi.fn(() => false);
+      const id = mintProjectId("/some/path", isTaken);
+
+      // Compared against the independent derivation, not another call to the
+      // function under test.
+      expect(id).toBe(generateProjectId("/some/path"));
+      expect(isTaken).toHaveBeenCalledWith(generateProjectId("/some/path"));
     });
 
     it("falls back to a fresh id when the path-derived id is taken", () => {
       // A project that moved away from this path keeps its original id, so the
       // hash of the path can already be claimed when a new repo appears there.
-      const taken = new Set([mintProjectId("/some/path", () => false)]);
-      const id = mintProjectId("/some/path", (candidate) => taken.has(candidate));
+      const preferred = generateProjectId("/some/path");
+      const id = mintProjectId("/some/path", (candidate) => candidate === preferred);
 
-      expect(taken.has(id)).toBe(false);
+      expect(id).not.toBe(preferred);
       expect(isValidProjectId(id)).toBe(true);
     });
 

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -97,7 +97,10 @@ async function makeDir(name: string): Promise<string> {
 }
 
 async function writeAnchor(projectPath: string, id: string): Promise<void> {
-  await new ProjectIdentityFiles().writeInRepoProjectIdentity(projectPath, { id, name: "Anchored" });
+  await new ProjectIdentityFiles().writeInRepoProjectIdentity(projectPath, {
+    id,
+    name: "Anchored",
+  });
 }
 
 describe("project identity across folder moves", () => {

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as schema from "../persistence/schema.js";
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    last_opened INTEGER NOT NULL,
+    color TEXT,
+    status TEXT,
+    daintree_config_present INTEGER,
+    in_repo_settings INTEGER,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    frecency_score REAL NOT NULL DEFAULT 3.0,
+    last_accessed_at INTEGER NOT NULL DEFAULT 0,
+    auto_parked_at INTEGER,
+    stats_commit_count INTEGER,
+    stats_issue_count INTEGER,
+    stats_pr_count INTEGER,
+    stats_provider_id TEXT,
+    stats_last_updated INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+let tmpRoot: string;
+
+const repairWorktrees = vi.fn(async () => {});
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-identity-test" },
+}));
+
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    async getRepositoryRoot(p: string): Promise<string> {
+      return p;
+    }
+    repairWorktrees(...args: string[][]) {
+      return repairWorktrees(...(args as []));
+    }
+  },
+}));
+
+const migrateEnvForProject = vi.fn();
+
+vi.mock("../ProjectSettingsManager.js", () => ({
+  ProjectSettingsManager: class {
+    deleteAllEnvForProject() {}
+    migrateEnvForProject(...args: string[]) {
+      migrateEnvForProject(...args);
+    }
+    getEffectiveNotificationSettings() {
+      return {};
+    }
+  },
+}));
+
+vi.mock("../ProjectStateManager.js", () => ({
+  ProjectStateManager: class {
+    invalidateProjectStateCache() {}
+  },
+}));
+
+vi.mock("../ProjectFileStore.js", () => ({ ProjectFileStore: class {} }));
+vi.mock("../GlobalFileStore.js", () => ({ GlobalFileStore: class {} }));
+vi.mock("../projectQuarantineCleanup.js", () => ({
+  cleanupQuarantinedProjectFiles: vi.fn(),
+}));
+
+import { ProjectStore } from "../ProjectStore.js";
+import { mintProjectId, isValidProjectId } from "../projectStorePaths.js";
+import { ProjectIdentityFiles } from "../ProjectIdentityFiles.js";
+
+/** Creates a real directory and returns its canonicalized path. */
+async function makeDir(name: string): Promise<string> {
+  const dir = path.join(tmpRoot, name);
+  await fs.promises.mkdir(dir, { recursive: true });
+  return fs.promises.realpath(dir);
+}
+
+async function writeAnchor(projectPath: string, id: string): Promise<void> {
+  await new ProjectIdentityFiles().writeInRepoProjectIdentity(projectPath, { id, name: "Anchored" });
+}
+
+describe("project identity across folder moves", () => {
+  let store: ProjectStore;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.promises.realpath(
+      fs.mkdtempSync(path.join(os.tmpdir(), "daintree-identity-"))
+    );
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+    repairWorktrees.mockClear();
+    migrateEnvForProject.mockClear();
+    store = new ProjectStore();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe("addProject move detection", () => {
+    it("keeps the original id when an anchored folder has moved", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+
+      // Simulate the user renaming the folder outside Daintree.
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      const canonicalMoved = await fs.promises.realpath(moved);
+
+      const reopened = await store.addProject(canonicalMoved);
+
+      expect(reopened.id).toBe(registered.id);
+      expect(reopened.path).toBe(canonicalMoved);
+      // One project, not two — the old row was repointed, not orphaned.
+      expect(store.getAllProjects()).toHaveLength(1);
+    });
+
+    it("does not copy or re-key state when adopting a moved folder", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      await store.addProject(await fs.promises.realpath(moved));
+
+      // Identity never changes, so there is nothing to migrate. A call here
+      // would mean the id had been re-keyed behind our back.
+      expect(migrateEnvForProject).not.toHaveBeenCalled();
+    });
+
+    it("repairs linked worktrees after adopting a moved folder", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      await store.addProject(await fs.promises.realpath(moved));
+
+      expect(repairWorktrees).toHaveBeenCalledTimes(1);
+    });
+
+    it("mints a distinct id for a copy whose original still exists", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+
+      // A clone inherits the tracked anchor, but the original is still there.
+      const clone = await makeDir("clone");
+      await writeAnchor(clone, registered.id);
+
+      const added = await store.addProject(clone);
+
+      expect(added.id).not.toBe(registered.id);
+      expect(store.getProjectById(registered.id)?.path).toBe(original);
+      expect(store.getAllProjects()).toHaveLength(2);
+    });
+
+    it("registers a new project when the anchor names nothing known", async () => {
+      const dir = await makeDir("unknown-anchor");
+      await writeAnchor(dir, "a".repeat(64));
+
+      const added = await store.addProject(dir);
+
+      expect(added.path).toBe(dir);
+      expect(store.getAllProjects()).toHaveLength(1);
+    });
+
+    it("ignores a malformed anchor without losing the rest of the identity", async () => {
+      const dir = await makeDir("bad-anchor");
+      await fs.promises.mkdir(path.join(dir, ".daintree"), { recursive: true });
+      await fs.promises.writeFile(
+        path.join(dir, ".daintree", "project.json"),
+        JSON.stringify({ version: 1, id: "not-a-valid-id", name: "Kept" }),
+        "utf-8"
+      );
+
+      const identity = await new ProjectIdentityFiles().readInRepoProjectIdentity(dir);
+
+      expect(identity.id).toBeUndefined();
+      expect(identity.name).toBe("Kept");
+    });
+  });
+
+  describe("relocateProject", () => {
+    it("preserves the project id when reattaching a folder", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+
+      const moved = path.join(tmpRoot, "elsewhere");
+      await fs.promises.rename(original, moved);
+      const canonicalMoved = await fs.promises.realpath(moved);
+
+      const relocated = await store.relocateProject(registered.id, canonicalMoved);
+
+      expect(relocated.id).toBe(registered.id);
+      expect(relocated.path).toBe(canonicalMoved);
+      expect(migrateEnvForProject).not.toHaveBeenCalled();
+    });
+
+    it("carries project metadata across a reattachment", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      store.updateProject(registered.id, { name: "Renamed", emoji: "🚀", pinned: true });
+
+      const moved = path.join(tmpRoot, "elsewhere");
+      await fs.promises.rename(original, moved);
+      const relocated = await store.relocateProject(
+        registered.id,
+        await fs.promises.realpath(moved)
+      );
+
+      expect(relocated.name).toBe("Renamed");
+      expect(relocated.emoji).toBe("🚀");
+      expect(relocated.pinned).toBe(true);
+    });
+
+    it("rejects reattaching onto a folder another project already owns", async () => {
+      const a = await makeDir("project-a");
+      const b = await makeDir("project-b");
+      const projectA = await store.addProject(a);
+      await store.addProject(b);
+
+      await expect(store.relocateProject(projectA.id, b)).rejects.toThrow(/already exists/i);
+      expect(store.getProjectById(projectA.id)?.path).toBe(a);
+    });
+
+    it("skips worktree repair when the path did not actually change", async () => {
+      const dir = await makeDir("unchanged");
+      const registered = await store.addProject(dir);
+
+      const relocated = await store.relocateProject(registered.id, dir);
+
+      expect(relocated.path).toBe(dir);
+      expect(repairWorktrees).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mintProjectId", () => {
+    it("prefers the path-derived id when it is free", () => {
+      const id = mintProjectId("/some/path", () => false);
+      expect(id).toBe(mintProjectId("/some/path", () => false));
+      expect(isValidProjectId(id)).toBe(true);
+    });
+
+    it("falls back to a fresh id when the path-derived id is taken", () => {
+      // A project that moved away from this path keeps its original id, so the
+      // hash of the path can already be claimed when a new repo appears there.
+      const taken = new Set([mintProjectId("/some/path", () => false)]);
+      const id = mintProjectId("/some/path", (candidate) => taken.has(candidate));
+
+      expect(taken.has(id)).toBe(false);
+      expect(isValidProjectId(id)).toBe(true);
+    });
+
+    it("treats Unicode-equivalent paths as the same project", () => {
+      const composed = "/Users/foo/café";
+      const decomposed = composed.normalize("NFD");
+
+      expect(mintProjectId(composed, () => false)).toBe(mintProjectId(decomposed, () => false));
+    });
+  });
+
+  describe("in-repo anchor durability", () => {
+    it("keeps the anchor when an unrelated metadata edit rewrites the file", async () => {
+      const dir = await makeDir("durable");
+      const identityFiles = new ProjectIdentityFiles();
+      const anchorId = "b".repeat(64);
+      await identityFiles.writeInRepoProjectIdentity(dir, { id: anchorId, name: "Before" });
+
+      // A plain rename goes through the same writer without naming an id.
+      await identityFiles.writeInRepoProjectIdentity(dir, { name: "After", emoji: "🌲" });
+
+      const identity = await identityFiles.readInRepoProjectIdentity(dir);
+      expect(identity.id).toBe(anchorId);
+      expect(identity.name).toBe("After");
+    });
+  });
+});

--- a/electron/services/__tests__/ProjectStore.test.ts
+++ b/electron/services/__tests__/ProjectStore.test.ts
@@ -523,38 +523,26 @@ describe("ProjectSettings validation", () => {
   });
 });
 
-describe("relocateProject — ID derivation helpers (smoke tests only)", () => {
-  it("new path produces a valid project ID", () => {
-    const newPath = "/Users/foo/moved-repo";
-    const newId = generateProjectId(newPath);
-    expect(isValidProjectId(newId)).toBe(true);
+// Relocation itself no longer derives an id from the path — a project id is
+// immutable once registered (#11282), so the behavioral coverage lives in
+// ProjectStore.identity.test.ts. What remains here is the state-directory
+// containment guarantee every id must satisfy.
+describe("state directory resolution", () => {
+  it("confines a project's state directory to the projects config root", () => {
+    const projectsConfigDir = path.resolve("/home/user/.config/daintree/projects");
+    const id = generateProjectId("/Users/foo/new-location");
+
+    const stateDir = getProjectStateDir(projectsConfigDir, id);
+
+    expect(stateDir).toBe(path.join(projectsConfigDir, id));
+    expect(stateDir!.startsWith(projectsConfigDir + path.sep)).toBe(true);
   });
 
-  it("different paths produce different project IDs", () => {
-    const oldPath = "/Users/foo/old-location";
-    const newPath = "/Users/foo/new-location";
-    const oldId = generateProjectId(oldPath);
-    const newId = generateProjectId(newPath);
-    expect(oldId).not.toBe(newId);
-  });
-
-  it("same path produces same project ID (no-op relocation path)", () => {
-    const path1 = "/Users/foo/my-project";
-    const id1 = generateProjectId(path1);
-    const id2 = generateProjectId(path1);
-    expect(id1).toBe(id2);
-  });
-
-  it("state dir path is computed correctly for new project ID", () => {
+  it("refuses ids that are not well-formed", () => {
     const projectsConfigDir = path.resolve("/home/user/.config/daintree/projects");
 
-    const newPath = "/Users/foo/new-location";
-    const newId = generateProjectId(newPath);
-    const newStateDir = getProjectStateDir(projectsConfigDir, newId);
-
-    expect(newStateDir).not.toBeNull();
-    expect(newStateDir!.startsWith(projectsConfigDir)).toBe(true);
-    expect(newStateDir).toBe(path.join(projectsConfigDir, newId));
+    expect(isValidProjectId("../escape")).toBe(false);
+    expect(getProjectStateDir(projectsConfigDir, "../escape")).toBeNull();
   });
 });
 

--- a/electron/services/__tests__/WorkspaceClient.loadOrder.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.loadOrder.test.ts
@@ -96,7 +96,10 @@ vi.mock("../events.js", () => ({
 }));
 
 vi.mock("../ProjectStore.js", () => ({
-  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+  projectStore: {
+    getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }),
+    resolveProjectIdForPath: vi.fn((p: string) => `id-for-${p}`),
+  },
 }));
 
 vi.mock("../../store.js", () => ({

--- a/electron/services/__tests__/WorkspaceClient.prewarm.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.prewarm.test.ts
@@ -117,7 +117,10 @@ vi.mock("../events.js", () => ({
 // into the `load-project` payload (#8316). Stub the store so importing the
 // pool doesn't trigger ProjectStore's `app.getPath("userData")` constructor.
 vi.mock("../ProjectStore.js", () => ({
-  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+  projectStore: {
+    getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }),
+    resolveProjectIdForPath: vi.fn((p: string) => `id-for-${p}`),
+  },
 }));
 
 vi.mock("../../store.js", () => ({

--- a/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.rateLimit.test.ts
@@ -94,7 +94,10 @@ vi.mock("../events.js", () => ({
 }));
 
 vi.mock("../ProjectStore.js", () => ({
-  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+  projectStore: {
+    getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }),
+    resolveProjectIdForPath: vi.fn((p: string) => `id-for-${p}`),
+  },
 }));
 
 vi.mock("../../store.js", () => ({

--- a/electron/services/__tests__/WorkspaceClient.readiness.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.readiness.test.ts
@@ -122,7 +122,10 @@ vi.mock("../events.js", () => ({
 // the `load-project` payload (#8316). Stub it so importing the pool doesn't
 // fire ProjectStore's eager `app.getPath("userData")` constructor.
 vi.mock("../ProjectStore.js", () => ({
-  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+  projectStore: {
+    getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }),
+    resolveProjectIdForPath: vi.fn((p: string) => `id-for-${p}`),
+  },
 }));
 
 import { WorkspaceClient } from "../WorkspaceClient.js";

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -123,7 +123,10 @@ vi.mock("../events.js", () => ({
 // the `load-project` payload (#8316). Stub it so importing the pool doesn't
 // fire ProjectStore's eager `app.getPath("userData")` constructor.
 vi.mock("../ProjectStore.js", () => ({
-  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+  projectStore: {
+    getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }),
+    resolveProjectIdForPath: vi.fn((p: string) => `id-for-${p}`),
+  },
 }));
 
 import path from "path";

--- a/electron/services/projectStorePaths.ts
+++ b/electron/services/projectStorePaths.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import path from "path";
 
 export const UTF8_BOM = "\uFEFF";
@@ -8,8 +8,41 @@ const RECIPES_FILENAME = "recipes.json";
 
 const STATE_FILENAME = "state.json";
 
+/**
+ * Legacy path-derived project id. Still the *minting* rule for a brand-new
+ * project (see {@link mintProjectId}), but it is no longer an identity oracle:
+ * once a project is registered its id is immutable, so a project that has moved
+ * has an id that no longer matches `generateProjectId(project.path)`. Never call
+ * this to *look up* an existing project \u2014 resolve by path through the DB
+ * instead, or the lookup silently misses every relocated project (#11282).
+ */
 export function generateProjectId(projectPath: string): string {
-  return createHash("sha256").update(projectPath).digest("hex");
+  return createHash("sha256").update(projectPath.normalize("NFC")).digest("hex");
+}
+
+/**
+ * Picks the id for a newly registered project at `normalizedPath`.
+ *
+ * Normally this is `generateProjectId(normalizedPath)`, which keeps ids stable
+ * and debuggable. But because ids now survive a folder move, the hash of a path
+ * is no longer guaranteed free: a project that moved away from `/foo` keeps
+ * `sha256("/foo")` forever, so a *different* repository later created at `/foo`
+ * would collide with its primary key. `isTaken` lets the caller consult the
+ * project table; on collision we fall back to random bytes.
+ *
+ * The fallback keeps the 64-lowercase-hex shape that {@link isValidProjectId}
+ * and {@link getProjectStateDir} depend on, so no state-directory or path-safety
+ * assumption changes.
+ */
+export function mintProjectId(normalizedPath: string, isTaken: (id: string) => boolean): string {
+  const preferred = generateProjectId(normalizedPath);
+  if (!isTaken(preferred)) return preferred;
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const candidate = randomBytes(32).toString("hex");
+    if (!isTaken(candidate)) return candidate;
+  }
+  throw new Error("Failed to mint a unique project id");
 }
 
 export function isValidProjectId(projectId: string): boolean {

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -11,7 +11,6 @@ import { type ProcessEntry, sendToEntryWindows } from "./types.js";
 import type { WorkspaceClientConfig } from "../../../shared/types/workspace-host.js";
 import type { ForgeProviderMatcher } from "../../../shared/utils/forgeHostnames.js";
 import { projectStore } from "../ProjectStore.js";
-import { generateProjectId } from "../projectStorePaths.js";
 import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
 
 const CLEANUP_GRACE_MS = 180_000;
@@ -40,7 +39,7 @@ async function readForgeSettingsForProject(projectPath: string): Promise<{
   let forgeProviderOverride: string | null = null;
   let forgeRemote: string | null = null;
   try {
-    const projectId = generateProjectId(projectPath);
+    const projectId = projectStore.resolveProjectIdForPath(projectPath);
     const settings = await projectStore.getProjectSettings(projectId).catch(() => null);
     forgeProviderOverride = settings?.forgeProviderOverride ?? null;
     forgeRemote = settings?.forgeRemote ?? settings?.githubRemote ?? null;

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -46,6 +46,10 @@ const projectClientMock = vi.hoisted(() => ({
 
 const notifyMock = vi.hoisted(() => vi.fn());
 const clearHibernateSessionMock = vi.hoisted(() => vi.fn());
+const setHibernateSessionMock = vi.hoisted(() => vi.fn());
+const hibernateSessionsMock = vi.hoisted(
+  () => ({}) as Record<string, { sessionId: string; cwd: string; agentId: string }>
+);
 const logErrorWithContextMock = vi.hoisted(() => vi.fn());
 const setProjectIdGetterMock = vi.hoisted(() => vi.fn());
 const panelPersistenceCancelMock = vi.hoisted(() => vi.fn());
@@ -88,6 +92,8 @@ vi.mock("../urlHistoryStore", () => ({
 vi.mock("../helpPanelStore", () => ({
   useHelpPanelStore: {
     getState: () => ({
+      hibernateSessions: hibernateSessionsMock,
+      setHibernateSession: setHibernateSessionMock,
       clearHibernateSession: clearHibernateSessionMock,
     }),
   },
@@ -199,6 +205,9 @@ describe("projectStore adversarial", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    for (const key of Object.keys(hibernateSessionsMock)) {
+      delete hibernateSessionsMock[key];
+    }
     clearListenerState();
     restoreLocalStorage();
     projectClientMock.getAll.mockResolvedValue([]);
@@ -556,9 +565,14 @@ describe("projectStore adversarial", () => {
     expect(useProjectStore.getState().error).toBe("Failed to remove project");
   });
 
-  it("GCs the old hibernate session when locating a project changes its id", async () => {
+  it("carries the hibernate session over if locating still changes the id", async () => {
     installProjectApi({});
     installLocalStorage(createStorageMock());
+    hibernateSessionsMock[projectA.id] = {
+      sessionId: "session-1",
+      cwd: "/tmp/project-a",
+      agentId: "claude",
+    };
     const relocated = { ...projectA, id: "project-a-relocated", path: "/tmp/project-a-moved" };
     projectClientMock.locate.mockResolvedValueOnce(relocated);
     projectClientMock.getAll.mockResolvedValue([relocated]);
@@ -566,8 +580,35 @@ describe("projectStore adversarial", () => {
     const { useProjectStore } = await import("../projectStore");
     await useProjectStore.getState().locateProject(projectA.id);
 
-    expect(clearHibernateSessionMock).toHaveBeenCalledTimes(1);
+    // Preserved under the new id and repointed at the new folder — the whole
+    // point of #11282 is that relocating never costs the user a conversation.
+    expect(setHibernateSessionMock).toHaveBeenCalledWith("project-a-relocated", {
+      sessionId: "session-1",
+      cwd: "/tmp/project-a-moved",
+      agentId: "claude",
+    });
     expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id);
+  });
+
+  it("still refreshes the project list when hibernate migration fails", async () => {
+    installProjectApi({});
+    installLocalStorage(createStorageMock());
+    setHibernateSessionMock.mockImplementationOnce(() => {
+      throw new Error("store unavailable");
+    });
+    hibernateSessionsMock[projectA.id] = {
+      sessionId: "session-1",
+      cwd: "/tmp/project-a",
+      agentId: "claude",
+    };
+    const relocated = { ...projectA, id: "project-a-relocated", path: "/tmp/project-a-moved" };
+    projectClientMock.locate.mockResolvedValueOnce(relocated);
+    projectClientMock.getAll.mockResolvedValue([relocated]);
+
+    const { useProjectStore } = await import("../projectStore");
+    await useProjectStore.getState().locateProject(projectA.id);
+
+    expect(useProjectStore.getState().projects).toEqual([relocated]);
   });
 
   it("does not GC the hibernate session when locating returns the same id", async () => {

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -608,6 +608,10 @@ describe("projectStore adversarial", () => {
     const { useProjectStore } = await import("../projectStore");
     await useProjectStore.getState().locateProject(projectA.id);
 
+    // The throwing setter must actually have been reached, and its failure must
+    // not cost the caller its list refresh or drop the surviving old entry.
+    expect(setHibernateSessionMock).toHaveBeenCalledTimes(1);
+    expect(clearHibernateSessionMock).not.toHaveBeenCalled();
     expect(useProjectStore.getState().projects).toEqual([relocated]);
   });
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -219,6 +219,32 @@ function cancelProjectReadRequests(): void {
   currentProjectRequestId++;
 }
 
+/**
+ * Moves a hibernated Assistant conversation from one project id to another,
+ * repointing its recorded working directory.
+ *
+ * Only reachable if main breaks the immutable-id invariant (#11282), so it is
+ * strictly a safety net: it must never take the relocation down with it, hence
+ * the swallowed failure. Losing the resume pointer costs one conversation;
+ * throwing here would abort the caller's project-list refresh too.
+ */
+function migrateHibernateSession(fromProjectId: string, toProjectId: string, newCwd: string): void {
+  try {
+    const helpPanel = useHelpPanelStore.getState();
+    const orphaned = helpPanel.hibernateSessions?.[fromProjectId];
+    if (orphaned) {
+      helpPanel.setHibernateSession(toProjectId, { ...orphaned, cwd: newCwd });
+    }
+    helpPanel.clearHibernateSession(fromProjectId);
+  } catch (error) {
+    logErrorWithContext(error, {
+      operation: "migrate_hibernate_session",
+      component: "projectStore",
+      details: { fromProjectId, toProjectId },
+    });
+  }
+}
+
 function getLocationProjectId(): string | null {
   return getViewWorkspaceId();
 }
@@ -858,11 +884,13 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     try {
       const updated = await projectClient.locate(projectId);
       if (updated) {
-        // Relocation regenerates the project id from its new path (sha256(path)),
-        // so the pre-relocation id is now dead. GC its orphaned hibernate session.
-        // Skip when the id is unchanged (canonicalization produced the same hash).
+        // Reattaching preserves the project id (#11282), so the hibernated
+        // Assistant conversation is still addressable and must be kept — this
+        // used to clear it, which is what made a folder move lose the
+        // conversation. Only a main-process invariant break could change the id
+        // here; carry the entry over rather than silently dropping it.
         if (updated.id !== projectId) {
-          useHelpPanelStore.getState().clearHibernateSession(projectId);
+          migrateHibernateSession(projectId, updated.id, updated.path);
         }
         const projects = await projectClient.getAll();
         set({ projects });


### PR DESCRIPTION
## Summary

- Phase 1 of #11282: stable project identity across folder moves and renames.
- A registered project id is now immutable. Reattaching a folder is an in-place path update on the same row, so everything keyed by the id keeps working with no copying, re-keying, or cleanup.
- Moves are detected automatically via an id anchor in `.daintree/project.json`, and linked git worktrees get repaired afterward.

Part of #11282.

## What this does

The issue's own decomposition is identity first, then state migration plus worktree repair, then continuity reporting. This PR is that first phase, plus the parts of phases 2 and 3 that fall out of it for free.

Root cause: `generateProjectId(path) = sha256(path)` made identity path-derived, so any folder move or rename minted a brand new project id. `relocateProject` then deleted the old row, re-inserted it under the new id, copied the per-project state directory across, dropped the old one, and the renderer's `locateProject` garbage-collected the now-orphaned Assistant hibernation entry.

The fix: once a project id is registered, it never changes. Reattaching a folder is an in-place path update on the same row, so everything keyed by the id (state directory, settings, secure env, panel/terminal ids, terminal `.restore` scrollback, Assistant hibernation, session journal) stays reachable with no copying, re-keying, or cleanup. The whole copy/delete/insert/env-migrate/rollback block is gone.

Moves are detected automatically. `.daintree/project.json` gains an optional `id` anchor holding the project's real 64-hex-character id. On open, if the anchor names a project whose registered path no longer exists, the folder is adopted at its new location with its identity intact.

Because `.daintree/` is git-tracked, a clone inherits the anchor, so the discriminator between a copy and a move is whether the anchored project's original path still exists: still there means it's a copy and gets its own identity. Every uncertain case falls back to registering a new project, which is the previous behavior.

Linked git worktrees are repaired after a move, via `git worktree repair` run from the new main-worktree path. Best-effort, never fatal.

## Why the id format didn't change

`isValidProjectId` is just `/^[0-9a-f]{64}$/`, and `getProjectStateDir` returns `null` for anything that doesn't match it. So the move anchor stores the project's actual sha256 id rather than switching to a UUID: no schema change, no migration, no state-directory changes needed.

`mintProjectId` also picked up a collision guard. A project that moves away from a given path keeps that path's hash as its id forever, so if a different repo were later created at the same path, it would otherwise collide with the old project's id on the primary key.

## Notable review fixes (second commit)

- Refuses to adopt the currently active project. Repointing a live project would strand its view, workspace host, and PTYs on the old path (`relocateProject` already refused this; the new adoption path had to as well).
- A leftover state directory now counts as a taken id, so an orphan from a failed cleanup can't serve a dead project's panels and secure env to an unrelated repo.
- Re-checks the path immediately before insert. Concurrent `addProject` calls could otherwise mint a random id and write two rows for one directory (the path column has no unique index).
- `WorkspaceHostPool` resolves ids through the database instead of hashing the path, which would miss every relocated project.

## Explicitly deferred

- The unified "Move or rename project" / "Locate moved project" dialog with the affected-state preview and D2 confirm (deliberately keeps this PR clear of the action-id / api-surface / actionMetadata / MCP-tier coupling).
- Relocating the currently open project (needs a quiesce-and-rebind coordinator).
- Rewriting path-bearing state: worktree ids, terminal/Assistant cwds, file-panel paths, window-state keys.
- Agent conversation continuity tiering (Preserved / Project-local / Provider migration required / Unavailable / Unverified).
- Submodules. `git worktree repair` doesn't touch them.
- `WorkspaceHostEventRouter` and the workspace-host `WorkspaceService` still derive ids by hashing a path; threading `projectId` through `ProcessEntry` needs fixture changes across five `WorkspaceClient` suites. Impact is limited to a stale forge-provider cache for a moved project.

No user-owned agent config (`~/.claude`, `~/.gemini`, `~/.codex`) is read, written, or otherwise touched (precedent #4100).

## Testing

- New `electron/services/__tests__/ProjectStore.identity.test.ts` (18 tests, real temp dirs + real `ProjectIdentityFiles` against an in-memory DB): anchored move keeps the id; copy-with-living-original gets its own; EACCES/EIO are not read as a move; active project is not adopted; unknown anchor is not trusted; a new repo at a vacated path gets a distinct id; anchor survives an unrelated metadata rewrite; worktree repair is/isn't invoked as appropriate.
- Replaced a block of tautological "id derivation smoke tests" in `ProjectStore.test.ts` that asserted the removed behavior.
- Rewrote the renderer hibernation tests: locating now carries the session over instead of clearing it, and a migration failure must not cost the project-list refresh.
- `npm run typecheck` clean. 2,103 tests pass locally across 99 files (`ProjectStore`, `StateManager`, identity files, `WorkspaceClient`, renderer store, `GitService`, full IPC handler suites).
