### PR TITLE
fix(recipes): preserve local recipe env values when .daintree/recipes is absent

### DIFF
--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -338,17 +338,23 @@ export class ProjectIdentityFiles {
    * exact bytes (`fs.readFile` UTF-8 result), so it matches what
    * {@link writeInRepoRecipe} and {@link getInRepoRecipeFileHash} produce when
    * the file is untouched.
+   *
+   * `dirExists` reports whether the `.daintree/recipes/` directory was present.
+   * An absent directory (e.g. a checked-out branch/commit that predates recipes)
+   * yields the same empty `recipes`/`hashes` as an authoritatively empty one, so
+   * callers that make destructive decisions must consult `dirExists` to avoid
+   * treating "not on this checkout" as "deleted" (#11347).
    */
   async readInRepoRecipesWithHashes(
     projectPath: string
-  ): Promise<{ recipes: TerminalRecipe[]; hashes: Map<string, string> }> {
+  ): Promise<{ recipes: TerminalRecipe[]; hashes: Map<string, string>; dirExists: boolean }> {
     const recipesDir = path.join(projectPath, DAINTREE_RECIPES_DIR);
     let entries;
     try {
       entries = await fs.readdir(recipesDir, { withFileTypes: true });
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT")
-        return { recipes: [], hashes: new Map() };
+        return { recipes: [], hashes: new Map(), dirExists: false };
       throw error;
     }
 
@@ -440,7 +446,7 @@ export class ProjectIdentityFiles {
         console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`, error);
       }
     }
-    return { recipes, hashes };
+    return { recipes, hashes, dirExists: true };
   }
 
   /**

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -343,24 +343,38 @@ export class ProjectIdentityFiles {
    * An absent directory (e.g. a checked-out branch/commit that predates recipes)
    * yields the same empty `recipes`/`hashes` as an authoritatively empty one, so
    * callers that make destructive decisions must consult `dirExists` to avoid
-   * treating "not on this checkout" as "deleted" (#11347).
+   * treating "not on this checkout" as "deleted" (#11347). `scanComplete` is
+   * `false` when the directory existed but at least one entry could not be read
+   * (a partial, non-authoritative snapshot) — destructive callers must treat
+   * that the same as an absent directory.
    */
-  async readInRepoRecipesWithHashes(
-    projectPath: string
-  ): Promise<{ recipes: TerminalRecipe[]; hashes: Map<string, string>; dirExists: boolean }> {
+  async readInRepoRecipesWithHashes(projectPath: string): Promise<{
+    recipes: TerminalRecipe[];
+    hashes: Map<string, string>;
+    dirExists: boolean;
+    scanComplete: boolean;
+  }> {
     const recipesDir = path.join(projectPath, DAINTREE_RECIPES_DIR);
     let entries;
     try {
       entries = await fs.readdir(recipesDir, { withFileTypes: true });
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT")
-        return { recipes: [], hashes: new Map(), dirExists: false };
+        return { recipes: [], hashes: new Map(), dirExists: false, scanComplete: true };
       throw error;
     }
 
     const recipes: TerminalRecipe[] = [];
     const hashes = new Map<string, string>();
     const seenIds = new Set<string>();
+    // Whether every listed entry was actually read. A per-file *read* failure
+    // (e.g. a concurrent branch checkout unlinking a recipe after `readdir` but
+    // before we open it) means this snapshot is not an authoritative view of the
+    // directory, so destructive reconciliation must not prune from it (#11347).
+    // A readable-but-malformed file (JSON/schema failure below) is different: it
+    // is genuinely skipped and does NOT taint the scan, otherwise one committed
+    // bad file would wedge pruning forever.
+    let scanComplete = true;
     for (const entry of entries) {
       if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
       try {
@@ -443,10 +457,22 @@ export class ProjectIdentityFiles {
         recipes.push(recipe);
         hashes.set(recipe.id, hashRecipePayload(content));
       } catch (error) {
-        console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`, error);
+        // A filesystem error (has a `code`) means the entry could not be read —
+        // an incomplete, non-authoritative scan. A SyntaxError from JSON.parse
+        // (no `code`) is a genuinely malformed file: skip it, but leave the scan
+        // authoritative so a permanently-bad file never blocks pruning.
+        if (error instanceof Error && "code" in error) {
+          scanComplete = false;
+          console.warn(`[ProjectIdentityFiles] Could not read recipe file: ${entry.name}`, error);
+        } else {
+          console.warn(
+            `[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`,
+            error
+          );
+        }
       }
     }
-    return { recipes, hashes, dirExists: true };
+    return { recipes, hashes, dirExists: true, scanComplete };
   }
 
   /**

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -308,7 +308,24 @@ export class ProjectStore {
   }
 
   async readInRepoRecipes(projectPath: string): Promise<TerminalRecipe[]> {
-    const { recipes, hashes } = await this.identityFiles.readInRepoRecipesWithHashes(projectPath);
+    const { recipes } = await this.readInRepoRecipesWithMeta(projectPath);
+    return recipes;
+  }
+
+  /**
+   * Cache-populating read shared by {@link readInRepoRecipes} and
+   * {@link reconcileProjectRecipes}. In addition to the recipes, it surfaces
+   * `dirExists` so reconciliation can tell an absent `.daintree/recipes/`
+   * directory (a checked-out branch/commit that predates recipes) apart from an
+   * authoritatively empty one — the former must never authorize pruning
+   * project-local mirrors (#11347). The public array-returning
+   * {@link readInRepoRecipes} keeps its signature for its unrelated callers.
+   */
+  private async readInRepoRecipesWithMeta(
+    projectPath: string
+  ): Promise<{ recipes: TerminalRecipe[]; dirExists: boolean }> {
+    const { recipes, hashes, dirExists } =
+      await this.identityFiles.readInRepoRecipesWithHashes(projectPath);
     // Replace this project's cached hashes with the freshly observed set so an
     // externally deleted recipe doesn't leave a stale entry pointing at a hash
     // for a file that no longer exists.
@@ -319,7 +336,7 @@ export class ProjectStore {
     for (const [recipeId, hash] of hashes) {
       this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipeId), hash);
     }
-    return recipes;
+    return { recipes, dirExists };
   }
 
   async deleteInRepoRecipe(projectPath: string, recipeName: string): Promise<void> {
@@ -1248,9 +1265,26 @@ export class ProjectStore {
     // Go through the cache-aware wrapper so the hash map is populated as a
     // side effect — otherwise the first renderer-driven edit after a project
     // load races the unrelated `getInRepoRecipes` call to populate the cache
-    // and may see a phantom RECIPE_STALE_CONFLICT.
-    const inRepoRecipes = await this.readInRepoRecipes(projectPath);
+    // and may see a phantom RECIPE_STALE_CONFLICT. `dirExists` distinguishes an
+    // absent `.daintree/recipes/` directory from an authoritatively empty one.
+    const { recipes: inRepoRecipes, dirExists } =
+      await this.readInRepoRecipesWithMeta(projectPath);
     const fileStoreRecipes = await this.fileStore.getRecipes(projectId);
+
+    // #11347: When the in-repo recipe directory is absent (e.g. the user checked
+    // out a branch or commit that predates `.daintree/recipes/`) we cannot tell
+    // a recipe that was deleted from one that merely lives on another checkout.
+    // If any project-local recipe is in-repo-scoped, pruning it would destroy
+    // local-only env values / usage metadata, and promoting a *sibling*
+    // local-only recipe would recreate the directory — making the very next
+    // reconcile observe `dirExists: true` and prune the recipe we just
+    // protected. So when the directory is missing and there is anything to
+    // protect, make no filesystem changes at all and defer reconciliation until
+    // the directory is observable again. Projects with only promotable
+    // (non-in-repo) recipes still migrate/collision-check as before.
+    if (!dirExists && fileStoreRecipes.some((r) => isInRepoRecipeId(r))) {
+      return [];
+    }
 
     const inRepoById = new Map(inRepoRecipes.map((r) => [r.id, r]));
     const fileStoreById = new Map(fileStoreRecipes.map((r) => [r.id, r]));

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -323,8 +323,8 @@ export class ProjectStore {
    */
   private async readInRepoRecipesWithMeta(
     projectPath: string
-  ): Promise<{ recipes: TerminalRecipe[]; dirExists: boolean }> {
-    const { recipes, hashes, dirExists } =
+  ): Promise<{ recipes: TerminalRecipe[]; dirExists: boolean; scanComplete: boolean }> {
+    const { recipes, hashes, dirExists, scanComplete } =
       await this.identityFiles.readInRepoRecipesWithHashes(projectPath);
     // Replace this project's cached hashes with the freshly observed set so an
     // externally deleted recipe doesn't leave a stale entry pointing at a hash
@@ -336,7 +336,7 @@ export class ProjectStore {
     for (const [recipeId, hash] of hashes) {
       this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipeId), hash);
     }
-    return { recipes, dirExists };
+    return { recipes, dirExists, scanComplete };
   }
 
   async deleteInRepoRecipe(projectPath: string, recipeName: string): Promise<void> {
@@ -1266,23 +1266,26 @@ export class ProjectStore {
     // side effect — otherwise the first renderer-driven edit after a project
     // load races the unrelated `getInRepoRecipes` call to populate the cache
     // and may see a phantom RECIPE_STALE_CONFLICT. `dirExists` distinguishes an
-    // absent `.daintree/recipes/` directory from an authoritatively empty one.
-    const { recipes: inRepoRecipes, dirExists } =
+    // absent `.daintree/recipes/` directory from an authoritatively empty one;
+    // `scanComplete` is false when the directory existed but a recipe file
+    // couldn't be read (a partial snapshot, e.g. mid-checkout).
+    const { recipes: inRepoRecipes, dirExists, scanComplete } =
       await this.readInRepoRecipesWithMeta(projectPath);
     const fileStoreRecipes = await this.fileStore.getRecipes(projectId);
 
     // #11347: When the in-repo recipe directory is absent (e.g. the user checked
-    // out a branch or commit that predates `.daintree/recipes/`) we cannot tell
-    // a recipe that was deleted from one that merely lives on another checkout.
+    // out a branch or commit that predates `.daintree/recipes/`), or the scan of
+    // it was incomplete (a file vanished/locked mid-read), we cannot tell a
+    // recipe that was deleted from one that merely lives on another checkout.
     // If any project-local recipe is in-repo-scoped, pruning it would destroy
     // local-only env values / usage metadata, and promoting a *sibling*
     // local-only recipe would recreate the directory — making the very next
     // reconcile observe `dirExists: true` and prune the recipe we just
-    // protected. So when the directory is missing and there is anything to
+    // protected. So when the view isn't authoritative and there is anything to
     // protect, make no filesystem changes at all and defer reconciliation until
     // the directory is observable again. Projects with only promotable
     // (non-in-repo) recipes still migrate/collision-check as before.
-    if (!dirExists && fileStoreRecipes.some((r) => isInRepoRecipeId(r))) {
+    if ((!dirExists || !scanComplete) && fileStoreRecipes.some((r) => isInRepoRecipeId(r))) {
       return [];
     }
 

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1269,8 +1269,11 @@ export class ProjectStore {
     // absent `.daintree/recipes/` directory from an authoritatively empty one;
     // `scanComplete` is false when the directory existed but a recipe file
     // couldn't be read (a partial snapshot, e.g. mid-checkout).
-    const { recipes: inRepoRecipes, dirExists, scanComplete } =
-      await this.readInRepoRecipesWithMeta(projectPath);
+    const {
+      recipes: inRepoRecipes,
+      dirExists,
+      scanComplete,
+    } = await this.readInRepoRecipesWithMeta(projectPath);
     const fileStoreRecipes = await this.fileStore.getRecipes(projectId);
 
     // #11347: When the in-repo recipe directory is absent (e.g. the user checked

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -138,7 +138,9 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(fs2[0]!.usageHistory).toEqual([123, 456]);
 
     // Reconciliation must not create the absent directory as a side effect.
-    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toThrow();
+    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
 
     // No in-repo recipes are visible while the directory is absent.
     const inr = await readInRepo();
@@ -164,11 +166,12 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(inr).toEqual([]);
   });
 
-  it("missing directory + mixed mirror & legacy recipe: mirror survives across two reconciliations (#11347)", async () => {
-    // Regression for the two-pass loss: with the directory absent, promoting the
-    // legacy recipe would recreate .daintree/recipes/, and the next reconcile
-    // (now seeing the dir) would prune the protected mirror. The guard must keep
-    // both recipes and leave the directory untouched, stably across passes.
+  it("missing directory + mirror & legacy recipe: reconcile is a stable no-op, mirror never lost (#11347)", async () => {
+    // Without the guard, the parent implementation would promote the legacy
+    // recipe (recreating .daintree/recipes/) AND prune the in-repo mirror in the
+    // same pass. The guard must instead protect the mirror and skip promotion, so
+    // repeated reconciliations leave the store and filesystem byte-for-byte
+    // unchanged — no sibling promotion opens a window that a later pass prunes.
     await fs.mkdir(projectPath, { recursive: true });
 
     const mirror = makeRecipe({
@@ -178,18 +181,25 @@ describe("ProjectStore recipe reconciliation", () => {
     });
     const legacy = makeRecipe({ id: "recipe-legacy-abc", name: "Legacy", projectId });
     await seedFileStore([mirror, legacy]);
+    const before = await readFileStore();
 
-    await store.reconcileProjectRecipes(projectPath, projectId);
-    await store.reconcileProjectRecipes(projectPath, projectId);
+    const collisions1 = await store.reconcileProjectRecipes(projectPath, projectId);
+    const after1 = await readFileStore();
+    const collisions2 = await store.reconcileProjectRecipes(projectPath, projectId);
+    const after2 = await readFileStore();
 
-    const fs2 = await readFileStore();
-    const survived = fs2.find((r) => r.id === mirror.id);
-    expect(survived).toBeDefined();
-    expect(survived!.terminals[0]!.env).toEqual({ TOKEN: "keep-me" });
-    expect(fs2.find((r) => r.id === legacy.id)).toBeDefined();
+    // Each pass reports no collisions and leaves the store unchanged.
+    expect(collisions1).toEqual([]);
+    expect(collisions2).toEqual([]);
+    expect(after1).toEqual(before);
+    expect(after2).toEqual(before);
 
-    // The directory is never created while a mirror needs protecting.
-    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toThrow();
+    // The mirror's local-only env survived and the directory was never created.
+    expect(after2.find((r) => r.id === mirror.id)?.terminals[0]!.env).toEqual({ TOKEN: "keep-me" });
+    expect(after2.find((r) => r.id === legacy.id)).toBeDefined();
+    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("reconciliation populates the in-repo hash cache so a follow-up checked write succeeds", async () => {
@@ -208,6 +218,105 @@ describe("ProjectStore recipe reconciliation", () => {
     // cached hash). Reconciling first must populate the cache.
     await fresh.reconcileProjectRecipes(projectPath, projectId);
     await expect(fresh.writeInRepoRecipeChecked(projectPath, recipe)).resolves.toBeUndefined();
+  });
+
+  it("opaque-UUID mirror (scope 'inrepo', no prefix) survives an absent directory (#11347)", async () => {
+    // Guards the object-based classification: a mirror identified by its scope,
+    // not an `inrepo-` id prefix, must also be protected when the directory is
+    // gone. A guard narrowed to `id.startsWith("inrepo-")` would drop this.
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const mirror = makeRecipe({
+      id: "recipe-opaque-uuid",
+      name: "Opaque Mirror",
+      scope: "inrepo",
+      terminals: [{ type: "terminal", command: "echo o", env: { API_KEY: "secret" } }],
+      lastUsedAt: 42,
+      usageHistory: [42],
+    });
+    await seedFileStore([mirror]);
+
+    await store.reconcileProjectRecipes(projectPath, projectId);
+
+    const fs2 = await readFileStore();
+    expect(fs2).toHaveLength(1);
+    expect(fs2[0]!.id).toBe("recipe-opaque-uuid");
+    expect(fs2[0]!.terminals[0]!.env).toEqual({ API_KEY: "secret" });
+    expect(fs2[0]!.lastUsedAt).toBe(42);
+    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("normal reconciliation merges local env values into the in-repo recipe instead of blanking them", async () => {
+    // The on-disk in-repo copy is redacted (env keys kept, values blanked); the
+    // real values live only in the file store. Reconcile with the directory
+    // present must merge those values back, not overwrite them with placeholders
+    // — the same env-preservation guarantee #11347 protects on the missing path.
+    const id = stableInRepoId("Merged");
+    const onDisk = makeRecipe({
+      id,
+      name: "Merged",
+      terminals: [{ type: "terminal", command: "echo x", env: { API_KEY: "v", NEW_KEY: "v" } }],
+    });
+    await seedInRepo(onDisk); // written redacted → on-disk env values become ""
+
+    const local = makeRecipe({
+      id,
+      name: "Merged",
+      terminals: [{ type: "terminal", command: "echo x", env: { API_KEY: "secret" } }],
+      lastUsedAt: 999,
+      usageHistory: [999],
+    });
+    await seedFileStore([local]);
+
+    await store.reconcileProjectRecipes(projectPath, projectId);
+
+    const fs2 = await readFileStore();
+    expect(fs2).toHaveLength(1);
+    // Keys come from the canonical on-disk recipe; values from the local copy.
+    expect(fs2[0]!.terminals[0]!.env).toEqual({ API_KEY: "secret", NEW_KEY: "" });
+    expect(fs2[0]!.lastUsedAt).toBe(999);
+    expect(fs2[0]!.usageHistory).toEqual([999]);
+  });
+
+  it("does not prune a mirror when a recipe file can't be read mid-scan (#11347)", async () => {
+    // readdir lists the file, but reading it fails (e.g. a checkout unlinks it
+    // between readdir and read). The snapshot is non-authoritative, so the mirror
+    // must survive rather than be classified stale.
+    const recipesDir = path.join(projectPath, ".daintree", "recipes");
+    await fs.mkdir(recipesDir, { recursive: true });
+    const mirror = makeRecipe({
+      id: stableInRepoId("Partial"),
+      name: "Partial",
+      terminals: [{ type: "terminal", command: "echo p", env: { SECRET: "keep" } }],
+    });
+    const filePath = path.join(recipesDir, "partial.json");
+    await fs.writeFile(filePath, JSON.stringify(mirror), "utf-8");
+    await seedFileStore([mirror]);
+    await fs.chmod(filePath, 0o000);
+
+    // Some environments (e.g. running as root) ignore the mode; only assert the
+    // partial-scan protection when the file is genuinely unreadable here.
+    let readable = true;
+    try {
+      await fs.readFile(filePath, "utf-8");
+    } catch {
+      readable = false;
+    }
+
+    try {
+      await store.reconcileProjectRecipes(projectPath, projectId);
+      const fs2 = await readFileStore();
+      expect(fs2).toHaveLength(1);
+      expect(fs2[0]!.id).toBe(mirror.id);
+      if (!readable) {
+        // Incomplete scan ⇒ the guard preserved the mirror and its env.
+        expect(fs2[0]!.terminals[0]!.env).toEqual({ SECRET: "keep" });
+      }
+    } finally {
+      await fs.chmod(filePath, 0o600);
+    }
   });
 
   it("in-repo recipe overwrites differing ProjectFileStore copy", async () => {

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -112,21 +112,102 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(fs2[0]!.name).toBe(recipe.name);
   });
 
-  it("ProjectFileStore-only recipe with inrepo- prefix is removed as stale", async () => {
-    const staleId = stableInRepoId("Deleted Recipe");
-    const staleRecipe = makeRecipe({
-      id: staleId,
-      name: "Deleted Recipe",
+  it("in-repo mirror survives when .daintree/recipes/ is absent, keeping env/metadata (#11347)", async () => {
+    // Model a real checkout: the project root exists but the recipes directory
+    // does not (e.g. checked out a branch/commit predating .daintree/recipes/).
+    // A missing directory must NOT be read as "the recipe was deleted" — doing
+    // so wipes the local-only env values and usage metadata this test guards.
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const mirror = makeRecipe({
+      id: stableInRepoId("Kept Recipe"),
+      name: "Kept Recipe",
+      terminals: [{ type: "terminal", command: "echo hi", env: { API_KEY: "secret" } }],
+      lastUsedAt: 123,
+      usageHistory: [123, 456],
     });
-    await seedFileStore([staleRecipe]);
+    await seedFileStore([mirror]);
+
+    await store.reconcileProjectRecipes(projectPath, projectId);
+
+    const fs2 = await readFileStore();
+    expect(fs2).toHaveLength(1);
+    expect(fs2[0]!.id).toBe(mirror.id);
+    expect(fs2[0]!.terminals[0]!.env).toEqual({ API_KEY: "secret" });
+    expect(fs2[0]!.lastUsedAt).toBe(123);
+    expect(fs2[0]!.usageHistory).toEqual([123, 456]);
+
+    // Reconciliation must not create the absent directory as a side effect.
+    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toThrow();
+
+    // No in-repo recipes are visible while the directory is absent.
+    const inr = await readInRepo();
+    expect(inr).toEqual([]);
+  });
+
+  it("in-repo mirror IS pruned when the directory exists but is empty", async () => {
+    // An empty-but-present directory is authoritative (e.g. the recipe file was
+    // deleted from .daintree/recipes/ while the dir itself remains). The mirror
+    // is genuinely stale here and must still be pruned — only the *missing*
+    // directory case is treated as inconclusive.
+    const recipesDir = path.join(projectPath, ".daintree", "recipes");
+    await fs.mkdir(recipesDir, { recursive: true });
+
+    const stale = makeRecipe({ id: stableInRepoId("Deleted Recipe"), name: "Deleted Recipe" });
+    await seedFileStore([stale]);
 
     await store.reconcileProjectRecipes(projectPath, projectId);
 
     const fs2 = await readFileStore();
     expect(fs2).toEqual([]);
-    // No promotion to in-repo
     const inr = await readInRepo();
     expect(inr).toEqual([]);
+  });
+
+  it("missing directory + mixed mirror & legacy recipe: mirror survives across two reconciliations (#11347)", async () => {
+    // Regression for the two-pass loss: with the directory absent, promoting the
+    // legacy recipe would recreate .daintree/recipes/, and the next reconcile
+    // (now seeing the dir) would prune the protected mirror. The guard must keep
+    // both recipes and leave the directory untouched, stably across passes.
+    await fs.mkdir(projectPath, { recursive: true });
+
+    const mirror = makeRecipe({
+      id: stableInRepoId("Mirror"),
+      name: "Mirror",
+      terminals: [{ type: "terminal", command: "echo m", env: { TOKEN: "keep-me" } }],
+    });
+    const legacy = makeRecipe({ id: "recipe-legacy-abc", name: "Legacy", projectId });
+    await seedFileStore([mirror, legacy]);
+
+    await store.reconcileProjectRecipes(projectPath, projectId);
+    await store.reconcileProjectRecipes(projectPath, projectId);
+
+    const fs2 = await readFileStore();
+    const survived = fs2.find((r) => r.id === mirror.id);
+    expect(survived).toBeDefined();
+    expect(survived!.terminals[0]!.env).toEqual({ TOKEN: "keep-me" });
+    expect(fs2.find((r) => r.id === legacy.id)).toBeDefined();
+
+    // The directory is never created while a mirror needs protecting.
+    await expect(fs.access(path.join(projectPath, ".daintree", "recipes"))).rejects.toThrow();
+  });
+
+  it("reconciliation populates the in-repo hash cache so a follow-up checked write succeeds", async () => {
+    // reconcileProjectRecipes now reads through a private helper; verify that
+    // helper still repopulates the hash cache the staleness guard depends on.
+    const recipe = makeRecipe({ id: stableInRepoId("Recon Cache"), name: "Recon Cache" });
+    await seedInRepo(recipe);
+
+    const fresh = new ProjectStore();
+    (fresh as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    (fresh as unknown as { fileStore: { projectsConfigDir: string } }).fileStore.projectsConfigDir =
+      tmpDir;
+    await fresh.initialize();
+
+    // Without any prior read, a checked write would conflict (file exists, no
+    // cached hash). Reconciling first must populate the cache.
+    await fresh.reconcileProjectRecipes(projectPath, projectId);
+    await expect(fresh.writeInRepoRecipeChecked(projectPath, recipe)).resolves.toBeUndefined();
   });
 
   it("in-repo recipe overwrites differing ProjectFileStore copy", async () => {

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -576,9 +576,12 @@ describe("readInRepoRecipesWithHashes", () => {
     await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r1", name: "First" }));
     await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r2", name: "Second" }));
 
-    const { recipes, hashes } = await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+    const { recipes, hashes, dirExists, scanComplete } =
+      await identityFiles.readInRepoRecipesWithHashes(tmpDir);
     expect(recipes).toHaveLength(2);
     expect(hashes.size).toBe(2);
+    expect(dirExists).toBe(true);
+    expect(scanComplete).toBe(true);
     for (const recipe of recipes) {
       const filename = recipe.name === "First" ? "first.json" : "second.json";
       const onDisk = await fs.readFile(path.join(tmpDir, DAINTREE_RECIPES_DIR, filename), "utf-8");
@@ -588,20 +591,45 @@ describe("readInRepoRecipesWithHashes", () => {
   });
 
   it("returns empty recipes and hashes and dirExists=false when the directory is missing", async () => {
-    const { recipes, hashes, dirExists } =
+    const { recipes, hashes, dirExists, scanComplete } =
       await identityFiles.readInRepoRecipesWithHashes(tmpDir);
     expect(recipes).toEqual([]);
     expect(hashes.size).toBe(0);
     expect(dirExists).toBe(false);
+    expect(scanComplete).toBe(true);
   });
 
-  it("returns dirExists=true for an existing but empty recipes directory", async () => {
+  it("returns dirExists=true and scanComplete=true for an existing but empty recipes directory", async () => {
     await fs.mkdir(path.join(tmpDir, DAINTREE_RECIPES_DIR), { recursive: true });
-    const { recipes, hashes, dirExists } =
+    const { recipes, hashes, dirExists, scanComplete } =
       await identityFiles.readInRepoRecipesWithHashes(tmpDir);
     expect(recipes).toEqual([]);
     expect(hashes.size).toBe(0);
     expect(dirExists).toBe(true);
+    expect(scanComplete).toBe(true);
+  });
+
+  it("reports scanComplete=false when a listed recipe file cannot be read", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    const filePath = path.join(recipesDir, "unreadable.json");
+    await fs.writeFile(filePath, JSON.stringify(makeRecipe({ id: "r1", name: "R1" })), "utf-8");
+    await fs.chmod(filePath, 0o000);
+
+    // Some environments (e.g. running as root) ignore the mode; only assert the
+    // partial-scan signal when the file is genuinely unreadable here.
+    let readable = true;
+    try {
+      await fs.readFile(filePath, "utf-8");
+    } catch {
+      readable = false;
+    }
+
+    const { dirExists, scanComplete } = await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+    expect(dirExists).toBe(true);
+    expect(scanComplete).toBe(readable);
+
+    await fs.chmod(filePath, 0o600); // restore so afterEach cleanup can remove it
   });
 });
 

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -587,10 +587,21 @@ describe("readInRepoRecipesWithHashes", () => {
     }
   });
 
-  it("returns empty recipes and empty hashes when the directory is missing", async () => {
-    const { recipes, hashes } = await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+  it("returns empty recipes and hashes and dirExists=false when the directory is missing", async () => {
+    const { recipes, hashes, dirExists } =
+      await identityFiles.readInRepoRecipesWithHashes(tmpDir);
     expect(recipes).toEqual([]);
     expect(hashes.size).toBe(0);
+    expect(dirExists).toBe(false);
+  });
+
+  it("returns dirExists=true for an existing but empty recipes directory", async () => {
+    await fs.mkdir(path.join(tmpDir, DAINTREE_RECIPES_DIR), { recursive: true });
+    const { recipes, hashes, dirExists } =
+      await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+    expect(recipes).toEqual([]);
+    expect(hashes.size).toBe(0);
+    expect(dirExists).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Checking out a branch or commit that predates `.daintree/recipes/` permanently wiped local-only recipe data (env values, `lastUsedAt`, `usageHistory`).
- Root cause: `ProjectIdentityFiles.readInRepoRecipesWithHashes()` returned an identical empty result whether the directory was missing or present-but-empty. `ProjectStore.reconcileProjectRecipes()`, which runs on every recipe fetch, treated any project-local in-repo-scoped recipe absent from that wrongly-empty set as stale and pruned it.
- Fix distinguishes "missing" from "authoritatively empty" and stops reconciliation from touching the filesystem whenever the scan isn't trustworthy.

Resolves #11347

## Changes

- `readInRepoRecipesWithHashes` now returns `dirExists` (missing vs. authoritatively empty) and `scanComplete` (false when the directory existed but a recipe file couldn't be read, i.e. a partial, non-authoritative snapshot such as mid-checkout). A readable but malformed file doesn't taint the scan, so one bad file can't wedge pruning forever.
- `reconcileProjectRecipes` now reads through a new private cache-owning `readInRepoRecipesWithMeta` (the public `readInRepoRecipes` array signature is unchanged for its other callers) and makes no filesystem changes when the view isn't authoritative (`!dirExists || !scanComplete`) and any project-local recipe is in-repo-scoped. Projects with only promotable (non-in-repo) recipes still migrate and collision-check as before.
- This also closes a two-pass loss where promoting a sibling legacy recipe would recreate the directory and let the next reconcile prune the protected mirror.
- No new syscalls: no TOCTOU stat pre-check, the existing `readdir` plus catch-ENOENT primitive already carried the signal.

Files: `electron/services/ProjectIdentityFiles.ts`, `electron/services/ProjectStore.ts`. Main-process only, no UI change, no new dependencies.

## Testing

Added coverage in `electron/services/__tests__/ProjectStore.recipes.test.ts` and `writeInRepoFiles.test.ts`:

- Missing-dir mirror survival with exact env and metadata.
- Opaque-UUID (scope) mirror survival.
- Empty-but-present directory still prunes.
- Mixed mirror plus legacy is a stable per-pass no-op.
- Partial-scan mirror survival.
- Env-value merge on the present-dir path.
- `dirExists` and `scanComplete` both ways.
- Reconcile populates the hash cache.
