### PR TITLE
feat(file-browser): rethink hidden-file model and add live filesystem updates

### DIFF
--- a/electron/ipc/handlers/fileBrowser.ts
+++ b/electron/ipc/handlers/fileBrowser.ts
@@ -145,8 +145,12 @@ export function buildFileBrowserNamespace(deps: HandlerDependencies) {
 
     const worktree = await resolveSenderWorktree(ctx, payload.worktreeId);
 
+    // Always raw: the browser shows every entry and does its own hiding (junk
+    // list + dotfile toggle) client-side. Passing this bypasses the per-dir
+    // `git check-ignore` pass — no renderer opt-out, so gitignored working
+    // folders can never be filtered back out here (#11330).
     return deps.worktreeService.getFileTree(worktree.path, payload.dirPath, {
-      includeIgnored: payload.includeIgnored,
+      includeIgnored: true,
     });
   };
 

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -477,12 +477,10 @@ export const CopyTreeGetFileTreePayloadSchema = z.object({
 });
 
 // Both strings are capped: they cross the boundary as untrusted input and end
-// up in path joins and a `git check-ignore` argv, neither of which should ever
-// see a megabyte-long value.
+// up in path joins, which should never see a megabyte-long value.
 export const FileBrowserListDirectoryPayloadSchema = z.object({
   worktreeId: z.string().min(1).max(4096),
   dirPath: z.string().max(4096).optional(),
-  includeIgnored: z.boolean().optional(),
 });
 
 // Batch-capped: one call validates the directory candidates of a single

--- a/electron/services/FileTreeService.ts
+++ b/electron/services/FileTreeService.ts
@@ -32,14 +32,16 @@ function _getBaseRealpath(resolvedBasePath: string): Promise<string> {
 
 export interface GetFileTreeOptions {
   /**
-   * Return gitignored entries too, each flagged `isIgnored: true`, instead of
-   * dropping them. Off by default so every existing caller (the copy-tree file
-   * picker) keeps the fail-closed listing it was written against.
+   * Raw-listing mode for the file browser: skip the `git check-ignore` pass
+   * entirely (no git subprocess, no `isIgnored` annotation) and return every
+   * entry — including gitignored ones and `.git` itself — so visibility is a
+   * pure client-side concern (the always-hidden junk list and the per-panel
+   * dotfile toggle live in the renderer, issue #11330).
    *
-   * Note this deliberately does not weaken the check-ignore failure path: when
-   * `git check-ignore` errors, every checked path is still treated as ignored,
-   * so an opted-in caller sees them marked rather than silently presented as
-   * clean.
+   * Off by default so the copy-tree file picker keeps its fail-closed listing:
+   * when the check-ignore invocation errors, every checked path is still
+   * treated as ignored rather than leaking. That path is deliberately untouched
+   * here — this flag bypasses the check, it does not weaken it.
    */
   includeIgnored?: boolean;
 }
@@ -90,57 +92,67 @@ export class FileTreeService {
 
       const entries = await fs.readdir(targetPath, { withFileTypes: true });
 
+      // Raw-listing mode (the file browser) skips the git check-ignore pass
+      // wholesale: no subprocess, no ignored-path set, and `.git` is returned
+      // like any other entry so the renderer's junk list — not this service —
+      // decides whether it is hidden. Default mode (copy-tree) is unchanged.
+      const skipIgnoreCheck = options.includeIgnored === true;
+
       const toGitPath = (p: string) => p.split(path.sep).join("/");
-      const pathsToCheck = entries
-        .filter((e) => e.name !== ".git")
-        .map((e) => toGitPath(path.join(relativeDirPath, e.name)));
       const ignoredPaths = new Set<string>();
 
-      try {
-        if (pathsToCheck.length > 0) {
-          const ignored = await checkIgnoredPaths(resolvedBasePath, pathsToCheck);
-          for (const p of ignored) {
+      if (!skipIgnoreCheck) {
+        const pathsToCheck = entries
+          .filter((e) => e.name !== ".git")
+          .map((e) => toGitPath(path.join(relativeDirPath, e.name)));
+
+        try {
+          if (pathsToCheck.length > 0) {
+            const ignored = await checkIgnoredPaths(resolvedBasePath, pathsToCheck);
+            for (const p of ignored) {
+              ignoredPaths.add(p);
+            }
+          }
+        } catch (error) {
+          // Fail closed: if the check-ignore invocation errors (E2BIG, ENOMEM,
+          // missing git, broken repo, …) populate the set with every path we
+          // tried to check so the downstream filter hides all of them. This
+          // is the same shape as "everything in this dir is gitignored" and
+          // prevents gitignored entries (build output, dependency folders,
+          // secret-like files) from leaking into the tree. A transient
+          // failure self-heals on the next successful call.
+          const now = Date.now();
+          const last = _lastWarnAt.get(resolvedBasePath) ?? 0;
+          if (now - last >= WARN_THROTTLE_MS) {
+            _lastWarnAt.set(resolvedBasePath, now);
+            console.warn("git check-ignore failed; hiding checked entries to prevent leak", {
+              code: (error as NodeJS.ErrnoException)?.code,
+              message: formatErrorMessage(error, "Unknown git check-ignore error"),
+              entryCount: pathsToCheck.length,
+            });
+          }
+          for (const p of pathsToCheck) {
             ignoredPaths.add(p);
           }
-        }
-      } catch (error) {
-        // Fail closed: if the check-ignore invocation errors (E2BIG, ENOMEM,
-        // missing git, broken repo, …) populate the set with every path we
-        // tried to check so the downstream filter hides all of them. This
-        // is the same shape as "everything in this dir is gitignored" and
-        // prevents gitignored entries (build output, dependency folders,
-        // secret-like files) from leaking into the tree. A transient
-        // failure self-heals on the next successful call.
-        const now = Date.now();
-        const last = _lastWarnAt.get(resolvedBasePath) ?? 0;
-        if (now - last >= WARN_THROTTLE_MS) {
-          _lastWarnAt.set(resolvedBasePath, now);
-          console.warn("git check-ignore failed; hiding checked entries to prevent leak", {
-            code: (error as NodeJS.ErrnoException)?.code,
-            message: formatErrorMessage(error, "Unknown git check-ignore error"),
-            entryCount: pathsToCheck.length,
-          });
-        }
-        for (const p of pathsToCheck) {
-          ignoredPaths.add(p);
         }
       }
 
       const statResults = await Promise.all(
         entries.map(async (entry) => {
-          if (entry.name === ".git") return null;
+          // `.git` is a structural exclusion only in default mode; raw mode
+          // surfaces it so the junk list can hide it transparently.
+          if (entry.name === ".git" && !skipIgnoreCheck) return null;
           if (entry.isSymbolicLink()) return null;
 
           const relativePath = path.join(relativeDirPath, entry.name);
           const gitRelativePath = toGitPath(relativePath);
 
-          const isIgnored = ignoredPaths.has(gitRelativePath);
-          if (isIgnored && !options.includeIgnored) return null;
+          if (ignoredPaths.has(gitRelativePath)) return null;
 
           const absolutePath = path.join(resolvedBasePath, relativePath);
           try {
             const fileStat = await fs.lstat(absolutePath);
-            return { fileStat, name: entry.name, gitRelativePath, isIgnored };
+            return { fileStat, name: entry.name, gitRelativePath };
           } catch {
             return null;
           }
@@ -150,14 +162,11 @@ export class FileTreeService {
       const nodes: FileTreeNode[] = [];
       for (const result of statResults) {
         if (!result) continue;
-        const { fileStat, name, gitRelativePath, isIgnored } = result;
-        // Omitted rather than set to `false` so the default listing serializes
-        // byte-for-byte as it did before the flag existed.
-        const ignoredField = isIgnored ? { isIgnored: true as const } : {};
+        const { fileStat, name, gitRelativePath } = result;
 
         const isDirectory = fileStat.isDirectory();
         if (isDirectory) {
-          nodes.push({ name, path: gitRelativePath, isDirectory, ...ignoredField });
+          nodes.push({ name, path: gitRelativePath, isDirectory });
           continue;
         }
 
@@ -167,7 +176,6 @@ export class FileTreeService {
             path: gitRelativePath,
             isDirectory,
             size: fileStat.size,
-            ...ignoredField,
           });
         } catch {
           // skip entries where size read fails

--- a/electron/services/__tests__/FileTreeService.includeIgnored.test.ts
+++ b/electron/services/__tests__/FileTreeService.includeIgnored.test.ts
@@ -11,7 +11,11 @@ vi.mock("../../utils/gitCheckIgnore.js", () => ({
 
 const mockedCheckIgnoredPaths = vi.mocked(checkIgnoredPaths);
 
-describe("FileTreeService includeIgnored", () => {
+// `includeIgnored: true` is the file browser's raw-listing mode: skip the git
+// check-ignore pass entirely (no subprocess, no annotation) and return every
+// entry, including gitignored ones and `.git` (#11330). Default mode — the
+// copy-tree picker — keeps its fail-closed, ignore-filtering behavior.
+describe("FileTreeService raw-listing mode (includeIgnored)", () => {
   let tempDir: string;
   let service: FileTreeService;
 
@@ -39,53 +43,64 @@ describe("FileTreeService includeIgnored", () => {
     expect(nodes.map((node) => node.path)).toEqual(["app.ts"]);
   });
 
-  it("returns ignored entries flagged when the caller opts in", async () => {
+  it("returns every entry in raw mode without running check-ignore", async () => {
+    // Even a mock that would report `dist` ignored must not be consulted — raw
+    // mode bypasses the pass entirely.
     mockedCheckIgnoredPaths.mockResolvedValue(new Set(["dist"]));
 
     const nodes = await service.getFileTree(tempDir, "", { includeIgnored: true });
 
-    expect(nodes.map((node) => [node.path, node.isIgnored === true])).toEqual([
-      ["dist", true],
-      ["app.ts", false],
-    ]);
+    expect(nodes.map((node) => node.path).sort()).toEqual(["app.ts", "dist"]);
+    expect(mockedCheckIgnoredPaths).not.toHaveBeenCalled();
   });
 
-  it("omits the flag entirely for entries git does not ignore", async () => {
+  it("never annotates entries with isIgnored in raw mode", async () => {
     const nodes = await service.getFileTree(tempDir, "", { includeIgnored: true });
 
-    // Absent rather than `false`, so an opted-in listing serializes the same as
-    // the default one for every clean entry.
     for (const node of nodes) {
       expect(Object.hasOwn(node, "isIgnored")).toBe(false);
     }
   });
 
-  it("still hides everything when check-ignore fails, even with includeIgnored off", async () => {
+  it("surfaces .git in raw mode so the junk list can hide it transparently", async () => {
+    await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
+
+    const nodes = await service.getFileTree(tempDir, "", { includeIgnored: true });
+
+    expect(nodes.some((node) => node.name === ".git")).toBe(true);
+  });
+
+  it("keeps .git out of the default (copy-tree) listing", async () => {
+    await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
+
+    const nodes = await service.getFileTree(tempDir);
+
+    expect(nodes.some((node) => node.name === ".git")).toBe(false);
+  });
+
+  it("still hides everything when check-ignore fails in default mode", async () => {
     mockedCheckIgnoredPaths.mockRejectedValue(new Error("git exploded"));
 
     const nodes = await service.getFileTree(tempDir);
 
     // Fail-closed: a broken git must never leak build output or secret-like
-    // files into the default listing.
+    // files into the default listing. Raw mode bypasses this path entirely, so
+    // the safety property is untouched.
     expect(nodes).toEqual([]);
   });
 
-  it("marks every entry ignored when check-ignore fails and the caller opted in", async () => {
-    mockedCheckIgnoredPaths.mockRejectedValue(new Error("git exploded"));
+  it("still drops symlinked entries in raw mode", async () => {
+    // Symlink-drop is a containment property, independent of ignore filtering —
+    // raw mode must not weaken it.
+    try {
+      await fs.symlink(path.join(tempDir, "app.ts"), path.join(tempDir, "link.ts"));
+    } catch {
+      // Some CI filesystems disallow symlinks; the drop is still asserted by the
+      // absence below, and a failed symlink create just means no link exists.
+    }
 
     const nodes = await service.getFileTree(tempDir, "", { includeIgnored: true });
 
-    // Opting in must not weaken the fail-closed path into a silent "everything
-    // is clean" — the entries appear, but honestly labelled.
-    expect(nodes.length).toBeGreaterThan(0);
-    expect(nodes.every((node) => node.isIgnored === true)).toBe(true);
-  });
-
-  it("keeps .git out of the listing regardless of the flag", async () => {
-    await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
-
-    const nodes = await service.getFileTree(tempDir, "", { includeIgnored: true });
-
-    expect(nodes.some((node) => node.name === ".git")).toBe(false);
+    expect(nodes.some((node) => node.name === "link.ts")).toBe(false);
   });
 });

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -862,6 +862,136 @@ describe("GitFileWatcher", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  // ---- Working-tree-changed signal (#11330) ----
+
+  describe("onWorktreeFilesChanged", () => {
+    it("fires once per debounced worktree flush, alongside onChange", async () => {
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn();
+      const mock = setupSubscribeMock();
+
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        onWorktreeFilesChanged,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 500,
+        worktreeMaxDebounceMs: 500,
+        worktreeMaxWaitMs: 2000,
+      });
+
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [{ type: "update" }, { type: "update" }, { type: "update" }]);
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+      // Rides the same flush as the git-status recompute — one raw-fs signal
+      // per coalesced burst, not one per event.
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires on a max-wait forced flush during a sustained burst", async () => {
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn();
+      const mock = setupSubscribeMock();
+
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        onWorktreeFilesChanged,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 500,
+        worktreeMaxDebounceMs: 500,
+        worktreeMaxWaitMs: 2000,
+      });
+
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [{ type: "update" }]);
+      for (let i = 0; i < 9; i++) {
+        await vi.advanceTimersByTimeAsync(200);
+        fireEvents(cb, [{ type: "update" }]);
+      }
+      expect(onWorktreeFilesChanged).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire for git-internal changes (HEAD/index)", async () => {
+      const gitDir = pathJoin("/repo", ".git");
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn();
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        onWorktreeFilesChanged,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 500,
+        worktreeMaxDebounceMs: 500,
+        worktreeMaxWaitMs: 2000,
+      });
+
+      await expect(gitWatcher.start()).resolves.toBe(true);
+
+      const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
+        [unknown, unknown, unknown] | undefined;
+      const dotGitCallback = dotGitCall?.[2] as
+        ((eventType: string, filename: string | Buffer | null) => void) | undefined;
+      expect(dotGitCallback).toBeDefined();
+
+      // HEAD/index writes route through the git-internal debounce, which only
+      // drives onChange — a repo-metadata change is not a working-tree write.
+      dotGitCallback?.("rename", "HEAD");
+      dotGitCallback?.("rename", "index");
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onWorktreeFilesChanged).not.toHaveBeenCalled();
+    });
+
+    it("does not fire a late flush after dispose", async () => {
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn();
+      const mock = setupSubscribeMock();
+
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        onWorktreeFilesChanged,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 150,
+        worktreeMaxDebounceMs: 800,
+        worktreeMaxWaitMs: 1500,
+      });
+
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [{ type: "update" }, { type: "update" }]);
+      gitWatcher.dispose();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(onWorktreeFilesChanged).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   // ---- Error handling tests (adapted to async Promise rejection) ----
 
   describe("startup error handling", () => {

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -64,6 +64,15 @@ export interface GitFileWatcherOptions {
    * config write instead of one per status pass (#9997).
    */
   onGitConfigChanged?: () => void;
+  /**
+   * Fired once per recursive-worktree flush — a raw filesystem write happened,
+   * regardless of whether git status content changed. Rides the existing
+   * adaptive-burst debounce (never the git-internal path), so it inherits the
+   * same coalescing as `onChange`. Drives the file browser's live refresh when
+   * a write lands in a gitignored path that leaves `git status` unchanged
+   * (#11330).
+   */
+  onWorktreeFilesChanged?: () => void;
   /** Watch the working tree recursively for file edits (macOS FSEvents). */
   watchWorktree?: boolean;
   /** Minimum debounce delay for worktree events — first event in a burst fires at this delay. */
@@ -114,6 +123,7 @@ export class GitFileWatcher {
   private readonly worktreeDebounceRampMs = 10;
   private readonly onChange: () => void;
   private readonly onGitConfigChanged: (() => void) | undefined;
+  private readonly onWorktreeFilesChanged: (() => void) | undefined;
   /** Set when the current (unflushed) burst touched `.git/config`. */
   private gitConfigChangePending = false;
   /** Directory holding `.git/config` — always the common dir. */
@@ -134,6 +144,7 @@ export class GitFileWatcher {
     this.worktreeQuietWindowMs = options.worktreeQuietWindowMs ?? 2_000;
     this.onChange = options.onChange;
     this.onGitConfigChanged = options.onGitConfigChanged;
+    this.onWorktreeFilesChanged = options.onWorktreeFilesChanged;
     this.onWatcherFailed = options.onWatcherFailed;
     this.onInotifyLimitReached = options.onInotifyLimitReached;
     this.onEmfileLimitReached = options.onEmfileLimitReached;
@@ -544,6 +555,11 @@ export class GitFileWatcher {
     this.worktreeBurstCount = 0;
     this.lastWorktreeFlushAt = Date.now();
     if (!this.disposed) {
+      // Raw-filesystem signal first, then the git-status recompute: a browser
+      // subscriber that only cares about files-on-disk shouldn't have to wait
+      // for the status pass, and firing it here (not the git-internal path)
+      // keeps it scoped to actual working-tree writes.
+      this.onWorktreeFilesChanged?.();
       this.onChange();
     }
   }

--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -61,6 +61,7 @@ export interface SnapshotBuilderHost {
   readonly baseMatchesUpstream: boolean | undefined;
   readonly lastFetchedAt: number | null;
   readonly lastGitStatusCheckedAt: number;
+  readonly workingTreeChangedAt: number;
   readonly fetchAuthFailed: boolean;
   readonly fetchNetworkFailed: boolean;
   readonly isFetchInFlight: boolean;
@@ -165,6 +166,9 @@ export class SnapshotBuilder {
       baseMatchesUpstream: this.host.baseMatchesUpstream ?? undefined,
       lastFetchedAt: this.host.lastFetchedAt ?? undefined,
       lastGitStatusCheckedAt: this.host.lastGitStatusCheckedAt,
+      // 0 → undefined so a worktree that has never seen a raw fs write serializes
+      // lean; the store side map treats absent as "no signal yet".
+      workingTreeChangedAt: this.host.workingTreeChangedAt || undefined,
       fetchAuthFailed: this.host.fetchAuthFailed || undefined,
       fetchNetworkFailed: this.host.fetchNetworkFailed || undefined,
       // Read in-flight state authoritatively at snapshot time (lesson #1700)

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -60,6 +60,13 @@ export interface WatcherControllerHost {
    * reload (#11155), without paying a git subprocess on every status pass.
    */
   onGitConfigChanged?(): void;
+  /**
+   * Fired once per recursive-worktree flush: a raw filesystem write happened,
+   * independent of whether git status changed. Lets the host stamp a
+   * working-tree-changed timestamp so the file browser can refresh on writes
+   * into gitignored paths that leave `git status` unmoved (#11330).
+   */
+  onWorktreeFilesChanged?(): void;
 }
 
 /**
@@ -163,6 +170,7 @@ export class WatcherController {
       debounceMs: this.host.gitWatchDebounceMs,
       onChange: () => this.handleGitFileChange(),
       onGitConfigChanged: () => this.host.onGitConfigChanged?.(),
+      onWorktreeFilesChanged: () => this.handleWorktreeFilesChanged(),
       watchWorktree: mode === "recursive",
       worktreeMinDebounceMs: WATCHER_WORKTREE_MIN_DEBOUNCE_MS,
       worktreeMaxDebounceMs: WATCHER_WORKTREE_MAX_DEBOUNCE_MS,
@@ -531,6 +539,17 @@ export class WatcherController {
         this.start("recursive");
       }
     }, WATCHER_RETRY_INTERVAL_MS).unref();
+  }
+
+  /**
+   * Forward the recursive watcher's raw-filesystem signal to the host, guarded
+   * so a callback from a watcher being rotated out or a stopped controller
+   * can't stamp the monitor after `stop()`. `flushWorktreeChange` already
+   * checks the watcher's own disposed flag; this is the controller-level gate.
+   */
+  private handleWorktreeFilesChanged(): void {
+    if (this.disposed || !this.host.isRunning) return;
+    this.host.onWorktreeFilesChanged?.();
   }
 
   private handleGitFileChange(): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -166,6 +166,12 @@ export class WorktreeMonitor {
   private gitWatchBudgetAllowed: boolean = true;
   private gitWatchDebounceMs: number;
   private lastGitStatusCompletedAt: number = 0;
+  // Monotonic timestamp of the last recursive-watcher flush — a raw filesystem
+  // write, independent of whether git status changed. Drives the file browser's
+  // live refresh for writes into gitignored paths (#11330). Excluded from
+  // snapshot dedup and carried through the store's side map like the
+  // git-status-checked timestamp.
+  private _workingTreeChangedAt: number = 0;
   // Stamped by the watcher's onTriggerUpdate hook before a forced refresh
   // fires. The stat pre-check compares against `lastStatBaselineAt` to know
   // whether an event arrived since the baseline was captured — if so, the
@@ -398,6 +404,7 @@ export class WorktreeMonitor {
         monitor.callbacks.onEmfileLimitReached?.(worktreeId),
       onWatcherRecovered: () => monitor.callbacks.onWatcherRecovered?.(monitor.id),
       onGitConfigChanged: () => monitor.callbacks.onGitConfigChanged?.(monitor.id),
+      onWorktreeFilesChanged: () => monitor.handleWorktreeFilesChanged(),
     };
     this.watcherController = new WatcherController(watcherHost);
 
@@ -548,6 +555,9 @@ export class WorktreeMonitor {
       },
       get lastGitStatusCheckedAt() {
         return monitor.lastGitStatusCompletedAt;
+      },
+      get workingTreeChangedAt() {
+        return monitor._workingTreeChangedAt;
       },
       get fetchAuthFailed() {
         return monitor._fetchAuthFailed;
@@ -1793,6 +1803,22 @@ export class WorktreeMonitor {
 
   async updateGitStatus(forceRefresh: boolean = false): Promise<void> {
     return this.gitStatusPass.run(forceRefresh);
+  }
+
+  /**
+   * A recursive-watcher flush: a raw filesystem write happened, whether or not
+   * git status changed. Stamp a monotonic timestamp and emit immediately so the
+   * file browser refreshes off the write itself rather than waiting for the
+   * next git-status pass. Two flushes inside one millisecond (or a backward
+   * clock adjustment) still strictly increase, so each registers downstream.
+   * Before the first status resolves there is no snapshot to emit — the stamp
+   * is retained and the first normal snapshot carries it.
+   */
+  private handleWorktreeFilesChanged(): void {
+    this._workingTreeChangedAt = Math.max(Date.now(), this._workingTreeChangedAt + 1);
+    if (this._hasInitialStatus) {
+      this.emitUpdate();
+    }
   }
 
   emitUpdate(): void {

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -52,6 +52,7 @@ function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilder
     baseMatchesUpstream: undefined,
     lastFetchedAt: null,
     lastGitStatusCheckedAt: 0,
+    workingTreeChangedAt: 0,
     fetchAuthFailed: false,
     fetchNetworkFailed: false,
     isFetchInFlight: false,
@@ -201,5 +202,14 @@ describe("SnapshotBuilder", () => {
     expect(new SnapshotBuilder(makeHost({ worktreeMode: "remote" })).build().worktreeMode).toBe(
       "remote"
     );
+  });
+
+  it("omits workingTreeChangedAt until a fs write is observed, then surfaces it", () => {
+    // 0 → undefined keeps the snapshot lean for a worktree that has never seen a
+    // raw fs write; a real stamp passes straight through for the store side map.
+    expect(new SnapshotBuilder(makeHost()).build().workingTreeChangedAt).toBeUndefined();
+
+    const stamped = makeHost({ workingTreeChangedAt: 1_725_000_000_000 });
+    expect(new SnapshotBuilder(stamped).build().workingTreeChangedAt).toBe(1_725_000_000_000);
   });
 });

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -72,6 +72,7 @@ interface MutableHost {
   onInotifyLimitReached: ReturnType<typeof vi.fn>;
   onEmfileLimitReached: ReturnType<typeof vi.fn>;
   onWatcherRecovered: ReturnType<typeof vi.fn>;
+  onWorktreeFilesChanged: ReturnType<typeof vi.fn>;
 }
 
 function makeHost(overrides: Partial<MutableHost> = {}): MutableHost {
@@ -89,6 +90,7 @@ function makeHost(overrides: Partial<MutableHost> = {}): MutableHost {
     onInotifyLimitReached: vi.fn(),
     onEmfileLimitReached: vi.fn(),
     onWatcherRecovered: vi.fn(),
+    onWorktreeFilesChanged: vi.fn(),
     ...overrides,
   };
 }
@@ -593,6 +595,41 @@ describe("WatcherController", () => {
     capturedOnEmfileLimitReached?.();
     expect(host.onInotifyLimitReached).toHaveBeenCalledWith("/test/worktree");
     expect(host.onEmfileLimitReached).toHaveBeenCalledWith("/test/worktree");
+  });
+
+  it("forwards onWorktreeFilesChanged to the host when the recursive watcher flushes", async () => {
+    mockWatcherStartResult = true;
+    const host = makeHost({ isElevated: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+    ctrl.start();
+    await settle();
+
+    const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
+      (() => void) | undefined;
+    expect(fireWorktreeFilesChanged).toBeDefined();
+
+    fireWorktreeFilesChanged?.();
+    expect(host.onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a late onWorktreeFilesChanged once the host is no longer running", async () => {
+    mockWatcherStartResult = true;
+    const host = makeHost({ isElevated: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+    ctrl.start();
+    await settle();
+
+    const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
+      (() => void) | undefined;
+
+    // A watcher rotated out (or a stopped controller) can still fire its
+    // debounced flush; the controller-level guard must not stamp the host
+    // after teardown.
+    host.isRunning = false;
+    ctrl.stop();
+    fireWorktreeFilesChanged?.();
+
+    expect(host.onWorktreeFilesChanged).not.toHaveBeenCalled();
   });
 
   it("uses the 250ms worktree min-debounce floor", async () => {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
@@ -886,4 +886,105 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
   });
+
+  describe("working-tree-changed signal (#11330)", () => {
+    const WATCH_CONFIG: WorktreeMonitorConfig = {
+      ...TEST_CONFIG,
+      gitWatchEnabled: true,
+    };
+    // Active worktree → recursive watcher, and start() resolves the initial
+    // git status synchronously so _hasInitialStatus is already true on return.
+    const ACTIVE_WORKTREE: Worktree = { ...TEST_WORKTREE, isCurrent: true };
+
+    beforeEach(() => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    it("a recursive-watcher flush emits a stamped snapshot without a git-status change", async () => {
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(monitor.hasInitialStatus).toBe(true);
+      // No raw-fs write yet, so the initial snapshot carries no stamp.
+      expect(
+        vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0]?.workingTreeChangedAt
+      ).toBeUndefined();
+
+      const statusCallsBefore = mockGetWorktreeChangesWithStats.mock.calls.length;
+      const emitsBefore = vi.mocked(callbacks.onUpdate).mock.calls.length;
+
+      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
+        (() => void) | undefined;
+      expect(fireWorktreeFilesChanged).toBeDefined();
+      fireWorktreeFilesChanged?.();
+
+      // Emitted off the write alone — a fresh snapshot, no extra git status run.
+      expect(vi.mocked(callbacks.onUpdate).mock.calls.length).toBe(emitsBefore + 1);
+      expect(mockGetWorktreeChangesWithStats.mock.calls.length).toBe(statusCallsBefore);
+      expect(
+        vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0]?.workingTreeChangedAt
+      ).toBeGreaterThan(0);
+
+      monitor.stop();
+    });
+
+    it("stamps a strictly increasing workingTreeChangedAt across successive flushes", async () => {
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as () => void;
+
+      // Two flushes with no timer advance between them: the monotonic guard
+      // (Math.max(now, prev + 1)) must still move the stamp forward even when
+      // Date.now() is unchanged.
+      fireWorktreeFilesChanged();
+      const first = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0]?.workingTreeChangedAt;
+      fireWorktreeFilesChanged();
+      const second = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0]?.workingTreeChangedAt;
+
+      expect(first).toBeGreaterThan(0);
+      expect(second).toBeGreaterThan(first ?? 0);
+
+      monitor.stop();
+    });
+
+    it("a flush before initial status stamps but does not emit; the first snapshot carries it", async () => {
+      // Background worktree defers its initial git status behind the 2-5s
+      // jitter, so _hasInitialStatus is still false right after start() — the
+      // only clean way to exercise the pre-initial-status branch. Driving the
+      // captured callback directly stands in for the recursive flush.
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(monitor.hasInitialStatus).toBe(false);
+      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+
+      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as () => void;
+      fireWorktreeFilesChanged();
+
+      // Stamped internally, but no incomplete snapshot emitted for it.
+      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+
+      // Once the deferred initial status lands, its first snapshot carries the
+      // retained stamp.
+      await flushInitialStatus();
+      expect(monitor.hasInitialStatus).toBe(true);
+      expect(callbacks.onUpdate).toHaveBeenCalled();
+      expect(
+        vi.mocked(callbacks.onUpdate).mock.calls[0]?.[0]?.workingTreeChangedAt
+      ).toBeGreaterThan(0);
+
+      monitor.stop();
+    });
+  });
 });

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -268,8 +268,8 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
   browserSelectedPath?: string;
   /** Worktree-relative directory paths to expand on open */
   browserExpandedPaths?: string[];
-  /** Whether gitignored entries start visible; defaults to false */
-  browserShowIgnored?: boolean;
+  /** Whether dot-prefixed entries start hidden; defaults to false (dotfiles visible) */
+  browserHideDotfiles?: boolean;
   /** Worktree-relative directory to root the tree at; "" or absent = worktree root */
   browserRootPath?: string;
   /** Whether the tree sidebar starts collapsed; absent or false = open */

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -152,10 +152,4 @@ export interface FileTreeNode {
   size?: number;
   /** Children (only populated for directories if expanded) */
   children?: FileTreeNode[];
-  /**
-   * Whether git reports this entry as ignored. Only ever set when the caller
-   * asked for ignored entries — the default listing filters them out, so an
-   * absent flag means "not ignored", never "unknown".
-   */
-  isIgnored?: boolean;
 }

--- a/shared/types/ipc/fileBrowser.ts
+++ b/shared/types/ipc/fileBrowser.ts
@@ -14,8 +14,6 @@ export interface FileBrowserListDirectoryPayload {
   worktreeId: string;
   /** Worktree-relative directory to list; absent or "" lists the root */
   dirPath?: string;
-  /** Include gitignored entries, each flagged `isIgnored`, instead of dropping them */
-  includeIgnored?: boolean;
 }
 
 /** Entries of one directory, directories first then case-insensitive by name. */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -718,8 +718,14 @@ export interface FileBrowserPanelData extends BasePanelData {
    * than a Set because panel data round-trips through JSON persistence.
    */
   browserExpandedPaths?: string[];
-  /** Whether gitignored entries are shown (dimmed). Absent defaults to false. */
-  browserShowIgnored?: boolean;
+  /**
+   * Whether dot-prefixed entries are hidden in this panel. Absent defaults to
+   * false — dotfiles are visible by default; the toolbar toggle hides them
+   * (#11330). Replaces the old `browserShowIgnored` field, which is
+   * intentionally not migrated: its meaning was inverted, so an old panel that
+   * showed gitignored files must not silently start hiding dotfiles.
+   */
+  browserHideDotfiles?: boolean;
   /**
    * Worktree-relative directory the tree is rooted at. Absent or "" = the
    * worktree root itself.

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -163,8 +163,8 @@ export interface PanelSnapshot {
   browserSelectedPath?: string;
   /** Worktree-relative directories expanded in a file browser panel */
   browserExpandedPaths?: string[];
-  /** Whether a file browser panel shows gitignored entries */
-  browserShowIgnored?: boolean;
+  /** Whether a file browser panel hides dot-prefixed entries */
+  browserHideDotfiles?: boolean;
   /** Worktree-relative directory a file browser panel is rooted at */
   browserRootPath?: string;
   /** Whether a file browser panel's tree sidebar is collapsed (only `true` persisted) */

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -182,6 +182,16 @@ export interface WorktreeSnapshot {
   /** Epoch ms of the last completed git status check for this worktree. */
   lastGitStatusCheckedAt?: number;
 
+  /**
+   * Monotonic epoch ms of the last recursive-watcher flush — a raw filesystem
+   * write, whether or not git status changed. Independent of
+   * `lastGitStatusCheckedAt`, and (like it) excluded from snapshot dedup and
+   * carried through the store's side map so a timestamp-only bump doesn't churn
+   * the worktree map. Drives the file browser's live refresh for writes into
+   * gitignored paths (#11330). Absent until the first fs write is observed.
+   */
+  workingTreeChangedAt?: number;
+
   /** True when this worktree's repo is in an auth-failed fetch state. */
   fetchAuthFailed?: boolean;
 
@@ -471,7 +481,7 @@ export type WorkspaceHostRequest =
       requestId: string;
       worktreePath: string;
       dirPath?: string;
-      /** Include gitignored entries, flagged `isIgnored`, instead of dropping them */
+      /** Raw-listing mode: skip the git check-ignore pass and return every entry (#11330) */
       includeIgnored?: boolean;
     }
   // Project Pulse operations

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -82,6 +82,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
   const store = createStore<WorktreeViewState & WorktreeViewActions>(() => ({
     worktrees,
     statusCheckedAt: new Map(),
+    workingTreeChangedAtById: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),

--- a/src/components/Settings/FileBrowserVisibilitySettings.tsx
+++ b/src/components/Settings/FileBrowserVisibilitySettings.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { EyeOff, Plus, RotateCcw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  usePreferencesStore,
+  DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN,
+  MAX_ALWAYS_HIDDEN_PATTERNS,
+  MAX_ALWAYS_HIDDEN_PATTERN_LENGTH,
+} from "@/store/preferencesStore";
+import { SettingsSection } from "./SettingsSection";
+
+function sameList(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+/**
+ * Editor for the app-global file-browser "always hidden" junk list (#11330).
+ * Every action commits to the store immediately — add, remove, reset — so there
+ * is no buffered state to flush and no second tab-flush registration to collide
+ * with the host tab's own save lifecycle. The add input is the only local state,
+ * committed on Enter or the add button.
+ */
+export function FileBrowserVisibilitySettings() {
+  const patterns = usePreferencesStore((s) => s.fileBrowserAlwaysHiddenPatterns);
+  const setPatterns = usePreferencesStore((s) => s.setFileBrowserAlwaysHiddenPatterns);
+  const resetPatterns = usePreferencesStore((s) => s.resetFileBrowserAlwaysHiddenPatterns);
+
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const isModified = !sameList(patterns, DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN);
+
+  const commitAdd = () => {
+    const trimmed = draft.trim();
+    if (trimmed === "") return;
+    if (trimmed.includes("/") || trimmed.includes("\\")) {
+      setError("Match by name only — no slashes");
+      return;
+    }
+    if (trimmed.length > MAX_ALWAYS_HIDDEN_PATTERN_LENGTH) {
+      setError("That pattern is too long");
+      return;
+    }
+    if (patterns.includes(trimmed)) {
+      setError("Already in the list");
+      return;
+    }
+    // Reject at the cap rather than let the sanitizer silently drop the add
+    // while the input clears as though it saved. Keep the draft so it isn't lost.
+    if (patterns.length >= MAX_ALWAYS_HIDDEN_PATTERNS) {
+      setError("List is full — remove one first");
+      return;
+    }
+    // The store re-sanitizes, so this stays the single source of truth for the
+    // list's shape; the UI validation above is only for immediate feedback.
+    setPatterns([...patterns, trimmed]);
+    setDraft("");
+    setError(null);
+  };
+
+  return (
+    <SettingsSection
+      id="file-browser-always-hidden"
+      icon={EyeOff}
+      title="Always-hidden files"
+      description="Files matching these names stay hidden in every file browser panel, whatever the dotfile toggle. Match by name; use * as a wildcard (for example ._* or *.log)."
+    >
+      <div className="space-y-3">
+        <ul className="flex flex-wrap gap-1.5" aria-label="Always-hidden patterns">
+          {patterns.length === 0 && (
+            <li className="text-xs text-daintree-text/40">Nothing is hidden</li>
+          )}
+          {patterns.map((pattern) => (
+            <li
+              key={pattern}
+              className="flex items-center gap-1 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/50 py-1 pl-2 pr-1 font-mono text-xs text-daintree-text"
+            >
+              <span className="break-all">{pattern}</span>
+              <button
+                type="button"
+                onClick={() => setPatterns(patterns.filter((p) => p !== pattern))}
+                aria-label={`Remove ${pattern}`}
+                className="flex h-4 w-4 items-center justify-center rounded text-daintree-text/50 transition-colors hover:bg-daintree-border/50 hover:text-daintree-text"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              if (error) setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commitAdd();
+              }
+            }}
+            placeholder="Add a name or pattern"
+            aria-label="Add an always-hidden pattern"
+            className={cn(
+              "flex-1 rounded-[var(--radius-md)] border bg-daintree-bg px-3 py-1.5 font-mono text-sm text-daintree-text",
+              "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent",
+              error ? "border-status-error/50" : "border-daintree-border"
+            )}
+          />
+          <button
+            type="button"
+            onClick={commitAdd}
+            disabled={draft.trim() === ""}
+            aria-label="Add pattern"
+            className="flex items-center gap-1 rounded-[var(--radius-md)] border border-daintree-border px-3 py-1.5 text-sm text-daintree-text/70 transition-colors hover:bg-daintree-border/50 hover:text-daintree-text disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            Add
+          </button>
+        </div>
+
+        {error && <p className="text-xs text-status-error">{error}</p>}
+
+        {isModified && (
+          <button
+            type="button"
+            onClick={() => {
+              resetPatterns();
+              setError(null);
+            }}
+            className="flex items-center gap-1 text-xs text-daintree-text/50 transition-colors hover:text-daintree-text"
+          >
+            <RotateCcw className="h-3 w-3" />
+            Reset to defaults
+          </button>
+        )}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -14,6 +14,7 @@ import {
   isDeletedWorktreeCleanupSeconds,
   DELETED_WORKTREE_CLEANUP_DEFAULT,
 } from "@/store/preferencesStore";
+import { FileBrowserVisibilitySettings } from "./FileBrowserVisibilitySettings";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect } from "./SettingsSelect";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
@@ -349,6 +350,8 @@ export function WorktreeSettingsTab() {
           onReset={() => setCleanupSeconds(DELETED_WORKTREE_CLEANUP_DEFAULT)}
         />
       </SettingsSection>
+
+      <FileBrowserVisibilitySettings />
     </div>
   );
 }

--- a/src/components/Settings/__tests__/FileBrowserVisibilitySettings.test.tsx
+++ b/src/components/Settings/__tests__/FileBrowserVisibilitySettings.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { FileBrowserVisibilitySettings } from "../FileBrowserVisibilitySettings";
+
+// Captured from the store at runtime (not imported from source) so the reset
+// assertion below is a behavioral check, not a copy of the default literal.
+let defaults: string[];
+
+function patterns(): string[] {
+  return usePreferencesStore.getState().fileBrowserAlwaysHiddenPatterns;
+}
+
+describe("FileBrowserVisibilitySettings", () => {
+  beforeAll(() => {
+    usePreferencesStore.getState().resetFileBrowserAlwaysHiddenPatterns();
+    defaults = [...patterns()];
+  });
+
+  beforeEach(() => {
+    usePreferencesStore.getState().setFileBrowserAlwaysHiddenPatterns([".DS_Store", "Thumbs.db"]);
+  });
+
+  it("renders a removable chip for each current pattern", () => {
+    render(<FileBrowserVisibilitySettings />);
+    expect(screen.getByLabelText("Remove .DS_Store")).toBeTruthy();
+    expect(screen.getByLabelText("Remove Thumbs.db")).toBeTruthy();
+  });
+
+  it("adds a pattern on Enter and clears the input", () => {
+    render(<FileBrowserVisibilitySettings />);
+    const input = screen.getByLabelText("Add an always-hidden pattern") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "*.log" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(patterns()).toEqual([".DS_Store", "Thumbs.db", "*.log"]);
+    expect(input.value).toBe("");
+  });
+
+  it("adds a pattern via the Add button", () => {
+    render(<FileBrowserVisibilitySettings />);
+    const input = screen.getByLabelText("Add an always-hidden pattern");
+
+    fireEvent.change(input, { target: { value: "desktop.ini" } });
+    fireEvent.click(screen.getByLabelText("Add pattern"));
+
+    expect(patterns()).toContain("desktop.ini");
+  });
+
+  it("removes the pattern whose chip button is clicked", () => {
+    render(<FileBrowserVisibilitySettings />);
+
+    fireEvent.click(screen.getByLabelText("Remove .DS_Store"));
+
+    expect(patterns()).toEqual(["Thumbs.db"]);
+  });
+
+  it("rejects a slash-containing pattern with an error and does not add it", () => {
+    render(<FileBrowserVisibilitySettings />);
+    const input = screen.getByLabelText("Add an always-hidden pattern");
+
+    fireEvent.change(input, { target: { value: "build/output" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText("Match by name only — no slashes")).toBeTruthy();
+    expect(patterns()).toEqual([".DS_Store", "Thumbs.db"]);
+  });
+
+  it("shows the empty affordance when nothing is hidden", () => {
+    usePreferencesStore.getState().setFileBrowserAlwaysHiddenPatterns([]);
+    render(<FileBrowserVisibilitySettings />);
+
+    expect(screen.getByText("Nothing is hidden")).toBeTruthy();
+  });
+
+  it("refuses to add past the cap and keeps the draft instead of silently dropping it", () => {
+    const full = Array.from({ length: 100 }, (_, i) => `pat-${i}`);
+    usePreferencesStore.getState().setFileBrowserAlwaysHiddenPatterns(full);
+    render(<FileBrowserVisibilitySettings />);
+    const input = screen.getByLabelText("Add an always-hidden pattern") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "one-more" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText("List is full — remove one first")).toBeTruthy();
+    expect(patterns()).not.toContain("one-more");
+    expect(input.value).toBe("one-more");
+  });
+
+  it("offers reset only when modified, and restores the defaults", () => {
+    // beforeEach left a custom list, which differs from defaults.
+    render(<FileBrowserVisibilitySettings />);
+
+    fireEvent.click(screen.getByText("Reset to defaults"));
+
+    expect(patterns()).toEqual(defaults);
+  });
+});

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -740,7 +740,17 @@ export const SETTINGS_REGISTRY = [
     importer: importWorktreeSettingsTab,
     LazyComponent: LazyWorktreeSettingsTab,
     searchNavDescription: "Configure where git worktrees are created",
-    searchNavKeywords: ["terminal", "worktree", "paths", "git", "directory"],
+    searchNavKeywords: [
+      "terminal",
+      "worktree",
+      "paths",
+      "git",
+      "directory",
+      "file browser",
+      "hidden files",
+      "dotfiles",
+      "junk files",
+    ],
     sections: [
       {
         id: "worktree-path-pattern",
@@ -757,6 +767,24 @@ export const SETTINGS_REGISTRY = [
           "directory",
           "location",
           "git",
+        ],
+      },
+      {
+        id: "file-browser-always-hidden",
+        section: "Always-hidden files",
+        title: "Always-hidden files",
+        description:
+          "Names always hidden in the file browser (junk like .DS_Store, Thumbs.db). Match by name; * is a wildcard.",
+        keywords: [
+          "file browser",
+          "hidden files",
+          "dotfiles",
+          "dot files",
+          "junk files",
+          "ds_store",
+          "thumbs.db",
+          "gitignore",
+          "ignored",
         ],
       },
     ],

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -173,11 +173,11 @@ describe("panelKindSerialisers", () => {
       ).toBe("src/app.ts");
     });
 
-    it("drops a non-boolean ignored toggle rather than coercing it", () => {
+    it("drops a non-boolean dotfile toggle rather than coercing it", () => {
       expect(
-        deserialize()({ id: "fb1", browserShowIgnored: "yes" }).browserShowIgnored
+        deserialize()({ id: "fb1", browserHideDotfiles: "yes" }).browserHideDotfiles
       ).toBeUndefined();
-      expect(deserialize()({ id: "fb1", browserShowIgnored: false }).browserShowIgnored).toBe(
+      expect(deserialize()({ id: "fb1", browserHideDotfiles: false }).browserHideDotfiles).toBe(
         false
       );
     });
@@ -195,6 +195,17 @@ describe("panelKindSerialisers", () => {
         deserialize()({ id: "fb1", browserSidebarCollapsed: "yes" }).browserSidebarCollapsed
       ).toBeUndefined();
       expect(deserialize()({ id: "fb1" }).browserSidebarCollapsed).toBeUndefined();
+    });
+
+    it("ignores a legacy browserShowIgnored key instead of migrating it", () => {
+      // The old field is unknown to the deserializer now; a persisted `true`
+      // must not resurface as the inverted new toggle (#10938 / #11330).
+      // Bound to a variable so the removed key isn't an object-literal excess
+      // property — a persisted blob really can carry unknown keys.
+      const legacy = { id: "fb1", browserShowIgnored: true };
+      const output = deserialize()(legacy);
+      expect(output.browserHideDotfiles).toBeUndefined();
+      expect(output).not.toHaveProperty("browserShowIgnored");
     });
   });
 

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -147,8 +147,8 @@ const BUILT_IN_DESERIALIZERS = {
       ? saved.browserSelectedPath
       : undefined,
     browserExpandedPaths: sanitizeExpandedPaths(saved.browserExpandedPaths),
-    browserShowIgnored:
-      typeof saved.browserShowIgnored === "boolean" ? saved.browserShowIgnored : undefined,
+    browserHideDotfiles:
+      typeof saved.browserHideDotfiles === "boolean" ? saved.browserHideDotfiles : undefined,
     browserRootPath: canonicalRelativePath(saved.browserRootPath),
     // Only a literal `true` restores collapsed: a hand-edited or corrupted
     // snapshot holding a string or object must fall back to the open default.

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -278,7 +278,7 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   // the tree and how it's laid out), which is exactly what a pinned panel keeps.
   browserSelectedPath: true,
   browserExpandedPaths: true,
-  browserShowIgnored: true,
+  browserHideDotfiles: true,
   browserRootPath: true,
   browserSidebarCollapsed: true,
   // BasePanelData carrier-bookkeeping timestamps — written by the base
@@ -454,7 +454,7 @@ const fileBrowserFixture: FileBrowserPanelData = {
   kind: "file-browser",
   browserSelectedPath: "src/app.ts",
   browserExpandedPaths: ["src"],
-  browserShowIgnored: true,
+  browserHideDotfiles: true,
   browserRootPath: "src",
   browserSidebarCollapsed: true,
 };
@@ -464,7 +464,7 @@ const savedFileBrowser: SavedTerminalData = {
   kind: "file-browser",
   browserSelectedPath: "src/app.ts",
   browserExpandedPaths: ["src"],
-  browserShowIgnored: true,
+  browserHideDotfiles: true,
   browserRootPath: "src",
   browserSidebarCollapsed: true,
 };
@@ -571,19 +571,19 @@ describe("panel serializer field coverage", () => {
     );
   });
 
-  it("file browser serializer keeps an explicit false for the ignored toggle", () => {
-    const withIgnoredOff: FileBrowserPanelData = {
+  it("file browser serializer keeps an explicit false for the dotfile toggle", () => {
+    const withDotfilesShown: FileBrowserPanelData = {
       ...fileBrowserFixture,
-      browserShowIgnored: false,
+      browserHideDotfiles: false,
     };
-    const output = getPanelKindConfig("file-browser")!.serialize!(withIgnoredOff) as Record<
+    const output = getPanelKindConfig("file-browser")!.serialize!(withDotfilesShown) as Record<
       string,
       unknown
     >;
 
     // Truthiness-based spreading would drop this, and the restored panel would
     // silently pick up whatever the default becomes.
-    expect(output.browserShowIgnored).toBe(false);
+    expect(output.browserHideDotfiles).toBe(false);
   });
 
   it("diff serializer covers every persisted diff field", () => {
@@ -673,17 +673,17 @@ describe("panel deserializer field coverage", () => {
     }
   });
 
-  it("file browser deserializer drops a non-boolean ignored toggle rather than coercing it", () => {
+  it("file browser deserializer drops a non-boolean dotfile toggle rather than coercing it", () => {
     const deserializer = getDeserializer("file-browser")!;
 
     const output = deserializer({
       ...savedFileBrowser,
-      browserShowIgnored: "yes",
+      browserHideDotfiles: "yes",
     }) as Record<string, unknown>;
 
-    // Coercing would turn any stray on-disk string into "show every ignored
-    // file", which is the opposite of the safe default.
-    expect(output.browserShowIgnored).toBeUndefined();
+    // Coercing would turn any stray on-disk string into "hide every dotfile",
+    // which is the opposite of the safe default (dotfiles visible).
+    expect(output.browserHideDotfiles).toBeUndefined();
   });
 
   it("terminal has no deserializer registry entry", () => {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -15,11 +15,18 @@ import { folderIncludePattern } from "@/lib/copyTreeFormat";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
 import { useFileBrowserTree } from "./useFileBrowserTree";
-import { ancestorDirectories, parentRootPath, type FlatTreeRow } from "./fileBrowserTree";
+import {
+  ancestorDirectories,
+  createVisibilityFilter,
+  isRowPathVisible,
+  parentRootPath,
+  type FlatTreeRow,
+} from "./fileBrowserTree";
 
 export type FileBrowserPaneProps = BasePanelProps;
 
@@ -69,14 +76,17 @@ export function FileBrowserPane({
       [id]
     )
   );
-  const showIgnored = usePanelStore(
+  const hideDotfiles = usePanelStore(
     useCallback(
       (state) => {
         const panel = state.panelsById[id];
-        return panel?.kind === "file-browser" ? panel.browserShowIgnored === true : false;
+        return panel?.kind === "file-browser" ? panel.browserHideDotfiles === true : false;
       },
       [id]
     )
+  );
+  const alwaysHiddenPatterns = usePreferencesStore(
+    (state) => state.fileBrowserAlwaysHiddenPatterns
   );
   const rootPath = usePanelStore(
     useCallback(
@@ -105,26 +115,48 @@ export function FileBrowserPane({
       [worktreeId]
     )
   );
-  // The worktree's own change tick — already coalesced by the watcher's
+  // The worktree's git-status change tick — already coalesced by the watcher's
   // adaptive burst debounce, so a bulk write lands as one tick.
-  const changeTick = useWorktreeStore(
+  const gitChangeTick = useWorktreeStore(
     useCallback(
       (state) =>
         worktreeId ? state.worktrees.get(worktreeId)?.worktreeChanges?.lastUpdated : undefined,
       [worktreeId]
     )
   );
+  // The raw filesystem-write tick, independent of git status. Combining the two
+  // is the fix for the issue's reproduction: a write into a gitignored folder
+  // moves this even though `worktreeChanges` (which dedups content-identical
+  // snapshots) never advances (#11330).
+  const fsChangeTick = useWorktreeStore(
+    useCallback(
+      (state) => (worktreeId ? state.workingTreeChangedAtById.get(worktreeId) : undefined),
+      [worktreeId]
+    )
+  );
+  // A single monotonic signal for "re-read the tree/file": whichever moved most
+  // recently. `|| undefined` so a never-changed worktree keeps the "no tick"
+  // identity the hook expects.
+  const changeTick = Math.max(gitChangeTick ?? 0, fsChangeTick ?? 0) || undefined;
 
   const stableExpandedPaths = useMemo(() => expandedPaths ?? EMPTY_PATHS, [expandedPaths]);
 
-  const { rows, isInitialLoading, rootError, ensureLoaded, refresh, isRefreshing } =
-    useFileBrowserTree({
-      worktreeId,
-      expandedPaths: stableExpandedPaths,
-      showIgnored,
-      rootPath,
-      changeTick,
-    });
+  const {
+    rows,
+    isInitialLoading,
+    rootError,
+    hasHiddenDotfiles,
+    ensureLoaded,
+    refresh,
+    isRefreshing,
+  } = useFileBrowserTree({
+    worktreeId,
+    expandedPaths: stableExpandedPaths,
+    hideDotfiles,
+    alwaysHiddenPatterns,
+    rootPath,
+    changeTick,
+  });
 
   const handleToggleExpanded = useCallback(
     (path: string, expand: boolean) => {
@@ -168,9 +200,20 @@ export function FileBrowserPane({
   // the open file 500 times.
   const viewerRevision = `${changeTick ?? 0}:${manualRefreshNonce}`;
 
-  const handleToggleIgnored = useCallback(() => {
-    setFileBrowserView(id, { browserShowIgnored: !showIgnored });
-  }, [id, showIgnored, setFileBrowserView]);
+  const handleToggleDotfiles = useCallback(() => {
+    setFileBrowserView(id, { browserHideDotfiles: !hideDotfiles });
+  }, [id, hideDotfiles, setFileBrowserView]);
+
+  // A selection the junk list or dotfile toggle now hides. The viewer already
+  // clears (the hidden row isn't in `rows`, so `selectedNode` is undefined),
+  // but the "Reveal" strip must also stay hidden: expanding ancestors can
+  // surface a collapsed row, never a filtered one, so offering it would be a
+  // dead end.
+  const selectionFilteredHidden = useMemo(() => {
+    if (selectedPath === null) return false;
+    const isVisible = createVisibilityFilter({ hideDotfiles, alwaysHiddenPatterns });
+    return !isRowPathVisible(selectedPath, rootPath, isVisible);
+  }, [selectedPath, hideDotfiles, alwaysHiddenPatterns, rootPath]);
 
   // Stable id for the tree column so the toggle's `aria-controls` can name the
   // region it discloses. Only referenced while the column is mounted (open).
@@ -292,13 +335,11 @@ export function FileBrowserPane({
         {row.isDirectory && (
           <>
             <ContextMenuItem onSelect={() => handleSetRoot(row.path)}>Set as root</ContextMenuItem>
-            {/* Disabled rather than hidden for ignored folders: CopyTree's
-                discovery respects .gitignore, so the copy would always come
-                back empty — but the item vanishing would read as a bug. */}
-            <ContextMenuItem
-              disabled={row.isIgnored}
-              onSelect={() => handleCopyFolderContext(row.path)}
-            >
+            {/* Always enabled: the browser no longer knows a folder's gitignore
+                status, and CopyTree still applies its own .gitignore-aware
+                discovery (reporting when nothing was eligible), so this stays
+                safe for a gitignored folder. */}
+            <ContextMenuItem onSelect={() => handleCopyFolderContext(row.path)}>
               Copy context
             </ContextMenuItem>
             <ContextMenuSeparator />
@@ -424,9 +465,9 @@ export function FileBrowserPane({
                 </FileViewerToolbar.IconButton>
               )}
               <FileViewerToolbar.IconButton
-                label="Show ignored"
-                pressed={showIgnored}
-                onClick={handleToggleIgnored}
+                label="Hide dotfiles"
+                pressed={hideDotfiles}
+                onClick={handleToggleDotfiles}
               >
                 <EyeOff className="h-4 w-4" />
               </FileViewerToolbar.IconButton>
@@ -498,30 +539,34 @@ export function FileBrowserPane({
     }
 
     if (rows.length === 0) {
+      // Only offer "Show dotfiles" when it can actually help — the toggle is on
+      // and this root holds dotfiles it is what's hiding. Otherwise the folder
+      // is genuinely empty (junk-only contents count as empty too).
+      const canRevealDotfiles = hideDotfiles && hasHiddenDotfiles;
       return (
         <div className="flex min-h-0 flex-1 items-center justify-center p-4">
           <EmptyState
-            variant={showIgnored ? "zero-data" : "filtered-empty"}
+            variant={canRevealDotfiles ? "filtered-empty" : "zero-data"}
             scale="sidebar"
             className="w-full"
-            {...(showIgnored ? { icon: <FolderTree className="h-5 w-5" /> } : {})}
+            {...(canRevealDotfiles ? {} : { icon: <FolderTree className="h-5 w-5" /> })}
             title={
-              showIgnored
-                ? rootPath
+              canRevealDotfiles
+                ? "Dotfiles are hidden here"
+                : rootPath
                   ? "This folder is empty"
                   : "This worktree is empty"
-                : "Everything here is ignored"
             }
             action={
-              showIgnored ? undefined : (
+              canRevealDotfiles ? (
                 <button
                   type="button"
-                  onClick={handleToggleIgnored}
+                  onClick={handleToggleDotfiles}
                   className="text-xs underline underline-offset-2"
                 >
-                  Show ignored files
+                  Show dotfiles
                 </button>
-              )
+              ) : undefined
             }
           />
         </div>
@@ -543,15 +588,18 @@ export function FileBrowserPane({
             click makes the selection reachable, and sitting above the rows it
             would shift them mid-gesture — the second click of a double-click
             would land one row off. */}
-        {selectedPath !== null && selectionInRoot && !selectedIsReachable && (
-          <button
-            type="button"
-            onClick={revealSelection}
-            className="shrink-0 truncate border-t border-daintree-border px-3 py-1 text-left font-mono text-[11px] text-daintree-text/60 transition-colors duration-150 ease-out hover:bg-tint/5 hover:text-daintree-text"
-          >
-            Reveal {selectedFileName}
-          </button>
-        )}
+        {selectedPath !== null &&
+          selectionInRoot &&
+          !selectedIsReachable &&
+          !selectionFilteredHidden && (
+            <button
+              type="button"
+              onClick={revealSelection}
+              className="shrink-0 truncate border-t border-daintree-border px-3 py-1 text-left font-mono text-[11px] text-daintree-text/60 transition-colors duration-150 ease-out hover:bg-tint/5 hover:text-daintree-text"
+            >
+              Reveal {selectedFileName}
+            </button>
+          )}
       </>
     );
   }

--- a/src/panels/file-browser/FileTreeView.tsx
+++ b/src/panels/file-browser/FileTreeView.tsx
@@ -316,8 +316,7 @@ function FileTreeRow({ row, isSelected, context }: FileTreeRowProps) {
         // (raised, not the selection's subtle) so it reads as "the menu targets
         // this row" without masquerading as the selection. Radix forwards
         // data-state onto this surface through the asChild trigger below.
-        "data-[state=open]:bg-overlay-raised data-[state=open]:text-daintree-text",
-        row.isIgnored && "opacity-55"
+        "data-[state=open]:bg-overlay-raised data-[state=open]:text-daintree-text"
       )}
     >
       {row.isDirectory ? (

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -38,6 +38,9 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
   useWorktreeStore: (selector: (state: unknown) => unknown) =>
     selector({
       worktrees: new Map([["wt-1", { path: "/repo", worktreeChanges: undefined }]]),
+      // The pane reads the raw filesystem-write side map for its change tick
+      // (#11330); an absent map would crash the `.get(worktreeId)` selector.
+      workingTreeChangedAtById: new Map<string, number>(),
     }),
 }));
 
@@ -54,7 +57,6 @@ vi.mock("../useFileBrowserTree", () => ({
         depth: 0,
         isExpanded: true,
         isLoading: false,
-        isIgnored: false,
       },
       // A file row so a selection can resolve a real viewer path.
       {
@@ -64,13 +66,14 @@ vi.mock("../useFileBrowserTree", () => ({
         depth: 1,
         isExpanded: false,
         isLoading: false,
-        isIgnored: false,
       },
     ],
     isInitialLoading: false,
     rootError: null,
+    hasHiddenDotfiles: false,
     ensureLoaded: vi.fn(),
     refresh: vi.fn(),
+    isRefreshing: false,
   }),
 }));
 

--- a/src/panels/file-browser/__tests__/FileTreeView.test.tsx
+++ b/src/panels/file-browser/__tests__/FileTreeView.test.tsx
@@ -37,7 +37,6 @@ function row(path: string, isDirectory = false): FlatTreeRow {
     depth: 0,
     isExpanded: false,
     isLoading: false,
-    isIgnored: false,
   };
 }
 

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -471,4 +471,9 @@ describe("isRowPathVisible", () => {
   it("is not visible for a path outside the root", () => {
     expect(isRowPathVisible("other/file.ts", "src", showAll)).toBe(false);
   });
+
+  it("treats the root itself as visible — the pump gate must never drop the root target", () => {
+    expect(isRowPathVisible("src", "src", showAll)).toBe(true);
+    expect(isRowPathVisible(".github", ".github", hideDotfiles)).toBe(true);
+  });
 });

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -3,7 +3,9 @@ import type { FileTreeNode } from "@shared/types";
 import {
   ancestorDirectories,
   canonicalizeRootPath,
+  createVisibilityFilter,
   flattenTree,
+  isRowPathVisible,
   parentRootPath,
   pruneListings,
   refreshTargets,
@@ -103,14 +105,25 @@ describe("flattenTree", () => {
     expect(rows[0]?.isLoading).toBe(false);
   });
 
-  it("marks ignored entries so the row can be dimmed", () => {
+  it("omits an entry the visibility filter rejects, and does not descend a hidden directory", () => {
     const listings = listingsOf({
-      "": [file("dist/bundle.js", { isIgnored: true }), file("index.ts")],
+      "": [dir(".git"), dir("src"), file(".env"), file("README.md")],
+      ".git": [file(".git/config")],
+      src: [file("src/index.ts")],
     });
 
-    const rows = flattenTree(listings, new Set(), new Set());
+    // Hide dotfiles: `.git` and `.env` drop out, and `.git`'s children are
+    // never walked even though its listing is cached and it's "expanded".
+    const isVisible = createVisibilityFilter({ hideDotfiles: true, alwaysHiddenPatterns: [] });
+    const rows = flattenTree(listings, new Set([".git", "src"]), new Set(), "", isVisible);
 
-    expect(rows.map((row) => row.isIgnored)).toEqual([true, false]);
+    expect(pathsOf(rows)).toEqual(["src", "src/index.ts", "README.md"]);
+  });
+
+  it("passes every entry through when no filter is supplied", () => {
+    const listings = listingsOf({ "": [file(".env"), file("README.md")] });
+
+    expect(pathsOf(flattenTree(listings, new Set(), new Set()))).toEqual([".env", "README.md"]);
   });
 
   it("stops descending past the depth guard instead of recursing forever", () => {
@@ -236,24 +249,8 @@ describe("resolveTreeKey", () => {
     // A directory whose *name* contains a slash-like structure would fool a
     // path-splitting parent lookup; depth is the authority.
     const rows: FlatTreeRow[] = [
-      {
-        path: "a",
-        name: "a",
-        isDirectory: true,
-        depth: 0,
-        isExpanded: true,
-        isLoading: false,
-        isIgnored: false,
-      },
-      {
-        path: "a/b",
-        name: "b",
-        isDirectory: true,
-        depth: 1,
-        isExpanded: true,
-        isLoading: false,
-        isIgnored: false,
-      },
+      { path: "a", name: "a", isDirectory: true, depth: 0, isExpanded: true, isLoading: false },
+      { path: "a/b", name: "b", isDirectory: true, depth: 1, isExpanded: true, isLoading: false },
       {
         path: "a/b/c",
         name: "c",
@@ -261,7 +258,6 @@ describe("resolveTreeKey", () => {
         depth: 2,
         isExpanded: false,
         isLoading: false,
-        isIgnored: false,
       },
     ];
 
@@ -362,5 +358,117 @@ describe("refreshTargets", () => {
     // `a` is expanded but sits outside the root — a refresh scoped to `src`
     // must not re-request it.
     expect(refreshTargets(listings, new Set(["a", "src/lib"]), "src")).toEqual(["src", "src/lib"]);
+  });
+
+  it("skips a hidden expanded directory and its subtree when given a visibility filter", () => {
+    const listings = listingsOf({
+      "": [dir(".cache"), dir("src")],
+      ".cache": [dir(".cache/inner")],
+      src: [file("src/a.ts")],
+    });
+    const isVisible = createVisibilityFilter({ hideDotfiles: true, alwaysHiddenPatterns: [] });
+
+    // `.cache` renders no row while dotfiles are hidden, so re-listing it (and
+    // `.cache/inner`) every tick is waste — only the root and `src` are targets.
+    expect(
+      refreshTargets(listings, new Set([".cache", ".cache/inner", "src"]), "", isVisible)
+    ).toEqual(["", "src"]);
+  });
+});
+
+describe("createVisibilityFilter", () => {
+  const hidden = (names: string[], visibility: Parameters<typeof createVisibilityFilter>[0]) =>
+    names.filter((name) => !createVisibilityFilter(visibility)(name));
+
+  it("hides exact junk-list basenames, nothing more", () => {
+    const isVisible = createVisibilityFilter({
+      hideDotfiles: false,
+      alwaysHiddenPatterns: [".DS_Store", "Thumbs.db"],
+    });
+    expect(isVisible(".DS_Store")).toBe(false);
+    expect(isVisible("Thumbs.db")).toBe(false);
+    // A literal pattern anchors both ends: no substring or prefix matches.
+    expect(isVisible("Thumbs.db.bak")).toBe(true);
+    expect(isVisible("my.DS_Store")).toBe(true);
+    expect(isVisible("index.ts")).toBe(true);
+  });
+
+  it("treats * as the only wildcard and anchors the rest, matching AppleDouble names", () => {
+    const isVisible = createVisibilityFilter({
+      hideDotfiles: false,
+      alwaysHiddenPatterns: ["._*", "*.log"],
+    });
+    expect(isVisible("._DS_Store")).toBe(false);
+    expect(isVisible("._")).toBe(false);
+    expect(isVisible("debug.log")).toBe(false);
+    expect(isVisible(".log")).toBe(false);
+    // No leading `._`, no `.log` suffix.
+    expect(isVisible("changelog.txt")).toBe(true);
+    expect(isVisible("a._b")).toBe(true);
+  });
+
+  it("treats `*` as a wildcard even against a filename that contains a literal `*`", () => {
+    // A left-to-right literal check would let the name's `*` consume the
+    // pattern's wildcard; `*` must still match everything.
+    const isVisible = createVisibilityFilter({ hideDotfiles: false, alwaysHiddenPatterns: ["*"] });
+    expect(isVisible("*a")).toBe(false);
+    expect(isVisible("anything")).toBe(false);
+    expect(isVisible("")).toBe(false);
+  });
+
+  it("does not let a pattern inject regex semantics", () => {
+    // `.` is a literal dot, not "any char"; `+` is literal, not a quantifier.
+    const isVisible = createVisibilityFilter({
+      hideDotfiles: false,
+      alwaysHiddenPatterns: ["a.b", "c+d"],
+    });
+    expect(isVisible("a.b")).toBe(false);
+    expect(isVisible("axb")).toBe(true);
+    expect(isVisible("c+d")).toBe(false);
+    expect(isVisible("cd")).toBe(true);
+  });
+
+  it("hides dot-prefixed entries only when the toggle is on, independent of the junk list", () => {
+    expect(hidden([".env", "src"], { hideDotfiles: true, alwaysHiddenPatterns: [] })).toEqual([
+      ".env",
+    ]);
+    expect(hidden([".env", "src"], { hideDotfiles: false, alwaysHiddenPatterns: [] })).toEqual([]);
+  });
+
+  it("matches a pathological star pattern in linear time without catastrophic backtracking", () => {
+    // A `.*`-per-`*` regex would take seconds on this input (a real ReDoS on
+    // user-persisted patterns); the two-pointer matcher returns immediately. The
+    // test hanging IS the failure mode we're guarding against.
+    const isVisible = createVisibilityFilter({
+      hideDotfiles: false,
+      alwaysHiddenPatterns: ["*a*a*a*a*a*a*a*a*a*a*b"],
+    });
+    const name = "a".repeat(64); // matches the a-runs, never the trailing `b`
+    expect(isVisible(name)).toBe(true); // not hidden — no `b`, so no match
+  });
+});
+
+describe("isRowPathVisible", () => {
+  const showAll = () => true;
+  const hideDotfiles = createVisibilityFilter({ hideDotfiles: true, alwaysHiddenPatterns: [] });
+
+  it("is visible when every segment below the root passes the filter", () => {
+    expect(isRowPathVisible("src/index.ts", "", showAll)).toBe(true);
+    expect(isRowPathVisible("src/index.ts", "", hideDotfiles)).toBe(true);
+  });
+
+  it("is hidden when any segment below the root is filtered", () => {
+    expect(isRowPathVisible(".git/config", "", hideDotfiles)).toBe(false);
+    expect(isRowPathVisible("src/.env", "", hideDotfiles)).toBe(false);
+  });
+
+  it("never tests the root's own segments — a dot-named root doesn't hide its children", () => {
+    // Rooted inside `.github`, a hideDotfiles filter still shows plain children.
+    expect(isRowPathVisible(".github/workflows", ".github", hideDotfiles)).toBe(true);
+    expect(isRowPathVisible(".github/.secret", ".github", hideDotfiles)).toBe(false);
+  });
+
+  it("is not visible for a path outside the root", () => {
+    expect(isRowPathVisible("other/file.ts", "src", showAll)).toBe(false);
   });
 });

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -32,7 +32,7 @@ describe("serializeFileBrowser", () => {
       ...basePanel,
       browserSelectedPath: "src/app.ts",
       browserExpandedPaths: ["src", "src/lib"],
-      browserShowIgnored: true,
+      browserHideDotfiles: true,
     };
 
     const restored = createFileBrowserDefaults(asOptions(serializeFileBrowser(panel)));
@@ -40,18 +40,30 @@ describe("serializeFileBrowser", () => {
     expect(restored).toEqual({
       browserSelectedPath: "src/app.ts",
       browserExpandedPaths: ["src", "src/lib"],
-      browserShowIgnored: true,
+      browserHideDotfiles: true,
     });
   });
 
-  it("preserves an explicitly-disabled ignored toggle through the round trip", () => {
+  it("preserves an explicitly-disabled dotfile toggle through the round trip", () => {
     // A truthiness check anywhere in the pair would drop `false` and let the
     // default silently override a deliberate choice.
-    const panel: FileBrowserPanelData = { ...basePanel, browserShowIgnored: false };
+    const panel: FileBrowserPanelData = { ...basePanel, browserHideDotfiles: false };
 
     const restored = createFileBrowserDefaults(asOptions(serializeFileBrowser(panel)));
 
-    expect(restored.browserShowIgnored).toBe(false);
+    expect(restored.browserHideDotfiles).toBe(false);
+  });
+
+  it("does not carry a legacy browserShowIgnored value into the new dotfile field", () => {
+    // The old field's meaning was inverted; an old panel that showed gitignored
+    // files must NOT hydrate as hiding dotfiles (#10938-class trap). The
+    // serializer only knows the new field, so the stale key is simply dropped.
+    const legacy = { ...basePanel, browserShowIgnored: true } as FileBrowserPanelData;
+
+    const snapshot = serializeFileBrowser(legacy);
+
+    expect(snapshot).not.toHaveProperty("browserHideDotfiles");
+    expect(snapshot).not.toHaveProperty("browserShowIgnored");
   });
 
   it("preserves an empty expansion list, which is not the same as never expanding", () => {

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -47,7 +47,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -64,7 +65,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -78,7 +80,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: undefined,
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -99,7 +102,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: props.expandedPaths,
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         }),
       { initialProps: { expandedPaths: [] as string[] } }
@@ -123,7 +127,8 @@ describe("useFileBrowserTree", () => {
         // A restored panel remembers `src/lib`, but `src` is not expanded, so
         // no row for `src/lib` can exist yet.
         expandedPaths: ["src/lib"],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -142,7 +147,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: ["src"],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: props.changeTick,
         }),
       { initialProps: { changeTick: 1 as number | undefined } }
@@ -170,7 +176,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: props.changeTick,
         }),
       { initialProps: { changeTick: 7 } }
@@ -193,7 +200,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -211,29 +219,145 @@ describe("useFileBrowserTree", () => {
     });
   });
 
-  it("passes includeIgnored and drops the cached listings when the toggle flips", async () => {
-    listDirectory.mockResolvedValue([file("a.ts")]);
+  it("never sends a server-side filter flag — every listing request is raw", async () => {
+    listDirectory.mockImplementation(async (payload) =>
+      payload.dirPath === "src" ? [file("src/app.ts")] : [dir("src")]
+    );
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: ["src"],
+        // Visibility is on, yet the request must stay raw: filtering is now the
+        // client's job, so no listing may carry an includeIgnored-style flag.
+        hideDotfiles: true,
+        alwaysHiddenPatterns: [".DS_Store"],
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() =>
+      expect(result.current.rows.map((row) => row.path)).toEqual(["src", "src/app.ts"])
+    );
+
+    for (const [payload] of listDirectory.mock.calls) {
+      expect(Object.keys(payload)).not.toContain("includeIgnored");
+    }
+  });
+
+  it("shows dot-prefixed entries by default and hides them once hideDotfiles is on", async () => {
+    listDirectory.mockResolvedValue([file(".env"), dir("src"), file("README.md")]);
 
     const { result, rerender } = renderHook(
-      (props: { showIgnored: boolean }) =>
+      (props: { hideDotfiles: boolean }) =>
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: props.showIgnored,
+          hideDotfiles: props.hideDotfiles,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         }),
-      { initialProps: { showIgnored: false } }
+      { initialProps: { hideDotfiles: false } }
     );
 
     await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
-    expect(listDirectory.mock.calls[0]?.[0].includeIgnored).toBeUndefined();
+    expect(result.current.rows.map((row) => row.path)).toEqual([".env", "src", "README.md"]);
 
-    rerender({ showIgnored: true });
+    rerender({ hideDotfiles: true });
 
-    // The flag changes what every listing contains, so a partial refresh would
-    // show ignored entries in some folders and hide them in others.
-    await waitFor(() => expect(listDirectory).toHaveBeenCalledTimes(2));
-    expect(listDirectory.mock.calls[1]?.[0].includeIgnored).toBe(true);
+    await waitFor(() =>
+      expect(result.current.rows.map((row) => row.path)).toEqual(["src", "README.md"])
+    );
+  });
+
+  it("hides an always-hidden junk entry even while dotfiles are shown", async () => {
+    listDirectory.mockResolvedValue([file(".DS_Store"), file(".env"), file("README.md")]);
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [".DS_Store"],
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    // Dotfiles are shown, so `.env` survives; the junk list still removes
+    // `.DS_Store` regardless of the dotfile toggle.
+    expect(result.current.rows.map((row) => row.path)).toEqual([".env", "README.md"]);
+  });
+
+  it("re-derives rows on a dotfile toggle without issuing a new listing request", async () => {
+    listDirectory.mockResolvedValue([file(".env"), file("README.md")]);
+
+    const { result, rerender } = renderHook(
+      (props: { hideDotfiles: boolean }) =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: [],
+          hideDotfiles: props.hideDotfiles,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+        }),
+      { initialProps: { hideDotfiles: false } }
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    const callsAfterInitialLoad = listDirectory.mock.calls.length;
+    expect(result.current.rows.map((row) => row.path)).toEqual([".env", "README.md"]);
+
+    rerender({ hideDotfiles: true });
+    await waitFor(() => expect(result.current.rows.map((row) => row.path)).toEqual(["README.md"]));
+
+    rerender({ hideDotfiles: false });
+    await waitFor(() =>
+      expect(result.current.rows.map((row) => row.path)).toEqual([".env", "README.md"])
+    );
+
+    // The regression guard for the "filter at derivation, not refetch" design:
+    // flipping visibility re-runs the row memo but must not drop the listing
+    // cache or spend another IPC call.
+    expect(listDirectory.mock.calls.length).toBe(callsAfterInitialLoad);
+  });
+
+  it("reports hidden dotfiles when a non-junk dot entry sits at the root", async () => {
+    listDirectory.mockResolvedValue([file(".env"), file("README.md")]);
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        // Independent of the toggle's own state: even with dotfiles hidden, the
+        // affordance needs to know something is there to reveal.
+        hideDotfiles: true,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.hasHiddenDotfiles).toBe(true);
+  });
+
+  it("reports no hidden dotfiles when the only dot entry is junk-listed", async () => {
+    listDirectory.mockResolvedValue([file(".DS_Store"), file("README.md")]);
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        hideDotfiles: true,
+        alwaysHiddenPatterns: [".DS_Store"],
+        changeTick: undefined,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    // The junk list already hides `.DS_Store`, so turning the dotfile toggle off
+    // would reveal nothing — the affordance must stay quiet.
+    expect(result.current.hasHiddenDotfiles).toBe(false);
   });
 
   it("leaves the tree usable when a single directory listing fails", async () => {
@@ -246,7 +370,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: ["src"],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -267,7 +392,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: props.changeTick,
         }),
       { initialProps: { changeTick: 1 } }
@@ -298,7 +424,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: props.changeTick,
         }),
       { initialProps: { changeTick: 1 } }
@@ -344,7 +471,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: rootEntries.map((node) => node.path),
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -371,7 +499,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: props.expandedPaths,
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         }),
       { initialProps: { expandedPaths: ["src"] as string[] } }
@@ -412,7 +541,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: rootEntries.map((node) => node.path),
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -439,7 +569,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: props.worktreeId,
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         }),
       { initialProps: { worktreeId: "wt-1" } }
@@ -468,7 +599,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         rootPath: "src/panels",
         changeTick: undefined,
       })
@@ -492,7 +624,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           rootPath: props.rootPath,
           changeTick: undefined,
         }),
@@ -535,7 +668,8 @@ describe("useFileBrowserTree", () => {
         // `other` survives in panel data from before the re-root; requesting it
         // would spend the channel budget on rows that can never render.
         expandedPaths: ["other"],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         rootPath: "src",
         changeTick: undefined,
       })
@@ -587,7 +721,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         })
       );
@@ -613,7 +748,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         })
       );
@@ -670,7 +806,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         })
       );
@@ -721,7 +858,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         })
       );
@@ -748,7 +886,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         })
       );
@@ -792,7 +931,8 @@ describe("useFileBrowserTree", () => {
           useFileBrowserTree({
             worktreeId: props.worktreeId,
             expandedPaths: [],
-            showIgnored: false,
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
             changeTick: undefined,
           }),
         { initialProps: { worktreeId: "wt-1" } }
@@ -832,7 +972,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -862,7 +1003,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: props.changeTick,
         }),
       { initialProps: { changeTick: 1 } }
@@ -891,7 +1033,8 @@ describe("useFileBrowserTree", () => {
       useFileBrowserTree({
         worktreeId: "wt-1",
         expandedPaths: [],
-        showIgnored: false,
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
         changeTick: undefined,
       })
     );
@@ -919,7 +1062,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: "wt-1",
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: props.changeTick,
         }),
       { initialProps: { changeTick: 1 } }
@@ -967,7 +1111,8 @@ describe("useFileBrowserTree", () => {
         useFileBrowserTree({
           worktreeId: props.worktreeId,
           expandedPaths: [],
-          showIgnored: false,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
           changeTick: undefined,
         }),
       { initialProps: { worktreeId: "wt-1" } }

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -6,7 +6,7 @@ export function createFileBrowserDefaults(
   options: FileBrowserPanelOptions
 ): Partial<FileBrowserPanelData> {
   return {
-    // `!= null` rather than truthiness: an explicit `false` for the ignored
+    // `!= null` rather than truthiness: an explicit `false` for the dotfile
     // toggle is a deliberate choice, and dropping it here would let a later
     // default stand in for it.
     ...(options.browserSelectedPath != null && {
@@ -15,8 +15,8 @@ export function createFileBrowserDefaults(
     ...(options.browserExpandedPaths != null && {
       browserExpandedPaths: options.browserExpandedPaths,
     }),
-    ...(options.browserShowIgnored != null && {
-      browserShowIgnored: options.browserShowIgnored,
+    ...(options.browserHideDotfiles != null && {
+      browserHideDotfiles: options.browserHideDotfiles,
     }),
     // Canonicalized on the way in: tree row keys are canonical listing paths,
     // and the up-one-level control does plain segment math on this value.

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -17,10 +17,90 @@ export interface FlatTreeRow {
   isExpanded: boolean;
   /** Directories only: whether a listing for this row is in flight */
   isLoading: boolean;
-  /** Whether git reports this entry as ignored (only ever true when showing ignored) */
-  isIgnored: boolean;
   /** Byte size for files; undefined for directories */
   size?: number;
+}
+
+/**
+ * The two visibility controls the browser applies client-side over the raw
+ * listing the service now returns (#11330): the app-global always-hidden junk
+ * list and the per-panel dotfile toggle. Both filter by entry basename.
+ */
+export interface FileVisibility {
+  /** Hide dot-prefixed entries (the per-panel toggle). */
+  hideDotfiles: boolean;
+  /** Always-hidden basename globs (literal text plus `*` wildcards). */
+  alwaysHiddenPatterns: readonly string[];
+}
+
+/**
+ * Anchored, case-sensitive basename glob match where `*` is the only wildcard
+ * (any run of characters) and every other character is literal. A two-pointer
+ * scan with single-star backtracking — O(name · pattern) worst case, never
+ * exponential — so a persisted pattern like `*a*a*…*b` can't wedge the render
+ * path the way a `.*`-per-`*` regex would (a real ReDoS on user-controlled
+ * patterns).
+ */
+function matchesBasenameGlob(name: string, pattern: string): boolean {
+  let n = 0;
+  let p = 0;
+  let starP = -1;
+  let starN = 0;
+  while (n < name.length) {
+    // `*` is matched as a wildcard BEFORE literal equality, so a filename that
+    // itself contains `*` (legal on POSIX) can't consume the pattern's wildcard
+    // as a literal — `*` must still match everything.
+    if (p < pattern.length && pattern[p] === "*") {
+      starP = p;
+      starN = n;
+      p += 1;
+    } else if (p < pattern.length && pattern[p] === name[n]) {
+      n += 1;
+      p += 1;
+    } else if (starP !== -1) {
+      // Backtrack: let the last `*` swallow one more character.
+      p = starP + 1;
+      starN += 1;
+      n = starN;
+    } else {
+      return false;
+    }
+  }
+  while (p < pattern.length && pattern[p] === "*") p += 1;
+  return p === pattern.length;
+}
+
+/**
+ * Build the per-entry visibility predicate for one panel's current settings. A
+ * `true` result means "show this entry".
+ */
+export function createVisibilityFilter(visibility: FileVisibility): (name: string) => boolean {
+  const { hideDotfiles, alwaysHiddenPatterns } = visibility;
+  return (name: string): boolean => {
+    for (const pattern of alwaysHiddenPatterns) {
+      if (matchesBasenameGlob(name, pattern)) return false;
+    }
+    if (hideDotfiles && name.startsWith(".")) return false;
+    return true;
+  };
+}
+
+/**
+ * Whether the row for a worktree-relative path is currently visible: every path
+ * segment below the browser root must pass the filter. Used to reconcile a
+ * selection that a visibility change has just hidden. The root's own segments
+ * are never tested — the root is the frame, not a row.
+ */
+export function isRowPathVisible(
+  relativePath: string,
+  rootPath: string,
+  isVisible: (name: string) => boolean
+): boolean {
+  const prefix = rootPath === "" ? "" : `${rootPath}/`;
+  if (prefix !== "" && !relativePath.startsWith(prefix)) return false;
+  const below = relativePath.slice(prefix.length);
+  const segments = below.split("/").filter(Boolean);
+  return segments.every((segment) => isVisible(segment));
 }
 
 /** Listing state for one directory, keyed by worktree-relative path ("" = root). */
@@ -39,7 +119,8 @@ export function flattenTree(
   listings: DirectoryListings,
   expandedPaths: ReadonlySet<string>,
   loadingPaths: ReadonlySet<string>,
-  rootPath = ""
+  rootPath = "",
+  isVisible?: (name: string) => boolean
 ): FlatTreeRow[] {
   const rows: FlatTreeRow[] = [];
 
@@ -52,6 +133,9 @@ export function flattenTree(
     if (!children) return;
 
     for (const node of children) {
+      // A hidden entry contributes no row and, for a directory, no subtree —
+      // so its children are never rendered and never fetched.
+      if (isVisible && !isVisible(node.name)) continue;
       const isExpanded = node.isDirectory && expandedPaths.has(node.path);
       rows.push({
         path: node.path,
@@ -60,7 +144,6 @@ export function flattenTree(
         depth,
         isExpanded,
         isLoading: node.isDirectory && loadingPaths.has(node.path) && !listings.has(node.path),
-        isIgnored: node.isIgnored === true,
         ...(node.size != null && { size: node.size }),
       });
       if (isExpanded) walk(node.path, depth + 1);
@@ -228,7 +311,8 @@ export function pruneListings(
 export function refreshTargets(
   listings: DirectoryListings,
   expandedPaths: ReadonlySet<string>,
-  rootPath = ""
+  rootPath = "",
+  isVisible?: (name: string) => boolean
 ): string[] {
   const targets = [rootPath];
   const walk = (dirPath: string, depth: number): void => {
@@ -237,6 +321,9 @@ export function refreshTargets(
     if (!children) return;
     for (const node of children) {
       if (!node.isDirectory || !expandedPaths.has(node.path)) continue;
+      // A hidden directory has no row, so re-listing it (and its subtree) every
+      // tick is pure waste — skip it and everything beneath it.
+      if (isVisible && !isVisible(node.name)) continue;
       targets.push(node.path);
       walk(node.path, depth + 1);
     }

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -96,6 +96,7 @@ export function isRowPathVisible(
   rootPath: string,
   isVisible: (name: string) => boolean
 ): boolean {
+  if (relativePath === rootPath) return true;
   const prefix = rootPath === "" ? "" : `${rootPath}/`;
   if (prefix !== "" && !relativePath.startsWith(prefix)) return false;
   const below = relativePath.slice(prefix.length);

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -12,7 +12,7 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
   return {
     ...(t.browserSelectedPath != null && { browserSelectedPath: t.browserSelectedPath }),
     ...(t.browserExpandedPaths != null && { browserExpandedPaths: t.browserExpandedPaths }),
-    ...(t.browserShowIgnored != null && { browserShowIgnored: t.browserShowIgnored }),
+    ...(t.browserHideDotfiles != null && { browserHideDotfiles: t.browserHideDotfiles }),
     // Truthiness, not `!= null`: "" is the worktree root, which is the same
     // state as the field being absent — persisting it would be noise.
     ...(t.browserRootPath ? { browserRootPath: t.browserRootPath } : {}),

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -3,16 +3,22 @@ import type { FileTreeNode } from "@shared/types";
 import { fileBrowserClient } from "@/clients/fileBrowserClient";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { flattenTree, pruneListings, refreshTargets, type FlatTreeRow } from "./fileBrowserTree";
+import {
+  createVisibilityFilter,
+  flattenTree,
+  isRowPathVisible,
+  pruneListings,
+  refreshTargets,
+  type FlatTreeRow,
+} from "./fileBrowserTree";
 
 /**
  * Ceiling on directory listings in flight at once.
  *
  * A restored panel can carry hundreds of expanded directories, and firing all
- * of them the instant the root lands would both blow past the IPC channel's
- * rate limit — failing the overflow outright — and hand the workspace host a
- * `git check-ignore` child process per request. Queuing keeps a wide tree slow
- * rather than broken.
+ * of them the instant the root lands would blow past the IPC channel's rate
+ * limit — failing the overflow outright. Queuing keeps a wide tree slow rather
+ * than broken.
  */
 const MAX_CONCURRENT_LISTINGS = 6;
 
@@ -39,7 +45,10 @@ const ROOT_RETRY_DELAYS_MS = [150, 400, 800] as const;
 export interface UseFileBrowserTreeArgs {
   worktreeId: string | undefined;
   expandedPaths: readonly string[];
-  showIgnored: boolean;
+  /** Hide dot-prefixed entries (the per-panel toggle). */
+  hideDotfiles: boolean;
+  /** App-global always-hidden basename globs (the junk list). */
+  alwaysHiddenPatterns: readonly string[];
   /**
    * Worktree-relative directory to root the tree at; "" = the worktree root.
    * Changing it is an identity reset, the same as switching worktrees: every
@@ -61,6 +70,12 @@ export interface UseFileBrowserTreeResult {
   isInitialLoading: boolean;
   /** Set when the root listing failed; per-directory failures are silent. */
   rootError: string | null;
+  /**
+   * Whether the current root holds dot-prefixed entries the dotfile toggle is
+   * governing — i.e. turning the toggle off would reveal something. Lets the
+   * empty state offer "Show dotfiles" only when it can actually help.
+   */
+  hasHiddenDotfiles: boolean;
   /** Fetch a directory if it isn't already loaded or in flight. */
   ensureLoaded: (dirPath: string) => void;
   /**
@@ -104,7 +119,8 @@ interface RootRetryState {
 export function useFileBrowserTree({
   worktreeId,
   expandedPaths,
-  showIgnored,
+  hideDotfiles,
+  alwaysHiddenPatterns,
   rootPath = "",
   changeTick,
 }: UseFileBrowserTreeArgs): UseFileBrowserTreeResult {
@@ -119,10 +135,11 @@ export function useFileBrowserTree({
   const isRefreshingRef = useRef(false);
 
   // Generation counter, bumped whenever the identity of what we are listing
-  // changes (worktree switch, ignored-filter flip). Every in-flight response
-  // carries the generation it was issued under and is dropped if it no longer
-  // matches, so a slow listing from the previous worktree can't land in the
-  // new one's tree.
+  // changes (worktree switch, root change). Every in-flight response carries
+  // the generation it was issued under and is dropped if it no longer matches,
+  // so a slow listing from the previous worktree can't land in the new one's
+  // tree. Visibility (junk list, dotfile toggle) is deliberately NOT part of
+  // identity — it filters the cached raw listing at render time, no refetch.
   const generationRef = useRef(0);
   const listingsRef = useRef(listings);
 
@@ -153,6 +170,16 @@ export function useFileBrowserTree({
 
   const expandedSet = useMemo(() => new Set(expandedPaths), [expandedPaths]);
   const expandedSetRef = useRef(expandedSet);
+
+  // Per-entry visibility for the current junk list + dotfile toggle. Filters
+  // rows at render time, but is also read by the fetch machinery (through
+  // `isVisibleRef`) so a hidden directory's subtree is never re-listed — it has
+  // no row, so paying for its listing on every tick is pure waste.
+  const isVisible = useMemo(
+    () => createVisibilityFilter({ hideDotfiles, alwaysHiddenPatterns }),
+    [hideDotfiles, alwaysHiddenPatterns]
+  );
+  const isVisibleRef = useRef(isVisible);
 
   // Set when a refresh could not run because its targets were already in
   // flight. Without it, a tick that arrives mid-flight is consumed by a request
@@ -206,7 +233,6 @@ export function useFileBrowserTree({
         const nodes = await fileBrowserClient.listDirectory({
           worktreeId,
           ...(dirPath !== "" && { dirPath }),
-          ...(showIgnored && { includeIgnored: true }),
         });
         if (generation !== generationRef.current) return;
 
@@ -294,7 +320,7 @@ export function useFileBrowserTree({
         pumpRef.current();
       }
     },
-    [worktreeId, showIgnored, rootPath, clearRootRetryTimer, resetRootRetryState, enqueueTargets]
+    [worktreeId, rootPath, clearRootRetryTimer, resetRootRetryState, enqueueTargets]
   );
 
   const pump = useCallback((): void => {
@@ -307,6 +333,10 @@ export function useFileBrowserTree({
       // produce responses the generation guard throws away.
       if (next.generation !== generationRef.current) continue;
       if (inFlightRef.current.has(next.dirPath)) continue;
+      // A target hidden after it was queued (junk list edited, or dotfiles
+      // toggled while it waited for a slot) renders no row — drop it rather
+      // than spend a listing. Re-shown, the expansion effect re-enqueues it.
+      if (!isRowPathVisible(next.dirPath, rootPath, isVisibleRef.current)) continue;
       void fetchDirectory(next.dirPath, next.generation);
     }
 
@@ -319,7 +349,7 @@ export function useFileBrowserTree({
       refreshPendingRef.current = false;
       const generation = generationRef.current;
       enqueueTargets(
-        refreshTargets(listingsRef.current, expandedSetRef.current, rootPath),
+        refreshTargets(listingsRef.current, expandedSetRef.current, rootPath, isVisibleRef.current),
         generation
       );
       pumpRef.current();
@@ -347,8 +377,9 @@ export function useFileBrowserTree({
   useLayoutEffect(() => {
     listingsRef.current = listings;
     expandedSetRef.current = expandedSet;
+    isVisibleRef.current = isVisible;
     pumpRef.current = pump;
-  }, [listings, expandedSet, pump]);
+  }, [listings, expandedSet, isVisible, pump]);
 
   // Cancel a pending root retry synchronously when the identity changes or the
   // panel unmounts. The generation bump that would invalidate the retry lives in
@@ -361,7 +392,7 @@ export function useFileBrowserTree({
     return () => {
       clearRootRetryTimer();
     };
-  }, [worktreeId, showIgnored, rootPath, clearRootRetryTimer]);
+  }, [worktreeId, rootPath, clearRootRetryTimer]);
 
   useEffect(() => {
     disposedRef.current = false;
@@ -389,7 +420,12 @@ export function useFileBrowserTree({
   const refresh = useCallback(
     (options?: { manual?: boolean }): void => {
       const generation = generationRef.current;
-      const targets = refreshTargets(listingsRef.current, expandedSetRef.current, rootPath);
+      const targets = refreshTargets(
+        listingsRef.current,
+        expandedSetRef.current,
+        rootPath,
+        isVisibleRef.current
+      );
       // A user press should spin the toolbar icon until the re-list drains. Set
       // this before `pump` so the flag is up if fetches start synchronously; a
       // no-op refresh (no worktree, no targets) drains inside `pump` and clears
@@ -410,10 +446,9 @@ export function useFileBrowserTree({
     [enqueueTargets, pump, rootPath]
   );
 
-  // Identity reset. Flipping the ignored filter changes what every listing
-  // contains, not just the root, so the whole cache is dropped rather than
-  // patched — a partial cache would show ignored entries in the folders that
-  // happened to reload and hide them everywhere else.
+  // Identity reset — only a worktree switch or a root change, not a visibility
+  // change: the listing is the same raw filesystem either way, so the junk
+  // list and dotfile toggle filter the cache in place rather than refetching.
   useEffect(() => {
     generationRef.current += 1;
     // Fresh identity, fresh retry budget — and cancel any retry still pending
@@ -433,7 +468,7 @@ export function useFileBrowserTree({
     setHasLoadedRoot(false);
     if (!worktreeId) return;
     void fetchDirectory(rootPath, generationRef.current);
-  }, [worktreeId, showIgnored, rootPath, fetchDirectory, resetRootRetryState]);
+  }, [worktreeId, rootPath, fetchDirectory, resetRootRetryState]);
 
   // Expanding a directory is what triggers its fetch; a restored panel expands
   // several at once, and each is requested the first time it becomes visible.
@@ -448,12 +483,16 @@ export function useFileBrowserTree({
       // expansion whose parent is collapsed (or gone) would otherwise fire a
       // request for a folder the user cannot see.
       if (!isReachable(listings, expandedSet, dirPath, rootPath)) continue;
+      // Nor fetch a directory the junk list / dotfile toggle currently hides:
+      // it renders no row, so its listing is unused. Showing it later re-runs
+      // this effect (isVisible is a dependency) and fetches it then.
+      if (!isRowPathVisible(dirPath, rootPath, isVisible)) continue;
       pendingTargets.push(dirPath);
     }
     if (pendingTargets.length === 0) return;
     enqueueTargets(pendingTargets, generationRef.current);
     pump();
-  }, [expandedSet, listings, hasLoadedRoot, rootPath, enqueueTargets, pump]);
+  }, [expandedSet, listings, hasLoadedRoot, rootPath, isVisible, enqueueTargets, pump]);
 
   // Forget collapsed subtrees so re-expanding re-reads rather than replaying a
   // listing that may be minutes stale on an actively-written worktree.
@@ -478,14 +517,24 @@ export function useFileBrowserTree({
   }, [changeTick, hasLoadedRoot, refresh]);
 
   const rows = useMemo(
-    () => flattenTree(listings, expandedSet, loadingPaths, rootPath),
-    [listings, expandedSet, loadingPaths, rootPath]
+    () => flattenTree(listings, expandedSet, loadingPaths, rootPath, isVisible),
+    [listings, expandedSet, loadingPaths, rootPath, isVisible]
   );
+
+  // Would toggling the dotfile filter off reveal anything at this root? A
+  // root-level dot entry that the junk list is *not* already hiding.
+  const hasHiddenDotfiles = useMemo(() => {
+    const rootNodes = listings.get(rootPath);
+    if (!rootNodes) return false;
+    const notJunk = createVisibilityFilter({ hideDotfiles: false, alwaysHiddenPatterns });
+    return rootNodes.some((node) => node.name.startsWith(".") && notJunk(node.name));
+  }, [listings, rootPath, alwaysHiddenPatterns]);
 
   return {
     rows,
     isInitialLoading: Boolean(worktreeId) && !hasLoadedRoot,
     rootError,
+    hasHiddenDotfiles,
     ensureLoaded,
     refresh,
     isRefreshing,

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -518,6 +518,7 @@ describe("destructive-action danger metadata", () => {
         ["wt-placeholder", { id: "wt-placeholder", hasTeardownCommand: true } as WorktreeSnapshot],
       ]),
       statusCheckedAt: new Map(),
+      workingTreeChangedAtById: new Map(),
       manualAssociations: new Map(),
       version: { epoch: "test", seq: 1 },
       tombstones: new Map(),

--- a/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
+++ b/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+
+// workingTreeChangedAt is the raw filesystem-write stamp (#11330). Like
+// lastGitStatusCheckedAt it advances on events that change nothing else in the
+// snapshot, so it lives in the workingTreeChangedAtById side map to keep the
+// worktrees Map identity stable on a timestamp-only bump. Unlike freshness, it
+// is independent of git status — a write into a gitignored path advances it
+// without moving worktreeChanges.
+
+const TEST_EPOCH = "test-epoch";
+let _seq = 0;
+function nextV(): WorktreeEventVersion {
+  return { epoch: TEST_EPOCH, seq: ++_seq };
+}
+
+function makeSnapshot(id: string, extra: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    name: id,
+    branch: "main",
+    path: `/repo/${id}`,
+    isCurrent: false,
+    isMainWorktree: false,
+    modifiedCount: 0,
+    changes: [],
+    summary: "",
+    mood: null,
+    gitDir: "",
+    ...extra,
+  } as unknown as WorktreeSnapshot;
+}
+
+describe("createWorktreeStore — workingTreeChangedAt side map", () => {
+  it("a timestamp-only update advances the side map without a new worktrees Map identity", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }), nextV());
+    const mapBefore = store.getState().worktrees;
+    const snapshotBefore = store.getState().worktrees.get("wt-1");
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 2_000 }), nextV());
+
+    expect(store.getState().worktrees).toBe(mapBefore);
+    expect(store.getState().worktrees.get("wt-1")).toBe(snapshotBefore);
+    expect(store.getState().workingTreeChangedAtById.get("wt-1")).toBe(2_000);
+  });
+
+  it("advances independently of git status — no lastGitStatusCheckedAt, no content change", () => {
+    // This is the issue's core: a write into a gitignored folder moves the fs
+    // stamp while git-status content (and freshness) stays put.
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }), nextV());
+    const freshnessBefore = store.getState().statusCheckedAt;
+    const mapBefore = store.getState().worktrees;
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 2_000 }), nextV());
+
+    expect(store.getState().workingTreeChangedAtById.get("wt-1")).toBe(2_000);
+    // Neither the worktrees identity nor the freshness map moved.
+    expect(store.getState().worktrees).toBe(mapBefore);
+    expect(store.getState().statusCheckedAt).toBe(freshnessBefore);
+  });
+
+  it("a content change produces a new Map identity and records the fs stamp", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }), nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { modifiedCount: 3, workingTreeChangedAt: 2_000 }),
+        nextV()
+      );
+
+    expect(store.getState().worktrees).not.toBe(mapBefore);
+    expect(store.getState().worktrees.get("wt-1")?.modifiedCount).toBe(3);
+    expect(store.getState().workingTreeChangedAtById.get("wt-1")).toBe(2_000);
+  });
+
+  it("an identical fs stamp keeps the side-map identity stable", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }), nextV());
+    const before = store.getState().workingTreeChangedAtById;
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }), nextV());
+
+    expect(store.getState().workingTreeChangedAtById).toBe(before);
+  });
+
+  it("applySnapshot rebuilds the side map for all worktrees and prunes removed ids", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [
+          makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }),
+          makeSnapshot("wt-2", { workingTreeChangedAt: 1_500 }),
+        ],
+        nextV()
+      );
+    expect(store.getState().workingTreeChangedAtById.get("wt-1")).toBe(1_000);
+    expect(store.getState().workingTreeChangedAtById.get("wt-2")).toBe(1_500);
+
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { workingTreeChangedAt: 2_000 })], nextV());
+    expect(store.getState().workingTreeChangedAtById.get("wt-1")).toBe(2_000);
+    expect(store.getState().workingTreeChangedAtById.has("wt-2")).toBe(false);
+  });
+
+  it("a value-equal snapshot with a fresher fs stamp updates the side map, not worktrees identity", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 })], nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { workingTreeChangedAt: 2_000 })], nextV());
+
+    expect(store.getState().worktrees).toBe(mapBefore);
+    expect(store.getState().workingTreeChangedAtById.get("wt-1")).toBe(2_000);
+  });
+
+  it("applyRemove drops the worktree's fs stamp entry", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 1_000 }), nextV());
+    expect(store.getState().workingTreeChangedAtById.has("wt-1")).toBe(true);
+
+    store.getState().applyRemove("wt-1", nextV());
+
+    expect(store.getState().workingTreeChangedAtById.has("wt-1")).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+  });
+});

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -709,4 +709,77 @@ describe("preferencesStore migration", () => {
       });
     });
   });
+
+  describe("fileBrowserAlwaysHiddenPatterns", () => {
+    it("is a non-empty curated default list on a fresh install", async () => {
+      const store = await loadStore();
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns.length).toBeGreaterThan(0);
+    });
+
+    it("setter trims, de-duplicates in order, and drops empty or path-separator entries", async () => {
+      const store = await loadStore();
+
+      store
+        .getState()
+        .setFileBrowserAlwaysHiddenPatterns([
+          "  .DS_Store  ",
+          ".DS_Store",
+          "",
+          "   ",
+          "a/b",
+          "c\\d",
+          "*.log",
+        ]);
+
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual([".DS_Store", "*.log"]);
+    });
+
+    it("preserves an explicitly empty list — hide-nothing is a real choice, not corruption", async () => {
+      const store = await loadStore();
+      store.getState().setFileBrowserAlwaysHiddenPatterns([]);
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual([]);
+    });
+
+    it("caps the list length and drops an over-long pattern", async () => {
+      const store = await loadStore();
+      const many = Array.from({ length: 250 }, (_, i) => `p${i}`);
+      store.getState().setFileBrowserAlwaysHiddenPatterns([...many, "x".repeat(500)]);
+
+      const result = store.getState().fileBrowserAlwaysHiddenPatterns;
+      expect(result.length).toBeLessThanOrEqual(100);
+      expect(result).not.toContain("x".repeat(500));
+    });
+
+    it("reset restores the fresh-install defaults after edits", async () => {
+      const store = await loadStore();
+      const fresh = [...store.getState().fileBrowserAlwaysHiddenPatterns];
+
+      store.getState().setFileBrowserAlwaysHiddenPatterns(["custom-only"]);
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual(["custom-only"]);
+
+      store.getState().resetFileBrowserAlwaysHiddenPatterns();
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual(fresh);
+    });
+
+    it("falls back to defaults when the persisted value is not an array", async () => {
+      setStoredState({ fileBrowserAlwaysHiddenPatterns: "nope" }, 13);
+      const store = await loadStore();
+
+      // A corrupt scalar can't survive hydration — same shape as fresh install.
+      expect(Array.isArray(store.getState().fileBrowserAlwaysHiddenPatterns)).toBe(true);
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns.length).toBeGreaterThan(0);
+    });
+
+    it("preserves a valid persisted array across hydration", async () => {
+      setStoredState({ fileBrowserAlwaysHiddenPatterns: ["*.tmp", "cache"] }, 13);
+      const store = await loadStore();
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual(["*.tmp", "cache"]);
+    });
+
+    it("sanitizes a partially-corrupt persisted array on hydration", async () => {
+      setStoredState({ fileBrowserAlwaysHiddenPatterns: ["ok", 5, "a/b", "  ok  "] }, 13);
+      const store = await loadStore();
+      expect(store.getState().fileBrowserAlwaysHiddenPatterns).toEqual(["ok"]);
+    });
+  });
 });

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -217,6 +217,16 @@ export interface WorktreeViewState {
    * always read freshness from here.
    */
   statusCheckedAt: Map<string, number>;
+  /**
+   * `worktreeId → workingTreeChangedAt` (monotonic epoch ms) — the last raw
+   * filesystem write the recursive watcher observed, independent of git status.
+   * Kept in a side map for the same reason as {@link statusCheckedAt}: it
+   * advances on writes that don't change the snapshot's compared fields, so
+   * folding it into `snapshotsEqual` would churn the `worktrees` Map identity.
+   * The file browser reads it per-id to refresh on writes into gitignored paths
+   * that leave `git status` unmoved (#11330).
+   */
+  workingTreeChangedAtById: Map<string, number>;
   manualAssociations: Map<string, ManualIssueAssociation>;
   /**
    * Host-minted `(epoch, seq)` stamp of the most recently applied event.
@@ -362,6 +372,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
   return createStore<WorktreeViewStore>((set, get) => ({
     worktrees: new Map(),
     statusCheckedAt: new Map(),
+    workingTreeChangedAtById: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),
@@ -421,6 +432,25 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       }
       const statusCheckedAtChanged = nextStatusCheckedAt !== prev.statusCheckedAt;
 
+      // Same rebuild for the working-tree-changed side map (also prunes removed
+      // ids), keeping identity when every stamp matches so browser subscribers
+      // see no spurious tick.
+      let nextWorkingTreeChangedAt = prev.workingTreeChangedAtById;
+      {
+        const rebuilt = new Map<string, number>();
+        for (const s of merged) {
+          if (s.workingTreeChangedAt !== undefined) {
+            rebuilt.set(s.id, s.workingTreeChangedAt);
+          }
+        }
+        const unchanged =
+          rebuilt.size === prev.workingTreeChangedAtById.size &&
+          [...rebuilt].every(([id, t]) => prev.workingTreeChangedAtById.get(id) === t);
+        if (!unchanged) nextWorkingTreeChangedAt = rebuilt;
+      }
+      const workingTreeChangedAtChanged =
+        nextWorkingTreeChangedAt !== prev.workingTreeChangedAtById;
+
       // Once hydrated, suppress redundant Map identity churn when every
       // incoming snapshot is value-equal to its existing counterpart. Cold
       // starts always rebuild so `isInitialized` flips correctly even when
@@ -441,6 +471,9 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           isReconnecting: false,
           reconnectingAt: null,
           ...(statusCheckedAtChanged ? { statusCheckedAt: nextStatusCheckedAt } : {}),
+          ...(workingTreeChangedAtChanged
+            ? { workingTreeChangedAtById: nextWorkingTreeChangedAt }
+            : {}),
           ...(tombstonesChanged ? { tombstones: new Map() } : {}),
           ...(associationsChanged ? { manualAssociations: manual } : {}),
         });
@@ -456,6 +489,9 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         isReconnecting: false,
         reconnectingAt: null,
         ...(statusCheckedAtChanged ? { statusCheckedAt: nextStatusCheckedAt } : {}),
+        ...(workingTreeChangedAtChanged
+          ? { workingTreeChangedAtById: nextWorkingTreeChangedAt }
+          : {}),
         ...(tombstonesChanged ? { tombstones: new Map() } : {}),
         ...(associationsChanged ? { manualAssociations: manual } : {}),
       });
@@ -505,10 +541,26 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       }
       const statusCheckedAtChanged = statusCheckedAt !== prevState.statusCheckedAt;
 
+      // The raw fs-write stamp advances independently of git status (it's the
+      // whole point of the signal), so a snapshot that's otherwise value-equal
+      // still needs to land in the side map — which is why it's applied even on
+      // the snapshotsEqual fast path below.
+      let workingTreeChangedAtById = prevState.workingTreeChangedAtById;
+      if (
+        merged.workingTreeChangedAt !== undefined &&
+        workingTreeChangedAtById.get(state.id) !== merged.workingTreeChangedAt
+      ) {
+        workingTreeChangedAtById = new Map(workingTreeChangedAtById);
+        workingTreeChangedAtById.set(state.id, merged.workingTreeChangedAt);
+      }
+      const workingTreeChangedAtChanged =
+        workingTreeChangedAtById !== prevState.workingTreeChangedAtById;
+
       if (existing && snapshotsEqual(existing, merged)) {
         set({
           version,
           ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
+          ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
           ...(tombstonesChanged ? { tombstones } : {}),
         });
         return;
@@ -519,6 +571,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         worktrees: next,
         version,
         ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
+        ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
         ...(tombstonesChanged ? { tombstones } : {}),
       });
     },
@@ -587,6 +640,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
       const hadWorktree = prevState.worktrees.has(worktreeId);
       const hadStatusCheckedAt = prevState.statusCheckedAt.has(worktreeId);
+      const hadWorkingTreeChangedAt = prevState.workingTreeChangedAtById.has(worktreeId);
       const hadDeletingId = prevState.deletingIds.has(worktreeId);
       const hadDeleteError = prevState.deleteErrors.has(worktreeId);
       const hadDeleteErrorArgs = prevState.deleteErrorArgs.has(worktreeId);
@@ -600,6 +654,10 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         ? new Map(prevState.statusCheckedAt)
         : prevState.statusCheckedAt;
       if (hadStatusCheckedAt) nextStatusCheckedAt.delete(worktreeId);
+      const nextWorkingTreeChangedAt = hadWorkingTreeChangedAt
+        ? new Map(prevState.workingTreeChangedAtById)
+        : prevState.workingTreeChangedAtById;
+      if (hadWorkingTreeChangedAt) nextWorkingTreeChangedAt.delete(worktreeId);
       const nextDeletingIds = hadDeletingId
         ? new Set(prevState.deletingIds)
         : prevState.deletingIds;
@@ -635,6 +693,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       set({
         worktrees: nextWorktrees,
         statusCheckedAt: nextStatusCheckedAt,
+        workingTreeChangedAtById: nextWorkingTreeChangedAt,
         deletingIds: nextDeletingIds,
         deleteErrors: nextDeleteErrors,
         deleteErrorArgs: nextDeleteErrorArgs,
@@ -1604,10 +1663,11 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.baseAheadCount === b.baseAheadCount &&
     a.baseBehindCount === b.baseBehindCount &&
     a.baseMatchesUpstream === b.baseMatchesUpstream &&
-    // lastGitStatusCheckedAt is deliberately NOT compared (like `timestamp`):
-    // it advances on every completed poll, so comparing it here would force a
-    // new worktrees Map identity per quiet tick. Freshness lives in the
-    // store's `statusCheckedAt` side map instead.
+    // lastGitStatusCheckedAt and workingTreeChangedAt are deliberately NOT
+    // compared (like `timestamp`): both advance on events that change nothing
+    // else in the snapshot, so comparing either here would force a new
+    // worktrees Map identity per quiet tick. They live in the store's
+    // `statusCheckedAt` / `workingTreeChangedAtById` side maps instead.
     a.lastFetchedAt === b.lastFetchedAt &&
     a.fetchAuthFailed === b.fetchAuthFailed &&
     a.fetchNetworkFailed === b.fetchNetworkFailed &&

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -16,6 +16,50 @@ export type DeletedWorktreeCleanupSeconds = 0 | 30 | 60 | 300;
 
 export const DELETED_WORKTREE_CLEANUP_DEFAULT: DeletedWorktreeCleanupSeconds = 60;
 
+/**
+ * File-browser "always hidden" junk list. Basename globs (literal text plus `*`
+ * wildcards) matched against entry names, hiding OS/tooling cruft in every
+ * panel regardless of the per-panel dotfile toggle (#11330). User-editable in
+ * settings; `.git` is a default rather than a structural exclusion so it can be
+ * removed to browse repository internals.
+ */
+export const DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN: readonly string[] = [
+  ".DS_Store",
+  "Thumbs.db",
+  "desktop.ini",
+  "._*",
+  ".git",
+];
+
+/** Caps kept small — this is a curated junk list, not a general ignore file. */
+export const MAX_ALWAYS_HIDDEN_PATTERNS = 100;
+export const MAX_ALWAYS_HIDDEN_PATTERN_LENGTH = 200;
+
+/**
+ * Coerce arbitrary input (hydrated JSON or a setter argument) into a clean
+ * basename-pattern list: strings only, trimmed, no empties, no path separators
+ * (basename matching only), de-duplicated in order, and bounded. A non-array
+ * falls back to the defaults; an array that legitimately reduces to empty stays
+ * empty — clearing the list is a deliberate "hide nothing" choice, not
+ * corruption.
+ */
+export function sanitizeAlwaysHiddenPatterns(value: unknown): string[] {
+  if (!Array.isArray(value)) return [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (trimmed === "" || trimmed.length > MAX_ALWAYS_HIDDEN_PATTERN_LENGTH) continue;
+    if (trimmed.includes("/") || trimmed.includes("\\")) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+    if (result.length >= MAX_ALWAYS_HIDDEN_PATTERNS) break;
+  }
+  return result;
+}
+
 interface PreferencesState {
   showProjectPulse: boolean;
   setShowProjectPulse: (show: boolean) => void;
@@ -72,6 +116,13 @@ interface PreferencesState {
    */
   deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds;
   setDeletedWorktreeCleanupSeconds: (value: DeletedWorktreeCleanupSeconds) => void;
+  /**
+   * Basename globs always hidden in the file browser, across every panel. See
+   * {@link DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN}.
+   */
+  fileBrowserAlwaysHiddenPatterns: string[];
+  setFileBrowserAlwaysHiddenPatterns: (patterns: string[]) => void;
+  resetFileBrowserAlwaysHiddenPatterns: () => void;
 }
 
 function isDockDensity(value: unknown): value is DockDensity {
@@ -122,6 +173,11 @@ function sanitizePersistedPreferences(
   if (!isDeletedWorktreeCleanupSeconds(sanitized.deletedWorktreeCleanupSeconds)) {
     sanitized.deletedWorktreeCleanupSeconds = DELETED_WORKTREE_CLEANUP_DEFAULT;
   }
+  // Absent (new field) → defaults; a hand-edited array is filtered to valid
+  // basename patterns; a legitimately empty list is preserved.
+  sanitized.fileBrowserAlwaysHiddenPatterns = sanitizeAlwaysHiddenPatterns(
+    sanitized.fileBrowserAlwaysHiddenPatterns
+  );
 
   // A truthy non-record value here would otherwise bypass the push-confirm gate.
   const skip = sanitized.skipPushConfirmByWorktreePath;
@@ -198,6 +254,11 @@ export const usePreferencesStore = create<PreferencesState>()(
         }),
       deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
       setDeletedWorktreeCleanupSeconds: (value) => set({ deletedWorktreeCleanupSeconds: value }),
+      fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
+      setFileBrowserAlwaysHiddenPatterns: (patterns) =>
+        set({ fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(patterns) }),
+      resetFileBrowserAlwaysHiddenPatterns: () =>
+        set({ fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN] }),
     }),
     {
       name: "daintree-preferences",
@@ -320,5 +381,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; fileBrowserAlwaysHiddenPatterns: string[] }",
 });

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -107,11 +107,11 @@ describe("setFileBrowserView", () => {
     expect(store.get().panelsById["panel-1"]).toBe(before);
   });
 
-  it("records an explicit false for the ignored toggle", () => {
-    setFileBrowserView("panel-1", { browserShowIgnored: true });
-    setFileBrowserView("panel-1", { browserShowIgnored: false });
+  it("records an explicit false for the dotfile toggle", () => {
+    setFileBrowserView("panel-1", { browserHideDotfiles: true });
+    setFileBrowserView("panel-1", { browserHideDotfiles: false });
 
-    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserShowIgnored: false });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserHideDotfiles: false });
   });
 
   it("collapses and re-opens the sidebar", () => {

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -6,7 +6,7 @@ type Set = PanelRegistryStoreApi["setState"];
 export interface FileBrowserViewPatch {
   browserSelectedPath?: string;
   browserExpandedPaths?: string[];
-  browserShowIgnored?: boolean;
+  browserHideDotfiles?: boolean;
   /** "" roots the tree back at the worktree root. */
   browserRootPath?: string;
   /** `true` collapses the tree sidebar; `false` and absent both mean open. */
@@ -38,9 +38,9 @@ export const createFileBrowserPanelActions = (
       const expandedUnchanged =
         patch.browserExpandedPaths === undefined ||
         sameStringList(panel.browserExpandedPaths, patch.browserExpandedPaths);
-      const ignoredUnchanged =
-        patch.browserShowIgnored === undefined ||
-        patch.browserShowIgnored === panel.browserShowIgnored;
+      const hideDotfilesUnchanged =
+        patch.browserHideDotfiles === undefined ||
+        patch.browserHideDotfiles === panel.browserHideDotfiles;
       // "" and absent are the same state (the worktree root), so resetting a
       // never-rooted panel must not count as a change.
       const rootUnchanged =
@@ -59,7 +59,7 @@ export const createFileBrowserPanelActions = (
       if (
         selectedUnchanged &&
         expandedUnchanged &&
-        ignoredUnchanged &&
+        hideDotfilesUnchanged &&
         rootUnchanged &&
         collapsedUnchanged
       )
@@ -73,8 +73,8 @@ export const createFileBrowserPanelActions = (
         ...(patch.browserExpandedPaths !== undefined && {
           browserExpandedPaths: patch.browserExpandedPaths,
         }),
-        ...(patch.browserShowIgnored !== undefined && {
-          browserShowIgnored: patch.browserShowIgnored,
+        ...(patch.browserHideDotfiles !== undefined && {
+          browserHideDotfiles: patch.browserHideDotfiles,
         }),
         ...(patch.browserRootPath !== undefined && {
           browserRootPath: patch.browserRootPath,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -61,7 +61,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   baseBranch?: string;
   browserSelectedPath?: string;
   browserExpandedPaths?: string[];
-  browserShowIgnored?: boolean;
+  browserHideDotfiles?: boolean;
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
   /**
@@ -123,7 +123,7 @@ export interface SavedTerminalData {
    */
   browserSelectedPath?: unknown;
   browserExpandedPaths?: unknown;
-  browserShowIgnored?: unknown;
+  browserHideDotfiles?: unknown;
   browserRootPath?: unknown;
   browserSidebarCollapsed?: unknown;
   exitBehavior?: PanelExitBehavior;


### PR DESCRIPTION
## Summary

- Replaces the file browser's gitignore-based hiding with a three-layer visibility model: an app-global, settings-editable "always hidden" junk list (defaults `.DS_Store`, `Thumbs.db`, `.git`, `desktop.ini`, `._*`, matched by basename glob, no ReDoS), a per-panel dotfile toggle (dotfiles visible by default, hidden via the eye toggle), and everything else always visible with no greyed-out styling.
- `FileTreeService` gains a raw-listing mode (reusing the existing internal `includeIgnored` option) that the file-browser IPC handler always requests. It skips the per-directory `git check-ignore` pass entirely, no subprocess, no `isIgnored` annotation, and returns `.git`. `CopyTree`'s fail-closed gitignore filtering is untouched.
- Visibility is applied as a pure filter at row-derivation over the cached raw listing, so toggling the junk list or dotfile setting re-derives instantly with no refetch, and hidden directories are never fetched or re-listed.
- Adds a filesystem "working-tree-changed" signal independent of the git-status change tick, so a write into a gitignored working folder refreshes an open browser even when `git status` is content-identical. Threaded from the recursive watcher (`onWorktreeFilesChanged`) through `WorktreeMonitor` (monotonic stamp plus immediate snapshot) into a dedicated store side map excluded from snapshot dedup.

Resolves #11330

## Changes

- New per-panel field `browserHideDotfiles` replaces `browserShowIgnored`, no migration since the semantics are inverted.
- Settings gets an "Always-hidden files" section in the Worktree tab: atomic commit, add/remove/reset to defaults.
- `FileTreeService`, `WorktreeMonitor`, `WatcherController`, and `SnapshotBuilder` updated to carry the new signal end to end.

## Testing

- Typecheck passes.
- 563 targeted unit and integration tests pass across the changed modules: `FileTreeService` raw mode, visibility matcher and hook, preferences store, panel persistence, watcher chain, store side map, settings editor.
- No new E2E spec. PR CI doesn't run E2E, and the chain is covered by targeted tests.

Out of scope: live updates are best-effort within the existing recursive-watcher scope. Writes under the watcher's skip-globbed directories (`node_modules`, `dist`, `build`, `target`) don't fire the signal, by existing design.