### PR TITLE
fix(file-viewer): suppress selection while drag-panning a zoomed image

### DIFF
--- a/src/components/FileViewer/ZoomableImage.tsx
+++ b/src/components/FileViewer/ZoomableImage.tsx
@@ -118,7 +118,9 @@ export function ZoomableImage({ filePath, rootPath, alt, cacheBust, onError }: Z
         onDoubleClick={resetView}
         style={TRANSPARENCY_CHECKERBOARD_STYLE}
         className={cn(
-          "flex h-full min-h-0 w-full flex-1 items-center justify-center overflow-hidden",
+          // select-none so drag-panning never starts a text/image selection that
+          // would paint the selection highlight over the image (#11325).
+          "flex h-full min-h-0 w-full flex-1 select-none items-center justify-center overflow-hidden",
           isZoomed ? "cursor-grab" : "cursor-default"
         )}
       >


### PR DESCRIPTION
## Summary

- Drag-panning a zoomed image in the file preview could start a browser text/image selection, which painted the selection highlight over the image mid-drag.
- Adds the Tailwind `select-none` class (`user-select: none`) to the pan container in `src/components/FileViewer/ZoomableImage.tsx` so a pointer drag no longer starts a selection.
- The child `<img>` inherits `user-select: none` from the container. `draggable={false}` on the `<img>` was already in place and stays as-is, for native image drag.

Resolves #11325

## Changes

- `src/components/FileViewer/ZoomableImage.tsx`: add `select-none` to the pan container's class list.

## Testing

- No new test added. The fix is CSS-only and not observable in jsdom, and a test asserting the class is present would just restate the source, which the project's no-tautological-assertions rule rules out.
- Verified prettier and eslint are clean on the changed file.