### PR TITLE
fix(dnd): prevent a wedged drag from disabling all drag-and-drop until reload

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -107,10 +107,11 @@ import {
   resolveGroupPlacementIndex,
   resolveGridInsertionIndexFromRects,
   findGroupIndex,
-  isNonDockableDockDrop,
   filterOutDockDroppables,
+  shouldCancelDrop,
   type OverDropData,
 } from "./dropResolution";
+import { useDragRecovery } from "./useDragRecovery";
 import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import {
   DURATION_100,
@@ -681,48 +682,56 @@ export function DndProvider({ children }: DndProviderProps) {
     );
   }, [activeId, activeData]);
 
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setIsCancelDrop(false);
+  const { beginDrag, finishDrag } = useDragRecovery();
 
-    const { active } = event;
-    const dragId = active.id as string;
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      // Synchronous: the data-dragging webview shield and the lost-mouseup
+      // watchdog must be armed before React commits the drag state (#11291).
+      beginDrag(event.activatorEvent);
+      setIsCancelDrop(false);
 
-    // Skip terminal-specific logic for worktree-sort drags
-    if (isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined)) {
-      // Pin a snapshot so handleDragEnd survives Virtuoso unmounting the
-      // source row when it scrolls outside the overscan window mid-drag.
-      activeWorktreeSortDataRef.current = active.data.current as Record<string, unknown>;
-      setActiveId(dragId);
-      setIsWorktreeSortActive(true);
-      const worktreeId = parseWorktreeSortDragId(dragId);
-      if (worktreeId) {
-        const wt = getCurrentViewStore().getState().worktrees.get(worktreeId);
-        setActiveSortWorktree(wt ?? null);
+      const { active } = event;
+      const dragId = active.id as string;
+
+      // Skip terminal-specific logic for worktree-sort drags
+      if (isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined)) {
+        // Pin a snapshot so handleDragEnd survives Virtuoso unmounting the
+        // source row when it scrolls outside the overscan window mid-drag.
+        activeWorktreeSortDataRef.current = active.data.current as Record<string, unknown>;
+        setActiveId(dragId);
+        setIsWorktreeSortActive(true);
+        const worktreeId = parseWorktreeSortDragId(dragId);
+        if (worktreeId) {
+          const wt = getCurrentViewStore().getState().worktrees.get(worktreeId);
+          setActiveSortWorktree(wt ?? null);
+        }
+        return;
       }
-      return;
-    }
 
-    const data = active.data.current as DragData | WorktreeDragData | undefined;
+      const data = active.data.current as DragData | WorktreeDragData | undefined;
 
-    const terminalId = data?.terminal?.id ?? parseAccordionDragId(dragId) ?? dragId;
+      const terminalId = data?.terminal?.id ?? parseAccordionDragId(dragId) ?? dragId;
 
-    setActiveId(dragId);
-    terminalInstanceService.lockResize(terminalId, true);
-    gridInsertMemoRef.current = null;
+      setActiveId(dragId);
+      terminalInstanceService.lockResize(terminalId, true);
+      gridInsertMemoRef.current = null;
 
-    // Clear any pending stabilization timers from previous drags
-    if (stabilizationTimerRef.current) {
-      clearTimeout(stabilizationTimerRef.current);
-      stabilizationTimerRef.current = null;
-    }
-    dockRetryTimersRef.current.forEach(clearTimeout);
-    dockRetryTimersRef.current.clear();
+      // Clear any pending stabilization timers from previous drags
+      if (stabilizationTimerRef.current) {
+        clearTimeout(stabilizationTimerRef.current);
+        stabilizationTimerRef.current = null;
+      }
+      dockRetryTimersRef.current.forEach(clearTimeout);
+      dockRetryTimersRef.current.clear();
 
-    if (data) {
-      setActiveData(data);
-      setOverContainer(data.sourceLocation);
-    }
-  }, []);
+      if (data) {
+        setActiveData(data);
+        setOverContainer(data.sourceLocation);
+      }
+    },
+    [beginDrag]
+  );
 
   const handleDragOver = useCallback((event: DragOverEvent) => {
     const { active, over } = event;
@@ -848,6 +857,7 @@ export function DndProvider({ children }: DndProviderProps) {
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      finishDrag();
       const { active, over } = event;
 
       // Handle worktree-sort drags before any terminal logic. The snapshot ref
@@ -1268,76 +1278,40 @@ export function DndProvider({ children }: DndProviderProps) {
       moveTabGroupToLocation,
       setFocused,
       activeWorktreeId,
+      finishDrag,
     ]
   );
 
-  const cancelDrop = useCallback(
-    (event: DragEndEvent) => {
+  // dnd-kit awaits this callback with no try/catch before releasing its
+  // internal active lock, so a throw here wedges every future drag until
+  // reload (#11291) — the verdict lives in shouldCancelDrop, a total function,
+  // and this glue fails closed on anything unexpected. The snapshot ref check
+  // matters: if Virtuoso has unmounted the source row, active.data.current is
+  // undefined but the ref still holds the worktree-sort drag data — converting
+  // to cancel here would lose the reorder entirely (#8393).
+  const cancelDrop = useCallback((event: DragEndEvent) => {
+    try {
       const { active, over } = event;
-
-      if (!over) {
-        setIsCancelDrop(true);
-        return true;
-      }
-
-      // Worktree-sort drags own their own drop logic in handleDragEnd; let
-      // every drop through. Also check the snapshot ref: if Virtuoso has
-      // unmounted the source row, active.data.current is undefined but the
-      // ref still holds the original drag data — converting to cancel here
-      // would lose the reorder entirely.
-      if (
+      const isWorktreeSort =
         activeWorktreeSortDataRef.current !== null ||
-        isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined)
-      ) {
-        return false;
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- dnd-kit data.current is loosely typed
-      const activeDataRaw = active.data.current as DragData | undefined;
-      const draggedId = activeDataRaw?.terminal?.id ?? (active?.id ? String(active.id) : null);
-
-      if (!activeDataRaw || !draggedId) {
-        setIsCancelDrop(true);
-        return true;
-      }
-
-      const overData = over.data.current as OverDropData | undefined;
-
-      const isGroupDrag =
-        activeDataRaw.groupId &&
-        activeDataRaw.groupPanelIds &&
-        activeDataRaw.groupPanelIds.length > 1;
-      const isWorktreeDrop = overData?.type === "worktree" && !!overData.worktreeId;
-      if (isWorktreeDrop && isGroupDrag) {
-        setIsCancelDrop(true);
-        return true;
-      }
-
-      // A panel whose kind the dock can't render must never commit into the
-      // dock — it would strand invisibly (#11054). Reject the drop so it snaps
-      // back to its origin. `cursor-no-drop` already signals this during hover
-      // (ContentDock), and `collisionDetection` keeps the dock out of the hover
-      // candidates, so this is the defensive final gate on the same capability
-      // predicate the launch menu and move-to-dock use.
-      const targetContainer =
-        overData?.container ??
-        (overData?.sortable?.containerId
-          ? resolveContainerId(overData.sortable.containerId)
-          : null);
-      if (isNonDockableDockDrop(targetContainer, activeDataRaw.terminal.kind)) {
-        setIsCancelDrop(true);
-        return true;
-      }
-
-      // Scrollable panel grid (#8805) — dock→grid drops are never rejected on
-      // capacity grounds; the grid scrolls vertically to absorb new panels.
-
-      return false;
-    },
-    [overContainer]
-  );
+        isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined);
+      const cancel = shouldCancelDrop({
+        hasOver: over !== null,
+        activeData: active.data.current,
+        overData: over?.data.current as OverDropData | undefined,
+        isWorktreeSort,
+      });
+      if (cancel) setIsCancelDrop(true);
+      return cancel;
+    } catch (error) {
+      console.warn("[DndProvider] cancelDrop failed; canceling drop to keep dnd-kit live", error);
+      setIsCancelDrop(true);
+      return true;
+    }
+  }, []);
 
   const handleDragCancel = useCallback(() => {
+    finishDrag();
     // Skip terminal unlock for worktree-sort drags (no lock was acquired)
     const isWorktreeSort = activeId ? parseWorktreeSortDragId(activeId) !== null : false;
     if (isWorktreeSort) {
@@ -1370,7 +1344,7 @@ export function DndProvider({ children }: DndProviderProps) {
     setIsWorktreeSortActive(false);
     setActiveSortWorktree(null);
     // No explicit refresh needed - terminals return to original state (no layout change)
-  }, [activeId, activeData]);
+  }, [activeId, activeData, finishDrag]);
 
   // Use rectIntersection as default (stable when cursor outside containers),
   // closestCenter for dock (1D horizontal) and worktree sort (1D vertical)

--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -39,7 +39,10 @@ export function DockPlaceholder({ className }: DockPlaceholderProps) {
 }
 
 export function SortableDockPlaceholder() {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+  // Drop target only — no activator attributes/listeners. Dragging the
+  // invisible placeholder itself produced drag data with no `terminal`,
+  // which wedged dnd-kit app-wide via a throwing cancelDrop (#11291).
+  const { setNodeRef, transform, transition } = useSortable({
     id: DOCK_PLACEHOLDER_ID,
     data: { container: "dock", isPlaceholder: true },
     animateLayoutChanges: () => false,
@@ -57,8 +60,6 @@ export function SortableDockPlaceholder() {
       <div
         ref={setNodeRef}
         style={style}
-        {...attributes}
-        {...listeners}
         className="h-full"
         data-placeholder-id={DOCK_PLACEHOLDER_ID}
       >

--- a/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
@@ -92,6 +92,10 @@ describe("shouldCancelDrop", () => {
       expect(run({ overData: { container: "grid" }, activeData: "panel-1" })).toBe(true);
     });
 
+    it("cancels placeholder data even on a data-less droppable like trash", () => {
+      expect(run({ hasOver: true, overData: null, activeData: placeholderData })).toBe(true);
+    });
+
     it("fails closed when reading the drag data throws", () => {
       const hostile = {
         get terminal(): never {
@@ -110,6 +114,25 @@ describe("shouldCancelDrop", () => {
         },
       };
       expect(run({ overData: { container: "grid" }, activeData: hostile })).toBe(true);
+    });
+
+    it("is total even when the params object itself throws on read", () => {
+      const hostile = {
+        get hasOver(): never {
+          throw new Error("boom");
+        },
+        get activeData(): never {
+          throw new Error("boom");
+        },
+        get overData(): never {
+          throw new Error("boom");
+        },
+        get isWorktreeSort(): never {
+          throw new Error("boom");
+        },
+      };
+      expect(() => shouldCancelDrop(hostile)).not.toThrow();
+      expect(shouldCancelDrop(hostile)).toBe(true);
     });
   });
 

--- a/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
@@ -1,114 +1,32 @@
-// Contract test for cancelDrop predicates added to DndProvider.
-// Mirrors the exact branch logic so we can assert rejection conditions
-// route to onDragCancel instead of onDragEnd. Following the same harness
-// pattern as DndProvider.trashDrop.test.ts.
+// Contract tests for the production cancel-drop verdict (#11291). dnd-kit
+// awaits `cancelDrop` with no try/catch before releasing its internal active
+// lock, so a single throw wedges every future drag until reload. The resolver
+// must therefore be total: any input — including the empty-dock placeholder's
+// terminal-less drag data — produces a verdict instead of throwing.
 import { describe, expect, it } from "vitest";
 
-import type { DragData } from "../DndProvider";
-import { isNonDockableDockDrop, type OverDropData } from "../dropResolution";
+import { shouldCancelDrop, type OverDropData } from "../dropResolution";
 
 // ── Helpers ──────────────────────────────────────────────
 
-/** Matches DraggableDragData discriminated union in SortableTerminal */
-type ActiveDragData = DragData & {
-  groupId?: string;
-  groupPanelIds?: string[];
-};
-
-function hasOver(overData: OverDropData | undefined | null): boolean {
-  return overData != null;
+function run(params: {
+  overData?: OverDropData | null;
+  activeData?: unknown;
+  isWorktreeSort?: boolean;
+  hasOver?: boolean;
+}): boolean {
+  const { overData = null, activeData, isWorktreeSort = false, hasOver } = params;
+  return shouldCancelDrop({
+    hasOver: hasOver ?? overData != null,
+    activeData,
+    overData: overData ?? undefined,
+    isWorktreeSort,
+  });
 }
 
-function hasDraggedId(data: ActiveDragData | undefined, activeId?: string): boolean {
-  const draggedId = data?.terminal?.id ?? activeId ?? null;
-  return draggedId != null;
-}
-
-function isGroupDrag(data: ActiveDragData): boolean {
-  return !!(data.groupId && data.groupPanelIds && data.groupPanelIds.length > 1);
-}
-
-function isWorktreeDrop(overData: OverDropData | undefined): boolean {
-  return overData?.type === "worktree" && !!overData.worktreeId;
-}
-
-function isDockToGridFull(
-  sourceLocation: string | undefined,
-  targetContainer: "grid" | "dock" | null,
-  gridIsFull: boolean
-): boolean {
-  return sourceLocation === "dock" && targetContainer === "grid" && gridIsFull;
-}
-
-// ── Predicate replicas (mirrors cancelDrop in DndProvider.tsx) ──
-
-type CancelDropResult = { cancel: true } | { cancel: false };
-
-/**
- * Full cancelDrop logic extracted for contract testing.
- * Mirrors the in-component callback exactly.
- */
-function runCancelDrop(params: {
-  overData: OverDropData | undefined | null;
-  activeData: ActiveDragData | undefined;
-  sourceLocation: "grid" | "dock" | undefined;
-  targetContainer: "grid" | "dock" | null;
-  gridIsFull: boolean;
-  isWorktreeSort: boolean;
-}): CancelDropResult {
-  const { overData, activeData, sourceLocation, targetContainer, gridIsFull, isWorktreeSort } =
-    params;
-
-  // Predicate 1: No over target
-  if (!hasOver(overData)) {
-    return { cancel: true };
-  }
-
-  // Worktree-sort handles its own rejection in handleDragEnd
-  if (isWorktreeSort) {
-    return { cancel: false };
-  }
-
-  if (!activeData || !hasDraggedId(activeData)) {
-    return { cancel: true };
-  }
-
-  // Predicate 2: Multi-panel group on worktree
-  if (isGroupDrag(activeData) && isWorktreeDrop(overData!)) {
-    return { cancel: true };
-  }
-
-  // Predicate 3: Dock drop of a kind the dock can't render (#11054). Calls the
-  // real helper so this stays a genuine test of production logic, not a copy.
-  if (isNonDockableDockDrop(targetContainer, activeData.terminal.kind)) {
-    return { cancel: true };
-  }
-
-  // Predicate 4: Dock-to-grid when grid is full
-  if (isDockToGridFull(sourceLocation, targetContainer, gridIsFull)) {
-    return { cancel: true };
-  }
-
-  return { cancel: false };
-}
-
-// ── Test data factories ─────────────────────────────────
-
-function makeDragData(overrides: Partial<ActiveDragData> = {}): ActiveDragData {
+function makeDragData(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
-    terminal: {
-      id: "panel-1",
-      title: "Test Panel",
-      kind: "terminal",
-      location: "grid",
-      worktreeId: null,
-      agentState: "idle",
-      visibility: true,
-      cwd: "/tmp",
-      columns: 80,
-      rows: 24,
-      workspaceId: null,
-    } as unknown as DragData["terminal"],
+    terminal: { id: "panel-1", title: "Test Panel", kind: "terminal", location: "grid" },
     sourceLocation: "grid",
     sourceIndex: 0,
     ...overrides,
@@ -116,113 +34,142 @@ function makeDragData(overrides: Partial<ActiveDragData> = {}): ActiveDragData {
 }
 
 /** Drag data for a panel of a specific kind (for the #11054 dockability guard). */
-function makeDragDataOfKind(kind: string, overrides: Partial<ActiveDragData> = {}): ActiveDragData {
-  const base = makeDragData(overrides);
-  return { ...base, terminal: { ...base.terminal, kind } as DragData["terminal"] };
+function makeDragDataOfKind(kind: string): Record<string, unknown> {
+  return makeDragData({
+    terminal: { id: "panel-1", title: "Test Panel", kind, location: "grid" },
+  });
 }
 
 // ── Tests ────────────────────────────────────────────────
 
-describe("cancelDrop predicates", () => {
+describe("shouldCancelDrop", () => {
   describe("no over target", () => {
-    it("cancels when overData is null", () => {
-      const result = runCancelDrop({
-        overData: null,
-        activeData: makeDragData(),
-        sourceLocation: "grid",
-        targetContainer: null,
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+    it("cancels when there is no over target", () => {
+      expect(run({ overData: null, activeData: makeDragData() })).toBe(true);
     });
 
     it("cancels when activeData is undefined", () => {
-      const result = runCancelDrop({
-        overData: { container: "grid" },
-        activeData: undefined,
-        sourceLocation: "grid",
-        targetContainer: "grid",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+      expect(run({ overData: { container: "grid" }, activeData: undefined })).toBe(true);
+    });
+  });
+
+  describe("placeholder and malformed drag data (#11291)", () => {
+    const placeholderData = { container: "dock", isPlaceholder: true };
+
+    it("cancels the empty-dock placeholder's terminal-less drag data without throwing", () => {
+      let result: boolean | undefined;
+      expect(() => {
+        result = run({ overData: { container: "grid" }, activeData: placeholderData });
+      }).not.toThrow();
+      expect(result).toBe(true);
+    });
+
+    it("cancels placeholder data dropped on a dock chip (sortable container)", () => {
+      expect(
+        run({
+          overData: { sortable: { containerId: "dock-container", index: 0 } },
+          activeData: placeholderData,
+        })
+      ).toBe(true);
+    });
+
+    it("cancels when terminal is present but has no string id", () => {
+      expect(
+        run({
+          overData: { container: "grid" },
+          activeData: makeDragData({ terminal: { kind: "terminal" } }),
+        })
+      ).toBe(true);
+      expect(
+        run({
+          overData: { container: "grid" },
+          activeData: makeDragData({ terminal: { id: 42, kind: "terminal" } }),
+        })
+      ).toBe(true);
+    });
+
+    it("cancels non-object drag data", () => {
+      expect(run({ overData: { container: "grid" }, activeData: "panel-1" })).toBe(true);
+    });
+
+    it("fails closed when reading the drag data throws", () => {
+      const hostile = {
+        get terminal(): never {
+          throw new Error("boom");
+        },
+      };
+      expect(run({ overData: { container: "grid" }, activeData: hostile })).toBe(true);
+    });
+
+    it("fails closed when a terminal field getter throws", () => {
+      const hostile = {
+        terminal: {
+          get id(): never {
+            throw new Error("boom");
+          },
+        },
+      };
+      expect(run({ overData: { container: "grid" }, activeData: hostile })).toBe(true);
     });
   });
 
   describe("valid drops pass through", () => {
     it("does not cancel a normal grid-to-grid drop", () => {
-      const result = runCancelDrop({
-        overData: { container: "grid", sortable: { index: 1 } },
-        activeData: makeDragData(),
-        sourceLocation: "grid",
-        targetContainer: "grid",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
+      expect(
+        run({ overData: { container: "grid", sortable: { index: 1 } }, activeData: makeDragData() })
+      ).toBe(false);
     });
 
     it("does not cancel a dock-to-dock drop", () => {
-      const result = runCancelDrop({
-        overData: { container: "dock" },
-        activeData: makeDragData({ sourceLocation: "dock" }),
-        sourceLocation: "dock",
-        targetContainer: "dock",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
+      expect(
+        run({
+          overData: { container: "dock" },
+          activeData: makeDragData({ sourceLocation: "dock" }),
+        })
+      ).toBe(false);
+    });
+
+    it("does not cancel a drop on a data-less droppable like trash", () => {
+      expect(run({ overData: {}, activeData: makeDragData() })).toBe(false);
+      expect(run({ hasOver: true, overData: null, activeData: makeDragData() })).toBe(false);
     });
   });
 
   describe("non-dockable dock drop (#11054)", () => {
     it("cancels a review panel dropped on the dock (direct container)", () => {
-      const result = runCancelDrop({
-        overData: { container: "dock" },
-        activeData: makeDragDataOfKind("review"),
-        sourceLocation: "grid",
-        targetContainer: "dock",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+      expect(
+        run({ overData: { container: "dock" }, activeData: makeDragDataOfKind("review") })
+      ).toBe(true);
     });
 
     it("cancels a dev-preview panel dropped on a dock chip (sortable container)", () => {
-      const result = runCancelDrop({
-        overData: { sortable: { containerId: "dock-container", index: 0 } },
-        activeData: makeDragDataOfKind("dev-preview"),
-        sourceLocation: "grid",
-        targetContainer: "dock",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+      expect(
+        run({
+          overData: { sortable: { containerId: "dock-container", index: 0 } },
+          activeData: makeDragDataOfKind("dev-preview"),
+        })
+      ).toBe(true);
     });
 
     it("does not cancel a dockable non-PTY (file) panel dropped on the dock", () => {
-      const result = runCancelDrop({
-        overData: { container: "dock" },
-        activeData: makeDragDataOfKind("file"),
-        sourceLocation: "grid",
-        targetContainer: "dock",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
+      expect(run({ overData: { container: "dock" }, activeData: makeDragDataOfKind("file") })).toBe(
+        false
+      );
+    });
+
+    it("treats a missing kind as a legacy PTY panel, which is dockable", () => {
+      expect(
+        run({
+          overData: { container: "dock" },
+          activeData: makeDragData({ terminal: { id: "panel-1" } }),
+        })
+      ).toBe(false);
     });
 
     it("does not cancel a dev-preview panel dropped on the grid (dock guard is target-scoped)", () => {
-      const result = runCancelDrop({
-        overData: { container: "grid" },
-        activeData: makeDragDataOfKind("dev-preview"),
-        sourceLocation: "grid",
-        targetContainer: "grid",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
+      expect(
+        run({ overData: { container: "grid" }, activeData: makeDragDataOfKind("dev-preview") })
+      ).toBe(false);
     });
   });
 
@@ -233,120 +180,54 @@ describe("cancelDrop predicates", () => {
     });
 
     it("cancels a multi-panel group dropped on a worktree", () => {
-      const result = runCancelDrop({
-        overData: { type: "worktree", worktreeId: "wt-1" },
-        activeData: groupData,
-        sourceLocation: "grid",
-        targetContainer: null,
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+      expect(
+        run({ overData: { type: "worktree", worktreeId: "wt-1" }, activeData: groupData })
+      ).toBe(true);
     });
 
     it("does not cancel a single panel dropped on a worktree", () => {
-      const result = runCancelDrop({
-        overData: { type: "worktree", worktreeId: "wt-1" },
-        activeData: makeDragData(),
-        sourceLocation: "grid",
-        targetContainer: null,
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
+      expect(
+        run({ overData: { type: "worktree", worktreeId: "wt-1" }, activeData: makeDragData() })
+      ).toBe(false);
     });
 
-    it("isGroupDrag returns false when groupPanelIds has only one entry", () => {
-      const singleEntryGroup = makeDragData({
-        groupId: "group-1",
-        groupPanelIds: ["panel-1"],
-      });
-      expect(isGroupDrag(singleEntryGroup)).toBe(false);
-    });
-  });
-
-  describe("grid full from dock", () => {
-    it("cancels dock-to-grid when grid is full", () => {
-      const result = runCancelDrop({
-        overData: { container: "grid" },
-        activeData: makeDragData({ sourceLocation: "dock" }),
-        sourceLocation: "dock",
-        targetContainer: "grid",
-        gridIsFull: true,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+    it("does not cancel a group whose groupPanelIds has only one entry", () => {
+      const singleEntryGroup = makeDragData({ groupId: "group-1", groupPanelIds: ["panel-1"] });
+      expect(
+        run({ overData: { type: "worktree", worktreeId: "wt-1" }, activeData: singleEntryGroup })
+      ).toBe(false);
     });
 
-    it("does not cancel dock-to-grid when grid has space", () => {
-      const result = runCancelDrop({
-        overData: { container: "grid" },
-        activeData: makeDragData({ sourceLocation: "dock" }),
-        sourceLocation: "dock",
-        targetContainer: "grid",
-        gridIsFull: false,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
-    });
-
-    it("does not cancel grid-to-grid when grid is full (same container reorder)", () => {
-      const result = runCancelDrop({
-        overData: { container: "grid" },
-        activeData: makeDragData({ sourceLocation: "grid" }),
-        sourceLocation: "grid",
-        targetContainer: "grid",
-        gridIsFull: true,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: false });
-    });
-  });
-
-  describe("trash droppable guard", () => {
-    it("extracted predicate cancels dock→trash when grid is full — real guard blocks this", () => {
-      // Trash droppable has no container type, so detectTargetContainer
-      // falls back to the tracked overContainer state. If the user
-      // dragged across the grid on the way to trash, overContainer
-      // could be "grid" and the grid-full predicate would erroneously
-      // fire. The component-level guard `overId !== TRASH_DROPPABLE_ID`
-      // prevents this. This test confirms the guard is load-bearing:
-      // without it, this scenario would cancel.
-      const result = runCancelDrop({
-        overData: {},
-        activeData: makeDragData({ sourceLocation: "dock" }),
-        sourceLocation: "dock",
-        targetContainer: "grid",
-        gridIsFull: true,
-        isWorktreeSort: false,
-      });
-      expect(result).toEqual({ cancel: true });
+    it("does not cancel a multi-panel group dropped on the grid", () => {
+      expect(run({ overData: { container: "grid" }, activeData: groupData })).toBe(false);
     });
   });
 
   describe("worktree-sort drags", () => {
     it("does not cancel worktree-sort with a valid over target", () => {
-      const result = runCancelDrop({
-        overData: { type: "worktree", worktreeId: "wt-2" },
-        activeData: makeDragData({ sourceLocation: "dock" }),
-        sourceLocation: "dock",
-        targetContainer: null,
-        gridIsFull: false,
-        isWorktreeSort: true,
-      });
-      expect(result).toEqual({ cancel: false });
+      expect(
+        run({
+          overData: { type: "worktree", worktreeId: "wt-2" },
+          activeData: makeDragData(),
+          isWorktreeSort: true,
+        })
+      ).toBe(false);
+    });
+
+    it("does not cancel worktree-sort even when the source row unmounted mid-drag", () => {
+      // Virtuoso can unmount the source row, dropping active.data.current to
+      // undefined — the snapshot ref in DndProvider still owns the reorder.
+      expect(
+        run({
+          overData: { type: "worktree", worktreeId: "wt-2" },
+          activeData: undefined,
+          isWorktreeSort: true,
+        })
+      ).toBe(false);
     });
 
     it("cancels worktree-sort with no over target (no-over predicate fires first)", () => {
-      const result = runCancelDrop({
-        overData: null,
-        activeData: makeDragData(),
-        sourceLocation: "dock",
-        targetContainer: null,
-        gridIsFull: false,
-        isWorktreeSort: true,
-      });
-      expect(result).toEqual({ cancel: true });
+      expect(run({ overData: null, activeData: makeDragData(), isWorktreeSort: true })).toBe(true);
     });
   });
 });

--- a/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
+import type { ReactNode } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 
 const mockUseDndPlaceholder = vi.fn();
 vi.mock("../DndProvider", () => ({
@@ -10,7 +11,35 @@ vi.mock("@/utils/terminalChrome", () => ({
   deriveTerminalChrome: () => ({ agentId: null }),
 }));
 
-import { DockPlaceholder } from "../DockPlaceholder";
+const { sortableListeners, setNodeRefSpy } = vi.hoisted(() => ({
+  sortableListeners: {
+    onPointerDown: vi.fn(),
+    onMouseDown: vi.fn(),
+    onTouchStart: vi.fn(),
+    onKeyDown: vi.fn(),
+  },
+  setNodeRefSpy: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: { role: "button", tabIndex: 0, "aria-describedby": "dnd-describedby" },
+    listeners: sortableListeners,
+    setNodeRef: setNodeRefSpy,
+    transform: null,
+    transition: undefined,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
+vi.mock("framer-motion", () => ({
+  m: { div: ({ children }: { children?: ReactNode }) => <div>{children}</div> },
+}));
+
+import { DockPlaceholder, SortableDockPlaceholder, DOCK_PLACEHOLDER_ID } from "../DockPlaceholder";
 
 // The mock's return value is untyped (any), so a plain literal stands in for the
 // active panel without an unsafe cast — DockPlaceholder only reads `kind`.
@@ -59,5 +88,48 @@ describe("DockPlaceholder height containment (#11055)", () => {
     const { container } = render(<DockPlaceholder />);
     expect(container.querySelector("[aria-hidden='true']")).not.toBeNull();
     expect(container.querySelector("[data-placeholder-body]")).toBeNull();
+  });
+});
+
+/**
+ * Regression coverage for #11291. The empty-dock placeholder used to spread
+ * useSortable's activator attributes/listeners, making the invisible strip a
+ * drag source whose terminal-less drag data threw inside cancelDrop and
+ * wedged dnd-kit app-wide. It must stay registered as a drop target
+ * (setNodeRef) but never activate a drag.
+ */
+describe("SortableDockPlaceholder is a drop target, not a drag source (#11291)", () => {
+  function renderPlaceholder() {
+    mockUseDndPlaceholder.mockReturnValue({ activeTerminal: null, isDragging: false });
+    const { container } = render(<SortableDockPlaceholder />);
+    const node = container.querySelector<HTMLElement>(
+      `[data-placeholder-id="${DOCK_PLACEHOLDER_ID}"]`
+    );
+    expect(node).not.toBeNull();
+    return node!;
+  }
+
+  it("stays registered as a droppable via setNodeRef", () => {
+    const node = renderPlaceholder();
+    expect(setNodeRefSpy).toHaveBeenCalledWith(node);
+  });
+
+  it("does not forward sortable activator attributes", () => {
+    const node = renderPlaceholder();
+    expect(node.getAttribute("role")).toBeNull();
+    expect(node.hasAttribute("tabindex")).toBe(false);
+    expect(node.hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  it("does not forward drag activator listeners", () => {
+    const node = renderPlaceholder();
+    fireEvent.pointerDown(node);
+    fireEvent.mouseDown(node);
+    fireEvent.touchStart(node);
+    fireEvent.keyDown(node, { code: "Enter" });
+    expect(sortableListeners.onPointerDown).not.toHaveBeenCalled();
+    expect(sortableListeners.onMouseDown).not.toHaveBeenCalled();
+    expect(sortableListeners.onTouchStart).not.toHaveBeenCalled();
+    expect(sortableListeners.onKeyDown).not.toHaveBeenCalled();
   });
 });

--- a/src/components/DragDrop/__tests__/useDragRecovery.test.tsx
+++ b/src/components/DragDrop/__tests__/useDragRecovery.test.tsx
@@ -153,10 +153,12 @@ describe("useDragRecovery", () => {
     });
 
     it("is cleared by a new drag starting while the timer is pending", () => {
+      // The second drag is mouse-activated on purpose: were the stale timer
+      // left armed, its callback would still see a live mouse drag and fire.
       const { result } = renderHook(() => useDragRecovery());
       result.current.beginDrag(mouseActivator());
       dispatchMouseOut(null);
-      result.current.beginDrag(new KeyboardEvent("keydown", { code: "Enter" }));
+      result.current.beginDrag(mouseActivator());
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
       expect(keydowns).toHaveLength(0);

--- a/src/components/DragDrop/__tests__/useDragRecovery.test.tsx
+++ b/src/components/DragDrop/__tests__/useDragRecovery.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+// Tests for the lost-mouseup drag watchdog (#11291). A mouseup swallowed by a
+// webview OOPIF never reaches the host document, leaving dnd-kit's internal
+// active lock held and every future drag silently ignored. The hook recovers
+// by dispatching a synthetic Escape keydown (dnd-kit's pointer sensors match
+// on `event.code`), and stamps the data-dragging webview shield synchronously
+// at drag start — before React commits — to close the frame-late gap.
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DRAG_RECOVERY_GRACE_MS, useDragRecovery } from "../useDragRecovery";
+
+const escapes: KeyboardEvent[] = [];
+
+function captureEscape(event: KeyboardEvent) {
+  if (event.code === "Escape") escapes.push(event);
+}
+
+function mouseActivator(): MouseEvent {
+  return new MouseEvent("mousedown", { bubbles: true });
+}
+
+function dispatchMouseOut(relatedTarget: EventTarget | null) {
+  document.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget }));
+}
+
+function dispatchMouseMove(buttons: number) {
+  document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, buttons }));
+}
+
+describe("useDragRecovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    escapes.length = 0;
+    document.addEventListener("keydown", captureEscape);
+  });
+
+  afterEach(() => {
+    document.removeEventListener("keydown", captureEscape);
+    vi.useRealTimers();
+    delete document.documentElement.dataset.dragging;
+  });
+
+  describe("data-dragging shield", () => {
+    it("stamps data-dragging synchronously on beginDrag, before any commit", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      expect(document.documentElement.dataset.dragging).toBe("true");
+    });
+
+    it("removes data-dragging on finishDrag", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      result.current.finishDrag();
+      expect(document.documentElement.dataset.dragging).toBeUndefined();
+    });
+
+    it("stamps the shield for non-mouse drags too", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(new KeyboardEvent("keydown", { code: "Enter" }));
+      expect(document.documentElement.dataset.dragging).toBe("true");
+    });
+
+    it("removes data-dragging when the hook unmounts mid-drag", () => {
+      const { result, unmount } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      act(() => unmount());
+      expect(document.documentElement.dataset.dragging).toBeUndefined();
+    });
+  });
+
+  describe("pointer-left-document grace timer", () => {
+    it("dispatches exactly one code-Escape keydown after the grace period", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS - 1);
+      expect(escapes).toHaveLength(0);
+
+      vi.advanceTimersByTime(1);
+      expect(escapes).toHaveLength(1);
+      expect(escapes[0]?.code).toBe("Escape");
+    });
+
+    it("does not stack timers across repeated boundary crossings", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+      dispatchMouseOut(null);
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS * 2);
+      expect(escapes).toHaveLength(1);
+    });
+
+    it("ignores mouseout within the document (non-null relatedTarget)", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(document.createElement("div"));
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(escapes).toHaveLength(0);
+    });
+
+    it("does not fire once the drag ended normally", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+      result.current.finishDrag();
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(escapes).toHaveLength(0);
+    });
+
+    it("is defused by re-entry with the button still held", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+      dispatchMouseMove(1);
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(escapes).toHaveLength(0);
+    });
+
+    it("does not fire after unmount", () => {
+      const { result, unmount } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+      act(() => unmount());
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(escapes).toHaveLength(0);
+    });
+  });
+
+  describe("released-elsewhere buttons check", () => {
+    it("recovers immediately when a mousemove reports no buttons during a live mouse drag", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseMove(0);
+
+      expect(escapes).toHaveLength(1);
+      expect(escapes[0]?.code).toBe("Escape");
+    });
+
+    it("does nothing on mousemove with buttons held", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseMove(1);
+      expect(escapes).toHaveLength(0);
+    });
+
+    it("does nothing when no drag is live", () => {
+      renderHook(() => useDragRecovery());
+      dispatchMouseMove(0);
+      dispatchMouseOut(null);
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(escapes).toHaveLength(0);
+    });
+
+    it("ignores mouse signals during keyboard-activated drags", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(new KeyboardEvent("keydown", { code: "Enter" }));
+      dispatchMouseMove(0);
+      dispatchMouseOut(null);
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(escapes).toHaveLength(0);
+    });
+  });
+});

--- a/src/components/DragDrop/__tests__/useDragRecovery.test.tsx
+++ b/src/components/DragDrop/__tests__/useDragRecovery.test.tsx
@@ -5,15 +5,27 @@
 // by dispatching a synthetic Escape keydown (dnd-kit's pointer sensors match
 // on `event.code`), and stamps the data-dragging webview shield synchronously
 // at drag start — before React commits — to close the frame-late gap.
-import { act, renderHook } from "@testing-library/react";
+import {
+  DndContext,
+  MouseSensor,
+  useDraggable,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { act, fireEvent, render, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DRAG_RECOVERY_GRACE_MS, useDragRecovery } from "../useDragRecovery";
 
-const escapes: KeyboardEvent[] = [];
+const keydowns: KeyboardEvent[] = [];
 
-function captureEscape(event: KeyboardEvent) {
-  if (event.code === "Escape") escapes.push(event);
+function captureKeydown(event: KeyboardEvent) {
+  keydowns.push(event);
+}
+
+function escapeCodes(): string[] {
+  return keydowns.map((event) => event.code);
 }
 
 function mouseActivator(): MouseEvent {
@@ -31,12 +43,12 @@ function dispatchMouseMove(buttons: number) {
 describe("useDragRecovery", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    escapes.length = 0;
-    document.addEventListener("keydown", captureEscape);
+    keydowns.length = 0;
+    document.addEventListener("keydown", captureKeydown);
   });
 
   afterEach(() => {
-    document.removeEventListener("keydown", captureEscape);
+    document.removeEventListener("keydown", captureKeydown);
     vi.useRealTimers();
     delete document.documentElement.dataset.dragging;
   });
@@ -48,11 +60,14 @@ describe("useDragRecovery", () => {
       expect(document.documentElement.dataset.dragging).toBe("true");
     });
 
-    it("removes data-dragging on finishDrag", () => {
+    it("leaves data-dragging in place on finishDrag for the activeId effect to remove", () => {
+      // A synchronous delete would drop the shield mid-event: the global
+      // escape dispatcher reads it during the same keydown propagation to
+      // keep a drag-canceling Escape from also popping the escape stack.
       const { result } = renderHook(() => useDragRecovery());
       result.current.beginDrag(mouseActivator());
       result.current.finishDrag();
-      expect(document.documentElement.dataset.dragging).toBeUndefined();
+      expect(document.documentElement.dataset.dragging).toBe("true");
     });
 
     it("stamps the shield for non-mouse drags too", () => {
@@ -70,17 +85,21 @@ describe("useDragRecovery", () => {
   });
 
   describe("pointer-left-document grace timer", () => {
-    it("dispatches exactly one code-Escape keydown after the grace period", () => {
+    it("dispatches exactly one Element-targeted, code-only Escape after the grace period", () => {
       const { result } = renderHook(() => useDragRecovery());
       result.current.beginDrag(mouseActivator());
       dispatchMouseOut(null);
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS - 1);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
 
       vi.advanceTimersByTime(1);
-      expect(escapes).toHaveLength(1);
-      expect(escapes[0]?.code).toBe("Escape");
+      expect(escapeCodes()).toEqual(["Escape"]);
+      // Element target: capture-phase key handlers cast event.target to
+      // HTMLElement and call .closest, which a Document target would break.
+      expect(keydowns[0]?.target).toBe(document.body);
+      // Code-only: app handlers matching event.key must not see this event.
+      expect(keydowns[0]?.key).toBe("");
     });
 
     it("does not stack timers across repeated boundary crossings", () => {
@@ -90,7 +109,18 @@ describe("useDragRecovery", () => {
       dispatchMouseOut(null);
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS * 2);
-      expect(escapes).toHaveLength(1);
+      expect(keydowns).toHaveLength(1);
+    });
+
+    it("recovers again after an unheard Escape (retry is not blocked)", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      dispatchMouseOut(null);
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+
+      expect(escapeCodes()).toEqual(["Escape", "Escape"]);
     });
 
     it("ignores mouseout within the document (non-null relatedTarget)", () => {
@@ -99,7 +129,7 @@ describe("useDragRecovery", () => {
       dispatchMouseOut(document.createElement("div"));
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
     });
 
     it("does not fire once the drag ended normally", () => {
@@ -109,7 +139,7 @@ describe("useDragRecovery", () => {
       result.current.finishDrag();
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
     });
 
     it("is defused by re-entry with the button still held", () => {
@@ -119,7 +149,17 @@ describe("useDragRecovery", () => {
       dispatchMouseMove(1);
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
+    });
+
+    it("is cleared by a new drag starting while the timer is pending", () => {
+      const { result } = renderHook(() => useDragRecovery());
+      result.current.beginDrag(mouseActivator());
+      dispatchMouseOut(null);
+      result.current.beginDrag(new KeyboardEvent("keydown", { code: "Enter" }));
+
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+      expect(keydowns).toHaveLength(0);
     });
 
     it("does not fire after unmount", () => {
@@ -129,7 +169,7 @@ describe("useDragRecovery", () => {
       act(() => unmount());
 
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
     });
   });
 
@@ -139,15 +179,14 @@ describe("useDragRecovery", () => {
       result.current.beginDrag(mouseActivator());
       dispatchMouseMove(0);
 
-      expect(escapes).toHaveLength(1);
-      expect(escapes[0]?.code).toBe("Escape");
+      expect(escapeCodes()).toEqual(["Escape"]);
     });
 
     it("does nothing on mousemove with buttons held", () => {
       const { result } = renderHook(() => useDragRecovery());
       result.current.beginDrag(mouseActivator());
       dispatchMouseMove(1);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
     });
 
     it("does nothing when no drag is live", () => {
@@ -155,7 +194,7 @@ describe("useDragRecovery", () => {
       dispatchMouseMove(0);
       dispatchMouseOut(null);
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
     });
 
     it("ignores mouse signals during keyboard-activated drags", () => {
@@ -164,7 +203,76 @@ describe("useDragRecovery", () => {
       dispatchMouseMove(0);
       dispatchMouseOut(null);
       vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
-      expect(escapes).toHaveLength(0);
+      expect(keydowns).toHaveLength(0);
     });
+  });
+});
+
+// End-to-end contract with a real dnd-kit DndContext + MouseSensor: the
+// watchdog's synthetic Escape must ride dnd-kit's own cancel path, release
+// its internal active lock, and let the NEXT drag activate — the app-wide
+// wedge #11291 describes is exactly this lock never being released.
+describe("useDragRecovery + dnd-kit integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete document.documentElement.dataset.dragging;
+  });
+
+  function DraggableBox() {
+    const { setNodeRef, listeners, attributes } = useDraggable({ id: "drag-1" });
+    return <div ref={setNodeRef} {...listeners} {...attributes} data-testid="draggable" />;
+  }
+
+  function Harness({ onStart, onCancel }: { onStart: () => void; onCancel: () => void }) {
+    const { beginDrag, finishDrag } = useDragRecovery();
+    const sensors = useSensors(useSensor(MouseSensor, { activationConstraint: { distance: 8 } }));
+    return (
+      <DndContext
+        sensors={sensors}
+        onDragStart={(event: DragStartEvent) => {
+          beginDrag(event.activatorEvent);
+          onStart();
+        }}
+        onDragEnd={finishDrag}
+        onDragCancel={() => {
+          finishDrag();
+          onCancel();
+        }}
+      >
+        <DraggableBox />
+      </DndContext>
+    );
+  }
+
+  function startMouseDrag(node: HTMLElement) {
+    fireEvent.mouseDown(node, { clientX: 10, clientY: 10, button: 0 });
+    fireEvent.mouseMove(document, { clientX: 40, clientY: 40 });
+  }
+
+  it("recovers a lost-mouseup drag and lets the next drag activate", () => {
+    const onStart = vi.fn();
+    const onCancel = vi.fn();
+    const { getByTestId } = render(<Harness onStart={onStart} onCancel={onCancel} />);
+    const node = getByTestId("draggable");
+
+    startMouseDrag(node);
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.dataset.dragging).toBe("true");
+
+    // The mouseup lands in a webview OOPIF: the host document sees the
+    // pointer leave and then nothing else.
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: null }));
+      vi.advanceTimersByTime(DRAG_RECOVERY_GRACE_MS);
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    // The lock is released: a second drag activates.
+    startMouseDrag(node);
+    expect(onStart).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -112,6 +112,66 @@ export function isNonDockableDockDrop(
   return targetContainer === "dock" && !panelKindIsDockable(kind ?? "terminal");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Inputs for the cancel-drop verdict, straight off dnd-kit's DragEndEvent. */
+export interface CancelDropParams {
+  hasOver: boolean;
+  /** `active.data.current` — untrusted: the empty-dock placeholder registers `{ container, isPlaceholder }` with no `terminal` (#11291). */
+  activeData: unknown;
+  overData: OverDropData | undefined;
+  isWorktreeSort: boolean;
+}
+
+/**
+ * Total cancel-drop verdict for panel drags. dnd-kit awaits the `cancelDrop`
+ * callback with no try/catch before releasing its internal active lock, so a
+ * single throw here silently wedges every future drag until reload (#11291).
+ * This resolver never throws: drag data without a real `terminal` cancels
+ * instead of dereferencing, and any unexpected failure fails closed to cancel.
+ */
+export function shouldCancelDrop({
+  hasOver,
+  activeData,
+  overData,
+  isWorktreeSort,
+}: CancelDropParams): boolean {
+  try {
+    if (!hasOver) return true;
+
+    // Worktree-sort drags own their drop logic in handleDragEnd; let every
+    // drop through, even when the source row unmounted mid-drag.
+    if (isWorktreeSort) return false;
+
+    if (!isRecord(activeData) || !isRecord(activeData.terminal)) return true;
+    const { id, kind } = activeData.terminal;
+    if (typeof id !== "string") return true;
+
+    const groupPanelIds = activeData.groupPanelIds;
+    const isGroupDrag =
+      !!activeData.groupId && Array.isArray(groupPanelIds) && groupPanelIds.length > 1;
+    const isWorktreeDrop = overData?.type === "worktree" && !!overData.worktreeId;
+    if (isGroupDrag && isWorktreeDrop) return true;
+
+    // A panel whose kind the dock can't render must never commit into the
+    // dock — it would strand invisibly (#11054). `cursor-no-drop` already
+    // signals this during hover and `collisionDetection` keeps the dock out
+    // of the hover candidates; this is the defensive final gate.
+    const targetContainer =
+      overData?.container ??
+      (overData?.sortable?.containerId ? resolveContainerId(overData.sortable.containerId) : null);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- kind comes off our own panel instances; an unknown string fails the dockable lookup closed
+    return isNonDockableDockDrop(
+      targetContainer,
+      typeof kind === "string" ? (kind as PanelKind) : undefined
+    );
+  } catch {
+    return true;
+  }
+}
+
 /** Minimal dnd-kit droppable shape the dock collision filter reads. */
 interface DockCollisionCandidate {
   data: { current?: { container?: string; sortable?: { containerId?: string } } | null };

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -132,13 +132,9 @@ export interface CancelDropParams {
  * This resolver never throws: drag data without a real `terminal` cancels
  * instead of dereferencing, and any unexpected failure fails closed to cancel.
  */
-export function shouldCancelDrop({
-  hasOver,
-  activeData,
-  overData,
-  isWorktreeSort,
-}: CancelDropParams): boolean {
+export function shouldCancelDrop(params: CancelDropParams): boolean {
   try {
+    const { hasOver, activeData, overData, isWorktreeSort } = params;
     if (!hasOver) return true;
 
     // Worktree-sort drags own their drop logic in handleDragEnd; let every
@@ -162,7 +158,6 @@ export function shouldCancelDrop({
     const targetContainer =
       overData?.container ??
       (overData?.sortable?.containerId ? resolveContainerId(overData.sortable.containerId) : null);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- kind comes off our own panel instances; an unknown string fails the dockable lookup closed
     return isNonDockableDockDrop(
       targetContainer,
       typeof kind === "string" ? (kind as PanelKind) : undefined

--- a/src/components/DragDrop/useDragRecovery.ts
+++ b/src/components/DragDrop/useDragRecovery.ts
@@ -53,24 +53,31 @@ export function useDragRecovery(): {
     (activatorEvent: Event | null | undefined) => {
       clearGraceTimer();
       liveDragRef.current = activatorEvent instanceof MouseEvent ? "mouse" : "other";
+      // eslint-disable-next-line react-compiler/react-compiler -- the webview shield must be up before React commits; the activeId-keyed effect lands a frame late, which is exactly the gap that loses the mouseup (#11291)
       document.documentElement.dataset.dragging = "true";
     },
     [clearGraceTimer]
   );
 
+  // Deliberately leaves data-dragging in place: useGlobalEscapeDispatcher
+  // reads it mid-propagation to keep a drag-canceling Escape from also
+  // popping the escape stack, so removal belongs to DndProvider's
+  // activeId-keyed effect, which runs after the event finishes.
   const finishDrag = useCallback(() => {
     liveDragRef.current = null;
     clearGraceTimer();
-    delete document.documentElement.dataset.dragging;
   }, [clearGraceTimer]);
 
   useEffect(() => {
     // Leaves liveDragRef set: a successful cancel lands in finishDrag via
     // onDragCancel, and an unheard Escape must not block a later retry.
+    // Dispatched on body, not document: capture-phase key handlers cast
+    // event.target to HTMLElement (`.closest`), which a Document target
+    // would break. It still bubbles to dnd-kit's document-level listener.
     const recover = () => {
       clearGraceTimer();
       if (liveDragRef.current !== "mouse") return;
-      document.dispatchEvent(
+      document.body.dispatchEvent(
         new KeyboardEvent("keydown", { code: "Escape", bubbles: true, cancelable: true })
       );
     };

--- a/src/components/DragDrop/useDragRecovery.ts
+++ b/src/components/DragDrop/useDragRecovery.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Grace period after the pointer leaves the host document before a live mouse
+ * drag is force-canceled. Long enough to survive a brief edge overshoot with
+ * the button held (no host events arrive from outside the window, so the
+ * timer can't be defused there); short enough that a wedged drag self-heals
+ * before it reads as broken.
+ */
+export const DRAG_RECOVERY_GRACE_MS = 500;
+
+type LiveDragKind = "mouse" | "other";
+
+/**
+ * Watchdog for drags whose native end event never reaches the host document
+ * (#11291). Electron webviews are OOPIFs: a mouseup landing in one is
+ * invisible to every host-side listener, so dnd-kit's internal active lock is
+ * never released and all future drags are silently ignored until reload.
+ *
+ * Recovery rides dnd-kit's own cancel path: its pointer sensors listen for
+ * keydown with `code === "Escape"` on the document, and that DragCancel path
+ * always resets the lock without entering `cancelDrop`. Two detectors, both
+ * scoped to mouse-activated drags:
+ * - `mousemove` with `buttons === 0` while a drag is live — proof positive
+ *   the release happened where the host couldn't see it; recover immediately.
+ * - `mouseout` with `relatedTarget === null` (pointer left the host document —
+ *   into a webview or out of the window) arms a grace timer; a return with
+ *   the button still held defuses it.
+ *
+ * Also stamps `data-dragging` on the root synchronously at drag start so the
+ * `[data-dragging] webview { pointer-events: none }` shield is up before the
+ * first frame — the activeId-keyed effect in DndProvider commits a frame
+ * late, which is exactly the window that loses the mouseup.
+ *
+ * State lives in refs, not React state: the listeners and timer must read
+ * live values, never a stale closure.
+ */
+export function useDragRecovery(): {
+  beginDrag: (activatorEvent: Event | null | undefined) => void;
+  finishDrag: () => void;
+} {
+  const liveDragRef = useRef<LiveDragKind | null>(null);
+  const graceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearGraceTimer = useCallback(() => {
+    if (graceTimerRef.current !== null) {
+      clearTimeout(graceTimerRef.current);
+      graceTimerRef.current = null;
+    }
+  }, []);
+
+  const beginDrag = useCallback(
+    (activatorEvent: Event | null | undefined) => {
+      clearGraceTimer();
+      liveDragRef.current = activatorEvent instanceof MouseEvent ? "mouse" : "other";
+      document.documentElement.dataset.dragging = "true";
+    },
+    [clearGraceTimer]
+  );
+
+  const finishDrag = useCallback(() => {
+    liveDragRef.current = null;
+    clearGraceTimer();
+    delete document.documentElement.dataset.dragging;
+  }, [clearGraceTimer]);
+
+  useEffect(() => {
+    // Leaves liveDragRef set: a successful cancel lands in finishDrag via
+    // onDragCancel, and an unheard Escape must not block a later retry.
+    const recover = () => {
+      clearGraceTimer();
+      if (liveDragRef.current !== "mouse") return;
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { code: "Escape", bubbles: true, cancelable: true })
+      );
+    };
+
+    const handleMouseOut = (event: MouseEvent) => {
+      if (liveDragRef.current !== "mouse" || event.relatedTarget !== null) return;
+      if (graceTimerRef.current !== null) return;
+      graceTimerRef.current = setTimeout(() => {
+        graceTimerRef.current = null;
+        recover();
+      }, DRAG_RECOVERY_GRACE_MS);
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (liveDragRef.current !== "mouse") return;
+      if (event.buttons === 0) {
+        recover();
+      } else {
+        clearGraceTimer();
+      }
+    };
+
+    document.addEventListener("mouseout", handleMouseOut);
+    document.addEventListener("mousemove", handleMouseMove);
+    return () => {
+      document.removeEventListener("mouseout", handleMouseOut);
+      document.removeEventListener("mousemove", handleMouseMove);
+      clearGraceTimer();
+      liveDragRef.current = null;
+      delete document.documentElement.dataset.dragging;
+    };
+  }, [clearGraceTimer]);
+
+  return { beginDrag, finishDrag };
+}


### PR DESCRIPTION
## Summary

- `dnd-kit` 6.3.1 awaits our `cancelDrop` callback with no `try`/`catch` before it clears its internal `activeRef`, so one stuck drag silently disables the entire `DndContext` until reload. Two confirmed entry paths from #11291: the empty-dock placeholder was itself a drag source whose drag data has no `terminal` field, so `cancelDrop` threw a `TypeError` reading `.terminal.kind`; and a fast release over a browser or dev-preview webview loses the `mouseup`, since the `[data-dragging]` pointer-events shield was only applied by a `useEffect` keyed on `activeId`, a frame or more late.
- Fix has three legs: `cancelDrop` can no longer throw, a new `useDragRecovery` watchdog closes the frame-late gap and recovers lost-`mouseup` drags, and the empty-dock placeholder is now a pure drop target.
- Resolves #11291

## Changes

- **`cancelDrop` can't throw anymore.** The verdict now lives in `shouldCancelDrop` (`src/components/DragDrop/dropResolution.ts`), a total resolver that runtime-guards the drag payload and fails closed to cancel on anything unexpected. The `DndProvider` glue that calls it is wrapped in its own `try`/`catch` too, belt and braces.
- **`useDragRecovery` watchdog** (`src/components/DragDrop/useDragRecovery.ts`) stamps `data-dragging` synchronously at drag start instead of waiting on the `activeId` effect, closing the frame-late gap. It also recovers lost-`mouseup` drags: a `mousemove` with `buttons === 0` during a live mouse drag recovers immediately, and a `mouseout` with `relatedTarget === null` (pointer left the host document) arms a 500ms grace timer. Recovery dispatches a synthetic Escape keydown on `document.body` with no `key` set, riding `dnd-kit`'s own `DragCancel` path, which always releases the lock. The event is code-only so the escape-stack dispatcher and other key-matching handlers ignore it. `finishDrag` deliberately still leaves `data-dragging` removal to the existing `activeId` effect, so the escape-stack gate in `useGlobalEscapeDispatcher` still sees it mid-propagation.
- **Empty-dock placeholder is drop-target only.** It keeps its `setNodeRef` droppable registration but no longer spreads the sortable activator attributes and listeners, so it can't be dragged.

## Testing

- `cancelDrop` contract tests rewritten to exercise the production resolver directly, the old file mirrored the logic locally and had drifted (a stale grid-full predicate among other things).
- New watchdog lifecycle tests, plus an integration test against a real `dnd-kit` `DndContext` + `MouseSensor` proving the synthetic Escape releases the lock and a second drag activates.
- New placeholder droppable-only regression tests.
- 240 `DragDrop` unit tests green. Ran `e2e/full/panels/core-drag-drop.spec.ts` locally against a fresh build, 5/5 passing.

## Notes

Nested `DndContext`s (panel and dock tab strips, portal tabs) have the same pre-existing lost-pointerup exposure over webviews. Out of scope here, worth a follow-up issue. Also worth flagging by design: a drag held outside the OS window for more than 500ms now snaps back, since nothing out there is droppable anyway and that beats a permanent wedge.
