### PR TITLE
fix(pty): journal agent sessions on project close/remove and scratch remove (#11340)

### DIFF
--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -47,6 +47,12 @@ vi.mock("../../../projectMenuState.js", () => ({
   refreshProjectMenuState: refreshProjectMenuStateMock,
 }));
 
+const teardownMock = vi.hoisted(() => ({
+  gracefulTeardownAndJournalProject:
+    vi.fn<(...args: unknown[]) => Promise<{ confirmed: boolean; terminalsKilled: number }>>(),
+}));
+vi.mock("../../../services/pty/projectSessionJournal.js", () => teardownMock);
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
@@ -55,6 +61,12 @@ import type { HandlerDependencies } from "../../types.js";
 describe("project:close handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: teardown confirmed with nothing to journal. Kill-branch tests
+    // override; non-kill tests never reach it.
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 0,
+    });
   });
 
   it("allows killing terminals for the active project and clears it", async () => {
@@ -65,6 +77,10 @@ describe("project:close handler", () => {
       status: "active",
     });
     projectStoreMock.clearProjectState.mockResolvedValue(undefined);
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 2,
+    });
 
     const ptyClient = {
       getProjectStats: vi.fn(async () => ({
@@ -72,7 +88,6 @@ describe("project:close handler", () => {
         processIds: [111, 222],
         terminalTypes: { terminal: 2 },
       })),
-      killByProject: vi.fn(async () => 2),
       onProjectSwitch: vi.fn(),
       setActiveProject: vi.fn(),
     };
@@ -103,7 +118,13 @@ describe("project:close handler", () => {
 
     expect(result.terminalsKilled).toBe(2);
     expect(result.processesKilled).toBe(2);
-    expect(ptyClient.killByProject).toHaveBeenCalledWith("project-active");
+    // The destructive close routes through graceful capture + journaling, not a
+    // bare kill (#11340).
+    expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalledWith(
+      "project-active",
+      ptyClient,
+      undefined
+    );
     expect(projectStoreMock.clearProjectState).toHaveBeenCalledWith("project-active");
     expect(projectStoreMock.clearCurrentProject).toHaveBeenCalled();
     expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-active", "closed");
@@ -218,7 +239,7 @@ describe("project:close handler", () => {
       await expect(
         handler(EVENT, "project-second-window", { killTerminals: false })
       ).rejects.toThrow("open in a window");
-      expect(ptyClient.killByProject).not.toHaveBeenCalled();
+      expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
       expect(projectStoreMock.clearProjectState).not.toHaveBeenCalled();
     });
 
@@ -318,14 +339,14 @@ describe("project:close handler", () => {
           processIds: [1],
           terminalTypes: { terminal: 1 },
         })),
-        // ...but another window switches away while the kill is in flight.
-        killByProject: vi.fn(async () => {
-          pointer = "project-other";
-          return 1;
-        }),
         onProjectSwitch: vi.fn(),
         setActiveProject: vi.fn(),
       };
+      // ...but another window switches away while the teardown is in flight.
+      teardownMock.gracefulTeardownAndJournalProject.mockImplementation(async () => {
+        pointer = "project-other";
+        return { confirmed: true, terminalsKilled: 1 };
+      });
 
       const deps = {
         mainWindow: {} as unknown,
@@ -360,10 +381,44 @@ describe("project:close handler", () => {
       const handler = getCloseHandler(deps);
       await handler(EVENT, "project-second-window", { killTerminals: true });
 
-      expect(ptyClient.killByProject).toHaveBeenCalledWith("project-second-window");
+      expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalledWith(
+        "project-second-window",
+        ptyClient,
+        undefined
+      );
       // The DB pointer names a different project, so it must NOT be cleared —
       // that bookkeeping tracks the pointer, not visibility.
       expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
+    });
+
+    it("fails closed on an unconfirmed teardown: keeps state and rejects", async () => {
+      // killTerminals is destructive, but a live host that can't confirm the
+      // kills must not have its restoration state wiped out from under still-
+      // running agents (#11340).
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-active",
+        name: "Active Project",
+        status: "active",
+        path: "/test/project-active",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+      teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+        confirmed: false,
+        terminalsKilled: 0,
+      });
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient: makePtyClient(),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+
+      await expect(handler(EVENT, "project-active", { killTerminals: true })).rejects.toThrow();
+
+      expect(projectStoreMock.clearProjectState).not.toHaveBeenCalled();
+      expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
   });
 
@@ -436,7 +491,6 @@ describe("project:close handler", () => {
         processIds: [444],
         terminalTypes: { terminal: 1 },
       })),
-      killByProject: vi.fn(async () => 1),
       onProjectSwitch: vi.fn(),
       setActiveProject: vi.fn(),
     };
@@ -469,6 +523,13 @@ describe("project:close handler", () => {
       killTerminals: true,
     });
 
+    // The teardown ran with the project's WorkspaceClient for branch lookups,
+    // but backgrounding (pauseProject) is exclusive to the non-kill path.
+    expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalledWith(
+      "project-active",
+      ptyClient,
+      worktreeService
+    );
     expect(worktreeService.pauseProject).not.toHaveBeenCalled();
   });
 

--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -420,6 +420,34 @@ describe("project:close handler", () => {
       expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
+
+    it("fails closed when the teardown throws unexpectedly: keeps state and rejects", async () => {
+      // The old handler had no way to reject on a kill failure; the new one must
+      // not clear state when the teardown helper throws (#11340).
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-active",
+        name: "Active Project",
+        status: "active",
+        path: "/test/project-active",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+      teardownMock.gracefulTeardownAndJournalProject.mockRejectedValue(
+        new Error("pty-host RPC exploded")
+      );
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient: makePtyClient(),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+
+      await expect(handler(EVENT, "project-active", { killTerminals: true })).rejects.toThrow();
+
+      expect(projectStoreMock.clearProjectState).not.toHaveBeenCalled();
+      expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
   });
 
   it("backgrounds a non-active project and calls pauseProject", async () => {

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -49,6 +49,12 @@ vi.mock("../../../projectMenuState.js", () => ({
   refreshProjectMenuState: refreshProjectMenuStateMock,
 }));
 
+const teardownMock = vi.hoisted(() => ({
+  gracefulTeardownAndJournalProject:
+    vi.fn<(...args: unknown[]) => Promise<{ confirmed: boolean; terminalsKilled: number }>>(),
+}));
+vi.mock("../../../services/pty/projectSessionJournal.js", () => teardownMock);
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
@@ -66,13 +72,20 @@ describe("project:remove handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 0,
+    });
   });
 
-  it("kills terminals before removing the project", async () => {
+  it("gracefully tears down and journals terminals before removing the project", async () => {
     projectStoreMock.removeProject.mockResolvedValue(undefined);
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 3,
+    });
 
     const ptyClient = {
-      killByProject: vi.fn(async () => 3),
       getProjectStats: vi.fn(),
       onProjectSwitch: vi.fn(),
       setActiveProject: vi.fn(),
@@ -88,24 +101,32 @@ describe("project:remove handler", () => {
 
     await handler(fakeEvent, "proj-1");
 
-    expect(ptyClient.killByProject).toHaveBeenCalledWith("proj-1");
+    // Journaling (not a bare kill) must run, and before the row is deleted (#11340).
+    expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalledWith(
+      "proj-1",
+      ptyClient,
+      undefined
+    );
     expect(projectStoreMock.removeProject).toHaveBeenCalledWith("proj-1");
 
-    const killOrder = ptyClient.killByProject.mock.invocationCallOrder[0];
-    const removeOrder = projectStoreMock.removeProject.mock.invocationCallOrder[0];
+    const killOrder = teardownMock.gracefulTeardownAndJournalProject.mock.invocationCallOrder[0]!;
+    const removeOrder = projectStoreMock.removeProject.mock.invocationCallOrder[0]!;
     expect(killOrder).toBeLessThan(removeOrder);
 
     // The row is gone, so a window still bound to it has no project open (#11136).
     expect(refreshProjectMenuStateMock).toHaveBeenCalled();
   });
 
-  it("still removes the project when killByProject fails", async () => {
+  it("fails closed: does NOT remove the project when the teardown is unconfirmed", async () => {
     projectStoreMock.removeProject.mockResolvedValue(undefined);
+    // Live host, kill unacknowledged — removing the row would orphan the still-
+    // running agents (#11340).
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: false,
+      terminalsKilled: 0,
+    });
 
     const ptyClient = {
-      killByProject: vi.fn(async () => {
-        throw new Error("PTY host disconnected");
-      }),
       getProjectStats: vi.fn(),
       onProjectSwitch: vi.fn(),
       setActiveProject: vi.fn(),
@@ -119,10 +140,37 @@ describe("project:remove handler", () => {
     registerProjectCrudHandlers(deps);
     const handler = getHandler(CHANNELS.PROJECT_REMOVE);
 
-    await handler(fakeEvent, "proj-2");
+    await expect(handler(fakeEvent, "proj-2")).rejects.toThrow();
 
-    expect(ptyClient.killByProject).toHaveBeenCalledWith("proj-2");
-    expect(projectStoreMock.removeProject).toHaveBeenCalledWith("proj-2");
+    expect(projectStoreMock.removeProject).not.toHaveBeenCalled();
+    expect(windowStateMock.pruneWindowStateForPath).not.toHaveBeenCalled();
+    expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+
+  it("removes the project when the host is confirmed gone (nothing to journal)", async () => {
+    projectStoreMock.removeProject.mockResolvedValue(undefined);
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 0,
+    });
+
+    const ptyClient = {
+      getProjectStats: vi.fn(),
+      onProjectSwitch: vi.fn(),
+      setActiveProject: vi.fn(),
+    };
+
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+    const handler = getHandler(CHANNELS.PROJECT_REMOVE);
+
+    await handler(fakeEvent, "proj-gone");
+
+    expect(projectStoreMock.removeProject).toHaveBeenCalledWith("proj-gone");
   });
 
   it("removes the project when no ptyClient is provided", async () => {
@@ -190,7 +238,6 @@ describe("project:remove handler", () => {
 
   it("throws on invalid projectId without calling cleanup or removal", async () => {
     const ptyClient = {
-      killByProject: vi.fn(async () => 0),
       getProjectStats: vi.fn(),
       onProjectSwitch: vi.fn(),
       setActiveProject: vi.fn(),
@@ -205,7 +252,7 @@ describe("project:remove handler", () => {
     const handler = getHandler(CHANNELS.PROJECT_REMOVE);
 
     await expect(handler(fakeEvent, "")).rejects.toThrow("Invalid project ID");
-    expect(ptyClient.killByProject).not.toHaveBeenCalled();
+    expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
     expect(projectStoreMock.removeProject).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -147,6 +147,35 @@ describe("project:remove handler", () => {
     expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
   });
 
+  it("fails closed when the teardown throws: the old swallow-and-remove is gone", async () => {
+    projectStoreMock.removeProject.mockResolvedValue(undefined);
+    // Pre-fix this handler caught the kill rejection and removed anyway; it must
+    // now propagate and keep the project (#11340).
+    teardownMock.gracefulTeardownAndJournalProject.mockRejectedValue(
+      new Error("PTY host disconnected")
+    );
+
+    const ptyClient = {
+      getProjectStats: vi.fn(),
+      onProjectSwitch: vi.fn(),
+      setActiveProject: vi.fn(),
+    };
+
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+    const handler = getHandler(CHANNELS.PROJECT_REMOVE);
+
+    await expect(handler(fakeEvent, "proj-throw")).rejects.toThrow();
+
+    expect(projectStoreMock.removeProject).not.toHaveBeenCalled();
+    expect(windowStateMock.pruneWindowStateForPath).not.toHaveBeenCalled();
+    expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+  });
+
   it("removes the project when the host is confirmed gone (nothing to journal)", async () => {
     projectStoreMock.removeProject.mockResolvedValue(undefined);
     teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -16,6 +16,15 @@ import type { Project } from "../../../types/index.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
 import { pruneWindowStateForPath } from "../../../windowState.js";
+import { gracefulTeardownAndJournalProject } from "../../../services/pty/projectSessionJournal.js";
+
+/**
+ * Rejection copy for a destructive teardown (close+kill / remove) the pty-host
+ * couldn't confirm. We deliberately keep the project's restoration state rather
+ * than wipe it out from under still-running agents (#11340).
+ */
+const UNCONFIRMED_TEARDOWN_MESSAGE =
+  "Couldn't confirm the project's terminals stopped, so its state was kept. Try again.";
 
 /**
  * Rejection copy for a close attempt against a project that is on-screen in
@@ -92,9 +101,22 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     const removedPath = projectStore.getProjectById(projectId)?.path ?? null;
 
     if (deps.ptyClient) {
-      await deps.ptyClient.killByProject(projectId).catch((err: unknown) => {
-        console.error(`[IPC] project:remove: Failed to kill terminals for ${projectId}:`, err);
-      });
+      // Gracefully tear down and journal each agent session before the row (and
+      // its restoration state) is permanently deleted. Fail closed: if the host
+      // can't confirm the kills, keep the project so its still-running agents
+      // aren't orphaned by a deleted row (#11340).
+      const { confirmed } = await gracefulTeardownAndJournalProject(
+        projectId,
+        deps.ptyClient,
+        deps.worktreeService
+      );
+      if (!confirmed) {
+        throw new AppError({
+          code: "INTERNAL",
+          message: UNCONFIRMED_TEARDOWN_MESSAGE,
+          context: { projectId },
+        });
+      }
     }
 
     await projectStore.removeProject(projectId);
@@ -196,10 +218,23 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
 
     try {
-      const ptyStats = await deps.ptyClient!.getProjectStats(projectId);
-
       if (killTerminals) {
-        const terminalsKilled = await deps.ptyClient!.killByProject(projectId);
+        // Gracefully tear down and journal each agent session before wiping the
+        // project's restoration state, so agent conversations stay resumable
+        // from the picker. Fail closed: if the host can't confirm the kills,
+        // keep the state rather than orphan still-running agents (#11340).
+        const { confirmed, terminalsKilled } = await gracefulTeardownAndJournalProject(
+          projectId,
+          deps.ptyClient!,
+          deps.worktreeService
+        );
+        if (!confirmed) {
+          throw new AppError({
+            code: "INTERNAL",
+            message: UNCONFIRMED_TEARDOWN_MESSAGE,
+            context: { projectId },
+          });
+        }
 
         await projectStore.clearProjectState(projectId);
 
@@ -228,6 +263,8 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
           terminalsKilled,
         };
       } else {
+        const ptyStats = await deps.ptyClient!.getProjectStats(projectId);
+
         // Re-check after the awaited stats call: the user can bring the project
         // on-screen in any window while it's in flight, and backgrounding it +
         // pausing its workspace host would then hit a visible project. Thrown as

--- a/electron/ipc/handlers/scratch/__tests__/remove.test.ts
+++ b/electron/ipc/handlers/scratch/__tests__/remove.test.ts
@@ -43,6 +43,12 @@ vi.mock("../../../utils.js", async (importOriginal) => {
   return { ...actual, broadcastToRenderer: broadcastMock.broadcastToRenderer };
 });
 
+const teardownMock = vi.hoisted(() => ({
+  gracefulTeardownAndJournalProject:
+    vi.fn<(...args: unknown[]) => Promise<{ confirmed: boolean; terminalsKilled: number }>>(),
+}));
+vi.mock("../../../../services/pty/projectSessionJournal.js", () => teardownMock);
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../../channels.js";
 import { registerScratchHandlers } from "../index.js";
@@ -67,39 +73,65 @@ describe("scratch:remove handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     scratchStoreMock.removeScratch.mockResolvedValue(undefined);
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 0,
+    });
   });
 
-  it("kills the scratch's terminals before deleting it", async () => {
-    const ptyClient = { killByProject: vi.fn(async () => 2) };
+  it("gracefully tears down and journals the scratch's terminals before deleting it", async () => {
+    const ptyClient = {};
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 2,
+    });
     registerScratchHandlers(makeDeps(ptyClient));
 
     await getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-1");
 
-    expect(ptyClient.killByProject).toHaveBeenCalledWith("scratch-1");
+    // Journaling (not a bare kill) runs, and before the folder is deleted (#11340).
+    expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalledWith(
+      "scratch-1",
+      ptyClient,
+      undefined
+    );
     expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-1");
 
-    // Killing after deletion would race the folder removal against live PTYs.
-    const killOrder = ptyClient.killByProject.mock.invocationCallOrder[0];
-    const removeOrder = scratchStoreMock.removeScratch.mock.invocationCallOrder[0];
+    const killOrder = teardownMock.gracefulTeardownAndJournalProject.mock.invocationCallOrder[0]!;
+    const removeOrder = scratchStoreMock.removeScratch.mock.invocationCallOrder[0]!;
     expect(killOrder).toBeLessThan(removeOrder);
   });
 
-  it("still deletes the scratch and notifies renderers when the kill fails", async () => {
-    const ptyClient = {
-      killByProject: vi.fn(async () => {
-        throw new Error("PTY host disconnected");
-      }),
-    };
-    registerScratchHandlers(makeDeps(ptyClient));
+  it("fails closed: keeps the scratch when the teardown is unconfirmed", async () => {
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: false,
+      terminalsKilled: 0,
+    });
+    registerScratchHandlers(makeDeps({}));
 
-    await expect(
-      getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-2")
-    ).resolves.toBeUndefined();
+    await expect(getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-2")).rejects.toThrow();
 
-    expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-2");
-    expect(broadcastMock.broadcastToRenderer).toHaveBeenCalledWith(
+    // Deleting the folder now would orphan the still-running agents (#11340).
+    expect(scratchStoreMock.removeScratch).not.toHaveBeenCalled();
+    expect(broadcastMock.broadcastToRenderer).not.toHaveBeenCalledWith(
       CHANNELS.SCRATCH_REMOVED,
       "scratch-2"
+    );
+  });
+
+  it("deletes the scratch when the host is confirmed gone (nothing to journal)", async () => {
+    teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
+      confirmed: true,
+      terminalsKilled: 0,
+    });
+    registerScratchHandlers(makeDeps({}));
+
+    await getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-gone");
+
+    expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-gone");
+    expect(broadcastMock.broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.SCRATCH_REMOVED,
+      "scratch-gone"
     );
   });
 
@@ -108,16 +140,16 @@ describe("scratch:remove handler", () => {
 
     await getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-3");
 
+    expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
     expect(scratchStoreMock.removeScratch).toHaveBeenCalledWith("scratch-3");
   });
 
   it("rejects a blank scratch id without touching the store", async () => {
-    const ptyClient = { killByProject: vi.fn(async () => 0) };
-    registerScratchHandlers(makeDeps(ptyClient));
+    registerScratchHandlers(makeDeps({}));
 
     await expect(getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "")).rejects.toThrow();
 
-    expect(ptyClient.killByProject).not.toHaveBeenCalled();
+    expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
     expect(scratchStoreMock.removeScratch).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/scratch/__tests__/remove.test.ts
+++ b/electron/ipc/handlers/scratch/__tests__/remove.test.ts
@@ -119,6 +119,22 @@ describe("scratch:remove handler", () => {
     );
   });
 
+  it("fails closed when the teardown throws: the old swallow-and-delete is gone", async () => {
+    // Pre-fix this handler caught the kill rejection and deleted anyway.
+    teardownMock.gracefulTeardownAndJournalProject.mockRejectedValue(
+      new Error("PTY host disconnected")
+    );
+    registerScratchHandlers(makeDeps({}));
+
+    await expect(getHandler(CHANNELS.SCRATCH_REMOVE)(fakeEvent, "scratch-throw")).rejects.toThrow();
+
+    expect(scratchStoreMock.removeScratch).not.toHaveBeenCalled();
+    expect(broadcastMock.broadcastToRenderer).not.toHaveBeenCalledWith(
+      CHANNELS.SCRATCH_REMOVED,
+      "scratch-throw"
+    );
+  });
+
   it("deletes the scratch when the host is confirmed gone (nothing to journal)", async () => {
     teardownMock.gracefulTeardownAndJournalProject.mockResolvedValue({
       confirmed: true,

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -21,6 +21,7 @@ import { scratchStore } from "../../../services/ScratchStore.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import { addProjectByPath } from "../projectCrud/crud.js";
+import { gracefulTeardownAndJournalProject } from "../../../services/pty/projectSessionJournal.js";
 import { createHardenedGit } from "../../../utils/hardenedGit.js";
 import { logError } from "../../../utils/logger.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -65,9 +66,20 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
         }
 
         if (deps.ptyClient) {
-          await deps.ptyClient.killByProject(scratchId).catch((err: unknown) => {
-            console.error(`[IPC] scratch:remove: Failed to kill terminals for ${scratchId}:`, err);
-          });
+          // Gracefully tear down and journal each agent session before the
+          // scratch folder is deleted, so agent conversations stay resumable.
+          // Fail closed: if the host can't confirm the kills, keep the scratch
+          // rather than orphan still-running agents (#11340).
+          const { confirmed } = await gracefulTeardownAndJournalProject(
+            scratchId,
+            deps.ptyClient,
+            deps.worktreeService
+          );
+          if (!confirmed) {
+            throw new Error(
+              "Couldn't confirm the scratch's terminals stopped, so it was kept. Try again."
+            );
+          }
         }
 
         await scratchStore.removeScratch(scratchId);

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -151,6 +151,18 @@ interface TerminalInfoResponse {
   capabilityAgentId?: BuiltInAgentId;
 }
 
+/**
+ * Result of {@link PtyClient.gracefulKillByProjectConfirmed}. `confirmed` is
+ * false only when a live host timed out without acknowledging the kill — the
+ * caller must NOT clear restoration state in that case, or still-running agents
+ * are orphaned. On the confirmed path `sessions` holds one entry per terminal
+ * (agentSessionId null for non-agents / unresumable terminals).
+ */
+export interface GracefulKillByProjectOutcome {
+  confirmed: boolean;
+  sessions: Array<{ id: string; agentSessionId: string | null }>;
+}
+
 export interface PtyClientConfig {
   /** Health check interval in milliseconds */
   healthCheckIntervalMs?: number;
@@ -1762,25 +1774,61 @@ export class PtyClient extends EventEmitter {
     return result.sessionId;
   }
 
+  /**
+   * Graceful project kill that reports whether the host actually confirmed the
+   * teardown, so destructive callers (project close+kill, project/scratch
+   * remove) can fail closed instead of wiping restoration state on a guess.
+   *
+   * Mirrors the single-terminal {@link gracefulKill} triage: a typed
+   * BrokerError of HOST_EXITED/APP_SHUTDOWN (or a locally-observed dead/disposed
+   * client) means the host is gone and teardown is real — confirmed, just with
+   * no sessions to capture. A per-request TIMEOUT with a live host means the
+   * teardown is NOT confirmed: agents may still be running, so the caller must
+   * keep the project's restoration state and let the user retry. Unexpected
+   * errors reject; callers treat that as fail-closed too.
+   */
+  async gracefulKillByProjectConfirmed(
+    projectId: string,
+    options?: { preserveSession?: boolean }
+  ): Promise<GracefulKillByProjectOutcome> {
+    const shard = this.shardForProjectQuery(projectId);
+    try {
+      const sessions = await sendPtyHostRpc<Array<{ id: string; agentSessionId: string | null }>>(
+        shard,
+        `graceful-kill-by-project-${projectId}`,
+        (requestId) => ({
+          type: "graceful-kill-by-project",
+          projectId,
+          requestId,
+          ...(options?.preserveSession !== undefined
+            ? { preserveSession: options.preserveSession }
+            : {}),
+        }),
+        { method: "graceful-kill-by-project", timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"] }
+      );
+      return { confirmed: true, sessions };
+    } catch (error) {
+      const isHostGoneBrokerError = error instanceof BrokerError && error.code !== "TIMEOUT";
+      if (isHostGoneBrokerError || !shard.lifecycle.child || this.isDisposed) {
+        // Host is gone: its terminals are gone with it. Teardown is confirmed;
+        // no sessions were capturable.
+        return { confirmed: true, sessions: [] };
+      }
+      if (error instanceof BrokerError && error.code === "TIMEOUT") {
+        // Live host, per-request timeout — the kill was not acknowledged.
+        return { confirmed: false, sessions: [] };
+      }
+      throw error;
+    }
+  }
+
   async gracefulKillByProject(
     projectId: string,
     options?: { preserveSession?: boolean }
   ): Promise<Array<{ id: string; agentSessionId: string | null }>> {
-    const shard = this.shardForProjectQuery(projectId);
-    const promise = sendPtyHostRpc<Array<{ id: string; agentSessionId: string | null }>>(
-      shard,
-      `graceful-kill-by-project-${projectId}`,
-      (requestId) => ({
-        type: "graceful-kill-by-project",
-        projectId,
-        requestId,
-        ...(options?.preserveSession !== undefined
-          ? { preserveSession: options.preserveSession }
-          : {}),
-      }),
-      { method: "graceful-kill-by-project", timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"] }
-    );
-    return promise.catch(() => []);
+    return this.gracefulKillByProjectConfirmed(projectId, options)
+      .then((outcome) => outcome.sessions)
+      .catch(() => []);
   }
 
   async killByProject(projectId: string): Promise<number> {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1786,6 +1786,14 @@ export class PtyClient extends EventEmitter {
    * teardown is NOT confirmed: agents may still be running, so the caller must
    * keep the project's restoration state and let the user retry. Unexpected
    * errors reject; callers treat that as fail-closed too.
+   *
+   * Contract of `confirmed: true`: the host acknowledged and ran the teardown
+   * (graceful shutdown + a fallback hard kill per terminal, see
+   * PtyManager.gracefulKillByProject), or the host is gone. It is NOT a
+   * guarantee that every OS process was reaped, and it does not reconcile with
+   * pty-host crash recovery, which can replay an in-flight `pendingSpawns`
+   * terminal as a fresh incarnation after a host exit — that race is owned by
+   * the crash-recovery path (#11339), not this method.
    */
   async gracefulKillByProjectConfirmed(
     projectId: string,

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -413,6 +413,57 @@ describe("PtyClient adversarial", () => {
     });
   });
 
+  it("GRACEFUL_KILL_BY_PROJECT_CONFIRMED_RESOLVES_CONFIRMED_WITH_SESSIONS", async () => {
+    const client = createReadyClient();
+
+    const promise = client.gracefulKillByProjectConfirmed("proj-a");
+    const request = mockChild.postMessage.mock.calls
+      .map((call: unknown[]) => call[0] as { type?: string; requestId?: string })
+      .find((msg) => msg?.type === "graceful-kill-by-project");
+    expect(request?.requestId).toBeTruthy();
+
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-result",
+      requestId: request!.requestId,
+      results: [{ id: "t1", agentSessionId: "sess-1" }],
+    });
+
+    await expect(promise).resolves.toEqual({
+      confirmed: true,
+      sessions: [{ id: "t1", agentSessionId: "sess-1" }],
+    });
+  });
+
+  it("GRACEFUL_KILL_BY_PROJECT_CONFIRMED_REPORTS_UNCONFIRMED_ON_LIVE_HOST_TIMEOUT", async () => {
+    const client = createReadyClient();
+
+    const promise = client.gracefulKillByProjectConfirmed("proj-a");
+    // A per-request timeout while the host is still alive: teardown was NOT
+    // acknowledged, so callers must fail closed. Unlike single-terminal
+    // gracefulKill, this path does not force a fallback kill.
+    await vi.advanceTimersByTimeAsync(11000);
+
+    await expect(promise).resolves.toEqual({ confirmed: false, sessions: [] });
+    const killByProjectCall = mockChild.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "kill-by-project"
+    );
+    expect(killByProjectCall).toBeUndefined();
+  });
+
+  it("GRACEFUL_KILL_BY_PROJECT_CONFIRMED_TREATS_HOST_EXIT_AS_CONFIRMED", async () => {
+    const client = createReadyClient();
+    // A fresh child for the restart so the exited emitter isn't reused.
+    shared.forkMock.mockReturnValue(createMockChild());
+
+    const promise = client.gracefulKillByProjectConfirmed("proj-a");
+    // Host dies before acking → the broker clears pending requests with a
+    // BrokerError("HOST_EXITED"). The terminals died with the host, so teardown
+    // is confirmed even though no sessions were capturable.
+    mockChild.emit("exit", 1);
+
+    await expect(promise).resolves.toEqual({ confirmed: true, sessions: [] });
+  });
+
   it("HOST_RESTART_CLEARS_MIGRATED_REQUESTS_TO_SENTINELS", async () => {
     const client = createReadyClient();
 

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -145,6 +145,31 @@ describe("journalAgentSession", () => {
     expect(await readSessionHistory(userDataDir)).toHaveLength(1);
   });
 
+  it("null generation journals fail-open and never reserves a respawned slot (#11340)", async () => {
+    const ledger = getLifecycleLedger();
+    // The same terminal id has respawned; the current generation belongs to the
+    // successor incarnation. (Simulates an evicted predecessor whose captured
+    // generation was frozen as null by a project-teardown journal.)
+    const successorGen = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    // Journaling the predecessor's session with an explicit null must NOT gate
+    // on the successor's current generation...
+    expect(
+      await journalAgentSession(makeRecord("sess-old"), { terminalId: "term-1", generation: null })
+    ).toBe(true);
+
+    // ...so the successor's own record at its real generation still lands. With
+    // the old `?? currentGeneration` fallback the predecessor would have
+    // consumed this slot and this write would be dropped.
+    expect(
+      await journalAgentSession(makeRecord("sess-new"), {
+        terminalId: "term-1",
+        generation: successorGen,
+      })
+    ).toBe(true);
+    expect(await readSessionHistory(userDataDir)).toHaveLength(2);
+  });
+
   it("releases the journal reservation when persistence fails, so a retry still lands", async () => {
     const ledger = getLifecycleLedger();
     const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });

--- a/electron/services/pty/__tests__/projectSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/projectSessionJournal.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const journalMock = vi.hoisted(() => ({
+  journalAgentSession: vi.fn<(...args: unknown[]) => Promise<boolean>>(),
+}));
+vi.mock("../agentSessionJournal.js", () => journalMock);
+
+const ledgerMock = vi.hoisted(() => ({
+  currentGeneration: vi.fn<(id: string) => number | undefined>(),
+}));
+vi.mock("../lifecycleLedger.js", () => ({
+  getLifecycleLedger: () => ledgerMock,
+}));
+
+import { gracefulTeardownAndJournalProject } from "../projectSessionJournal.js";
+import type { PtyClient } from "../../PtyClient.js";
+import type { WorkspaceClient } from "../../WorkspaceClient.js";
+
+interface FakeTerminal {
+  id: string;
+  projectId?: string;
+  launchAgentId?: string;
+  worktreeId?: string;
+  title?: string;
+  titleMode?: string;
+  lastObservedTitle?: string;
+  cwd: string;
+  agentLaunchFlags?: string[];
+  agentModelId?: string;
+  spawnedAt: number;
+}
+
+function makePtyClient(config: {
+  terminals?: FakeTerminal[] | (() => Promise<FakeTerminal[]>);
+  outcome: { confirmed: boolean; sessions: Array<{ id: string; agentSessionId: string | null }> };
+}): { client: PtyClient; gracefulKillByProjectConfirmed: ReturnType<typeof vi.fn> } {
+  const gracefulKillByProjectConfirmed = vi.fn(async () => config.outcome);
+  const getAllTerminalsAsync = vi.fn(async () =>
+    typeof config.terminals === "function" ? await config.terminals() : (config.terminals ?? [])
+  );
+  const client = {
+    getAllTerminalsAsync,
+    gracefulKillByProjectConfirmed,
+  } as unknown as PtyClient;
+  return { client, gracefulKillByProjectConfirmed };
+}
+
+function makeWorkspaceClient(branchByWorktree: Record<string, string | null>): WorkspaceClient {
+  return {
+    getMonitorAsync: vi.fn(async (wid: string) => {
+      const branch = branchByWorktree[wid];
+      return branch === undefined ? null : { branch };
+    }),
+  } as unknown as WorkspaceClient;
+}
+
+describe("gracefulTeardownAndJournalProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    journalMock.journalAgentSession.mockResolvedValue(true);
+    ledgerMock.currentGeneration.mockReturnValue(undefined);
+  });
+
+  it("journals only in-scope agent terminals with a captured session", async () => {
+    const { client } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+        // non-agent: no launchAgentId
+        { id: "t2", projectId: "proj", cwd: "/b", spawnedAt: 1 },
+        // other project: filtered out at snapshot
+        { id: "t3", projectId: "other", launchAgentId: "claude", cwd: "/c", spawnedAt: 1 },
+      ],
+      outcome: {
+        confirmed: true,
+        sessions: [
+          { id: "t1", agentSessionId: "s1" },
+          { id: "t2", agentSessionId: null },
+          { id: "t3", agentSessionId: "s3" },
+        ],
+      },
+    });
+
+    const result = await gracefulTeardownAndJournalProject("proj", client);
+
+    expect(result).toEqual({ confirmed: true, terminalsKilled: 3 });
+    expect(journalMock.journalAgentSession).toHaveBeenCalledTimes(1);
+    const [record, ctx] = journalMock.journalAgentSession.mock.calls[0]!;
+    expect(record).toMatchObject({ sessionId: "s1", agentId: "claude", projectId: "proj" });
+    expect(ctx).toMatchObject({ terminalId: "t1" });
+  });
+
+  it("freezes each terminal's generation before the kill and passes it to the journal", async () => {
+    ledgerMock.currentGeneration.mockReturnValue(7);
+    const { client, gracefulKillByProjectConfirmed } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+      ],
+      outcome: { confirmed: true, sessions: [{ id: "t1", agentSessionId: "s1" }] },
+    });
+
+    await gracefulTeardownAndJournalProject("proj", client);
+
+    const genOrder = ledgerMock.currentGeneration.mock.invocationCallOrder[0]!;
+    const killOrder = gracefulKillByProjectConfirmed.mock.invocationCallOrder[0]!;
+    expect(genOrder).toBeLessThan(killOrder);
+
+    const [, ctx] = journalMock.journalAgentSession.mock.calls[0]!;
+    expect(ctx).toEqual({ terminalId: "t1", generation: 7 });
+  });
+
+  it("prefers the observed title unless a user title lock is set", async () => {
+    const { client } = makePtyClient({
+      terminals: [
+        {
+          id: "t1",
+          projectId: "proj",
+          launchAgentId: "claude",
+          title: "typed",
+          lastObservedTitle: "observed",
+          titleMode: "auto",
+          cwd: "/a",
+          spawnedAt: 1,
+        },
+        {
+          id: "t2",
+          projectId: "proj",
+          launchAgentId: "claude",
+          title: "locked",
+          lastObservedTitle: "observed2",
+          titleMode: "user",
+          cwd: "/b",
+          spawnedAt: 1,
+        },
+      ],
+      outcome: {
+        confirmed: true,
+        sessions: [
+          { id: "t1", agentSessionId: "s1" },
+          { id: "t2", agentSessionId: "s2" },
+        ],
+      },
+    });
+
+    await gracefulTeardownAndJournalProject("proj", client);
+
+    const byId = new Map(
+      journalMock.journalAgentSession.mock.calls.map((c) => [
+        (c[0] as { sessionId: string }).sessionId,
+        c[0] as { title: string | null },
+      ])
+    );
+    expect(byId.get("s1")?.title).toBe("observed");
+    expect(byId.get("s2")?.title).toBe("locked");
+  });
+
+  it("resolves a worktree branch and ignores HEAD", async () => {
+    const { client } = makePtyClient({
+      terminals: [
+        {
+          id: "t1",
+          projectId: "proj",
+          launchAgentId: "claude",
+          worktreeId: "w1",
+          cwd: "/a",
+          spawnedAt: 1,
+        },
+        {
+          id: "t2",
+          projectId: "proj",
+          launchAgentId: "claude",
+          worktreeId: "w2",
+          cwd: "/b",
+          spawnedAt: 1,
+        },
+      ],
+      outcome: {
+        confirmed: true,
+        sessions: [
+          { id: "t1", agentSessionId: "s1" },
+          { id: "t2", agentSessionId: "s2" },
+        ],
+      },
+    });
+    const workspaceClient = makeWorkspaceClient({ w1: "feature/x", w2: "HEAD" });
+
+    await gracefulTeardownAndJournalProject("proj", client, workspaceClient);
+
+    const byId = new Map(
+      journalMock.journalAgentSession.mock.calls.map((c) => [
+        (c[0] as { sessionId: string }).sessionId,
+        c[0] as { branch?: string },
+      ])
+    );
+    expect(byId.get("s1")?.branch).toBe("feature/x");
+    expect(byId.get("s2")?.branch).toBeUndefined();
+  });
+
+  it("isolates a per-record journal failure so the rest still journal", async () => {
+    journalMock.journalAgentSession
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValue(true);
+    const { client } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+        { id: "t2", projectId: "proj", launchAgentId: "claude", cwd: "/b", spawnedAt: 1 },
+      ],
+      outcome: {
+        confirmed: true,
+        sessions: [
+          { id: "t1", agentSessionId: "s1" },
+          { id: "t2", agentSessionId: "s2" },
+        ],
+      },
+    });
+
+    await expect(gracefulTeardownAndJournalProject("proj", client)).resolves.toEqual({
+      confirmed: true,
+      terminalsKilled: 2,
+    });
+    expect(journalMock.journalAgentSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes an unconfirmed outcome through without journaling", async () => {
+    const { client } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+      ],
+      outcome: { confirmed: false, sessions: [] },
+    });
+
+    const result = await gracefulTeardownAndJournalProject("proj", client);
+
+    expect(result).toEqual({ confirmed: false, terminalsKilled: 0 });
+    expect(journalMock.journalAgentSession).not.toHaveBeenCalled();
+  });
+
+  it("returns confirmed with nothing to journal when the host was already gone", async () => {
+    const { client } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+      ],
+      outcome: { confirmed: true, sessions: [] },
+    });
+
+    const result = await gracefulTeardownAndJournalProject("proj", client);
+
+    expect(result).toEqual({ confirmed: true, terminalsKilled: 0 });
+    expect(journalMock.journalAgentSession).not.toHaveBeenCalled();
+  });
+
+  it("survives a failed terminal snapshot (best-effort) and still reports the kill", async () => {
+    const { client } = makePtyClient({
+      terminals: () => Promise.reject(new Error("host unreachable")),
+      outcome: { confirmed: true, sessions: [{ id: "t1", agentSessionId: "s1" }] },
+    });
+
+    const result = await gracefulTeardownAndJournalProject("proj", client);
+
+    // Info is absent, so nothing is journaled — but the kill outcome is honored.
+    expect(result).toEqual({ confirmed: true, terminalsKilled: 1 });
+    expect(journalMock.journalAgentSession).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/pty/__tests__/projectSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/projectSessionJournal.test.ts
@@ -108,6 +108,24 @@ describe("gracefulTeardownAndJournalProject", () => {
     expect(ctx).toEqual({ terminalId: "t1", generation: 7 });
   });
 
+  it("passes an explicit null generation when the ledger has evicted the entry", async () => {
+    // Bounded LRU can evict a live agent terminal → currentGeneration is
+    // undefined at freeze. The helper must send null (frozen-unknown), not
+    // undefined, so the funnel fails open instead of re-reading a respawn (#11340).
+    ledgerMock.currentGeneration.mockReturnValue(undefined);
+    const { client } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+      ],
+      outcome: { confirmed: true, sessions: [{ id: "t1", agentSessionId: "s1" }] },
+    });
+
+    await gracefulTeardownAndJournalProject("proj", client);
+
+    const [, ctx] = journalMock.journalAgentSession.mock.calls[0]!;
+    expect(ctx).toEqual({ terminalId: "t1", generation: null });
+  });
+
   it("prefers the observed title unless a user title lock is set", async () => {
     const { client } = makePtyClient({
       terminals: [

--- a/electron/services/pty/__tests__/projectSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/projectSessionJournal.test.ts
@@ -218,6 +218,73 @@ describe("gracefulTeardownAndJournalProject", () => {
       terminalsKilled: 2,
     });
     expect(journalMock.journalAgentSession).toHaveBeenCalledTimes(2);
+    // The second session must genuinely be journaled — not the first retried.
+    const journaledIds = journalMock.journalAgentSession.mock.calls.map(
+      (c) => (c[0] as { sessionId: string }).sessionId
+    );
+    expect(journaledIds).toEqual(expect.arrayContaining(["s1", "s2"]));
+  });
+
+  it("journals without a branch when the worktree lookup hangs past the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { client } = makePtyClient({
+        terminals: [
+          {
+            id: "t1",
+            projectId: "proj",
+            launchAgentId: "claude",
+            worktreeId: "w1",
+            cwd: "/a",
+            spawnedAt: 1,
+          },
+        ],
+        outcome: { confirmed: true, sessions: [{ id: "t1", agentSessionId: "s1" }] },
+      });
+      // getMonitorAsync never resolves — the 200ms race timer must win.
+      const workspaceClient = {
+        getMonitorAsync: vi.fn(() => new Promise(() => {})),
+      } as unknown as WorkspaceClient;
+
+      const promise = gracefulTeardownAndJournalProject("proj", client, workspaceClient);
+      await vi.advanceTimersByTimeAsync(250);
+
+      await expect(promise).resolves.toEqual({ confirmed: true, terminalsKilled: 1 });
+      const [record] = journalMock.journalAgentSession.mock.calls[0]!;
+      expect((record as { branch?: string }).branch).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("awaits each journal write before resolving (not fire-and-forget)", async () => {
+    let resolveJournal: (v: boolean) => void = () => {};
+    journalMock.journalAgentSession.mockReturnValue(
+      new Promise<boolean>((res) => {
+        resolveJournal = res;
+      })
+    );
+    const { client } = makePtyClient({
+      terminals: [
+        { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+      ],
+      outcome: { confirmed: true, sessions: [{ id: "t1", agentSessionId: "s1" }] },
+    });
+
+    let settled = false;
+    const promise = gracefulTeardownAndJournalProject("proj", client).then((r) => {
+      settled = true;
+      return r;
+    });
+
+    // Drain all microtasks — the helper should be parked on the pending journal.
+    await new Promise((r) => setImmediate(r));
+    expect(journalMock.journalAgentSession).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    resolveJournal(true);
+    await expect(promise).resolves.toEqual({ confirmed: true, terminalsKilled: 1 });
+    expect(settled).toBe(true);
   });
 
   it("passes an unconfirmed outcome through without journaling", async () => {

--- a/electron/services/pty/agentSessionJournal.ts
+++ b/electron/services/pty/agentSessionJournal.ts
@@ -12,10 +12,19 @@ export interface JournalCloseContext {
   /**
    * Launch generation of the closing incarnation. Capture it BEFORE initiating
    * the kill: a restart can respawn the same terminal id mid-close, and the
-   * record must stay attributed to the generation that produced it. Falls back
-   * to the ledger's current generation when omitted.
+   * record must stay attributed to the generation that produced it.
+   *
+   * Three states:
+   * - `number` — the frozen generation; gate on it.
+   * - omitted (`undefined`) — no generation captured; fall back to the ledger's
+   *   current generation (used by callers that resolve it just-in-time).
+   * - `null` — the caller froze the generation but the ledger had evicted the
+   *   entry (bounded LRU), so it is genuinely UNKNOWN. Journal fail-open and do
+   *   NOT consult the current generation: a same-id respawn would otherwise gate
+   *   the predecessor's record on the successor's generation and suppress the
+   *   successor's real record later (#11340).
    */
-  generation?: number;
+  generation?: number | null;
 }
 
 /**
@@ -39,7 +48,13 @@ export async function journalAgentSession(
   ctx: JournalCloseContext
 ): Promise<boolean> {
   const ledger = getLifecycleLedger();
-  const generation = ctx.generation ?? ledger.currentGeneration(ctx.terminalId);
+  // A null generation is an explicit "frozen but unknown" — fail open without
+  // consulting the current (possibly respawned) generation. Omitted falls back
+  // to the current generation; a number gates on itself.
+  const generation =
+    ctx.generation === null
+      ? undefined
+      : (ctx.generation ?? ledger.currentGeneration(ctx.terminalId));
   const gatedGeneration =
     generation !== undefined && ledger.currentGeneration(ctx.terminalId) !== undefined
       ? generation

--- a/electron/services/pty/projectSessionJournal.ts
+++ b/electron/services/pty/projectSessionJournal.ts
@@ -120,7 +120,10 @@ export async function gracefulTeardownAndJournalProject(
             cwd: info.cwd ?? undefined,
             branch: info.worktreeId ? branchByWorktree.get(info.worktreeId) : undefined,
           },
-          { terminalId: result.id, generation: generationById.get(result.id) }
+          // `?? null` marks an evicted/unknown generation as explicitly frozen
+          // so the journal funnel fails open instead of re-reading a respawn's
+          // current generation (#11340).
+          { terminalId: result.id, generation: generationById.get(result.id) ?? null }
         );
       } catch (err) {
         // One failed journal write must not block the rest.

--- a/electron/services/pty/projectSessionJournal.ts
+++ b/electron/services/pty/projectSessionJournal.ts
@@ -29,6 +29,14 @@ const BRANCH_LOOKUP_TIMEOUT_MS = 200;
  * restoration state / don't remove the entity — or still-running agents are
  * orphaned. `terminalsKilled` counts the terminals the host reported tearing
  * down (0 when the host was already gone).
+ *
+ * Journaling is best-effort and does NOT gate `confirmed`: a failed pre-kill
+ * snapshot, a capture whose terminal info didn't survive the snapshot, or a
+ * single journal write that throws all lose that one resume record but never
+ * block the teardown the caller asked for — exactly as `shutdown.ts` behaves.
+ * The kill confirmation, not journaling success, is what protects restoration
+ * state. Losing a resume record is strictly better than the pre-fix behavior,
+ * which journaled nothing at all.
  */
 export async function gracefulTeardownAndJournalProject(
   scopeId: string,

--- a/electron/services/pty/projectSessionJournal.ts
+++ b/electron/services/pty/projectSessionJournal.ts
@@ -1,0 +1,125 @@
+import type { PtyClient } from "../PtyClient.js";
+import type { WorkspaceClient } from "../WorkspaceClient.js";
+import { getLifecycleLedger } from "./lifecycleLedger.js";
+import { journalAgentSession } from "./agentSessionJournal.js";
+import { createLogger } from "../../utils/logger.js";
+
+const logger = createLogger("main:ProjectSessionJournal");
+
+type TerminalInfo = Awaited<ReturnType<PtyClient["getAllTerminalsAsync"]>>[number];
+
+/** How long to wait for a worktree branch lookup before journaling without it. */
+const BRANCH_LOOKUP_TIMEOUT_MS = 200;
+
+/**
+ * Gracefully tear down every terminal in a project scope (a project id or a
+ * scratch id — both are opaque scope ids to the PTY host) and journal each
+ * agent's session the way app shutdown does, BEFORE the caller deletes the
+ * scope's restoration state.
+ *
+ * This mirrors the journaling block in `electron/lifecycle/shutdown.ts` at
+ * single-scope granularity, minus the projectStore terminal-state writeback:
+ * every caller here (project close+kill, project remove, scratch remove) clears
+ * or deletes that state immediately, so writing captured session ids back into
+ * it would be pointless. The exactly-once journal funnel is what actually keeps
+ * the agent conversations resumable from the picker.
+ *
+ * Returns `confirmed` straight from the kill: when it is false a live host timed
+ * out without acknowledging the kill, so the caller MUST fail closed — keep the
+ * restoration state / don't remove the entity — or still-running agents are
+ * orphaned. `terminalsKilled` counts the terminals the host reported tearing
+ * down (0 when the host was already gone).
+ */
+export async function gracefulTeardownAndJournalProject(
+  scopeId: string,
+  ptyClient: PtyClient,
+  workspaceClient?: WorkspaceClient
+): Promise<{ confirmed: boolean; terminalsKilled: number }> {
+  // Snapshot terminal infos for this scope BEFORE the kill — info is gone once
+  // the PTY exits. Best-effort: a failed snapshot just skips journaling.
+  let infoById = new Map<string, TerminalInfo>();
+  try {
+    const all = await ptyClient.getAllTerminalsAsync();
+    infoById = new Map(all.filter((t) => t.projectId === scopeId).map((t) => [t.id, t]));
+  } catch {
+    // Snapshot is best-effort; the journal loop below skips when info is absent.
+  }
+
+  // Freeze each terminal's launch generation alongside the info snapshot, before
+  // any kill — the journal write must stay attributed to the incarnation being
+  // torn down, not a respawn that races the close (#10950).
+  const ledger = getLifecycleLedger();
+  const generationById = new Map<string, number | undefined>(
+    [...infoById.keys()].map((id) => [id, ledger.currentGeneration(id)])
+  );
+
+  const outcome = await ptyClient.gracefulKillByProjectConfirmed(scopeId);
+
+  const captured = outcome.sessions
+    .filter((r) => r.agentSessionId)
+    .map((r) => ({ result: r, info: infoById.get(r.id) }))
+    .filter((c): c is { result: (typeof c)["result"]; info: NonNullable<(typeof c)["info"]> } =>
+      Boolean(c.info?.launchAgentId)
+    );
+
+  if (captured.length > 0) {
+    // Resolve unique worktree branches in parallel, each time-boxed, so a
+    // stalled workspace host can't push this past the caller's budget.
+    const uniqueWorktreeIds = [
+      ...new Set(
+        captured
+          .map((c) => c.info.worktreeId)
+          .filter((w): w is string => typeof w === "string" && w.length > 0)
+      ),
+    ];
+    const branchByWorktree = new Map<string, string>();
+    await Promise.all(
+      uniqueWorktreeIds.map(async (wid) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          const snapshot = await Promise.race([
+            workspaceClient ? workspaceClient.getMonitorAsync(wid) : Promise.resolve(null),
+            new Promise<null>((resolve) => {
+              timer = setTimeout(() => resolve(null), BRANCH_LOOKUP_TIMEOUT_MS);
+            }),
+          ]);
+          const branch = snapshot?.branch;
+          if (branch && branch !== "HEAD") branchByWorktree.set(wid, branch);
+        } catch {
+          // best-effort
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      })
+    );
+
+    for (const { result, info } of captured) {
+      try {
+        await journalAgentSession(
+          {
+            sessionId: result.agentSessionId as string,
+            agentId: info.launchAgentId as string,
+            worktreeId: info.worktreeId ?? null,
+            // Prefer the observed task title, matching the shutdown / kill close
+            // paths — except under a user title lock, where the record reads the
+            // same as the frozen live tab.
+            title:
+              (info.titleMode === "user" ? info.title : (info.lastObservedTitle ?? info.title)) ??
+              null,
+            projectId: info.projectId ?? null,
+            agentLaunchFlags: info.agentLaunchFlags,
+            agentModelId: info.agentModelId,
+            cwd: info.cwd ?? undefined,
+            branch: info.worktreeId ? branchByWorktree.get(info.worktreeId) : undefined,
+          },
+          { terminalId: result.id, generation: generationById.get(result.id) }
+        );
+      } catch (err) {
+        // One failed journal write must not block the rest.
+        logger.warn(`Failed to journal agent session for ${result.id}`, { err });
+      }
+    }
+  }
+
+  return { confirmed: outcome.confirmed, terminalsKilled: outcome.sessions.length };
+}


### PR DESCRIPTION
## Summary

Closing a project with `killTerminals` (the stop action), removing a project, and removing a scratch workspace all tore terminals down through a bare `killByProject` call. That call never ran the agent quit sequence or journaled the live session id, so agent conversations were vanishing from the resume picker. On an RPC failure or timeout from the pty-host, the same code normalized the result to zero killed (or empty) while still clearing the persisted restoration state, orphaning still-running agents underneath a "successful" close.

Resolves #11340

## Changes

- Added `PtyClient.gracefulKillByProjectConfirmed()`, applying the same typed `BrokerError` triage as the existing single-terminal `gracefulKill`: `HOST_EXITED`/`APP_SHUTDOWN` (or a dead/disposed client) is confirmed, since the host is gone and there's nothing left to capture; a `TIMEOUT` against a live host is unconfirmed. The existing array-returning `gracefulKillByProject` now delegates to it, so the shutdown, freeMemory, hibernation, and idle callers that already use it keep their exact prior behavior.
- Added `gracefulTeardownAndJournalProject()`, mirroring `shutdown.ts` at project scope: snapshot terminal info and freeze each terminal's launch generation before the kill, run the graceful session-preserving kill, then journal each captured agent session (branch-resolved, timeboxed) through the existing exactly-once journaling funnel.
- The project-close handler (when `killTerminals` is set), the project-remove handler, and the scratch-remove handler now route through that helper and fail closed: on an unconfirmed kill, or an unexpected thrown error, they keep the restoration state, don't delete the project or scratch, and reject the operation instead of orphaning still-running agents.
- `journalAgentSession` gains a null value for "frozen but unknown" generation. The bounded lifecycle ledger can evict a live agent terminal, and passing that undefined generation through the old `?? currentGeneration` fallback could reserve a respawned incarnation's journal slot and suppress its real record. The new null value fails open without consulting the current generation. Existing callers still only pass `number | undefined`, so their behavior is unchanged.

### Scope notes

`killByProject` stays as a low-level primitive but is no longer used anywhere in the product. Two edge cases are documented as best-effort and out of scope: a pty-host crash replaying a pending-spawn terminal after a host exit, and partial terminal-info snapshots losing best-effort journaling. Both overlap the sibling issue, #11339.

## Testing

176 targeted tests pass locally: a new helper test suite, adversarial tests for the `PtyClient` triage logic, and fail-closed/journal-await/generation-eviction regression tests across the three handlers and the journal funnel. Local runs use `--no-file-parallelism` due to a worktree-only Electron binary extraction race; CI's fresh install isn't affected.
