### PR TITLE
fix: don't delete a project's terminal restore files when its state is unreadable

### DIFF
--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -253,6 +253,16 @@ export class ProjectStateManager {
         return null;
       }
 
+      // A present-but-non-array `terminals` field means the enumeration we can
+      // recover is incomplete — we fall back to zero ids below, so this project
+      // can't be trusted to gate the destructive orphan sweep any more than a
+      // corrupt file could. Flag it. A missing or null field is a legitimately
+      // empty project, not corruption, and must not flag. (Individual entries
+      // that fail schema validation are dropped as genuine orphans — the
+      // terminal won't be restored, so its scrollback is already dead.)
+      if (parsed.terminals != null && !Array.isArray(parsed.terminals)) {
+        this.unreadableProjectIds.add(projectId);
+      }
       const rawTerminals = Array.isArray(parsed.terminals) ? parsed.terminals : [];
       const validTerminals = filterValidTerminalEntries(
         rawTerminals,

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -26,6 +26,16 @@ export interface ProjectStateReadResult {
 export class ProjectStateManager {
   private projectStateCache = new Map<string, ProjectStateCacheEntry>();
   private pendingQuarantines = new Map<string, string>();
+  // Projects whose state.json existed on disk this session but could not be read
+  // into a complete terminal enumeration — future-schema quarantine, parse
+  // failure, or any non-ENOENT read error. Distinct from `pendingQuarantines`
+  // (a one-shot signal drained by hydration): this set is append-only and never
+  // cleared for the lifetime of the process, so destructive maintenance that
+  // relies on a *complete* set of known terminal ids (the boot .restore sweep)
+  // can fail closed for a project whose ids it could never learn. An ENOENT
+  // (genuinely no saved state) is authoritative emptiness, not unreadability,
+  // and must never land here.
+  private unreadableProjectIds = new Set<string>();
   private writeQueues = new Map<string, Promise<void>>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -215,6 +225,10 @@ export class ProjectStateManager {
           ? rawVersion
           : 0;
       if (onDiskVersion > PROJECT_STATE_SCHEMA_VERSION) {
+        // Record unreadability before touching disk: a future-version file
+        // holds terminal ids this build can't parse, so its scrollback must
+        // survive the orphan sweep even if the quarantine rename below fails.
+        this.unreadableProjectIds.add(projectId);
         // Avoid a deterministic destination so neither POSIX silently
         // clobbers a prior quarantine nor Windows throws EEXIST. A previously
         // quarantined .future-v{N} file is preserved with a timestamp suffix.
@@ -296,6 +310,10 @@ export class ProjectStateManager {
         this.setProjectStateCache(projectId, null);
         return null;
       }
+      // State existed but couldn't be read (parse failure, EACCES/EMFILE/EIO,
+      // etc.). Record it before the corruption quarantine below so a double
+      // fault — unreadable AND unrenameable — is still visible to the sweep.
+      this.unreadableProjectIds.add(projectId);
       console.error(`[ProjectStateManager] Failed to load state for project ${projectId}:`, error);
       try {
         const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
@@ -319,6 +337,20 @@ export class ProjectStateManager {
       return { state, quarantinedPath };
     }
     return { state };
+  }
+
+  /**
+   * Whether this project's state.json existed but could not be read into a
+   * complete terminal enumeration at any point this session (future-schema
+   * quarantine, parse failure, or a non-ENOENT read error). Unlike
+   * `getProjectStateWithRecovery`, this is a non-draining peek — reading it
+   * never clears it — because destructive maintenance that gates on a complete
+   * set of known ids must fail closed for the whole process lifetime, not just
+   * until the recovery signal is consumed by hydration. A project that has
+   * simply never persisted state (ENOENT) reads back false.
+   */
+  wasStateUnreadableThisSession(projectId: string): boolean {
+    return this.unreadableProjectIds.has(projectId);
   }
 
   async clearProjectState(projectId: string): Promise<void> {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1100,6 +1100,10 @@ export class ProjectStore {
     return this.stateManager.getProjectStateWithRecovery(projectId);
   }
 
+  wasStateUnreadableThisSession(projectId: string): boolean {
+    return this.stateManager.wasStateUnreadableThisSession(projectId);
+  }
+
   async clearProjectState(projectId: string): Promise<void> {
     return this.stateManager.clearProjectState(projectId);
   }

--- a/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
@@ -237,6 +237,22 @@ describe("ProjectStateManager.getProjectState ENOENT branch (mocked fs)", () => 
     expect(result).toBeNull();
     expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
   });
+
+  it("marks and quarantines on a non-ENOENT read failure (EACCES)", async () => {
+    // A read errno other than ENOENT must go through the corruption path, not
+    // the empty-state short-circuit — otherwise an unreadable project would be
+    // treated as authoritatively empty and lose its restore files.
+    fsPromisesMock.readFile.mockRejectedValue(
+      Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+    );
+
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).toBeNull();
+    expect(result.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
 });
 
 describe("ProjectStateManager unreadable-session mark under rename double-fault (mocked fs)", () => {

--- a/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
@@ -238,3 +238,51 @@ describe("ProjectStateManager.getProjectState ENOENT branch (mocked fs)", () => 
     expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ProjectStateManager unreadable-session mark under rename double-fault (mocked fs)", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    utilsMock.resilientAtomicWriteFile.mockResolvedValue(undefined);
+    utilsMock.resilientUnlink.mockResolvedValue(undefined);
+    fsPromisesMock.mkdir.mockResolvedValue(undefined);
+    // The quarantine rename itself fails — the double fault (unreadable AND
+    // unrenameable) that would otherwise be invisible to every signal.
+    utilsMock.resilientRename.mockRejectedValue(
+      Object.assign(new Error("EACCES"), { code: "EACCES" })
+    );
+
+    tempDir = path.join(os.tmpdir(), "daintree-unreadable-adv");
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/adversarial-unreadable-project");
+  });
+
+  it("marks the project when a corruption read AND its quarantine rename both fail", async () => {
+    fsPromisesMock.readFile.mockResolvedValue("{ not valid json");
+
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).toBeNull();
+    // Rename failed, so hydration gets no recovery path...
+    expect(result.quarantinedPath).toBeUndefined();
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
+    // ...but the destructive-safety mark must still be set.
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
+
+  it("marks the project when a future-version read AND its quarantine rename both fail", async () => {
+    fsPromisesMock.readFile.mockResolvedValue(
+      JSON.stringify({ _schemaVersion: 99, projectId, terminals: [] })
+    );
+
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).toBeNull();
+    expect(result.quarantinedPath).toBeUndefined();
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
+});

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -444,10 +444,40 @@ describe("ProjectStateManager unreadable-session tracking", () => {
     expect(manager.wasStateUnreadableThisSession(projectId)).toBe(false);
   });
 
-  it("does not mark a project whose state reads back valid", async () => {
+  it("does not mark a project whose state reads back valid from disk", async () => {
     await manager.saveProjectState(projectId, makeState());
+    // Drop the write-through cache so getProjectState exercises the real
+    // disk-read path rather than returning the just-saved in-memory state.
+    manager.invalidateProjectStateCache(projectId);
 
     expect(await manager.getProjectState(projectId)).not.toBeNull();
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(false);
+  });
+
+  it("marks a project whose parsed state has a non-array terminals field", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({ projectId, terminals: { not: "an array" } }),
+      "utf-8"
+    );
+
+    const state = await manager.getProjectState(projectId);
+
+    // The state is still usable (terminals fall back to empty)...
+    expect(state).not.toBeNull();
+    expect(state!.terminals).toEqual([]);
+    // ...but the incomplete enumeration must protect its restore files.
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
+
+  it("does not mark a project whose terminals field is absent (legitimately empty)", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, JSON.stringify({ projectId }), "utf-8");
+
+    const state = await manager.getProjectState(projectId);
+
+    expect(state).not.toBeNull();
     expect(manager.wasStateUnreadableThisSession(projectId)).toBe(false);
   });
 
@@ -485,18 +515,28 @@ describe("ProjectStateManager unreadable-session tracking", () => {
     expect(manager.wasStateUnreadableThisSession(otherId)).toBe(false);
   });
 
-  it("keeps the mark after the recovery signal is drained (non-draining)", async () => {
+  it("keeps the mark across drain and a valid re-save (non-draining, append-only)", async () => {
     const filePath = stateFilePath(tempDir, projectId)!;
     await fs.writeFile(filePath, "{ not valid json", "utf-8");
 
-    const recovered = await manager.getProjectStateWithRecovery(projectId);
-    expect(recovered.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
+    // First recovery read triggers quarantine and drains pendingQuarantines.
+    const first = await manager.getProjectStateWithRecovery(projectId);
+    expect(first.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
 
-    // Second recovery read drains pendingQuarantines...
-    const drained = await manager.getProjectStateWithRecovery(projectId);
-    expect(drained.quarantinedPath).toBeUndefined();
+    // Second recovery read proves pendingQuarantines was already drained...
+    const second = await manager.getProjectStateWithRecovery(projectId);
+    expect(second.quarantinedPath).toBeUndefined();
 
-    // ...but the unreadable-session mark must persist regardless.
+    // ...while the unreadable-session mark stays set across repeated peeks.
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+
+    // And it survives a successful re-save + fresh disk read: recovering into a
+    // valid (possibly empty) state does not prove the original terminal ids came
+    // back, so the sweep stays conservative for the rest of the session.
+    await manager.saveProjectState(projectId, makeState());
+    manager.invalidateProjectStateCache(projectId);
+    expect(await manager.getProjectState(projectId)).not.toBeNull();
     expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
   });
 });

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -423,6 +423,84 @@ describe("ProjectStateManager quarantine recovery", () => {
   });
 });
 
+describe("ProjectStateManager unreadable-session tracking", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-state-unreadable-"));
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/unreadable-project");
+    await fs.mkdir(path.join(tempDir, projectId), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not mark a project whose state file is absent (ENOENT)", async () => {
+    expect(await manager.getProjectState(projectId)).toBeNull();
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(false);
+  });
+
+  it("does not mark a project whose state reads back valid", async () => {
+    await manager.saveProjectState(projectId, makeState());
+
+    expect(await manager.getProjectState(projectId)).not.toBeNull();
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(false);
+  });
+
+  it("marks a project whose state JSON is corrupt", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+
+    await manager.getProjectState(projectId);
+
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
+
+  it("marks a project whose state is a future schema version", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({ _schemaVersion: 99, projectId, terminals: [] }),
+      "utf-8"
+    );
+
+    await manager.getProjectState(projectId);
+
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
+
+  it("scopes the mark per project — an unrelated project stays unmarked", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+    await manager.getProjectState(projectId);
+
+    const otherId = generateProjectId("/test/healthy-project");
+    await fs.mkdir(path.join(tempDir, otherId), { recursive: true });
+
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+    expect(manager.wasStateUnreadableThisSession(otherId)).toBe(false);
+  });
+
+  it("keeps the mark after the recovery signal is drained (non-draining)", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+
+    const recovered = await manager.getProjectStateWithRecovery(projectId);
+    expect(recovered.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
+
+    // Second recovery read drains pendingQuarantines...
+    const drained = await manager.getProjectStateWithRecovery(projectId);
+    expect(drained.quarantinedPath).toBeUndefined();
+
+    // ...but the unreadable-session mark must persist regardless.
+    expect(manager.wasStateUnreadableThisSession(projectId)).toBe(true);
+  });
+});
+
 describe("ProjectStateManager schema version", () => {
   let tempDir: string;
   let manager: ProjectStateManager;

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -315,7 +315,7 @@ import { CHANNELS } from "../../ipc/channels.js";
 import { store } from "../../store.js";
 
 describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
-  beforeEach(() => {
+  function resetSweepMocks() {
     evictSessionFilesMock.mockReset();
     evictSessionFilesMock.mockResolvedValue({ deleted: 0, bytesFreed: 0 });
     projectStoreMock.getAllProjects.mockReset();
@@ -324,7 +324,12 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
     projectStoreMock.getProjectState.mockResolvedValue(null);
     projectStoreMock.wasStateUnreadableThisSession.mockReset();
     projectStoreMock.wasStateUnreadableThisSession.mockReturnValue(false);
-  });
+  }
+
+  beforeEach(resetSweepMocks);
+  // Restore defaults so a custom implementation set here can't leak into the
+  // sibling "task ordering" describe — these hoisted mocks are shared.
+  afterEach(resetSweepMocks);
 
   it("passes a populated knownIds set when every project-state read is reliable", async () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }, { id: "proj-b" }]);
@@ -335,30 +340,51 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
           // NOT, on its own, disable the orphan pass.
           null
     );
-    projectStoreMock.wasStateUnreadableThisSession.mockReturnValue(false);
 
     await __test__.evictStaleSessionFiles();
 
     expect(evictSessionFilesMock).toHaveBeenCalledTimes(1);
     const arg = evictSessionFilesMock.mock.calls[0][0];
     expect(arg.knownIds).toBeInstanceOf(Set);
-    expect([...(arg.knownIds ?? [])]).toEqual(
-      expect.arrayContaining(["term-a1", "term-a2"])
-    );
+    expect([...(arg.knownIds ?? [])].sort()).toEqual(["term-a1", "term-a2"]);
+  });
+
+  it("passes an empty knownIds set (not undefined) when all reads are benignly empty", async () => {
+    // Guards against a `knownIds.size === 0 ? undefined : knownIds` regression:
+    // emptiness alone must not disable the orphan pass — only an unreadable flag.
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }, { id: "proj-b" }]);
+    projectStoreMock.getProjectState.mockResolvedValue(null);
+
+    await __test__.evictStaleSessionFiles();
+
+    expect(evictSessionFilesMock).toHaveBeenCalledTimes(1);
+    const arg = evictSessionFilesMock.mock.calls[0][0];
+    expect(arg.knownIds).toBeInstanceOf(Set);
+    expect([...(arg.knownIds ?? [])]).toEqual([]);
   });
 
   it("passes knownIds undefined when any project state was unreadable this session", async () => {
+    // The flag is populated only as a deferred (microtask) side effect of
+    // getProjectState resolving, so this passes only if the sweep AWAITS every
+    // read before consulting wasStateUnreadableThisSession. A regression that
+    // checked the flag before awaiting the reads would see an empty set and
+    // wrongly build a knownIds Set — catching an inactive project first
+    // discovered by the sweep.
+    const unreadable = new Set<string>();
     projectStoreMock.getAllProjects.mockReturnValue([
       { id: "proj-a" },
       { id: "proj-quarantined" },
     ]);
-    projectStoreMock.getProjectState.mockImplementation(async (id: string) =>
-      id === "proj-a" ? { terminals: [{ id: "term-a1" }] } : null
-    );
-    // Only the quarantined project trips the flag — the all-or-nothing rule
-    // must still disable the orphan pass for the entire sweep.
-    projectStoreMock.wasStateUnreadableThisSession.mockImplementation(
-      (id: string) => id === "proj-quarantined"
+    projectStoreMock.getProjectState.mockImplementation(async (id: string) => {
+      await Promise.resolve();
+      if (id === "proj-quarantined") {
+        unreadable.add(id);
+        return null;
+      }
+      return { terminals: [{ id: "term-a1" }] };
+    });
+    projectStoreMock.wasStateUnreadableThisSession.mockImplementation((id: string) =>
+      unreadable.has(id)
     );
 
     await __test__.evictStaleSessionFiles();

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -160,8 +160,18 @@ vi.mock("../../services/IdleTerminalNotificationService.js", () => ({
   getIdleTerminalNotificationService: vi.fn(),
 }));
 
+const evictSessionFilesMock = vi.hoisted(() =>
+  vi.fn<
+    (opts: {
+      ttlMs: number;
+      maxBytes: number;
+      knownIds?: Set<string>;
+    }) => Promise<{ deleted: number; bytesFreed: number }>
+  >(async () => ({ deleted: 0, bytesFreed: 0 }))
+);
+
 vi.mock("../../services/pty/terminalSessionPersistence.js", () => ({
-  evictSessionFiles: vi.fn(async () => ({ deleted: 0, bytesFreed: 0 })),
+  evictSessionFiles: evictSessionFilesMock,
   SESSION_EVICTION_TTL_MS: 0,
   SESSION_EVICTION_MAX_BYTES: 0,
 }));
@@ -235,11 +245,16 @@ vi.mock("../../ipc/handlers/projectCrud/index.js", () => ({
   getProjectStatsService: vi.fn(),
 }));
 
+const projectStoreMock = vi.hoisted(() => ({
+  getAllProjects: vi.fn<() => { id: string }[]>(() => []),
+  getProjectState: vi.fn<(id: string) => Promise<{ terminals?: { id: string }[] } | null>>(
+    async () => null
+  ),
+  wasStateUnreadableThisSession: vi.fn<(id: string) => boolean>(() => false),
+}));
+
 vi.mock("../../services/ProjectStore.js", () => ({
-  projectStore: {
-    getAllProjects: () => [],
-    getProjectState: vi.fn(),
-  },
+  projectStore: projectStoreMock,
 }));
 
 vi.mock("../../setup/environment.js", () => ({
@@ -291,13 +306,67 @@ vi.mock("electron", () => ({
   ipcMain: { handle: vi.fn() },
 }));
 
-import { initGlobalServices } from "../globalServicesInit.js";
+import { initGlobalServices, __test__ } from "../globalServicesInit.js";
 import { getGlobalServicesInitialized, setGlobalServicesInitialized } from "../serviceRefs.js";
 import type { WindowRegistry } from "../WindowRegistry.js";
 import { app, ipcMain } from "electron";
 import type { Mock } from "vitest";
 import { CHANNELS } from "../../ipc/channels.js";
 import { store } from "../../store.js";
+
+describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
+  beforeEach(() => {
+    evictSessionFilesMock.mockReset();
+    evictSessionFilesMock.mockResolvedValue({ deleted: 0, bytesFreed: 0 });
+    projectStoreMock.getAllProjects.mockReset();
+    projectStoreMock.getAllProjects.mockReturnValue([]);
+    projectStoreMock.getProjectState.mockReset();
+    projectStoreMock.getProjectState.mockResolvedValue(null);
+    projectStoreMock.wasStateUnreadableThisSession.mockReset();
+    projectStoreMock.wasStateUnreadableThisSession.mockReturnValue(false);
+  });
+
+  it("passes a populated knownIds set when every project-state read is reliable", async () => {
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }, { id: "proj-b" }]);
+    projectStoreMock.getProjectState.mockImplementation(async (id: string) =>
+      id === "proj-a"
+        ? { terminals: [{ id: "term-a1" }, { id: "term-a2" }] }
+        : // proj-b reads back a benign null (never persisted state) — a null must
+          // NOT, on its own, disable the orphan pass.
+          null
+    );
+    projectStoreMock.wasStateUnreadableThisSession.mockReturnValue(false);
+
+    await __test__.evictStaleSessionFiles();
+
+    expect(evictSessionFilesMock).toHaveBeenCalledTimes(1);
+    const arg = evictSessionFilesMock.mock.calls[0][0];
+    expect(arg.knownIds).toBeInstanceOf(Set);
+    expect([...(arg.knownIds ?? [])]).toEqual(
+      expect.arrayContaining(["term-a1", "term-a2"])
+    );
+  });
+
+  it("passes knownIds undefined when any project state was unreadable this session", async () => {
+    projectStoreMock.getAllProjects.mockReturnValue([
+      { id: "proj-a" },
+      { id: "proj-quarantined" },
+    ]);
+    projectStoreMock.getProjectState.mockImplementation(async (id: string) =>
+      id === "proj-a" ? { terminals: [{ id: "term-a1" }] } : null
+    );
+    // Only the quarantined project trips the flag — the all-or-nothing rule
+    // must still disable the orphan pass for the entire sweep.
+    projectStoreMock.wasStateUnreadableThisSession.mockImplementation(
+      (id: string) => id === "proj-quarantined"
+    );
+
+    await __test__.evictStaleSessionFiles();
+
+    expect(evictSessionFilesMock).toHaveBeenCalledTimes(1);
+    expect(evictSessionFilesMock.mock.calls[0][0].knownIds).toBeUndefined();
+  });
+});
 
 describe("initGlobalServices task ordering", () => {
   beforeEach(() => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -371,10 +371,7 @@ describe("evictStaleSessionFiles orphan-pass safety (#11349)", () => {
     // wrongly build a knownIds Set — catching an inactive project first
     // discovered by the sweep.
     const unreadable = new Set<string>();
-    projectStoreMock.getAllProjects.mockReturnValue([
-      { id: "proj-a" },
-      { id: "proj-quarantined" },
-    ]);
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-a" }, { id: "proj-quarantined" }]);
     projectStoreMock.getProjectState.mockImplementation(async (id: string) => {
       await Promise.resolve();
       if (id === "proj-quarantined") {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -117,10 +117,28 @@ async function evictStaleSessionFiles(): Promise<void> {
       }
     }
 
+    // If any project's state was unreadable this session, `knownIds` is
+    // incomplete — it's missing every terminal id belonging to that project.
+    // A .restore file carries only a bare terminal id (no project reference),
+    // so the missing ids can't be attributed back to the affected project;
+    // the orphan pass can't tell "this project's scrollback" from a genuine
+    // orphan. Fail closed: skip the orphan-eviction pass entirely this cycle
+    // (pass knownIds: undefined) rather than delete recoverable scrollback.
+    // TTL and max-size passes don't depend on cross-project attribution, so
+    // they keep running as backstops.
+    const orphanSweepUnsafe = allProjects.some((p) =>
+      projectStore.wasStateUnreadableThisSession(p.id)
+    );
+    if (orphanSweepUnsafe) {
+      console.warn(
+        "[MAIN] Session eviction: skipping orphan pass — at least one project's state was unreadable or quarantined this session; retaining all .restore files to avoid deleting recoverable scrollback (TTL and size-cap passes still active)"
+      );
+    }
+
     const result = await evictSessionFiles({
       ttlMs: SESSION_EVICTION_TTL_MS,
       maxBytes: SESSION_EVICTION_MAX_BYTES,
-      knownIds,
+      knownIds: orphanSweepUnsafe ? undefined : knownIds,
     });
 
     if (result.deleted > 0) {


### PR DESCRIPTION
## Summary
- On boot, `evictStaleSessionFiles()` scans every project's `state.json` for live terminal ids to decide which `.restore` scrollback files in the shared session directory are orphans safe to delete.
- `getProjectState()` returns `null` both for a genuine version-downgrade/corruption quarantine and for any transient non-ENOENT read error (`EACCES`, `EMFILE`, `EIO`), so an affected project contributed zero ids and its restore files got permanently deleted instead of quarantined, unrecoverable even after re-upgrading.
- Fix: track which projects had unreadable state this session and fail closed on the orphan-deletion pass when any did.

Resolves #11349

## Changes
- `ProjectStateManager` now tracks an append-only, session-persistent `unreadableProjectIds` set, flagged before the quarantine rename in the future-version branch, the generic-error/corruption branch, and now also when parsed state has a non-array `terminals` field, so even a double fault (unreadable and unrenameable) gets recorded.
- Added a non-draining `wasStateUnreadableThisSession()` peek, delegated through `ProjectStore`, kept separate from the one-shot `pendingQuarantines` drain that hydration consumes.
- `evictStaleSessionFiles()` now fails closed: if any project's state was unreadable this session it passes `knownIds: undefined`, disabling only the orphan-deletion pass. The TTL and size-cap passes keep running as backstops.
- Restore filenames only carry a bare terminal id, no project id, so per-project exclusion isn't possible. All-or-nothing on the orphan pass for that boot is the safe move.

## Testing
- 124 tests passing across `ProjectStateManager.test.ts`, `ProjectStateManager.adversarial.test.ts`, `terminalSessionPersistence.test.ts`, and `globalServicesInit.order.test.ts`.
- Reviewed twice by Codex for correctness and test coverage, all findings addressed.

Follow-up (out of scope): the sweep's unchunked `Promise.all` over every project's `getProjectState` call is itself a plausible source of EMFILE errors. Chunking it, following the existing `STAT_CHUNK_SIZE` precedent, is a candidate follow-up.