### PR TITLE
feat(project): relocate an open project via a quiesce-and-rebind coordinator (#11282 phase 3)

### DIFF
--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -8,6 +8,7 @@ import {
   projectViewManagersFrom,
 } from "../../../window/activeProjectIds.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
+import { projectRelocationCoordinator } from "../../../services/ProjectRelocationCoordinator.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -302,11 +303,14 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
 
     const newPath = result.filePaths[0];
-    const relocated = await projectStore.relocateProject(projectId, newPath);
-    // Every cached view of this project replaces it by immutable id, so the new
-    // path reaches windows other than the one that ran the locate flow (#11282).
-    broadcastToRenderer(CHANNELS.PROJECT_UPDATED, relocated);
-    return relocated;
+    // Route through the relocation coordinator: it forks internally — an OPEN
+    // project (visible in any window) runs the phase-3 quiesce/rebind pipeline
+    // so the live view/host/PTYs are repointed rather than stranded; a closed
+    // reattach delegates to the phase-1/2 path. It broadcasts PROJECT_UPDATED to
+    // every cached view by immutable id, so the new path reaches windows other
+    // than the one that ran the locate flow (#11282).
+    projectRelocationCoordinator.configure(deps);
+    return projectRelocationCoordinator.relocate({ projectId, mode: "reattach", newPath });
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_LOCATE, handleProjectLocate));
 

--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -1,0 +1,411 @@
+import { existsSync, statSync } from "fs";
+import { rename } from "fs/promises";
+import path from "path";
+import type { BrowserWindow, WebContents } from "electron";
+import { CHANNELS } from "../ipc/channels.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
+import { projectStore, normalizeProjectPath } from "./ProjectStore.js";
+import { collectActiveProjectIds, projectViewManagersFrom } from "../window/activeProjectIds.js";
+import { writeHibernatedMarker } from "./pty/terminalSessionPersistence.js";
+import { logError, logInfo } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import type { PtyClient } from "./PtyClient.js";
+import type { WorkspaceClient } from "./WorkspaceClient.js";
+import type { WindowRegistry, WindowContext } from "../window/WindowRegistry.js";
+import type { WorktreePortBroker } from "./WorktreePortBroker.js";
+import type { Project } from "../types/index.js";
+
+/**
+ * Relocating a currently-OPEN project (#11282, phase 3).
+ *
+ * Phases 1/2 preserve project identity and rebase persisted path-bearing state,
+ * but they deliberately REFUSE the active project: repointing a live one would
+ * strand its `WebContentsView`, workspace host and PTYs on the old path. This
+ * coordinator is the quiesce-and-rebind pipeline that makes an open relocation
+ * safe — and the same pipeline performs a Daintree-MANAGED move (`fs.rename`)
+ * rather than only reattaching after an external one.
+ *
+ * The renderer is repointed LIVE: the project path was engineered out of the
+ * view's URL/argv (#9162), so a `PROJECT_UPDATED` broadcast + an in-place store
+ * rebase is enough — the React tree and xterm instances are never torn down.
+ *
+ * `fs.rename` is the single commit boundary. Before it, a failure rolls back by
+ * reopening the runtimes at the original path (nothing durable changed). After
+ * it, every remaining step is forward-only — PTY kills and host disposal can't
+ * be cleanly reversed, so a failure surfaces the Tier-3 worktree-load banner
+ * (whose existing Retry re-runs the reopen at the now-current path) rather than
+ * renaming backward (#8473).
+ */
+
+/** Phase 3 only implements `"refuse"`; the `"hibernate"` continuity path (which
+ * tears down the Assistant's whole sub-agent tree) is deferred to phase 4/5. */
+export type AssistantDisposition = "refuse";
+
+export type ProjectRelocationReason =
+  | "not-found"
+  | "in-progress"
+  | "cross-volume"
+  | "assistant-active"
+  | "invalid-destination"
+  | "destination-exists"
+  | "same-path";
+
+export class ProjectRelocationError extends Error {
+  constructor(
+    readonly reason: ProjectRelocationReason,
+    message: string
+  ) {
+    super(message);
+    this.name = "ProjectRelocationError";
+  }
+}
+
+export interface ProjectRelocationDeps {
+  ptyClient?: PtyClient;
+  worktreeService?: WorkspaceClient;
+  windowRegistry?: WindowRegistry;
+  worktreePortBroker?: WorktreePortBroker;
+  mainWindow?: BrowserWindow;
+}
+
+export interface RelocateProjectRequest {
+  projectId: string;
+  /**
+   * `"move"` performs the `fs.rename` (Daintree-managed, same-volume only for
+   * the first cut). `"reattach"` adopts a folder already sitting at `newPath`
+   * (moved externally).
+   */
+  mode: "move" | "reattach";
+  /** Managed move: the full destination root. Reattach: where the folder is now. */
+  newPath: string;
+  assistantDisposition?: AssistantDisposition;
+}
+
+interface TargetWindow {
+  windowId: number;
+  ctx: WindowContext;
+}
+
+export class ProjectRelocationCoordinator {
+  private deps: ProjectRelocationDeps = {};
+  private readonly relocating = new Set<string>();
+
+  configure(deps: ProjectRelocationDeps): void {
+    this.deps = deps;
+  }
+
+  isRelocating(projectId: string): boolean {
+    return this.relocating.has(projectId);
+  }
+
+  /**
+   * Relocate a project. Routes an OPEN project (visible in any window) through
+   * the quiesce/rebind pipeline; a closed reattach delegates to the existing
+   * phase-1/2 `ProjectStore.relocateProject` (already correct for a project with
+   * no live runtimes). Broadcasts the final `PROJECT_UPDATED` in both branches.
+   */
+  async relocate(request: RelocateProjectRequest): Promise<Project> {
+    const { projectId, mode } = request;
+    const disposition = request.assistantDisposition ?? "refuse";
+
+    // --- Establish ownership SYNCHRONOUSLY, before the first await: whether this
+    // project is open, and which windows show it, must not shift under a
+    // concurrent switch/close (#11131 TOCTOU).
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new ProjectRelocationError("not-found", `Project not found: ${projectId}`);
+    }
+    if (this.relocating.has(projectId)) {
+      throw new ProjectRelocationError(
+        "in-progress",
+        `A relocation is already running for "${project.name}".`
+      );
+    }
+    const openAtEntry = collectActiveProjectIds(
+      projectViewManagersFrom(this.deps.windowRegistry),
+      projectStore.getCurrentProjectId(),
+      "project-relocation"
+    ).has(projectId);
+    const targetWindows = openAtEntry ? this.snapshotWindowsShowingProject(projectId) : [];
+
+    // Closed reattach: the folder is already on disk and nothing is live, so the
+    // phase-1/2 path is correct as-is — no need to spin up the quiesce machinery.
+    if (mode === "reattach" && !openAtEntry) {
+      const relocated = await projectStore.relocateProject(projectId, request.newPath);
+      broadcastToRenderer(CHANNELS.PROJECT_UPDATED, relocated);
+      return relocated;
+    }
+
+    this.relocating.add(projectId);
+    try {
+      return await this.runPipeline(project, request, disposition, targetWindows);
+    } finally {
+      this.relocating.delete(projectId);
+      projectStore.endRelocationRewrite(projectId);
+    }
+  }
+
+  private async runPipeline(
+    project: Project,
+    request: RelocateProjectRequest,
+    disposition: AssistantDisposition,
+    targetWindows: TargetWindow[]
+  ): Promise<Project> {
+    const { projectId, mode } = request;
+    const oldRoot = project.path;
+
+    // --- Assistant guard. Killing the Assistant's PTY tears down its whole
+    // sub-agent tree (a security-boundary action, #7509); phase 3 refuses rather
+    // than silently destroying in-flight agent work. Phase 4/5 own hibernate.
+    if (disposition === "refuse" && (await getAssistantBackend(projectId))) {
+      throw new ProjectRelocationError(
+        "assistant-active",
+        "Stop the Daintree Assistant for this project before moving it."
+      );
+    }
+
+    // --- Preflight: ALL validation before anything is stopped.
+    let requestedNewRoot = normalizeProjectPath(request.newPath);
+    if (mode === "move") {
+      requestedNewRoot = this.validateManagedMove(oldRoot, request.newPath);
+    } else if (!existsSync(request.newPath)) {
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        `The folder to reattach doesn't exist: ${request.newPath}`
+      );
+    }
+
+    // --- Quiesce the project's live runtimes (borrowed from `project:free-memory`
+    // MINUS the renderer eviction — keeping the view + xterm alive is the point).
+    await this.quiesceProject(projectId, oldRoot);
+
+    // --- Arm the state-write guard so a late renderer layout write can't clobber
+    // the migration once we cross the boundary.
+    projectStore.beginRelocationRewrite(projectId, oldRoot, requestedNewRoot);
+
+    // ===================== COMMIT BOUNDARY (fs.rename) =====================
+    // Above this try/catch: rollback is safe. A managed move's rename is the
+    // point of no return — everything after it is forward-only, never a reverse
+    // rename. A reattach is already disk-committed at entry, so it has no
+    // pre-commit window to roll back.
+    if (mode === "move") {
+      try {
+        await rename(oldRoot, requestedNewRoot);
+      } catch (error) {
+        // Pre-commit failure: nothing durable changed. Reopen at the ORIGINAL
+        // path so the user is left exactly where they started.
+        projectStore.endRelocationRewrite(projectId);
+        await this.reopenProjectAtPath(projectId, oldRoot, targetWindows);
+        throw new ProjectRelocationError(
+          "invalid-destination",
+          formatErrorMessage(error, "Couldn't move the project folder")
+        );
+      }
+    }
+
+    // --- Finalize durable state (DB path + phase-2 migration + git/submodule
+    // repair), PRESERVING the project's status so an open project stays open.
+    const updated = await projectStore.finalizeRelocatedPath({
+      projectId,
+      expectedOldPath: oldRoot,
+      newPath: requestedNewRoot,
+      status: project.status,
+    });
+    const newRoot = updated.path;
+    // Re-align the write guard with the canonicalized root.
+    projectStore.beginRelocationRewrite(projectId, oldRoot, newRoot);
+
+    // --- Repoint every cached view's `ViewEntry.projectPath` on its switchChain.
+    await this.rebindViews(projectId, newRoot);
+
+    // --- Live-repoint the renderer: replaces the project by id and (with the
+    // phase-3 renderer change) rebases the live panel/worktree stores in place.
+    broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
+
+    // --- Reopen the workspace host / worktree feed / PTY context at the new
+    // path. Forward-fail: a failure here shows the Tier-3 banner (Retry re-runs
+    // loadProject at the now-current path) rather than reverting the move.
+    await this.reopenProjectAtPath(projectId, newRoot, targetWindows);
+
+    logInfo("project.relocated", { projectId, mode });
+    return updated;
+  }
+
+  /**
+   * Reject a managed move we can't perform atomically, and return the normalized
+   * destination root. Same-volume only for the first cut: a same-volume rename
+   * is O(1)/atomic on APFS; a cross-volume move is a non-atomic copy (out of
+   * scope). The destination must not exist yet, and its parent must.
+   */
+  private validateManagedMove(oldRootRaw: string, newPathRaw: string): string {
+    if (!newPathRaw || !path.isAbsolute(newPathRaw)) {
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        "The destination must be an absolute path."
+      );
+    }
+    const oldRoot = normalizeProjectPath(oldRootRaw);
+    const newRoot = normalizeProjectPath(newPathRaw);
+    if (newRoot === oldRoot) {
+      throw new ProjectRelocationError(
+        "same-path",
+        "The destination is the project's current folder."
+      );
+    }
+    if (newRoot.startsWith(oldRoot + path.sep)) {
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        "Can't move a project into its own subfolder."
+      );
+    }
+    if (existsSync(newRoot)) {
+      throw new ProjectRelocationError(
+        "destination-exists",
+        `Something already exists at ${newRoot}.`
+      );
+    }
+    const parent = path.dirname(newRoot);
+    let parentStat: ReturnType<typeof statSync>;
+    try {
+      parentStat = statSync(parent);
+    } catch {
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        `The destination's parent folder doesn't exist: ${parent}.`
+      );
+    }
+    if (!parentStat.isDirectory()) {
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        `The destination's parent isn't a folder: ${parent}.`
+      );
+    }
+    // Same-volume check: compare the OLD root's device with the destination
+    // PARENT's (the new root doesn't exist yet). Cheap + synchronous — refuse
+    // before we stop anything.
+    let oldDev: number;
+    try {
+      oldDev = statSync(oldRoot).dev;
+    } catch (error) {
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        formatErrorMessage(error, "Couldn't inspect the project folder")
+      );
+    }
+    if (oldDev !== parentStat.dev) {
+      throw new ProjectRelocationError(
+        "cross-volume",
+        "Moving across volumes isn't supported yet — the destination is on a different disk."
+      );
+    }
+    return newRoot;
+  }
+
+  private async quiesceProject(projectId: string, oldRoot: string): Promise<void> {
+    const { ptyClient, worktreeService } = this.deps;
+    // Graceful, session-preserving PTY kill. Capture agent session ids (retained
+    // for phase-5 continuity) and write hibernation markers so a reopen/restart
+    // resumes rather than starting cold. Snapshot flush already happens inside
+    // TerminalProcess.kill() (#3177) — do NOT add another here.
+    if (ptyClient) {
+      const killed = await ptyClient.gracefulKillByProject(projectId, { preserveSession: true });
+      for (const terminal of killed) writeHibernatedMarker(terminal.id);
+    }
+    // Force-drop the workspace host rooted at the OLD path, bypassing the
+    // refCount guard the open window holds (the folder is moving out from under
+    // it). Respawned at the new path by the reopen's loadProject. The renderer
+    // view is deliberately NOT evicted.
+    worktreeService?.evictProjectForRelocation(oldRoot);
+  }
+
+  /** Repoint `ViewEntry.projectPath` on every window's cached/active view. */
+  private async rebindViews(projectId: string, newRoot: string): Promise<void> {
+    const registry = this.deps.windowRegistry;
+    if (!registry) return;
+    for (const ctx of registry.all()) {
+      const pvm = ctx.services.projectViewManager;
+      if (!pvm) continue;
+      try {
+        await pvm.rebindProjectPath(projectId, newRoot);
+      } catch (error) {
+        logError("relocate-rebind-view-failed", error, { projectId, windowId: ctx.windowId });
+      }
+    }
+  }
+
+  /**
+   * Reopen the workspace host + worktree feed + PTY context at `root` for each
+   * window that was showing the project — the post-swap subset of
+   * `activateProjectView` (no view swap, since the view stays on-screen).
+   */
+  private async reopenProjectAtPath(
+    projectId: string,
+    root: string,
+    targetWindows: TargetWindow[]
+  ): Promise<void> {
+    const { worktreeService, ptyClient, worktreePortBroker } = this.deps;
+    for (const { windowId, ctx } of targetWindows) {
+      const view = ctx.services.projectViewManager?.views.get(projectId)?.view;
+      const wc: WebContents | undefined = view?.webContents;
+      const live = wc && !wc.isDestroyed() ? wc : null;
+
+      // Repoint the PTY host's active project/path for this window so future
+      // spawns land at the new root.
+      try {
+        ptyClient?.onProjectSwitch(windowId, projectId, root);
+      } catch (error) {
+        logError("relocate-onProjectSwitch-failed", error, { projectId, windowId });
+      }
+
+      let worktreeLoadError: string | null = null;
+      if (worktreeService) {
+        try {
+          await worktreeService.loadProject(root, windowId);
+          if (live) {
+            worktreeService.attachDirectPort(windowId, live);
+            const host = worktreeService.getHostForProject(root);
+            if (host && worktreePortBroker) worktreePortBroker.brokerPort(host, live);
+          }
+        } catch (error) {
+          worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
+          logError("relocate-load-project-failed", error, { projectId, windowId });
+        }
+      }
+
+      if (live) {
+        live.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, { projectId, worktreeLoadError });
+      }
+    }
+  }
+
+  private snapshotWindowsShowingProject(projectId: string): TargetWindow[] {
+    const registry = this.deps.windowRegistry;
+    if (!registry) return [];
+    const result: TargetWindow[] = [];
+    for (const ctx of registry.all()) {
+      if (ctx.services.projectViewManager?.getActiveProjectId() === projectId) {
+        result.push({ windowId: ctx.windowId, ctx });
+      }
+    }
+    return result;
+  }
+}
+
+/**
+ * Read the Assistant backend for a project, if one is live. Dynamically imported
+ * to avoid pulling the heavy HelpSessionService into this module's eval graph
+ * (the IPC layer loads it lazily too).
+ */
+async function getAssistantBackend(
+  projectId: string
+): Promise<{ terminalId: string; webContentsId: number } | null> {
+  try {
+    const { helpSessionService } = await import("./HelpSessionService.js");
+    return helpSessionService.getAssistantBackend(projectId);
+  } catch (error) {
+    logError("relocate-assistant-check-failed", error, { projectId });
+    return null;
+  }
+}
+
+export const projectRelocationCoordinator = new ProjectRelocationCoordinator();

--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -11,9 +11,14 @@ import { logError, logInfo } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import type { PtyClient } from "./PtyClient.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
-import type { WindowRegistry, WindowContext } from "../window/WindowRegistry.js";
+import type { WindowRegistry } from "../window/WindowRegistry.js";
 import type { WorktreePortBroker } from "./WorktreePortBroker.js";
 import type { Project } from "../types/index.js";
+
+// How long the state-write rewrite guard lingers after a relocation resolves, to
+// absorb a renderer layout write debounced with the old root (the persistence
+// debounce is ~500ms; this comfortably outlasts it).
+const RELOCATION_GUARD_GRACE_MS = 3000;
 
 /**
  * Relocating a currently-OPEN project (#11282, phase 3).
@@ -83,12 +88,12 @@ export interface RelocateProjectRequest {
 
 interface TargetWindow {
   windowId: number;
-  ctx: WindowContext;
 }
 
 export class ProjectRelocationCoordinator {
   private deps: ProjectRelocationDeps = {};
   private readonly relocating = new Set<string>();
+  private readonly guardReleaseTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   configure(deps: ProjectRelocationDeps): void {
     this.deps = deps;
@@ -108,7 +113,7 @@ export class ProjectRelocationCoordinator {
     const { projectId, mode } = request;
     const disposition = request.assistantDisposition ?? "refuse";
 
-    // --- Establish ownership SYNCHRONOUSLY, before the first await: whether this
+    // Establish ownership SYNCHRONOUSLY, before the first await: whether this
     // project is open, and which windows show it, must not shift under a
     // concurrent switch/close (#11131 TOCTOU).
     const project = projectStore.getProjectById(projectId);
@@ -128,21 +133,39 @@ export class ProjectRelocationCoordinator {
     ).has(projectId);
     const targetWindows = openAtEntry ? this.snapshotWindowsShowingProject(projectId) : [];
 
-    // Closed reattach: the folder is already on disk and nothing is live, so the
-    // phase-1/2 path is correct as-is — no need to spin up the quiesce machinery.
-    if (mode === "reattach" && !openAtEntry) {
-      const relocated = await projectStore.relocateProject(projectId, request.newPath);
-      broadcastToRenderer(CHANNELS.PROJECT_UPDATED, relocated);
-      return relocated;
-    }
-
+    // Reserve BEFORE any branch so a concurrent relocation of the same project —
+    // closed-delegate or pipeline — is rejected, not interleaved.
     this.relocating.add(projectId);
     try {
+      // Closed reattach: the folder is already on disk and nothing is live, so
+      // the phase-1/2 path is correct as-is — no quiesce machinery needed.
+      if (mode === "reattach" && !openAtEntry) {
+        const relocated = await projectStore.relocateProject(projectId, request.newPath);
+        broadcastToRenderer(CHANNELS.PROJECT_UPDATED, relocated);
+        return relocated;
+      }
       return await this.runPipeline(project, request, disposition, targetWindows);
     } finally {
       this.relocating.delete(projectId);
-      projectStore.endRelocationRewrite(projectId);
+      // Hold the state-write rewrite a beat past the operation: a renderer layout
+      // write debounced with the old root can land after `relocate` resolves, and
+      // must still be rebased. Released only if no newer relocation re-armed it.
+      this.scheduleGuardRelease(projectId);
     }
+  }
+
+  private scheduleGuardRelease(projectId: string): void {
+    // Cancel any pending release so only the LATEST relocation's timer survives —
+    // otherwise an older timer could fire after a newer relocation re-armed the
+    // guard and delete it before that relocation's own grace expired.
+    const existing = this.guardReleaseTimers.get(projectId);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.guardReleaseTimers.delete(projectId);
+      if (!this.relocating.has(projectId)) projectStore.endRelocationRewrite(projectId);
+    }, RELOCATION_GUARD_GRACE_MS);
+    timer.unref?.();
+    this.guardReleaseTimers.set(projectId, timer);
   }
 
   private async runPipeline(
@@ -154,17 +177,30 @@ export class ProjectRelocationCoordinator {
     const { projectId, mode } = request;
     const oldRoot = project.path;
 
-    // --- Assistant guard. Killing the Assistant's PTY tears down its whole
-    // sub-agent tree (a security-boundary action, #7509); phase 3 refuses rather
-    // than silently destroying in-flight agent work. Phase 4/5 own hibernate.
-    if (disposition === "refuse" && (await getAssistantBackend(projectId))) {
-      throw new ProjectRelocationError(
-        "assistant-active",
-        "Stop the Daintree Assistant for this project before moving it."
-      );
+    // Assistant guard, FAIL-CLOSED. Killing the Assistant's PTY tears down its
+    // whole sub-agent tree (a security-boundary action, #7509); phase 3 refuses
+    // rather than silently destroying in-flight agent work. A failed check is
+    // treated as "may be active" — never as "clear". Phase 4/5 own hibernate.
+    if (disposition === "refuse") {
+      let assistant: { terminalId: string; webContentsId: number } | null;
+      try {
+        assistant = await getAssistantBackend(projectId);
+      } catch (error) {
+        logError("relocate-assistant-check-failed", error, { projectId });
+        throw new ProjectRelocationError(
+          "assistant-active",
+          "Couldn't check the Daintree Assistant for this project — stop it and try again."
+        );
+      }
+      if (assistant) {
+        throw new ProjectRelocationError(
+          "assistant-active",
+          "Stop the Daintree Assistant for this project before moving it."
+        );
+      }
     }
 
-    // --- Preflight: ALL validation before anything is stopped.
+    // Preflight: ALL validation before anything is stopped.
     let requestedNewRoot = normalizeProjectPath(request.newPath);
     if (mode === "move") {
       requestedNewRoot = this.validateManagedMove(oldRoot, request.newPath);
@@ -175,25 +211,40 @@ export class ProjectRelocationCoordinator {
       );
     }
 
-    // --- Quiesce the project's live runtimes (borrowed from `project:free-memory`
-    // MINUS the renderer eviction — keeping the view + xterm alive is the point).
+    // Refuse a destination already registered to a DIFFERENT project BEFORE
+    // touching anything — otherwise a managed move could rename the folder into
+    // place and only then discover the conflict at finalize, stranding one
+    // project's folder under another's row (`getProjectByPath` compares the
+    // stored path without needing the folder to exist yet, so this is safe
+    // pre-rename).
+    const conflict = await projectStore.getProjectByPath(requestedNewRoot);
+    if (conflict && conflict.id !== projectId) {
+      throw new ProjectRelocationError(
+        "destination-exists",
+        `Another project ("${conflict.name}") is already registered at that location.`
+      );
+    }
+
+    // Quiesce the project's live runtimes (borrowed from `project:free-memory`
+    // minus the renderer eviction — keeping the view + xterm alive is the point).
     await this.quiesceProject(projectId, oldRoot);
 
-    // --- Arm the state-write guard so a late renderer layout write can't clobber
-    // the migration once we cross the boundary.
+    // Arm the state-write guard so a late renderer layout write can't clobber the
+    // migration once we cross the boundary.
     projectStore.beginRelocationRewrite(projectId, oldRoot, requestedNewRoot);
 
-    // ===================== COMMIT BOUNDARY (fs.rename) =====================
-    // Above this try/catch: rollback is safe. A managed move's rename is the
-    // point of no return — everything after it is forward-only, never a reverse
-    // rename. A reattach is already disk-committed at entry, so it has no
-    // pre-commit window to roll back.
+    // fs.rename is the commit boundary. Before this try/catch a failure rolls
+    // back (reopen at the original path; nothing durable changed). A managed
+    // move's rename is the point of no return — everything after is forward-only,
+    // never a reverse rename. A reattach is already disk-committed at entry.
     if (mode === "move") {
       try {
         await rename(oldRoot, requestedNewRoot);
       } catch (error) {
-        // Pre-commit failure: nothing durable changed. Reopen at the ORIGINAL
-        // path so the user is left exactly where they started.
+        // Pre-commit failure. The quiesce did kill this project's PTYs (their
+        // sessions are preserved and restartable) and dropped the host, so this
+        // is a non-destructive reopen at the original path, not a perfect
+        // undo — reopen restores the workspace host + worktree feed there.
         projectStore.endRelocationRewrite(projectId);
         await this.reopenProjectAtPath(projectId, oldRoot, targetWindows);
         throw new ProjectRelocationError(
@@ -203,27 +254,48 @@ export class ProjectRelocationCoordinator {
       }
     }
 
-    // --- Finalize durable state (DB path + phase-2 migration + git/submodule
-    // repair), PRESERVING the project's status so an open project stays open.
-    const updated = await projectStore.finalizeRelocatedPath({
-      projectId,
-      expectedOldPath: oldRoot,
-      newPath: requestedNewRoot,
-      status: project.status,
-    });
+    // Finalize durable state (DB path + phase-2 migration + git/submodule repair),
+    // PRESERVING the project's status so an open project stays open.
+    let updated: Project;
+    try {
+      updated = await projectStore.finalizeRelocatedPath({
+        projectId,
+        expectedOldPath: oldRoot,
+        newPath: requestedNewRoot,
+        status: project.status,
+      });
+    } catch (error) {
+      // Post-commit: the folder is at the new root but the DB update failed. Do
+      // NOT reverse the rename. The row still points at the (now-missing) old
+      // path, so the project surfaces as "missing" and the user can re-locate it
+      // at the new path — the reattach flow, which will now succeed.
+      logError("relocate-finalize-failed-after-move", error, {
+        projectId,
+        oldRoot,
+        newRoot: requestedNewRoot,
+      });
+      // Build the message directly: `formatErrorMessage` returns the cause's own
+      // message for a normal Error and would drop the actionable guidance, so
+      // append the cause rather than passing it as the fallback.
+      const cause = formatErrorMessage(error, "unknown error");
+      throw new ProjectRelocationError(
+        "invalid-destination",
+        `The folder moved to ${requestedNewRoot} but updating the project failed — re-locate it there (${cause})`
+      );
+    }
     const newRoot = updated.path;
     // Re-align the write guard with the canonicalized root.
     projectStore.beginRelocationRewrite(projectId, oldRoot, newRoot);
 
-    // --- Repoint every cached view's `ViewEntry.projectPath` on its switchChain.
+    // Repoint every cached view's `ViewEntry.projectPath` on its switchChain.
     await this.rebindViews(projectId, newRoot);
 
-    // --- Live-repoint the renderer: replaces the project by id and (with the
-    // phase-3 renderer change) rebases the live panel/worktree stores in place.
+    // Live-repoint the renderer: replaces the project by id and (with the phase-3
+    // renderer change) rebases the live panel/worktree stores in place.
     broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
 
-    // --- Reopen the workspace host / worktree feed / PTY context at the new
-    // path. Forward-fail: a failure here shows the Tier-3 banner (Retry re-runs
+    // Reopen the workspace host / worktree feed / PTY context at the new path.
+    // Forward-fail: a failure here shows the Tier-3 banner (Retry re-runs
     // loadProject at the now-current path) rather than reverting the move.
     await this.reopenProjectAtPath(projectId, newRoot, targetWindows);
 
@@ -343,10 +415,17 @@ export class ProjectRelocationCoordinator {
     root: string,
     targetWindows: TargetWindow[]
   ): Promise<void> {
-    const { worktreeService, ptyClient, worktreePortBroker } = this.deps;
-    for (const { windowId, ctx } of targetWindows) {
-      const view = ctx.services.projectViewManager?.views.get(projectId)?.view;
-      const wc: WebContents | undefined = view?.webContents;
+    const { worktreeService, ptyClient, worktreePortBroker, windowRegistry } = this.deps;
+    for (const { windowId } of targetWindows) {
+      // Re-resolve the window from the LIVE registry, not the entry snapshot: the
+      // user may have switched it to another project (or closed it) while we
+      // awaited. Reopening a window that no longer shows this project would
+      // cross-route another project's PTY port / worktree feed (#11101).
+      const ctx = windowRegistry?.getByWindowId(windowId);
+      const pvm = ctx?.services.projectViewManager;
+      if (!pvm || pvm.getActiveProjectId() !== projectId) continue;
+
+      const wc: WebContents | undefined = pvm.views.get(projectId)?.view?.webContents;
       const live = wc && !wc.isDestroyed() ? wc : null;
 
       // Repoint the PTY host's active project/path for this window so future
@@ -361,10 +440,24 @@ export class ProjectRelocationCoordinator {
       if (worktreeService) {
         try {
           await worktreeService.loadProject(root, windowId);
-          if (live) {
+          // Re-check AFTER the load await: a switch during loadProject could have
+          // moved this window to another project, and attaching our (now
+          // background) view's port to the window's new workspace entry would
+          // cross-route it. Skip the port wiring if that happened.
+          const stillShowing =
+            windowRegistry
+              ?.getByWindowId(windowId)
+              ?.services.projectViewManager?.getActiveProjectId() === projectId;
+          if (live && stillShowing) {
             worktreeService.attachDirectPort(windowId, live);
             const host = worktreeService.getHostForProject(root);
-            if (host && worktreePortBroker) worktreePortBroker.brokerPort(host, live);
+            if (host && worktreePortBroker && !worktreePortBroker.brokerPort(host, live)) {
+              // The reload succeeded but the worktree MessagePort never
+              // connected, so the renderer can't fetch its state — surface it as
+              // a load failure so the banner + Retry stay (mirrors switch.ts).
+              worktreeLoadError =
+                "Reloaded the project but couldn't connect to the worktree service";
+            }
           }
         } catch (error) {
           worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
@@ -373,7 +466,13 @@ export class ProjectRelocationCoordinator {
       }
 
       if (live) {
-        live.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, { projectId, worktreeLoadError });
+        // Best-effort: the view can die between the guard and the send, and a
+        // notification failure must not turn a committed move into a rejection.
+        try {
+          live.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, { projectId, worktreeLoadError });
+        } catch (error) {
+          logError("relocate-status-send-failed", error, { projectId, windowId });
+        }
       }
     }
   }
@@ -384,7 +483,7 @@ export class ProjectRelocationCoordinator {
     const result: TargetWindow[] = [];
     for (const ctx of registry.all()) {
       if (ctx.services.projectViewManager?.getActiveProjectId() === projectId) {
-        result.push({ windowId: ctx.windowId, ctx });
+        result.push({ windowId: ctx.windowId });
       }
     }
     return result;
@@ -394,18 +493,15 @@ export class ProjectRelocationCoordinator {
 /**
  * Read the Assistant backend for a project, if one is live. Dynamically imported
  * to avoid pulling the heavy HelpSessionService into this module's eval graph
- * (the IPC layer loads it lazily too).
+ * (the IPC layer loads it lazily too). THROWS on failure — the caller fails
+ * closed (treats an unverifiable Assistant as possibly-active) rather than
+ * risking a silent sub-agent-tree kill.
  */
 async function getAssistantBackend(
   projectId: string
 ): Promise<{ terminalId: string; webContentsId: number } | null> {
-  try {
-    const { helpSessionService } = await import("./HelpSessionService.js");
-    return helpSessionService.getAssistantBackend(projectId);
-  } catch (error) {
-    logError("relocate-assistant-check-failed", error, { projectId });
-    return null;
-  }
+  const { helpSessionService } = await import("./HelpSessionService.js");
+  return helpSessionService.getAssistantBackend(projectId);
 }
 
 export const projectRelocationCoordinator = new ProjectRelocationCoordinator();

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -165,6 +165,15 @@ export class ProjectStore {
   // so the same recipe id in two different project clones stays separate.
   private inRepoRecipeHashes = new Map<string, string>();
 
+  // Operation-scoped path rewrites for projects being relocated by the phase-3
+  // coordinator (#11282). While a project id is present here, EVERY persisted
+  // state write for it is rebased old→new before hitting disk — so a debounced
+  // renderer layout write still in flight with the OLD root (the live-repoint
+  // keeps the view alive, so it keeps writing) can't clobber the migrated state
+  // after the folder move. Bounded to the coordinator's operation via
+  // begin/endRelocationRewrite.
+  private relocationRewrites = new Map<string, { oldPath: string; newPath: string }>();
+
   constructor() {
     this.userDataDir = app.getPath("userData");
     this.projectsConfigDir = path.join(this.userDataDir, "projects");
@@ -865,9 +874,10 @@ export class ProjectStore {
    * a failure in any ancillary surface is logged rather than surfaced as a
    * relocation error (reporting failure after the row moved would misrepresent
    * the real state). Each surface is an independently-settled thunk, so neither a
-   * rejection nor a SYNCHRONOUS throw in one can skip the others. Callers only
-   * reach here for a genuine move of a non-active project — both adoption and
-   * explicit relocation guard the current project.
+   * rejection nor a SYNCHRONOUS throw in one can skip the others. Reached for a
+   * genuine folder move via any path: closed-project reattach/adoption, or the
+   * phase-3 coordinator relocating an OPEN project (which has already quiesced
+   * that project's live runtimes before the rewrite runs).
    */
   private async migratePathBearingStateAfterMove(
     projectId: string,
@@ -910,8 +920,57 @@ export class ProjectStore {
       throw new Error(`Project not found: ${projectId}`);
     }
 
+    // Defense-in-depth: an OPEN project must go through the phase-3
+    // quiesce/rebind coordinator (which calls `finalizeRelocatedPath` directly
+    // after tearing down its runtimes), never this closed-project reattach path
+    // — repointing a live view/host/PTY from here would strand them on the old
+    // path (#11282). This single-window pointer only catches the last-focused
+    // window; the authoritative open-anywhere fork lives at the IPC boundary
+    // (`collectActiveProjectIds`), which routes open projects to the coordinator.
     if (projectId === this.getCurrentProjectId()) {
       throw new Error("Cannot relocate the currently active project");
+    }
+
+    // A plain reattach always parks the project as `closed`; the coordinator is
+    // the only caller that preserves an open project's live status.
+    return this.finalizeRelocatedPath({
+      projectId,
+      expectedOldPath: project.path,
+      newPath,
+      status: "closed",
+    });
+  }
+
+  /**
+   * Commit a project's move to a folder that ALREADY exists at `newPath`:
+   * canonicalize the new Git root, update the immutable-id row, and rebase every
+   * path-bearing surface. The caller owns the filesystem move — a plain reattach
+   * via {@link relocateProject} (folder moved externally), or the phase-3
+   * relocation coordinator after its own same-volume `fs.rename`.
+   *
+   * Split out from `relocateProject` so the coordinator can relocate an OPEN
+   * project while PRESERVING its `status` (forcing `"closed"` would make the
+   * visible project and the DB row disagree); `relocateProject` always closes.
+   *
+   * `expectedOldPath` guards a concurrent move: if the row no longer points where
+   * the caller captured it, the state rebase would run against a stale old root,
+   * so bail rather than corrupt state.
+   */
+  async finalizeRelocatedPath(opts: {
+    projectId: string;
+    expectedOldPath: string;
+    newPath: string;
+    status: Project["status"];
+  }): Promise<Project> {
+    const { projectId, expectedOldPath, newPath, status } = opts;
+    const project = this.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+    if (normalizeProjectPath(project.path) !== normalizeProjectPath(expectedOldPath)) {
+      throw new Error(
+        `Project ${projectId} moved concurrently (expected ${expectedOldPath}, found ${project.path})`
+      );
     }
 
     // Normalize to the same NFC spelling `addProject`/`getProjectByPath` use, so
@@ -935,7 +994,7 @@ export class ProjectStore {
     const oldPath = project.path;
     const updatedProject = this.updateProject(projectId, {
       path: canonicalNewPath,
-      status: "closed",
+      status,
     });
 
     if (normalizeProjectPath(oldPath) !== normalizeProjectPath(canonicalNewPath)) {
@@ -1069,12 +1128,32 @@ export class ProjectStore {
 
   // --- State ---
 
+  /**
+   * Arm the operation-scoped state-write rewrite for a relocating project
+   * (#11282, phase 3). Until {@link endRelocationRewrite}, any persisted state
+   * write for `projectId` is rebased old→new, so a late renderer write with the
+   * old root can't undo the folder-move migration. Idempotent per id.
+   */
+  beginRelocationRewrite(projectId: string, oldPath: string, newPath: string): void {
+    this.relocationRewrites.set(projectId, { oldPath, newPath });
+  }
+
+  endRelocationRewrite(projectId: string): void {
+    this.relocationRewrites.delete(projectId);
+  }
+
+  private applyRelocationRewrite(projectId: string, state: ProjectState): ProjectState {
+    const rewrite = this.relocationRewrites.get(projectId);
+    if (!rewrite) return state;
+    return rewriteProjectStatePaths(state, rewrite.oldPath, rewrite.newPath);
+  }
+
   async saveProjectState(projectId: string, state: ProjectState): Promise<void> {
     // Invalidate before the write so any in-flight prefetch sees a version bump
     // and discards its result — otherwise a prefetch resolving after the write
     // could clobber the cache with pre-mutation state.
     invalidatePrefetchCache(projectId);
-    return this.stateManager.saveProjectState(projectId, state);
+    return this.stateManager.saveProjectState(projectId, this.applyRelocationRewrite(projectId, state));
   }
 
   async enqueueProjectStateUpdate(
@@ -1087,6 +1166,7 @@ export class ProjectStore {
         // Same contract as saveProjectState: invalidate before the write so an
         // in-flight prefetch can't clobber the cache with pre-mutation state.
         invalidatePrefetchCache(projectId);
+        return this.applyRelocationRewrite(projectId, updated);
       }
       return updated;
     });

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1153,7 +1153,10 @@ export class ProjectStore {
     // and discards its result — otherwise a prefetch resolving after the write
     // could clobber the cache with pre-mutation state.
     invalidatePrefetchCache(projectId);
-    return this.stateManager.saveProjectState(projectId, this.applyRelocationRewrite(projectId, state));
+    return this.stateManager.saveProjectState(
+      projectId,
+      this.applyRelocationRewrite(projectId, state)
+    );
   }
 
   async enqueueProjectStateUpdate(

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -321,6 +321,18 @@ export class WorkspaceClient extends EventEmitter {
     return this.pool.evictProject(projectPath);
   }
 
+  /**
+   * Force-evict the workspace host for a project being RELOCATED, bypassing the
+   * `refCount > 0` guard that {@link evictProject} honors. Only the phase-3
+   * relocation coordinator calls this — after the folder moves, the old host is
+   * respawned at the new path by the reopening `loadProject`
+   * (see {@link WorkspaceHostPool.evictProjectForRelocation}).
+   */
+  evictProjectForRelocation(projectPath: string): void {
+    if (this.isDisposed) return;
+    this.pool.evictProjectForRelocation(projectPath);
+  }
+
   pauseHealthCheck(): void {
     for (const entry of this.pool.entries.values()) {
       entry.host.pauseHealthCheck();

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -32,6 +32,7 @@ vi.mock("fs/promises", () => ({
 
 const mockProjectStore = vi.hoisted(() => ({
   getProjectById: vi.fn(),
+  getProjectByPath: vi.fn(async () => null as { id: string; name: string } | null),
   getCurrentProjectId: vi.fn(() => null as string | null),
   finalizeRelocatedPath: vi.fn(),
   relocateProject: vi.fn(),
@@ -94,8 +95,10 @@ function makePvm(activeProjectId: string | null) {
 }
 
 function makeDeps(pvm: ReturnType<typeof makePvm> | null) {
+  const ctx = { windowId: 1, services: { projectViewManager: pvm } };
   const windowRegistry = {
-    all: () => (pvm ? [{ windowId: 1, services: { projectViewManager: pvm } }] : []),
+    all: () => (pvm ? [ctx] : []),
+    getByWindowId: (id: number) => (pvm && id === 1 ? ctx : undefined),
   };
   const ptyClient = {
     gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
@@ -128,10 +131,9 @@ beforeEach(() => {
   fsState.renameReject = null;
   fsState.renameCalls = [];
   mockProjectStore.getProjectById.mockReturnValue(makeProject());
+  mockProjectStore.getProjectByPath.mockResolvedValue(null);
   mockProjectStore.getCurrentProjectId.mockReturnValue(null);
-  mockProjectStore.finalizeRelocatedPath.mockResolvedValue(
-    makeProject({ path: NEW_ROOT })
-  );
+  mockProjectStore.finalizeRelocatedPath.mockResolvedValue(makeProject({ path: NEW_ROOT }));
   mockProjectStore.relocateProject.mockResolvedValue(makeProject({ path: NEW_ROOT }));
   mockAssistant.getAssistantBackend.mockReturnValue(null);
 });
@@ -169,7 +171,10 @@ describe("ProjectRelocationCoordinator — managed move of an open project", () 
 
     // Rebind + live-repoint + reopen at the NEW path.
     expect(pvm.rebindProjectPath).toHaveBeenCalledWith(PROJECT_ID, NEW_ROOT);
-    expect(mockBroadcast).toHaveBeenCalledWith(CHANNELS.PROJECT_UPDATED, makeProject({ path: NEW_ROOT }));
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      CHANNELS.PROJECT_UPDATED,
+      makeProject({ path: NEW_ROOT })
+    );
     expect(deps.worktreeService.loadProject).toHaveBeenCalledWith(NEW_ROOT, 1);
     expect(deps.ptyClient.onProjectSwitch).toHaveBeenCalledWith(1, PROJECT_ID, NEW_ROOT);
 
@@ -179,9 +184,9 @@ describe("ProjectRelocationCoordinator — managed move of an open project", () 
       worktreeLoadError: null,
     });
     expect(result.path).toBe(NEW_ROOT);
-    // Reservation released.
+    // Reservation released synchronously (the rewrite guard is released later on
+    // a grace timer, so it is not asserted here).
     expect(coordinator.isRelocating(PROJECT_ID)).toBe(false);
-    expect(mockProjectStore.endRelocationRewrite).toHaveBeenCalledWith(PROJECT_ID);
   });
 
   it("refuses a cross-volume move up front — nothing is stopped or renamed", async () => {
@@ -217,7 +222,10 @@ describe("ProjectRelocationCoordinator — guard fork", () => {
 
     expect(mockProjectStore.relocateProject).toHaveBeenCalledWith(PROJECT_ID, NEW_ROOT);
     expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
-    expect(mockBroadcast).toHaveBeenCalledWith(CHANNELS.PROJECT_UPDATED, makeProject({ path: NEW_ROOT }));
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      CHANNELS.PROJECT_UPDATED,
+      makeProject({ path: NEW_ROOT })
+    );
   });
 
   it("routes an open reattach through the coordinator pipeline", async () => {
@@ -311,6 +319,40 @@ describe("ProjectRelocationCoordinator — guards", () => {
 
     expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
     expect(fsState.renameCalls).toHaveLength(0);
+  });
+
+  it("fails CLOSED when the Assistant check itself throws", async () => {
+    mockAssistant.getAssistantBackend.mockImplementation(() => {
+      throw new Error("help service unavailable");
+    });
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "assistant-active" });
+
+    // A failed check must NOT be read as "no Assistant" — nothing is torn down.
+    expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(fsState.renameCalls).toHaveLength(0);
+  });
+
+  it("refuses a destination already registered to a different project (before quiescing)", async () => {
+    mockProjectStore.getProjectByPath.mockResolvedValue({ id: "other-proj", name: "Other" });
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "destination-exists" });
+
+    expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(fsState.renameCalls).toHaveLength(0);
+    expect(mockProjectStore.finalizeRelocatedPath).not.toHaveBeenCalled();
   });
 
   it("rejects a concurrent relocation for the same project", async () => {

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks (hoisted so vi.mock factories can reference them) ---------------
+
+const fsState = vi.hoisted(() => ({
+  existing: new Set<string>(),
+  devByPath: new Map<string, number>(),
+  renameReject: null as Error | null,
+  renameCalls: [] as Array<{ from: string; to: string }>,
+}));
+
+vi.mock("fs", () => ({
+  existsSync: (p: string) => fsState.existing.has(p),
+  statSync: (p: string) => {
+    if (!fsState.existing.has(p)) {
+      const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    }
+    return { dev: fsState.devByPath.get(p) ?? 1, isDirectory: () => true };
+  },
+}));
+
+vi.mock("fs/promises", () => ({
+  rename: async (from: string, to: string) => {
+    fsState.renameCalls.push({ from, to });
+    if (fsState.renameReject) throw fsState.renameReject;
+    fsState.existing.delete(from);
+    fsState.existing.add(to);
+  },
+}));
+
+const mockProjectStore = vi.hoisted(() => ({
+  getProjectById: vi.fn(),
+  getCurrentProjectId: vi.fn(() => null as string | null),
+  finalizeRelocatedPath: vi.fn(),
+  relocateProject: vi.fn(),
+  beginRelocationRewrite: vi.fn(),
+  endRelocationRewrite: vi.fn(),
+}));
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: mockProjectStore,
+  normalizeProjectPath: (p: string) => p.normalize("NFC"),
+}));
+
+const mockBroadcast = vi.hoisted(() => vi.fn());
+vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: mockBroadcast }));
+
+const mockAssistant = vi.hoisted(() => ({
+  getAssistantBackend: vi.fn(() => null as { terminalId: string; webContentsId: number } | null),
+}));
+vi.mock("../HelpSessionService.js", () => ({ helpSessionService: mockAssistant }));
+
+const mockWriteHibernatedMarker = vi.hoisted(() => vi.fn());
+vi.mock("../pty/terminalSessionPersistence.js", () => ({
+  writeHibernatedMarker: mockWriteHibernatedMarker,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+import { CHANNELS } from "../../ipc/channels.js";
+import {
+  ProjectRelocationCoordinator,
+  ProjectRelocationError,
+} from "../ProjectRelocationCoordinator.js";
+
+// --- Fixtures --------------------------------------------------------------
+
+const PROJECT_ID = "abc123";
+const OLD_ROOT = "/vol/projects/proj";
+const NEW_ROOT = "/vol/projects/proj-renamed";
+
+function makeProject(overrides: Record<string, unknown> = {}) {
+  return { id: PROJECT_ID, path: OLD_ROOT, name: "Proj", status: "active", ...overrides };
+}
+
+interface FakeView {
+  webContents: { isDestroyed: () => boolean; send: ReturnType<typeof vi.fn> };
+}
+
+function makePvm(activeProjectId: string | null) {
+  const view: FakeView = { webContents: { isDestroyed: () => false, send: vi.fn() } };
+  return {
+    getActiveProjectId: () => activeProjectId,
+    getOutgoingBridgeProjectId: () => null,
+    rebindProjectPath: vi.fn(async () => view.webContents),
+    views: new Map([[PROJECT_ID, { view }]]),
+    _view: view,
+  };
+}
+
+function makeDeps(pvm: ReturnType<typeof makePvm> | null) {
+  const windowRegistry = {
+    all: () => (pvm ? [{ windowId: 1, services: { projectViewManager: pvm } }] : []),
+  };
+  const ptyClient = {
+    gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
+    onProjectSwitch: vi.fn(),
+  };
+  const worktreeService = {
+    evictProjectForRelocation: vi.fn(),
+    loadProject: vi.fn(async () => {}),
+    getHostForProject: vi.fn(() => ({}) as unknown),
+    attachDirectPort: vi.fn(),
+  };
+  const worktreePortBroker = { brokerPort: vi.fn(() => true) };
+  return { ptyClient, worktreeService, windowRegistry, worktreePortBroker };
+}
+
+// deps use runtime-shaped fakes; the coordinator only touches the methods above.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function configure(coordinator: ProjectRelocationCoordinator, deps: ReturnType<typeof makeDeps>) {
+  coordinator.configure(deps as any);
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fsState.existing = new Set([OLD_ROOT, "/vol/projects"]);
+  fsState.devByPath = new Map([
+    [OLD_ROOT, 10],
+    ["/vol/projects", 10],
+  ]);
+  fsState.renameReject = null;
+  fsState.renameCalls = [];
+  mockProjectStore.getProjectById.mockReturnValue(makeProject());
+  mockProjectStore.getCurrentProjectId.mockReturnValue(null);
+  mockProjectStore.finalizeRelocatedPath.mockResolvedValue(
+    makeProject({ path: NEW_ROOT })
+  );
+  mockProjectStore.relocateProject.mockResolvedValue(makeProject({ path: NEW_ROOT }));
+  mockAssistant.getAssistantBackend.mockReturnValue(null);
+});
+
+describe("ProjectRelocationCoordinator — managed move of an open project", () => {
+  it("quiesces, renames once, finalizes with preserved status, rebinds and reopens", async () => {
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    const result = await coordinator.relocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    // Quiesce: graceful, session-preserving PTY kill + hibernation marker + host evict.
+    expect(deps.ptyClient.gracefulKillByProject).toHaveBeenCalledWith(PROJECT_ID, {
+      preserveSession: true,
+    });
+    expect(mockWriteHibernatedMarker).toHaveBeenCalledWith("t1");
+    expect(deps.worktreeService.evictProjectForRelocation).toHaveBeenCalledWith(OLD_ROOT);
+
+    // Exactly one rename, forward-only.
+    expect(fsState.renameCalls).toEqual([{ from: OLD_ROOT, to: NEW_ROOT }]);
+
+    // Finalize preserves the OPEN project's status (not forced "closed").
+    expect(mockProjectStore.finalizeRelocatedPath).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      expectedOldPath: OLD_ROOT,
+      newPath: NEW_ROOT,
+      status: "active",
+    });
+
+    // Rebind + live-repoint + reopen at the NEW path.
+    expect(pvm.rebindProjectPath).toHaveBeenCalledWith(PROJECT_ID, NEW_ROOT);
+    expect(mockBroadcast).toHaveBeenCalledWith(CHANNELS.PROJECT_UPDATED, makeProject({ path: NEW_ROOT }));
+    expect(deps.worktreeService.loadProject).toHaveBeenCalledWith(NEW_ROOT, 1);
+    expect(deps.ptyClient.onProjectSwitch).toHaveBeenCalledWith(1, PROJECT_ID, NEW_ROOT);
+
+    // The renderer view is never evicted (kept alive) — a clean worktree-load status is sent.
+    expect(pvm._view.webContents.send).toHaveBeenCalledWith(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+      projectId: PROJECT_ID,
+      worktreeLoadError: null,
+    });
+    expect(result.path).toBe(NEW_ROOT);
+    // Reservation released.
+    expect(coordinator.isRelocating(PROJECT_ID)).toBe(false);
+    expect(mockProjectStore.endRelocationRewrite).toHaveBeenCalledWith(PROJECT_ID);
+  });
+
+  it("refuses a cross-volume move up front — nothing is stopped or renamed", async () => {
+    // Destination parent on a different device.
+    fsState.existing.add("/other");
+    fsState.devByPath.set("/other", 99);
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: "/other/proj" })
+    ).rejects.toMatchObject({ reason: "cross-volume" });
+
+    expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(deps.worktreeService.evictProjectForRelocation).not.toHaveBeenCalled();
+    expect(fsState.renameCalls).toHaveLength(0);
+    expect(mockProjectStore.finalizeRelocatedPath).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProjectRelocationCoordinator — guard fork", () => {
+  it("delegates a closed reattach to ProjectStore.relocateProject (no quiesce)", async () => {
+    fsState.existing.add(NEW_ROOT);
+    const pvm = makePvm(null); // not the active project in any window
+    const deps = makeDeps(pvm);
+    mockProjectStore.getCurrentProjectId.mockReturnValue(null);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await coordinator.relocate({ projectId: PROJECT_ID, mode: "reattach", newPath: NEW_ROOT });
+
+    expect(mockProjectStore.relocateProject).toHaveBeenCalledWith(PROJECT_ID, NEW_ROOT);
+    expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(mockBroadcast).toHaveBeenCalledWith(CHANNELS.PROJECT_UPDATED, makeProject({ path: NEW_ROOT }));
+  });
+
+  it("routes an open reattach through the coordinator pipeline", async () => {
+    fsState.existing.add(NEW_ROOT);
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await coordinator.relocate({ projectId: PROJECT_ID, mode: "reattach", newPath: NEW_ROOT });
+
+    // Reattach: folder already at newPath, so no rename, but full quiesce/rebind.
+    expect(fsState.renameCalls).toHaveLength(0);
+    expect(deps.ptyClient.gracefulKillByProject).toHaveBeenCalled();
+    expect(mockProjectStore.finalizeRelocatedPath).toHaveBeenCalled();
+    expect(mockProjectStore.relocateProject).not.toHaveBeenCalled();
+  });
+
+  it("treats a second-window (unfocused) project as open via the id union", async () => {
+    // getCurrentProjectId (last-focused window) does NOT name this project, but a
+    // PVM does — the union must still route it through the coordinator.
+    mockProjectStore.getCurrentProjectId.mockReturnValue("some-other-project");
+    fsState.existing.add(NEW_ROOT);
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await coordinator.relocate({ projectId: PROJECT_ID, mode: "reattach", newPath: NEW_ROOT });
+
+    expect(deps.ptyClient.gracefulKillByProject).toHaveBeenCalled();
+    expect(mockProjectStore.relocateProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProjectRelocationCoordinator — rollback vs forward-fail boundary", () => {
+  it("rolls back before the rename: a rename failure reopens at the ORIGINAL path and never renames backward", async () => {
+    fsState.renameReject = new Error("EPERM");
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toBeInstanceOf(ProjectRelocationError);
+
+    // Durable state untouched, reopened at the old path.
+    expect(mockProjectStore.finalizeRelocatedPath).not.toHaveBeenCalled();
+    expect(deps.worktreeService.loadProject).toHaveBeenCalledWith(OLD_ROOT, 1);
+    // Only the forward rename was attempted — never a reverse rename.
+    expect(fsState.renameCalls).toEqual([{ from: OLD_ROOT, to: NEW_ROOT }]);
+    expect(coordinator.isRelocating(PROJECT_ID)).toBe(false);
+  });
+
+  it("forward-fails after the rename: a reopen failure surfaces the Tier-3 banner and does NOT revert", async () => {
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    deps.worktreeService.loadProject.mockRejectedValue(new Error("host spawn failed"));
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    const result = await coordinator.relocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    // The move committed and is NOT reverted.
+    expect(fsState.renameCalls).toEqual([{ from: OLD_ROOT, to: NEW_ROOT }]);
+    expect(result.path).toBe(NEW_ROOT);
+    // The failure surfaces as a worktree-load error banner (Retry recovers).
+    expect(pvm._view.webContents.send).toHaveBeenCalledWith(
+      CHANNELS.PROJECT_WORKTREE_LOAD_STATUS,
+      expect.objectContaining({ projectId: PROJECT_ID, worktreeLoadError: expect.any(String) })
+    );
+  });
+});
+
+describe("ProjectRelocationCoordinator — guards", () => {
+  it("refuses to relocate while the Daintree Assistant is active", async () => {
+    mockAssistant.getAssistantBackend.mockReturnValue({ terminalId: "help-1", webContentsId: 5 });
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "assistant-active" });
+
+    expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(fsState.renameCalls).toHaveLength(0);
+  });
+
+  it("rejects a concurrent relocation for the same project", async () => {
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
+    // Hold the first relocation open inside the reopen step.
+    let releaseLoad: () => void = () => {};
+    deps.worktreeService.loadProject.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseLoad = resolve;
+      })
+    );
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    const first = coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT });
+    // Let the first reach its awaiting reopen.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "in-progress" });
+
+    releaseLoad();
+    await first;
+  });
+
+  it("rejects an unknown project", async () => {
+    mockProjectStore.getProjectById.mockReturnValue(null);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "not-found" });
+  });
+});

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -155,6 +155,53 @@ describe("project identity across folder moves", () => {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
+  describe("finalizeRelocatedPath (phase 3)", () => {
+    it("preserves the given status instead of forcing 'closed'", async () => {
+      const original = await makeDir("orig-active");
+      const registered = await store.addProject(original);
+      store.updateProject(registered.id, { status: "active" });
+      const moved = await makeDir("moved-active");
+
+      const result = await store.finalizeRelocatedPath({
+        projectId: registered.id,
+        expectedOldPath: registered.path,
+        newPath: moved,
+        status: "active",
+      });
+
+      expect(result.status).toBe("active");
+      expect(result.path).toBe(moved);
+      // The path changed, so the phase-2 migration + worktree repair ran.
+      expect(enqueueProjectStateUpdate).toHaveBeenCalled();
+      expect(repairWorktrees).toHaveBeenCalled();
+    });
+
+    it("closes the project when a plain relocateProject delegates", async () => {
+      const original = await makeDir("orig-closed");
+      const registered = await store.addProject(original);
+      store.updateProject(registered.id, { status: "active" });
+      const moved = await makeDir("moved-closed");
+
+      const result = await store.relocateProject(registered.id, moved);
+      expect(result.status).toBe("closed");
+    });
+
+    it("refuses to finalize when the row no longer points at the expected old path", async () => {
+      const original = await makeDir("orig-stale");
+      const registered = await store.addProject(original);
+      const moved = await makeDir("moved-stale");
+
+      await expect(
+        store.finalizeRelocatedPath({
+          projectId: registered.id,
+          expectedOldPath: path.join(tmpRoot, "somewhere-else"),
+          newPath: moved,
+          status: "active",
+        })
+      ).rejects.toThrow(/moved concurrently/);
+    });
+  });
+
   describe("addProject move detection", () => {
     it("keeps the original id when an anchored folder has moved", async () => {
       const original = await makeDir("original");

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -480,6 +480,27 @@ export class WorkspaceHostPool {
     return true;
   }
 
+  /**
+   * Force-evict the workspace host for a project being RELOCATED, even while a
+   * window still holds it (`refCount > 0`). The normal {@link evictProject}
+   * refuses a held host; relocation is the one caller that must drop a live one —
+   * its folder is moving out from under it, so the process (and its watchers,
+   * rooted at the vanishing old path) has to be torn down and respawned at the
+   * new path by a subsequent `loadProject`. Reverse routing rooted at the old
+   * path is cleared here so a worktree lookup for a since-moved path can't match
+   * a stale entry; the reload repopulates it for the new root. Fire-and-forget
+   * dispose: a same-volume `fs.rename` doesn't require the host to have exited
+   * first (POSIX moves the inode; open handles follow it).
+   */
+  evictProjectForRelocation(projectPath: string): void {
+    const normalized = this.normalizeProjectPath(projectPath);
+    const entry = this.entries.get(normalized);
+    if (entry) this.evictEntry(normalized, entry);
+    for (const [worktreePath, rootPath] of this.worktreePathToProject) {
+      if (rootPath === normalized) this.worktreePathToProject.delete(worktreePath);
+    }
+  }
+
   private evictEntry(projectPath: string, entry: ProcessEntry): void {
     if (entry.cleanupTimeout) {
       clearTimeout(entry.cleanupTimeout);

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -353,6 +353,37 @@ export class ProjectViewManager {
     return task;
   }
 
+  /**
+   * Repoint a project's cached view at its new folder after a phase-3 relocation
+   * (#11282). The view stays on-screen with its live React/xterm state intact —
+   * only `ViewEntry.projectPath` (consumed by the next `switchTo`, the
+   * swap-failure rollback and diagnostics) is stale after the move. Enqueued on
+   * the same `switchChain` as `switchTo`, so it can't interleave with a
+   * concurrent switch that would read or overwrite the entry mid-rebind
+   * (#10808/#10931). Resolves to the view's live `WebContents` (for the
+   * coordinator's targeted repoint send), or `null` when no cached view exists
+   * or it was torn down — the Electron 41+ `webContents` getter can be undefined
+   * for a destroyed view, so it is guarded before any read.
+   */
+  async rebindProjectPath(
+    projectId: string,
+    newPath: string
+  ): Promise<Electron.WebContents | null> {
+    const task = this.switchChain.then(() => {
+      const entry = this.views.get(projectId);
+      if (!entry) return null;
+      entry.projectPath = newPath;
+      const wc = entry.view?.webContents;
+      if (!wc || wc.isDestroyed()) return null;
+      return wc;
+    });
+    this.switchChain = task.then(
+      () => undefined,
+      () => undefined
+    );
+    return task;
+  }
+
   clearPaintGate(): void {
     PaintGateController.clearPaintGate(this);
   }

--- a/src/store/__tests__/rebaseProjectViewRuntimePaths.test.ts
+++ b/src/store/__tests__/rebaseProjectViewRuntimePaths.test.ts
@@ -27,7 +27,10 @@ function makeFakeStore<T extends object>(initial: T): FakeStore<T> {
 
 // Mutable holder the mocks delegate to. The exported store objects are STABLE
 // (so `import { usePanelStore }` binds once); each call reads the current fake.
-const holders = vi.hoisted(() => ({ panels: null as any, selection: null as any }));
+const holders: { panels: any; selection: any } = vi.hoisted(() => ({
+  panels: null,
+  selection: null,
+}));
 
 vi.mock("../panelStore", () => ({
   usePanelStore: {
@@ -108,7 +111,9 @@ describe("rebaseProjectViewRuntimePaths", () => {
 
   it("is a no-op for the panel store when nothing lives under the old root", () => {
     panels._reset({
-      panelsById: { a: { kind: "terminal", cwd: "/somewhere/else", worktreeId: "/somewhere/else" } },
+      panelsById: {
+        a: { kind: "terminal", cwd: "/somewhere/else", worktreeId: "/somewhere/else" },
+      },
       panelIds: ["a"],
       panelIdsByWorktreeId: { "/somewhere/else": ["a"] },
       tabGroups: new Map(),

--- a/src/store/__tests__/rebaseProjectViewRuntimePaths.test.ts
+++ b/src/store/__tests__/rebaseProjectViewRuntimePaths.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Minimal fake zustand-shaped stores so the rebase logic is tested without
+// pulling in the heavy real panel/worktree slice systems.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface FakeStore<T> {
+  getState: () => T;
+  setState: (partial: Partial<T> | ((s: T) => Partial<T>)) => void;
+  _reset: (next: T) => void;
+}
+
+function makeFakeStore<T extends object>(initial: T): FakeStore<T> {
+  let state = initial;
+  return {
+    getState: () => state,
+    setState: (partial) => {
+      const next = typeof partial === "function" ? partial(state) : partial;
+      // Mirror zustand: an updater that returns the SAME state ref is a no-op.
+      if (next === state) return;
+      state = { ...state, ...next };
+    },
+    _reset: (next) => {
+      state = next;
+    },
+  };
+}
+
+// Mutable holder the mocks delegate to. The exported store objects are STABLE
+// (so `import { usePanelStore }` binds once); each call reads the current fake.
+const holders = vi.hoisted(() => ({ panels: null as any, selection: null as any }));
+
+vi.mock("../panelStore", () => ({
+  usePanelStore: {
+    getState: () => holders.panels.getState(),
+    setState: (p: any) => holders.panels.setState(p),
+  },
+}));
+vi.mock("../worktreeStore", () => ({
+  useWorktreeSelectionStore: {
+    getState: () => holders.selection.getState(),
+    setState: (p: any) => holders.selection.setState(p),
+  },
+}));
+
+import { rebaseProjectViewRuntimePaths } from "../rebaseProjectViewRuntimePaths";
+
+const OLD = "/vol/projects/proj";
+const NEW = "/vol/projects/proj-renamed";
+
+let panels: FakeStore<any>;
+let selection: FakeStore<any>;
+
+beforeEach(() => {
+  panels = makeFakeStore<any>({
+    panelsById: {
+      main1: { kind: "terminal", cwd: `${OLD}/pkg`, worktreeId: OLD },
+      main2: { kind: "file", filePath: `${OLD}/README.md`, worktreeId: OLD },
+      // A linked worktree in a SEPARATE location — must be left untouched.
+      linked1: { kind: "terminal", cwd: "/vol/wts/feature/x", worktreeId: "/vol/wts/feature" },
+    },
+    panelIds: ["main1", "main2", "linked1"],
+    panelIdsByWorktreeId: {
+      [OLD]: ["main1", "main2"],
+      "/vol/wts/feature": ["linked1"],
+    },
+    tabGroups: new Map([["g1", { id: "g1", worktreeId: OLD }]]),
+  });
+  selection = makeFakeStore<any>({ activeWorktreeId: OLD });
+  holders.panels = panels;
+  holders.selection = selection;
+});
+
+describe("rebaseProjectViewRuntimePaths", () => {
+  it("rebases main-worktree panel cwd/worktreeId/filePath to the new root", () => {
+    rebaseProjectViewRuntimePaths(OLD, NEW);
+    const state = panels.getState();
+    expect(state.panelsById.main1).toMatchObject({ cwd: `${NEW}/pkg`, worktreeId: NEW });
+    expect(state.panelsById.main2).toMatchObject({ filePath: `${NEW}/README.md`, worktreeId: NEW });
+  });
+
+  it("leaves panels on a linked worktree in a separate location untouched", () => {
+    rebaseProjectViewRuntimePaths(OLD, NEW);
+    const state = panels.getState();
+    expect(state.panelsById.linked1).toEqual({
+      kind: "terminal",
+      cwd: "/vol/wts/feature/x",
+      worktreeId: "/vol/wts/feature",
+    });
+  });
+
+  it("rebuilds the per-worktree index under the new worktree id, preserving order", () => {
+    rebaseProjectViewRuntimePaths(OLD, NEW);
+    const state = panels.getState();
+    expect(state.panelIdsByWorktreeId[NEW]).toEqual(["main1", "main2"]);
+    expect(state.panelIdsByWorktreeId[OLD]).toBeUndefined();
+    expect(state.panelIdsByWorktreeId["/vol/wts/feature"]).toEqual(["linked1"]);
+  });
+
+  it("rebases tab-group worktree bindings", () => {
+    rebaseProjectViewRuntimePaths(OLD, NEW);
+    expect(panels.getState().tabGroups.get("g1")).toMatchObject({ worktreeId: NEW });
+  });
+
+  it("rebases the active worktree selection id", () => {
+    rebaseProjectViewRuntimePaths(OLD, NEW);
+    expect(selection.getState().activeWorktreeId).toBe(NEW);
+  });
+
+  it("is a no-op for the panel store when nothing lives under the old root", () => {
+    panels._reset({
+      panelsById: { a: { kind: "terminal", cwd: "/somewhere/else", worktreeId: "/somewhere/else" } },
+      panelIds: ["a"],
+      panelIdsByWorktreeId: { "/somewhere/else": ["a"] },
+      tabGroups: new Map(),
+    });
+    const before = panels.getState();
+    rebaseProjectViewRuntimePaths(OLD, NEW);
+    expect(panels.getState()).toBe(before);
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1024,9 +1024,11 @@ if (typeof window !== "undefined" && window.electron?.project) {
   const listenerState = getProjectStoreListenerState();
   listenerState.applyUpdated = (updated) => {
     let priorPath: string | undefined;
+    let isCurrentView = false;
     useProjectStore.setState((state) => {
       const prior = state.projects.find((p) => p.id === updated.id);
       priorPath = prior?.path;
+      isCurrentView = state.currentProject?.id === updated.id;
       const projects = prior
         ? state.projects.map((p) => (p.id === updated.id ? updated : p))
         : [...state.projects, updated];
@@ -1037,7 +1039,19 @@ if (typeof window !== "undefined" && window.electron?.project) {
     // A folder move/reattach keeps the id but changes the path (#11282); repoint
     // the hibernated Assistant cwd so a later resume lands in the new folder.
     if (priorPath && priorPath !== updated.path) {
-      rebaseHibernateSessionCwd(updated.id, priorPath, updated.path);
+      const from = priorPath;
+      const to = updated.path;
+      rebaseHibernateSessionCwd(updated.id, from, to);
+      // Phase 3 relocates an OPEN project without reloading its view, so this
+      // view's LIVE panel/worktree stores still hold old-root paths. Rebase them
+      // in place so panels stay bound to their (renamed) worktrees. Lazily
+      // imported so the panel/worktree stores never enter this module's eval
+      // graph (store-init-order); only run for the view actually showing it.
+      if (isCurrentView) {
+        void import("./rebaseProjectViewRuntimePaths").then((m) =>
+          m.rebaseProjectViewRuntimePaths(from, to)
+        );
+      }
     }
   };
   listenerState.applyRemoved = (projectId) => {

--- a/src/store/rebaseProjectViewRuntimePaths.ts
+++ b/src/store/rebaseProjectViewRuntimePaths.ts
@@ -1,0 +1,97 @@
+import type { PanelInstance, TabGroup } from "@shared/types/panel";
+import { rebaseAbsolutePath } from "@shared/utils/projectPathRelocation";
+import { usePanelStore } from "./panelStore";
+import { useWorktreeSelectionStore } from "./worktreeStore";
+
+/**
+ * Live in-memory rebase of a project VIEW's runtime path state after its folder
+ * moves/renames (#11282, phase 3). Phase 2 rebases the PERSISTED `state.json`;
+ * this is its renderer-live twin — a relocation keeps the WebContentsView (and
+ * every xterm instance) alive, so the in-memory panel/worktree stores must be
+ * repointed in place, or panels would stay bound to the OLD main-worktree id and
+ * appear orphaned once the reopened worktree feed re-lists ids at the new root.
+ *
+ * Reuses the conservative phase-2 {@link rebaseAbsolutePath} primitive: it only
+ * touches absolute paths at/under `oldRoot`, matching at a segment boundary, and
+ * leaves relative values, URLs and opaque ids untouched — so it is safe to run
+ * across every candidate field without per-kind narrowing.
+ */
+
+// Absolute-path-bearing fields that can appear on a live panel. `worktreeId` is
+// itself a normalized absolute path (the worktree root); `cwd` is on PTY panels;
+// `filePath`/`markdownFilePath` on file/diff panels. Worktree-relative browser
+// paths, URLs and opaque command/env state are deliberately excluded — the
+// primitive leaves them alone anyway.
+const PANEL_PATH_FIELDS = ["worktreeId", "cwd", "filePath", "markdownFilePath"] as const;
+
+function rebasePanel(panel: PanelInstance, oldRoot: string, newRoot: string): PanelInstance {
+  let patch: Record<string, string> | null = null;
+  const record = panel as unknown as Record<string, unknown>;
+  for (const field of PANEL_PATH_FIELDS) {
+    const value = record[field];
+    if (typeof value !== "string") continue;
+    const next = rebaseAbsolutePath(value, oldRoot, newRoot);
+    if (next !== value) (patch ??= {})[field] = next;
+  }
+  return patch ? ({ ...panel, ...patch } as PanelInstance) : panel;
+}
+
+export function rebaseProjectViewRuntimePaths(oldRoot: string, newRoot: string): void {
+  usePanelStore.setState((state) => {
+    let changed = false;
+
+    const panelsById: Record<string, PanelInstance> = {};
+    for (const [id, panel] of Object.entries(state.panelsById)) {
+      const next = rebasePanel(panel, oldRoot, newRoot);
+      if (next !== panel) changed = true;
+      panelsById[id] = next;
+    }
+
+    // Tab-group worktree bindings (a tab group is pinned to one worktree id).
+    let tabGroups = state.tabGroups;
+    let groupsChanged = false;
+    const nextGroups = new Map<string, TabGroup>();
+    for (const [gid, group] of state.tabGroups) {
+      const wt = group.worktreeId;
+      const next = typeof wt === "string" ? rebaseAbsolutePath(wt, oldRoot, newRoot) : wt;
+      if (next !== wt) {
+        groupsChanged = true;
+        nextGroups.set(gid, { ...group, worktreeId: next });
+      } else {
+        nextGroups.set(gid, group);
+      }
+    }
+    if (groupsChanged) {
+      tabGroups = nextGroups;
+      changed = true;
+    }
+
+    if (!changed) return state;
+
+    // Rebuild the per-worktree panel index — its KEYS are worktree ids, which
+    // just changed. Membership and order are preserved (only the bucket key
+    // moves), so rebuild from `panelIds` rather than mutating buckets in place.
+    const panelIdsByWorktreeId: Record<string, string[]> = {};
+    for (const id of state.panelIds) {
+      const panel = panelsById[id];
+      if (!panel) continue;
+      const key = panel.worktreeId ?? "__none__";
+      (panelIdsByWorktreeId[key] ??= []).push(id);
+    }
+
+    return { panelsById, panelIdsByWorktreeId, tabGroups };
+  });
+
+  // The active worktree selection is a worktree id (absolute path). Repoint it
+  // directly rather than via `setActiveWorktree` — the reopened worktree feed
+  // hasn't re-listed the new id yet, and the setter's terminal-policy side
+  // effects would fire against a not-yet-present worktree.
+  const selection = useWorktreeSelectionStore.getState();
+  const activeId = selection.activeWorktreeId;
+  if (typeof activeId === "string") {
+    const next = rebaseAbsolutePath(activeId, oldRoot, newRoot);
+    if (next !== activeId) {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: next });
+    }
+  }
+}

--- a/src/store/rebaseProjectViewRuntimePaths.ts
+++ b/src/store/rebaseProjectViewRuntimePaths.ts
@@ -1,4 +1,10 @@
-import type { PanelInstance, TabGroup } from "@shared/types/panel";
+import {
+  isDevPreviewPanel,
+  isFilePanel,
+  isPtyPanel,
+  type PanelInstance,
+  type TabGroup,
+} from "@shared/types/panel";
 import { rebaseAbsolutePath } from "@shared/utils/projectPathRelocation";
 import { usePanelStore } from "./panelStore";
 import { useWorktreeSelectionStore } from "./worktreeStore";
@@ -13,27 +19,28 @@ import { useWorktreeSelectionStore } from "./worktreeStore";
  *
  * Reuses the conservative phase-2 {@link rebaseAbsolutePath} primitive: it only
  * touches absolute paths at/under `oldRoot`, matching at a segment boundary, and
- * leaves relative values, URLs and opaque ids untouched — so it is safe to run
- * across every candidate field without per-kind narrowing.
+ * leaves relative values, URLs and opaque ids untouched. Kind-aware so the
+ * discriminated union stays typed — `worktreeId` on every panel, `cwd` on
+ * terminal/dev-preview panels, absolute `filePath` on file panels. (Diff and
+ * file-browser paths are worktree-relative; browser fields are URLs.)
  */
-
-// Absolute-path-bearing fields that can appear on a live panel. `worktreeId` is
-// itself a normalized absolute path (the worktree root); `cwd` is on PTY panels;
-// `filePath`/`markdownFilePath` on file/diff panels. Worktree-relative browser
-// paths, URLs and opaque command/env state are deliberately excluded — the
-// primitive leaves them alone anyway.
-const PANEL_PATH_FIELDS = ["worktreeId", "cwd", "filePath", "markdownFilePath"] as const;
-
 function rebasePanel(panel: PanelInstance, oldRoot: string, newRoot: string): PanelInstance {
-  let patch: Record<string, string> | null = null;
-  const record = panel as unknown as Record<string, unknown>;
-  for (const field of PANEL_PATH_FIELDS) {
-    const value = record[field];
-    if (typeof value !== "string") continue;
-    const next = rebaseAbsolutePath(value, oldRoot, newRoot);
-    if (next !== value) (patch ??= {})[field] = next;
+  let next = panel;
+
+  if (next.worktreeId != null) {
+    const worktreeId = rebaseAbsolutePath(next.worktreeId, oldRoot, newRoot);
+    if (worktreeId !== next.worktreeId) next = { ...next, worktreeId };
   }
-  return patch ? ({ ...panel, ...patch } as PanelInstance) : panel;
+  if ((isPtyPanel(next) || isDevPreviewPanel(next)) && typeof next.cwd === "string") {
+    const cwd = rebaseAbsolutePath(next.cwd, oldRoot, newRoot);
+    if (cwd !== next.cwd) next = { ...next, cwd };
+  }
+  if (isFilePanel(next) && typeof next.filePath === "string") {
+    const filePath = rebaseAbsolutePath(next.filePath, oldRoot, newRoot);
+    if (filePath !== next.filePath) next = { ...next, filePath };
+  }
+
+  return next;
 }
 
 export function rebaseProjectViewRuntimePaths(oldRoot: string, newRoot: string): void {
@@ -68,15 +75,17 @@ export function rebaseProjectViewRuntimePaths(oldRoot: string, newRoot: string):
 
     if (!changed) return state;
 
-    // Rebuild the per-worktree panel index — its KEYS are worktree ids, which
-    // just changed. Membership and order are preserved (only the bucket key
-    // moves), so rebuild from `panelIds` rather than mutating buckets in place.
+    // The per-worktree index's KEYS are worktree ids, which just changed. A
+    // relocation only RENAMES ids (old root → new root); bucket MEMBERSHIP and
+    // order are untouched, so remap the keys and reuse each bucket array
+    // verbatim rather than rebuilding from `panelIds` (which could reorder within
+    // a bucket). The "__none__" bucket and buckets for linked worktrees outside
+    // the old root keep their keys — rebaseAbsolutePath no-ops on them.
     const panelIdsByWorktreeId: Record<string, string[]> = {};
-    for (const id of state.panelIds) {
-      const panel = panelsById[id];
-      if (!panel) continue;
-      const key = panel.worktreeId ?? "__none__";
-      (panelIdsByWorktreeId[key] ??= []).push(id);
+    for (const [worktreeId, ids] of Object.entries(state.panelIdsByWorktreeId)) {
+      const key =
+        worktreeId === "__none__" ? worktreeId : rebaseAbsolutePath(worktreeId, oldRoot, newRoot);
+      panelIdsByWorktreeId[key] = ids;
     }
 
     return { panelsById, panelIdsByWorktreeId, tabGroups };


### PR DESCRIPTION
Phase 3 of #11282. Phases 1 (stable identity) and 2 (path-bearing state rewrite) preserve a project across a folder move but deliberately **refuse the active project** — repointing a live one would strand its `WebContentsView`, workspace host and PTYs on the old path. This adds the **quiesce-and-rebind coordinator** that makes relocating a currently-OPEN project safe, and unlocks a Daintree-**managed** move (`fs.rename`) rather than only reattaching after an external one.

### What it does

`ProjectRelocationCoordinator.relocate({ projectId, mode: "move" | "reattach", newPath })`:

- **Guard fork** — `collectActiveProjectIds(...)` (the union of every window's live view + switch bridge, not the single-window `getCurrentProjectId`), resolved synchronously at entry. Open-anywhere → the pipeline; a closed reattach → the existing phase-1/2 `relocateProject`.
- **Preflight** — Assistant refuse-guard (fail-closed), absolute/same/subfolder/dest-exists/parent-is-dir checks, a same-volume `dev`-id check (cross-volume is refused for the first cut), and a destination-already-registered check — all **before** anything is stopped.
- **Quiesce** — graceful, session-preserving PTY kill (+ hibernation markers) and a refcount-bypassing workspace-host drop, borrowed from `project:free-memory` but **without** evicting the renderer view (keeping the view + xterm alive is the point).
- **`fs.rename` is the single commit boundary** — a failure before it rolls back (reopen at the original path; nothing durable changed); after it every step is forward-only (never a reverse rename), and a failure surfaces the existing Tier-3 worktree-load banner whose **Retry** re-runs the reopen at the now-current path.
- **Finalize** — `ProjectStore.finalizeRelocatedPath` (extracted, status-preserving so an open project stays open) runs the phase-2 migration + `git worktree repair`; a late renderer write is caught by an operation-scoped rewrite guard held a grace beat past the op.
- **Rebind** — `ProjectViewManager.rebindProjectPath` on the switch chain, a live `PROJECT_UPDATED` repoint (no reload), and a reopen (workspace host + worktree feed + PTY context) at the new path, re-verifying each window still shows the project before and after the load.
- **Renderer** — `rebaseProjectViewRuntimePaths` rebases live panel `cwd`/`worktreeId`/`filePath`, remaps the per-worktree index, and rebases tab-group + active-worktree selection in place, reusing the conservative phase-2 `rebaseAbsolutePath`.

`PROJECT_LOCATE` now routes through the coordinator (open → pipeline, closed → delegate).

### Scoped to stay reviewable (deferred, follow-ups)

- **Full renderer cross-store rebase** — this covers panels/tab-groups/active-worktree; still stale after an open relocate: layout-undo history, terminal MRU, two-pane split ratios, diff-viewed markers, dev-server sessions, fleet snapshots, and trashed/backgrounded group metadata. Most reconcile on the worktree refresh; the rest are follow-ups.
- **Assistant continuity** — phase 3 only **refuses** when the Assistant is live; the `hibernate` disposition (which tears down the sub-agent tree) and continuity reporting are phase 4/5.
- **Crash-safety** — an in-memory recovery path; a durable pending-relocation journal (app-crash mid-move) is a separate hardening pass.
- **Also deferred**: a main-process spawn-freeze consumed by every spawn path, a DB unique constraint on project path, a full switch↔relocation gate with epochs, `tryAdoptMovedProject` open-routing, and dedicated `WorkspaceHostPool`/`ProjectViewManager` unit tests.

The unified move-or-rename **dialog** (Project Settings + context menu + "Locate moved project") is phase 4 — this phase provides the coordinator it will drive.

### Testing

Coordinator suite (happy-path managed move, cross-volume refusal, guard-fork open/closed/second-window, rollback-before-rename, forward-fail-after-rename, Assistant refuse + fail-closed, destination-conflict, concurrent-relocation, not-found), renderer-rebase suite, and a `finalizeRelocatedPath` status-preservation + concurrent-move-guard block. Reviewed twice by Codex (max reasoning); the confirmed correctness fixes are in. Full typecheck + own-file lint/format clean.