### PR TITLE
fix(diff): show a deleted image's prior version instead of an error

### DIFF
--- a/electron/ipc/handlers/__tests__/diffMedia.test.ts
+++ b/electron/ipc/handlers/__tests__/diffMedia.test.ts
@@ -8,6 +8,7 @@ const ipcMainMock = vi.hoisted(() => ({
 }));
 
 const readFileAtHeadMock = vi.hoisted(() => vi.fn());
+const readPreviousFileVersionMock = vi.hoisted(() => vi.fn());
 const getGitServiceMock = vi.hoisted(() => vi.fn());
 
 const fileHandleMock = vi.hoisted(() => ({
@@ -67,8 +68,12 @@ describe("diffMedia readFileVersions", () => {
     vi.clearAllMocks();
     _resetRateLimitQueuesForTest();
 
-    getGitServiceMock.mockReturnValue({ readFileAtHead: readFileAtHeadMock });
+    getGitServiceMock.mockReturnValue({
+      readFileAtHead: readFileAtHeadMock,
+      readPreviousFileVersion: readPreviousFileVersionMock,
+    });
     readFileAtHeadMock.mockResolvedValue({ ok: true, content: HEAD_BUFFER });
+    readPreviousFileVersionMock.mockResolvedValue({ ok: false, reason: "NOT_FOUND" });
 
     fsMock.realpath.mockImplementation(async (p: string) => p);
     fsMock.stat.mockResolvedValue({ size: WORKING_BUFFER.byteLength, isFile: () => true });
@@ -141,6 +146,46 @@ describe("diffMedia readFileVersions", () => {
     });
   });
 
+  it("falls back to the prior committed version when HEAD lacks the file", async () => {
+    const previousBuffer = Buffer.from("previous-image-bytes");
+    readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "NOT_FOUND" });
+    readPreviousFileVersionMock.mockResolvedValue({ ok: true, content: previousBuffer });
+
+    const result = await invoke({ cwd: REPO_ROOT, filePath: "img.png" });
+
+    expect(result.head).toEqual({
+      ok: true,
+      dataUrl: `data:image/png;base64,${previousBuffer.toString("base64")}`,
+      byteSize: previousBuffer.byteLength,
+    });
+  });
+
+  it("does not consult history when HEAD has the file", async () => {
+    await invoke({ cwd: REPO_ROOT, filePath: "img.png" });
+
+    expect(readPreviousFileVersionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not consult history for a TOO_LARGE HEAD blob", async () => {
+    readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "TOO_LARGE" });
+
+    const result = await invoke({ cwd: REPO_ROOT, filePath: "img.png" });
+
+    expect(result.head).toEqual({ ok: false, error: "TOO_LARGE" });
+    expect(readPreviousFileVersionMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a fallback failure to a HEAD-side ERROR instead of rejecting", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "NOT_FOUND" });
+    readPreviousFileVersionMock.mockRejectedValue(new Error("git exploded"));
+
+    const result = await invoke({ cwd: REPO_ROOT, filePath: "img.png" });
+
+    expect(result.head).toEqual({ ok: false, error: "ERROR" });
+    expect(result.working.ok).toBe(true);
+  });
+
   it("maps a missing working-tree file to NOT_FOUND", async () => {
     fsMock.realpath.mockImplementation(async (p: string) => {
       if (p === REPO_ROOT) return REPO_ROOT;
@@ -179,6 +224,7 @@ describe("diffMedia readFileVersions", () => {
 
     expect(result.head).toEqual({ ok: false, error: "ERROR" });
     expect(result.working.ok).toBe(true);
+    expect(readPreviousFileVersionMock).not.toHaveBeenCalled();
   });
 
   it("returns ERROR for a working-tree file that escapes the root via symlink", async () => {

--- a/electron/ipc/handlers/__tests__/diffMedia.test.ts
+++ b/electron/ipc/handlers/__tests__/diffMedia.test.ts
@@ -144,11 +144,23 @@ describe("diffMedia readFileVersions", () => {
       dataUrl: `data:image/png;base64,${WORKING_BUFFER.toString("base64")}`,
       byteSize: WORKING_BUFFER.byteLength,
     });
+    // A present working copy means untracked/re-added, not a committed
+    // deletion — no history walk.
+    expect(readPreviousFileVersionMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to the prior committed version when HEAD lacks the file", async () => {
-    const previousBuffer = Buffer.from("previous-image-bytes");
+  // Committed deletion: nothing at literal HEAD and nothing on disk.
+  function mockCommittedDeletion(): void {
     readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "NOT_FOUND" });
+    fsMock.realpath.mockImplementation(async (p: string) => {
+      if (p === REPO_ROOT) return REPO_ROOT;
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+  }
+
+  it("falls back to the prior committed version for a committed deletion", async () => {
+    const previousBuffer = Buffer.from("previous-image-bytes");
+    mockCommittedDeletion();
     readPreviousFileVersionMock.mockResolvedValue({ ok: true, content: previousBuffer });
 
     const result = await invoke({ cwd: REPO_ROOT, filePath: "img.png" });
@@ -158,6 +170,7 @@ describe("diffMedia readFileVersions", () => {
       dataUrl: `data:image/png;base64,${previousBuffer.toString("base64")}`,
       byteSize: previousBuffer.byteLength,
     });
+    expect(result.working).toEqual({ ok: false, error: "NOT_FOUND" });
   });
 
   it("does not consult history when HEAD has the file", async () => {
@@ -177,13 +190,13 @@ describe("diffMedia readFileVersions", () => {
 
   it("maps a fallback failure to a HEAD-side ERROR instead of rejecting", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    readFileAtHeadMock.mockResolvedValue({ ok: false, reason: "NOT_FOUND" });
+    mockCommittedDeletion();
     readPreviousFileVersionMock.mockRejectedValue(new Error("git exploded"));
 
     const result = await invoke({ cwd: REPO_ROOT, filePath: "img.png" });
 
     expect(result.head).toEqual({ ok: false, error: "ERROR" });
-    expect(result.working.ok).toBe(true);
+    expect(result.working).toEqual({ ok: false, error: "NOT_FOUND" });
   });
 
   it("maps a missing working-tree file to NOT_FOUND", async () => {

--- a/electron/ipc/handlers/diffMedia.ts
+++ b/electron/ipc/handlers/diffMedia.ts
@@ -73,9 +73,13 @@ function validatePayload(payload: DiffMediaReadFileVersionsPayload): void {
 
 async function readHeadSide(cwd: string, filePath: string, mime: string): Promise<DiffMediaSide> {
   try {
-    const result = await gitServiceCache
-      .getGitService(cwd)
-      .readFileAtHead(filePath, DIFF_MEDIA_MAX_BYTES);
+    const gitService = gitServiceCache.getGitService(cwd);
+    let result = await gitService.readFileAtHead(filePath, DIFF_MEDIA_MAX_BYTES);
+    if (!result.ok && result.reason === "NOT_FOUND") {
+      // An already-committed deletion has no blob at literal HEAD — fall back
+      // to the last commit whose tree still contained the path.
+      result = await gitService.readPreviousFileVersion(filePath, DIFF_MEDIA_MAX_BYTES);
+    }
     if (!result.ok) {
       return { ok: false, error: result.reason };
     }

--- a/electron/ipc/handlers/diffMedia.ts
+++ b/electron/ipc/handlers/diffMedia.ts
@@ -73,13 +73,9 @@ function validatePayload(payload: DiffMediaReadFileVersionsPayload): void {
 
 async function readHeadSide(cwd: string, filePath: string, mime: string): Promise<DiffMediaSide> {
   try {
-    const gitService = gitServiceCache.getGitService(cwd);
-    let result = await gitService.readFileAtHead(filePath, DIFF_MEDIA_MAX_BYTES);
-    if (!result.ok && result.reason === "NOT_FOUND") {
-      // An already-committed deletion has no blob at literal HEAD — fall back
-      // to the last commit whose tree still contained the path.
-      result = await gitService.readPreviousFileVersion(filePath, DIFF_MEDIA_MAX_BYTES);
-    }
+    const result = await gitServiceCache
+      .getGitService(cwd)
+      .readFileAtHead(filePath, DIFF_MEDIA_MAX_BYTES);
     if (!result.ok) {
       return { ok: false, error: result.reason };
     }
@@ -88,6 +84,29 @@ async function readHeadSide(cwd: string, filePath: string, mime: string): Promis
     console.error("[IPC] diff-media HEAD read failed:", error);
     return { ok: false, error: "ERROR" };
   }
+}
+
+async function readPreviousSide(
+  cwd: string,
+  filePath: string,
+  mime: string
+): Promise<DiffMediaSide> {
+  try {
+    const result = await gitServiceCache
+      .getGitService(cwd)
+      .readPreviousFileVersion(filePath, DIFF_MEDIA_MAX_BYTES);
+    if (!result.ok) {
+      return { ok: false, error: result.reason };
+    }
+    return toImageSide(mime, result.content);
+  } catch (error) {
+    console.error("[IPC] diff-media prior-version read failed:", error);
+    return { ok: false, error: "ERROR" };
+  }
+}
+
+function isMissing(side: DiffMediaSide): boolean {
+  return !side.ok && side.error === "NOT_FOUND";
 }
 
 // Same containment discipline as files:read — realpath containment against the
@@ -192,10 +211,21 @@ async function handleReadFileVersions(
     };
   }
 
-  const [head, working] = await Promise.all([
+  const [headAtHead, working] = await Promise.all([
     readHeadSide(payload.cwd, payload.filePath, mime),
     readWorkingSide(payload.cwd, payload.filePath, mime),
   ]);
+
+  // Both sides missing is the signature of an already-committed deletion —
+  // literal HEAD has moved past the delete, so show the last committed
+  // version. Gated on the working side too: for a never-tracked path (a
+  // working copy exists) rev-list would scan the full history just to
+  // return nothing.
+  const head =
+    isMissing(headAtHead) && isMissing(working)
+      ? await readPreviousSide(payload.cwd, payload.filePath, mime)
+      : headAtHead;
+
   return { head, working };
 }
 

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -27,6 +27,10 @@ export type HeadFileReadResult =
 const MISSING_AT_HEAD_RE =
   /does not exist in|exists on disk, but not in|invalid object name|not a valid object name|bad revision|bad file/i;
 
+// Git error text when a revision argument cannot resolve at all — an unborn
+// HEAD (empty repo) has no commits to walk, so there is no prior version.
+const UNRESOLVABLE_REVISION_RE = /unknown revision|ambiguous argument|bad default revision/i;
+
 export class GitService {
   private git: Promise<SimpleGit> | null = null;
   private rootPath: string;
@@ -314,12 +318,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     }
   }
 
-  /**
-   * Read a file's blob content at HEAD. Size-checks via `cat-file -s` before
-   * reading so an oversized blob is never loaded, and reads the content with
-   * `binaryCatFile` (Buffer-safe — `raw()` is utf8-lossy for binary blobs).
-   */
-  async readFileAtHead(filePath: string, maxBytes: number): Promise<HeadFileReadResult> {
+  // Reject absolute, NUL-byte, and traversal paths, and return the path in
+  // git object-spec form (forward slashes, even on Windows).
+  private normalizeTreePath(filePath: string): string {
     if (isAbsolute(filePath)) {
       throw new Error("Absolute paths are not allowed");
     }
@@ -333,11 +334,18 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       throw new Error("Path traversal detected");
     }
 
-    // Git object specs always use forward slashes, even on Windows. The
-    // `HEAD:` prefix also guarantees the spec never starts with a dash.
-    const objectSpec = `HEAD:${normalizedPath.replaceAll("\\", "/")}`;
-    const git = await this.getGit();
+    return normalizedPath.replaceAll("\\", "/");
+  }
 
+  // Size-probe then read a blob at `<rev>:<path>`. The rev prefix keeps the
+  // spec from ever starting with a dash (`binaryCatFile` has no
+  // `--end-of-options`).
+  private async readBlobAtSpec(
+    git: SimpleGit,
+    objectSpec: string,
+    maxBytes: number,
+    op: string
+  ): Promise<HeadFileReadResult> {
     let sizeRaw: string;
     try {
       sizeRaw = await git.raw(["cat-file", "-s", "--end-of-options", objectSpec]);
@@ -345,7 +353,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       if (MISSING_AT_HEAD_RE.test((error as Error).message ?? "")) {
         return { ok: false, reason: "NOT_FOUND" };
       }
-      throw toGitOperationError(error, { cwd: this.rootPath, op: "read-file-at-head" });
+      throw toGitOperationError(error, { cwd: this.rootPath, op });
     }
 
     const size = Number.parseInt(sizeRaw.trim(), 10);
@@ -360,13 +368,73 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       if (MISSING_AT_HEAD_RE.test((error as Error).message ?? "")) {
         return { ok: false, reason: "NOT_FOUND" };
       }
-      throw toGitOperationError(error, { cwd: this.rootPath, op: "read-file-at-head" });
+      throw toGitOperationError(error, { cwd: this.rootPath, op });
     }
 
     if (content.byteLength > maxBytes) {
       return { ok: false, reason: "TOO_LARGE" };
     }
     return { ok: true, content };
+  }
+
+  /**
+   * Read a file's blob content at HEAD. Size-checks via `cat-file -s` before
+   * reading so an oversized blob is never loaded, and reads the content with
+   * `binaryCatFile` (Buffer-safe — `raw()` is utf8-lossy for binary blobs).
+   */
+  async readFileAtHead(filePath: string, maxBytes: number): Promise<HeadFileReadResult> {
+    const treePath = this.normalizeTreePath(filePath);
+    const git = await this.getGit();
+    return this.readBlobAtSpec(git, `HEAD:${treePath}`, maxBytes, "read-file-at-head");
+  }
+
+  /**
+   * Read the last committed version of a file that no longer exists at HEAD —
+   * the blob from the newest commit whose tree still contains the path.
+   * Renames are not followed (`rev-list` has no `--follow`), matching
+   * `readFileAtHead`'s limitation.
+   */
+  async readPreviousFileVersion(filePath: string, maxBytes: number): Promise<HeadFileReadResult> {
+    const treePath = this.normalizeTreePath(filePath);
+    const git = await this.getGit();
+
+    let revListRaw: string;
+    try {
+      revListRaw = await git.raw(["rev-list", "-2", "--end-of-options", "HEAD", "--", treePath]);
+    } catch (error) {
+      const message = (error as Error).message ?? "";
+      if (UNRESOLVABLE_REVISION_RE.test(message) || MISSING_AT_HEAD_RE.test(message)) {
+        return { ok: false, reason: "NOT_FOUND" };
+      }
+      throw toGitOperationError(error, { cwd: this.rootPath, op: "read-previous-file-version" });
+    }
+
+    // commits[0] removed (or last touched) the path; commits[1] is the newest
+    // commit whose tree still contains it. Fewer than two commits means no
+    // prior version exists (never tracked, or added and deleted in one
+    // commit).
+    const commits = revListRaw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (commits.length < 2) {
+      return { ok: false, reason: "NOT_FOUND" };
+    }
+
+    const previousCommit = commits[1];
+    if (!/^([0-9a-f]{40}|[0-9a-f]{64})$/i.test(previousCommit)) {
+      throw toGitOperationError(new Error("Unexpected rev-list output"), {
+        cwd: this.rootPath,
+        op: "read-previous-file-version",
+      });
+    }
+
+    return this.readBlobAtSpec(
+      git,
+      `${previousCommit}:${treePath}`,
+      maxBytes,
+      "read-previous-file-version"
+    );
   }
 
   async compareWorktrees(

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -398,9 +398,20 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     const treePath = this.normalizeTreePath(filePath);
     const git = await this.getGit();
 
+    // `--literal-pathspecs` because `--` only blocks option injection — a
+    // legal filename containing glob magic (`image[1].png`) would otherwise
+    // match unrelated files' history.
     let revListRaw: string;
     try {
-      revListRaw = await git.raw(["rev-list", "-2", "--end-of-options", "HEAD", "--", treePath]);
+      revListRaw = await git.raw([
+        "--literal-pathspecs",
+        "rev-list",
+        "-2",
+        "--end-of-options",
+        "HEAD",
+        "--",
+        treePath,
+      ]);
     } catch (error) {
       const message = (error as Error).message ?? "";
       if (UNRESOLVABLE_REVISION_RE.test(message) || MISSING_AT_HEAD_RE.test(message)) {
@@ -411,8 +422,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
     // commits[0] removed (or last touched) the path; commits[1] is the newest
     // commit whose tree still contains it. Fewer than two commits means no
-    // prior version exists (never tracked, or added and deleted in one
-    // commit).
+    // prior version is reachable (never tracked, or the deleting commit is
+    // the only one visible — e.g. shallow/truncated history).
     const commits = revListRaw
       .split(/\r?\n/)
       .map((line) => line.trim())

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -656,7 +656,7 @@ describe("GitService.readPreviousFileVersion", () => {
 
   function mockRevList(output: string): void {
     gitClientMock.raw.mockImplementation(async (args: string[]) =>
-      args[0] === "rev-list" ? output : "10\n"
+      args.includes("rev-list") ? output : "10\n"
     );
   }
 
@@ -684,6 +684,7 @@ describe("GitService.readPreviousFileVersion", () => {
     const result = await service.readPreviousFileVersion("-flag.png", 1024);
 
     expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "--literal-pathspecs",
       "rev-list",
       "-2",
       "--end-of-options",
@@ -709,6 +710,7 @@ describe("GitService.readPreviousFileVersion", () => {
     await service.readPreviousFileVersion("assets\\logo.png", 1024);
 
     expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "--literal-pathspecs",
       "rev-list",
       "-2",
       "--end-of-options",
@@ -718,7 +720,26 @@ describe("GitService.readPreviousFileVersion", () => {
     ]);
   });
 
-  it("returns NOT_FOUND when the file was added and deleted in a single commit", async () => {
+  it("passes glob metacharacters through as a literal pathspec", async () => {
+    mockRevList(`${DELETING_SHA}\n${PREVIOUS_SHA}\n`);
+    binaryCatFileMock.mockResolvedValue(Buffer.from("data"));
+    const service = new GitService(tempDir);
+
+    await service.readPreviousFileVersion("image[1].png", 1024);
+
+    expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "--literal-pathspecs",
+      "rev-list",
+      "-2",
+      "--end-of-options",
+      "HEAD",
+      "--",
+      "image[1].png",
+    ]);
+    expect(binaryCatFileMock).toHaveBeenCalledWith(["blob", `${PREVIOUS_SHA}:image[1].png`]);
+  });
+
+  it("returns NOT_FOUND when only the deleting commit is reachable for the path", async () => {
     mockRevList(`${DELETING_SHA}\n`);
     const service = new GitService(tempDir);
 
@@ -756,7 +777,7 @@ describe("GitService.readPreviousFileVersion", () => {
 
   it("maps a path missing at the prior commit to NOT_FOUND", async () => {
     gitClientMock.raw.mockImplementation(async (args: string[]) => {
-      if (args[0] === "rev-list") return `${DELETING_SHA}\n${PREVIOUS_SHA}\n`;
+      if (args.includes("rev-list")) return `${DELETING_SHA}\n${PREVIOUS_SHA}\n`;
       throw new Error(`fatal: path 'img.png' does not exist in '${PREVIOUS_SHA}'`);
     });
     const service = new GitService(tempDir);
@@ -781,7 +802,9 @@ describe("GitService.readPreviousFileVersion", () => {
 
   it("rejects an oversized prior blob from the size probe without reading content", async () => {
     gitClientMock.raw.mockImplementation(async (args: string[]) =>
-      args[0] === "rev-list" ? `${DELETING_SHA}\n${PREVIOUS_SHA}\n` : `${String(5 * 1024 * 1024)}\n`
+      args.includes("rev-list")
+        ? `${DELETING_SHA}\n${PREVIOUS_SHA}\n`
+        : `${String(5 * 1024 * 1024)}\n`
     );
     const service = new GitService(tempDir);
 

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -633,3 +633,171 @@ describe("GitService.readFileAtHead", () => {
     });
   });
 });
+
+describe("GitService.readPreviousFileVersion", () => {
+  let tempDir: string;
+  const binaryCatFileMock = vi.fn();
+  const DELETING_SHA = "a".repeat(40);
+  const PREVIOUS_SHA = "b".repeat(40);
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-git-prev-"));
+    vi.clearAllMocks();
+    createHardenedGitMock.mockImplementation(() => ({
+      ...gitClientMock,
+      binaryCatFile: binaryCatFileMock,
+    }));
+    gitClientMock.raw.mockResolvedValue("");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function mockRevList(output: string): void {
+    gitClientMock.raw.mockImplementation(async (args: string[]) =>
+      args[0] === "rev-list" ? output : "10\n"
+    );
+  }
+
+  it("rejects absolute paths before touching git", async () => {
+    const service = new GitService(tempDir);
+    await expect(service.readPreviousFileVersion("/etc/passwd.png", 1024)).rejects.toThrow(
+      /absolute/i
+    );
+    expect(gitClientMock.raw).not.toHaveBeenCalled();
+  });
+
+  it("rejects traversal that only appears after normalization", async () => {
+    const service = new GitService(tempDir);
+    await expect(service.readPreviousFileVersion("assets/../../outside.png", 1024)).rejects.toThrow(
+      /traversal/i
+    );
+    expect(gitClientMock.raw).not.toHaveBeenCalled();
+  });
+
+  it("walks history behind --end-of-options and reads the second commit's blob", async () => {
+    mockRevList(`${DELETING_SHA}\n${PREVIOUS_SHA}\n`);
+    binaryCatFileMock.mockResolvedValue(Buffer.from("old-bytes"));
+    const service = new GitService(tempDir);
+
+    const result = await service.readPreviousFileVersion("-flag.png", 1024);
+
+    expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "rev-list",
+      "-2",
+      "--end-of-options",
+      "HEAD",
+      "--",
+      "-flag.png",
+    ]);
+    expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "cat-file",
+      "-s",
+      "--end-of-options",
+      `${PREVIOUS_SHA}:-flag.png`,
+    ]);
+    expect(binaryCatFileMock).toHaveBeenCalledWith(["blob", `${PREVIOUS_SHA}:-flag.png`]);
+    expect(result).toEqual({ ok: true, content: Buffer.from("old-bytes") });
+  });
+
+  it("converts backslash separators to git's forward-slash path", async () => {
+    mockRevList(`${DELETING_SHA}\n${PREVIOUS_SHA}\n`);
+    binaryCatFileMock.mockResolvedValue(Buffer.from("data"));
+    const service = new GitService(tempDir);
+
+    await service.readPreviousFileVersion("assets\\logo.png", 1024);
+
+    expect(gitClientMock.raw).toHaveBeenCalledWith([
+      "rev-list",
+      "-2",
+      "--end-of-options",
+      "HEAD",
+      "--",
+      "assets/logo.png",
+    ]);
+  });
+
+  it("returns NOT_FOUND when the file was added and deleted in a single commit", async () => {
+    mockRevList(`${DELETING_SHA}\n`);
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("once.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns NOT_FOUND for a never-tracked file", async () => {
+    mockRevList("");
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("untracked.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns NOT_FOUND for an unborn HEAD in an empty repository", async () => {
+    gitClientMock.raw.mockRejectedValue(
+      new Error(
+        "fatal: ambiguous argument 'HEAD': unknown revision or working tree path not in the working tree."
+      )
+    );
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("img.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+  });
+
+  it("maps a path missing at the prior commit to NOT_FOUND", async () => {
+    gitClientMock.raw.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-list") return `${DELETING_SHA}\n${PREVIOUS_SHA}\n`;
+      throw new Error(`fatal: path 'img.png' does not exist in '${PREVIOUS_SHA}'`);
+    });
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("img.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "NOT_FOUND",
+    });
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("never passes malformed rev-list output to cat-file", async () => {
+    mockRevList("--flag-injection\nnot-a-sha\n");
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("img.png", 1024)).rejects.toThrow(
+      GitOperationError
+    );
+    expect(gitClientMock.raw).toHaveBeenCalledTimes(1);
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized prior blob from the size probe without reading content", async () => {
+    gitClientMock.raw.mockImplementation(async (args: string[]) =>
+      args[0] === "rev-list" ? `${DELETING_SHA}\n${PREVIOUS_SHA}\n` : `${String(5 * 1024 * 1024)}\n`
+    );
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("big.png", 1024)).resolves.toEqual({
+      ok: false,
+      reason: "TOO_LARGE",
+    });
+    expect(binaryCatFileMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces unexpected rev-list failures as git operation errors", async () => {
+    gitClientMock.raw.mockRejectedValue(new Error("git exploded"));
+    const service = new GitService(tempDir);
+
+    await expect(service.readPreviousFileVersion("img.png", 1024)).rejects.toThrow(
+      GitOperationError
+    );
+  });
+});

--- a/src/components/FileViewer/ImageDiffViewer.tsx
+++ b/src/components/FileViewer/ImageDiffViewer.tsx
@@ -310,10 +310,16 @@ export function ImageDiffViewer({ relPath, worktreePath, status }: ImageDiffView
     );
   }
 
-  if (loadState === "error" || (versions !== null && !versions.head.ok && !versions.working.ok)) {
+  // Single-pane statuses (added/deleted) always render their dedicated pane —
+  // its per-side message covers a missing version; the aggregate error is
+  // reserved for comparisons where both sides genuinely failed.
+  const bothSidesFailed = versions !== null && !versions.head.ok && !versions.working.ok;
+
+  if (loadState === "error" || (singleSide === null && bothSidesFailed)) {
     return (
       <div className="flex h-full min-h-0 w-full flex-col items-center justify-center">
         <EmptyState
+          className="self-stretch"
           variant="zero-data"
           scale="canvas"
           icon={<ImageOff />}

--- a/src/components/FileViewer/ImageDiffViewer.tsx
+++ b/src/components/FileViewer/ImageDiffViewer.tsx
@@ -66,9 +66,11 @@ interface ImagePaneProps {
   side: DiffMediaSide;
   relPath: string;
   caption?: string;
+  /** Offered only for transient read failures, not genuinely absent versions */
+  onRetry?: () => void;
 }
 
-function ImagePane({ label, side, relPath, caption }: ImagePaneProps) {
+function ImagePane({ label, side, relPath, caption, onRetry }: ImagePaneProps) {
   const [dims, setDims] = useState<{ width: number; height: number } | null>(null);
   const [decodeFailed, setDecodeFailed] = useState(false);
   const src = side.ok ? side.dataUrl : null;
@@ -103,9 +105,16 @@ function ImagePane({ label, side, relPath, caption }: ImagePaneProps) {
             onError={() => setDecodeFailed(true)}
           />
         ) : (
-          <p className="px-4 text-center text-xs text-muted-foreground">
-            {side.ok ? "Couldn't display this version" : sideErrorMessage(side.error)}
-          </p>
+          <div className="flex flex-col items-center gap-2 px-4">
+            <p className="text-center text-xs text-muted-foreground">
+              {side.ok ? "Couldn't display this version" : sideErrorMessage(side.error)}
+            </p>
+            {!side.ok && side.error === "ERROR" && onRetry ? (
+              <Button variant="outline" size="sm" onClick={onRetry}>
+                Retry
+              </Button>
+            ) : null}
+          </div>
         )}
       </div>
       {side.ok && !decodeFailed ? (
@@ -347,6 +356,7 @@ export function ImageDiffViewer({ relPath, worktreePath, status }: ImageDiffView
           side={versions[singleSide]}
           relPath={relPath}
           caption={caption}
+          onRetry={retry}
         />
       </div>
     );

--- a/src/components/FileViewer/__tests__/ImageDiffViewer.test.tsx
+++ b/src/components/FileViewer/__tests__/ImageDiffViewer.test.tsx
@@ -91,6 +91,20 @@ describe("ImageDiffViewer", () => {
     expect(screen.queryByRole("button", { name: "Swipe" })).toBeNull();
   });
 
+  it("keeps the single-pane layout for a deleted file with no readable prior version", async () => {
+    mockReadFileVersions.mockResolvedValue({
+      head: { ok: false, error: "NOT_FOUND" },
+      working: { ok: false, error: "NOT_FOUND" },
+    } satisfies DiffMediaFileVersions);
+
+    render(<ImageDiffViewer relPath="gone.png" worktreePath="/repo" status="deleted" />);
+
+    expect(await screen.findByText("Deleted — no working version")).toBeDefined();
+    expect(screen.getByText("No version to show")).toBeDefined();
+    expect(screen.queryByText("Couldn't load image versions")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
   it("shows a per-side message and hides compare modes when one side is too large", async () => {
     mockReadFileVersions.mockResolvedValue({
       head: { ok: false, error: "TOO_LARGE" },

--- a/src/components/FileViewer/__tests__/ImageDiffViewer.test.tsx
+++ b/src/components/FileViewer/__tests__/ImageDiffViewer.test.tsx
@@ -105,6 +105,25 @@ describe("ImageDiffViewer", () => {
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 
+  it("offers Retry in the deleted-file pane after a transient HEAD failure", async () => {
+    mockReadFileVersions.mockResolvedValueOnce({
+      head: { ok: false, error: "ERROR" },
+      working: { ok: false, error: "NOT_FOUND" },
+    } satisfies DiffMediaFileVersions);
+    mockReadFileVersions.mockResolvedValueOnce({
+      head: { ok: true, dataUrl: HEAD_URL, byteSize: 4 },
+      working: { ok: false, error: "NOT_FOUND" },
+    } satisfies DiffMediaFileVersions);
+
+    render(<ImageDiffViewer relPath="gone.png" worktreePath="/repo" status="deleted" />);
+
+    expect(await screen.findByText("Couldn't load this version")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await screen.findByAltText("HEAD version of gone.png");
+    expect(mockReadFileVersions).toHaveBeenCalledTimes(2);
+  });
+
   it("shows a per-side message and hides compare modes when one side is too large", async () => {
     mockReadFileVersions.mockResolvedValue({
       head: { ok: false, error: "TOO_LARGE" },


### PR DESCRIPTION
## Summary

- Clicking a deleted image in the diff viewer showed the aggregate "Couldn't load image versions" error instead of the dedicated deleted-file single-pane view, because once a deletion is committed, literal HEAD no longer has the blob, so both sides fail to read and the error branch outranks the deleted-file branch.
- The error `EmptyState` also collapsed to a `fit-content` column because its flex parent's `items-center` made the container query measure under 280px, wrapping the title and description one word per line.

Resolves #11292

## Changes

- `GitService.ts`: extracted `normalizeTreePath` and `readBlobAtSpec` helpers (`readFileAtHead` behavior unchanged) and added `readPreviousFileVersion`, which walks `git --literal-pathspecs rev-list -2 --end-of-options HEAD -- <path>` through the existing hardened simple-git instance, validates the prior commit SHA as full hex, and reads the blob via a cat-file size probe plus `binaryCatFile`. It never uses `git show`, so the textconv/smudge surface stays closed. `--literal-pathspecs` keeps glob-magic filenames (`image[1].png`) from matching unrelated history. Renames aren't followed, the same accepted limitation `readFileAtHead` already has.
- `diffMedia` handler: after both sides resolve, a head and working double `NOT_FOUND` (the signature of a committed deletion) now triggers one history-walk fallback for the head side. Gating on the working side too means untracked or newly added images never pay for a full history rev-list scan. No IPC payload or schema changes.
- `ImageDiffViewer.tsx`: single-pane statuses (added, untracked, deleted) now always render their dedicated pane instead of falling into the aggregate double-error state. A transient per-side `ERROR` gets an in-pane Retry button; `NOT_FOUND`/`TOO_LARGE`/`UNSUPPORTED` don't. The aggregate error `EmptyState` gets a self-stretch style so its container query measures the pane's width instead of `fit-content`, fixing the one-word-per-line wrapping.

Out of scope: the issue also flagged a dialog-title vs path-bar filename mismatch. That's a separate, unconfirmed navigation concern and isn't addressed here.

## Testing

134 tests pass across the touched suites (12 added, 4 updated):

- `GitService.test.ts`: new `readPreviousFileVersion` suite covering argv safety (including literal pathspecs and end-of-options), `commits[1]` selection, unborn HEAD, truncated history, malformed rev-list output, and size caps.
- `diffMedia.test.ts`: fallback boundary cases (committed deletion vs untracked vs `TOO_LARGE` vs a thrown error).
- `ImageDiffViewer.test.tsx`: deleted double-`NOT_FOUND` single-pane rendering and transient-failure Retry recovery.
- Both `DiffPane` consumer test suites.

Prettier and eslint are clean on all changed files.

