### PR TITLE
fix(plugin): stop bundling React 19 into the plugin SDK, and close two authoring-toolchain gaps

### DIFF
--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -79,6 +79,11 @@ const SOURCEMAP_EXTS = new Set([".js.map", ".mjs.map"]);
 // declared assets, so these are excluded from packing AND rejected by
 // {@link verifyPluginArchive}.
 const ROOT_DEV_FILE_NAMES: ReadonlySet<string> = new Set([
+  // The author's own shipping-policy ignore file (see the CLI packager). It
+  // describes what to leave out; shipping it would be pointless noise, and it
+  // has to be named here because this packer walks the tree with `readdir` and
+  // so — unlike the CLI's globby pass — does not skip dotfiles.
+  ".dntrignore",
   "package.json",
   "package-lock.json",
   "npm-shrinkwrap.json",

--- a/electron/services/__tests__/PluginArchive.integration.test.ts
+++ b/electron/services/__tests__/PluginArchive.integration.test.ts
@@ -603,6 +603,14 @@ describe("isExcludedArchiveEntry (shared CLI exclusion predicate)", () => {
     expect(isExcludedArchiveEntry("tsconfig.build.json")).toBe(true);
   });
 
+  it("excludes the author's root-level .dntrignore but not a nested one", () => {
+    // It states what to leave out, so shipping it is pointless — and this
+    // packer walks with readdir, so unlike the CLI's globby pass it would
+    // otherwise include the dotfile.
+    expect(isExcludedArchiveEntry(".dntrignore")).toBe(true);
+    expect(isExcludedArchiveEntry("dist/.dntrignore")).toBe(false);
+  });
+
   it("excludes root-level build configs", () => {
     expect(isExcludedArchiveEntry("vite.config.ts")).toBe(true);
     expect(isExcludedArchiveEntry("vite.config.server.ts")).toBe(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23297,6 +23297,8 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@types/react": "^19.0.0",
+        "react": "^19.2.1",
         "tsup": "^8.5.0",
         "zod": "^4.3.6"
       },
@@ -23304,7 +23306,13 @@
         "node": ">=22.13"
       },
       "peerDependencies": {
+        "react": "^19.0.0",
         "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "packages/plugin-testing": {

--- a/packages/daintree-plugin/src/__tests__/dev.test.ts
+++ b/packages/daintree-plugin/src/__tests__/dev.test.ts
@@ -49,7 +49,11 @@ let pluginDir: string;
 let pluginsRoot: string;
 
 beforeEach(async () => {
-  vi.clearAllMocks();
+  // resetAllMocks, not clearAllMocks: clearing wipes recorded calls but leaves
+  // queued `mockImplementationOnce` entries behind, so a test that ends without
+  // consuming its queue poisons the next one. Every mock here is a
+  // `vi.fn(impl)`, which reset restores to that original implementation.
+  vi.resetAllMocks();
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-dev-test-"));
   pluginDir = path.join(tmpDir, "my-plugin");
   pluginsRoot = path.join(tmpDir, "plugins-root");
@@ -155,6 +159,12 @@ describe("runDev", () => {
     const calls = vi.mocked(sendCliRequest).mock.calls.map((c) => c[0]);
     expect(calls).toContain("plugin.dev.start");
     expect(calls).toContain("plugin.dev.stop");
+
+    // dist/<main> must exist before Daintree loads the plugin, or the marker is
+    // in place with no bundle for the dev worker to import.
+    expect(vi.mocked(runVitePlanBuild).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(sendCliRequest).mock.invocationCallOrder[0]
+    );
 
     const watch = await spawnViteWatchMock.mock.results[0].value;
     expect(watch.kill).toHaveBeenCalled();

--- a/packages/daintree-plugin/src/__tests__/dev.test.ts
+++ b/packages/daintree-plugin/src/__tests__/dev.test.ts
@@ -3,11 +3,23 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-vi.mock("../lib/viteBuild.js", () => ({
-  runViteBuild: vi.fn(async () => {}),
-  // Synchronous like the real helper: returns a live child handle, not a Promise.
-  spawnViteWatch: vi.fn(() => ({ kill: vi.fn(), catch: vi.fn() })),
-}));
+vi.mock("../lib/viteBuild.js", async (importOriginal) => {
+  // `resolveVitePlan` stays real: it's pure filesystem inspection, and it's
+  // what decides how many watchers spawn, so stubbing it would hide the
+  // behavior these tests exist to pin. `runVitePlanBuild` must be mocked
+  // rather than spread through from the original — it calls `runViteBuild`
+  // via its own module-local binding, which no mock of the export can
+  // intercept, so a real one would shell out to a Vite that isn't installed
+  // in the fixture. What the plan *contains* is covered in viteBuild.test.ts;
+  // here we assert dev.ts hands the resolved plan to the builder.
+  const actual = await importOriginal<typeof import("../lib/viteBuild.js")>();
+  return {
+    ...actual,
+    runVitePlanBuild: vi.fn(async () => {}),
+    // Synchronous like the real helper: returns a live child handle, not a Promise.
+    spawnViteWatch: vi.fn(() => ({ kill: vi.fn(), catch: vi.fn() })),
+  };
+});
 vi.mock("../ipc/client.js", () => ({
   sendCliRequest: vi.fn(async () => ({ status: "ok" })),
   DaintreeUnavailableError: class extends Error {},
@@ -17,7 +29,7 @@ vi.mock("../commands/validate.js", () => ({
 }));
 
 import { linkDevPlugin, cleanupDevLink, runDev, type DevLink } from "../commands/dev.js";
-import { runViteBuild, spawnViteWatch } from "../lib/viteBuild.js";
+import { runVitePlanBuild, spawnViteWatch } from "../lib/viteBuild.js";
 import { sendCliRequest } from "../ipc/client.js";
 
 let tmpDir: string;
@@ -123,8 +135,11 @@ describe("runDev", () => {
 
     await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
 
-    expect(runViteBuild).toHaveBeenCalledWith(pluginDir);
-    expect(spawnViteWatch).toHaveBeenCalledWith(pluginDir);
+    expect(runVitePlanBuild).toHaveBeenCalledWith(
+      pluginDir,
+      expect.objectContaining({ dualConfig: false })
+    );
+    expect(spawnViteWatch).toHaveBeenCalledWith(pluginDir, ["build", "--watch"]);
     const calls = vi.mocked(sendCliRequest).mock.calls.map((c) => c[0]);
     expect(calls).toContain("plugin.dev.start");
     expect(calls).toContain("plugin.dev.stop");
@@ -170,7 +185,7 @@ describe("runDev", () => {
       skipBuild: true,
       keepAliveSignal: controller.signal,
     });
-    expect(runViteBuild).not.toHaveBeenCalled();
+    expect(runVitePlanBuild).not.toHaveBeenCalled();
     expect(vi.mocked(sendCliRequest).mock.calls.map((c) => c[0])).toContain("plugin.dev.start");
   });
 
@@ -185,6 +200,70 @@ describe("runDev", () => {
 
     expect(spawnViteWatch).not.toHaveBeenCalled();
     expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
+  });
+
+  describe("with a server config (dual-target plugin)", () => {
+    beforeEach(async () => {
+      await fs.writeFile(path.join(pluginDir, "vite.config.server.ts"), "export default {};");
+    });
+
+    it("builds both targets before handing the plugin to Daintree", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
+
+      // The server bundle has to exist before plugin.dev.start, or the marker
+      // is in place with no worker entry for the host to import.
+      const plan = vi.mocked(runVitePlanBuild).mock.calls[0][1];
+      expect(plan.dualConfig).toBe(true);
+      expect(plan.oneShot).toHaveLength(2);
+    });
+
+    it("watches both targets with output-clearing disabled", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
+
+      // Without --no-emptyOutDir each watcher re-empties the shared dist/ on
+      // every incremental rebuild, so a browser save deletes the worker bundle.
+      const watchArgs = vi.mocked(spawnViteWatch).mock.calls.map((c) => c[1]);
+      expect(watchArgs).toEqual([
+        ["build", "--watch", "--no-emptyOutDir"],
+        ["build", "--watch", "--config", "vite.config.server.ts", "--no-emptyOutDir"],
+      ]);
+    });
+
+    it("kills every watcher on teardown", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
+
+      const spawned = vi.mocked(spawnViteWatch).mock.results.map((r) => r.value);
+      expect(spawned).toHaveLength(2);
+      for (const watch of spawned) {
+        expect(watch.kill).toHaveBeenCalled();
+      }
+    });
+
+    it("kills the first watcher when the second fails to spawn", async () => {
+      const first = { kill: vi.fn(), catch: vi.fn() };
+      vi.mocked(spawnViteWatch)
+        .mockImplementationOnce(() => first)
+        .mockImplementationOnce(() => {
+          throw new Error("Couldn't find Vite");
+        });
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal })
+      ).rejects.toThrow(/Vite/);
+
+      // A half-started session must not leak a live Vite process.
+      expect(first.kill).toHaveBeenCalled();
+      expect(vi.mocked(sendCliRequest).mock.calls.map((c) => c[0])).toContain("plugin.dev.stop");
+      expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
+    });
   });
 
   it("rejects a plugin with no main entry", async () => {

--- a/packages/daintree-plugin/src/__tests__/dev.test.ts
+++ b/packages/daintree-plugin/src/__tests__/dev.test.ts
@@ -3,6 +3,19 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+// Only `kill()` and `catch()` are exercised, so the fake stops there. It's
+// declared through `vi.hoisted` and referenced directly rather than through
+// `vi.mocked()` on the real export, so its type stays the fake's own shape:
+// routing it via the export's `ResultPromise` signature would force an unsafe
+// assertion on every `mockImplementationOnce`.
+const { spawnViteWatchMock } = vi.hoisted(() => ({
+  // Synchronous like the real helper: returns a live child handle, not a Promise.
+  spawnViteWatchMock: vi.fn((_dir: string, _args?: string[]) => ({
+    kill: vi.fn(),
+    catch: vi.fn(),
+  })),
+}));
+
 vi.mock("../lib/viteBuild.js", async (importOriginal) => {
   // `resolveVitePlan` stays real: it's pure filesystem inspection, and it's
   // what decides how many watchers spawn, so stubbing it would hide the
@@ -16,8 +29,7 @@ vi.mock("../lib/viteBuild.js", async (importOriginal) => {
   return {
     ...actual,
     runVitePlanBuild: vi.fn(async () => {}),
-    // Synchronous like the real helper: returns a live child handle, not a Promise.
-    spawnViteWatch: vi.fn(() => ({ kill: vi.fn(), catch: vi.fn() })),
+    spawnViteWatch: spawnViteWatchMock,
   };
 });
 vi.mock("../ipc/client.js", () => ({
@@ -29,7 +41,7 @@ vi.mock("../commands/validate.js", () => ({
 }));
 
 import { linkDevPlugin, cleanupDevLink, runDev, type DevLink } from "../commands/dev.js";
-import { runVitePlanBuild, spawnViteWatch } from "../lib/viteBuild.js";
+import { runVitePlanBuild } from "../lib/viteBuild.js";
 import { sendCliRequest } from "../ipc/client.js";
 
 let tmpDir: string;
@@ -139,12 +151,12 @@ describe("runDev", () => {
       pluginDir,
       expect.objectContaining({ dualConfig: false })
     );
-    expect(spawnViteWatch).toHaveBeenCalledWith(pluginDir, ["build", "--watch"]);
+    expect(spawnViteWatchMock).toHaveBeenCalledWith(pluginDir, ["build", "--watch"]);
     const calls = vi.mocked(sendCliRequest).mock.calls.map((c) => c[0]);
     expect(calls).toContain("plugin.dev.start");
     expect(calls).toContain("plugin.dev.stop");
 
-    const watch = await vi.mocked(spawnViteWatch).mock.results[0].value;
+    const watch = await spawnViteWatchMock.mock.results[0].value;
     expect(watch.kill).toHaveBeenCalled();
     // The dev artifacts are gone after teardown.
     expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
@@ -160,7 +172,7 @@ describe("runDev", () => {
   });
 
   it("unloads and cleans up when the build watcher fails to start", async () => {
-    vi.mocked(spawnViteWatch).mockImplementationOnce(() => {
+    spawnViteWatchMock.mockImplementationOnce(() => {
       throw new Error("Couldn't find Vite");
     });
     const controller = new AbortController();
@@ -198,7 +210,7 @@ describe("runDev", () => {
       runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal })
     ).rejects.toThrow(/isn't running/);
 
-    expect(spawnViteWatch).not.toHaveBeenCalled();
+    expect(spawnViteWatchMock).not.toHaveBeenCalled();
     expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
   });
 
@@ -226,7 +238,7 @@ describe("runDev", () => {
 
       // Without --no-emptyOutDir each watcher re-empties the shared dist/ on
       // every incremental rebuild, so a browser save deletes the worker bundle.
-      const watchArgs = vi.mocked(spawnViteWatch).mock.calls.map((c) => c[1]);
+      const watchArgs = spawnViteWatchMock.mock.calls.map((c) => c[1]);
       expect(watchArgs).toEqual([
         ["build", "--watch", "--no-emptyOutDir"],
         ["build", "--watch", "--config", "vite.config.server.ts", "--no-emptyOutDir"],
@@ -238,7 +250,7 @@ describe("runDev", () => {
       controller.abort();
       await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
 
-      const spawned = vi.mocked(spawnViteWatch).mock.results.map((r) => r.value);
+      const spawned = spawnViteWatchMock.mock.results.map((r) => r.value);
       expect(spawned).toHaveLength(2);
       for (const watch of spawned) {
         expect(watch.kill).toHaveBeenCalled();
@@ -247,7 +259,7 @@ describe("runDev", () => {
 
     it("kills the first watcher when the second fails to spawn", async () => {
       const first = { kill: vi.fn(), catch: vi.fn() };
-      vi.mocked(spawnViteWatch)
+      spawnViteWatchMock
         .mockImplementationOnce(() => first)
         .mockImplementationOnce(() => {
           throw new Error("Couldn't find Vite");

--- a/packages/daintree-plugin/src/__tests__/new.test.ts
+++ b/packages/daintree-plugin/src/__tests__/new.test.ts
@@ -47,6 +47,15 @@ describe("scaffoldPlugin", () => {
       expect((pkg.scripts as Record<string, string>).package).toContain("daintree-plugin package");
       await expect(fs.access(path.join(result.dir, "src", "index.ts"))).resolves.toBeUndefined();
       await expect(fs.access(path.join(result.dir, ".gitignore"))).resolves.toBeUndefined();
+
+      // The starter .dntrignore documents the mechanism but must not actually
+      // drop anything from a fresh plugin — every rule ships commented out.
+      const dntrignore = await fs.readFile(path.join(result.dir, ".dntrignore"), "utf8");
+      const activeRules = dntrignore
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith("#"));
+      expect(activeRules).toEqual([]);
     });
   }
 

--- a/packages/daintree-plugin/src/__tests__/package.test.ts
+++ b/packages/daintree-plugin/src/__tests__/package.test.ts
@@ -117,6 +117,50 @@ describe("runPackage", () => {
     await expect(runPackage({ dir: tmpDir, skipBuild: true })).rejects.toThrow(/validation failed/);
   });
 
+  describe(".dntrignore", () => {
+    it("excludes files that .gitignore keeps tracked", async () => {
+      await fixture();
+      await writeFile("README.md", "# docs");
+      await writeFile("notes/design.md", "# notes");
+      await writeFile(".dntrignore", "notes/\n");
+
+      const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+      expect(result.files.some((f) => f.startsWith("notes/"))).toBe(false);
+      // Un-ignored siblings still ship — this prunes, it doesn't allowlist.
+      expect(result.files).toContain("README.md");
+    });
+
+    it("prunes stray files inside protected build output", async () => {
+      await fixture();
+      await writeFile("dist/docs/internal.md", "# internal");
+      await writeFile(".dntrignore", "dist/docs/\n");
+
+      const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+      // dist/ is force-included against .gitignore, so this is the case that
+      // fails if .dntrignore is applied only to the gitignore-aware pass.
+      expect(result.files).not.toContain("dist/docs/internal.md");
+      expect(result.files).toContain("dist/index.js");
+    });
+
+    it("cannot drop the manifest", async () => {
+      await fixture();
+      await writeFile(".dntrignore", "plugin.json\n");
+
+      const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+      expect(result.files).toContain("plugin.json");
+    });
+
+    it("keeps itself out of the archive", async () => {
+      await fixture();
+      await writeFile(".dntrignore", "notes/\n");
+
+      const result = await runPackage({ dir: tmpDir, skipBuild: true });
+      expect(result.files).not.toContain(".dntrignore");
+      const verify = await verifyPluginArchive(result.outputPath!);
+      expect(verify.valid).toBe(true);
+    });
+  });
+
   it("dry run never invokes the Vite build (no vite in fixture)", async () => {
     await fixture();
     // No node_modules/.bin/vite exists; if dry-run tried to build it would throw.

--- a/packages/daintree-plugin/src/__tests__/package.test.ts
+++ b/packages/daintree-plugin/src/__tests__/package.test.ts
@@ -142,6 +142,80 @@ describe("runPackage", () => {
       expect(result.files).toContain("dist/index.js");
     });
 
+    it("is not overridden by a .gitignore negation", async () => {
+      await fixture();
+      await writeFile("README.md", "# readme");
+      // `*.md` + `!README.md` is an everyday .gitignore shape. Folding both
+      // files into one ordered rule list would let that negation cancel the
+      // .dntrignore rule and ship the file anyway.
+      await writeFile(".gitignore", "dist/\nnode_modules/\n*.md\n!README.md\n");
+      await writeFile(".dntrignore", "README.md\n");
+
+      const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+      expect(result.files).not.toContain("README.md");
+    });
+
+    it("cannot re-include a file .gitignore dropped", async () => {
+      await fixture();
+      await writeFile("secret.txt", "shh");
+      await writeFile(".gitignore", "dist/\nnode_modules/\nsecret.txt\n");
+      // .dntrignore only ever subtracts; a negation in it must not add back.
+      await writeFile(".dntrignore", "!secret.txt\n");
+
+      const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+      expect(result.files).not.toContain("secret.txt");
+    });
+
+    it("fails before writing when it would drop a manifest-referenced file", async () => {
+      await fixture();
+      await writeFile(".dntrignore", "dist/index.js\n");
+
+      // Named error, not a silently broken archive — and it fires on the dry
+      // run too, which is the documented way to audit the file list.
+      await expect(runPackage({ dir: tmpDir, dryRun: true, skipBuild: true })).rejects.toThrow(
+        /dist\/index\.js/
+      );
+
+      await expect(runPackage({ dir: tmpDir, skipBuild: true })).rejects.toThrow(/dist\/index\.js/);
+      const entries = await fs.readdir(tmpDir);
+      expect(entries.some((e) => e.endsWith(".dntr"))).toBe(false);
+    });
+
+    it("fails when it would drop a contributed skill", async () => {
+      await writeFile(
+        "plugin.json",
+        JSON.stringify({
+          name: "acme.packtest",
+          version: "0.2.0",
+          main: "dist/index.js",
+          engines: { daintree: "^0.11.0" },
+          contributes: { skills: [{ id: "tdd", name: "TDD", path: "skills/tdd.md" }] },
+        })
+      );
+      await writeFile("dist/index.js", "export const x = 1;");
+      await writeFile("skills/tdd.md", "# tdd");
+      await writeFile(".gitignore", "dist/\nnode_modules/\n");
+      // A plausible authoring mistake: excluding docs also excludes the skill,
+      // which the host would otherwise just skip with a warning at runtime.
+      await writeFile(".dntrignore", "*.md\n");
+
+      await expect(runPackage({ dir: tmpDir, dryRun: true, skipBuild: true })).rejects.toThrow(
+        /skills\/tdd\.md/
+      );
+    });
+
+    it("leaves vendored runtime deps under the build output alone", async () => {
+      await fixture();
+      await writeFile("dist/node_modules/dep/index.js", "module.exports = {}");
+      await writeFile(".dntrignore", "notes/\n");
+
+      // Only a ROOT node_modules is excluded from a .dntr, so a plugin that
+      // vendors its runtime deps into dist/ ships them.
+      const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+      expect(result.files).toContain("dist/node_modules/dep/index.js");
+      expect(result.files.some((f) => f.startsWith("node_modules/"))).toBe(false);
+    });
+
     it("cannot drop the manifest", async () => {
       await fixture();
       await writeFile(".dntrignore", "plugin.json\n");
@@ -159,6 +233,25 @@ describe("runPackage", () => {
       const verify = await verifyPluginArchive(result.outputPath!);
       expect(verify.valid).toBe(true);
     });
+  });
+
+  it("preserves a gitignored custom output dir referenced with a leading ./", async () => {
+    await writeFile(
+      "plugin.json",
+      JSON.stringify({
+        name: "acme.packtest",
+        version: "0.2.0",
+        main: "./build/index.js",
+        engines: { daintree: "^0.11.0" },
+      })
+    );
+    await writeFile("build/index.js", "export const x = 1;");
+    await writeFile(".gitignore", "build/\nnode_modules/\n");
+
+    // The `./` has to be stripped before the top segment is read, or `build/`
+    // is never treated as protected and the entry point is silently dropped.
+    const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+    expect(result.files).toContain("build/index.js");
   });
 
   it("dry run never invokes the Vite build (no vite in fixture)", async () => {

--- a/packages/daintree-plugin/src/__tests__/viteBuild.test.ts
+++ b/packages/daintree-plugin/src/__tests__/viteBuild.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { resolveViteBin, spawnViteWatch } from "../lib/viteBuild.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveViteBin,
+  spawnViteWatch,
+  findServerConfig,
+  resolveVitePlan,
+} from "../lib/viteBuild.js";
 
 describe("viteBuild", () => {
   it("resolveViteBin throws a fix-it message when Vite isn't installed", () => {
@@ -10,5 +18,65 @@ describe("viteBuild", () => {
     // An `async` spawnViteWatch would unwrap execa's ResultPromise and resolve
     // only on the watcher's exit, hanging the dev loop. Lock it as a plain fn.
     expect(spawnViteWatch.constructor.name).toBe("Function");
+  });
+});
+
+describe("resolveVitePlan", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-viteplan-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("plans a single pass when there is no server config", async () => {
+    const plan = resolveVitePlan(dir);
+    expect(plan.dualConfig).toBe(false);
+    expect(plan.oneShot).toHaveLength(1);
+    expect(plan.watch).toHaveLength(1);
+  });
+
+  it("leaves output-clearing alone for a single-config project", async () => {
+    // Nothing else writes to dist/, so rebuilds should keep sweeping stale
+    // chunks — --no-emptyOutDir would make them accumulate for the session.
+    expect(resolveVitePlan(dir).watch.flat()).not.toContain("--no-emptyOutDir");
+  });
+
+  it.each(["vite.config.server.ts", "vite.config.server.mts", "vite.config.server.js"])(
+    "detects %s",
+    async (name) => {
+      await fs.writeFile(path.join(dir, name), "export default {};");
+      expect(findServerConfig(dir)).toBe(name);
+      expect(resolveVitePlan(dir).dualConfig).toBe(true);
+    }
+  );
+
+  it("builds the default config before the server config", async () => {
+    await fs.writeFile(path.join(dir, "vite.config.server.ts"), "export default {};");
+    const [first, second] = resolveVitePlan(dir).oneShot;
+    // The default pass is the one that legitimately empties dist/; running it
+    // second would delete the server bundle it had just produced.
+    expect(first).not.toContain("--config");
+    expect(second).toContain("--config");
+  });
+
+  it("disables output-clearing on both watchers when two share a dist", async () => {
+    await fs.writeFile(path.join(dir, "vite.config.server.ts"), "export default {};");
+    const plan = resolveVitePlan(dir);
+    expect(plan.watch).toHaveLength(2);
+    for (const args of plan.watch) {
+      expect(args).toContain("--no-emptyOutDir");
+    }
+  });
+
+  it("keeps one-shot builds clearing output even in dual-config mode", async () => {
+    await fs.writeFile(path.join(dir, "vite.config.server.ts"), "export default {};");
+    // Sequential passes don't race, so a one-shot build should still start from
+    // a clean dist/ — carrying --no-emptyOutDir here would leak stale output
+    // into every package.
+    expect(resolveVitePlan(dir).oneShot.flat()).not.toContain("--no-emptyOutDir");
   });
 });

--- a/packages/daintree-plugin/src/__tests__/viteBuild.test.ts
+++ b/packages/daintree-plugin/src/__tests__/viteBuild.test.ts
@@ -45,14 +45,28 @@ describe("resolveVitePlan", () => {
     expect(resolveVitePlan(dir).watch.flat()).not.toContain("--no-emptyOutDir");
   });
 
-  it.each(["vite.config.server.ts", "vite.config.server.mts", "vite.config.server.js"])(
-    "detects %s",
-    async (name) => {
-      await fs.writeFile(path.join(dir, name), "export default {};");
-      expect(findServerConfig(dir)).toBe(name);
-      expect(resolveVitePlan(dir).dualConfig).toBe(true);
-    }
-  );
+  // Every extension Vite 8 accepts for a config file; missing one silently
+  // downgrades that project to a single-target plan.
+  it.each([
+    "vite.config.server.js",
+    "vite.config.server.mjs",
+    "vite.config.server.ts",
+    "vite.config.server.cjs",
+    "vite.config.server.mts",
+    "vite.config.server.cts",
+  ])("detects %s", async (name) => {
+    await fs.writeFile(path.join(dir, name), "export default {};");
+    expect(findServerConfig(dir)).toBe(name);
+    expect(resolveVitePlan(dir).dualConfig).toBe(true);
+  });
+
+  it("resolves a bare filename so Vite reads it relative to the plugin dir", async () => {
+    await fs.writeFile(path.join(dir, "vite.config.server.ts"), "export default {};");
+    const serverArgs = resolveVitePlan(dir).oneShot[1];
+    // The watcher runs with cwd set to the plugin dir, so an absolute path here
+    // would still work but a path relative to the CLI's own cwd would not.
+    expect(serverArgs[serverArgs.indexOf("--config") + 1]).toBe("vite.config.server.ts");
+  });
 
   it("builds the default config before the server config", async () => {
     await fs.writeFile(path.join(dir, "vite.config.server.ts"), "export default {};");

--- a/packages/daintree-plugin/src/commands/dev.ts
+++ b/packages/daintree-plugin/src/commands/dev.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import os from "node:os";
 import type { ResultPromise } from "execa";
 import { runValidate } from "./validate.js";
-import { runViteBuild, spawnViteWatch } from "../lib/viteBuild.js";
+import { resolveVitePlan, runVitePlanBuild, spawnViteWatch } from "../lib/viteBuild.js";
 import { sendCliRequest } from "../ipc/client.js";
 
 // Mirrors the (unexported) DEV_MARKER_FILENAME in
@@ -121,13 +121,24 @@ async function sendDevStop(pluginId: string): Promise<void> {
   }
 }
 
-/** Stop the build watcher, ask Daintree to unload, and remove the dev artifacts. */
-async function stopDev(pluginId: string, link: DevLink, watch: ResultPromise): Promise<void> {
-  try {
-    watch.kill();
-  } catch {
-    // already exited
+/** Kill every watcher, best-effort and independently — one throw must not strand the rest. */
+function killWatchers(watchers: readonly ResultPromise[]): void {
+  for (const watch of watchers) {
+    try {
+      watch.kill();
+    } catch {
+      // already exited
+    }
   }
+}
+
+/** Stop the build watchers, ask Daintree to unload, and remove the dev artifacts. */
+async function stopDev(
+  pluginId: string,
+  link: DevLink,
+  watchers: readonly ResultPromise[]
+): Promise<void> {
+  killWatchers(watchers);
   await sendDevStop(pluginId);
   await cleanupDevLink(link);
 }
@@ -135,9 +146,10 @@ async function stopDev(pluginId: string, link: DevLink, watch: ResultPromise): P
 /**
  * Run the hot-reload dev loop for the plugin in `dir`: build once, symlink it
  * into the plugins root with a `.dev-marker`, tell the running Daintree to load
- * + activate it, then keep a `vite build --watch` alive so saves rebuild
- * `dist/` (Daintree's dev worker watches `dist/` and reloads). Ctrl-C tears
- * everything back down.
+ * + activate it, then keep `vite build --watch` alive so saves rebuild `dist/`
+ * (Daintree's dev worker watches `dist/` and reloads). A plugin with a Node
+ * server entry gets a watcher per config, so worker sources rebuild too.
+ * Ctrl-C tears everything back down.
  */
 export async function runDev(opts: DevOptions = {}): Promise<void> {
   const dir = path.resolve(opts.dir ?? process.cwd());
@@ -157,10 +169,12 @@ export async function runDev(opts: DevOptions = {}): Promise<void> {
   const pluginId = manifest.name;
   const pluginsRoot = opts.pluginsRoot ?? defaultPluginsRoot();
 
+  const plan = resolveVitePlan(dir);
+
   // Build once so dist/<main> exists before Daintree loads the plugin —
   // otherwise the marker is present but the worker has no bundle to import.
   if (!opts.skipBuild) {
-    await runViteBuild(dir);
+    await runVitePlanBuild(dir, plan);
   }
 
   const link = await linkDevPlugin({ pluginDir: dir, pluginsRoot, pluginId });
@@ -175,18 +189,25 @@ export async function runDev(opts: DevOptions = {}): Promise<void> {
   // `spawnViteWatch` returns the live child handle synchronously (do NOT await
   // it — awaiting the ResultPromise would block until the watcher exits). If it
   // throws (Vite missing), the plugin is already loaded in Daintree, so unload
-  // it and remove the dev artifacts before surfacing the error.
-  let watch: ResultPromise;
+  // it and remove the dev artifacts before surfacing the error. A throw on the
+  // second spawn must also kill the first, or the failed session leaks a live
+  // Vite process.
+  const watchers: ResultPromise[] = [];
   try {
-    watch = spawnViteWatch(dir);
+    for (const args of plan.watch) {
+      watchers.push(spawnViteWatch(dir, args));
+    }
   } catch (err) {
+    killWatchers(watchers);
     await sendDevStop(pluginId);
     await cleanupDevLink(link);
     throw err;
   }
   // A watch crash is informational, not fatal to the session — surface it via
   // its inherited stdio; don't let the rejection bubble as unhandled.
-  watch.catch(() => {});
+  for (const watch of watchers) {
+    watch.catch(() => {});
+  }
 
   console.log(`Watching ${pluginId} for changes. Press Ctrl-C to stop.`);
 
@@ -194,7 +215,7 @@ export async function runDev(opts: DevOptions = {}): Promise<void> {
   const stopOnce = async (exitAfter: boolean): Promise<void> => {
     if (stopping) return;
     stopping = true;
-    await stopDev(pluginId, link, watch);
+    await stopDev(pluginId, link, watchers);
     if (exitAfter) process.exit(0);
   };
 

--- a/packages/daintree-plugin/src/commands/dev.ts
+++ b/packages/daintree-plugin/src/commands/dev.ts
@@ -195,18 +195,20 @@ export async function runDev(opts: DevOptions = {}): Promise<void> {
   const watchers: ResultPromise[] = [];
   try {
     for (const args of plan.watch) {
-      watchers.push(spawnViteWatch(dir, args));
+      const watch = spawnViteWatch(dir, args);
+      // Attach before the next spawn can throw, not after the loop: execa
+      // rejects on signal termination, so a watcher killed by the catch below
+      // would otherwise reject with nobody listening and mask the real error.
+      // A watch crash is informational anyway, not fatal to the session — it
+      // surfaces through the inherited stdio.
+      watch.catch(() => {});
+      watchers.push(watch);
     }
   } catch (err) {
     killWatchers(watchers);
     await sendDevStop(pluginId);
     await cleanupDevLink(link);
     throw err;
-  }
-  // A watch crash is informational, not fatal to the session — surface it via
-  // its inherited stdio; don't let the rejection bubble as unhandled.
-  for (const watch of watchers) {
-    watch.catch(() => {});
   }
 
   console.log(`Watching ${pluginId} for changes. Press Ctrl-C to stop.`);

--- a/packages/daintree-plugin/src/commands/package.ts
+++ b/packages/daintree-plugin/src/commands/package.ts
@@ -18,6 +18,64 @@ import { runValidate } from "./validate.js";
  */
 const DNTRIGNORE_FILENAME = ".dntrignore";
 
+/**
+ * The paths `.dntrignore` leaves alone, evaluated WITHOUT `.gitignore`.
+ *
+ * Passing both files to one globby call folds them into a single ordered rule
+ * list, where a negation in either can cancel a rule from the other — a
+ * `.gitignore` of `*.md` + `!README.md`, an everyday shape, would re-include a
+ * README that `.dntrignore` had excluded. Intersecting two independent passes
+ * instead keeps `.dntrignore` strictly subtractive: a path ships only if
+ * neither policy drops it, and neither file can un-ignore the other's rules.
+ *
+ * `node_modules` / `.git` are skipped explicitly because this pass has no
+ * `.gitignore` to skip them for it. Both patterns are root-anchored to match
+ * the normative exclusion list exactly: a recursively-prefixed form would also
+ * drop a nested `dist/node_modules`, which the archive predicate permits and a
+ * plugin vendoring its runtime deps genuinely ships.
+ */
+async function dntrignoreKept(dir: string): Promise<Set<string>> {
+  return new Set(
+    await globby("**/*", {
+      cwd: dir,
+      ignoreFiles: [DNTRIGNORE_FILENAME],
+      ignore: ["node_modules/**", ".git/**"],
+      dot: false,
+      onlyFiles: true,
+    })
+  );
+}
+
+/**
+ * Paths the manifest points at, which the archive is invalid without.
+ * `verifyPluginArchive` already rejects a missing `main` or view
+ * `componentPath`, but only after the `.dntr` has been written — and a dry run
+ * never reaches it at all. Skills aren't verified there either: a dropped skill
+ * just goes quiet at runtime. Since `.dntrignore` makes excluding these easy for
+ * the first time, check them up front instead.
+ */
+function requiredManifestPaths(manifest: MinimalManifest): string[] {
+  const refs = new Set<string>();
+  // Normalized exactly the way `verifyPluginArchive` normalizes (strip a
+  // leading `./`, nothing else). Being more lenient here — folding backslashes,
+  // say — would let a reference pass this check and then fail verification
+  // after the archive had already been written, which is the failure mode this
+  // check exists to remove.
+  const add = (ref?: string) => {
+    if (ref) refs.add(ref.startsWith("./") ? ref.slice(2) : ref);
+  };
+  add(manifest.main);
+  for (const view of manifest.contributes?.views ??
+    manifest.contributes?.experimental_views ??
+    []) {
+    add(view.componentPath);
+  }
+  for (const skill of manifest.contributes?.skills ?? []) {
+    add(skill.path);
+  }
+  return [...refs];
+}
+
 export interface PackageOptions {
   dir?: string;
   verbose?: boolean;
@@ -41,6 +99,7 @@ interface MinimalManifest {
     views?: Array<{ componentPath?: string }>;
     /** @deprecated Renamed to `views` in the 1.0 freeze; still honored here. */
     experimental_views?: Array<{ componentPath?: string }>;
+    skills?: Array<{ path?: string }>;
   };
 }
 
@@ -53,7 +112,11 @@ function protectedDirs(manifest: MinimalManifest): string[] {
   const dirs = new Set<string>(["dist"]);
   const add = (ref?: string) => {
     if (!ref) return;
-    const normalized = ref.replace(/\\/g, "/");
+    // The leading `./` has to come off before splitting, or the top segment is
+    // "." and a gitignored custom output dir (`main: "./build/index.js"`) never
+    // gets preserved — the manifest is valid and the file exists, but it would
+    // be left out of the archive.
+    const normalized = ref.replace(/\\/g, "/").replace(/^\.\//, "");
     const top = normalized.split("/")[0];
     if (top && top !== "." && top !== "..") dirs.add(top);
   };
@@ -92,28 +155,29 @@ export async function runPackage(opts: PackageOptions = {}): Promise<PackageResu
     await runVitePlanBuild(dir, resolveVitePlan(dir));
   }
 
-  // Candidate set honoring .gitignore (drops cruft like .env, coverage/) plus
-  // the author's own `.dntrignore`. globby merges the two pattern sets, so
-  // `.dntrignore` adds to `.gitignore` rather than replacing it.
+  // Candidate set honoring .gitignore (drops cruft like .env, coverage/).
   const gitignored = await globby("**/*", {
     cwd: dir,
     gitignore: true,
-    ignoreFiles: [DNTRIGNORE_FILENAME],
     dot: false,
     onlyFiles: true,
   });
 
   // Build output / manifest-referenced dirs must ship even if gitignored.
-  // `.dntrignore` still applies here: `.gitignore` states repo policy (which is
-  // why build output is deliberately un-ignored above), but `.dntrignore`
-  // states shipping policy, so it has to be able to drop stray files that live
-  // *inside* a protected dir — `dist/docs/**` being the motivating case.
   const preserved = await globby(
     protectedDirs(manifest).map((d) => `${d}/**/*`),
-    { cwd: dir, ignoreFiles: [DNTRIGNORE_FILENAME], dot: false, onlyFiles: true }
+    { cwd: dir, dot: false, onlyFiles: true }
   );
 
-  const candidates = new Set<string>([...gitignored, ...preserved, "plugin.json"]);
+  // `.dntrignore` prunes the union, including the preserved set: `.gitignore`
+  // states repo policy (which is why build output is deliberately un-ignored
+  // above), but `.dntrignore` states shipping policy, so it has to reach stray
+  // files living *inside* a protected dir — `dist/docs/**` being the case that
+  // motivated it.
+  const kept = await dntrignoreKept(dir);
+  const candidates = new Set<string>([...gitignored, ...preserved].filter((f) => kept.has(f)));
+  // The manifest is the one file no policy may drop.
+  candidates.add("plugin.json");
 
   const sourcemaps = opts.sourcemaps ?? false;
   const files = [...candidates]
@@ -123,6 +187,14 @@ export async function runPackage(opts: PackageOptions = {}): Promise<PackageResu
 
   if (!files.includes("plugin.json")) {
     throw new Error("plugin.json not found in the plugin directory");
+  }
+
+  const missing = requiredManifestPaths(manifest).filter((ref) => !files.includes(ref));
+  if (missing.length > 0) {
+    throw new Error(
+      `Manifest references ${missing.length === 1 ? "a file that isn't" : "files that aren't"} in the archive: ${missing.join(", ")}. ` +
+        `Check .gitignore and ${DNTRIGNORE_FILENAME}, or run the build first.`
+    );
   }
 
   if (opts.verbose || opts.dryRun) {

--- a/packages/daintree-plugin/src/commands/package.ts
+++ b/packages/daintree-plugin/src/commands/package.ts
@@ -6,8 +6,17 @@ import {
   isExcludedArchiveEntry,
   verifyPluginArchive,
 } from "../../../../electron/services/PluginArchive.js";
-import { runViteBuild } from "../lib/viteBuild.js";
+import { resolveVitePlan, runVitePlanBuild } from "../lib/viteBuild.js";
 import { runValidate } from "./validate.js";
+
+/**
+ * Per-plugin shipping-policy ignore file, `.gitignore` syntax. Only the archive
+ * root is consulted — this is package-level policy (the `.npmignore` analogue),
+ * and honoring nested copies would let a vendored asset directory silently
+ * rewrite what ships. The file itself never lands in the archive: it's excluded
+ * normatively in `PluginArchive.ts` so the host's own packer drops it too.
+ */
+const DNTRIGNORE_FILENAME = ".dntrignore";
 
 export interface PackageOptions {
   dir?: string;
@@ -58,8 +67,9 @@ function protectedDirs(manifest: MinimalManifest): string[] {
 }
 
 /**
- * Build (unless `--skip-build`), collect files honoring `.gitignore` plus the
- * normative `.dntr` exclusion list, and write a deterministic
+ * Build (unless `--skip-build`), collect files honoring `.gitignore`, the
+ * author's `.dntrignore`, and the normative `.dntr` exclusion list, and write a
+ * deterministic
  * `{pluginId}-{version}.dntr`. Reuses the host's archive writer so CLI output
  * is byte-identical to Daintree's own packer on the same OS.
  */
@@ -76,22 +86,31 @@ export async function runPackage(opts: PackageOptions = {}): Promise<PackageResu
   ) as MinimalManifest;
 
   // A dry run is a no-side-effects preview — never trigger the Vite build.
+  // A plugin with a Node server entry needs both passes, or `dist/server.js`
+  // ships stale (or missing) while the browser bundle is fresh.
   if (!opts.skipBuild && !opts.dryRun) {
-    await runViteBuild(dir);
+    await runVitePlanBuild(dir, resolveVitePlan(dir));
   }
 
-  // Candidate set honoring .gitignore (drops cruft like .env, coverage/).
+  // Candidate set honoring .gitignore (drops cruft like .env, coverage/) plus
+  // the author's own `.dntrignore`. globby merges the two pattern sets, so
+  // `.dntrignore` adds to `.gitignore` rather than replacing it.
   const gitignored = await globby("**/*", {
     cwd: dir,
     gitignore: true,
+    ignoreFiles: [DNTRIGNORE_FILENAME],
     dot: false,
     onlyFiles: true,
   });
 
   // Build output / manifest-referenced dirs must ship even if gitignored.
+  // `.dntrignore` still applies here: `.gitignore` states repo policy (which is
+  // why build output is deliberately un-ignored above), but `.dntrignore`
+  // states shipping policy, so it has to be able to drop stray files that live
+  // *inside* a protected dir — `dist/docs/**` being the motivating case.
   const preserved = await globby(
     protectedDirs(manifest).map((d) => `${d}/**/*`),
-    { cwd: dir, dot: false, onlyFiles: true }
+    { cwd: dir, ignoreFiles: [DNTRIGNORE_FILENAME], dot: false, onlyFiles: true }
   );
 
   const candidates = new Set<string>([...gitignored, ...preserved, "plugin.json"]);

--- a/packages/daintree-plugin/src/lib/viteBuild.ts
+++ b/packages/daintree-plugin/src/lib/viteBuild.ts
@@ -37,7 +37,77 @@ export async function runViteBuild(dir: string, args: string[] = ["build"]): Pro
  * NOT `async`: it returns execa's `ResultPromise`, which is both awaitable and a
  * live child handle. Wrapping it in `async` would await the process to *exit*.
  */
-export function spawnViteWatch(dir: string): ResultPromise {
+export function spawnViteWatch(dir: string, args: string[] = ["build", "--watch"]): ResultPromise {
   const bin = resolveViteBin(dir);
-  return execa(bin, ["build", "--watch"], { cwd: dir, stdio: "inherit" });
+  return execa(bin, args, { cwd: dir, stdio: "inherit" });
+}
+
+// A plugin with a Node entry (stdio MCP server) is built by a second Vite pass
+// against its own config, because one `vite build` runs one config object at a
+// time. The scaffold names that file `vite.config.server.ts`; the other
+// extensions are accepted so a hand-rolled project isn't locked out.
+const SERVER_CONFIG_NAMES = [
+  "vite.config.server.ts",
+  "vite.config.server.mts",
+  "vite.config.server.js",
+  "vite.config.server.mjs",
+] as const;
+
+/** The plugin's server-target Vite config filename, or null if it has none. */
+export function findServerConfig(dir: string): string | null {
+  return SERVER_CONFIG_NAMES.find((name) => existsSync(path.join(dir, name))) ?? null;
+}
+
+export interface VitePlan {
+  /** Whether this project has a second, server-target config. */
+  dualConfig: boolean;
+  /** Arg sets for a one-shot build, in order. Run these sequentially. */
+  oneShot: string[][];
+  /** Arg sets to spawn concurrently as watchers. */
+  watch: string[][];
+}
+
+/**
+ * Work out how many Vite passes this plugin needs and with which flags.
+ *
+ * One-shot builds run sequentially, so the default `emptyOutDir: true` on the
+ * browser config is right: the first pass cleans `dist/`, and the server config
+ * (which the scaffold gives `emptyOutDir: false`) then appends to it.
+ *
+ * Watch mode can't rely on that ordering. Vite's `prepareOutDirPlugin` drops the
+ * environment from its `rendered` set on every `watchChange`, so `renderStart`
+ * re-empties `outDir` on *every* incremental rebuild — not just the first. With
+ * two watchers on a shared `dist/`, each browser save would delete the server
+ * bundle (and the server watcher wouldn't rebuild it until its own sources
+ * changed). `--no-emptyOutDir` is Vite's cac-negated form of the `--emptyOutDir`
+ * flag; it isn't in `vite build --help`, but it does reach
+ * `build.emptyOutDir = false` and inline CLI options win over the config file,
+ * so it fixes already-scaffolded plugins without touching an author's config.
+ *
+ * The flag is applied only in dual-config mode. A single-config project keeps
+ * plain `vite build --watch` so its rebuilds still sweep away stale chunks —
+ * the cost of `--no-emptyOutDir` is exactly that stale output lingers for the
+ * session, which is only worth paying when the alternative is deleting a
+ * sibling target's bundle.
+ */
+export function resolveVitePlan(dir: string): VitePlan {
+  const serverConfig = findServerConfig(dir);
+  if (!serverConfig) {
+    return { dualConfig: false, oneShot: [["build"]], watch: [["build", "--watch"]] };
+  }
+  return {
+    dualConfig: true,
+    oneShot: [["build"], ["build", "--config", serverConfig]],
+    watch: [
+      ["build", "--watch", "--no-emptyOutDir"],
+      ["build", "--watch", "--config", serverConfig, "--no-emptyOutDir"],
+    ],
+  };
+}
+
+/** Run every pass of a one-shot build, in order. */
+export async function runVitePlanBuild(dir: string, plan: VitePlan): Promise<void> {
+  for (const args of plan.oneShot) {
+    await runViteBuild(dir, args);
+  }
 }

--- a/packages/daintree-plugin/src/lib/viteBuild.ts
+++ b/packages/daintree-plugin/src/lib/viteBuild.ts
@@ -46,11 +46,15 @@ export function spawnViteWatch(dir: string, args: string[] = ["build", "--watch"
 // against its own config, because one `vite build` runs one config object at a
 // time. The scaffold names that file `vite.config.server.ts`; the other
 // extensions are accepted so a hand-rolled project isn't locked out.
+// Ordered to match Vite 8's own DEFAULT_CONFIG_FILES precedence, so a project
+// with more than one resolves the same way Vite would.
 const SERVER_CONFIG_NAMES = [
-  "vite.config.server.ts",
-  "vite.config.server.mts",
   "vite.config.server.js",
   "vite.config.server.mjs",
+  "vite.config.server.ts",
+  "vite.config.server.cjs",
+  "vite.config.server.mts",
+  "vite.config.server.cts",
 ] as const;
 
 /** The plugin's server-target Vite config filename, or null if it has none. */

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -186,6 +186,19 @@ dist/
 .dev-marker
 `;
 
+// Ships commented-out so a fresh plugin excludes nothing extra — it exists to
+// make the mechanism discoverable, since `.gitignore` alone can't express
+// "tracked in the repo, but not shipped to users".
+const DNTRIGNORE = `# Files to keep OUT of the packaged .dntr, in .gitignore syntax.
+# Applies on top of .gitignore, and unlike .gitignore it also applies inside
+# dist/ — so build output you don't want to distribute can be excluded here.
+# Run \`daintree-plugin package --dry-run\` to audit the resulting file list.
+
+# docs/
+# screenshots/
+# dist/*.stats.html
+`;
+
 function commandEntry(ctx: ScaffoldContext): string {
   const title = q(`${ctx.displayName}: Run`);
   const description = q(`Run the ${ctx.displayName} command.`);
@@ -311,6 +324,7 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
         "tsconfig.json": tsconfig(false),
         "vite.config.ts": viteConfig({ index: "src/index.ts" }),
         ".gitignore": GITIGNORE,
+        ".dntrignore": DNTRIGNORE,
         "src/index.ts": commandEntry(ctx),
       };
     }
@@ -330,6 +344,7 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
         "tsconfig.json": tsconfig(true),
         "vite.config.ts": viteConfig({ index: "src/index.ts", panel: "src/panel.tsx" }),
         ".gitignore": GITIGNORE,
+        ".dntrignore": DNTRIGNORE,
         "src/index.ts": viewEntry(ctx),
         "src/panel.tsx": panelComponent(ctx),
       };
@@ -351,6 +366,7 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
         "vite.config.ts": viteConfig({ index: "src/index.ts" }),
         "vite.config.server.ts": viteServerConfig({ server: "src/server.ts" }),
         ".gitignore": GITIGNORE,
+        ".dntrignore": DNTRIGNORE,
         "src/index.ts": mcpEntry(ctx),
         "src/server.ts": mcpServer(ctx),
       };
@@ -394,6 +410,7 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
         }),
         "vite.config.server.ts": viteServerConfig({ server: "src/server.ts" }),
         ".gitignore": GITIGNORE,
+        ".dntrignore": DNTRIGNORE,
         "src/index.ts": commandEntry(ctx),
         "src/panel.tsx": panelComponent(ctx),
         "src/server.ts": mcpServer(ctx),

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -34,9 +34,17 @@
     "prepare": "tsup"
   },
   "peerDependencies": {
+    "react": "^19.0.0",
     "zod": "^4.0.0"
   },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@types/react": "^19.0.0",
+    "react": "^19.2.1",
     "tsup": "^8.5.0",
     "zod": "^4.3.6"
   }

--- a/packages/plugin-sdk/src/__tests__/declaredDependencies.test.ts
+++ b/packages/plugin-sdk/src/__tests__/declaredDependencies.test.ts
@@ -54,9 +54,14 @@ async function sourceFiles(dir: string): Promise<string[]> {
  * package must be declared, because tsup externalizes exactly the declared
  * `dependencies` + `peerDependencies` and silently *inlines* everything else.
  * React was undeclared, so the whole runtime got bundled into `dist/react.js`
- * and panels shipped a second React copy. This catches the next one generically
- * — add an import of `react-dom` (or anything else) without declaring it and
- * this fails, rather than the regression surfacing as a bundle-size surprise.
+ * and panels shipped a second React copy.
+ *
+ * Scope is deliberately narrow: direct imports in this package's own `.ts`
+ * sources, matched by regex rather than parsed. It's the fast, readable half of
+ * the guard and it names the offending file. The exhaustive half — anything
+ * bundled transitively, including through the `shared/` code the entries
+ * re-export — is asserted against the real build's esbuild metafile in
+ * `reactExternal.test.ts`, which needs no parser and cannot be fooled.
  */
 describe("@daintreehq/plugin-sdk — every imported package is declared", () => {
   it("imports no npm package that is missing from dependencies or peerDependencies", async () => {

--- a/packages/plugin-sdk/src/__tests__/declaredDependencies.test.ts
+++ b/packages/plugin-sdk/src/__tests__/declaredDependencies.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const sdkDir = path.resolve(here, "../..");
+
+/** Every `from "..."` / `import("...")` specifier in a source file. */
+function importSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  // Static `import ... from "x"` and `export ... from "x"`, plus bare
+  // `import "x"` side-effect imports and dynamic `import("x")`.
+  const patterns = [
+    /\bfrom\s*["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\bimport\s+["']([^"']+)["']/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+/**
+ * The npm package a specifier resolves to, or null when it isn't a package at
+ * all (relative path, Node builtin, absolute). Scoped names keep two segments.
+ */
+function packageName(specifier: string): string | null {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return null;
+  if (specifier.startsWith("node:")) return null;
+  const segments = specifier.split("/");
+  const name = specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+  return name || null;
+}
+
+async function sourceFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") continue;
+      files.push(...(await sourceFiles(full)));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Guards the invariant behind #11296: anything the SDK imports from an npm
+ * package must be declared, because tsup externalizes exactly the declared
+ * `dependencies` + `peerDependencies` and silently *inlines* everything else.
+ * React was undeclared, so the whole runtime got bundled into `dist/react.js`
+ * and panels shipped a second React copy. This catches the next one generically
+ * — add an import of `react-dom` (or anything else) without declaring it and
+ * this fails, rather than the regression surfacing as a bundle-size surprise.
+ */
+describe("@daintreehq/plugin-sdk — every imported package is declared", () => {
+  it("imports no npm package that is missing from dependencies or peerDependencies", async () => {
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(sdkDir, "package.json"), "utf8")
+    ) as Record<string, Record<string, string> | undefined>;
+    const declared = new Set([
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {}),
+    ]);
+
+    const files = await sourceFiles(path.join(sdkDir, "src"));
+    expect(files.length).toBeGreaterThan(0);
+
+    const undeclared = new Map<string, string[]>();
+    for (const file of files) {
+      const source = await fs.readFile(file, "utf8");
+      for (const specifier of importSpecifiers(source)) {
+        const pkg = packageName(specifier);
+        if (!pkg || declared.has(pkg)) continue;
+        const rel = path.relative(sdkDir, file);
+        undeclared.set(pkg, [...(undeclared.get(pkg) ?? []), rel]);
+      }
+    }
+
+    expect(
+      Object.fromEntries(undeclared),
+      "undeclared packages would be bundled into the SDK output"
+    ).toEqual({});
+  });
+});

--- a/packages/plugin-sdk/src/__tests__/reactExternal.test.ts
+++ b/packages/plugin-sdk/src/__tests__/reactExternal.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build, type RollupOutput } from "vite";
+import { daintreePlugin } from "../../../plugin-vite/src/index.js";
+
+const execFileAsync = promisify(execFile);
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const sdkDir = path.resolve(here, "../..");
+const repoRoot = path.resolve(sdkDir, "../..");
+
+/**
+ * Strings that only appear in a real React implementation. React 19 ships both
+ * in its development *and* production builds, so a bundle that inlined either
+ * one trips these — which matters because `process.env.NODE_ENV` is undefined
+ * in a browser panel bundle, making the development build the one that would
+ * actually have shipped.
+ */
+const REACT_IMPLEMENTATION_MARKERS = [
+  "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE",
+  "react.transitional.element",
+];
+
+interface EsbuildMetafile {
+  inputs: Record<string, unknown>;
+  outputs: Record<string, { imports?: Array<{ path: string; external?: boolean }> }>;
+}
+
+let sdkOutDir: string;
+let metafile: EsbuildMetafile;
+
+/**
+ * Build the SDK exactly as `npm run build` would — its own `tsup.config.ts`,
+ * from its own directory. The `cwd` is load-bearing rather than incidental:
+ * tsup derives its externals from the `package.json` at `process.cwd()` and
+ * exposes no `cwd` option, so running this from the repo root would resolve the
+ * *root* manifest, auto-externalize React from there, and pass even if
+ * `packages/plugin-sdk/package.json` had lost its React peer entirely.
+ *
+ * Declarations are skipped (`--no-dts`) because this asserts on the JS bundle;
+ * the dts pipeline is covered by the package's own build in CI.
+ */
+beforeAll(async () => {
+  sdkOutDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-sdk-build-"));
+  await execFileAsync(
+    process.execPath,
+    [
+      path.join(repoRoot, "node_modules/tsup/dist/cli-default.js"),
+      "--out-dir",
+      sdkOutDir,
+      "--metafile",
+      "--no-dts",
+      "--silent",
+    ],
+    { cwd: sdkDir }
+  );
+  metafile = JSON.parse(
+    await fs.readFile(path.join(sdkOutDir, "metafile-esm.json"), "utf8")
+  ) as EsbuildMetafile;
+}, 120_000);
+
+afterAll(async () => {
+  await fs.rm(sdkOutDir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe("@daintreehq/plugin-sdk/react — React stays external", () => {
+  it("pulls no React source into the SDK bundle", () => {
+    const reactInputs = Object.keys(metafile.inputs).filter((input) =>
+      /(^|[/\\])node_modules[/\\]react(-dom)?[/\\]/.test(input)
+    );
+    expect(reactInputs).toEqual([]);
+  });
+
+  it("emits react as an external import of the react entry", () => {
+    const [, reactEntry] =
+      Object.entries(metafile.outputs).find(([out]) => out.endsWith("react.js")) ?? [];
+    expect(reactEntry, "tsup emitted no react.js entry").toBeDefined();
+
+    const reactImports = (reactEntry?.imports ?? []).filter((i) => i.path === "react");
+    expect(reactImports.length).toBeGreaterThan(0);
+    // Every one of them must be external — a single bundled copy is the bug.
+    expect(reactImports.every((i) => i.external === true)).toBe(true);
+  });
+
+  it("ships no React implementation in the emitted entry", async () => {
+    const code = await fs.readFile(path.join(sdkOutDir, "react.js"), "utf8");
+    for (const marker of REACT_IMPLEMENTATION_MARKERS) {
+      expect(code).not.toContain(marker);
+    }
+  });
+});
+
+/**
+ * The consumer half of the contract. The SDK keeping React external only helps
+ * if a plugin author's own build preserves that — so this builds a fixture
+ * panel through the real `@daintreehq/plugin-vite` preset against the real SDK
+ * output and checks React never lands in the final bundle. Together with the
+ * assertions above this covers both sides of the duplicate-React hazard: the
+ * host serves one React instance through its import map, and a second copy
+ * reaching a panel is what produces `Invalid hook call` (#11296).
+ */
+describe("consumer panel build — React never reaches the bundle", () => {
+  let fixtureDir: string;
+  let chunk: { code: string; imports: string[]; modules: Record<string, unknown> };
+
+  beforeAll(async () => {
+    fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-panel-fixture-"));
+    await fs.writeFile(
+      path.join(fixtureDir, "panel.js"),
+      // Importing the hook is the whole point — it is the SDK export with a
+      // real React dependency behind it.
+      'import { useHostChannel } from "@daintreehq/plugin-sdk/react";\nexport { useHostChannel };\n'
+    );
+
+    const result = await build({
+      root: fixtureDir,
+      logLevel: "silent",
+      plugins: [daintreePlugin()],
+      resolve: {
+        // Stand in for the workspace resolution a real plugin gets from its
+        // own node_modules, pointed at the build produced above.
+        alias: { "@daintreehq/plugin-sdk/react": path.join(sdkOutDir, "react.js") },
+      },
+      build: {
+        lib: { entry: { panel: path.join(fixtureDir, "panel.js") }, formats: ["es"] },
+        // Kept in memory: the assertions read the rollup output directly, so
+        // nothing needs to touch disk.
+        write: false,
+        minify: false,
+      },
+    });
+
+    // Vite 8 resolves `build()` to one RollupOutput per build environment, so
+    // the result is an array even for this single-target fixture.
+    const outputs = (Array.isArray(result) ? result : [result]) as RollupOutput[];
+    const entry = outputs.flatMap((o) => o.output).find((o) => o.type === "chunk" && o.isEntry);
+    if (!entry || entry.type !== "chunk") throw new Error("fixture build emitted no entry chunk");
+    chunk = { code: entry.code, imports: entry.imports, modules: entry.modules };
+  }, 120_000);
+
+  afterAll(async () => {
+    await fs.rm(fixtureDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("leaves react as a bare external import", () => {
+    expect(chunk.imports).toContain("react");
+  });
+
+  it("bundles no module from the React package", () => {
+    const reactModules = Object.keys(chunk.modules).filter((id) =>
+      /(^|[/\\])node_modules[/\\]react(-dom)?[/\\]/.test(id)
+    );
+    expect(reactModules).toEqual([]);
+  });
+
+  it("ships no React implementation in the panel bundle", () => {
+    for (const marker of REACT_IMPLEMENTATION_MARKERS) {
+      expect(chunk.code).not.toContain(marker);
+    }
+  });
+});

--- a/packages/plugin-sdk/src/__tests__/reactExternal.test.ts
+++ b/packages/plugin-sdk/src/__tests__/reactExternal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
 import { promisify } from "node:util";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -47,17 +48,19 @@ let metafile: EsbuildMetafile;
  */
 beforeAll(async () => {
   sdkOutDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-sdk-build-"));
+  // Resolved rather than hard-coded to `<root>/node_modules/...` so a nested or
+  // deduped install still finds the CLI next to tsup's own entry point.
+  const tsupCli = path.join(
+    path.dirname(createRequire(import.meta.url).resolve("tsup")),
+    "cli-default.js"
+  );
   await execFileAsync(
     process.execPath,
-    [
-      path.join(repoRoot, "node_modules/tsup/dist/cli-default.js"),
-      "--out-dir",
-      sdkOutDir,
-      "--metafile",
-      "--no-dts",
-      "--silent",
-    ],
-    { cwd: sdkDir }
+    [tsupCli, "--out-dir", sdkOutDir, "--metafile", "--no-dts", "--silent"],
+    // Shorter than the hook budget below: a vitest hook timeout does not kill
+    // the child, so without this a hung build outlives the hook and races the
+    // afterAll cleanup.
+    { cwd: sdkDir, timeout: 90_000 }
   );
   metafile = JSON.parse(
     await fs.readFile(path.join(sdkOutDir, "metafile-esm.json"), "utf8")
@@ -74,6 +77,18 @@ describe("@daintreehq/plugin-sdk/react — React stays external", () => {
       /(^|[/\\])node_modules[/\\]react(-dom)?[/\\]/.test(input)
     );
     expect(reactInputs).toEqual([]);
+  });
+
+  it("bundles nothing from node_modules at all", () => {
+    // Transitive and parser-free: every declared dependency is externalized, so
+    // any npm package appearing as a build input means something reachable from
+    // an entry — including through `shared/`, which the entries re-export —
+    // pulled in an undeclared package and got inlined. React was the first such
+    // case; this catches the next one without following imports by hand.
+    const bundledPackages = Object.keys(metafile.inputs).filter((input) =>
+      /(^|[/\\])node_modules[/\\]/.test(input)
+    );
+    expect(bundledPackages).toEqual([]);
   });
 
   it("emits react as an external import of the react entry", () => {
@@ -117,15 +132,37 @@ describe("consumer panel build — React never reaches the bundle", () => {
       'import { useHostChannel } from "@daintreehq/plugin-sdk/react";\nexport { useHostChannel };\n'
     );
 
+    // A real node_modules layout rather than a `resolve.alias`. Two reasons:
+    // it's what a plugin author actually has, and — the load-bearing one — the
+    // SDK's own bare `react` import resolves relative to *the SDK's* location,
+    // so an aliased copy sitting in a bare temp dir could never resolve React
+    // at all. The build would then fail on an unresolved import instead of
+    // bundling React, and the assertions below could never go red for the
+    // reason they exist.
+    const sdkPkgDir = path.join(fixtureDir, "node_modules/@daintreehq/plugin-sdk");
+    await fs.mkdir(sdkPkgDir, { recursive: true });
+    await fs.cp(sdkOutDir, path.join(sdkPkgDir, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(sdkPkgDir, "package.json"),
+      JSON.stringify({
+        name: "@daintreehq/plugin-sdk",
+        version: "0.0.0-fixture",
+        type: "module",
+        exports: { "./react": "./dist/react.js" },
+      })
+    );
+    // Real React, so a regression bundles the genuine runtime (markers and all)
+    // rather than a stub that would slip past the marker assertions.
+    await fs.symlink(
+      path.join(repoRoot, "node_modules/react"),
+      path.join(fixtureDir, "node_modules/react"),
+      process.platform === "win32" ? "junction" : undefined
+    );
+
     const result = await build({
       root: fixtureDir,
       logLevel: "silent",
       plugins: [daintreePlugin()],
-      resolve: {
-        // Stand in for the workspace resolution a real plugin gets from its
-        // own node_modules, pointed at the build produced above.
-        alias: { "@daintreehq/plugin-sdk/react": path.join(sdkOutDir, "react.js") },
-      },
       build: {
         lib: { entry: { panel: path.join(fixtureDir, "panel.js") }, formats: ["es"] },
         // Kept in memory: the assertions read the rollup output directly, so

--- a/packages/plugin-sdk/src/__tests__/reactExternal.test.ts
+++ b/packages/plugin-sdk/src/__tests__/reactExternal.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { build, type RollupOutput } from "vite";
+import { build } from "vite";
 import { daintreePlugin } from "../../../plugin-vite/src/index.js";
 
 const execFileAsync = promisify(execFile);
@@ -135,10 +135,13 @@ describe("consumer panel build — React never reaches the bundle", () => {
       },
     });
 
-    // Vite 8 resolves `build()` to one RollupOutput per build environment, so
-    // the result is an array even for this single-target fixture.
-    const outputs = (Array.isArray(result) ? result : [result]) as RollupOutput[];
-    const entry = outputs.flatMap((o) => o.output).find((o) => o.type === "chunk" && o.isEntry);
+    // Vite 8 resolves `build()` to one bundle per build environment, so the
+    // result is an array even for this single-target fixture. The `"output" in`
+    // guard also discards the watcher arm of the return union.
+    const bundles = Array.isArray(result) ? result : [result];
+    const entry = bundles
+      .flatMap((bundle) => ("output" in bundle ? bundle.output : []))
+      .find((out) => out.type === "chunk" && out.isEntry);
     if (!entry || entry.type !== "chunk") throw new Error("fixture build emitted no entry chunk");
     chunk = { code: entry.code, imports: entry.imports, modules: entry.modules };
   }, 120_000);

--- a/packages/plugin-sdk/tsup.config.ts
+++ b/packages/plugin-sdk/tsup.config.ts
@@ -8,25 +8,42 @@ export default defineConfig({
   format: ["esm"],
   target: "node22",
   platform: "node",
-  // Types-only barrel: the entries re-export with `export type *`, so the
-  // emitted `dist/*.js` are effectively empty and the `dist/*.d.ts` carry the
-  // whole surface. `resolve: true` follows the re-export chain into
-  // `shared/types/*.ts` and inlines those internal types into the published
-  // declarations — without it the `.d.ts` would point at `../../shared/...`
-  // paths that don't exist in a consumer's node_modules. `ignoreDeprecations:
-  // "6.0"` is scoped to the dts pipeline only: tsup's dts bundler
-  // (rollup-plugin-dts) injects a deprecated `baseUrl` that trips TS5101 under
-  // TypeScript 6. The package's `tsconfig.json` (used by `typecheck`) stays
-  // clean. Mirrors `packages/daintree-plugin/tsup.config.ts`.
+  // The `index` entry is a near types-only barrel (`export type *` plus a
+  // handful of explicit runtime const re-exports), but `react` is NOT: it ships
+  // real hook implementations, so `dist/react.js` carries actual code and the
+  // externals below are load-bearing rather than cosmetic.
+  //
+  // `resolve: true` follows the re-export chain into `shared/types/*.ts` and
+  // inlines those internal types into the published declarations — without it
+  // the `.d.ts` would point at `../../shared/...` paths that don't exist in a
+  // consumer's node_modules. `ignoreDeprecations: "6.0"` is scoped to the dts
+  // pipeline only: tsup's dts bundler (rollup-plugin-dts) injects a deprecated
+  // `baseUrl` that trips TS5101 under TypeScript 6. The package's
+  // `tsconfig.json` (used by `typecheck`) stays clean. Mirrors
+  // `packages/daintree-plugin/tsup.config.ts`.
   dts: {
     resolve: true,
     compilerOptions: { ignoreDeprecations: "6.0" },
   },
   clean: true,
-  // `PluginChannelSchema` is public surface typed as `z.ZodType<T>`. Without
-  // keeping zod external, the dts bundler inlines zod's CJS runtime and mangles
-  // the qualified `z.ZodType` reference into invalid `undefined<T>` syntax.
-  // Externalizing it emits a clean `import type { z } from "zod"` — zod is a
-  // peer dependency plugin authors already have for authoring schemas.
-  external: ["zod"],
+  // Both entries here are also `peerDependencies`, which tsup already
+  // auto-externalizes (as `^name($|/|\\)` regexes, so subpaths like
+  // `react/jsx-runtime` are covered too). Listing them again is documentation,
+  // not mechanism — the peer declaration in `package.json` is what actually
+  // keeps them out of the bundle, for the esbuild JS pass and the dts pass
+  // alike. Removing them from `peerDependencies` would silently re-inline them.
+  //
+  // `zod`: `PluginChannelSchema` is public surface typed as `z.ZodType<T>`.
+  // Without keeping zod external, the dts bundler inlines zod's CJS runtime and
+  // mangles the qualified `z.ZodType` reference into invalid `undefined<T>`
+  // syntax. Externalizing it emits a clean `import type { z } from "zod"`.
+  //
+  // `react`: the `react` entry's hooks import `useState`/`useEffect`/etc. for
+  // real. Bundling React here would inline a *second* React copy (and, since
+  // `process.env.NODE_ENV` is undefined in a browser panel bundle, the
+  // development build) alongside the host's own instance — plugin views resolve
+  // bare `react` to the host's single copy via the import map, so a bundled
+  // copy means two Reacts and `Invalid hook call` (#11296). This is the same
+  // contract `@daintreehq/plugin-vite` enforces on the consumer side.
+  external: ["zod", "react"],
 });

--- a/packages/plugin-sdk/tsup.config.ts
+++ b/packages/plugin-sdk/tsup.config.ts
@@ -26,12 +26,12 @@ export default defineConfig({
     compilerOptions: { ignoreDeprecations: "6.0" },
   },
   clean: true,
-  // Both entries here are also `peerDependencies`, which tsup already
-  // auto-externalizes (as `^name($|/|\\)` regexes, so subpaths like
-  // `react/jsx-runtime` are covered too). Listing them again is documentation,
-  // not mechanism — the peer declaration in `package.json` is what actually
-  // keeps them out of the bundle, for the esbuild JS pass and the dts pass
-  // alike. Removing them from `peerDependencies` would silently re-inline them.
+  // Both entries here are also `peerDependencies`, which tsup auto-externalizes
+  // on its own (as `^name($|/|\\)` regexes, so subpaths like
+  // `react/jsx-runtime` are covered without listing them). The two mechanisms
+  // are redundant on purpose: the peer declaration is the consumer-facing
+  // contract and the regex form that catches subpaths, while this list states
+  // the intent at the build config and holds even if the manifest is edited.
   //
   // `zod`: `PluginChannelSchema` is public surface typed as `z.ZodType<T>`.
   // Without keeping zod external, the dts bundler inlines zod's CJS runtime and


### PR DESCRIPTION
## Summary

Issue #11296 identified four gaps in the plugin authoring toolchain, all found by an external developer building two real plugins against Daintree 0.27 and 0.28. This PR fixes the first three. The fourth (publishing the five authoring packages: `@daintreehq/plugin-sdk`, `plugin-testing`, `plugin-vite`, `daintree-plugin`, `create-daintree-plugin` to npm) is maintainer infrastructure, not a code change. It needs OIDC trusted publishing registered and a package tag pushed, so it stays open on the issue.

Resolves #11296

## Changes

**1. React 19 was getting bundled into the SDK.** `packages/plugin-sdk/tsup.config.ts` only externalized `zod`. React was neither a dependency nor a peerDependency of the package, so `tsup` inlined the entire React 19 runtime into `dist/react.js`. Because `process.env.NODE_ENV` is undefined in a browser panel bundle, the development build is what actually shipped. Consumers already keep their own bare `react` import external via the `@daintreehq/plugin-vite` preset, so a panel importing one SDK hook ended up loading two copies of React, exactly the `Invalid hook call` hazard that preset exists to prevent.

`react` is now an optional peerDependency in `packages/plugin-sdk/package.json`, mirroring `@daintreehq/plugin-vite` which already declares it that way, and that's what makes `tsup` externalize it. It's externalized via the regex `^react($|/|\)` so `react/jsx-runtime` and similar subpaths are covered too. `dist/react.js` went from inlining the full runtime to 2,333 bytes with two bare `react` imports. `react-dom` is deliberately not declared: nothing in the SDK imports it. The stale "types-only barrel" comment on the react entry is also corrected, since it ships real runtime exports.

**2. `dev` only watched the default Vite config.** `daintree-plugin dev` built and watched only the default Vite config, so worker source files never rebuilt. The root cause is worse than the issue described: Vite 8's internal `prepareOutDirPlugin` drops the build environment from its `rendered` tracking set on every `watchChange` event, so `outDir` gets re-emptied on every incremental rebuild, not just the first. With two watchers sharing one `dist/`, they continuously delete each other's output.

`dev` and `package` now resolve a build plan up front. One-shot builds run the default config and the server config in sequence (the default pass cleans, the server pass appends); watch mode runs both together with `--no-emptyOutDir`, Vite's cac-negated form of `--emptyOutDir`. It doesn't appear in `vite build --help`, but it does reach `build.emptyOutDir = false`, fixing already-scaffolded plugins without touching an author's committed config. It's only applied in the dual-config case, so a single-config project still gets its stale chunks swept normally. `package` had the identical bug (it also only built the default config), so an MCP-server scaffold could ship a stale `dist/server.js`. Fixed too.

**3. No package-specific ignore file.** `package` selected archive contents from `.gitignore` plus a hardcoded exclusion list, so developer docs leaked into the distributed archive unless the author manually staged a clean directory first.

A root `.dntrignore` (`.gitignore` syntax) now prunes both the gitignore-aware file set and the protected build-output set, so it can reach and exclude stray files inside `dist/`, something the old exclusion list couldn't do. It's strictly subtractive by design: evaluated in its own pass and intersected with the existing rules, rather than folded into one ordered rule list, because a negation in either file could otherwise cancel an exclusion from the other (a `.gitignore` of `*.md` plus `!README.md` could re-include a file `.dntrignore` had excluded). Since excluding a needed file is now easy to do for the first time, `package` also validates up front, before writing anything, that every manifest-referenced path exists on disk: the main entry file, each view's `componentPath`, and skill paths (previously unvalidated anywhere). This fails with a named error and runs during `--dry-run` too. The scaffold gains a commented starter `.dntrignore`, and the file is always excluded from produced archives.

## Testing

Added the consumer-build regression test the issue asked for. It runs the real `tsup` build in a child process with the working directory pinned to the plugin-sdk package, since `tsup` reads its externals list from `process.cwd()` and has no separate working-directory option; running from the monorepo root would resolve the root manifest and falsely pass even with the peerDependency fix reverted. It asserts, via the esbuild metafile, that nothing from `node_modules` is bundled, then builds a fixture plugin panel through the real `@daintreehq/plugin-vite` preset against a real fixture `node_modules` layout and asserts React stays external there too.

Verified red before green: reverting the fix fails 6 assertions, and removing just the consumer-side externalization fails 3 more.

## Non-goal

The signal handlers in `dev.ts` are still installed after the plugin's symlink and marker file are written to disk. A Ctrl-C during a narrow window early in startup can strand the dev marker file without cleaning it up. Pre-existing, unchanged by this PR, and probably worth its own issue rather than fixing here.
