### PR TITLE
feat(project): rewrite path-bearing state after a project folder move (#11282 phase 2)

### DIFF
--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -925,6 +925,19 @@ describe("createWindowWithState", () => {
       expect(getState()["/old"]).toBeUndefined();
     });
 
+    it("rekeyWindowStateForPath gives the moved entry a fresh (most-recent) MRU slot", () => {
+      // /new pre-exists as the OLDEST entry; a naive in-place overwrite would keep
+      // it oldest and make the relocated project the first evicted. It must be
+      // re-inserted last.
+      const e = (x: number) => ({ x, y: 0, width: 800, height: 600, isMaximized: false });
+      const getState = makeStateful({ "/new": e(1), "/keep": e(2), "/old": e(3) });
+
+      rekeyWindowStateForPath("/old", "/new");
+
+      const keys = Object.keys(getState());
+      expect(keys[keys.length - 1]).toBe("/new");
+    });
+
     it("rekeyWindowStateForPath is a no-op when the old path is absent or paths match", () => {
       makeStateful({ "/b": { x: 0, y: 0, width: 800, height: 600 } });
       windowStatesStoreMock.set.mockClear();

--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -62,7 +62,11 @@ vi.mock("../services/ProjectStore.js", () => ({
   },
 }));
 
-import { createWindowWithState, pruneWindowStateForPath } from "../windowState.js";
+import {
+  createWindowWithState,
+  pruneWindowStateForPath,
+  rekeyWindowStateForPath,
+} from "../windowState.js";
 
 describe("createWindowWithState", () => {
   // Helper: fire the deferred 'show' handler (fullscreen is applied after show)
@@ -886,6 +890,47 @@ describe("createWindowWithState", () => {
       windowStatesStoreMock.set.mockClear();
 
       pruneWindowStateForPath("/missing");
+
+      expect(windowStatesStoreMock.set).not.toHaveBeenCalled();
+    });
+
+    it("rekeyWindowStateForPath moves bounds to the new key, preserving others and __legacy__", () => {
+      const oldEntry = { x: 1, y: 2, width: 800, height: 600, isMaximized: false };
+      const otherEntry = { x: 9, y: 9, width: 400, height: 300, isMaximized: false };
+      const getState = makeStateful({
+        "/old/project": oldEntry,
+        "/other": otherEntry,
+        __legacy__: otherEntry,
+      });
+
+      rekeyWindowStateForPath("/old/project", "/new/renamed");
+
+      const state = getState();
+      expect(state["/old/project"]).toBeUndefined();
+      expect(state["/new/renamed"]).toEqual(oldEntry);
+      expect(state["/other"]).toBeDefined();
+      expect(state["__legacy__"]).toBeDefined();
+      const lastSet = windowStatesStoreMock.set.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+      expect(Object.values(lastSet)).not.toContain(undefined);
+    });
+
+    it("rekeyWindowStateForPath lets the moved bounds win over a stale destination entry", () => {
+      const oldEntry = { x: 1, y: 2, width: 800, height: 600, isMaximized: false };
+      const staleAtNew = { x: 5, y: 5, width: 100, height: 100, isMaximized: false };
+      const getState = makeStateful({ "/old": oldEntry, "/new": staleAtNew });
+
+      rekeyWindowStateForPath("/old", "/new");
+
+      expect(getState()["/new"]).toEqual(oldEntry);
+      expect(getState()["/old"]).toBeUndefined();
+    });
+
+    it("rekeyWindowStateForPath is a no-op when the old path is absent or paths match", () => {
+      makeStateful({ "/b": { x: 0, y: 0, width: 800, height: 600 } });
+      windowStatesStoreMock.set.mockClear();
+
+      rekeyWindowStateForPath("/missing", "/new");
+      rekeyWindowStateForPath("/b", "/b");
 
       expect(windowStatesStoreMock.set).not.toHaveBeenCalled();
     });

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -302,7 +302,11 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
 
     const newPath = result.filePaths[0];
-    return projectStore.relocateProject(projectId, newPath);
+    const relocated = await projectStore.relocateProject(projectId, newPath);
+    // Every cached view of this project replaces it by immutable id, so the new
+    // path reaches windows other than the one that ran the locate flow (#11282).
+    broadcastToRenderer(CHANNELS.PROJECT_UPDATED, relocated);
+    return relocated;
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_LOCATE, handleProjectLocate));
 

--- a/electron/services/PendingHelpHibernationStore.ts
+++ b/electron/services/PendingHelpHibernationStore.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { app } from "electron";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
+import { rebaseAbsolutePath } from "../../shared/utils/projectPathRelocation.js";
 
 const FILE_NAME = "help-pending-hibernation.json";
 const FILE_VERSION = 1;
@@ -95,6 +96,22 @@ export class PendingHelpHibernationStore {
     if (!this.entries.has(projectId)) return Promise.resolve();
     this.entries.delete(projectId);
     return this.persist();
+  }
+
+  /**
+   * Rebase a project's captured Assistant cwd after a folder move/rename
+   * (#11282, phase 2), so the hibernated conversation resumes in the moved
+   * folder rather than the vanished old one. No-op when the project has no
+   * entry or its cwd is unaffected by the move.
+   */
+  async rewriteProjectPath(projectId: string, oldRoot: string, newRoot: string): Promise<void> {
+    await this.load();
+    const entry = this.entries.get(projectId);
+    if (!entry) return;
+    const nextCwd = rebaseAbsolutePath(entry.cwd, oldRoot, newRoot);
+    if (nextCwd === entry.cwd) return;
+    this.entries.set(projectId, { ...entry, cwd: nextCwd });
+    await this.persist();
   }
 
   private isValid(value: unknown): value is PendingHelpHibernation {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -847,44 +847,56 @@ export class ProjectStore {
   }
 
   /**
-   * Rebase every piece of Daintree-owned path-bearing state that a moved or
-   * renamed project folder leaves stale (#11282, phase 2). The project id is
+   * Rebase the path-bearing Daintree state this phase covers after a moved or
+   * renamed project folder leaves it stale (#11282, phase 2). The project id is
    * immutable (phase 1), so id-keyed files — the state dir, settings, secure
-   * env, hibernation token — stay reachable; but the absolute paths INSIDE them
+   * env, hibernation token — stay reachable; the absolute paths INSIDE them
    * (panel cwds, worktree ids, file-panel paths, MRU entries, captured session
-   * dirs) and the path-KEYED window-state store still point at the old folder,
-   * and are rewritten here.
+   * dirs, Assistant hibernation cwd) and the path-KEYED window-state store are
+   * rewritten here.
+   *
+   * Deliberately NOT covered yet (tracked as follow-ups under #11282): recipe
+   * `worktreeId` bindings, `terminalSettings.defaultWorkingDirectory`, and the
+   * worktree-keyed `worktreeIssueMap` / `wslGitByWorktree` / preset maps — each
+   * needs its own serialized/global-map rewrite contract, kept out to keep this
+   * phase reviewable.
    *
    * Best-effort by design: the DB row has already moved and is authoritative, so
    * a failure in any ancillary surface is logged rather than surfaced as a
    * relocation error (reporting failure after the row moved would misrepresent
-   * the real state). Each surface is independent so one failure can't skip the
-   * others. Callers only reach here for a genuine move of a non-active project —
-   * both adoption and explicit relocation guard the current project.
+   * the real state). Each surface is an independently-settled thunk, so neither a
+   * rejection nor a SYNCHRONOUS throw in one can skip the others. Callers only
+   * reach here for a genuine move of a non-active project — both adoption and
+   * explicit relocation guard the current project.
    */
   private async migratePathBearingStateAfterMove(
     projectId: string,
     oldPath: string,
     newPath: string
   ): Promise<void> {
-    const surfaces: Array<Promise<unknown>> = [
-      this.enqueueProjectStateUpdate(projectId, (existing) => {
-        if (!existing) return null;
-        const rewritten = rewriteProjectStatePaths(existing, oldPath, newPath);
-        // Same object reference back ⇒ nothing rebased ⇒ skip the disk write.
-        return rewritten === existing ? null : rewritten;
-      }),
-      (async () => {
+    // Thunks (not eager promises): running each through Promise.resolve().then
+    // converts a synchronous throw while BUILDING the promise — e.g. the first
+    // `getPendingHelpHibernationStore()` touches `app.getPath` — into a rejected
+    // result instead of letting it escape allSettled and reject the relocation.
+    const surfaces: Array<() => Promise<unknown>> = [
+      () =>
+        this.enqueueProjectStateUpdate(projectId, (existing) => {
+          if (!existing) return null;
+          const rewritten = rewriteProjectStatePaths(existing, oldPath, newPath);
+          // Same object reference back ⇒ nothing rebased ⇒ skip the disk write.
+          return rewritten === existing ? null : rewritten;
+        }),
+      async () => {
         // Dynamic import breaks the ProjectStore ⇄ windowState cycle at module
         // eval (windowState imports the projectStore singleton).
         const { rekeyWindowStateForPath } = await import("../windowState.js");
         rekeyWindowStateForPath(oldPath, newPath);
-      })(),
-      rewriteAgentSessionPathsForProject(projectId, oldPath, newPath),
-      getPendingHelpHibernationStore().rewriteProjectPath(projectId, oldPath, newPath),
+      },
+      () => rewriteAgentSessionPathsForProject(projectId, oldPath, newPath),
+      () => getPendingHelpHibernationStore().rewriteProjectPath(projectId, oldPath, newPath),
     ];
 
-    const results = await Promise.allSettled(surfaces);
+    const results = await Promise.allSettled(surfaces.map((task) => Promise.resolve().then(task)));
     for (const result of results) {
       if (result.status === "rejected") {
         logError(`Failed to migrate path-bearing state for ${projectId}`, result.reason);
@@ -902,7 +914,11 @@ export class ProjectStore {
       throw new Error("Cannot relocate the currently active project");
     }
 
-    const canonicalNewPath = await this.getGitRoot(newPath);
+    // Normalize to the same NFC spelling `addProject`/`getProjectByPath` use, so
+    // a decomposed-Unicode destination on macOS is stored in the form later
+    // lookups query by — otherwise `resolveProjectIdForPath` misses it and falls
+    // back to the path hash, defeating the immutable id (#11282).
+    const canonicalNewPath = normalizeProjectPath(await this.getGitRoot(newPath));
 
     // A project id is immutable once registered, so reattaching a folder is a
     // path update on the existing row — not a new identity (#11282). Everything

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -48,6 +48,10 @@ import { isInRepoRecipeId } from "../../shared/utils/recipeFilename.js";
 
 import { computeFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
+import { rewriteProjectStatePaths } from "./projectPathStateRewrite.js";
+import { rewriteAgentSessionPathsForProject } from "./pty/agentSessionHistory.js";
+import { getPendingHelpHibernationStore } from "./PendingHelpHibernationStore.js";
+import { repairMovedSubmodulePaths } from "./git/submodulePathRepair.js";
 
 export const DEFAULT_PROJECT_EMOJI = "🌲";
 
@@ -74,12 +78,15 @@ function isEnoent(error: unknown): boolean {
  * a repair failure must not fail the relocation and strand the user with an
  * unregistered project.
  */
-async function repairLinkedWorktrees(projectPath: string): Promise<void> {
+async function repairLinkedWorktrees(oldPath: string, newPath: string): Promise<void> {
   try {
-    await new GitService(projectPath).repairWorktrees();
+    await new GitService(newPath).repairWorktrees();
   } catch (error) {
-    logError(`Failed to repair linked worktrees for ${projectPath}`, error);
+    logError(`Failed to repair linked worktrees for ${newPath}`, error);
   }
+  // `git worktree repair` ignores submodules; rebase any absolute submodule
+  // pointers the move left stale ourselves (#11282). Never throws.
+  await repairMovedSubmodulePaths(oldPath, newPath);
 }
 
 /**
@@ -506,7 +513,8 @@ export class ProjectStore {
     });
 
     this.pruneInRepoRecipeHashes(anchored.path);
-    await repairLinkedWorktrees(normalizedPath);
+    await this.migratePathBearingStateAfterMove(anchorId, anchored.path, normalizedPath);
+    await repairLinkedWorktrees(anchored.path, normalizedPath);
 
     return adopted;
   }
@@ -838,6 +846,52 @@ export class ProjectStore {
     return missingIds;
   }
 
+  /**
+   * Rebase every piece of Daintree-owned path-bearing state that a moved or
+   * renamed project folder leaves stale (#11282, phase 2). The project id is
+   * immutable (phase 1), so id-keyed files — the state dir, settings, secure
+   * env, hibernation token — stay reachable; but the absolute paths INSIDE them
+   * (panel cwds, worktree ids, file-panel paths, MRU entries, captured session
+   * dirs) and the path-KEYED window-state store still point at the old folder,
+   * and are rewritten here.
+   *
+   * Best-effort by design: the DB row has already moved and is authoritative, so
+   * a failure in any ancillary surface is logged rather than surfaced as a
+   * relocation error (reporting failure after the row moved would misrepresent
+   * the real state). Each surface is independent so one failure can't skip the
+   * others. Callers only reach here for a genuine move of a non-active project —
+   * both adoption and explicit relocation guard the current project.
+   */
+  private async migratePathBearingStateAfterMove(
+    projectId: string,
+    oldPath: string,
+    newPath: string
+  ): Promise<void> {
+    const surfaces: Array<Promise<unknown>> = [
+      this.enqueueProjectStateUpdate(projectId, (existing) => {
+        if (!existing) return null;
+        const rewritten = rewriteProjectStatePaths(existing, oldPath, newPath);
+        // Same object reference back ⇒ nothing rebased ⇒ skip the disk write.
+        return rewritten === existing ? null : rewritten;
+      }),
+      (async () => {
+        // Dynamic import breaks the ProjectStore ⇄ windowState cycle at module
+        // eval (windowState imports the projectStore singleton).
+        const { rekeyWindowStateForPath } = await import("../windowState.js");
+        rekeyWindowStateForPath(oldPath, newPath);
+      })(),
+      rewriteAgentSessionPathsForProject(projectId, oldPath, newPath),
+      getPendingHelpHibernationStore().rewriteProjectPath(projectId, oldPath, newPath),
+    ];
+
+    const results = await Promise.allSettled(surfaces);
+    for (const result of results) {
+      if (result.status === "rejected") {
+        logError(`Failed to migrate path-bearing state for ${projectId}`, result.reason);
+      }
+    }
+  }
+
   async relocateProject(projectId: string, newPath: string): Promise<Project> {
     const project = this.getProjectById(projectId);
     if (!project) {
@@ -853,9 +907,10 @@ export class ProjectStore {
     // A project id is immutable once registered, so reattaching a folder is a
     // path update on the existing row — not a new identity (#11282). Everything
     // keyed by the id (state dir, settings, secure env, panel/terminal ids,
-    // Assistant hibernation, session journal) therefore stays reachable with no
-    // copying, re-keying or cleanup at all, and there is no half-migrated state
-    // for a failure to strand.
+    // Assistant hibernation, session journal) stays reachable with no copying or
+    // re-keying of the containers. The absolute paths stored INSIDE that state,
+    // plus the path-keyed window-state store, are rebased separately by
+    // `migratePathBearingStateAfterMove` below (phase 2).
     const existingAtNewPath = await this.getProjectByPath(canonicalNewPath);
     if (existingAtNewPath && existingAtNewPath.id !== projectId) {
       throw new Error(`A project already exists at that location: ${existingAtNewPath.name}`);
@@ -871,7 +926,8 @@ export class ProjectStore {
       // The old path no longer backs this project — drop its cached recipe
       // hashes so they don't linger.
       this.pruneInRepoRecipeHashes(oldPath);
-      await repairLinkedWorktrees(canonicalNewPath);
+      await this.migratePathBearingStateAfterMove(projectId, oldPath, canonicalNewPath);
+      await repairLinkedWorktrees(oldPath, canonicalNewPath);
     }
 
     return updatedProject;

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -2,7 +2,6 @@ import { events } from "./events.js";
 import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { getForgeBridge } from "../workspace-host/forgeBridge.js";
 import { BatchLoader } from "../workspace-host/batchLoader.js";
@@ -374,9 +373,12 @@ class PullRequestService {
     return Math.max(0, FOCUS_CATCHUP_THROTTLE_MS - (Date.now() - this.lastCheckAt));
   }
 
-  public initialize(cwd: string): void {
+  public initialize(cwd: string, projectId: string): void {
     this.cwd = cwd;
-    this.projectId = generateProjectId(cwd);
+    // Immutable id threaded from main via load-project. The host has no DB
+    // access, so hashing `cwd` here (the old behaviour) would mint a stale id
+    // for any relocated project and detach every id-keyed lookup (#11282).
+    this.projectId = projectId;
     logInfo("PullRequestService initialized", { cwd, projectId: this.projectId });
   }
 

--- a/electron/services/__tests__/PendingHelpHibernationStore.test.ts
+++ b/electron/services/__tests__/PendingHelpHibernationStore.test.ts
@@ -302,4 +302,48 @@ describe("PendingHelpHibernationStore", () => {
     expect(entry).not.toBeNull();
     expect(entry?.panelWasOpen).toBeUndefined();
   });
+
+  describe("rewriteProjectPath", () => {
+    it("rebases only the matching project's cwd and persists it", async () => {
+      const store = new PendingHelpHibernationStore(filePath);
+      await store.load();
+      await store.set("proj-1", {
+        agentId: "claude",
+        agentSessionId: "id-1",
+        cwd: "/old/project/sub",
+        capturedAt: Date.now(),
+      });
+      await store.set("proj-2", {
+        agentId: "claude",
+        agentSessionId: "id-2",
+        cwd: "/old/project/sub",
+        capturedAt: Date.now(),
+      });
+
+      await store.rewriteProjectPath("proj-1", "/old/project", "/new/renamed");
+
+      expect(store.get("proj-1")?.cwd).toBe("/new/renamed/sub");
+      expect(store.get("proj-2")?.cwd).toBe("/old/project/sub");
+
+      const fresh = new PendingHelpHibernationStore(filePath);
+      await fresh.load();
+      expect(fresh.get("proj-1")?.cwd).toBe("/new/renamed/sub");
+    });
+
+    it("is a no-op for a missing project or a cwd outside the old root", async () => {
+      const store = new PendingHelpHibernationStore(filePath);
+      await store.load();
+      await store.set("proj-1", {
+        agentId: "claude",
+        agentSessionId: "id-1",
+        cwd: "/elsewhere/dir",
+        capturedAt: Date.now(),
+      });
+
+      await store.rewriteProjectPath("missing", "/old/project", "/new/renamed");
+      await store.rewriteProjectPath("proj-1", "/old/project", "/new/renamed");
+
+      expect(store.get("proj-1")?.cwd).toBe("/elsewhere/dir");
+    });
+  });
 });

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -242,6 +242,22 @@ describe("project identity across folder moves", () => {
       expect(repairMovedSubmodulePaths).not.toHaveBeenCalled();
     });
 
+    it("isolates a synchronously-throwing migration surface — the move still succeeds and repairs run", async () => {
+      rewriteHibernationProjectPath.mockImplementationOnce(() => {
+        throw new Error("app.getPath exploded");
+      });
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      const canonicalMoved = await fs.promises.realpath(moved);
+
+      // A sync throw while building a surface must NOT reject the adoption.
+      await expect(store.addProject(canonicalMoved)).resolves.toMatchObject({ id: registered.id });
+      expect(repairMovedSubmodulePaths).toHaveBeenCalledWith(original, canonicalMoved);
+    });
+
     it("mints a distinct id for a copy whose original still exists", async () => {
       const original = await makeDir("original");
       const registered = await store.addProject(original);
@@ -409,6 +425,24 @@ describe("project identity across folder moves", () => {
 
       expect(relocated.path).toBe(dir);
       expect(repairWorktrees).not.toHaveBeenCalled();
+    });
+
+    it("stores a decomposed-Unicode destination in NFC so the immutable id still resolves", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+
+      // A real destination whose name is NFD ("cafe" + combining acute U+0301).
+      // getGitRoot realpaths it (bytes preserved on APFS/ext4), and the store must
+      // persist and resolve the NFC ("é") form rather than the raw NFD spelling.
+      const nfdDir = await makeDir("relocated-cafe\u0301");
+      const nfc = nfdDir.normalize("NFC");
+      const relocated = await store.relocateProject(registered.id, nfdDir);
+
+      expect(relocated.id).toBe(registered.id);
+      expect(relocated.path).toBe(nfc);
+      expect(store.resolveProjectIdForPath(nfc)).toBe(registered.id);
+      // The raw NFD spelling resolves too, since lookups normalize.
+      expect(store.resolveProjectIdForPath(nfdDir)).toBe(registered.id);
     });
   });
 

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -39,6 +39,30 @@ let tmpRoot: string;
 
 const repairWorktrees = vi.fn(async () => {});
 
+// Phase-2 path-bearing-state migration surfaces (#11282). Mocked so the identity
+// suite stays DB-focused and can assert the orchestration wiring directly. These
+// are referenced in vi.mock factories at hoist time, so they must be vi.hoisted.
+const {
+  enqueueProjectStateUpdate,
+  rekeyWindowStateForPath,
+  rewriteAgentSessionPathsForProject,
+  rewriteHibernationProjectPath,
+  repairMovedSubmodulePaths,
+} = vi.hoisted(() => ({
+  enqueueProjectStateUpdate: vi.fn(async () => {}),
+  rekeyWindowStateForPath: vi.fn(),
+  rewriteAgentSessionPathsForProject: vi.fn(async () => {}),
+  rewriteHibernationProjectPath: vi.fn(async () => {}),
+  repairMovedSubmodulePaths: vi.fn(async () => {}),
+}));
+
+vi.mock("../../windowState.js", () => ({ rekeyWindowStateForPath }));
+vi.mock("../pty/agentSessionHistory.js", () => ({ rewriteAgentSessionPathsForProject }));
+vi.mock("../PendingHelpHibernationStore.js", () => ({
+  getPendingHelpHibernationStore: () => ({ rewriteProjectPath: rewriteHibernationProjectPath }),
+}));
+vi.mock("../git/submodulePathRepair.js", () => ({ repairMovedSubmodulePaths }));
+
 vi.mock("../persistence/db.js", () => ({
   getSharedDb: () => db,
   openDb: vi.fn(),
@@ -76,6 +100,9 @@ vi.mock("../ProjectSettingsManager.js", () => ({
 vi.mock("../ProjectStateManager.js", () => ({
   ProjectStateManager: class {
     invalidateProjectStateCache() {}
+    enqueueProjectStateUpdate(...args: unknown[]) {
+      return enqueueProjectStateUpdate(...(args as []));
+    }
   },
 }));
 
@@ -115,6 +142,11 @@ describe("project identity across folder moves", () => {
     db = drizzle(sqlite, { schema });
     repairWorktrees.mockClear();
     migrateEnvForProject.mockClear();
+    enqueueProjectStateUpdate.mockClear();
+    rekeyWindowStateForPath.mockClear();
+    rewriteAgentSessionPathsForProject.mockClear();
+    rewriteHibernationProjectPath.mockClear();
+    repairMovedSubmodulePaths.mockClear();
     store = new ProjectStore();
   });
 
@@ -166,6 +198,48 @@ describe("project identity across folder moves", () => {
       await store.addProject(await fs.promises.realpath(moved));
 
       expect(repairWorktrees).toHaveBeenCalledTimes(1);
+    });
+
+    it("rewrites all path-bearing state surfaces after adopting a moved folder", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      const canonicalMoved = await fs.promises.realpath(moved);
+      await store.addProject(canonicalMoved);
+
+      // Every ancillary surface is rebased with the immutable id and old→new roots.
+      expect(rekeyWindowStateForPath).toHaveBeenCalledWith(original, canonicalMoved);
+      expect(rewriteAgentSessionPathsForProject).toHaveBeenCalledWith(
+        registered.id,
+        original,
+        canonicalMoved
+      );
+      expect(rewriteHibernationProjectPath).toHaveBeenCalledWith(
+        registered.id,
+        original,
+        canonicalMoved
+      );
+      expect(repairMovedSubmodulePaths).toHaveBeenCalledWith(original, canonicalMoved);
+      // The per-project state write is queued (never a raw read-merge-write) with
+      // the immutable id and a path-rewriting updater.
+      expect(enqueueProjectStateUpdate).toHaveBeenCalledWith(registered.id, expect.any(Function));
+    });
+
+    it("does not rewrite path-bearing state when the current project is declined for adoption", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original);
+      await writeAnchor(original, registered.id);
+      db.insert(schema.appState).values({ key: "currentProjectId", value: registered.id }).run();
+
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      await store.addProject(await fs.promises.realpath(moved));
+
+      expect(rekeyWindowStateForPath).not.toHaveBeenCalled();
+      expect(repairMovedSubmodulePaths).not.toHaveBeenCalled();
     });
 
     it("mints a distinct id for a copy whose original still exists", async () => {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -161,9 +161,6 @@ function mockForgeProviderResolved(
     getForgeBridge: () => bridge,
     initForgeBridge: vi.fn(() => bridge),
   }));
-  vi.doMock("../projectStorePaths.js", () => ({
-    generateProjectId: vi.fn().mockReturnValue("test-project-id"),
-  }));
   vi.doMock("../../utils/hardenedGit.js", () => ({
     createHardenedGit: vi.fn().mockReturnValue({
       getConfig: vi.fn().mockResolvedValue("https://github.com/testowner/testrepo.git"),
@@ -191,9 +188,6 @@ function mockForgeProviderUnresolved(opts?: {
   vi.doMock("../../workspace-host/forgeBridge.js", () => ({
     getForgeBridge: () => bridge,
     initForgeBridge: vi.fn(() => bridge),
-  }));
-  vi.doMock("../projectStorePaths.js", () => ({
-    generateProjectId: vi.fn().mockReturnValue("test-project-id"),
   }));
   const getConfig =
     opts?.getConfig ?? vi.fn().mockResolvedValue("https://github.com/testowner/testrepo.git");
@@ -277,7 +271,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -322,7 +316,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/declined" })
@@ -357,7 +351,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -393,7 +387,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -423,7 +417,7 @@ describe("PullRequestService", () => {
     const issues: DaintreeEventMap["sys:issue:detected"][] = [];
     const unsubscribe = events.on("sys:issue:detected", (payload) => issues.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/widget", issueNumber: 88 })
@@ -456,7 +450,7 @@ describe("PullRequestService", () => {
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     pullRequestService.setForgeSettings({
       forgeProviderOverride: null,
       forgeDefaultProviderId: null,
@@ -482,7 +476,7 @@ describe("PullRequestService", () => {
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     pullRequestService.setForgeSettings({
       forgeProviderOverride: null,
       forgeDefaultProviderId: null,
@@ -504,7 +498,7 @@ describe("PullRequestService", () => {
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     await pullRequestService.refresh();
 
     expect(bridge.resolveProvider).toHaveBeenCalledWith(
@@ -540,7 +534,7 @@ describe("PullRequestService", () => {
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     await pullRequestService.refresh();
 
     expect(getConfig).toHaveBeenCalledWith("remote.origin.url");
@@ -557,7 +551,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -589,7 +583,7 @@ describe("PullRequestService", () => {
     const unsubscribeCleared = events.on("sys:pr:cleared", (p) => cleared.push(p));
     const unsubscribeDetected = events.on("sys:pr:detected", (p) => detected.push(p));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/no-pr" })
@@ -621,7 +615,7 @@ describe("PullRequestService", () => {
     const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
     const unsubscribeCleared = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -672,7 +666,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -725,7 +719,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -781,7 +775,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -833,7 +827,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -880,7 +874,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -921,7 +915,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -973,7 +967,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1015,7 +1009,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1065,7 +1059,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1125,7 +1119,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1188,7 +1182,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1243,7 +1237,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
     events.emit(
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1282,7 +1276,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -1320,7 +1314,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -1356,7 +1350,7 @@ describe("PullRequestService", () => {
       const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
       const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1402,7 +1396,7 @@ describe("PullRequestService", () => {
       const notifications: DaintreeEventMap["ui:notify"][] = [];
       const unsubNotify = events.on("ui:notify", (payload) => notifications.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1443,7 +1437,7 @@ describe("PullRequestService", () => {
       const detected: DaintreeEventMap["sys:pr:detected"][] = [];
       const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1487,7 +1481,7 @@ describe("PullRequestService", () => {
       const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
       const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1522,7 +1516,7 @@ describe("PullRequestService", () => {
       const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
       const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1548,7 +1542,7 @@ describe("PullRequestService", () => {
       const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
       const unsubscribe = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1592,7 +1586,7 @@ describe("PullRequestService", () => {
       const unsubDetected = events.on("sys:pr:detected", (payload) => detected.push(payload));
       const unsubCleared = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-a", branch: "feature/a" })
@@ -1665,7 +1659,7 @@ describe("PullRequestService", () => {
       const unsubCleared = events.on("sys:pr:cleared", (payload) => cleared.push(payload));
       const unsubNotify = events.on("ui:notify", (payload) => notifications.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -1710,7 +1704,7 @@ describe("PullRequestService", () => {
     const detected: DaintreeEventMap["sys:pr:detected"][] = [];
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -1734,7 +1728,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1761,7 +1755,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1786,7 +1780,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1828,7 +1822,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1862,7 +1856,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1891,7 +1885,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       pullRequestService.notifyForgeProviderRegistryUpdated();
       await vi.advanceTimersByTimeAsync(1_000);
       expect(bridge.resolveProvider).not.toHaveBeenCalled();
@@ -1913,7 +1907,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1942,7 +1936,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1969,7 +1963,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -1997,7 +1991,7 @@ describe("PullRequestService", () => {
       const { pullRequestService } = await import("../PullRequestService.js");
       const { events } = await import("../events.js");
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
@@ -2039,7 +2033,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -2070,7 +2064,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -2093,7 +2087,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -2118,7 +2112,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -2139,7 +2133,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -2170,7 +2164,7 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
-    pullRequestService.initialize("/repo");
+    pullRequestService.initialize("/repo", "test-project-id");
 
     events.emit(
       "sys:worktree:update",
@@ -2214,7 +2208,7 @@ describe("PullRequestService", () => {
       const detected: DaintreeEventMap["sys:issue:detected"][] = [];
       const unsubscribe = events.on("sys:issue:detected", (payload) => detected.push(payload));
 
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
       events.emit(
         "sys:worktree:update",
         makeWorktreeSnapshot({
@@ -2294,7 +2288,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 0, ciStatus: "pending" }));
@@ -2307,7 +2301,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 10, ciStatus: "pending" }));
@@ -2320,7 +2314,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 20, ciStatus: "pending" }));
@@ -2333,7 +2327,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       // SUCCESS PR with high count — should be ignored
@@ -2355,7 +2349,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 20, ciStatus: "success" }));
@@ -2368,7 +2362,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.clear();
@@ -2381,7 +2375,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 5 }));
@@ -2399,7 +2393,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 8 }));
@@ -2416,7 +2410,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 8 }));
@@ -2435,7 +2429,7 @@ describe("PullRequestService", () => {
       mockForgeProviderResolved();
 
       const { pullRequestService } = await import("../PullRequestService.js");
-      pullRequestService.initialize("/repo");
+      pullRequestService.initialize("/repo", "test-project-id");
 
       const svc = pullRequestService as any;
       svc.detectedPRs.set("wt-1", makeDetectedPR({ stagnantPollCount: 8 }));
@@ -2593,7 +2587,7 @@ describe("PullRequestService", () => {
         const detected: DaintreeEventMap["sys:pr:detected"][] = [];
         const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
-        pullRequestService.initialize("/repo");
+        pullRequestService.initialize("/repo", "test-project-id");
         events.emit(
           "sys:worktree:update",
           makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -2626,7 +2620,7 @@ describe("PullRequestService", () => {
         const { events } = await import("../events.js");
         const svc = pullRequestService as any;
 
-        pullRequestService.initialize("/repo");
+        pullRequestService.initialize("/repo", "test-project-id");
         svc.repoRef = makeMockRepoRef();
         svc.detectedPRs.set("wt-1", makeDetectedPR({ number: 7, ciStatus: "pending" }));
         svc.boostExpiresAt = Date.now() + 15 * 60 * 1000;
@@ -2662,7 +2656,7 @@ describe("PullRequestService", () => {
         const { events } = await import("../events.js");
         const svc = pullRequestService as any;
 
-        pullRequestService.initialize("/repo");
+        pullRequestService.initialize("/repo", "test-project-id");
         svc.repoRef = makeMockRepoRef();
         svc.detectedPRs.set("wt-1", makeDetectedPR({ number: 7, ciStatus: "success" }));
 
@@ -2688,7 +2682,7 @@ describe("PullRequestService", () => {
         const { events } = await import("../events.js");
         const svc = pullRequestService as any;
 
-        pullRequestService.initialize("/repo");
+        pullRequestService.initialize("/repo", "test-project-id");
         svc.repoRef = makeMockRepoRef();
         svc.detectedPRs.set("wt-1", makeDetectedPR({ number: 7, ciStatus: "pending" }));
 
@@ -2733,7 +2727,7 @@ describe("PullRequestService", () => {
         const { events } = await import("../events.js");
         const svc = pullRequestService as any;
 
-        pullRequestService.initialize("/repo");
+        pullRequestService.initialize("/repo", "test-project-id");
         events.emit(
           "sys:worktree:update",
           makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
@@ -2778,7 +2772,7 @@ describe("PullRequestService", () => {
         const { events } = await import("../events.js");
         const svc = pullRequestService as any;
 
-        pullRequestService.initialize("/repo");
+        pullRequestService.initialize("/repo", "test-project-id");
         svc.repoRef = makeMockRepoRef();
         // Two distinct PR objects coincidentally numbered 42: one PENDING (to be
         // swept), one SUCCESS (must survive untouched).

--- a/electron/services/__tests__/projectPathStateRewrite.test.ts
+++ b/electron/services/__tests__/projectPathStateRewrite.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { rewriteProjectStatePaths } from "../projectPathStateRewrite.js";
+import type { ProjectState } from "../../../shared/types/project.js";
+
+const OLD = "/old/project";
+const NEW = "/new/renamed";
+
+function baseState(overrides: Partial<ProjectState> = {}): ProjectState {
+  return {
+    projectId: "p1",
+    sidebarWidth: 240,
+    terminals: [],
+    ...overrides,
+  };
+}
+
+describe("rewriteProjectStatePaths", () => {
+  it("rebases activeWorktreeId (a worktree id is an absolute path)", () => {
+    const state = baseState({ activeWorktreeId: "/old/project" });
+    expect(rewriteProjectStatePaths(state, OLD, NEW).activeWorktreeId).toBe("/new/renamed");
+  });
+
+  it("rebases panel cwd, worktreeId, filePath and legacy markdownFilePath", () => {
+    const state = baseState({
+      terminals: [
+        {
+          id: "t1",
+          title: "sh",
+          location: "grid",
+          cwd: "/old/project/sub",
+          worktreeId: "/old/project",
+          filePath: "/old/project/README.md",
+          markdownFilePath: "/old/project/notes.md",
+        },
+      ],
+    });
+    const panel = rewriteProjectStatePaths(state, OLD, NEW).terminals[0];
+    expect(panel.cwd).toBe("/new/renamed/sub");
+    expect(panel.worktreeId).toBe("/new/renamed");
+    expect(panel.filePath).toBe("/new/renamed/README.md");
+    expect(panel.markdownFilePath).toBe("/new/renamed/notes.md");
+  });
+
+  it("does NOT rewrite worktree-relative browser paths, URLs, or opaque data", () => {
+    const state = baseState({
+      terminals: [
+        {
+          id: "t1",
+          title: "browser",
+          location: "grid",
+          browserRootPath: "src",
+          browserSelectedPath: "src/index.ts",
+          browserExpandedPaths: ["src", "src/lib"],
+          browserUrl: "http://localhost:3000/old/project",
+          devServerUrl: "http://localhost:5173",
+          command: "run /old/project",
+          env: { PWD: "/old/project" },
+          extensionState: { path: "/old/project" },
+        },
+      ],
+    });
+    const out = rewriteProjectStatePaths(state, OLD, NEW);
+    // Nothing absolute changed → same object reference preserved.
+    expect(out).toBe(state);
+    const panel = out.terminals[0];
+    expect(panel.browserRootPath).toBe("src");
+    expect(panel.browserSelectedPath).toBe("src/index.ts");
+    expect(panel.browserUrl).toBe("http://localhost:3000/old/project");
+    expect(panel.command).toBe("run /old/project");
+    expect(panel.env).toEqual({ PWD: "/old/project" });
+    expect(panel.extensionState).toEqual({ path: "/old/project" });
+  });
+
+  it("rebases tab-group worktree bindings", () => {
+    const state = baseState({
+      tabGroups: [
+        {
+          id: "g1",
+          location: "grid",
+          worktreeId: "/old/project",
+          activeTabId: "t1",
+          panelIds: ["t1"],
+        },
+        {
+          id: "g2",
+          location: "grid",
+          activeTabId: "t2",
+          panelIds: ["t2"],
+        },
+      ],
+    });
+    const groups = rewriteProjectStatePaths(state, OLD, NEW).tabGroups!;
+    expect(groups[0].worktreeId).toBe("/new/renamed");
+    expect(groups[1].worktreeId).toBeUndefined();
+  });
+
+  it("rebases worktree: MRU entries and leaves terminal: entries alone", () => {
+    const state = baseState({ mruList: ["terminal:t-1", "worktree:/old/project"] });
+    expect(rewriteProjectStatePaths(state, OLD, NEW).mruList).toEqual([
+      "terminal:t-1",
+      "worktree:/new/renamed",
+    ]);
+  });
+
+  it("returns the SAME reference when nothing matches", () => {
+    const state = baseState({
+      activeWorktreeId: "/somewhere/else",
+      terminals: [{ id: "t1", title: "sh", location: "grid", cwd: "/somewhere/else" }],
+      mruList: ["terminal:t-1"],
+    });
+    expect(rewriteProjectStatePaths(state, OLD, NEW)).toBe(state);
+  });
+
+  it("does not mutate the input state", () => {
+    const state = baseState({ activeWorktreeId: "/old/project" });
+    const snapshot = JSON.parse(JSON.stringify(state));
+    rewriteProjectStatePaths(state, OLD, NEW);
+    expect(state).toEqual(snapshot);
+  });
+});

--- a/electron/services/git/__tests__/submodulePathRepair.test.ts
+++ b/electron/services/git/__tests__/submodulePathRepair.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../../utils/logger.js", () => ({
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import { repairMovedSubmodulePaths } from "../submodulePathRepair.js";
+
+const OLD = "/old/project";
+
+describe("repairMovedSubmodulePaths", () => {
+  let newRoot: string;
+
+  beforeEach(async () => {
+    newRoot = await mkdtemp(path.join(os.tmpdir(), "submod-repair-"));
+    await mkdir(path.join(newRoot, ".git"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(newRoot, { recursive: true, force: true });
+  });
+
+  async function writeModuleConfig(rel: string, worktreeValue: string): Promise<string> {
+    const file = path.join(newRoot, ".git", rel, "config");
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(
+      file,
+      `[core]\n\trepositoryformatversion = 0\n\tbare = false\n\tworktree = ${worktreeValue}\n`,
+      "utf-8"
+    );
+    return file;
+  }
+
+  async function writeGitlink(checkoutRel: string, gitdirValue: string): Promise<string> {
+    const dir = path.join(newRoot, checkoutRel);
+    await mkdir(dir, { recursive: true });
+    const file = path.join(dir, ".git");
+    await writeFile(file, `gitdir: ${gitdirValue}\n`, "utf-8");
+    return file;
+  }
+
+  it("rebases an absolute core.worktree and absolute gitlink pointer under the old root", async () => {
+    const config = await writeModuleConfig("modules/lib", "/old/project/vendor/lib");
+    const gitlink = await writeGitlink("vendor/lib", "/old/project/.git/modules/lib");
+
+    await repairMovedSubmodulePaths(OLD, newRoot);
+
+    expect(await readFile(config, "utf-8")).toContain(`worktree = ${newRoot}/vendor/lib`);
+    expect(await readFile(gitlink, "utf-8")).toBe(`gitdir: ${newRoot}/.git/modules/lib\n`);
+  });
+
+  it("leaves relative pointers byte-for-byte unchanged", async () => {
+    const config = await writeModuleConfig("modules/lib", "../../../vendor/lib");
+    const gitlink = await writeGitlink("vendor/lib", "../.git/modules/lib");
+    const configBefore = await readFile(config, "utf-8");
+    const gitlinkBefore = await readFile(gitlink, "utf-8");
+
+    await repairMovedSubmodulePaths(OLD, newRoot);
+
+    expect(await readFile(config, "utf-8")).toBe(configBefore);
+    expect(await readFile(gitlink, "utf-8")).toBe(gitlinkBefore);
+  });
+
+  it("does not touch a sibling that merely shares the old-root prefix", async () => {
+    const config = await writeModuleConfig("modules/lib", "/old/project-copy/vendor/lib");
+    const before = await readFile(config, "utf-8");
+
+    await repairMovedSubmodulePaths(OLD, newRoot);
+
+    expect(await readFile(config, "utf-8")).toBe(before);
+  });
+
+  it("rebases a quoted core.worktree containing spaces, keeping it quoted", async () => {
+    const config = await writeModuleConfig("modules/lib", '"/old/project/my vendor/lib"');
+
+    await repairMovedSubmodulePaths(OLD, newRoot);
+
+    expect(await readFile(config, "utf-8")).toContain(`worktree = "${newRoot}/my vendor/lib"`);
+  });
+
+  it("repairs a submodule owned by a linked worktree (worktrees/<id>/modules)", async () => {
+    const config = await writeModuleConfig("worktrees/wt1/modules/lib", "/old/project/vendor/lib");
+
+    await repairMovedSubmodulePaths(OLD, newRoot);
+
+    expect(await readFile(config, "utf-8")).toContain(`worktree = ${newRoot}/vendor/lib`);
+  });
+
+  it("keeps repairing other modules when one config is malformed, and never throws", async () => {
+    await writeFile(
+      path.join(newRoot, ".git", "modules", "broken", "config"),
+      "not an ini at all",
+      "utf-8"
+    ).catch(() => {});
+    await mkdir(path.join(newRoot, ".git", "modules", "broken"), { recursive: true });
+    await writeFile(path.join(newRoot, ".git", "modules", "broken", "config"), "\x00\x00garbage");
+    const good = await writeModuleConfig("modules/good", "/old/project/vendor/good");
+
+    await expect(repairMovedSubmodulePaths(OLD, newRoot)).resolves.toBeUndefined();
+
+    expect(await readFile(good, "utf-8")).toContain(`worktree = ${newRoot}/vendor/good`);
+  });
+
+  it("is a no-op when old and new roots are equal or empty", async () => {
+    const config = await writeModuleConfig("modules/lib", "/old/project/vendor/lib");
+    const before = await readFile(config, "utf-8");
+
+    await repairMovedSubmodulePaths(OLD, OLD);
+    await repairMovedSubmodulePaths("", newRoot);
+
+    expect(await readFile(config, "utf-8")).toBe(before);
+  });
+});

--- a/electron/services/git/__tests__/submodulePathRepair.test.ts
+++ b/electron/services/git/__tests__/submodulePathRepair.test.ts
@@ -105,6 +105,17 @@ describe("repairMovedSubmodulePaths", () => {
     expect(await readFile(good, "utf-8")).toContain(`worktree = ${newRoot}/vendor/good`);
   });
 
+  it("preserves CRLF line endings when rewriting the config", async () => {
+    const file = path.join(newRoot, ".git", "modules", "lib", "config");
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, `[core]\r\n\tworktree = /old/project/vendor/lib\r\n`, "utf-8");
+
+    await repairMovedSubmodulePaths(OLD, newRoot);
+
+    const out = await readFile(file, "utf-8");
+    expect(out).toBe(`[core]\r\n\tworktree = ${newRoot}/vendor/lib\r\n`);
+  });
+
   it("is a no-op when old and new roots are equal or empty", async () => {
     const config = await writeModuleConfig("modules/lib", "/old/project/vendor/lib");
     const before = await readFile(config, "utf-8");

--- a/electron/services/git/submodulePathRepair.ts
+++ b/electron/services/git/submodulePathRepair.ts
@@ -165,13 +165,15 @@ function rewriteCoreWorktree(
     }
     if (section !== "core") continue;
 
-    const kv = line.match(/^(\s*worktree\s*=\s*)(.*)$/i);
+    const kv = line.match(/^(\s*worktree\s*=\s*)(.*?)(\s*)$/i);
     if (!kv) continue;
 
     const { value, quoted } = decodeConfigValue(kv[2]);
     const next = transform(value);
     if (next !== value) {
-      lines[i] = kv[1] + encodeConfigValue(next, quoted);
+      // kv[3] preserves the line's trailing whitespace — notably a CRLF's `\r`,
+      // so a Windows-authored config keeps its line endings intact.
+      lines[i] = kv[1] + encodeConfigValue(next, quoted) + kv[3];
       changed = true;
     }
     // Only the first core.worktree matters.

--- a/electron/services/git/submodulePathRepair.ts
+++ b/electron/services/git/submodulePathRepair.ts
@@ -2,7 +2,10 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { resilientAtomicWriteFile } from "../../utils/fs.js";
 import { logError } from "../../utils/logger.js";
-import { rebaseAbsolutePath, isAbsoluteFsPath } from "../../../shared/utils/projectPathRelocation.js";
+import {
+  rebaseAbsolutePath,
+  isAbsoluteFsPath,
+} from "../../../shared/utils/projectPathRelocation.js";
 
 /**
  * Repair submodule metadata that a project-folder move/rename leaves stale
@@ -96,7 +99,11 @@ async function collectConfigFiles(dir: string, out: string[]): Promise<void> {
  * `oldRoot`. `moduleDir` is the config's directory — git resolves a relative
  * `core.worktree` against it.
  */
-async function repairOneModule(configFile: string, oldRoot: string, newRoot: string): Promise<void> {
+async function repairOneModule(
+  configFile: string,
+  oldRoot: string,
+  newRoot: string
+): Promise<void> {
   try {
     const moduleDir = path.dirname(configFile);
     const original = await safeReadFile(configFile);
@@ -197,7 +204,10 @@ function decodeConfigValue(raw: string): { value: string; quoted: boolean } {
 function encodeConfigValue(value: string, quoted: boolean): string {
   const needsQuote = quoted || /[\s"\\]/.test(value);
   if (!needsQuote) return value;
-  const escaped = value.replace(/(["\\])/g, "\\$1").replace(/\t/g, "\\t").replace(/\n/g, "\\n");
+  const escaped = value
+    .replace(/(["\\])/g, "\\$1")
+    .replace(/\t/g, "\\t")
+    .replace(/\n/g, "\\n");
   return `"${escaped}"`;
 }
 

--- a/electron/services/git/submodulePathRepair.ts
+++ b/electron/services/git/submodulePathRepair.ts
@@ -1,0 +1,217 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { resilientAtomicWriteFile } from "../../utils/fs.js";
+import { logError } from "../../utils/logger.js";
+import { rebaseAbsolutePath, isAbsoluteFsPath } from "../../../shared/utils/projectPathRelocation.js";
+
+/**
+ * Repair submodule metadata that a project-folder move/rename leaves stale
+ * (#11282, phase 2). `git worktree repair` fixes linked worktrees but does
+ * NOTHING for submodules, and neither does `git submodule sync`/`absorbgitdirs`:
+ * an absolute path already baked into an absorbed submodule's `gitdir:` pointer
+ * or its `core.worktree` config is invisible to git porcelain. Modern git writes
+ * these RELATIVE by default, which survive a same-volume move untouched — so
+ * only ABSOLUTE pointers under the old root are rewritten, via a literal prefix
+ * substitution. Relative pointers are left byte-for-byte unchanged.
+ *
+ * Best-effort and per-file isolated: a malformed or unwritable config never
+ * aborts the others, and the function never rejects — the DB row has already
+ * moved and is authoritative, so a repair failure must not fail the relocation.
+ */
+export async function repairMovedSubmodulePaths(oldRoot: string, newRoot: string): Promise<void> {
+  if (!oldRoot || !newRoot || oldRoot === newRoot) return;
+
+  try {
+    const commonGitDir = await resolveGitDir(newRoot);
+    if (!commonGitDir) return;
+
+    // Absorbed submodules live under `<git>/modules`; submodules owned by a
+    // linked worktree live under `<git>/worktrees/<id>/modules`.
+    const scanRoots = [path.join(commonGitDir, "modules")];
+    const worktreesDir = path.join(commonGitDir, "worktrees");
+    for (const entry of await safeReaddir(worktreesDir)) {
+      scanRoots.push(path.join(worktreesDir, entry, "modules"));
+    }
+
+    const configFiles: string[] = [];
+    for (const root of scanRoots) {
+      await collectConfigFiles(root, configFiles);
+    }
+
+    for (const configFile of configFiles) {
+      await repairOneModule(configFile, oldRoot, newRoot);
+    }
+  } catch (error) {
+    logError(`Failed to repair submodule pointers under ${newRoot}`, error);
+  }
+}
+
+/**
+ * Resolve the repository's common git directory for a main worktree. Normally
+ * `<root>/.git` is a directory; when it is a `gitdir:` file (root is itself a
+ * linked worktree) we follow it and honour a `commondir` sibling.
+ */
+async function resolveGitDir(root: string): Promise<string | null> {
+  const dotGit = path.join(root, ".git");
+  let info;
+  try {
+    info = await stat(dotGit);
+  } catch {
+    return null;
+  }
+  if (info.isDirectory()) return dotGit;
+  if (!info.isFile()) return null;
+
+  const pointer = await safeReadFile(dotGit);
+  const match = pointer?.match(/^gitdir:\s*(.+?)\s*$/m);
+  if (!match) return null;
+  const gitDir = path.resolve(root, match[1]);
+  const commonDirFile = await safeReadFile(path.join(gitDir, "commondir"));
+  if (commonDirFile) {
+    return path.resolve(gitDir, commonDirFile.trim());
+  }
+  return gitDir;
+}
+
+async function collectConfigFiles(dir: string, out: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectConfigFiles(full, out);
+    } else if (entry.isFile() && entry.name === "config") {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Rewrite one module's `core.worktree` (in its config) and the submodule
+ * checkout's `.git` gitlink pointer, when either holds an absolute path under
+ * `oldRoot`. `moduleDir` is the config's directory — git resolves a relative
+ * `core.worktree` against it.
+ */
+async function repairOneModule(configFile: string, oldRoot: string, newRoot: string): Promise<void> {
+  try {
+    const moduleDir = path.dirname(configFile);
+    const original = await safeReadFile(configFile);
+    if (original === null) return;
+
+    let worktreeRaw: string | null = null;
+    const rewrittenConfig = rewriteCoreWorktree(original, (value) => {
+      worktreeRaw = value;
+      return isAbsoluteFsPath(value) ? rebaseAbsolutePath(value, oldRoot, newRoot) : value;
+    });
+    if (rewrittenConfig.changed) {
+      await resilientAtomicWriteFile(configFile, rewrittenConfig.text, "utf-8");
+    }
+
+    // Locate the submodule checkout to repair its `.git` pointer file. Use the
+    // post-rewrite core.worktree so a just-fixed absolute value points at the
+    // new location; a relative value resolves against the module dir.
+    if (worktreeRaw === null) return;
+    const effectiveWorktree = isAbsoluteFsPath(worktreeRaw)
+      ? rebaseAbsolutePath(worktreeRaw, oldRoot, newRoot)
+      : path.resolve(moduleDir, worktreeRaw);
+
+    await repairGitlinkPointer(path.join(effectiveWorktree, ".git"), oldRoot, newRoot);
+  } catch (error) {
+    logError(`Failed to repair submodule config ${configFile}`, error);
+  }
+}
+
+/** Rewrite an absolute `gitdir:` pointer in a submodule's `.git` file. */
+async function repairGitlinkPointer(
+  gitlinkFile: string,
+  oldRoot: string,
+  newRoot: string
+): Promise<void> {
+  const content = await safeReadFile(gitlinkFile);
+  if (content === null) return;
+  const match = content.match(/^(gitdir:\s*)(.+?)(\s*)$/m);
+  if (!match) return;
+  const target = match[2];
+  if (!isAbsoluteFsPath(target)) return;
+  const rebased = rebaseAbsolutePath(target, oldRoot, newRoot);
+  if (rebased === target) return;
+  const next = content.replace(match[0], `${match[1]}${rebased}${match[3]}`);
+  await resilientAtomicWriteFile(gitlinkFile, next, "utf-8");
+}
+
+/**
+ * Rewrite the `worktree` value inside the `[core]` section of a git config,
+ * preserving all other content, whitespace, quoting and line endings. Handles
+ * git's quoted-value form (`worktree = "with space"`).
+ */
+function rewriteCoreWorktree(
+  text: string,
+  transform: (value: string) => string
+): { text: string; changed: boolean } {
+  const lines = text.split("\n");
+  let section: string | null = null;
+  let changed = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const header = line.match(/^\s*\[([^\]]+)\]/);
+    if (header) {
+      section = header[1].trim().toLowerCase().split(/\s+/)[0];
+      continue;
+    }
+    if (section !== "core") continue;
+
+    const kv = line.match(/^(\s*worktree\s*=\s*)(.*)$/i);
+    if (!kv) continue;
+
+    const { value, quoted } = decodeConfigValue(kv[2]);
+    const next = transform(value);
+    if (next !== value) {
+      lines[i] = kv[1] + encodeConfigValue(next, quoted);
+      changed = true;
+    }
+    // Only the first core.worktree matters.
+    break;
+  }
+
+  return { text: lines.join("\n"), changed };
+}
+
+function decodeConfigValue(raw: string): { value: string; quoted: boolean } {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    const inner = trimmed
+      .slice(1, -1)
+      .replace(/\\(["\\tn])/g, (_m, c) => (c === "t" ? "\t" : c === "n" ? "\n" : c));
+    return { value: inner, quoted: true };
+  }
+  return { value: trimmed, quoted: false };
+}
+
+function encodeConfigValue(value: string, quoted: boolean): string {
+  const needsQuote = quoted || /[\s"\\]/.test(value);
+  if (!needsQuote) return value;
+  const escaped = value.replace(/(["\\])/g, "\\$1").replace(/\t/g, "\\t").replace(/\n/g, "\\n");
+  return `"${escaped}"`;
+}
+
+async function safeReadFile(file: string): Promise<string | null> {
+  try {
+    return await readFile(file, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    return [];
+  }
+}

--- a/electron/services/projectPathStateRewrite.ts
+++ b/electron/services/projectPathStateRewrite.ts
@@ -1,0 +1,113 @@
+import type { ProjectState, PanelSnapshot, TabGroup } from "../../shared/types/project.js";
+import { rebaseAbsolutePath, rebaseMruEntry } from "../../shared/utils/projectPathRelocation.js";
+
+/**
+ * Rewrite the absolute-path-bearing fields of a persisted {@link ProjectState}
+ * after a project folder move/rename (#11282, phase 2).
+ *
+ * Only fields whose values are genuine absolute filesystem paths are rebased:
+ * PTY `cwd`, file-panel `filePath`/`markdownFilePath`, `worktreeId` (a worktree
+ * id is a normalized absolute path), `activeWorktreeId`, tab-group worktree
+ * bindings, and `worktree:` MRU entries. Deliberately excluded — they are not
+ * absolute filesystem bindings and blanket substitution would corrupt them:
+ *   - `browserRootPath` / `browserSelectedPath` / `browserExpandedPaths` are
+ *     worktree-RELATIVE and move with the folder untouched.
+ *   - `browserUrl` / `devServerUrl` / `browserHistory` are URLs.
+ *   - `command` / `env` / `extensionState` are opaque user/plugin data.
+ *   - panel/terminal/tab/layout ids, terminal sizes, drafts and focus state.
+ *
+ * Returns the SAME object reference when nothing changed so callers can skip the
+ * disk write; clones only the arrays/objects that actually change.
+ */
+export function rewriteProjectStatePaths(
+  state: ProjectState,
+  oldRoot: string,
+  newRoot: string
+): ProjectState {
+  let changed = false;
+
+  const nextActive =
+    state.activeWorktreeId !== undefined
+      ? rebaseAbsolutePath(state.activeWorktreeId, oldRoot, newRoot)
+      : state.activeWorktreeId;
+  if (nextActive !== state.activeWorktreeId) changed = true;
+
+  let terminals = state.terminals;
+  if (Array.isArray(state.terminals)) {
+    let terminalsChanged = false;
+    const rewritten = state.terminals.map((panel) => {
+      const next = rewritePanelPaths(panel, oldRoot, newRoot);
+      if (next !== panel) terminalsChanged = true;
+      return next;
+    });
+    if (terminalsChanged) {
+      terminals = rewritten;
+      changed = true;
+    }
+  }
+
+  let tabGroups = state.tabGroups;
+  if (Array.isArray(state.tabGroups)) {
+    let tabGroupsChanged = false;
+    const rewritten = state.tabGroups.map((group) => {
+      const next = rewriteTabGroupPaths(group, oldRoot, newRoot);
+      if (next !== group) tabGroupsChanged = true;
+      return next;
+    });
+    if (tabGroupsChanged) {
+      tabGroups = rewritten;
+      changed = true;
+    }
+  }
+
+  let mruList = state.mruList;
+  if (Array.isArray(state.mruList)) {
+    let mruChanged = false;
+    const rewritten = state.mruList.map((entry) => {
+      const next = rebaseMruEntry(entry, oldRoot, newRoot);
+      if (next !== entry) mruChanged = true;
+      return next;
+    });
+    if (mruChanged) {
+      mruList = rewritten;
+      changed = true;
+    }
+  }
+
+  if (!changed) return state;
+  return {
+    ...state,
+    activeWorktreeId: nextActive,
+    terminals,
+    ...(state.tabGroups !== undefined ? { tabGroups } : {}),
+    ...(state.mruList !== undefined ? { mruList } : {}),
+  };
+}
+
+function rewritePanelPaths(panel: PanelSnapshot, oldRoot: string, newRoot: string): PanelSnapshot {
+  const patch: Partial<PanelSnapshot> = {};
+  let changed = false;
+
+  const rebaseField = (key: "cwd" | "worktreeId" | "filePath" | "markdownFilePath"): void => {
+    const value = panel[key];
+    if (value === undefined) return;
+    const next = rebaseAbsolutePath(value, oldRoot, newRoot);
+    if (next !== value) {
+      patch[key] = next;
+      changed = true;
+    }
+  };
+
+  rebaseField("cwd");
+  rebaseField("worktreeId");
+  rebaseField("filePath");
+  rebaseField("markdownFilePath");
+
+  return changed ? { ...panel, ...patch } : panel;
+}
+
+function rewriteTabGroupPaths(group: TabGroup, oldRoot: string, newRoot: string): TabGroup {
+  if (group.worktreeId === undefined) return group;
+  const next = rebaseAbsolutePath(group.worktreeId, oldRoot, newRoot);
+  return next === group.worktreeId ? group : { ...group, worktreeId: next };
+}

--- a/electron/services/projectPathStateRewrite.ts
+++ b/electron/services/projectPathStateRewrite.ts
@@ -1,4 +1,5 @@
-import type { ProjectState, PanelSnapshot, TabGroup } from "../../shared/types/project.js";
+import type { ProjectState, PanelSnapshot } from "../../shared/types/project.js";
+import type { TabGroup } from "../../shared/types/panel.js";
 import { rebaseAbsolutePath, rebaseMruEntry } from "../../shared/utils/projectPathRelocation.js";
 
 /**

--- a/electron/services/pty/__tests__/agentSessionHistory.rewrite.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.rewrite.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  rewriteAgentSessionPathsForProject,
+  readSessionHistory,
+  readSessionHistorySync,
+  getSessionHistoryPath,
+  type AgentSessionRecord,
+} from "../agentSessionHistory.js";
+
+const OLD = "/old/project";
+const NEW = "/new/renamed";
+
+describe("rewriteAgentSessionPathsForProject", () => {
+  let userDataDir: string;
+  const previousUserData = process.env.DAINTREE_USER_DATA;
+
+  beforeEach(async () => {
+    userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "daintree-history-rewrite-"));
+    process.env.DAINTREE_USER_DATA = userDataDir;
+  });
+
+  afterEach(async () => {
+    process.env.DAINTREE_USER_DATA = previousUserData;
+    await fsp.rm(userDataDir, { recursive: true, force: true });
+  });
+
+  async function seed(records: AgentSessionRecord[]): Promise<void> {
+    await fsp.writeFile(getSessionHistoryPath(userDataDir)!, JSON.stringify(records));
+  }
+
+  const rec = (over: Partial<AgentSessionRecord>): AgentSessionRecord => ({
+    sessionId: "s1",
+    agentId: "claude",
+    worktreeId: null,
+    title: null,
+    projectId: null,
+    savedAt: 1000,
+    ...over,
+  });
+
+  it("rebases worktreeId and cwd only for the matching project's records", async () => {
+    await seed([
+      rec({ sessionId: "a", projectId: "p1", worktreeId: "/old/project", cwd: "/old/project/wt" }),
+      rec({ sessionId: "b", projectId: "p2", worktreeId: "/old/project", cwd: "/old/project" }),
+      rec({ sessionId: "c", projectId: null, worktreeId: "/old/project", cwd: "/old/project" }),
+    ]);
+
+    await rewriteAgentSessionPathsForProject("p1", OLD, NEW);
+
+    const out = await readSessionHistory(userDataDir);
+    const byId = Object.fromEntries(out.map((r) => [r.sessionId, r]));
+    expect(byId.a.worktreeId).toBe("/new/renamed");
+    expect(byId.a.cwd).toBe("/new/renamed/wt");
+    // Other project and legacy null-project records are untouched.
+    expect(byId.b.worktreeId).toBe("/old/project");
+    expect(byId.c.worktreeId).toBe("/old/project");
+  });
+
+  it("leaves records with worktreeId outside the old root unchanged", async () => {
+    await seed([
+      rec({ sessionId: "a", projectId: "p1", worktreeId: "/elsewhere/wt", cwd: "/elsewhere/wt" }),
+    ]);
+
+    await rewriteAgentSessionPathsForProject("p1", OLD, NEW);
+
+    const out = await readSessionHistory(userDataDir);
+    expect(out[0].worktreeId).toBe("/elsewhere/wt");
+    expect(out[0].cwd).toBe("/elsewhere/wt");
+  });
+
+  it("preserves record order and timestamps", async () => {
+    await seed([
+      rec({ sessionId: "a", projectId: "p1", worktreeId: "/old/project", savedAt: 3000 }),
+      rec({ sessionId: "b", projectId: "p1", worktreeId: "/old/project", savedAt: 2000 }),
+    ]);
+
+    await rewriteAgentSessionPathsForProject("p1", OLD, NEW);
+
+    const out = await readSessionHistory(userDataDir);
+    expect(out.map((r) => r.sessionId)).toEqual(["a", "b"]);
+    expect(out.map((r) => r.savedAt)).toEqual([3000, 2000]);
+  });
+
+  it("refreshes the read cache so a subsequent sync read sees the rewrite", async () => {
+    await seed([rec({ sessionId: "a", projectId: "p1", worktreeId: "/old/project" })]);
+    // Prime the cache with the pre-rewrite value.
+    expect(readSessionHistorySync(userDataDir)[0].worktreeId).toBe("/old/project");
+
+    await rewriteAgentSessionPathsForProject("p1", OLD, NEW);
+
+    expect(readSessionHistorySync(userDataDir)[0].worktreeId).toBe("/new/renamed");
+  });
+
+  it("does not write when nothing changed (no matching project record)", async () => {
+    await seed([rec({ sessionId: "a", projectId: "other", worktreeId: "/old/project" })]);
+    const before = await fsp.stat(getSessionHistoryPath(userDataDir)!);
+
+    await rewriteAgentSessionPathsForProject("p1", OLD, NEW);
+
+    const after = await fsp.stat(getSessionHistoryPath(userDataDir)!);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+
+  it("is a no-op when old equals new", async () => {
+    await seed([rec({ sessionId: "a", projectId: "p1", worktreeId: "/old/project" })]);
+    await rewriteAgentSessionPathsForProject("p1", OLD, OLD);
+    const out = await readSessionHistory(userDataDir);
+    expect(out[0].worktreeId).toBe("/old/project");
+  });
+});

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -12,6 +12,7 @@ import type {
   AgentSessionRecord,
   AgentSessionRetentionDays,
 } from "../../../shared/types/ipc/agentSessionHistory.js";
+import { rebaseAbsolutePath } from "../../../shared/utils/projectPathRelocation.js";
 
 export type { AgentSessionRecord };
 
@@ -273,6 +274,44 @@ export async function pruneAgentSessions(
       mode: OWNER_RW_FILE_MODE,
     });
     refreshCacheAfterWrite(filePath, pruned);
+  });
+}
+
+/**
+ * Rebase the absolute `worktreeId` and `cwd` of one project's records after a
+ * folder move/rename (#11282, phase 2), so a relocated project's captured agent
+ * sessions stay grouped under the moved worktrees and resume in the right place.
+ * Only records whose non-null `projectId` matches are touched — legacy
+ * `projectId: null` records are left alone rather than guessing their owner.
+ * Shares the write queue so it can't interleave with an in-flight persist, and
+ * skips the disk write entirely when nothing changed.
+ */
+export async function rewriteAgentSessionPathsForProject(
+  projectId: string,
+  oldRoot: string,
+  newRoot: string,
+  userData?: string
+): Promise<void> {
+  const filePath = getSessionHistoryPath(userData);
+  if (!filePath || !projectId || !oldRoot || !newRoot || oldRoot === newRoot) return;
+
+  await enqueueWrite(async () => {
+    const existing = await readSessionHistory(userData);
+    let changed = false;
+    const rewritten = existing.map((r) => {
+      if (r.projectId !== projectId) return r;
+      const nextWorktreeId =
+        r.worktreeId !== null ? rebaseAbsolutePath(r.worktreeId, oldRoot, newRoot) : r.worktreeId;
+      const nextCwd = r.cwd !== undefined ? rebaseAbsolutePath(r.cwd, oldRoot, newRoot) : r.cwd;
+      if (nextWorktreeId === r.worktreeId && nextCwd === r.cwd) return r;
+      changed = true;
+      return { ...r, worktreeId: nextWorktreeId, cwd: nextCwd };
+    });
+    if (!changed) return;
+    await resilientAtomicWriteFile(filePath, JSON.stringify(rewritten, null, 2), "utf-8", {
+      mode: OWNER_RW_FILE_MODE,
+    });
+    refreshCacheAfterWrite(filePath, rewritten);
   });
 }
 

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -5,7 +5,6 @@ import { broadcastToRenderer } from "../../ipc/utils.js";
 import { notifyError } from "../../ipc/errorHandlers.js";
 import { clearWslGitEntry } from "../../store.js";
 import { gitServiceCache } from "../GitServiceCache.js";
-import { generateProjectId } from "../projectStorePaths.js";
 import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } from "./types.js";
 import type { WorkspaceHostEvent, WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 
@@ -327,10 +326,9 @@ export class WorkspaceHostEventRouter {
         // ignore it. No cache to drop on main's side: `GitService.getRemoteUrl`
         // re-runs `getRemotes` on every call, and `GitServiceCache` only pools
         // the client instance, never the URL.
-        const projectId = generateProjectId(entry.projectPath);
         broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
           name: "forge:remote-changed",
-          payload: { projectId },
+          payload: { projectId: entry.projectId },
         });
         break;
       }

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -196,7 +196,11 @@ export class WorkspaceHostPool {
 
   // ── Process lifecycle ──
 
-  private makeInitPromise(host: WorkspaceHostProcess, normalizedPath: string): Promise<void> {
+  private makeInitPromise(
+    host: WorkspaceHostProcess,
+    normalizedPath: string,
+    projectId: string
+  ): Promise<void> {
     return (async () => {
       const [, forgeSettings] = await Promise.all([
         host.waitForReady(),
@@ -207,6 +211,7 @@ export class WorkspaceHostPool {
         type: "load-project",
         requestId,
         rootPath: normalizedPath,
+        projectId,
         globalEnvVars: store.get("globalEnvironmentVariables") ?? {},
         wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
         forgeProviderOverride: forgeSettings.forgeProviderOverride,
@@ -277,7 +282,8 @@ export class WorkspaceHostPool {
       host.updateMonitorConfig(this.monitorConfigCache);
     }
 
-    const initPromise = this.makeInitPromise(host, normalizedPath);
+    const projectId = projectStore.resolveProjectIdForPath(normalizedPath);
+    const initPromise = this.makeInitPromise(host, normalizedPath, projectId);
 
     const newEntry: ProcessEntry = {
       host,
@@ -287,6 +293,7 @@ export class WorkspaceHostPool {
       cleanupTimeout: null,
       windowIds: new Set([windowId]),
       projectPath: normalizedPath,
+      projectId,
       directPortViews: new Map(),
     };
 
@@ -348,7 +355,8 @@ export class WorkspaceHostPool {
       host.updateMonitorConfig(this.monitorConfigCache);
     }
 
-    const initPromise = this.makeInitPromise(host, normalizedPath);
+    const projectId = projectStore.resolveProjectIdForPath(normalizedPath);
+    const initPromise = this.makeInitPromise(host, normalizedPath, projectId);
 
     const entry: ProcessEntry = {
       host,
@@ -358,6 +366,7 @@ export class WorkspaceHostPool {
       cleanupTimeout: null,
       windowIds: new Set(),
       projectPath: normalizedPath,
+      projectId,
       directPortViews: new Map(),
     };
 
@@ -554,6 +563,7 @@ export class WorkspaceHostPool {
       type: "load-project",
       requestId,
       rootPath: entry.projectPath,
+      projectId: entry.projectId,
       globalEnvVars: store.get("globalEnvironmentVariables") ?? {},
       wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
       forgeProviderOverride: forgeSettings.forgeProviderOverride,

--- a/electron/services/workspace-client/__tests__/WorkspaceCopyTreeClient.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceCopyTreeClient.test.ts
@@ -22,6 +22,7 @@ function makeEntry(host: WorkspaceHostProcess, projectPath: string): ProcessEntr
     cleanupTimeout: null,
     windowIds: new Set(),
     projectPath,
+    projectId: `id:${projectPath}`,
     directPortViews: new Map(),
   };
 }

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -24,7 +24,6 @@ vi.mock("../../GitServiceCache.js", () => ({
 import { broadcastToRenderer } from "../../../ipc/utils.js";
 import { events } from "../../events.js";
 import { gitServiceCache } from "../../GitServiceCache.js";
-import { generateProjectId } from "../../projectStorePaths.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
 import type { RateLimitInfo } from "../../../../shared/types/forge.js";
 
@@ -51,6 +50,7 @@ function makeEntry(overrides: Partial<ProcessEntry> = {}): ProcessEntry {
     cleanupTimeout: null,
     windowIds: new Set(),
     projectPath: "/project/test",
+    projectId: "test-project-id",
     directPortViews: new Map(),
     ...overrides,
   };
@@ -1030,27 +1030,28 @@ describe("WorkspaceHostEventRouter", () => {
 
   describe("forge-remote-changed (#11155)", () => {
     it("broadcasts a project-scoped signal so the renderer re-resolves its provider", () => {
-      const entry = makeEntry({ projectPath: "/project/test" });
+      const entry = makeEntry({ projectPath: "/project/test", projectId: "test-project-id" });
       router.routeHostEvent(entry, { type: "forge-remote-changed" });
 
       expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
       expect(broadcastToRenderer).toHaveBeenCalledWith(CHANNELS.EVENTS_PUSH, {
         name: "forge:remote-changed",
-        payload: { projectId: generateProjectId("/project/test") },
+        payload: { projectId: "test-project-id" },
       });
     });
 
     it("scopes the signal to the emitting host's project", () => {
-      router.routeHostEvent(makeEntry({ projectPath: "/a" }), { type: "forge-remote-changed" });
-      router.routeHostEvent(makeEntry({ projectPath: "/b" }), { type: "forge-remote-changed" });
+      router.routeHostEvent(makeEntry({ projectPath: "/a", projectId: "project-a-id" }), {
+        type: "forge-remote-changed",
+      });
+      router.routeHostEvent(makeEntry({ projectPath: "/b", projectId: "project-b-id" }), {
+        type: "forge-remote-changed",
+      });
 
       const projectIds = vi
         .mocked(broadcastToRenderer)
         .mock.calls.map(([, payload]) => (payload as { payload: { projectId: string } }).payload);
-      expect(projectIds).toEqual([
-        { projectId: generateProjectId("/a") },
-        { projectId: generateProjectId("/b") },
-      ]);
+      expect(projectIds).toEqual([{ projectId: "project-a-id" }, { projectId: "project-b-id" }]);
     });
 
     it("carries no remote URL — https remotes can embed credentials", () => {

--- a/electron/services/workspace-client/types.ts
+++ b/electron/services/workspace-client/types.ts
@@ -12,6 +12,12 @@ export interface ProcessEntry {
   cleanupTimeout: NodeJS.Timeout | null;
   windowIds: Set<number>;
   projectPath: string;
+  /**
+   * Immutable project id (`resolveProjectIdForPath`), resolved once at entry
+   * construction. Sent on every `load-project` and used for id-keyed broadcasts
+   * so a relocated project's events aren't dropped by a stale path hash (#11282).
+   */
+  projectId: string;
   directPortViews: Map<number, WebContents>;
 }
 

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -218,6 +218,28 @@ export function pruneWindowStateForPath(projectPath: string): void {
   }
 }
 
+/**
+ * Move a project's saved window bounds from `oldPath` to `newPath` after a
+ * folder move/rename (#11282, phase 2). Unlike {@link pruneWindowStateForPath}
+ * this preserves the bounds rather than dropping them, so a relocated project's
+ * window reopens where the user left it instead of reverting to defaults. The
+ * moved project's bounds win over any stale entry already sitting at `newPath`.
+ * No-op when the old path has no saved state. Routes through the same capped
+ * writer and never persists `undefined` (electron-store v11 rejects it).
+ */
+export function rekeyWindowStateForPath(oldPath: string, newPath: string): void {
+  if (!oldPath || !newPath || oldPath === newPath) return;
+  const windowStates: WindowStatesMap | undefined = windowStatesStore.get("windowStates");
+  if (!windowStates || !(oldPath in windowStates)) return;
+  const bounds = windowStates[oldPath];
+  delete windowStates[oldPath];
+  windowStates[newPath] = bounds;
+  commitWindowStates(windowStates);
+  if (lastSavedProjectPath === oldPath) {
+    lastSavedProjectPath = newPath;
+  }
+}
+
 export function createWindowWithState(
   options: Electron.BrowserWindowConstructorOptions,
   projectPath?: string | null

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -233,6 +233,11 @@ export function rekeyWindowStateForPath(oldPath: string, newPath: string): void 
   if (!windowStates || !(oldPath in windowStates)) return;
   const bounds = windowStates[oldPath];
   delete windowStates[oldPath];
+  // Delete any stale entry already at the destination before reassigning, so the
+  // moved bounds take a FRESH (most-recent) insertion slot. Insertion order is
+  // the MRU-cap policy (see commitWindowStates); overwriting in place would leave
+  // the relocated project in the stale entry's old, possibly-evicted position.
+  delete windowStates[newPath];
   windowStates[newPath] = bounds;
   commitWindowStates(windowStates);
   if (lastSavedProjectPath === oldPath) {

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -443,6 +443,7 @@ port.on("message", async (rawMsg: any) => {
         await workspaceService.loadProject(
           request.requestId,
           request.rootPath,
+          request.projectId,
           request.globalEnvVars,
           request.wslGitByWorktree,
           request.forgeProviderOverride !== undefined ||

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -2,7 +2,7 @@ import type { TypedEventBus } from "../services/events.js";
 import type { PRServiceStatus, WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 
 interface PullRequestServiceLike {
-  initialize(rootPath: string): void;
+  initialize(rootPath: string, projectId: string): void;
   start(startupDelayMs?: number): Promise<void>;
   stop(): void;
   reset(): void;
@@ -107,6 +107,7 @@ export class PRIntegrationService {
 
   async initialize(
     projectRootPath: string,
+    projectId: string,
     getMonitorCandidates: () => Array<{
       worktreeId: string;
       branch?: string;
@@ -120,7 +121,7 @@ export class PRIntegrationService {
 
     this.cleanup();
 
-    this.prService.initialize(projectRootPath);
+    this.prService.initialize(projectRootPath, projectId);
     this.initializedForPath = projectRootPath;
 
     this.prEventUnsubscribers.push(
@@ -220,10 +221,10 @@ export class PRIntegrationService {
     return this.prService.getProviderContext();
   }
 
-  resetPRState(projectRootPath: string | null): void {
+  resetPRState(projectRootPath: string | null, projectId: string | null): void {
     this.prService.reset();
-    if (projectRootPath) {
-      this.prService.initialize(projectRootPath);
+    if (projectRootPath && projectId) {
+      this.prService.initialize(projectRootPath, projectId);
       void this.startPolling();
     }
   }
@@ -242,7 +243,8 @@ export class PRIntegrationService {
   updateForgeCredentials(
     _providerId: string,
     credentials: import("../../shared/types/forge.js").Credentials | null,
-    projectRootPath: string | null
+    projectRootPath: string | null,
+    projectId: string | null
   ): void {
     // Credential VALUES are not applied in this process — every forge call
     // from the host goes through the RPC bridge to main, where the provider
@@ -252,8 +254,8 @@ export class PRIntegrationService {
       void this.prService.refresh();
     } else {
       this.prService.reset();
-      if (projectRootPath) {
-        this.prService.initialize(projectRootPath);
+      if (projectRootPath && projectId) {
+        this.prService.initialize(projectRootPath, projectId);
         void this.startPolling();
       }
     }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -3350,7 +3350,12 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     providerId: string,
     credentials: import("../../shared/types/forge.js").Credentials | null
   ): void {
-    this.prService.updateForgeCredentials(providerId, credentials, this.projectRootPath, this.projectId);
+    this.prService.updateForgeCredentials(
+      providerId,
+      credentials,
+      this.projectRootPath,
+      this.projectId
+    );
     if (credentials) {
       // A new credential may resolve previously-failing auth — drop suspensions so
       // the next scheduled fetch retries. Network/transient entries stay so we

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -3535,7 +3535,12 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   private async loadProjectEnvVars(projectId: string): Promise<Record<string, string>> {
     try {
       const userDataDir = process.env.DAINTREE_USER_DATA ?? "";
-      const filePath = settingsFilePath(userDataDir, projectId);
+      if (!userDataDir) return {};
+      // Settings live under `<userData>/projects/<id>/settings.json` (see
+      // ProjectStore's `projectsConfigDir`). DAINTREE_USER_DATA is the bare
+      // userData root, so the `projects` segment must be added here — without it
+      // the read silently missed and env vars never reached the host (#11282).
+      const filePath = settingsFilePath(pathResolve(userDataDir, "projects"), projectId);
       if (!filePath) return {};
       const raw = await readFile(filePath, "utf8");
       const parsed: unknown = JSON.parse(raw);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -5,7 +5,7 @@ import { existsSync } from "fs";
 import { stat, readFile, access, mkdir, realpath } from "fs/promises";
 import { resolve as pathResolve, isAbsolute, dirname } from "path";
 import { validateBranchName } from "../../shared/utils/pathPattern.js";
-import { generateProjectId, settingsFilePath } from "../services/projectStorePaths.js";
+import { settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
 import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
 import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
@@ -214,6 +214,10 @@ export class WorkspaceService {
   private git: SimpleGit | null = null;
   private pollingEnabled: boolean = true;
   private projectRootPath: string | null = null;
+  // Immutable project id threaded from main via load-project (#11282). The host
+  // has no DB access, so it can never re-derive this from the path — hashing the
+  // path would mint a stale id for any relocated project.
+  private projectId: string | null = null;
   private projectEnvVars: Record<string, string> = {};
   private lifecycleService = new WorktreeLifecycleService();
   private listService = new WorktreeListService();
@@ -586,6 +590,7 @@ export class WorkspaceService {
   async loadProject(
     requestId: string,
     projectRootPath: string,
+    projectId: string,
     globalEnvVars?: Record<string, string>,
     wslGitByWorktree?: Record<string, { enabled: boolean; dismissed: boolean }>,
     forgeSettings?: {
@@ -614,6 +619,7 @@ export class WorkspaceService {
         throw new Error(`Project directory does not exist: ${projectRootPath}`);
       }
       this.projectRootPath = projectRootPath;
+      this.projectId = projectId;
       // Backstop for a disabled or silently-degraded git watcher (#11155).
       this.startForgeRemoteDetection();
       if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
@@ -626,7 +632,7 @@ export class WorkspaceService {
         pullRequestService.setForgeSettings(forgeSettings);
       }
       // Merge: global (lowest priority) < project-level < DAINTREE_* (set in buildEnv)
-      const projectEnvVars = await this.loadProjectEnvVars(projectRootPath);
+      const projectEnvVars = await this.loadProjectEnvVars(projectId);
       this.projectEnvVars = { ...(globalEnvVars ?? {}), ...projectEnvVars };
       this.git = await createHardenedGit(projectRootPath, this._shutdownController.signal);
       this.listService.setGit(this.git, projectRootPath);
@@ -3317,7 +3323,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   }
 
   resetPRState(requestId: string): void {
-    this.prService.resetPRState(this.projectRootPath);
+    this.prService.resetPRState(this.projectRootPath, this.projectId);
     this.sendEvent({ type: "reset-pr-state-result", requestId, success: true });
   }
 
@@ -3344,7 +3350,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     providerId: string,
     credentials: import("../../shared/types/forge.js").Credentials | null
   ): void {
-    this.prService.updateForgeCredentials(providerId, credentials, this.projectRootPath);
+    this.prService.updateForgeCredentials(providerId, credentials, this.projectRootPath, this.projectId);
     if (credentials) {
       // A new credential may resolve previously-failing auth — drop suspensions so
       // the next scheduled fetch retries. Network/transient entries stay so we
@@ -3384,11 +3390,11 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   }
 
   private initializePRService(): Promise<void> {
-    if (!this.projectRootPath) {
+    if (!this.projectRootPath || !this.projectId) {
       return Promise.resolve();
     }
 
-    return this.prService.initialize(this.projectRootPath, () => {
+    return this.prService.initialize(this.projectRootPath, this.projectId, () => {
       const candidates: Array<{
         worktreeId: string;
         branch?: string;
@@ -3441,6 +3447,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.mainBranch = "main";
     this.git = null;
     this.projectRootPath = null;
+    this.projectId = null;
     this.projectEnvVars = {};
     this.wslDefaultDistroPromise = null;
     this.wslLastKnownDefaultDistro = undefined;
@@ -3525,10 +3532,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     return envs !== null && Object.keys(envs).length > 0;
   }
 
-  private async loadProjectEnvVars(projectRootPath: string): Promise<Record<string, string>> {
+  private async loadProjectEnvVars(projectId: string): Promise<Record<string, string>> {
     try {
       const userDataDir = process.env.DAINTREE_USER_DATA ?? "";
-      const projectId = generateProjectId(projectRootPath);
       const filePath = settingsFilePath(userDataDir, projectId);
       if (!filePath) return {};
       const raw = await readFile(filePath, "utf8");

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -32,7 +32,7 @@ describe("PRIntegrationService", () => {
   let eventBus: TypedEventBus;
   let callbacks: PRIntegrationCallbacks;
   interface PullRequestServiceLike {
-    initialize(rootPath: string): void;
+    initialize(rootPath: string, projectId: string): void;
     start(startupDelayMs?: number): Promise<void>;
     stop(): void;
     reset(): void;
@@ -73,7 +73,7 @@ describe("PRIntegrationService", () => {
     const emitSpy = vi.spyOn(eventBus, "emit");
     const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-    await service.initialize("/repo", () => [
+    await service.initialize("/repo", "test-project-id", () => [
       { worktreeId: "wt-linked", branch: "feature/foo", issueNumber: 42, isMainWorktree: false },
     ]);
 
@@ -91,7 +91,7 @@ describe("PRIntegrationService", () => {
     const emitSpy = vi.spyOn(eventBus, "emit");
     const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-    await service.initialize("/repo", () => [
+    await service.initialize("/repo", "test-project-id", () => [
       { worktreeId: "wt-root", branch: "develop", issueNumber: undefined, isMainWorktree: true },
       { worktreeId: "wt-linked", branch: "feature/bar", issueNumber: 10, isMainWorktree: false },
     ]);
@@ -108,7 +108,7 @@ describe("PRIntegrationService", () => {
   describe("forwards canonical owner/repo (#8452)", () => {
     it("threads owner/repo from a non-GitHub sys:pr:detected event to onPRDetected", async () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
-      await service.initialize("/repo", () => []);
+      await service.initialize("/repo", "test-project-id", () => []);
 
       eventBus.emit("sys:pr:detected", {
         worktreeId: "wt-1",
@@ -136,7 +136,7 @@ describe("PRIntegrationService", () => {
 
     it("forwards isCiStatusLoading from a phase-1 sys:pr:detected event to onPRDetected (#9551)", async () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
-      await service.initialize("/repo", () => []);
+      await service.initialize("/repo", "test-project-id", () => []);
 
       eventBus.emit("sys:pr:detected", {
         worktreeId: "wt-1",
@@ -159,7 +159,7 @@ describe("PRIntegrationService", () => {
 
     it("threads owner/repo from a non-GitHub sys:issue:detected event to onIssueDetected", async () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
-      await service.initialize("/repo", () => []);
+      await service.initialize("/repo", "test-project-id", () => []);
 
       eventBus.emit("sys:issue:detected", {
         worktreeId: "wt-2",
@@ -248,7 +248,7 @@ describe("PRIntegrationService", () => {
         onDetectionStateChanged,
       });
 
-      await service.initialize("/repo", () => []);
+      await service.initialize("/repo", "test-project-id", () => []);
 
       eventBus.emit("sys:pr:detection-state", { tripped: true, timestamp: Date.now() });
       expect(onDetectionStateChanged).toHaveBeenCalledWith(true);
@@ -260,7 +260,7 @@ describe("PRIntegrationService", () => {
 
     it("does not throw when the optional callback is omitted", async () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
-      await service.initialize("/repo", () => []);
+      await service.initialize("/repo", "test-project-id", () => []);
 
       expect(() =>
         eventBus.emit("sys:pr:detection-state", { tripped: true, timestamp: Date.now() })
@@ -278,17 +278,17 @@ describe("PRIntegrationService", () => {
       });
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-      service.resetPRState("/repo");
+      service.resetPRState("/repo", "test-project-id");
 
       expect(callOrder.slice(0, 2)).toEqual(["reset", "initialize"]);
-      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo", "test-project-id");
       expect(prServiceMock.start).toHaveBeenCalled();
     });
 
     it("only calls reset when projectRootPath is null", () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-      service.resetPRState(null);
+      service.resetPRState(null, null);
 
       expect(prServiceMock.reset).toHaveBeenCalled();
       expect(prServiceMock.initialize).not.toHaveBeenCalled();
@@ -319,7 +319,8 @@ describe("PRIntegrationService", () => {
       service.updateForgeCredentials(
         "builtin.github",
         { kind: "bearer", value: "ghp_abc123" },
-        "/repo"
+        "/repo",
+        "test-project-id"
       );
 
       expect(prServiceMock.refresh).toHaveBeenCalledTimes(1);
@@ -335,17 +336,17 @@ describe("PRIntegrationService", () => {
       });
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-      service.updateForgeCredentials("builtin.github", null, "/repo");
+      service.updateForgeCredentials("builtin.github", null, "/repo", "test-project-id");
 
       expect(prServiceMock.refresh).not.toHaveBeenCalled();
       expect(callOrder.slice(0, 2)).toEqual(["reset", "initialize"]);
-      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo", "test-project-id");
     });
 
     it("only resets when credentials and path are null", () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-      service.updateForgeCredentials("builtin.github", null, null);
+      service.updateForgeCredentials("builtin.github", null, null, null);
 
       expect(prServiceMock.reset).toHaveBeenCalledTimes(1);
       expect(prServiceMock.initialize).not.toHaveBeenCalled();
@@ -355,7 +356,12 @@ describe("PRIntegrationService", () => {
     it("refreshes for any providerId since the relay only signals presence", () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
-      service.updateForgeCredentials("builtin.unknown", { kind: "bearer", value: "abc" }, "/repo");
+      service.updateForgeCredentials(
+        "builtin.unknown",
+        { kind: "bearer", value: "abc" },
+        "/repo",
+        "test-project-id"
+      );
 
       expect(prServiceMock.refresh).toHaveBeenCalledTimes(1);
     });
@@ -370,12 +376,12 @@ describe("PRIntegrationService", () => {
       const emitSpy = vi.spyOn(eventBus, "emit");
       const service = makeWorkerService();
 
-      await service.initialize("/repo", () => [
+      await service.initialize("/repo", "test-project-id", () => [
         { worktreeId: "wt-1", branch: "feature/foo", issueNumber: 7, isMainWorktree: false },
       ]);
 
       // Detection wiring is intact: candidates are still seeded…
-      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo", "test-project-id");
       const updateCalls = emitSpy.mock.calls.filter(([ev]) => ev === "sys:worktree:update");
       expect(updateCalls).toHaveLength(1);
       // …but the automatic polling loop never starts.
@@ -390,28 +396,33 @@ describe("PRIntegrationService", () => {
 
     it("resetPRState() reinitializes without restarting polling", () => {
       const service = makeWorkerService();
-      service.resetPRState("/repo");
+      service.resetPRState("/repo", "test-project-id");
       expect(prServiceMock.reset).toHaveBeenCalled();
-      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo", "test-project-id");
       expect(prServiceMock.start).not.toHaveBeenCalled();
     });
 
     it("updateForgeCredentials(null) reinitializes without restarting polling", () => {
       const service = makeWorkerService();
-      service.updateForgeCredentials("builtin.github", null, "/repo");
-      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      service.updateForgeCredentials("builtin.github", null, "/repo", "test-project-id");
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo", "test-project-id");
       expect(prServiceMock.start).not.toHaveBeenCalled();
     });
 
     it("keeps the on-demand refresh path functional", () => {
       const service = makeWorkerService();
-      service.updateForgeCredentials("builtin.github", { kind: "bearer", value: "ghp_x" }, "/repo");
+      service.updateForgeCredentials(
+        "builtin.github",
+        { kind: "bearer", value: "ghp_x" },
+        "/repo",
+        "test-project-id"
+      );
       expect(prServiceMock.refresh).toHaveBeenCalledTimes(1);
     });
 
     it("attended remains the default when options are omitted", async () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
-      await service.initialize("/repo", () => []);
+      await service.initialize("/repo", "test-project-id", () => []);
       expect(prServiceMock.start).toHaveBeenCalledTimes(1);
     });
   });

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -114,7 +114,7 @@ describe("WorkspaceService adversarial", () => {
       throw new Error("Corrupted worktree metadata");
     });
 
-    await service.loadProject("req-load", "/repo");
+    await service.loadProject("req-load", "/repo", "ws-test-project-id");
 
     expect(sentEvents).toContainEqual(
       expect.objectContaining({
@@ -130,7 +130,7 @@ describe("WorkspaceService adversarial", () => {
     // The project directory was removed/moved externally before this load.
     vi.mocked(existsSync).mockReturnValueOnce(false);
 
-    await service.loadProject("req-missing", "/missing/path");
+    await service.loadProject("req-missing", "/missing/path", "ws-test-project-id");
 
     expect(sentEvents).toContainEqual(
       expect.objectContaining({

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -1491,7 +1491,7 @@ describe("WorkspaceService.loadProject performance behavior", () => {
     service["initializePRService"] = vi.fn().mockReturnValue(prPromise);
     service["refreshAll"] = vi.fn().mockReturnValue(refreshPromise);
 
-    await service.loadProject("req-1", "/test/root");
+    await service.loadProject("req-1", "/test/root", "ws-test-project-id");
 
     expect(mockSendEvent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
@@ -45,7 +45,6 @@ vi.mock("../../utils/gitUtils.js", () => ({
 }));
 vi.mock("../../utils/fs.js", () => ({ waitForPathExists: vi.fn() }));
 vi.mock("../../services/projectStorePaths.js", () => ({
-  generateProjectId: vi.fn(),
   settingsFilePath: vi.fn(),
 }));
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -300,6 +300,13 @@ export type WorkspaceHostRequest =
       type: "load-project";
       requestId: string;
       rootPath: string;
+      /**
+       * Immutable project id resolved by main (`resolveProjectIdForPath`) and
+       * threaded in because the host has no DB access (#11282). The host must
+       * never hash `rootPath` for identity — a relocated project's id no longer
+       * equals `sha256(path)`, so hashing would read the wrong state directory.
+       */
+      projectId: string;
       globalEnvVars?: Record<string, string>;
       /**
        * Persisted per-worktree WSL git opt-in state (Windows only). Map key is

--- a/shared/utils/__tests__/projectPathRelocation.test.ts
+++ b/shared/utils/__tests__/projectPathRelocation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  rebaseAbsolutePath,
+  rebaseMruEntry,
+  isAbsoluteFsPath,
+} from "../projectPathRelocation.js";
+
+describe("isAbsoluteFsPath", () => {
+  it("recognizes POSIX, drive-letter and UNC absolutes", () => {
+    expect(isAbsoluteFsPath("/old/repo")).toBe(true);
+    expect(isAbsoluteFsPath("C:\\old\\repo")).toBe(true);
+    expect(isAbsoluteFsPath("C:/old/repo")).toBe(true);
+    expect(isAbsoluteFsPath("\\\\server\\share")).toBe(true);
+  });
+
+  it("rejects relative paths and non-paths", () => {
+    expect(isAbsoluteFsPath("src/index.ts")).toBe(false);
+    expect(isAbsoluteFsPath("./a")).toBe(false);
+    expect(isAbsoluteFsPath("worktree:wt")).toBe(false);
+  });
+});
+
+describe("rebaseAbsolutePath", () => {
+  const OLD = "/old/project";
+  const NEW = "/new/renamed-project";
+
+  it("rewrites the exact root", () => {
+    expect(rebaseAbsolutePath(OLD, OLD, NEW)).toBe(NEW);
+  });
+
+  it("rewrites descendants at a segment boundary", () => {
+    expect(rebaseAbsolutePath("/old/project/src/a.ts", OLD, NEW)).toBe(
+      "/new/renamed-project/src/a.ts"
+    );
+    expect(rebaseAbsolutePath("/old/project/.git", OLD, NEW)).toBe(
+      "/new/renamed-project/.git"
+    );
+  });
+
+  it("does NOT rewrite a sibling that merely shares a prefix", () => {
+    expect(rebaseAbsolutePath("/old/project-copy", OLD, NEW)).toBe("/old/project-copy");
+    expect(rebaseAbsolutePath("/old/project-copy/x", OLD, NEW)).toBe("/old/project-copy/x");
+  });
+
+  it("does NOT rewrite an unrelated path", () => {
+    expect(rebaseAbsolutePath("/somewhere/else", OLD, NEW)).toBe("/somewhere/else");
+  });
+
+  it("leaves relative values untouched (worktree-relative panel paths)", () => {
+    expect(rebaseAbsolutePath("src/index.ts", OLD, NEW)).toBe("src/index.ts");
+    expect(rebaseAbsolutePath("", OLD, NEW)).toBe("");
+  });
+
+  it("tolerates trailing separators on either root", () => {
+    expect(rebaseAbsolutePath("/old/project/a", "/old/project/", NEW)).toBe(
+      "/new/renamed-project/a"
+    );
+    expect(rebaseAbsolutePath("/old/project/", OLD, "/new/renamed-project/")).toBe(
+      "/new/renamed-project"
+    );
+  });
+
+  it("handles Windows drive-letter roots with backslashes", () => {
+    expect(rebaseAbsolutePath("C:\\old\\project\\src", "C:\\old\\project", "D:\\moved")).toBe(
+      "D:\\moved\\src"
+    );
+    expect(rebaseAbsolutePath("C:\\old\\project-copy", "C:\\old\\project", "D:\\moved")).toBe(
+      "C:\\old\\project-copy"
+    );
+  });
+
+  it("returns value unchanged when roots are empty", () => {
+    expect(rebaseAbsolutePath("/old/project/a", "", NEW)).toBe("/old/project/a");
+    expect(rebaseAbsolutePath("/old/project/a", OLD, "")).toBe("/old/project/a");
+  });
+});
+
+describe("rebaseMruEntry", () => {
+  const OLD = "/old/project";
+  const NEW = "/new/renamed-project";
+
+  it("rewrites the path inside a worktree: entry", () => {
+    expect(rebaseMruEntry("worktree:/old/project", OLD, NEW)).toBe(
+      "worktree:/new/renamed-project"
+    );
+    expect(rebaseMruEntry("worktree:/old/project/wt", OLD, NEW)).toBe(
+      "worktree:/new/renamed-project/wt"
+    );
+  });
+
+  it("leaves terminal: entries and non-matching worktree entries untouched", () => {
+    expect(rebaseMruEntry("terminal:t-1", OLD, NEW)).toBe("terminal:t-1");
+    expect(rebaseMruEntry("worktree:/other/place", OLD, NEW)).toBe("worktree:/other/place");
+  });
+});

--- a/shared/utils/__tests__/projectPathRelocation.test.ts
+++ b/shared/utils/__tests__/projectPathRelocation.test.ts
@@ -69,6 +69,31 @@ describe("rebaseAbsolutePath", () => {
     );
   });
 
+  it("folds case and separators for Windows-flavored roots", () => {
+    // Stored value spelled with lowercase drive + forward slashes still matches.
+    expect(rebaseAbsolutePath("c:/old/project/src", "C:\\old\\project", "D:\\moved")).toBe(
+      "D:\\moved/src"
+    );
+    // Exact root, case-insensitive.
+    expect(rebaseAbsolutePath("C:/OLD/Project", "c:\\old\\project", "D:\\moved")).toBe("D:\\moved");
+    // Case-only sibling must still NOT match a different folder.
+    expect(rebaseAbsolutePath("C:\\old\\project2", "C:\\old\\project", "D:\\moved")).toBe(
+      "C:\\old\\project2"
+    );
+  });
+
+  it("does NOT treat a backslash as a boundary on POSIX (a file literally named with one)", () => {
+    // On POSIX, `\` is a valid filename character — `/old/project\copy` is a
+    // sibling file, not a descendant of `/old/project`.
+    expect(rebaseAbsolutePath("/old/project\\copy", OLD, NEW)).toBe("/old/project\\copy");
+  });
+
+  it("rebases UNC descendants", () => {
+    expect(
+      rebaseAbsolutePath("\\\\server\\share\\proj\\a", "\\\\server\\share\\proj", "\\\\server\\share\\moved")
+    ).toBe("\\\\server\\share\\moved\\a");
+  });
+
   it("returns value unchanged when roots are empty", () => {
     expect(rebaseAbsolutePath("/old/project/a", "", NEW)).toBe("/old/project/a");
     expect(rebaseAbsolutePath("/old/project/a", OLD, "")).toBe("/old/project/a");

--- a/shared/utils/__tests__/projectPathRelocation.test.ts
+++ b/shared/utils/__tests__/projectPathRelocation.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  rebaseAbsolutePath,
-  rebaseMruEntry,
-  isAbsoluteFsPath,
-} from "../projectPathRelocation.js";
+import { rebaseAbsolutePath, rebaseMruEntry, isAbsoluteFsPath } from "../projectPathRelocation.js";
 
 describe("isAbsoluteFsPath", () => {
   it("recognizes POSIX, drive-letter and UNC absolutes", () => {
@@ -32,9 +28,7 @@ describe("rebaseAbsolutePath", () => {
     expect(rebaseAbsolutePath("/old/project/src/a.ts", OLD, NEW)).toBe(
       "/new/renamed-project/src/a.ts"
     );
-    expect(rebaseAbsolutePath("/old/project/.git", OLD, NEW)).toBe(
-      "/new/renamed-project/.git"
-    );
+    expect(rebaseAbsolutePath("/old/project/.git", OLD, NEW)).toBe("/new/renamed-project/.git");
   });
 
   it("does NOT rewrite a sibling that merely shares a prefix", () => {
@@ -90,7 +84,11 @@ describe("rebaseAbsolutePath", () => {
 
   it("rebases UNC descendants", () => {
     expect(
-      rebaseAbsolutePath("\\\\server\\share\\proj\\a", "\\\\server\\share\\proj", "\\\\server\\share\\moved")
+      rebaseAbsolutePath(
+        "\\\\server\\share\\proj\\a",
+        "\\\\server\\share\\proj",
+        "\\\\server\\share\\moved"
+      )
     ).toBe("\\\\server\\share\\moved\\a");
   });
 
@@ -105,9 +103,7 @@ describe("rebaseMruEntry", () => {
   const NEW = "/new/renamed-project";
 
   it("rewrites the path inside a worktree: entry", () => {
-    expect(rebaseMruEntry("worktree:/old/project", OLD, NEW)).toBe(
-      "worktree:/new/renamed-project"
-    );
+    expect(rebaseMruEntry("worktree:/old/project", OLD, NEW)).toBe("worktree:/new/renamed-project");
     expect(rebaseMruEntry("worktree:/old/project/wt", OLD, NEW)).toBe(
       "worktree:/new/renamed-project/wt"
     );

--- a/shared/utils/projectPathRelocation.ts
+++ b/shared/utils/projectPathRelocation.ts
@@ -19,15 +19,34 @@ export function isAbsoluteFsPath(value: string): boolean {
   return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
 }
 
-function stripTrailingSep(p: string): string {
-  return p.length > 1 && (p.endsWith("/") || p.endsWith("\\")) ? p.replace(/[\\/]+$/, "") : p;
+/** Windows-flavored absolute path (drive-letter or UNC), where `\` and `/` are
+ * both separators and comparison is case-insensitive. */
+function isWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
+}
+
+/**
+ * Drop a trailing separator, but never reduce a value to a bare volume root
+ * (`/`, `C:`, `\\`) — those aren't project directories and stripping them would
+ * corrupt an exact-root rebase.
+ */
+function stripTrailingSep(value: string): string {
+  if (value.length <= 1) return value;
+  const stripped = value.replace(/[\\/]+$/, "");
+  if (stripped === "" || /^[A-Za-z]:$/.test(stripped)) return value;
+  return stripped;
 }
 
 /**
  * Rebase an absolute filesystem path from `oldRoot` to `newRoot`.
  *
  * Returns `value` with its `oldRoot` prefix replaced by `newRoot`, matching
- * only at a path-segment boundary so `/repo` never rewrites `/repo-copy`.
+ * only at a path-segment boundary so `/repo` never rewrites `/repo-copy`. On
+ * Windows-flavored roots (drive/UNC) the comparison is case-insensitive and
+ * treats `\` and `/` as equivalent separators; on POSIX only `/` is a separator
+ * and comparison is exact — so a POSIX file literally named `project\copy` next
+ * to `/old/project` is left alone. The original suffix spelling is preserved.
+ *
  * `value` is returned unchanged when it is not an absolute path, or not at/under
  * `oldRoot`. The transform is deliberately conservative — a stale path is safer
  * than corrupting an unrelated project's data — so it never infers through
@@ -37,14 +56,23 @@ export function rebaseAbsolutePath(value: string, oldRoot: string, newRoot: stri
   if (typeof value !== "string" || !value || !oldRoot || !newRoot) return value;
   if (!isAbsoluteFsPath(value)) return value;
 
+  const windows = isWindowsPath(oldRoot) || isWindowsPath(value);
+  const separators = windows ? "\\/" : "/";
+  const fold = (s: string): string => (windows ? s.replace(/\\/g, "/").toLowerCase() : s);
+
   const v = stripTrailingSep(value);
   const o = stripTrailingSep(oldRoot);
   const n = stripTrailingSep(newRoot);
 
-  if (v === o) return n;
+  if (fold(v) === fold(o)) return n;
 
-  // Segment boundary against either separator — a path can carry mixed ones.
-  if (v.startsWith(`${o}/`) || v.startsWith(`${o}\\`)) {
+  // Descendant: the char immediately after the old-root prefix must be a
+  // separator, and the prefix must match (case-/separator-folded on Windows).
+  if (
+    v.length > o.length &&
+    separators.includes(v[o.length]) &&
+    fold(v.slice(0, o.length)) === fold(o)
+  ) {
     return n + v.slice(o.length);
   }
   return value;

--- a/shared/utils/projectPathRelocation.ts
+++ b/shared/utils/projectPathRelocation.ts
@@ -1,0 +1,64 @@
+/**
+ * Path rebasing for project folder moves/renames (#11282, phase 2).
+ *
+ * A same-volume project-folder rename re-prefixes every absolute path at or
+ * below the old root. `Worktree.id` is itself a normalized absolute path, so a
+ * single conservative prefix substitution rewrites worktree ids, panel cwds,
+ * file-panel paths and session-history entries alike.
+ *
+ * Pure string ops (no node `path`) so this is safe to import from renderer code
+ * as well as main.
+ */
+
+/**
+ * True for an absolute filesystem path: POSIX (`/...`), Windows drive
+ * (`C:\...` / `C:/...`) or UNC (`\\server\...`). Anything else — a relative
+ * path, a URL, an opaque id — is left untouched by {@link rebaseAbsolutePath}.
+ */
+export function isAbsoluteFsPath(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\");
+}
+
+function stripTrailingSep(p: string): string {
+  return p.length > 1 && (p.endsWith("/") || p.endsWith("\\")) ? p.replace(/[\\/]+$/, "") : p;
+}
+
+/**
+ * Rebase an absolute filesystem path from `oldRoot` to `newRoot`.
+ *
+ * Returns `value` with its `oldRoot` prefix replaced by `newRoot`, matching
+ * only at a path-segment boundary so `/repo` never rewrites `/repo-copy`.
+ * `value` is returned unchanged when it is not an absolute path, or not at/under
+ * `oldRoot`. The transform is deliberately conservative — a stale path is safer
+ * than corrupting an unrelated project's data — so it never infers through
+ * symlinks and never touches relative values.
+ */
+export function rebaseAbsolutePath(value: string, oldRoot: string, newRoot: string): string {
+  if (typeof value !== "string" || !value || !oldRoot || !newRoot) return value;
+  if (!isAbsoluteFsPath(value)) return value;
+
+  const v = stripTrailingSep(value);
+  const o = stripTrailingSep(oldRoot);
+  const n = stripTrailingSep(newRoot);
+
+  if (v === o) return n;
+
+  // Segment boundary against either separator — a path can carry mixed ones.
+  if (v.startsWith(`${o}/`) || v.startsWith(`${o}\\`)) {
+    return n + v.slice(o.length);
+  }
+  return value;
+}
+
+/**
+ * Rebase a quick-switcher MRU entry. Entries are `worktree:<absolute-path>` or
+ * `terminal:<id>`; only the worktree suffix is a filesystem path, so `terminal:`
+ * entries pass through untouched.
+ */
+export function rebaseMruEntry(entry: string, oldRoot: string, newRoot: string): string {
+  const prefix = "worktree:";
+  if (!entry.startsWith(prefix)) return entry;
+  const p = entry.slice(prefix.length);
+  const rebased = rebaseAbsolutePath(p, oldRoot, newRoot);
+  return rebased === p ? entry : `${prefix}${rebased}`;
+}

--- a/shared/utils/projectPathRelocation.ts
+++ b/shared/utils/projectPathRelocation.ts
@@ -68,9 +68,10 @@ export function rebaseAbsolutePath(value: string, oldRoot: string, newRoot: stri
 
   // Descendant: the char immediately after the old-root prefix must be a
   // separator, and the prefix must match (case-/separator-folded on Windows).
+  const boundary = v.length > o.length ? v[o.length] : undefined;
   if (
-    v.length > o.length &&
-    separators.includes(v[o.length]) &&
+    boundary !== undefined &&
+    separators.includes(boundary) &&
     fold(v.slice(0, o.length)) === fold(o)
   ) {
     return n + v.slice(o.length);

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -637,4 +637,56 @@ describe("projectStore adversarial", () => {
 
     expect(clearHibernateSessionMock).not.toHaveBeenCalled();
   });
+
+  it("rebases the hibernated Assistant cwd when onUpdated changes the path (same id, #11282)", async () => {
+    const updatedCallbacks: Array<(project: ProjectShape) => void> = [];
+    installProjectApi({
+      onUpdated: (callback) => {
+        updatedCallbacks.push(callback);
+        return vi.fn();
+      },
+    });
+    installLocalStorage(createStorageMock());
+    hibernateSessionsMock[projectA.id] = {
+      sessionId: "session-1",
+      cwd: `${projectA.path}/sub`,
+      agentId: "claude",
+    };
+
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA], currentProject: projectA });
+
+    updatedCallbacks[0]!({ ...projectA, path: "/tmp/project-a-moved" });
+
+    // Same id, new folder: the resume pointer is repointed in place, never GC'd.
+    expect(setHibernateSessionMock).toHaveBeenCalledWith(projectA.id, {
+      sessionId: "session-1",
+      cwd: "/tmp/project-a-moved/sub",
+      agentId: "claude",
+    });
+    expect(clearHibernateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the hibernated cwd untouched when onUpdated does not change the path", async () => {
+    const updatedCallbacks: Array<(project: ProjectShape) => void> = [];
+    installProjectApi({
+      onUpdated: (callback) => {
+        updatedCallbacks.push(callback);
+        return vi.fn();
+      },
+    });
+    installLocalStorage(createStorageMock());
+    hibernateSessionsMock[projectA.id] = {
+      sessionId: "session-1",
+      cwd: projectA.path,
+      agentId: "claude",
+    };
+
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA], currentProject: projectA });
+
+    updatedCallbacks[0]!({ ...projectA, name: "Renamed only" });
+
+    expect(setHibernateSessionMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -14,6 +14,7 @@ import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistenc
 import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { rebaseAbsolutePath } from "@shared/utils/projectPathRelocation";
 import { isClientAppError } from "@/utils/clientAppError";
 import { getViewWorkspaceId } from "./viewWorkspaceId";
 import {
@@ -240,6 +241,31 @@ function migrateHibernateSession(fromProjectId: string, toProjectId: string, new
       operation: "migrate_hibernate_session",
       component: "projectStore",
       details: { fromProjectId, toProjectId },
+    });
+  }
+}
+
+/**
+ * Repoint a hibernated Assistant conversation's recorded working directory after
+ * its project folder moved (#11282, phase 2). Reattaching keeps the same project
+ * id, so — unlike {@link migrateHibernateSession} — this rewrites the cwd in
+ * place rather than moving between ids. No-op when there is no hibernated session
+ * or its cwd is unaffected by the move. Swallows failure: losing one resume
+ * pointer must never abort the project-list refresh that triggered it.
+ */
+function rebaseHibernateSessionCwd(projectId: string, oldPath: string, newPath: string): void {
+  try {
+    const helpPanel = useHelpPanelStore.getState();
+    const session = helpPanel.hibernateSessions?.[projectId];
+    if (!session) return;
+    const nextCwd = rebaseAbsolutePath(session.cwd, oldPath, newPath);
+    if (nextCwd === session.cwd) return;
+    helpPanel.setHibernateSession(projectId, { ...session, cwd: nextCwd });
+  } catch (error) {
+    logErrorWithContext(error, {
+      operation: "rebase_hibernate_session_cwd",
+      component: "projectStore",
+      details: { projectId },
     });
   }
 }
@@ -997,15 +1023,22 @@ panelPersistence.setProjectIdGetter(() => useProjectStore.getState().currentProj
 if (typeof window !== "undefined" && window.electron?.project) {
   const listenerState = getProjectStoreListenerState();
   listenerState.applyUpdated = (updated) => {
+    let priorPath: string | undefined;
     useProjectStore.setState((state) => {
-      const exists = state.projects.some((p) => p.id === updated.id);
-      const projects = exists
+      const prior = state.projects.find((p) => p.id === updated.id);
+      priorPath = prior?.path;
+      const projects = prior
         ? state.projects.map((p) => (p.id === updated.id ? updated : p))
         : [...state.projects, updated];
       const currentProject =
         state.currentProject?.id === updated.id ? updated : state.currentProject;
       return { projects, currentProject };
     });
+    // A folder move/reattach keeps the id but changes the path (#11282); repoint
+    // the hibernated Assistant cwd so a later resume lands in the new folder.
+    if (priorPath && priorPath !== updated.path) {
+      rebaseHibernateSessionCwd(updated.id, priorPath, updated.path);
+    }
   };
   listenerState.applyRemoved = (projectId) => {
     useProjectStore.setState((state) => {


### PR DESCRIPTION
## Summary

Part of #11282 (phase 2 of 5).

Phase 1 (#11285, merged) made project identity immutable across folder moves. This phase rewrites everything that still stored an absolute path once a non-active project is relocated (the "Locate moved project" flow) or auto-adopted after an external move.

## What this does

### 1. Rewrite path-bearing state

A shared `migratePathBearingStateAfterMove` helper is called from both `relocateProject` (explicit locate flow) and `tryAdoptMovedProject` (automatic reattach). For non-active projects only, it rewrites:

- Per-project `state.json` via `enqueueProjectStateUpdate` (never a raw read-merge-write): panel `cwd` / `worktreeId` / `filePath` / `markdownFilePath`, `activeWorktreeId`, `tabGroups[].worktreeId`, and the `worktree:` MRU entries.
- The window-state store (rekeys `windowStates[old]` to `[new]`).
- Session history (`worktreeId` / `cwd` in the global `agent-session-history.json`).
- Assistant hibernation `cwd`, in both the main-process `PendingHelpHibernationStore` and the renderer `helpPanelStore`, via the `project:updated` broadcast.

One conservative `rebaseAbsolutePath` primitive drives every rewrite: segment-boundary matching, absolute paths only, path-flavor aware. Worktree-relative browser paths, URLs, and opaque `command` / `env` / `extensionState` fields are deliberately left alone. The migration is best-effort (`Promise.allSettled`) since the DB row is already the source of truth by the time it runs; an ancillary failure gets logged, not surfaced.

### 2. Kill the last path-derived id lookups

The immutable `projectId` is now threaded through `ProcessEntry` and the load-project protocol into the workspace-host utility process, which has no DB access of its own. That removes the three remaining `generateProjectId(path)` lookups: `WorkspaceHostEventRouter`, `WorkspaceService.loadProjectEnvVars`, and `PullRequestService.initialize`.

### 3. Submodule pointer repair

`git worktree repair` doesn't touch submodules, so a best-effort pass rebases absolute `core.worktree` / `gitdir:` pointers under the old root. Relative pointers are left untouched since they survive a same-volume move on their own.

## Deferred to later phases

Kept out of this PR to stay reviewable, tracked as follow-ups under #11282:

- Other path-bearing stores with their own rewrite contracts: recipe `worktreeId`, `terminalSettings.defaultWorkingDirectory`, `worktreeIssueMap`, `wslGitByWorktree`, `agentSettings[*].worktreePresets`, `DevPreviewManifest`, run history.
- Relocating the currently active project, multi-window active-guard hardening, and the quiesce step needed before rewriting a live project's state. That's phase 3.

## Testing

New and updated unit tests cover the `rebaseAbsolutePath` primitive, the state rewriter, window-state rekeying, submodule repair (temp-dir fixtures, including CRLF, quoting, and relative vs. absolute pointers), session-history and hibernation rewrites, `ProjectStore` orchestration (including sync-throw isolation and NFC normalization), the renderer-side hibernation rebase, and the updated workspace-host fixtures.

`npm run typecheck` is clean and 591 targeted tests pass. Reviewed with two parallel Codex passes; fixes applied for normalization and edge cases.
