### PR TITLE
feat(file-browser): add Source/Rendered selector to Markdown previews

### DIFF
--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -19,10 +19,12 @@ import {
 } from "@/components/FileViewer/fileReadErrors";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
+import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { filesClient } from "@/clients/filesClient";
 import { isClientAppError } from "@/utils/clientAppError";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
+import type { FileRenderMode } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 
 export interface FileBrowserViewerProps {
@@ -54,6 +56,14 @@ type ViewerState =
   | { status: "image" }
   | { status: "error"; message: string };
 
+// Markdown gets a Source/Rendered switch mirroring FilePane's toggle. Typed at
+// the constant so the option values stay `FileRenderMode` rather than widening
+// to `string`; a two-entry list only — the browser preview has no diff mode.
+const MARKDOWN_MODE_OPTIONS: Array<{ value: FileRenderMode; label: string }> = [
+  { value: "source", label: "Source" },
+  { value: "rendered", label: "Rendered" },
+];
+
 /**
  * Read-only viewer beside the tree.
  *
@@ -71,6 +81,12 @@ export function FileBrowserViewer({
   revision,
 }: FileBrowserViewerProps) {
   const [state, setState] = useState<ViewerState>({ status: "idle" });
+  // Sticky Source/Rendered choice for markdown, defaulting to the rendered view
+  // this pane has always shown. Deliberately not reset on file change: a reader
+  // paging through docs in source keeps source, mirroring FilePane (whose
+  // per-panel mode also survives a file swap). Non-markdown files simply hide
+  // the toggle, so a stale "source" never applies where it can't be honoured.
+  const [markdownMode, setMarkdownMode] = useState<FileRenderMode>("rendered");
   // Bumped on every load so `HtmlViewer` re-navigates its sandboxed frame when
   // an agent rewrites the file underneath it.
   const [reloadNonce, setReloadNonce] = useState(0);
@@ -259,6 +275,13 @@ export function FileBrowserViewer({
   return (
     <>
       <FileViewerToolbar.Root>
+        {isMarkdownFilePath(filePath) && (
+          <SegmentedToggle<FileRenderMode>
+            options={MARKDOWN_MODE_OPTIONS}
+            value={markdownMode}
+            onChange={setMarkdownMode}
+          />
+        )}
         <FileViewerToolbar.Path
           path={relativePath ?? fileName}
           copied={pathCopied}
@@ -380,7 +403,7 @@ export function FileBrowserViewer({
             content={state.content}
             filePath={filePath}
             rootPath={rootPath}
-            viewMode="rendered"
+            viewMode={markdownMode}
             className="h-full"
           />
         ) : (

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -98,11 +98,15 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     expect(screen.getByRole("button", { name: "Rendered" })).toBeTruthy();
   });
 
-  it("switches the markdown viewer to source when Source is picked", async () => {
+  it("switches the markdown viewer between source and rendered", async () => {
     renderViewer("/repo/docs/spec.md");
     await waitFor(() => expect(currentViewMode()).toBe("rendered"));
     await clickMode("Source");
     await waitFor(() => expect(currentViewMode()).toBe("source"));
+    // Round-trip so the "rendered" segment's mapping is exercised too, not just
+    // the "source" one.
+    await clickMode("Rendered");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
   });
 
   it("keeps the chosen mode sticky across a different markdown file", async () => {
@@ -127,8 +131,26 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     await waitFor(() => expect(currentViewMode()).toBe("source"));
   });
 
-  it("shows no toggle and renders source for a non-markdown file", async () => {
-    renderViewer("/repo/src/notes.txt");
+  it("drops the toggle and its stale source choice when switching to a non-markdown file", async () => {
+    // Start on markdown in Source, then navigate to a .txt in the same viewer —
+    // the tree's real usage. Proves the markdown-only toggle disappears and the
+    // sticky "source" choice can't leak into the CodeViewer (non-markdown) branch.
+    const { rerender } = renderViewer("/repo/docs/a.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    await clickMode("Source");
+    await waitFor(() => expect(currentViewMode()).toBe("source"));
+
+    rerender(
+      <TooltipProvider>
+        <FileBrowserViewer
+          filePath="/repo/src/notes.txt"
+          rootPath="/repo"
+          fileName="notes.txt"
+          relativePath="notes.txt"
+          revision="r1"
+        />
+      </TooltipProvider>
+    );
     await screen.findByTestId("code-viewer-mock");
     expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { render, act, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// FileBrowserViewer is the read-only preview beside the tree. #11319 adds a
+// Source/Rendered toggle for markdown, mirroring FilePane. Mock the heavy leaf
+// viewers so only FileBrowserViewer's own toolbar + mode wiring renders, and
+// capture the viewMode handed to MarkdownViewer — the seam the toggle drives.
+const { readMock } = vi.hoisted(() => ({ readMock: vi.fn() }));
+vi.mock("@/clients/filesClient", () => ({
+  filesClient: { read: readMock },
+}));
+
+// dispatch() resolves an ActionDispatchResult union and never rejects; the
+// toolbar's external-action handlers branch on `.ok`, so honour that shape.
+const { dispatchMock } = vi.hoisted(() => ({ dispatchMock: vi.fn() }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+// A real MarkdownViewer lazy-loads its renderer, hiding the prop under test.
+// The mock surfaces viewMode as a data attribute so the toggle wiring is
+// observable — without it the mode plumbing could be deleted and stay green.
+vi.mock("@/components/Markdown/MarkdownViewer", () => ({
+  MarkdownViewer: (props: { viewMode: string }) => (
+    <div data-testid="markdown-viewer-mock" data-view-mode={props.viewMode} />
+  ),
+}));
+vi.mock("@/components/FileViewer/CodeViewer", () => ({
+  CodeViewer: () => <div data-testid="code-viewer-mock" />,
+}));
+vi.mock("@/components/Html/HtmlViewer", () => ({
+  HtmlViewer: () => <div data-testid="html-viewer-mock" />,
+}));
+
+import { FileBrowserViewer } from "../FileBrowserViewer";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function renderViewer(filePath: string) {
+  const fileName = filePath.split("/").pop() ?? filePath;
+  return render(
+    <TooltipProvider>
+      <FileBrowserViewer
+        filePath={filePath}
+        rootPath="/repo"
+        fileName={fileName}
+        relativePath={fileName}
+        revision="r1"
+      />
+    </TooltipProvider>
+  );
+}
+
+// SegmentedToggle renders literal-text buttons; its accessible name is the
+// visible label, so click by role + name.
+async function clickMode(label: "Source" | "Rendered") {
+  const button = await screen.findByRole("button", { name: label });
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function currentViewMode(): string | null {
+  return screen.getByTestId("markdown-viewer-mock").getAttribute("data-view-mode");
+}
+
+beforeEach(() => {
+  readMock.mockReset();
+  readMock.mockResolvedValue({ content: "# hello" });
+  dispatchMock.mockReset();
+  dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+  // SegmentedToggle's motion hook (and InlineStatusBanner) read matchMedia at
+  // render time; jsdom does not implement it, so provide a no-op stub.
+  if (typeof window.matchMedia !== "function") {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
+  it("shows the toggle and defaults to the rendered view for a markdown file", async () => {
+    renderViewer("/repo/docs/spec.md");
+    // Default preserves the pane's long-standing rendered-first behaviour.
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    expect(screen.getByRole("button", { name: "Source" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Rendered" })).toBeTruthy();
+  });
+
+  it("switches the markdown viewer to source when Source is picked", async () => {
+    renderViewer("/repo/docs/spec.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    await clickMode("Source");
+    await waitFor(() => expect(currentViewMode()).toBe("source"));
+  });
+
+  it("keeps the chosen mode sticky across a different markdown file", async () => {
+    const { rerender } = renderViewer("/repo/docs/a.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    await clickMode("Source");
+    await waitFor(() => expect(currentViewMode()).toBe("source"));
+
+    // Selecting another markdown file in the tree must not silently revert the
+    // reader's choice back to rendered — the mode is sticky, mirroring FilePane.
+    rerender(
+      <TooltipProvider>
+        <FileBrowserViewer
+          filePath="/repo/docs/b.md"
+          rootPath="/repo"
+          fileName="b.md"
+          relativePath="b.md"
+          revision="r1"
+        />
+      </TooltipProvider>
+    );
+    await waitFor(() => expect(currentViewMode()).toBe("source"));
+  });
+
+  it("shows no toggle and renders source for a non-markdown file", async () => {
+    renderViewer("/repo/src/notes.txt");
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
+    expect(screen.queryByTestId("markdown-viewer-mock")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a Source/Rendered segmented selector to Markdown previews in the file browser panel, mirroring the toggle already available in the standalone file viewer pane.
- The render mode is a local sticky `useState` defaulting to `rendered`, so existing behavior is preserved for every file that isn't Markdown.
- The toggle only shows up for Markdown files and is passed straight through to `MarkdownViewer`'s `viewMode` prop.

Resolves #11319

## Changes

- `src/panels/file-browser/FileBrowserViewer.tsx`: adds the Source/Rendered toggle, gated on `isMarkdownFilePath`, wired to a local `FileRenderMode` state.
- `src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx`: new test file covering the toggle (4 tests).

Scope is deliberately limited to Source/Rendered. No diff mode, no wrap-lines toggle, no HTML source view, all of which stay specific to the standalone file viewer.

## Testing

- 4/4 new unit tests passing.
- Prettier and eslint clean on both touched files (one pre-existing baselined warning left untouched).