### PR TITLE
fix(plugin): thread real project and worktree context into plugin invocations

### DIFF
--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -249,7 +249,8 @@ if (active) {
   console.log(active.name, active.branch, active.path);
 }
 
-// All worktrees across all projects
+// All worktrees in the project the plugin is acting on behalf of — the one
+// shown in the focused window. Empty when no window resolves (#11297).
 const all = await host.getWorktrees();
 
 // Subscribe to changes (await the disposer — the subscription methods are async)

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -14,6 +14,18 @@ const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
 const mockActivatePluginForView = vi.fn();
+const mockGetActiveWorktreeIdForWindow = vi.fn<(windowId: number | undefined) => Promise<string | null>>();
+const mockGetProjectForWebContents = vi.fn<(webContentsId: number) => string | null>();
+const mockGetWindowForWebContents = vi.fn<(wc: { id: number }) => { id: number } | null>();
+
+// plugin:invoke resolves the sender's project/worktree through the registry
+// (#11297). Mocked so a test can register a sender without standing up a real
+// BrowserWindow; unregistered senders fall through to null, which is what the
+// pre-existing null-context assertions below rely on.
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getProjectForWebContents: (...args: [number]) => mockGetProjectForWebContents(...args),
+  getWindowForWebContents: (...args: [{ id: number }]) => mockGetWindowForWebContents(...args),
+}));
 
 vi.mock("../../../services/PluginService.js", () => ({
   pluginService: {
@@ -27,6 +39,8 @@ vi.mock("../../../services/PluginService.js", () => ({
     registerPluginAction: (...args: unknown[]) => mockRegisterPluginAction(...args),
     unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
     activatePluginForView: (...args: unknown[]) => mockActivatePluginForView(...args),
+    getActiveWorktreeIdForWindow: (windowId: number | undefined) =>
+      mockGetActiveWorktreeIdForWindow(windowId),
     // No-op for tests that don't care about implicit activation; the IPC
     // handler awaits it before resolving the impl set.
     activatePluginsForFileDecorationScope: vi.fn().mockResolvedValue(undefined),
@@ -110,6 +124,11 @@ beforeEach(() => {
   mockShowOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
   mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.my-plugin" });
   mockNetFetch.mockReset();
+  // Default: the sender is not a registered project view, so plugin:invoke
+  // resolves a null project / no window — the pre-#11297 context shape.
+  mockGetProjectForWebContents.mockReturnValue(null);
+  mockGetWindowForWebContents.mockReturnValue(null);
+  mockGetActiveWorktreeIdForWindow.mockResolvedValue(null);
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
 });
@@ -1008,6 +1027,87 @@ describe("registerPluginHandlers", () => {
       worktreeId: null,
       webContentsId: 7,
       pluginId: "acme.my-plugin",
+    });
+  });
+
+  // ── #11297: plugin:invoke carries the sender's real project/worktree ──
+
+  function getInvokeHandler(): (...args: unknown[]) => unknown {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find((c: unknown[]) => c[0] === "plugin:invoke")![1] as (
+      ...args: unknown[]
+    ) => unknown;
+  }
+
+  const trustedSender = (id: number) => ({
+    senderFrame: { url: "app://daintree/" },
+    sender: { id },
+  });
+
+  it("PLUGIN_INVOKE resolves the sender's project and active worktree into ctx", async () => {
+    mockDispatchHandler.mockResolvedValue(undefined);
+    mockGetProjectForWebContents.mockReturnValue("proj-a");
+    mockGetWindowForWebContents.mockReturnValue({ id: 42 });
+    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-a");
+
+    await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+
+    expect(mockGetActiveWorktreeIdForWindow).toHaveBeenCalledWith(42);
+    expect(mockDispatchHandler.mock.calls[0][2]).toEqual({
+      projectId: "proj-a",
+      worktreeId: "wt-a",
+      webContentsId: 7,
+      pluginId: "acme.my-plugin",
+    });
+  });
+
+  it("PLUGIN_INVOKE passes an undefined windowId when the sender has no window", async () => {
+    mockDispatchHandler.mockResolvedValue(undefined);
+    mockGetProjectForWebContents.mockReturnValue("proj-a");
+    mockGetWindowForWebContents.mockReturnValue(null);
+
+    await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+
+    // Never a guessed window — the service is asked for `undefined` and
+    // answers null rather than widening to a cross-project aggregate.
+    expect(mockGetActiveWorktreeIdForWindow).toHaveBeenCalledWith(undefined);
+    expect(mockDispatchHandler.mock.calls[0][2]).toMatchObject({
+      projectId: "proj-a",
+      worktreeId: null,
+    });
+  });
+
+  it("PLUGIN_INVOKE nulls the worktree when the sender's project rebinds mid-lookup", async () => {
+    mockDispatchHandler.mockResolvedValue(undefined);
+    mockGetWindowForWebContents.mockReturnValue({ id: 42 });
+    // Pinned at entry as proj-a; by the time the worktree lookup resolves the
+    // window has been rebound to proj-b. The worktree belongs to proj-b, so
+    // pairing it with proj-a would reintroduce exactly the cross-project
+    // mismatch #11297 is about.
+    mockGetProjectForWebContents.mockReturnValueOnce("proj-a").mockReturnValue("proj-b");
+    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-b");
+
+    await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+
+    expect(mockDispatchHandler.mock.calls[0][2]).toEqual({
+      projectId: "proj-a",
+      worktreeId: null,
+      webContentsId: 7,
+      pluginId: "acme.my-plugin",
+    });
+  });
+
+  it("PLUGIN_INVOKE keeps the worktree when the sender's project is unchanged", async () => {
+    mockDispatchHandler.mockResolvedValue(undefined);
+    mockGetWindowForWebContents.mockReturnValue({ id: 42 });
+    mockGetProjectForWebContents.mockReturnValue("proj-a");
+    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-a");
+
+    await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+
+    expect(mockDispatchHandler.mock.calls[0][2]).toMatchObject({
+      projectId: "proj-a",
+      worktreeId: "wt-a",
     });
   });
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -14,17 +14,24 @@ const mockListPluginActions = vi.fn();
 const mockRegisterPluginAction = vi.fn();
 const mockUnregisterPluginAction = vi.fn();
 const mockActivatePluginForView = vi.fn();
-const mockGetActiveWorktreeIdForWindow = vi.fn<(windowId: number | undefined) => Promise<string | null>>();
+const mockGetActiveWorktreeIdForWindow =
+  vi.fn<(windowId: number | undefined) => Promise<string | null>>();
 const mockGetProjectForWebContents = vi.fn<(webContentsId: number) => string | null>();
 const mockGetWindowForWebContents = vi.fn<(wc: { id: number }) => { id: number } | null>();
+const mockIsCachedViewWebContents = vi.fn<(webContentsId: number) => boolean>();
 
 // plugin:invoke resolves the sender's project/worktree through the registry
 // (#11297). Mocked so a test can register a sender without standing up a real
 // BrowserWindow; unregistered senders fall through to null, which is what the
 // pre-existing null-context assertions below rely on.
-vi.mock("../../../window/webContentsRegistry.js", () => ({
+// Spread the real module rather than replacing it: a bare factory would drop
+// every other export, so any transitive importer reaching for one gets
+// `undefined` and fails far from here.
+vi.mock("../../../window/webContentsRegistry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../window/webContentsRegistry.js")>()),
   getProjectForWebContents: (...args: [number]) => mockGetProjectForWebContents(...args),
   getWindowForWebContents: (...args: [{ id: number }]) => mockGetWindowForWebContents(...args),
+  isCachedViewWebContents: (...args: [number]) => mockIsCachedViewWebContents(...args),
 }));
 
 vi.mock("../../../services/PluginService.js", () => ({
@@ -128,6 +135,7 @@ beforeEach(() => {
   // resolves a null project / no window — the pre-#11297 context shape.
   mockGetProjectForWebContents.mockReturnValue(null);
   mockGetWindowForWebContents.mockReturnValue(null);
+  mockIsCachedViewWebContents.mockReturnValue(false);
   mockGetActiveWorktreeIdForWindow.mockResolvedValue(null);
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
@@ -1061,16 +1069,16 @@ describe("registerPluginHandlers", () => {
     });
   });
 
-  it("PLUGIN_INVOKE passes an undefined windowId when the sender has no window", async () => {
+  it("PLUGIN_INVOKE yields a null worktree when the sender has no window", async () => {
     mockDispatchHandler.mockResolvedValue(undefined);
     mockGetProjectForWebContents.mockReturnValue("proj-a");
     mockGetWindowForWebContents.mockReturnValue(null);
 
     await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
 
-    // Never a guessed window — the service is asked for `undefined` and
-    // answers null rather than widening to a cross-project aggregate.
-    expect(mockGetActiveWorktreeIdForWindow).toHaveBeenCalledWith(undefined);
+    // Never a guessed window: without one there is nothing to scope to, so the
+    // workspace is not consulted at all rather than widening to an aggregate.
+    expect(mockGetActiveWorktreeIdForWindow).not.toHaveBeenCalled();
     expect(mockDispatchHandler.mock.calls[0][2]).toMatchObject({
       projectId: "proj-a",
       worktreeId: null,
@@ -1080,14 +1088,26 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INVOKE nulls the worktree when the sender's project rebinds mid-lookup", async () => {
     mockDispatchHandler.mockResolvedValue(undefined);
     mockGetWindowForWebContents.mockReturnValue({ id: 42 });
-    // Pinned at entry as proj-a; by the time the worktree lookup resolves the
-    // window has been rebound to proj-b. The worktree belongs to proj-b, so
-    // pairing it with proj-a would reintroduce exactly the cross-project
-    // mismatch #11297 is about.
-    mockGetProjectForWebContents.mockReturnValueOnce("proj-a").mockReturnValue("proj-b");
-    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-b");
+    mockGetProjectForWebContents.mockReturnValue("proj-a");
 
-    await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+    // Hold the worktree lookup open so the rebind provably lands *during* the
+    // await. Flipping the registry between two synchronous calls would pass
+    // even if both ran before the lookup started, leaving the real race open.
+    let releaseLookup!: (id: string) => void;
+    mockGetActiveWorktreeIdForWindow.mockReturnValue(
+      new Promise<string>((resolve) => {
+        releaseLookup = resolve;
+      })
+    );
+
+    const pending = getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+    await Promise.resolve();
+    // The window moved to proj-b while the lookup was in flight, so the
+    // worktree it returns is proj-b's. Pairing it with the pinned proj-a would
+    // recreate exactly the cross-project mismatch #11297 is about.
+    mockGetProjectForWebContents.mockReturnValue("proj-b");
+    releaseLookup("wt-b");
+    await pending;
 
     expect(mockDispatchHandler.mock.calls[0][2]).toEqual({
       projectId: "proj-a",
@@ -1097,18 +1117,44 @@ describe("registerPluginHandlers", () => {
     });
   });
 
-  it("PLUGIN_INVOKE keeps the worktree when the sender's project is unchanged", async () => {
+  it("PLUGIN_INVOKE never gives an unbound sender a worktree", async () => {
+    // A sender with no project binding has no project to speak for, so a
+    // window-keyed worktree would attach another project's state to a context
+    // whose projectId is null. Null is an identity here, not a wildcard.
     mockDispatchHandler.mockResolvedValue(undefined);
+    mockGetProjectForWebContents.mockReturnValue(null);
     mockGetWindowForWebContents.mockReturnValue({ id: 42 });
+    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-somebody-elses");
+
+    await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
+
+    expect(mockDispatchHandler.mock.calls[0][2]).toEqual({
+      projectId: null,
+      worktreeId: null,
+      webContentsId: 7,
+      pluginId: "acme.my-plugin",
+    });
+    // Resolved to no window, so the workspace is never even asked.
+    expect(mockGetActiveWorktreeIdForWindow).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INVOKE never gives a cached background view a worktree", async () => {
+    // A deactivated project view stays registered to its own project while its
+    // window displays another, so the window's binding does not speak for it.
+    mockDispatchHandler.mockResolvedValue(undefined);
     mockGetProjectForWebContents.mockReturnValue("proj-a");
-    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-a");
+    mockGetWindowForWebContents.mockReturnValue({ id: 42 });
+    mockIsCachedViewWebContents.mockReturnValue(true);
+    mockGetActiveWorktreeIdForWindow.mockResolvedValue("wt-b");
 
     await getInvokeHandler()(trustedSender(7), "acme.my-plugin", "get-data");
 
     expect(mockDispatchHandler.mock.calls[0][2]).toMatchObject({
       projectId: "proj-a",
-      worktreeId: "wt-a",
+      worktreeId: null,
     });
+    // A cached view resolves to no window, so the workspace is never asked.
+    expect(mockGetActiveWorktreeIdForWindow).not.toHaveBeenCalled();
   });
 
   it("PLUGIN_INVOKE handler propagates errors from dispatchHandler", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -82,6 +82,10 @@ import type {
 import type { IpcContext } from "../types.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { assertIpcSecurityReady } from "../ipcGuard.js";
+import {
+  getProjectForWebContents,
+  getWindowForWebContents,
+} from "../../window/webContentsRegistry.js";
 
 type PluginServiceSingleton = typeof PluginServiceModule.pluginService;
 
@@ -1187,6 +1191,14 @@ export function registerPluginHandlers(): () => void {
     CHANNELS.PLUGIN_INVOKE,
     async (event, pluginId: string, channel: string, ...args: unknown[]) => {
       const start = Date.now();
+      // Pin the sender's scope synchronously, before any await: a project view
+      // can be evicted (LRU, under memory pressure) or rebound to another
+      // project while the dispatch is in flight, taking its registry binding
+      // with it. Resolved here, the context always describes the renderer that
+      // actually made the call.
+      const senderWebContentsId = event.sender.id;
+      const senderProjectId = getProjectForWebContents(senderWebContentsId);
+      const senderWindowId = getWindowForWebContents(event.sender)?.id;
       const senderUrl = event.senderFrame?.url;
       if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
         // Trust check rejected — args are attacker-controlled and unvalidated,
@@ -1210,14 +1222,32 @@ export function registerPluginHandlers(): () => void {
         });
         throw new Error(`plugin:invoke rejected: untrusted sender (url=${senderUrl ?? "unknown"})`);
       }
-      const ctx: PluginIpcContext = {
-        projectId: null,
-        worktreeId: null,
-        webContentsId: event.sender.id,
-        pluginId,
-      };
       try {
-        return await (await getPluginService()).dispatchHandler(pluginId, channel, ctx, args);
+        const service = await getPluginService();
+        // Resolving the worktree needs a round-trip to the workspace host, so
+        // it can't be pinned synchronously like the ids above.
+        // `getActiveWorktreeIdForWindow` swallows its own failures — a wedged
+        // workspace host degrades the context to null rather than failing the
+        // invocation it sits in front of.
+        let worktreeId = await service.getActiveWorktreeIdForWindow(senderWindowId);
+        // The window id survives a project switch, so a rebind during the await
+        // would pair the sender's projectId with the *replacement* project's
+        // worktree. Snapshots carry no project id to filter on, so re-check the
+        // binding instead and drop to null on a mismatch: a null worktree is
+        // honest, a cross-project one is the bug this fixes.
+        if (
+          worktreeId !== null &&
+          getProjectForWebContents(senderWebContentsId) !== senderProjectId
+        ) {
+          worktreeId = null;
+        }
+        const ctx: PluginIpcContext = {
+          projectId: senderProjectId,
+          worktreeId,
+          webContentsId: senderWebContentsId,
+          pluginId,
+        };
+        return await service.dispatchHandler(pluginId, channel, ctx, args);
       } catch (err) {
         // A throwing plugin handler is already audited at the dispatch
         // boundary (#10463); recording it again here would double-count the

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -85,6 +85,7 @@ import { assertIpcSecurityReady } from "../ipcGuard.js";
 import {
   getProjectForWebContents,
   getWindowForWebContents,
+  isCachedViewWebContents,
 } from "../../window/webContentsRegistry.js";
 
 type PluginServiceSingleton = typeof PluginServiceModule.pluginService;
@@ -1198,7 +1199,18 @@ export function registerPluginHandlers(): () => void {
       // actually made the call.
       const senderWebContentsId = event.sender.id;
       const senderProjectId = getProjectForWebContents(senderWebContentsId);
-      const senderWindowId = getWindowForWebContents(event.sender)?.id;
+      // The worktree lookup is keyed by window, but a window's workspace binding
+      // tracks its *visible* project — so it only speaks for this sender when
+      // this sender is the visible view. A cached (deactivated) view stays
+      // registered to its own project while its window shows another, and an
+      // unregistered sender has no project to speak for at all; in both cases a
+      // window-keyed answer would pair one project's id with another project's
+      // worktree, which is the mismatch #11297 is about. Leave the window
+      // unresolved and take the null.
+      const senderWindowId =
+        senderProjectId !== null && !isCachedViewWebContents(senderWebContentsId)
+          ? getWindowForWebContents(event.sender)?.id
+          : undefined;
       const senderUrl = event.senderFrame?.url;
       if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
         // Trust check rejected — args are attacker-controlled and unvalidated,
@@ -1224,22 +1236,25 @@ export function registerPluginHandlers(): () => void {
       }
       try {
         const service = await getPluginService();
-        // Resolving the worktree needs a round-trip to the workspace host, so
-        // it can't be pinned synchronously like the ids above.
-        // `getActiveWorktreeIdForWindow` swallows its own failures — a wedged
-        // workspace host degrades the context to null rather than failing the
-        // invocation it sits in front of.
-        let worktreeId = await service.getActiveWorktreeIdForWindow(senderWindowId);
-        // The window id survives a project switch, so a rebind during the await
-        // would pair the sender's projectId with the *replacement* project's
-        // worktree. Snapshots carry no project id to filter on, so re-check the
-        // binding instead and drop to null on a mismatch: a null worktree is
-        // honest, a cross-project one is the bug this fixes.
-        if (
-          worktreeId !== null &&
-          getProjectForWebContents(senderWebContentsId) !== senderProjectId
-        ) {
-          worktreeId = null;
+        // No trustworthy window means no worktree — short-circuit rather than
+        // query, so the invariant holds here regardless of what the service
+        // would answer.
+        let worktreeId: string | null = null;
+        if (senderWindowId !== undefined) {
+          // Resolving the worktree needs a round-trip to the workspace host, so
+          // it can't be pinned synchronously like the ids above.
+          // `getActiveWorktreeIdForWindow` swallows its own failures — a wedged
+          // workspace host degrades the context rather than failing the
+          // invocation it sits in front of.
+          worktreeId = await service.getActiveWorktreeIdForWindow(senderWindowId);
+          // The window id survives a project switch, so a rebind during the
+          // await would pair the sender's projectId with the *replacement*
+          // project's worktree. Snapshots carry no project id to filter on, so
+          // re-check the binding instead and drop to null on a mismatch: a null
+          // worktree is honest, a cross-project one is the bug this fixes.
+          if (getProjectForWebContents(senderWebContentsId) !== senderProjectId) {
+            worktreeId = null;
+          }
         }
         const ctx: PluginIpcContext = {
           projectId: senderProjectId,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -105,6 +105,7 @@ import type {
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeStatus } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import { getPtyClient } from "../window/serviceRefs.js";
+import { getWindowForWebContents } from "../window/webContentsRegistry.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
 import {
   registerPanelKind,
@@ -2435,14 +2436,78 @@ export class PluginService {
     return { path: suffix.length > 0 ? path.join(base, suffix) : base, rootClass: "project" };
   }
 
+  /**
+   * Worktree snapshots for the window the plugin is acting on behalf of.
+   *
+   * The host API this feeds (`getActiveWorktree` / `getWorktrees` /
+   * `getWorktreeStatus`) is a single long-lived closure per plugin — built once
+   * by `createHost()` at activation and shared across every window and project
+   * — and its methods take no arguments, so there is no per-call sender to key
+   * off. The focused-window heuristic below is therefore the only scoping
+   * structurally available here, and it deliberately reuses the dispatcher's
+   * existing targeting policy so the two can't drift. Ambient "active window"
+   * state is weaker than a real per-call context: a plugin acting from a timer
+   * while the user switches windows can still observe the newly-focused
+   * window's worktrees. Threading a true per-invocation context would mean
+   * redesigning the utility-process RPC bridge; that is out of scope for
+   * #11297, which only asks that a resolvable window actually be honoured.
+   *
+   * When no window resolves, this returns `[]` rather than falling back to the
+   * cross-project aggregate. The aggregate is *worse* than nothing: callers all
+   * pick the first `isCurrent` snapshot, so an unscoped fetch hands back a
+   * confidently wrong worktree from whichever project happens to be current —
+   * exactly the bug in #11297. Empty degrades honestly (no active worktree),
+   * and every caller already handles it: `getActiveWorktree` → `null`,
+   * `process.spawn` cwd → host cwd, and `${worktree}`/`${project}` allowlist
+   * tokens drop the unresolvable entry so containment denies rather than
+   * widens (#9492).
+   */
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {
     const client = this.workspaceClient;
     if (!client) return [];
+    const windowId = this.resolveActiveWindowId();
+    if (windowId === undefined) return [];
     try {
-      return await client.getAllStatesAsync();
+      return await client.getAllStatesAsync(windowId);
     } catch (err) {
       console.error("[PluginService] Failed to fetch worktree snapshots:", err);
       return [];
+    }
+  }
+
+  /**
+   * The BrowserWindow id backing the renderer this plugin is acting on behalf
+   * of, or `undefined` when none resolves (no live window, or the view is not
+   * registered). Never falls back to an arbitrary window.
+   */
+  private resolveActiveWindowId(): number | undefined {
+    const webContents = this.dispatcher.resolveActiveWebContents();
+    if (!webContents) return undefined;
+    return getWindowForWebContents(webContents)?.id;
+  }
+
+  /**
+   * The active worktree id for a specific window, for `plugin:invoke`'s IPC
+   * context (#11297). Unlike {@link fetchAllWorktreeSnapshots} this is
+   * sender-precise: the IPC handler has the real invoking `webContents`, so it
+   * resolves the window that actually made the call rather than the focused
+   * one. The asymmetry is deliberate — use real sender scope wherever one
+   * exists.
+   *
+   * Returns `null` for an unresolved window instead of widening to the
+   * cross-project aggregate, and swallows lookup failures: this sits on the
+   * critical path of every plugin invocation, so a wedged or crashed workspace
+   * host must degrade the context rather than fail the invoke.
+   */
+  async getActiveWorktreeIdForWindow(windowId: number | undefined): Promise<string | null> {
+    const client = this.workspaceClient;
+    if (!client || windowId === undefined) return null;
+    try {
+      const snapshots = await client.getAllStatesAsync(windowId);
+      return snapshots.find((s) => s.isCurrent === true)?.id ?? null;
+    } catch (err) {
+      console.error("[PluginService] Failed to resolve active worktree for window:", err);
+      return null;
     }
   }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2437,35 +2437,31 @@ export class PluginService {
   }
 
   /**
-   * Worktree snapshots for the window the plugin is acting on behalf of.
+   * Worktree snapshots for the project the plugin is acting on behalf of.
    *
-   * The host API this feeds (`getActiveWorktree` / `getWorktrees` /
-   * `getWorktreeStatus`) is a single long-lived closure per plugin — built once
-   * by `createHost()` at activation and shared across every window and project
-   * — and its methods take no arguments, so there is no per-call sender to key
-   * off. The focused-window heuristic below is therefore the only scoping
-   * structurally available here, and it deliberately reuses the dispatcher's
-   * existing targeting policy so the two can't drift. Ambient "active window"
-   * state is weaker than a real per-call context: a plugin acting from a timer
-   * while the user switches windows can still observe the newly-focused
-   * window's worktrees. Threading a true per-invocation context would mean
-   * redesigning the utility-process RPC bridge; that is out of scope for
-   * #11297, which only asks that a resolvable window actually be honoured.
+   * The host APIs this feeds (`getActiveWorktree` / `getWorktrees` /
+   * `getWorktreeStatus`, plus worktree-scoped storage, `${worktree}`/`${project}`
+   * allowlist roots and the `process.spawn` cwd default) hang off a single
+   * long-lived closure per plugin — `createHost()` runs once at activation and
+   * its methods take no arguments — so there is no per-call sender to key off.
+   * Scoping to the focused window is the only resolution structurally available
+   * without redesigning the utility-process RPC bridge, which #11297 does not
+   * ask for. It is genuinely weaker than a real per-invocation context: a plugin
+   * acting from a timer observes whichever project is focused *then*, not the
+   * one it was invoked from.
    *
-   * When no window resolves, this returns `[]` rather than falling back to the
-   * cross-project aggregate. The aggregate is *worse* than nothing: callers all
-   * pick the first `isCurrent` snapshot, so an unscoped fetch hands back a
-   * confidently wrong worktree from whichever project happens to be current —
-   * exactly the bug in #11297. Empty degrades honestly (no active worktree),
-   * and every caller already handles it: `getActiveWorktree` → `null`,
-   * `process.spawn` cwd → host cwd, and `${worktree}`/`${project}` allowlist
-   * tokens drop the unresolvable entry so containment denies rather than
-   * widens (#9492).
+   * Returns `[]` when no window resolves rather than falling back to the
+   * cross-project aggregate. This is not merely narrowing — the selected root
+   * can change from one project to another, which is the point — but the empty
+   * case fails closed: `getActiveWorktree` → `null`, worktree storage → no
+   * target, and token-rooted allowlist entries drop so containment denies
+   * (#9492). An aggregate would instead answer confidently with an arbitrary
+   * project's worktree, which is exactly the bug being fixed.
    */
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {
     const client = this.workspaceClient;
     if (!client) return [];
-    const windowId = this.resolveActiveWindowId();
+    const windowId = this.resolveScopeWindowId();
     if (windowId === undefined) return [];
     try {
       return await client.getAllStatesAsync(windowId);
@@ -2476,12 +2472,13 @@ export class PluginService {
   }
 
   /**
-   * The BrowserWindow id backing the renderer this plugin is acting on behalf
-   * of, or `undefined` when none resolves (no live window, or the view is not
-   * registered). Never falls back to an arbitrary window.
+   * The BrowserWindow id whose visible project the plugin is acting on, or
+   * `undefined` when none resolves. Uses the dispatcher's strict scope resolver,
+   * not its dispatch-targeting one — the latter scans every window in insertion
+   * order, which would reintroduce "some other project's worktree" here.
    */
-  private resolveActiveWindowId(): number | undefined {
-    const webContents = this.dispatcher.resolveActiveWebContents();
+  private resolveScopeWindowId(): number | undefined {
+    const webContents = this.dispatcher.resolveScopeWebContents();
     if (!webContents) return undefined;
     return getWindowForWebContents(webContents)?.id;
   }

--- a/electron/services/__tests__/PluginService.hostApiMisc.test.ts
+++ b/electron/services/__tests__/PluginService.hostApiMisc.test.ts
@@ -62,7 +62,8 @@ vi.mock("../../window/windowRef.js", () => ({
   getMainWindow: vi.fn(() => null),
   setProjectViewManager: vi.fn(),
 }));
-vi.mock("../../window/webContentsRegistry.js", () => ({
+vi.mock("../../window/webContentsRegistry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../window/webContentsRegistry.js")>()),
   getWindowForWebContents: webContentsRegistryMock.getWindowForWebContents,
 }));
 vi.mock("../../ipc/utils.js", () => ({
@@ -528,7 +529,21 @@ describe("Plugin worktree host API", () => {
   function createMockClient(initial: WorktreeSnapshotLike[] = []) {
     const emitter = new EventEmitter();
     let states = initial;
-    const getAllStatesAsync = vi.fn(() => Promise.resolve(states));
+    // Answer ONLY for a resolved window id. An unscoped call yields a distinct
+    // "other project" snapshot so a regression back to the aggregate surfaces
+    // as wrong data rather than silently passing (#11297).
+    const foreign: WorktreeSnapshotLike[] = [
+      {
+        id: "foreign",
+        worktreeId: "foreign",
+        path: "/tmp/foreign",
+        name: "foreign",
+        isCurrent: true,
+      },
+    ];
+    const getAllStatesAsync = vi.fn((windowId?: number) =>
+      Promise.resolve(windowId === undefined ? foreign : states)
+    );
     const client = Object.assign(emitter, {
       getAllStatesAsync,
       setStates: (next: WorktreeSnapshotLike[]) => {
@@ -642,6 +657,26 @@ describe("Plugin worktree host API", () => {
       await (service as unknown as ServiceWithWindowLookup).getActiveWorktreeIdForWindow(undefined)
     ).toBeNull();
     expect(client.getAllStatesAsync).not.toHaveBeenCalled();
+  });
+
+  it("gives worktree-scoped storage no target when no window resolves", async () => {
+    // Storage resolves its backing file from the same snapshot fetch. If an
+    // unresolved window fell back to the aggregate, a plugin's worktree-scoped
+    // data would be read from — and written into — an arbitrary project's file.
+    const { service } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    const storage = (
+      service as unknown as {
+        storage: {
+          resolveStorageFilePath: (id: string, scope: string) => Promise<string | undefined>;
+        };
+      }
+    ).storage;
+
+    expect(await storage.resolveStorageFilePath("acme.wt-host", "worktree")).toContain("/tmp/b");
+
+    windowRefMock.getProjectViewManager.mockReturnValue(null);
+    // No target at all — `set` throws on undefined rather than picking a file.
+    expect(await storage.resolveStorageFilePath("acme.wt-host", "worktree")).toBeUndefined();
   });
 
   it("getActiveWorktreeIdForWindow degrades to null when the workspace host fails", async () => {

--- a/electron/services/__tests__/PluginService.hostApiMisc.test.ts
+++ b/electron/services/__tests__/PluginService.hostApiMisc.test.ts
@@ -33,6 +33,9 @@ const windowRefMock = vi.hoisted(() => ({
   getWindowRegistry: vi.fn(() => null),
   getProjectViewManager: vi.fn(() => null),
 }));
+const webContentsRegistryMock = vi.hoisted(() => ({
+  getWindowForWebContents: vi.fn((_wc: unknown): { id: number } | null => null),
+}));
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
 const projectStoreMock = vi.hoisted(() => ({
   getCurrentProject: vi.fn((): { path: string } | null => null),
@@ -58,6 +61,9 @@ vi.mock("../../window/windowRef.js", () => ({
   setMainWindow: vi.fn(),
   getMainWindow: vi.fn(() => null),
   setProjectViewManager: vi.fn(),
+}));
+vi.mock("../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: webContentsRegistryMock.getWindowForWebContents,
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
@@ -470,6 +476,26 @@ describe("capabilities declaration logging", () => {
 });
 
 describe("Plugin worktree host API", () => {
+  // The host worktree APIs window-scope their snapshot fetch (#11297): they
+  // resolve the renderer the plugin is acting for, map it to a BrowserWindow,
+  // and pass that id to `getAllStatesAsync`. With no resolvable window they
+  // return empty rather than a cross-project aggregate, so these tests must
+  // stand up a resolvable one. `getAllStatesAsync` itself ignores the id, so
+  // the assertions below still exercise the projection, not the routing.
+  const fakeActiveWebContents = { id: 99, isDestroyed: () => false };
+
+  beforeEach(() => {
+    windowRefMock.getProjectViewManager.mockReturnValue({
+      getActiveView: () => ({ webContents: fakeActiveWebContents }),
+    } as never);
+    webContentsRegistryMock.getWindowForWebContents.mockReturnValue({ id: 1 });
+  });
+
+  afterEach(() => {
+    windowRefMock.getProjectViewManager.mockReturnValue(null);
+    webContentsRegistryMock.getWindowForWebContents.mockReturnValue(null);
+  });
+
   type WorktreeSnapshotLike = {
     id: string;
     worktreeId: string;
@@ -558,6 +584,75 @@ describe("Plugin worktree host API", () => {
   it("getActiveWorktree returns null when no worktree is current", async () => {
     const { host } = await setup([mkSnap({ id: "a", isCurrent: false })]);
     expect(await host.getActiveWorktree()).toBeNull();
+  });
+
+  // ── #11297: window scoping ──
+
+  it("scopes the snapshot fetch to the resolved window's id", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    await host.getActiveWorktree();
+    // Not called bare: an unscoped fetch aggregates every open project and
+    // hands back whichever `isCurrent` snapshot happens to sort first.
+    expect(client.getAllStatesAsync).toHaveBeenCalledWith(1);
+  });
+
+  it("returns empty rather than a cross-project aggregate when no window resolves", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    windowRefMock.getProjectViewManager.mockReturnValue(null);
+
+    expect(await host.getWorktrees()).toEqual([]);
+    expect(await host.getActiveWorktree()).toBeNull();
+    // The unscoped call is the bug — it must never be reached.
+    expect(client.getAllStatesAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when the resolved webContents maps to no window", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    webContentsRegistryMock.getWindowForWebContents.mockReturnValue(null);
+
+    expect(await host.getWorktrees()).toEqual([]);
+    expect(client.getAllStatesAsync).not.toHaveBeenCalled();
+  });
+
+  // ── #11297: sender-precise lookup backing plugin:invoke's IPC context ──
+
+  type ServiceWithWindowLookup = {
+    getActiveWorktreeIdForWindow: (windowId: number | undefined) => Promise<string | null>;
+  };
+
+  it("getActiveWorktreeIdForWindow resolves the given window's current worktree", async () => {
+    const { service, client } = await setup([
+      mkSnap({ id: "a", isCurrent: false }),
+      mkSnap({ id: "b", isCurrent: true }),
+    ]);
+
+    const id = await (service as unknown as ServiceWithWindowLookup).getActiveWorktreeIdForWindow(
+      7
+    );
+    expect(id).toBe("b");
+    // Uses the id it was handed — the caller's real sender — not the
+    // focused-window heuristic the host APIs fall back to.
+    expect(client.getAllStatesAsync).toHaveBeenCalledWith(7);
+  });
+
+  it("getActiveWorktreeIdForWindow returns null for an unresolved window without querying", async () => {
+    const { service, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+
+    expect(
+      await (service as unknown as ServiceWithWindowLookup).getActiveWorktreeIdForWindow(undefined)
+    ).toBeNull();
+    expect(client.getAllStatesAsync).not.toHaveBeenCalled();
+  });
+
+  it("getActiveWorktreeIdForWindow degrades to null when the workspace host fails", async () => {
+    // This sits on the critical path of every plugin:invoke — a wedged
+    // workspace host must cost the context, not the invocation.
+    const { service, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    client.getAllStatesAsync.mockRejectedValueOnce(new Error("workspace host down"));
+
+    await expect(
+      (service as unknown as ServiceWithWindowLookup).getActiveWorktreeIdForWindow(7)
+    ).resolves.toBeNull();
   });
 
   it("getWorktrees returns frozen snapshots for every worktree", async () => {

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -26,6 +26,31 @@ vi.mock("../ProjectStore.js", () => ({
   },
 }));
 
+// `${worktree}` / `${project}` allowlist tokens expand from worktree snapshots,
+// which are now fetched scoped to the window the plugin is acting for (#11297).
+// With no resolvable window the fetch returns empty and every token-rooted path
+// is denied — correct in production (an unresolvable window must not widen the
+// allowlist), but these tests need a window to stand in for the visible one.
+const windowScopeMock = vi.hoisted(() => ({
+  /** Set to false to simulate "no renderer resolves" — see the deny test. */
+  hasActiveView: true,
+}));
+vi.mock("../../window/windowRef.js", () => ({
+  getWindowRegistry: vi.fn(() => null),
+  getProjectViewManager: vi.fn(() =>
+    windowScopeMock.hasActiveView
+      ? { getActiveView: () => ({ webContents: { id: 99, isDestroyed: () => false } }) }
+      : null
+  ),
+  setWindowRegistry: vi.fn(),
+  setMainWindow: vi.fn(),
+  getMainWindow: vi.fn(() => null),
+  setProjectViewManager: vi.fn(),
+}));
+vi.mock("../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: vi.fn(() => ({ id: 1 })),
+}));
+
 const appendSpy = vi.fn();
 vi.mock("../PluginActionAuditService.js", () => ({
   getPluginActionAuditService: () => ({ append: appendSpy }),
@@ -270,6 +295,25 @@ describe("host.git capability gating + commit safeguard", () => {
 });
 
 describe("host.fs ${worktree}/${project} token expansion", () => {
+  afterEach(() => {
+    windowScopeMock.hasActiveView = true;
+  });
+
+  it("denies a token-rooted path when no window resolves (#11297)", async () => {
+    // Window scoping only ever narrows: with no resolvable renderer the
+    // snapshot fetch is empty, the token can't expand, and the entry drops so
+    // containment denies (#9492). It must never fall back to the cross-project
+    // aggregate, which could root the token in a project the user isn't in.
+    const worktree = join(baseDir, "wt-unscoped");
+    await fs.mkdir(worktree, { recursive: true });
+    setWorktrees([{ path: worktree, isCurrent: true }]);
+    const host = registerPlugin(["fs:project-read", "fs:project-write"], ["${worktree}"]);
+
+    windowScopeMock.hasActiveView = false;
+
+    await expect(host.fs.readFile(join(worktree, "note.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+
   it("expands ${worktree} to the active worktree and contains within it", async () => {
     const worktree = join(baseDir, "wt-feature");
     await fs.mkdir(worktree, { recursive: true });

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -47,7 +47,8 @@ vi.mock("../../window/windowRef.js", () => ({
   getMainWindow: vi.fn(() => null),
   setProjectViewManager: vi.fn(),
 }));
-vi.mock("../../window/webContentsRegistry.js", () => ({
+vi.mock("../../window/webContentsRegistry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../window/webContentsRegistry.js")>()),
   getWindowForWebContents: vi.fn(() => ({ id: 1 })),
 }));
 

--- a/electron/services/plugin/PluginRendererDispatcher.ts
+++ b/electron/services/plugin/PluginRendererDispatcher.ts
@@ -94,8 +94,13 @@ export class PluginRendererDispatcher {
    * project view first, then fall back to the global `ProjectViewManager`.
    * Returns `null` (rather than throwing) when no renderer is available so
    * {@link sendDispatchToRenderer} can return an error result.
+   *
+   * Public because `PluginService.fetchAllWorktreeSnapshots()` needs the same
+   * targeting policy to window-scope the host worktree APIs (#11297). Both
+   * callers are answering the identical question — "which renderer is this
+   * plugin acting on behalf of?" — so they must not drift apart.
    */
-  private resolveActiveWebContents(): Electron.WebContents | null {
+  resolveActiveWebContents(): Electron.WebContents | null {
     const registry = getWindowRegistry();
     if (registry) {
       // Plugin dispatches carry no source window, so target the focused window

--- a/electron/services/plugin/PluginRendererDispatcher.ts
+++ b/electron/services/plugin/PluginRendererDispatcher.ts
@@ -94,13 +94,8 @@ export class PluginRendererDispatcher {
    * project view first, then fall back to the global `ProjectViewManager`.
    * Returns `null` (rather than throwing) when no renderer is available so
    * {@link sendDispatchToRenderer} can return an error result.
-   *
-   * Public because `PluginService.fetchAllWorktreeSnapshots()` needs the same
-   * targeting policy to window-scope the host worktree APIs (#11297). Both
-   * callers are answering the identical question — "which renderer is this
-   * plugin acting on behalf of?" — so they must not drift apart.
    */
-  resolveActiveWebContents(): Electron.WebContents | null {
+  private resolveActiveWebContents(): Electron.WebContents | null {
     const registry = getWindowRegistry();
     if (registry) {
       // Plugin dispatches carry no source window, so target the focused window
@@ -126,6 +121,30 @@ export class PluginRendererDispatcher {
       return fallback;
     }
     return null;
+  }
+
+  /**
+   * The visible project view of the focused window, or `null`.
+   *
+   * Deliberately stricter than {@link resolveActiveWebContents}, which falls
+   * back to scanning every window in insertion order. Dispatch has to land
+   * somewhere — a UI action that reaches no renderer is a failed command — so
+   * a best-effort target beats nothing. Scope resolution has the opposite
+   * requirement: naming the wrong window's project silently misroutes
+   * filesystem roots, plugin storage and worktree reads, which is the bug in
+   * #11297 wearing a different hat. Here "no answer" beats "a plausible one".
+   */
+  resolveScopeWebContents(): Electron.WebContents | null {
+    const primary = getWindowRegistry()?.getPrimary();
+    if (primary) {
+      if (primary.browserWindow.isDestroyed()) return null;
+      const webContents = primary.services.projectViewManager?.getActiveView()?.webContents;
+      return webContents && !webContents.isDestroyed() ? webContents : null;
+    }
+    // No window registry (single-window / pre-registry boot): the process-wide
+    // ProjectViewManager is unambiguous because there is only one window.
+    const fallback = getProjectViewManager()?.getActiveView()?.webContents;
+    return fallback && !fallback.isDestroyed() ? fallback : null;
   }
 
   /**

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1580,6 +1580,14 @@ interface PanelViewProps {
      * host never mutates it; plugins should treat the contents as read-only.
      */
     readonly initialArgs?: Record<string, unknown>;
+    /**
+     * The worktree the panel instance belongs to, as recorded on the panel at
+     * spawn time. Lets a view reconstruct its own context without dispatching
+     * `worktree.getCurrent` — which resolves the *visible* worktree, not the
+     * one that owns the panel, and so returns the wrong answer for a background
+     * or restored panel. `undefined` for a panel spawned without a worktree.
+     */
+    readonly worktreeId?: string;
 }
 /**
  * What just happened to one plugin panel instance (#11301). The renderer owns

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -453,6 +453,8 @@ describe("plugin-sdk boundary", () => {
       // panel record. A view that only ever sees one of them cannot tell a
       // temporary unmount from a permanent close.
       expectTypeOf(props.panelRemovedSignal).toEqualTypeOf<AbortSignal>();
+      // Optional: a panel can be spawned without a worktree (#11297).
+      expectTypeOf(props.worktreeId).toEqualTypeOf<string | undefined>();
     });
 
     it("exposes the panel lifecycle contract as named SDK types", () => {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -218,6 +218,14 @@ export interface PanelViewProps {
    * host never mutates it; plugins should treat the contents as read-only.
    */
   readonly initialArgs?: Record<string, unknown>;
+  /**
+   * The worktree the panel instance belongs to, as recorded on the panel at
+   * spawn time. Lets a view reconstruct its own context without dispatching
+   * `worktree.getCurrent` — which resolves the *visible* worktree, not the
+   * one that owns the panel, and so returns the wrong answer for a background
+   * or restored panel. `undefined` for a panel spawned without a worktree.
+   */
+  readonly worktreeId?: string;
 }
 
 /**

--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -61,6 +61,9 @@ export interface PluginViewContentProps {
    * the button is not rendered.
    */
   onRequestClose?: () => void;
+  /** The worktree owning the panel instance, forwarded to the view as
+   * `PanelViewProps.worktreeId` so it can reconstruct its own context (#11297). */
+  worktreeId?: string;
 }
 
 /**
@@ -240,7 +243,12 @@ export function makePluginViewContent(
     return null;
   }
 
-  function PluginViewContent({ panelId, initialArgs, onRequestClose }: PluginViewContentProps) {
+  function PluginViewContent({
+    panelId,
+    initialArgs,
+    onRequestClose,
+    worktreeId,
+  }: PluginViewContentProps) {
     // Store the lazy component in state so retries can swap in a fresh ref
     // without a useMemo dependency array. Each `lazy()` wrapper caches its
     // import result on its own payload, so a chunk-load failure is sticky for
@@ -364,6 +372,7 @@ export function makePluginViewContent(
                 disposeSignal={controller.signal}
                 panelRemovedSignal={panelRemovedSignal}
                 initialArgs={initialArgs}
+                worktreeId={worktreeId}
               />
               <PluginViewMountReporter panelId={panelId} />
             </ContentFadeIn>

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -102,6 +102,7 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Plugi
           panelId={panelProps.id}
           initialArgs={extensionState}
           onRequestClose={handleRequestClose}
+          worktreeId={panelProps.worktreeId}
         />
       </ContentPanel>
     );

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -175,7 +175,7 @@ describe("makePluginViewContent", () => {
       const Content = makePluginViewContent(makeContentConfig());
 
       const initialArgs = { path: "/repo/src/index.ts", line: 12 };
-      render(<Content panelId="panel-args" initialArgs={initialArgs} />);
+      render(<Content panelId="panel-args" initialArgs={initialArgs} worktreeId="wt-7" />);
 
       await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
       const props = capturedProps[capturedProps.length - 1]!;
@@ -183,7 +183,38 @@ describe("makePluginViewContent", () => {
       expect(props.pluginId).toBe("acme");
       // The bag is forwarded by reference, not reconstructed.
       expect(props.initialArgs).toBe(initialArgs);
+      // #11297: the owning worktree reaches the view so it can reconstruct its
+      // own context instead of dispatching worktree.getCurrent, which resolves
+      // the *visible* worktree rather than the panel's.
+      expect(props.worktreeId).toBe("wt-7");
       expect(props.disposeSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
+  it("leaves worktreeId undefined for a panel spawned without one", async () => {
+    const capturedProps: Array<Record<string, unknown>> = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CapturingView(props: Record<string, unknown>) {
+            capturedProps.push(props);
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
+
+    try {
+      const { makePluginViewContent } = await import("../PluginViewContent");
+      const Content = makePluginViewContent(makeContentConfig());
+
+      render(<Content panelId="panel-no-wt" />);
+
+      await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
+      expect(capturedProps[capturedProps.length - 1]!.worktreeId).toBeUndefined();
     } finally {
       vi.doUnmock("react");
     }

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -193,33 +193,6 @@ describe("makePluginViewContent", () => {
     }
   });
 
-  it("leaves worktreeId undefined for a panel spawned without one", async () => {
-    const capturedProps: Array<Record<string, unknown>> = [];
-    vi.doMock("react", async () => {
-      const actual = await vi.importActual<typeof import("react")>("react");
-      return {
-        ...actual,
-        lazy: () =>
-          function CapturingView(props: Record<string, unknown>) {
-            capturedProps.push(props);
-            return <div data-testid="plugin-view" />;
-          },
-      };
-    });
-
-    try {
-      const { makePluginViewContent } = await import("../PluginViewContent");
-      const Content = makePluginViewContent(makeContentConfig());
-
-      render(<Content panelId="panel-no-wt" />);
-
-      await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
-      expect(capturedProps[capturedProps.length - 1]!.worktreeId).toBeUndefined();
-    } finally {
-      vi.doUnmock("react");
-    }
-  });
-
   it("subscribes to plugin:panel-kinds-changed on mount and unsubscribes on unmount", async () => {
     const cleanupSpy = vi.fn();
     onPanelKindsChangedMock.mockReturnValue(cleanupSpy);

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -314,6 +314,45 @@ describe("makePluginViewHost", () => {
     }
   });
 
+  it("passes the panel's own worktreeId to the mounted view (#11297)", async () => {
+    const capturedProps: Array<Record<string, unknown>> = [];
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: () =>
+          function CapturingView(props: Record<string, unknown>) {
+            capturedProps.push(props);
+            return <div data-testid="plugin-view" />;
+          },
+      };
+    });
+
+    try {
+      const { makePluginViewHost } = await import("../PluginViewHost");
+      const Host = makePluginViewHost(makeConfig());
+
+      render(
+        <Host
+          id="panel-wt"
+          title="Dashboard"
+          isFocused={false}
+          onFocus={(): void => {}}
+          onClose={(): void => {}}
+          worktreeId="wt-owning"
+        />
+      );
+
+      await waitFor(() => expect(screen.queryByTestId("plugin-view")).toBeTruthy());
+      // The value already rides the panel instance; before #11297 the host
+      // dropped it on the floor, leaving a view opened from the generic New
+      // Panel palette with no way to know which worktree it belonged to.
+      expect(capturedProps[capturedProps.length - 1]!.worktreeId).toBe("wt-owning");
+    } finally {
+      vi.doUnmock("react");
+    }
+  });
+
   it("keeps the plugin view mounted across panel prop changes (#11240)", async () => {
     // The content component type must be created once, at factory-construction
     // scope. Constructing it during the host's render mints a new type per

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -2869,7 +2869,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "panel",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Spawn (or focus an existing) plugin-contributed panel kind, handing it an initial argument. Args: \`kind\` (required) — the plugin panel kind id from \`contributes.panels\`; \`initialArgs\` (optional) — an opaque bag delivered to the view as \`PanelViewProps.initialArgs\` (e.g. \`{ path }\` to open a file); \`worktreeId\` (optional) — target worktree; \`reuseExisting\` (optional, default true) — focus an existing panel of this kind in the worktree instead of spawning a second one. Returns \`{ panelId }\`. Errors when \`kind\` is not a registered plugin panel kind.",
+    "description": "Spawn (or focus an existing) plugin-contributed panel kind, handing it an initial argument. Args: \`kind\` (required) — the plugin panel kind id from \`contributes.panels\`; \`initialArgs\` (optional) — an opaque bag delivered to the view as \`PanelViewProps.initialArgs\` (e.g. \`{ path }\` to open a file); \`worktreeId\` (optional) — target worktree, which must belong to the current project; \`reuseExisting\` (optional, default true) — focus an existing panel of this kind in the worktree instead of spawning a second one. Returns \`{ panelId }\`. Errors when \`kind\` is not a registered plugin panel kind, when \`worktreeId\` belongs to another project, or — transiently, retry — when the project's worktrees haven't loaded yet.",
     "examples": undefined,
     "id": "panel.openPluginPanel",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/panelCoreActions.openPluginPanel.test.ts
+++ b/src/services/actions/definitions/__tests__/panelCoreActions.openPluginPanel.test.ts
@@ -141,30 +141,27 @@ describe("panel.openPluginPanel", () => {
     expect(activateTerminal).not.toHaveBeenCalled();
   });
 
-  it("rejects rather than falling back to the active worktree", async () => {
-    await expect(setup({ kind: "acme.dash", worktreeId: "wt-other" })).rejects.toThrow();
-    expect(addPanel).not.toHaveBeenCalled();
-  });
-
-  it("rejects a supplied worktreeId when no worktrees have loaded yet", async () => {
+  it("distinguishes an unloaded worktree list from a foreign id", async () => {
     // Membership can't be established, so it can't be granted — bypassing the
-    // check on an empty list would re-admit arbitrary ids.
+    // check on an empty list would re-admit arbitrary ids. But this failure is
+    // transient and worth retrying, so it must not read as "wrong project".
     worktrees = [];
     await expect(setup({ kind: "acme.dash", worktreeId: "wt-1" })).rejects.toThrow(
-      /does not belong to the current project/
+      /haven't loaded yet/
     );
     expect(addPanel).not.toHaveBeenCalled();
   });
 
-  it("does not consult the worktree list when no worktreeId is supplied", async () => {
-    // The default path must keep working while a project is still loading.
+  it("still spawns with the active worktree when none is supplied and none have loaded", async () => {
+    // The default path must keep working while a project is still loading —
+    // the check applies only to a caller-named target.
     worktrees = [];
     await setup({ kind: "acme.dash" });
     expect(addPanel).toHaveBeenCalledTimes(1);
     expect(addPanel.mock.calls[0]![0].worktreeId).toBe("wt-active");
   });
 
-  it("does not reuse a panel in a foreign worktree by rejecting before the lookup", async () => {
+  it("does not reuse an existing panel that sits in a foreign worktree", async () => {
     panelStoreMock.getState.mockReturnValue({
       panelIds: ["p-foreign"],
       panelsById: {

--- a/src/services/actions/definitions/__tests__/panelCoreActions.openPluginPanel.test.ts
+++ b/src/services/actions/definitions/__tests__/panelCoreActions.openPluginPanel.test.ts
@@ -18,10 +18,16 @@ import { registerPanelCoreActions } from "../panelCoreActions";
 const addPanel = vi.fn();
 const activateTerminal = vi.fn();
 
+/** Worktrees the current project owns, as `callbacks.getWorktrees()` sees them. */
+let worktrees: Array<{ id: string }> = [];
+
 function setup(args?: unknown) {
   const actions: ActionRegistry = new Map();
   const callbacks = {
     getActiveWorktreeId: () => "wt-active",
+    // A supplied worktreeId is checked for membership in the current project
+    // (#11297), so the mock has to carry the ids these cases pass in.
+    getWorktrees: () => worktrees,
   } as unknown as ActionCallbacks;
   registerPanelCoreActions(actions, callbacks);
   const factory = actions.get("panel.openPluginPanel");
@@ -32,6 +38,7 @@ function setup(args?: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  worktrees = [{ id: "wt-active" }, { id: "wt-1" }];
   addPanel.mockResolvedValue("panel-new");
   panelStoreMock.getState.mockReturnValue({
     panelIds: [],
@@ -120,5 +127,59 @@ describe("panel.openPluginPanel", () => {
     await setup({ kind: "acme.dash", worktreeId: "wt-1", reuseExisting: false });
     expect(activateTerminal).not.toHaveBeenCalled();
     expect(addPanel).toHaveBeenCalledTimes(1);
+  });
+
+  // ── #11297: a foreign worktreeId must not be persisted onto the panel ──
+
+  it("rejects a worktreeId that belongs to another project", async () => {
+    await expect(setup({ kind: "acme.dash", worktreeId: "wt-other" })).rejects.toThrow(
+      /does not belong to the current project/
+    );
+    // The whole point: nothing is persisted. Silently spawning under another
+    // project is what made the command look like a no-op.
+    expect(addPanel).not.toHaveBeenCalled();
+    expect(activateTerminal).not.toHaveBeenCalled();
+  });
+
+  it("rejects rather than falling back to the active worktree", async () => {
+    await expect(setup({ kind: "acme.dash", worktreeId: "wt-other" })).rejects.toThrow();
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("rejects a supplied worktreeId when no worktrees have loaded yet", async () => {
+    // Membership can't be established, so it can't be granted — bypassing the
+    // check on an empty list would re-admit arbitrary ids.
+    worktrees = [];
+    await expect(setup({ kind: "acme.dash", worktreeId: "wt-1" })).rejects.toThrow(
+      /does not belong to the current project/
+    );
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not consult the worktree list when no worktreeId is supplied", async () => {
+    // The default path must keep working while a project is still loading.
+    worktrees = [];
+    await setup({ kind: "acme.dash" });
+    expect(addPanel).toHaveBeenCalledTimes(1);
+    expect(addPanel.mock.calls[0]![0].worktreeId).toBe("wt-active");
+  });
+
+  it("does not reuse a panel in a foreign worktree by rejecting before the lookup", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["p-foreign"],
+      panelsById: {
+        "p-foreign": {
+          id: "p-foreign",
+          kind: "acme.dash",
+          worktreeId: "wt-other",
+          location: "grid",
+        },
+      },
+      addPanel,
+      activateTerminal,
+    });
+
+    await expect(setup({ kind: "acme.dash", worktreeId: "wt-other" })).rejects.toThrow();
+    expect(activateTerminal).not.toHaveBeenCalled();
   });
 });

--- a/src/services/actions/definitions/panelCoreActions.ts
+++ b/src/services/actions/definitions/panelCoreActions.ts
@@ -128,7 +128,7 @@ export function registerPanelCoreActions(
     id: "panel.openPluginPanel",
     title: "Open Plugin Panel",
     description:
-      "Spawn (or focus an existing) plugin-contributed panel kind, handing it an initial argument. Args: `kind` (required) — the plugin panel kind id from `contributes.panels`; `initialArgs` (optional) — an opaque bag delivered to the view as `PanelViewProps.initialArgs` (e.g. `{ path }` to open a file); `worktreeId` (optional) — target worktree; `reuseExisting` (optional, default true) — focus an existing panel of this kind in the worktree instead of spawning a second one. Returns `{ panelId }`. Errors when `kind` is not a registered plugin panel kind.",
+      "Spawn (or focus an existing) plugin-contributed panel kind, handing it an initial argument. Args: `kind` (required) — the plugin panel kind id from `contributes.panels`; `initialArgs` (optional) — an opaque bag delivered to the view as `PanelViewProps.initialArgs` (e.g. `{ path }` to open a file); `worktreeId` (optional) — target worktree, which must belong to the current project; `reuseExisting` (optional, default true) — focus an existing panel of this kind in the worktree instead of spawning a second one. Returns `{ panelId }`. Errors when `kind` is not a registered plugin panel kind, when `worktreeId` belongs to another project, or — transiently, retry — when the project's worktrees haven't loaded yet.",
     category: "panel",
     kind: "command",
     danger: "safe",
@@ -150,13 +150,20 @@ export function registerPanelCoreActions(
       // cross-project id is persisted verbatim onto the panel, which then
       // spawns under a project the user isn't looking at and reads as "the
       // command did nothing" (#11297). Reject rather than silently substituting
-      // the active worktree: a caller that named the wrong worktree wants to
-      // know, and a silent fallback is exactly the class of bug #7880 banned.
-      // An empty worktree list (project still loading) means membership can't
-      // be established, so it rejects too — bypassing the check there would
-      // re-admit arbitrary ids through the one window where it matters.
-      if (worktreeId !== undefined && !callbacks.getWorktrees().some((w) => w.id === worktreeId)) {
-        throw new Error(`Worktree "${worktreeId}" does not belong to the current project`);
+      // the active worktree — a silent fallback on a named target is the class
+      // of bug #7880 banned. An unloaded worktree list can't establish
+      // membership either, so it also rejects, but says so distinctly: that one
+      // is transient and worth retrying, a foreign id never will be.
+      if (worktreeId !== undefined) {
+        const projectWorktrees = callbacks.getWorktrees();
+        if (projectWorktrees.length === 0) {
+          throw new Error(
+            `Can't verify worktree "${worktreeId}": the project's worktrees haven't loaded yet`
+          );
+        }
+        if (!projectWorktrees.some((w) => w.id === worktreeId)) {
+          throw new Error(`Worktree "${worktreeId}" does not belong to the current project`);
+        }
       }
 
       const state = usePanelStore.getState();

--- a/src/services/actions/definitions/panelCoreActions.ts
+++ b/src/services/actions/definitions/panelCoreActions.ts
@@ -144,6 +144,21 @@ export function registerPanelCoreActions(
         throw new Error(`"${kind}" is not a registered plugin panel kind`);
       }
 
+      // A supplied worktreeId must belong to the dispatching renderer's own
+      // project. This action runs in the invoking project's V8 context, so
+      // `getWorktrees()` is already the right scope. Without the check a
+      // cross-project id is persisted verbatim onto the panel, which then
+      // spawns under a project the user isn't looking at and reads as "the
+      // command did nothing" (#11297). Reject rather than silently substituting
+      // the active worktree: a caller that named the wrong worktree wants to
+      // know, and a silent fallback is exactly the class of bug #7880 banned.
+      // An empty worktree list (project still loading) means membership can't
+      // be established, so it rejects too — bypassing the check there would
+      // re-admit arbitrary ids through the one window where it matters.
+      if (worktreeId !== undefined && !callbacks.getWorktrees().some((w) => w.id === worktreeId)) {
+        throw new Error(`Worktree "${worktreeId}" does not belong to the current project`);
+      }
+
       const state = usePanelStore.getState();
       const targetWorktreeId = worktreeId ?? callbacks.getActiveWorktreeId();
 


### PR DESCRIPTION
## Summary

Every renderer to plugin invocation built its `PluginIpcContext` with `projectId: null` and `worktreeId: null`, even though the invoking `webContents` was right there in the handler. `host.getActiveWorktree()` made it worse: it aggregated worktree snapshots across every open project and returned the first `isCurrent` one, no window scoping at all. With several projects loaded, a plugin command would get a worktree from a different project than the visible one, create its panel under the wrong project, and just look like it did nothing. The `windowId` plumbing already existed in `WorkspaceClient.getAllStatesAsync()`, the plugin path just never passed one through.

Resolves #11297

## Changes

1. `electron/ipc/handlers/plugin.ts`: `plugin:invoke` now resolves the sender's real project and active worktree. Sender scope is pinned synchronously at handler entry, before any `await`, since a project view can be evicted or rebound mid-dispatch.
2. `electron/services/PluginService.ts`: `fetchAllWorktreeSnapshots()` now scopes to the focused window's visible project instead of aggregating across all of them. That single change fixes `getActiveWorktree`, `getWorktrees`, `getWorktreeStatus`, worktree-scoped plugin storage, the `${worktree}`/`${project}` fs allowlist roots, and the `process.spawn` cwd default, with no `PluginHostApi` signature change.
3. `src/services/actions/definitions/panelCoreActions.ts`: `panel.openPluginPanel` rejects a `worktreeId` that doesn't belong to the caller's project instead of persisting it silently, and reports "worktrees haven't loaded yet" distinctly from "wrong project" since only the former is worth retrying.
4. `shared/types/plugin.ts`: `PanelViewProps` gains a `worktreeId` field, so a panel opened from the generic New Panel palette can reconstruct its own context. The value already rode the panel instance, the host just dropped it on the way to the view.

### Design notes

This is a deliberate asymmetry. `plugin:invoke` has a real sender, so it can use precise sender scope. The host worktree APIs hang off one long-lived per-plugin closure with no per-call sender, so they can only scope to the focused window. Threading true per-invocation context through those calls would mean redesigning the utility-process RPC bridge, out of scope here.

The fix fails closed. When no trustworthy window resolves, the result is empty or null rather than the old cross-project aggregate, because an aggregate that confidently answers with an arbitrary project's worktree is the bug itself. A window's binding tracks its visible project, so it only speaks for a sender that IS the visible view: a cached background view stays registered to its own project while its window shows another, and an unbound sender has no project to speak for. Both cases get a null worktree rather than another project's.

`host.getWorktrees()` now returns the acting project's worktrees only, not all of them. `docs/plugins/host-api.md` is updated since it documented the old cross-project behavior.

## Testing

658 targeted tests pass across 18 suites. `eslint` and `prettier` clean on changed files. New coverage includes the mid-await project-rebind race (the lookup is held open so the race actually gets scheduled), unbound-sender and cached-view cases, window-scoped snapshot fetching, deny-on-no-window for `${worktree}` allowlist tokens, and the `panel.openPluginPanel` rejection paths. Ran `npm run api-surface:update` for the `PanelViewProps` change.

### Known limitation

`process.spawn`'s cwd default still falls back to the host cwd when no worktree resolves, so that one consumer isn't monotonically narrowing along with the rest. Left as-is: fixing it is a behavior change for existing plugins and outside this issue's scope.
