### PR TITLE
fix(panel): remove the worktree color stripe from panel frames

### DIFF
--- a/shared/theme/builtInThemes/bondi.ts
+++ b/shared/theme/builtInThemes/bondi.ts
@@ -90,7 +90,7 @@ export const theme: BuiltInThemeSource = {
   tokens: {
     "accent-muted": "rgba(23,132,99,0.30)",
     "accent-soft": "rgba(23,132,99,0.18)",
-    // De-aliased from accent/accentSecondary hues so worktree badges and
+    // De-aliased from accent/accentSecondary hues so worktree colors and
     // pills never read as the focus signal.
     "category-green": "oklch(0.53 0.15 142)",
     "category-teal": "oklch(0.5 0.075 187)",

--- a/shared/theme/builtInThemes/bondi.ts
+++ b/shared/theme/builtInThemes/bondi.ts
@@ -90,7 +90,7 @@ export const theme: BuiltInThemeSource = {
   tokens: {
     "accent-muted": "rgba(23,132,99,0.30)",
     "accent-soft": "rgba(23,132,99,0.18)",
-    // De-aliased from accent/accentSecondary hues so worktree stripes and
+    // De-aliased from accent/accentSecondary hues so worktree badges and
     // pills never read as the focus signal.
     "category-green": "oklch(0.53 0.15 142)",
     "category-teal": "oklch(0.5 0.075 187)",

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -506,10 +506,9 @@ export function FleetArmingRibbon(): ReactElement | null {
           className={cn(
             "relative flex items-center gap-3 overflow-hidden border-b border-daintree-border px-3 py-2 text-[12px] text-daintree-text outline-hidden",
             "bg-category-amber-subtle",
-            // Non-color structural cue: 2px amber left-edge stripe. Mirrors the
-            // panel-worktree-identity idiom so the "mode surface" reads even
-            // with CVD / low-saturation themes where the amber tint alone
-            // might not register as a distinct surface.
+            // Non-color structural cue: 2px amber left-edge stripe, so the
+            // "mode surface" reads even with CVD / low-saturation themes where
+            // the amber tint alone might not register as a distinct surface.
             "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-[var(--color-category-amber-border)]"
           )}
           data-testid="fleet-arming-ribbon"

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -503,12 +503,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
       data-selected={isSelected || undefined}
       data-hibernated={isHibernated || undefined}
       data-fleet-dimmed={isFleetDimmed || undefined}
-      style={{
-        contain: "content",
-        ...(worktreeAccentColor
-          ? ({ "--worktree-color": worktreeAccentColor } as React.CSSProperties)
-          : undefined),
-      }}
+      style={{ contain: "content" }}
       className={cn(
         // Dual sizing contract, because the panel root is hosted under both
         // block-level and flex parents. `h-full` fills the block wrappers the
@@ -541,7 +536,6 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
                     ? "panel-state-hibernated"
                     : "border-overlay hover:border-tint/[0.08]"),
         location === "grid" && isMaximized && "border-0 rounded-none z-[var(--z-maximized)]",
-        worktreeAccentColor && location === "grid" && !isMaximized && "panel-worktree-identity",
         // Voice-dictation lock border overrides ambient state colours so the
         // pinned target stays unambiguously visible. Applied after the state
         // ternary so its border-color/box-shadow wins by source order.

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -664,9 +664,7 @@ function PanelHeaderComponent({
                 ? "bg-tint/[0.05]"
                 : "bg-[var(--panel-header-bg,transparent)]",
         // Mirror the fleet ribbon's 2px amber left stripe on follower panes.
-        // Renders via `before:` so it stacks alongside the worktree-identity
-        // `after:` stripe on the panel container without conflicting. The
-        // stripe sits in the title bar — fovea-adjacent when reading the
+        // The stripe sits in the title bar — fovea-adjacent when reading the
         // pane body — so users don't have to look up at the ribbon to verify
         // which panes will receive their keystrokes.
         isFleetFollower &&

--- a/src/index.css
+++ b/src/index.css
@@ -1501,8 +1501,8 @@ body,
 
 /* Fleet exit ring pulse — fired once on the panel that becomes the new
  * primary when the user exits fleet mode. Painted on a dedicated overlay
- * element so it doesn't fight the panel container's `::after` worktree
- * stripe or the existing border-color transitions.
+ * element so it doesn't fight the panel container's existing border-color
+ * transitions.
  */
 @keyframes fleet-exit-pulse {
   0% {
@@ -2012,24 +2012,6 @@ body,
   box-shadow:
     inset 0 0 0 1px color-mix(in oklab, var(--color-border-subtle) 14%, transparent),
     0 0 0 1px color-mix(in oklab, var(--color-border-subtle) 8%, transparent);
-}
-
-/* Per-worktree color identity — left-edge stripe on grid panels */
-.panel-worktree-identity {
-  position: relative;
-}
-
-.panel-worktree-identity::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: var(--panel-state-edge-inset-block);
-  bottom: var(--panel-state-edge-inset-block);
-  width: 3px;
-  border-radius: 0 var(--panel-state-edge-radius) var(--panel-state-edge-radius) 0;
-  background-color: var(--worktree-color);
-  z-index: 1;
-  pointer-events: none;
 }
 
 /* Backwards compatibility for older selection class */


### PR DESCRIPTION
## Summary

- Removes the colored 3px left-edge stripe from panel frames (`.panel-worktree-identity` in `src/index.css`, plus the `--worktree-color` inline custom property in `ContentPanel.tsx`).
- The stripe pulled from a deterministic 8-color palette to mark which git worktree a panel belonged to, but two of those colors are orange and amber, which collide with the app's `status-warning` color and the amber voice-dictation-lock border. An external plugin developer mistook the orange stripe on his plugin's panel for a warning indicator.
- Both labeled worktree-identity surfaces stay as-is and remain the source of truth: the branch badge in the panel header, and the colored worktree card in the sidebar. `shared/theme/worktreeColors.ts` is unchanged since the badge and fleet dots still consume it.

Resolves #11303

## Changes

- `src/index.css`: deleted `.panel-worktree-identity` and its `::after` stripe rule; updated the `fleet-exit-pulse` keyframe comment that referenced it.
- `src/components/Panel/ContentPanel.tsx`: dropped the class and the now-dead `--worktree-color` custom property from the panel root.
- `src/components/Panel/PanelHeader.tsx`, `src/components/Fleet/FleetArmingRibbon.tsx`, `shared/theme/builtInThemes/bondi.ts`: comment-only cleanup of stale references to the removed stripe.

Side effect: this also fixes a latent bug. `.animate-terminal-ping::after` targets the same panel root as `.panel-worktree-identity`, so the stripe's `width: 3px`, background, and `z-index: 1` could have contaminated the ping ring wherever both classes matched the same element.

Deliberately left alone:
- `--panel-state-edge-inset-block` and `--panel-state-edge-radius` (`src/index.css:686-687`) are now unused, but they're part of a validated public semantic-token contract (`shared/theme/types.ts`, `shared/theme/themes.ts`, `shared/theme/colorValidator.ts`), and the theme drift guard exempts semantic tokens. Removing them belongs in a separate contract-deprecation change.
- `docs/themes/visual-guide.md` documents an agent-state edge rail, which is a pre-existing, unrelated description. Left untouched.

## Testing

169 targeted tests pass across `ContentPanel.fleetDim`, `ContentPanel.focus`, `PanelHeader`, `worktreeColors`, and `builtInThemes`. eslint and prettier are clean on all 5 changed files.
