### PR TITLE
fix(persistence): merge concurrent layout writes across project windows

### DIFF
--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -121,6 +121,68 @@ describe("setTerminals merge (#11350)", () => {
   });
 });
 
+describe("two-writer composition (#11350)", () => {
+  /** A mutable disk so two queued writers see each other's committed result. */
+  function statefulDisk(initial: ProjectState | null): () => ProjectState | null {
+    let disk = initial;
+    projectStoreMock.enqueueProjectStateUpdate.mockImplementation(
+      async (
+        _projectId: string,
+        updater: (s: ProjectState | null) => ProjectState | null | Promise<ProjectState | null>
+      ) => {
+        disk = await updater(disk);
+      }
+    );
+    return () => disk;
+  }
+
+  it("preserves a move from writer A and an addition from stale writer B", async () => {
+    const disk = statefulDisk(baseState([term("1", "grid")]));
+
+    // A moves panel 1 to the dock.
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1", "dock")],
+      changedIds: ["1"],
+      removedIds: [],
+    });
+    // B never saw the move (still holds panel 1 in the grid) and adds panel 2.
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1", "grid"), term("2")],
+      changedIds: ["2"],
+      removedIds: [],
+    });
+
+    const merged = disk()?.terminals ?? [];
+    expect(merged.find((t) => t.id === "1")?.location).toBe("dock");
+    expect(ids(merged)).toEqual(["1", "2"]);
+  });
+
+  it("resolves edit-vs-delete of the same id by queue order (last writer wins)", async () => {
+    const disk = statefulDisk(baseState([term("1"), term("2", "grid")]));
+
+    // A closes panel 2.
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1")],
+      changedIds: [],
+      removedIds: ["2"],
+    });
+    // B, which ran second, edited panel 2 (moved it to the dock).
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1"), term("2", "dock")],
+      changedIds: ["2"],
+      removedIds: [],
+    });
+
+    const merged = disk()?.terminals ?? [];
+    expect(merged.find((t) => t.id === "2")?.location).toBe("dock");
+    expect(ids(merged)).toEqual(["1", "2"]);
+  });
+});
+
 describe("setTabGroups merge (#11350)", () => {
   it("preserves a sibling's tab group the writer never knew", async () => {
     const saved = onDisk(baseState([], [group("g1", ["1", "2"]), group("gSib", ["3", "4"])]));

--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ProjectState, TerminalSnapshot, TabGroup } from "../../../types/index.js";
+
+// Capture the updater the handler enqueues so we can run it against a chosen
+// on-disk state and assert the merged result, without a real ProjectStore.
+const projectStoreMock = vi.hoisted(() => ({
+  enqueueProjectStateUpdate: vi.fn(),
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+import { terminalLayoutNamespace } from "../terminalLayout.js";
+
+const setTerminals = terminalLayoutNamespace.ops.setTerminals.handler as (payload: {
+  projectId: string;
+  terminals: TerminalSnapshot[];
+  changedIds?: string[];
+  removedIds?: string[];
+}) => Promise<void>;
+
+const setTabGroups = terminalLayoutNamespace.ops.setTabGroups.handler as (payload: {
+  projectId: string;
+  tabGroups: TabGroup[];
+  changedIds?: string[];
+  removedIds?: string[];
+}) => Promise<void>;
+
+function term(id: string, location: "grid" | "dock" = "grid"): TerminalSnapshot {
+  // `cwd` is required by TerminalSnapshotSchema's refine for PTY-backed kinds
+  // (kind defaults to "terminal"); without it sanitizeTerminals drops the entry.
+  return { id, title: `T${id}`, cwd: "/tmp", location } as TerminalSnapshot;
+}
+
+function group(id: string, panelIds: string[]): TabGroup {
+  return { id, location: "grid", panelIds, activeTabId: panelIds[0]! } as TabGroup;
+}
+
+/** Arrange the on-disk state and return an accessor for the saved result. */
+function onDisk(existing: ProjectState | null): () => ProjectState | null {
+  let saved: ProjectState | null = null;
+  projectStoreMock.enqueueProjectStateUpdate.mockImplementation(
+    async (
+      _projectId: string,
+      updater: (s: ProjectState | null) => ProjectState | null | Promise<ProjectState | null>
+    ) => {
+      saved = await updater(existing);
+    }
+  );
+  return () => saved;
+}
+
+function ids(entries: { id: string }[] | undefined): string[] {
+  return (entries ?? []).map((e) => e.id);
+}
+
+const baseState = (terminals: TerminalSnapshot[], tabGroups: TabGroup[] = []): ProjectState => ({
+  projectId: "p1",
+  sidebarWidth: 350,
+  terminals,
+  tabGroups,
+});
+
+beforeEach(() => {
+  projectStoreMock.enqueueProjectStateUpdate.mockReset();
+});
+
+describe("setTerminals merge (#11350)", () => {
+  it("preserves a sibling window's addition the writer never knew", async () => {
+    const saved = onDisk(baseState([term("1"), term("2"), term("3"), term("4")]));
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1"), term("2"), term("3")],
+      changedIds: [],
+      removedIds: [],
+    });
+    expect(new Set(ids(saved()?.terminals))).toEqual(new Set(["1", "2", "3", "4"]));
+  });
+
+  it("persists an explicit close via removedIds", async () => {
+    const saved = onDisk(baseState([term("1"), term("2"), term("3")]));
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1"), term("3")],
+      changedIds: [],
+      removedIds: ["2"],
+    });
+    expect(ids(saved()?.terminals)).toEqual(["1", "3"]);
+  });
+
+  it("does not resurrect a sibling-deleted entry the writer did not change", async () => {
+    // Sibling already deleted 2 (disk = [1]); this stale writer adds 3.
+    const saved = onDisk(baseState([term("1")]));
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1"), term("2"), term("3")],
+      changedIds: ["3"],
+      removedIds: [],
+    });
+    expect(ids(saved()?.terminals)).toEqual(["1", "3"]);
+  });
+
+  it("preserves a disjoint move by a sibling window", async () => {
+    // Sibling moved panel 1 to the dock (disk); this stale writer still has it
+    // in the grid and only added panel 2.
+    const saved = onDisk(baseState([term("1", "dock")]));
+    await setTerminals({
+      projectId: "p1",
+      terminals: [term("1", "grid"), term("2")],
+      changedIds: ["2"],
+      removedIds: [],
+    });
+    const merged = saved()?.terminals ?? [];
+    expect(merged.find((t) => t.id === "1")?.location).toBe("dock");
+    expect(ids(merged)).toContain("2");
+  });
+
+  it("full-replaces when no delta metadata is supplied (legacy path)", async () => {
+    const saved = onDisk(baseState([term("1"), term("2"), term("3")]));
+    await setTerminals({ projectId: "p1", terminals: [term("1")] });
+    expect(ids(saved()?.terminals)).toEqual(["1"]);
+  });
+});
+
+describe("setTabGroups merge (#11350)", () => {
+  it("preserves a sibling's tab group the writer never knew", async () => {
+    const saved = onDisk(baseState([], [group("g1", ["1", "2"]), group("gSib", ["3", "4"])]));
+    await setTabGroups({
+      projectId: "p1",
+      tabGroups: [group("g1", ["1", "2"])],
+      changedIds: [],
+      removedIds: [],
+    });
+    expect(new Set(ids(saved()?.tabGroups))).toEqual(new Set(["g1", "gSib"]));
+  });
+
+  it("removes a tab group via removedIds", async () => {
+    const saved = onDisk(baseState([], [group("g1", ["1", "2"]), group("g2", ["3", "4"])]));
+    await setTabGroups({
+      projectId: "p1",
+      tabGroups: [group("g1", ["1", "2"])],
+      changedIds: [],
+      removedIds: ["g2"],
+    });
+    expect(ids(saved()?.tabGroups)).toEqual(["g1"]);
+  });
+});

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -20,6 +20,7 @@ import {
   sanitizeDraftInputs,
 } from "../terminalLayout.js";
 import { sanitizeTabGroups } from "../../../schemas/index.js";
+import { mergeIdArray } from "../../../../shared/utils/layoutMerge.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 import type { ProjectSwitchOutgoingState } from "../../../../shared/types/ipc/project.js";
@@ -296,15 +297,45 @@ async function persistOutgoingProjectState(
       : undefined;
   // Queued so the read-merge-write can't clobber concurrent queued writers
   // (terminalLayout handlers) now that the persist runs alongside the swap.
-  await projectStore.enqueueProjectStateUpdate(previousProjectId, (existing) => ({
-    ...(existing ?? { projectId: previousProjectId, sidebarWidth: 350, terminals: [] }),
-    projectId: previousProjectId,
-    ...(validTerminals !== undefined && { terminals: validTerminals }),
-    ...(validSizes !== undefined && { terminalSizes: validSizes }),
-    ...(validDrafts !== undefined && { draftInputs: validDrafts }),
-    ...(validTabGroups !== undefined && { tabGroups: validTabGroups }),
-    activeWorktreeId: outgoingState.activeWorktreeId,
-  }));
+  await projectStore.enqueueProjectStateUpdate(previousProjectId, (existing) => {
+    const terminalDelta = outgoingState.terminalDelta;
+    const tabGroupDelta = outgoingState.tabGroupDelta;
+    // With a delta, merge by id so a stale outgoing snapshot only affects the
+    // entries this window actually changed, preserving a sibling window's
+    // concurrent additions/moves/deletions (#11350). Without one, fall back to
+    // the legacy full replace.
+    const mergedTerminals =
+      validTerminals === undefined
+        ? undefined
+        : terminalDelta
+          ? mergeIdArray(
+              existing?.terminals ?? [],
+              validTerminals,
+              terminalDelta.changedIds,
+              terminalDelta.removedIds
+            )
+          : validTerminals;
+    const mergedTabGroups =
+      validTabGroups === undefined
+        ? undefined
+        : tabGroupDelta
+          ? mergeIdArray(
+              existing?.tabGroups ?? [],
+              validTabGroups,
+              tabGroupDelta.changedIds,
+              tabGroupDelta.removedIds
+            )
+          : validTabGroups;
+    return {
+      ...(existing ?? { projectId: previousProjectId, sidebarWidth: 350, terminals: [] }),
+      projectId: previousProjectId,
+      ...(mergedTerminals !== undefined && { terminals: mergedTerminals }),
+      ...(validSizes !== undefined && { terminalSizes: validSizes }),
+      ...(validDrafts !== undefined && { draftInputs: validDrafts }),
+      ...(mergedTabGroups !== undefined && { tabGroups: mergedTabGroups }),
+      activeWorktreeId: outgoingState.activeWorktreeId,
+    };
+  });
 }
 
 type ActivateOptions = {

--- a/electron/ipc/handlers/terminalLayout.preload.ts
+++ b/electron/ipc/handlers/terminalLayout.preload.ts
@@ -26,14 +26,27 @@ type FocusPanelState = NonNullable<FocusModeResult["focusPanelState"]>;
 
 export interface TerminalLayoutPreloadBindings {
   getTerminals(projectId: string): Promise<TerminalSnapshot[]>;
-  setTerminals(projectId: string, terminals: TerminalSnapshot[]): Promise<void>;
+  // `changedIds`/`removedIds` describe what this renderer changed relative to
+  // its last-persisted baseline so Main can merge concurrent writes from
+  // sibling windows of the same project (#11350). Omit both for a full replace.
+  setTerminals(
+    projectId: string,
+    terminals: TerminalSnapshot[],
+    changedIds?: string[],
+    removedIds?: string[]
+  ): Promise<void>;
   getTerminalSizes(projectId: string): Promise<Record<string, { cols: number; rows: number }>>;
   setTerminalSizes(
     projectId: string,
     terminalSizes: Record<string, { cols: number; rows: number }>
   ): Promise<void>;
   getTabGroups(projectId: string): Promise<TabGroup[]>;
-  setTabGroups(projectId: string, tabGroups: TabGroup[]): Promise<void>;
+  setTabGroups(
+    projectId: string,
+    tabGroups: TabGroup[],
+    changedIds?: string[],
+    removedIds?: string[]
+  ): Promise<void>;
   getFocusMode(projectId: string): Promise<FocusModeResult>;
   setFocusMode(
     projectId: string,
@@ -52,10 +65,12 @@ export function buildTerminalLayoutPreloadBindings(invoke: Invoker): TerminalLay
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTerminals, projectId) as Promise<
         TerminalSnapshot[]
       >,
-    setTerminals: (projectId, terminals) =>
+    setTerminals: (projectId, terminals, changedIds, removedIds) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.setTerminals, {
         projectId,
         terminals,
+        changedIds,
+        removedIds,
       }) as Promise<void>,
     getTerminalSizes: (projectId) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTerminalSizes, projectId) as Promise<
@@ -68,10 +83,12 @@ export function buildTerminalLayoutPreloadBindings(invoke: Invoker): TerminalLay
       }) as Promise<void>,
     getTabGroups: (projectId) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getTabGroups, projectId) as Promise<TabGroup[]>,
-    setTabGroups: (projectId, tabGroups) =>
+    setTabGroups: (projectId, tabGroups, changedIds, removedIds) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.setTabGroups, {
         projectId,
         tabGroups,
+        changedIds,
+        removedIds,
       }) as Promise<void>,
     getFocusMode: (projectId) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getFocusMode, projectId) as Promise<FocusModeResult>,

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -7,7 +7,24 @@ import {
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalSnapshot, TabGroup } from "../../types/index.js";
 import { defineIpcNamespace, op } from "../define.js";
+import { mergeIdArray } from "../../../shared/utils/layoutMerge.js";
 import { TERMINAL_LAYOUT_METHOD_CHANNELS } from "./terminalLayout.preload.js";
+
+/**
+ * Coerce an over-the-wire id list into a clean `string[]`, or `undefined` when
+ * absent. Absent delta metadata means a legacy full-replace write (see
+ * `setTerminals` / `setTabGroups` below); a present-but-malformed value is
+ * treated as an empty list rather than throwing.
+ */
+function sanitizeIdList(value: unknown): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((id): id is string => typeof id === "string");
+}
 
 /**
  * Validate and filter terminal snapshots using the Zod schema.
@@ -81,7 +98,12 @@ export const terminalLayoutNamespace = defineIpcNamespace({
     ),
     setTerminals: op(
       TERMINAL_LAYOUT_METHOD_CHANNELS.setTerminals,
-      async (payload: { projectId: string; terminals: TerminalSnapshot[] }): Promise<void> => {
+      async (payload: {
+        projectId: string;
+        terminals: TerminalSnapshot[];
+        changedIds?: string[];
+        removedIds?: string[];
+      }): Promise<void> => {
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -94,12 +116,25 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         }
 
         const validTerminals = sanitizeTerminals(terminals, `project:set-terminals(${projectId})`);
+        // Delta metadata lets Main merge concurrent writes from sibling windows
+        // of the same project instead of blindly replacing the array (#11350).
+        // Absent metadata = legacy full-replace write.
+        const changedIds = sanitizeIdList(payload.changedIds);
+        const removedIds = sanitizeIdList(payload.removedIds);
 
         await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
-          terminals: validTerminals,
+          terminals:
+            changedIds === undefined
+              ? validTerminals
+              : mergeIdArray(
+                  existingState?.terminals ?? [],
+                  validTerminals,
+                  changedIds,
+                  removedIds ?? []
+                ),
           tabGroups: existingState?.tabGroups ?? [],
           terminalLayout: existingState?.terminalLayout,
           focusMode: existingState?.focusMode,
@@ -169,7 +204,12 @@ export const terminalLayoutNamespace = defineIpcNamespace({
     ),
     setTabGroups: op(
       TERMINAL_LAYOUT_METHOD_CHANNELS.setTabGroups,
-      async (payload: { projectId: string; tabGroups: TabGroup[] }): Promise<void> => {
+      async (payload: {
+        projectId: string;
+        tabGroups: TabGroup[];
+        changedIds?: string[];
+        removedIds?: string[];
+      }): Promise<void> => {
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -182,13 +222,24 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         }
 
         const sanitizedTabGroups = sanitizeTabGroups(tabGroups, projectId) as TabGroup[];
+        // See setTerminals: merge sibling-window writes by tab-group id (#11350).
+        const changedIds = sanitizeIdList(payload.changedIds);
+        const removedIds = sanitizeIdList(payload.removedIds);
 
         await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
           activeWorktreeId: existingState?.activeWorktreeId,
           sidebarWidth: existingState?.sidebarWidth ?? 350,
           terminals: existingState?.terminals ?? [],
-          tabGroups: sanitizedTabGroups,
+          tabGroups:
+            changedIds === undefined
+              ? sanitizedTabGroups
+              : mergeIdArray(
+                  existingState?.tabGroups ?? [],
+                  sanitizedTabGroups,
+                  changedIds,
+                  removedIds ?? []
+                ),
           terminalLayout: existingState?.terminalLayout,
           focusMode: existingState?.focusMode,
           focusPanelState: existingState?.focusPanelState,

--- a/electron/services/smokeTest.ts
+++ b/electron/services/smokeTest.ts
@@ -317,7 +317,12 @@ async function runSmokeProjectPersistenceChecks(window: BrowserWindow): Promise<
         `(async () => {
           const projectId = ${projectIdJson};
           const terminals = ${terminalsJson};
-          await window.electron.project.setTerminals(projectId, terminals);
+          await window.electron.project.setTerminals(
+            projectId,
+            terminals,
+            terminals.map((t) => t.id),
+            []
+          );
           const saved = await window.electron.project.getTerminals(projectId);
           return {
             count: Array.isArray(saved) ? saved.length : -1,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -640,8 +640,16 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     /**
      * Save terminal snapshots for a project (per-project panel state).
      * Used for preserving panel layout when switching away from a project.
+     * `changedIds`/`removedIds` describe what this renderer changed relative to
+     * its last-persisted baseline so Main can merge concurrent writes from
+     * sibling windows of the same project (#11350). Omit both for a full replace.
      */
-    setTerminals(projectId: string, terminals: TerminalSnapshot[]): Promise<void>;
+    setTerminals(
+      projectId: string,
+      terminals: TerminalSnapshot[],
+      changedIds?: string[],
+      removedIds?: string[]
+    ): Promise<void>;
     /**
      * Get terminal dimensions for a project.
      * Used for restoring terminal sizes when switching to a project.
@@ -672,9 +680,15 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getTabGroups(projectId: string): Promise<TabGroup[]>;
     /**
      * Save tab groups for a project.
-     * Used for persisting tab group state per-project.
+     * Used for persisting tab group state per-project. `changedIds`/`removedIds`
+     * merge concurrent writes from sibling windows of the same project (#11350).
      */
-    setTabGroups(projectId: string, tabGroups: TabGroup[]): Promise<void>;
+    setTabGroups(
+      projectId: string,
+      tabGroups: TabGroup[],
+      changedIds?: string[],
+      removedIds?: string[]
+    ): Promise<void>;
     /**
      * Get focus mode state for a project.
      * Used for restoring focus mode when switching projects.

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1222,7 +1222,14 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "project:set-tab-groups": {
-    args: [payload: { projectId: string; tabGroups: import("../panel.js").TabGroup[] }];
+    args: [
+      payload: {
+        projectId: string;
+        tabGroups: import("../panel.js").TabGroup[];
+        changedIds?: string[] | undefined;
+        removedIds?: string[] | undefined;
+      },
+    ];
     result: void;
   };
   "project:set-terminal-sizes": {
@@ -1232,7 +1239,14 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "project:set-terminals": {
-    args: [payload: { projectId: string; terminals: import("../project.js").PanelSnapshot[] }];
+    args: [
+      payload: {
+        projectId: string;
+        terminals: import("../project.js").PanelSnapshot[];
+        changedIds?: string[] | undefined;
+        removedIds?: string[] | undefined;
+      },
+    ];
     result: void;
   };
   "run-history:append": {

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -1,5 +1,6 @@
 import type { Project, TerminalSnapshot } from "../project.js";
 import type { TabGroup } from "../panel.js";
+import type { IdArrayDelta } from "../../utils/layoutMerge.js";
 import type { HydrateResult } from "./app.js";
 
 /**
@@ -14,6 +15,15 @@ export interface ProjectSwitchOutgoingState {
   draftInputs?: Record<string, string>;
   tabGroups?: TabGroup[];
   activeWorktreeId?: string;
+  /**
+   * What this window changed in `terminals`/`tabGroups` relative to its
+   * last-persisted baseline. When present, Main merges the arrays by id instead
+   * of full-replacing, so switching away from a project open in another window
+   * doesn't clobber that window's concurrent layout changes (#11350). Absent =
+   * legacy full replace.
+   */
+  terminalDelta?: IdArrayDelta;
+  tabGroupDelta?: IdArrayDelta;
 }
 
 /** Payload for project:on-switch event with cancellation token */

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeIdArrayDelta, mergeIdArray } from "../layoutMerge";
+import { computeIdArrayDelta, mergeIdArray, deepEqualIgnoringUndefined } from "../layoutMerge";
 
 interface Entry {
   id: string;
@@ -8,6 +8,46 @@ interface Entry {
 
 const eq = (a: Entry, b: Entry) => a.v === b.v;
 const ids = (entries: Entry[]) => entries.map((e) => e.id);
+
+describe("deepEqualIgnoringUndefined", () => {
+  it("treats a missing key and an explicit undefined value as equal", () => {
+    // The exact JSON-round-trip mismatch behind #11350's false-positive changes.
+    expect(deepEqualIgnoringUndefined({ id: "p", worktreeId: undefined }, { id: "p" })).toBe(true);
+    expect(deepEqualIgnoringUndefined({ id: "p" }, { id: "p", worktreeId: undefined })).toBe(true);
+  });
+
+  it("still reports a genuine value difference", () => {
+    expect(deepEqualIgnoringUndefined({ id: "p", loc: "grid" }, { id: "p", loc: "dock" })).toBe(
+      false
+    );
+  });
+
+  it("compares nested objects and arrays with the same rule", () => {
+    expect(
+      deepEqualIgnoringUndefined(
+        { id: "g", panelIds: ["a", "b"], worktreeId: undefined },
+        { id: "g", panelIds: ["a", "b"] }
+      )
+    ).toBe(true);
+    expect(
+      deepEqualIgnoringUndefined({ id: "g", panelIds: ["a", "b"] }, { id: "g", panelIds: ["a"] })
+    ).toBe(false);
+  });
+
+  it("does not conflate a real key with an undefined-valued one of a different name", () => {
+    expect(deepEqualIgnoringUndefined({ id: "p", a: undefined }, { id: "p", b: 1 })).toBe(false);
+  });
+});
+
+describe("computeIdArrayDelta with JSON-round-trip equality", () => {
+  it("does not flag an entry that differs only by a dropped undefined key", () => {
+    const base = [{ id: "1" }]; // as read back from disk (undefined keys dropped)
+    const current = [{ id: "1", v: undefined } as Entry]; // freshly serialized
+    const delta = computeIdArrayDelta(base, current, deepEqualIgnoringUndefined);
+    expect(delta.changedIds).toEqual([]);
+    expect(delta.removedIds).toEqual([]);
+  });
+});
 
 describe("computeIdArrayDelta", () => {
   it("reports added ids as changed", () => {
@@ -140,6 +180,13 @@ describe("mergeIdArray", () => {
     const existing = [{ id: "1" }, { id: "2" }, { id: "sib" }];
     const merged = mergeIdArray(existing, [], [], ["1", "2"]);
     expect(ids(merged)).toEqual(["sib"]);
+  });
+
+  it("does not throw on malformed existing/incoming entries", () => {
+    const existing = [null, { id: "1" }, { notId: true }] as unknown as Entry[];
+    const incoming = [{ id: "1" }, undefined, { id: "2" }] as unknown as Entry[];
+    const merged = mergeIdArray(existing, incoming, ["2"], []);
+    expect(ids(merged)).toEqual(["1", "2"]);
   });
 
   it("round-trips a delta computed from a shared baseline", () => {

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { computeIdArrayDelta, mergeIdArray } from "../layoutMerge";
+
+interface Entry {
+  id: string;
+  v?: string;
+}
+
+const eq = (a: Entry, b: Entry) => a.v === b.v;
+const ids = (entries: Entry[]) => entries.map((e) => e.id);
+
+describe("computeIdArrayDelta", () => {
+  it("reports added ids as changed", () => {
+    const delta = computeIdArrayDelta([{ id: "1" }], [{ id: "1" }, { id: "2" }], eq);
+    expect(delta.changedIds).toEqual(["2"]);
+    expect(delta.removedIds).toEqual([]);
+  });
+
+  it("reports content changes as changed", () => {
+    const delta = computeIdArrayDelta([{ id: "1", v: "a" }], [{ id: "1", v: "b" }], eq);
+    expect(delta.changedIds).toEqual(["1"]);
+    expect(delta.removedIds).toEqual([]);
+  });
+
+  it("reports missing baseline entries as removed", () => {
+    const delta = computeIdArrayDelta([{ id: "1" }, { id: "2" }], [{ id: "1" }], eq);
+    expect(delta.changedIds).toEqual([]);
+    expect(delta.removedIds).toEqual(["2"]);
+  });
+
+  it("produces an empty delta when content is identical regardless of order", () => {
+    const delta = computeIdArrayDelta(
+      [
+        { id: "1", v: "a" },
+        { id: "2", v: "b" },
+      ],
+      [
+        { id: "2", v: "b" },
+        { id: "1", v: "a" },
+      ],
+      eq
+    );
+    expect(delta.changedIds).toEqual([]);
+    expect(delta.removedIds).toEqual([]);
+  });
+
+  it("handles simultaneous add, change, and remove", () => {
+    const delta = computeIdArrayDelta(
+      [
+        { id: "1", v: "a" },
+        { id: "2", v: "b" },
+      ],
+      [
+        { id: "1", v: "a2" },
+        { id: "3", v: "c" },
+      ],
+      eq
+    );
+    expect(new Set(delta.changedIds)).toEqual(new Set(["1", "3"]));
+    expect(delta.removedIds).toEqual(["2"]);
+  });
+});
+
+describe("mergeIdArray", () => {
+  it("preserves a sibling's addition unknown to the writer", () => {
+    // disk has a sibling's panel 4; writer only knows 1,2,3 and added nothing new.
+    const existing = [{ id: "1" }, { id: "2" }, { id: "3" }, { id: "4" }];
+    const incoming = [{ id: "1" }, { id: "2" }, { id: "3" }];
+    const merged = mergeIdArray(existing, incoming, [], []);
+    expect(new Set(ids(merged))).toEqual(new Set(["1", "2", "3", "4"]));
+  });
+
+  it("applies the writer's addition", () => {
+    const existing = [{ id: "1" }];
+    const incoming = [{ id: "1" }, { id: "2" }];
+    const merged = mergeIdArray(existing, incoming, ["2"], []);
+    expect(ids(merged)).toEqual(["1", "2"]);
+  });
+
+  it("removes an explicitly-removed entry (close persists)", () => {
+    const existing = [{ id: "1" }, { id: "2" }, { id: "3" }];
+    const incoming = [{ id: "1" }, { id: "3" }];
+    const merged = mergeIdArray(existing, incoming, [], ["2"]);
+    expect(ids(merged)).toEqual(["1", "3"]);
+  });
+
+  it("preserves a disjoint move: a sibling's edit to an entry the writer did not change", () => {
+    // A moved panel 1 to dock (on disk). B is stale (panel 1 still grid) and adds panel 2.
+    const existing = [{ id: "1", v: "dock" }];
+    const incoming = [
+      { id: "1", v: "grid" },
+      { id: "2", v: "new" },
+    ];
+    const merged = mergeIdArray(existing, incoming, ["2"], []);
+    // Panel 1 keeps the sibling's dock value; panel 2 is added.
+    expect(merged).toEqual([
+      { id: "1", v: "dock" },
+      { id: "2", v: "new" },
+    ]);
+  });
+
+  it("does not resurrect a sibling-deleted entry the writer did not change", () => {
+    // A closed panel 2 (disk = [1]). B is stale ([1,2]) and adds panel 3.
+    const existing = [{ id: "1" }];
+    const incoming = [{ id: "1" }, { id: "2" }, { id: "3" }];
+    const merged = mergeIdArray(existing, incoming, ["3"], []);
+    expect(ids(merged)).toEqual(["1", "3"]);
+  });
+
+  it("lets the writer's own change win for a shared id (last-writer-wins)", () => {
+    const existing = [{ id: "1", v: "disk" }];
+    const incoming = [{ id: "1", v: "mine" }];
+    const merged = mergeIdArray(existing, incoming, ["1"], []);
+    expect(merged).toEqual([{ id: "1", v: "mine" }]);
+  });
+
+  it("applies the incoming order for known entries (reorder persists)", () => {
+    const existing = [{ id: "1" }, { id: "2" }, { id: "3" }];
+    const incoming = [{ id: "3" }, { id: "2" }, { id: "1" }];
+    const merged = mergeIdArray(existing, incoming, [], []);
+    expect(ids(merged)).toEqual(["3", "2", "1"]);
+  });
+
+  it("appends sibling-only additions after the writer's known entries", () => {
+    const existing = [{ id: "1" }, { id: "sib" }];
+    const incoming = [{ id: "1" }, { id: "2" }];
+    const merged = mergeIdArray(existing, incoming, ["2"], []);
+    expect(ids(merged)).toEqual(["1", "2", "sib"]);
+  });
+
+  it("clears all known entries when the writer removes everything it knew", () => {
+    // "Close all panels" in the only window: removedIds covers the full baseline.
+    const existing = [{ id: "1" }, { id: "2" }];
+    const merged = mergeIdArray(existing, [], [], ["1", "2"]);
+    expect(merged).toEqual([]);
+  });
+
+  it("keeps a sibling's panel when the writer closes all of its own", () => {
+    // Writer knew [1,2] and closed both; a sibling added 'sib' the writer never knew.
+    const existing = [{ id: "1" }, { id: "2" }, { id: "sib" }];
+    const merged = mergeIdArray(existing, [], [], ["1", "2"]);
+    expect(ids(merged)).toEqual(["sib"]);
+  });
+
+  it("round-trips a delta computed from a shared baseline", () => {
+    const base = [
+      { id: "1", v: "a" },
+      { id: "2", v: "b" },
+    ];
+    const current = [
+      { id: "1", v: "a" },
+      { id: "2", v: "b2" },
+      { id: "3", v: "c" },
+    ];
+    const { changedIds, removedIds } = computeIdArrayDelta(base, current, eq);
+    // Disk still equals the shared baseline (no sibling activity).
+    const merged = mergeIdArray(base, current, changedIds, removedIds);
+    expect(merged).toEqual(current);
+  });
+});

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeIdArrayDelta, mergeIdArray, deepEqualIgnoringUndefined } from "../layoutMerge";
+import { computeIdArrayDelta, mergeIdArray, deepEqualIgnoringUndefined } from "../layoutMerge.js";
 
 interface Entry {
   id: string;

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -1,0 +1,130 @@
+/**
+ * Three-way merge for the per-project layout arrays (terminal/panel snapshots
+ * and tab groups) that are persisted concurrently by multiple windows viewing
+ * the same project.
+ *
+ * The problem (#11350): the same project can be open in more than one window
+ * (#5033 / #5492). Each window hydrates its layout once from a point-in-time
+ * read, then autosaves its whole in-memory array back to the shared project
+ * state. Those writes are serialized in Main but never merged, so a window
+ * holding an older snapshot silently overwrites a sibling window's additions,
+ * moves, and deletions — a dropped panel becomes unreachable on next load.
+ *
+ * The fix is a compact three-way merge. A writing renderer sends its full array
+ * plus two id lists derived from its own last-acknowledged baseline:
+ *   - `changedIds`: entries the writer added or modified since its baseline.
+ *   - `removedIds`: entries present in its baseline but gone from its array.
+ * Main merges the incoming array against the on-disk array so that a writer only
+ * ever affects entries it actually touched; everything else (a sibling window's
+ * concurrent changes) is preserved. Entries the writer did not change take the
+ * on-disk value, so a sibling's edit survives; an entry the writer never knew
+ * (a sibling's addition) is kept; an entry the writer did not change but that a
+ * sibling deleted is not resurrected.
+ *
+ * Ordering is resolved last-writer-wins: the merged result follows the incoming
+ * array's order for entries the writer knows, with sibling-only entries appended.
+ * A concurrent reorder can therefore be superseded, but no entry is ever lost —
+ * which is the invariant #11350 requires.
+ *
+ * Pure and dependency-free so both the renderer (delta computation) and Main
+ * (merge application) can share it.
+ */
+
+export interface IdArrayDelta {
+  /** Ids the writer added or whose content changed relative to its baseline. */
+  changedIds: string[];
+  /** Ids present in the writer's baseline but absent from its current array. */
+  removedIds: string[];
+}
+
+/**
+ * Compute the delta between a renderer's last-acknowledged baseline and its
+ * current array. `equals` decides whether an entry's content changed (identity
+ * is by `id`; content equality is caller-defined, e.g. a deep comparison).
+ */
+export function computeIdArrayDelta<T extends { id: string }>(
+  base: readonly T[],
+  current: readonly T[],
+  equals: (a: T, b: T) => boolean
+): IdArrayDelta {
+  const baseById = new Map<string, T>();
+  for (const entry of base) {
+    baseById.set(entry.id, entry);
+  }
+
+  const changedIds: string[] = [];
+  const currentIds = new Set<string>();
+  for (const entry of current) {
+    currentIds.add(entry.id);
+    const prev = baseById.get(entry.id);
+    if (prev === undefined || !equals(prev, entry)) {
+      changedIds.push(entry.id);
+    }
+  }
+
+  const removedIds: string[] = [];
+  for (const entry of base) {
+    if (!currentIds.has(entry.id)) {
+      removedIds.push(entry.id);
+    }
+  }
+
+  return { changedIds, removedIds };
+}
+
+/**
+ * Merge a writer's `incoming` array into the current on-disk `existing` array,
+ * applying only the changes the writer actually made (`changedIds` /
+ * `removedIds`) and preserving every other existing entry — including entries a
+ * sibling window added or modified.
+ *
+ * Semantics per id:
+ *   - in `removedIds`  → dropped (the writer deleted it).
+ *   - in `changedIds`  → the incoming value wins (the writer added/changed it).
+ *   - otherwise, present on disk → the on-disk value is kept (preserves a
+ *     sibling's concurrent edit; a same-value no-op is a harmless identity).
+ *   - otherwise, absent from disk → dropped (a sibling deleted it and the writer
+ *     did not touch it, so the writer has no authority to resurrect it).
+ * Existing entries the writer never knew (not in `incoming`, not in
+ * `removedIds`) are appended, preserving sibling additions.
+ */
+export function mergeIdArray<T extends { id: string }>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  changedIds: readonly string[],
+  removedIds: readonly string[]
+): T[] {
+  const existingById = new Map<string, T>();
+  for (const entry of existing) {
+    existingById.set(entry.id, entry);
+  }
+  const changed = new Set(changedIds);
+  const removed = new Set(removedIds);
+  const incomingIds = new Set<string>();
+
+  const result: T[] = [];
+  for (const entry of incoming) {
+    incomingIds.add(entry.id);
+    if (removed.has(entry.id)) {
+      continue;
+    }
+    if (changed.has(entry.id)) {
+      result.push(entry);
+      continue;
+    }
+    const onDisk = existingById.get(entry.id);
+    if (onDisk !== undefined) {
+      result.push(onDisk);
+    }
+    // else: a sibling deleted it and the writer did not change it — do not
+    // resurrect.
+  }
+
+  for (const entry of existing) {
+    if (!incomingIds.has(entry.id) && !removed.has(entry.id)) {
+      result.push(entry);
+    }
+  }
+
+  return result;
+}

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -28,6 +28,14 @@
  *
  * Pure and dependency-free so both the renderer (delta computation) and Main
  * (merge application) can share it.
+ *
+ * Known limitation (follow-up, not a regression vs. the old full-replace): the
+ * delta is entry-level. A panel whose only change since the writer's baseline is
+ * an ambient runtime field (e.g. an agent's `agentState`) is reported as changed,
+ * so Main replaces the whole entry — including its layout fields. If a sibling
+ * window moved that same panel, the ambient-driven save can overwrite the move.
+ * The old code overwrote every panel's layout on every save, so this is strictly
+ * better; fully fixing it needs a field-level merge and is tracked separately.
  */
 
 export interface IdArrayDelta {
@@ -35,6 +43,62 @@ export interface IdArrayDelta {
   changedIds: string[];
   /** Ids present in the writer's baseline but absent from its current array. */
   removedIds: string[];
+}
+
+function hasStringId(entry: unknown): entry is { id: string } {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    typeof (entry as { id?: unknown }).id === "string" &&
+    (entry as { id: string }).id.length > 0
+  );
+}
+
+/**
+ * Deep structural equality that treats a missing key and a key whose value is
+ * `undefined` as equivalent — i.e. JSON round-trip semantics. Layout arrays are
+ * persisted as JSON (which drops `undefined`-valued keys), but the in-memory
+ * snapshots a renderer diffs against still carry explicit `undefined` keys
+ * (e.g. `worktreeId: undefined`). A key-count comparison would then flag an
+ * otherwise-identical entry as changed on the first save after hydration, which
+ * would wrongly grant the writer authority to overwrite a sibling's edit
+ * (#11350). Ignoring `undefined`-valued keys makes the delta reflect real
+ * changes only. `NaN` is treated as equal to itself.
+ */
+export function deepEqualIgnoringUndefined(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (typeof left === "number" && typeof right === "number") {
+    return Number.isNaN(left) && Number.isNaN(right);
+  }
+  if (typeof left !== typeof right) return false;
+  if (left === null || right === null) return false;
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+    for (let i = 0; i < left.length; i += 1) {
+      if (!deepEqualIgnoringUndefined(left[i], right[i])) return false;
+    }
+    return true;
+  }
+
+  if (typeof left === "object") {
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord).filter((k) => leftRecord[k] !== undefined);
+    const rightKeys = Object.keys(rightRecord).filter((k) => rightRecord[k] !== undefined);
+    if (leftKeys.length !== rightKeys.length) return false;
+    for (const key of leftKeys) {
+      // A key defined on the left but absent/undefined on the right recurses as
+      // (definedValue, undefined) → type mismatch → not equal, so a differing
+      // key set of equal size is still caught here.
+      if (!deepEqualIgnoringUndefined(leftRecord[key], rightRecord[key])) return false;
+    }
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -49,12 +113,13 @@ export function computeIdArrayDelta<T extends { id: string }>(
 ): IdArrayDelta {
   const baseById = new Map<string, T>();
   for (const entry of base) {
-    baseById.set(entry.id, entry);
+    if (hasStringId(entry)) baseById.set(entry.id, entry);
   }
 
   const changedIds: string[] = [];
   const currentIds = new Set<string>();
   for (const entry of current) {
+    if (!hasStringId(entry)) continue;
     currentIds.add(entry.id);
     const prev = baseById.get(entry.id);
     if (prev === undefined || !equals(prev, entry)) {
@@ -63,9 +128,9 @@ export function computeIdArrayDelta<T extends { id: string }>(
   }
 
   const removedIds: string[] = [];
-  for (const entry of base) {
-    if (!currentIds.has(entry.id)) {
-      removedIds.push(entry.id);
+  for (const id of baseById.keys()) {
+    if (!currentIds.has(id)) {
+      removedIds.push(id);
     }
   }
 
@@ -96,7 +161,9 @@ export function mergeIdArray<T extends { id: string }>(
 ): T[] {
   const existingById = new Map<string, T>();
   for (const entry of existing) {
-    existingById.set(entry.id, entry);
+    // Defensive: a malformed on-disk entry (null / missing id) must not crash
+    // the merge or the whole per-project write queue (#11350). Skip it.
+    if (hasStringId(entry)) existingById.set(entry.id, entry);
   }
   const changed = new Set(changedIds);
   const removed = new Set(removedIds);
@@ -104,6 +171,7 @@ export function mergeIdArray<T extends { id: string }>(
 
   const result: T[] = [];
   for (const entry of incoming) {
+    if (!hasStringId(entry)) continue;
     incomingIds.add(entry.id);
     if (removed.has(entry.id)) {
       continue;
@@ -120,7 +188,7 @@ export function mergeIdArray<T extends { id: string }>(
     // resurrect.
   }
 
-  for (const entry of existing) {
+  for (const entry of existingById.values()) {
     if (!incomingIds.has(entry.id) && !removed.has(entry.id)) {
       result.push(entry);
     }

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -55,50 +55,47 @@ function hasStringId(entry: unknown): entry is { id: string } {
 }
 
 /**
- * Deep structural equality that treats a missing key and a key whose value is
- * `undefined` as equivalent — i.e. JSON round-trip semantics. Layout arrays are
- * persisted as JSON (which drops `undefined`-valued keys), but the in-memory
- * snapshots a renderer diffs against still carry explicit `undefined` keys
- * (e.g. `worktreeId: undefined`). A key-count comparison would then flag an
- * otherwise-identical entry as changed on the first save after hydration, which
- * would wrongly grant the writer authority to overwrite a sibling's edit
- * (#11350). Ignoring `undefined`-valued keys makes the delta reflect real
- * changes only. `NaN` is treated as equal to itself.
+ * Recursively rewrite a value into the exact shape JSON serialization would
+ * produce: `undefined`-valued object keys are dropped, `undefined`/hole array
+ * elements and non-finite numbers become `null`, and object keys are sorted so
+ * ordering never matters. Functions/symbols are dropped by JSON downstream.
+ */
+function canonicalizeForJson(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((element) => (element === undefined ? null : canonicalizeForJson(element)));
+  }
+  const record = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    if (record[key] !== undefined) {
+      out[key] = canonicalizeForJson(record[key]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Structural equality under JSON round-trip semantics. Layout arrays are
+ * persisted as JSON, which drops `undefined`-valued keys and maps array holes /
+ * non-finite numbers to `null`; the in-memory snapshots a renderer diffs
+ * against still carry explicit `undefined` keys (e.g. `worktreeId: undefined`).
+ * A naive comparison would then flag an otherwise-identical entry as changed on
+ * the first save after hydration, wrongly granting the writer authority to
+ * overwrite a sibling's edit (#11350). Comparing the canonical JSON form makes
+ * the delta reflect only changes that survive a persist round-trip.
  */
 export function deepEqualIgnoringUndefined(left: unknown, right: unknown): boolean {
   if (left === right) return true;
-  if (typeof left === "number" && typeof right === "number") {
-    return Number.isNaN(left) && Number.isNaN(right);
+  try {
+    return JSON.stringify(canonicalizeForJson(left)) === JSON.stringify(canonicalizeForJson(right));
+  } catch {
+    // Non-serializable input (BigInt, circular): treat as changed so the entry
+    // is sent rather than silently dropped from the delta.
+    return false;
   }
-  if (typeof left !== typeof right) return false;
-  if (left === null || right === null) return false;
-
-  if (Array.isArray(left) || Array.isArray(right)) {
-    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
-      return false;
-    }
-    for (let i = 0; i < left.length; i += 1) {
-      if (!deepEqualIgnoringUndefined(left[i], right[i])) return false;
-    }
-    return true;
-  }
-
-  if (typeof left === "object") {
-    const leftRecord = left as Record<string, unknown>;
-    const rightRecord = right as Record<string, unknown>;
-    const leftKeys = Object.keys(leftRecord).filter((k) => leftRecord[k] !== undefined);
-    const rightKeys = Object.keys(rightRecord).filter((k) => rightRecord[k] !== undefined);
-    if (leftKeys.length !== rightKeys.length) return false;
-    for (const key of leftKeys) {
-      // A key defined on the left but absent/undefined on the right recurses as
-      // (definedValue, undefined) → type mismatch → not equal, so a differing
-      // key set of equal size is still caught here.
-      if (!deepEqualIgnoringUndefined(leftRecord[key], rightRecord[key])) return false;
-    }
-    return true;
-  }
-
-  return false;
 }
 
 /**

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -328,8 +328,13 @@ export const projectClient = {
     return window.electron.project.getTerminals(projectId);
   },
 
-  setTerminals: (projectId: string, terminals: TerminalSnapshot[]): Promise<void> => {
-    return window.electron.project.setTerminals(projectId, terminals);
+  setTerminals: (
+    projectId: string,
+    terminals: TerminalSnapshot[],
+    changedIds?: string[],
+    removedIds?: string[]
+  ): Promise<void> => {
+    return window.electron.project.setTerminals(projectId, terminals, changedIds, removedIds);
   },
 
   getTerminalSizes: (
@@ -357,8 +362,13 @@ export const projectClient = {
     return window.electron.project.getTabGroups(projectId);
   },
 
-  setTabGroups: (projectId: string, tabGroups: TabGroup[]): Promise<void> => {
-    return window.electron.project.setTabGroups(projectId, tabGroups);
+  setTabGroups: (
+    projectId: string,
+    tabGroups: TabGroup[],
+    changedIds?: string[],
+    removedIds?: string[]
+  ): Promise<void> => {
+    return window.electron.project.setTabGroups(projectId, tabGroups, changedIds, removedIds);
   },
 
   readClaudeMd: (projectId: string): Promise<string | null> => {

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -73,6 +73,8 @@ vi.mock("@/utils/logger", () => ({
 vi.mock("../persistence/panelPersistence", () => ({
   panelPersistence: {
     setProjectIdGetter: setProjectIdGetterMock,
+    flush: vi.fn(),
+    whenIdle: vi.fn(() => Promise.resolve()),
     cancel: panelPersistenceCancelMock,
   },
   panelToSnapshot: vi.fn((panel: { id: string; kind: string }) => ({

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -72,6 +72,8 @@ vi.mock("../persistence/panelPersistence", () => ({
   panelPersistence: {
     setProjectIdGetter: vi.fn(),
     getPreviousSnapshotMap: vi.fn(() => undefined),
+    computeTerminalDelta: vi.fn(() => ({ changedIds: [], removedIds: [] })),
+    computeTabGroupDelta: vi.fn(() => ({ changedIds: [], removedIds: [] })),
     cancel: vi.fn(),
   },
   panelToSnapshot: vi.fn((t: { id: string; kind: string }) => ({

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -74,6 +74,8 @@ vi.mock("../persistence/panelPersistence", () => ({
     getPreviousSnapshotMap: vi.fn(() => undefined),
     computeTerminalDelta: vi.fn(() => ({ changedIds: [], removedIds: [] })),
     computeTabGroupDelta: vi.fn(() => ({ changedIds: [], removedIds: [] })),
+    flush: vi.fn(),
+    whenIdle: vi.fn(() => Promise.resolve()),
     cancel: vi.fn(),
   },
   panelToSnapshot: vi.fn((t: { id: string; kind: string }) => ({

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -434,9 +434,11 @@ describe("PanelPersistence", () => {
       expect(removedIds).toEqual([]);
     });
 
-    it("does not re-send unchanged panels against a JSON-round-tripped baseline", async () => {
-      // Regression for the undefined-vs-missing key mismatch: priming from disk
-      // shape and saving the same panels must be a no-op, not a full rewrite.
+    it("emits an empty delta for panels unchanged since a JSON-round-tripped baseline", async () => {
+      // Regression for the undefined-vs-missing key mismatch: a baseline read
+      // back from disk drops undefined-valued keys, but the delta must still
+      // report no change so Main's merge is a no-op and cannot overwrite a
+      // sibling's edit.
       const client = createMockProjectClient();
       const persistence = new PanelPersistence(client, { debounceMs: 100 });
 
@@ -447,7 +449,9 @@ describe("PanelPersistence", () => {
       persistence.save([a, b], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTerminals).not.toHaveBeenCalled();
+      const [, , changedIds, removedIds] = client.setTerminals.mock.calls[0]!;
+      expect(changedIds).toEqual([]);
+      expect(removedIds).toEqual([]);
     });
 
     it("emits only the newly added panel in changedIds against a hydrated baseline", async () => {
@@ -1042,6 +1046,13 @@ describe("PanelPersistence", () => {
 
       persistence.save([createMockTerminal({ ...panel, title: "Renamed" })], projectId);
       await vi.advanceTimersByTimeAsync(100);
+      // The fragment is captured from queued state synchronously at save() time,
+      // but the second write is serialized behind the in-flight first write and
+      // is not sent until that resolves (#11350).
+      expect(client.setTerminals).toHaveBeenCalledTimes(1);
+
+      resolveFirstPersist?.();
+      await persistence.whenIdle();
 
       expect(client.setTerminals).toHaveBeenCalledTimes(2);
       const secondSave = client.setTerminals.mock.calls[1]![1] as TerminalSnapshot[];
@@ -1052,9 +1063,6 @@ describe("PanelPersistence", () => {
           browserUrl: "https://example.com",
         })
       );
-
-      resolveFirstPersist?.();
-      await persistence.whenIdle();
     });
   });
 

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -416,6 +416,12 @@ describe("PanelPersistence", () => {
   });
 
   describe("layout merge delta (#11350)", () => {
+    // Mirror how a baseline is actually seeded at hydration: read back from
+    // disk (JSON), which drops undefined-valued keys. A strict key-count
+    // comparison would then mark an untouched panel changed on the first save.
+    const hydratedBaseline = (...terminals: TerminalInstance[]): TerminalSnapshot[] =>
+      terminals.map((t) => JSON.parse(JSON.stringify(panelToSnapshot(t))) as TerminalSnapshot);
+
     it("marks every panel changed when there is no primed baseline", async () => {
       const client = createMockProjectClient();
       const persistence = new PanelPersistence(client, { debounceMs: 100 });
@@ -428,13 +434,29 @@ describe("PanelPersistence", () => {
       expect(removedIds).toEqual([]);
     });
 
-    it("emits only the newly added panel in changedIds against a primed baseline", async () => {
+    it("does not re-send unchanged panels against a JSON-round-tripped baseline", async () => {
+      // Regression for the undefined-vs-missing key mismatch: priming from disk
+      // shape and saving the same panels must be a no-op, not a full rewrite.
       const client = createMockProjectClient();
       const persistence = new PanelPersistence(client, { debounceMs: 100 });
 
       const a = createMockTerminal({ id: "a" });
       const b = createMockTerminal({ id: "b" });
-      persistence.primeProject(projectId, [panelToSnapshot(a), panelToSnapshot(b)]);
+      persistence.primeProject(projectId, hydratedBaseline(a, b));
+
+      persistence.save([a, b], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTerminals).not.toHaveBeenCalled();
+    });
+
+    it("emits only the newly added panel in changedIds against a hydrated baseline", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const a = createMockTerminal({ id: "a" });
+      const b = createMockTerminal({ id: "b" });
+      persistence.primeProject(projectId, hydratedBaseline(a, b));
 
       persistence.save([a, b, createMockTerminal({ id: "c" })], projectId);
       await vi.advanceTimersByTimeAsync(100);
@@ -444,18 +466,53 @@ describe("PanelPersistence", () => {
       expect(removedIds).toEqual([]);
     });
 
-    it("emits a closed panel in removedIds against a primed baseline", async () => {
+    it("emits a closed panel in removedIds against a hydrated baseline", async () => {
       const client = createMockProjectClient();
       const persistence = new PanelPersistence(client, { debounceMs: 100 });
 
       const a = createMockTerminal({ id: "a" });
       const b = createMockTerminal({ id: "b" });
-      persistence.primeProject(projectId, [panelToSnapshot(a), panelToSnapshot(b)]);
+      persistence.primeProject(projectId, hydratedBaseline(a, b));
 
       persistence.save([a], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
       const [, , changedIds, removedIds] = client.setTerminals.mock.calls[0]!;
+      expect(changedIds).toEqual([]);
+      expect(removedIds).toEqual(["b"]);
+    });
+
+    it("computes an overlapping save's delta against the acknowledged baseline", async () => {
+      // Regression: while the first send (add b) is still in flight, a second
+      // save (remove b) must diff against the baseline the first write commits
+      // ([a, b]), so it emits removedIds:["b"]. If it diffed against the stale
+      // [a], it would omit the tombstone and Main would resurrect b.
+      const client = createMockProjectClient();
+      let resolveFirst: (() => void) | undefined;
+      const firstSend = new Promise<void>((resolve) => {
+        resolveFirst = () => resolve();
+      });
+      client.setTerminals.mockReturnValueOnce(firstSend).mockResolvedValue(undefined);
+
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+      const a = createMockTerminal({ id: "a" });
+      const b = createMockTerminal({ id: "b" });
+      persistence.primeProject(projectId, hydratedBaseline(a));
+
+      persistence.save([a, b], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(client.setTerminals).toHaveBeenCalledTimes(1);
+
+      persistence.save([a], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+      // Second write is chained behind the in-flight first write.
+      expect(client.setTerminals).toHaveBeenCalledTimes(1);
+
+      resolveFirst?.();
+      await vi.runAllTimersAsync();
+
+      expect(client.setTerminals).toHaveBeenCalledTimes(2);
+      const [, , changedIds, removedIds] = client.setTerminals.mock.calls[1]!;
       expect(changedIds).toEqual([]);
       expect(removedIds).toEqual(["b"]);
     });

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -140,7 +140,9 @@ describe("PanelPersistence", () => {
         expect.arrayContaining([
           expect.objectContaining({ id: "grid-1" }),
           expect.objectContaining({ id: "dock-1" }),
-        ])
+        ]),
+        expect.any(Array),
+        expect.any(Array)
       );
 
       const savedTerminals = client.setTerminals.mock.calls[0]![1] as TerminalSnapshot[];
@@ -246,20 +248,25 @@ describe("PanelPersistence", () => {
       persistence.save([terminal], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTerminals).toHaveBeenCalledWith(projectId, [
-        {
-          id: "test-1",
-          kind: "terminal",
-          launchAgentId: "claude",
-          title: "Claude",
-          cwd: "/test",
-          worktreeId: "wt-1",
-          location: "grid",
-          command: "claude --model sonnet-4",
-          agentState: "working",
-          lastStateChange: 1700000000000,
-        },
-      ]);
+      expect(client.setTerminals).toHaveBeenCalledWith(
+        projectId,
+        [
+          {
+            id: "test-1",
+            kind: "terminal",
+            launchAgentId: "claude",
+            title: "Claude",
+            cwd: "/test",
+            worktreeId: "wt-1",
+            location: "grid",
+            command: "claude --model sonnet-4",
+            agentState: "working",
+            lastStateChange: 1700000000000,
+          },
+        ],
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
 
     it("excludes transient detectedProcessId from persisted snapshots", async () => {
@@ -326,13 +333,18 @@ describe("PanelPersistence", () => {
       persistence.save([terminal], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTerminals).toHaveBeenCalledWith(projectId, [
-        expect.objectContaining({
-          id: "test-1",
-          title: "Custom",
-          cwd: "/custom/path",
-        }),
-      ]);
+      expect(client.setTerminals).toHaveBeenCalledWith(
+        projectId,
+        [
+          expect.objectContaining({
+            id: "test-1",
+            title: "Custom",
+            cwd: "/custom/path",
+          }),
+        ],
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
 
     it("skips save if no project ID is provided", async () => {
@@ -359,7 +371,12 @@ describe("PanelPersistence", () => {
 
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTerminals).toHaveBeenCalledWith("from-option", expect.any(Array));
+      expect(client.setTerminals).toHaveBeenCalledWith(
+        "from-option",
+        expect.any(Array),
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
 
     it("skips redundant persist when transformed payload is unchanged", async () => {
@@ -391,8 +408,56 @@ describe("PanelPersistence", () => {
       expect(client.setTerminals).toHaveBeenCalledTimes(2);
       expect(client.setTerminals).toHaveBeenLastCalledWith(
         projectId,
-        expect.arrayContaining([expect.objectContaining({ title: "Two" })])
+        expect.arrayContaining([expect.objectContaining({ title: "Two" })]),
+        expect.any(Array),
+        expect.any(Array)
       );
+    });
+  });
+
+  describe("layout merge delta (#11350)", () => {
+    it("marks every panel changed when there is no primed baseline", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      persistence.save([createMockTerminal({ id: "a" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , changedIds, removedIds] = client.setTerminals.mock.calls[0]!;
+      expect(changedIds).toEqual(["a"]);
+      expect(removedIds).toEqual([]);
+    });
+
+    it("emits only the newly added panel in changedIds against a primed baseline", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const a = createMockTerminal({ id: "a" });
+      const b = createMockTerminal({ id: "b" });
+      persistence.primeProject(projectId, [panelToSnapshot(a), panelToSnapshot(b)]);
+
+      persistence.save([a, b, createMockTerminal({ id: "c" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , changedIds, removedIds] = client.setTerminals.mock.calls[0]!;
+      expect(changedIds).toEqual(["c"]);
+      expect(removedIds).toEqual([]);
+    });
+
+    it("emits a closed panel in removedIds against a primed baseline", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const a = createMockTerminal({ id: "a" });
+      const b = createMockTerminal({ id: "b" });
+      persistence.primeProject(projectId, [panelToSnapshot(a), panelToSnapshot(b)]);
+
+      persistence.save([a], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , changedIds, removedIds] = client.setTerminals.mock.calls[0]!;
+      expect(changedIds).toEqual([]);
+      expect(removedIds).toEqual(["b"]);
     });
   });
 
@@ -467,13 +532,18 @@ describe("PanelPersistence", () => {
       persistence.save([browserPanel], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTerminals).toHaveBeenCalledWith(projectId, [
-        expect.objectContaining({
-          id: "browser-1",
-          kind: "browser",
-          browserUrl: "https://localhost:3000",
-        }),
-      ]);
+      expect(client.setTerminals).toHaveBeenCalledWith(
+        projectId,
+        [
+          expect.objectContaining({
+            id: "browser-1",
+            kind: "browser",
+            browserUrl: "https://localhost:3000",
+          }),
+        ],
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
   });
 
@@ -953,15 +1023,20 @@ describe("PanelPersistence", () => {
       persistence.save([devPreviewPanel], projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTerminals).toHaveBeenCalledWith(projectId, [
-        expect.objectContaining({
-          id: "dev-preview-1",
-          kind: "dev-preview",
-          browserUrl: "http://localhost:5173",
-          command: "npm run dev",
-          devPreviewConsoleOpen: true,
-        }),
-      ]);
+      expect(client.setTerminals).toHaveBeenCalledWith(
+        projectId,
+        [
+          expect.objectContaining({
+            id: "dev-preview-1",
+            kind: "dev-preview",
+            browserUrl: "http://localhost:5173",
+            command: "npm run dev",
+            devPreviewConsoleOpen: true,
+          }),
+        ],
+        expect.any(Array),
+        expect.any(Array)
+      );
 
       const saved = client.setTerminals.mock.calls[0]![1][0] as Record<string, unknown>;
       expect(saved.devServerStatus).toBeUndefined();

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -110,7 +110,12 @@ describe("PanelPersistence.saveTabGroups", () => {
       persistence.saveTabGroups(tabGroups, projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTabGroups).toHaveBeenCalledWith(projectId, [explicitGroup]);
+      expect(client.setTabGroups).toHaveBeenCalledWith(
+        projectId,
+        [explicitGroup],
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
 
     it("persists multiple explicit groups", async () => {
@@ -141,7 +146,9 @@ describe("PanelPersistence.saveTabGroups", () => {
 
       expect(client.setTabGroups).toHaveBeenCalledWith(
         projectId,
-        expect.arrayContaining([group1, group2])
+        expect.arrayContaining([group1, group2]),
+        expect.any(Array),
+        expect.any(Array)
       );
       const savedGroups = client.setTabGroups.mock.calls[0]![1] as TabGroup[];
       expect(savedGroups).toHaveLength(2);
@@ -173,7 +180,12 @@ describe("PanelPersistence.saveTabGroups", () => {
       persistence.saveTabGroups(tabGroups, projectId);
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTabGroups).toHaveBeenCalledWith(projectId, []);
+      expect(client.setTabGroups).toHaveBeenCalledWith(
+        projectId,
+        [],
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
   });
 
@@ -214,7 +226,12 @@ describe("PanelPersistence.saveTabGroups", () => {
 
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(client.setTabGroups).toHaveBeenCalledWith("from-option", expect.any(Array));
+      expect(client.setTabGroups).toHaveBeenCalledWith(
+        "from-option",
+        expect.any(Array),
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
   });
 
@@ -246,7 +263,12 @@ describe("PanelPersistence.saveTabGroups", () => {
       await vi.advanceTimersByTimeAsync(100);
 
       expect(client.setTabGroups).toHaveBeenCalledTimes(1);
-      expect(client.setTabGroups).toHaveBeenCalledWith(projectId, [group1]);
+      expect(client.setTabGroups).toHaveBeenCalledWith(
+        projectId,
+        [group1],
+        expect.any(Array),
+        expect.any(Array)
+      );
     });
 
     it("skips redundant tab group persist when payload is unchanged", async () => {
@@ -350,6 +372,50 @@ describe("PanelPersistence.saveTabGroups", () => {
 
       const savedGroups = client.setTabGroups.mock.calls[0]![1] as TabGroup[];
       expect(savedGroups[0]!.worktreeId).toBeUndefined();
+    });
+  });
+
+  describe("layout merge delta (#11350)", () => {
+    const g = (id: string, panelIds: string[]): TabGroup => ({
+      id,
+      panelIds,
+      activeTabId: panelIds[0]!,
+      location: "grid",
+    });
+
+    it("emits a deleted group in removedIds once the baseline is primed", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      persistence.primeTabGroups(projectId, [g("g1", ["a", "b"]), g("g2", ["c", "d"])]);
+
+      // User dissolves g2, leaving only g1.
+      persistence.saveTabGroups(new Map([["g1", g("g1", ["a", "b"])]]), projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , changedIds, removedIds] = client.setTabGroups.mock.calls[0]!;
+      expect(changedIds).toEqual([]);
+      expect(removedIds).toEqual(["g2"]);
+    });
+
+    it("emits a newly added group in changedIds against a primed baseline", async () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      persistence.primeTabGroups(projectId, [g("g1", ["a", "b"])]);
+
+      persistence.saveTabGroups(
+        new Map([
+          ["g1", g("g1", ["a", "b"])],
+          ["g2", g("g2", ["c", "d"])],
+        ]),
+        projectId
+      );
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [, , changedIds, removedIds] = client.setTabGroups.mock.calls[0]!;
+      expect(changedIds).toEqual(["g2"]);
+      expect(removedIds).toEqual([]);
     });
   });
 });

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -329,7 +329,7 @@ describe("PanelPersistence.saveTabGroups", () => {
       expect(client.setTabGroups).not.toHaveBeenCalled();
 
       persistence.flush();
-      await vi.runAllTicks();
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(client.setTabGroups).toHaveBeenCalledTimes(1);
     });

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -4,6 +4,7 @@ import { debounce } from "@/utils/debounce";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
+import { computeIdArrayDelta } from "@shared/utils/layoutMerge";
 import { logError } from "@/utils/logger";
 
 type ProjectClientType = typeof projectClient;
@@ -193,23 +194,34 @@ export class PanelPersistence {
         : 0;
       const payloadBytes = collectPerf ? estimatePayloadBytes(transformed) : null;
 
-      this.pendingPersist = this.client.setTerminals(projectId, transformed).catch((error) => {
-        logError("Failed to persist terminals", error);
-        if (collectPerf) {
-          const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-          markRendererPerformance("persistence_terminals_save", {
-            projectId,
-            terminalCount: transformed.length,
-            payloadBytes,
-            durationMs: Number((now - startedAt).toFixed(3)),
-            ok: false,
-          });
-        }
-        if (snapshotsEqual(this.queuedTerminalsByProject.get(projectId), transformed)) {
-          this.queuedTerminalsByProject.delete(projectId);
-        }
-        throw error;
-      });
+      // Describe what changed relative to this renderer's last-acknowledged
+      // baseline so Main merges concurrent writes from sibling windows of the
+      // same project instead of clobbering them (#11350).
+      const { changedIds, removedIds } = computeIdArrayDelta(
+        this.persistedTerminalsByProject.get(projectId) ?? [],
+        transformed,
+        deepEqual
+      );
+
+      this.pendingPersist = this.client
+        .setTerminals(projectId, transformed, changedIds, removedIds)
+        .catch((error) => {
+          logError("Failed to persist terminals", error);
+          if (collectPerf) {
+            const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+            markRendererPerformance("persistence_terminals_save", {
+              projectId,
+              terminalCount: transformed.length,
+              payloadBytes,
+              durationMs: Number((now - startedAt).toFixed(3)),
+              ok: false,
+            });
+          }
+          if (snapshotsEqual(this.queuedTerminalsByProject.get(projectId), transformed)) {
+            this.queuedTerminalsByProject.delete(projectId);
+          }
+          throw error;
+        });
       this.pendingPersist = this.pendingPersist.then(() => {
         if (collectPerf) {
           const now = typeof performance !== "undefined" ? performance.now() : Date.now();
@@ -246,8 +258,15 @@ export class PanelPersistence {
         : 0;
       const payloadBytes = collectPerf ? estimatePayloadBytes(tabGroups) : null;
 
+      // Merge concurrent tab-group writes from sibling windows (#11350).
+      const { changedIds, removedIds } = computeIdArrayDelta(
+        this.persistedTabGroupsByProject.get(projectId) ?? [],
+        tabGroups,
+        deepEqual
+      );
+
       this.pendingTabGroupPersist = this.client
-        .setTabGroups(projectId, tabGroups)
+        .setTabGroups(projectId, tabGroups, changedIds, removedIds)
         .catch((error) => {
           logError("Failed to persist tab groups", error);
           if (collectPerf) {
@@ -374,6 +393,19 @@ export class PanelPersistence {
   primeProject(projectId: string, snapshots: PanelSnapshot[]): void {
     if (this.persistedTerminalsByProject.has(projectId)) return;
     this.persistedTerminalsByProject.set(projectId, snapshots);
+  }
+
+  /**
+   * Seed the tab-group baseline for a project from hydration, mirroring
+   * {@link primeProject}. Without this, the first tab-group save has no baseline
+   * to diff against, so a group the user deletes before that save cannot emit a
+   * `removedIds` tombstone and Main would resurrect it from a sibling's on-disk
+   * copy (#11350). Only primes if not already present so a post-hydration save
+   * isn't clobbered.
+   */
+  primeTabGroups(projectId: string, groups: TabGroup[]): void {
+    if (this.persistedTabGroupsByProject.has(projectId)) return;
+    this.persistedTabGroupsByProject.set(projectId, groups);
   }
 
   /**

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -150,25 +150,6 @@ function snapshotsEqual<T>(left: T[] | undefined, right: T[]): boolean {
   return true;
 }
 
-/**
- * Order-sensitive array equality using JSON-round-trip semantics (a missing key
- * equals a key whose value is `undefined`). Used to decide whether a save is a
- * genuine no-op against the last-acknowledged baseline: a baseline read back
- * from disk has its `undefined`-valued keys stripped, so a strict comparison
- * would report a spurious change and re-send an empty delta on every first save
- * after hydration (#11350). Order-sensitive so a pure reorder still persists.
- */
-function snapshotsCanonicalEqual<T>(left: T[] | undefined, right: T[]): boolean {
-  if (left === right) return true;
-  if (!left || left.length !== right.length) return false;
-  for (let i = 0; i < left.length; i += 1) {
-    if (!deepEqualIgnoringUndefined(left[i], right[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
 function shouldCollectPersistencePerf(): boolean {
   if (typeof window === "undefined") return false;
   return isRendererPerfCaptureEnabled() || Array.isArray(window.__DAINTREE_PERF_MARKS__);
@@ -221,8 +202,10 @@ export class PanelPersistence {
         .catch(() => {})
         .then(async () => {
           // Baseline now reflects the previous committed write for this project.
-          const baseline = this.persistedTerminalsByProject.get(projectId) ?? [];
-          if (snapshotsCanonicalEqual(baseline, transformed)) {
+          // Skip using the raw (possibly undefined) value so a first save with
+          // no established baseline still sends; diff against `?? []`.
+          const baseline = this.persistedTerminalsByProject.get(projectId);
+          if (snapshotsEqual(baseline, transformed)) {
             this.clearQueuedTerminalsIfMatches(projectId, transformed);
             return;
           }
@@ -235,7 +218,7 @@ export class PanelPersistence {
           // baseline so Main merges concurrent writes from sibling windows of
           // the same project instead of clobbering them (#11350).
           const { changedIds, removedIds } = computeIdArrayDelta(
-            baseline,
+            baseline ?? [],
             transformed,
             deepEqualIgnoringUndefined
           );
@@ -287,8 +270,8 @@ export class PanelPersistence {
       const run = prior
         .catch(() => {})
         .then(async () => {
-          const baseline = this.persistedTabGroupsByProject.get(projectId) ?? [];
-          if (snapshotsCanonicalEqual(baseline, tabGroups)) {
+          const baseline = this.persistedTabGroupsByProject.get(projectId);
+          if (snapshotsEqual(baseline, tabGroups)) {
             this.clearQueuedTabGroupsIfMatches(projectId, tabGroups);
             return;
           }
@@ -299,7 +282,7 @@ export class PanelPersistence {
             : 0;
           // Merge concurrent tab-group writes from sibling windows (#11350).
           const { changedIds, removedIds } = computeIdArrayDelta(
-            baseline,
+            baseline ?? [],
             tabGroups,
             deepEqualIgnoringUndefined
           );
@@ -416,8 +399,12 @@ export class PanelPersistence {
     this.debouncedSaveTabGroups.cancel();
     this.queuedTerminalsByProject.clear();
     this.queuedTabGroupsByProject.clear();
-    this.terminalWriteTailByProject.clear();
-    this.tabGroupWriteTailByProject.clear();
+    // Deliberately keep the per-project write tails: cancel() abandons pending
+    // debounced work, but a send already in flight cannot be recalled. A save
+    // that arrives after cancel must still chain behind that in-flight write so
+    // its delta is computed against the acknowledged baseline, not a stale one
+    // (#11350). The tail entries are overwritten by the next save or drop at
+    // process end.
     this.pendingPersist = null;
     this.pendingTabGroupPersist = null;
   }

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -4,7 +4,11 @@ import { debounce } from "@/utils/debounce";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
-import { computeIdArrayDelta } from "@shared/utils/layoutMerge";
+import {
+  computeIdArrayDelta,
+  deepEqualIgnoringUndefined,
+  type IdArrayDelta,
+} from "@shared/utils/layoutMerge";
 import { logError } from "@/utils/logger";
 
 type ProjectClientType = typeof projectClient;
@@ -146,6 +150,25 @@ function snapshotsEqual<T>(left: T[] | undefined, right: T[]): boolean {
   return true;
 }
 
+/**
+ * Order-sensitive array equality using JSON-round-trip semantics (a missing key
+ * equals a key whose value is `undefined`). Used to decide whether a save is a
+ * genuine no-op against the last-acknowledged baseline: a baseline read back
+ * from disk has its `undefined`-valued keys stripped, so a strict comparison
+ * would report a spurious change and re-send an empty delta on every first save
+ * after hydration (#11350). Order-sensitive so a pure reorder still persists.
+ */
+function snapshotsCanonicalEqual<T>(left: T[] | undefined, right: T[]): boolean {
+  if (left === right) return true;
+  if (!left || left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i += 1) {
+    if (!deepEqualIgnoringUndefined(left[i], right[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function shouldCollectPersistencePerf(): boolean {
   if (typeof window === "undefined") return false;
   return isRendererPerfCaptureEnabled() || Array.isArray(window.__DAINTREE_PERF_MARKS__);
@@ -171,6 +194,15 @@ export class PanelPersistence {
   private readonly persistedTerminalsByProject = new Map<string, PanelSnapshot[]>();
   private readonly queuedTabGroupsByProject = new Map<string, TabGroup[]>();
   private readonly persistedTabGroupsByProject = new Map<string, TabGroup[]>();
+  // Per-project write tails. Each debounced flush chains its delta computation
+  // and send onto the previous write for the same project so the delta is
+  // always computed against the baseline the previous write acknowledged. Two
+  // overlapping flushes (a send in flight longer than the debounce interval)
+  // must not both diff against the same stale baseline, or one would resurrect
+  // an entry the other removed (#11350). Tails swallow rejections so a failed
+  // write never blocks the next one.
+  private readonly terminalWriteTailByProject = new Map<string, Promise<void>>();
+  private readonly tabGroupWriteTailByProject = new Map<string, Promise<void>>();
   private pendingPersist: Promise<void> | null = null;
   private pendingTabGroupPersist: Promise<void> | null = null;
 
@@ -179,129 +211,148 @@ export class PanelPersistence {
     this.options = { ...DEFAULT_OPTIONS, ...options };
 
     this.debouncedSave = debounce((projectId: string, transformed: PanelSnapshot[]) => {
-      if (snapshotsEqual(this.persistedTerminalsByProject.get(projectId), transformed)) {
-        if (snapshotsEqual(this.queuedTerminalsByProject.get(projectId), transformed)) {
-          this.queuedTerminalsByProject.delete(projectId);
-        }
-        return;
-      }
-
       const collectPerf = shouldCollectPersistencePerf();
-      const startedAt = collectPerf
-        ? typeof performance !== "undefined"
-          ? performance.now()
-          : Date.now()
-        : 0;
       const payloadBytes = collectPerf ? estimatePayloadBytes(transformed) : null;
 
-      // Describe what changed relative to this renderer's last-acknowledged
-      // baseline so Main merges concurrent writes from sibling windows of the
-      // same project instead of clobbering them (#11350).
-      const { changedIds, removedIds } = computeIdArrayDelta(
-        this.persistedTerminalsByProject.get(projectId) ?? [],
-        transformed,
-        deepEqual
-      );
-
-      this.pendingPersist = this.client
-        .setTerminals(projectId, transformed, changedIds, removedIds)
-        .catch((error) => {
-          logError("Failed to persist terminals", error);
-          if (collectPerf) {
-            const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-            markRendererPerformance("persistence_terminals_save", {
-              projectId,
-              terminalCount: transformed.length,
-              payloadBytes,
-              durationMs: Number((now - startedAt).toFixed(3)),
-              ok: false,
-            });
+      const prior = this.terminalWriteTailByProject.get(projectId) ?? Promise.resolve();
+      const run = prior
+        // A failed prior write must not poison the chain; it left the baseline
+        // untouched, so the next write's delta stays correct.
+        .catch(() => {})
+        .then(async () => {
+          // Baseline now reflects the previous committed write for this project.
+          const baseline = this.persistedTerminalsByProject.get(projectId) ?? [];
+          if (snapshotsCanonicalEqual(baseline, transformed)) {
+            this.clearQueuedTerminalsIfMatches(projectId, transformed);
+            return;
           }
-          if (snapshotsEqual(this.queuedTerminalsByProject.get(projectId), transformed)) {
-            this.queuedTerminalsByProject.delete(projectId);
+          const startedAt = collectPerf
+            ? typeof performance !== "undefined"
+              ? performance.now()
+              : Date.now()
+            : 0;
+          // Describe what changed relative to this renderer's last-acknowledged
+          // baseline so Main merges concurrent writes from sibling windows of
+          // the same project instead of clobbering them (#11350).
+          const { changedIds, removedIds } = computeIdArrayDelta(
+            baseline,
+            transformed,
+            deepEqualIgnoringUndefined
+          );
+          try {
+            await this.client.setTerminals(projectId, transformed, changedIds, removedIds);
+            if (collectPerf) {
+              const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+              markRendererPerformance("persistence_terminals_save", {
+                projectId,
+                terminalCount: transformed.length,
+                payloadBytes,
+                durationMs: Number((now - startedAt).toFixed(3)),
+                ok: true,
+              });
+            }
+            this.persistedTerminalsByProject.set(projectId, transformed);
+            this.clearQueuedTerminalsIfMatches(projectId, transformed);
+          } catch (error) {
+            logError("Failed to persist terminals", error);
+            if (collectPerf) {
+              const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+              markRendererPerformance("persistence_terminals_save", {
+                projectId,
+                terminalCount: transformed.length,
+                payloadBytes,
+                durationMs: Number((now - startedAt).toFixed(3)),
+                ok: false,
+              });
+            }
+            this.clearQueuedTerminalsIfMatches(projectId, transformed);
+            throw error;
           }
-          throw error;
         });
-      this.pendingPersist = this.pendingPersist.then(() => {
-        if (collectPerf) {
-          const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-          markRendererPerformance("persistence_terminals_save", {
-            projectId,
-            terminalCount: transformed.length,
-            payloadBytes,
-            durationMs: Number((now - startedAt).toFixed(3)),
-            ok: true,
-          });
-        }
-        this.persistedTerminalsByProject.set(projectId, transformed);
-        if (snapshotsEqual(this.queuedTerminalsByProject.get(projectId), transformed)) {
-          this.queuedTerminalsByProject.delete(projectId);
-        }
-      });
+
+      this.pendingPersist = run;
+      this.terminalWriteTailByProject.set(
+        projectId,
+        run.catch(() => {})
+      );
       // Prevent unhandled rejection warning since this runs in background
-      this.pendingPersist.catch(() => {});
+      run.catch(() => {});
     }, this.options.debounceMs);
 
     this.debouncedSaveTabGroups = debounce((projectId: string, tabGroups: TabGroup[]) => {
-      if (snapshotsEqual(this.persistedTabGroupsByProject.get(projectId), tabGroups)) {
-        if (snapshotsEqual(this.queuedTabGroupsByProject.get(projectId), tabGroups)) {
-          this.queuedTabGroupsByProject.delete(projectId);
-        }
-        return;
-      }
-
       const collectPerf = shouldCollectPersistencePerf();
-      const startedAt = collectPerf
-        ? typeof performance !== "undefined"
-          ? performance.now()
-          : Date.now()
-        : 0;
       const payloadBytes = collectPerf ? estimatePayloadBytes(tabGroups) : null;
 
-      // Merge concurrent tab-group writes from sibling windows (#11350).
-      const { changedIds, removedIds } = computeIdArrayDelta(
-        this.persistedTabGroupsByProject.get(projectId) ?? [],
-        tabGroups,
-        deepEqual
-      );
-
-      this.pendingTabGroupPersist = this.client
-        .setTabGroups(projectId, tabGroups, changedIds, removedIds)
-        .catch((error) => {
-          logError("Failed to persist tab groups", error);
-          if (collectPerf) {
-            const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-            markRendererPerformance("persistence_tab_groups_save", {
-              projectId,
-              tabGroupCount: tabGroups.length,
-              payloadBytes,
-              durationMs: Number((now - startedAt).toFixed(3)),
-              ok: false,
-            });
+      const prior = this.tabGroupWriteTailByProject.get(projectId) ?? Promise.resolve();
+      const run = prior
+        .catch(() => {})
+        .then(async () => {
+          const baseline = this.persistedTabGroupsByProject.get(projectId) ?? [];
+          if (snapshotsCanonicalEqual(baseline, tabGroups)) {
+            this.clearQueuedTabGroupsIfMatches(projectId, tabGroups);
+            return;
           }
-          if (snapshotsEqual(this.queuedTabGroupsByProject.get(projectId), tabGroups)) {
-            this.queuedTabGroupsByProject.delete(projectId);
+          const startedAt = collectPerf
+            ? typeof performance !== "undefined"
+              ? performance.now()
+              : Date.now()
+            : 0;
+          // Merge concurrent tab-group writes from sibling windows (#11350).
+          const { changedIds, removedIds } = computeIdArrayDelta(
+            baseline,
+            tabGroups,
+            deepEqualIgnoringUndefined
+          );
+          try {
+            await this.client.setTabGroups(projectId, tabGroups, changedIds, removedIds);
+            if (collectPerf) {
+              const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+              markRendererPerformance("persistence_tab_groups_save", {
+                projectId,
+                tabGroupCount: tabGroups.length,
+                payloadBytes,
+                durationMs: Number((now - startedAt).toFixed(3)),
+                ok: true,
+              });
+            }
+            this.persistedTabGroupsByProject.set(projectId, tabGroups);
+            this.clearQueuedTabGroupsIfMatches(projectId, tabGroups);
+          } catch (error) {
+            logError("Failed to persist tab groups", error);
+            if (collectPerf) {
+              const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+              markRendererPerformance("persistence_tab_groups_save", {
+                projectId,
+                tabGroupCount: tabGroups.length,
+                payloadBytes,
+                durationMs: Number((now - startedAt).toFixed(3)),
+                ok: false,
+              });
+            }
+            this.clearQueuedTabGroupsIfMatches(projectId, tabGroups);
+            throw error;
           }
-          throw error;
         });
-      this.pendingTabGroupPersist = this.pendingTabGroupPersist.then(() => {
-        if (collectPerf) {
-          const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-          markRendererPerformance("persistence_tab_groups_save", {
-            projectId,
-            tabGroupCount: tabGroups.length,
-            payloadBytes,
-            durationMs: Number((now - startedAt).toFixed(3)),
-            ok: true,
-          });
-        }
-        this.persistedTabGroupsByProject.set(projectId, tabGroups);
-        if (snapshotsEqual(this.queuedTabGroupsByProject.get(projectId), tabGroups)) {
-          this.queuedTabGroupsByProject.delete(projectId);
-        }
-      });
-      this.pendingTabGroupPersist.catch(() => {});
+
+      this.pendingTabGroupPersist = run;
+      this.tabGroupWriteTailByProject.set(
+        projectId,
+        run.catch(() => {})
+      );
+      run.catch(() => {});
     }, this.options.debounceMs);
+  }
+
+  private clearQueuedTerminalsIfMatches(projectId: string, transformed: PanelSnapshot[]): void {
+    if (snapshotsEqual(this.queuedTerminalsByProject.get(projectId), transformed)) {
+      this.queuedTerminalsByProject.delete(projectId);
+    }
+  }
+
+  private clearQueuedTabGroupsIfMatches(projectId: string, tabGroups: TabGroup[]): void {
+    if (snapshotsEqual(this.queuedTabGroupsByProject.get(projectId), tabGroups)) {
+      this.queuedTabGroupsByProject.delete(projectId);
+    }
   }
 
   save(terminals: TerminalInstance[], projectId?: string): void {
@@ -365,8 +416,34 @@ export class PanelPersistence {
     this.debouncedSaveTabGroups.cancel();
     this.queuedTerminalsByProject.clear();
     this.queuedTabGroupsByProject.clear();
+    this.terminalWriteTailByProject.clear();
+    this.tabGroupWriteTailByProject.clear();
     this.pendingPersist = null;
     this.pendingTabGroupPersist = null;
+  }
+
+  /**
+   * Compute the terminal delta a caller outside the debounced save path (e.g.
+   * the synchronous project-switch outgoing-state capture) should send so Main
+   * merges it against the shared on-disk state instead of full-replacing and
+   * clobbering a sibling window's changes (#11350). Diffs against this
+   * renderer's last-acknowledged baseline using JSON-round-trip equality.
+   */
+  computeTerminalDelta(projectId: string, snapshots: PanelSnapshot[]): IdArrayDelta {
+    return computeIdArrayDelta(
+      this.persistedTerminalsByProject.get(projectId) ?? [],
+      snapshots,
+      deepEqualIgnoringUndefined
+    );
+  }
+
+  /** Tab-group counterpart to {@link computeTerminalDelta} (#11350). */
+  computeTabGroupDelta(projectId: string, groups: TabGroup[]): IdArrayDelta {
+    return computeIdArrayDelta(
+      this.persistedTabGroupsByProject.get(projectId) ?? [],
+      groups,
+      deepEqualIgnoringUndefined
+    );
   }
 
   async whenIdle(): Promise<void> {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -83,11 +83,20 @@ function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
 
   const tabGroupArray = Array.from(tabGroups.values()).filter((g) => g.panelIds.length > 1);
 
+  // Diff against this window's last-persisted baseline so Main merges these
+  // arrays by id rather than full-replacing — otherwise a stale outgoing
+  // snapshot silently drops a sibling window's concurrent changes to the same
+  // project (#11350). Same delta contract as the debounced autosave path.
+  const terminalDelta = panelPersistence.computeTerminalDelta(projectId, terminals);
+  const tabGroupDelta = panelPersistence.computeTabGroupDelta(projectId, tabGroupArray);
+
   return {
     terminals,
     draftInputs,
     tabGroups: tabGroupArray,
     activeWorktreeId,
+    terminalDelta,
+    tabGroupDelta,
   };
 }
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -635,6 +635,17 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     // stale snapshot/IPC can't clobber it.
     if (requestId !== projectTransitionRequestId) return;
 
+    // Settle any pending/in-flight layout autosave for the outgoing project so
+    // buildOutgoingState's delta is computed against the acknowledged baseline.
+    // Otherwise a send still in flight leaves the baseline stale, the delta
+    // comes out empty, and Main's merge resurrects an entry the user just
+    // removed (#11350).
+    if (currentProjectId) {
+      panelPersistence.flush();
+      await panelPersistence.whenIdle().catch(() => {});
+      if (requestId !== projectTransitionRequestId) return;
+    }
+
     // Capture outgoing state just before firing, after the paint. The outgoing
     // view is not detached until the main process handles the IPC, so the panel
     // store still reflects the outgoing project here.
@@ -863,6 +874,14 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
 
     await yieldToPaint();
     if (requestId !== projectTransitionRequestId) return;
+
+    // Settle pending/in-flight layout autosave so the outgoing delta is
+    // computed against the acknowledged baseline (#11350; see switchProject).
+    if (currentProjectId) {
+      panelPersistence.flush();
+      await panelPersistence.whenIdle().catch(() => {});
+      if (requestId !== projectTransitionRequestId) return;
+    }
 
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
     projectClient.reopen(projectId, outgoingState).catch((error) => {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -572,7 +572,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
             if (currentProjectId) {
               panelPersistence.primeTabGroups(
                 currentProjectId,
-                tabGroups.filter((g) => Array.isArray(g.panelIds) && g.panelIds.length > 1)
+                tabGroups.filter((g) => g && Array.isArray(g.panelIds) && g.panelIds.length > 1)
               );
             }
             options.hydrateTabGroups(remappedTabGroups);

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -564,6 +564,17 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
                       : group
                   )
                 : tabGroups;
+            // Seed the tab-group persistence baseline from the on-disk state
+            // (pre-remap ids mirror what's actually persisted) so the first
+            // save can emit correct removals and Main can merge concurrent
+            // writes from sibling windows instead of resurrecting deleted
+            // groups (#11350). Mirrors the terminal `primeProject` above.
+            if (currentProjectId) {
+              panelPersistence.primeTabGroups(
+                currentProjectId,
+                tabGroups.filter((g) => Array.isArray(g.panelIds) && g.panelIds.length > 1)
+              );
+            }
             options.hydrateTabGroups(remappedTabGroups);
             markRendererPerformance(PERF_MARKS.HYDRATE_RESTORE_TAB_GROUPS_END, {
               tabGroupCount: tabGroupRestoreCount,


### PR DESCRIPTION
## Summary

- The app lets you open the same project in more than one window, but each window only hydrates its layout once and then autosaves the entire `terminals`/`tabGroups` arrays back to shared per-project state on a debounce. That's last-write-wins, so a stale window can silently clobber a sibling's added, moved, or closed panels.
- Worst case: a panel dropped from the overwritten array becomes unreachable on next load, even though its process may still be alive headlessly.
- Fixes it with a Main-process three-way merge driven by a renderer-computed delta, so both windows' changes survive.

Resolves #11350

## Changes

- New pure module `shared/utils/layoutMerge.ts`: `computeIdArrayDelta`, `mergeIdArray`, and a JSON-faithful `deepEqualIgnoringUndefined` helper. A writer only touches the entries it actually changed, sibling additions/edits are preserved, deletions are never resurrected, and ordering stays last-writer-wins.
- `setTerminals`/`setTabGroups` now accept an optional `changedIds`/`removedIds` delta and merge inside the existing per-project write queue. No delta passed falls back to the old full-replace behavior.
- Project switch-out capture (`buildOutgoingState` feeding `persistOutgoingProjectState`) also merges by delta now, and flushes and awaits any pending autosaves first so its delta is computed against the acknowledged baseline rather than a stale one.
- `panelPersistence.ts` computes its delta against the last-acknowledged baseline, serializes writes per project so overlapping saves can't resurrect a removed entry, and primes the tab-group baseline at hydration time.

Scope for reviewers: the merge is entry-level, so an ambient-only field change on a panel (an agent's `agentState`, say) can still let a stale layout win for that same panel. That's strictly better than the old full-replace, but a complete fix needs a field-level merge as a follow-up. This PR also only fixes the persisted end-state, not live cross-window re-sync (a broadcast so an already-open window reflects a sibling's change without a reload); that's a separate follow-up too.

## Testing

- Pure merge and delta unit tests.
- Handler-level tests for two concurrent writers, moving a panel, deleting one without resurrecting it, and edit-vs-delete conflicts.
- `panelPersistence` tests for delta emission, JSON-round-tripped baseline handling, and overlapping-save serialization.
- Tab-group merge and baseline priming tests, plus defensive handling of malformed entries.
- All targeted suites pass, 261 tests total. Local checks: prettier and eslint clean on the touched files.