### PR TITLE
fix(pty): stop failed journal reads from truncating session history

### DIFF
--- a/electron/services/pty/__tests__/agentSessionHistory.adversarial.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.adversarial.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// Fault-injection control shared with the hoisted module mocks below. Faults are
+// one-shot and scoped to the journal path, so fixture setup (writeFile/mkdtemp)
+// and post-condition reads still hit the real filesystem. This lets us force the
+// exact failure classes #11348 is about — a transient read error (EACCES/EIO/
+// EMFILE/EBUSY) on an EXISTING journal — which no portable real-fs trick or
+// chmod can produce reliably (chmod is bypassed by root and is a Windows no-op).
+const h = vi.hoisted(() => {
+  interface Fault {
+    code: string;
+  }
+  const armed: { read: Fault | null; stat: Fault | null; renameFail: boolean } = {
+    read: null,
+    stat: null,
+    renameFail: false,
+  };
+  const isJournalPath = (p: unknown): boolean =>
+    typeof p === "string" && p.endsWith("agent-session-history.json");
+  const takeFault = (slot: "read" | "stat", p: unknown): Error | null => {
+    const fault = armed[slot];
+    if (!fault || !isJournalPath(p)) return null;
+    armed[slot] = null; // one-shot: the next call to the same path succeeds
+    return Object.assign(new Error(fault.code), { code: fault.code });
+  };
+  const reset = (): void => {
+    armed.read = null;
+    armed.stat = null;
+    armed.renameFail = false;
+  };
+  return { armed, takeFault, reset };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    default: actual,
+    readFile: (...args: Parameters<typeof actual.readFile>) => {
+      const fault = h.takeFault("read", args[0]);
+      return fault ? Promise.reject(fault) : actual.readFile(...args);
+    },
+    stat: (...args: Parameters<typeof actual.stat>) => {
+      const fault = h.takeFault("stat", args[0]);
+      return fault ? Promise.reject(fault) : actual.stat(...args);
+    },
+  };
+});
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    default: actual,
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => {
+      const fault = h.takeFault("read", args[0]);
+      if (fault) throw fault;
+      return actual.readFileSync(...args);
+    },
+    statSync: (...args: Parameters<typeof actual.statSync>) => {
+      const fault = h.takeFault("stat", args[0]);
+      if (fault) throw fault;
+      return actual.statSync(...args);
+    },
+  };
+});
+
+vi.mock("../../../utils/fs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../utils/fs.js")>();
+  return {
+    ...actual,
+    resilientRename: (...args: Parameters<typeof actual.resilientRename>) =>
+      h.armed.renameFail
+        ? Promise.reject(Object.assign(new Error("EACCES"), { code: "EACCES" }))
+        : actual.resilientRename(...args),
+    resilientRenameSync: (...args: Parameters<typeof actual.resilientRenameSync>) => {
+      if (h.armed.renameFail) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      return actual.resilientRenameSync(...args);
+    },
+  };
+});
+
+import {
+  persistAgentSession,
+  pruneAgentSessions,
+  clearAgentSessions,
+  rewriteAgentSessionPathsForProject,
+  readSessionHistory,
+  readSessionHistorySync,
+  listAgentSessions,
+  getSessionHistoryPath,
+  type AgentSessionRecord,
+} from "../agentSessionHistory.js";
+
+function rec(sessionId: string, worktreeId: string | null, projectId: string | null = null) {
+  return {
+    sessionId,
+    agentId: "claude",
+    worktreeId,
+    title: null,
+    projectId,
+    savedAt: Date.now(),
+  } satisfies AgentSessionRecord;
+}
+
+describe("agentSessionHistory — transient read faults (adversarial)", () => {
+  let userDataDir: string;
+  const previousUserData = process.env.DAINTREE_USER_DATA;
+
+  beforeEach(async () => {
+    userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "daintree-session-adv-"));
+    process.env.DAINTREE_USER_DATA = userDataDir;
+    h.reset();
+  });
+
+  afterEach(async () => {
+    h.reset();
+    vi.clearAllMocks();
+    process.env.DAINTREE_USER_DATA = previousUserData;
+    await fsp.rm(userDataDir, { recursive: true, force: true });
+  });
+
+  async function quarantineSidecars(): Promise<string[]> {
+    return (await fsp.readdir(userDataDir)).filter((f) => f.includes(".corrupted."));
+  }
+
+  async function seedJournal(records: AgentSessionRecord[]): Promise<void> {
+    // Direct write (bypasses the writers' cache refresh) so the reader under test
+    // must hit disk — the fault then classifies against real on-disk content.
+    await fsp.writeFile(getSessionHistoryPath(userDataDir)!, JSON.stringify(records));
+  }
+
+  async function readOnDisk(): Promise<AgentSessionRecord[]> {
+    const raw = await fsp.readFile(getSessionHistoryPath(userDataDir)!, "utf8");
+    return JSON.parse(raw) as AgentSessionRecord[];
+  }
+
+  it("async read returns [] on a transient EACCES without quarantining, then recovers", async () => {
+    await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    h.armed.stat = { code: "EACCES" };
+
+    // The transient failure degrades this one read to [] — but must NOT quarantine.
+    expect(await readSessionHistory(userDataDir)).toEqual([]);
+    expect(await quarantineSidecars()).toEqual([]);
+
+    // Fault was one-shot: the file is intact and the next read returns it.
+    expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["a", "b"]);
+  });
+
+  it("sync read returns [] on a transient EMFILE without quarantining, then recovers", async () => {
+    await seedJournal([rec("a", "wt-1")]);
+
+    // Both sync entry points degrade to [] on the transient failure (faults are
+    // one-shot, so each read re-arms) — and neither quarantines.
+    h.armed.stat = { code: "EMFILE" };
+    expect(readSessionHistorySync(userDataDir)).toEqual([]);
+    h.armed.stat = { code: "EMFILE" };
+    expect(listAgentSessions(undefined, userDataDir)).toEqual([]);
+    expect(await quarantineSidecars()).toEqual([]);
+
+    // Fault cleared: the file was never touched, so the next read returns it.
+    expect(listAgentSessions(undefined, userDataDir).map((r) => r.sessionId)).toEqual(["a"]);
+  });
+
+  it("persistAgentSession aborts on an unreadable journal, preserving existing records", async () => {
+    const seed = [rec("a", "wt-1"), rec("b", "wt-2"), rec("c", "wt-3")];
+    await seedJournal(seed);
+    h.armed.read = { code: "EACCES" }; // fail the content read specifically
+
+    await expect(persistAgentSession(rec("new", "wt-4"), userDataDir)).rejects.toThrow(
+      /could not be read/
+    );
+
+    // The on-disk journal is byte-for-byte unchanged: no overwrite, no quarantine.
+    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a", "b", "c"]);
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("pruneAgentSessions aborts on an unreadable journal rather than writing []", async () => {
+    await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    h.armed.stat = { code: "EMFILE" };
+
+    await expect(pruneAgentSessions(7, userDataDir)).rejects.toThrow(/could not be read/);
+
+    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a", "b"]);
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("clearAgentSessions(worktree) aborts on an unreadable journal, sparing other worktrees", async () => {
+    await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    h.armed.stat = { code: "EIO" };
+
+    await expect(clearAgentSessions("wt-1", userDataDir)).rejects.toThrow(/could not be read/);
+
+    // wt-2 (and even wt-1) survive: a failed read must never wipe the journal.
+    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a", "b"]);
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("rewriteAgentSessionPathsForProject aborts on an unreadable journal", async () => {
+    await seedJournal([rec("a", "/old/wt-1", "proj-1")]);
+    h.armed.stat = { code: "EBUSY" };
+
+    await expect(
+      rewriteAgentSessionPathsForProject("proj-1", "/old", "/new", userDataDir)
+    ).rejects.toThrow(/could not be read/);
+
+    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a"]);
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("does not poison the cache with [] after a transient failure between two reads", async () => {
+    await persistAgentSession(rec("first", "wt-1"), userDataDir); // primes the cache
+    expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["first"]);
+
+    // Change the file out-of-band, then fail the very next stat (transient).
+    await seedJournal([rec("second", "wt-1")]);
+    h.armed.stat = { code: "EIO" };
+
+    // The failed read reports [] once and evicts the stale cache entry...
+    expect(await readSessionHistory(userDataDir)).toEqual([]);
+    // ...so the following read reflects the real on-disk change (not [] or "first").
+    expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["second"]);
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("treats a failed quarantine as unreadable: the corrupt file is left intact, not overwritten", async () => {
+    await fsp.writeFile(getSessionHistoryPath(userDataDir)!, "totally not json");
+    h.armed.renameFail = true; // the quarantine rename will reject
+
+    await expect(persistAgentSession(rec("recovery", "wt-1"), userDataDir)).rejects.toThrow(
+      /could not be read/
+    );
+
+    // Because quarantine failed, the original corrupt bytes must remain in place
+    // (never clobbered by a fresh write) and no sidecar was produced.
+    expect(await fsp.readFile(getSessionHistoryPath(userDataDir)!, "utf8")).toBe(
+      "totally not json"
+    );
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("does not wedge the write queue: a follow-up persist lands after one aborts", async () => {
+    await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    h.armed.stat = { code: "EACCES" }; // one-shot: only the first read fails
+
+    // Enqueue both without awaiting so they share the serial write queue.
+    const first = persistAgentSession(rec("blocked", "wt-3"), userDataDir);
+    const second = persistAgentSession(rec("landed", "wt-4"), userDataDir);
+
+    await expect(first).rejects.toThrow(/could not be read/);
+    await expect(second).resolves.toBeUndefined();
+
+    const after = (await readSessionHistory(userDataDir)).map((r) => r.sessionId).sort();
+    expect(after).toEqual(["a", "b", "landed"]); // "blocked" never landed; seeds survived
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+});

--- a/electron/services/pty/__tests__/agentSessionHistory.adversarial.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.adversarial.test.ts
@@ -13,25 +13,34 @@ const h = vi.hoisted(() => {
   interface Fault {
     code: string;
   }
-  const armed: { read: Fault | null; stat: Fault | null; renameFail: boolean } = {
+  const armed: { read: Fault | null; stat: Fault | null; renameFault: string | null } = {
     read: null,
     stat: null,
-    renameFail: false,
+    renameFault: null,
   };
   const isJournalPath = (p: unknown): boolean =>
     typeof p === "string" && p.endsWith("agent-session-history.json");
+  const makeError = (code: string): Error => Object.assign(new Error(code), { code });
   const takeFault = (slot: "read" | "stat", p: unknown): Error | null => {
     const fault = armed[slot];
     if (!fault || !isJournalPath(p)) return null;
     armed[slot] = null; // one-shot: the next call to the same path succeeds
-    return Object.assign(new Error(fault.code), { code: fault.code });
+    return makeError(fault.code);
+  };
+  // The quarantine-rename fault is one-shot and journal-path-scoped too, so it
+  // can only fail the rename of the corrupt journal it's meant to simulate.
+  const takeRenameFault = (src: unknown): Error | null => {
+    const code = armed.renameFault;
+    if (!code || !isJournalPath(src)) return null;
+    armed.renameFault = null; // one-shot
+    return makeError(code);
   };
   const reset = (): void => {
     armed.read = null;
     armed.stat = null;
-    armed.renameFail = false;
+    armed.renameFault = null;
   };
-  return { armed, takeFault, reset };
+  return { armed, takeFault, takeRenameFault, reset };
 });
 
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -72,12 +81,13 @@ vi.mock("../../../utils/fs.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../utils/fs.js")>();
   return {
     ...actual,
-    resilientRename: (...args: Parameters<typeof actual.resilientRename>) =>
-      h.armed.renameFail
-        ? Promise.reject(Object.assign(new Error("EACCES"), { code: "EACCES" }))
-        : actual.resilientRename(...args),
+    resilientRename: (...args: Parameters<typeof actual.resilientRename>) => {
+      const fault = h.takeRenameFault(args[0]);
+      return fault ? Promise.reject(fault) : actual.resilientRename(...args);
+    },
     resilientRenameSync: (...args: Parameters<typeof actual.resilientRenameSync>) => {
-      if (h.armed.renameFail) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      const fault = h.takeRenameFault(args[0]);
+      if (fault) throw fault;
       return actual.resilientRenameSync(...args);
     },
   };
@@ -133,9 +143,8 @@ describe("agentSessionHistory — transient read faults (adversarial)", () => {
     await fsp.writeFile(getSessionHistoryPath(userDataDir)!, JSON.stringify(records));
   }
 
-  async function readOnDisk(): Promise<AgentSessionRecord[]> {
-    const raw = await fsp.readFile(getSessionHistoryPath(userDataDir)!, "utf8");
-    return JSON.parse(raw) as AgentSessionRecord[];
+  async function rawOnDisk(): Promise<string> {
+    return fsp.readFile(getSessionHistoryPath(userDataDir)!, "utf8");
   }
 
   it("async read returns [] on a transient EACCES without quarantining, then recovers", async () => {
@@ -166,53 +175,59 @@ describe("agentSessionHistory — transient read faults (adversarial)", () => {
   });
 
   it("persistAgentSession aborts on an unreadable journal, preserving existing records", async () => {
-    const seed = [rec("a", "wt-1"), rec("b", "wt-2"), rec("c", "wt-3")];
-    await seedJournal(seed);
+    await seedJournal([rec("a", "wt-1"), rec("b", "wt-2"), rec("c", "wt-3")]);
+    const before = await rawOnDisk();
     h.armed.read = { code: "EACCES" }; // fail the content read specifically
 
     await expect(persistAgentSession(rec("new", "wt-4"), userDataDir)).rejects.toThrow(
       /could not be read/
     );
 
-    // The on-disk journal is byte-for-byte unchanged: no overwrite, no quarantine.
-    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a", "b", "c"]);
+    // Byte-for-byte unchanged: no overwrite, no quarantine.
+    expect(await rawOnDisk()).toBe(before);
     expect(await quarantineSidecars()).toEqual([]);
   });
 
   it("pruneAgentSessions aborts on an unreadable journal rather than writing []", async () => {
     await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    const before = await rawOnDisk();
     h.armed.stat = { code: "EMFILE" };
 
     await expect(pruneAgentSessions(7, userDataDir)).rejects.toThrow(/could not be read/);
 
-    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a", "b"]);
+    expect(await rawOnDisk()).toBe(before);
     expect(await quarantineSidecars()).toEqual([]);
   });
 
   it("clearAgentSessions(worktree) aborts on an unreadable journal, sparing other worktrees", async () => {
     await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    const before = await rawOnDisk();
     h.armed.stat = { code: "EIO" };
 
     await expect(clearAgentSessions("wt-1", userDataDir)).rejects.toThrow(/could not be read/);
 
     // wt-2 (and even wt-1) survive: a failed read must never wipe the journal.
-    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a", "b"]);
+    expect(await rawOnDisk()).toBe(before);
     expect(await quarantineSidecars()).toEqual([]);
   });
 
   it("rewriteAgentSessionPathsForProject aborts on an unreadable journal", async () => {
     await seedJournal([rec("a", "/old/wt-1", "proj-1")]);
+    const before = await rawOnDisk();
     h.armed.stat = { code: "EBUSY" };
 
     await expect(
       rewriteAgentSessionPathsForProject("proj-1", "/old", "/new", userDataDir)
     ).rejects.toThrow(/could not be read/);
 
-    expect((await readOnDisk()).map((r) => r.sessionId)).toEqual(["a"]);
+    expect(await rawOnDisk()).toBe(before);
     expect(await quarantineSidecars()).toEqual([]);
   });
 
-  it("does not poison the cache with [] after a transient failure between two reads", async () => {
+  it("recovers to on-disk truth after a transient read failure (no [] or stale poisoning)", async () => {
+    // End-to-end guard: a transient failure must not leave the reader stuck
+    // serving [] or a stale cache entry. (The stat size/mtime gate also guards
+    // this, so it validates observable recovery, not the cache-evict line alone.)
     await persistAgentSession(rec("first", "wt-1"), userDataDir); // primes the cache
     expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["first"]);
 
@@ -220,16 +235,17 @@ describe("agentSessionHistory — transient read faults (adversarial)", () => {
     await seedJournal([rec("second", "wt-1")]);
     h.armed.stat = { code: "EIO" };
 
-    // The failed read reports [] once and evicts the stale cache entry...
+    // The failed read reports [] once...
     expect(await readSessionHistory(userDataDir)).toEqual([]);
     // ...so the following read reflects the real on-disk change (not [] or "first").
     expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["second"]);
+    expect(listAgentSessions(undefined, userDataDir).map((r) => r.sessionId)).toEqual(["second"]);
     expect(await quarantineSidecars()).toEqual([]);
   });
 
   it("treats a failed quarantine as unreadable: the corrupt file is left intact, not overwritten", async () => {
     await fsp.writeFile(getSessionHistoryPath(userDataDir)!, "totally not json");
-    h.armed.renameFail = true; // the quarantine rename will reject
+    h.armed.renameFault = "EACCES"; // the quarantine rename will reject (non-ENOENT)
 
     await expect(persistAgentSession(rec("recovery", "wt-1"), userDataDir)).rejects.toThrow(
       /could not be read/
@@ -237,13 +253,52 @@ describe("agentSessionHistory — transient read faults (adversarial)", () => {
 
     // Because quarantine failed, the original corrupt bytes must remain in place
     // (never clobbered by a fresh write) and no sidecar was produced.
-    expect(await fsp.readFile(getSessionHistoryPath(userDataDir)!, "utf8")).toBe(
-      "totally not json"
-    );
+    expect(await rawOnDisk()).toBe("totally not json");
     expect(await quarantineSidecars()).toEqual([]);
   });
 
-  it("does not wedge the write queue: a follow-up persist lands after one aborts", async () => {
+  it("proceeds when the corrupt file was already quarantined concurrently (rename ENOENT)", async () => {
+    // Simulates the un-queued sync quarantine (listAgentSessions) winning the race:
+    // by the time this persist tries to quarantine, the corrupt file is already
+    // gone (rename → ENOENT). That must NOT abort — the source is handled, so a
+    // fresh journal is written rather than the just-closed record being lost.
+    await fsp.writeFile(getSessionHistoryPath(userDataDir)!, "already being quarantined");
+    h.armed.renameFault = "ENOENT";
+
+    await expect(
+      persistAgentSession(rec("survivor", "wt-1"), userDataDir)
+    ).resolves.toBeUndefined();
+
+    expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["survivor"]);
+  });
+
+  it("sync read leaves a corrupt file intact when its quarantine rename fails", async () => {
+    // Exercises the SYNC corrupt→quarantine→failed-rename→unreadable branch.
+    await fsp.writeFile(getSessionHistoryPath(userDataDir)!, "sync corrupt bytes");
+    h.armed.renameFault = "EACCES";
+
+    expect(readSessionHistorySync(userDataDir)).toEqual([]);
+    expect(await rawOnDisk()).toBe("sync corrupt bytes");
+    expect(await quarantineSidecars()).toEqual([]);
+  });
+
+  it("clear-all writes [] without reading, even when the journal is unreadable", async () => {
+    await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
+    // Arm a READ fault: clear-all (no worktreeId) must take its read-free branch.
+    // refreshCacheAfterWrite legitimately calls statSync, so a stat fault would
+    // misfire — a read fault proves nothing read the journal.
+    h.armed.read = { code: "EACCES" };
+
+    await expect(clearAgentSessions(undefined, userDataDir)).resolves.toBeUndefined();
+
+    expect(h.armed.read).not.toBeNull(); // never consumed ⇒ no read happened
+    expect(await rawOnDisk()).toBe("[]");
+  });
+
+  it("recovers on the write queue: a follow-up persist lands after one aborts", async () => {
+    // Scoped to rejection recovery — an aborting predecessor must not wedge the
+    // queue or block its follower. Serialization itself is covered by the
+    // "preserves all records under concurrent writes" test in the sibling suite.
     await seedJournal([rec("a", "wt-1"), rec("b", "wt-2")]);
     h.armed.stat = { code: "EACCES" }; // one-shot: only the first read fails
 

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -571,19 +571,68 @@ describe("agentSessionHistory", () => {
     });
   });
 
-  it("handles corrupt JSON gracefully", async () => {
+  async function quarantineSidecars(dir: string): Promise<string[]> {
+    const entries = await fsp.readdir(dir);
+    return entries.filter((f) => f.includes(".corrupted."));
+  }
+
+  it("quarantines corrupt JSON instead of silently dropping it, then recovers", async () => {
     const filePath = getSessionHistoryPath(userDataDir)!;
     await fsp.writeFile(filePath, "not json at all");
 
     const records = await readSessionHistory(userDataDir);
     expect(records).toEqual([]);
 
-    // Can still persist after corruption
+    // The corrupt bytes are preserved to a `.corrupted.<ts>` sidecar, not lost.
+    const sidecars = await quarantineSidecars(userDataDir);
+    expect(sidecars).toHaveLength(1);
+    expect(await fsp.readFile(path.join(userDataDir, sidecars[0]), "utf8")).toBe("not json at all");
+    // The original path was moved aside, so a fresh journal can be written.
+    await expect(fsp.access(filePath)).rejects.toThrow();
+
+    // Can still persist after corruption — a fresh single-record journal.
     await persistAgentSession(
       { sessionId: "recovery", agentId: "claude", worktreeId: null, title: null, projectId: null },
       userDataDir
     );
     const after = await readSessionHistory(userDataDir);
     expect(after).toHaveLength(1);
+    expect(after[0].sessionId).toBe("recovery");
+  });
+
+  it.each(["{}", "null", '{"records":[]}', '"a string"'])(
+    "quarantines a well-formed but non-array journal root: %s",
+    async (rootJson) => {
+      const filePath = getSessionHistoryPath(userDataDir)!;
+      await fsp.writeFile(filePath, rootJson);
+
+      expect(await readSessionHistory(userDataDir)).toEqual([]);
+      expect(await quarantineSidecars(userDataDir)).toHaveLength(1);
+      // Sync read path quarantines identically (the sidecar already exists, so a
+      // second read simply sees ENOENT and returns []).
+      expect(readSessionHistorySync(userDataDir)).toEqual([]);
+    }
+  );
+
+  it("returns [] for an absent journal without creating a quarantine sidecar (ENOENT)", async () => {
+    // No file written — a genuinely-empty history must never be quarantined.
+    expect(await readSessionHistory(userDataDir)).toEqual([]);
+    expect(readSessionHistorySync(userDataDir)).toEqual([]);
+    expect(await quarantineSidecars(userDataDir)).toEqual([]);
+  });
+
+  it("persistAgentSession quarantines a corrupt journal, then writes a fresh one", async () => {
+    const filePath = getSessionHistoryPath(userDataDir)!;
+    await fsp.writeFile(filePath, "}{ not json");
+
+    await persistAgentSession(
+      { sessionId: "fresh", agentId: "claude", worktreeId: "wt-1", title: null, projectId: null },
+      userDataDir
+    );
+
+    // Corrupt bytes preserved to a sidecar; the live journal holds only the new record.
+    expect(await quarantineSidecars(userDataDir)).toHaveLength(1);
+    const after = await readSessionHistory(userDataDir);
+    expect(after.map((r) => r.sessionId)).toEqual(["fresh"]);
   });
 });

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -280,6 +280,31 @@ describe("agentSessionHistory", () => {
     expect(records).toEqual([]);
   });
 
+  it("clearAgentSessions rejects an empty-string worktreeId without wiping history", async () => {
+    const filePath = getSessionHistoryPath(userDataDir)!;
+    await persistAgentSession(
+      { sessionId: "s1", agentId: "claude", worktreeId: "wt-1", title: null, projectId: null },
+      userDataDir
+    );
+    await persistAgentSession(
+      { sessionId: "s2", agentId: "gemini", worktreeId: "wt-2", title: null, projectId: null },
+      userDataDir
+    );
+    const before = await fsp.readFile(filePath, "utf8");
+
+    // An empty scope must NOT escalate to clear-all (#7880 fallback-default rule).
+    await expect(clearAgentSessions("", userDataDir)).rejects.toThrow(
+      /non-empty string or undefined/
+    );
+
+    // Both records survive, byte-for-byte.
+    expect(await fsp.readFile(filePath, "utf8")).toBe(before);
+    expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId).sort()).toEqual([
+      "s1",
+      "s2",
+    ]);
+  });
+
   it("clearAgentSessions clears only specified worktree", async () => {
     await persistAgentSession(
       { sessionId: "s1", agentId: "claude", worktreeId: "wt-1", title: null, projectId: null },

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -621,6 +621,23 @@ describe("agentSessionHistory", () => {
     expect(await quarantineSidecars(userDataDir)).toEqual([]);
   });
 
+  it.each(["sync not json", "{}", "null"])(
+    "readSessionHistorySync quarantines a corrupt/non-array journal (sync path): %s",
+    async (badContent) => {
+      // Drives the SYNC reader (readFileSync/normalizeRecords/resilientRenameSync)
+      // directly — no prior async read moves the file first.
+      const filePath = getSessionHistoryPath(userDataDir)!;
+      await fsp.writeFile(filePath, badContent);
+
+      expect(readSessionHistorySync(userDataDir)).toEqual([]);
+
+      const sidecars = await quarantineSidecars(userDataDir);
+      expect(sidecars).toHaveLength(1);
+      expect(await fsp.readFile(path.join(userDataDir, sidecars[0]), "utf8")).toBe(badContent);
+      await expect(fsp.access(filePath)).rejects.toThrow();
+    }
+  );
+
   it("persistAgentSession quarantines a corrupt journal, then writes a fresh one", async () => {
     const filePath = getSessionHistoryPath(userDataDir)!;
     await fsp.writeFile(filePath, "}{ not json");

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -157,7 +157,9 @@ describe("journalAgentSession", () => {
 
     await expect(
       journalAgentSession(makeRecord("sess-1"), { terminalId: "term-1", generation })
-    ).rejects.toThrow();
+      // Assert the specific unreadable-read abort (not just any throw): with the
+      // fix reverted, the failure would come from the atomic write, not the read.
+    ).rejects.toThrow(/could not be read/);
 
     // A failed persist must NOT emit the "recorded" signal — the reservation is
     // rescinded, not consumed, so the retry below is not gated out as a duplicate.
@@ -172,6 +174,8 @@ describe("journalAgentSession", () => {
     });
     expect(retried).toBe(true);
     expect(await readSessionHistory(userDataDir)).toHaveLength(1);
+    // Exactly one "recorded" event overall — only the successful retry emitted.
+    expect(recordedEvents).toEqual([{ sessionId: "sess-1" }]);
   });
 
   it("applies retention on the main-side write", async () => {

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -145,18 +145,23 @@ describe("journalAgentSession", () => {
     expect(await readSessionHistory(userDataDir)).toHaveLength(1);
   });
 
-  it("releases the journal reservation when the write fails, so a retry still lands", async () => {
+  it("releases the journal reservation when persistence fails, so a retry still lands", async () => {
     const ledger = getLifecycleLedger();
     const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
 
-    // Force the first write to fail: point the journal at a path where the
-    // history file location is a directory, so the atomic write rejects.
+    // Force the first persist to fail: point the journal at a directory. The
+    // read-modify-write now rejects while reading (EISDIR ⇒ unreadable), before
+    // it would ever overwrite — proving the abort path propagates the failure.
     const filePath = path.join(userDataDir, "agent-session-history.json");
     await fsp.mkdir(filePath, { recursive: true });
 
     await expect(
       journalAgentSession(makeRecord("sess-1"), { terminalId: "term-1", generation })
     ).rejects.toThrow();
+
+    // A failed persist must NOT emit the "recorded" signal — the reservation is
+    // rescinded, not consumed, so the retry below is not gated out as a duplicate.
+    expect(recordedEvents).toEqual([]);
 
     await fsp.rm(filePath, { recursive: true, force: true });
 

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -488,10 +488,19 @@ export async function clearAgentSessions(worktreeId?: string, userData?: string)
   const filePath = getSessionHistoryPath(userData);
   if (!filePath) return;
 
+  // Guard the destructive scope: ONLY an explicit `undefined` means "clear all".
+  // A provided-but-empty worktreeId is a malformed scope (e.g. from the
+  // unvalidated IPC/MCP boundary) — refuse it rather than let `!worktreeId`
+  // silently escalate a scoped clear into wiping every worktree's history
+  // (the #7880 "no silent fallback default on a destructive submit" rule).
+  if (worktreeId === "") {
+    throw new Error("clearAgentSessions: worktreeId must be a non-empty string or undefined");
+  }
+
   // Share the write queue with persistAgentSession so a clear can't interleave
   // with an in-flight persist's read-modify-write and resurrect a cleared record.
   await enqueueWrite(async () => {
-    if (!worktreeId) {
+    if (worktreeId === undefined) {
       // Clear all
       await resilientAtomicWriteFile(filePath, "[]", "utf-8", { mode: OWNER_RW_FILE_MODE });
       refreshCacheAfterWrite(filePath, []);

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -4,6 +4,8 @@ import { mkdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import {
   resilientAtomicWriteFile,
+  resilientRename,
+  resilientRenameSync,
   tightenDirPermissions,
   OWNER_RW_FILE_MODE,
   OWNER_RWX_DIR_MODE,
@@ -108,6 +110,42 @@ function evictRecords(
 }
 
 /**
+ * Thrown by {@link normalizeRecords} when a readable, well-formed JSON document
+ * has a root that is not an array (e.g. `{}` or `null`). This is proven content
+ * corruption — bytes that can never yield records — so it routes through the
+ * same quarantine path as a `JSON.parse` `SyntaxError`, and is deliberately
+ * distinct from a transient filesystem error (EACCES/EIO/EMFILE), which must
+ * never trigger quarantine or an overwrite. Mirrors `GlobalFileStore.getRecipes`
+ * throwing on a non-array root rather than silently degrading to `[]`.
+ */
+class InvalidSessionHistoryShapeError extends Error {
+  constructor() {
+    super("session history root is not an array");
+    this.name = "InvalidSessionHistoryShapeError";
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    error != null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+/**
+ * Proven corruption: a readable file whose bytes can never be valid journal
+ * content — malformed JSON (`SyntaxError`) or a well-formed non-array root. Only
+ * these are quarantined and treated as a fresh-but-empty journal. Every other
+ * read failure (EACCES/EIO/EMFILE/EBUSY/…) is transient/unknown: the file may be
+ * intact but temporarily unreadable, so it must NOT be quarantined or overwritten.
+ */
+function isCorruptionError(error: unknown): boolean {
+  return error instanceof SyntaxError || error instanceof InvalidSessionHistoryShapeError;
+}
+
+/**
  * Normalize parsed journal JSON into records, dropping the legacy `snapshot`
  * key. The exit-snapshot feature (#10850/#10855) was removed; journals written
  * while it was enabled still carry a `snapshot` tail on disk. Stripping it on
@@ -115,9 +153,14 @@ function evictRecords(
  * `agentSessionHistory.list` action, whose raw result is serialized without
  * `resultSchema` parsing — and the next `persistAgentSession`/`pruneAgentSessions`
  * rewrite purges it from disk, so the file self-heals without a versioned migration.
+ *
+ * Throws {@link InvalidSessionHistoryShapeError} on a non-array root so the
+ * caller can quarantine the corrupt file instead of silently overwriting it.
  */
 function normalizeRecords(parsed: unknown): AgentSessionRecord[] {
-  if (!Array.isArray(parsed)) return [];
+  if (!Array.isArray(parsed)) {
+    throw new InvalidSessionHistoryShapeError();
+  }
   return parsed.map((raw) => {
     if (raw && typeof raw === "object" && "snapshot" in raw) {
       const { snapshot: _snapshot, ...rest } = raw as Record<string, unknown>;
@@ -175,43 +218,141 @@ function refreshCacheAfterWrite(filePath: string, records: AgentSessionRecord[])
   }
 }
 
+/**
+ * Tri-state read outcome (per #11348 / lesson #11130 — an ambiguous read must
+ * never be treated as "safe to overwrite"):
+ * - `ok` with `records` — the journal was read (or is genuinely absent, or was
+ *   corrupt-and-successfully-quarantined). Safe to treat as ground truth.
+ * - `unreadable` — the file exists but could not be read (transient fs error,
+ *   or an unrecoverable failed quarantine). A read-modify-write MUST abort on
+ *   this rather than overwrite the still-present on-disk records with `[]`.
+ */
+type SessionHistoryReadResult =
+  { status: "ok"; records: AgentSessionRecord[] } | { status: "unreadable"; error: unknown };
+
+/**
+ * Best-effort archive of a corrupt journal to a timestamped sidecar, matching
+ * the sibling stores (`GlobalFileStore`/`ProjectFileStore`). Returns whether the
+ * rename succeeded: a FAILED quarantine must be surfaced as `unreadable` (never
+ * "empty and safe to overwrite"), so the caller preserves the corrupt bytes for
+ * a later retry instead of clobbering the file we failed to move aside.
+ */
+async function quarantineCorruptJournal(filePath: string, error: unknown): Promise<boolean> {
+  console.error("[agentSessionHistory] Corrupt session journal:", error);
+  try {
+    const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
+    await resilientRename(filePath, quarantinePath);
+    console.warn(`[agentSessionHistory] Corrupted session journal moved to ${quarantinePath}`);
+    return true;
+  } catch (renameError) {
+    console.error(
+      "[agentSessionHistory] Failed to quarantine corrupt session journal:",
+      renameError
+    );
+    return false;
+  }
+}
+
+function quarantineCorruptJournalSync(filePath: string, error: unknown): boolean {
+  console.error("[agentSessionHistory] Corrupt session journal:", error);
+  try {
+    const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
+    resilientRenameSync(filePath, quarantinePath);
+    console.warn(`[agentSessionHistory] Corrupted session journal moved to ${quarantinePath}`);
+    return true;
+  } catch (renameError) {
+    console.error(
+      "[agentSessionHistory] Failed to quarantine corrupt session journal:",
+      renameError
+    );
+    return false;
+  }
+}
+
+/**
+ * The error a read-modify-write raises when it refuses to overwrite a journal it
+ * could not read. Rejecting (rather than silently resolving) is load-bearing:
+ * `journalAgentSession` treats a resolved `persistAgentSession` as a completed
+ * write — it emits `agent-session:recorded` and consumes the lifecycle ledger's
+ * exactly-once reservation. A silent abort would fire that event and burn the
+ * reservation despite writing nothing, blocking any retry. Rejection instead
+ * rescinds the reservation and suppresses the event, so a later capture retries.
+ */
+function unreadableJournalError(error: unknown): Error {
+  return new Error(
+    "Refusing to overwrite the agent session journal: it exists but could not be read " +
+      "(transient filesystem error or unrecoverable quarantine); preserving on-disk records",
+    { cause: error }
+  );
+}
+
 // NOTE: on a cache hit these readers return the cached array BY REFERENCE (that
 // shared-instance reuse is the whole point — a copy on every read would defeat
 // the cache). Callers MUST treat the result as read-only; never sort/push/splice
 // it in place. The production caller, listAgentSessions(), is safe: evictRecords()
 // only reads the input and returns freshly-built arrays.
-export function readSessionHistorySync(userData?: string): AgentSessionRecord[] {
+function readSessionHistoryResultSync(userData?: string): SessionHistoryReadResult {
   const filePath = getSessionHistoryPath(userData);
-  if (!filePath) return [];
+  if (!filePath) return { status: "ok", records: [] };
   try {
     const s = statSync(filePath);
     const cached = readCache(filePath, s.size, s.mtimeMs);
-    if (cached) return cached;
+    if (cached) return { status: "ok", records: cached };
     const content = readFileSync(filePath, "utf8");
     const records = normalizeRecords(JSON.parse(content));
     writeCache(filePath, records, s.size, s.mtimeMs);
-    return records;
-  } catch {
+    return { status: "ok", records };
+  } catch (error) {
+    // Never let a failed read leave a `[]` cached as if it were the journal.
     historyCache.delete(filePath);
-    return [];
+    if (isMissingPathError(error)) return { status: "ok", records: [] };
+    if (isCorruptionError(error)) {
+      return quarantineCorruptJournalSync(filePath, error)
+        ? { status: "ok", records: [] }
+        : { status: "unreadable", error };
+    }
+    console.warn("[agentSessionHistory] Failed to read session journal:", error);
+    return { status: "unreadable", error };
   }
 }
 
-export async function readSessionHistory(userData?: string): Promise<AgentSessionRecord[]> {
+async function readSessionHistoryResult(userData?: string): Promise<SessionHistoryReadResult> {
   const filePath = getSessionHistoryPath(userData);
-  if (!filePath) return [];
+  if (!filePath) return { status: "ok", records: [] };
   try {
     const s = await stat(filePath);
     const cached = readCache(filePath, s.size, s.mtimeMs);
-    if (cached) return cached;
+    if (cached) return { status: "ok", records: cached };
     const content = await readFile(filePath, "utf8");
     const records = normalizeRecords(JSON.parse(content));
     writeCache(filePath, records, s.size, s.mtimeMs);
-    return records;
-  } catch {
+    return { status: "ok", records };
+  } catch (error) {
     historyCache.delete(filePath);
-    return [];
+    if (isMissingPathError(error)) return { status: "ok", records: [] };
+    if (isCorruptionError(error)) {
+      return (await quarantineCorruptJournal(filePath, error))
+        ? { status: "ok", records: [] }
+        : { status: "unreadable", error };
+    }
+    console.warn("[agentSessionHistory] Failed to read session journal:", error);
+    return { status: "unreadable", error };
   }
+}
+
+// Read-only consumers (listAgentSessions and the MCP list action) collapse an
+// unreadable journal to `[]` — a transient failure degrades the displayed list
+// for one read without touching disk. The `unreadable` outcome is never cached,
+// so the next read re-attempts the file. The read-modify-write paths use
+// readSessionHistoryResult directly and ABORT on `unreadable`.
+export function readSessionHistorySync(userData?: string): AgentSessionRecord[] {
+  const result = readSessionHistoryResultSync(userData);
+  return result.status === "ok" ? result.records : [];
+}
+
+export async function readSessionHistory(userData?: string): Promise<AgentSessionRecord[]> {
+  const result = await readSessionHistoryResult(userData);
+  return result.status === "ok" ? result.records : [];
 }
 
 export async function persistAgentSession(
@@ -230,8 +371,17 @@ export async function persistAgentSession(
     const now = Date.now();
     const fullRecord: AgentSessionRecord = { ...record, savedAt: now };
 
-    const existing = await readSessionHistory(userData);
-    const updated = evictRecords([fullRecord, ...existing], now, retentionDaysToMs(retentionDays));
+    const existing = await readSessionHistoryResult(userData);
+    if (existing.status === "unreadable") {
+      // The journal exists but couldn't be read — overwriting now would destroy
+      // the on-disk records. Abort so a later capture retries once it's readable.
+      throw unreadableJournalError(existing.error);
+    }
+    const updated = evictRecords(
+      [fullRecord, ...existing.records],
+      now,
+      retentionDaysToMs(retentionDays)
+    );
 
     await resilientAtomicWriteFile(filePath, JSON.stringify(updated, null, 2), "utf-8", {
       mode: OWNER_RW_FILE_MODE,
@@ -268,8 +418,12 @@ export async function pruneAgentSessions(
   if (!filePath) return;
 
   await enqueueWrite(async () => {
-    const existing = await readSessionHistory(userData);
-    const pruned = evictRecords(existing, Date.now(), retentionDaysToMs(retentionDays));
+    const existing = await readSessionHistoryResult(userData);
+    if (existing.status === "unreadable") {
+      // Don't prune to `[]` over a journal we couldn't read; abort and retry later.
+      throw unreadableJournalError(existing.error);
+    }
+    const pruned = evictRecords(existing.records, Date.now(), retentionDaysToMs(retentionDays));
     await resilientAtomicWriteFile(filePath, JSON.stringify(pruned, null, 2), "utf-8", {
       mode: OWNER_RW_FILE_MODE,
     });
@@ -296,9 +450,13 @@ export async function rewriteAgentSessionPathsForProject(
   if (!filePath || !projectId || !oldRoot || !newRoot || oldRoot === newRoot) return;
 
   await enqueueWrite(async () => {
-    const existing = await readSessionHistory(userData);
+    const existing = await readSessionHistoryResult(userData);
+    if (existing.status === "unreadable") {
+      // Rebasing an unreadable journal would rewrite it from `[]`; abort instead.
+      throw unreadableJournalError(existing.error);
+    }
     let changed = false;
-    const rewritten = existing.map((r) => {
+    const rewritten = existing.records.map((r) => {
       if (r.projectId !== projectId) return r;
       const nextWorktreeId =
         r.worktreeId !== null ? rebaseAbsolutePath(r.worktreeId, oldRoot, newRoot) : r.worktreeId;
@@ -329,8 +487,13 @@ export async function clearAgentSessions(worktreeId?: string, userData?: string)
       return;
     }
 
-    const existing = await readSessionHistory(userData);
-    const filtered = existing.filter((r) => r.worktreeId !== worktreeId);
+    const existing = await readSessionHistoryResult(userData);
+    if (existing.status === "unreadable") {
+      // Clearing one worktree must not wipe every other worktree's records when
+      // the read fails; abort so the untouched journal survives.
+      throw unreadableJournalError(existing.error);
+    }
+    const filtered = existing.records.filter((r) => r.worktreeId !== worktreeId);
     await resilientAtomicWriteFile(filePath, JSON.stringify(filtered, null, 2), "utf-8", {
       mode: OWNER_RW_FILE_MODE,
     });

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -245,6 +245,13 @@ async function quarantineCorruptJournal(filePath: string, error: unknown): Promi
     console.warn(`[agentSessionHistory] Corrupted session journal moved to ${quarantinePath}`);
     return true;
   } catch (renameError) {
+    if (isMissingPathError(renameError)) {
+      // The corrupt file is already gone — a concurrent read (listAgentSessions
+      // is not queued) quarantined it, or it was removed out-of-band. There's
+      // nothing left to preserve, so report success and let the caller start
+      // from a fresh empty journal rather than spuriously refusing to write.
+      return true;
+    }
     console.error(
       "[agentSessionHistory] Failed to quarantine corrupt session journal:",
       renameError
@@ -261,6 +268,10 @@ function quarantineCorruptJournalSync(filePath: string, error: unknown): boolean
     console.warn(`[agentSessionHistory] Corrupted session journal moved to ${quarantinePath}`);
     return true;
   } catch (renameError) {
+    if (isMissingPathError(renameError)) {
+      // Already quarantined/removed by a concurrent path — treat as handled.
+      return true;
+    }
     console.error(
       "[agentSessionHistory] Failed to quarantine corrupt session journal:",
       renameError


### PR DESCRIPTION
## Summary
- `readSessionHistory`/`readSessionHistorySync` used to collapse every read failure (ENOENT, EACCES/EIO/EMFILE, JSON syntax errors, wrong shape) into an empty array, and the read-modify-write writers (`persistAgentSession`, `pruneAgentSessions`, `clearAgentSessions`, `rewriteAgentSessionPathsForProject`) then atomically overwrote the journal with that empty read, silently wiping up to 50 records per worktree.
- The fix classifies reads into three outcomes: ENOENT is genuinely empty (`[]`), proven corruption (a JSON syntax error or a non-array root, now detected via a new `InvalidSessionHistoryShapeError`) quarantines the file to `<path>.corrupted.<timestamp>` before treating it as empty, and any other filesystem error is "unreadable" and now throws instead of silently overwriting, so existing records survive and the next capture retries.
- Also hardened `clearAgentSessions` so only an explicit `undefined` worktreeId clears all history; a provided empty string now rejects instead of silently escalating a scoped clear into a full wipe.

Resolves #11348

## Changes
- `electron/services/pty/agentSessionHistory.ts`: tri-state read classification, quarantine-on-corruption (matching the sibling `GlobalFileStore`/`ProjectFileStore` pattern), throw-on-unreadable in the four read-modify-write writers, and the `clearAgentSessions` empty-string guard.
- `electron/services/pty/__tests__/agentSessionHistory.adversarial.test.ts` (new): fault-injection suite for transient EACCES/EIO/EMFILE/EBUSY, corrupt/non-array quarantine (sync + async), failed quarantine, concurrent-quarantine ENOENT, clear-all-no-read, and write-queue recovery.
- `electron/services/pty/__tests__/agentSessionHistory.test.ts` and `agentSessionJournal.test.ts`: strengthened existing corrupt-JSON/ENOENT/journal coverage.

## Testing
- 65 targeted tests pass across the three test files.
- Own-file eslint and prettier clean.