### PR TITLE
feat(plugin): gate empty detail tabs, list contributions, and report install progress

### DIFF
--- a/e2e/full/plugins/core-plugin-manager.spec.ts
+++ b/e2e/full/plugins/core-plugin-manager.spec.ts
@@ -78,13 +78,11 @@ test.describe.serial("Core: Plugin manager view", () => {
     await expect(detailHeading).toBeVisible({ timeout: T_MEDIUM });
     await expect(detailHeading.locator("..").getByText("v0.1.0")).toBeVisible();
 
-    // Permissions tab: hello-daintree declares no capabilities.
-    await window.locator(SEL.plugin.tabPermissions).click();
-    await expect(window.locator(SEL.plugin.tabPermissions)).toHaveAttribute(
-      "aria-selected",
-      "true"
-    );
-    await expect(window.getByText("No special permissions")).toBeVisible({ timeout: T_SHORT });
+    // hello-daintree declares no capabilities and no settings, so Overview is
+    // the only tab it earns (#11302) — three near-empty tabs used to make a
+    // successful install read as half-finished.
+    await expect(window.locator(SEL.plugin.tabPermissions)).toHaveCount(0, { timeout: T_SHORT });
+    await expect(window.locator(SEL.plugin.tabSettings)).toHaveCount(0);
 
     await closePluginManager(window);
   });

--- a/e2e/full/plugins/core-plugin-permissions.spec.ts
+++ b/e2e/full/plugins/core-plugin-permissions.spec.ts
@@ -68,7 +68,7 @@ test.describe.serial("Core: Plugin permissions tab", () => {
     await closePluginManager(window);
   });
 
-  test("still reads 'No special permissions' for the capability-free sample", async () => {
+  test("hides the Permissions tab entirely for the capability-free sample (#11302)", async () => {
     const { window } = ctx;
     await openPluginManager(window);
 
@@ -78,8 +78,11 @@ test.describe.serial("Core: Plugin permissions tab", () => {
       .first()
       .click();
 
-    await window.locator(SEL.plugin.tabPermissions).click();
-    await expect(window.getByText("No special permissions")).toBeVisible({ timeout: T_SHORT });
+    // Overview must be present so the pane isn't just failing to render.
+    await expect(window.locator(SEL.plugin.tabOverview)).toBeVisible({ timeout: T_SHORT });
+    // A tab whose whole content was "No special permissions" is now absent.
+    await expect(window.locator(SEL.plugin.tabPermissions)).toHaveCount(0);
+    await expect(window.getByText("No special permissions")).toHaveCount(0);
 
     // The danger banner must NOT appear for a plugin with no capabilities.
     await expect(

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -963,6 +963,10 @@ export const CHANNELS = {
   PLUGIN_SETTINGS_SET_VALUE: "plugin:settings-set-value",
   PLUGIN_SETTINGS_DELETE_VALUE: "plugin:settings-delete-value",
   PLUGIN_SETTINGS_REVEAL_SECRET: "plugin:settings-reveal-secret",
+  /** Cancel an in-flight plugin install by its job id (#11302). */
+  PLUGIN_CANCEL_INSTALL: "plugin:cancel-install",
+  /** Phase/entry progress for an in-flight install, targeted at the initiating window (#11302). */
+  PLUGIN_INSTALL_PROGRESS: "plugin:install-progress",
   /** Native folder/file chooser for plugin path/directory/file settings fields. */
   PLUGIN_PICK_PATH: "plugin:pick-path",
   /** Existence probe for a stored plugin `mustExist` path setting. */

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -95,6 +95,7 @@ vi.mock("electron", () => ({
 import { registerPluginHandlers } from "../plugin.js";
 import { _resetIpcGuardForTesting, markIpcSecurityReady } from "../../ipcGuard.js";
 import { PluginInvokeOwnershipError } from "../../../services/plugin/PluginInvokeErrors.js";
+import { pluginInstallJobs } from "../../../services/plugin/PluginInstallJobRegistry.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -437,7 +438,7 @@ describe("registerPluginHandlers", () => {
 
   it("PLUGIN_INSTALL_FROM_URL rejects an empty URL without claiming not-implemented", async () => {
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "  ");
+    const result = await handler({ sender: { id: 1 } }, "  ");
     expect(result).toEqual({ status: "invalid-url" });
   });
 
@@ -479,7 +480,7 @@ describe("registerPluginHandlers", () => {
       mockResponse({ headers: { "content-type": "application/zip" } })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/p.dntr");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/p.dntr");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
     expect(mockInstallPlugin).toHaveBeenCalledTimes(1);
     const [archivePath, opts] = mockInstallPlugin.mock.calls[0] as [string, unknown];
@@ -492,7 +493,7 @@ describe("registerPluginHandlers", () => {
       mockResponse({ headers: { "content-type": "application/x-dntr" } })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/download");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/download");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
   });
 
@@ -504,7 +505,7 @@ describe("registerPluginHandlers", () => {
     async (contentType) => {
       mockNetFetch.mockResolvedValue(mockResponse({ headers: { "content-type": contentType } }));
       const handler = getHandler("plugin:install-from-url");
-      const result = await handler({}, "https://example.com/download");
+      const result = await handler({ sender: { id: 1 } }, "https://example.com/download");
       expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
     }
   );
@@ -512,7 +513,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_URL falls back to the .dntr suffix for an unrecognised MIME", async () => {
     mockNetFetch.mockResolvedValue(mockResponse({ headers: { "content-type": "text/html" } }));
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/p.dntr");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/p.dntr");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
   });
 
@@ -521,7 +522,7 @@ describe("registerPluginHandlers", () => {
       mockResponse({ headers: { "content-type": "application/zip; charset=utf-8" } })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/download");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/download");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
   });
 
@@ -530,7 +531,7 @@ describe("registerPluginHandlers", () => {
       mockResponse({ headers: { "content-type": "application/zipper" } })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/download")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/download")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -544,7 +545,7 @@ describe("registerPluginHandlers", () => {
       mockResponse({ headers: { "content-type": "application/zip" }, body: null })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -562,7 +563,7 @@ describe("registerPluginHandlers", () => {
       })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/p.dntr");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/p.dntr");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
     // Writing the full 30 MB to a real temp file and hashing it back is slow on
     // Windows CI (disk + Defender), so this boundary case gets a wider timeout.
@@ -577,7 +578,7 @@ describe("registerPluginHandlers", () => {
       })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -589,7 +590,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_URL rejects an unknown MIME with no .dntr suffix", async () => {
     mockNetFetch.mockResolvedValue(mockResponse({ headers: { "content-type": "text/html" } }));
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/oops");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/oops");
     expect(result).toEqual({
       status: "failed",
       errors: [{ code: "content_type_rejected", message: expect.any(String) }],
@@ -600,7 +601,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_URL returns fetch_failed on a non-2xx response", async () => {
     mockNetFetch.mockResolvedValue(mockResponse({ ok: false, status: 404 }));
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -612,7 +613,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_URL returns fetch_failed on a network error", async () => {
     mockNetFetch.mockRejectedValue(new Error("ENOTFOUND"));
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -623,7 +624,7 @@ describe("registerPluginHandlers", () => {
   it("PLUGIN_INSTALL_FROM_URL returns fetch_timeout when the request aborts", async () => {
     mockNetFetch.mockRejectedValue(abortError("AbortError"));
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -641,7 +642,7 @@ describe("registerPluginHandlers", () => {
       })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -659,7 +660,7 @@ describe("registerPluginHandlers", () => {
       })
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -670,7 +671,7 @@ describe("registerPluginHandlers", () => {
 
   it("PLUGIN_INSTALL_FROM_URL rejects a non-http(s) scheme as invalid-url", async () => {
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "file:///etc/passwd");
+    const result = await handler({ sender: { id: 1 } }, "file:///etc/passwd");
     expect(result).toEqual({ status: "invalid-url" });
     expect(mockNetFetch).not.toHaveBeenCalled();
   });
@@ -684,7 +685,7 @@ describe("registerPluginHandlers", () => {
     "https://10.0.0.5/p.dntr",
   ])("PLUGIN_INSTALL_FROM_URL rejects private/loopback host %s as invalid-url", async (url) => {
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, url);
+    const result = await handler({ sender: { id: 1 } }, url);
     expect(result).toEqual({ status: "invalid-url" });
     expect(mockNetFetch).not.toHaveBeenCalled();
   });
@@ -697,7 +698,7 @@ describe("registerPluginHandlers", () => {
     "PLUGIN_INSTALL_FROM_URL rejects an embedded-credentials URL %s as invalid-url",
     async (url) => {
       const handler = getHandler("plugin:install-from-url");
-      const result = await handler({}, url);
+      const result = await handler({ sender: { id: 1 } }, url);
       expect(result).toEqual({ status: "invalid-url" });
       // Never fetched, so the credentials are never sent or persisted as
       // installer originalUrl provenance.
@@ -714,7 +715,7 @@ describe("registerPluginHandlers", () => {
       )
       .mockResolvedValueOnce(mockResponse({ headers: { "content-type": "application/zip" } }));
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/p.dntr");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/p.dntr");
     expect(result).toEqual({ status: "installed", pluginId: "acme.my-plugin" });
     expect(mockNetFetch).toHaveBeenCalledTimes(2);
     // Redirects are followed manually so each hop can be revalidated.
@@ -735,7 +736,7 @@ describe("registerPluginHandlers", () => {
         mockResponse({ status: 302, headers: { location: privateTarget } })
       );
       const handler = getHandler("plugin:install-from-url");
-      const result = (await handler({}, "https://example.com/p.dntr")) as {
+      const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
         status: string;
         errors: Array<{ code: string }>;
       };
@@ -755,7 +756,7 @@ describe("registerPluginHandlers", () => {
       )
     );
     const handler = getHandler("plugin:install-from-url");
-    const result = (await handler({}, "https://example.com/p.dntr")) as {
+    const result = (await handler({ sender: { id: 1 } }, "https://example.com/p.dntr")) as {
       status: string;
       errors: Array<{ code: string }>;
     };
@@ -773,7 +774,7 @@ describe("registerPluginHandlers", () => {
       errors: [{ code: "manifest_invalid", message: "bad manifest" }],
     });
     const handler = getHandler("plugin:install-from-url");
-    const result = await handler({}, "https://example.com/p.dntr");
+    const result = await handler({ sender: { id: 1 } }, "https://example.com/p.dntr");
     expect(result).toEqual({
       status: "failed",
       errors: [{ code: "manifest_invalid", message: "bad manifest" }],
@@ -782,7 +783,7 @@ describe("registerPluginHandlers", () => {
 
   it("PLUGIN_INSTALL_FROM_PATH rejects an empty path without touching the installer", async () => {
     const handler = getHandler("plugin:install-from-path");
-    const result = await handler({}, "");
+    const result = await handler({ sender: { id: 1 } }, "");
     expect(result).toEqual({
       status: "failed",
       errors: [{ code: "archive_invalid", message: expect.any(String) }],
@@ -792,14 +793,14 @@ describe("registerPluginHandlers", () => {
 
   it("PLUGIN_INSTALL_FROM_PATH rejects a relative path", async () => {
     const handler = getHandler("plugin:install-from-path");
-    const result = await handler({}, "relative/plugin.dntr");
+    const result = await handler({ sender: { id: 1 } }, "relative/plugin.dntr");
     expect(result).toMatchObject({ status: "failed", errors: [{ code: "archive_invalid" }] });
     expect(mockInstallPlugin).not.toHaveBeenCalled();
   });
 
   it("PLUGIN_INSTALL_FROM_PATH rejects a non-.dntr extension", async () => {
     const handler = getHandler("plugin:install-from-path");
-    const result = await handler({}, "/tmp/not-a-plugin.txt");
+    const result = await handler({ sender: { id: 1 } }, "/tmp/not-a-plugin.txt");
     expect(result).toEqual({
       status: "failed",
       errors: [{ code: "archive_invalid", message: "Only .dntr files can be installed" }],
@@ -809,7 +810,7 @@ describe("registerPluginHandlers", () => {
 
   it("PLUGIN_INSTALL_FROM_PATH fails when the file can't be read", async () => {
     const handler = getHandler("plugin:install-from-path");
-    const result = await handler({}, "/tmp/does-not-exist-9295.dntr");
+    const result = await handler({ sender: { id: 1 } }, "/tmp/does-not-exist-9295.dntr");
     expect(result).toMatchObject({ status: "failed", errors: [{ code: "archive_invalid" }] });
     expect(mockInstallPlugin).not.toHaveBeenCalled();
   });
@@ -819,7 +820,7 @@ describe("registerPluginHandlers", () => {
     await writeFile(file, Buffer.from("not a zip"));
     try {
       const handler = getHandler("plugin:install-from-path");
-      const result = await handler({}, file);
+      const result = await handler({ sender: { id: 1 } }, file);
       expect(result).toMatchObject({ status: "failed", errors: [{ code: "archive_invalid" }] });
       expect(mockInstallPlugin).not.toHaveBeenCalled();
     } finally {
@@ -834,7 +835,7 @@ describe("registerPluginHandlers", () => {
     mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.dropped" });
     try {
       const handler = getHandler("plugin:install-from-path");
-      const result = await handler({}, file);
+      const result = await handler({ sender: { id: 1 } }, file);
       expect(mockInstallPlugin).toHaveBeenCalledWith(file);
       expect(result).toEqual({ status: "installed", pluginId: "acme.dropped" });
     } finally {
@@ -848,7 +849,7 @@ describe("registerPluginHandlers", () => {
     mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.upper" });
     try {
       const handler = getHandler("plugin:install-from-path");
-      const result = await handler({}, file);
+      const result = await handler({ sender: { id: 1 } }, file);
       expect(mockInstallPlugin).toHaveBeenCalledWith(file);
       expect(result).toEqual({ status: "installed", pluginId: "acme.upper" });
     } finally {
@@ -2108,5 +2109,104 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// #11302: install progress + cancellation. The handler layer owns job
+// registration and the targeted progress push; the registry owns the state
+// machine (covered separately). These assert the seam between them.
+describe("plugin install jobs (#11302)", () => {
+  // Must be UUID-shaped: the handler rejects anything else before registering.
+  const JOB_ID = "3f1c9a20-7d44-4e1b-9c88-0a5b6d2e4f77";
+
+  function getHandler(channel: string) {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find((c: unknown[]) => c[0] === channel)![1] as (
+      ...args: unknown[]
+    ) => unknown;
+  }
+
+  afterEach(() => {
+    pluginInstallJobs.end(JOB_ID);
+  });
+
+  it("registers a cancel op alongside the install ops", () => {
+    registerPluginHandlers();
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:cancel-install", expect.any(Function));
+  });
+
+  it("threads the jobId into installPlugin so the installer can find its signal", async () => {
+    const file = join(tmpdir(), `plugin-job-${process.pid}.dntr`);
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.job" });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      await handler({ sender: { id: 1 } }, file, JOB_ID);
+      expect(mockInstallPlugin).toHaveBeenCalledWith(file, { jobId: JOB_ID });
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("registers the job for the duration of the install and drops it afterwards", async () => {
+    const file = join(tmpdir(), `plugin-job-live-${process.pid}.dntr`);
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    let signalDuringInstall: AbortSignal | undefined;
+    mockInstallPlugin.mockImplementation(() => {
+      signalDuringInstall = pluginInstallJobs.signal(JOB_ID);
+      return Promise.resolve({ status: "installed", pluginId: "acme.job" });
+    });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      await handler({ sender: { id: 1 } }, file, JOB_ID);
+      // Live while the install runs...
+      expect(signalDuringInstall).toBeDefined();
+      // ...and reaped by the handler's finally, so nothing leaks between installs.
+      expect(pluginInstallJobs.signal(JOB_ID)).toBeUndefined();
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("ignores a malformed jobId rather than registering it", async () => {
+    const file = join(tmpdir(), `plugin-job-bad-${process.pid}.dntr`);
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.job" });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      // Not UUID-shaped: a compromised renderer must not be able to push
+      // arbitrary strings into the registry or the progress payload.
+      await handler({ sender: { id: 1 } }, file, "../../etc/passwd");
+      expect(pluginInstallJobs.signal("../../etc/passwd")).toBeUndefined();
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("cancels a live job and reports it", async () => {
+    const file = join(tmpdir(), `plugin-job-cancel-${process.pid}.dntr`);
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    const cancel = getHandler("plugin:cancel-install");
+    let cancelResult: unknown;
+    mockInstallPlugin.mockImplementation(async () => {
+      cancelResult = await cancel({}, JOB_ID);
+      return { status: "cancelled" };
+    });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      const result = await handler({ sender: { id: 1 } }, file, JOB_ID);
+      expect(cancelResult).toBe(true);
+      expect(result).toEqual({ status: "cancelled" });
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("reports false for an unknown or already-finished job", async () => {
+    const cancel = getHandler("plugin:cancel-install");
+    // Nothing is in flight — the renderer must learn the cancel did nothing
+    // rather than see a button that silently no-ops.
+    expect(await cancel({}, "00000000-0000-4000-8000-000000000000")).toBe(false);
+    expect(await cancel({}, "not a job id")).toBe(false);
   });
 });

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -2171,13 +2171,52 @@ describe("plugin install jobs (#11302)", () => {
   it("ignores a malformed jobId rather than registering it", async () => {
     const file = join(tmpdir(), `plugin-job-bad-${process.pid}.dntr`);
     await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
-    mockInstallPlugin.mockResolvedValue({ status: "installed", pluginId: "acme.job" });
+    const BAD_ID = "../../etc/passwd";
+    // Inspect DURING the install: the wrapper's `finally` reaps the record
+    // either way, so checking after the handler returns would pass even if the
+    // malformed id had been accepted.
+    let registeredDuringInstall: AbortSignal | undefined;
+    let optsDuringInstall: unknown;
+    mockInstallPlugin.mockImplementation((_p: string, opts: unknown) => {
+      registeredDuringInstall = pluginInstallJobs.signal(BAD_ID);
+      optsDuringInstall = opts;
+      return Promise.resolve({ status: "installed", pluginId: "acme.job" });
+    });
     try {
       const handler = getHandler("plugin:install-from-path");
       // Not UUID-shaped: a compromised renderer must not be able to push
       // arbitrary strings into the registry or the progress payload.
-      await handler({ sender: { id: 1 } }, file, "../../etc/passwd");
-      expect(pluginInstallJobs.signal("../../etc/passwd")).toBeUndefined();
+      await handler({ sender: { id: 1 } }, file, BAD_ID);
+      expect(registeredDuringInstall).toBeUndefined();
+      // ...and the rejected id must not reach the installer either.
+      expect(optsDuringInstall).toBeUndefined();
+    } finally {
+      await rm(file, { force: true });
+    }
+  });
+
+  it("installs without a job rather than joining an id another install already owns", async () => {
+    // Two installs under one id would share a controller and an emitter:
+    // cancelling one would abort the other, either could commit the other's
+    // record, and progress would be pushed to the wrong window. The second must
+    // therefore run detached — no progress — rather than latch onto the first.
+    const file = join(tmpdir(), `plugin-job-dup-${process.pid}.dntr`);
+    await writeFile(file, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    const firstEmit = vi.fn();
+    pluginInstallJobs.begin(JOB_ID, firstEmit);
+    let optsDuringInstall: unknown = "unset";
+    mockInstallPlugin.mockImplementation((_p: string, opts: unknown) => {
+      optsDuringInstall = opts;
+      return Promise.resolve({ status: "installed", pluginId: "acme.job" });
+    });
+    try {
+      const handler = getHandler("plugin:install-from-path");
+      await handler({ sender: { id: 1 } }, file, JOB_ID);
+      expect(optsDuringInstall).toBeUndefined();
+      // The pre-existing owner's emitter never saw the interloper's progress.
+      expect(firstEmit).not.toHaveBeenCalled();
+      // ...and its job survived the second install's teardown.
+      expect(pluginInstallJobs.signal(JOB_ID)).toBeDefined();
     } finally {
       await rm(file, { force: true });
     }

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -12,6 +12,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   installFromFile: "plugin:install-from-file",
   installFromPath: "plugin:install-from-path",
   installFromUrl: "plugin:install-from-url",
+  cancelInstall: "plugin:cancel-install",
   uninstall: "plugin:uninstall",
   checkForUpdate: "plugin:check-for-update",
   toolbarButtons: "plugin:toolbar-buttons",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -47,6 +47,8 @@ import {
   type PanelKindConfig,
 } from "../../../shared/config/panelKindRegistry.js";
 import { isPluginInvokeOwnershipError } from "../../services/plugin/PluginInvokeErrors.js";
+import { pluginInstallJobs } from "../../services/plugin/PluginInstallJobRegistry.js";
+import { sendToRendererContext } from "../utils.js";
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
 import { getPluginKeybindings } from "../../services/pluginKeybindingRegistry.js";
 import { getPluginContextMenuItems } from "../../services/pluginContextMenuRegistry.js";
@@ -181,12 +183,61 @@ async function handleInstall(
   return (await getPluginService()).installPlugin(archivePath, opts);
 }
 
+// Job ids are renderer-minted UUIDs used only as a correlation key. Bound the
+// shape so a hostile renderer can't push unbounded strings into the registry or
+// into the log line that echoes the id.
+const INSTALL_JOB_ID_PATTERN = /^[0-9a-fA-F-]{8,64}$/;
+
+/**
+ * Run an install under an optional progress/cancellation job (#11302).
+ *
+ * Registration lives here rather than in the install handlers themselves so the
+ * exported `handleInstallFromPath` / `handleInstallFromUrl` keep their plain
+ * signatures for the CLI server (`PluginCliServer.ts`), which installs with no
+ * renderer to report to. Progress is targeted at the initiating window: a
+ * background install in another project view must not paint this one's UI.
+ *
+ * The `finally` is the only place a record is dropped — cancellation merely
+ * aborts the signal, and the install's own `finally` still owns the staging
+ * directory and the install lock.
+ */
+async function withInstallJob(
+  ctx: IpcContext,
+  jobId: string | undefined,
+  run: () => Promise<PluginInstallResult>
+): Promise<PluginInstallResult> {
+  if (!jobId || !INSTALL_JOB_ID_PATTERN.test(jobId)) return run();
+  const registered = pluginInstallJobs.begin(jobId, (event) => {
+    sendToRendererContext(ctx, CHANNELS.PLUGIN_INSTALL_PROGRESS, event);
+  });
+  if (!registered) return run();
+  try {
+    return await run();
+  } finally {
+    pluginInstallJobs.end(jobId);
+  }
+}
+
+/**
+ * Abort an in-flight install. Returns false when the job is unknown (already
+ * finished, or never existed) or has passed the commit point — the renderer
+ * surfaces that as "too late" rather than leaving a Cancel button that silently
+ * does nothing.
+ */
+function handleCancelInstall(jobId: string): boolean {
+  if (typeof jobId !== "string" || !INSTALL_JOB_ID_PATTERN.test(jobId)) return false;
+  return pluginInstallJobs.cancel(jobId);
+}
+
 // Install-from-file owns the native-picker entry point; the selected path runs
 // the SAME trust gate + installer as the drag-and-drop path
 // ({@link handleInstallFromPath}) so both renderer entries validate identically.
 // A dismissed picker resolves `cancelled`; validation failures come back as
 // structured `{ status: "failed" }` data the dialog can render inline.
-async function handleInstallFromFile(ctx: IpcContext): Promise<PluginInstallResult> {
+async function handleInstallFromFile(
+  ctx: IpcContext,
+  jobId?: string
+): Promise<PluginInstallResult> {
   const win = ctx.senderWindow ?? BrowserWindow.getFocusedWindow();
   const dialogOptions = {
     title: "Install plugin",
@@ -199,7 +250,9 @@ async function handleInstallFromFile(ctx: IpcContext): Promise<PluginInstallResu
   if (result.canceled || result.filePaths.length === 0) {
     return { status: "cancelled" };
   }
-  return handleInstallFromPath(result.filePaths[0]!);
+  // The job starts once a path exists — time spent in the native picker isn't
+  // install progress, and a Cancel button for it would duplicate the picker's own.
+  return withInstallJob(ctx, jobId, () => handleInstallFromPath(result.filePaths[0]!, jobId));
 }
 
 // Bounded download limits for install-from-URL (F24). Mirrors the spec in
@@ -229,7 +282,10 @@ function isAbortLikeError(err: unknown): boolean {
  * `{ status: "failed" }` data (never thrown) so the tab can render an inline
  * message.
  */
-export async function handleInstallFromPath(path: string): Promise<PluginInstallResult> {
+export async function handleInstallFromPath(
+  path: string,
+  jobId?: string
+): Promise<PluginInstallResult> {
   const invalid = await validateDntrArchivePath(path);
   if (invalid) return invalid;
   const service = await getPluginService();
@@ -238,7 +294,27 @@ export async function handleInstallFromPath(path: string): Promise<PluginInstall
   // its startup sweep deletes staging directories and the kill-switch blocklist
   // is still unset. Wait it out — a no-op once init has settled.
   await service.waitForInit();
-  return service.installPlugin(path);
+  // Call through with a single argument when there is no job, so the installer
+  // sees exactly the same shape it always did.
+  return jobId === undefined ? service.installPlugin(path) : service.installPlugin(path, { jobId });
+}
+
+/** Namespace entry for install-from-path — registers the job, then delegates. */
+async function handleInstallFromPathOp(
+  ctx: IpcContext,
+  path: string,
+  jobId?: string
+): Promise<PluginInstallResult> {
+  return withInstallJob(ctx, jobId, () => handleInstallFromPath(path, jobId));
+}
+
+/** Namespace entry for install-from-URL — registers the job, then delegates. */
+async function handleInstallFromUrlOp(
+  ctx: IpcContext,
+  url: string,
+  jobId?: string
+): Promise<PluginInstallResult> {
+  return withInstallJob(ctx, jobId, () => handleInstallFromUrl(url, jobId));
 }
 
 /**
@@ -256,7 +332,10 @@ export async function handleInstallFromPath(path: string): Promise<PluginInstall
  * (PluginService extracts into its own temp dir and doesn't take ownership of
  * the download artifact).
  */
-export async function handleInstallFromUrl(url: string): Promise<PluginInstallResult> {
+export async function handleInstallFromUrl(
+  url: string,
+  jobId?: string
+): Promise<PluginInstallResult> {
   if (typeof url !== "string" || url.trim().length === 0) {
     return { status: "invalid-url" };
   }
@@ -295,10 +374,18 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
   let sizeAborted = false;
   let wroteTempFile = false;
 
+  // The user's cancel joins the size cap and the download deadline on the same
+  // composed signal (#11302), so aborting during the download drops the socket
+  // instead of waiting for the installer to notice at the next checkpoint.
+  const jobSignal = pluginInstallJobs.signal(jobId);
+  const cancelledDuringDownload = () => jobSignal?.aborted === true;
+
   try {
+    pluginInstallJobs.setPhase(jobId, "downloading");
     const signal = AbortSignal.any([
       sizeController.signal,
       AbortSignal.timeout(PLUGIN_DOWNLOAD_TIMEOUT_MS),
+      ...(jobSignal ? [jobSignal] : []),
     ]);
 
     let response: Response;
@@ -316,6 +403,9 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
       }
       response = guarded.response;
     } catch (err) {
+      // A user cancel aborts the same composed signal as the deadline, so check
+      // it first — otherwise cancelling would report a timeout that never happened.
+      if (cancelledDuringDownload()) return { status: "cancelled" };
       if (isAbortLikeError(err)) {
         return failed("fetch_timeout", "The download timed out before it finished.");
       }
@@ -383,6 +473,9 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
       if (sizeAborted) {
         return failed("size_exceeded", "The plugin file is larger than the 30 MB limit.");
       }
+      // The size cap sets its own flag above, so anything abort-like left here
+      // is either the user's cancel or the deadline — cancel wins.
+      if (cancelledDuringDownload()) return { status: "cancelled" };
       if (isAbortLikeError(err)) {
         return failed("fetch_timeout", "The download timed out before it finished.");
       }
@@ -392,6 +485,7 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
     return (await getPluginService()).installPlugin(tempPath, {
       source: "url",
       originalUrl: trimmed,
+      ...(jobId === undefined ? {} : { jobId }),
     });
   } finally {
     if (wroteTempFile) {
@@ -1001,8 +1095,13 @@ export const pluginNamespace = defineIpcNamespace({
     installFromFile: op(PLUGIN_METHOD_CHANNELS.installFromFile, handleInstallFromFile, {
       withContext: true,
     }),
-    installFromPath: op(PLUGIN_METHOD_CHANNELS.installFromPath, handleInstallFromPath),
-    installFromUrl: op(PLUGIN_METHOD_CHANNELS.installFromUrl, handleInstallFromUrl),
+    installFromPath: op(PLUGIN_METHOD_CHANNELS.installFromPath, handleInstallFromPathOp, {
+      withContext: true,
+    }),
+    installFromUrl: op(PLUGIN_METHOD_CHANNELS.installFromUrl, handleInstallFromUrlOp, {
+      withContext: true,
+    }),
+    cancelInstall: op(PLUGIN_METHOD_CHANNELS.cancelInstall, handleCancelInstall),
     uninstall: op(PLUGIN_METHOD_CHANNELS.uninstall, handleUninstall),
     checkForUpdate: op(PLUGIN_METHOD_CHANNELS.checkForUpdate, handleCheckForUpdate),
     toolbarButtons: op(PLUGIN_METHOD_CHANNELS.toolbarButtons, handleToolbarButtons),

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -1,5 +1,5 @@
 import { ipcMain, dialog, BrowserWindow, net } from "electron";
-import { open, writeFile, rm, access } from "node:fs/promises";
+import { open, writeFile, rm, access, stat } from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -145,6 +145,18 @@ async function validateDntrArchivePath(archivePath: string): Promise<PluginInsta
   if (extname(archivePath).toLowerCase() !== ".dntr") {
     return fail("Only .dntr files can be installed");
   }
+  // Require a REGULAR file before opening it. `open()` on a FIFO blocks forever
+  // when no writer exists, and the extension check alone doesn't stop someone
+  // dropping a `pipe.dntr` — that would wedge the IPC call and strand its
+  // install job with no timeout to rescue it. `stat` follows symlinks, so a
+  // symlink to a real archive still installs.
+  try {
+    if (!(await stat(archivePath)).isFile()) {
+      return fail("That path isn't a regular file");
+    }
+  } catch {
+    return fail("Couldn't read the dropped file");
+  }
   let header: Buffer;
   try {
     const fh = await open(archivePath, "r");
@@ -200,19 +212,27 @@ const INSTALL_JOB_ID_PATTERN = /^[0-9a-fA-F-]{8,64}$/;
  * The `finally` is the only place a record is dropped — cancellation merely
  * aborts the signal, and the install's own `finally` still owns the staging
  * directory and the install lock.
+ *
+ * `run` receives the id to actually use, which is `undefined` whenever the job
+ * could not be registered. That matters: the installer resolves its signal by
+ * looking the id up in the process-wide registry, so running with an id owned
+ * by a DIFFERENT live install would splice the two together — cancelling one
+ * would abort the other, either could commit the other's record, and progress
+ * would be pushed to the wrong window. Better to install without progress than
+ * to install under someone else's job.
  */
 async function withInstallJob(
   ctx: IpcContext,
   jobId: string | undefined,
-  run: () => Promise<PluginInstallResult>
+  run: (effectiveJobId: string | undefined) => Promise<PluginInstallResult>
 ): Promise<PluginInstallResult> {
-  if (!jobId || !INSTALL_JOB_ID_PATTERN.test(jobId)) return run();
+  if (!jobId || !INSTALL_JOB_ID_PATTERN.test(jobId)) return run(undefined);
   const registered = pluginInstallJobs.begin(jobId, (event) => {
     sendToRendererContext(ctx, CHANNELS.PLUGIN_INSTALL_PROGRESS, event);
   });
-  if (!registered) return run();
+  if (!registered) return run(undefined);
   try {
-    return await run();
+    return await run(jobId);
   } finally {
     pluginInstallJobs.end(jobId);
   }
@@ -252,7 +272,7 @@ async function handleInstallFromFile(
   }
   // The job starts once a path exists — time spent in the native picker isn't
   // install progress, and a Cancel button for it would duplicate the picker's own.
-  return withInstallJob(ctx, jobId, () => handleInstallFromPath(result.filePaths[0]!, jobId));
+  return withInstallJob(ctx, jobId, (id) => handleInstallFromPath(result.filePaths[0]!, id));
 }
 
 // Bounded download limits for install-from-URL (F24). Mirrors the spec in
@@ -305,7 +325,7 @@ async function handleInstallFromPathOp(
   path: string,
   jobId?: string
 ): Promise<PluginInstallResult> {
-  return withInstallJob(ctx, jobId, () => handleInstallFromPath(path, jobId));
+  return withInstallJob(ctx, jobId, (id) => handleInstallFromPath(path, id));
 }
 
 /** Namespace entry for install-from-URL — registers the job, then delegates. */
@@ -314,7 +334,7 @@ async function handleInstallFromUrlOp(
   url: string,
   jobId?: string
 ): Promise<PluginInstallResult> {
-  return withInstallJob(ctx, jobId, () => handleInstallFromUrl(url, jobId));
+  return withInstallJob(ctx, jobId, (id) => handleInstallFromUrl(url, id));
 }
 
 /**

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2993,6 +2993,11 @@ function buildElectronApi(): ElectronAPI {
         _eventBusOn("plugin:actions-changed", callback),
       onProvenanceChanged: (callback: (payload: Record<string, never>) => void) =>
         _eventBusOn("plugin:provenance-changed", callback),
+      // Direct channel, not the event bus: install progress is targeted at the
+      // window that started the install, never broadcast to every view (#11302).
+      onInstallProgress: (
+        callback: (event: import("../shared/types/plugin.js").PluginInstallProgressEvent) => void
+      ) => _typedOn(CHANNELS.PLUGIN_INSTALL_PROGRESS, callback),
       onBackgroundUpdateAvailable: (
         callback: (
           payload: import("../shared/types/plugin.js").PluginBackgroundUpdateCheckResult

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -440,17 +440,6 @@ export async function extractPluginArchive(
 ): Promise<void> {
   const inactivityMs = opts?.inactivityTimeoutMs ?? PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS;
   const totalMs = opts?.totalDeadlineMs ?? PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS;
-  const stat = await fs.stat(archivePath);
-  if (stat.size > MAX_DNTR_BYTES) {
-    throw new Error(`Archive size ${stat.size} exceeds ${MAX_DNTR_BYTES} byte limit`);
-  }
-
-  const root = path.resolve(destDir);
-  const zipfile = await openZip(archivePath);
-  if (zipfile.entryCount > MAX_DNTR_ENTRIES) {
-    zipfile.close();
-    throw new Error(`Archive exceeds ${MAX_DNTR_ENTRIES} entry limit`);
-  }
 
   // Absolute deadline + caller cancellation, composed once for the whole
   // extraction. A dedicated controller (rather than `AbortSignal.timeout`) so
@@ -459,6 +448,14 @@ export async function extractPluginArchive(
   // and would fall through the `reason instanceof Error` unwrap below. Cleared
   // in the `finally` so a fast extraction doesn't leave a 2-minute timer
   // holding the event loop.
+  //
+  // Armed BEFORE the first archive I/O: `fs.stat` and `openZip` on a stalled
+  // network/FUSE mount are themselves unbounded, and the caller is already
+  // holding `install.lock` and a staging dir by the time we get here. Neither
+  // call takes a signal, so the deadline can't interrupt one mid-flight — but
+  // checking either side of them bounds the damage to a single hung syscall
+  // instead of the whole extraction, and honours a cancel that landed while we
+  // were queued.
   const deadlineController = new AbortController();
   const deadlineTimer = setTimeout(
     () =>
@@ -473,7 +470,34 @@ export async function extractPluginArchive(
     ? AbortSignal.any([deadlineController.signal, opts.signal])
     : deadlineController.signal;
 
+  /** The abort reason as an Error, for throwing out of the pre-flight checks. */
+  const abortError = (): Error =>
+    outerSignal.reason instanceof Error
+      ? outerSignal.reason
+      : new Error("Extraction was cancelled");
+
   try {
+    if (outerSignal.aborted) throw abortError();
+
+    const stat = await fs.stat(archivePath);
+    if (stat.size > MAX_DNTR_BYTES) {
+      throw new Error(`Archive size ${stat.size} exceeds ${MAX_DNTR_BYTES} byte limit`);
+    }
+    if (outerSignal.aborted) throw abortError();
+
+    const root = path.resolve(destDir);
+    const zipfile = await openZip(archivePath);
+    // Anything that throws past this point must close the zip, or the archive's
+    // file descriptor leaks for the life of the process.
+    if (zipfile.entryCount > MAX_DNTR_ENTRIES) {
+      zipfile.close();
+      throw new Error(`Archive exceeds ${MAX_DNTR_ENTRIES} entry limit`);
+    }
+    if (outerSignal.aborted) {
+      zipfile.close();
+      throw abortError();
+    }
+
     return await runExtraction(zipfile, root, {
       inactivityMs,
       outerSignal,
@@ -534,6 +558,13 @@ function runExtraction(
     outerSignal.addEventListener("abort", onOuterAbort, { once: true });
 
     zipfile.on("entry", (entry: yauzl.Entry) => {
+      // yauzl's `close()` only flips its `isOpen` flag — a central-directory
+      // read already in flight when we aborted still emits its entry. Without
+      // this guard a cancelled extraction would keep reporting progress and,
+      // worse, `mkdir` a staging directory the installer's cleanup had already
+      // removed, resurrecting `.install-tmp-*` after the install gave up.
+      if (settled) return;
+
       const name = normalizePath(entry.fileName);
 
       if (++entryCount > MAX_DNTR_ENTRIES) {
@@ -571,17 +602,32 @@ function runExtraction(
         return fail(new Error(`Entry "${name}" escapes the extraction directory`));
       }
 
-      // Directory entry — create and advance.
+      // Directory entry — create and advance. The `settled` recheck stops a
+      // cancelled extraction from recreating directories under a staging tree
+      // the caller has already reaped.
       if (name.endsWith("/")) {
-        fs.mkdir(resolved, { recursive: true }).then(() => zipfile.readEntry(), fail);
+        fs.mkdir(resolved, { recursive: true }).then(() => {
+          if (!settled) zipfile.readEntry();
+        }, fail);
         return;
       }
 
-      onEntry?.(name);
+      // Progress reporting must never be able to kill the extraction. This runs
+      // from a yauzl EventEmitter callback, OUTSIDE the promise executor, so an
+      // uncaught throw here would escape as a main-process exception (which
+      // Daintree's global handler turns into a relaunch) rather than a rejection.
+      try {
+        onEntry?.(name);
+      } catch (err) {
+        return fail(err instanceof Error ? err : new Error(String(err)));
+      }
 
       fs.mkdir(path.dirname(resolved), { recursive: true }).then(() => {
+        // The abort may have landed while the mkdir was in flight.
+        if (settled) return;
         zipfile.openReadStream(entry, (err, stream) => {
           if (err) return fail(err);
+          if (settled) return stream.destroy();
           const out = createWriteStream(resolved, { mode: 0o644 });
 
           // Abort the transfer if the entry stalls. `pipeline` destroys both

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -22,9 +22,47 @@ export const MAX_DNTR_ENTRIES = 4096;
 // every chunk, so a large archive isn't penalised for making steady progress.
 export const PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS = 30_000;
 
+/**
+ * Absolute ceiling on a single extraction, independent of the per-entry
+ * inactivity watchdog (#11302). A stream that trickles a byte every few seconds
+ * resets {@link PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS} forever and never trips it,
+ * so a hostile or pathological source could still hold `install.lock` and its
+ * staging dir indefinitely. Four times the inactivity window and generous for
+ * the 30 MB `MAX_DNTR_BYTES` cap — a legitimate local archive extracts in
+ * well under a second.
+ */
+export const PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS = 120_000;
+
+/**
+ * Thrown (as the abort `reason`) when {@link PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS}
+ * elapses. A distinct type rather than a message the installer greps for, so
+ * the "too slow" outcome maps to its own install error code without coupling to
+ * user-facing copy.
+ */
+export class PluginArchiveDeadlineError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginArchiveDeadlineError";
+  }
+}
+
 export interface ExtractOptions {
   /** Override the per-entry inactivity abort. Tests only — production uses the default. */
   inactivityTimeoutMs?: number;
+  /** Override the absolute extraction deadline. Tests only — production uses the default. */
+  totalDeadlineMs?: number;
+  /**
+   * Caller-owned cancellation (#11302). Aborting it fails the extraction with
+   * the signal's own `reason`, so "the user cancelled" stays distinguishable
+   * from a stall or the absolute deadline in the message the installer reports.
+   */
+  signal?: AbortSignal;
+  /**
+   * Called with each validated file entry's normalized path, just before it
+   * streams to disk. Progress reporting only — the extraction ignores what it
+   * returns and a throw from it is not caught, so keep it trivial.
+   */
+  onEntry?: (entryName: string) => void;
 }
 
 const REQUIRED_EXCLUSIONS: readonly string[] = ["node_modules/", ".git/"];
@@ -390,7 +428,10 @@ export async function readArchiveManifest(archivePath: string): Promise<PluginMa
  *
  * A file entry that goes quiet for {@link PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS}
  * aborts the whole extraction with a rejection rather than hanging, so the
- * caller's cleanup always runs.
+ * caller's cleanup always runs. {@link PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS} bounds
+ * the extraction as a whole, catching the trickling stream that resets the
+ * per-entry timer forever, and `opts.signal` lets the caller cancel outright
+ * (#11302). All three abort sources reject with their own `Error` reason.
  */
 export async function extractPluginArchive(
   archivePath: string,
@@ -398,6 +439,7 @@ export async function extractPluginArchive(
   opts?: ExtractOptions
 ): Promise<void> {
   const inactivityMs = opts?.inactivityTimeoutMs ?? PLUGIN_ARCHIVE_ENTRY_INACTIVITY_MS;
+  const totalMs = opts?.totalDeadlineMs ?? PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS;
   const stat = await fs.stat(archivePath);
   if (stat.size > MAX_DNTR_BYTES) {
     throw new Error(`Archive size ${stat.size} exceeds ${MAX_DNTR_BYTES} byte limit`);
@@ -410,6 +452,49 @@ export async function extractPluginArchive(
     throw new Error(`Archive exceeds ${MAX_DNTR_ENTRIES} entry limit`);
   }
 
+  // Absolute deadline + caller cancellation, composed once for the whole
+  // extraction. A dedicated controller (rather than `AbortSignal.timeout`) so
+  // the deadline rejects with a plain `Error` carrying a readable message —
+  // `AbortSignal.timeout` raises a DOMException that isn't an `Error` in Node
+  // and would fall through the `reason instanceof Error` unwrap below. Cleared
+  // in the `finally` so a fast extraction doesn't leave a 2-minute timer
+  // holding the event loop.
+  const deadlineController = new AbortController();
+  const deadlineTimer = setTimeout(
+    () =>
+      deadlineController.abort(
+        new PluginArchiveDeadlineError(
+          `Extraction exceeded the ${totalMs}ms limit before finishing`
+        )
+      ),
+    totalMs
+  );
+  const outerSignal = opts?.signal
+    ? AbortSignal.any([deadlineController.signal, opts.signal])
+    : deadlineController.signal;
+
+  try {
+    return await runExtraction(zipfile, root, {
+      inactivityMs,
+      outerSignal,
+      onEntry: opts?.onEntry,
+    });
+  } finally {
+    clearTimeout(deadlineTimer);
+  }
+}
+
+/**
+ * The entry pump for {@link extractPluginArchive}. Split out only so the
+ * deadline timer above has a `finally` to clear itself in without wrapping the
+ * whole promise body.
+ */
+function runExtraction(
+  zipfile: yauzl.ZipFile,
+  root: string,
+  opts: { inactivityMs: number; outerSignal: AbortSignal; onEntry?: (name: string) => void }
+): Promise<void> {
+  const { inactivityMs, outerSignal, onEntry } = opts;
   return new Promise<void>((resolve, reject) => {
     let settled = false;
     // Running total of declared uncompressed bytes. yauzl validates each
@@ -427,10 +512,26 @@ export async function extractPluginArchive(
     const fail = (err: Error) => {
       if (settled) return;
       settled = true;
+      outerSignal.removeEventListener("abort", onOuterAbort);
       activeTransfer?.abort();
       zipfile.close();
       reject(err);
     };
+
+    // A cancel or deadline that lands between entries (or during a directory
+    // mkdir) has no in-flight pipeline to reject, so tear down here instead.
+    // `fail` latches `settled` first, so whichever abort source fires first owns
+    // the reported reason — the `activeTransfer.abort()` it then issues can't
+    // overwrite it with the generic "was interrupted" message.
+    function onOuterAbort() {
+      const reason: unknown = outerSignal.reason;
+      fail(reason instanceof Error ? reason : new Error("Extraction was cancelled"));
+    }
+    if (outerSignal.aborted) {
+      onOuterAbort();
+      return;
+    }
+    outerSignal.addEventListener("abort", onOuterAbort, { once: true });
 
     zipfile.on("entry", (entry: yauzl.Entry) => {
       const name = normalizePath(entry.fileName);
@@ -476,6 +577,8 @@ export async function extractPluginArchive(
         return;
       }
 
+      onEntry?.(name);
+
       fs.mkdir(path.dirname(resolved), { recursive: true }).then(() => {
         zipfile.openReadStream(entry, (err, stream) => {
           if (err) return fail(err);
@@ -512,7 +615,13 @@ export async function extractPluginArchive(
             abort: () => controller.abort(new Error(`Extraction of "${name}" was interrupted`)),
           };
 
-          pipeline(stream, out, { signal: controller.signal }).then(
+          // The per-entry stall controller plus the extraction-wide deadline /
+          // cancel signal. `AbortSignal.any` preserves the `reason` of whichever
+          // source fires first, so the single unwrap below reports the true
+          // cause instead of collapsing all three into one message.
+          const entrySignal = AbortSignal.any([controller.signal, outerSignal]);
+
+          pipeline(stream, out, { signal: entrySignal }).then(
             () => {
               clearTimer();
               activeTransfer = null;
@@ -526,11 +635,11 @@ export async function extractPluginArchive(
               // `pipeline` surfaces a genuine stream/fs failure as-is and only
               // rejects with an AbortError when our abort was the sole cause —
               // and that AbortError drops the reason we passed, so recover the
-              // entry-naming stall/teardown error from the signal. Discriminate
-              // on the rejection itself (not `signal.aborted`): a real error
-              // that merely raced the inactivity deadline must still win over
-              // the stall message.
-              const reason = controller.signal.reason;
+              // stall / deadline / cancel error from the composed signal.
+              // Discriminate on the rejection itself (not `signal.aborted`): a
+              // real error that merely raced one of those deadlines must still
+              // win over their messages.
+              const reason: unknown = entrySignal.reason;
               fail(err.name === "AbortError" && reason instanceof Error ? reason : err);
             }
           );
@@ -541,6 +650,7 @@ export async function extractPluginArchive(
     zipfile.on("end", () => {
       if (!settled) {
         settled = true;
+        outerSignal.removeEventListener("abort", onOuterAbort);
         zipfile.close();
         resolve();
       }

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -513,26 +513,38 @@ describe("extractPluginArchive cancellation and absolute deadline (#11302)", () 
   it("still reports a genuine stream failure that beats a real cancel", async () => {
     // Regression guard for the pre-existing discrimination rule: a real error
     // must win over an abort reason, or a broken archive would be misreported
-    // as a user cancellation. The cancel here is genuinely fired — a test that
-    // built a controller and never aborted it would pass with all of the
-    // cancel/error discrimination deleted.
+    // as a user cancellation. The cancel is genuinely fired — a test that built
+    // a controller and never aborted it would pass with all of the cancel/error
+    // discrimination deleted.
+    //
+    // Ordering has to be unambiguous or this races on a loaded runner. Hand the
+    // live stream to `pipeline` FIRST, destroy it on the next tick (so the
+    // rejection is a real stream error, not a premature-close from a stream that
+    // was already dead at attach time), and fire the cancel a clear margin
+    // later. The cancel therefore always lands after the extraction has settled
+    // — which is exactly the "a real error wins" claim being asserted.
     const { archivePath, dest } = await stallingArchive("race");
     const controller = new AbortController();
+    let aborted = false;
     const spy = vi
       .spyOn(yauzl.ZipFile.prototype, "openReadStream")
       .mockImplementation((_entry, callback) => {
         const failing = new Readable({ read() {} });
-        // Destroy first, then cancel on the next macrotask, so the stream error
-        // is unambiguously the first cause.
-        failing.destroy(new Error("disk-exploded"));
-        setTimeout(() => controller.abort(new Error("user-said-stop")), 0);
         callback(null, failing);
+        process.nextTick(() => failing.destroy(new Error("disk-exploded")));
+        setTimeout(() => {
+          aborted = true;
+          controller.abort(new Error("user-said-stop"));
+        }, 250);
       });
 
     try {
       await expect(
         extractPluginArchive(archivePath, dest, { signal: controller.signal })
       ).rejects.toThrow("disk-exploded");
+      // The stream error resolved the extraction before the cancel even fired,
+      // so this also proves the failure wasn't a cancel misreported as an error.
+      expect(aborted).toBe(false);
     } finally {
       spy.mockRestore();
     }

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -5,7 +5,12 @@ import os from "os";
 import zlib from "zlib";
 import { Readable } from "stream";
 import yauzl from "yauzl";
-import { packPluginArchive, extractPluginArchive, MAX_DNTR_ENTRIES } from "../PluginArchive.js";
+import {
+  packPluginArchive,
+  extractPluginArchive,
+  MAX_DNTR_ENTRIES,
+  PluginArchiveDeadlineError,
+} from "../PluginArchive.js";
 
 let tmpDir: string;
 
@@ -392,5 +397,163 @@ describe("extractPluginArchive", () => {
     } finally {
       openReadStreamSpy.mockRestore();
     }
+  });
+});
+
+// #11302: the per-entry inactivity watchdog only catches a stream that goes
+// fully silent. A source that trickles a byte just inside the window resets it
+// forever, and before this there was no way for a user to give up on one — the
+// install lock and staging dir stayed held either way. These cover the two new
+// abort sources and the reason each one surfaces.
+describe("extractPluginArchive cancellation and absolute deadline (#11302)", () => {
+  /** A zip whose entries never finish, to keep extraction pinned open. */
+  function stallStreams(): { spy: ReturnType<typeof vi.spyOn>; streams: Readable[] } {
+    const streams: Readable[] = [];
+    const spy = vi
+      .spyOn(yauzl.ZipFile.prototype, "openReadStream")
+      .mockImplementation((_entry, callback) => {
+        const stalled = new Readable({ read() {} });
+        streams.push(stalled);
+        stalled.push(Buffer.from("partial"));
+        callback(null, stalled);
+      });
+    return { spy, streams };
+  }
+
+  async function stallingArchive(name: string): Promise<{ archivePath: string; dest: string }> {
+    const archivePath = path.join(tmpDir, `${name}.dntr`);
+    await fs.writeFile(archivePath, buildRawZip([{ name: "dist/first.js", content: "a" }]));
+    const dest = path.join(tmpDir, `extracted-${name}`);
+    await fs.mkdir(dest, { recursive: true });
+    return { archivePath, dest };
+  }
+
+  it("rejects with the caller's own reason when the external signal aborts", async () => {
+    const { archivePath, dest } = await stallingArchive("cancel");
+    const { spy, streams } = stallStreams();
+    const controller = new AbortController();
+
+    try {
+      const promise = extractPluginArchive(archivePath, dest, {
+        signal: controller.signal,
+        // Long enough that neither built-in guard can be what fires.
+        inactivityTimeoutMs: 60_000,
+        totalDeadlineMs: 60_000,
+      });
+      // Cancel only once a transfer is genuinely in flight, so this exercises
+      // the pipeline-abort path rather than the pre-flight short-circuit.
+      await vi.waitFor(() => expect(streams.length).toBe(1));
+      controller.abort(new Error("user-said-stop"));
+
+      // The caller's reason survives — it is NOT collapsed into a generic
+      // AbortError or the entry-stall message, which is what lets the installer
+      // report "cancelled" rather than "the archive is broken".
+      await expect(promise).rejects.toThrow("user-said-stop");
+      expect(streams[0]!.destroyed).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects with a deadline error when a trickling stream outlives the total budget", async () => {
+    const { archivePath, dest } = await stallingArchive("deadline");
+    // A stream that keeps emitting just often enough to reset the per-entry
+    // watchdog forever — exactly the case the inactivity timer cannot catch.
+    const timers: ReturnType<typeof setInterval>[] = [];
+    const spy = vi
+      .spyOn(yauzl.ZipFile.prototype, "openReadStream")
+      .mockImplementation((_entry, callback) => {
+        const trickle = new Readable({ read() {} });
+        timers.push(setInterval(() => trickle.push(Buffer.from("x")), 5));
+        callback(null, trickle);
+      });
+
+    try {
+      await expect(
+        extractPluginArchive(archivePath, dest, {
+          inactivityTimeoutMs: 5_000,
+          totalDeadlineMs: 60,
+        })
+      ).rejects.toThrow(PluginArchiveDeadlineError);
+    } finally {
+      for (const t of timers) clearInterval(t);
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const { archivePath, dest } = await stallingArchive("pre-aborted");
+    const { spy } = stallStreams();
+    try {
+      await expect(
+        extractPluginArchive(archivePath, dest, {
+          signal: AbortSignal.abort(new Error("already-cancelled")),
+        })
+      ).rejects.toThrow("already-cancelled");
+      // Nothing was ever opened — the abort short-circuits the entry pump.
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("still reports a genuine stream failure that races a cancel", async () => {
+    // Regression guard for the pre-existing discrimination rule: a real error
+    // must win over an abort reason, or a broken archive would be misreported
+    // as a user cancellation.
+    const { archivePath, dest } = await stallingArchive("race");
+    const controller = new AbortController();
+    const spy = vi
+      .spyOn(yauzl.ZipFile.prototype, "openReadStream")
+      .mockImplementation((_entry, callback) => {
+        const failing = new Readable({ read() {} });
+        setTimeout(() => failing.destroy(new Error("disk-exploded")), 5);
+        callback(null, failing);
+      });
+
+    try {
+      await expect(
+        extractPluginArchive(archivePath, dest, { signal: controller.signal })
+      ).rejects.toThrow("disk-exploded");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("reports each validated file entry, in archive order, and no directories", async () => {
+    const src = path.join(tmpDir, "src-onentry");
+    await createFixture(src, {
+      "plugin.json": JSON.stringify(validManifest()),
+      "dist/index.js": "console.log(1);",
+      "dist/nested/deep.js": "console.log(2);",
+    });
+    const archivePath = path.join(tmpDir, "onentry.dntr");
+    await packPluginArchive(src, archivePath);
+    const dest = path.join(tmpDir, "extracted-onentry");
+    await fs.mkdir(dest, { recursive: true });
+
+    const seen: string[] = [];
+    await extractPluginArchive(archivePath, dest, { onEntry: (n) => seen.push(n) });
+
+    expect(seen).toContain("plugin.json");
+    expect(seen).toContain("dist/index.js");
+    expect(seen).toContain("dist/nested/deep.js");
+    // Directory entries are created, not streamed, so they are not progress.
+    expect(seen.some((n) => n.endsWith("/"))).toBe(false);
+  });
+
+  it("leaves no pending deadline timer behind on a fast, successful extraction", async () => {
+    // The 2-minute default would otherwise keep the event loop alive long after
+    // a sub-second install finished.
+    const src = path.join(tmpDir, "src-timer");
+    await createFixture(src, { "plugin.json": JSON.stringify(validManifest()) });
+    const archivePath = path.join(tmpDir, "timer.dntr");
+    await packPluginArchive(src, archivePath);
+    const dest = path.join(tmpDir, "extracted-timer");
+    await fs.mkdir(dest, { recursive: true });
+
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    await extractPluginArchive(archivePath, dest);
+    expect(clearSpy).toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/PluginArchive.extract.test.ts
+++ b/electron/services/__tests__/PluginArchive.extract.test.ts
@@ -460,21 +460,34 @@ describe("extractPluginArchive cancellation and absolute deadline (#11302)", () 
     // A stream that keeps emitting just often enough to reset the per-entry
     // watchdog forever — exactly the case the inactivity timer cannot catch.
     const timers: ReturnType<typeof setInterval>[] = [];
+    let chunksPushed = 0;
     const spy = vi
       .spyOn(yauzl.ZipFile.prototype, "openReadStream")
       .mockImplementation((_entry, callback) => {
         const trickle = new Readable({ read() {} });
-        timers.push(setInterval(() => trickle.push(Buffer.from("x")), 5));
+        timers.push(
+          setInterval(() => {
+            chunksPushed++;
+            trickle.push(Buffer.from("x"));
+          }, 10)
+        );
         callback(null, trickle);
       });
 
     try {
       await expect(
         extractPluginArchive(archivePath, dest, {
-          inactivityTimeoutMs: 5_000,
-          totalDeadlineMs: 60,
+          // Deliberately far apart: the inactivity watchdog must never be what
+          // fires, and the budget must be wide enough that the trickle has
+          // demonstrably started before the deadline lands. A budget so tight it
+          // expires before the first chunk would pass without proving anything.
+          inactivityTimeoutMs: 10_000,
+          totalDeadlineMs: 300,
         })
       ).rejects.toThrow(PluginArchiveDeadlineError);
+      // Proof the stream was alive throughout — a dead stream would have been
+      // the inactivity watchdog's job, not the deadline's.
+      expect(chunksPushed).toBeGreaterThan(1);
     } finally {
       for (const t of timers) clearInterval(t);
       spy.mockRestore();
@@ -497,17 +510,22 @@ describe("extractPluginArchive cancellation and absolute deadline (#11302)", () 
     }
   });
 
-  it("still reports a genuine stream failure that races a cancel", async () => {
+  it("still reports a genuine stream failure that beats a real cancel", async () => {
     // Regression guard for the pre-existing discrimination rule: a real error
     // must win over an abort reason, or a broken archive would be misreported
-    // as a user cancellation.
+    // as a user cancellation. The cancel here is genuinely fired — a test that
+    // built a controller and never aborted it would pass with all of the
+    // cancel/error discrimination deleted.
     const { archivePath, dest } = await stallingArchive("race");
     const controller = new AbortController();
     const spy = vi
       .spyOn(yauzl.ZipFile.prototype, "openReadStream")
       .mockImplementation((_entry, callback) => {
         const failing = new Readable({ read() {} });
-        setTimeout(() => failing.destroy(new Error("disk-exploded")), 5);
+        // Destroy first, then cancel on the next macrotask, so the stream error
+        // is unambiguously the first cause.
+        failing.destroy(new Error("disk-exploded"));
+        setTimeout(() => controller.abort(new Error("user-said-stop")), 0);
         callback(null, failing);
       });
 
@@ -535,16 +553,56 @@ describe("extractPluginArchive cancellation and absolute deadline (#11302)", () 
     const seen: string[] = [];
     await extractPluginArchive(archivePath, dest, { onEntry: (n) => seen.push(n) });
 
-    expect(seen).toContain("plugin.json");
-    expect(seen).toContain("dist/index.js");
-    expect(seen).toContain("dist/nested/deep.js");
+    // plugin.json is the mandated first entry of the format, and a nested file
+    // can't precede its own parent directory's sibling — assert the sequence,
+    // not just membership, so a reordered or duplicated report is caught.
+    expect(seen[0]).toBe("plugin.json");
+    expect(seen.indexOf("dist/index.js")).toBeGreaterThan(0);
+    expect(seen.indexOf("dist/nested/deep.js")).toBeGreaterThan(seen.indexOf("dist/index.js"));
+    expect(new Set(seen).size).toBe(seen.length);
     // Directory entries are created, not streamed, so they are not progress.
     expect(seen.some((n) => n.endsWith("/"))).toBe(false);
   });
 
-  it("leaves no pending deadline timer behind on a fast, successful extraction", async () => {
-    // The 2-minute default would otherwise keep the event loop alive long after
-    // a sub-second install finished.
+  it("does not report entries once the extraction has already been cancelled", async () => {
+    // yauzl's `close()` only flips a flag — a central-directory read in flight
+    // still emits its entry. Without the `settled` guard those late entries
+    // would report progress for a dead install and `mkdir` a staging dir the
+    // caller's cleanup had already removed.
+    const src = path.join(tmpDir, "src-latefire");
+    await createFixture(src, {
+      "plugin.json": JSON.stringify(validManifest()),
+      "dist/a.js": "1",
+      "dist/b.js": "2",
+      "dist/c.js": "3",
+    });
+    const archivePath = path.join(tmpDir, "latefire.dntr");
+    await packPluginArchive(src, archivePath);
+    const dest = path.join(tmpDir, "extracted-latefire");
+    await fs.mkdir(dest, { recursive: true });
+
+    const controller = new AbortController();
+    const seen: string[] = [];
+    await expect(
+      extractPluginArchive(archivePath, dest, {
+        signal: controller.signal,
+        onEntry: (n) => {
+          seen.push(n);
+          // Cancel from inside the very first report.
+          if (seen.length === 1) controller.abort(new Error("stop-now"));
+        },
+      })
+    ).rejects.toThrow("stop-now");
+
+    expect(seen).toEqual(["plugin.json"]);
+  });
+
+  it("clears the deadline timer on a fast, successful extraction", async () => {
+    // The 2-minute default would otherwise hold the event loop open long after a
+    // sub-second install finished. Identify the deadline timer specifically by
+    // its unique delay — the pre-existing per-entry inactivity watchdog also
+    // calls setTimeout/clearTimeout, so a bare "clearTimeout was called" would
+    // pass even if the deadline timer were never cleared at all.
     const src = path.join(tmpDir, "src-timer");
     await createFixture(src, { "plugin.json": JSON.stringify(validManifest()) });
     const archivePath = path.join(tmpDir, "timer.dntr");
@@ -552,8 +610,27 @@ describe("extractPluginArchive cancellation and absolute deadline (#11302)", () 
     const dest = path.join(tmpDir, "extracted-timer");
     await fs.mkdir(dest, { recursive: true });
 
+    const DEADLINE = 987_654;
+    const realSetTimeout = globalThis.setTimeout;
+    let deadlineHandle: unknown;
+    const setSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: () => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      const handle = realSetTimeout(fn, ms, ...rest);
+      if (ms === DEADLINE) deadlineHandle = handle;
+      return handle;
+    }) as unknown as typeof globalThis.setTimeout);
     const clearSpy = vi.spyOn(globalThis, "clearTimeout");
-    await extractPluginArchive(archivePath, dest);
-    expect(clearSpy).toHaveBeenCalled();
+
+    try {
+      await extractPluginArchive(archivePath, dest, { totalDeadlineMs: DEADLINE });
+      expect(deadlineHandle).toBeDefined();
+      expect(clearSpy.mock.calls.some(([h]) => h === deadlineHandle)).toBe(true);
+    } finally {
+      setSpy.mockRestore();
+      clearSpy.mockRestore();
+    }
   });
 });

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -111,6 +111,10 @@ vi.mock("../plugin-capability/instances.js", () => ({
 
 import { PluginService } from "../PluginService.js";
 import { packPluginArchive } from "../PluginArchive.js";
+// Namespace import so the extraction-deadline path can be forced via a spy —
+// reproducing a real 120s trickle in a unit test isn't practical.
+import * as PluginArchive from "../PluginArchive.js";
+import { pluginInstallJobs } from "../plugin/PluginInstallJobRegistry.js";
 import { resilientRename } from "../../utils/fs.js";
 import { PluginBlocklistService } from "../plugin/PluginBlocklistService.js";
 
@@ -226,6 +230,98 @@ describe("installPlugin — happy path", () => {
     expect(entries.filter((e) => e.startsWith(".install-tmp-"))).toHaveLength(0);
     expect(entries.filter((e) => e.includes(".old-"))).toHaveLength(0);
     expect(entries).toContain("acme.clean");
+
+    service.dispose();
+  });
+});
+
+// #11302: an install can now be given up on. The guarantee that matters is not
+// just that it stops — it's that stopping leaves the plugins root exactly as it
+// was and, critically, releases `install.lock` so the very next install works.
+// A cancel that stranded the lock would be worse than the silent install it
+// replaced. These run against the real lockfile and a real archive.
+describe("installPlugin — cancellation (#11302)", () => {
+  it("returns cancelled, writes nothing, and frees the lock for the next install", async () => {
+    const archive = await makeArchive(
+      { name: "acme.cancelled", version: "1.0.0" },
+      { "dist/index.js": "module.exports = {};" }
+    );
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    const jobId = "cancel-me";
+
+    pluginInstallJobs.begin(jobId, () => {});
+    // Cancel before the installer reaches its first checkpoint, which is the
+    // point right after the lock is acquired — proper-lockfile can't be
+    // interrupted, so that checkpoint is the earliest a cancel can be honoured.
+    pluginInstallJobs.cancel(jobId);
+    const result = await service.installPlugin(archive, { jobId });
+    pluginInstallJobs.end(jobId);
+
+    expect(result).toEqual({ status: "cancelled" });
+    expect(await exists(path.join(pluginsRoot, "acme.cancelled"))).toBe(false);
+    const entries = await fs.readdir(pluginsRoot);
+    expect(entries.filter((e) => e.startsWith(".install-tmp-"))).toHaveLength(0);
+
+    // The real proof the lock was released: a second install through the same
+    // root succeeds instead of timing out on a stranded `install.lock`.
+    const followUp = await service.installPlugin(archive);
+    expect(followUp).toEqual({ status: "installed", pluginId: "acme.cancelled" });
+
+    service.dispose();
+  });
+
+  it("cancels mid-extraction and still leaves no staging directory behind", async () => {
+    const archive = await makeArchive(
+      { name: "acme.midcancel", version: "1.0.0" },
+      { "dist/index.js": "module.exports = {};" }
+    );
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    const jobId = "cancel-mid";
+
+    // Cancel the instant extraction reports its first entry, so the abort lands
+    // inside `extractPluginArchive` rather than at a checkpoint between steps.
+    pluginInstallJobs.begin(jobId, (event) => {
+      if (event.phase === "extracting") pluginInstallJobs.cancel(jobId);
+    });
+    const result = await service.installPlugin(archive, { jobId });
+    pluginInstallJobs.end(jobId);
+
+    expect(result).toEqual({ status: "cancelled" });
+    expect(await exists(path.join(pluginsRoot, "acme.midcancel"))).toBe(false);
+    const entries = await fs.readdir(pluginsRoot);
+    expect(entries.filter((e) => e.startsWith(".install-tmp-"))).toHaveLength(0);
+
+    service.dispose();
+  });
+
+  it("reports extraction_timeout, not archive_invalid, when the deadline trips", async () => {
+    // A slow source is not a corrupt archive — the codes drive different advice.
+    const archive = await makeArchive({ name: "acme.slowpoke", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const extractSpy = vi
+      .spyOn(PluginArchive, "extractPluginArchive")
+      .mockRejectedValueOnce(new PluginArchive.PluginArchiveDeadlineError("too slow"));
+
+    const result = await service.installPlugin(archive);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors[0]?.code).toBe("extraction_timeout");
+    }
+    expect(await exists(path.join(pluginsRoot, "acme.slowpoke"))).toBe(false);
+
+    extractSpy.mockRestore();
+    service.dispose();
+  });
+
+  it("installs normally when no job is registered for the supplied id", async () => {
+    // A stale jobId (its registration already torn down) must not wedge the
+    // install — the registry is advisory, never a gate.
+    const archive = await makeArchive({ name: "acme.nojob", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const result = await service.installPlugin(archive, { jobId: "never-registered" });
+    expect(result).toEqual({ status: "installed", pluginId: "acme.nojob" });
 
     service.dispose();
   });

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -278,10 +278,13 @@ describe("installPlugin — cancellation (#11302)", () => {
     const service = new PluginService(pluginsRoot, "0.0.0");
     const jobId = "cancel-mid";
 
-    // Cancel the instant extraction reports its first entry, so the abort lands
-    // inside `extractPluginArchive` rather than at a checkpoint between steps.
+    // Cancel on the first ENTRY report, not the phase transition. The
+    // `extracting` phase is emitted BEFORE `extractPluginArchive` is called, so
+    // cancelling there would be caught by the post-extraction checkpoint and the
+    // test would pass even if the signal were never threaded into extraction at
+    // all. An entry event only exists once extraction is genuinely under way.
     pluginInstallJobs.begin(jobId, (event) => {
-      if (event.phase === "extracting") pluginInstallJobs.cancel(jobId);
+      if (event.entry !== undefined) pluginInstallJobs.cancel(jobId);
     });
     const result = await service.installPlugin(archive, { jobId });
     pluginInstallJobs.end(jobId);

--- a/electron/services/plugin/PluginInstallJobRegistry.ts
+++ b/electron/services/plugin/PluginInstallJobRegistry.ts
@@ -16,12 +16,21 @@ export const PLUGIN_INSTALL_PROGRESS_THROTTLE_MS = 150;
  * `AbortSignal.any` composition so the installer can tell "cancelled" apart
  * from a stall or the extraction deadline and return `{ status: "cancelled" }`
  * instead of a failure the user never caused.
+ *
+ * A distinct class, not a sentinel message: the extraction seam surfaces
+ * archive-controlled errors, and identifying a cancel by string equality would
+ * let one whose message happened to match be reported as the user's own doing.
  */
-export const PLUGIN_INSTALL_CANCELLED_REASON = "plugin-install-cancelled";
+export class PluginInstallCancelledError extends Error {
+  constructor() {
+    super("Plugin install was cancelled");
+    this.name = "PluginInstallCancelledError";
+  }
+}
 
 /** True when `err` is the abort reason {@link PluginInstallJobRegistry.cancel} raises. */
 export function isInstallCancellation(err: unknown): boolean {
-  return err instanceof Error && err.message === PLUGIN_INSTALL_CANCELLED_REASON;
+  return err instanceof PluginInstallCancelledError;
 }
 
 type Emit = (event: PluginInstallProgressEvent) => void;
@@ -153,7 +162,7 @@ export class PluginInstallJobRegistry {
     if (!job || !job.cancellable) return false;
     if (job.controller.signal.aborted) return false;
     this.clearTimer(job);
-    job.controller.abort(new Error(PLUGIN_INSTALL_CANCELLED_REASON));
+    job.controller.abort(new PluginInstallCancelledError());
     return true;
   }
 

--- a/electron/services/plugin/PluginInstallJobRegistry.ts
+++ b/electron/services/plugin/PluginInstallJobRegistry.ts
@@ -1,0 +1,183 @@
+import type {
+  PluginInstallPhase,
+  PluginInstallProgressEvent,
+} from "../../../shared/types/plugin.js";
+
+/**
+ * Trailing coalesce window for archive-entry updates (#11302). Extraction can
+ * fire hundreds of entries in a few milliseconds; forwarding each one would
+ * flood the IPC bridge and thrash the renderer for detail nobody can read.
+ * Phase changes bypass this — they're rare and are the part users act on.
+ */
+export const PLUGIN_INSTALL_PROGRESS_THROTTLE_MS = 150;
+
+/**
+ * The abort `reason` for a user-initiated cancel. Carried through
+ * `AbortSignal.any` composition so the installer can tell "cancelled" apart
+ * from a stall or the extraction deadline and return `{ status: "cancelled" }`
+ * instead of a failure the user never caused.
+ */
+export const PLUGIN_INSTALL_CANCELLED_REASON = "plugin-install-cancelled";
+
+/** True when `err` is the abort reason {@link PluginInstallJobRegistry.cancel} raises. */
+export function isInstallCancellation(err: unknown): boolean {
+  return err instanceof Error && err.message === PLUGIN_INSTALL_CANCELLED_REASON;
+}
+
+type Emit = (event: PluginInstallProgressEvent) => void;
+
+interface JobRecord {
+  controller: AbortController;
+  emit: Emit;
+  /** Flipped false at the commit point; a cancel after that is refused. */
+  cancellable: boolean;
+  phase: PluginInstallPhase;
+  /** Pending trailing entry emission, if any. */
+  timer: ReturnType<typeof setTimeout> | null;
+  /** The most recent entry seen while the trailing timer was armed. */
+  pendingEntry: string | null;
+  lastEntryAt: number;
+}
+
+/**
+ * In-flight plugin installs that can report progress and be cancelled (#11302).
+ *
+ * Deliberately standalone rather than state on `PluginService`: the IPC handler
+ * layer loads the plugin service lazily, and the install-from-URL download leg
+ * needs the job's `AbortSignal` *before* the installer is ever reached. A small
+ * module-scoped registry lets the handler, the download, and the installer share
+ * one controller without any of them importing each other.
+ *
+ * Records are keyed by a caller-minted job id and live exactly as long as the
+ * install call that registered them — {@link begin} is always paired with a
+ * {@link end} in the caller's `finally`. {@link cancel} only aborts the
+ * controller; it never touches the staging directory or the install lock,
+ * because the installer's own `finally` already owns both and reaping them from
+ * the outside would race a write still in flight.
+ */
+export class PluginInstallJobRegistry {
+  private readonly jobs = new Map<string, JobRecord>();
+
+  /**
+   * Register a job and return its cancellation signal. Re-registering a live id
+   * is a caller bug (ids are UUIDs), so the existing record wins and the new
+   * caller silently gets no progress rather than hijacking someone else's job.
+   */
+  begin(jobId: string, emit: Emit): AbortSignal | null {
+    if (this.jobs.has(jobId)) return null;
+    const controller = new AbortController();
+    this.jobs.set(jobId, {
+      controller,
+      emit,
+      cancellable: true,
+      phase: "extracting",
+      timer: null,
+      pendingEntry: null,
+      lastEntryAt: 0,
+    });
+    return controller.signal;
+  }
+
+  /** The live signal for `jobId`, or null if it isn't registered. */
+  signal(jobId: string | undefined): AbortSignal | undefined {
+    if (!jobId) return undefined;
+    return this.jobs.get(jobId)?.controller.signal;
+  }
+
+  /**
+   * Move a job to `phase` and push it immediately. Phase transitions are the
+   * coarse, user-meaningful events, so they're never coalesced — and any entry
+   * still queued behind the throttle is dropped, since it belongs to the phase
+   * being left.
+   */
+  setPhase(jobId: string | undefined, phase: PluginInstallPhase): void {
+    const job = jobId ? this.jobs.get(jobId) : undefined;
+    if (!job) return;
+    this.clearTimer(job);
+    job.phase = phase;
+    job.emit({ jobId: jobId!, phase, cancellable: job.cancellable });
+  }
+
+  /**
+   * Report the archive entry currently being extracted. Leading-edge immediate,
+   * then trailing-edge coalesced, so the first entry shows instantly and a burst
+   * settles on the last one instead of dropping it.
+   */
+  reportEntry(jobId: string | undefined, entry: string): void {
+    const job = jobId ? this.jobs.get(jobId) : undefined;
+    if (!job) return;
+    const now = Date.now();
+    if (job.timer === null && now - job.lastEntryAt >= PLUGIN_INSTALL_PROGRESS_THROTTLE_MS) {
+      job.lastEntryAt = now;
+      job.emit({ jobId: jobId!, phase: job.phase, entry, cancellable: job.cancellable });
+      return;
+    }
+    job.pendingEntry = entry;
+    job.timer ??= setTimeout(() => {
+      job.timer = null;
+      const pending = job.pendingEntry;
+      job.pendingEntry = null;
+      if (pending === null) return;
+      job.lastEntryAt = Date.now();
+      job.emit({ jobId: jobId!, phase: job.phase, entry: pending, cancellable: job.cancellable });
+    }, PLUGIN_INSTALL_PROGRESS_THROTTLE_MS);
+  }
+
+  /**
+   * Close the cancellation window before the irreversible swap begins. Returns
+   * false if the job was already cancelled, so the installer can bail out rather
+   * than commit an install the user just aborted — the check and the flip happen
+   * together here so a cancel can't land in between.
+   */
+  commit(jobId: string | undefined): boolean {
+    const job = jobId ? this.jobs.get(jobId) : undefined;
+    if (!job) return true;
+    if (job.controller.signal.aborted) return false;
+    job.cancellable = false;
+    return true;
+  }
+
+  /** Whether `jobId` is registered and still accepting a cancel. */
+  isCancellable(jobId: string): boolean {
+    const job = this.jobs.get(jobId);
+    return job !== undefined && job.cancellable && !job.controller.signal.aborted;
+  }
+
+  /**
+   * Abort the job. Returns false for an unknown job or one that has already
+   * passed the commit point — the caller surfaces that as "too late to cancel"
+   * rather than pretending it worked.
+   */
+  cancel(jobId: string): boolean {
+    const job = this.jobs.get(jobId);
+    if (!job || !job.cancellable) return false;
+    if (job.controller.signal.aborted) return false;
+    this.clearTimer(job);
+    job.controller.abort(new Error(PLUGIN_INSTALL_CANCELLED_REASON));
+    return true;
+  }
+
+  /** Drop the record and any pending trailing emission. Idempotent. */
+  end(jobId: string | undefined): void {
+    const job = jobId ? this.jobs.get(jobId) : undefined;
+    if (!job) return;
+    this.clearTimer(job);
+    this.jobs.delete(jobId!);
+  }
+
+  /** Live job count — for tests asserting nothing leaks. */
+  get size(): number {
+    return this.jobs.size;
+  }
+
+  private clearTimer(job: JobRecord): void {
+    if (job.timer !== null) {
+      clearTimeout(job.timer);
+      job.timer = null;
+    }
+    job.pendingEntry = null;
+  }
+}
+
+/** Process-wide registry — installs are serialized by `install.lock` regardless. */
+export const pluginInstallJobs = new PluginInstallJobRegistry();

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -9,7 +9,13 @@ import {
   isPrivateOrLoopbackHostname,
   SCOPED_PLUGIN_NAME_PATTERN,
 } from "../../schemas/plugin.js";
-import { extractPluginArchive, computeArchiveHash, readArchiveManifest } from "../PluginArchive.js";
+import {
+  extractPluginArchive,
+  computeArchiveHash,
+  readArchiveManifest,
+  PluginArchiveDeadlineError,
+} from "../PluginArchive.js";
+import { pluginInstallJobs, isInstallCancellation } from "./PluginInstallJobRegistry.js";
 import { MAX_DNTR_BYTES } from "../../utils/pluginArchiveConstants.js";
 import {
   PLUGIN_DOWNLOAD_TIMEOUT_MS,
@@ -281,8 +287,21 @@ export class PluginInstaller {
       );
     }
 
+    // Progress + cancellation ride an optional caller-minted job (#11302). With
+    // no `jobId` every call below is a no-op and the install behaves exactly as
+    // it did before, minus the extraction deadline, which applies unconditionally.
+    const jobId = opts?.jobId;
+    const jobSignal = pluginInstallJobs.signal(jobId);
+    const cancelled: PluginInstallResult = { status: "cancelled" };
+
     let tmpDir: string | null = null;
     try {
+      // `proper-lockfile` has no signal support, so a cancel issued while we
+      // were queued behind another install can only be honoured here — the
+      // first point after acquisition. Nothing is staged yet, so returning
+      // straight out just releases the lock in the `finally`.
+      if (jobSignal?.aborted) return cancelled;
+
       tmpDir = await fs.mkdtemp(path.join(this.pluginsRoot, ".install-tmp-"));
 
       // 1. Materialize the plugin into the temp dir.
@@ -292,6 +311,8 @@ export class PluginInstaller {
       } catch (err) {
         return fail("archive_invalid", `Install source not found: ${(err as Error).message}`);
       }
+
+      pluginInstallJobs.setPhase(jobId, "extracting");
 
       let hash: string | null = null;
       if (sourceIsDir) {
@@ -305,8 +326,21 @@ export class PluginInstaller {
         }
       } else {
         try {
-          await extractPluginArchive(archivePath, tmpDir);
+          await extractPluginArchive(archivePath, tmpDir, {
+            signal: jobSignal,
+            onEntry: (entry) => pluginInstallJobs.reportEntry(jobId, entry),
+          });
         } catch (err) {
+          // Three abort sources reach here with distinct reasons. A user cancel
+          // isn't a failure at all — it returns the same `cancelled` status the
+          // dismissed file picker does, so no error surface is raised for
+          // something the user asked for. The absolute deadline gets its own
+          // code: the archive may be perfectly valid and merely arriving too
+          // slowly, so "check the file" would be the wrong advice.
+          if (isInstallCancellation(err)) return cancelled;
+          if (err instanceof PluginArchiveDeadlineError) {
+            return fail("extraction_timeout", `Extraction timed out: ${err.message}`);
+          }
           return fail("archive_invalid", `Failed to extract archive: ${(err as Error).message}`);
         }
         try {
@@ -315,6 +349,9 @@ export class PluginInstaller {
           return fail("hash_failed", `Failed to compute archive hash: ${(err as Error).message}`);
         }
       }
+
+      if (jobSignal?.aborted) return cancelled;
+      pluginInstallJobs.setPhase(jobId, "validating");
 
       // 2. Read + strictly validate the manifest.
       let rawManifest: string;
@@ -397,6 +434,14 @@ export class PluginInstaller {
       if (lockCompromised) {
         return fail("lock_failed", "Install lock was compromised mid-install; aborted before swap");
       }
+
+      // Commit point. Everything above is staged in `tmpDir` and throwing it
+      // away costs nothing; everything below unloads the running plugin and
+      // renames directories. `commit()` closes the cancellation window and
+      // reports whether a cancel beat it — one guarded step, so a cancel can't
+      // slip between "still cancellable" and the first irreversible operation.
+      if (!pluginInstallJobs.commit(jobId)) return cancelled;
+      pluginInstallJobs.setPhase(jobId, "activating");
 
       if (existing) {
         try {

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -246,10 +246,23 @@ export class PluginInstaller {
     archivePath: string,
     opts?: PluginInstallOptions
   ): Promise<PluginInstallResult> {
-    const fail = (code: PluginInstallErrorCode, message: string): PluginInstallResult => ({
-      status: "failed",
-      errors: [{ code, message }],
-    });
+    // Progress + cancellation ride an optional caller-minted job (#11302). With
+    // no `jobId` every registry call below is a no-op and the install behaves
+    // exactly as it did before, minus the extraction deadline, which applies
+    // unconditionally.
+    const jobId = opts?.jobId;
+    const jobSignal = pluginInstallJobs.signal(jobId);
+    const cancelled: PluginInstallResult = { status: "cancelled" };
+
+    // A cancel the user already asked for outranks whatever error the
+    // now-doomed operation happens to surface. Without this, cancelling during
+    // (say) `computeArchiveHash` and having the underlying read then fail with
+    // EIO would report `hash_failed` — blaming the archive for something the
+    // user deliberately stopped. Safe past the commit point too: `commit()`
+    // refuses once aborted, so reaching the post-swap failure paths proves no
+    // cancel was ever accepted.
+    const fail = (code: PluginInstallErrorCode, message: string): PluginInstallResult =>
+      jobSignal?.aborted === true ? cancelled : { status: "failed", errors: [{ code, message }] };
 
     await fs.mkdir(this.pluginsRoot, { recursive: true });
 
@@ -286,13 +299,6 @@ export class PluginInstaller {
         `Couldn't acquire the plugin install lock: ${(err as Error).message}`
       );
     }
-
-    // Progress + cancellation ride an optional caller-minted job (#11302). With
-    // no `jobId` every call below is a no-op and the install behaves exactly as
-    // it did before, minus the extraction deadline, which applies unconditionally.
-    const jobId = opts?.jobId;
-    const jobSignal = pluginInstallJobs.signal(jobId);
-    const cancelled: PluginInstallResult = { status: "cancelled" };
 
     let tmpDir: string | null = null;
     try {

--- a/electron/services/plugin/__tests__/PluginInstallJobRegistry.test.ts
+++ b/electron/services/plugin/__tests__/PluginInstallJobRegistry.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PluginInstallJobRegistry,
+  PLUGIN_INSTALL_PROGRESS_THROTTLE_MS,
+  isInstallCancellation,
+} from "../PluginInstallJobRegistry.js";
+import type { PluginInstallProgressEvent } from "../../../../shared/types/plugin.js";
+
+describe("PluginInstallJobRegistry (#11302)", () => {
+  let registry: PluginInstallJobRegistry;
+  let events: PluginInstallProgressEvent[];
+  const emit = (e: PluginInstallProgressEvent) => events.push(e);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    registry = new PluginInstallJobRegistry();
+    events = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hands back a live signal for a registered job and nothing for an unknown one", () => {
+    const signal = registry.begin("job-1", emit);
+    expect(signal?.aborted).toBe(false);
+    expect(registry.signal("job-1")).toBe(signal);
+    expect(registry.signal("job-2")).toBeUndefined();
+    expect(registry.signal(undefined)).toBeUndefined();
+  });
+
+  it("refuses to re-register a live id so a second caller can't hijack the job", () => {
+    const first = registry.begin("job-1", emit);
+    expect(registry.begin("job-1", emit)).toBeNull();
+    // The original job keeps its own controller — cancelling still targets it.
+    registry.cancel("job-1");
+    expect(first?.aborted).toBe(true);
+  });
+
+  it("aborts with a reason the installer can recognise as a cancel", () => {
+    const signal = registry.begin("job-1", emit);
+    expect(registry.cancel("job-1")).toBe(true);
+    expect(isInstallCancellation(signal?.reason)).toBe(true);
+    expect(isInstallCancellation(new Error("something else"))).toBe(false);
+  });
+
+  it("reports failure when cancelling an unknown job", () => {
+    expect(registry.cancel("never-registered")).toBe(false);
+  });
+
+  it("cancels only once — a second cancel reports that nothing was done", () => {
+    registry.begin("job-1", emit);
+    expect(registry.cancel("job-1")).toBe(true);
+    expect(registry.cancel("job-1")).toBe(false);
+  });
+
+  it("pushes phase changes immediately, without waiting on the entry throttle", () => {
+    registry.begin("job-1", emit);
+    registry.setPhase("job-1", "extracting");
+    registry.setPhase("job-1", "validating");
+    expect(events.map((e) => e.phase)).toEqual(["extracting", "validating"]);
+  });
+
+  it("coalesces an entry burst down to the first and the last", () => {
+    registry.begin("job-1", emit);
+    registry.setPhase("job-1", "extracting");
+    events.length = 0;
+
+    registry.reportEntry("job-1", "a.js");
+    registry.reportEntry("job-1", "b.js");
+    registry.reportEntry("job-1", "c.js");
+    // Leading edge only so far — the rest are still behind the trailing timer.
+    expect(events.map((e) => e.entry)).toEqual(["a.js"]);
+
+    vi.advanceTimersByTime(PLUGIN_INSTALL_PROGRESS_THROTTLE_MS);
+    // The burst settles on the newest entry, not a stale middle one.
+    expect(events.map((e) => e.entry)).toEqual(["a.js", "c.js"]);
+  });
+
+  it("drops a queued entry when the phase moves on, so no stale row outlives it", () => {
+    registry.begin("job-1", emit);
+    registry.setPhase("job-1", "extracting");
+    registry.reportEntry("job-1", "a.js");
+    registry.reportEntry("job-1", "b.js");
+    events.length = 0;
+
+    registry.setPhase("job-1", "validating");
+    vi.advanceTimersByTime(PLUGIN_INSTALL_PROGRESS_THROTTLE_MS * 2);
+    expect(events).toEqual([{ jobId: "job-1", phase: "validating", cancellable: true }]);
+  });
+
+  it("ignores progress for a job that was never registered", () => {
+    registry.setPhase("ghost", "extracting");
+    registry.reportEntry("ghost", "a.js");
+    vi.advanceTimersByTime(PLUGIN_INSTALL_PROGRESS_THROTTLE_MS);
+    expect(events).toEqual([]);
+  });
+
+  it("closes the cancel window at commit and reports it on later events", () => {
+    registry.begin("job-1", emit);
+    expect(registry.isCancellable("job-1")).toBe(true);
+    expect(registry.commit("job-1")).toBe(true);
+    expect(registry.isCancellable("job-1")).toBe(false);
+
+    registry.setPhase("job-1", "activating");
+    expect(events.at(-1)).toEqual({
+      jobId: "job-1",
+      phase: "activating",
+      cancellable: false,
+    });
+  });
+
+  it("refuses a cancel once the job has committed", () => {
+    registry.begin("job-1", emit);
+    registry.commit("job-1");
+    expect(registry.cancel("job-1")).toBe(false);
+  });
+
+  it("reports a lost commit race so the installer bails instead of committing", () => {
+    registry.begin("job-1", emit);
+    registry.cancel("job-1");
+    expect(registry.commit("job-1")).toBe(false);
+  });
+
+  it("treats commit for an untracked job as permission to proceed", () => {
+    // Installs without a jobId must not be blocked by the registry.
+    expect(registry.commit(undefined)).toBe(true);
+    expect(registry.commit("ghost")).toBe(true);
+  });
+
+  it("drops the record and its pending timer on end", () => {
+    registry.begin("job-1", emit);
+    registry.setPhase("job-1", "extracting");
+    registry.reportEntry("job-1", "a.js");
+    registry.reportEntry("job-1", "b.js");
+    events.length = 0;
+
+    registry.end("job-1");
+    expect(registry.size).toBe(0);
+    expect(registry.signal("job-1")).toBeUndefined();
+
+    // The queued trailing emission must not fire after the job is gone.
+    vi.advanceTimersByTime(PLUGIN_INSTALL_PROGRESS_THROTTLE_MS * 2);
+    expect(events).toEqual([]);
+  });
+
+  it("is idempotent on end", () => {
+    registry.begin("job-1", emit);
+    registry.end("job-1");
+    registry.end("job-1");
+    registry.end(undefined);
+    expect(registry.size).toBe(0);
+  });
+
+  it("keeps concurrent jobs isolated", () => {
+    const a = registry.begin("job-a", emit);
+    const b = registry.begin("job-b", emit);
+    registry.cancel("job-a");
+    expect(a?.aborted).toBe(true);
+    expect(b?.aborted).toBe(false);
+    expect(registry.size).toBe(2);
+  });
+});

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1867,6 +1867,15 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      */
     onProvenanceChanged(callback: (payload: Record<string, never>) => void): () => void;
     /**
+     * Subscribe to phase/entry progress for installs started with a `jobId`
+     * (#11302). Only the window that started the install receives its events;
+     * filter by `jobId` anyway, since one window can start several in sequence.
+     * Returns a cleanup.
+     */
+    onInstallProgress(
+      callback: (event: import("../plugin.js").PluginInstallProgressEvent) => void
+    ): () => void;
+    /**
      * Subscribe to background update-check results (#10893). Fires with the
      * batched set of URL-installed plugins that have updates available. Returns
      * a cleanup.

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -409,6 +409,9 @@ export interface GeneratedElectronAPI {
     activateForView(
       ...args: IpcInvokeMap["plugin:activate-for-view"]["args"]
     ): Promise<IpcInvokeMap["plugin:activate-for-view"]["result"]>;
+    cancelInstall(
+      ...args: IpcInvokeMap["plugin:cancel-install"]["args"]
+    ): Promise<IpcInvokeMap["plugin:cancel-install"]["result"]>;
     checkForUpdate(
       ...args: IpcInvokeMap["plugin:check-for-update"]["args"]
     ): Promise<IpcInvokeMap["plugin:check-for-update"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -956,6 +956,10 @@ export interface GeneratedIpcInvokeMap {
     args: [enabled: boolean];
     result: import("../plugin.js").PluginBackgroundUpdateCheckSettings;
   };
+  "plugin:cancel-install": {
+    args: [jobId: string];
+    result: boolean;
+  };
   "plugin:check-for-update": {
     args: [pluginId: string];
     result: import("../plugin.js").PluginCheckUpdateResult;
@@ -997,15 +1001,15 @@ export interface GeneratedIpcInvokeMap {
     result: import("../plugin.js").PluginInstallResult;
   };
   "plugin:install-from-file": {
-    args: [];
+    args: [jobId?: string | undefined];
     result: import("../plugin.js").PluginInstallResult;
   };
   "plugin:install-from-path": {
-    args: [path: string];
+    args: [path: string, jobId?: string | undefined];
     result: import("../plugin.js").PluginInstallResult;
   };
   "plugin:install-from-url": {
-    args: [url: string];
+    args: [url: string, jobId?: string | undefined];
     result: import("../plugin.js").PluginInstallResult;
   };
   "plugin:keybindings": {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1651,6 +1651,10 @@ export interface IpcEventMap {
   // Agent install progress events
   "setup:agent-install-progress": AgentInstallProgressEvent;
 
+  // Plugin install progress (#11302) — targeted at the window that started the
+  // install, not a global broadcast, so it is NOT an event-bus channel.
+  "plugin:install-progress": import("../plugin.js").PluginInstallProgressEvent;
+
   // System events
   "system:wake": SystemWakePayload;
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -937,10 +937,14 @@ export interface InstalledPluginRecord {
  * - `fetch_timeout` — the download exceeded the shared `PLUGIN_DOWNLOAD_TIMEOUT_MS` deadline (30s)
  * - `size_exceeded` — declared `Content-Length` or the streamed bytes exceeded 30 MB
  * - `content_type_rejected` — response wasn't a plugin archive (bad MIME and the URL doesn't end in `.dntr`)
+ * - `extraction_timeout` — extraction ran past `PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS` (#11302), distinct
+ *   from `archive_invalid`: the archive may be fine and the source merely too slow, so the
+ *   actionable advice is "try again", not "check the file"
  */
 export type PluginInstallErrorCode =
   | "lock_failed"
   | "archive_invalid"
+  | "extraction_timeout"
   | "manifest_invalid"
   | "engine_incompatible"
   | "namespace_unauthorized"
@@ -1003,6 +1007,38 @@ export interface PluginInstallOptions {
   source?: PluginInstallSource;
   /** Original download URL for catalog/url installs. Never logged. */
   originalUrl?: string | null;
+  /**
+   * Correlation id for progress reporting and cancellation (#11302). Minted by
+   * the caller that wants feedback; omitting it installs exactly as before, just
+   * without progress events or a cancel target. Not persisted.
+   */
+  jobId?: string;
+}
+
+/**
+ * Coarse stage of an in-flight install (#11302). Deliberately a small fixed
+ * sequence rather than the agent installer's raw stdout chunks — a plugin
+ * install is a known series of steps, not a subprocess emitting text.
+ *
+ * `downloading` only occurs for install-from-URL. Everything through
+ * `validating` is staged in a scratch directory and freely cancellable;
+ * `activating` marks the commit point, past which cancellation is refused
+ * because the swap and load are already underway.
+ */
+export type PluginInstallPhase = "downloading" | "extracting" | "validating" | "activating";
+
+/** Progress push for an install started with a {@link PluginInstallOptions.jobId}. */
+export interface PluginInstallProgressEvent {
+  /** The `jobId` the caller supplied; events for other jobs must be ignored. */
+  jobId: string;
+  phase: PluginInstallPhase;
+  /**
+   * The archive entry currently being written, during `extracting` only.
+   * Throttled — this is a liveness detail, not a complete log of every entry.
+   */
+  entry?: string;
+  /** False once the install has passed the commit point and can no longer be cancelled. */
+  cancellable: boolean;
 }
 
 export interface LoadedPluginInfo {

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -19,7 +19,10 @@ import { systemClient } from "@/clients/systemClient";
 import {
   BUILT_IN_PLUGIN_CAPABILITIES,
   type LoadedPluginInfo,
+  type PanelContribution,
+  type PluginActionContribution,
   type PluginAuthor,
+  type PluginCapability,
   type PluginInstallSource,
 } from "@shared/types/plugin";
 
@@ -39,14 +42,32 @@ const BADGE_CLASS =
   "inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-overlay-subtle border border-daintree-border/50 text-daintree-text/60 uppercase tracking-wide";
 
 /**
+ * Declared capabilities in the order {@link BUILT_IN_PLUGIN_CAPABILITIES} defines
+ * them, so the Permissions list reads the same for every plugin. Computed by the
+ * pane (not inside {@link PluginCapabilityList}) because the same emptiness that
+ * would render a bare "no permissions" line is what hides the tab entirely.
+ */
+function grantedCapabilities(plugin: LoadedPluginInfo) {
+  const declared = new Set(plugin.manifest.capabilities ?? []);
+  return BUILT_IN_PLUGIN_CAPABILITIES.filter((c) => declared.has(c));
+}
+
+/**
  * Surfaces a plugin's declared capabilities (#9556) as a labelled, risk-coloured
  * list with an effective-danger summary. Read-only — the data already rides on
  * `LoadedPluginInfo`; this only presents it so users can audit what an installed
  * plugin is allowed to do without re-opening the install dialog.
+ *
+ * Only rendered when `granted` is non-empty (#11302) — a plugin that declares no
+ * capabilities has no Permissions tab at all, so there's no empty branch here.
  */
-function PluginCapabilityList({ plugin }: { plugin: LoadedPluginInfo }) {
-  const declared = new Set(plugin.manifest.capabilities ?? []);
-  const granted = BUILT_IN_PLUGIN_CAPABILITIES.filter((c) => declared.has(c));
+function PluginCapabilityList({
+  plugin,
+  granted,
+}: {
+  plugin: LoadedPluginInfo;
+  granted: readonly PluginCapability[];
+}) {
   const allowedUrls = plugin.manifest.scopes?.network?.allowedUrls;
 
   return (
@@ -54,25 +75,87 @@ function PluginCapabilityList({ plugin }: { plugin: LoadedPluginInfo }) {
       <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
         Permissions
       </h4>
-      {granted.length === 0 ? (
-        <p className="text-xs text-daintree-text/40">No special permissions</p>
-      ) : (
-        <>
-          {plugin.pluginDanger === "confirm" && (
-            <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
-              <AlertTriangle className="w-3.5 h-3.5 text-status-warning shrink-0 mt-0.5" />
-              <p className="text-[11px] text-status-warning break-words">
-                Requests sensitive permissions — review before enabling
-              </p>
-            </div>
-          )}
-          <ul className="space-y-1.5">
-            {granted.map((capability) => (
-              <CapabilityRow key={capability} capability={capability} allowedUrls={allowedUrls} />
-            ))}
-          </ul>
-        </>
+      {plugin.pluginDanger === "confirm" && (
+        <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
+          <AlertTriangle className="w-3.5 h-3.5 text-status-warning shrink-0 mt-0.5" />
+          <p className="text-[11px] text-status-warning break-words">
+            Requests sensitive permissions — review before enabling
+          </p>
+        </div>
       )}
+      <ul className="space-y-1.5">
+        {granted.map((capability) => (
+          <CapabilityRow key={capability} capability={capability} allowedUrls={allowedUrls} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The commands a plugin contributes to the command palette (#11302). A minimal
+ * plugin's whole surface is often one command, and before this the Plugin
+ * Manager never named it — leaving no obvious entry point after install. Read
+ * straight off the loaded manifest; no IPC.
+ *
+ * Styled neutrally (no accent, no manifest-supplied colour): this is reference
+ * material, not a focus signal. `kind: "query"` commands are reachable by
+ * automation rather than the palette, so the hint distinguishes them. The
+ * manifest's self-declared `danger` is deliberately NOT shown — the host's
+ * `effectiveDanger` is the only authority on that, and echoing an unverified
+ * claim here would read as a host guarantee.
+ */
+function PluginContributedCommands({ commands }: { commands: PluginActionContribution[] }) {
+  return (
+    <div className="space-y-2">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+        Commands
+      </h4>
+      <ul className="space-y-2">
+        {commands.map((command) => (
+          <li key={command.id} className="text-xs">
+            <div className="text-daintree-text/80">{command.title}</div>
+            {command.description && (
+              <div className="text-[11px] text-daintree-text/50 mt-0.5 break-words">
+                {command.description}
+              </div>
+            )}
+            <div className="text-[11px] text-daintree-text/40 mt-0.5">
+              {command.kind === "query"
+                ? "Available to agents and automation"
+                : "Run it from the command palette"}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The panel kinds a plugin contributes (#11302), so a freshly installed plugin
+ * names the panel you can open instead of leaving you to discover it. Panels
+ * hidden from the palette (`showInPalette: false`) are still listed — the plugin
+ * opens those itself — but labelled accurately so the row isn't a dead end.
+ */
+function PluginContributedPanels({ panels }: { panels: PanelContribution[] }) {
+  return (
+    <div className="space-y-2">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+        Panels
+      </h4>
+      <ul className="space-y-2">
+        {panels.map((panel) => (
+          <li key={panel.id} className="text-xs">
+            <div className="text-daintree-text/80">{panel.name}</div>
+            <div className="text-[11px] text-daintree-text/40 mt-0.5">
+              {panel.showInPalette === false
+                ? "Opened by the plugin"
+                : "Open it from the new-panel menu"}
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -174,6 +257,9 @@ export function PluginDetailPane({
   const hasSettings = (plugin.manifest.contributes.settings?.length ?? 0) > 0;
   const mcpServers = plugin.manifest.contributes.mcpServers ?? [];
   const hasMcpServers = mcpServers.length > 0;
+  const granted = grantedCapabilities(plugin);
+  const commands = plugin.manifest.contributes.commands ?? [];
+  const panels = plugin.manifest.contributes.panels ?? [];
   const [activeTab, setActiveTab] = useState<PluginDetailTab>("overview");
 
   // URL-installed plugins have an upstream to re-fetch and compare against;
@@ -188,14 +274,29 @@ export function PluginDetailPane({
       ? "Built-in plugins update with Daintree"
       : "No update URL — reinstall from a file to update";
 
+  // Every tab past Overview is earned by content (#11302). A minimal plugin that
+  // declares no settings and no capabilities used to get three tabs, two of them
+  // a single muted "nothing here" line — which reads as a half-finished install.
+  // The MCP-servers tab set this precedent; Settings and Permissions now follow
+  // it. Overview is unconditional so there is always somewhere to land.
   const tabs: SettingsSubtabItem[] = [
     { id: "overview", label: "Overview" },
-    { id: "settings", label: "Settings" },
-    { id: "capabilities", label: "Permissions" },
+    ...(hasSettings ? [{ id: "settings", label: "Settings" }] : []),
+    ...(granted.length > 0 ? [{ id: "capabilities", label: "Permissions" }] : []),
     // Only plugins that actually contribute MCP servers get the runtime tab —
     // it surfaces subprocess health and restart, which is meaningless otherwise.
     ...(hasMcpServers ? [{ id: "mcp-servers", label: "MCP servers" }] : []),
   ];
+
+  // Selecting a *different* plugin remounts this subtree (the scroll wrapper is
+  // keyed on `plugin.manifest.name`), which resets `activeTab`. Reinstalling the
+  // SAME plugin does not — the key is unchanged — so a version that drops its
+  // last setting can strand `activeTab` on a tab that no longer exists. Derive
+  // the rendered tab instead of syncing state in an effect: one expression, no
+  // extra render, and it doubles as the `onChange` guard so the tab list and the
+  // guard can't drift apart the way they did before.
+  const isVisibleTab = (id: string): id is PluginDetailTab => tabs.some((t) => t.id === id);
+  const currentTab: PluginDetailTab = isVisibleTab(activeTab) ? activeTab : "overview";
 
   return (
     <div className="text-daintree-text">
@@ -301,21 +402,14 @@ export function PluginDetailPane({
       <div className="mt-4">
         <SettingsSubtabBar
           subtabs={tabs}
-          activeId={activeTab}
+          activeId={currentTab}
           onChange={(id) => {
-            if (
-              id === "overview" ||
-              id === "settings" ||
-              id === "capabilities" ||
-              (id === "mcp-servers" && hasMcpServers)
-            ) {
-              setActiveTab(id);
-            }
+            if (isVisibleTab(id)) setActiveTab(id);
           }}
         />
       </div>
 
-      {activeTab === "overview" && (
+      {currentTab === "overview" && (
         <div className="space-y-4">
           {plugin.manifest.description ? (
             <p className="text-xs text-daintree-text/70 select-text">
@@ -324,6 +418,10 @@ export function PluginDetailPane({
           ) : (
             <p className="text-xs text-daintree-text/40">No description provided.</p>
           )}
+
+          {commands.length > 0 && <PluginContributedCommands commands={commands} />}
+
+          {panels.length > 0 && <PluginContributedPanels panels={panels} />}
 
           {plugin.manifest.authors && plugin.manifest.authors.length > 0 && (
             <PluginContributors authors={plugin.manifest.authors} />
@@ -352,17 +450,14 @@ export function PluginDetailPane({
 
       {/* Settings render whether or not the plugin is enabled — values persist
           independently of the plugin's runtime, so users can pre-configure a
-          plugin before turning it on, or keep editing it while it's off. */}
-      {activeTab === "settings" &&
-        (hasSettings ? (
-          <PluginSettingsForm plugin={plugin} />
-        ) : (
-          <p className="text-xs text-daintree-text/40">This plugin has no settings.</p>
-        ))}
+          plugin before turning it on, or keep editing it while it's off. The tab
+          only exists when the plugin declares settings, so there's no empty
+          branch to fall back to. */}
+      {currentTab === "settings" && <PluginSettingsForm plugin={plugin} />}
 
-      {activeTab === "capabilities" && <PluginCapabilityList plugin={plugin} />}
+      {currentTab === "capabilities" && <PluginCapabilityList plugin={plugin} granted={granted} />}
 
-      {activeTab === "mcp-servers" && hasMcpServers && (
+      {currentTab === "mcp-servers" && hasMcpServers && (
         <PluginMcpServersSection pluginId={plugin.manifest.name} declared={mcpServers} />
       )}
     </div>

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AlertCircle, AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
 import {
   getPluginCategoryMeta,
@@ -297,6 +297,15 @@ export function PluginDetailPane({
   // guard can't drift apart the way they did before.
   const isVisibleTab = (id: string): id is PluginDetailTab => tabs.some((t) => t.id === id);
   const currentTab: PluginDetailTab = isVisibleTab(activeTab) ? activeTab : "overview";
+
+  // The derivation above keeps the RENDER correct, but `activeTab` itself would
+  // stay pointing at the vanished tab — so a later reinstall that restores it
+  // would teleport the user back there without them asking. Fold the fallback
+  // into state once the tab set has actually changed. Ordinary local UI state
+  // sync, unrelated to the single-data-loading-effect rule (#4958).
+  useEffect(() => {
+    if (currentTab !== activeTab) setActiveTab(currentTab);
+  }, [currentTab, activeTab]);
 
   return (
     <div className="text-daintree-text">

--- a/src/components/Plugin/PluginInstallProgressBanner.tsx
+++ b/src/components/Plugin/PluginInstallProgressBanner.tsx
@@ -1,0 +1,90 @@
+import { Download } from "lucide-react";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { useDeferredLoading } from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import type { PluginInstallPhase, PluginInstallProgressEvent } from "@shared/types/plugin";
+
+const PHASE_TITLES: Record<PluginInstallPhase, string> = {
+  downloading: "Downloading the plugin",
+  extracting: "Unpacking the plugin",
+  validating: "Checking the plugin",
+  activating: "Finishing the install",
+};
+
+/** Longest entry path shown before the middle is elided. */
+const MAX_ENTRY_CHARS = 48;
+
+/**
+ * Keep the tail of a long archive path — the filename is what identifies the
+ * entry, and a left-truncated path is unreadable. Elides the middle so the
+ * top-level directory still anchors it.
+ */
+function truncateEntry(entry: string): string {
+  if (entry.length <= MAX_ENTRY_CHARS) return entry;
+  const tail = entry.slice(-(MAX_ENTRY_CHARS - 12));
+  return `${entry.slice(0, 9)}…${tail}`;
+}
+
+interface PluginInstallProgressBannerProps {
+  /** True while an install call is in flight, whether or not progress has arrived. */
+  isInstalling: boolean;
+  /** Latest progress push for the in-flight job, or null before the first one. */
+  progress: PluginInstallProgressEvent | null;
+  onCancel: () => void;
+}
+
+/**
+ * Phase + current archive entry for an in-flight install, with a cancel (#11302).
+ *
+ * Before this, installing reported nothing until it finished — on a slow source
+ * the Plugin Manager simply sat there, which is what made the 0.27.0 extraction
+ * hang read as a frozen app rather than a stuck download.
+ *
+ * Gated at the Doherty threshold: a local `.dntr` installs in well under 400ms
+ * and flashing a banner for it would be noise. The layout is a fixed one-line
+ * shape, so there's no skeleton stage — the banner either isn't warranted yet or
+ * has real content to show.
+ *
+ * Neutral severity, no accent: this is ambient progress, not a focus anchor or a
+ * problem. The live region announces phase changes only — the entry line churns
+ * every ~150ms and reading it aloud would be unusable.
+ */
+export function PluginInstallProgressBanner({
+  isInstalling,
+  progress,
+  onCancel,
+}: PluginInstallProgressBannerProps) {
+  const show = useDeferredLoading(isInstalling, UI_DOHERTY_THRESHOLD);
+  if (!show) return null;
+
+  // No event yet: the install has been dispatched but main hasn't reached its
+  // first phase. Name the step that is actually happening rather than inventing
+  // a phase the installer might skip.
+  const phase = progress?.phase;
+  const title = phase ? PHASE_TITLES[phase] : "Installing the plugin";
+  // `cancellable` is authoritative and false past the commit point. Absent an
+  // event we assume cancellable — the install can't have committed yet.
+  const cancellable = progress?.cancellable ?? true;
+
+  return (
+    <InlineStatusBanner
+      icon={Download}
+      severity="neutral"
+      title={title}
+      contextLine={phase === "extracting" && progress?.entry ? truncateEntry(progress.entry) : ""}
+      role="status"
+      ariaLive="polite"
+      animated
+      actions={[
+        {
+          id: "cancel-install",
+          label: "Cancel install",
+          variant: "dismiss",
+          onClick: onCancel,
+          disabled: !cancellable,
+          title: cancellable ? undefined : "Too late to cancel — the install is being finalised",
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/Plugin/PluginInstallProgressBanner.tsx
+++ b/src/components/Plugin/PluginInstallProgressBanner.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Download } from "lucide-react";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useDeferredLoading } from "@/hooks";
@@ -25,11 +26,16 @@ function truncateEntry(entry: string): string {
   return `${entry.slice(0, 9)}…${tail}`;
 }
 
+/** Past this, name the wait explicitly rather than leaving a phase sitting there. */
+const LONG_WAIT_MS = 5000;
+
 interface PluginInstallProgressBannerProps {
-  /** True while an install call is in flight, whether or not progress has arrived. */
+  /** True while an install job is in flight, whether or not progress has arrived. */
   isInstalling: boolean;
   /** Latest progress push for the in-flight job, or null before the first one. */
   progress: PluginInstallProgressEvent | null;
+  /** True once the user has asked to cancel and main hasn't finished unwinding. */
+  cancelRequested: boolean;
   onCancel: () => void;
 }
 
@@ -43,37 +49,60 @@ interface PluginInstallProgressBannerProps {
  * Gated at the Doherty threshold: a local `.dntr` installs in well under 400ms
  * and flashing a banner for it would be noise. The layout is a fixed one-line
  * shape, so there's no skeleton stage — the banner either isn't warranted yet or
- * has real content to show.
+ * has real content to show. Past five seconds it says so, since `validating` and
+ * `activating` carry no entry line and would otherwise look stalled.
  *
  * Neutral severity, no accent: this is ambient progress, not a focus anchor or a
- * problem. The live region announces phase changes only — the entry line churns
- * every ~150ms and reading it aloud would be unusable.
+ * problem. `aria-live` is off on purpose — `InlineStatusBanner` announces
+ * atomically, so a polite region would re-read the whole banner every time the
+ * archive entry changes (~150ms). Announcing a fragment of a file path several
+ * times a second is worse than announcing nothing; the outcome of the install is
+ * still surfaced by the error/notice region the Plugin Manager already owns.
  */
 export function PluginInstallProgressBanner({
   isInstalling,
   progress,
+  cancelRequested,
   onCancel,
 }: PluginInstallProgressBannerProps) {
   const show = useDeferredLoading(isInstalling, UI_DOHERTY_THRESHOLD);
+  const [longWait, setLongWait] = useState(false);
+
+  useEffect(() => {
+    if (!isInstalling) {
+      setLongWait(false);
+      return;
+    }
+    const timer = setTimeout(() => setLongWait(true), LONG_WAIT_MS);
+    return () => clearTimeout(timer);
+  }, [isInstalling]);
+
   if (!show) return null;
 
   // No event yet: the install has been dispatched but main hasn't reached its
   // first phase. Name the step that is actually happening rather than inventing
   // a phase the installer might skip.
   const phase = progress?.phase;
-  const title = phase ? PHASE_TITLES[phase] : "Installing the plugin";
+  const title = cancelRequested
+    ? "Cancelling the install"
+    : phase
+      ? PHASE_TITLES[phase]
+      : "Installing the plugin";
   // `cancellable` is authoritative and false past the commit point. Absent an
-  // event we assume cancellable — the install can't have committed yet.
+  // event we assume cancellable — the install can't have committed yet, and main
+  // rejects a cancel it can't honour anyway.
   const cancellable = progress?.cancellable ?? true;
+  const entryLine = phase === "extracting" && progress?.entry ? truncateEntry(progress.entry) : "";
 
   return (
     <InlineStatusBanner
       icon={Download}
       severity="neutral"
       title={title}
-      contextLine={phase === "extracting" && progress?.entry ? truncateEntry(progress.entry) : ""}
+      description={longWait && !cancelRequested ? "Still working…" : undefined}
+      contextLine={entryLine}
       role="status"
-      ariaLive="polite"
+      ariaLive="off"
       animated
       actions={[
         {
@@ -81,8 +110,10 @@ export function PluginInstallProgressBanner({
           label: "Cancel install",
           variant: "dismiss",
           onClick: onCancel,
-          disabled: !cancellable,
-          title: cancellable ? undefined : "Too late to cancel — the install is being finalised",
+          // No tooltip on the disabled state: a native disabled button takes no
+          // pointer events and no focus, so the tooltip would be unreachable —
+          // the "Finishing the install" title already says why it's off.
+          disabled: !cancellable || cancelRequested,
         },
       ]}
     />

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -527,8 +527,9 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
       {/* Top-level, not inside the install controls: a drop-install and a URL
           install start from different surfaces but report to the same place. */}
       <PluginInstallProgressBanner
-        isInstalling={pm.isInstalling}
+        isInstalling={pm.hasActiveInstallJob}
         progress={pm.installProgress}
+        cancelRequested={pm.cancelRequested}
         onCancel={pm.cancelActiveInstall}
       />
 

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/utils";
 import { isMac, isWindows } from "@/lib/platform";
 import { usePluginManager } from "./usePluginManager";
 import { PluginDetailPane, SOURCE_BADGE_LABELS, pluginLabel } from "./PluginDetailPane";
+import { PluginInstallProgressBanner } from "./PluginInstallProgressBanner";
 import { PluginCatalog } from "./PluginCatalog";
 import { PluginIconTile } from "./pluginIcons";
 import { groupPluginsByCategory } from "./pluginGrouping";
@@ -522,6 +523,14 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
           ]}
         />
       )}
+
+      {/* Top-level, not inside the install controls: a drop-install and a URL
+          install start from different surfaces but report to the same place. */}
+      <PluginInstallProgressBanner
+        isInstalling={pm.isInstalling}
+        progress={pm.installProgress}
+        onCancel={pm.cancelActiveInstall}
+      />
 
       <div
         className="relative flex flex-1 min-h-0 overflow-hidden"

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -40,6 +40,14 @@ beforeEach(() => {
       ),
       restart: vi.fn(() => Promise.resolve()),
     },
+    // PluginSettingsForm hydrates from these the moment a Settings tab renders.
+    plugin: {
+      getSettingValues: vi.fn(() => Promise.resolve({})),
+      setSettingValue: vi.fn(() => Promise.resolve()),
+      deleteSettingValue: vi.fn(() => Promise.resolve()),
+      revealSecretSetting: vi.fn(() => Promise.resolve(null)),
+      pathExists: vi.fn(() => Promise.resolve(true)),
+    },
   } as unknown as Window["electron"];
 });
 
@@ -134,11 +142,6 @@ function withAuthors(
 }
 
 describe("PluginDetailPane capabilities", () => {
-  it("shows the no-permissions empty state when no capabilities are declared", () => {
-    renderPane(makePlugin());
-    expect(screen.getByText("No special permissions")).toBeTruthy();
-  });
-
   it("renders a labelled row for each declared capability", () => {
     renderPane(withCapabilities(["fs:project-read", "shell:exec"]));
     expect(screen.getByText("Read project files")).toBeTruthy();
@@ -281,6 +284,166 @@ describe("PluginDetailPane MCP servers tab (issue #10584)", () => {
     fireEvent.click(screen.getByRole("tab", { name: "MCP servers" }));
     expect(await screen.findByText("Demo Server")).toBeTruthy();
     expect(pluginMcpListMock).toHaveBeenCalled();
+  });
+});
+
+describe("PluginDetailPane content-gated tabs (#11302)", () => {
+  function withContributes(
+    contributes: Partial<LoadedPluginInfo["manifest"]["contributes"]>,
+    overrides: Partial<LoadedPluginInfo> = {}
+  ): LoadedPluginInfo {
+    const base = makePlugin(overrides);
+    return {
+      ...base,
+      manifest: {
+        ...base.manifest,
+        contributes: { ...base.manifest.contributes, ...contributes },
+      },
+    };
+  }
+
+  const SETTING = {
+    id: "token",
+    type: "string" as const,
+    label: "API token",
+    scope: "user" as const,
+  };
+
+  it("leaves a plugin with no settings and no capabilities on Overview alone", () => {
+    renderOverview(makePlugin());
+    const tabs = screen.getAllByRole("tab").map((t) => t.textContent);
+    expect(tabs).toEqual(["Overview"]);
+  });
+
+  it("hides Settings when the plugin declares none", () => {
+    renderOverview(makePlugin());
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
+  });
+
+  it("shows Settings when the plugin declares one", () => {
+    renderOverview(withContributes({ settings: [SETTING] }));
+    expect(screen.getByRole("tab", { name: "Settings" })).toBeTruthy();
+  });
+
+  it("shows Permissions when the plugin declares a built-in capability", () => {
+    renderOverview(withCapabilities(["fs:project-read"]));
+    expect(screen.getByRole("tab", { name: "Permissions" })).toBeTruthy();
+  });
+
+  it("shows Permissions only when the plugin declares a built-in capability", () => {
+    renderOverview(makePlugin());
+    expect(screen.queryByRole("tab", { name: "Permissions" })).toBeNull();
+  });
+
+  it("falls back to Overview when the active tab disappears on a same-id reinstall", () => {
+    // The detail subtree is keyed on the plugin NAME, so reinstalling the same
+    // plugin re-renders in place rather than remounting — a version that drops
+    // its last setting would otherwise strand the pane on a dead tab.
+    const withSettings = withContributes({ settings: [SETTING] });
+    const { rerender } = render(
+      <TooltipProvider>
+        <PluginDetailPane
+          plugin={withSettings}
+          checkingUpdate={false}
+          upToDate={false}
+          onUninstall={vi.fn()}
+          onCheckForUpdate={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Settings" }));
+    expect(screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")).toBe(
+      "true"
+    );
+
+    rerender(
+      <TooltipProvider>
+        <PluginDetailPane
+          plugin={makePlugin()}
+          checkingUpdate={false}
+          upToDate={false}
+          onUninstall={vi.fn()}
+          onCheckForUpdate={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
+    expect(screen.getByRole("tab", { name: "Overview" }).getAttribute("aria-selected")).toBe(
+      "true"
+    );
+  });
+});
+
+describe("PluginDetailPane overview contributions (#11302)", () => {
+  function withContributes(
+    contributes: Partial<LoadedPluginInfo["manifest"]["contributes"]>
+  ): LoadedPluginInfo {
+    const base = makePlugin();
+    return {
+      ...base,
+      manifest: {
+        ...base.manifest,
+        contributes: { ...base.manifest.contributes, ...contributes },
+      },
+    };
+  }
+
+  const COMMAND = {
+    id: "acme.demo.greet",
+    title: "Say hello",
+    description: "Prints a greeting",
+    category: "Demo",
+    kind: "command" as const,
+    danger: "safe" as const,
+  };
+
+  const PANEL = {
+    id: "acme.demo.board",
+    name: "Demo board",
+    iconId: "layout",
+    color: "#888888",
+    hasPty: false,
+    canRestart: false,
+    canConvert: false,
+    showInPalette: true,
+  };
+
+  it("names each contributed command and how to reach it", () => {
+    renderOverview(withContributes({ commands: [COMMAND] }));
+    expect(screen.getByText("Say hello")).toBeTruthy();
+    expect(screen.getByText("Prints a greeting")).toBeTruthy();
+    expect(screen.getByText("Run it from the command palette")).toBeTruthy();
+  });
+
+  it("distinguishes query commands, which the palette never lists", () => {
+    renderOverview(withContributes({ commands: [{ ...COMMAND, kind: "query" }] }));
+    expect(screen.getByText("Available to agents and automation")).toBeTruthy();
+    expect(screen.queryByText("Run it from the command palette")).toBeNull();
+  });
+
+  it("never echoes the manifest's self-declared danger", () => {
+    // Only the host's effectiveDanger is authoritative; rendering the plugin's
+    // own claim here would read as a host guarantee it never made.
+    renderOverview(withContributes({ commands: [{ ...COMMAND, danger: "confirm" }] }));
+    expect(screen.queryByText(/confirm/i)).toBeNull();
+  });
+
+  it("names each contributed panel and how to open it", () => {
+    renderOverview(withContributes({ panels: [PANEL] }));
+    expect(screen.getByText("Demo board")).toBeTruthy();
+    expect(screen.getByText("Open it from the new-panel menu")).toBeTruthy();
+  });
+
+  it("labels a palette-hidden panel accurately rather than dropping it", () => {
+    renderOverview(withContributes({ panels: [{ ...PANEL, showInPalette: false }] }));
+    expect(screen.getByText("Demo board")).toBeTruthy();
+    expect(screen.getByText("Opened by the plugin")).toBeTruthy();
+  });
+
+  it("omits both sections entirely when the plugin contributes neither", () => {
+    renderOverview(makePlugin());
+    expect(screen.queryByText("Commands")).toBeNull();
+    expect(screen.queryByText("Panels")).toBeNull();
   });
 });
 

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -371,6 +371,25 @@ describe("PluginDetailPane content-gated tabs (#11302)", () => {
     expect(screen.getByRole("tab", { name: "Overview" }).getAttribute("aria-selected")).toBe(
       "true"
     );
+
+    // The vanished tab must not resurrect as active when a later version brings
+    // it back — deriving the rendered tab alone would leave `activeTab` pointing
+    // at "settings", teleporting the user there without them asking.
+    rerender(
+      <TooltipProvider>
+        <PluginDetailPane
+          plugin={withSettings}
+          checkingUpdate={false}
+          upToDate={false}
+          onUninstall={vi.fn()}
+          onCheckForUpdate={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+    expect(screen.getByRole("tab", { name: "Settings" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Overview" }).getAttribute("aria-selected")).toBe(
+      "true"
+    );
   });
 });
 
@@ -425,7 +444,12 @@ describe("PluginDetailPane overview contributions (#11302)", () => {
     // Only the host's effectiveDanger is authoritative; rendering the plugin's
     // own claim here would read as a host guarantee it never made.
     renderOverview(withContributes({ commands: [{ ...COMMAND, danger: "confirm" }] }));
-    expect(screen.queryByText(/confirm/i)).toBeNull();
+    // Anchor on the row actually existing first — a bare "no /confirm/ anywhere"
+    // assertion would also pass if commands stopped rendering entirely.
+    const row = screen.getByText("Say hello").closest("li");
+    expect(row).toBeTruthy();
+    if (!row) return;
+    expect(within(row).queryByText(/confirm/i)).toBeNull();
   });
 
   it("names each contributed panel and how to open it", () => {

--- a/src/components/Plugin/__tests__/PluginInstallProgressBanner.test.tsx
+++ b/src/components/Plugin/__tests__/PluginInstallProgressBanner.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { PluginInstallProgressBanner } from "../PluginInstallProgressBanner";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import type { PluginInstallProgressEvent } from "@shared/types/plugin";
+
+// The disabled Cancel carries an explanatory tooltip, so InlineStatusBanner
+// needs a provider — the app supplies one at the App.tsx root.
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <TooltipProvider>{children}</TooltipProvider>
+);
+
+function progress(over: Partial<PluginInstallProgressEvent> = {}): PluginInstallProgressEvent {
+  return { jobId: "job-1", phase: "extracting", cancellable: true, ...over };
+}
+
+/** Push past the Doherty gate so the banner is allowed to render. */
+function settle() {
+  act(() => {
+    vi.advanceTimersByTime(UI_DOHERTY_THRESHOLD + 10);
+  });
+}
+
+describe("PluginInstallProgressBanner (#11302)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // jsdom ships no matchMedia; InlineStatusBanner reads prefers-reduced-motion.
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays hidden for an install that finishes inside the Doherty threshold", () => {
+    const { rerender } = render(
+      <PluginInstallProgressBanner isInstalling progress={null} onCancel={vi.fn()} />,
+      { wrapper }
+    );
+    act(() => {
+      vi.advanceTimersByTime(UI_DOHERTY_THRESHOLD - 50);
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+
+    // A local .dntr installs in well under 400ms; flashing a banner for it is noise.
+    rerender(
+      <PluginInstallProgressBanner isInstalling={false} progress={null} onCancel={vi.fn()} />
+    );
+    settle();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("names the step once the wait is long enough to be worth reporting", () => {
+    render(<PluginInstallProgressBanner isInstalling progress={null} onCancel={vi.fn()} />, {
+      wrapper,
+    });
+    settle();
+    // No event yet — it must not invent a phase the installer may skip.
+    expect(screen.getByText("Installing the plugin")).toBeTruthy();
+  });
+
+  it("reports each phase in the user's terms", () => {
+    const { rerender } = render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ phase: "downloading" })}
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    expect(screen.getByText("Downloading the plugin")).toBeTruthy();
+
+    rerender(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ phase: "validating" })}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Checking the plugin")).toBeTruthy();
+
+    rerender(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ phase: "activating", cancellable: false })}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Finishing the install")).toBeTruthy();
+  });
+
+  it("shows the archive entry while extracting, and only then", () => {
+    const { rerender } = render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ entry: "dist/index.js" })}
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    expect(screen.getByText("dist/index.js")).toBeTruthy();
+
+    // An entry left over from extraction must not trail into a later phase.
+    rerender(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ phase: "validating", entry: "dist/index.js" })}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("dist/index.js")).toBeNull();
+  });
+
+  it("elides a long entry path from the middle, keeping the filename readable", () => {
+    const entry = `dist/${"deeply-nested/".repeat(6)}component.js`;
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ entry })}
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    expect(screen.queryByText(entry)).toBeNull();
+    // The filename — the part that identifies the entry — survives truncation.
+    expect(screen.getByText(/component\.js$/)).toBeTruthy();
+  });
+
+  it("routes the cancel button to the caller", () => {
+    const onCancel = vi.fn();
+    render(<PluginInstallProgressBanner isInstalling progress={progress()} onCancel={onCancel} />, {
+      wrapper,
+    });
+    settle();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel install" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables cancel once the install has passed its commit point", () => {
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ phase: "activating", cancellable: false })}
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    // Past the swap there is nothing left to abort — a live button here would
+    // promise a rollback the installer no longer offers.
+    expect(screen.getByRole("button", { name: "Cancel install" })).toHaveProperty("disabled", true);
+  });
+
+  it("keeps cancel available before any progress arrives", () => {
+    render(<PluginInstallProgressBanner isInstalling progress={null} onCancel={vi.fn()} />, {
+      wrapper,
+    });
+    settle();
+    expect(screen.getByRole("button", { name: "Cancel install" })).toHaveProperty(
+      "disabled",
+      false
+    );
+  });
+});

--- a/src/components/Plugin/__tests__/PluginInstallProgressBanner.test.tsx
+++ b/src/components/Plugin/__tests__/PluginInstallProgressBanner.test.tsx
@@ -45,7 +45,12 @@ describe("PluginInstallProgressBanner (#11302)", () => {
 
   it("stays hidden for an install that finishes inside the Doherty threshold", () => {
     const { rerender } = render(
-      <PluginInstallProgressBanner isInstalling progress={null} onCancel={vi.fn()} />,
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={null}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />,
       { wrapper }
     );
     act(() => {
@@ -55,16 +60,29 @@ describe("PluginInstallProgressBanner (#11302)", () => {
 
     // A local .dntr installs in well under 400ms; flashing a banner for it is noise.
     rerender(
-      <PluginInstallProgressBanner isInstalling={false} progress={null} onCancel={vi.fn()} />
+      <PluginInstallProgressBanner
+        isInstalling={false}
+        progress={null}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />
     );
     settle();
     expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("names the step once the wait is long enough to be worth reporting", () => {
-    render(<PluginInstallProgressBanner isInstalling progress={null} onCancel={vi.fn()} />, {
-      wrapper,
-    });
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={null}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />,
+      {
+        wrapper,
+      }
+    );
     settle();
     // No event yet — it must not invent a phase the installer may skip.
     expect(screen.getByText("Installing the plugin")).toBeTruthy();
@@ -75,6 +93,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ phase: "downloading" })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />,
       { wrapper }
@@ -86,6 +105,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ phase: "validating" })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />
     );
@@ -95,6 +115,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ phase: "activating", cancellable: false })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />
     );
@@ -106,6 +127,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ entry: "dist/index.js" })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />,
       { wrapper }
@@ -118,6 +140,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ phase: "validating", entry: "dist/index.js" })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />
     );
@@ -130,6 +153,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ entry })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />,
       { wrapper }
@@ -142,9 +166,17 @@ describe("PluginInstallProgressBanner (#11302)", () => {
 
   it("routes the cancel button to the caller", () => {
     const onCancel = vi.fn();
-    render(<PluginInstallProgressBanner isInstalling progress={progress()} onCancel={onCancel} />, {
-      wrapper,
-    });
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress()}
+        cancelRequested={false}
+        onCancel={onCancel}
+      />,
+      {
+        wrapper,
+      }
+    );
     settle();
     fireEvent.click(screen.getByRole("button", { name: "Cancel install" }));
     expect(onCancel).toHaveBeenCalledTimes(1);
@@ -155,6 +187,7 @@ describe("PluginInstallProgressBanner (#11302)", () => {
       <PluginInstallProgressBanner
         isInstalling
         progress={progress({ phase: "activating", cancellable: false })}
+        cancelRequested={false}
         onCancel={vi.fn()}
       />,
       { wrapper }
@@ -166,13 +199,123 @@ describe("PluginInstallProgressBanner (#11302)", () => {
   });
 
   it("keeps cancel available before any progress arrives", () => {
-    render(<PluginInstallProgressBanner isInstalling progress={null} onCancel={vi.fn()} />, {
-      wrapper,
-    });
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={null}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />,
+      {
+        wrapper,
+      }
+    );
     settle();
     expect(screen.getByRole("button", { name: "Cancel install" })).toHaveProperty(
       "disabled",
       false
     );
+  });
+});
+
+describe("PluginInstallProgressBanner long waits and cancel state (#11302)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("says it is still working once the wait passes five seconds", () => {
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress({ phase: "validating" })}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    // Validating and activating carry no entry line, so without this the banner
+    // would sit on one unchanging title and read as hung.
+    expect(screen.queryByText("Still working…")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText("Still working…")).toBeTruthy();
+  });
+
+  it("drops the long-wait note when the install ends", () => {
+    const { rerender } = render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress()}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText("Still working…")).toBeTruthy();
+
+    rerender(
+      <PluginInstallProgressBanner
+        isInstalling={false}
+        progress={null}
+        cancelRequested={false}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("Still working…")).toBeNull();
+  });
+
+  it("reports the cancel and stops accepting clicks once it has been requested", () => {
+    const onCancel = vi.fn();
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress()}
+        cancelRequested
+        onCancel={onCancel}
+      />,
+      { wrapper }
+    );
+    settle();
+    // The title must reflect the request immediately — main takes a moment to
+    // unwind, and leaving "Unpacking the plugin" up reads as the click failing.
+    expect(screen.getByText("Cancelling the install")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel install" })).toHaveProperty("disabled", true);
+  });
+
+  it("suppresses the long-wait note while a cancel is unwinding", () => {
+    render(
+      <PluginInstallProgressBanner
+        isInstalling
+        progress={progress()}
+        cancelRequested
+        onCancel={vi.fn()}
+      />,
+      { wrapper }
+    );
+    settle();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    // "Still working…" alongside "Cancelling the install" would contradict itself.
+    expect(screen.queryByText("Still working…")).toBeNull();
   });
 });

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -97,6 +97,10 @@ beforeEach(() => {
       uninstall: vi.fn().mockResolvedValue(undefined),
       checkForUpdate: vi.fn().mockResolvedValue({ status: "up-to-date" }),
       onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
+      // Install progress + cancel (#11302). The hook subscribes on mount and
+      // mints a jobId for every install, so both must exist for any install path.
+      onInstallProgress: vi.fn().mockReturnValue(() => {}),
+      cancelInstall: vi.fn().mockResolvedValue(true),
       // PluginSettingsForm hydrates stored values for any plugin that
       // contributes settings — stub the full surface so those rows render.
       getSettingValues: vi.fn().mockResolvedValue({ values: {}, secretsSet: [] }),
@@ -285,15 +289,16 @@ describe("PluginManagerView", () => {
     );
   });
 
-  it("shows a no-settings note in the detail pane when a plugin contributes none", async () => {
+  it("hides the Settings tab entirely when a plugin contributes none (#11302)", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
     renderDialog();
     await screen.findAllByText("Acme Demo");
 
     await selectPlugin();
-    // Navigate to the Settings tab to confirm no-settings note.
-    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
-    expect(await screen.findByText("This plugin has no settings.")).toBeTruthy();
+    await screen.findByRole("tab", { name: "Overview" });
+    // A tab whose only content was "this plugin has no settings" is noise —
+    // it's now absent rather than empty.
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
   });
 
   it("shows an empty detail pane before any plugin is selected", async () => {
@@ -578,9 +583,8 @@ describe("PluginManagerView", () => {
     // for a built-in.
     await selectPlugin();
     expect(await screen.findByText("Built-in")).toBeTruthy();
-    // Navigate to Settings tab to check "no settings" note (built-in has no settings).
-    fireEvent.click(await screen.findByRole("tab", { name: "Settings" }));
-    expect(await screen.findByText("This plugin has no settings.")).toBeTruthy();
+    // The built-in contributes no settings, so it earns no Settings tab (#11302).
+    expect(screen.queryByRole("tab", { name: "Settings" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Uninstall Acme Demo" })).toBeNull();
   });
 
@@ -701,7 +705,8 @@ describe("PluginManagerView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
     await waitFor(() =>
       expect(window.electron.plugin.installFromUrl).toHaveBeenCalledWith(
-        "https://example.com/p.dntr"
+        "https://example.com/p.dntr",
+        expect.any(String)
       )
     );
   });
@@ -750,7 +755,8 @@ describe("PluginManagerView", () => {
 
     await waitFor(() =>
       expect(window.electron.plugin.installFromUrl).toHaveBeenCalledWith(
-        "https://example.com/p.dntr"
+        "https://example.com/p.dntr",
+        expect.any(String)
       )
     );
   });
@@ -860,7 +866,8 @@ describe("PluginManagerView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Install over HTTP" }));
     await waitFor(() =>
       expect(window.electron.plugin.installFromUrl).toHaveBeenCalledWith(
-        "http://example.com/p.dntr"
+        "http://example.com/p.dntr",
+        expect.any(String)
       )
     );
   });
@@ -943,7 +950,8 @@ describe("PluginManagerView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Install over HTTP" }));
     await waitFor(() =>
       expect(window.electron.plugin.installFromUrl).toHaveBeenCalledWith(
-        "http://example.com/p.dntr"
+        "http://example.com/p.dntr",
+        expect.any(String)
       )
     );
   });
@@ -1529,7 +1537,10 @@ describe("PluginManagerView", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
       await waitFor(() =>
-        expect(installMock()).toHaveBeenCalledWith("https://example.com/acme.a.dntr")
+        expect(installMock()).toHaveBeenCalledWith(
+          "https://example.com/acme.a.dntr",
+          expect.any(String)
+        )
       );
     });
 

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -3,10 +3,12 @@ import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type {
   LoadedPluginInfo,
   PluginDeepLinkIntent,
   PluginInstallError,
+  PluginInstallProgressEvent,
 } from "@shared/types/plugin";
 
 /**
@@ -39,6 +41,10 @@ function installErrorMessage(error: PluginInstallError | undefined): string {
       return "That URL didn't return a plugin archive (.dntr). Check the URL and try again.";
     case "fetch_failed":
       return "Couldn't download the plugin. Check the URL and try again.";
+    case "extraction_timeout":
+      // The archive itself may be fine — it just never finished arriving, so
+      // "check the file" would send the user down the wrong path (#11302).
+      return "Unpacking the plugin took too long and was stopped. Try installing it again.";
     default:
       return error?.message ?? "Installation failed. Check the file and try again.";
   }
@@ -160,6 +166,60 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   // a render, so two drops dispatched before React flushes could both read a
   // stale `false`; the ref flips immediately and serializes them.
   const installingRef = useRef(false);
+  // Install progress + cancellation (#11302). `installJobIdRef` is the live
+  // correlation key: the push channel is already scoped to this window, but one
+  // window installs several archives in sequence (a multi-file drop), so events
+  // are matched against the job that is actually in flight. Held in a ref, not
+  // state, so the subscription below can stay mounted-once and never re-bind.
+  const installJobIdRef = useRef<string | null>(null);
+  const [installProgress, setInstallProgress] = useState<PluginInstallProgressEvent | null>(null);
+
+  // Progress subscription. Its own mount-once effect with no dependencies —
+  // folding it into the `refreshKey` loading effect would resubscribe on every
+  // list refresh and cross-cancel the load (#4958). Mirrors the shape of the
+  // provenance subscription below.
+  useEffect(() => {
+    return window.electron.plugin.onInstallProgress((event) => {
+      if (event.jobId !== installJobIdRef.current) return;
+      setInstallProgress(event);
+    });
+  }, []);
+
+  /**
+   * Run an install under a fresh progress/cancel job. The id is minted here (not
+   * by main) so the Cancel button has a target from the very first render,
+   * rather than only after the first progress event arrives. The `finally`
+   * clears state only if this job is still the current one, so a superseding
+   * install can't have its banner wiped by its predecessor settling late.
+   */
+  const runInstallJob = async <T>(run: (jobId: string) => Promise<T>): Promise<T> => {
+    const jobId = crypto.randomUUID();
+    installJobIdRef.current = jobId;
+    setInstallProgress(null);
+    try {
+      return await run(jobId);
+    } finally {
+      if (installJobIdRef.current === jobId) {
+        installJobIdRef.current = null;
+        setInstallProgress(null);
+      }
+    }
+  };
+
+  /**
+   * Ask main to abort the in-flight install. Deliberately does NOT clear local
+   * state: the original install promise is still pending and owns the teardown,
+   * and main may refuse (the install has passed its commit point) — in which
+   * case the banner should keep showing the real state rather than a cancel that
+   * didn't happen.
+   */
+  const cancelActiveInstall = () => {
+    const jobId = installJobIdRef.current;
+    if (!jobId) return;
+    safeFireAndForget(window.electron.plugin.cancelInstall(jobId), {
+      context: "usePluginManager.cancelActiveInstall",
+    });
+  };
 
   // Clear the "Already up to date" auto-dismiss timer on unmount.
   useEffect(() => {
@@ -351,7 +411,7 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     if (isInstalling) return;
     setIsInstalling(true);
     try {
-      const result = await window.electron.plugin.installFromFile();
+      const result = await runInstallJob((jobId) => window.electron.plugin.installFromFile(jobId));
       handleInstallResult(result);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to install plugin"));
@@ -364,7 +424,9 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   const performInstallFromUrl = async (url: string) => {
     setIsInstalling(true);
     try {
-      const result = await window.electron.plugin.installFromUrl(url);
+      const result = await runInstallJob((jobId) =>
+        window.electron.plugin.installFromUrl(url, jobId)
+      );
       handleInstallResult(result);
       // Keep the dialog open for URL-correctable failures so the user can edit
       // in place: a malformed URL, a download error (404 / DNS), or a response
@@ -473,7 +535,12 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
           continue;
         }
         try {
-          const result = await window.electron.plugin.installFromPath(path);
+          const result = await runInstallJob((jobId) =>
+            window.electron.plugin.installFromPath(path, jobId)
+          );
+          // A cancel abandons the whole drop, not just this file — the user
+          // stopped the batch, so silently installing the rest would ignore them.
+          if (result.status === "cancelled") break;
           if (result.status === "failed") {
             failures.push(`${file.name} — ${result.errors[0]?.message ?? "install failed"}`);
           } else {
@@ -707,7 +774,9 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     setIsReinstalling(true);
     try {
       setError(null);
-      const result = await window.electron.plugin.installFromUrl(url);
+      const result = await runInstallJob((jobId) =>
+        window.electron.plugin.installFromUrl(url, jobId)
+      );
       handleInstallResult(result);
       advanceUpdateQueue();
     } catch (err) {
@@ -747,6 +816,8 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     urlInput,
     setUrlInput,
     isInstalling,
+    installProgress,
+    cancelActiveInstall,
     handleInstallFromFile,
     handleInstallFromUrl,
     pendingHttpUrl,

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -173,6 +173,19 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   // state, so the subscription below can stay mounted-once and never re-bind.
   const installJobIdRef = useRef<string | null>(null);
   const [installProgress, setInstallProgress] = useState<PluginInstallProgressEvent | null>(null);
+  // Whether ANY install job is in flight. The banner gates on this rather than
+  // on `isInstalling`, because the pre-existing activity booleans are per-entry-
+  // point (`isInstalling` for file/URL/drop, `isReinstalling` for an update) and
+  // are cleared unconditionally by whichever call settles first — so a
+  // reinstall would show no banner at all, and a superseded install's `finally`
+  // could hide its successor's. This one is owned solely by `runInstallJob` and
+  // cleared under the same job-identity guard as the progress state.
+  const [hasActiveInstallJob, setHasActiveInstallJob] = useState(false);
+  // Set the moment the user clicks Cancel, so the button stops accepting
+  // clicks before main answers. Never unset here: either the install ends (and
+  // `runInstallJob` clears it) or main refused because the install already
+  // committed — in which case there is nothing left to cancel either way.
+  const [cancelRequested, setCancelRequested] = useState(false);
 
   // Progress subscription. Its own mount-once effect with no dependencies —
   // folding it into the `refreshKey` loading effect would resubscribe on every
@@ -196,26 +209,31 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     const jobId = crypto.randomUUID();
     installJobIdRef.current = jobId;
     setInstallProgress(null);
+    setCancelRequested(false);
+    setHasActiveInstallJob(true);
     try {
       return await run(jobId);
     } finally {
       if (installJobIdRef.current === jobId) {
         installJobIdRef.current = null;
         setInstallProgress(null);
+        setCancelRequested(false);
+        setHasActiveInstallJob(false);
       }
     }
   };
 
   /**
-   * Ask main to abort the in-flight install. Deliberately does NOT clear local
-   * state: the original install promise is still pending and owns the teardown,
-   * and main may refuse (the install has passed its commit point) — in which
-   * case the banner should keep showing the real state rather than a cancel that
-   * didn't happen.
+   * Ask main to abort the in-flight install. Deliberately does NOT clear the
+   * install state: the original install promise is still pending and owns the
+   * teardown, and main may refuse (the install has passed its commit point) —
+   * in which case the banner should keep showing the real state rather than a
+   * cancel that didn't happen.
    */
   const cancelActiveInstall = () => {
     const jobId = installJobIdRef.current;
-    if (!jobId) return;
+    if (!jobId || cancelRequested) return;
+    setCancelRequested(true);
     safeFireAndForget(window.electron.plugin.cancelInstall(jobId), {
       context: "usePluginManager.cancelActiveInstall",
     });
@@ -772,6 +790,12 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     }
     reinstallingRef.current = true;
     setIsReinstalling(true);
+    // Dismiss the update confirm before the download starts. It has served its
+    // purpose (the user accepted), and leaving it up would stack a modal over
+    // the progress banner — burying the Cancel button behind the very dialog
+    // the user just dismissed. `advanceUpdateQueue` below still drives the
+    // batch; it sets the next `pendingUpdate` itself and never reads this one.
+    setPendingUpdate(null);
     try {
       setError(null);
       const result = await runInstallJob((jobId) =>
@@ -816,7 +840,9 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     urlInput,
     setUrlInput,
     isInstalling,
+    hasActiveInstallJob,
     installProgress,
+    cancelRequested,
     cancelActiveInstall,
     handleInstallFromFile,
     handleInstallFromUrl,


### PR DESCRIPTION
## Summary

A few Plugin Manager and installer problems, found while watching an external developer install a real minimal plugin.

Resolves #11302

## Detail tabs

Settings and Permissions used to always render on a plugin's detail pane, even when empty, showing muted lines like "This plugin has no settings" and "No special permissions". Three tabs with two of them empty made a successful install feel incomplete.

Now those tabs are earned by content, matching the existing MCP-servers tab precedent in `PluginDetailPane.tsx`. A plugin declaring no settings and no built-in capabilities gets Overview alone. The rendered tab is derived from the same visible-tabs list the tab-change guard reads from, so a same-id reinstall can't strand the pane on a tab that no longer exists, and the two lists can't drift apart the way they originally did.

## Overview contributions

Overview now lists the plugin's contributed commands and panels straight off the already-loaded manifest, no new IPC. Each entry names how to reach it: "Run it from the command palette" for commands, "Open it from the new-panel menu" for panels. Panels hidden from the palette are still listed, just labelled accurately.

The manifest's self-declared `danger` field is deliberately never shown. Only the host's `effectiveDanger` is authoritative. A plugin can't be trusted to rate its own risk.

## Install progress and cancellation

`extractPluginArchive` gains an absolute 120 second deadline via a new `PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS` constant, composed with `AbortSignal.any` alongside the existing per-entry inactivity watchdog and a new caller-supplied cancel signal. This closes the trickling-stream hole the per-entry timer can't catch: a byte every few seconds resets it forever while the install holds `install.lock` and a staging directory.

A new `PluginInstallJobRegistry` owns per-job cancellation, throttles phase and entry progress to about every 150ms, and defines a commit boundary that closes the cancel window before the irreversible directory swap. The Plugin Manager shows phase and current archive entry behind the existing 400ms Doherty gate, with a Cancel button. Cancelling returns `{status: "cancelled"}`, releases the lock, and reaps the staging directory.

This adds a new `plugin:install-progress` push event (in `IpcEventMap`, so exempt from the hand-written-channel ratchet) and a codegen'd `cancelInstall` operation.

Note the progress event is a structured phase enum, not a copy of `AgentInstallProgressEvent`'s stdout-chunk shape. Only the wiring mechanism was mirrored from the agent installer's `onAgentInstallProgress` precedent, not its data shape: a plugin install is a fixed sequence of steps, not a subprocess emitting arbitrary text.

## Changes

- `PluginDetailPane.tsx`: gate Settings/Permissions/MCP tabs on content, derive rendered tab and tab-change guard from one shared visible-tabs list, list contributed commands/panels on Overview
- `PluginArchive.ts`: absolute extraction deadline (`PLUGIN_ARCHIVE_TOTAL_DEADLINE_MS`) composed via `AbortSignal.any` with the per-entry watchdog and a cancel signal
- `PluginInstallJobRegistry.ts` (new): per-job cancellation, throttled progress events, commit boundary before the directory swap
- `PluginInstaller.ts`, `plugin.ts` / `plugin.preload.ts`: wire job registry into the install path, add `cancelInstall`
- `PluginInstallProgressBanner.tsx` (new): phase/entry UI behind the Doherty gate, with Cancel
- `channels.ts`, `preload.cts`, `shared/types/ipc/*`: new `plugin:install-progress` event and codegen'd `cancelInstall` op
- E2E: `core-plugin-manager.spec.ts`, `core-plugin-permissions.spec.ts` updated for hidden-tab behaviour

## Testing

Locally: 3,925 tests across 715 suites green, covering plugin services, the full IPC surface (including channel-drift and handler-coverage guards), plugin and settings components, and CLI-server/setup paths. Typecheck clean. Lint ratchet net -19 warnings. `check:ipc` and `check:channels` pass.

`core-plugin-manager.spec.ts` and `core-plugin-permissions.spec.ts` were updated for the hidden-tab behaviour but run on CI, not locally.