### PR TITLE
fix(worktree): gate delete confirm on fresh git status

### DIFF
--- a/electron/utils/worktreePortTimeouts.ts
+++ b/electron/utils/worktreePortTimeouts.ts
@@ -44,6 +44,10 @@ export const WORKTREE_PORT_TIMEOUTS_MS: Partial<Record<WorktreePortAction, numbe
   "resource-action": 15 * 60_000,
   "run-lifecycle-setup": 15 * 60_000,
   refresh: 60_000,
+  // Awaits a single-worktree `monitor.refresh()`, watchdogged host-side at 45s
+  // (HOST_REFRESH_TIMEOUT_MS). Match `refresh`'s 60s so the host stays the
+  // limiting factor and the delete-confirm read isn't cut short on a slow repo.
+  "get-worktree-changes": 60_000,
 };
 
 /**

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -237,6 +237,12 @@ async function handleWorktreePortRequest(
         break;
       }
 
+      case "get-worktree-changes": {
+        const changes = await workspaceService.getFreshWorktreeChanges(msg.payload.worktreeId);
+        result = { changes };
+        break;
+      }
+
       default: {
         const _exhaustive: never = msg;
         throw new Error(

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2167,12 +2167,17 @@ export class WorkspaceService {
   async getFreshWorktreeChanges(worktreeId: string): Promise<WorktreeChanges | null> {
     const monitor = this.monitors.get(worktreeId);
     if (!monitor) return null;
-    await withTimeout(
-      monitor.refresh(),
+    // `getFreshChanges()` forces a real `git status` that bypasses the
+    // single-flight status pass — a `refresh()` here would silently no-op (and
+    // return the stale snapshot) whenever a background poll is mid-pass, which
+    // is precisely the stale read #11343 must not make. Watchdogged so a
+    // degraded repo can't hang the port request; a rejection propagates so the
+    // caller fails closed rather than proceeding on stale data.
+    return withTimeout(
+      monitor.getFreshChanges(),
       HOST_REFRESH_TIMEOUT_MS,
       `get-worktree-changes watchdog: ${worktreeId}`
     );
-    return monitor.getWorktreeChanges();
   }
 
   /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -23,6 +23,7 @@ import type {
   PluginWorktreeLinkedPR,
 } from "../../shared/types/plugin.js";
 import type { CIStatus, NormalizedPRState } from "../../shared/types/forge.js";
+import type { WorktreeChanges } from "../../shared/types/git.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
 import { withTimeout } from "../utils/withTimeout.js";
 import { detectWslPath, getDefaultWslDistro } from "../utils/wsl.js";
@@ -2146,6 +2147,32 @@ export class WorkspaceService {
       this.sendEvent({ type: "refresh-result", requestId, success: false, error: message });
       return { ok: false, error: message };
     }
+  }
+
+  /**
+   * Force a fresh `git status` for one worktree and return its change set
+   * directly (#11343).
+   *
+   * The delete-confirm surfaces (local dialog + MCP confirm) must derive the
+   * D2/D3 tier and the changed-file preview from LIVE changes — a backgrounded
+   * worktree's cached snapshot can be ~30s stale, which lets a force-delete
+   * skip the typed-name gate and silently discard uncommitted work. This runs
+   * `monitor.refresh()` (which bypasses the adaptive-poll cache) and reads the
+   * resulting changes back off the same monitor, so the caller gets a value
+   * that provably reflects the refresh — no dependency on the broadcast landing
+   * on the (separate) worktree port first. Watchdogged like `refresh()` so a
+   * degraded repo can't hang the port request. `null` when no monitor exists
+   * for the id (already removed).
+   */
+  async getFreshWorktreeChanges(worktreeId: string): Promise<WorktreeChanges | null> {
+    const monitor = this.monitors.get(worktreeId);
+    if (!monitor) return null;
+    await withTimeout(
+      monitor.refresh(),
+      HOST_REFRESH_TIMEOUT_MS,
+      `get-worktree-changes watchdog: ${worktreeId}`
+    );
+    return monitor.getWorktreeChanges();
   }
 
   /**

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -11,7 +11,7 @@ import type {
 } from "../../shared/types/worktree.js";
 import type { CIStatusState } from "../../shared/types/forge.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
-import { invalidateGitStatusCache } from "../utils/git.js";
+import { invalidateGitStatusCache, getWorktreeChangesWithStats } from "../utils/git.js";
 import { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/index.js";
 import { deriveIssueTitleFromBranch } from "../services/issueExtractor.js";
 import { FetchScheduler, type FetchSchedulerHost } from "./FetchScheduler.js";
@@ -1522,6 +1522,29 @@ export class WorktreeMonitor {
 
   getWorktreeChanges(): WorktreeChanges | null {
     return this.worktreeChanges;
+  }
+
+  /**
+   * Read a GUARANTEED-fresh `git status` for this worktree, bypassing the
+   * single-flight status pass (#11343).
+   *
+   * `refresh()` → `updateGitStatus(true)` → `GitStatusPass.run(true)` early
+   * returns when another pass is already in flight (a background poll, the
+   * dialog-open probe, a watcher-triggered pass), leaving `getWorktreeChanges()`
+   * on a stale snapshot. For the delete-confirm safety gate a stale-empty read
+   * is exactly the data-loss bug being fixed, so this calls the underlying
+   * status function directly with `forceRefresh: true` — which bypasses the TTL
+   * cache AND the in-flight dedup — yielding a value that reflects the tree at
+   * call time regardless of any concurrent pass. Read-only: it does not mutate
+   * monitor state or broadcast; the caller consumes the returned value. Rejects
+   * (rather than returning stale) if the status read fails, so callers fail
+   * closed.
+   */
+  getFreshChanges(): Promise<WorktreeChanges> {
+    return getWorktreeChangesWithStats(this.path, {
+      forceRefresh: true,
+      wsl: this.wslInvocation,
+    });
   }
 
   triggerRefreshIfUpdating(): void {

--- a/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
@@ -913,4 +913,30 @@ describe("WorkspaceService.deleteWorktree", () => {
       expect(service.getAcknowledgedMutationIds()).toEqual([]);
     });
   });
+
+  describe("getFreshWorktreeChanges (#11343)", () => {
+    it("forces a monitor refresh and returns its fresh changes", async () => {
+      const monitor = createAndRegisterMonitor();
+      const refreshSpy = vi.spyOn(monitor, "refresh").mockResolvedValue(undefined);
+      const fresh = {
+        worktreeId: "/test/worktree",
+        rootPath: "/test/worktree",
+        changedFileCount: 2,
+        changes: [
+          { path: "a.ts", status: "modified" as const, insertions: null, deletions: null },
+          { path: "n.txt", status: "untracked" as const, insertions: null, deletions: null },
+        ],
+      };
+      vi.spyOn(monitor, "getWorktreeChanges").mockReturnValue(fresh);
+
+      const result = await service.getFreshWorktreeChanges("/test/worktree");
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(fresh);
+    });
+
+    it("returns null when no monitor exists for the id", async () => {
+      await expect(service.getFreshWorktreeChanges("/nonexistent")).resolves.toBeNull();
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
@@ -915,9 +915,8 @@ describe("WorkspaceService.deleteWorktree", () => {
   });
 
   describe("getFreshWorktreeChanges (#11343)", () => {
-    it("forces a monitor refresh and returns its fresh changes", async () => {
+    it("returns a guaranteed-fresh status read (bypassing the single-flight pass)", async () => {
       const monitor = createAndRegisterMonitor();
-      const refreshSpy = vi.spyOn(monitor, "refresh").mockResolvedValue(undefined);
       const fresh = {
         worktreeId: "/test/worktree",
         rootPath: "/test/worktree",
@@ -927,12 +926,24 @@ describe("WorkspaceService.deleteWorktree", () => {
           { path: "n.txt", status: "untracked" as const, insertions: null, deletions: null },
         ],
       };
-      vi.spyOn(monitor, "getWorktreeChanges").mockReturnValue(fresh);
+      // The service must read through getFreshChanges (forced git status), NOT
+      // refresh()/getWorktreeChanges() which can no-op to a stale snapshot when
+      // a poll is mid-pass.
+      const freshSpy = vi.spyOn(monitor, "getFreshChanges").mockResolvedValue(fresh);
 
       const result = await service.getFreshWorktreeChanges("/test/worktree");
 
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(freshSpy).toHaveBeenCalledTimes(1);
       expect(result).toEqual(fresh);
+    });
+
+    it("propagates a fresh-read failure so callers fail closed", async () => {
+      const monitor = createAndRegisterMonitor();
+      vi.spyOn(monitor, "getFreshChanges").mockRejectedValue(new Error("git status failed"));
+
+      await expect(service.getFreshWorktreeChanges("/test/worktree")).rejects.toThrow(
+        "git status failed"
+      );
     });
 
     it("returns null when no monitor exists for the id", async () => {

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -16,6 +16,7 @@ import type {
   WorktreeSnapshot,
   WorktreeEventVersion,
 } from "./workspace-host.js";
+import type { WorktreeChanges } from "./git.js";
 
 export type WorktreePortResourceAction = "provision" | "teardown" | "resume" | "pause" | "status";
 
@@ -115,6 +116,19 @@ export interface WorktreePortProtocol {
   "has-resource-config": {
     payload: { rootPath: string };
     result: { hasConfig: boolean };
+  };
+  // On-demand FRESH git-status read for a single worktree. Forces the monitor
+  // to re-run `git status` (bypassing the adaptive-poll cache) and returns the
+  // resulting change set directly in the response. Safety-critical for the
+  // delete-confirm surfaces (#11343): the delete dialog and the MCP confirm
+  // must decide the D2/D3 tier from live changes, not a snapshot that can be
+  // ~30s stale for a backgrounded worktree. Returning the changes in the reply
+  // (rather than relying on the broadcast → store round-trip, which crosses a
+  // different channel and can land after the reply) keeps the read race-free.
+  // `null` when no monitor exists for the id (already removed).
+  "get-worktree-changes": {
+    payload: { worktreeId: string };
+    result: { changes: WorktreeChanges | null };
   };
 }
 

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -6,6 +6,7 @@ import type {
   IssueAssociation,
 } from "@shared/types";
 import type { PRServiceStatus } from "@shared/types/workspace-host";
+import type { WorktreeChanges } from "@shared/types/git";
 
 /**
  * @example
@@ -22,6 +23,20 @@ export const worktreeClient = {
 
   refresh: (worktreeId?: string): Promise<void> => {
     return window.electron.worktree.refresh(worktreeId);
+  },
+
+  /**
+   * Force a fresh `git status` for one worktree and return the change set
+   * directly (#11343). Unlike `refresh` (which resolves `void` and relies on
+   * the follow-up broadcast to update the store), this returns the live
+   * changes in the reply, so a destructive-confirm surface can gate on them
+   * race-free. `null` when the worktree's monitor no longer exists.
+   */
+  getFreshChanges: async (worktreeId: string): Promise<WorktreeChanges | null> => {
+    const { changes } = await window.electron.worktreePort.request("get-worktree-changes", {
+      worktreeId,
+    });
+    return changes;
   },
 
   refreshPullRequests: (): Promise<void> => {

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -144,6 +144,16 @@ export function McpConfirmDialog() {
               </div>
             </div>
           )}
+          {current.preview && current.preview.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+                Working tree changes
+              </div>
+              <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
+                {current.preview.join("\n")}
+              </pre>
+            </div>
+          )}
           <div className="space-y-2">
             <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
               Arguments

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -120,6 +120,7 @@ export function McpConfirmDialog() {
         cancelLabel="Cancel"
         onConfirm={() => resolveOnce(current.requestId, "approved")}
         variant={variant}
+        confirmDisabled={Boolean(current.previewPending)}
         confirmCooldownMs={isDestructive ? CONFIRM_COOLDOWN_MS : undefined}
         cooldownKey={current.requestId}
       >
@@ -144,14 +145,18 @@ export function McpConfirmDialog() {
               </div>
             </div>
           )}
-          {current.preview && current.preview.length > 0 && (
+          {(current.previewPending || (current.preview && current.preview.length > 0)) && (
             <div className="space-y-2">
               <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
                 Working tree changes
               </div>
-              <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
-                {current.preview.join("\n")}
-              </pre>
+              {current.previewPending ? (
+                <div className="text-xs text-daintree-text/60">Checking current changes…</div>
+              ) : (
+                <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
+                  {current.preview?.join("\n")}
+                </pre>
+              )}
             </div>
           )}
           <div className="space-y-2">

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
@@ -6,6 +6,11 @@ import { AlertTriangle, Trash2 } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
 import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
 import { deriveEffectiveTier } from "@/services/actions/deriveEffectiveTier";
+import {
+  buildWorktreeDeletePreview,
+  summarizeWorktreeChanges,
+  type WorktreeDeletePreview,
+} from "@/components/Worktree/worktreeDeletePreview";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import type { WorktreeState } from "@/types";
@@ -24,16 +29,32 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [confirmInput, setConfirmInput] = useState("");
   const [hasDevPreview, setHasDevPreview] = useState(false);
+  // Fresh git-status snapshot fetched when the dialog opens and re-checked on
+  // submit (#11343). The prop `worktree.worktreeChanges` can be ~30s stale for
+  // a backgrounded worktree, which would let a force-delete skip the D3 gate
+  // and silently discard uncommitted work. `null` = not yet fetched / monitor
+  // gone (fall back to the prop snapshot); `verifyFailed` = the fresh fetch
+  // errored, so we FAIL CLOSED (treat the tree as dirty, escalate the tier).
+  const [freshPreview, setFreshPreview] = useState<WorktreeDeletePreview | null>(null);
+  const [verifyFailed, setVerifyFailed] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  // Tracks the live `isOpen` so an in-flight submit revalidation can abort if
+  // the user cancels the dialog mid-fetch instead of dispatching after close.
+  const openRef = useRef(isOpen);
+  openRef.current = isOpen;
 
   const { counts: terminalCounts } = useWorktreeTerminals(worktree.id);
 
-  const changes = worktree.worktreeChanges?.changes ?? [];
-  const trackedChangeCount = changes.filter(
-    (c) => c.status !== "untracked" && c.status !== "ignored"
-  ).length;
-  const untrackedFileCount = changes.filter((c) => c.status === "untracked").length;
-  const hasTrackedChanges = trackedChangeCount > 0;
-  const hasUntrackedFiles = untrackedFileCount > 0;
+  // Preview + tier derive from the FRESH fetch when available, else the prop
+  // snapshot as an initial seed. A failed fetch fails closed via
+  // `hasTrackedChanges` so the D3 typed-name gate is never skipped on stale
+  // (or unverifiable) state.
+  const seedSummary = summarizeWorktreeChanges(worktree.worktreeChanges?.changes);
+  const effectiveSummary = freshPreview ?? seedSummary;
+  const trackedChangeCount = effectiveSummary.trackedChangeCount;
+  const untrackedFileCount = effectiveSummary.untrackedFileCount;
+  const hasTrackedChanges = verifyFailed || effectiveSummary.hasTrackedChanges;
+  const hasUntrackedFiles = effectiveSummary.hasUntrackedFiles;
   const hasChanges = hasTrackedChanges || hasUntrackedFiles;
   const hasTerminals = terminalCounts.total > 0;
 
@@ -55,7 +76,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       hasTrackedChanges,
     }) === "D3";
   const isConfirmMatched = confirmInput === confirmTarget;
-  const canSubmit = !isHighTier || isConfirmMatched;
+  const canSubmit = (!isHighTier || isConfirmMatched) && !isDeleting;
 
   useEffect(() => {
     if (isOpen) {
@@ -64,7 +85,30 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       setDeleteBranch(false);
       setConfirmInput("");
       setHasDevPreview(false);
+      setIsDeleting(false);
     }
+  }, [isOpen, worktree.id]);
+
+  // Fetch a FRESH git-status snapshot when the dialog opens so the tier + the
+  // changed-file preview reflect live changes, not a possibly-stale cache
+  // (#11343). Guarded against stale-closure on unmount/worktree change. A
+  // failed fetch fails closed (`verifyFailed`) — we never silently fall back to
+  // the stale snapshot and offer the lower tier.
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setFreshPreview(null);
+    setVerifyFailed(false);
+    buildWorktreeDeletePreview(worktree.id)
+      .then((preview) => {
+        if (!cancelled) setFreshPreview(preview);
+      })
+      .catch(() => {
+        if (!cancelled) setVerifyFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [isOpen, worktree.id]);
 
   // Disclose a running dev server in the "What will happen" list so the user
@@ -100,9 +144,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     }
   }, [canDeleteBranch, deleteBranch]);
 
-  const handleDelete = () => {
-    if (isHighTier && !isConfirmMatched) return;
-
+  const dispatchDelete = () => {
     const effectiveDeleteBranch = deleteBranch && canDeleteBranch;
     const options = {
       force,
@@ -117,6 +159,51 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     onClose();
   };
 
+  // Re-check LIVE changes immediately before a force-delete dispatch (#11343).
+  // An agent can write files between open and submit; without this, a delete
+  // that looked D2 at open could discard tracked work the typed-name gate was
+  // meant to guard. If the fresh check now escalates to D3 and the name isn't
+  // matched, we surface the gate instead of dispatching. Fails closed on fetch
+  // error. Only the force path needs this — a non-force delete can never
+  // discard tracked changes (the backend guard rejects a dirty non-force
+  // delete), so it dispatches synchronously and keeps its immediate dismiss.
+  const revalidateThenDelete = async () => {
+    setIsDeleting(true);
+    let preview: WorktreeDeletePreview | null = null;
+    let failed = false;
+    try {
+      preview = await buildWorktreeDeletePreview(worktree.id);
+    } catch {
+      failed = true;
+    }
+    if (!openRef.current) return;
+    setFreshPreview(preview);
+    setVerifyFailed(failed);
+    const freshHasTracked = failed ? true : (preview ?? seedSummary).hasTrackedChanges;
+    const freshTier = deriveEffectiveTier("worktree.delete", {
+      force: true,
+      isProtectedBranch,
+      isMainWorktree: worktree.isMainWorktree === true,
+      hasTrackedChanges: freshHasTracked,
+    });
+    if (freshTier === "D3" && confirmInput !== confirmTarget) {
+      // Escalated on fresh data — show the typed-name gate, do not dispatch.
+      setIsDeleting(false);
+      return;
+    }
+    dispatchDelete();
+  };
+
+  const handleDelete = () => {
+    if (isHighTier && !isConfirmMatched) return;
+    if (isDeleting) return;
+    if (!force) {
+      dispatchDelete();
+      return;
+    }
+    void revalidateThenDelete();
+  };
+
   const deleteButtonLabel = !force
     ? "Delete worktree"
     : isHighTier
@@ -124,7 +211,23 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       : "Force delete worktree";
 
   let advisoryBanner: React.ReactNode = null;
-  if (hasChanges) {
+  if (verifyFailed) {
+    // Fresh-status fetch failed: we can't confirm what's in the tree, so we
+    // fail closed (the tier is already escalated via `hasTrackedChanges`) and
+    // say so plainly rather than implying a clean/known state.
+    advisoryBanner = (
+      <div
+        role="alert"
+        className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
+      >
+        <AlertTriangle className="w-4 h-4 shrink-0" />
+        <p>
+          Couldn't verify this worktree's current changes. Force delete may discard uncommitted work
+          — proceed only if you're sure. This is irreversible.
+        </p>
+      </div>
+    );
+  } else if (hasChanges) {
     if (!force) {
       advisoryBanner = (
         <div

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -8,6 +8,7 @@ import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
 import { deriveEffectiveTier } from "@/services/actions/deriveEffectiveTier";
 import {
   buildWorktreeDeletePreview,
+  formatWorktreeChangeRows,
   summarizeWorktreeChanges,
   type WorktreeDeletePreview,
 } from "@/components/Worktree/worktreeDeletePreview";
@@ -38,10 +39,18 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const [freshPreview, setFreshPreview] = useState<WorktreeDeletePreview | null>(null);
   const [verifyFailed, setVerifyFailed] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  // Tracks the live `isOpen` so an in-flight submit revalidation can abort if
-  // the user cancels the dialog mid-fetch instead of dispatching after close.
-  const openRef = useRef(isOpen);
-  openRef.current = isOpen;
+  // Monotonic session token bumped on every open/close/worktree change (in the
+  // open effect below). An in-flight submit revalidation captures the token and
+  // aborts if it changed while awaiting — so a close→reopen (or worktree swap)
+  // during the fetch can't let a stale closure dispatch against the new session
+  // (an ABA race a plain boolean flag would miss). `mountedRef` covers unmount.
+  const sessionRef = useRef(0);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const { counts: terminalCounts } = useWorktreeTerminals(worktree.id);
 
@@ -57,6 +66,13 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const hasUntrackedFiles = effectiveSummary.hasUntrackedFiles;
   const hasChanges = hasTrackedChanges || hasUntrackedFiles;
   const hasTerminals = terminalCounts.total > 0;
+
+  // Actual file list a force-delete would discard — a D2 preview must show
+  // real content, not just a count (#11343). Prefer the fresh fetch's changes,
+  // fall back to the prop snapshot before it resolves.
+  const previewChangeRows = formatWorktreeChangeRows(
+    freshPreview?.changes ?? worktree.worktreeChanges?.changes ?? []
+  );
 
   const isProtectedBranch = isProtectedBranchName(worktree.branch?.toLowerCase());
   const isDetachedHead = !worktree.branch;
@@ -95,6 +111,9 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   // failed fetch fails closed (`verifyFailed`) — we never silently fall back to
   // the stale snapshot and offer the lower tier.
   useEffect(() => {
+    // Bump the session on every open/close/worktree change so an in-flight
+    // submit revalidation can detect it's stale (see `revalidateThenDelete`).
+    sessionRef.current += 1;
     if (!isOpen) return;
     let cancelled = false;
     setFreshPreview(null);
@@ -168,6 +187,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   // discard tracked changes (the backend guard rejects a dirty non-force
   // delete), so it dispatches synchronously and keeps its immediate dismiss.
   const revalidateThenDelete = async () => {
+    const session = sessionRef.current;
     setIsDeleting(true);
     let preview: WorktreeDeletePreview | null = null;
     let failed = false;
@@ -176,7 +196,10 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     } catch {
       failed = true;
     }
-    if (!openRef.current) return;
+    // Abort if the dialog closed/reopened/changed worktree or unmounted while
+    // the fresh re-check was in flight — never dispatch against a session the
+    // user is no longer looking at.
+    if (!mountedRef.current || sessionRef.current !== session) return;
     setFreshPreview(preview);
     setVerifyFailed(failed);
     const freshHasTracked = failed ? true : (preview ?? seedSummary).hasTrackedChanges;
@@ -361,6 +384,24 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
           </div>
 
           {advisoryBanner}
+
+          {force && !verifyFailed && previewChangeRows.length > 0 && (
+            <div>
+              <span
+                role="heading"
+                aria-level={3}
+                className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60"
+              >
+                Files that will be lost
+              </span>
+              <pre
+                data-testid="delete-worktree-file-list"
+                className="mt-2 max-h-32 overflow-auto text-xs text-daintree-text/70 bg-daintree-bg p-3 rounded border border-border-strong font-mono whitespace-pre-wrap break-all"
+              >
+                {previewChangeRows.join("\n")}
+              </pre>
+            </div>
+          )}
 
           <label className="flex items-center gap-2 cursor-pointer">
             <input

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -47,6 +47,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const sessionRef = useRef(0);
   const mountedRef = useRef(true);
   useEffect(() => {
+    // Set on SETUP as well as clearing on cleanup — under React StrictMode the
+    // mount effect runs setup → cleanup → setup, so a setup that only cleared
+    // would leave `mountedRef` false after remount and make every force-delete
+    // abort at the revalidation guard in dev.
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+import { StrictMode } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import type { WorktreeState } from "@/types";
@@ -996,6 +997,30 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
       expect(startDeleteMock).toHaveBeenCalledTimes(1);
     });
     expect(startDeleteMock).toHaveBeenCalledWith("wt-1", { force: true, deleteBranch: false });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("still dispatches a force-delete under StrictMode (mountedRef remount guard)", async () => {
+    // StrictMode runs mount effects setup→cleanup→setup; a mounted flag that
+    // only cleared would be false after remount and abort every force-delete.
+    buildPreviewMock.mockResolvedValue(makePreview([{ path: "new.txt", status: "untracked" }]));
+    const onClose = vi.fn();
+    const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
+    render(
+      <StrictMode>
+        <WorktreeDeleteDialog isOpen={true} onClose={onClose} worktree={worktree} />
+      </StrictMode>
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    await waitFor(() => {
+      expect(buildPreviewMock).toHaveBeenCalled();
+    });
+    fireEvent.click(screen.getByTestId("delete-worktree-confirm"));
+
+    await waitFor(() => {
+      expect(startDeleteMock).toHaveBeenCalledTimes(1);
+    });
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -15,11 +15,20 @@ vi.stubGlobal(
   }
 );
 
-const { startDeleteMock, terminalCountsMock, devPreviewGetByWorktreeMock } = vi.hoisted(() => ({
-  startDeleteMock: vi.fn(),
-  terminalCountsMock: { total: 0 },
-  devPreviewGetByWorktreeMock: vi.fn(),
-}));
+const { startDeleteMock, terminalCountsMock, devPreviewGetByWorktreeMock, buildPreviewMock } =
+  vi.hoisted(() => ({
+    startDeleteMock: vi.fn(),
+    terminalCountsMock: { total: 0 },
+    devPreviewGetByWorktreeMock: vi.fn(),
+    buildPreviewMock: vi.fn(),
+  }));
+
+// Mock only the fresh-fetch builder; keep `summarizeWorktreeChanges` real so
+// the prop-seed path (existing render assertions) is exercised unchanged.
+vi.mock("@/components/Worktree/worktreeDeletePreview", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../worktreeDeletePreview")>();
+  return { ...actual, buildWorktreeDeletePreview: buildPreviewMock };
+});
 
 (globalThis as Record<string, unknown>).window = globalThis.window ?? {};
 (window as unknown as Record<string, unknown>).electron = {
@@ -110,11 +119,35 @@ function makeChanges(files: Array<{ path: string; status: GitStatus }>): Worktre
   };
 }
 
+// A fresh delete preview (what buildWorktreeDeletePreview resolves to) for the
+// on-open / on-submit fetch (#11343).
+function makePreview(files: Array<{ path: string; status: GitStatus }>) {
+  const changes = files.map((f) => ({
+    path: f.path,
+    status: f.status,
+    insertions: null,
+    deletions: null,
+  }));
+  const trackedChangeCount = changes.filter(
+    (c) => c.status !== "untracked" && c.status !== "ignored"
+  ).length;
+  const untrackedFileCount = changes.filter((c) => c.status === "untracked").length;
+  return {
+    trackedChangeCount,
+    untrackedFileCount,
+    hasTrackedChanges: trackedChangeCount > 0,
+    hasUntrackedFiles: untrackedFileCount > 0,
+    changes,
+  };
+}
+
 describe("WorktreeDeleteDialog — warning messages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -280,6 +313,8 @@ describe("WorktreeDeleteDialog — body copy", () => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -462,6 +497,8 @@ describe("WorktreeDeleteDialog — medium tier (no name confirmation)", () => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -514,6 +551,8 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -680,6 +719,8 @@ describe("WorktreeDeleteDialog — immediate dismiss", () => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -713,6 +754,8 @@ describe("WorktreeDeleteDialog — dev preview disclosure (#9084)", () => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -784,6 +827,8 @@ describe("WorktreeDeleteDialog — state reset", () => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    // Default: no fresh override → dialog uses the prop seed (existing tests).
+    buildPreviewMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -810,5 +855,109 @@ describe("WorktreeDeleteDialog — state reset", () => {
       name: /close all terminals/i,
     }) as HTMLInputElement;
     expect(reopened.checked).toBe(true);
+  });
+});
+
+describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    terminalCountsMock.total = 0;
+    devPreviewGetByWorktreeMock.mockResolvedValue(null);
+    buildPreviewMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("fetches fresh worktree changes when the dialog opens", async () => {
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    await waitFor(() => {
+      expect(buildPreviewMock).toHaveBeenCalledWith("wt-1");
+    });
+  });
+
+  it("escalates to the D3 typed-name gate when fresh status reveals tracked changes the prop missed", async () => {
+    // Prop snapshot is stale-empty (the backgrounded-worktree bug); the fresh
+    // fetch reveals an agent's in-progress tracked edits.
+    buildPreviewMock.mockResolvedValue(makePreview([{ path: "src/app.ts", status: "modified" }]));
+    const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    });
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("fails closed with an escalation and a warning when the fresh fetch errors", async () => {
+    buildPreviewMock.mockRejectedValue(new Error("refresh timeout"));
+    const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    // The "couldn't verify" banner surfaces regardless of force.
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't verify this worktree's current changes/)).toBeDefined();
+    });
+
+    // With force on, the fail-closed state demands the typed-name gate.
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("blocks a force-delete at submit time when files changed after open", async () => {
+    // Open sees a clean tree (D2, no gate); an agent writes a tracked file
+    // before the user clicks — the submit-time re-check must catch it.
+    buildPreviewMock.mockResolvedValueOnce(makePreview([]));
+    const onClose = vi.fn();
+    const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={onClose} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    await waitFor(() => {
+      expect(buildPreviewMock).toHaveBeenCalledTimes(1);
+    });
+    // Clean at open → no typed-name gate, button enabled.
+    expect(screen.queryByTestId("delete-worktree-confirm-input")).toBeNull();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    // Now a tracked change appears; submit must revalidate and refuse.
+    buildPreviewMock.mockResolvedValueOnce(
+      makePreview([{ path: "src/app.ts", status: "modified" }])
+    );
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    });
+    expect(startDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a force-delete after submit re-check confirms it is still safe", async () => {
+    // Untracked-only stays D2 both at open and submit → no gate, delete runs.
+    buildPreviewMock.mockResolvedValue(makePreview([{ path: "new.txt", status: "untracked" }]));
+    const onClose = vi.fn();
+    const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={onClose} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    await waitFor(() => {
+      expect(buildPreviewMock).toHaveBeenCalled();
+    });
+    fireEvent.click(screen.getByTestId("delete-worktree-confirm"));
+
+    await waitFor(() => {
+      expect(startDeleteMock).toHaveBeenCalledTimes(1);
+    });
+    expect(startDeleteMock).toHaveBeenCalledWith("wt-1", { force: true, deleteBranch: false });
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -941,6 +941,44 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
     expect(startDeleteMock).not.toHaveBeenCalled();
   });
 
+  it("shows the actual fresh file list a force delete would discard (D2 content preview)", async () => {
+    buildPreviewMock.mockResolvedValue(
+      makePreview([
+        { path: "src/app.ts", status: "modified" },
+        { path: "new.txt", status: "untracked" },
+      ])
+    );
+    const worktree = makeWorktree(makeChanges([]), { branch: "feature/x", name: "feature/x" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    // No list until the destructive path is armed.
+    expect(screen.queryByTestId("delete-worktree-file-list")).toBeNull();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    await waitFor(() => {
+      const list = screen.getByTestId("delete-worktree-file-list");
+      expect(list.textContent).toContain("M src/app.ts");
+      expect(list.textContent).toContain("? new.txt");
+    });
+  });
+
+  it("hides the file list and shows the warning when verification fails", async () => {
+    buildPreviewMock.mockRejectedValue(new Error("refresh timeout"));
+    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]), {
+      branch: "feature/x",
+      name: "feature/x",
+    });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't verify this worktree's current changes/)).toBeDefined();
+    });
+    expect(screen.queryByTestId("delete-worktree-file-list")).toBeNull();
+  });
+
   it("dispatches a force-delete after submit re-check confirms it is still safe", async () => {
     // Untracked-only stays D2 both at open and submit → no gate, delete runs.
     buildPreviewMock.mockResolvedValue(makePreview([{ path: "new.txt", status: "untracked" }]));

--- a/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FileChangeDetail, GitStatus, WorktreeChanges } from "@shared/types/git";
+
+const { getFreshChangesMock } = vi.hoisted(() => ({
+  getFreshChangesMock: vi.fn(),
+}));
+
+vi.mock("@/clients", () => ({
+  worktreeClient: { getFreshChanges: getFreshChangesMock },
+}));
+
+import {
+  summarizeWorktreeChanges,
+  buildWorktreeDeletePreview,
+  formatWorktreeDeletePreviewLines,
+} from "../worktreeDeletePreview";
+
+function file(path: string, status: GitStatus): FileChangeDetail {
+  return { path, status, insertions: null, deletions: null };
+}
+
+function changes(files: FileChangeDetail[]): WorktreeChanges {
+  return {
+    worktreeId: "wt-1",
+    rootPath: "/wt",
+    changedFileCount: files.length,
+    changes: files,
+  };
+}
+
+describe("summarizeWorktreeChanges", () => {
+  it("counts tracked changes excluding untracked and ignored", () => {
+    const summary = summarizeWorktreeChanges([
+      file("a.ts", "modified"),
+      file("b.ts", "deleted"),
+      file("new.txt", "untracked"),
+      file("node_modules/x", "ignored"),
+    ]);
+    expect(summary.trackedChangeCount).toBe(2);
+    expect(summary.untrackedFileCount).toBe(1);
+    expect(summary.hasTrackedChanges).toBe(true);
+    expect(summary.hasUntrackedFiles).toBe(true);
+  });
+
+  it("treats untracked-only sets as having no tracked changes (no D3 escalation — #4927)", () => {
+    const summary = summarizeWorktreeChanges([
+      file("a.txt", "untracked"),
+      file("b.txt", "untracked"),
+    ]);
+    expect(summary.trackedChangeCount).toBe(0);
+    expect(summary.hasTrackedChanges).toBe(false);
+    expect(summary.untrackedFileCount).toBe(2);
+  });
+
+  it("handles null/empty input as no changes", () => {
+    expect(summarizeWorktreeChanges(null)).toEqual({
+      trackedChangeCount: 0,
+      untrackedFileCount: 0,
+      hasTrackedChanges: false,
+      hasUntrackedFiles: false,
+    });
+    expect(summarizeWorktreeChanges([]).hasTrackedChanges).toBe(false);
+  });
+});
+
+describe("buildWorktreeDeletePreview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the fresh summary and file list from a forced status fetch", async () => {
+    getFreshChangesMock.mockResolvedValue(
+      changes([file("a.ts", "modified"), file("n.txt", "untracked")])
+    );
+    const preview = await buildWorktreeDeletePreview("wt-1");
+    expect(getFreshChangesMock).toHaveBeenCalledWith("wt-1");
+    expect(preview).not.toBeNull();
+    expect(preview?.trackedChangeCount).toBe(1);
+    expect(preview?.untrackedFileCount).toBe(1);
+    expect(preview?.changes).toHaveLength(2);
+  });
+
+  it("returns null when the monitor is gone (getFreshChanges resolves null)", async () => {
+    getFreshChangesMock.mockResolvedValue(null);
+    await expect(buildWorktreeDeletePreview("wt-1")).resolves.toBeNull();
+  });
+
+  it("propagates a fetch error so callers can fail closed", async () => {
+    getFreshChangesMock.mockRejectedValue(new Error("timeout"));
+    await expect(buildWorktreeDeletePreview("wt-1")).rejects.toThrow("timeout");
+  });
+});
+
+describe("formatWorktreeDeletePreviewLines", () => {
+  it("returns a couldn't-verify note for a null preview (fail-closed display)", () => {
+    expect(formatWorktreeDeletePreviewLines(null)).toEqual([
+      "⚠ Could not verify current changes — proceed with caution.",
+    ]);
+  });
+
+  it("returns a clean-tree note when there are no changes", () => {
+    const preview = {
+      trackedChangeCount: 0,
+      untrackedFileCount: 0,
+      hasTrackedChanges: false,
+      hasUntrackedFiles: false,
+      changes: [],
+    };
+    expect(formatWorktreeDeletePreviewLines(preview)).toEqual(["No uncommitted changes."]);
+  });
+
+  it("lists the actual files under a counts header", () => {
+    const files = [file("src/app.ts", "modified"), file("new.txt", "untracked")];
+    const preview = {
+      trackedChangeCount: 1,
+      untrackedFileCount: 1,
+      hasTrackedChanges: true,
+      hasUntrackedFiles: true,
+      changes: files,
+    };
+    const lines = formatWorktreeDeletePreviewLines(preview);
+    expect(lines[0]).toBe("1 uncommitted tracked file and 1 untracked file:");
+    expect(lines).toContain("  M src/app.ts");
+    expect(lines).toContain("  ? new.txt");
+  });
+
+  it("caps the file list and reports the overflow count", () => {
+    const files = Array.from({ length: 15 }, (_, i) => file(`f${i}.ts`, "modified"));
+    const preview = {
+      trackedChangeCount: 15,
+      untrackedFileCount: 0,
+      hasTrackedChanges: true,
+      hasUntrackedFiles: false,
+      changes: files,
+    };
+    const lines = formatWorktreeDeletePreviewLines(preview);
+    // header + 12 files + overflow line
+    expect(lines).toHaveLength(14);
+    expect(lines[lines.length - 1]).toBe("  …and 3 more");
+  });
+});

--- a/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeletePreview.test.ts
@@ -13,6 +13,7 @@ import {
   summarizeWorktreeChanges,
   buildWorktreeDeletePreview,
   formatWorktreeDeletePreviewLines,
+  formatWorktreeChangeRows,
 } from "../worktreeDeletePreview";
 
 function file(path: string, status: GitStatus): FileChangeDetail {
@@ -137,5 +138,35 @@ describe("formatWorktreeDeletePreviewLines", () => {
     // header + 12 files + overflow line
     expect(lines).toHaveLength(14);
     expect(lines[lines.length - 1]).toBe("  …and 3 more");
+  });
+});
+
+describe("formatWorktreeChangeRows", () => {
+  it("prefixes each file with its status glyph", () => {
+    const rows = formatWorktreeChangeRows([
+      file("a.ts", "modified"),
+      file("b.ts", "deleted"),
+      file("c.ts", "added"),
+      file("n.txt", "untracked"),
+    ]);
+    expect(rows).toEqual(["  M a.ts", "  D b.ts", "  A c.ts", "  ? n.txt"]);
+  });
+
+  it("drops ignored files (not part of what a delete discards)", () => {
+    const rows = formatWorktreeChangeRows([
+      file("a.ts", "modified"),
+      file("node_modules/x", "ignored"),
+    ]);
+    expect(rows).toEqual(["  M a.ts"]);
+  });
+
+  it("caps at the limit and appends an overflow row (ignored excluded from the count)", () => {
+    const files = [
+      ...Array.from({ length: 14 }, (_, i) => file(`f${i}.ts`, "modified")),
+      file("ignore.me", "ignored"),
+    ];
+    const rows = formatWorktreeChangeRows(files);
+    expect(rows).toHaveLength(13); // 12 files + overflow
+    expect(rows[rows.length - 1]).toBe("  …and 2 more");
   });
 });

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -67,8 +67,8 @@ export async function buildWorktreeDeletePreview(
   return { ...summarizeWorktreeChanges(changes), changes };
 }
 
-/** Max file rows shown in the compact MCP preview before collapsing the tail. */
-const PREVIEW_FILE_LIMIT = 12;
+/** Max file rows shown in a compact preview before collapsing the tail. */
+export const PREVIEW_FILE_LIMIT = 12;
 
 const STATUS_GLYPH: Record<FileChangeDetail["status"], string> = {
   modified: "M",
@@ -80,6 +80,24 @@ const STATUS_GLYPH: Record<FileChangeDetail["status"], string> = {
   untracked: "?",
   ignored: "!",
 };
+
+/**
+ * Render a change set as capped, glyph-prefixed file rows (`  M src/app.ts`),
+ * shared by the local delete dialog and the MCP preview so both show the same
+ * actual content (the D2 "a count is insufficient" rule). Ignored files are
+ * dropped — they're not part of what a delete discards.
+ */
+export function formatWorktreeChangeRows(
+  changes: FileChangeDetail[],
+  limit: number = PREVIEW_FILE_LIMIT
+): string[] {
+  const shown = changes.filter((c) => c.status !== "ignored");
+  const rows = shown.slice(0, limit).map((c) => `  ${STATUS_GLYPH[c.status] ?? "?"} ${c.path}`);
+  if (shown.length > limit) {
+    rows.push(`  …and ${shown.length - limit} more`);
+  }
+  return rows;
+}
 
 /**
  * Render a preview as plain lines for the MCP confirm surface — a header
@@ -106,12 +124,5 @@ export function formatWorktreeDeletePreviewLines(preview: WorktreeDeletePreview 
   if (untrackedFileCount > 0) {
     parts.push(`${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`);
   }
-  const lines = [`${parts.join(" and ")}:`];
-  for (const c of changes.slice(0, PREVIEW_FILE_LIMIT)) {
-    lines.push(`  ${STATUS_GLYPH[c.status] ?? "?"} ${c.path}`);
-  }
-  if (changes.length > PREVIEW_FILE_LIMIT) {
-    lines.push(`  …and ${changes.length - PREVIEW_FILE_LIMIT} more`);
-  }
-  return lines;
+  return [`${parts.join(" and ")}:`, ...formatWorktreeChangeRows(changes)];
 }

--- a/src/components/Worktree/worktreeDeletePreview.ts
+++ b/src/components/Worktree/worktreeDeletePreview.ts
@@ -1,0 +1,117 @@
+import { worktreeClient } from "@/clients";
+import type { FileChangeDetail, WorktreeChanges } from "@shared/types/git";
+
+/**
+ * Canonical fresh preview for the worktree-delete confirm surfaces (#11343).
+ *
+ * Both the local `WorktreeDeleteDialog` and the MCP confirm surface must decide
+ * the D2/D3 tier and render the changed-file preview from a LIVE git status —
+ * a backgrounded worktree's cached snapshot can be ~30s stale, which is exactly
+ * what lets a force-delete skip the typed-name gate and discard uncommitted
+ * work. This module owns the one fresh fetch and the tracked/untracked
+ * classification both surfaces share.
+ */
+
+/** Counts derived from a change set, split the way the D3 tier gate needs. */
+export interface WorktreeChangeSummary {
+  /** Tracked (non-untracked, non-ignored) changes — the D3 escalation input. */
+  trackedChangeCount: number;
+  /** Untracked files (D2-relevant, never D3 on their own — see #4927). */
+  untrackedFileCount: number;
+  hasTrackedChanges: boolean;
+  hasUntrackedFiles: boolean;
+}
+
+/** A fresh delete preview: the change summary plus the raw file list. */
+export interface WorktreeDeletePreview extends WorktreeChangeSummary {
+  changes: FileChangeDetail[];
+}
+
+/**
+ * Split a change set into tracked/untracked counts. Ignored files never count
+ * (they aren't part of the working tree the user cares about); untracked files
+ * are surfaced separately because they gate the D2 preview but must NOT drive
+ * the D3 typed-name gate on their own (regressing that collapse is #4927).
+ */
+export function summarizeWorktreeChanges(
+  changes: FileChangeDetail[] | null | undefined
+): WorktreeChangeSummary {
+  const list = changes ?? [];
+  const trackedChangeCount = list.filter(
+    (c) => c.status !== "untracked" && c.status !== "ignored"
+  ).length;
+  const untrackedFileCount = list.filter((c) => c.status === "untracked").length;
+  return {
+    trackedChangeCount,
+    untrackedFileCount,
+    hasTrackedChanges: trackedChangeCount > 0,
+    hasUntrackedFiles: untrackedFileCount > 0,
+  };
+}
+
+/**
+ * Force a fresh `git status` for the worktree and return its delete preview.
+ *
+ * Rejects if the fresh fetch fails or times out — callers MUST fail closed on
+ * rejection (escalate the tier / warn), never silently fall back to the stale
+ * cached snapshot, which would recreate the exact bug being fixed. Resolves
+ * `null` only when the worktree's monitor no longer exists (already removed),
+ * which callers may treat as "nothing to gate".
+ */
+export async function buildWorktreeDeletePreview(
+  worktreeId: string
+): Promise<WorktreeDeletePreview | null> {
+  const fresh: WorktreeChanges | null = await worktreeClient.getFreshChanges(worktreeId);
+  if (!fresh) return null;
+  const changes = fresh.changes ?? [];
+  return { ...summarizeWorktreeChanges(changes), changes };
+}
+
+/** Max file rows shown in the compact MCP preview before collapsing the tail. */
+const PREVIEW_FILE_LIMIT = 12;
+
+const STATUS_GLYPH: Record<FileChangeDetail["status"], string> = {
+  modified: "M",
+  added: "A",
+  deleted: "D",
+  renamed: "R",
+  copied: "C",
+  conflicted: "U",
+  untracked: "?",
+  ignored: "!",
+};
+
+/**
+ * Render a preview as plain lines for the MCP confirm surface — a header
+ * naming the tracked/untracked counts, then the actual file list (capped), so
+ * the approver sees the real content a force-delete would discard rather than
+ * just raw args (the #11343 MCP gap, and the D2 "preview of actual content"
+ * rule). `null` means the fresh fetch could not be verified: surface that
+ * explicitly rather than implying a clean tree.
+ */
+export function formatWorktreeDeletePreviewLines(preview: WorktreeDeletePreview | null): string[] {
+  if (preview === null) {
+    return ["⚠ Could not verify current changes — proceed with caution."];
+  }
+  const { trackedChangeCount, untrackedFileCount, changes } = preview;
+  if (changes.length === 0) {
+    return ["No uncommitted changes."];
+  }
+  const parts: string[] = [];
+  if (trackedChangeCount > 0) {
+    parts.push(
+      `${trackedChangeCount} uncommitted tracked file${trackedChangeCount === 1 ? "" : "s"}`
+    );
+  }
+  if (untrackedFileCount > 0) {
+    parts.push(`${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`);
+  }
+  const lines = [`${parts.join(" and ")}:`];
+  for (const c of changes.slice(0, PREVIEW_FILE_LIMIT)) {
+    lines.push(`  ${STATUS_GLYPH[c.status] ?? "?"} ${c.path}`);
+  }
+  if (changes.length > PREVIEW_FILE_LIMIT) {
+    lines.push(`  …and ${changes.length - PREVIEW_FILE_LIMIT} more`);
+  }
+  return lines;
+}

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   list: vi.fn(() => [] as ActionManifestEntry[]),
   get: vi.fn((_id: string): ActionManifestEntry | null => null),
   dispatch: vi.fn(),
+  buildPreview: vi.fn(),
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -19,7 +20,16 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
-import { useMcpBridge } from "../useMcpBridge";
+// Mock only the fresh-fetch builder; keep the real formatter so the preview
+// lines the bridge emits are exercised. Default (set per-test in beforeEach)
+// resolves null → no preview, so the confirm-flow tests stay unaffected.
+vi.mock("@/components/Worktree/worktreeDeletePreview", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/Worktree/worktreeDeletePreview")>();
+  return { ...actual, buildWorktreeDeletePreview: mocks.buildPreview };
+});
+
+import { useMcpBridge, buildMcpConfirmPreview } from "../useMcpBridge";
 
 function safeManifestEntry(overrides: Partial<ActionManifestEntry> = {}): ActionManifestEntry {
   return {
@@ -71,6 +81,9 @@ describe("useMcpBridge", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no fresh preview → the off-critical-path fetch is a no-op, so
+    // the confirmation-flow tests are unaffected by the #11343 preview change.
+    mocks.buildPreview.mockResolvedValue(null);
     __resetMcpConfirmStoreForTesting();
     manifestHandler = undefined;
     dispatchHandler = undefined;
@@ -627,5 +640,92 @@ describe("useMcpBridge", () => {
     await Promise.resolve();
 
     expect(sendDispatchActionResponse).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the fresh changed-file preview into the confirm store for worktree.delete (#11343)", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+    mocks.buildPreview.mockResolvedValue({
+      trackedChangeCount: 1,
+      untrackedFileCount: 0,
+      hasTrackedChanges: true,
+      hasUntrackedFiles: false,
+      changes: [{ path: "src/app.ts", status: "modified", insertions: null, deletions: null }],
+    });
+
+    renderHook(() => useMcpBridge());
+
+    const dispatched = dispatchHandler?.({
+      requestId: "req-preview",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-1" },
+    });
+
+    // Modal is enqueued immediately — the preview fetch runs off the critical
+    // path, so `current` is set before the preview lands.
+    await Promise.resolve();
+    expect(useMcpConfirmStore.getState().current?.requestId).toBe("req-preview");
+
+    // The fresh preview patches the pending item in place once it resolves.
+    await vi.waitFor(() => {
+      expect(mocks.buildPreview).toHaveBeenCalledWith("wt-1");
+      const preview = useMcpConfirmStore.getState().current?.preview;
+      expect(preview?.[0]).toContain("1 uncommitted tracked file");
+      expect(preview).toContain("  M src/app.ts");
+    });
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    await dispatched;
+  });
+});
+
+describe("buildMcpConfirmPreview (#11343)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildPreview.mockResolvedValue(null);
+  });
+
+  it("returns undefined for actions that are not worktree.delete", async () => {
+    await expect(
+      buildMcpConfirmPreview("terminal.kill", { terminalId: "t-1" })
+    ).resolves.toBeUndefined();
+    expect(mocks.buildPreview).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when worktree.delete args carry no worktreeId", async () => {
+    await expect(
+      buildMcpConfirmPreview("worktree.delete", { force: true })
+    ).resolves.toBeUndefined();
+    expect(mocks.buildPreview).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when the monitor is gone (builder resolves null)", async () => {
+    mocks.buildPreview.mockResolvedValue(null);
+    await expect(
+      buildMcpConfirmPreview("worktree.delete", { worktreeId: "wt-1" })
+    ).resolves.toBeUndefined();
+    expect(mocks.buildPreview).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("surfaces the fresh changed-file list for worktree.delete", async () => {
+    mocks.buildPreview.mockResolvedValue({
+      trackedChangeCount: 1,
+      untrackedFileCount: 0,
+      hasTrackedChanges: true,
+      hasUntrackedFiles: false,
+      changes: [{ path: "src/app.ts", status: "modified", insertions: null, deletions: null }],
+    });
+    const lines = await buildMcpConfirmPreview("worktree.delete", {
+      worktreeId: "wt-1",
+      force: true,
+    });
+    expect(lines?.[0]).toContain("1 uncommitted tracked file");
+    expect(lines).toContain("  M src/app.ts");
+  });
+
+  it("fails closed with a couldn't-verify note when the fresh fetch throws", async () => {
+    mocks.buildPreview.mockRejectedValue(new Error("timeout"));
+    const lines = await buildMcpConfirmPreview("worktree.delete", { worktreeId: "wt-1" });
+    expect(lines).toEqual(["⚠ Could not verify current changes — proceed with caution."]);
   });
 });

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -662,16 +662,19 @@ describe("useMcpBridge", () => {
     });
 
     // Modal is enqueued immediately — the preview fetch runs off the critical
-    // path, so `current` is set before the preview lands.
+    // path, so `current` is set (with approval gated) before the preview lands.
     await Promise.resolve();
     expect(useMcpConfirmStore.getState().current?.requestId).toBe("req-preview");
+    expect(useMcpConfirmStore.getState().current?.previewPending).toBe(true);
 
-    // The fresh preview patches the pending item in place once it resolves.
+    // The fresh preview patches the pending item in place and re-enables
+    // approval once it resolves.
     await vi.waitFor(() => {
       expect(mocks.buildPreview).toHaveBeenCalledWith("wt-1");
-      const preview = useMcpConfirmStore.getState().current?.preview;
-      expect(preview?.[0]).toContain("1 uncommitted tracked file");
-      expect(preview).toContain("  M src/app.ts");
+      const current = useMcpConfirmStore.getState().current;
+      expect(current?.previewPending).toBe(false);
+      expect(current?.preview?.[0]).toContain("1 uncommitted tracked file");
+      expect(current?.preview).toContain("  M src/app.ts");
     });
 
     useMcpConfirmStore.getState().resolveCurrent("approved");

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -3,6 +3,10 @@ import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { requestMcpConfirmation, useMcpConfirmStore } from "@/store/mcpConfirmStore";
 import { runWithMcpSpawnFocusSuppressed } from "@/store/mcpSpawnFocusGuard";
+import {
+  buildWorktreeDeletePreview,
+  formatWorktreeDeletePreviewLines,
+} from "@/components/Worktree/worktreeDeletePreview";
 import type { ActionDispatchResult, ActionId } from "@shared/types/actions";
 import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -35,6 +39,39 @@ const MCP_SPAWN_TAGGED_ACTIONS = new Set([
 
 function shouldTagMcpSpawn(actionId: string): boolean {
   return actionId.startsWith("agent.") || MCP_SPAWN_TAGGED_ACTIONS.has(actionId);
+}
+
+/**
+ * Build a fresh changed-file preview for confirm surfaces that discard content
+ * (#11343). Today only `worktree.delete` qualifies: its raw args ({worktreeId,
+ * force}) tell the approver nothing about what a force-delete would destroy, so
+ * we fetch live git status and surface the actual file list. Fails closed — a
+ * fetch error yields the "couldn't verify" note rather than an empty preview
+ * that would imply a clean tree. Returns `undefined` for actions with no
+ * preview so the dialog just shows args as before.
+ *
+ * Exported for unit tests; the bridge is the only production caller.
+ */
+export async function buildMcpConfirmPreview(
+  actionId: string,
+  args: unknown
+): Promise<string[] | undefined> {
+  if (actionId !== "worktree.delete") return undefined;
+  const worktreeId =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? (args as Record<string, unknown>).worktreeId
+      : undefined;
+  if (typeof worktreeId !== "string" || worktreeId.length === 0) return undefined;
+  try {
+    const preview = await buildWorktreeDeletePreview(worktreeId);
+    // Monitor gone / already removed → nothing meaningful to preview.
+    if (!preview) return undefined;
+    return formatWorktreeDeletePreviewLines(preview);
+  } catch {
+    // Fetch failed → fail closed: surface that we couldn't verify rather than
+    // an empty preview that would imply a clean tree.
+    return formatWorktreeDeletePreviewLines(null);
+  }
 }
 
 /**
@@ -96,6 +133,15 @@ export function useMcpBridge(): void {
             const definition = actionService.getDispatchMeta(actionId as ActionId);
             if (definition?.danger === "confirm") {
               inFlightConfirms.add(requestId);
+              // Fetch the fresh changed-file preview OFF the critical path so
+              // the modal appears immediately (never blocked on a git status)
+              // and the confirm queue isn't reordered by fetch latency (#11343).
+              // It patches the pending item in place when it lands; a no-op if
+              // the request already resolved. Best-effort/fail-closed inside.
+              void buildMcpConfirmPreview(actionId, args).then((preview) => {
+                if (disposed || !preview) return;
+                useMcpConfirmStore.getState().setPreview(requestId, preview);
+              });
               let decision: McpConfirmationDecision;
               try {
                 decision = await requestMcpConfirmation({

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -42,6 +42,20 @@ function shouldTagMcpSpawn(actionId: string): boolean {
 }
 
 /**
+ * The worktree id a `worktree.delete` dispatch targets, or undefined when the
+ * action isn't a worktree delete or carries no usable id. Determines whether a
+ * fresh changed-file preview should be fetched for the confirm modal (#11343).
+ */
+function worktreeDeleteTargetId(actionId: string, args: unknown): string | undefined {
+  if (actionId !== "worktree.delete") return undefined;
+  const worktreeId =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? (args as Record<string, unknown>).worktreeId
+      : undefined;
+  return typeof worktreeId === "string" && worktreeId.length > 0 ? worktreeId : undefined;
+}
+
+/**
  * Build a fresh changed-file preview for confirm surfaces that discard content
  * (#11343). Today only `worktree.delete` qualifies: its raw args ({worktreeId,
  * force}) tell the approver nothing about what a force-delete would destroy, so
@@ -56,12 +70,8 @@ export async function buildMcpConfirmPreview(
   actionId: string,
   args: unknown
 ): Promise<string[] | undefined> {
-  if (actionId !== "worktree.delete") return undefined;
-  const worktreeId =
-    args && typeof args === "object" && !Array.isArray(args)
-      ? (args as Record<string, unknown>).worktreeId
-      : undefined;
-  if (typeof worktreeId !== "string" || worktreeId.length === 0) return undefined;
+  const worktreeId = worktreeDeleteTargetId(actionId, args);
+  if (worktreeId === undefined) return undefined;
   try {
     const preview = await buildWorktreeDeletePreview(worktreeId);
     // Monitor gone / already removed → nothing meaningful to preview.
@@ -136,12 +146,18 @@ export function useMcpBridge(): void {
               // Fetch the fresh changed-file preview OFF the critical path so
               // the modal appears immediately (never blocked on a git status)
               // and the confirm queue isn't reordered by fetch latency (#11343).
-              // It patches the pending item in place when it lands; a no-op if
-              // the request already resolved. Best-effort/fail-closed inside.
-              void buildMcpConfirmPreview(actionId, args).then((preview) => {
-                if (disposed || !preview) return;
-                useMcpConfirmStore.getState().setPreview(requestId, preview);
-              });
+              // While it's in flight the modal keeps approval disabled
+              // (previewPending) so the approver can't confirm a destructive
+              // dispatch before seeing what it affects. `setPreview` patches the
+              // item and re-enables approval when the fetch lands (empty lines
+              // when there's nothing to show); a no-op if already resolved.
+              const previewPending = worktreeDeleteTargetId(actionId, args) !== undefined;
+              if (previewPending) {
+                void buildMcpConfirmPreview(actionId, args).then((preview) => {
+                  if (disposed) return;
+                  useMcpConfirmStore.getState().setPreview(requestId, preview ?? []);
+                });
+              }
               let decision: McpConfirmationDecision;
               try {
                 decision = await requestMcpConfirmation({
@@ -162,6 +178,7 @@ export function useMcpBridge(): void {
                   // only for unpinned external dispatch; the dialog renders a
                   // "Requested by" row when set, stays provenance-free when not.
                   callerInfo,
+                  previewPending,
                 });
               } finally {
                 inFlightConfirms.delete(requestId);

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -48,10 +48,10 @@ function shouldTagMcpSpawn(actionId: string): boolean {
  */
 function worktreeDeleteTargetId(actionId: string, args: unknown): string | undefined {
   if (actionId !== "worktree.delete") return undefined;
-  const worktreeId =
-    args && typeof args === "object" && !Array.isArray(args)
-      ? (args as Record<string, unknown>).worktreeId
-      : undefined;
+  if (args === null || typeof args !== "object" || !("worktreeId" in args)) return undefined;
+  // `in` narrows `args.worktreeId` to `unknown` — no cast needed (and no
+  // no-unsafe-type-assertion warning).
+  const worktreeId = args.worktreeId;
   return typeof worktreeId === "string" && worktreeId.length > 0 ? worktreeId : undefined;
 }
 

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -33,6 +33,15 @@ export interface PendingMcpConfirm {
    * the dialog shows a "Requested by" row only for genuine external clients.
    */
   callerInfo?: McpBearerIdentity;
+  /**
+   * Fresh, human-readable preview lines describing the ACTUAL content this
+   * dispatch would affect — e.g. the changed-file list a `worktree.delete`
+   * would discard (#11343). The bridge computes these from a live fetch just
+   * before enqueuing so the approver sees real content, not just raw args
+   * (the D2 "preview of actual content" rule). Absent for dispatches with no
+   * meaningful preview.
+   */
+  preview?: string[];
   enqueuedAt: number;
 }
 
@@ -43,6 +52,7 @@ interface McpConfirmState {
 
 interface McpConfirmActions {
   enqueue: (item: PendingMcpConfirm) => void;
+  setPreview: (requestId: string, preview: string[]) => void;
   resolveCurrent: (decision: McpConfirmationDecision) => void;
   drop: (requestId: string) => void;
   reset: () => void;
@@ -79,6 +89,25 @@ export const useMcpConfirmStore = create<McpConfirmState & McpConfirmActions>((s
       set({ current: item });
     } else {
       set({ queue: [...queue, item] });
+    }
+  },
+
+  // Attach a late-arriving preview to an already-enqueued item (#11343). The
+  // fresh changed-file fetch runs off the critical path so the modal appears
+  // immediately; when it lands we patch the matching item (current or queued)
+  // in place. A no-op if the request already resolved/dropped — the fetch is
+  // best-effort and must never resurrect a settled confirmation.
+  setPreview: (requestId, preview) => {
+    const { current, queue } = get();
+    if (current?.requestId === requestId) {
+      set({ current: { ...current, preview } });
+      return;
+    }
+    const idx = queue.findIndex((item) => item.requestId === requestId);
+    if (idx !== -1) {
+      const next = [...queue];
+      next[idx] = { ...next[idx], preview };
+      set({ queue: next });
     }
   },
 

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -36,12 +36,19 @@ export interface PendingMcpConfirm {
   /**
    * Fresh, human-readable preview lines describing the ACTUAL content this
    * dispatch would affect — e.g. the changed-file list a `worktree.delete`
-   * would discard (#11343). The bridge computes these from a live fetch just
-   * before enqueuing so the approver sees real content, not just raw args
-   * (the D2 "preview of actual content" rule). Absent for dispatches with no
-   * meaningful preview.
+   * would discard (#11343). The bridge computes these from a live fetch that
+   * runs off the critical path (so the modal opens immediately); the lines are
+   * patched in via `setPreview` when the fetch lands. Absent for dispatches
+   * with no meaningful preview.
    */
   preview?: string[];
+  /**
+   * True while the fresh preview fetch is still in flight (#11343). The modal
+   * opens immediately but keeps its approve button disabled until the preview
+   * (or a verification-failure note) arrives, so an approver can't confirm a
+   * destructive dispatch before seeing what it affects. Cleared by `setPreview`.
+   */
+  previewPending?: boolean;
   enqueuedAt: number;
 }
 
@@ -92,21 +99,22 @@ export const useMcpConfirmStore = create<McpConfirmState & McpConfirmActions>((s
     }
   },
 
-  // Attach a late-arriving preview to an already-enqueued item (#11343). The
-  // fresh changed-file fetch runs off the critical path so the modal appears
-  // immediately; when it lands we patch the matching item (current or queued)
-  // in place. A no-op if the request already resolved/dropped — the fetch is
-  // best-effort and must never resurrect a settled confirmation.
+  // Attach a late-arriving preview to an already-enqueued item and clear its
+  // pending flag (#11343). The fresh changed-file fetch runs off the critical
+  // path so the modal appears immediately; when it lands we patch the matching
+  // item (current or queued) in place and re-enable approval. A no-op if the
+  // request already resolved/dropped — the fetch is best-effort and must never
+  // resurrect a settled confirmation.
   setPreview: (requestId, preview) => {
     const { current, queue } = get();
     if (current?.requestId === requestId) {
-      set({ current: { ...current, preview } });
+      set({ current: { ...current, preview, previewPending: false } });
       return;
     }
     const idx = queue.findIndex((item) => item.requestId === requestId);
     if (idx !== -1) {
       const next = [...queue];
-      next[idx] = { ...next[idx], preview };
+      next[idx] = { ...next[idx], preview, previewPending: false };
       set({ queue: next });
     }
   },

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -107,16 +107,16 @@ export const useMcpConfirmStore = create<McpConfirmState & McpConfirmActions>((s
   // resurrect a settled confirmation.
   setPreview: (requestId, preview) => {
     const { current, queue } = get();
-    if (current?.requestId === requestId) {
+    if (current !== null && current.requestId === requestId) {
       set({ current: { ...current, preview, previewPending: false } });
       return;
     }
     const idx = queue.findIndex((item) => item.requestId === requestId);
-    if (idx !== -1) {
-      const next = [...queue];
-      next[idx] = { ...next[idx], preview, previewPending: false };
-      set({ queue: next });
-    }
+    const target = queue[idx];
+    if (target === undefined) return;
+    const next = [...queue];
+    next[idx] = { ...target, preview, previewPending: false };
+    set({ queue: next });
   },
 
   resolveCurrent: (decision) => {


### PR DESCRIPTION
## Summary

- The worktree delete confirmation decided the D2 vs. D3 (typed-name) tier, and its preview, from a cached `worktreeChanges` snapshot that can be up to 30 seconds stale for backgrounded worktrees.
- That let a force-delete skip the typed-name gate and silently discard uncommitted work, since the backend's dirty guard is skipped whenever `force` is true.
- This adds a fresh, race-free read of git status and wires both confirm surfaces to it, so the tier decision and the preview are always based on current state.

Resolves #11343

## Changes

- New race-free primitive: worktree-port action `get-worktree-changes` routed through `WorkspaceService.getFreshWorktreeChanges` to `WorktreeMonitor.getFreshChanges`, which reads a guaranteed-fresh `git status` via `getWorktreeChangesWithStats({ forceRefresh: true })`, bypassing the single-flight status pass, the TTL cache, and in-flight dedup.
- Shared canonical builder (`src/components/Worktree/worktreeDeletePreview.ts`): fresh fetch, tracked/untracked classification, and file-list/row formatting, used by both confirm surfaces.
- `WorktreeDeleteDialog`: fetches fresh state on open (drives the tier decision and the preview), revalidates on force submit (blocks and escalates to the typed-name gate if fresh status now shows tracked changes), fails closed on fetch error (escalates and shows a "couldn't verify" banner), shows the actual fresh file list a force-delete would discard, and adds a session token plus mounted guard so a close/reopen or unmount can't dispatch a stale delete.
- MCP confirm surface: enqueues the modal immediately and fills in the fresh changed-file preview off the critical path, gating approval (`previewPending`) until the preview or a verification-failure note arrives, so an approver can't confirm a destructive `worktree.delete` before seeing what it affects.

Deliberate scope decisions: the backend `deleteWorktree` force-path guard is unchanged, since force is explicitly meant to discard changes. The generic MCP dialog doesn't get a typed-name gate either, since the human clicking approve is the gate there, and the issue only asked for the fresh file list on that surface.

## Testing

165 targeted tests pass: dialog stale-escalation, fail-closed, submit revalidation, StrictMode remounts, and file-list rendering; the builder, summarizer, and formatter; the MCP preview flow and its `previewPending` gate; backend fresh-read and fail-closed behavior; and port timeouts. Reviewed in two passes by Codex, with all confirmed findings fixed.
