### PR TITLE
fix(ui): shared SpinningIcon so refresh buttons finish their spin

### DIFF
--- a/src/components/Diagnostics/WhySlowContent.tsx
+++ b/src/components/Diagnostics/WhySlowContent.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Gauge, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { systemClient } from "@/clients/systemClient";
 import { logError } from "@/utils/logger";
 import type { WhySlowSnapshot } from "@shared/types/whySlow";
@@ -245,7 +246,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
             className="flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] text-xs text-daintree-text/70 hover:text-daintree-text hover:bg-tint/[0.06] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-50"
             aria-label="Refresh diagnostics snapshot"
           >
-            <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
+            <SpinningIcon icon={RefreshCw} active={isRefreshing} className="w-3.5 h-3.5" />
             Refresh
           </button>
         </div>

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -9,6 +9,7 @@ import { CapabilityRow } from "./capabilityMeta";
 import { PluginMcpServersSection } from "./PluginMcpServersSection";
 import { PluginSettingsForm } from "@/components/Settings/PluginSettingsForm";
 import { Button } from "@/components/ui/button";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import {
   SettingsSubtabBar,
   type SettingsSubtabItem,
@@ -369,7 +370,7 @@ export function PluginDetailPane({
                   disabled={checkingUpdate}
                   aria-label={`Check ${label} for updates`}
                 >
-                  <RefreshCw className={checkingUpdate ? "animate-spin" : undefined} />
+                  <SpinningIcon icon={RefreshCw} active={checkingUpdate} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">{updateTooltip}</TooltipContent>

--- a/src/components/Plugin/PluginMcpServersSection.tsx
+++ b/src/components/Plugin/PluginMcpServersSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AlertCircle, ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -308,7 +309,7 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
                   disabled={isRestarting || isSpawning}
                   className="shrink-0"
                 >
-                  <RefreshCw className={`w-3.5 h-3.5 ${isRestarting ? "animate-spin" : ""}`} />
+                  <SpinningIcon icon={RefreshCw} active={isRestarting} className="w-3.5 h-3.5" />
                   {status === "not-started" ? "Start server" : "Restart server"}
                 </Button>
               </div>

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -21,6 +21,7 @@ import {
   WifiOff,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { Activity } from "@/components/icons";
 import { PulseHeatmap, getPulseHeatmapRowWidth, getPulseHeatLevelBackground } from "./PulseHeatmap";
 import { PulseSummary } from "./PulseSummary";
@@ -611,9 +612,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
             className="pulse-control rounded-md p-1.5 text-daintree-text/55 transition-colors hover:text-daintree-text/80 disabled:opacity-50 disabled:pointer-events-none"
             aria-label="Refresh"
           >
-            <RefreshCw
-              className={cn("w-3 h-3", isLoading && "animate-spin motion-reduce:animate-none")}
-            />
+            <SpinningIcon icon={RefreshCw} active={isLoading} className="w-3 h-3" />
           </button>
         </div>
       </div>

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -235,7 +235,12 @@ describe("ProjectPulseCard — accessibility (issue #7229)", () => {
 
   it("refresh spinner respects motion-reduce", async () => {
     const content = await readFile(CARD_PATH, "utf-8");
-    expect(content).toContain("motion-reduce:animate-none");
+    // The refresh spinner is the shared SpinningIcon (#11323), whose spin is
+    // globally neutralized under reduced-motion by the `@variant reduce-motion`
+    // block in index.css — so the old per-element `motion-reduce:animate-none`
+    // utility is redundant and deliberately dropped. Assert the delegation
+    // instead: SpinningIcon is the reduced-motion-safe primitive.
+    expect(content).toContain("<SpinningIcon icon={RefreshCw} active={isLoading}");
   });
 });
 

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useId } from "react";
 import { Code2, CheckCircle, AlertCircle, RefreshCw, ExternalLink } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { editorClient } from "@/clients/editorClient";
@@ -190,7 +190,7 @@ export function EditorIntegrationTab() {
                     aria-label="Re-scan for installed editors"
                     className="p-2 rounded-[var(--radius-md)] border border-daintree-border hover:bg-tint/5 text-daintree-text/60 hover:text-daintree-text transition-colors disabled:opacity-40 disabled:pointer-events-none"
                   >
-                    <RefreshCw className={cn("w-4 h-4", isRescanning && "animate-spin")} />
+                    <SpinningIcon icon={RefreshCw} active={isRescanning} className="w-4 h-4" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Re-scan for installed editors</TooltipContent>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -32,7 +32,6 @@ import {
   useKeybindingDisplay,
   useDohertyGate,
   useKeepMounted,
-  useSkeletonDisplayFloor,
 } from "@/hooks";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { WorktreeSidebarSearchBar, QuickStateFilterBar } from "@/components/Worktree";
@@ -40,6 +39,7 @@ import { useBuiltinView } from "@/registry/builtinRendererRegistry";
 import type { ForgeBulkCreateWorktreeDialogProps } from "@/types/forgeSlotProps";
 import { useResolvedForgeProvider } from "@/hooks/useResolvedForgeProvider";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useDndMonitor } from "@dnd-kit/core";
@@ -508,13 +508,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     Date.now() - reconnectingAt >= RECONNECT_ESCALATE_MS;
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
-  // Pressing Refresh is a direct user action, so the icon must spin *immediately*
-  // — not behind the Doherty onset gate (that gate defers spinners for passive
-  // background work, where sub-400ms churn shouldn't flash). The display floor
-  // shows the spin on press and holds it for a minimum dwell so fast refreshes
-  // still complete a perceptible spin instead of flickering. See the
-  // direct-action vs. background-work distinction in animationUtils.ts.
-  const showRefreshSpinner = useSkeletonDisplayFloor(isRefreshing);
   // Gate the "Reconnecting…" indicator behind the Doherty threshold so routine
   // sub-400ms port replacements don't flash the spinner. A real host crash
   // takes 2–4s to recover, well past the threshold.
@@ -1714,7 +1707,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               aria-keyshortcuts={refreshAriaShortcut}
               title={formatButtonTitle("Refresh sidebar", refreshShortcut)}
             >
-              <RefreshCw className={`w-3.5 h-3.5 ${showRefreshSpinner ? "animate-spin" : ""}`} />
+              <SpinningIcon icon={RefreshCw} active={isRefreshing} className="w-3.5 h-3.5" />
             </button>
           </div>
           <button

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -69,12 +69,17 @@ describe("SidebarContent header reveal — issue #6964", () => {
     expect(source).toContain("motion-reduce:transition-none");
   });
 
-  it("gates the refresh spinner on useSkeletonDisplayFloor so a fast refresh stays perceptible", () => {
-    expect(source).toContain("useSkeletonDisplayFloor");
-    expect(source).toMatch(
-      /showRefreshSpinner\s*=\s*useSkeletonDisplayFloor\(\s*isRefreshing\s*\)/
-    );
-    expect(source).toMatch(/showRefreshSpinner\s*\?\s*"animate-spin"/);
+  it("delegates the refresh spin to SpinningIcon driven by the raw refresh flag (#11323)", () => {
+    // The refresh spin is owned by the shared SpinningIcon primitive, which
+    // finishes the current rotation before stopping instead of snapping back.
+    // It must be driven by the raw `isRefreshing` transition flag — the old
+    // `useSkeletonDisplayFloor` wall-clock floor gated duration, not rotation
+    // phase, so it snapped mid-turn and is deliberately gone from this button.
+    expect(source).toMatch(/<SpinningIcon\b[^>]*icon=\{RefreshCw\}[^>]*active=\{isRefreshing\}/);
+    expect(source).not.toContain("useSkeletonDisplayFloor");
+    expect(source).not.toContain("showRefreshSpinner");
+    // No hand-rolled conditional class toggle survives on the refresh icon.
+    expect(source).not.toMatch(/showRefreshSpinner\s*\?\s*"animate-spin"/);
     expect(source).not.toMatch(/isRefreshing\s*\?\s*"animate-spin"/);
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -75,7 +75,10 @@ describe("SidebarContent header reveal — issue #6964", () => {
     // It must be driven by the raw `isRefreshing` transition flag — the old
     // `useSkeletonDisplayFloor` wall-clock floor gated duration, not rotation
     // phase, so it snapped mid-turn and is deliberately gone from this button.
-    expect(source).toMatch(/<SpinningIcon\b[^>]*icon=\{RefreshCw\}[^>]*active=\{isRefreshing\}/);
+    // Scope the positive match to the header so an unrelated SpinningIcon
+    // elsewhere in the file can't mask a regression to a static header icon.
+    const header = headerSlice(source);
+    expect(header).toMatch(/<SpinningIcon\b[^>]*icon=\{RefreshCw\}[^>]*active=\{isRefreshing\}/);
     expect(source).not.toContain("useSkeletonDisplayFloor");
     expect(source).not.toContain("showRefreshSpinner");
     // No hand-rolled conditional class toggle survives on the refresh icon.

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -13,8 +13,8 @@ describe("SidebarContent reconnecting indicator — issue #8074", () => {
 
   it("gates the reconnecting indicator behind useDohertyGate", () => {
     // Doherty Threshold (400ms): routine sub-second port replacements must not
-    // flash a spinner. The reconnecting state mirrors the existing
-    // showRefreshSpinner pattern on the same component.
+    // flash a spinner. The reconnecting indicator is gated on onset the same way
+    // other deferred-display state on this component is.
     expect(source).toMatch(/const showReconnecting = useDohertyGate\(isReconnecting\)/);
   });
 

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -24,6 +24,7 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { basename } from "@shared/utils/path";
 import { usePanelDialogStore } from "@/store/panelDialogStore";
@@ -1499,11 +1500,10 @@ export function ReviewHubContent({
                 )}
                 aria-label="Refresh"
               >
-                <RefreshCw
-                  className={cn(
-                    "w-3.5 h-3.5",
-                    (loading || isBackgroundRefreshing) && "animate-spin"
-                  )}
+                <SpinningIcon
+                  icon={RefreshCw}
+                  active={loading || isBackgroundRefreshing}
+                  className="w-3.5 h-3.5"
                 />
               </button>
             )}

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -12,6 +12,7 @@ import {
 import type { AgentAvailabilityState, AgentCliDetail } from "@shared/types";
 import { Button } from "@/components/ui/button";
 import { RefreshCw, ExternalLink } from "lucide-react";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { getInstallBlocksForCurrentOS } from "@/lib/agentInstall";
 import { InstallBlock } from "@/components/Setup/InstallBlock";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -272,7 +273,7 @@ export function AgentInstallSection({
             disabled={isRefreshingCli}
             className="text-daintree-text/50 hover:text-daintree-text"
           >
-            <RefreshCw size={14} className={cn("mr-1.5", isRefreshingCli && "animate-spin")} />
+            <SpinningIcon icon={RefreshCw} active={isRefreshingCli} size={14} className="mr-1.5" />
             Re-check
           </Button>
         </div>

--- a/src/components/ui/SpinningIcon.tsx
+++ b/src/components/ui/SpinningIcon.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import type { LucideIcon, LucideProps } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getPerformanceModeFloor, UI_SPIN_CYCLE_MS } from "@/lib/animationUtils";
@@ -6,7 +7,9 @@ import { getPerformanceModeFloor, UI_SPIN_CYCLE_MS } from "@/lib/animationUtils"
 interface SpinningIconProps extends Omit<LucideProps, "ref"> {
   /** The Lucide icon to render (e.g. `RefreshCw`). Rendered directly, so the
    *  spin runs on the same `<svg>` the call site would have rendered itself —
-   *  no wrapping element, no changed transform origin. */
+   *  no wrapping element, no changed transform origin. Must be a STABLE
+   *  component identity: swapping `icon` mid-spin replaces the `<svg>` and
+   *  restarts its animation from 0°. */
   icon: LucideIcon;
   /** True while the underlying operation is running. Drives the spin. */
   active: boolean;
@@ -33,7 +36,13 @@ interface SpinningIconProps extends Omit<LucideProps, "ref"> {
  *
  * `spinning` is set true only by the rising-edge layout effect and false only by
  * the iteration handler or the backstop — never transiently during a render, so
- * the `animate-spin` class is present continuously from press to boundary.
+ * the `animate-spin` class is present continuously from press to boundary. The
+ * ≥1-rotation guarantee holds for a spin that starts from rest and commits
+ * `active: true` for at least one render (an entirely-batched true→false pulse
+ * commits nothing and cannot spin — that is the caller's contract, satisfied by
+ * the async loading flags every call site drives this with). Re-activating
+ * during the finishing tail keeps the existing rotation going (smooth, never a
+ * snap) rather than re-arming a fresh full-rotation debt for the new press.
  */
 export function SpinningIcon({ icon: Icon, active, className, ...rest }: SpinningIconProps) {
   const [spinning, setSpinning] = useState(active);
@@ -61,10 +70,25 @@ export function SpinningIcon({ icon: Icon, active, className, ...rest }: Spinnin
       // Ignore a bubbling animation from a descendant or from a stale node that
       // has already been swapped out.
       if (event.target !== svgRef.current) return;
+      // Only Tailwind's `spin` keyframe marks a rotation boundary — a second
+      // looping animation on this SVG would otherwise stop the spin at its own
+      // (arbitrary) phase. Plain Events (jsdom, which never runs CSS animations)
+      // aren't AnimationEvents and pass through.
+      if (
+        typeof AnimationEvent !== "undefined" &&
+        event instanceof AnimationEvent &&
+        event.animationName !== "spin"
+      ) {
+        return;
+      }
       if (!stopRequestedRef.current) return;
       stopRequestedRef.current = false;
       clearTimer();
-      setSpinning(false);
+      // Commit synchronously: `animationiteration` is not a discrete event, so a
+      // scheduled update could remove the class a frame or two after the 0°
+      // boundary, letting the compositor over-rotate and snap. flushSync drops
+      // the class within this handler, before the next paint.
+      flushSync(() => setSpinning(false));
     },
     [clearTimer]
   );
@@ -108,5 +132,5 @@ export function SpinningIcon({ icon: Icon, active, className, ...rest }: Spinnin
 
   useLayoutEffect(() => () => clearTimer(), [clearTimer]);
 
-  return <Icon ref={setSvgRef} className={cn(className, spinning && "animate-spin")} {...rest} />;
+  return <Icon {...rest} ref={setSvgRef} className={cn(className, spinning && "animate-spin")} />;
 }

--- a/src/components/ui/SpinningIcon.tsx
+++ b/src/components/ui/SpinningIcon.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import type { LucideIcon, LucideProps } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getPerformanceModeFloor, UI_SPIN_CYCLE_MS } from "@/lib/animationUtils";
+
+interface SpinningIconProps extends Omit<LucideProps, "ref"> {
+  /** The Lucide icon to render (e.g. `RefreshCw`). Rendered directly, so the
+   *  spin runs on the same `<svg>` the call site would have rendered itself —
+   *  no wrapping element, no changed transform origin. */
+  icon: LucideIcon;
+  /** True while the underlying operation is running. Drives the spin. */
+  active: boolean;
+}
+
+/**
+ * A refresh/reload icon that spins correctly: it always plays at least one full
+ * rotation, keeps spinning while `active`, and — crucially — finishes the
+ * current rotation before stopping rather than snapping back to 0°.
+ *
+ * The stop is driven by the icon's own `animationiteration` DOM event, not a
+ * wall-clock timer: the class is removed only at a true 360° boundary (visually
+ * identical to 0°), and the compositor's animation clock stays correct even when
+ * Chromium throttles background tabs. Requirement mapping:
+ *   - "≥1 full rotation even if the op resolves instantly": `spinning` is only
+ *     ever lowered at an iteration boundary or the backstop, so a same-tick
+ *     `active` true→false still runs a whole turn.
+ *   - "keep spinning while running": `active` holds `spinning` true.
+ *   - "finish the current rotation, never snap": the falling edge NEVER lowers
+ *     `spinning` in render — it only requests a stop at the next boundary.
+ *   - "never stuck forever": a one-shot backstop timer clears the spin when the
+ *     CSS animation is suppressed (reduced-motion / performance mode) and no
+ *     `animationiteration` event will ever fire.
+ *
+ * `spinning` is set true only by the rising-edge layout effect and false only by
+ * the iteration handler or the backstop — never transiently during a render, so
+ * the `animate-spin` class is present continuously from press to boundary.
+ */
+export function SpinningIcon({ icon: Icon, active, className, ...rest }: SpinningIconProps) {
+  const [spinning, setSpinning] = useState(active);
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // A stop was requested (active went false) but we're waiting for the current
+  // rotation to complete. Cleared when it does, or when active rises again.
+  const stopRequestedRef = useRef(false);
+  // Latest committed `spinning`, read by the falling-edge effect to decide
+  // whether there is anything to gracefully stop. Written during render so it is
+  // current by the time the layout effect runs.
+  const spinningRef = useRef(spinning);
+  spinningRef.current = spinning;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const handleIteration = useCallback(
+    (event: Event) => {
+      // Ignore a bubbling animation from a descendant or from a stale node that
+      // has already been swapped out.
+      if (event.target !== svgRef.current) return;
+      if (!stopRequestedRef.current) return;
+      stopRequestedRef.current = false;
+      clearTimer();
+      setSpinning(false);
+    },
+    [clearTimer]
+  );
+
+  const setSvgRef = useCallback(
+    (node: SVGSVGElement | null) => {
+      const previous = svgRef.current;
+      if (previous && previous !== node) {
+        previous.removeEventListener("animationiteration", handleIteration);
+      }
+      svgRef.current = node;
+      if (node) node.addEventListener("animationiteration", handleIteration);
+    },
+    [handleIteration]
+  );
+
+  useLayoutEffect(() => {
+    if (active) {
+      // Rising edge (or re-activation during the finishing tail): cancel any
+      // pending graceful stop and make sure we're spinning.
+      stopRequestedRef.current = false;
+      clearTimer();
+      setSpinning(true);
+      return;
+    }
+    // Falling edge: keep the class on (do NOT lower `spinning` here, or the
+    // animation would restart at 0° and snap). Request a stop at the next
+    // rotation boundary and arm a backstop for the case where the CSS animation
+    // is suppressed (reduced-motion / performance mode) and no boundary fires.
+    if (!spinningRef.current) return;
+    stopRequestedRef.current = true;
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      // A re-activation may have cancelled the stop between arming and firing.
+      if (!stopRequestedRef.current) return;
+      stopRequestedRef.current = false;
+      setSpinning(false);
+    }, getPerformanceModeFloor(UI_SPIN_CYCLE_MS));
+  }, [active, clearTimer]);
+
+  useLayoutEffect(() => () => clearTimer(), [clearTimer]);
+
+  return <Icon ref={setSvgRef} className={cn(className, spinning && "animate-spin")} {...rest} />;
+}

--- a/src/components/ui/__tests__/SpinningIcon.test.tsx
+++ b/src/components/ui/__tests__/SpinningIcon.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act, render, cleanup } from "@testing-library/react";
+import { RefreshCw } from "lucide-react";
+import { SpinningIcon } from "../SpinningIcon";
+import { UI_SPIN_CYCLE_MS } from "@/lib/animationUtils";
+
+/** The single spinning `<svg>` the component renders. */
+function svgOf(container: HTMLElement): SVGSVGElement {
+  const svg = container.querySelector("svg");
+  if (!svg) throw new Error("no svg rendered");
+  return svg;
+}
+
+function isSpinning(container: HTMLElement): boolean {
+  return svgOf(container).classList.contains("animate-spin");
+}
+
+/** jsdom never runs CSS animations, so the real `animationiteration` never
+ *  fires. Dispatch it manually at the rotation boundary the component waits on. */
+function fireIteration(target: Element): void {
+  act(() => {
+    target.dispatchEvent(new Event("animationiteration", { bubbles: true }));
+  });
+}
+
+describe("SpinningIcon", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("does not spin when inactive", () => {
+    const { container } = render(<SpinningIcon icon={RefreshCw} active={false} />);
+    expect(isSpinning(container)).toBe(false);
+  });
+
+  it("spins from the first render when mounted active", () => {
+    const { container } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    expect(isSpinning(container)).toBe(true);
+  });
+
+  it("starts spinning immediately on the rising edge", () => {
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={false} />);
+    expect(isSpinning(container)).toBe(false);
+    rerender(<SpinningIcon icon={RefreshCw} active={true} />);
+    expect(isSpinning(container)).toBe(true);
+  });
+
+  it("keeps spinning across rotation boundaries while active", () => {
+    const { container } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    const svg = svgOf(container);
+    fireIteration(svg);
+    fireIteration(svg);
+    expect(isSpinning(container)).toBe(true);
+  });
+
+  it("holds the spin past a fast completion until the next rotation boundary, then stops", () => {
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    const svg = svgOf(container);
+    // Operation resolves — but the current rotation must finish first.
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    expect(isSpinning(container)).toBe(true);
+    // The rotation completes: class is removed exactly at the 360° boundary.
+    fireIteration(svg);
+    expect(isSpinning(container)).toBe(false);
+  });
+
+  it("guarantees a rotation even when the active window is a single commit", () => {
+    // Models an instant refresh: active is observably true for exactly one
+    // render before flipping false. The spin must still hold until a boundary.
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={false} />);
+    rerender(<SpinningIcon icon={RefreshCw} active={true} />);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    expect(isSpinning(container)).toBe(true);
+    fireIteration(svgOf(container));
+    expect(isSpinning(container)).toBe(false);
+  });
+
+  it("only stops on the first boundary after the operation ends, not before", () => {
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    const svg = svgOf(container);
+    // Long operation: several boundaries pass while still active.
+    fireIteration(svg);
+    fireIteration(svg);
+    expect(isSpinning(container)).toBe(true);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    // Still spinning until the next boundary.
+    expect(isSpinning(container)).toBe(true);
+    fireIteration(svg);
+    expect(isSpinning(container)).toBe(false);
+  });
+
+  it("clears the spin via the backstop timer when no iteration event fires", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    expect(isSpinning(container)).toBe(true);
+    // Reduced-motion / performance mode suppresses the CSS animation, so no
+    // `animationiteration` ever fires — the backstop must release the spin.
+    act(() => {
+      vi.advanceTimersByTime(UI_SPIN_CYCLE_MS);
+    });
+    expect(isSpinning(container)).toBe(false);
+  });
+
+  it("does not stop early: the backstop has not fired before one full cycle", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    act(() => {
+      vi.advanceTimersByTime(UI_SPIN_CYCLE_MS - 1);
+    });
+    expect(isSpinning(container)).toBe(true);
+  });
+
+  it("cancels a pending stop when the operation restarts before completion", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    const svg = svgOf(container);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    // Re-activated during the finishing tail.
+    rerender(<SpinningIcon icon={RefreshCw} active={true} />);
+    // The stale stop request must not fire on the next boundary...
+    fireIteration(svg);
+    expect(isSpinning(container)).toBe(true);
+    // ...nor via the (now-cancelled) backstop timer.
+    act(() => {
+      vi.advanceTimersByTime(UI_SPIN_CYCLE_MS * 2);
+    });
+    expect(isSpinning(container)).toBe(true);
+  });
+
+  it("ignores an iteration bubbling from a descendant node", () => {
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    const svg = svgOf(container);
+    const child = svg.querySelector("path");
+    expect(child).not.toBeNull();
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    // A bubbling animationiteration whose target is a child <path>, not the
+    // spinning <svg>, must not be mistaken for the icon's own boundary.
+    if (child) fireIteration(child);
+    expect(isSpinning(container)).toBe(true);
+    // The real boundary (target === svg) still stops it.
+    fireIteration(svg);
+    expect(isSpinning(container)).toBe(false);
+  });
+
+  it("forwards Lucide props and merges className", () => {
+    const { container } = render(
+      <SpinningIcon icon={RefreshCw} active={true} className="w-3.5 h-3.5" size={14} />
+    );
+    const svg = svgOf(container);
+    expect(svg.classList.contains("w-3.5")).toBe(true);
+    expect(svg.classList.contains("h-3.5")).toBe(true);
+    expect(svg.classList.contains("animate-spin")).toBe(true);
+    expect(svg.getAttribute("width")).toBe("14");
+  });
+
+  it("clears the backstop timer on unmount", () => {
+    vi.useFakeTimers();
+    const { rerender, unmount } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+    // No pending timer callback fires into an unmounted tree.
+    act(() => {
+      vi.advanceTimersByTime(UI_SPIN_CYCLE_MS * 2);
+    });
+  });
+});

--- a/src/components/ui/__tests__/SpinningIcon.test.tsx
+++ b/src/components/ui/__tests__/SpinningIcon.test.tsx
@@ -169,4 +169,44 @@ describe("SpinningIcon", () => {
       vi.advanceTimersByTime(UI_SPIN_CYCLE_MS * 2);
     });
   });
+
+  it("collapses the backstop to 0ms under performance mode", () => {
+    vi.useFakeTimers();
+    document.body.dataset.performanceMode = "true";
+    try {
+      const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+      rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+      // Perf mode suppresses the CSS animation (no iteration event) AND collapses
+      // JS timers to 0 — so the spin releases on the next flush, not after a full
+      // 1s cycle. Advancing 1ms (far short of UI_SPIN_CYCLE_MS) proves the floor.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(isSpinning(container)).toBe(false);
+    } finally {
+      delete document.body.dataset.performanceMode;
+    }
+  });
+
+  it("ignores an animationiteration from a different animation on the same node", () => {
+    if (typeof AnimationEvent === "undefined") return; // jsdom without AnimationEvent
+    const { container, rerender } = render(<SpinningIcon icon={RefreshCw} active={true} />);
+    const svg = svgOf(container);
+    rerender(<SpinningIcon icon={RefreshCw} active={false} />);
+    // A second looping animation (not Tailwind's `spin`) reaching its own
+    // boundary must not stop the refresh spin at an arbitrary phase.
+    act(() => {
+      svg.dispatchEvent(
+        new AnimationEvent("animationiteration", { animationName: "pulse", bubbles: true })
+      );
+    });
+    expect(isSpinning(container)).toBe(true);
+    // The real `spin` boundary still stops it.
+    act(() => {
+      svg.dispatchEvent(
+        new AnimationEvent("animationiteration", { animationName: "spin", bubbles: true })
+      );
+    });
+    expect(isSpinning(container)).toBe(false);
+  });
 });

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -26,6 +26,7 @@ import {
   UI_ANIMATION_DURATION,
   UI_DOHERTY_THRESHOLD,
   UI_PALETTE_STALE_DELAY,
+  UI_SPIN_CYCLE_MS,
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
   UI_ENTER_EASING,
@@ -354,5 +355,32 @@ describe("panel-motion-tier CSS contract (#10704)", () => {
     const match = css.match(/--ease-out-expo\s*:\s*([^;]+);/);
     expect(match).not.toBeNull();
     expect(match?.[1]?.trim()).toBe(PANEL_RESTORE_EASING);
+  });
+});
+
+describe("UI_SPIN_CYCLE_MS ↔ Tailwind .animate-spin drift contract", () => {
+  // UI_SPIN_CYCLE_MS is the JS backstop that clears a spinning refresh icon when
+  // the CSS animation is suppressed (reduced-motion / performance mode) and no
+  // `animationiteration` event ever fires. It is only correct while it equals
+  // one real rotation of Tailwind's built-in `.animate-spin`. Tailwind owns that
+  // duration via `--animate-spin: spin <N>s linear infinite` in its shipped
+  // theme.css — a second, independent source of truth. Parse it and fail here if
+  // a Tailwind upgrade ever changes the spin duration out from under the
+  // constant, rather than shipping a backstop that stops mid-rotation.
+  const themeCss = readFileSync(
+    resolve(__dirname, "../../../node_modules/tailwindcss/theme.css"),
+    "utf8"
+  );
+
+  it("Tailwind declares --animate-spin as an infinite linear spin", () => {
+    expect(themeCss).toMatch(/--animate-spin\s*:\s*spin\s+[\d.]+s\s+linear\s+infinite/);
+  });
+
+  it("UI_SPIN_CYCLE_MS equals Tailwind's spin duration in milliseconds", () => {
+    const match = themeCss.match(/--animate-spin\s*:\s*spin\s+([\d.]+)s\b/);
+    expect(match).not.toBeNull();
+    if (!match?.[1]) return;
+    const tailwindMs = Math.round(Number.parseFloat(match[1]) * 1000);
+    expect(UI_SPIN_CYCLE_MS).toBe(tailwindMs);
   });
 });

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -384,3 +384,24 @@ describe("UI_SPIN_CYCLE_MS ↔ Tailwind .animate-spin drift contract", () => {
     expect(UI_SPIN_CYCLE_MS).toBe(tailwindMs);
   });
 });
+
+describe(".animate-spin suppression CSS contract (SpinningIcon backstop premise)", () => {
+  // SpinningIcon's JS backstop timer exists ONLY because reduced-motion and
+  // performance mode set `animation: none` on the spinning icon, so no
+  // `animationiteration` event ever fires to stop it at a rotation boundary.
+  // Guard that premise — if either rule stopped suppressing the animation, the
+  // backstop would be arming for a case that no longer needs it (harmless), but
+  // if BOTH the event and the suppression drifted, a real user could be stranded
+  // mid-spin. These assertions fail loudly if the suppression is removed.
+  const css = readFileSync(resolve(__dirname, "../../index.css"), "utf8");
+
+  it("reduced-motion neutralizes .animate-spin", () => {
+    expect(css).toMatch(/\.animate-spin\b[\s\S]{0,800}animation:\s*none/);
+  });
+
+  it("performance mode disables animation globally with !important", () => {
+    expect(css).toMatch(
+      /body\[data-performance-mode="true"\] \*[\s\S]*?animation:\s*none\s*!important/
+    );
+  });
+});

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -112,6 +112,17 @@ export const UI_INLINE_LOADING_GATE_MS = 200;
  *  Not an animation token — a perceptual floor, same family as the gates. */
 export const UI_SKELETON_FLOOR_MS = DURATION_250;
 
+/** One full rotation of Tailwind's built-in `.animate-spin` utility, which runs
+ *  `spin 1s linear infinite` (`--animate-spin` in tailwindcss/theme.css, not
+ *  overridden in this repo). `SpinningIcon` uses this as the backstop timer that
+ *  clears a spinning refresh icon when the CSS animation is suppressed
+ *  (reduced-motion / performance mode) and therefore never fires an
+ *  `animationiteration` event to stop it at a rotation boundary. Pinned to
+ *  Tailwind's duration; the drift-contract test in animationUtils.test.ts parses
+ *  theme.css and fails if the two diverge. Not a design-motion token — a
+ *  mechanism constant coupled to a third-party default. */
+export const UI_SPIN_CYCLE_MS = 1_000;
+
 /** Feedback-hint window for direct user actions (e.g. `Button`'s `loading`
  *  state). Distinct in role from the skeleton/Doherty gates: those *delay*
  *  showing a placeholder to avoid flicker on background work, whereas a

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -4,6 +4,7 @@ import { basename, join } from "@shared/utils/path";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
@@ -107,13 +108,14 @@ export function FileBrowserPane({
 
   const stableExpandedPaths = useMemo(() => expandedPaths ?? EMPTY_PATHS, [expandedPaths]);
 
-  const { rows, isInitialLoading, rootError, ensureLoaded, refresh } = useFileBrowserTree({
-    worktreeId,
-    expandedPaths: stableExpandedPaths,
-    showIgnored,
-    rootPath,
-    changeTick,
-  });
+  const { rows, isInitialLoading, rootError, ensureLoaded, refresh, isRefreshing } =
+    useFileBrowserTree({
+      worktreeId,
+      expandedPaths: stableExpandedPaths,
+      showIgnored,
+      rootPath,
+      changeTick,
+    });
 
   const handleToggleExpanded = useCallback(
     (path: string, expand: boolean) => {
@@ -149,7 +151,7 @@ export function FileBrowserPane({
   const [manualRefreshNonce, setManualRefreshNonce] = useState(0);
   const handleRefresh = useCallback(() => {
     setManualRefreshNonce((nonce) => nonce + 1);
-    refresh();
+    refresh({ manual: true });
   }, [refresh]);
 
   // One value per refresh *cycle*, not per directory listed. Deriving it from
@@ -401,7 +403,7 @@ export function FileBrowserPane({
               <EyeOff className="h-3.5 w-3.5" />
             </FileViewerToolbar.IconButton>
             <FileViewerToolbar.IconButton label="Refresh" onClick={handleRefresh}>
-              <RefreshCw className="h-3.5 w-3.5" />
+              <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-3.5 w-3.5" />
             </FileViewerToolbar.IconButton>
           </div>
           {renderTree()}

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -824,4 +824,172 @@ describe("useFileBrowserTree", () => {
       expect(listDirectory.mock.calls.some((call) => call[0].worktreeId === "wt-1")).toBe(false);
     });
   });
+
+  it("raises isRefreshing while a manual refresh is in flight, then clears it on drain", async () => {
+    listDirectory.mockResolvedValue([file("a.ts")]);
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        showIgnored: false,
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.isRefreshing).toBe(false);
+
+    const slow = deferred<FileTreeNode[]>();
+    listDirectory.mockReturnValueOnce(slow.promise);
+    act(() => {
+      result.current.refresh({ manual: true });
+    });
+    // The re-list is still reading the disk — the toolbar icon must spin.
+    expect(result.current.isRefreshing).toBe(true);
+
+    await act(async () => {
+      slow.resolve([file("a.ts")]);
+    });
+    await waitFor(() => expect(result.current.isRefreshing).toBe(false));
+  });
+
+  it("leaves isRefreshing dormant for a passive change-tick refresh", async () => {
+    listDirectory.mockResolvedValue([file("v1.ts")]);
+
+    const { result, rerender } = renderHook(
+      (props: { changeTick: number }) =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: props.changeTick,
+        }),
+      { initialProps: { changeTick: 1 } }
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+
+    const slow = deferred<FileTreeNode[]>();
+    listDirectory.mockReturnValueOnce(slow.promise);
+    rerender({ changeTick: 2 });
+    await waitFor(() => expect(listDirectory).toHaveBeenCalledTimes(2));
+
+    // A background refresh must not spin the manual Refresh icon on every
+    // filesystem change.
+    expect(result.current.isRefreshing).toBe(false);
+    await act(async () => {
+      slow.resolve([file("v2.ts")]);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("leaves isRefreshing dormant for a non-manual refresh() call", async () => {
+    listDirectory.mockResolvedValue([file("a.ts")]);
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        showIgnored: false,
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+
+    const slow = deferred<FileTreeNode[]>();
+    listDirectory.mockReturnValueOnce(slow.promise);
+    act(() => {
+      result.current.refresh();
+    });
+    expect(result.current.isRefreshing).toBe(false);
+
+    await act(async () => {
+      slow.resolve([file("a.ts")]);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("holds isRefreshing across a collision replay until the final drain", async () => {
+    listDirectory.mockResolvedValue([file("v1.ts")]);
+
+    const { result, rerender } = renderHook(
+      (props: { changeTick: number }) =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: props.changeTick,
+        }),
+      { initialProps: { changeTick: 1 } }
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+
+    // A background refresh's root re-list is held open.
+    const slowBg = deferred<FileTreeNode[]>();
+    listDirectory.mockReturnValueOnce(slowBg.promise);
+    rerender({ changeTick: 2 });
+    await waitFor(() => expect(listDirectory).toHaveBeenCalledTimes(2));
+
+    // The user presses Refresh while that re-list is still in flight. Its target
+    // collides, so the actual re-run is deferred — but the spin starts now.
+    act(() => {
+      result.current.refresh({ manual: true });
+    });
+    expect(result.current.isRefreshing).toBe(true);
+
+    // The deferred replay's listing.
+    const replay = deferred<FileTreeNode[]>();
+    listDirectory.mockReturnValueOnce(replay.promise);
+
+    // Background listing settles → the collision replay is enqueued and starts.
+    // Work is still pending, so the spin must not stop here.
+    await act(async () => {
+      slowBg.resolve([file("v2.ts")]);
+    });
+    expect(result.current.isRefreshing).toBe(true);
+
+    // The replay finally settles → the manual refresh cycle ends.
+    await act(async () => {
+      replay.resolve([file("v3.ts")]);
+    });
+    await waitFor(() => expect(result.current.isRefreshing).toBe(false));
+  });
+
+  it("clears an in-flight manual refresh's spin when the worktree switches", async () => {
+    const slow = deferred<FileTreeNode[]>();
+    listDirectory.mockResolvedValue([file("a.ts")]);
+
+    const { result, rerender } = renderHook(
+      (props: { worktreeId: string }) =>
+        useFileBrowserTree({
+          worktreeId: props.worktreeId,
+          expandedPaths: [],
+          showIgnored: false,
+          changeTick: undefined,
+        }),
+      { initialProps: { worktreeId: "wt-1" } }
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+
+    listDirectory.mockReturnValueOnce(slow.promise);
+    act(() => {
+      result.current.refresh({ manual: true });
+    });
+    expect(result.current.isRefreshing).toBe(true);
+
+    // Switching worktrees abandons the in-flight refresh; the spin must not
+    // survive the identity reset.
+    listDirectory.mockResolvedValue([file("b.ts")]);
+    rerender({ worktreeId: "wt-2" });
+    expect(result.current.isRefreshing).toBe(false);
+
+    await act(async () => {
+      slow.resolve([file("a.ts")]);
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
 });

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -63,8 +63,18 @@ export interface UseFileBrowserTreeResult {
   rootError: string | null;
   /** Fetch a directory if it isn't already loaded or in flight. */
   ensureLoaded: (dirPath: string) => void;
-  /** Re-list the root and every reachable expanded directory. */
-  refresh: () => void;
+  /**
+   * Re-list the root and every reachable expanded directory. Pass
+   * `{ manual: true }` for a user-initiated refresh so the toolbar spinner
+   * runs; background (change-tick) refreshes leave it dormant.
+   */
+  refresh: (options?: { manual?: boolean }) => void;
+  /**
+   * True while a *manual* refresh's listings are still in flight. Drives the
+   * toolbar Refresh spinner; stays false for passive change-tick refreshes so
+   * the button doesn't spin on every filesystem change.
+   */
+  isRefreshing: boolean;
 }
 
 interface QueueEntry {
@@ -102,6 +112,11 @@ export function useFileBrowserTree({
   const [loadingPaths, setLoadingPaths] = useState<ReadonlySet<string>>(new Set());
   const [rootError, setRootError] = useState<string | null>(null);
   const [hasLoadedRoot, setHasLoadedRoot] = useState(false);
+  // True from a manual refresh press until its listings fully drain. A ref
+  // mirrors it so the drain check in `pump` (which runs off refs, not state)
+  // can decide whether a completed drain belongs to a manual refresh.
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const isRefreshingRef = useRef(false);
 
   // Generation counter, bumped whenever the identity of what we are listing
   // changes (worktree switch, ignored-filter flip). Every in-flight response
@@ -308,6 +323,19 @@ export function useFileBrowserTree({
         generation
       );
       pumpRef.current();
+    } else if (
+      isRefreshingRef.current &&
+      physicalInFlightRef.current === 0 &&
+      queueRef.current.length === 0 &&
+      rootRetryTimerRef.current === null
+    ) {
+      // A manual refresh's listings have fully drained (no deferred replay per
+      // the branch above, and no silent root-retry still armed) — end the spin
+      // cycle. `else if` keeps the flag up while a collision replay is still
+      // queued; the `rootRetryTimerRef` guard keeps it up across a transient
+      // root failure's backoff so the spin doesn't stop then resume on retry.
+      isRefreshingRef.current = false;
+      setIsRefreshing(false);
     }
   }, [fetchDirectory, enqueueTargets, rootPath]);
 
@@ -358,18 +386,29 @@ export function useFileBrowserTree({
     [enqueueTargets, pump]
   );
 
-  const refresh = useCallback((): void => {
-    const generation = generationRef.current;
-    const targets = refreshTargets(listingsRef.current, expandedSetRef.current, rootPath);
-    // A target already in flight read the filesystem before this refresh was
-    // asked for, so its result may not reflect the change that triggered us.
-    // Defer rather than accept that response as final.
-    if (targets.some((target) => inFlightRef.current.has(target))) {
-      refreshPendingRef.current = true;
-    }
-    enqueueTargets(targets, generation);
-    pump();
-  }, [enqueueTargets, pump, rootPath]);
+  const refresh = useCallback(
+    (options?: { manual?: boolean }): void => {
+      const generation = generationRef.current;
+      const targets = refreshTargets(listingsRef.current, expandedSetRef.current, rootPath);
+      // A user press should spin the toolbar icon until the re-list drains. Set
+      // this before `pump` so the flag is up if fetches start synchronously; a
+      // no-op refresh (no worktree, no targets) drains inside `pump` and clears
+      // it again in the same batch, so the icon never flickers.
+      if (options?.manual) {
+        isRefreshingRef.current = true;
+        setIsRefreshing(true);
+      }
+      // A target already in flight read the filesystem before this refresh was
+      // asked for, so its result may not reflect the change that triggered us.
+      // Defer rather than accept that response as final.
+      if (targets.some((target) => inFlightRef.current.has(target))) {
+        refreshPendingRef.current = true;
+      }
+      enqueueTargets(targets, generation);
+      pump();
+    },
+    [enqueueTargets, pump, rootPath]
+  );
 
   // Identity reset. Flipping the ignored filter changes what every listing
   // contains, not just the root, so the whole cache is dropped rather than
@@ -383,6 +422,11 @@ export function useFileBrowserTree({
     inFlightRef.current.clear();
     queueRef.current = [];
     refreshPendingRef.current = false;
+    // A worktree switch abandons any in-flight manual refresh; its drain will
+    // never complete for this identity, so end the spin here rather than leave
+    // the icon stuck.
+    isRefreshingRef.current = false;
+    setIsRefreshing(false);
     setListings(new Map());
     setLoadingPaths(new Set());
     setRootError(null);
@@ -444,6 +488,7 @@ export function useFileBrowserTree({
     rootError,
     ensureLoaded,
     refresh,
+    isRefreshing,
   };
 }
 

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -28,6 +28,7 @@ import { isImageFilePath, isSvgFilePath } from "@/components/FileViewer/filePrev
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 import { formatBytes } from "@/lib/formatBytes";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
+import { SpinningIcon } from "@/components/ui/SpinningIcon";
 import { useDiffContent } from "@/panels/diff/useDiffContent";
 import type { DiffSubject } from "@/panels/diff/diffContentCache";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -358,6 +359,10 @@ export function FilePane({
   // re-navigates — a rewritten report re-renders on refresh/focus. Bumping on
   // every load, not just entry-file changes, keeps relative assets fresh too.
   const [reloadNonce, setReloadNonce] = useState(0);
+  // Which surface a toolbar Refresh press is currently spinning for (or null).
+  // The mode is captured at click so a mode switch mid-refresh doesn't settle
+  // the spin against the wrong signal. Drives the shared SpinningIcon.
+  const [refreshingMode, setRefreshingMode] = useState<FileViewMode | null>(null);
 
   const metadata = useMemo(() => {
     if (loadState !== "loaded" || content === null) return null;
@@ -463,6 +468,23 @@ export function FilePane({
   useEffect(() => {
     loadFile(false);
   }, [loadFile]);
+
+  // Toolbar Refresh: spin the icon until the refreshed surface settles. Capture
+  // the mode at press time so switching source⇄diff mid-refresh can't clear the
+  // spin against the wrong signal. A synchronous branch (image/svg, or an
+  // already-loaded diff) settles the same tick — SpinningIcon still guarantees a
+  // full rotation from the single active render.
+  const handleToolbarRefresh = useCallback(() => {
+    setRefreshingMode(viewMode);
+    if (viewMode === "diff") retryDiff();
+    else loadFile(false);
+  }, [viewMode, retryDiff, loadFile]);
+
+  useEffect(() => {
+    if (refreshingMode === null) return;
+    const settled = refreshingMode === "diff" ? diffContent !== undefined : loadState !== "loading";
+    if (settled) setRefreshingMode(null);
+  }, [refreshingMode, diffContent, loadState]);
 
   // Leaving Diff — by choice or because the change vanished — lands on source
   // cached before the edit that prompted the diff in the first place. Re-read it
@@ -609,11 +631,8 @@ export function FilePane({
           )}
           {/* Refresh follows what's on screen — re-reading the file wouldn't
               refetch a diff, and vice versa. */}
-          <FileViewerToolbar.IconButton
-            label="Refresh"
-            onClick={() => (viewMode === "diff" ? retryDiff() : loadFile(false))}
-          >
-            <RefreshCw className="w-4 h-4" />
+          <FileViewerToolbar.IconButton label="Refresh" onClick={handleToolbarRefresh}>
+            <SpinningIcon icon={RefreshCw} active={refreshingMode !== null} className="w-4 h-4" />
           </FileViewerToolbar.IconButton>
           <FileViewerToolbar.IconButton
             label={openTarget === "browser" ? "Open in browser" : "Open in editor"}

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -482,9 +482,17 @@ export function FilePane({
 
   useEffect(() => {
     if (refreshingMode === null) return;
-    const settled = refreshingMode === "diff" ? diffContent !== undefined : loadState !== "loading";
+    // The refreshed surface is no longer on screen (mode switched, or diff mode
+    // clamped away when the change vanished) → the spin is moot, disarm it. This
+    // also covers an abandoned diff: `diffSubject` going null leaves diffContent
+    // `undefined` forever, which would otherwise strand the spin on "diff".
+    const settled =
+      refreshingMode !== viewMode ||
+      (refreshingMode === "diff"
+        ? diffSubject === null || diffContent !== undefined
+        : loadState !== "loading");
     if (settled) setRefreshingMode(null);
-  }, [refreshingMode, diffContent, loadState]);
+  }, [refreshingMode, viewMode, diffSubject, diffContent, loadState]);
 
   // Leaving Diff — by choice or because the change vanished — lands on source
   // cached before the edit that prompted the diff in the first place. Re-read it

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1086,3 +1086,73 @@ describe("FilePane diff mode (#11274)", () => {
     });
   });
 });
+
+describe("FilePane toolbar refresh spin (#11323)", () => {
+  function deferredValue<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  function renderFilePane() {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/src/index.ts" };
+    return render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="index.ts"
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  function refreshIcon(container: HTMLElement): SVGSVGElement {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Refresh"
+    );
+    if (!button) throw new Error("Refresh button not rendered");
+    const svg = button.querySelector("svg");
+    if (!svg) throw new Error("Refresh icon not rendered");
+    return svg;
+  }
+
+  it("spins while a source refresh is in flight, then finishes the rotation once it settles", async () => {
+    readMock.mockReset();
+    readMock.mockResolvedValueOnce({ content: "v1" });
+    const { container } = renderFilePane();
+
+    // Initial load settles with no refresh in progress — the icon is still.
+    await waitFor(() =>
+      expect(refreshIcon(container).classList.contains("animate-spin")).toBe(false)
+    );
+
+    // The refresh read is held open so the operation is observably "running".
+    const pending = deferredValue<{ content: string }>();
+    readMock.mockReturnValueOnce(pending.promise);
+    await act(async () => {
+      Array.from(container.querySelectorAll("button"))
+        .find((b) => b.getAttribute("aria-label") === "Refresh")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(refreshIcon(container).classList.contains("animate-spin")).toBe(true);
+
+    // The read settles: the spin request is released, but the class must remain
+    // until the rotation boundary rather than snapping back mid-turn.
+    await act(async () => {
+      pending.resolve({ content: "v2" });
+    });
+    expect(refreshIcon(container).classList.contains("animate-spin")).toBe(true);
+
+    // The rotation completes → the icon stops at 0°.
+    act(() => {
+      refreshIcon(container).dispatchEvent(new Event("animationiteration", { bubbles: true }));
+    });
+    expect(refreshIcon(container).classList.contains("animate-spin")).toBe(false);
+  });
+});

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1096,9 +1096,8 @@ describe("FilePane toolbar refresh spin (#11323)", () => {
     return { promise, resolve };
   }
 
-  function renderFilePane() {
-    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/src/index.ts" };
-    return render(
+  function paneForRefresh() {
+    return (
       <TooltipProvider>
         <FilePane
           id="file-1"
@@ -1110,6 +1109,11 @@ describe("FilePane toolbar refresh spin (#11323)", () => {
         />
       </TooltipProvider>
     );
+  }
+
+  function renderFilePane() {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/src/index.ts" };
+    return render(paneForRefresh());
   }
 
   function refreshIcon(container: HTMLElement): SVGSVGElement {
@@ -1150,6 +1154,53 @@ describe("FilePane toolbar refresh spin (#11323)", () => {
     expect(refreshIcon(container).classList.contains("animate-spin")).toBe(true);
 
     // The rotation completes → the icon stops at 0°.
+    act(() => {
+      refreshIcon(container).dispatchEvent(new Event("animationiteration", { bubbles: true }));
+    });
+    expect(refreshIcon(container).classList.contains("animate-spin")).toBe(false);
+  });
+
+  it("does not strand the spin when a diff refresh is abandoned before it resolves (#11323)", async () => {
+    // A modified file so Diff mode is available; the diff never resolves
+    // (content stays undefined), the exact shape that stranded the old predicate.
+    worktreeState.worktrees.set("wt-1", {
+      path: "/repo",
+      worktreeChanges: { changes: [{ path: "/repo/src/index.ts", status: "modified" }] },
+    });
+    useDiffContentMock.mockReturnValue({ content: undefined, stale: false, retry: vi.fn() });
+    readMock.mockReset();
+    readMock.mockResolvedValue({ content: "v1" });
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: "/repo/src/index.ts",
+      worktreeId: "wt-1",
+      fileViewMode: "diff",
+    };
+    const { container, rerender } = render(paneForRefresh());
+    await act(async () => {});
+
+    // Refresh while the diff is still loading → the icon spins.
+    await act(async () => {
+      Array.from(container.querySelectorAll("button"))
+        .find((b) => b.getAttribute("aria-label") === "Refresh")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(refreshIcon(container).classList.contains("animate-spin")).toBe(true);
+
+    // Abandon the diff by switching to Source before it ever resolves. The old
+    // `diffContent !== undefined` predicate would wait forever; the spin must
+    // release instead of being stranded.
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: "/repo/src/index.ts",
+      worktreeId: "wt-1",
+      fileViewMode: "source",
+    };
+    rerender(paneForRefresh());
+    await act(async () => {});
+
     act(() => {
       refreshIcon(container).dispatchEvent(new Event("animationiteration", { bubbles: true }));
     });


### PR DESCRIPTION
## Summary

- The file browser panel's refresh button had no spin animation at all, and the worktree sidebar's refresh button snapped back to 0° mid-rotation, because both toggled the `animate-spin` class off at an arbitrary point in the cycle.
- Adds a shared `SpinningIcon` component: it always completes at least one full rotation, keeps spinning while the operation is active, and only stops at a real 360° boundary via the `animationiteration` DOM event, never a mid-turn snap.
- A backstop timer (`UI_SPIN_CYCLE_MS`, pinned to Tailwind's `animate-spin` duration via a drift test) clears the spin if reduced-motion or performance mode suppresses the CSS animation and no iteration event fires, so it can't get stuck spinning forever.

Resolves #11323

## Changes

- `src/components/ui/SpinningIcon.tsx` + `src/lib/animationUtils.ts`: new shared primitive and `UI_SPIN_CYCLE_MS` constant.
- Wired into every refresh button called out in the issue: `FileBrowserPane`, `FilePane` (including diff mode), `SidebarContent`, `EditorIntegrationTab`, `ReviewHubContent`, `PluginMcpServersSection`, `PluginDetailPane`, `AgentCard`, `WhySlowContent`, `ProjectPulseCard`.
- `useFileBrowserTree` gains a manual-gated `isRefreshing` flag so the file browser's refresh button, which previously had no feedback at all, now spins.
- `FilePane` gets an armed refresh signal that captures the active mode, so the spin disarms correctly when the refreshed surface leaves screen or a diff's subject vanishes mid-load, instead of stranding the spin.
- Sidebar drops its old `useSkeletonDisplayFloor` wall-clock floor, since it floored duration rather than rotation phase and the snap could still happen; its `headerReveal` test is rewritten and scoped to the header slice.
- Hardening pass: `flushSync` on the spin-stop at the rotation boundary (a non-discrete `animationiteration` can't commit a frame late into an over-rotation snap), guard the iteration handler on `animationName === 'spin'` (a second animation on the same SVG can't stop the spin at the wrong phase), and spread `{...rest}` before the internal ref/className so a caller-supplied ref can't clobber the listener.

## Testing

- New unit tests for `SpinningIcon` covering the rotation-boundary stop, the backstop timer, reduced-motion/performance-mode suppression, and foreign-animation guarding.
- Updated/added tests for `useFileBrowserTree`, `FilePane`, and the sidebar wiring, including the diff-refresh-abandon case.
- Full local test suite, typecheck, and lint pass.