### PR TITLE
fix(dock): dock chip reorder silently no-ops for worktree-less panels

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -983,16 +983,16 @@ export function DndProvider({ children }: DndProviderProps) {
         }
 
         if (overTerminal && actualDraggedId !== actualOverId) {
-          const containerTerminals: CarrierPanel[] = [];
-          for (const tid of freshTerminalIds) {
-            const t = freshTerminalsById[tid];
-            if (!t || (t.worktreeId ?? null) !== (accordionWorktreeId ?? null)) continue;
-            if (sourceLocation === "dock") {
-              if (t.location === "dock") containerTerminals.push(t);
-            } else {
-              if (t.location === "grid" || t.location === undefined) containerTerminals.push(t);
-            }
-          }
+          // Index in the same scope space reorderTerminals splices — for a dock
+          // location that space includes global (worktree-less) panels even
+          // though the accordion only lists the worktree's own terminals; an
+          // exact-scoped index here would move the wrong chip (#11289).
+          const containerTerminals = filterTerminalsByContainer(
+            freshTerminalsById,
+            freshTerminalIds,
+            sourceLocation ?? "grid",
+            accordionWorktreeId
+          );
 
           const oldIndex = containerTerminals.findIndex((t) => t.id === actualDraggedId);
           const newIndex = containerTerminals.findIndex((t) => t.id === actualOverId);

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -167,6 +167,36 @@ describe("filterTerminalsByContainer", () => {
     const result = filterTerminalsByContainer(byId, ["null"], "grid", null);
     expect(result.map((t) => t.id)).toEqual(["null"]);
   });
+
+  // #11289 — the dock renders global (worktree-less) panels in every
+  // worktree-scoped dock, so the drop-commit list must include them too.
+  it("includes global dock panels when a worktree is active (#11289)", () => {
+    const tG = makeTerminal("g", "dock", undefined);
+    const byId = { ...terminalsById, g: tG };
+    const result = filterTerminalsByContainer(byId, ["a", "b", "g", "c", "d"], "dock", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["b", "g"]);
+  });
+
+  it("still excludes other worktrees' dock panels alongside global ones", () => {
+    const tG = makeTerminal("g", "dock", undefined);
+    const byId = { ...terminalsById, g: tG };
+    const result = filterTerminalsByContainer(byId, ["d", "g", "b"], "dock", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["g", "b"]);
+  });
+
+  it("keeps the grid worktree-exact — global grid panels stay excluded", () => {
+    const tGG = makeTerminal("gg", "grid", undefined);
+    const byId = { ...terminalsById, gg: tGG };
+    const result = filterTerminalsByContainer(byId, [...panelIds, "gg"], "grid", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["a", "c"]);
+  });
+
+  it("returns only global dock panels when no worktree is active", () => {
+    const tG = makeTerminal("g", "dock", undefined);
+    const byId = { ...terminalsById, g: tG };
+    const result = filterTerminalsByContainer(byId, ["b", "g", "d"], "dock", null);
+    expect(result.map((t) => t.id)).toEqual(["g"]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -295,6 +325,15 @@ describe("resolveTargetIndex", () => {
     const ids = [...panelIds, "d"];
     // "d" is wt2 and won't appear when filtering for wt1
     expect(resolveTargetIndex(byId, ids, "wt1", "grid", "d", undefined, false)).toBe(3);
+  });
+
+  it("resolves dock indices over the rendered order including global chips (#11289)", () => {
+    const tG = makeTerminal("g", "dock", undefined);
+    const tH = makeTerminal("h", "dock", "wt1");
+    const byId = { g: tG, h: tH };
+    // Rendered dock for wt1 is [g, h]; dropping on "h" must yield index 1,
+    // not 0 over a globals-stripped list.
+    expect(resolveTargetIndex(byId, ["g", "h"], "wt1", "dock", "h", undefined, false)).toBe(1);
   });
 
   // Geometry-aware branch (dock→grid single-terminal drops). Over rect spans

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -2,6 +2,7 @@ import type { TabGroup } from "@shared/types";
 import type { PanelKind } from "@shared/types/panel";
 import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { panelMatchesWorktreeScope } from "@/store/slices/panelRegistry/worktreeIndex";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
@@ -187,7 +188,12 @@ export function filterOutDockDroppables<T extends DockCollisionCandidate>(contai
   );
 }
 
-/** Filter terminals to those in a given container and worktree, preserving panelIds order. */
+/**
+ * Filter terminals to those in a given container and worktree, preserving
+ * panelIds order. Scope matching is shared with the dock render path so drop
+ * indices are computed over exactly the chips the dock shows — global panels
+ * included (#11289); grid stays worktree-exact.
+ */
 export function filterTerminalsByContainer(
   terminalsById: Record<string, CarrierPanel | undefined>,
   panelIds: readonly string[],
@@ -197,7 +203,7 @@ export function filterTerminalsByContainer(
   const result: CarrierPanel[] = [];
   for (const tid of panelIds) {
     const t = terminalsById[tid];
-    if (!t || (t.worktreeId ?? undefined) !== (worktreeId ?? undefined)) continue;
+    if (!t || !panelMatchesWorktreeScope(t.worktreeId, worktreeId, container)) continue;
     if (container === "dock") {
       if (t.location === "dock") result.push(t);
     } else {

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -20,6 +20,7 @@ import {
 } from "@shared/types/panel";
 import { extractHostPort } from "@/components/Browser/browserUtils";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { panelMatchesWorktreeScope } from "@/store/slices/panelRegistry/worktreeIndex";
 import type { TrashedTerminal } from "@/store/slices";
 import { DockedTerminalItem } from "./DockedTerminalItem";
 import { DockedNonPtyPanelItem } from "./DockedNonPtyPanelItem";
@@ -211,7 +212,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     for (const terminal of dockTerminalsRaw) {
       if (
         terminal.id !== helpTerminalId &&
-        (terminal.worktreeId == null || terminal.worktreeId === activeWorktreeId)
+        panelMatchesWorktreeScope(terminal.worktreeId, activeWorktreeId, "dock")
       ) {
         result.push(terminal);
       }

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -718,16 +718,32 @@ describe("dock ↔ grid transitions", () => {
 
     it("rebuilds the per-worktree buckets after a global chip reorder", () => {
       const g1 = createGlobalMockTerminal("g1", "dock");
+      const g2 = createGlobalMockTerminal("g2", "dock");
       const a = createMockTerminal("a", "dock");
       const x = makeWt2Terminal("x", "dock");
-      seedPanels([g1, a, x]);
+      seedPanels([g1, g2, a, x]);
+
+      // Rendered dock for wt-1 is [g1, g2, a] — drag g2 to the front.
+      usePanelStore.getState().reorderTerminals(1, 0, "dock", "wt-1");
+
+      const buckets = usePanelStore.getState().panelIdsByWorktreeId;
+      expect(buckets["__none__"]).toEqual(["g2", "g1"]);
+      expect(buckets["wt-1"]).toEqual(["a"]);
+      expect(buckets["wt-2"]).toEqual(["x"]);
+    });
+
+    it("reorders a dock that contains only global chips while a worktree is active", () => {
+      // The literal issue repro: panels launched with no worktree active, then
+      // a worktree is selected — the exact-match scope saw an empty list and
+      // every drag silently no-opped.
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const g2 = createGlobalMockTerminal("g2", "dock");
+      seedPanels([g1, g2]);
 
       usePanelStore.getState().reorderTerminals(0, 1, "dock", "wt-1");
 
-      const buckets = usePanelStore.getState().panelIdsByWorktreeId;
-      expect(buckets["__none__"]).toEqual(["g1"]);
-      expect(buckets["wt-1"]).toEqual(["a"]);
-      expect(buckets["wt-2"]).toEqual(["x"]);
+      expect(dockOrder("wt-1")).toEqual(["g2", "g1"]);
+      expect(usePanelStore.getState().panelIds).toEqual(["g2", "g1"]);
     });
 
     it("counts global chips when inserting a grid panel into a dock slot", () => {
@@ -742,19 +758,42 @@ describe("dock ↔ grid transitions", () => {
       expect(dockOrder("wt-1")).toEqual(["g1", "t", "a"]);
     });
 
-    it("keeps a global member's committed position on group reorder", () => {
+    it("inserts at the dock front ahead of a leading global chip", () => {
       const g1 = createGlobalMockTerminal("g1", "dock");
       const a = createMockTerminal("a", "dock");
+      const t = createMockTerminal("t", "grid");
+      seedPanels([g1, a, t]);
+
+      usePanelStore.getState().moveTerminalToPosition("t", 0, "dock", "wt-1");
+
+      expect(dockOrder("wt-1")).toEqual(["t", "g1", "a"]);
+    });
+
+    it("keeps a global group's members in their committed position on group reorder", () => {
+      // A global tab group (worktreeId undefined, global members) is what the
+      // dock launcher produces with no worktree active — the realistic
+      // explicit-group shape that renders in every worktree's dock.
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const g2 = createGlobalMockTerminal("g2", "dock");
       const c = createMockTerminal("c", "dock");
-      seedPanels([g1, a, c]);
-      const group = createMockTabGroup("G", ["g1", "a"], "dock");
-      usePanelStore.setState({ tabGroups: new Map([["G", group]]) });
+      const d = createMockTerminal("d", "dock");
+      seedPanels([g1, g2, c, d]);
+      const globalGroup: TabGroup = {
+        id: "G",
+        panelIds: ["g1", "g2"],
+        activeTabId: "g1",
+        location: "dock",
+        worktreeId: undefined,
+      };
+      usePanelStore.setState({ tabGroups: new Map([["G", globalGroup]]) });
 
-      // Groups render as [G(g1, a), c] — move G after c.
-      usePanelStore.getState().reorderTabGroups(0, 1, "dock", "wt-1");
+      // Groups render as [G(g1, g2), c, d] — move c after d. The global
+      // group must hold position 0; the pre-fix tail eviction shoved its
+      // members to the end instead.
+      usePanelStore.getState().reorderTabGroups(1, 2, "dock", "wt-1");
 
-      expect(dockOrder("wt-1")).toEqual(["c", "g1", "a"]);
-      expect(usePanelStore.getState().panelIds).toEqual(["c", "g1", "a"]);
+      expect(dockOrder("wt-1")).toEqual(["g1", "g2", "d", "c"]);
+      expect(usePanelStore.getState().panelIds).toEqual(["g1", "g2", "d", "c"]);
     });
 
     it("reorders single-chip groups across a global chip correctly", () => {

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -665,4 +665,121 @@ describe("dock ↔ grid transitions", () => {
       expect(usePanelStore.getState().tabGroups.has("g1")).toBe(false);
     });
   });
+
+  describe("worktree-scoped dock ordering with global panels (#11289)", () => {
+    function seedPanels(terminals: PtyPanelData[]) {
+      const panelsById = Object.fromEntries(terminals.map((t) => [t.id, t]));
+      const panelIds = terminals.map((t) => t.id);
+      usePanelStore.setState({
+        panelsById,
+        panelIds,
+        panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
+      });
+    }
+
+    function makeWt2Terminal(id: string, location: "grid" | "dock"): PtyPanelData {
+      return { ...createMockTerminal(id, location), worktreeId: "wt-2" };
+    }
+
+    function dockOrder(worktreeId: string): string[] {
+      return usePanelStore
+        .getState()
+        .getTabGroups("dock", worktreeId)
+        .flatMap((g) => g.panelIds);
+    }
+
+    it("reorders a global chip among scoped chips instead of silently no-opping", () => {
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const a = createMockTerminal("a", "dock");
+      const b = createMockTerminal("b", "dock");
+      const x = makeWt2Terminal("x", "dock");
+      seedPanels([g1, a, b, x]);
+
+      // Rendered dock for wt-1 is [g1, a, b] — drag g1 to the end.
+      usePanelStore.getState().reorderTerminals(0, 2, "dock", "wt-1");
+
+      expect(dockOrder("wt-1")).toEqual(["a", "b", "g1"]);
+      expect(usePanelStore.getState().panelIds).toEqual(["a", "b", "g1", "x"]);
+    });
+
+    it("reorders a scoped chip past a global chip into the rendered slot", () => {
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const a = createMockTerminal("a", "dock");
+      const b = createMockTerminal("b", "dock");
+      const x = makeWt2Terminal("x", "dock");
+      seedPanels([g1, a, b, x]);
+
+      // Rendered dock for wt-1 is [g1, a, b] — drag "a" (index 1) to the front.
+      usePanelStore.getState().reorderTerminals(1, 0, "dock", "wt-1");
+
+      expect(dockOrder("wt-1")).toEqual(["a", "g1", "b"]);
+      expect(usePanelStore.getState().panelIds).toEqual(["a", "g1", "b", "x"]);
+    });
+
+    it("rebuilds the per-worktree buckets after a global chip reorder", () => {
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const a = createMockTerminal("a", "dock");
+      const x = makeWt2Terminal("x", "dock");
+      seedPanels([g1, a, x]);
+
+      usePanelStore.getState().reorderTerminals(0, 1, "dock", "wt-1");
+
+      const buckets = usePanelStore.getState().panelIdsByWorktreeId;
+      expect(buckets["__none__"]).toEqual(["g1"]);
+      expect(buckets["wt-1"]).toEqual(["a"]);
+      expect(buckets["wt-2"]).toEqual(["x"]);
+    });
+
+    it("counts global chips when inserting a grid panel into a dock slot", () => {
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const a = createMockTerminal("a", "dock");
+      const t = createMockTerminal("t", "grid");
+      seedPanels([g1, a, t]);
+
+      // Rendered dock for wt-1 is [g1, a]; slot 1 sits between them.
+      usePanelStore.getState().moveTerminalToPosition("t", 1, "dock", "wt-1");
+
+      expect(dockOrder("wt-1")).toEqual(["g1", "t", "a"]);
+    });
+
+    it("keeps a global member's committed position on group reorder", () => {
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const a = createMockTerminal("a", "dock");
+      const c = createMockTerminal("c", "dock");
+      seedPanels([g1, a, c]);
+      const group = createMockTabGroup("G", ["g1", "a"], "dock");
+      usePanelStore.setState({ tabGroups: new Map([["G", group]]) });
+
+      // Groups render as [G(g1, a), c] — move G after c.
+      usePanelStore.getState().reorderTabGroups(0, 1, "dock", "wt-1");
+
+      expect(dockOrder("wt-1")).toEqual(["c", "g1", "a"]);
+      expect(usePanelStore.getState().panelIds).toEqual(["c", "g1", "a"]);
+    });
+
+    it("reorders single-chip groups across a global chip correctly", () => {
+      const g1 = createGlobalMockTerminal("g1", "dock");
+      const a = createMockTerminal("a", "dock");
+      const b = createMockTerminal("b", "dock");
+      seedPanels([g1, a, b]);
+
+      // Virtual groups render as [g1], [a], [b] — move b to the front.
+      usePanelStore.getState().reorderTabGroups(2, 0, "dock", "wt-1");
+
+      expect(dockOrder("wt-1")).toEqual(["b", "g1", "a"]);
+      expect(usePanelStore.getState().panelIds).toEqual(["b", "g1", "a"]);
+    });
+
+    it("keeps grid reorders worktree-exact — global grid panels stay out of scope", () => {
+      const gg = createGlobalMockTerminal("gg", "grid");
+      const a = createMockTerminal("a", "grid");
+      const b = createMockTerminal("b", "grid");
+      seedPanels([gg, a, b]);
+
+      // Grid scope for wt-1 is [a, b]; swapping them must not move gg.
+      usePanelStore.getState().reorderTerminals(0, 1, "grid", "wt-1");
+
+      expect(usePanelStore.getState().panelIds).toEqual(["gg", "b", "a"]);
+    });
+  });
 });

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
@@ -4,6 +4,7 @@ import {
   removeFromWorktreeIndex,
   transferBetweenWorktreeIndex,
   buildWorktreeIndex,
+  panelMatchesWorktreeScope,
   type PanelIdsByWorktreeId,
 } from "../worktreeIndex";
 
@@ -124,6 +125,39 @@ describe("worktreeIndex", () => {
       };
       const after = transferBetweenWorktreeIndex(before, "wt-A", "wt-B", "panel-1");
       expect(after["wt-C"]).toBe(wtCBucket);
+    });
+  });
+
+  describe("panelMatchesWorktreeScope", () => {
+    it("matches exact worktree ids at both locations", () => {
+      expect(panelMatchesWorktreeScope("wt-A", "wt-A", "dock")).toBe(true);
+      expect(panelMatchesWorktreeScope("wt-A", "wt-A", "grid")).toBe(true);
+    });
+
+    it("rejects mismatched concrete worktree ids at both locations", () => {
+      expect(panelMatchesWorktreeScope("wt-A", "wt-B", "dock")).toBe(false);
+      expect(panelMatchesWorktreeScope("wt-A", "wt-B", "grid")).toBe(false);
+    });
+
+    it("includes a global panel in a concrete worktree's dock but not its grid (#11289)", () => {
+      expect(panelMatchesWorktreeScope(undefined, "wt-A", "dock")).toBe(true);
+      expect(panelMatchesWorktreeScope(undefined, "wt-A", "grid")).toBe(false);
+    });
+
+    it("matches a global panel against an empty scope at both locations", () => {
+      expect(panelMatchesWorktreeScope(undefined, undefined, "dock")).toBe(true);
+      expect(panelMatchesWorktreeScope(undefined, null, "grid")).toBe(true);
+    });
+
+    it("rejects a scoped panel against an empty scope", () => {
+      expect(panelMatchesWorktreeScope("wt-A", undefined, "dock")).toBe(false);
+      expect(panelMatchesWorktreeScope("wt-A", null, "grid")).toBe(false);
+    });
+
+    it("normalizes a null panel worktreeId like undefined", () => {
+      expect(panelMatchesWorktreeScope(null, "wt-A", "dock")).toBe(true);
+      expect(panelMatchesWorktreeScope(null, "wt-A", "grid")).toBe(false);
+      expect(panelMatchesWorktreeScope(null, undefined, "grid")).toBe(true);
     });
   });
 

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -6,7 +6,7 @@ import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, removePanelIdsFromTabGroups } from "./helpers";
-import { buildWorktreeIndex } from "./worktreeIndex";
+import { buildWorktreeIndex, panelMatchesWorktreeScope } from "./worktreeIndex";
 import { getNarrowPanel } from "./selectors";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 
@@ -27,9 +27,11 @@ export const createOrderingActions = (
 
     set((state) => {
       const hasWorktreeFilter = worktreeId !== undefined;
-      const targetWorktreeId = worktreeId ?? null;
+      // Location-aware scope: a worktree's dock renders global (worktree-less)
+      // panels too, so the commit-side list must include them or the indices
+      // diverge from the rendered order (#11289). Grid stays worktree-exact.
       const matchesWorktree = (t: CarrierPanel) =>
-        !hasWorktreeFilter || (t.worktreeId ?? null) === targetWorktreeId;
+        !hasWorktreeFilter || panelMatchesWorktreeScope(t.worktreeId, worktreeId, location);
       const matchesLocation = (t: CarrierPanel) =>
         location === "grid"
           ? t.location === "grid" || t.location === undefined
@@ -85,11 +87,14 @@ export const createOrderingActions = (
       const terminal = state.panelsById[id];
       if (!terminal) return state;
 
+      // Adoption target for worktree-less panels promoted to the grid (#11290).
       const targetWorktreeId =
         worktreeId !== undefined ? worktreeId : (terminal.worktreeId ?? null);
       const hasWorktreeFilter = worktreeId !== undefined;
+      // Same location-aware scope as reorderTerminals (#11289): a dock target
+      // must count global panels when computing the insertion slot.
       const matchesWorktree = (t: CarrierPanel) =>
-        !hasWorktreeFilter || (t.worktreeId ?? null) === (targetWorktreeId ?? null);
+        !hasWorktreeFilter || panelMatchesWorktreeScope(t.worktreeId, worktreeId, location);
       const matchesLocation = (t: CarrierPanel) =>
         location === "grid"
           ? t.location === "grid" || t.location === undefined

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -10,7 +10,12 @@ import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, dissolvePanelFromGroup } from "./helpers";
-import { buildWorktreeIndex, NO_WORKTREE, transferBetweenWorktreeIndex } from "./worktreeIndex";
+import {
+  buildWorktreeIndex,
+  NO_WORKTREE,
+  panelMatchesWorktreeScope,
+  transferBetweenWorktreeIndex,
+} from "./worktreeIndex";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 
@@ -77,17 +82,6 @@ function getPanelTabGroupLocation(
   )
     return null;
   return panel.location === "dock" ? "dock" : "grid";
-}
-
-function panelMatchesWorktreeScope(
-  panelWorktreeId: string | undefined,
-  worktreeId: string | undefined,
-  location: TabGroupLocation
-): boolean {
-  if ((panelWorktreeId ?? undefined) === worktreeId) return true;
-  // Docked global panels are intentionally visible in every worktree-scoped dock.
-  // Grid panels remain worktree-exact to avoid leaking global panels into every grid.
-  return location === "dock" && panelWorktreeId === undefined && worktreeId !== undefined;
 }
 
 export const createTabGroupActions = (
@@ -560,8 +554,6 @@ export const createTabGroupActions = (
     if (fromGroupIndex === toGroupIndex) return;
 
     set((state) => {
-      const targetWorktreeId = worktreeId ?? null;
-
       const allGroups = get().getTabGroups(location, worktreeId ?? undefined);
 
       if (fromGroupIndex < 0 || fromGroupIndex >= allGroups.length) return state;
@@ -585,7 +577,10 @@ export const createTabGroupActions = (
         const groupPanelIds = group.panelIds.filter((pid) => {
           const t = state.panelsById[pid];
           if (!t) return false;
-          if ((t.worktreeId ?? null) !== targetWorktreeId) return false;
+          // Same scope predicate as getTabGroups — an exact-match filter here
+          // would evict a global dock member into the tail bucket, discarding
+          // the position the drag just committed (#11289).
+          if (!panelMatchesWorktreeScope(t.worktreeId, worktreeId, location)) return false;
           if (t.location === "trash") return false;
           const effectiveLocation = t.location ?? "grid";
           return effectiveLocation === location;
@@ -602,15 +597,12 @@ export const createTabGroupActions = (
         }
       }
 
-      // Add terminals in this location but other worktrees
+      // Append every location-matched panel the group pass didn't place —
+      // other worktrees' panels, plus any in-scope edge case getTabGroups
+      // excluded. Unconditional so no panel is ever dropped from panelIds.
       for (const tid of state.panelIds) {
         const t = state.panelsById[tid];
-        if (
-          t &&
-          !processedIds.has(tid) &&
-          matchesLocation(t) &&
-          (t.worktreeId ?? null) !== targetWorktreeId
-        ) {
+        if (t && !processedIds.has(tid) && matchesLocation(t)) {
           newLocationIds.push(tid);
           processedIds.add(tid);
         }

--- a/src/store/slices/panelRegistry/worktreeIndex.ts
+++ b/src/store/slices/panelRegistry/worktreeIndex.ts
@@ -10,10 +10,31 @@
  * — touching an unrelated worktree's bucket would re-fire every per-row
  * selector on every per-terminal tick.
  */
+import type { TabGroupLocation } from "@shared/types/panel";
+
 export type PanelIdsByWorktreeId = Record<string, string[]>;
 
 /** Bucket key for panels with `worktreeId === undefined`. */
 export const NO_WORKTREE = "__none__";
+
+/**
+ * Single source of truth for whether a panel belongs to a worktree scope at a
+ * location. Docked global (worktree-less) panels are intentionally visible in
+ * every worktree-scoped dock; grid panels remain worktree-exact so globals
+ * never leak into a worktree's grid. Every dock render AND reorder-commit path
+ * must share this predicate — a stricter commit-side filter is how dock chip
+ * reorders silently no-op (#11289).
+ */
+export function panelMatchesWorktreeScope(
+  panelWorktreeId: string | null | undefined,
+  worktreeId: string | null | undefined,
+  location: TabGroupLocation
+): boolean {
+  const panelWt = panelWorktreeId ?? undefined;
+  const scopeWt = worktreeId ?? undefined;
+  if (panelWt === scopeWt) return true;
+  return location === "dock" && panelWt === undefined && scopeWt !== undefined;
+}
 
 function bucketKey(worktreeId: string | undefined | null): string {
   return worktreeId ?? NO_WORKTREE;


### PR DESCRIPTION
## Summary

- Dragging a dock chip played the full drag animation, then silently snapped back whenever the dragged chip was a worktree-less "global" panel while a worktree was active. No error, no log, just a revert.
- Root cause: the dock intentionally renders global panels (no `worktreeId`) in every worktree-scoped dock via `panelMatchesWorktreeScope`, but every commit-side path filtered worktree-exact instead, so the dragged chip was missing from the list the commit indexed into. `filterTerminalsByContainer` returned `oldIndex: -1` (silent no-op), `reorderTerminals`/`moveTerminalToPosition` spliced a globals-stripped list (wrong slot when a scoped chip was dragged past a global one), and `reorderTabGroups` evicted global group members into a tail bucket (group drags committed the wrong order).
- Fix makes the scope predicate the single source of truth: `panelMatchesWorktreeScope` is now exported from `worktreeIndex.ts` (normalizing a null/undefined sentinel divergence between `ordering.ts` and the rest of the codebase) and used by the dock render filter (`ContentDock`), the drop-index resolution (`filterTerminalsByContainer` / `resolveTargetIndex`), all three store mutations (`reorderTerminals`, `moveTerminalToPosition`, `reorderTabGroups`), and the accordion reorder branch of `DndProvider.handleDragEnd`. Render and commit can no longer disagree about membership.

Resolves #11289

## Changes

- Grid scoping stays worktree-exact everywhere, locked in by negative tests. Only dock scoping widens.
- `reorderTabGroups`' tail append is now unconditional, so a location-matched panel the group pass doesn't place can never drop out of `panelIds`.
- Second commit: an adversarial review caught that the accordion (worktree sidebar) branch still computed indices over an exact-scoped inline list while the store now splices the widened list, so dragging a sidebar dock row would move the wrong chip when a global chip was present. It now calls `filterTerminalsByContainer` so caller and store share one index space.

## Testing

- Predicate matrix (`worktreeIndex.test.ts`); global/mixed dock membership and dock index resolution (`dropResolution.test.ts`); store-mutation regressions including the literal issue repro (global-only dock), scoped-past-global slots, dock-front insertion, a realistic global tab group drag, multi-global bucket order, and grid-exact negatives (`dockGridTransitions.test.ts`).
- 287 targeted tests green locally. eslint/prettier clean on all changed files.

## Notes for reviewers

- Reordering relative to a global chip necessarily shifts that chip's interleave position in other worktrees' docks, since global panels have one shared position in `panelIds`. Per-worktree ordering would need a different persisted model and is out of scope here.
- An accordion drag dropped onto a global dock chip now commits a reorder the same way dropping onto a scoped chip does. That was previously a silent no-op, and it's consistent with the fix's overall approach.
- Pre-existing and untouched: spawn-batch index-only panels are invisible to the reorder paths, and `terminalLayoutActions` can pass `undefined` (unfiltered) worktree scope with no active worktree. Both are grid-side and orthogonal to this fix.
