### PR TITLE
feat(file-browser): collapsible tree sidebar and aligned headers

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -272,6 +272,8 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
   browserShowIgnored?: boolean;
   /** Worktree-relative directory to root the tree at; "" or absent = worktree root */
   browserRootPath?: string;
+  /** Whether the tree sidebar starts collapsed; absent or false = open */
+  browserSidebarCollapsed?: boolean;
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -704,10 +704,10 @@ export interface DiffPanelData extends BasePanelData {
  * absolute (the root comes from `worktreeId`, like `DiffPanelData.filePath`),
  * so moving or renaming the worktree can't strand the panel on a dead path.
  *
- * All three fields persist: the issue's contract is that a pinned panel keeps
- * its expansion and selection, and `promoteDialogPanelToGrid` reuses the same
- * panel record, so anything stored here also survives dialog → grid promotion
- * without a side channel.
+ * Every field persists: the issue's contract is that a pinned panel keeps its
+ * expansion, selection and layout, and `promoteDialogPanelToGrid` reuses the
+ * same panel record, so anything stored here also survives dialog → grid
+ * promotion without a side channel.
  */
 export interface FileBrowserPanelData extends BasePanelData {
   kind: "file-browser";
@@ -725,6 +725,11 @@ export interface FileBrowserPanelData extends BasePanelData {
    * worktree root itself.
    */
   browserRootPath?: string;
+  /**
+   * Whether the tree sidebar is collapsed. Absent or `false` = open (the
+   * default); only `true` is persisted, so an open panel stays sparse.
+   */
+  browserSidebarCollapsed?: boolean;
 }
 
 export type PanelInstance =

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -167,6 +167,8 @@ export interface PanelSnapshot {
   browserShowIgnored?: boolean;
   /** Worktree-relative directory a file browser panel is rooted at */
   browserRootPath?: string;
+  /** Whether a file browser panel's tree sidebar is collapsed (only `true` persisted) */
+  browserSidebarCollapsed?: boolean;
   /** Legacy pre-file-panel field: absolute path shown in a markdown panel */
   markdownFilePath?: string;
   /** Legacy pre-file-panel field: markdown panel view mode */

--- a/src/components/FileViewer/FileViewerToolbar.tsx
+++ b/src/components/FileViewer/FileViewerToolbar.tsx
@@ -158,16 +158,35 @@ function IconButton({
   label,
   onClick,
   pressed,
+  expanded,
+  controls,
+  sidebarToggle,
   children,
   "data-testid": testId,
 }: {
   label: string;
   onClick: () => void;
-  /** Renders the button as a toggle with a pressed state. */
+  /** Renders the button as a toggle with an `aria-pressed` state. */
   pressed?: boolean;
+  /**
+   * Renders the button as a disclosure control with `aria-expanded` (show/hide
+   * a region), the WAI-ARIA APG pattern for a collapsible sidebar. Mutually
+   * exclusive with `pressed` — never set both, so the button carries one role.
+   */
+  expanded?: boolean;
+  /** id of the region a disclosure button controls; omit while that region is unmounted. */
+  controls?: string;
+  /**
+   * Opts the button out of the persistent `toolbar-icon-button` armed chip via
+   * `data-sidebar-toggle` (see `toolbar.css`): a sidebar toggle sits in its
+   * "on" state almost always, so the icon swap, not a lit background, carries
+   * the state.
+   */
+  sidebarToggle?: boolean;
   children: React.ReactNode;
   "data-testid"?: string;
 }) {
+  const active = pressed === true || expanded === true;
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -176,10 +195,13 @@ function IconButton({
           onClick={onClick}
           aria-label={label}
           aria-pressed={pressed}
+          aria-expanded={expanded}
+          aria-controls={controls}
+          data-sidebar-toggle={sidebarToggle ? "" : undefined}
           data-testid={testId}
           className={cn(
             "toolbar-icon-button p-1.5 rounded",
-            pressed ? "text-daintree-text" : "text-daintree-text/60"
+            active ? "text-daintree-text" : "text-daintree-text/60"
           )}
         >
           {children}

--- a/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
@@ -253,4 +253,41 @@ describe("FileViewerToolbar.IconButton", () => {
       screen.getByRole("button", { name: "Wrap long lines" }).getAttribute("aria-pressed")
     ).toBe("true");
   });
+
+  it("renders as a disclosure with aria-expanded/aria-controls instead of aria-pressed (#11328)", () => {
+    render(
+      <FileViewerToolbar.IconButton
+        label="Toggle file tree"
+        onClick={vi.fn()}
+        expanded
+        controls="tree-region"
+        sidebarToggle
+      >
+        <svg />
+      </FileViewerToolbar.IconButton>
+    );
+
+    const button = screen.getByRole("button", { name: "Toggle file tree" });
+    // Disclosure semantics: expanded/controls present, pressed absent so it
+    // isn't announced as a two-state toggle button.
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(button.getAttribute("aria-controls")).toBe("tree-region");
+    expect(button.hasAttribute("aria-pressed")).toBe(false);
+    // Opts out of the persistent toolbar armed chip (toolbar.css).
+    expect(button.hasAttribute("data-sidebar-toggle")).toBe(true);
+  });
+
+  it("omits aria-controls when the disclosed region is unmounted", () => {
+    render(
+      <FileViewerToolbar.IconButton label="Toggle file tree" onClick={vi.fn()} expanded={false}>
+        <svg />
+      </FileViewerToolbar.IconButton>
+    );
+
+    const button = screen.getByRole("button", { name: "Toggle file tree" });
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    // A dangling aria-controls would point at a collapsed (removed) region.
+    expect(button.hasAttribute("aria-controls")).toBe(false);
+    expect(button.hasAttribute("data-sidebar-toggle")).toBe(false);
+  });
 });

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -228,16 +228,28 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
       expect(sidebarBlock![0]).toContain("aria-pressed={!isFocusMode}");
     });
 
-    it("carves the sidebar toggle out of the armed aria-pressed rule in toolbar.css", async () => {
+    it("carves both sidebar toggles out of the armed rules in toolbar.css (#8357, #11328)", async () => {
       const css = await fs.readFile(TOOLBAR_CSS_PATH, "utf-8");
-      expect(css).toContain(
-        '.toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle]))'
+      // The app sidebar toggle uses aria-pressed; the file-browser tree toggle
+      // uses aria-expanded (a disclosure). Both carry data-sidebar-toggle and
+      // must be excluded so neither shows a persistent armed chip.
+      const pressedOptOut = css.match(
+        /\.toolbar-icon-button\[aria-pressed="true"\]:where\(:not\(\[data-sidebar-toggle\]\)\)/g
       );
-      // The carve-out must not regress to an un-excluded standalone selector.
+      const expandedOptOut = css.match(
+        /\.toolbar-icon-button\[aria-expanded="true"\]:where\(:not\(\[data-sidebar-toggle\]\)\)/g
+      );
+      // Relational invariant: wherever the pressed rule is carved out (base,
+      // light, forced-colors), the expanded rule is too — so reverting one
+      // block's aria-expanded selector to the un-excluded form fails here.
+      expect(expandedOptOut?.length ?? 0).toBeGreaterThan(0);
+      expect(expandedOptOut?.length).toBe(pressedOptOut?.length);
+      // Neither icon-button carve-out may regress to an un-excluded standalone selector.
       expect(css).not.toMatch(/\.toolbar-icon-button\[aria-pressed="true"\],/);
-      // Other armed selectors stay intact so dropdowns/agent buttons keep the highlight.
-      expect(css).toContain('.toolbar-icon-button[aria-expanded="true"]');
+      expect(css).not.toMatch(/\.toolbar-icon-button\[aria-expanded="true"\],/);
+      // Agent-button armed selectors stay intact so dropdowns keep the highlight.
       expect(css).toContain('.toolbar-agent-button[aria-pressed="true"]');
+      expect(css).toContain('.toolbar-agent-button[aria-expanded="true"]');
     });
   });
 

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -185,9 +185,9 @@ describe("panelKindSerialisers", () => {
     it("restores a collapsed sidebar only from a literal true", () => {
       // Only `true` collapses; `false` and absent are the open default, and a
       // corrupted string/object must fall back to open rather than crash the pane.
-      expect(deserialize()({ id: "fb1", browserSidebarCollapsed: true }).browserSidebarCollapsed).toBe(
-        true
-      );
+      expect(
+        deserialize()({ id: "fb1", browserSidebarCollapsed: true }).browserSidebarCollapsed
+      ).toBe(true);
       expect(
         deserialize()({ id: "fb1", browserSidebarCollapsed: false }).browserSidebarCollapsed
       ).toBeUndefined();

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -181,6 +181,21 @@ describe("panelKindSerialisers", () => {
         false
       );
     });
+
+    it("restores a collapsed sidebar only from a literal true", () => {
+      // Only `true` collapses; `false` and absent are the open default, and a
+      // corrupted string/object must fall back to open rather than crash the pane.
+      expect(deserialize()({ id: "fb1", browserSidebarCollapsed: true }).browserSidebarCollapsed).toBe(
+        true
+      );
+      expect(
+        deserialize()({ id: "fb1", browserSidebarCollapsed: false }).browserSidebarCollapsed
+      ).toBeUndefined();
+      expect(
+        deserialize()({ id: "fb1", browserSidebarCollapsed: "yes" }).browserSidebarCollapsed
+      ).toBeUndefined();
+      expect(deserialize()({ id: "fb1" }).browserSidebarCollapsed).toBeUndefined();
+    });
   });
 
   describe("unknown kind", () => {

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -150,6 +150,9 @@ const BUILT_IN_DESERIALIZERS = {
     browserShowIgnored:
       typeof saved.browserShowIgnored === "boolean" ? saved.browserShowIgnored : undefined,
     browserRootPath: canonicalRelativePath(saved.browserRootPath),
+    // Only a literal `true` restores collapsed: a hand-edited or corrupted
+    // snapshot holding a string or object must fall back to the open default.
+    browserSidebarCollapsed: saved.browserSidebarCollapsed === true ? true : undefined,
   }),
   diff: (saved) => ({
     filePath: saved.filePath,

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -274,12 +274,13 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   isVisible: false,
   extensionState: false,
   pluginId: false,
-  // FileBrowserPanelData persisted fields — all four are user intent (where
-  // they are in the tree), which is exactly what a pinned panel must keep.
+  // FileBrowserPanelData persisted fields — all user intent (where they are in
+  // the tree and how it's laid out), which is exactly what a pinned panel keeps.
   browserSelectedPath: true,
   browserExpandedPaths: true,
   browserShowIgnored: true,
   browserRootPath: true,
+  browserSidebarCollapsed: true,
   // BasePanelData carrier-bookkeeping timestamps — written by the base
   // serialization layer in panelToSnapshot, not per-kind serializers.
   createdAt: false,
@@ -455,6 +456,7 @@ const fileBrowserFixture: FileBrowserPanelData = {
   browserExpandedPaths: ["src"],
   browserShowIgnored: true,
   browserRootPath: "src",
+  browserSidebarCollapsed: true,
 };
 
 const savedFileBrowser: SavedTerminalData = {
@@ -464,6 +466,7 @@ const savedFileBrowser: SavedTerminalData = {
   browserExpandedPaths: ["src"],
   browserShowIgnored: true,
   browserRootPath: "src",
+  browserSidebarCollapsed: true,
 };
 
 const diffFixture: DiffPanelData = {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { CornerLeftUp, EyeOff, FolderRoot, FolderTree, RefreshCw } from "lucide-react";
 import { basename, join } from "@shared/utils/path";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
@@ -87,6 +87,15 @@ export function FileBrowserPane({
       [id]
     )
   );
+  const sidebarCollapsed = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser" ? panel.browserSidebarCollapsed === true : false;
+      },
+      [id]
+    )
+  );
 
   // Resolved fresh from the worktree store rather than persisted, so a rename
   // or move is reflected without restarting the panel.
@@ -162,6 +171,13 @@ export function FileBrowserPane({
   const handleToggleIgnored = useCallback(() => {
     setFileBrowserView(id, { browserShowIgnored: !showIgnored });
   }, [id, showIgnored, setFileBrowserView]);
+
+  // Stable id for the tree column so the toggle's `aria-controls` can name the
+  // region it discloses. Only referenced while the column is mounted (open).
+  const treeSidebarId = useId();
+  const handleToggleSidebar = useCallback(() => {
+    setFileBrowserView(id, { browserSidebarCollapsed: !sidebarCollapsed });
+  }, [id, sidebarCollapsed, setFileBrowserView]);
 
   const handleSetRoot = useCallback(
     (path: string) => {
@@ -365,49 +381,62 @@ export function FileBrowserPane({
           on the AppDialog surface — so a plain flex-1/min-h-0 chain fills it
           without the content-sized-parent collapse trap. */}
       <div className="flex min-h-0 w-full flex-1 bg-daintree-bg">
-        <div
-          ref={treeColumnRef}
-          className="flex min-h-0 w-72 shrink-0 flex-col self-stretch border-r border-daintree-border bg-daintree-sidebar"
-        >
-          <div className="flex shrink-0 items-center gap-0.5 border-b border-daintree-border px-1.5 py-1">
-            {/* Root anchor mirrors the diff sidebar's header: where am I
+        {/* Collapsed unmounts the column entirely (not width 0): a persistent
+            toggle in the viewer header re-opens it, so there's no orphaned
+            control to home. The tree data hook stays mounted in the pane, so
+            the selected file still resolves while the tree is hidden. */}
+        {!sidebarCollapsed && (
+          <div
+            id={treeSidebarId}
+            ref={treeColumnRef}
+            className="flex min-h-0 w-72 shrink-0 flex-col self-stretch border-r border-daintree-border bg-daintree-sidebar"
+          >
+            {/* py-1.5 + border-overlay + 16px icons match FileViewerToolbar.Root
+                so the two header bars share one height and border token, and the
+                line under them reads continuous across the divider (#11328). */}
+            <div className="flex shrink-0 items-center gap-0.5 border-b border-overlay px-1.5 py-1.5">
+              {/* Root anchor mirrors the diff sidebar's header: where am I
                 rooted, then the controls that reshape the view. The root icon
                 doubles as the way back when the tree is rooted somewhere. */}
-            {rootPath !== "" ? (
-              <FileViewerToolbar.IconButton label="Back to worktree root" onClick={handleResetRoot}>
-                <FolderRoot className="h-3.5 w-3.5" />
-              </FileViewerToolbar.IconButton>
-            ) : (
-              // Same footprint as the button so the path text doesn't shift
-              // when the tree is re-rooted.
-              <span className="shrink-0 p-1.5 text-daintree-text/40" aria-hidden="true">
-                <FolderRoot className="h-3.5 w-3.5" />
+              {rootPath !== "" ? (
+                <FileViewerToolbar.IconButton
+                  label="Back to worktree root"
+                  onClick={handleResetRoot}
+                >
+                  <FolderRoot className="h-4 w-4" />
+                </FileViewerToolbar.IconButton>
+              ) : (
+                // Same footprint as the button so the path text doesn't shift
+                // when the tree is re-rooted.
+                <span className="shrink-0 p-1.5 text-daintree-text/40" aria-hidden="true">
+                  <FolderRoot className="h-4 w-4" />
+                </span>
+              )}
+              <span
+                className="min-w-0 flex-1 truncate font-mono text-[11px] text-daintree-text/40"
+                title={rootPath ? `${basename(worktreePath)}/${rootPath}` : worktreePath}
+              >
+                {rootPath || (worktreePath ? basename(worktreePath) : "")}
               </span>
-            )}
-            <span
-              className="min-w-0 flex-1 truncate font-mono text-[11px] text-daintree-text/40"
-              title={rootPath ? `${basename(worktreePath)}/${rootPath}` : worktreePath}
-            >
-              {rootPath || (worktreePath ? basename(worktreePath) : "")}
-            </span>
-            {rootPath !== "" && (
-              <FileViewerToolbar.IconButton label="Up one level" onClick={handleUpOneLevel}>
-                <CornerLeftUp className="h-3.5 w-3.5" />
+              {rootPath !== "" && (
+                <FileViewerToolbar.IconButton label="Up one level" onClick={handleUpOneLevel}>
+                  <CornerLeftUp className="h-4 w-4" />
+                </FileViewerToolbar.IconButton>
+              )}
+              <FileViewerToolbar.IconButton
+                label="Show ignored"
+                pressed={showIgnored}
+                onClick={handleToggleIgnored}
+              >
+                <EyeOff className="h-4 w-4" />
               </FileViewerToolbar.IconButton>
-            )}
-            <FileViewerToolbar.IconButton
-              label="Show ignored"
-              pressed={showIgnored}
-              onClick={handleToggleIgnored}
-            >
-              <EyeOff className="h-3.5 w-3.5" />
-            </FileViewerToolbar.IconButton>
-            <FileViewerToolbar.IconButton label="Refresh" onClick={handleRefresh}>
-              <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-3.5 w-3.5" />
-            </FileViewerToolbar.IconButton>
+              <FileViewerToolbar.IconButton label="Refresh" onClick={handleRefresh}>
+                <SpinningIcon icon={RefreshCw} active={isRefreshing} className="h-4 w-4" />
+              </FileViewerToolbar.IconButton>
+            </div>
+            {renderTree()}
           </div>
-          {renderTree()}
-        </div>
+        )}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           <FileBrowserViewer
             filePath={selectedFilePath}
@@ -415,6 +444,9 @@ export function FileBrowserPane({
             fileName={selectedFileName}
             relativePath={selectedNode?.isDirectory === false ? (selectedPath ?? null) : null}
             revision={viewerRevision}
+            sidebarCollapsed={sidebarCollapsed}
+            onToggleSidebar={handleToggleSidebar}
+            treeSidebarId={treeSidebarId}
           />
         </div>
       </div>

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ExternalLink, FileText, RefreshCw, XCircle } from "lucide-react";
+import { ExternalLink, FileText, PanelLeftClose, PanelLeftOpen, RefreshCw, XCircle } from "lucide-react";
 import { FolderOpen } from "@/components/icons";
 import { actionService } from "@/services/ActionService";
 import { CodeViewer } from "@/components/FileViewer/CodeViewer";
@@ -42,6 +42,15 @@ export interface FileBrowserViewerProps {
    * reflected instead of leaving stale bytes on screen.
    */
   revision: string;
+  /** Whether the tree sidebar is collapsed; drives the disclosure toggle's icon and state. */
+  sidebarCollapsed: boolean;
+  /** Opens/closes the tree sidebar. Owned by the pane, which persists the state. */
+  onToggleSidebar: () => void;
+  /**
+   * id of the tree column the toggle discloses. Referenced by `aria-controls`
+   * only while the column is mounted (open); the pane unmounts it when collapsed.
+   */
+  treeSidebarId: string;
 }
 
 /** Which external surface a toolbar action aims the current file at. */
@@ -79,6 +88,9 @@ export function FileBrowserViewer({
   fileName,
   relativePath,
   revision,
+  sidebarCollapsed,
+  onToggleSidebar,
+  treeSidebarId,
 }: FileBrowserViewerProps) {
   const [state, setState] = useState<ViewerState>({ status: "idle" });
   // Sticky Source/Rendered choice for markdown, defaulting to the rendered view
@@ -257,52 +269,63 @@ export function FileBrowserViewer({
 
   const reveal = revealCopy();
 
-  if (!filePath) {
-    return (
-      <div className="flex h-full w-full items-center justify-center p-6">
-        <EmptyState
-          variant="zero-data"
-          scale="canvas"
-          icon={<FileText className="h-6 w-6" />}
-          title="Nothing selected"
-          description="Pick a file in the tree to read it here."
-          className="w-full"
-        />
-      </div>
-    );
-  }
-
+  // One persistent toolbar with the tree toggle as its first control, rendered
+  // whether or not a file is selected: the toggle is the sidebar's only home
+  // once collapsed, and the empty state has no toolbar of its own. Keeping a
+  // single Root (rather than one per branch) preserves the toggle's DOM node
+  // and keyboard focus across selection changes. `aria-controls` names the tree
+  // region only while it's mounted — omitted when collapsed to avoid a dangling
+  // reference. A static "Toggle file tree" label per the toggle-label rule; the
+  // icon swap and `aria-expanded` carry the open/closed state.
   return (
     <>
       <FileViewerToolbar.Root>
-        {isMarkdownFilePath(filePath) && (
-          <SegmentedToggle<FileRenderMode>
-            options={MARKDOWN_MODE_OPTIONS}
-            value={markdownMode}
-            onChange={setMarkdownMode}
-          />
+        <FileViewerToolbar.IconButton
+          label="Toggle file tree"
+          expanded={!sidebarCollapsed}
+          controls={sidebarCollapsed ? undefined : treeSidebarId}
+          sidebarToggle
+          onClick={onToggleSidebar}
+          data-testid="file-browser-sidebar-toggle"
+        >
+          {sidebarCollapsed ? (
+            <PanelLeftOpen className="h-4 w-4" />
+          ) : (
+            <PanelLeftClose className="h-4 w-4" />
+          )}
+        </FileViewerToolbar.IconButton>
+        {filePath && (
+          <>
+            {isMarkdownFilePath(filePath) && (
+              <SegmentedToggle<FileRenderMode>
+                options={MARKDOWN_MODE_OPTIONS}
+                value={markdownMode}
+                onChange={setMarkdownMode}
+              />
+            )}
+            <FileViewerToolbar.Path
+              path={relativePath ?? fileName}
+              copied={pathCopied}
+              onCopy={handleCopyPath}
+            />
+            <FileViewerToolbar.Actions>
+              <FileViewerToolbar.IconButton
+                label={reveal.label}
+                onClick={() => void handleExternalAction("reveal")}
+              >
+                <FolderOpen className="h-4 w-4" />
+              </FileViewerToolbar.IconButton>
+              <FileViewerToolbar.IconButton
+                label="Open in editor"
+                onClick={() => void handleExternalAction("editor")}
+              >
+                <ExternalLink className="h-4 w-4" />
+              </FileViewerToolbar.IconButton>
+            </FileViewerToolbar.Actions>
+          </>
         )}
-        <FileViewerToolbar.Path
-          path={relativePath ?? fileName}
-          copied={pathCopied}
-          onCopy={handleCopyPath}
-        />
-        <FileViewerToolbar.Actions>
-          <FileViewerToolbar.IconButton
-            label={reveal.label}
-            onClick={() => void handleExternalAction("reveal")}
-          >
-            <FolderOpen className="h-4 w-4" />
-          </FileViewerToolbar.IconButton>
-          <FileViewerToolbar.IconButton
-            label="Open in editor"
-            onClick={() => void handleExternalAction("editor")}
-          >
-            <ExternalLink className="h-4 w-4" />
-          </FileViewerToolbar.IconButton>
-        </FileViewerToolbar.Actions>
       </FileViewerToolbar.Root>
-      {externalError && (
+      {filePath && externalError && (
         <InlineStatusBanner
           icon={XCircle}
           severity="error"
@@ -327,7 +350,24 @@ export function FileBrowserViewer({
           }
         />
       )}
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{renderBody()}</div>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {filePath ? (
+          renderBody()
+        ) : (
+          // flex-1 + min-h-0, not h-full: below the now-persistent toolbar a
+          // 100%-height body would overflow the viewer column.
+          <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+            <EmptyState
+              variant="zero-data"
+              scale="canvas"
+              icon={<FileText className="h-6 w-6" />}
+              title="Nothing selected"
+              description="Pick a file in the tree to read it here."
+              className="w-full"
+            />
+          </div>
+        )}
+      </div>
     </>
   );
 

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ExternalLink, FileText, PanelLeftClose, PanelLeftOpen, RefreshCw, XCircle } from "lucide-react";
+import {
+  ExternalLink,
+  FileText,
+  PanelLeftClose,
+  PanelLeftOpen,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
 import { FolderOpen } from "@/components/icons";
 import { actionService } from "@/services/ActionService";
 import { CodeViewer } from "@/components/FileViewer/CodeViewer";
@@ -372,8 +379,9 @@ export function FileBrowserViewer({
   );
 
   function renderBody() {
-    // Narrows `filePath` for this closure — the early return above already
-    // guarantees it, but that narrowing doesn't flow into a nested function.
+    // Narrows `filePath` for this closure — the caller only reaches here through
+    // the truthy `filePath` branch above, but that narrowing doesn't flow into a
+    // nested function.
     if (!filePath) return null;
     switch (state.status) {
       case "idle":

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { render, act, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// FileBrowserPane hosts the tree column beside the viewer. #11328 adds a
+// collapse toggle (in the viewer's header) that unmounts the tree column and a
+// shared header height so the divider line reads continuous. These tests drive
+// the pane with the heavy tree/viewer leaves stubbed, but keep the REAL
+// FileBrowserViewer so the toggle and the shared toolbar `Root` actually render
+// — that's what makes the aria-controls and header-alignment invariants real.
+
+const { setFileBrowserViewMock } = vi.hoisted(() => ({ setFileBrowserViewMock: vi.fn() }));
+
+interface MockPanel {
+  id: string;
+  kind: "file-browser";
+  browserSelectedPath?: string;
+  browserExpandedPaths?: string[];
+  browserShowIgnored?: boolean;
+  browserRootPath?: string;
+  browserSidebarCollapsed?: boolean;
+}
+
+const mockPanel: MockPanel = { id: "fb-1", kind: "file-browser" };
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      panelsById: { "fb-1": mockPanel },
+      setFileBrowserView: setFileBrowserViewMock,
+    }),
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      worktrees: new Map([["wt-1", { path: "/repo", worktreeChanges: undefined }]]),
+    }),
+}));
+
+// The tree data hook does real IPC + virtualization; stub it to a single row so
+// the tree column renders its header (and the FileTreeView stub below), without
+// touching filesClient.
+vi.mock("../useFileBrowserTree", () => ({
+  useFileBrowserTree: () => ({
+    rows: [
+      {
+        path: "src",
+        name: "src",
+        isDirectory: true,
+        depth: 0,
+        isExpanded: false,
+        isLoading: false,
+        isIgnored: false,
+      },
+    ],
+    isInitialLoading: false,
+    rootError: null,
+    ensureLoaded: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../FileTreeView", () => ({
+  FileTreeView: () => <div data-testid="file-tree-view" role="tree" tabIndex={-1} />,
+}));
+
+// ContentPanel is chrome around the body; render just the children so the
+// pane's own layout is what's under test.
+vi.mock("@/components/Panel/ContentPanel", () => ({
+  ContentPanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Viewer leaf modules the real FileBrowserViewer imports — never reached with no
+// file selected, but stubbed so their heavy renderers stay out of the suite.
+vi.mock("@/clients/filesClient", () => ({ filesClient: { read: vi.fn() } }));
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
+vi.mock("@/components/FileViewer/CodeViewer", () => ({ CodeViewer: () => null }));
+vi.mock("@/components/Html/HtmlViewer", () => ({ HtmlViewer: () => null }));
+
+import { FileBrowserPane } from "../FileBrowserPane";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function renderPane() {
+  return render(
+    <TooltipProvider>
+      <FileBrowserPane
+        id="fb-1"
+        title="Files"
+        worktreeId="wt-1"
+        isFocused
+        location="grid"
+        onFocus={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+function classToken(el: Element, predicate: (cls: string) => boolean): string | undefined {
+  return Array.from(el.classList).find(predicate);
+}
+
+beforeEach(() => {
+  setFileBrowserViewMock.mockReset();
+  mockPanel.browserSidebarCollapsed = undefined;
+  mockPanel.browserSelectedPath = undefined;
+  mockPanel.browserRootPath = undefined;
+  mockPanel.browserShowIgnored = undefined;
+  for (const name of ["matchMedia"] as const) {
+    if (typeof window[name] !== "function") {
+      Object.defineProperty(window, name, {
+        writable: true,
+        configurable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+  }
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+});
+
+describe("FileBrowserPane collapsible sidebar (#11328)", () => {
+  it("renders the tree column when open and names it from the toggle's aria-controls", () => {
+    renderPane();
+
+    expect(screen.getByTestId("file-tree-view")).toBeTruthy();
+    const toggle = screen.getByTestId("file-browser-sidebar-toggle");
+    const controlsId = toggle.getAttribute("aria-controls");
+    // The disclosure names a region that actually exists in the DOM — not a
+    // dangling id.
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("unmounts the tree column when collapsed and drops the dangling aria-controls", () => {
+    const { rerender } = renderPane();
+    const controlsId = screen
+      .getByTestId("file-browser-sidebar-toggle")
+      .getAttribute("aria-controls");
+    expect(document.getElementById(controlsId!)).not.toBeNull();
+
+    mockPanel.browserSidebarCollapsed = true;
+    rerender(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="grid"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.queryByTestId("file-tree-view")).toBeNull();
+    const toggle = screen.getByTestId("file-browser-sidebar-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.hasAttribute("aria-controls")).toBe(false);
+    // The named region is gone, so nothing resolves the old id either.
+    expect(document.getElementById(controlsId!)).toBeNull();
+  });
+
+  it("shares one height and border token between the two header bars", () => {
+    renderPane();
+
+    const treeColumn = document.getElementById(
+      screen.getByTestId("file-browser-sidebar-toggle").getAttribute("aria-controls")!
+    )!;
+    // The tree column's own header row (border-b) sits beside the viewer toolbar.
+    const sidebarHeader = treeColumn.querySelector<HTMLElement>(":scope > div")!;
+    const toolbarRoot = screen
+      .getByTestId("file-browser-sidebar-toggle")
+      .closest<HTMLElement>("[class~='border-b']")!;
+
+    const vPad = (el: Element) => classToken(el, (c) => /^py-/.test(c));
+    const borderColor = (el: Element) =>
+      classToken(el, (c) => c === "border-overlay" || c === "border-daintree-border");
+
+    // Relational invariant: whatever the shared toolbar uses, the sidebar header
+    // matches it — so the line under the two bars reads continuous. A regression
+    // that reverts one side (py-1 / border-daintree-border) fails here.
+    expect(sidebarHeader).not.toBe(toolbarRoot);
+    expect(vPad(sidebarHeader)).toBe(vPad(toolbarRoot));
+    expect(borderColor(sidebarHeader)).toBe(borderColor(toolbarRoot));
+  });
+
+  it("toggles the persisted collapsed state on click, inverting the current value", () => {
+    renderPane();
+
+    act(() => {
+      screen
+        .getByTestId("file-browser-sidebar-toggle")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserSidebarCollapsed: true,
+    });
+  });
+
+  it("keeps keyboard focus on the toggle across a collapse", () => {
+    const { rerender } = renderPane();
+    const toggle = screen.getByTestId("file-browser-sidebar-toggle");
+    act(() => toggle.focus());
+    expect(document.activeElement).toBe(toggle);
+
+    mockPanel.browserSidebarCollapsed = true;
+    rerender(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="grid"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    // The single persistent Root keeps the same toggle node, so focus survives
+    // the tree column unmounting rather than falling to <body>.
+    expect(document.activeElement).toBe(screen.getByTestId("file-browser-sidebar-toggle"));
+  });
+});

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, act, screen } from "@testing-library/react";
+import { render, act, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // FileBrowserPane hosts the tree column beside the viewer. #11328 adds a
@@ -9,7 +9,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // FileBrowserViewer so the toggle and the shared toolbar `Root` actually render
 // — that's what makes the aria-controls and header-alignment invariants real.
 
-const { setFileBrowserViewMock } = vi.hoisted(() => ({ setFileBrowserViewMock: vi.fn() }));
+const { setFileBrowserViewMock, readMock } = vi.hoisted(() => ({
+  setFileBrowserViewMock: vi.fn(),
+  readMock: vi.fn(),
+}));
 
 interface MockPanel {
   id: string;
@@ -49,6 +52,16 @@ vi.mock("../useFileBrowserTree", () => ({
         name: "src",
         isDirectory: true,
         depth: 0,
+        isExpanded: true,
+        isLoading: false,
+        isIgnored: false,
+      },
+      // A file row so a selection can resolve a real viewer path.
+      {
+        path: "src/app.ts",
+        name: "app.ts",
+        isDirectory: false,
+        depth: 1,
         isExpanded: false,
         isLoading: false,
         isIgnored: false,
@@ -71,12 +84,15 @@ vi.mock("@/components/Panel/ContentPanel", () => ({
   ContentPanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
-// Viewer leaf modules the real FileBrowserViewer imports — never reached with no
-// file selected, but stubbed so their heavy renderers stay out of the suite.
-vi.mock("@/clients/filesClient", () => ({ filesClient: { read: vi.fn() } }));
+// Viewer leaf modules the real FileBrowserViewer imports. Stubbed so their heavy
+// renderers stay out of the suite; CodeViewer surfaces a marker so a selected
+// file's viewer is observable across a collapse.
+vi.mock("@/clients/filesClient", () => ({ filesClient: { read: readMock } }));
 vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
-vi.mock("@/components/FileViewer/CodeViewer", () => ({ CodeViewer: () => null }));
+vi.mock("@/components/FileViewer/CodeViewer", () => ({
+  CodeViewer: () => <div data-testid="code-viewer" />,
+}));
 vi.mock("@/components/Html/HtmlViewer", () => ({ HtmlViewer: () => null }));
 
 import { FileBrowserPane } from "../FileBrowserPane";
@@ -104,6 +120,8 @@ function classToken(el: Element, predicate: (cls: string) => boolean): string | 
 
 beforeEach(() => {
   setFileBrowserViewMock.mockReset();
+  readMock.mockReset();
+  readMock.mockResolvedValue({ content: "hello" });
   mockPanel.browserSidebarCollapsed = undefined;
   mockPanel.browserSelectedPath = undefined;
   mockPanel.browserRootPath = undefined;
@@ -194,13 +212,21 @@ describe("FileBrowserPane collapsible sidebar (#11328)", () => {
     const vPad = (el: Element) => classToken(el, (c) => /^py-/.test(c));
     const borderColor = (el: Element) =>
       classToken(el, (c) => c === "border-overlay" || c === "border-daintree-border");
+    const iconSize = (el: Element) => classToken(el.querySelector("svg")!, (c) => /^h-/.test(c));
+
+    // Guard against a vacuous undefined === undefined pass.
+    expect(sidebarHeader).not.toBe(toolbarRoot);
+    expect(vPad(sidebarHeader)).toBeDefined();
+    expect(borderColor(sidebarHeader)).toBeDefined();
+    expect(iconSize(sidebarHeader)).toBeDefined();
 
     // Relational invariant: whatever the shared toolbar uses, the sidebar header
     // matches it — so the line under the two bars reads continuous. A regression
-    // that reverts one side (py-1 / border-daintree-border) fails here.
-    expect(sidebarHeader).not.toBe(toolbarRoot);
+    // that reverts one side (py-1 / border-daintree-border / h-3.5 icons) fails
+    // here. Icon height is the row's tallest child, so it drives the height parity.
     expect(vPad(sidebarHeader)).toBe(vPad(toolbarRoot));
     expect(borderColor(sidebarHeader)).toBe(borderColor(toolbarRoot));
+    expect(iconSize(sidebarHeader)).toBe(iconSize(toolbarRoot));
   });
 
   it("toggles the persisted collapsed state on click, inverting the current value", () => {
@@ -215,6 +241,51 @@ describe("FileBrowserPane collapsible sidebar (#11328)", () => {
     expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
       browserSidebarCollapsed: true,
     });
+  });
+
+  it("re-opens from the collapsed state, so the toggle inverts rather than always collapsing", () => {
+    // Without this, a handler hardcoded to always write `true` would pass every
+    // other test while stranding the user in a collapsed tree they can't reopen.
+    mockPanel.browserSidebarCollapsed = true;
+    renderPane();
+
+    act(() => {
+      screen
+        .getByTestId("file-browser-sidebar-toggle")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserSidebarCollapsed: false,
+    });
+  });
+
+  it("keeps the selected file's viewer mounted when the sidebar collapses", async () => {
+    mockPanel.browserSelectedPath = "src/app.ts";
+    const { rerender } = renderPane();
+    // The viewer resolves and renders the (stubbed) code viewer for the selection.
+    await waitFor(() => expect(screen.getByTestId("code-viewer")).toBeTruthy());
+    expect(screen.getByTestId("file-tree-view")).toBeTruthy();
+
+    mockPanel.browserSidebarCollapsed = true;
+    rerender(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-1"
+          isFocused
+          location="grid"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    // The viewer lives in the non-collapsing column, so collapsing the tree must
+    // not blank or reload it — only the tree column disappears.
+    expect(screen.queryByTestId("file-tree-view")).toBeNull();
+    expect(screen.getByTestId("code-viewer")).toBeTruthy();
   });
 
   it("keeps keyboard focus on the toggle across a collapse", () => {

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -181,8 +181,10 @@ describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
 
   it("is the first control in the toolbar in both the empty and file-selected states", async () => {
     const { rerender } = renderViewer(null);
+    // `?.` keeps the assertion honest under noUncheckedIndexedAccess: an empty
+    // button list yields undefined, which still fails the toBe below.
     const firstEmpty = screen.getAllByRole("button")[0];
-    expect(firstEmpty.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
+    expect(firstEmpty?.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
 
     rerender(
       <TooltipProvider>
@@ -202,7 +204,7 @@ describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
     // Still first, ahead of the reveal/open-in-editor actions — the toggle
     // stays flush at the far left of the header per the issue.
     const firstWithFile = screen.getAllByRole("button")[0];
-    expect(firstWithFile.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
+    expect(firstWithFile?.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
   });
 
   it("exposes an inverse aria-expanded and names the tree region only while expanded", () => {

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -36,16 +36,22 @@ vi.mock("@/components/Html/HtmlViewer", () => ({
 import { FileBrowserViewer } from "../FileBrowserViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-function renderViewer(filePath: string) {
-  const fileName = filePath.split("/").pop() ?? filePath;
+function renderViewer(
+  filePath: string | null,
+  opts: { sidebarCollapsed?: boolean; onToggleSidebar?: () => void } = {}
+) {
+  const fileName = filePath ? (filePath.split("/").pop() ?? filePath) : "";
   return render(
     <TooltipProvider>
       <FileBrowserViewer
         filePath={filePath}
         rootPath="/repo"
         fileName={fileName}
-        relativePath={fileName}
+        relativePath={filePath ? fileName : null}
         revision="r1"
+        sidebarCollapsed={opts.sidebarCollapsed ?? false}
+        onToggleSidebar={opts.onToggleSidebar ?? vi.fn()}
+        treeSidebarId="file-tree-column"
       />
     </TooltipProvider>
   );
@@ -125,6 +131,9 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
           fileName="b.md"
           relativePath="b.md"
           revision="r1"
+          sidebarCollapsed={false}
+          onToggleSidebar={vi.fn()}
+          treeSidebarId="file-tree-column"
         />
       </TooltipProvider>
     );
@@ -148,6 +157,9 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
           fileName="notes.txt"
           relativePath="notes.txt"
           revision="r1"
+          sidebarCollapsed={false}
+          onToggleSidebar={vi.fn()}
+          treeSidebarId="file-tree-column"
         />
       </TooltipProvider>
     );
@@ -155,5 +167,80 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
     expect(screen.queryByTestId("markdown-viewer-mock")).toBeNull();
+  });
+});
+
+describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
+  it("renders the toggle even with nothing selected, so the collapsed sidebar has a home", () => {
+    renderViewer(null);
+    // The empty state has no toolbar of its own; the persistent Root is what
+    // keeps a re-open control on screen once the tree is collapsed.
+    expect(screen.getByTestId("file-browser-sidebar-toggle")).toBeTruthy();
+    expect(screen.getByText("Nothing selected")).toBeTruthy();
+  });
+
+  it("is the first control in the toolbar in both the empty and file-selected states", async () => {
+    const { rerender } = renderViewer(null);
+    const firstEmpty = screen.getAllByRole("button")[0];
+    expect(firstEmpty.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
+
+    rerender(
+      <TooltipProvider>
+        <FileBrowserViewer
+          filePath="/repo/src/notes.txt"
+          rootPath="/repo"
+          fileName="notes.txt"
+          relativePath="notes.txt"
+          revision="r1"
+          sidebarCollapsed={false}
+          onToggleSidebar={vi.fn()}
+          treeSidebarId="file-tree-column"
+        />
+      </TooltipProvider>
+    );
+    await screen.findByTestId("code-viewer-mock");
+    // Still first, ahead of the reveal/open-in-editor actions — the toggle
+    // stays flush at the far left of the header per the issue.
+    const firstWithFile = screen.getAllByRole("button")[0];
+    expect(firstWithFile.getAttribute("data-testid")).toBe("file-browser-sidebar-toggle");
+  });
+
+  it("exposes an inverse aria-expanded and names the tree region only while expanded", () => {
+    const { rerender } = renderViewer(null, { sidebarCollapsed: false });
+    const expanded = screen.getByTestId("file-browser-sidebar-toggle");
+    // Disclosure semantics (aria-expanded), not a pressed toggle.
+    expect(expanded.getAttribute("aria-expanded")).toBe("true");
+    expect(expanded.getAttribute("aria-pressed")).toBeNull();
+    expect(expanded.getAttribute("aria-controls")).toBe("file-tree-column");
+
+    rerender(
+      <TooltipProvider>
+        <FileBrowserViewer
+          filePath={null}
+          rootPath="/repo"
+          fileName=""
+          relativePath={null}
+          revision="r1"
+          sidebarCollapsed={true}
+          onToggleSidebar={vi.fn()}
+          treeSidebarId="file-tree-column"
+        />
+      </TooltipProvider>
+    );
+    const collapsed = screen.getByTestId("file-browser-sidebar-toggle");
+    expect(collapsed.getAttribute("aria-expanded")).toBe("false");
+    // The tree column is unmounted while collapsed, so aria-controls must not
+    // dangle at a missing id.
+    expect(collapsed.getAttribute("aria-controls")).toBeNull();
+  });
+
+  it("invokes onToggleSidebar when clicked", async () => {
+    const onToggleSidebar = vi.fn();
+    renderViewer(null, { onToggleSidebar });
+    const toggle = screen.getByTestId("file-browser-sidebar-toggle");
+    await act(async () => {
+      toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -70,6 +70,19 @@ describe("serializeFileBrowser", () => {
     const reset: FileBrowserPanelData = { ...basePanel, browserRootPath: "" };
     expect(serializeFileBrowser(reset)).toEqual({});
   });
+
+  it("round-trips a collapsed sidebar but keeps the open default sparse", () => {
+    const collapsed: FileBrowserPanelData = { ...basePanel, browserSidebarCollapsed: true };
+    expect(createFileBrowserDefaults(asOptions(serializeFileBrowser(collapsed)))).toEqual({
+      browserSidebarCollapsed: true,
+    });
+
+    // `false` is the default open state, the same as absent — persisting it
+    // would be noise, so neither an explicit `false` nor an omitted field writes.
+    const open: FileBrowserPanelData = { ...basePanel, browserSidebarCollapsed: false };
+    expect(serializeFileBrowser(open)).toEqual({});
+    expect(serializeFileBrowser(basePanel)).toEqual({});
+  });
 });
 
 describe("createFileBrowserDefaults", () => {

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -23,5 +23,8 @@ export function createFileBrowserDefaults(
     ...(options.browserRootPath != null && {
       browserRootPath: canonicalizeRootPath(options.browserRootPath),
     }),
+    // Only a collapsed sidebar materializes a field: `false` and absent are the
+    // same open state, so we never stamp a default the serializer then drops.
+    ...(options.browserSidebarCollapsed === true && { browserSidebarCollapsed: true }),
   };
 }

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -3,10 +3,10 @@ import type { PanelSnapshot } from "@shared/types/project";
 
 /**
  * Every field persists, unlike the diff panel's runtime-only change set: the
- * issue's contract is that a pinned browser keeps its root, expansion and
- * selection, and all three are user intent rather than derived data. A path
- * that has since been deleted simply doesn't resolve to a row on restore, which
- * is the same outcome as never having expanded it.
+ * issue's contract is that a pinned browser keeps its root, expansion,
+ * selection and layout, all user intent rather than derived data. A path that
+ * has since been deleted simply doesn't resolve to a row on restore, which is
+ * the same outcome as never having expanded it.
  */
 export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnapshot> {
   return {
@@ -16,5 +16,8 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     // Truthiness, not `!= null`: "" is the worktree root, which is the same
     // state as the field being absent — persisting it would be noise.
     ...(t.browserRootPath ? { browserRootPath: t.browserRootPath } : {}),
+    // Truthiness, not `!= null`: `false` is the default open state, the same as
+    // the field being absent, so only a collapsed sidebar earns a persisted bit.
+    ...(t.browserSidebarCollapsed ? { browserSidebarCollapsed: true } : {}),
   };
 }

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -114,6 +114,39 @@ describe("setFileBrowserView", () => {
     expect(store.get().panelsById["panel-1"]).toMatchObject({ browserShowIgnored: false });
   });
 
+  it("collapses and re-opens the sidebar", () => {
+    setFileBrowserView("panel-1", { browserSidebarCollapsed: true });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarCollapsed: true });
+
+    // Re-opening after collapse still writes a new record; the serializer is
+    // what strips `false` back out of the persisted snapshot, not the store.
+    const collapsed = store.get().panelsById["panel-1"];
+    setFileBrowserView("panel-1", { browserSidebarCollapsed: false });
+    expect(store.get().panelsById["panel-1"]).not.toBe(collapsed);
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarCollapsed: false });
+  });
+
+  it("treats collapsing an already-open panel with false as a no-op", () => {
+    // `false` and absent are the same open state, so patching `false` onto a
+    // panel that never collapsed must not churn a fresh object every render.
+    const before = store.get().panelsById["panel-1"];
+
+    setFileBrowserView("panel-1", { browserSidebarCollapsed: false });
+
+    expect(store.get().panelsById["panel-1"]).toBe(before);
+  });
+
+  it("preserves other browser fields when the sidebar collapses", () => {
+    setFileBrowserView("panel-1", { browserSelectedPath: "src/app.ts" });
+    setFileBrowserView("panel-1", { browserSidebarCollapsed: true });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({
+      browserSidebarCollapsed: true,
+      browserSelectedPath: "src/app.ts",
+      browserExpandedPaths: ["src"],
+    });
+  });
+
   it("ignores a panel of another kind rather than stamping browser fields onto it", () => {
     const other = makeSet({
       panelsById: {

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -9,6 +9,8 @@ export interface FileBrowserViewPatch {
   browserShowIgnored?: boolean;
   /** "" roots the tree back at the worktree root. */
   browserRootPath?: string;
+  /** `true` collapses the tree sidebar; `false` and absent both mean open. */
+  browserSidebarCollapsed?: boolean;
 }
 
 function sameStringList(a: string[] | undefined, b: string[]): boolean {
@@ -44,11 +46,24 @@ export const createFileBrowserPanelActions = (
       const rootUnchanged =
         patch.browserRootPath === undefined ||
         patch.browserRootPath === (panel.browserRootPath ?? "");
+      // `false` and absent are the same open state, so patching `false` onto a
+      // never-collapsed panel must not count as a change. Compared as
+      // normalized booleans rather than raw optionals for that reason.
+      const collapsedUnchanged =
+        patch.browserSidebarCollapsed === undefined ||
+        (patch.browserSidebarCollapsed === true) === (panel.browserSidebarCollapsed === true);
 
       // Bail on a no-op write. The tree calls this on every arrow key, and a
       // fresh panel object each time would re-render every panel-store
       // subscriber and re-write the persisted snapshot for nothing.
-      if (selectedUnchanged && expandedUnchanged && ignoredUnchanged && rootUnchanged) return state;
+      if (
+        selectedUnchanged &&
+        expandedUnchanged &&
+        ignoredUnchanged &&
+        rootUnchanged &&
+        collapsedUnchanged
+      )
+        return state;
 
       const nextPanel = {
         ...panel,
@@ -63,6 +78,9 @@ export const createFileBrowserPanelActions = (
         }),
         ...(patch.browserRootPath !== undefined && {
           browserRootPath: patch.browserRootPath,
+        }),
+        ...(patch.browserSidebarCollapsed !== undefined && {
+          browserSidebarCollapsed: patch.browserSidebarCollapsed,
         }),
       };
 

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -117,16 +117,18 @@
  * provides the containment edge.
  *
  * Comes after :hover in source order so the ring survives hover-over-armed (equal
- * specificity, later wins). The sidebar toggle opts out via
- * [data-sidebar-toggle]: it's pressed nearly all the time (sidebar visible),
- * so an always-on armed state reads as noise rather than state — the
- * PanelLeftClose/PanelLeftOpen icon swap carries the signal instead (#8357).
- * The exclusion is wrapped in :where() so armed stays (0,2,0) — equal to
- * hover and :active, preserving both the source-order tiebreaker above and
- * the momentary :active background on other pressed buttons. */
+ * specificity, later wins). Sidebar toggles opt out via [data-sidebar-toggle]:
+ * they sit in their "on" state nearly all the time (sidebar visible), so an
+ * always-on armed chip reads as noise rather than state — the
+ * PanelLeftClose/PanelLeftOpen icon swap carries the signal instead (#8357,
+ * #11328). The opt-out covers both the app sidebar toggle (aria-pressed) and
+ * the file-browser tree toggle (aria-expanded disclosure). The exclusion is
+ * wrapped in :where() so armed stays (0,2,0) — equal to hover and :active,
+ * preserving both the source-order tiebreaker above and the momentary :active
+ * background on other pressed buttons. */
 .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
 .toolbar-icon-button[aria-checked="true"],
-.toolbar-icon-button[aria-expanded="true"],
+.toolbar-icon-button[aria-expanded="true"]:where(:not([data-sidebar-toggle])),
 .toolbar-icon-button[data-state="open"],
 .toolbar-agent-button[aria-pressed="true"],
 .toolbar-agent-button[aria-expanded="true"],
@@ -154,7 +156,8 @@
 :where(.light, [data-color-mode="light"])
   .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
 :where(.light, [data-color-mode="light"]) .toolbar-icon-button[aria-checked="true"],
-:where(.light, [data-color-mode="light"]) .toolbar-icon-button[aria-expanded="true"],
+:where(.light, [data-color-mode="light"])
+  .toolbar-icon-button[aria-expanded="true"]:where(:not([data-sidebar-toggle])),
 :where(.light, [data-color-mode="light"]) .toolbar-icon-button[data-state="open"],
 :where(.light, [data-color-mode="light"]) .toolbar-agent-button[aria-pressed="true"],
 :where(.light, [data-color-mode="light"]) .toolbar-agent-button[aria-expanded="true"],
@@ -592,7 +595,7 @@
 @media (forced-colors: active) {
   .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
   .toolbar-icon-button[aria-checked="true"],
-  .toolbar-icon-button[aria-expanded="true"],
+  .toolbar-icon-button[aria-expanded="true"]:where(:not([data-sidebar-toggle])),
   .toolbar-icon-button[data-state="open"],
   .toolbar-agent-button[aria-pressed="true"],
   .toolbar-agent-button[aria-expanded="true"],

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -63,6 +63,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   browserExpandedPaths?: string[];
   browserShowIgnored?: boolean;
   browserRootPath?: string;
+  browserSidebarCollapsed?: boolean;
   /**
    * Preserved user-initiated focus timestamp from the saved snapshot. The
    * post-hydration focus picker in `useAppHydration` reads this off
@@ -124,6 +125,7 @@ export interface SavedTerminalData {
   browserExpandedPaths?: unknown;
   browserShowIgnored?: unknown;
   browserRootPath?: unknown;
+  browserSidebarCollapsed?: unknown;
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];


### PR DESCRIPTION
## Summary

- The file tree in the file browser panel was a fixed 288px column with no way to hide it, which was a real problem for reading a file since that space was gone for good.
- Added a disclosure toggle at the far left of the file header bar (`FileViewerToolbar.Root`) that swaps the `PanelLeft` icon and carries `aria-expanded`/`aria-controls`. That toolbar now renders even with no file selected, so the toggle always has a home.
- The collapsed state persists with the rest of the panel's view state, and the two header bars now share height, border token, and icon size so the divider line reads as one continuous line across the panel instead of breaking at the sidebar boundary.

Resolves #11328

## Changes

- New `browserSidebarCollapsed` field threaded through the panel, project, and options types, the serializer, defaults, and the store slice. It's sparse, only `true` persists.
- `FileBrowserViewer` renders a persistent `FileViewerToolbar.Root` with the disclosure toggle as its first control in both the selected and empty states.
- `FileBrowserPane` unmounts the tree column when collapsed, owns the collapsed state and tree region id, and conforms the sidebar header to `FileViewerToolbar.Root` (`py-1.5`, `border-overlay`, 16px icons).
- `FileViewerToolbar.IconButton` extended to pass through `aria-expanded`/`aria-controls`/`data-sidebar-toggle`, and the toolbar's armed-state CSS opt-out extended to `aria-expanded` so the sidebar toggle doesn't carry a persistent armed chip.
- `FileViewerToolbar.Root` is shared chrome used by `FilePane` and the file viewer modal too, so the alignment change applies to the component itself rather than forking it.

## Testing

- 138 tests passing, prettier and eslint clean.
- Added coverage during review for a collapsed-to-open toggle case (guards against a hardcoded handler stranding the tree collapsed), a case confirming the selected file survives a collapse/expand cycle, and a strengthened header-alignment invariant test.
