### PR TITLE
fix(panels): adopt the active worktree when promoting worktree-less panels to the grid

### DIFF
--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PanelInstance, PtyPanelData, TabGroup } from "@shared/types/panel";
+import type { FilePanelData, PanelInstance, PtyPanelData, TabGroup } from "@shared/types/panel";
 import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { buildWorktreeIndex, NO_WORKTREE } from "../worktreeIndex";
@@ -322,17 +322,15 @@ describe("dock ↔ grid transitions", () => {
 
     it("adopts the active worktree for a non-PTY file panel promoted from the dock", () => {
       usePanelStore.setState((state) => {
-        const panelsById = {
-          ...state.panelsById,
-          "file-1": {
-            id: "file-1",
-            kind: "file",
-            title: "spec.md",
-            location: "dock",
-            isVisible: false,
-            filePath: "/repo/spec.md",
-          } as PanelInstance,
+        const filePanel: FilePanelData = {
+          id: "file-1",
+          kind: "file",
+          title: "spec.md",
+          location: "dock",
+          isVisible: false,
+          filePath: "/repo/spec.md",
         };
+        const panelsById = { ...state.panelsById, "file-1": filePanel };
         const panelIds = [...state.panelIds, "file-1"];
         return {
           panelsById,
@@ -480,18 +478,16 @@ describe("dock ↔ grid transitions", () => {
 
     it("adopts the active worktree when promoting a worktree-less dialog panel to the grid", () => {
       usePanelStore.setState((state) => {
-        const panelsById = {
-          ...state.panelsById,
-          "dlg-1": {
-            id: "dlg-1",
-            kind: "file",
-            title: "outside.md",
-            location: "dialog",
-            isVisible: false,
-            filePath: "/outside/outside.md",
-            excludeFromPersistence: true,
-          } as PanelInstance,
+        const dialogPanel: FilePanelData = {
+          id: "dlg-1",
+          kind: "file",
+          title: "outside.md",
+          location: "dialog",
+          isVisible: false,
+          filePath: "/outside/outside.md",
+          excludeFromPersistence: true,
         };
+        const panelsById = { ...state.panelsById, "dlg-1": dialogPanel };
         const panelIds = [...state.panelIds, "dlg-1"];
         return {
           panelsById,
@@ -533,6 +529,11 @@ describe("dock ↔ grid transitions", () => {
       expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1"]);
       expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t2"]);
       expect(recordSpy.mock.calls).toEqual([["t1", 3, "wt-1", "explicit"]]);
+      // The group adopts while the trashed member keeps its old attribution
+      // and its membership slot — the same trade moveTabGroupToWorktree makes;
+      // every consumer filters trashed members out of live group reads.
+      expect(state.tabGroups.get("g1")!.worktreeId).toBe("wt-1");
+      expect(state.tabGroups.get("g1")!.panelIds).toEqual(["t1", "t2"]);
     });
 
     it("leaves a worktree-less dock group global when no worktree is active", () => {

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -110,6 +110,7 @@ describe("dock ↔ grid transitions", () => {
 
   afterEach(() => {
     setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+    vi.restoreAllMocks();
   });
 
   describe("moveTerminalToDock visibility parity", () => {
@@ -301,8 +302,10 @@ describe("dock ↔ grid transitions", () => {
 
     it("assigns the active worktree and transfers the index bucket when promoting a worktree-less dock panel", () => {
       const globalDocked = createGlobalMockTerminal("global-dock", "dock");
+      const globalSibling = createGlobalMockTerminal("global-2", "dock");
+      const existing = createMockTerminal("wt1-existing", "grid");
       const unrelated = { ...createMockTerminal("wt2-panel", "grid"), worktreeId: "wt-2" };
-      setTerminals([globalDocked, unrelated]);
+      setTerminals([globalDocked, globalSibling, existing, unrelated]);
       activateWorktree("wt-1");
 
       const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
@@ -312,9 +315,41 @@ describe("dock ↔ grid transitions", () => {
       const state = usePanelStore.getState();
       expect(state.panelsById["global-dock"]!.worktreeId).toBe("wt-1");
       expect(state.panelsById["global-dock"]!.location).toBe("grid");
-      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["global-dock"]);
-      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["wt1-existing", "global-dock"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["global-2"]);
       expect(state.panelIdsByWorktreeId["wt-2"]).toBe(bucketsBefore["wt-2"]);
+    });
+
+    it("adopts the active worktree for a non-PTY file panel promoted from the dock", () => {
+      usePanelStore.setState((state) => {
+        const panelsById = {
+          ...state.panelsById,
+          "file-1": {
+            id: "file-1",
+            kind: "file",
+            title: "spec.md",
+            location: "dock",
+            isVisible: false,
+            filePath: "/repo/spec.md",
+          } as PanelInstance,
+        };
+        const panelIds = [...state.panelIds, "file-1"];
+        return {
+          panelsById,
+          panelIds,
+          panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
+        };
+      });
+      activateWorktree("wt-1");
+
+      const moved = usePanelStore.getState().moveTerminalToGrid("file-1");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["file-1"]!.worktreeId).toBe("wt-1");
+      expect(state.panelsById["file-1"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["file-1"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
     });
 
     it("leaves a worktree-less panel unassigned when no worktree is active", () => {
@@ -347,34 +382,58 @@ describe("dock ↔ grid transitions", () => {
       expect(state.panelIdsByWorktreeId).toBe(bucketsBefore);
     });
 
+    const spyOnLedger = () => {
+      vi.spyOn(agentLifecycleLedger, "currentGeneration").mockReturnValue(3);
+      return vi
+        .spyOn(agentLifecycleLedger, "recordWorktreeAttribution")
+        .mockReturnValue({ accepted: true });
+    };
+
     it("records explicit ledger attribution for a promoted ledger-tracked panel", () => {
       const globalDocked = createGlobalMockTerminal("global-dock", "dock");
       setTerminals([globalDocked]);
       activateWorktree("wt-1");
-
-      const genSpy = vi.spyOn(agentLifecycleLedger, "currentGeneration").mockReturnValue(3);
-      const recordSpy = vi
-        .spyOn(agentLifecycleLedger, "recordWorktreeAttribution")
-        .mockReturnValue({ accepted: true });
+      const recordSpy = spyOnLedger();
 
       usePanelStore.getState().moveTerminalToGrid("global-dock");
 
       expect(recordSpy).toHaveBeenCalledWith("global-dock", 3, "wt-1", "explicit");
-      genSpy.mockRestore();
-      recordSpy.mockRestore();
+    });
+
+    it("records explicit ledger attribution on a drag-style adoption", () => {
+      const globalDocked = createGlobalMockTerminal("t1", "dock");
+      setTerminals([globalDocked]);
+      const recordSpy = spyOnLedger();
+
+      usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid", "wt-1");
+
+      expect(recordSpy).toHaveBeenCalledWith("t1", 3, "wt-1", "explicit");
+    });
+
+    it("records no ledger attribution when promotion adopts nothing", () => {
+      const globalDocked = createGlobalMockTerminal("global-dock", "dock");
+      setTerminals([globalDocked]);
+      setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+      const recordSpy = spyOnLedger();
+
+      usePanelStore.getState().moveTerminalToGrid("global-dock");
+
+      expect(recordSpy).not.toHaveBeenCalled();
     });
 
     it("assigns the active worktree to a promoted worktree-less dock group and its members", () => {
       const t1 = createGlobalMockTerminal("t1", "dock");
       const t2 = createGlobalMockTerminal("t2", "dock");
+      const existing = createMockTerminal("wt1-existing", "grid");
       const unrelated = { ...createMockTerminal("wt2-panel", "grid"), worktreeId: "wt-2" };
-      setTerminals([t1, t2, unrelated]);
+      setTerminals([t1, t2, existing, unrelated]);
       const group: TabGroup = {
         ...createMockTabGroup("g1", ["t1", "t2"], "dock"),
         worktreeId: undefined,
       };
       usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
       activateWorktree("wt-1");
+      const recordSpy = spyOnLedger();
 
       const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
       const moved = usePanelStore.getState().moveTerminalToGrid("t1");
@@ -388,9 +447,92 @@ describe("dock ↔ grid transitions", () => {
         expect(state.panelsById[pid]!.location).toBe("grid");
         expect(state.panelsById[pid]!.isVisible).toBe(true);
       }
-      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1", "t2"]);
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["wt1-existing", "t1", "t2"]);
       expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
       expect(state.panelIdsByWorktreeId["wt-2"]).toBe(bucketsBefore["wt-2"]);
+      expect(recordSpy.mock.calls).toEqual([
+        ["t1", 3, "wt-1", "explicit"],
+        ["t2", 3, "wt-1", "explicit"],
+      ]);
+    });
+
+    it("re-homes a drifted member indexed under another worktree when promoting a worktree-less group", () => {
+      const t1 = createGlobalMockTerminal("t1", "dock");
+      const drifted = { ...createMockTerminal("t2", "dock"), worktreeId: "wt-3" };
+      setTerminals([t1, drifted]);
+      const group: TabGroup = {
+        ...createMockTabGroup("g1", ["t1", "t2"], "dock"),
+        worktreeId: undefined,
+      };
+      usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
+      activateWorktree("wt-1");
+
+      const moved = usePanelStore.getState().moveTabGroupToLocation("g1", "grid");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBe("wt-1");
+      expect(state.panelsById["t2"]!.worktreeId).toBe("wt-1");
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1", "t2"]);
+      expect(state.panelIdsByWorktreeId["wt-3"]).toBeUndefined();
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+    });
+
+    it("adopts the active worktree when promoting a worktree-less dialog panel to the grid", () => {
+      usePanelStore.setState((state) => {
+        const panelsById = {
+          ...state.panelsById,
+          "dlg-1": {
+            id: "dlg-1",
+            kind: "file",
+            title: "outside.md",
+            location: "dialog",
+            isVisible: false,
+            filePath: "/outside/outside.md",
+            excludeFromPersistence: true,
+          } as PanelInstance,
+        };
+        const panelIds = [...state.panelIds, "dlg-1"];
+        return {
+          panelsById,
+          panelIds,
+          panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
+        };
+      });
+      activateWorktree("wt-1");
+
+      const promoted = usePanelStore.getState().promoteDialogPanelToGrid("dlg-1");
+
+      expect(promoted).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["dlg-1"]!.worktreeId).toBe("wt-1");
+      expect(state.panelsById["dlg-1"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["dlg-1"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+    });
+
+    it("skips trashed members when promoting a worktree-less dock group", () => {
+      const t1 = createGlobalMockTerminal("t1", "dock");
+      const t2 = createGlobalMockTerminal("t2", "trash");
+      setTerminals([t1, t2]);
+      const group: TabGroup = {
+        ...createMockTabGroup("g1", ["t1", "t2"], "dock"),
+        worktreeId: undefined,
+      };
+      usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
+      activateWorktree("wt-1");
+      const recordSpy = spyOnLedger();
+
+      const moved = usePanelStore.getState().moveTabGroupToLocation("g1", "grid");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBe("wt-1");
+      expect(state.panelsById["t2"]!.worktreeId).toBeUndefined();
+      expect(state.panelsById["t2"]!.location).toBe("trash");
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t2"]);
+      expect(recordSpy.mock.calls).toEqual([["t1", 3, "wt-1", "explicit"]]);
     });
 
     it("leaves a worktree-less dock group global when no worktree is active", () => {
@@ -405,11 +547,12 @@ describe("dock ↔ grid transitions", () => {
       setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
 
       const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
-      const moved = usePanelStore.getState().moveTabGroupToLocation("g1", "grid");
+      const moved = usePanelStore.getState().moveTerminalToGrid("t1");
 
       expect(moved).toBe(true);
       const state = usePanelStore.getState();
       expect(state.tabGroups.get("g1")!.worktreeId).toBeUndefined();
+      expect(state.tabGroups.get("g1")!.location).toBe("grid");
       expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();
       expect(state.panelsById["t2"]!.worktreeId).toBeUndefined();
       expect(state.panelIdsByWorktreeId).toBe(bucketsBefore);
@@ -417,16 +560,18 @@ describe("dock ↔ grid transitions", () => {
     });
 
     it("adopts the drop target worktree on a drag-style dock-to-grid move", () => {
+      const existing = createMockTerminal("wt1-existing", "grid");
       const globalDocked = createGlobalMockTerminal("t1", "dock");
-      setTerminals([globalDocked]);
+      const globalSibling = createGlobalMockTerminal("global-2", "dock");
+      setTerminals([existing, globalDocked, globalSibling]);
 
       usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid", "wt-1");
 
       const state = usePanelStore.getState();
       expect(state.panelsById["t1"]!.worktreeId).toBe("wt-1");
       expect(state.panelsById["t1"]!.location).toBe("grid");
-      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1"]);
-      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1", "wt1-existing"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["global-2"]);
     });
 
     it("keeps a worktree-less panel global on a drag-style move with no target worktree", () => {
@@ -434,6 +579,18 @@ describe("dock ↔ grid transitions", () => {
       setTerminals([globalDocked]);
 
       usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid", null);
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();
+      expect(state.panelsById["t1"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t1"]);
+    });
+
+    it("keeps a worktree-less panel global on a drag-style move with an omitted target worktree", () => {
+      const globalDocked = createGlobalMockTerminal("t1", "dock");
+      setTerminals([globalDocked]);
+
+      usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid");
 
       const state = usePanelStore.getState();
       expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PanelInstance, PtyPanelData, TabGroup } from "@shared/types/panel";
+import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
+import { buildWorktreeIndex, NO_WORKTREE } from "../worktreeIndex";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -46,9 +49,12 @@ vi.mock("@/store/layoutConfigStore", () => ({
 const { usePanelStore } = await import("../../../panelStore");
 
 function setTerminals(terminals: PtyPanelData[]) {
+  const panelsById = Object.fromEntries(terminals.map((t) => [t.id, t]));
+  const panelIds = terminals.map((t) => t.id);
   usePanelStore.setState({
-    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
-    panelIds: terminals.map((t) => t.id),
+    panelsById,
+    panelIds,
+    panelIdsByWorktreeId: buildWorktreeIndex(panelIds, panelsById),
   });
 }
 
@@ -96,9 +102,14 @@ describe("dock ↔ grid transitions", () => {
     usePanelStore.setState({
       panelsById: {},
       panelIds: [],
+      panelIdsByWorktreeId: {},
       tabGroups: new Map(),
       trashedTerminals: new Map(),
     });
+  });
+
+  afterEach(() => {
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
   });
 
   describe("moveTerminalToDock visibility parity", () => {
@@ -280,6 +291,166 @@ describe("dock ↔ grid transitions", () => {
       expect(updated!.isVisible).toBe(true);
       expect(updated!.runtimeStatus).toBe("running");
       expect(usePanelStore.getState().getTabGroups("dock", "wt-1")).toHaveLength(0);
+    });
+  });
+
+  describe("worktree-less panel promotion (#11290)", () => {
+    const activateWorktree = (id: string) => {
+      setWorktreeSelectionAccessor(() => ({ activeWorktreeId: id, restoreWorktreeId: null }));
+    };
+
+    it("assigns the active worktree and transfers the index bucket when promoting a worktree-less dock panel", () => {
+      const globalDocked = createGlobalMockTerminal("global-dock", "dock");
+      const unrelated = { ...createMockTerminal("wt2-panel", "grid"), worktreeId: "wt-2" };
+      setTerminals([globalDocked, unrelated]);
+      activateWorktree("wt-1");
+
+      const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
+      const moved = usePanelStore.getState().moveTerminalToGrid("global-dock");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["global-dock"]!.worktreeId).toBe("wt-1");
+      expect(state.panelsById["global-dock"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["global-dock"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+      expect(state.panelIdsByWorktreeId["wt-2"]).toBe(bucketsBefore["wt-2"]);
+    });
+
+    it("leaves a worktree-less panel unassigned when no worktree is active", () => {
+      const globalDocked = createGlobalMockTerminal("global-dock", "dock");
+      setTerminals([globalDocked]);
+      setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+
+      const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
+      const moved = usePanelStore.getState().moveTerminalToGrid("global-dock");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["global-dock"]!.worktreeId).toBeUndefined();
+      expect(state.panelsById["global-dock"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId).toBe(bucketsBefore);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["global-dock"]);
+    });
+
+    it("never replaces a real worktree attribution on promotion", () => {
+      const docked = { ...createMockTerminal("t1", "dock"), worktreeId: "wt-2" };
+      setTerminals([docked]);
+      activateWorktree("wt-1");
+
+      const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
+      const moved = usePanelStore.getState().moveTerminalToGrid("t1");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBe("wt-2");
+      expect(state.panelIdsByWorktreeId).toBe(bucketsBefore);
+    });
+
+    it("records explicit ledger attribution for a promoted ledger-tracked panel", () => {
+      const globalDocked = createGlobalMockTerminal("global-dock", "dock");
+      setTerminals([globalDocked]);
+      activateWorktree("wt-1");
+
+      const genSpy = vi.spyOn(agentLifecycleLedger, "currentGeneration").mockReturnValue(3);
+      const recordSpy = vi
+        .spyOn(agentLifecycleLedger, "recordWorktreeAttribution")
+        .mockReturnValue({ accepted: true });
+
+      usePanelStore.getState().moveTerminalToGrid("global-dock");
+
+      expect(recordSpy).toHaveBeenCalledWith("global-dock", 3, "wt-1", "explicit");
+      genSpy.mockRestore();
+      recordSpy.mockRestore();
+    });
+
+    it("assigns the active worktree to a promoted worktree-less dock group and its members", () => {
+      const t1 = createGlobalMockTerminal("t1", "dock");
+      const t2 = createGlobalMockTerminal("t2", "dock");
+      const unrelated = { ...createMockTerminal("wt2-panel", "grid"), worktreeId: "wt-2" };
+      setTerminals([t1, t2, unrelated]);
+      const group: TabGroup = {
+        ...createMockTabGroup("g1", ["t1", "t2"], "dock"),
+        worktreeId: undefined,
+      };
+      usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
+      activateWorktree("wt-1");
+
+      const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
+      const moved = usePanelStore.getState().moveTerminalToGrid("t1");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.tabGroups.get("g1")!.worktreeId).toBe("wt-1");
+      expect(state.tabGroups.get("g1")!.location).toBe("grid");
+      for (const pid of ["t1", "t2"]) {
+        expect(state.panelsById[pid]!.worktreeId).toBe("wt-1");
+        expect(state.panelsById[pid]!.location).toBe("grid");
+        expect(state.panelsById[pid]!.isVisible).toBe(true);
+      }
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1", "t2"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+      expect(state.panelIdsByWorktreeId["wt-2"]).toBe(bucketsBefore["wt-2"]);
+    });
+
+    it("leaves a worktree-less dock group global when no worktree is active", () => {
+      const t1 = createGlobalMockTerminal("t1", "dock");
+      const t2 = createGlobalMockTerminal("t2", "dock");
+      setTerminals([t1, t2]);
+      const group: TabGroup = {
+        ...createMockTabGroup("g1", ["t1", "t2"], "dock"),
+        worktreeId: undefined,
+      };
+      usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
+      setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+
+      const bucketsBefore = usePanelStore.getState().panelIdsByWorktreeId;
+      const moved = usePanelStore.getState().moveTabGroupToLocation("g1", "grid");
+
+      expect(moved).toBe(true);
+      const state = usePanelStore.getState();
+      expect(state.tabGroups.get("g1")!.worktreeId).toBeUndefined();
+      expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();
+      expect(state.panelsById["t2"]!.worktreeId).toBeUndefined();
+      expect(state.panelIdsByWorktreeId).toBe(bucketsBefore);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t1", "t2"]);
+    });
+
+    it("adopts the drop target worktree on a drag-style dock-to-grid move", () => {
+      const globalDocked = createGlobalMockTerminal("t1", "dock");
+      setTerminals([globalDocked]);
+
+      usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid", "wt-1");
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBe("wt-1");
+      expect(state.panelsById["t1"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId["wt-1"]).toEqual(["t1"]);
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toBeUndefined();
+    });
+
+    it("keeps a worktree-less panel global on a drag-style move with no target worktree", () => {
+      const globalDocked = createGlobalMockTerminal("t1", "dock");
+      setTerminals([globalDocked]);
+
+      usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid", null);
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();
+      expect(state.panelsById["t1"]!.location).toBe("grid");
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t1"]);
+    });
+
+    it("does not adopt a worktree when a drag-style move targets the dock", () => {
+      const globalGrid = createGlobalMockTerminal("t1", "grid");
+      setTerminals([globalGrid]);
+
+      usePanelStore.getState().moveTerminalToPosition("t1", 0, "dock", "wt-1");
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["t1"]!.worktreeId).toBeUndefined();
+      expect(state.panelsById["t1"]!.location).toBe("dock");
+      expect(state.panelIdsByWorktreeId[NO_WORKTREE]).toEqual(["t1"]);
     });
   });
 

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -621,6 +621,13 @@ export const createCorePanelActions = (
     let promoted = false;
     let atLimit = false;
 
+    // A dialog panel opened for a path outside every registered worktree has
+    // no worktreeId; promoting it into the grid without one strands it outside
+    // the active worktree's rendered bucket (#11290), same as a dock
+    // promotion. Adopt the active worktree; a real attribution is kept.
+    const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
+    let backfilledWorktreeId: string | null = null;
+
     set((state) => {
       // Re-read inside the updater: the panel may have been closed or already
       // promoted between the host's click handler and this commit.
@@ -639,8 +646,12 @@ export const createCorePanelActions = (
       // Drop `excludeFromPersistence` rather than setting it false: the field is
       // optional, and a lingering `false` would read as a deliberate opt-in.
       const { excludeFromPersistence: _ephemeral, ...persistable } = panel;
+      const adoptedWorktreeId =
+        panel.worktreeId == null && activeWorktreeId !== null ? activeWorktreeId : null;
+      backfilledWorktreeId = adoptedWorktreeId;
       const updatedPanel = {
         ...persistable,
+        ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
         location: "grid" as const,
         isVisible: true,
       } as PanelInstance;
@@ -648,8 +659,32 @@ export const createCorePanelActions = (
       const newById = { ...state.panelsById, [id]: updatedPanel };
       saveNormalized(newById, state.panelIds);
       promoted = true;
-      return { panelsById: newById };
+      return {
+        panelsById: newById,
+        ...(adoptedWorktreeId !== null && {
+          panelIdsByWorktreeId: transferBetweenWorktreeIndex(
+            state.panelIdsByWorktreeId,
+            panel.worktreeId,
+            adoptedWorktreeId,
+            id
+          ),
+        }),
+      };
     });
+
+    // A user-initiated promotion is explicit worktree attribution — recorded
+    // so later cwd-based inference can never silently re-home the panel.
+    if (backfilledWorktreeId !== null) {
+      const ledgerGeneration = agentLifecycleLedger.currentGeneration(id);
+      if (ledgerGeneration !== undefined) {
+        agentLifecycleLedger.recordWorktreeAttribution(
+          id,
+          ledgerGeneration,
+          backfilledWorktreeId,
+          "explicit"
+        );
+      }
+    }
 
     if (atLimit) {
       notify({

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -24,8 +24,9 @@ import {
   consumeBatch,
 } from "./hydrationBatch";
 import type { HydrationBatchToken } from "./types";
-import { removeFromWorktreeIndex } from "./worktreeIndex";
+import { removeFromWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
+import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 import { countPanelsTowardLimit } from "./panelCount";
 import { usePanelLimitStore } from "@/store/panelLimitStore";
 import { notify } from "@/lib/notify";
@@ -538,6 +539,13 @@ export const createCorePanelActions = (
     let moveSucceeded = false;
     let terminal: PanelInstance | undefined;
 
+    // A worktree-less dock panel is visible in every worktree's dock, but the
+    // grid renders only the active worktree's index bucket — landing there
+    // without a worktreeId strands it off-screen (#11290). Promotion adopts
+    // the active worktree; a real existing attribution is never changed.
+    const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
+    let backfilledWorktreeId: string | null = null;
+
     set((state) => {
       terminal = state.panelsById[id];
       if (!terminal || terminal.location === "grid") return state;
@@ -547,14 +555,23 @@ export const createCorePanelActions = (
       moveSucceeded = true;
       const groupPrune = removePanelIdsFromTabGroups(state.tabGroups, new Set([id]));
       const t = terminal!;
+      const adoptedWorktreeId =
+        t.worktreeId == null && activeWorktreeId !== null ? activeWorktreeId : null;
+      backfilledWorktreeId = adoptedWorktreeId;
       const updatedPanel = isPtyPanel(t)
         ? {
             ...t,
+            ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
             location: "grid" as const,
             isVisible: true,
             runtimeStatus: deriveRuntimeStatus(true, t.flowStatus, t.runtimeStatus),
           }
-        : { ...t, location: "grid" as const, isVisible: true };
+        : {
+            ...t,
+            ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
+            location: "grid" as const,
+            isVisible: true,
+          };
       const newById = { ...state.panelsById, [id]: updatedPanel };
       saveNormalized(newById, state.panelIds);
       if (groupPrune.changed) {
@@ -562,9 +579,31 @@ export const createCorePanelActions = (
       }
       return {
         panelsById: newById,
+        ...(adoptedWorktreeId !== null && {
+          panelIdsByWorktreeId: transferBetweenWorktreeIndex(
+            state.panelIdsByWorktreeId,
+            t.worktreeId,
+            adoptedWorktreeId,
+            id
+          ),
+        }),
         ...(groupPrune.changed && { tabGroups: groupPrune.tabGroups }),
       };
     });
+
+    // A user-initiated promotion is explicit worktree attribution — recorded
+    // so later cwd-based inference can never silently re-home the panel.
+    if (backfilledWorktreeId !== null) {
+      const ledgerGeneration = agentLifecycleLedger.currentGeneration(id);
+      if (ledgerGeneration !== undefined) {
+        agentLifecycleLedger.recordWorktreeAttribution(
+          id,
+          ledgerGeneration,
+          backfilledWorktreeId,
+          "explicit"
+        );
+      }
+    }
 
     // Only apply renderer policy for PTY-backed panels if move succeeded
     if (moveSucceeded && terminal && panelKindHasPty(terminal.kind ?? "terminal")) {

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -8,6 +8,7 @@ import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, removePanelIdsFromTabGroups } from "./helpers";
 import { buildWorktreeIndex } from "./worktreeIndex";
 import { getNarrowPanel } from "./selectors";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
@@ -78,6 +79,8 @@ export const createOrderingActions = (
   },
 
   moveTerminalToPosition: (id, toIndex, location, worktreeId) => {
+    let backfilledWorktreeId: string | null = null;
+
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
@@ -118,9 +121,19 @@ export const createOrderingActions = (
 
       const isVisible = location === "grid";
       const ptyTerminal = isPtyPanel(terminal) ? terminal : undefined;
+      // A worktree-less dock panel dropped into the grid adopts the drop
+      // target's worktree — the grid renders only that worktree's index
+      // bucket, so an unset worktreeId would strand it off-screen (#11290).
+      // The rebuild below re-buckets the panel; a real attribution is kept.
+      const adoptedWorktreeId =
+        location === "grid" && terminal.worktreeId == null && targetWorktreeId != null
+          ? targetWorktreeId
+          : null;
+      backfilledWorktreeId = adoptedWorktreeId;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- spread preserves the panel's discriminant; overrides are base-field-compatible
       const updatedTerminal = {
         ...terminal,
+        ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
         location,
         isVisible,
         runtimeStatus: deriveRuntimeStatus(
@@ -150,6 +163,20 @@ export const createOrderingActions = (
         ...(groupPrune.changed && { tabGroups: groupPrune.tabGroups }),
       };
     });
+
+    // A user-initiated promotion is explicit worktree attribution — recorded
+    // so later cwd-based inference can never silently re-home the panel.
+    if (backfilledWorktreeId !== null) {
+      const ledgerGeneration = agentLifecycleLedger.currentGeneration(id);
+      if (ledgerGeneration !== undefined) {
+        agentLifecycleLedger.recordWorktreeAttribution(
+          id,
+          ledgerGeneration,
+          backfilledWorktreeId,
+          "explicit"
+        );
+      }
+    }
 
     const terminal = get().panelsById[id];
     if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -154,8 +154,7 @@ export const createOrderingActions = (
         saveTabGroups(groupPrune.tabGroups);
       }
       // Rebuild bucket order so per-worktree selectors observe the new order
-      // (issue #7451). The panel's worktreeId field is unchanged here, but its
-      // position within the bucket may have shifted.
+      // (issue #7451) and any adopted worktreeId lands in the right bucket.
       return {
         panelsById: newById,
         panelIds: newIds,

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -11,6 +11,8 @@ import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, dissolvePanelFromGroup } from "./helpers";
 import { buildWorktreeIndex, NO_WORKTREE, transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
+import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -405,13 +407,29 @@ export const createTabGroupActions = (
     // Scrollable grid (#8805): tab-group moves to the grid no longer gate on a
     // screen-fit cap. The grid scrolls vertically so the move always succeeds.
 
+    // A worktree-less dock group is visible in every worktree's dock, but the
+    // grid renders only the active worktree's index bucket — landing there
+    // without a worktreeId strands the whole group off-screen (#11290).
+    // Promotion adopts the active worktree for the group and every live
+    // member; a real existing group attribution is never changed.
+    const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
+    const adoptedWorktreeId =
+      location === "grid" && group.worktreeId == null && activeWorktreeId !== null
+        ? activeWorktreeId
+        : null;
+    const backfilledPanelIds: string[] = [];
+
     set((state) => {
       const newTabGroups = new Map(state.tabGroups);
-      const updatedGroup: TabGroup = { ...group, location };
+      const updatedGroup: TabGroup =
+        adoptedWorktreeId !== null
+          ? { ...group, location, worktreeId: adoptedWorktreeId }
+          : { ...group, location };
       newTabGroups.set(groupId, updatedGroup);
 
       const panelIdSet = new Set(group.panelIds);
       const newById = { ...state.panelsById };
+      let newIndex = state.panelIdsByWorktreeId;
       for (const pid of panelIdSet) {
         const t = newById[pid];
         if (!t) continue;
@@ -419,6 +437,7 @@ export const createTabGroupActions = (
         const ptyT = isPtyPanel(t) ? t : undefined;
         newById[pid] = {
           ...t,
+          ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
           location,
           isVisible: location === "grid",
           runtimeStatus: deriveRuntimeStatus(
@@ -427,12 +446,36 @@ export const createTabGroupActions = (
             ptyT?.runtimeStatus
           ),
         } as PanelInstance;
+        if (adoptedWorktreeId !== null) {
+          newIndex = transferBetweenWorktreeIndex(newIndex, t.worktreeId, adoptedWorktreeId, pid);
+          backfilledPanelIds.push(pid);
+        }
       }
 
       saveNormalized(newById, state.panelIds);
       saveTabGroups(newTabGroups);
-      return { panelsById: newById, tabGroups: newTabGroups };
+      return {
+        panelsById: newById,
+        tabGroups: newTabGroups,
+        ...(adoptedWorktreeId !== null && { panelIdsByWorktreeId: newIndex }),
+      };
     });
+
+    // A user-initiated promotion is explicit worktree attribution — recorded
+    // so later cwd-based inference can never silently re-home the panels.
+    if (adoptedWorktreeId !== null) {
+      for (const pid of backfilledPanelIds) {
+        const ledgerGeneration = agentLifecycleLedger.currentGeneration(pid);
+        if (ledgerGeneration !== undefined) {
+          agentLifecycleLedger.recordWorktreeAttribution(
+            pid,
+            ledgerGeneration,
+            adoptedWorktreeId,
+            "explicit"
+          );
+        }
+      }
+    }
 
     for (const panelId of group.panelIds) {
       const terminal = get().panelsById[panelId];


### PR DESCRIPTION
## Summary

Dock panels and tab groups with no `worktreeId` are deliberately shown in every worktree's dock. The grid, though, only renders the active worktree's exact bucket (`panelIdsByWorktreeId[activeWorktreeId ?? "__none__"]`). Every path that promoted one of these panels to the grid left `worktreeId` unset, so the panel landed off-screen: the process kept running, but there was no way to reach it or close it.

The fix assigns the active worktree at move time, the same way it already works for panels that arrive with a `worktreeId`. Neither display filter changes.

Resolves #11290

## Changes

- **`moveTerminalToGrid` (`core.ts`)**: the double-click path. A worktree-less panel now adopts the active worktree, and its id transfers between index buckets via `transferBetweenWorktreeIndex` in the same `set()` commit.
- **`moveTabGroupToLocation` (`tabGroups.ts`)**: same adoption for a worktree-less group and every live member on a dock-to-grid move (the grouped half of the same double-click gesture). Trashed members keep their old slot and attribution, matching `moveTabGroupToWorktree`.
- **`moveTerminalToPosition` (`ordering.ts`)**: drag-style dock-to-grid moves apply the already-known drop-target worktree to worktree-less panels; the existing full index rebuild re-buckets them.
- **`promoteDialogPanelToGrid` (`core.ts`)**: a gap found in review. A dialog opened for a path outside every registered worktree (`useWorktreeIdForPath` returns undefined) hit the same stranding. It now adopts identically.
- All adopted panels get explicit ledger attribution via `agentLifecycleLedger.recordWorktreeAttribution`, mirroring `moveTerminalToWorktree`, so later cwd-based inference can't re-home them.
- Adoption is gated on a non-null active worktree, mirroring `resolveRestoredWorktreeId`: with no active worktree, the `__none__` bucket already matches the grid's lookup key, so nothing changes.

## Testing

Added 13 new test cases to `dockGridTransitions.test.ts` covering all four promotion paths: bucket transfer with occupied target buckets and surviving source buckets, unrelated-bucket reference stability, null-active and real-attribution guards, drifted-member re-home, trashed-member skip, per-member/drag-and-drop/negative ledger attribution, and non-PTY and dialog panel adoption. `setTerminals` now seeds `panelIdsByWorktreeId` so the index assertions actually mean something.

275 tests across the covering suites pass locally. Changed files are clean under prettier and eslint.

`e2e/full/panels/core-drag-drop.spec.ts` covers the drag-and-drop UI wiring, but it needs a full app build that isn't run locally in this pipeline. The changed layer (store mutations) is directly covered by the unit suite.

## Follow-up (out of scope)

The non-PTY hydration recreation path (`panelRestorePhase.ts`, `buildArgsForNonPtyRecreation`) doesn't run `resolveRestoredWorktreeId` the way its three PTY siblings do, so a persisted worktree-less grid panel of a non-PTY kind is still recreated stranded on restart. A correct fix needs to be location-aware (unconditionally re-homing would destroy deliberately-global dock panels), so it belongs in a separate hydration-scoped change.