### PR TITLE
fix(terminal): pin docked terminal viewport to bottom on reveal (#11316)

### DIFF
--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -490,6 +490,24 @@ export class TerminalResizeController {
     managed.terminal.resize(cols, rows);
   }
 
+  /**
+   * Re-pin the viewport to the bottom after a resize-completion, mirroring the
+   * auto-follow intent {@link commitResize} already enforces. A column-count
+   * reflow mutates the buffer's ybase/ydisp deep inside xterm's `Buffer._reflow`
+   * without ever firing `terminal.onScroll` (#11316), so the flags this checks
+   * stay correct-but-stale and a bottom-following terminal can be left parked a
+   * few rows above the bottom — and once off-bottom, new output stops
+   * auto-following. Restore the bottom unless the user had deliberately scrolled
+   * back. Guarded exactly like `commitResize` (`latestWasAtBottom &&
+   * !isUserScrolledBack`); `scrollToBottom` sets ydisp=ybase synchronously, so
+   * it is a no-op when already pinned.
+   */
+  private pinToBottomAfterResize(managed: ManagedTerminal): void {
+    if (managed.latestWasAtBottom && !managed.isUserScrolledBack) {
+      managed.terminal.scrollToBottom();
+    }
+  }
+
   applyDeferredResize(id: string): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
@@ -529,6 +547,7 @@ export class TerminalResizeController {
     this.cancelPendingResize(id);
     this.resizeTerminal(managed, targetCols, targetRows);
     terminalClient.resize(id, targetCols, targetRows);
+    this.pinToBottomAfterResize(managed);
   }
 
   /**
@@ -619,6 +638,7 @@ export class TerminalResizeController {
       this.resizeTerminal(managed, cols, rows);
     }
     terminalClient.resize(id, cols, rows);
+    this.pinToBottomAfterResize(managed);
     return true;
   }
 
@@ -659,9 +679,7 @@ export class TerminalResizeController {
     if (!flushedHeldBytes) {
       this.deps.dataBuffer.resumeFlush(id);
     }
-    if (managed.latestWasAtBottom && !managed.isUserScrolledBack) {
-      managed.terminal.scrollToBottom();
-    }
+    this.pinToBottomAfterResize(managed);
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -330,6 +330,10 @@ describe("TerminalResizeController", () => {
     expect(resetForTerminal).toHaveBeenCalledWith("term-1");
     expect(managed.terminal.resize).toHaveBeenCalledWith(132, 41);
     expect(resizeMock).toHaveBeenCalledWith("term-1", 132, 41);
+    // A bottom-following pane (latestWasAtBottom && !isUserScrolledBack) is
+    // re-pinned after the commit — the shared pin the reveal path now mirrors
+    // (#11316).
+    expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
   });
 
   describe("pre-resize flush budget", () => {
@@ -529,6 +533,8 @@ describe("TerminalResizeController", () => {
 
     expect(managed.terminal.resize).not.toHaveBeenCalled();
     expect(resizeMock).not.toHaveBeenCalled();
+    // No resize happened → no pin (#11316).
+    expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("applyDeferredResize defers a grid change on a streaming main-buffer pane to the watchdog (#10863 choke point)", () => {
@@ -556,6 +562,9 @@ describe("TerminalResizeController", () => {
     expect(resizeMock).not.toHaveBeenCalled();
     expect(managed.revealPendingRepair).toBe(true);
     expect(managed.revealPendingGeneration).toBe(7);
+    // The resize was deferred to the watchdog → the pin must not fire here
+    // either (#11316).
+    expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("applyDeferredResize still applies a grid change on a streaming ALT-buffer pane (alt exempt from the re-wrap hazard)", () => {
@@ -603,6 +612,8 @@ describe("TerminalResizeController", () => {
 
     expect(managed.terminal.resize).not.toHaveBeenCalled();
     expect(resizeMock).not.toHaveBeenCalled();
+    // Cache-match early return → no resize, no pin (#11316).
+    expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("applyDeferredResize syncs xterm and PTY atomically for settled-strategy agents", () => {
@@ -641,6 +652,37 @@ describe("TerminalResizeController", () => {
     vi.advanceTimersByTime(500);
     expect(managed.terminal.resize).toHaveBeenCalledTimes(1);
     expect(resizeMock).toHaveBeenCalledTimes(1);
+    // The wake-path resize re-pins a bottom-following pane — the reveal-path gap
+    // this fix closes (#11316: a reflow shifts the viewport off-bottom without
+    // firing onScroll, so the deferred resize must restore the bottom).
+    expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
+  });
+
+  it("applyDeferredResize preserves a deliberately user-scrolled viewport", () => {
+    const managed = createManagedTerminal();
+    managed.terminal.cols = 80;
+    managed.terminal.rows = 24;
+    managed.latestCols = 160;
+    managed.latestRows = 40;
+    // The user scrolled up before hiding — the reveal-path resize must reflow
+    // but NEVER yank the viewport back to the bottom (#11316).
+    managed.isUserScrolledBack = true;
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    controller.applyDeferredResize("term-1");
+
+    expect(managed.terminal.resize).toHaveBeenCalledWith(160, 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+    expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("applyDeferredResize cancels a pending settled timer before atomic resync", () => {
@@ -1851,6 +1893,26 @@ describe("TerminalResizeController", () => {
       // Must NOT route through fitAddon.fit() — that resizes xterm before the PTY
       // and would break settled-strategy atomicity.
       expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+      // The reveal-path reflow re-pins a bottom-following pane — the missing
+      // pin that left docked terminals parked above the bottom (#11316).
+      expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
+    });
+
+    it("preserves a deliberately user-scrolled viewport across a fresh reflow", () => {
+      const managed = createManagedTerminal();
+      // Grid drifts (box proposes 100x30, xterm is 80x24) so a real reflow runs,
+      // but the user had scrolled up before hiding — the reveal must not yank the
+      // viewport back to the bottom (#11316).
+      managed.isUserScrolledBack = true;
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+      expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
     });
 
     it("does NOT reflow a live alt-screen TUI even when the grid drifted (OpenCode clobber regression)", () => {
@@ -1870,6 +1932,9 @@ describe("TerminalResizeController", () => {
       expect(ok).toBe(true);
       expect(managed.terminal.resize).not.toHaveBeenCalled();
       expect(resizeMock).not.toHaveBeenCalled();
+      // The alt-buffer early return sits above the pin — never scroll a live
+      // full-screen TUI (#11316).
+      expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
     });
 
     it("defers a grid-changing reflow while the pane is still streaming output (#10863)", () => {
@@ -2025,6 +2090,10 @@ describe("TerminalResizeController", () => {
       expect(ok).toBe(true);
       expect(managed.terminal.resize).not.toHaveBeenCalled();
       expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+      // Even with no xterm reflow, a successful main-buffer reconcile re-pins a
+      // bottom-following pane — this self-heals a viewport left off-bottom by an
+      // earlier silent reflow, and is a no-op when already at bottom (#11316).
+      expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
     });
 
     it("falls back to cell-metric math when no proposable dimensions exist", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -589,6 +589,11 @@ describe("TerminalResizeController", () => {
     expect(managed.terminal.resize).toHaveBeenCalledWith(120, 40);
     expect(resizeMock).toHaveBeenCalledWith("term-1", 120, 40);
     expect(managed.revealPendingRepair).toBeUndefined();
+    // applyDeferredResize does resize alt buffers, so the shared pin runs here
+    // too — intentionally mirroring commitResize (a real alt buffer has no
+    // scrollback, so scrollToBottom is a no-op). reconcileGeometryFresh differs:
+    // it exits above the pin for alt. Locking the asymmetry (#11316).
+    expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
   });
 
   it("applyDeferredResize is a no-op when xterm dims already match latest", () => {
@@ -667,6 +672,36 @@ describe("TerminalResizeController", () => {
     // The user scrolled up before hiding — the reveal-path resize must reflow
     // but NEVER yank the viewport back to the bottom (#11316).
     managed.isUserScrolledBack = true;
+
+    const controller = new TerminalResizeController({
+      getInstance: vi.fn(() => managed),
+      dataBuffer: {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
+      } as any,
+    });
+
+    controller.applyDeferredResize("term-1");
+
+    expect(managed.terminal.resize).toHaveBeenCalledWith(160, 40);
+    expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+    expect(managed.terminal.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("applyDeferredResize does not pin when the pane was not following the bottom", () => {
+    const managed = createManagedTerminal();
+    managed.terminal.cols = 80;
+    managed.terminal.rows = 24;
+    managed.latestCols = 160;
+    managed.latestRows = 40;
+    // Auto-follow was already off before the hide (latestWasAtBottom captured
+    // false), and the user has not scrolled back — the pin's OTHER predicate.
+    // Guards against the helper degenerating to `if (!isUserScrolledBack)`, which
+    // every other test would still pass (#11316).
+    managed.latestWasAtBottom = false;
+    managed.isUserScrolledBack = false;
 
     const controller = new TerminalResizeController({
       getInstance: vi.fn(() => managed),
@@ -2011,6 +2046,9 @@ describe("TerminalResizeController", () => {
       expect(ok).toBe(true);
       expect(managed.terminal.resize).not.toHaveBeenCalled();
       expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+      // Streaming only blocks a grid-CHANGING reflow; a successful no-drift
+      // reconcile still self-heals bottom-follow (#11316).
+      expect(managed.terminal.scrollToBottom).toHaveBeenCalledOnce();
     });
 
     it("ignores an active resize lock without clearing it (the reveal exception)", () => {


### PR DESCRIPTION
## Summary

Resolves #11316. When a docked terminal is hidden and then revealed, it sometimes reappears a few rows above the bottom. Once it's off the bottom, it also stops following new output.

The cause is a reflow inside xterm. We're on `@xterm/xterm` `6.1.0-beta.290`, and in that source, `Buffer._reflow` mutates `ybase` and `ydisp` on a column-count change without firing `terminal.onScroll`. A docked terminal reopens into a narrower width, which hits the `_reflowSmaller` path. That path's `ybase` increment loop has a cap guard that silently stops incrementing once scrollback is near its max, which is what leaves the viewport a few rows above bottom.

Our `latestWasAtBottom` and `isUserScrolledBack` flags are only updated from the `onScroll` handler, so after a reflow they're correct but stale. There's nothing left to correct the drift.

The bottom-pin correction (`if (latestWasAtBottom && !isUserScrolledBack) terminal.scrollToBottom()`) already existed in `TerminalResizeController.commitResize`, the `ResizeObserver` live-resize path, but it was never wired into the reveal/wake-path geometry writers, `applyDeferredResize` and `reconcileGeometryFresh`, which resize xterm directly.

## Fix

- Extracted the pin into a shared private helper, `pinToBottomAfterResize(managed)`, and call it from all three resize-completion sites: `commitResize`, `applyDeferredResize`, `reconcileGeometryFresh`. This restores bottom-follow on the reveal/wake path after a reflow, mirroring `commitResize` exactly: no `requestAnimationFrame`, no new flags, no scroll-suppression wrapper.
- In `reconcileGeometryFresh` the pin sits below the alt-buffer early return, so a live full-screen TUI is never scrolled.
- `TerminalRevealController`'s call ordering, flagged high-risk for regressions in #5878 and #7762, is byte-for-byte unchanged. The whole fix lives inside `TerminalResizeController`.

## Tests

Added to `TerminalResizeController.test.ts`:

- Pin fires across both reveal-path methods when following the bottom.
- User-scrolled viewports are preserved for both methods.
- Negative test: no pin when `latestWasAtBottom` is false.
- Alt-buffer reconcile never pins.
- Streaming no-drift reconcile self-heals.
- Assertions locking in the intentional alt-buffer asymmetry.

Local run: 94 tests pass in `TerminalResizeController.test.ts` (117 across the 4 terminal test files).

## Known follow-ups (out of scope)

Pre-existing, distinct from the reported bug, surfaced by adversarial review:

1. Resizing while the alternate buffer is active reflows the inactive normal buffer too, but `scrollToBottom` only affects the active buffer, so on alt-exit the normal buffer can be misclassified as user-scrolled. This is pre-existing since `commitResize` had the same active-buffer limitation. A proper fix needs cross-buffer bottom-follow-intent tracking plus a pin on alt-exit reactivation.
2. The pre-open seed resize in `TerminalInstanceService.ensureOpened()` sits outside the pinned paths. A narrow `fullWakeForVisibilityRestore` case (an unopened terminal with pre-existing scrollback and seeded dimensions exactly matching the latest) could skip the pin via `applyDeferredResize`'s cache-match early return.

## Files changed

- `src/services/terminal/TerminalResizeController.ts`
- `src/services/terminal/__tests__/TerminalResizeController.test.ts`
