### PR TITLE
fix(pty): replay the launch command on pty-host crash so agents resume

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -224,7 +224,7 @@ describe("agent command launch", () => {
     expect(ptyClient.listenerCount("exit")).toBe(0);
   });
 
-  it("Windows agent terminal writes command immediately without clear preamble", async () => {
+  it("Windows agent terminal carries the command as postSpawnInput, not an inline write", async () => {
     Object.defineProperty(process, "platform", { value: "win32" });
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
@@ -239,8 +239,11 @@ describe("agent command launch", () => {
       command: "claude",
     });
 
-    expect(ptyClient.write).toHaveBeenCalledTimes(1);
-    expect(ptyClient.write.mock.calls[0][1]).toBe("claude\r");
+    // The command rides postSpawnInput so PtyClient owns the write and re-injects
+    // it on crash replay (#11339); the handler no longer writes it directly.
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.postSpawnInput).toBe("claude\r");
+    expect(ptyClient.write).not.toHaveBeenCalled();
   });
 
   it("skips stdin write entirely for POSIX command launches", async () => {

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -581,6 +581,57 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.worktreeId).toBe("wt-123");
   });
+
+  it("caches the launch command as postSpawnInput for a wrapper-less shell (#11339)", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    const os = await import("os");
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cwd: os.homedir(),
+        cols: 80,
+        rows: 24,
+        // nushell can't host a startup wrapper on any platform.
+        shell: "/usr/bin/nu",
+        command: "claude --resume s-1",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    // The command rides postSpawnInput (PtyClient owns the write + crash replay),
+    // not an inline lifecycle-handler write.
+    expect(spawnArgs.postSpawnInput).toBe("claude --resume s-1\r");
+    expect(ptyClient.write).not.toHaveBeenCalled();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "omits postSpawnInput for a wrapper-capable shell — the command rides args (#11339)",
+    async () => {
+      const deps = { ptyClient } as unknown as HandlerDependencies;
+      registerTerminalLifecycleHandlers(deps);
+
+      const handler = getSpawnHandler();
+      const os = await import("os");
+      await handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cwd: os.homedir(),
+          cols: 80,
+          rows: 24,
+          shell: "/bin/bash",
+          command: "claude --resume s-1",
+        } as unknown as Parameters<typeof handler>[1]
+      );
+
+      const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+      expect(spawnArgs.postSpawnInput).toBeUndefined();
+      // The command is embedded in the shell startup args instead.
+      expect(spawnArgs.args?.join(" ")).toContain("claude --resume s-1");
+    }
+  );
 });
 
 describe("terminal spawn shell-injection hardening (#6065)", () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -598,6 +598,16 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       ? commandLaunchShell.shell
       : validatedOptions.shell || projectShell;
 
+    // Shells that can't host a startup wrapper (fish, nushell, unrecognized
+    // Windows shells) launch bare and get the command typed in after spawn.
+    // Cache it on the spawn options so PtyClient owns the write and, crucially,
+    // re-injects it on every pendingSpawns replay — a pty-host crash respawn
+    // would otherwise bring these terminals back as an empty prompt, losing the
+    // (possibly resume) launch entirely (#11339). Wrapper shells already carry
+    // the command in `args`, so they replay faithfully with no postSpawnInput.
+    const postSpawnInput =
+      safeCommand.length > 0 && !commandLaunchShell ? `${safeCommand}\r` : undefined;
+
     try {
       // Every terminal is an interactive shell. Agent launches inject their
       // command after the shell's first prompt renders — never `exec`'d over
@@ -626,17 +636,11 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         agentPresetColor: validatedOptions.agentPresetColor,
         originalAgentPresetId:
           validatedOptions.originalAgentPresetId ?? validatedOptions.agentPresetId,
+        // Executed immediately by PtyClient after the spawn message (FIFO on the
+        // same channel), so users don't stare at a blank prompt; the shell stays
+        // the parent process and reclaims the foreground when the command exits.
+        postSpawnInput,
       });
-
-      if (safeCommand.length > 0 && !commandLaunchShell) {
-        // Execute immediately. node-pty queues the write against the spawned
-        // shell, so users do not stare at a blank prompt while we wait for RC
-        // files/prompt detection. The shell still remains the parent process;
-        // when the command exits, the terminal returns to a normal shell.
-        if (ptyClient.hasTerminal(id)) {
-          ptyClient.write(id, `${safeCommand}\r`);
-        }
-      }
 
       return id;
     } catch (error) {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -777,7 +777,7 @@ export class PtyClient extends EventEmitter {
       // clearing) stay in respawnPendingForShard() above.
       for (const [id, options] of this.pendingSpawns) {
         if (this.ownerKey(id) !== shard.key) continue;
-        shard.send({ type: "spawn", id, options });
+        this.sendSpawnWithPostInput(shard, id, options);
       }
     }
     const pendingPortWindowIds = new Set(shard.pendingMessagePorts.keys());
@@ -785,6 +785,31 @@ export class PtyClient extends EventEmitter {
     if (shard.shouldResyncProjectContext) {
       shard.shouldResyncProjectContext = false;
       this.syncProjectContextToShard(shard, pendingPortWindowIds);
+    }
+  }
+
+  /**
+   * Send a spawn to a shard and, for command launches on shells that couldn't
+   * host a startup wrapper, re-inject the launch command right after it (#11339).
+   * The command rides `options.postSpawnInput` in `pendingSpawns`, so every
+   * replay path (initial pre-ready replay, crash respawn, crash-budget
+   * migration) funnels through here and the terminal comes back running its
+   * command — including a resume — instead of a bare prompt. The write is FIFO
+   * behind the spawn on the same channel and the host's spawn handler registers
+   * the terminal synchronously, so it lands on the live PTY.
+   */
+  private sendSpawnWithPostInput(shard: PtyShard, id: string, options: PtyHostSpawnOptions): void {
+    // Never deliver into a shard that isn't ready yet. A post-fork/pre-ready
+    // send is queued by the host AND re-sent by the first-ready replay below,
+    // which for a command launch would run the command (and any resume) twice.
+    // The entry is already in `pendingSpawns`, so the first-ready replay (which
+    // runs after `markReady`, i.e. once this guard passes) delivers it exactly
+    // once. This makes the "double-spawn-safe" invariant explicit rather than
+    // relying on the pre-fork transport drop.
+    if (!shard.isRunning()) return;
+    shard.send({ type: "spawn", id, options });
+    if (options.postSpawnInput) {
+      shard.send({ type: "write", id, data: options.postSpawnInput });
     }
   }
 
@@ -840,7 +865,7 @@ export class PtyClient extends EventEmitter {
       const generation = ledger.recordLaunch(id, ledgerFactsFromSpawnOptions(options));
       const stamped: PtyHostSpawnOptions = { ...options, launchGeneration: generation };
       this.pendingSpawns.set(id, stamped);
-      shard.send({ type: "spawn", id, options: stamped });
+      this.sendSpawnWithPostInput(shard, id, stamped);
     }
 
     // Re-enable IPC data mirrors that were active before crash
@@ -933,7 +958,7 @@ export class PtyClient extends EventEmitter {
       this.pendingSpawns.set(id, stamped);
       this.terminalOwners.set(id, DEFAULT_SHARD_KEY);
       migratedIds.push(id);
-      target.send({ type: "spawn", id, options: stamped });
+      this.sendSpawnWithPostInput(target, id, stamped);
     }
     for (const id of migratedIds) {
       if (this.ipcDataMirrorIds.has(id)) {
@@ -1390,7 +1415,7 @@ export class PtyClient extends EventEmitter {
     const shard = this.ensureShardForProject(resolvedProjectId);
     this.terminalOwners.set(id, shard.key);
     this.pendingSpawns.set(id, resolvedOptions);
-    shard.send({ type: "spawn", id, options: resolvedOptions });
+    this.sendSpawnWithPostInput(shard, id, resolvedOptions);
   }
 
   /**

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -178,6 +178,11 @@ describe("PtyClient fabric", () => {
       expect(forks).toHaveLength(3);
       const shardA = projectShard("project-a");
       const shardB = projectShard("project-b");
+      // On-demand project shards deliver their queued spawn on first ready; the
+      // pre-ready send is gated so it isn't delivered twice (once queued, once
+      // by the first-ready replay).
+      shardA.child.emit("message", { type: "ready" });
+      shardB.child.emit("message", { type: "ready" });
       expect(shardA.serviceName).not.toBe(shardB.serviceName);
       expect(messagesOfType(shardA.child, "spawn").map((m) => m.id)).toEqual(["t1"]);
       expect(messagesOfType(shardB.child, "spawn").map((m) => m.id)).toEqual(["t2"]);

--- a/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
@@ -74,6 +74,13 @@ function spawnMessages(
     .map((msg) => ({ id: msg.id!, options: msg.options! }));
 }
 
+function writeMessages(child: MockUtilityProcess): Array<{ id: string; data: string }> {
+  return child.postMessage.mock.calls
+    .map((call: unknown[]) => call[0] as { type?: string; id?: string; data?: string })
+    .filter((msg) => msg?.type === "write")
+    .map((msg) => ({ id: msg.id!, data: msg.data! }));
+}
+
 describe("PtyClient lifecycle ledger", () => {
   let mockChild: MockUtilityProcess;
   let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
@@ -164,6 +171,63 @@ describe("PtyClient lifecycle ledger", () => {
     });
     expect(ledger.recordJournal("t1", 1, "sess-before-crash").accepted).toBe(true);
     expect(ledger.recordJournal("t1", 2, "sess-after-crash").accepted).toBe(true);
+  });
+
+  it("re-injects postSpawnInput on crash respawn so wrapper-less shells resume (#11339)", () => {
+    const client = createReadyClient();
+    // A command launch on a shell that can't host a startup wrapper (fish,
+    // nushell, unrecognized Windows shell): the IPC handler puts the launch
+    // command on `postSpawnInput` instead of in `args`.
+    client.spawn("t1", { ...baseOptions, postSpawnInput: "claude --resume s-1\r" });
+
+    // Initial spawn injects the command exactly once, right after the spawn.
+    expect(writeMessages(mockChild)).toEqual([{ id: "t1", data: "claude --resume s-1\r" }]);
+
+    const restartedChild = createMockChild();
+    shared.forkMock.mockReturnValue(restartedChild);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(200);
+    restartedChild.emit("message", { type: "ready" });
+
+    const replayed = spawnMessages(restartedChild);
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]!.options.postSpawnInput).toBe("claude --resume s-1\r");
+    // Re-injected exactly once on the fresh host — the terminal comes back
+    // running its command (here a resume), not as a bare prompt and not twice.
+    expect(writeMessages(restartedChild)).toEqual([{ id: "t1", data: "claude --resume s-1\r" }]);
+  });
+
+  it("replays wrapper args verbatim on crash respawn — a resume survives (#11339)", () => {
+    const client = createReadyClient();
+    // Wrapper-capable shells (zsh/bash/sh/pwsh/cmd) embed the launch command in
+    // `args`, so a resume launch already resumes on verbatim replay — no
+    // postSpawnInput and no separate write should appear.
+    const wrapperArgs = [
+      "-lic",
+      "trap : INT\nclaude --resume s-1\ntrap - INT\nexec '/bin/bash' -l",
+    ];
+    client.spawn("t1", {
+      ...baseOptions,
+      shell: "/bin/bash",
+      args: wrapperArgs,
+      command: "claude --resume s-1",
+    });
+
+    const restartedChild = createMockChild();
+    shared.forkMock.mockReturnValue(restartedChild);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(200);
+    restartedChild.emit("message", { type: "ready" });
+
+    const replayed = spawnMessages(restartedChild);
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]!.options.shell).toBe("/bin/bash");
+    expect(replayed[0]!.options.args).toEqual(wrapperArgs);
+    expect(replayed[0]!.options.postSpawnInput).toBeUndefined();
+    // No stray post-spawn write for a wrapper shell.
+    expect(writeMessages(restartedChild)).toHaveLength(0);
   });
 
   it("keeps the same generation for the initial-ready replay (nothing was delivered)", () => {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -82,6 +82,20 @@ export interface PtyHostSpawnOptions {
    * session journaling exactly-once per terminal incarnation.
    */
   launchGeneration?: number;
+  /**
+   * Command to type into the PTY immediately after spawn, for command launches
+   * on shells that can't host a startup wrapper (`buildCommandLaunchShell`
+   * returned null — fish, nushell, an unrecognized Windows shell). The wrapper
+   * shells (zsh/bash/sh/pwsh/cmd) embed the launch command in `args`, but these
+   * shells launch bare and the command is written in afterwards.
+   *
+   * Cached here so it rides `pendingSpawns` and is re-injected on every replay —
+   * a pty-host crash respawn, a crash-budget migration, and the pre-ready
+   * initial replay — so a resumed (or any) launch survives a crash on these
+   * shells instead of coming back as an empty prompt (#11339). Main owns the
+   * write: the pty-host ignores this field.
+   */
+  postSpawnInput?: string;
 }
 
 /** Per-project terminal-workload memory, deduplicated by PID. */


### PR DESCRIPTION
## Summary
- pty-host crash respawn replays terminals from a durable `pendingSpawns` record, but shells that can't host a startup wrapper (fish, nushell, unrecognized Windows shells) launched bare after a crash, because their launch command was written by a one-off post-spawn IPC step that `pendingSpawns` never recorded. Any resume in flight got dropped.
- The issue asked for capturing the session id at crash time, but there's no window to do that: the process holding the live pty is the one that died, so OOM, SIGSEGV, and watchdog SIGKILL all tear down the Mojo/MessagePort channel synchronously with the isolate before anything can run a graceful quit-and-capture. Session ids also aren't in normal PTY output, agents only print their resume hint in the quit farewell. So the resumable id has to already be in the launch to survive a crash, and for the shells that can host a wrapper, it already is (baked into the replayed args). This PR makes that faithful replay work for every shell instead of reconstructing a lossy resume command.

Resolves #11339

## Changes
- Add `postSpawnInput` to `PtyHostSpawnOptions`; the spawn IPC handler puts the launch command there for wrapper-less shells instead of writing it itself.
- Add a `sendSpawnWithPostInput` helper in `PtyClient` and funnel all four spawn-send sites through it (initial spawn, pre-ready replay, crash respawn, crash-budget migration), re-injecting the command right after each spawn.
- Gate the send on shard readiness: a pre-ready send would get queued by the host and then re-sent by the first-ready replay, double-launching the command. The entry stays in `pendingSpawns` so the replay delivers it exactly once, making the existing double-spawn-safe invariant explicit in code.
- Document a known limitation in code: agents launched cold, whose session id was never captured, still relaunch cold after a crash. There's no capture window and the id isn't in normal output; resuming those would mean parsing each agent's on-disk session store across 15+ bespoke formats, which is out of scope here.
- Touches the same `PtyClient`/pty-host teardown lane as #11340 (project-close journaling) and #11341 (duplicate-spawn) in this batch, but stays scoped to the spawn-send path, not `cleanupOrphanedPtysForShard` or `killByProject`.

## Testing
- 260 tests pass across 14 `PtyClient` and terminal-handler files; 122 branch-owned tests re-verified after a rebase.
- Prettier clean, eslint 0 errors on changed files.
- Adversarial Codex review caught and fixed a lossy-rebuild approach and a pre-ready double-injection race before this commit landed.