### PR TITLE
fix(file-browser): gate folder-load spinner behind anti-flicker delay

### DIFF
--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -90,6 +90,17 @@ export const UI_PALETTE_STALE_DELAY = DURATION_200;
  *  Not an animation token — a perceptual floor, same family as Doherty. */
 export const UI_SKELETON_GATE_MS = 200;
 
+/** UX anti-flicker gate for a granular, per-item *inline* loading indicator —
+ *  e.g. the file-tree folder-expansion spinner (`FileTreeRow`). A folder whose
+ *  listing resolves in under this window shows nothing, killing the flash on a
+ *  warm-cache expand. Intentionally shorter than `UI_DOHERTY_THRESHOLD`, which
+ *  governs page/panel-level spinners: 400ms is too sluggish for feedback this
+ *  granular, and issue #11318 asks for ~200ms here specifically. Shares the
+ *  200ms value with the skeleton gate by coincidence, not by coupling — the two
+ *  can diverge freely. Not an animation token — a perceptual floor, same family
+ *  as the Doherty/skeleton gates. */
+export const UI_INLINE_LOADING_GATE_MS = 200;
+
 /** Minimum on-screen dwell once a skeleton has crossed its onset gate. The
  *  onset gates (`useSkeletonGate`, `useDohertyGate`) only suppress *early*
  *  display; nothing stops a skeleton that just appeared from tearing down in

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
+import { Spinner } from "@/components/ui/Spinner";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { resolveTreeKey, type FlatTreeRow } from "./fileBrowserTree";
 
 export interface FileTreeViewProps {
@@ -248,6 +251,13 @@ interface FileTreeRowProps {
 function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
   const { onSelect, onToggleExpanded, onRootFolder } = context;
 
+  // Defer the folder-load spinner past the anti-flicker gate so a fast
+  // expansion flashes nothing. Drives only the indicator — the tree's content
+  // and children stay wired to the raw `row.isLoading`/listings state. Virtuoso
+  // unmounts off-screen rows, so this cosmetic timer restarts if a still-loading
+  // row scrolls out of view and back; harmless (the fetch itself keeps running).
+  const showLoadingSpinner = useDeferredLoading(row.isLoading, UI_SKELETON_GATE_MS);
+
   const handleClick = () => {
     onSelect(row.path);
     if (row.isDirectory) onToggleExpanded(row.path, !row.isExpanded);
@@ -290,6 +300,9 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
     <div
       id={rowDomId(context.instanceId, row.path)}
       role="treeitem"
+      // Pin the accessible name to the row name so the nested loading
+      // `role="status"` (below) can't fold "Loading folder contents" into it.
+      aria-label={row.name}
       aria-level={row.depth + 1}
       aria-selected={isSelected}
       {...(row.isDirectory && { "aria-expanded": row.isExpanded })}
@@ -328,8 +341,16 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         <File className="h-3.5 w-3.5 shrink-0 text-daintree-text/30" aria-hidden="true" />
       )}
       <span className={cn("truncate", isSelected && "font-medium")}>{row.name}</span>
-      {row.isLoading && (
-        <span className="ml-1 shrink-0 text-[10px] text-daintree-text/40">Loading…</span>
+      {showLoadingSpinner && (
+        // Subdued via `text-daintree-text/40` (Spinner strokes currentColor) so
+        // it stays quiet even on a selected row, per accent restraint.
+        <span
+          role="status"
+          aria-label="Loading folder contents"
+          className="ml-1 inline-flex shrink-0 text-daintree-text/40"
+        >
+          <Spinner size="xs" />
+        </span>
       )}
     </div>
   );

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useRef } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
+import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { Spinner } from "@/components/ui/Spinner";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
@@ -256,7 +256,7 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
   // and children stay wired to the raw `row.isLoading`/listings state. Virtuoso
   // unmounts off-screen rows, so this cosmetic timer restarts if a still-loading
   // row scrolls out of view and back; harmless (the fetch itself keeps running).
-  const showLoadingSpinner = useDeferredLoading(row.isLoading, UI_SKELETON_GATE_MS);
+  const showLoadingSpinner = useDeferredLoading(row.isLoading, UI_INLINE_LOADING_GATE_MS);
 
   const handleClick = () => {
     onSelect(row.path);
@@ -346,7 +346,7 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         // it stays quiet even on a selected row, per accent restraint.
         <span
           role="status"
-          aria-label="Loading folder contents"
+          aria-label={`Loading contents of ${row.name}`}
           className="ml-1 inline-flex shrink-0 text-daintree-text/40"
         >
           <Spinner size="xs" />

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
 import { forwardRef } from "react";
 import type { ReactNode } from "react";
+import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
 
@@ -132,7 +133,70 @@ describe("FileTreeView context-menu interactions", () => {
       mixed.getByRole("treeitem", { name: "README.md" }).firstElementChild?.tagName.toLowerCase()
     ).toBe("span");
   });
+});
 
+describe("FileTreeView folder-load spinner", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows no indicator until the anti-flicker gate elapses, then a named status", () => {
+    vi.useFakeTimers();
+    const loadingRows = [{ ...row("src", true), isLoading: true }];
+    // No row menu here: keep the row on its plain path so Radix internals don't
+    // interleave with the fake-timer clock.
+    const { queryByRole, getByRole, queryByText } = renderTree({
+      rows: loadingRows,
+      rowContextMenu: undefined,
+    });
+
+    // Fast load: nothing during the gate, and the old immediate "Loading…"
+    // text is gone entirely.
+    expect(queryByRole("status")).toBeNull();
+    expect(queryByText(/Loading/)).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(UI_SKELETON_GATE_MS - 1);
+    });
+    expect(queryByRole("status")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(getByRole("status", { name: "Loading folder contents" })).toBeTruthy();
+
+    // The nested status must not bleed into the row's own accessible name.
+    expect(getByRole("treeitem", { name: "src" })).toBeTruthy();
+  });
+
+  it("never shows the indicator when loading resolves before the gate", () => {
+    vi.useFakeTimers();
+    const { queryByRole, rerender } = renderTree({
+      rows: [{ ...row("src", true), isLoading: true }],
+      rowContextMenu: undefined,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(UI_SKELETON_GATE_MS - 1);
+    });
+    rerender(
+      <FileTreeView
+        rows={[row("src", true)]}
+        selectedPath={null}
+        onSelect={vi.fn()}
+        onToggleExpanded={vi.fn()}
+        label="Files"
+      />
+    );
+    act(() => {
+      vi.advanceTimersByTime(UI_SKELETON_GATE_MS);
+    });
+
+    expect(queryByRole("status")).toBeNull();
+  });
+});
+
+describe("FileTreeView menu contract", () => {
   it("advertises data-row-menu only when rows actually have menus", () => {
     // The attribute is the contract with the global Shift+F10 handler: it
     // stands down inside surfaces that route the key to a row-level menu, so

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render } from "@testing-library/react";
 import { forwardRef } from "react";
 import type { ReactNode } from "react";
-import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
+import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
 
@@ -156,14 +156,14 @@ describe("FileTreeView folder-load spinner", () => {
     expect(queryByText(/Loading/)).toBeNull();
 
     act(() => {
-      vi.advanceTimersByTime(UI_SKELETON_GATE_MS - 1);
+      vi.advanceTimersByTime(UI_INLINE_LOADING_GATE_MS - 1);
     });
     expect(queryByRole("status")).toBeNull();
 
     act(() => {
       vi.advanceTimersByTime(1);
     });
-    expect(getByRole("status", { name: "Loading folder contents" })).toBeTruthy();
+    expect(getByRole("status", { name: "Loading contents of src" })).toBeTruthy();
 
     // The nested status must not bleed into the row's own accessible name.
     expect(getByRole("treeitem", { name: "src" })).toBeTruthy();
@@ -177,7 +177,7 @@ describe("FileTreeView folder-load spinner", () => {
     });
 
     act(() => {
-      vi.advanceTimersByTime(UI_SKELETON_GATE_MS - 1);
+      vi.advanceTimersByTime(UI_INLINE_LOADING_GATE_MS - 1);
     });
     rerender(
       <FileTreeView
@@ -189,7 +189,7 @@ describe("FileTreeView folder-load spinner", () => {
       />
     );
     act(() => {
-      vi.advanceTimersByTime(UI_SKELETON_GATE_MS);
+      vi.advanceTimersByTime(UI_INLINE_LOADING_GATE_MS);
     });
 
     expect(queryByRole("status")).toBeNull();

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -97,8 +97,9 @@ describe("flattenTree", () => {
 
     const rows = flattenTree(listings, new Set(["src"]), new Set(["src"]));
 
-    // A refresh re-fetches an already-loaded directory; showing "Loading…" on a
-    // row whose contents are already on screen would be noise on every tick.
+    // A refresh re-fetches an already-loaded directory; showing a loading
+    // indicator on a row whose contents are already on screen would be noise on
+    // every tick.
     expect(rows[0]?.isLoading).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Expanding a folder in the file tree showed a `Loading…` text label immediately, so even folders that resolved almost instantly flashed the label for a frame or two.
- Gates the indicator behind a 200ms anti-flicker delay via a new `useDeferredLoading` call, and swaps the text label for a small inline spinner.

Resolves #11318

## Changes

- `src/panels/file-browser/FileTreeView.tsx`: `FileTreeRow` now gates the indicator through `useDeferredLoading(row.isLoading, UI_INLINE_LOADING_GATE_MS)`. The `Loading…` span is replaced by a subdued (`text-daintree-text/40`), 12px `<Spinner size="xs" />` wrapped in `<span role="status" aria-label={\`Loading contents of ${row.name}\`}>`. Added `aria-label={row.name}` on the treeitem so the nested status element can't pollute the row's accessible name. The gated boolean only controls spinner visibility; content and children still key off the raw loading state.
- `src/lib/animationUtils.ts`: new `UI_INLINE_LOADING_GATE_MS = 200` constant, a dedicated onset gate for granular per-row indicators like this one. It's intentionally shorter than the 400ms `UI_DOHERTY_THRESHOLD` used for page/panel-level spinners, documented inline as an explicit #11318 exception rather than a change to the general rule.
- Tests: `FileTreeView.test.tsx` gains two fake-timer cases, one for the gate boundary plus accessible-name preservation, one for a fast-resolve-before-gate path that shows nothing. `fileBrowserTree.test.ts` had a stale `Loading…` comment refreshed.

## Notes for reviewers

- Virtuoso recycles off-screen rows, so the per-row gate timer restarts on scroll-out and scroll-in. Cosmetic only, not a bug.
- Live-region announcement reliability across VoiceOver/NVDA and the tree icon's `/40` opacity contrast are pre-existing and out of scope here. Flagging both for a manual accessibility pass.

## Testing

- `FileTreeView.test.tsx`: fake-timer coverage for the gate boundary, accessible-name preservation, and the fast-resolve-before-gate case
- `fileBrowserTree.test.ts` updated and passing
