### PR TITLE
fix(file-browser): silence transient root-listing error on switch-back

### DIFF
--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -561,6 +561,10 @@ describe("useFileBrowserTree", () => {
     });
 
     afterEach(() => {
+      // Restore spies BEFORE the clock: `restoreAllMocks` reinstalls setTimeout's
+      // captured original, which — if the fake clock were already uninstalled —
+      // would be the fake timer, leaking it into the next file and hanging it.
+      vi.restoreAllMocks();
       vi.useRealTimers();
     });
 
@@ -602,7 +606,7 @@ describe("useFileBrowserTree", () => {
       expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
     });
 
-    it("surfaces a persistent root failure only after the retry budget is spent, then clears on a successful manual retry", async () => {
+    it("surfaces a persistent root failure only after the whole retry budget is spent, at the exact backoff boundaries", async () => {
       listDirectory.mockRejectedValue(new Error("worktree is gone"));
 
       const { result } = renderHook(() =>
@@ -614,27 +618,72 @@ describe("useFileBrowserTree", () => {
         })
       );
 
-      // Initial failure is silent.
+      // Initial failure is silent — one attempt so far, skeleton still up.
       await flush();
+      expect(listDirectory).toHaveBeenCalledTimes(1);
       expect(result.current.rootError).toBeNull();
       expect(result.current.isInitialLoading).toBe(true);
 
-      // First retry (150ms) also fails — still silent.
+      // Retry 1 fires at exactly t=150, not a millisecond before (a shorter delay
+      // would fire at 149 and this would catch it).
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(150);
+        await vi.advanceTimersByTimeAsync(149);
       });
+      expect(listDirectory).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(listDirectory).toHaveBeenCalledTimes(2);
       expect(result.current.rootError).toBeNull();
-      expect(result.current.isInitialLoading).toBe(true);
 
-      // Second retry (400ms) fails and exhausts the budget — now it surfaces.
+      // Retry 2 fires at t=550 (delay 400 after retry 1), not before.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(400);
+        await vi.advanceTimersByTimeAsync(399);
       });
+      expect(listDirectory).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(listDirectory).toHaveBeenCalledTimes(3);
+      expect(result.current.rootError).toBeNull();
+
+      // Retry 3 fires at t=1350 (delay 800) and exhausts the budget — only now
+      // does the banner appear.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(799);
+      });
+      expect(listDirectory).toHaveBeenCalledTimes(3);
+      expect(result.current.rootError).toBeNull();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(listDirectory).toHaveBeenCalledTimes(4);
       expect(result.current.rootError).toContain("worktree is gone");
       expect(result.current.isInitialLoading).toBe(false);
+    });
 
-      // A manual retry that succeeds clears the error and populates rows, and
-      // resetting the budget lets a later failure enter grace again.
+    it("resets the budget on a successful retry so a later failure re-enters the grace window", async () => {
+      // Fail the whole initial streak so the banner surfaces, then heal manually.
+      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+
+      const { result } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        })
+      );
+
+      await flush();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+        await vi.advanceTimersByTimeAsync(400);
+        await vi.advanceTimersByTimeAsync(800);
+      });
+      expect(result.current.rootError).toContain("worktree is gone");
+
+      // A manual refresh succeeds: error clears, rows populate, budget resets.
       listDirectory.mockResolvedValue([file("a.ts")]);
       await act(async () => {
         result.current.refresh();
@@ -643,38 +692,26 @@ describe("useFileBrowserTree", () => {
       });
       expect(result.current.rootError).toBeNull();
       expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
-    });
 
-    it("does not surface a root error until the retry budget is exhausted across a longer failure streak", async () => {
-      // Fails on the initial request and both retries, then would succeed — but
-      // the budget is only two retries, so the third failure surfaces the error.
-      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+      // A LATER failure must re-enter grace (silent) rather than surface at once —
+      // which only holds if success reset nextDelayIndex to 0.
+      listDirectory.mockReset();
+      listDirectory.mockRejectedValueOnce(new Error("flap")).mockResolvedValue([file("b.ts")]);
+      await act(async () => {
+        result.current.refresh();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Refresh failure is silent and the last good rows stay visible.
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
 
-      const { result } = renderHook(() =>
-        useFileBrowserTree({
-          worktreeId: "wt-1",
-          expandedPaths: [],
-          showIgnored: false,
-          changeTick: undefined,
-        })
-      );
-
-      await flush();
-      const callsAfterMount = listDirectory.mock.calls.length;
-      expect(callsAfterMount).toBe(1);
-
+      // Its fresh 150ms retry succeeds and swaps in the new listing.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(150);
       });
-      expect(listDirectory.mock.calls.length).toBe(2);
       expect(result.current.rootError).toBeNull();
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(400);
-      });
-      // Three attempts total (mount + two retries), then the banner.
-      expect(listDirectory.mock.calls.length).toBe(3);
-      expect(result.current.rootError).toContain("worktree is gone");
+      expect(result.current.rows.map((row) => row.path)).toEqual(["b.ts"]);
     });
 
     it("cancels a scheduled root retry on unmount so it never fires", async () => {
@@ -701,13 +738,13 @@ describe("useFileBrowserTree", () => {
       expect(listDirectory.mock.calls.length).toBe(callsAtUnmount);
     });
 
-    it("bails on the fire path when the retry callback runs after unmount", async () => {
-      // Capture the scheduled callback so we can invoke it manually — simulating
-      // the event loop having dequeued it before clearTimeout could cancel it.
+    it("a superseded retry callback that fires late issues no request (handle guard)", async () => {
+      // Capture the scheduled retry so we can invoke it manually — simulating the
+      // event loop having dequeued it before clearTimeout could cancel it.
       const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+      listDirectory.mockRejectedValueOnce(new Error("Worktree not found: wt-1"));
 
-      const { unmount } = renderHook(() =>
+      const { result } = renderHook(() =>
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
@@ -717,17 +754,31 @@ describe("useFileBrowserTree", () => {
       );
 
       await flush();
-      const scheduled = timeoutSpy.mock.calls.find(([, delay]) => delay === 150);
-      expect(scheduled).toBeDefined();
-      const retryCallback = scheduled![0] as () => void;
+      // Exactly one 150ms timer — the root retry — so we can't grab the wrong one.
+      const scheduled = timeoutSpy.mock.calls.filter(([, delay]) => delay === 150);
+      expect(scheduled).toHaveLength(1);
+      const staleCallback = scheduled[0]![0] as () => void;
+
+      // Supersede that pending retry with a successful manual refresh, which
+      // clears the timer (rootRetryTimerRef → null). The captured callback is now
+      // stale but still references its old handle. Kept mounted and same-identity
+      // so ONLY the handle guard — not the disposed/generation guards, nor
+      // fetchDirectory's own disposed check — can stop it.
+      listDirectory.mockResolvedValue([file("a.ts")]);
+      await act(async () => {
+        result.current.refresh();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
 
       const callsBefore = listDirectory.mock.calls.length;
-      unmount();
-      // The on-fire generation/disposed guard — not clearTimeout — must refuse
-      // to issue a request here.
       act(() => {
-        retryCallback();
+        staleCallback();
       });
+      // Without the `rootRetryTimerRef.current !== handle` guard this would
+      // enqueue + pump another root listing.
       expect(listDirectory.mock.calls.length).toBe(callsBefore);
     });
 

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { FileTreeNode } from "@shared/types";
 import type { FileBrowserListDirectoryPayload } from "@shared/types/ipc/fileBrowser";
@@ -234,29 +234,6 @@ describe("useFileBrowserTree", () => {
     // show ignored entries in some folders and hide them in others.
     await waitFor(() => expect(listDirectory).toHaveBeenCalledTimes(2));
     expect(listDirectory.mock.calls[1]?.[0].includeIgnored).toBe(true);
-  });
-
-  it("surfaces a root failure and clears it once a retry succeeds", async () => {
-    listDirectory.mockRejectedValueOnce(new Error("worktree is gone"));
-
-    const { result } = renderHook(() =>
-      useFileBrowserTree({
-        worktreeId: "wt-1",
-        expandedPaths: [],
-        showIgnored: false,
-        changeTick: undefined,
-      })
-    );
-
-    await waitFor(() => expect(result.current.rootError).toContain("worktree is gone"));
-
-    listDirectory.mockResolvedValue([file("a.ts")]);
-    act(() => {
-      result.current.refresh();
-    });
-
-    await waitFor(() => expect(result.current.rootError).toBeNull());
-    expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
   });
 
   it("leaves the tree usable when a single directory listing fails", async () => {
@@ -569,5 +546,231 @@ describe("useFileBrowserTree", () => {
     // if the effect later requested the outside-root directory.
     await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
     expect(listDirectory.mock.calls.map((call) => call[0]?.dirPath)).toEqual(["src"]);
+  });
+
+  // Switching back to an idle project re-fetches the tree while the workspace
+  // host is still being repointed to this window, so the first root listing can
+  // throw a transient `Worktree not found`. These tests pin the silent-retry
+  // grace window: only a failure that persists across the whole backoff paints
+  // the banner. Fake timers are scoped here so the real-timer tests above are
+  // untouched; `waitFor` is deliberately avoided while they're active (its
+  // polling timer would need advancing and can hang).
+  describe("root retry grace window", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Flush the mocked-promise microtasks the hook awaits, without advancing any
+    // timer. Promises aren't faked, so this settles the pending listDirectory.
+    async function flush() {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    it("keeps a single transient root failure invisible and self-heals on retry", async () => {
+      // Mount fails with the switch-back race error; the retry succeeds.
+      listDirectory
+        .mockRejectedValueOnce(new Error("Worktree not found: wt-1"))
+        .mockResolvedValue([file("a.ts")]);
+
+      const { result } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        })
+      );
+
+      await flush();
+      // The transient failure must never surface: still loading, no banner.
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.isInitialLoading).toBe(true);
+
+      // The first (150ms) retry succeeds and the tree renders — error never seen.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.isInitialLoading).toBe(false);
+      expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
+    });
+
+    it("surfaces a persistent root failure only after the retry budget is spent, then clears on a successful manual retry", async () => {
+      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+
+      const { result } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        })
+      );
+
+      // Initial failure is silent.
+      await flush();
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.isInitialLoading).toBe(true);
+
+      // First retry (150ms) also fails — still silent.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.isInitialLoading).toBe(true);
+
+      // Second retry (400ms) fails and exhausts the budget — now it surfaces.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      expect(result.current.rootError).toContain("worktree is gone");
+      expect(result.current.isInitialLoading).toBe(false);
+
+      // A manual retry that succeeds clears the error and populates rows, and
+      // resetting the budget lets a later failure enter grace again.
+      listDirectory.mockResolvedValue([file("a.ts")]);
+      await act(async () => {
+        result.current.refresh();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.rows.map((row) => row.path)).toEqual(["a.ts"]);
+    });
+
+    it("does not surface a root error until the retry budget is exhausted across a longer failure streak", async () => {
+      // Fails on the initial request and both retries, then would succeed — but
+      // the budget is only two retries, so the third failure surfaces the error.
+      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+
+      const { result } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        })
+      );
+
+      await flush();
+      const callsAfterMount = listDirectory.mock.calls.length;
+      expect(callsAfterMount).toBe(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+      expect(listDirectory.mock.calls.length).toBe(2);
+      expect(result.current.rootError).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(400);
+      });
+      // Three attempts total (mount + two retries), then the banner.
+      expect(listDirectory.mock.calls.length).toBe(3);
+      expect(result.current.rootError).toContain("worktree is gone");
+    });
+
+    it("cancels a scheduled root retry on unmount so it never fires", async () => {
+      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+
+      const { unmount } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        })
+      );
+
+      await flush();
+      const callsAtUnmount = listDirectory.mock.calls.length;
+
+      unmount();
+
+      // Advancing well past every backoff must not resurrect the retry.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(listDirectory.mock.calls.length).toBe(callsAtUnmount);
+    });
+
+    it("bails on the fire path when the retry callback runs after unmount", async () => {
+      // Capture the scheduled callback so we can invoke it manually — simulating
+      // the event loop having dequeued it before clearTimeout could cancel it.
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      listDirectory.mockRejectedValue(new Error("worktree is gone"));
+
+      const { unmount } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        })
+      );
+
+      await flush();
+      const scheduled = timeoutSpy.mock.calls.find(([, delay]) => delay === 150);
+      expect(scheduled).toBeDefined();
+      const retryCallback = scheduled![0] as () => void;
+
+      const callsBefore = listDirectory.mock.calls.length;
+      unmount();
+      // The on-fire generation/disposed guard — not clearTimeout — must refuse
+      // to issue a request here.
+      act(() => {
+        retryCallback();
+      });
+      expect(listDirectory.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("drops an old identity's pending retry and gives the new identity a fresh budget", async () => {
+      listDirectory.mockImplementation(async (payload) => {
+        throw new Error(`Worktree not found: ${payload.worktreeId}`);
+      });
+
+      const { result, rerender } = renderHook(
+        (props: { worktreeId: string }) =>
+          useFileBrowserTree({
+            worktreeId: props.worktreeId,
+            expandedPaths: [],
+            showIgnored: false,
+            changeTick: undefined,
+          }),
+        { initialProps: { worktreeId: "wt-1" } }
+      );
+
+      // wt-1 fails on mount and schedules a retry we're about to strand.
+      await flush();
+
+      // Switch identity before wt-1's retry can fire; wt-2 fails once then heals.
+      listDirectory.mockReset();
+      listDirectory
+        .mockRejectedValueOnce(new Error("Worktree not found: wt-2"))
+        .mockResolvedValue([file("b.ts")]);
+      rerender({ worktreeId: "wt-2" });
+      await flush();
+
+      // wt-2's grace window is fresh (index 0), so its 150ms retry succeeds.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+      expect(result.current.rootError).toBeNull();
+      expect(result.current.rows.map((row) => row.path)).toEqual(["b.ts"]);
+
+      // Advancing past wt-1's old backoff must not resurrect it — no wt-1 call
+      // was issued after the switch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(listDirectory.mock.calls.some((call) => call[0].worktreeId === "wt-1")).toBe(false);
+    });
   });
 });

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -28,11 +28,13 @@ const MAX_CONCURRENT_LISTINGS = 6;
  *
  * 150ms first, because `getAllStatesAsync` coalesces its result for 150ms
  * (`STATES_INFLIGHT_COALESCE_WINDOW_MS`) — a sooner retry would only replay the
- * same stale empty answer. ~400ms second, to leave the host the "several
- * hundred ms" its own load can take and to align with the skeleton's Doherty
- * gate. Worst case a genuinely broken worktree surfaces after ~550ms + latency.
+ * same stale empty answer. Then 400ms and 800ms: `switch.ts`'s own comment puts
+ * the warm-`loadProject` window at "several hundred ms" (prune/list/status
+ * sync/LFS probe), and a reporter saw the banner outlast a shorter budget, so
+ * the schedule reaches ~1.35s of grace to clear that window with margin while
+ * still surfacing a genuinely broken worktree in under ~1.5s.
  */
-const ROOT_RETRY_DELAYS_MS = [150, 400] as const;
+const ROOT_RETRY_DELAYS_MS = [150, 400, 800] as const;
 
 export interface UseFileBrowserTreeArgs {
   worktreeId: string | undefined;
@@ -166,8 +168,16 @@ export function useFileBrowserTree({
     [clearRootRetryTimer]
   );
 
+  const enqueueTargets = useCallback((targets: readonly string[], generation: number): void => {
+    for (const dirPath of targets) {
+      if (inFlightRef.current.has(dirPath)) continue;
+      if (queueRef.current.some((entry) => entry.dirPath === dirPath)) continue;
+      queueRef.current.push({ dirPath, generation });
+    }
+  }, []);
+
   const fetchDirectory = useCallback(
-    async function fetchDirectory(dirPath: string, generation: number): Promise<void> {
+    async (dirPath: string, generation: number): Promise<void> => {
       if (!worktreeId || disposedRef.current) return;
       inFlightRef.current.set(dirPath, generation);
       physicalInFlightRef.current += 1;
@@ -223,21 +233,23 @@ export function useFileBrowserTree({
             clearRootRetryTimer();
             const handle = setTimeout(() => {
               // Guard on fire, not just via cleanup: `clearTimeout` can't recall
-              // a callback the event loop already dequeued. Bail unless this is
-              // still the live, non-superseded retry for the current identity.
+              // a callback the event loop already dequeued, and a superseding
+              // success/refresh nulls the handle out from under it. The identity
+              // switch is covered separately by the layout-effect cancel below.
               if (
                 generation !== generationRef.current ||
                 disposedRef.current ||
-                rootRetryTimerRef.current !== handle ||
-                rootRetryStateRef.current.generation !== generation
+                rootRetryTimerRef.current !== handle
               ) {
                 return;
               }
               rootRetryTimerRef.current = null;
-              // A manual refresh may already be re-listing the root; that request
-              // is the retry, so don't stack a duplicate on top of it.
-              if (inFlightRef.current.has(rootPath)) return;
-              void fetchDirectory(rootPath, generation);
+              // Route the retry through the shared queue rather than calling
+              // fetchDirectory directly: it dedups against any root work a manual
+              // refresh already queued or put in flight, and honours the
+              // concurrency ceiling instead of firing a seventh request past it.
+              enqueueTargets([rootPath], generation);
+              pumpRef.current();
             }, delay);
             rootRetryTimerRef.current = handle;
             return;
@@ -267,16 +279,8 @@ export function useFileBrowserTree({
         pumpRef.current();
       }
     },
-    [worktreeId, showIgnored, rootPath, clearRootRetryTimer, resetRootRetryState]
+    [worktreeId, showIgnored, rootPath, clearRootRetryTimer, resetRootRetryState, enqueueTargets]
   );
-
-  const enqueueTargets = useCallback((targets: readonly string[], generation: number): void => {
-    for (const dirPath of targets) {
-      if (inFlightRef.current.has(dirPath)) continue;
-      if (queueRef.current.some((entry) => entry.dirPath === dirPath)) continue;
-      queueRef.current.push({ dirPath, generation });
-    }
-  }, []);
 
   const pump = useCallback((): void => {
     if (disposedRef.current) return;
@@ -317,6 +321,19 @@ export function useFileBrowserTree({
     expandedSetRef.current = expandedSet;
     pumpRef.current = pump;
   }, [listings, expandedSet, pump]);
+
+  // Cancel a pending root retry synchronously when the identity changes or the
+  // panel unmounts. The generation bump that would invalidate the retry lives in
+  // a *passive* effect, so between this commit and that effect there is a window
+  // where the old timer could still fire, pass its generation guard, and briefly
+  // repaint the previous worktree's error. A layout-effect cleanup runs during
+  // commit — before that passive effect and before the loop yields to any timer
+  // — closing the window. (Same reasoning as the ref publish above.)
+  useLayoutEffect(() => {
+    return () => {
+      clearRootRetryTimer();
+    };
+  }, [worktreeId, showIgnored, rootPath, clearRootRetryTimer]);
 
   useEffect(() => {
     disposedRef.current = false;

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -16,6 +16,24 @@ import { flattenTree, pruneListings, refreshTargets, type FlatTreeRow } from "./
  */
 const MAX_CONCURRENT_LISTINGS = 6;
 
+/**
+ * Backoff schedule for silently retrying a failed *root* listing before
+ * surfacing an error. Switching back to an idle project reactivates its view
+ * and re-fetches the tree while the workspace host is still being repointed to
+ * this window — `activateProjectView` sends `PROJECT_ON_SWITCH` before it awaits
+ * `loadWorktrees` — so the first `listDirectory` can throw `Worktree not found`
+ * for a few hundred ms before self-healing. Retrying instead of immediately
+ * painting a red banner keeps that transient invisible; the banner is reserved
+ * for a failure that persists across the whole schedule.
+ *
+ * 150ms first, because `getAllStatesAsync` coalesces its result for 150ms
+ * (`STATES_INFLIGHT_COALESCE_WINDOW_MS`) — a sooner retry would only replay the
+ * same stale empty answer. ~400ms second, to leave the host the "several
+ * hundred ms" its own load can take and to align with the skeleton's Doherty
+ * gate. Worst case a genuinely broken worktree surfaces after ~550ms + latency.
+ */
+const ROOT_RETRY_DELAYS_MS = [150, 400] as const;
+
 export interface UseFileBrowserTreeArgs {
   worktreeId: string | undefined;
   expandedPaths: readonly string[];
@@ -50,6 +68,17 @@ export interface UseFileBrowserTreeResult {
 interface QueueEntry {
   dirPath: string;
   generation: number;
+}
+
+/**
+ * Tracks the current root-failure streak. Keyed by the generation that owns it
+ * so a retry scheduled under a previous identity can't consume the new one's
+ * budget; `nextDelayIndex` walks `ROOT_RETRY_DELAYS_MS` and is reset to 0 on any
+ * root success or identity reset.
+ */
+interface RootRetryState {
+  generation: number;
+  nextDelayIndex: number;
 }
 
 /**
@@ -98,6 +127,13 @@ export function useFileBrowserTree({
   // nobody is looking at, and racing the replacement panel's own requests.
   const disposedRef = useRef(false);
 
+  // Silent-retry bookkeeping for a failed *root* listing. The timer handle lets
+  // us both cancel a pending retry (unmount / identity reset) and detect on fire
+  // whether it was superseded; the state carries the streak's generation and its
+  // position in `ROOT_RETRY_DELAYS_MS`. See `fetchDirectory`'s root catch branch.
+  const rootRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rootRetryStateRef = useRef<RootRetryState>({ generation: 0, nextDelayIndex: 0 });
+
   const expandedSet = useMemo(() => new Set(expandedPaths), [expandedPaths]);
   const expandedSetRef = useRef(expandedSet);
 
@@ -113,8 +149,25 @@ export function useFileBrowserTree({
   // capture a stale closure.
   const pumpRef = useRef<() => void>(() => {});
 
+  const clearRootRetryTimer = useCallback((): void => {
+    if (rootRetryTimerRef.current !== null) {
+      clearTimeout(rootRetryTimerRef.current);
+      rootRetryTimerRef.current = null;
+    }
+  }, []);
+
+  // Replenish the retry budget for a fresh streak under `generation` and drop
+  // any retry still pending from the old one.
+  const resetRootRetryState = useCallback(
+    (generation: number): void => {
+      clearRootRetryTimer();
+      rootRetryStateRef.current = { generation, nextDelayIndex: 0 };
+    },
+    [clearRootRetryTimer]
+  );
+
   const fetchDirectory = useCallback(
-    async (dirPath: string, generation: number): Promise<void> => {
+    async function fetchDirectory(dirPath: string, generation: number): Promise<void> {
       if (!worktreeId || disposedRef.current) return;
       inFlightRef.current.set(dirPath, generation);
       physicalInFlightRef.current += 1;
@@ -144,6 +197,7 @@ export function useFileBrowserTree({
           return next;
         });
         if (dirPath === rootPath) {
+          resetRootRetryState(generation);
           setRootError(null);
           setHasLoadedRoot(true);
         }
@@ -154,6 +208,42 @@ export function useFileBrowserTree({
           // browser works" and "it doesn't". A single directory that failed
           // (deleted mid-expand, permissions) just stays unloaded, and the next
           // refresh retries it.
+          //
+          // But a root failure right after switching back to an idle project is
+          // usually transient — the workspace host is still being repointed to
+          // this window — so retry silently on a short backoff, staying in the
+          // skeleton, and only paint the banner once the budget is spent.
+          if (rootRetryStateRef.current.generation !== generation) {
+            rootRetryStateRef.current = { generation, nextDelayIndex: 0 };
+          }
+          const attempt = rootRetryStateRef.current.nextDelayIndex;
+          const delay = ROOT_RETRY_DELAYS_MS[attempt];
+          if (delay !== undefined) {
+            rootRetryStateRef.current.nextDelayIndex = attempt + 1;
+            clearRootRetryTimer();
+            const handle = setTimeout(() => {
+              // Guard on fire, not just via cleanup: `clearTimeout` can't recall
+              // a callback the event loop already dequeued. Bail unless this is
+              // still the live, non-superseded retry for the current identity.
+              if (
+                generation !== generationRef.current ||
+                disposedRef.current ||
+                rootRetryTimerRef.current !== handle ||
+                rootRetryStateRef.current.generation !== generation
+              ) {
+                return;
+              }
+              rootRetryTimerRef.current = null;
+              // A manual refresh may already be re-listing the root; that request
+              // is the retry, so don't stack a duplicate on top of it.
+              if (inFlightRef.current.has(rootPath)) return;
+              void fetchDirectory(rootPath, generation);
+            }, delay);
+            rootRetryTimerRef.current = handle;
+            return;
+          }
+          // Budget spent: the failure is real. Surface it exactly as before.
+          clearRootRetryTimer();
           setRootError(formatErrorMessage(error, "Couldn't read this worktree"));
           setHasLoadedRoot(true);
         } else {
@@ -177,7 +267,7 @@ export function useFileBrowserTree({
         pumpRef.current();
       }
     },
-    [worktreeId, showIgnored, rootPath]
+    [worktreeId, showIgnored, rootPath, clearRootRetryTimer, resetRootRetryState]
   );
 
   const enqueueTargets = useCallback((targets: readonly string[], generation: number): void => {
@@ -234,11 +324,13 @@ export function useFileBrowserTree({
       disposedRef.current = true;
       queueRef.current = [];
       refreshPendingRef.current = false;
+      // Drop any pending root retry so it can't fire into an unmounted panel.
+      clearRootRetryTimer();
       // Invalidate everything still in the air so a late response can't commit
       // into a store the panel no longer owns.
       generationRef.current += 1;
     };
-  }, []);
+  }, [clearRootRetryTimer]);
 
   const ensureLoaded = useCallback(
     (dirPath: string): void => {
@@ -268,6 +360,9 @@ export function useFileBrowserTree({
   // happened to reload and hide them everywhere else.
   useEffect(() => {
     generationRef.current += 1;
+    // Fresh identity, fresh retry budget — and cancel any retry still pending
+    // for the previous one so it can't leak an error into this tree.
+    resetRootRetryState(generationRef.current);
     inFlightRef.current.clear();
     queueRef.current = [];
     refreshPendingRef.current = false;
@@ -277,7 +372,7 @@ export function useFileBrowserTree({
     setHasLoadedRoot(false);
     if (!worktreeId) return;
     void fetchDirectory(rootPath, generationRef.current);
-  }, [worktreeId, showIgnored, rootPath, fetchDirectory]);
+  }, [worktreeId, showIgnored, rootPath, fetchDirectory, resetRootRetryState]);
 
   // Expanding a directory is what triggers its fetch; a restored panel expands
   // several at once, and each is requested the first time it becomes visible.


### PR DESCRIPTION
## Summary

- The file browser flashed a red "Couldn't read this worktree" / "Worktree not found" error banner when switching back to an idle project, then self-healed almost instantly.
- Confirmed root cause on the issue: in `switch.ts`, `activateProjectView` sends `PROJECT_ON_SWITCH` before awaiting `loadWorktrees`, so the first `listDirectory` call can throw `Worktree not found` for a few hundred milliseconds while the workspace host is still repointing to the window.
- Fix is renderer-only: a failed root listing now retries silently instead of surfacing the error on the first failure.

Resolves #11320

## Changes

- `src/panels/file-browser/useFileBrowserTree.ts`: a failed ROOT listing now retries silently on a `[150, 400, 800]` ms backoff, staying in the existing loading skeleton. The red banner only appears once the roughly 1.35s retry budget is exhausted, reserving it for failures that persist across retries. A successful root listing clears the error and resets the budget. Non-root directory failures are unchanged and still surface immediately. Retries cancel synchronously via a layout effect on identity change or unmount, and are routed through the existing queue/pump so they dedupe against in-flight or queued root work and respect the existing concurrency ceiling.
- `src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx`: rewrote the old immediate-surface test to require the retry budget be exhausted first. Added tests for silent self-heal on a single transient failure, exact backoff boundaries, the retry handle guard, budget reset on success, and cancellation on unmount/identity change.

## Testing

- 60 file-browser unit tests pass locally.
- Prettier and eslint clean on the changed files.