### PR TITLE
fix(file-browser): improve right-click context menu behavior

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2610,6 +2610,16 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     outline-offset: -2px;
   }
 
+  /* The file-browser row whose context menu is open marks its target with a
+     background tint via data-state="open", which is stripped here. Right-click
+     no longer moves the selection, so without this the targeted row would carry
+     no forced-colors cue at all. Scoped to [role="treeitem"] so it stays
+     independent of the menuitem fallback above. */
+  [role="treeitem"][data-state="open"] {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+
   button,
   [role="button"],
   [type="button"],

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -198,26 +198,47 @@ export function FileBrowserPane({
     [worktreeId]
   );
 
-  const handleCopyAbsolutePath = useCallback(
+  const copyToClipboard = useCallback((text: string, errorTitle: string) => {
+    const write = () =>
+      navigator.clipboard.writeText(text).catch((error: unknown) => {
+        // A silent failure leaves the previous clipboard contents in place,
+        // and the user's next paste would be the wrong value.
+        notify({
+          type: "error",
+          title: errorTitle,
+          message:
+            error instanceof Error && error.name === "NotAllowedError"
+              ? "The clipboard is unavailable while another app holds it."
+              : "The clipboard rejected the write.",
+          action: { label: "Retry", onClick: () => void write() },
+        });
+      });
+    void write();
+  }, []);
+
+  const handleCopyFullPath = useCallback(
     (path: string) => {
       if (!worktreePath) return;
-      const write = () =>
-        navigator.clipboard.writeText(join(worktreePath, path)).catch((error: unknown) => {
-          // A silent failure leaves the previous clipboard contents in place,
-          // and the user's next paste would be the wrong path.
-          notify({
-            type: "error",
-            title: "Couldn't copy path",
-            message:
-              error instanceof Error && error.name === "NotAllowedError"
-                ? "The clipboard is unavailable while another app holds it."
-                : "The clipboard rejected the write.",
-            action: { label: "Retry", onClick: () => void write() },
-          });
-        });
-      void write();
+      copyToClipboard(join(worktreePath, path), "Couldn't copy path");
     },
-    [worktreePath]
+    [worktreePath, copyToClipboard]
+  );
+
+  // row.path is already relative to the true worktree root even when the tree
+  // has been re-rooted to a subfolder, so it copies verbatim — no rootPath
+  // stripping or re-joining, which would only double-prefix a correct value.
+  const handleCopyRelativePath = useCallback(
+    (path: string) => {
+      copyToClipboard(path, "Couldn't copy path");
+    },
+    [copyToClipboard]
+  );
+
+  const handleCopyFileName = useCallback(
+    (name: string) => {
+      copyToClipboard(name, "Couldn't copy file name");
+    },
+    [copyToClipboard]
   );
 
   const reveal = useMemo(() => revealCopy(), []);
@@ -265,13 +286,28 @@ export function FileBrowserPane({
             <ContextMenuSeparator />
           </>
         )}
-        <ContextMenuItem onSelect={() => handleCopyAbsolutePath(row.path)}>
-          Copy path
+        <ContextMenuItem onSelect={() => handleCopyFullPath(row.path)}>
+          Copy full path
         </ContextMenuItem>
+        <ContextMenuItem onSelect={() => handleCopyRelativePath(row.path)}>
+          Copy relative path
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => handleCopyFileName(row.name)}>
+          Copy file name
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => handleReveal(row.path)}>{reveal.label}</ContextMenuItem>
       </>
     ),
-    [handleSetRoot, handleCopyFolderContext, handleCopyAbsolutePath, handleReveal, reveal]
+    [
+      handleSetRoot,
+      handleCopyFolderContext,
+      handleCopyFullPath,
+      handleCopyRelativePath,
+      handleCopyFileName,
+      handleReveal,
+      reveal,
+    ]
   );
 
   // A restored panel remembers a selection whose ancestors may be collapsed.

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -21,8 +21,9 @@ export interface FileTreeViewProps {
   onRootFolder?: (path: string) => void;
   /**
    * Menu items for a row's right-click menu; return null for no menu. The
-   * view owns the Radix wiring (and selects the row on right-click so the
-   * menu visibly targets it); the pane owns what the items do.
+   * view owns the Radix wiring (and lifts the row while its menu is open so
+   * the menu visibly targets it, without moving the selection); the pane owns
+   * what the items do.
    */
   rowContextMenu?: (row: FlatTreeRow) => React.ReactNode;
   /** Accessible name for the tree, since the panel header isn't part of it. */
@@ -273,12 +274,6 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         }
       : undefined;
 
-  // Select on right-click, without toggling expansion: the menu acts on this
-  // row, and the selection highlight is what shows the user which one.
-  const handleContextMenu = () => {
-    onSelect(row.path);
-  };
-
   const handleChevronClick = (event: React.MouseEvent) => {
     // Toggling from the chevron must not move the selection: it is the
     // "peek inside without leaving where I am" affordance.
@@ -317,6 +312,11 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         "transition-colors duration-150 ease-out",
         isSelected ? "bg-overlay-subtle text-daintree-text" : "text-daintree-text/70",
         !isSelected && "hover:bg-tint/5",
+        // The row whose context menu is open lifts to a distinct neutral tier
+        // (raised, not the selection's subtle) so it reads as "the menu targets
+        // this row" without masquerading as the selection. Radix forwards
+        // data-state onto this surface through the asChild trigger below.
+        "data-[state=open]:bg-overlay-raised data-[state=open]:text-daintree-text",
         row.isIgnored && "opacity-55"
       )}
     >
@@ -363,7 +363,7 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
   }
 
   return (
-    <div className="h-6 w-full px-1" onContextMenu={handleContextMenu}>
+    <div className="h-6 w-full px-1">
       <ContextMenu>
         <ContextMenuTrigger asChild>{rowSurface}</ContextMenuTrigger>
         <ContextMenuContent>{menuItems}</ContextMenuContent>

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -59,12 +59,27 @@ function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {})
 }
 
 describe("FileTreeView context-menu interactions", () => {
-  it("selects a row on right-click so the menu visibly targets it", () => {
-    const { onSelect, getByRole } = renderTree();
+  it("leaves the selection untouched on right-click", () => {
+    // Right-click must not swap the viewed file: the menu acts on the
+    // right-clicked row directly, so moving the selection would pull the
+    // viewer off the file the user was looking at mid-gesture. The open-state
+    // lift — not the selection — is what shows which row the menu targets.
+    const { onSelect, getByRole } = renderTree({ selectedPath: "README.md" });
 
     fireEvent.contextMenu(getByRole("treeitem", { name: "src" }));
 
-    expect(onSelect).toHaveBeenCalledWith("src");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("still selects a row on a plain click", () => {
+    // Only right-click is decoupled from selection; the ordinary click path
+    // must still drive it. A file row avoids coupling the assertion to the
+    // directory-expansion toggle a folder click also fires.
+    const { onSelect, getByRole } = renderTree();
+
+    fireEvent.click(getByRole("treeitem", { name: "README.md" }));
+
+    expect(onSelect).toHaveBeenCalledWith("README.md");
   });
 
   it("replays the ContextMenu key as a contextmenu event on the selected row", () => {

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render } from "@testing-library/react";
 import { forwardRef } from "react";
 import type { ReactNode } from "react";
 import { UI_INLINE_LOADING_GATE_MS } from "@/lib/animationUtils";
+import { ContextMenuItem } from "@/components/ui/context-menu";
 import { FileTreeView } from "../FileTreeView";
 import type { FlatTreeRow } from "../fileBrowserTree";
 
@@ -59,15 +60,29 @@ function renderTree(overrides: Partial<Parameters<typeof FileTreeView>[0]> = {})
 }
 
 describe("FileTreeView context-menu interactions", () => {
-  it("leaves the selection untouched on right-click", () => {
-    // Right-click must not swap the viewed file: the menu acts on the
-    // right-clicked row directly, so moving the selection would pull the
-    // viewer off the file the user was looking at mid-gesture. The open-state
-    // lift — not the selection — is what shows which row the menu targets.
-    const { onSelect, getByRole } = renderTree({ selectedPath: "README.md" });
+  it("opens the menu on the right-clicked row without moving the selection", async () => {
+    // Right-click must not swap the viewed file: the menu targets the
+    // right-clicked row directly (shown by that row's own open-state lift), so
+    // moving the selection would pull the viewer off the file the user was
+    // looking at mid-gesture. A row-specific menu item lets us prove the menu
+    // opened on the row that was clicked, not merely that something opened.
+    const onSelect = vi.fn();
+    const { getByRole, findByRole } = render(
+      <FileTreeView
+        rows={ROWS}
+        selectedPath="README.md"
+        onSelect={onSelect}
+        onToggleExpanded={vi.fn()}
+        rowContextMenu={(clicked) => <ContextMenuItem>Act on {clicked.name}</ContextMenuItem>}
+        label="Files"
+      />
+    );
 
     fireEvent.contextMenu(getByRole("treeitem", { name: "src" }));
 
+    // The menu opens on the row that was right-clicked...
+    expect(await findByRole("menuitem", { name: "Act on src" })).toBeTruthy();
+    // ...while the previously selected row — and thus the viewer — stays put.
     expect(onSelect).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Right-clicking a row in the file browser no longer moves the tree selection, so the file being viewed stays open when you right-click a different row. This matches VS Code and JetBrains, neither of which swaps the open editor on a right-click. The row the context menu is currently targeting lifts to `bg-overlay-raised`, a background distinct from the selected row's own highlight, so it's still clear which row the menu acts on. A forced-colors fallback outline keeps that cue visible when the OS strips background tints.
- The single `Copy path` menu item is replaced with three: Copy full path, Copy relative path (relative to the true worktree root, even when the tree has been re-rooted to a subfolder), and Copy file name. The clipboard write/error/retry logic is factored into one shared helper used by all three, and a separator groups the copy actions apart from Reveal.

Resolves #11327

## Changes

- `src/panels/file-browser/FileTreeView.tsx`: right-click no longer dispatches a selection change; menu-target row gets its own highlight state.
- `src/panels/file-browser/FileBrowserPane.tsx`: split `Copy path` into full path / relative path / file name, with a shared clipboard helper and a separator ahead of Reveal.
- `src/index.css`: `bg-overlay-raised` styling for the menu-target row plus the forced-colors outline fallback.
- `src/panels/file-browser/__tests__/FileTreeView.test.tsx`: coverage for the decoupled selection and the menu-target highlight.

## Testing

- File-browser unit suite: 80 tests across 5 files, all green.
- Prettier and eslint clean on the changed files, no lint-ratchet regression.
- Branch rebased cleanly onto `origin/develop`.
