### PR TITLE
feat(file-browser): resizable tree sidebar

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -277,6 +277,8 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
   browserSidebarCollapsed?: boolean;
   /** Last-known tree structure to paint before the first live listing (#11367) */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
+  /** Tree column width in px to restore; absent or 288 = the default width */
+  browserSidebarWidth?: number;
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -774,6 +774,13 @@ export interface FileBrowserPanelData extends BasePanelData {
    * eviction; only the persisted record survives.
    */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
+  /**
+   * Dragged width of the tree column in px. Absent = the 288px default; only a
+   * non-default, in-range width is persisted, so an unresized panel stays
+   * sparse. Independent of `browserSidebarCollapsed`: collapsing never clears
+   * it, so re-opening restores the last-dragged width (#11331).
+   */
+  browserSidebarWidth?: number;
 }
 
 export type PanelInstance =

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -172,6 +172,8 @@ export interface PanelSnapshot {
   browserSidebarCollapsed?: boolean;
   /** Last-known tree structure of a file browser panel (#11367) */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
+  /** File browser tree column width in px (only a non-default, in-range value persisted) */
+  browserSidebarWidth?: number;
   /** Legacy pre-file-panel field: absolute path shown in a markdown panel */
   markdownFilePath?: string;
   /** Legacy pre-file-panel field: markdown panel view mode */

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -152,6 +152,11 @@ const DURABLE_ALLOWLIST = new Set([
 
   // Find bar match-case toggle active state (single primary anchor per active focus region)
   "src/components/Browser/FindBar.tsx",
+
+  // File-browser tree-column resize handle: focus ring + grip accent mark the
+  // one keyboard-focusable separator (single focus anchor per active focus
+  // region), mirroring the PortalDock/Sidebar resize-handle convention (#11331)
+  "src/panels/file-browser/FileBrowserPane.tsx",
 ]);
 
 // Pre-existing accent usage inherited from cleanup buckets #5978-#5986 (all

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -487,6 +487,32 @@ describe("panelKindSerialisers", () => {
         );
       });
     });
+
+    it("restores an in-range sidebar width verbatim", () => {
+      expect(deserialize()({ id: "fb1", browserSidebarWidth: 360 }).browserSidebarWidth).toBe(360);
+    });
+
+    it("clamps a finite out-of-range sidebar width into the bounds", () => {
+      expect(deserialize()({ id: "fb1", browserSidebarWidth: 5000 }).browserSidebarWidth).toBe(600);
+      expect(deserialize()({ id: "fb1", browserSidebarWidth: 20 }).browserSidebarWidth).toBe(200);
+    });
+
+    it("drops a non-number or non-finite sidebar width rather than rendering a broken column", () => {
+      // The snapshot schema passes unknown keys through, so a hand-edited string
+      // or a NaN/Infinity must fall back to the default (undefined), never reach
+      // the pane as an inline style width.
+      expect(
+        deserialize()({ id: "fb1", browserSidebarWidth: "300" }).browserSidebarWidth
+      ).toBeUndefined();
+      expect(
+        deserialize()({ id: "fb1", browserSidebarWidth: Number.NaN }).browserSidebarWidth
+      ).toBeUndefined();
+      expect(
+        deserialize()({ id: "fb1", browserSidebarWidth: Number.POSITIVE_INFINITY })
+          .browserSidebarWidth
+      ).toBeUndefined();
+      expect(deserialize()({ id: "fb1" }).browserSidebarWidth).toBeUndefined();
+    });
   });
 
   describe("unknown kind", () => {

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -9,6 +9,7 @@ import {
   MAX_SNAPSHOT_NODES,
   MAX_SNAPSHOT_TEXT_CHARS,
 } from "@/panels/file-browser/fileBrowserTree";
+import { normalizeFileBrowserSidebarWidth } from "@/panels/file-browser/sidebarWidth";
 
 type PanelKindDeserializer = (saved: SavedTerminalData) => Partial<AddTerminalArgs>;
 
@@ -250,6 +251,10 @@ const BUILT_IN_DESERIALIZERS = {
     // snapshot holding a string or object must fall back to the open default.
     browserSidebarCollapsed: saved.browserSidebarCollapsed === true ? true : undefined,
     browserTreeSnapshot: sanitizeTreeSnapshot(saved.browserTreeSnapshot),
+    // A finite number is clamped into range; a string/NaN/Infinity from a
+    // hand-edited snapshot falls back to the default rather than becoming a
+    // broken inline `style.width` (#11331).
+    browserSidebarWidth: normalizeFileBrowserSidebarWidth(saved.browserSidebarWidth),
   }),
   diff: (saved) => ({
     filePath: saved.filePath,

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -285,6 +285,7 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   // must ride the panel record because nothing renderer-side survives LRU
   // eviction.
   browserTreeSnapshot: true,
+  browserSidebarWidth: true,
   // BasePanelData carrier-bookkeeping timestamps — written by the base
   // serialization layer in panelToSnapshot, not per-kind serializers.
   createdAt: false,
@@ -473,6 +474,9 @@ const fileBrowserFixture: FileBrowserPanelData = {
   browserRootPath: "src",
   browserSidebarCollapsed: true,
   browserTreeSnapshot: browserTreeSnapshotFixture,
+  // A non-default width (the serializer omits 288), so the coverage spread emits
+  // the key instead of dropping it as a default.
+  browserSidebarWidth: 360,
 };
 
 const savedFileBrowser: SavedTerminalData = {
@@ -484,6 +488,7 @@ const savedFileBrowser: SavedTerminalData = {
   browserRootPath: "src",
   browserSidebarCollapsed: true,
   browserTreeSnapshot: browserTreeSnapshotFixture,
+  browserSidebarWidth: 360,
 };
 
 const diffFixture: DiffPanelData = {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -696,7 +696,10 @@ export function FileBrowserPane({
           // mousemove/mouseup the document listeners depend on — without it a
           // drag onto the viewer sticks. Events still bubble to `document`
           // through this element; `fixed` keeps it out of the flex layout.
-          <div data-testid="file-browser-resize-shield" className="fixed inset-0 z-50 cursor-col-resize" />
+          <div
+            data-testid="file-browser-resize-shield"
+            className="fixed inset-0 z-50 cursor-col-resize"
+          />
         )}
       </div>
     </ContentPanel>

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -301,6 +301,9 @@ export function FileBrowserPane({
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
+      // Only the primary button drags: a right/middle press must not start a
+      // resize (and can't overwrite an in-flight drag's cleanup ref).
+      if (e.button !== 0) return;
       // Skip the second mousedown of a double-click: the browser fires mousedown
       // twice before dblclick, so guarding inside the dblclick handler is too
       // late — the drag would already have jittered the width by a pixel.
@@ -311,6 +314,13 @@ export function FileBrowserPane({
       const startWidth = sidebarWidth;
 
       const handleMouseMove = (ev: MouseEvent) => {
+        // The button was released where we couldn't see the mouseup (over the
+        // HTML-preview iframe, or outside the window). Recover on the next move
+        // that reaches us rather than staying wedged in a resize.
+        if (ev.buttons === 0) {
+          cleanup();
+          return;
+        }
         const next = clampFileBrowserSidebarWidth(startWidth + (ev.clientX - startX));
         setFileBrowserView(id, { browserSidebarWidth: next });
       };
@@ -680,6 +690,14 @@ export function FileBrowserPane({
             treeSidebarId={treeSidebarId}
           />
         </div>
+        {isResizing && (
+          // Drag shield: while resizing, cover the surface so the HTML-preview
+          // iframe (which the divider drags straight over) can't swallow the
+          // mousemove/mouseup the document listeners depend on — without it a
+          // drag onto the viewer sticks. Events still bubble to `document`
+          // through this element; `fixed` keeps it out of the flex layout.
+          <div data-testid="file-browser-resize-shield" className="fixed inset-0 z-50 cursor-col-resize" />
+        )}
       </div>
     </ContentPanel>
   );

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import type React from "react";
 import { CornerLeftUp, EyeOff, FolderRoot, FolderTree, RefreshCw } from "lucide-react";
 import { basename, join } from "@shared/utils/path";
+import { cn } from "@/lib/utils";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -21,6 +23,14 @@ import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
 import { useFileBrowserTree } from "./useFileBrowserTree";
+import {
+  FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH,
+  FILE_BROWSER_SIDEBAR_MAX_WIDTH,
+  FILE_BROWSER_SIDEBAR_MIN_WIDTH,
+  FILE_BROWSER_SIDEBAR_RESIZE_STEP,
+  FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE,
+  clampFileBrowserSidebarWidth,
+} from "./sidebarWidth";
 import {
   ancestorDirectories,
   createVisibilityFilter,
@@ -112,6 +122,22 @@ export function FileBrowserPane({
       (state) => {
         const panel = state.panelsById[id];
         return panel?.kind === "file-browser" ? panel.browserTreeSnapshot : undefined;
+      },
+      [id]
+    )
+  );
+  // Clamped at read so a persisted value from a future bounds change (or a
+  // corrupted snapshot the deserializer somehow let through) can never render a
+  // broken column; returns a stable primitive so the selector doesn't churn.
+  const sidebarWidth = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser"
+          ? clampFileBrowserSidebarWidth(
+              panel.browserSidebarWidth ?? FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH
+            )
+          : FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH;
       },
       [id]
     )
@@ -264,6 +290,94 @@ export function FileBrowserPane({
   const handleToggleSidebar = useCallback(() => {
     setFileBrowserView(id, { browserSidebarCollapsed: !sidebarCollapsed });
   }, [id, sidebarCollapsed, setFileBrowserView]);
+
+  // Tree-column resize, modeled on PortalDock's handle: delta math from a
+  // mousedown-captured start (no DOM measure), continuous writes through the
+  // 500ms-debounced panel store, and a ref-held teardown so an unmount mid-drag
+  // can drop the document listeners. The column is left-anchored, so dragging
+  // right widens (the mirror of PortalDock's right-anchored dock).
+  const [isResizing, setIsResizing] = useState(false);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      // Skip the second mousedown of a double-click: the browser fires mousedown
+      // twice before dblclick, so guarding inside the dblclick handler is too
+      // late — the drag would already have jittered the width by a pixel.
+      if (e.detail > 1) return;
+      e.preventDefault();
+      setIsResizing(true);
+      const startX = e.clientX;
+      const startWidth = sidebarWidth;
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        const next = clampFileBrowserSidebarWidth(startWidth + (ev.clientX - startX));
+        setFileBrowserView(id, { browserSidebarWidth: next });
+      };
+      const handleMouseUp = () => cleanup();
+      const cleanup = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        dragCleanupRef.current = null;
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+      dragCleanupRef.current = cleanup;
+    },
+    [id, sidebarWidth, setFileBrowserView]
+  );
+
+  const handleResizeDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setFileBrowserView(id, { browserSidebarWidth: FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH });
+    },
+    [id, setFileBrowserView]
+  );
+
+  // Left-anchored splitter: ArrowRight widens, ArrowLeft narrows; Home/End jump
+  // to the bounds per the WAI-ARIA window-splitter pattern, Shift for a coarse
+  // step (matching PortalDock's keyboard convention).
+  const handleResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const step = e.shiftKey
+        ? FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE
+        : FILE_BROWSER_SIDEBAR_RESIZE_STEP;
+      let next: number;
+      switch (e.key) {
+        case "ArrowRight":
+          next = sidebarWidth + step;
+          break;
+        case "ArrowLeft":
+          next = sidebarWidth - step;
+          break;
+        case "Home":
+          next = FILE_BROWSER_SIDEBAR_MIN_WIDTH;
+          break;
+        case "End":
+          next = FILE_BROWSER_SIDEBAR_MAX_WIDTH;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      setFileBrowserView(id, { browserSidebarWidth: clampFileBrowserSidebarWidth(next) });
+    },
+    [id, sidebarWidth, setFileBrowserView]
+  );
+
+  // The document listeners outlive the grip on two lifecycles the mouseup can't
+  // cover: the pane unmounting mid-drag (project switch), and the tree column
+  // unmounting because the sidebar collapsed mid-drag (the pane stays mounted,
+  // so its unmount effect never fires). Both drop the listeners here.
+  useEffect(() => {
+    return () => dragCleanupRef.current?.();
+  }, []);
+  useEffect(() => {
+    if (sidebarCollapsed) dragCleanupRef.current?.();
+  }, [sidebarCollapsed]);
 
   const handleSetRoot = useCallback(
     (path: string) => {
@@ -473,7 +587,8 @@ export function FileBrowserPane({
           <div
             id={treeSidebarId}
             ref={treeColumnRef}
-            className="flex min-h-0 w-72 shrink-0 flex-col self-stretch border-r border-daintree-border bg-daintree-sidebar"
+            className="relative flex min-h-0 shrink-0 flex-col self-stretch border-r border-daintree-border bg-daintree-sidebar"
+            style={{ width: sidebarWidth }}
           >
             {/* py-1.5 + border-overlay + 16px icons match FileViewerToolbar.Root
                 so the two header bars share one height and border token, and the
@@ -519,6 +634,38 @@ export function FileBrowserPane({
               </FileViewerToolbar.IconButton>
             </div>
             {renderTree()}
+            {/* Straddles the right border between the tree and the viewer. Lives
+                inside the collapsible column, so it unmounts with the tree —
+                no grip while collapsed, per #11331. Styling mirrors the
+                worktree Sidebar / PortalDock handle: a thin pill that thickens
+                on hover, an accent focus anchor for keyboard resize. */}
+            <div
+              role="separator"
+              aria-label="Resize file tree"
+              aria-orientation="vertical"
+              aria-controls={treeSidebarId}
+              aria-valuenow={Math.round(sidebarWidth)}
+              aria-valuemin={FILE_BROWSER_SIDEBAR_MIN_WIDTH}
+              aria-valuemax={FILE_BROWSER_SIDEBAR_MAX_WIDTH}
+              tabIndex={0}
+              data-testid="file-browser-sidebar-resize"
+              className={cn(
+                "group absolute -right-1.5 top-0 bottom-0 z-10 flex w-3 cursor-col-resize items-center justify-center",
+                "transition-colors hover:bg-overlay-soft focus:bg-tint/[0.04] focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/50",
+                isResizing && "bg-overlay-medium"
+              )}
+              onMouseDown={handleResizeStart}
+              onDoubleClick={handleResizeDoubleClick}
+              onKeyDown={handleResizeKeyDown}
+            >
+              <div
+                className={cn(
+                  "h-8 w-px rounded-full transition-[width] delay-100 duration-150 group-hover:w-0.5",
+                  "bg-daintree-text/20 group-hover:bg-daintree-text/35 group-focus:bg-daintree-accent",
+                  isResizing && "bg-daintree-text/50"
+                )}
+              />
+            </div>
           </div>
         )}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -534,8 +534,12 @@ describe("FileBrowserPane resizable sidebar (#11331)", () => {
     fireEvent.mouseMove(document, { clientX: 100 - (DEFAULT_W - MIN_W) - 500, buttons: 1 }); // past min
     fireEvent.mouseUp(document);
 
-    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", { browserSidebarWidth: MAX_W });
-    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", { browserSidebarWidth: MIN_W });
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", {
+      browserSidebarWidth: MAX_W,
+    });
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", {
+      browserSidebarWidth: MIN_W,
+    });
   });
 
   it("mounts a drag shield only while resizing so a child iframe can't swallow the drag", () => {

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -116,6 +116,13 @@ vi.mock("@/components/FileViewer/CodeViewer", () => ({
 vi.mock("@/components/Html/HtmlViewer", () => ({ HtmlViewer: () => null }));
 
 import { FileBrowserPane } from "../FileBrowserPane";
+import {
+  FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH as DEFAULT_W,
+  FILE_BROWSER_SIDEBAR_MIN_WIDTH as MIN_W,
+  FILE_BROWSER_SIDEBAR_MAX_WIDTH as MAX_W,
+  FILE_BROWSER_SIDEBAR_RESIZE_STEP as STEP_W,
+  FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE as COARSE_W,
+} from "../sidebarWidth";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 function renderPane() {
@@ -447,57 +454,115 @@ describe("FileBrowserPane resizable sidebar (#11331)", () => {
     return screen.getByTestId("file-browser-sidebar-resize");
   }
 
+  // A width the store setter can't produce by default (min < X < max, not the
+  // default) so the assertion proves the wiring carried the stored value, not a
+  // coincidental default.
+  const STORED = MIN_W + 137;
+
+  // Make the (otherwise non-reactive) panel-store mock stateful, so a sequence
+  // of interactions reads the width the previous one wrote — the only way to
+  // test cumulative keyboard steps and a real collapse→reopen restore.
+  function makeStoreStateful() {
+    setFileBrowserViewMock.mockImplementation((_id: string, patch: Partial<MockPanel>) => {
+      Object.assign(mockPanel, patch);
+    });
+  }
+
   it("drives the tree column width and separator value from the stored width", () => {
-    mockPanel.browserSidebarWidth = 400;
+    mockPanel.browserSidebarWidth = STORED;
     renderPane();
 
-    expect(treeColumn().style.width).toBe("400px");
-    expect(separator().getAttribute("aria-valuenow")).toBe("400");
+    expect(treeColumn().style.width).toBe(`${STORED}px`);
+    expect(separator().getAttribute("aria-valuenow")).toBe(String(STORED));
   });
 
-  it("falls back to the 288px default when no width is stored", () => {
+  it("falls back to the default width when none is stored", () => {
     renderPane();
 
-    expect(treeColumn().style.width).toBe("288px");
-    expect(separator().getAttribute("aria-valuenow")).toBe("288");
+    // Wiring, not a copied literal: the rendered width tracks the module default,
+    // whatever it is, so changing the constant can't silently strand this.
+    expect(treeColumn().style.width).toBe(`${DEFAULT_W}px`);
+    expect(separator().getAttribute("aria-valuenow")).toBe(String(DEFAULT_W));
   });
 
-  it("exposes a focusable vertical separator with the bounds as ARIA values", () => {
+  it("names the separator and points aria-controls at the resolvable tree column", () => {
     renderPane();
-    const handle = separator();
+    // Query by the accessible role + name so a broken aria-label actually fails.
+    const handle = screen.getByRole("separator", { name: "Resize file tree" });
 
-    expect(handle.getAttribute("role")).toBe("separator");
     expect(handle.getAttribute("aria-orientation")).toBe("vertical");
-    expect(handle.getAttribute("aria-valuemin")).toBe("200");
-    expect(handle.getAttribute("aria-valuemax")).toBe("600");
-    expect(handle.getAttribute("tabindex")).toBe("0");
+    expect(handle.getAttribute("aria-valuemin")).toBe(String(MIN_W));
+    expect(handle.getAttribute("aria-valuemax")).toBe(String(MAX_W));
+    expect(handle.tabIndex).toBe(0);
+    // aria-controls resolves to the actual tree column, not a dangling id.
+    const controls = handle.getAttribute("aria-controls");
+    expect(controls).toBeTruthy();
+    expect(document.getElementById(controls!)).toBe(treeColumn());
   });
 
   it("widens on a rightward drag and narrows on a leftward drag, writing every move", () => {
-    renderPane(); // starts at 288
-    const handle = separator();
-
-    fireEvent.mouseDown(handle, { clientX: 100, detail: 1 });
-    fireEvent.mouseMove(document, { clientX: 150 }); // +50 → 338
-    fireEvent.mouseMove(document, { clientX: 120 }); // -20 vs start → 308
-    fireEvent.mouseUp(document);
-
-    // Continuous writes, one per move, delta from the mousedown-captured start.
-    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", { browserSidebarWidth: 338 });
-    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", { browserSidebarWidth: 308 });
-  });
-
-  it("clamps a drag past either bound to the min and max", () => {
+    mockPanel.browserSidebarWidth = STORED;
     renderPane();
     const handle = separator();
 
-    fireEvent.mouseDown(handle, { clientX: 100, detail: 1 });
-    fireEvent.mouseMove(document, { clientX: 1200 }); // +1100 → clamp 600
-    fireEvent.mouseMove(document, { clientX: 0 }); // -100 vs start → clamp 200
+    fireEvent.mouseDown(handle, { clientX: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, buttons: 1 }); // +50
+    fireEvent.mouseMove(document, { clientX: 80, buttons: 1 }); // -20 vs start
     fireEvent.mouseUp(document);
 
-    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", { browserSidebarWidth: 600 });
-    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", { browserSidebarWidth: 200 });
+    // Continuous writes, one per move, delta derived from the mousedown-captured
+    // start — expectations computed from the inputs, not hard-coded pixels.
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", {
+      browserSidebarWidth: STORED + 50,
+    });
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", {
+      browserSidebarWidth: STORED - 20,
+    });
+
+    // Releasing ends the drag: a later move must not keep resizing.
+    setFileBrowserViewMock.mockClear();
+    fireEvent.mouseMove(document, { clientX: 500, buttons: 1 });
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps a drag past either bound to the min and max", () => {
+    renderPane(); // default
+    const handle = separator();
+
+    fireEvent.mouseDown(handle, { clientX: 100 });
+    fireEvent.mouseMove(document, { clientX: 100 + (MAX_W - DEFAULT_W) + 500, buttons: 1 }); // past max
+    fireEvent.mouseMove(document, { clientX: 100 - (DEFAULT_W - MIN_W) - 500, buttons: 1 }); // past min
+    fireEvent.mouseUp(document);
+
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", { browserSidebarWidth: MAX_W });
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", { browserSidebarWidth: MIN_W });
+  });
+
+  it("mounts a drag shield only while resizing so a child iframe can't swallow the drag", () => {
+    renderPane();
+    expect(screen.queryByTestId("file-browser-resize-shield")).toBeNull();
+
+    fireEvent.mouseDown(separator(), { clientX: 100 });
+    expect(screen.getByTestId("file-browser-resize-shield")).toBeTruthy();
+
+    fireEvent.mouseUp(document);
+    expect(screen.queryByTestId("file-browser-resize-shield")).toBeNull();
+  });
+
+  it("ends the drag when the button is released off-document (buttons === 0)", () => {
+    renderPane();
+    const handle = separator();
+
+    fireEvent.mouseDown(handle, { clientX: 100 });
+    fireEvent.mouseMove(document, { clientX: 150, buttons: 1 }); // a real move writes
+    expect(setFileBrowserViewMock).toHaveBeenCalledTimes(1);
+
+    // Released over the iframe / outside the window: the next move reports no
+    // buttons, so the drag self-terminates instead of wedging.
+    fireEvent.mouseMove(document, { clientX: 200, buttons: 0 });
+    fireEvent.mouseMove(document, { clientX: 260, buttons: 1 });
+    expect(setFileBrowserViewMock).toHaveBeenCalledTimes(1); // no writes after recovery
+    expect(screen.queryByTestId("file-browser-resize-shield")).toBeNull();
   });
 
   it("ignores the second mousedown of a double-click so the reset doesn't jitter first", () => {
@@ -506,39 +571,73 @@ describe("FileBrowserPane resizable sidebar (#11331)", () => {
 
     // detail > 1 is the browser's synthetic second mousedown before dblclick.
     fireEvent.mouseDown(handle, { clientX: 100, detail: 2 });
-    fireEvent.mouseMove(document, { clientX: 300 });
+    fireEvent.mouseMove(document, { clientX: 300, buttons: 1 });
 
     // No drag listener was attached, so the move writes nothing.
     expect(setFileBrowserViewMock).not.toHaveBeenCalled();
   });
 
+  it("does not start a drag from a non-primary mouse button", () => {
+    renderPane();
+
+    fireEvent.mouseDown(separator(), { clientX: 100, button: 2 });
+    fireEvent.mouseMove(document, { clientX: 300, buttons: 2 });
+
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+
   it("resets to the default width on double-click", () => {
-    mockPanel.browserSidebarWidth = 500;
+    mockPanel.browserSidebarWidth = MAX_W;
     renderPane();
 
     fireEvent.doubleClick(separator());
 
-    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", { browserSidebarWidth: 288 });
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", { browserSidebarWidth: DEFAULT_W });
   });
 
-  it("resizes from the keyboard: arrows step, Shift coarsens, Home/End jump to bounds", () => {
-    renderPane(); // 288
+  it("steps by the fine step, coarsens under Shift, and jumps to the bounds", () => {
+    renderPane(); // default
     const handle = separator();
 
     fireEvent.keyDown(handle, { key: "ArrowRight" });
-    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 298 });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", {
+      browserSidebarWidth: DEFAULT_W + STEP_W,
+    });
 
     fireEvent.keyDown(handle, { key: "ArrowLeft" });
-    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 278 });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", {
+      browserSidebarWidth: DEFAULT_W - STEP_W,
+    });
 
     fireEvent.keyDown(handle, { key: "ArrowRight", shiftKey: true });
-    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 338 });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", {
+      browserSidebarWidth: DEFAULT_W + COARSE_W,
+    });
 
     fireEvent.keyDown(handle, { key: "Home" });
-    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 200 });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: MIN_W });
 
     fireEvent.keyDown(handle, { key: "End" });
-    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 600 });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: MAX_W });
+  });
+
+  it("accumulates keyboard steps against the live width, not a stale base", () => {
+    makeStoreStateful();
+    const { rerender } = renderPane(); // default
+
+    fireEvent.keyDown(separator(), { key: "ArrowRight" }); // +1 step
+    rerender(paneJsx());
+    fireEvent.keyDown(separator(), { key: "ArrowRight" }); // +2 steps, reading the live width
+    rerender(paneJsx());
+
+    // A handler reading a stale base would stall at +1 step; the width must
+    // compound across presses.
+    expect(mockPanel.browserSidebarWidth).toBe(DEFAULT_W + 2 * STEP_W);
+    expect(treeColumn().style.width).toBe(`${DEFAULT_W + 2 * STEP_W}px`);
+
+    fireEvent.keyDown(separator(), { key: "ArrowLeft" }); // back down one
+    rerender(paneJsx());
+    expect(mockPanel.browserSidebarWidth).toBe(DEFAULT_W + STEP_W);
   });
 
   it("ignores keys that aren't resize controls", () => {
@@ -556,30 +655,35 @@ describe("FileBrowserPane resizable sidebar (#11331)", () => {
     expect(screen.queryByTestId("file-browser-sidebar-resize")).toBeNull();
   });
 
-  it("restores the previously-dragged width after collapse and re-expand", () => {
-    mockPanel.browserSidebarWidth = 420;
+  it("keeps a resized width across a real collapse and reopen (driven through the store)", () => {
+    makeStoreStateful();
     const { rerender } = renderPane();
-    expect(treeColumn().style.width).toBe("420px");
 
-    mockPanel.browserSidebarCollapsed = true;
+    // Widen to the max via the keyboard; the stateful store now holds it.
+    fireEvent.keyDown(separator(), { key: "End" });
+    rerender(paneJsx());
+    expect(mockPanel.browserSidebarWidth).toBe(MAX_W);
+
+    // Collapse via the toggle — the pane writes only the collapsed flag, so a
+    // regression that also cleared the width here would strand the reopen.
+    fireEvent.click(screen.getByTestId("file-browser-sidebar-toggle"));
     rerender(paneJsx());
     expect(screen.queryByTestId("file-browser-sidebar-resize")).toBeNull();
+    expect(mockPanel.browserSidebarWidth).toBe(MAX_W);
 
-    // Width is decoupled from the collapsed flag, so re-opening comes back at the
-    // last-dragged width rather than the default.
-    mockPanel.browserSidebarCollapsed = false;
+    // Reopen — the width is restored from the store, not reset to default.
+    fireEvent.click(screen.getByTestId("file-browser-sidebar-toggle"));
     rerender(paneJsx());
-    expect(treeColumn().style.width).toBe("420px");
-    expect(separator().getAttribute("aria-valuenow")).toBe("420");
+    expect(treeColumn().style.width).toBe(`${MAX_W}px`);
   });
 
   it("drops the document listeners when the pane unmounts mid-drag", () => {
     const { unmount } = renderPane();
 
-    fireEvent.mouseDown(separator(), { clientX: 100, detail: 1 });
+    fireEvent.mouseDown(separator(), { clientX: 100 });
     unmount();
     // The unmount effect fired the drag cleanup, so this move reaches no listener.
-    fireEvent.mouseMove(document, { clientX: 400 });
+    fireEvent.mouseMove(document, { clientX: 400, buttons: 1 });
 
     expect(setFileBrowserViewMock).not.toHaveBeenCalled();
   });
@@ -587,12 +691,12 @@ describe("FileBrowserPane resizable sidebar (#11331)", () => {
   it("drops the document listeners when the sidebar collapses mid-drag", () => {
     const { rerender } = renderPane();
 
-    fireEvent.mouseDown(separator(), { clientX: 100, detail: 1 });
+    fireEvent.mouseDown(separator(), { clientX: 100 });
     // Collapse unmounts the grip but not the pane, so a dedicated effect must
     // fire the same cleanup — otherwise the document listeners keep writing.
     mockPanel.browserSidebarCollapsed = true;
     rerender(paneJsx());
-    fireEvent.mouseMove(document, { clientX: 400 });
+    fireEvent.mouseMove(document, { clientX: 400, buttons: 1 });
 
     expect(setFileBrowserViewMock).not.toHaveBeenCalled();
   });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, act, screen, waitFor } from "@testing-library/react";
+import { render, act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // FileBrowserPane hosts the tree column beside the viewer. #11328 adds a
@@ -55,6 +55,7 @@ interface MockPanel {
   browserShowIgnored?: boolean;
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
+  browserSidebarWidth?: number;
 }
 
 const mockPanel: MockPanel = { id: "fb-1", kind: "file-browser" };
@@ -150,6 +151,7 @@ beforeEach(() => {
   mockPanel.browserSelectedPath = undefined;
   mockPanel.browserRootPath = undefined;
   mockPanel.browserShowIgnored = undefined;
+  mockPanel.browserSidebarWidth = undefined;
   for (const name of ["matchMedia"] as const) {
     if (typeof window[name] !== "function") {
       Object.defineProperty(window, name, {
@@ -412,6 +414,186 @@ describe("last-known tree capture (#11367)", () => {
     unmount();
 
     // A null capture must not clobber a previously persisted snapshot.
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileBrowserPane resizable sidebar (#11331)", () => {
+  // A fresh element per call: React's reconciler bails on a referentially-equal
+  // root element, so reusing one constant across two rerenders would silently
+  // skip the second (the mock store is only re-read when the tree reconciles).
+  const paneJsx = () => (
+    <TooltipProvider>
+      <FileBrowserPane
+        id="fb-1"
+        title="Files"
+        worktreeId="wt-1"
+        isFocused
+        location="grid"
+        onFocus={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+
+  function treeColumn(): HTMLElement {
+    const controlsId = screen
+      .getByTestId("file-browser-sidebar-toggle")
+      .getAttribute("aria-controls")!;
+    return document.getElementById(controlsId)!;
+  }
+
+  function separator(): HTMLElement {
+    return screen.getByTestId("file-browser-sidebar-resize");
+  }
+
+  it("drives the tree column width and separator value from the stored width", () => {
+    mockPanel.browserSidebarWidth = 400;
+    renderPane();
+
+    expect(treeColumn().style.width).toBe("400px");
+    expect(separator().getAttribute("aria-valuenow")).toBe("400");
+  });
+
+  it("falls back to the 288px default when no width is stored", () => {
+    renderPane();
+
+    expect(treeColumn().style.width).toBe("288px");
+    expect(separator().getAttribute("aria-valuenow")).toBe("288");
+  });
+
+  it("exposes a focusable vertical separator with the bounds as ARIA values", () => {
+    renderPane();
+    const handle = separator();
+
+    expect(handle.getAttribute("role")).toBe("separator");
+    expect(handle.getAttribute("aria-orientation")).toBe("vertical");
+    expect(handle.getAttribute("aria-valuemin")).toBe("200");
+    expect(handle.getAttribute("aria-valuemax")).toBe("600");
+    expect(handle.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("widens on a rightward drag and narrows on a leftward drag, writing every move", () => {
+    renderPane(); // starts at 288
+    const handle = separator();
+
+    fireEvent.mouseDown(handle, { clientX: 100, detail: 1 });
+    fireEvent.mouseMove(document, { clientX: 150 }); // +50 → 338
+    fireEvent.mouseMove(document, { clientX: 120 }); // -20 vs start → 308
+    fireEvent.mouseUp(document);
+
+    // Continuous writes, one per move, delta from the mousedown-captured start.
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", { browserSidebarWidth: 338 });
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", { browserSidebarWidth: 308 });
+  });
+
+  it("clamps a drag past either bound to the min and max", () => {
+    renderPane();
+    const handle = separator();
+
+    fireEvent.mouseDown(handle, { clientX: 100, detail: 1 });
+    fireEvent.mouseMove(document, { clientX: 1200 }); // +1100 → clamp 600
+    fireEvent.mouseMove(document, { clientX: 0 }); // -100 vs start → clamp 200
+    fireEvent.mouseUp(document);
+
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(1, "fb-1", { browserSidebarWidth: 600 });
+    expect(setFileBrowserViewMock).toHaveBeenNthCalledWith(2, "fb-1", { browserSidebarWidth: 200 });
+  });
+
+  it("ignores the second mousedown of a double-click so the reset doesn't jitter first", () => {
+    renderPane();
+    const handle = separator();
+
+    // detail > 1 is the browser's synthetic second mousedown before dblclick.
+    fireEvent.mouseDown(handle, { clientX: 100, detail: 2 });
+    fireEvent.mouseMove(document, { clientX: 300 });
+
+    // No drag listener was attached, so the move writes nothing.
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+
+  it("resets to the default width on double-click", () => {
+    mockPanel.browserSidebarWidth = 500;
+    renderPane();
+
+    fireEvent.doubleClick(separator());
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", { browserSidebarWidth: 288 });
+  });
+
+  it("resizes from the keyboard: arrows step, Shift coarsens, Home/End jump to bounds", () => {
+    renderPane(); // 288
+    const handle = separator();
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 298 });
+
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 278 });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight", shiftKey: true });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 338 });
+
+    fireEvent.keyDown(handle, { key: "Home" });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 200 });
+
+    fireEvent.keyDown(handle, { key: "End" });
+    expect(setFileBrowserViewMock).toHaveBeenLastCalledWith("fb-1", { browserSidebarWidth: 600 });
+  });
+
+  it("ignores keys that aren't resize controls", () => {
+    renderPane();
+
+    fireEvent.keyDown(separator(), { key: "a" });
+
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+
+  it("renders no resize separator while the sidebar is collapsed", () => {
+    mockPanel.browserSidebarCollapsed = true;
+    renderPane();
+
+    expect(screen.queryByTestId("file-browser-sidebar-resize")).toBeNull();
+  });
+
+  it("restores the previously-dragged width after collapse and re-expand", () => {
+    mockPanel.browserSidebarWidth = 420;
+    const { rerender } = renderPane();
+    expect(treeColumn().style.width).toBe("420px");
+
+    mockPanel.browserSidebarCollapsed = true;
+    rerender(paneJsx());
+    expect(screen.queryByTestId("file-browser-sidebar-resize")).toBeNull();
+
+    // Width is decoupled from the collapsed flag, so re-opening comes back at the
+    // last-dragged width rather than the default.
+    mockPanel.browserSidebarCollapsed = false;
+    rerender(paneJsx());
+    expect(treeColumn().style.width).toBe("420px");
+    expect(separator().getAttribute("aria-valuenow")).toBe("420");
+  });
+
+  it("drops the document listeners when the pane unmounts mid-drag", () => {
+    const { unmount } = renderPane();
+
+    fireEvent.mouseDown(separator(), { clientX: 100, detail: 1 });
+    unmount();
+    // The unmount effect fired the drag cleanup, so this move reaches no listener.
+    fireEvent.mouseMove(document, { clientX: 400 });
+
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+
+  it("drops the document listeners when the sidebar collapses mid-drag", () => {
+    const { rerender } = renderPane();
+
+    fireEvent.mouseDown(separator(), { clientX: 100, detail: 1 });
+    // Collapse unmounts the grip but not the pane, so a dedicated effect must
+    // fire the same cleanup — otherwise the document listeners keep writing.
+    mockPanel.browserSidebarCollapsed = true;
+    rerender(paneJsx());
+    fireEvent.mouseMove(document, { clientX: 400 });
+
     expect(setFileBrowserViewMock).not.toHaveBeenCalled();
   });
 });

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -115,6 +115,33 @@ describe("serializeFileBrowser", () => {
     // A panel that never captured one stays sparse.
     expect(serializeFileBrowser(basePanel)).toEqual({});
   });
+
+  it("round-trips a non-default sidebar width but keeps the 288 default sparse", () => {
+    const resized: FileBrowserPanelData = { ...basePanel, browserSidebarWidth: 420 };
+    expect(createFileBrowserDefaults(asOptions(serializeFileBrowser(resized)))).toEqual({
+      browserSidebarWidth: 420,
+    });
+
+    // 288 is the default width, the same state as absent — a reset-to-default or
+    // never-resized panel must not persist a width.
+    const atDefault: FileBrowserPanelData = { ...basePanel, browserSidebarWidth: 288 };
+    expect(serializeFileBrowser(atDefault)).toEqual({});
+    expect(serializeFileBrowser(basePanel)).toEqual({});
+  });
+
+  it("persists both a collapsed sidebar and a custom width together", () => {
+    // Collapse doesn't clear the width, so a panel collapsed while wide keeps
+    // both bits — re-opening restores the last-dragged width.
+    const both: FileBrowserPanelData = {
+      ...basePanel,
+      browserSidebarCollapsed: true,
+      browserSidebarWidth: 360,
+    };
+    expect(serializeFileBrowser(both)).toEqual({
+      browserSidebarCollapsed: true,
+      browserSidebarWidth: 360,
+    });
+  });
 });
 
 describe("createFileBrowserDefaults", () => {

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -1,10 +1,15 @@
 import type { FileBrowserPanelData } from "@shared/types/panel";
 import type { FileBrowserPanelOptions } from "@shared/types/addPanelOptions";
 import { canonicalizeRootPath } from "./fileBrowserTree";
+import {
+  FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH,
+  normalizeFileBrowserSidebarWidth,
+} from "./sidebarWidth";
 
 export function createFileBrowserDefaults(
   options: FileBrowserPanelOptions
 ): Partial<FileBrowserPanelData> {
+  const width = normalizeFileBrowserSidebarWidth(options.browserSidebarWidth);
   return {
     // `!= null` rather than truthiness: an explicit `false` for the dotfile
     // toggle is a deliberate choice, and dropping it here would let a later
@@ -29,5 +34,9 @@ export function createFileBrowserDefaults(
     ...(options.browserTreeSnapshot != null && {
       browserTreeSnapshot: options.browserTreeSnapshot,
     }),
+    // Only a non-default width materializes: 288 and absent are the same state,
+    // so a default-width panel stays sparse just like the collapsed bit.
+    ...(width != null &&
+      width !== FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH && { browserSidebarWidth: width }),
   };
 }

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -1,5 +1,6 @@
 import type { FileBrowserPanelData } from "@shared/types/panel";
 import type { PanelSnapshot } from "@shared/types/project";
+import { FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH } from "./sidebarWidth";
 
 /**
  * Every field persists, unlike the diff panel's runtime-only change set: the
@@ -22,5 +23,11 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     // the field being absent, so only a collapsed sidebar earns a persisted bit.
     ...(t.browserSidebarCollapsed ? { browserSidebarCollapsed: true } : {}),
     ...(t.browserTreeSnapshot != null && { browserTreeSnapshot: t.browserTreeSnapshot }),
+    // Only a non-default width earns a persisted number: 288 is the default, the
+    // same as absent, so an unresized or reset-to-default panel stays sparse.
+    ...(t.browserSidebarWidth != null &&
+    t.browserSidebarWidth !== FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH
+      ? { browserSidebarWidth: t.browserSidebarWidth }
+      : {}),
   };
 }

--- a/src/panels/file-browser/sidebarWidth.ts
+++ b/src/panels/file-browser/sidebarWidth.ts
@@ -23,10 +23,7 @@ export const FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE = 50;
  */
 export function clampFileBrowserSidebarWidth(width: number): number {
   if (!Number.isFinite(width)) return FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH;
-  return Math.min(
-    Math.max(width, FILE_BROWSER_SIDEBAR_MIN_WIDTH),
-    FILE_BROWSER_SIDEBAR_MAX_WIDTH
-  );
+  return Math.min(Math.max(width, FILE_BROWSER_SIDEBAR_MIN_WIDTH), FILE_BROWSER_SIDEBAR_MAX_WIDTH);
 }
 
 /**

--- a/src/panels/file-browser/sidebarWidth.ts
+++ b/src/panels/file-browser/sidebarWidth.ts
@@ -14,8 +14,15 @@ export const FILE_BROWSER_SIDEBAR_MAX_WIDTH = 600;
 export const FILE_BROWSER_SIDEBAR_RESIZE_STEP = 10;
 export const FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE = 50;
 
-/** Clamp a finite width into the allowed range. */
+/**
+ * Clamp a width into the allowed range, folding non-finite input (`NaN`,
+ * `Infinity`) back to the default. `Math.min(Math.max(NaN, …))` is `NaN`, which
+ * would otherwise survive as an invalid inline `style.width` and, because
+ * `NaN !== NaN`, churn the store on every write — so the finite guard is
+ * load-bearing, not cosmetic.
+ */
 export function clampFileBrowserSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) return FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH;
   return Math.min(
     Math.max(width, FILE_BROWSER_SIDEBAR_MIN_WIDTH),
     FILE_BROWSER_SIDEBAR_MAX_WIDTH

--- a/src/panels/file-browser/sidebarWidth.ts
+++ b/src/panels/file-browser/sidebarWidth.ts
@@ -1,0 +1,35 @@
+/**
+ * Bounds and steps for the file-browser tree column's draggable width (#11331).
+ *
+ * Fixed constants rather than container-relative bounds, matching the two
+ * existing resize handles (worktree `Sidebar` 200/600, `PortalDock` 320/1200):
+ * the viewer half is already `min-w-0 flex-1`, so it shrinks/scrolls when the
+ * panel is narrow, and a persisted width that never depends on transient
+ * layout stays stable across restores and window sizes.
+ */
+export const FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH = 288; // the old fixed `w-72`
+export const FILE_BROWSER_SIDEBAR_MIN_WIDTH = 200;
+export const FILE_BROWSER_SIDEBAR_MAX_WIDTH = 600;
+/** Keyboard nudge; Shift multiplies to the coarse step. */
+export const FILE_BROWSER_SIDEBAR_RESIZE_STEP = 10;
+export const FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE = 50;
+
+/** Clamp a finite width into the allowed range. */
+export function clampFileBrowserSidebarWidth(width: number): number {
+  return Math.min(
+    Math.max(width, FILE_BROWSER_SIDEBAR_MIN_WIDTH),
+    FILE_BROWSER_SIDEBAR_MAX_WIDTH
+  );
+}
+
+/**
+ * Normalize a possibly-untrusted persisted width to a valid number or
+ * undefined. The snapshot schema passes unknown keys through, so a hand-edited
+ * or corrupted value (a string, `NaN`, `Infinity`) must fall back to the
+ * default rather than reach the pane as an inline `style.width`; a finite
+ * number is clamped into range.
+ */
+export function normalizeFileBrowserSidebarWidth(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return clampFileBrowserSidebarWidth(value);
+}

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -174,6 +174,56 @@ describe("setFileBrowserView", () => {
     });
   });
 
+  it("stores a dragged width and resets it back to the default", () => {
+    setFileBrowserView("panel-1", { browserSidebarWidth: 420 });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarWidth: 420 });
+
+    // Reset writes the explicit default; the serializer, not the store, is what
+    // strips 288 back out of the persisted snapshot.
+    const resized = store.get().panelsById["panel-1"];
+    setFileBrowserView("panel-1", { browserSidebarWidth: 288 });
+    expect(store.get().panelsById["panel-1"]).not.toBe(resized);
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarWidth: 288 });
+  });
+
+  it("treats resetting a never-resized panel to the default width as a no-op", () => {
+    // Absent width and 288 are the same state, so a double-click reset on a panel
+    // that never resized must not churn a fresh object every render.
+    const before = store.get().panelsById["panel-1"];
+
+    setFileBrowserView("panel-1", { browserSidebarWidth: 288 });
+
+    expect(store.get().panelsById["panel-1"]).toBe(before);
+  });
+
+  it("treats a width identical to the current one as a no-op", () => {
+    setFileBrowserView("panel-1", { browserSidebarWidth: 420 });
+    const resized = store.get().panelsById["panel-1"];
+
+    setFileBrowserView("panel-1", { browserSidebarWidth: 420 });
+
+    expect(store.get().panelsById["panel-1"]).toBe(resized);
+  });
+
+  it("clamps an out-of-range width into the allowed bounds before storing", () => {
+    setFileBrowserView("panel-1", { browserSidebarWidth: 5000 });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarWidth: 600 });
+
+    setFileBrowserView("panel-1", { browserSidebarWidth: 50 });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarWidth: 200 });
+  });
+
+  it("preserves selection and expansion when the width changes", () => {
+    setFileBrowserView("panel-1", { browserSelectedPath: "src/app.ts" });
+    setFileBrowserView("panel-1", { browserSidebarWidth: 400 });
+
+    expect(store.get().panelsById["panel-1"]).toMatchObject({
+      browserSidebarWidth: 400,
+      browserSelectedPath: "src/app.ts",
+      browserExpandedPaths: ["src"],
+    });
+  });
+
   it("ignores a panel of another kind rather than stamping browser fields onto it", () => {
     const other = makeSet({
       panelsById: {

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -213,6 +213,21 @@ describe("setFileBrowserView", () => {
     expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarWidth: 200 });
   });
 
+  it("ignores a non-finite width rather than storing NaN and churning", () => {
+    // NaN is valid under TS's `number`, but `NaN === NaN` is false, so storing it
+    // would re-create the panel object (and re-persist) on every write and render
+    // an invalid inline width. The chokepoint must treat it as a no-op.
+    setFileBrowserView("panel-1", { browserSidebarWidth: 400 });
+    const stored = store.get().panelsById["panel-1"];
+
+    setFileBrowserView("panel-1", { browserSidebarWidth: Number.NaN });
+    expect(store.get().panelsById["panel-1"]).toBe(stored);
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserSidebarWidth: 400 });
+
+    setFileBrowserView("panel-1", { browserSidebarWidth: Number.POSITIVE_INFINITY });
+    expect(store.get().panelsById["panel-1"]).toBe(stored);
+  });
+
   it("preserves selection and expansion when the width changes", () => {
     setFileBrowserView("panel-1", { browserSelectedPath: "src/app.ts" });
     setFileBrowserView("panel-1", { browserSidebarWidth: 400 });

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -2,6 +2,10 @@ import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
 import { deepEqualIgnoringUndefined } from "@shared/utils/layoutMerge";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { saveNormalized } from "./persistence";
+import {
+  FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH,
+  clampFileBrowserSidebarWidth,
+} from "@/panels/file-browser/sidebarWidth";
 
 type Set = PanelRegistryStoreApi["setState"];
 
@@ -15,6 +19,8 @@ export interface FileBrowserViewPatch {
   browserSidebarCollapsed?: boolean;
   /** Last-known tree structure, captured as the view goes away (#11367). */
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
+  /** Tree column width in px; clamped into range before it lands. */
+  browserSidebarWidth?: number;
 }
 
 function sameStringList(a: string[] | undefined, b: string[]): boolean {
@@ -26,15 +32,22 @@ function sameStringList(a: string[] | undefined, b: string[]): boolean {
 export const createFileBrowserPanelActions = (
   set: Set
 ): Pick<PanelRegistrySlice, "setFileBrowserView"> => ({
-  // One setter for all three fields rather than three: expanding a folder from
-  // the keyboard moves the selection at the same time, and two sequential
-  // writes would persist an intermediate state where the selected row does not
-  // exist in the expanded tree.
+  // One setter for every view field rather than one per field: expanding a
+  // folder from the keyboard moves the selection at the same time, and two
+  // sequential writes would persist an intermediate state where the selected
+  // row does not exist in the expanded tree.
   setFileBrowserView: (id: string, patch: FileBrowserViewPatch) => {
     set((state) => {
       const panel = state.panelsById[id];
       if (!panel) return state;
       if (panel.kind !== "file-browser") return state;
+
+      // Clamp at the single write chokepoint so a continuous drag (or any
+      // programmatic caller) can never persist an out-of-range width.
+      const nextWidth =
+        patch.browserSidebarWidth === undefined
+          ? undefined
+          : clampFileBrowserSidebarWidth(patch.browserSidebarWidth);
 
       const selectedUnchanged =
         patch.browserSelectedPath === undefined ||
@@ -62,17 +75,25 @@ export const createFileBrowserPanelActions = (
       const treeSnapshotUnchanged =
         patch.browserTreeSnapshot === undefined ||
         deepEqualIgnoringUndefined(patch.browserTreeSnapshot, panel.browserTreeSnapshot);
+      // Absent width and the 288 default are the same state, so resetting a
+      // never-resized panel to the default must count as a no-op — normalized
+      // through `?? DEFAULT` on both sides, like the collapsed flag.
+      const widthUnchanged =
+        nextWidth === undefined ||
+        nextWidth === (panel.browserSidebarWidth ?? FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH);
 
       // Bail on a no-op write. The tree calls this on every arrow key, and a
-      // fresh panel object each time would re-render every panel-store
-      // subscriber and re-write the persisted snapshot for nothing.
+      // drag calls it on every mousemove; a fresh panel object each time would
+      // re-render every panel-store subscriber and re-write the persisted
+      // snapshot for nothing.
       if (
         selectedUnchanged &&
         expandedUnchanged &&
         hideDotfilesUnchanged &&
         rootUnchanged &&
         collapsedUnchanged &&
-        treeSnapshotUnchanged
+        treeSnapshotUnchanged &&
+        widthUnchanged
       )
         return state;
 
@@ -96,6 +117,7 @@ export const createFileBrowserPanelActions = (
         ...(patch.browserTreeSnapshot !== undefined && {
           browserTreeSnapshot: patch.browserTreeSnapshot,
         }),
+        ...(nextWidth !== undefined && { browserSidebarWidth: nextWidth }),
       };
 
       const newById = { ...state.panelsById, [id]: nextPanel };

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -4,7 +4,7 @@ import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { saveNormalized } from "./persistence";
 import {
   FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH,
-  clampFileBrowserSidebarWidth,
+  normalizeFileBrowserSidebarWidth,
 } from "@/panels/file-browser/sidebarWidth";
 
 type Set = PanelRegistryStoreApi["setState"];
@@ -42,12 +42,15 @@ export const createFileBrowserPanelActions = (
       if (!panel) return state;
       if (panel.kind !== "file-browser") return state;
 
-      // Clamp at the single write chokepoint so a continuous drag (or any
-      // programmatic caller) can never persist an out-of-range width.
+      // Normalize at the single write chokepoint so a continuous drag (or any
+      // programmatic caller) can never persist an out-of-range or non-finite
+      // width: a finite value is clamped into range, and `NaN`/`Infinity`
+      // (valid under TS's `number`) collapse to `undefined` and are ignored as
+      // a no-op rather than churning the store with an invalid value.
       const nextWidth =
         patch.browserSidebarWidth === undefined
           ? undefined
-          : clampFileBrowserSidebarWidth(patch.browserSidebarWidth);
+          : normalizeFileBrowserSidebarWidth(patch.browserSidebarWidth);
 
       const selectedUnchanged =
         patch.browserSelectedPath === undefined ||

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -66,6 +66,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
   browserTreeSnapshot?: FileBrowserTreeSnapshot;
+  browserSidebarWidth?: number;
   /**
    * Preserved user-initiated focus timestamp from the saved snapshot. The
    * post-hydration focus picker in `useAppHydration` reads this off
@@ -129,6 +130,7 @@ export interface SavedTerminalData {
   browserRootPath?: unknown;
   browserSidebarCollapsed?: unknown;
   browserTreeSnapshot?: unknown;
+  browserSidebarWidth?: unknown;
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];


### PR DESCRIPTION
## Summary

- The file browser panel's tree column was fixed at 288px (`w-72`) with no way to resize it. This adds a draggable divider between the tree and the file viewer, following the same convention already used by the worktree sidebar and PortalDock's resize handles.
- The chosen width persists in the panel's view state as `browserSidebarWidth`, and is kept decoupled from the collapse feature in #11328: no resize grip while the sidebar is collapsed, and re-expanding restores the last dragged width rather than snapping back to default.
- Width is clamped between 200 and 600px, default 288px. The divider is a keyboard-operable `role="separator"` element: arrow keys step the width, Shift+Arrow makes coarser steps, Home/End jump to the bounds, and double-click resets to the default.

Resolves #11331

## Changes

- New `src/panels/file-browser/sidebarWidth.ts` for the clamp/step logic.
- Persistence threaded through `shared/types/panel.ts`, `shared/types/addPanelOptions.ts`, `shared/types/project.ts`, `src/utils/stateHydration/statePatcher.ts`, and `src/config/panelKindSerialisers.ts`.
- Hardened the drag lifecycle: a drag shield so the HTML preview iframe can't swallow mouse events mid-drag, recovery for when the mouse button releases outside the document (`buttons === 0`), and rejection of non-finite width values at the store's chokepoint so bad values can't get persisted.

## Testing

96 targeted tests pass locally across `FileBrowserPane.test.tsx`, `serializer.test.ts`, `panelKindSerialisers.test.ts`, and the panelRegistry `fileBrowser` tests. Reviewed with two adversarial Codex passes; all findings from those reviews were fixed and confirmed.