### PR TITLE
fix(recipes): serialize recipe writes, persist usage metadata

### DIFF
--- a/electron/services/GlobalFileStore.ts
+++ b/electron/services/GlobalFileStore.ts
@@ -9,8 +9,38 @@ const RECIPES_FILENAME = "recipes.json";
 export class GlobalFileStore {
   private recipesPath: string;
 
+  // Serialize read-modify-write cycles for the single global recipes file.
+  // ipcMain.handle runs handlers concurrently, so two unqueued mutations read
+  // the same snapshot and the last write clobbers the other. One file, so a
+  // single scalar tail (no per-key map) suffices.
+  private recipesWriteTail: Promise<void> = Promise.resolve();
+
   constructor(private globalConfigDir: string) {
     this.recipesPath = path.join(globalConfigDir, RECIPES_FILENAME);
+  }
+
+  /**
+   * Serialize recipe read-modify-write updates. Each queued updater runs after
+   * the previous has committed, so its reads see the prior write's result. The
+   * updater does its own reads (via {@link getRecipes}) and returns the list to
+   * persist, or `null` to skip the write. Updaters must not call another queued
+   * method (they would chain behind the awaiting outer turn and self-deadlock);
+   * the unqueued {@link getRecipes} is safe. `.catch(() => {})` keeps one failed
+   * update from poisoning the chain — the failure still reaches its own caller.
+   */
+  private enqueueRecipesUpdate(
+    updater: () => TerminalRecipe[] | null | Promise<TerminalRecipe[] | null>
+  ): Promise<void> {
+    const next = this.recipesWriteTail
+      .catch(() => {})
+      .then(async () => {
+        const updated = await updater();
+        if (updated !== null) {
+          await this.saveRecipesInner(updated);
+        }
+      });
+    this.recipesWriteTail = next;
+    return next;
   }
 
   async getRecipes(): Promise<TerminalRecipe[]> {
@@ -41,6 +71,12 @@ export class GlobalFileStore {
   }
 
   async saveRecipes(recipes: TerminalRecipe[]): Promise<void> {
+    // Blind full replacement. Takes a queue turn so it can't land between a
+    // competing update's read and write, but reads nothing itself.
+    await this.enqueueRecipesUpdate(() => recipes);
+  }
+
+  private async saveRecipesInner(recipes: TerminalRecipe[]): Promise<void> {
     const attemptSave = async (ensureDir: boolean): Promise<void> => {
       if (ensureDir) {
         await fs.mkdir(this.globalConfigDir, { recursive: true });
@@ -67,36 +103,41 @@ export class GlobalFileStore {
   }
 
   async addRecipe(recipe: TerminalRecipe): Promise<void> {
-    const recipes = await this.getRecipes();
-    recipes.push(recipe);
-    await this.saveRecipes(recipes);
+    await this.enqueueRecipesUpdate(async () => {
+      const recipes = await this.getRecipes();
+      recipes.push(recipe);
+      return recipes;
+    });
   }
 
   async updateRecipe(
     recipeId: string,
     updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>
   ): Promise<void> {
-    const recipes = await this.getRecipes();
-    const index = recipes.findIndex((r) => r.id === recipeId);
-    if (index === -1) {
-      throw new Error(`Global recipe ${recipeId} not found`);
-    }
-    // Defense-in-depth: strip immutable fields even if a caller bypasses
-    // the compile-time Omit (e.g., via untyped bridge or JSON payload).
-    const {
-      id: _id,
-      projectId: _pid,
-      createdAt: _ca,
-      worktreeId: _wid,
-      ...safeUpdates
-    } = updates as Record<string, unknown>;
-    recipes[index] = { ...recipes[index], ...safeUpdates };
-    await this.saveRecipes(recipes);
+    await this.enqueueRecipesUpdate(async () => {
+      const recipes = await this.getRecipes();
+      const index = recipes.findIndex((r) => r.id === recipeId);
+      if (index === -1) {
+        throw new Error(`Global recipe ${recipeId} not found`);
+      }
+      // Defense-in-depth: strip immutable fields even if a caller bypasses
+      // the compile-time Omit (e.g., via untyped bridge or JSON payload).
+      const {
+        id: _id,
+        projectId: _pid,
+        createdAt: _ca,
+        worktreeId: _wid,
+        ...safeUpdates
+      } = updates as Record<string, unknown>;
+      recipes[index] = { ...recipes[index], ...safeUpdates };
+      return recipes;
+    });
   }
 
   async deleteRecipe(recipeId: string): Promise<void> {
-    const recipes = await this.getRecipes();
-    const filtered = recipes.filter((r) => r.id !== recipeId);
-    await this.saveRecipes(filtered);
+    await this.enqueueRecipesUpdate(async () => {
+      const recipes = await this.getRecipes();
+      return recipes.filter((r) => r.id !== recipeId);
+    });
   }
 }

--- a/electron/services/GlobalFileStore.ts
+++ b/electron/services/GlobalFileStore.ts
@@ -44,20 +44,32 @@ export class GlobalFileStore {
   }
 
   async getRecipes(): Promise<TerminalRecipe[]> {
+    let content: string;
     try {
-      const content = await fs.readFile(this.recipesPath, "utf-8");
-      const parsed = JSON.parse(content);
-
-      if (!Array.isArray(parsed)) {
-        throw new Error("recipes is not an array");
-      }
-
-      return filterValidTerminalEntries(parsed, TerminalRecipeSchema, "GlobalFileStore");
+      content = await fs.readFile(this.recipesPath, "utf-8");
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT") {
         return [];
       }
-      console.error("[GlobalFileStore] Failed to load recipes:", error);
+      // A transient read failure (EACCES/EIO/EBUSY) is NOT corruption. Returning
+      // [] here would let a queued mutator (add/update/delete) overwrite the
+      // whole store from an empty base — silent data loss. Rethrow so the
+      // mutator aborts and the on-disk recipes survive (mirrors
+      // ProjectFileStore.getRecipes).
+      console.error("[GlobalFileStore] Failed to read recipes:", error);
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+      if (!Array.isArray(parsed)) {
+        throw new Error("recipes is not an array");
+      }
+    } catch (error) {
+      // Only genuinely malformed content reaches here — quarantine and reset to
+      // empty so the app recovers instead of failing every read.
+      console.error("[GlobalFileStore] Failed to parse recipes:", error);
       try {
         const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const quarantinePath = `${this.recipesPath}.corrupted.${suffix}`;
@@ -68,6 +80,8 @@ export class GlobalFileStore {
       }
       return [];
     }
+
+    return filterValidTerminalEntries(parsed, TerminalRecipeSchema, "GlobalFileStore");
   }
 
   async saveRecipes(recipes: TerminalRecipe[]): Promise<void> {

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -11,6 +11,12 @@ export const RECIPES_SCHEMA_VERSION = 1;
 export class ProjectFileStore {
   constructor(private projectsConfigDir: string) {}
 
+  // Serialize read-modify-write cycles per project. ipcMain.handle runs
+  // handlers concurrently, so two unqueued mutations for the same projectId
+  // read the same on-disk snapshot and the last write silently clobbers the
+  // other. Mirrors ProjectStateManager.enqueueProjectStateUpdate.
+  private readonly recipesWriteQueues = new Map<string, Promise<void>>();
+
   // --- Recipes ---
 
   async getRecipes(projectId: string): Promise<TerminalRecipe[]> {
@@ -123,7 +129,58 @@ export class ProjectFileStore {
     return [];
   }
 
+  /**
+   * Serialize recipe read-modify-write updates per project. Each queued
+   * updater runs after the previous one has committed, so its own reads see
+   * the prior update's on-disk result rather than a stale pre-write snapshot.
+   * The updater does its own reads (via {@link getRecipes}) and returns the
+   * recipe list to persist, or `null` to skip the write (idempotent no-op).
+   *
+   * The three load-bearing details mirror
+   * ProjectStateManager.enqueueProjectStateUpdate: `.catch(() => {})` keeps one
+   * failed update from poisoning the chain (the failure still propagates to
+   * that update's own caller); `.then(cleanup, cleanup)` instead of `.finally`
+   * avoids leaving an unhandled rejected promise; and cleanup deletes the map
+   * entry only when it still points at this tail, so a newer tail isn't
+   * dropped.
+   *
+   * Updaters MUST NOT call another queued method for the same projectId
+   * (saveRecipes / add / update / delete), or the inner call would chain behind
+   * the outer turn that is awaiting it and self-deadlock. They may freely call
+   * the unqueued {@link getRecipes} and any store other than this recipe queue.
+   */
+  enqueueRecipesUpdate(
+    projectId: string,
+    updater: () => TerminalRecipe[] | null | Promise<TerminalRecipe[] | null>
+  ): Promise<void> {
+    const current = this.recipesWriteQueues.get(projectId) ?? Promise.resolve();
+    const next = current
+      .catch(() => {})
+      .then(async () => {
+        const updated = await updater();
+        if (updated !== null) {
+          await this.saveRecipesInner(projectId, updated);
+        }
+      });
+    this.recipesWriteQueues.set(projectId, next);
+    const cleanup = () => {
+      if (this.recipesWriteQueues.get(projectId) === next) {
+        this.recipesWriteQueues.delete(projectId);
+      }
+    };
+    next.then(cleanup, cleanup);
+    return next;
+  }
+
   async saveRecipes(projectId: string, recipes: TerminalRecipe[]): Promise<void> {
+    // Blind full replacement (bulk save / import / reorder). Still takes a turn
+    // in the queue so it can't land between a competing update's read and
+    // write, but performs no read of its own — preserving the pre-queue
+    // semantics of an unconditional overwrite.
+    await this.enqueueRecipesUpdate(projectId, () => recipes);
+  }
+
+  private async saveRecipesInner(projectId: string, recipes: TerminalRecipe[]): Promise<void> {
     const stateDir = getProjectStateDir(this.projectsConfigDir, projectId);
     if (!stateDir) {
       throw new Error(`Invalid project ID: ${projectId}`);
@@ -162,9 +219,11 @@ export class ProjectFileStore {
   }
 
   async addRecipe(projectId: string, recipe: TerminalRecipe): Promise<void> {
-    const recipes = await this.getRecipes(projectId);
-    recipes.push(recipe);
-    await this.saveRecipes(projectId, recipes);
+    await this.enqueueRecipesUpdate(projectId, async () => {
+      const recipes = await this.getRecipes(projectId);
+      recipes.push(recipe);
+      return recipes;
+    });
   }
 
   async updateRecipe(
@@ -172,26 +231,29 @@ export class ProjectFileStore {
     recipeId: string,
     updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>
   ): Promise<void> {
-    const recipes = await this.getRecipes(projectId);
-    const index = recipes.findIndex((r) => r.id === recipeId);
-    if (index === -1) {
-      throw new Error(`Recipe ${recipeId} not found in project ${projectId}`);
-    }
-    // Defense-in-depth: strip immutable fields even if a caller bypasses
-    // the compile-time Omit.
-    const {
-      id: _id,
-      projectId: _pid,
-      createdAt: _ca,
-      ...safeUpdates
-    } = updates as Record<string, unknown>;
-    recipes[index] = { ...recipes[index], ...safeUpdates };
-    await this.saveRecipes(projectId, recipes);
+    await this.enqueueRecipesUpdate(projectId, async () => {
+      const recipes = await this.getRecipes(projectId);
+      const index = recipes.findIndex((r) => r.id === recipeId);
+      if (index === -1) {
+        throw new Error(`Recipe ${recipeId} not found in project ${projectId}`);
+      }
+      // Defense-in-depth: strip immutable fields even if a caller bypasses
+      // the compile-time Omit.
+      const {
+        id: _id,
+        projectId: _pid,
+        createdAt: _ca,
+        ...safeUpdates
+      } = updates as Record<string, unknown>;
+      recipes[index] = { ...recipes[index], ...safeUpdates };
+      return recipes;
+    });
   }
 
   async deleteRecipe(projectId: string, recipeId: string): Promise<void> {
-    const recipes = await this.getRecipes(projectId);
-    const filtered = recipes.filter((r) => r.id !== recipeId);
-    await this.saveRecipes(projectId, filtered);
+    await this.enqueueRecipesUpdate(projectId, async () => {
+      const recipes = await this.getRecipes(projectId);
+      return recipes.filter((r) => r.id !== recipeId);
+    });
   }
 }

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -27,9 +27,16 @@ import {
  * actually persists. Hashing the raw in-memory recipe would produce
  * spurious conflicts on every write because `projectId`/`worktreeId`/env
  * values would never match the redacted on-disk bytes.
+ *
+ * `lastUsedAt`/`usageHistory` are machine-local frecency data that must never
+ * enter the git-tracked canonical file (#11354): now that in-repo usage
+ * metadata is persisted to the ProjectFileStore mirror, a later substantive
+ * edit carries those fields on the in-memory recipe, so they are stripped here
+ * at the serialization boundary rather than relying on every caller to omit
+ * them. They live only in the mirror; reconcile re-merges them on load.
  */
 export function buildInRepoRecipePayloadString(recipe: TerminalRecipe): string {
-  const { projectId: _p, worktreeId: _w, ...shareable } = recipe;
+  const { projectId: _p, worktreeId: _w, lastUsedAt: _l, usageHistory: _u, ...shareable } = recipe;
   const sanitizedTerminals = shareable.terminals.map((t) => {
     if (!t.env || Object.keys(t.env).length === 0) return t;
     const redactedEnv: Record<string, string> = {};

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1262,139 +1262,148 @@ export class ProjectStore {
     projectPath: string,
     projectId: string
   ): Promise<RecipeNameCollision[]> {
-    // Go through the cache-aware wrapper so the hash map is populated as a
-    // side effect — otherwise the first renderer-driven edit after a project
-    // load races the unrelated `getInRepoRecipes` call to populate the cache
-    // and may see a phantom RECIPE_STALE_CONFLICT. `dirExists` distinguishes an
-    // absent `.daintree/recipes/` directory from an authoritatively empty one;
-    // `scanComplete` is false when the directory existed but a recipe file
-    // couldn't be read (a partial snapshot, e.g. mid-checkout).
-    const {
-      recipes: inRepoRecipes,
-      dirExists,
-      scanComplete,
-    } = await this.readInRepoRecipesWithMeta(projectPath);
-    const fileStoreRecipes = await this.fileStore.getRecipes(projectId);
-
-    // #11347: When the in-repo recipe directory is absent (e.g. the user checked
-    // out a branch or commit that predates `.daintree/recipes/`), or the scan of
-    // it was incomplete (a file vanished/locked mid-read), we cannot tell a
-    // recipe that was deleted from one that merely lives on another checkout.
-    // If any project-local recipe is in-repo-scoped, pruning it would destroy
-    // local-only env values / usage metadata, and promoting a *sibling*
-    // local-only recipe would recreate the directory — making the very next
-    // reconcile observe `dirExists: true` and prune the recipe we just
-    // protected. So when the view isn't authoritative and there is anything to
-    // protect, make no filesystem changes at all and defer reconciliation until
-    // the directory is observable again. Projects with only promotable
-    // (non-in-repo) recipes still migrate/collision-check as before.
-    if ((!dirExists || !scanComplete) && fileStoreRecipes.some((r) => isInRepoRecipeId(r))) {
-      return [];
-    }
-
-    const inRepoById = new Map(inRepoRecipes.map((r) => [r.id, r]));
-    const fileStoreById = new Map(fileStoreRecipes.map((r) => [r.id, r]));
-
-    let promoted = false;
+    // Fold the whole read-compute-write into one queued turn so it can't
+    // interleave with concurrent add/update/delete on the same project — the
+    // reconcile-vs-CRUD TOCTOU a per-method queue would otherwise leave open.
+    // The collision list is captured via this closure and returned after the
+    // queued promise resolves. The updater calls only unqueued fileStore reads
+    // (getRecipes) and in-repo writes (writeInRepoRecipe), never a queued
+    // fileStore mutator, so it cannot self-deadlock behind its own turn.
     const collisions: RecipeNameCollision[] = [];
-    // Project-local recipes that couldn't be promoted (filename collision) but
-    // must survive in ProjectFileStore rather than being dropped.
-    const keptLocal: TerminalRecipe[] = [];
-    const seenFilenames = new Map<string, string>();
-    for (const recipe of inRepoById.values()) {
-      seenFilenames.set(safeRecipeFilename(recipe.name), recipe.id);
-    }
+    await this.fileStore.enqueueRecipesUpdate(projectId, async () => {
+      // Go through the cache-aware wrapper so the hash map is populated as a
+      // side effect — otherwise the first renderer-driven edit after a project
+      // load races the unrelated `getInRepoRecipes` call to populate the cache
+      // and may see a phantom RECIPE_STALE_CONFLICT. `dirExists` distinguishes
+      // an absent `.daintree/recipes/` directory from an authoritatively empty
+      // one; `scanComplete` is false when the directory existed but a recipe
+      // file couldn't be read (a partial snapshot, e.g. mid-checkout).
+      const {
+        recipes: inRepoRecipes,
+        dirExists,
+        scanComplete,
+      } = await this.readInRepoRecipesWithMeta(projectPath);
+      const fileStoreRecipes = await this.fileStore.getRecipes(projectId);
 
-    for (const recipe of fileStoreRecipes) {
-      if (inRepoById.has(recipe.id)) continue;
-      if (isInRepoRecipeId(recipe)) continue; // stale, removed below
-
-      const filename = safeRecipeFilename(recipe.name);
-      const ownerId = seenFilenames.get(filename);
-      if (ownerId !== undefined && ownerId !== recipe.id) {
-        // Can't promote: a different recipe already owns this filename. Keep
-        // it as a project-local recipe and report the collision upward.
-        collisions.push({
-          filename,
-          keptId: ownerId,
-          droppedId: recipe.id,
-          droppedName: recipe.name,
-        });
-        keptLocal.push(recipe);
-        continue;
+      // #11347: When the in-repo recipe directory is absent (e.g. the user checked
+      // out a branch or commit that predates `.daintree/recipes/`), or the scan of
+      // it was incomplete (a file vanished/locked mid-read), we cannot tell a
+      // recipe that was deleted from one that merely lives on another checkout.
+      // If any project-local recipe is in-repo-scoped, pruning it would destroy
+      // local-only env values / usage metadata, and promoting a *sibling*
+      // local-only recipe would recreate the directory — making the very next
+      // reconcile observe `dirExists: true` and prune the recipe we just
+      // protected. So when the view isn't authoritative and there is anything to
+      // protect, make no filesystem changes at all and defer reconciliation until
+      // the directory is observable again. Projects with only promotable
+      // (non-in-repo) recipes still migrate/collision-check as before.
+      if ((!dirExists || !scanComplete) && fileStoreRecipes.some((r) => isInRepoRecipeId(r))) {
+        return null;
       }
 
-      await this.writeInRepoRecipe(projectPath, recipe);
-      inRepoById.set(recipe.id, recipe);
-      seenFilenames.set(filename, recipe.id);
-      promoted = true;
-    }
+      const inRepoById = new Map(inRepoRecipes.map((r) => [r.id, r]));
+      const fileStoreById = new Map(fileStoreRecipes.map((r) => [r.id, r]));
 
-    const hasStale = fileStoreRecipes.some((r) => isInRepoRecipeId(r) && !inRepoById.has(r.id));
+      let promoted = false;
+      // Project-local recipes that couldn't be promoted (filename collision) but
+      // must survive in ProjectFileStore rather than being dropped.
+      const keptLocal: TerminalRecipe[] = [];
+      const seenFilenames = new Map<string, string>();
+      for (const recipe of inRepoById.values()) {
+        seenFilenames.set(safeRecipeFilename(recipe.name), recipe.id);
+      }
 
-    const reconciledIds = new Set(inRepoById.keys());
-    const sizeChanged = reconciledIds.size !== fileStoreById.size;
-    const idsChanged = ![...reconciledIds].every((id) => fileStoreById.has(id));
+      for (const recipe of fileStoreRecipes) {
+        if (inRepoById.has(recipe.id)) continue;
+        if (isInRepoRecipeId(recipe)) continue; // stale, removed below
 
-    if (!promoted && !hasStale && !sizeChanged && !idsChanged && collisions.length === 0) {
-      // IDs match perfectly — check content before skipping
-      let contentDiffers = false;
+        const filename = safeRecipeFilename(recipe.name);
+        const ownerId = seenFilenames.get(filename);
+        if (ownerId !== undefined && ownerId !== recipe.id) {
+          // Can't promote: a different recipe already owns this filename. Keep
+          // it as a project-local recipe and report the collision upward.
+          collisions.push({
+            filename,
+            keptId: ownerId,
+            droppedId: recipe.id,
+            droppedName: recipe.name,
+          });
+          keptLocal.push(recipe);
+          continue;
+        }
+
+        await this.writeInRepoRecipe(projectPath, recipe);
+        inRepoById.set(recipe.id, recipe);
+        seenFilenames.set(filename, recipe.id);
+        promoted = true;
+      }
+
+      const hasStale = fileStoreRecipes.some((r) => isInRepoRecipeId(r) && !inRepoById.has(r.id));
+
+      const reconciledIds = new Set(inRepoById.keys());
+      const sizeChanged = reconciledIds.size !== fileStoreById.size;
+      const idsChanged = ![...reconciledIds].every((id) => fileStoreById.has(id));
+
+      if (!promoted && !hasStale && !sizeChanged && !idsChanged && collisions.length === 0) {
+        // IDs match perfectly — check content before skipping
+        let contentDiffers = false;
+        for (const recipe of inRepoById.values()) {
+          const existing = fileStoreById.get(recipe.id);
+          if (!existing) continue;
+          const {
+            projectId: _p1,
+            worktreeId: _w1,
+            ...inRepoNorm
+          } = recipe as unknown as Record<string, unknown>;
+          const {
+            projectId: _p2,
+            worktreeId: _w2,
+            ...fsNorm
+          } = existing as unknown as Record<string, unknown>;
+          if (JSON.stringify(inRepoNorm) !== JSON.stringify(fsNorm)) {
+            contentDiffers = true;
+            break;
+          }
+        }
+        if (!contentDiffers) return null;
+      }
+
+      // Build reconciled list: start from in-repo canonical, merge fileStore-only
+      // fields (env values, metadata) so they survive the write-back.
+      const reconciled: TerminalRecipe[] = [];
       for (const recipe of inRepoById.values()) {
         const existing = fileStoreById.get(recipe.id);
-        if (!existing) continue;
-        const {
-          projectId: _p1,
-          worktreeId: _w1,
-          ...inRepoNorm
-        } = recipe as unknown as Record<string, unknown>;
-        const {
-          projectId: _p2,
-          worktreeId: _w2,
-          ...fsNorm
-        } = existing as unknown as Record<string, unknown>;
-        if (JSON.stringify(inRepoNorm) !== JSON.stringify(fsNorm)) {
-          contentDiffers = true;
-          break;
+        if (!existing) {
+          reconciled.push(recipe);
+          continue;
         }
-      }
-      if (!contentDiffers) return collisions;
-    }
 
-    // Build reconciled list: start from in-repo canonical, merge fileStore-only
-    // fields (env values, metadata) so they survive the write-back.
-    const reconciled: TerminalRecipe[] = [];
-    for (const recipe of inRepoById.values()) {
-      const existing = fileStoreById.get(recipe.id);
-      if (!existing) {
-        reconciled.push(recipe);
-        continue;
+        const mergedTerminals = recipe.terminals.map((inRepoT, i) => {
+          const existingT = existing.terminals[i];
+          if (!existingT?.env || Object.keys(existingT.env).length === 0) return inRepoT;
+          const env: Record<string, string> = {};
+          for (const key of Object.keys(inRepoT.env ?? {})) {
+            env[key] = existingT.env[key] ?? "";
+          }
+          return { ...inRepoT, env };
+        });
+
+        reconciled.push({
+          ...recipe,
+          terminals: mergedTerminals,
+          projectId: existing.projectId,
+          worktreeId: existing.worktreeId,
+          lastUsedAt: existing.lastUsedAt,
+          usageHistory: existing.usageHistory,
+        });
       }
 
-      const mergedTerminals = recipe.terminals.map((inRepoT, i) => {
-        const existingT = existing.terminals[i];
-        if (!existingT?.env || Object.keys(existingT.env).length === 0) return inRepoT;
-        const env: Record<string, string> = {};
-        for (const key of Object.keys(inRepoT.env ?? {})) {
-          env[key] = existingT.env[key] ?? "";
-        }
-        return { ...inRepoT, env };
-      });
+      // Keep project-local recipes that couldn't be promoted (filename collision)
+      // so they survive the write-back rather than being silently dropped.
+      reconciled.push(...keptLocal);
 
-      reconciled.push({
-        ...recipe,
-        terminals: mergedTerminals,
-        projectId: existing.projectId,
-        worktreeId: existing.worktreeId,
-        lastUsedAt: existing.lastUsedAt,
-        usageHistory: existing.usageHistory,
-      });
-    }
-
-    // Keep project-local recipes that couldn't be promoted (filename collision)
-    // so they survive the write-back rather than being silently dropped.
-    reconciled.push(...keptLocal);
-
-    await this.fileStore.saveRecipes(projectId, reconciled);
+      return reconciled;
+    });
     return collisions;
   }
 

--- a/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
@@ -172,6 +172,26 @@ describe("GlobalFileStore adversarial", () => {
     expect(utilsMock.resilientRename).toHaveBeenCalledWith(RECIPES_FILE, expect.any(String));
   });
 
+  it("non-ENOENT read errors throw and are NOT quarantined (transient failure != corruption)", async () => {
+    const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
+    fsMock.readFile.mockRejectedValue(eacces);
+
+    await expect(store.getRecipes()).rejects.toThrow("EACCES");
+    // A read I/O error must not move the file aside — the data is still there.
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe does not overwrite the store when the read fails with a transient error", async () => {
+    const eio = Object.assign(new Error("EIO"), { code: "EIO" });
+    fsMock.readFile.mockRejectedValue(eio);
+
+    await expect(
+      store.addRecipe({ id: "r1", name: "test", terminals: [], createdAt: 1000 } as never)
+    ).rejects.toThrow("EIO");
+    // The mutator aborts rather than saving [justTheNewRecipe] over the store.
+    expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
+  });
+
   it("addRecipe loads + appends + saves without mutating the loaded array for caller", async () => {
     fsMock.readFile.mockResolvedValue(JSON.stringify([]));
 

--- a/electron/services/__tests__/GlobalFileStore.serialization.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.serialization.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "path";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+const utilsMock = vi.hoisted(() => ({
+  resilientRename: vi.fn(),
+  resilientAtomicWriteFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({ default: fsMock, ...fsMock }));
+vi.mock("../../utils/fs.js", () => utilsMock);
+
+import { GlobalFileStore } from "../GlobalFileStore.js";
+import type { TerminalRecipe } from "../../types/index.js";
+
+const CONFIG_DIR = path.normalize("/tmp/daintree-global");
+const RECIPES_FILE = path.join(CONFIG_DIR, "recipes.json");
+
+function recipe(id: string): TerminalRecipe {
+  return { id, name: id, terminals: [], createdAt: 1000 } as TerminalRecipe;
+}
+
+/**
+ * Model the single global recipes.json. `readFile` returns the last-written
+ * bare array (ENOENT when absent); `resilientAtomicWriteFile` records it. The
+ * optional per-write delay widens the read→write window so an unserialized
+ * implementation would lose one of two concurrent updates.
+ */
+function installDiskModel(writeDelayMs = 0): { content: string | null } {
+  const box: { content: string | null } = { content: null };
+  fsMock.readFile.mockImplementation(async () => {
+    if (box.content === null) {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }
+    return box.content;
+  });
+  utilsMock.resilientAtomicWriteFile.mockImplementation(async (_filePath: string, data: string) => {
+    if (writeDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, writeDelayMs));
+    box.content = data;
+  });
+  return box;
+}
+
+describe("GlobalFileStore write serialization", () => {
+  let store: GlobalFileStore;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store = new GlobalFileStore(CONFIG_DIR);
+    fsMock.mkdir.mockResolvedValue(undefined);
+    utilsMock.resilientRename.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("serializes two concurrent addRecipe calls so neither update is lost", async () => {
+    installDiskModel(5);
+
+    await Promise.all([store.addRecipe(recipe("g1")), store.addRecipe(recipe("g2"))]);
+
+    const result = await store.getRecipes();
+    expect(result.map((r) => r.id).sort()).toEqual(["g1", "g2"]);
+  });
+
+  it("serializes many concurrent adds — every global recipe survives", async () => {
+    installDiskModel(2);
+
+    const ids = Array.from({ length: 8 }, (_, i) => `g${i}`);
+    await Promise.all(ids.map((id) => store.addRecipe(recipe(id))));
+
+    const result = await store.getRecipes();
+    expect(result.map((r) => r.id).sort()).toEqual([...ids].sort());
+  });
+
+  it("a failing update rejects its own caller but does not poison later updates", async () => {
+    installDiskModel(2);
+    await store.addRecipe(recipe("g1"));
+
+    const failing = store.updateRecipe("missing", { name: "x" });
+    const following = store.addRecipe(recipe("g2"));
+
+    await expect(failing).rejects.toThrow(/not found/);
+    await expect(following).resolves.toBeUndefined();
+
+    const result = await store.getRecipes();
+    expect(result.map((r) => r.id).sort()).toEqual(["g1", "g2"]);
+  });
+
+  it("interleaved add / update / delete apply in enqueue order", async () => {
+    installDiskModel(2);
+
+    await Promise.all([
+      store.addRecipe(recipe("keep")),
+      store.addRecipe(recipe("drop")),
+      store.updateRecipe("keep", { name: "renamed" }),
+      store.deleteRecipe("drop"),
+    ]);
+
+    const result = await store.getRecipes();
+    expect(result.map((r) => r.id)).toEqual(["keep"]);
+    expect(result[0]!.name).toBe("renamed");
+  });
+
+  it("bulk saveRecipes takes a queue turn but performs no read of its own", async () => {
+    installDiskModel(2);
+    await store.addRecipe(recipe("pre"));
+    fsMock.readFile.mockClear();
+
+    await store.saveRecipes([recipe("only")]);
+
+    expect(fsMock.readFile).not.toHaveBeenCalled();
+    expect(utilsMock.resilientAtomicWriteFile).toHaveBeenLastCalledWith(
+      RECIPES_FILE,
+      expect.any(String),
+      "utf-8"
+    );
+    expect((await store.getRecipes()).map((r) => r.id)).toEqual(["only"]);
+  });
+});

--- a/electron/services/__tests__/GlobalFileStore.serialization.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.serialization.test.ts
@@ -107,7 +107,17 @@ describe("GlobalFileStore write serialization", () => {
     expect(result[0]!.name).toBe("renamed");
   });
 
-  it("bulk saveRecipes takes a queue turn but performs no read of its own", async () => {
+  it("bulk saveRecipes is serialized in the queue — an add enqueued behind it sees its result", async () => {
+    installDiskModel(3);
+
+    const savePromise = store.saveRecipes([recipe("base")]);
+    const addPromise = store.addRecipe(recipe("added"));
+    await Promise.all([savePromise, addPromise]);
+
+    expect((await store.getRecipes()).map((r) => r.id)).toEqual(["base", "added"]);
+  });
+
+  it("bulk saveRecipes performs no read of its own (pure blind overwrite)", async () => {
     installDiskModel(2);
     await store.addRecipe(recipe("pre"));
     fsMock.readFile.mockClear();
@@ -121,5 +131,33 @@ describe("GlobalFileStore write serialization", () => {
       "utf-8"
     );
     expect((await store.getRecipes()).map((r) => r.id)).toEqual(["only"]);
+  });
+
+  it("a failed WRITE rejects its own caller but the store recovers from the last durable snapshot", async () => {
+    const box = installDiskModel();
+    await store.addRecipe(recipe("g1"));
+
+    const realWrite = utilsMock.resilientAtomicWriteFile.getMockImplementation()!;
+    let failNext = true;
+    utilsMock.resilientAtomicWriteFile.mockImplementation(
+      async (filePath: string, data: string) => {
+        if (failNext) {
+          failNext = false;
+          throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+        }
+        return realWrite(filePath, data);
+      }
+    );
+    void box;
+
+    const failing = store.updateRecipe("g1", { name: "renamed" });
+    const following = store.addRecipe(recipe("g2"));
+
+    await expect(failing).rejects.toThrow("EACCES");
+    await expect(following).resolves.toBeUndefined();
+
+    const result = await store.getRecipes();
+    expect(result.map((r) => r.id).sort()).toEqual(["g1", "g2"]);
+    expect(result.find((r) => r.id === "g1")?.name).toBe("g1");
   });
 });

--- a/electron/services/__tests__/ProjectFileStore.serialization.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.serialization.test.ts
@@ -155,12 +155,22 @@ describe("ProjectFileStore write serialization", () => {
     expect((await store.getRecipes(VALID_ID)).map((r) => r.id)).toEqual(["a1"]);
   });
 
-  it("bulk saveRecipes takes a queue turn but performs no read of its own", async () => {
-    installDiskModel(2);
+  it("bulk saveRecipes is serialized in the queue — an add enqueued behind it sees its result", async () => {
+    installDiskModel(3);
 
-    // A blind replacement racing an add: both are serialized, so the final
-    // state is deterministic (whichever enqueued last wins the file), and the
-    // blind save never issues its own read.
+    // Enqueue a blind replacement, then an add. Serialized in order, the add
+    // reads the just-saved list and appends to it → [base, added]. If
+    // saveRecipes bypassed the queue, the two would interleave on the widened
+    // write window and one would be lost (final would be [base] or [added]).
+    const savePromise = store.saveRecipes(VALID_ID, [recipe("base")]);
+    const addPromise = store.addRecipe(VALID_ID, recipe("added"));
+    await Promise.all([savePromise, addPromise]);
+
+    expect((await store.getRecipes(VALID_ID)).map((r) => r.id)).toEqual(["base", "added"]);
+  });
+
+  it("bulk saveRecipes performs no read of its own (pure blind overwrite)", async () => {
+    installDiskModel(2);
     await store.addRecipe(VALID_ID, recipe("pre"));
     fsMock.readFile.mockClear();
 
@@ -168,5 +178,73 @@ describe("ProjectFileStore write serialization", () => {
 
     expect(fsMock.readFile).not.toHaveBeenCalled();
     expect((await store.getRecipes(VALID_ID)).map((r) => r.id)).toEqual(["only"]);
+  });
+
+  it("a failed WRITE rejects its own caller but the store recovers from the last durable snapshot", async () => {
+    const disk = installDiskModel();
+    await store.addRecipe(VALID_ID, recipe("r1"));
+
+    // Fail exactly the next write (the update); later writes go through.
+    const realWrite = utilsMock.resilientAtomicWriteFile.getMockImplementation()!;
+    let failNext = true;
+    utilsMock.resilientAtomicWriteFile.mockImplementation(
+      async (filePath: string, data: string) => {
+        if (failNext) {
+          failNext = false;
+          throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+        }
+        return realWrite(filePath, data);
+      }
+    );
+
+    const failing = store.updateRecipe(VALID_ID, "r1", { name: "renamed" });
+    const following = store.addRecipe(VALID_ID, recipe("r2"));
+
+    await expect(failing).rejects.toThrow("EACCES");
+    await expect(following).resolves.toBeUndefined();
+
+    const result = await store.getRecipes(VALID_ID);
+    expect(result.map((r) => r.id).sort()).toEqual(["r1", "r2"]);
+    // The rejected rename never persisted; r1 kept its original name.
+    expect(result.find((r) => r.id === "r1")?.name).toBe("r1");
+  });
+
+  it("cleanup uses an identity guard: a completed op keeps a newer tail, and the map empties on drain", async () => {
+    const disk = installDiskModel();
+    const queues = (store as unknown as { recipesWriteQueues: Map<string, Promise<unknown>> })
+      .recipesWriteQueues;
+
+    // Gate op1's write so op2 enqueues behind it — the map tail becomes op2.
+    let release1: () => void = () => {};
+    const gate1 = new Promise<void>((resolve) => {
+      release1 = resolve;
+    });
+    let firstWrite = true;
+    utilsMock.resilientAtomicWriteFile.mockImplementation(
+      async (filePath: string, data: string) => {
+        if (firstWrite) {
+          firstWrite = false;
+          await gate1;
+        }
+        disk.set(filePath, data);
+      }
+    );
+
+    const p1 = store.addRecipe(VALID_ID, recipe("r1"));
+    const p2 = store.addRecipe(VALID_ID, recipe("r2"));
+    const tailAfterTwo = queues.get(VALID_ID);
+    expect(tailAfterTwo).toBeDefined();
+
+    release1();
+    await p1;
+    // op1's cleanup ran but the map still points at op2's tail: the
+    // `map.get(key) === next` guard prevented op1 from dropping op2's entry.
+    expect(queues.get(VALID_ID)).toBe(tailAfterTwo);
+
+    await p2;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Fully drained → entry removed (no per-project map leak).
+    expect(queues.has(VALID_ID)).toBe(false);
+    expect((await store.getRecipes(VALID_ID)).map((r) => r.id).sort()).toEqual(["r1", "r2"]);
   });
 });

--- a/electron/services/__tests__/ProjectFileStore.serialization.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.serialization.test.ts
@@ -181,7 +181,7 @@ describe("ProjectFileStore write serialization", () => {
   });
 
   it("a failed WRITE rejects its own caller but the store recovers from the last durable snapshot", async () => {
-    const disk = installDiskModel();
+    installDiskModel();
     await store.addRecipe(VALID_ID, recipe("r1"));
 
     // Fail exactly the next write (the update); later writes go through.

--- a/electron/services/__tests__/ProjectFileStore.serialization.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.serialization.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "path";
+
+const fsMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+const fsSyncMock = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+}));
+
+const utilsMock = vi.hoisted(() => ({
+  resilientRename: vi.fn(),
+  resilientAtomicWriteFile: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({ default: fsMock, ...fsMock }));
+vi.mock("fs", () => ({ ...fsSyncMock }));
+vi.mock("../../utils/fs.js", () => utilsMock);
+
+import { ProjectFileStore } from "../ProjectFileStore.js";
+import type { TerminalRecipe } from "../../types/index.js";
+
+const VALID_ID = "a".repeat(64);
+const OTHER_ID = "b".repeat(64);
+const CONFIG_DIR = path.normalize("/tmp/daintree-projects");
+
+function recipeFilePath(projectId: string): string {
+  return path.join(CONFIG_DIR, projectId, "recipes.json");
+}
+
+function recipe(id: string): TerminalRecipe {
+  return { id, name: id, terminals: [], createdAt: 1000 } as TerminalRecipe;
+}
+
+/**
+ * Model recipes.json on disk keyed by file path. `readFile` returns the
+ * last-written envelope (ENOENT when absent); `resilientAtomicWriteFile`
+ * records it. An optional per-write delay widens the read→write window so that
+ * an *unserialized* implementation would lose one of two concurrent updates —
+ * making these tests fail loudly if the queue is ever removed.
+ */
+function installDiskModel(writeDelayMs = 0): Map<string, string> {
+  const disk = new Map<string, string>();
+  fsMock.readFile.mockImplementation(async (filePath: string) => {
+    const content = disk.get(filePath);
+    if (content === undefined) {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }
+    return content;
+  });
+  utilsMock.resilientAtomicWriteFile.mockImplementation(async (filePath: string, data: string) => {
+    if (writeDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, writeDelayMs));
+    disk.set(filePath, data);
+  });
+  return disk;
+}
+
+describe("ProjectFileStore write serialization", () => {
+  let store: ProjectFileStore;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    store = new ProjectFileStore(CONFIG_DIR);
+    fsMock.mkdir.mockResolvedValue(undefined);
+    utilsMock.resilientRename.mockResolvedValue(undefined);
+    fsSyncMock.existsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("serializes two concurrent addRecipe calls so neither update is lost", async () => {
+    installDiskModel(5);
+
+    await Promise.all([
+      store.addRecipe(VALID_ID, recipe("r1")),
+      store.addRecipe(VALID_ID, recipe("r2")),
+    ]);
+
+    const result = await store.getRecipes(VALID_ID);
+    expect(result.map((r) => r.id).sort()).toEqual(["r1", "r2"]);
+  });
+
+  it("serializes many concurrent adds — every recipe survives the chain", async () => {
+    installDiskModel(2);
+
+    const ids = Array.from({ length: 8 }, (_, i) => `r${i}`);
+    await Promise.all(ids.map((id) => store.addRecipe(VALID_ID, recipe(id))));
+
+    const result = await store.getRecipes(VALID_ID);
+    expect(result.map((r) => r.id).sort()).toEqual([...ids].sort());
+  });
+
+  it("a failing update rejects its own caller but does not poison later updates", async () => {
+    installDiskModel(2);
+    await store.addRecipe(VALID_ID, recipe("r1"));
+
+    // updateRecipe on a missing id throws inside its queued turn; a mutation
+    // enqueued right behind it must still commit.
+    const failing = store.updateRecipe(VALID_ID, "missing", { name: "x" });
+    const following = store.addRecipe(VALID_ID, recipe("r2"));
+
+    await expect(failing).rejects.toThrow(/not found/);
+    await expect(following).resolves.toBeUndefined();
+
+    const result = await store.getRecipes(VALID_ID);
+    expect(result.map((r) => r.id).sort()).toEqual(["r1", "r2"]);
+  });
+
+  it("interleaved add / update / delete on one project apply in enqueue order", async () => {
+    installDiskModel(2);
+
+    await Promise.all([
+      store.addRecipe(VALID_ID, recipe("keep")),
+      store.addRecipe(VALID_ID, recipe("drop")),
+      store.updateRecipe(VALID_ID, "keep", { name: "renamed" }),
+      store.deleteRecipe(VALID_ID, "drop"),
+    ]);
+
+    const result = await store.getRecipes(VALID_ID);
+    expect(result.map((r) => r.id)).toEqual(["keep"]);
+    expect(result[0]!.name).toBe("renamed");
+  });
+
+  it("a stalled project queue does not block a different project's queue", async () => {
+    const disk = installDiskModel();
+
+    // Gate the first write for VALID_ID until we release it; OTHER_ID must be
+    // free to complete meanwhile (proves per-projectId keying, not one global
+    // lock).
+    let releaseA: () => void = () => {};
+    const aGate = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const gatedPath = recipeFilePath(VALID_ID);
+    utilsMock.resilientAtomicWriteFile.mockImplementation(
+      async (filePath: string, data: string) => {
+        if (filePath === gatedPath) await aGate;
+        disk.set(filePath, data);
+      }
+    );
+
+    const aPromise = store.addRecipe(VALID_ID, recipe("a1"));
+    const bPromise = store.addRecipe(OTHER_ID, recipe("b1"));
+
+    // B resolves while A is still gated.
+    await expect(bPromise).resolves.toBeUndefined();
+    expect((await store.getRecipes(OTHER_ID)).map((r) => r.id)).toEqual(["b1"]);
+
+    releaseA();
+    await aPromise;
+    expect((await store.getRecipes(VALID_ID)).map((r) => r.id)).toEqual(["a1"]);
+  });
+
+  it("bulk saveRecipes takes a queue turn but performs no read of its own", async () => {
+    installDiskModel(2);
+
+    // A blind replacement racing an add: both are serialized, so the final
+    // state is deterministic (whichever enqueued last wins the file), and the
+    // blind save never issues its own read.
+    await store.addRecipe(VALID_ID, recipe("pre"));
+    fsMock.readFile.mockClear();
+
+    await store.saveRecipes(VALID_ID, [recipe("only")]);
+
+    expect(fsMock.readFile).not.toHaveBeenCalled();
+    expect((await store.getRecipes(VALID_ID)).map((r) => r.id)).toEqual(["only"]);
+  });
+});

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -563,6 +563,28 @@ describe("ProjectStore recipe reconciliation", () => {
     const inr = await readInRepo();
     expect(inr).toHaveLength(1);
   });
+
+  it("serializes reconcile against a concurrent addRecipe (neither clobbers the other)", async () => {
+    // Seed one in-repo recipe so reconcile has real write work (backfill it to
+    // the ProjectFileStore mirror). reconcile does a full read-compute-write of
+    // recipes.json; addRecipe does a read-modify-write of the same file. Run
+    // both at once: without per-project serialization, reconcile's full-list
+    // write (built from a pre-add snapshot) clobbers the freshly added recipe,
+    // or the add clobbers reconcile's backfill — one recipe is always lost.
+    const inRepo = makeRecipe({ id: "recipe-inrepo", name: "In Repo", scope: "inrepo" });
+    await seedInRepo(inRepo);
+
+    const added = makeRecipe({ id: "recipe-added", name: "Added", projectId });
+    await Promise.all([
+      store.reconcileProjectRecipes(projectPath, projectId),
+      store.addRecipe(projectId, added),
+    ]);
+
+    const ids = (await readFileStore()).map((r) => r.id).sort();
+    // Both survive regardless of which turn the queue ran first.
+    expect(ids).toContain("recipe-added");
+    expect(ids).toContain("recipe-inrepo");
+  });
 });
 
 describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard, #9186)", () => {

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -564,13 +564,14 @@ describe("ProjectStore recipe reconciliation", () => {
     expect(inr).toHaveLength(1);
   });
 
-  it("serializes reconcile against a concurrent addRecipe (neither clobbers the other)", async () => {
-    // Seed one in-repo recipe so reconcile has real write work (backfill it to
-    // the ProjectFileStore mirror). reconcile does a full read-compute-write of
-    // recipes.json; addRecipe does a read-modify-write of the same file. Run
-    // both at once: without per-project serialization, reconcile's full-list
-    // write (built from a pre-add snapshot) clobbers the freshly added recipe,
-    // or the add clobbers reconcile's backfill — one recipe is always lost.
+  it("reconcile and a concurrent addRecipe are serialized — the mirror ends with the exact expected set", async () => {
+    // Integration check that reconcile shares the ProjectFileStore write queue
+    // with CRUD: reconcile does a full read-compute-write of recipes.json and
+    // addRecipe a read-modify-write of the same file. Because they serialize,
+    // the mirror ends with EXACTLY both recipes for either enqueue order — no
+    // lost update, no duplicate. (The deterministic proof that the queue kills
+    // an unserialized implementation lives in the ProjectFileStore/GlobalFileStore
+    // serialization unit tests; this asserts reconcile is wired into it.)
     const inRepo = makeRecipe({ id: "recipe-inrepo", name: "In Repo", scope: "inrepo" });
     await seedInRepo(inRepo);
 
@@ -581,9 +582,7 @@ describe("ProjectStore recipe reconciliation", () => {
     ]);
 
     const ids = (await readFileStore()).map((r) => r.id).sort();
-    // Both survive regardless of which turn the queue ran first.
-    expect(ids).toContain("recipe-added");
-    expect(ids).toContain("recipe-inrepo");
+    expect(ids).toEqual(["recipe-added", "recipe-inrepo"]);
   });
 });
 

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -510,6 +510,16 @@ describe("writeInRepoRecipe", () => {
     expect(payload).not.toContain("wt-1");
   });
 
+  it("buildInRepoRecipePayloadString strips lastUsedAt and usageHistory (frecency stays out of git)", () => {
+    const recipe = makeRecipe({ lastUsedAt: 1717171717, usageHistory: [1000, 2000, 3000] });
+    const payload = buildInRepoRecipePayloadString(recipe);
+    const parsed = JSON.parse(payload);
+    expect(parsed.lastUsedAt).toBeUndefined();
+    expect(parsed.usageHistory).toBeUndefined();
+    expect(payload).not.toContain("1717171717");
+    expect(payload).not.toContain("usageHistory");
+  });
+
   it("hashRecipePayload is deterministic and produces a 64-char hex digest", () => {
     const a = hashRecipePayload("hello");
     const b = hashRecipePayload("hello");

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2089,7 +2089,7 @@ describe("recipeStore", () => {
       );
     });
 
-    it("updateRecipe skips file write for metadata-only in-repo update", async () => {
+    it("persists a metadata-only in-repo update to the ProjectFileStore mirror, not the canonical file", async () => {
       const inRepoRecipe = {
         id: "inrepo-test",
         name: "Team Recipe",
@@ -2106,8 +2106,50 @@ describe("recipeStore", () => {
 
       await useRecipeStore.getState().updateRecipe("inrepo-test", { lastUsedAt: 999 });
 
+      // The canonical git-tracked .daintree/recipes/*.json file is never
+      // touched by a frecency stamp (that's what metadataOnlyKeys guards).
       expect(updateInRepoRecipeMock).not.toHaveBeenCalled();
-      expect(updateRecipeMock).not.toHaveBeenCalled();
+      // But the ProjectFileStore mirror IS updated so in-repo usage metadata
+      // survives a reload the way project/global recipes already do (#11354).
+      expect(updateRecipeMock).toHaveBeenCalledWith(
+        "project-1",
+        "inrepo-test",
+        expect.objectContaining({ lastUsedAt: 999 })
+      );
+      expect(globalUpdateRecipeMock).not.toHaveBeenCalled();
+    });
+
+    it("degrades gracefully when the in-repo mirror entry is not yet reconciled", async () => {
+      const inRepoRecipe = {
+        id: "inrepo-test",
+        name: "Team Recipe",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+        lastUsedAt: 100,
+      };
+      useRecipeStore.setState({
+        inRepoRecipes: [inRepoRecipe],
+        globalRecipes: [],
+        projectRecipes: [],
+        recipes: [inRepoRecipe],
+        currentProjectId: "project-1",
+      });
+
+      // Before the first reconcile backfills the mirror, ProjectFileStore
+      // .updateRecipe throws "not found". A low-stakes frecency stamp must not
+      // reject its caller or roll back the optimistic in-memory update.
+      updateRecipeMock.mockRejectedValueOnce(
+        new Error("Recipe inrepo-test not found in project project-1")
+      );
+
+      await expect(
+        useRecipeStore.getState().updateRecipe("inrepo-test", { lastUsedAt: 999 })
+      ).resolves.toBeUndefined();
+
+      expect(updateInRepoRecipeMock).not.toHaveBeenCalled();
+      const state = useRecipeStore.getState();
+      expect(state.inRepoRecipes[0]?.lastUsedAt).toBe(999);
+      expect(state.recipes[0]?.lastUsedAt).toBe(999);
     });
 
     it("deleteRecipe routes in-repo recipe to deleteInRepoRecipe client", async () => {
@@ -2477,7 +2519,7 @@ describe("recipeStore", () => {
       expect(useRecipeStore.getState().inRepoRecipes[0]?.name).toBe("cafe");
     });
 
-    it("in-repo recipe with projectId=undefined does NOT route to global on update", async () => {
+    it("in-repo recipe with projectId=undefined routes metadata to the mirror via currentProjectId, not global", async () => {
       useRecipeStore.setState({
         inRepoRecipes: [
           {
@@ -2502,9 +2544,16 @@ describe("recipeStore", () => {
 
       await useRecipeStore.getState().updateRecipe("inrepo-test", { lastUsedAt: 999 });
 
-      // lastUsedAt is metadata-only, so no IPC write is performed
+      // Canonical in-repo recipes carry no embedded projectId, so the metadata
+      // mirror write must resolve the project from currentProjectId — and must
+      // never fall back to the global store.
       expect(updateInRepoRecipeMock).not.toHaveBeenCalled();
       expect(globalUpdateRecipeMock).not.toHaveBeenCalled();
+      expect(updateRecipeMock).toHaveBeenCalledWith(
+        "project-1",
+        "inrepo-test",
+        expect.objectContaining({ lastUsedAt: 999 })
+      );
     });
   });
 

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2104,19 +2104,22 @@ describe("recipeStore", () => {
         currentProjectId: "project-1",
       });
 
-      await useRecipeStore.getState().updateRecipe("inrepo-test", { lastUsedAt: 999 });
+      await useRecipeStore
+        .getState()
+        .updateRecipe("inrepo-test", { lastUsedAt: 999, usageHistory: [111, 999] });
 
       // The canonical git-tracked .daintree/recipes/*.json file is never
       // touched by a frecency stamp (that's what metadataOnlyKeys guards).
       expect(updateInRepoRecipeMock).not.toHaveBeenCalled();
-      // But the ProjectFileStore mirror IS updated so in-repo usage metadata
-      // survives a reload the way project/global recipes already do (#11354).
-      expect(updateRecipeMock).toHaveBeenCalledWith(
-        "project-1",
-        "inrepo-test",
-        expect.objectContaining({ lastUsedAt: 999 })
-      );
       expect(globalUpdateRecipeMock).not.toHaveBeenCalled();
+      // The ProjectFileStore mirror IS updated so in-repo usage metadata
+      // survives a reload the way project/global recipes already do (#11354).
+      // The patch is exactly the usage fields — no terminals or other keys.
+      expect(updateRecipeMock).toHaveBeenCalledTimes(1);
+      expect(updateRecipeMock).toHaveBeenCalledWith("project-1", "inrepo-test", {
+        lastUsedAt: 999,
+        usageHistory: [111, 999],
+      });
     });
 
     it("degrades gracefully when the in-repo mirror entry is not yet reconciled", async () => {
@@ -2146,10 +2149,36 @@ describe("recipeStore", () => {
         useRecipeStore.getState().updateRecipe("inrepo-test", { lastUsedAt: 999 })
       ).resolves.toBeUndefined();
 
+      // The mirror write WAS attempted (and rejected) — not silently skipped.
+      expect(updateRecipeMock).toHaveBeenCalledTimes(1);
       expect(updateInRepoRecipeMock).not.toHaveBeenCalled();
       const state = useRecipeStore.getState();
       expect(state.inRepoRecipes[0]?.lastUsedAt).toBe(999);
       expect(state.recipes[0]?.lastUsedAt).toBe(999);
+    });
+
+    it("an empty in-repo update is a true no-op (no mirror write, no canonical write)", async () => {
+      const inRepoRecipe = {
+        id: "inrepo-test",
+        name: "Team Recipe",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+      };
+      useRecipeStore.setState({
+        inRepoRecipes: [inRepoRecipe],
+        globalRecipes: [],
+        projectRecipes: [],
+        recipes: [inRepoRecipe],
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore.getState().updateRecipe("inrepo-test", {});
+
+      // `[].every(...)` is vacuously true, so an empty patch is metadata-only —
+      // but it must not issue a spurious empty mirror IPC call.
+      expect(updateRecipeMock).not.toHaveBeenCalled();
+      expect(updateInRepoRecipeMock).not.toHaveBeenCalled();
+      expect(globalUpdateRecipeMock).not.toHaveBeenCalled();
     });
 
     it("deleteRecipe routes in-repo recipe to deleteInRepoRecipe client", async () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -1847,6 +1847,67 @@ describe("recipeStore", () => {
       expect(state.recipes[0]?.terminals[0]?.env).toEqual({ TOKEN: "" });
     });
 
+    it("loadRecipes hydrates in-repo usage metadata into inRepoRecipes so the UI shows persisted frecency (#11354)", async () => {
+      const inRepoRecipe = {
+        id: "recipe-opaque-abc",
+        name: "Team Recipe",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell" }],
+        createdAt: 500,
+      };
+      // The canonical read carries NO usage (stripped from the git-tracked file);
+      // the mirror does.
+      const projectMirror = {
+        ...inRepoRecipe,
+        projectId: "project-1",
+        lastUsedAt: 900,
+        usageHistory: [800, 900],
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectMirror], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      // RecipeManager renders inRepoRecipes directly, so the raw list must carry
+      // the mirror's frecency after reload — otherwise team recipes read "Never
+      // used" even though usage was persisted.
+      const state = useRecipeStore.getState();
+      expect(state.inRepoRecipes[0]?.lastUsedAt).toBe(900);
+      expect(state.inRepoRecipes[0]?.usageHistory).toEqual([800, 900]);
+    });
+
+    it("loadRecipes keeps project and in-repo recipes when the global read fails", async () => {
+      const inRepoRecipe = {
+        id: "recipe-opaque-abc",
+        name: "Team Recipe",
+        scope: "inrepo" as const,
+        terminals: [{ type: "terminal" as const, title: "Shell" }],
+        createdAt: 500,
+      };
+      const projectRecipe = {
+        id: "proj-recipe-1",
+        name: "Proj",
+        projectId: "project-1",
+        terminals: [{ type: "terminal" as const, title: "Shell" }],
+        createdAt: 600,
+      };
+      // GlobalFileStore.getRecipes now rethrows non-ENOENT read errors; a global
+      // read failure must degrade global to [] rather than clearing every store.
+      globalGetRecipesMock.mockRejectedValueOnce(
+        Object.assign(new Error("EACCES"), { code: "EACCES" })
+      );
+      getRecipesMock.mockResolvedValueOnce({ recipes: [projectRecipe], collisions: [] });
+      getInRepoRecipesMock.mockResolvedValueOnce([inRepoRecipe]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      const state = useRecipeStore.getState();
+      expect(state.globalRecipes).toEqual([]);
+      expect(state.projectRecipes).toHaveLength(1);
+      expect(state.inRepoRecipes).toHaveLength(1);
+    });
+
     it("createRecipe assigns an opaque UUID id (not name-derived) and inrepo scope", async () => {
       await useRecipeStore
         .getState()

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -456,8 +456,24 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         const metadataOnlyKeys = new Set(["lastUsedAt", "usageHistory"]);
         const updateKeys = Object.keys(updates);
         const isMetadataOnly = updateKeys.every((k) => metadataOnlyKeys.has(k));
-        if (!isMetadataOnly) {
-          const projectId = get().currentProjectId;
+        const projectId = get().currentProjectId;
+        if (isMetadataOnly) {
+          // Frecency-only edit (lastUsedAt / usageHistory). Persist it to the
+          // ProjectFileStore mirror — never the canonical git-tracked
+          // .daintree/recipes/*.json file (that's exactly what metadataOnlyKeys
+          // keeps out) — so in-repo usage metadata survives a reload the same
+          // way project and global recipes already do (#11354). Best-effort:
+          // the mirror entry only exists once reconcileProjectRecipes has
+          // backfilled it (after the first load), so a not-yet-reconciled
+          // "recipe not found" degrades to losing this one stamp rather than
+          // rolling back the optimistic update or surfacing a toast for a
+          // low-stakes write.
+          if (projectId) {
+            await projectClient.updateRecipe(projectId, id, sanitizedUpdates).catch((error) => {
+              logError("Failed to persist in-repo recipe usage metadata", error);
+            });
+          }
+        } else {
           if (!projectId) throw new Error("No current project");
           const previousName =
             updates.name && updates.name !== recipe.name ? recipe.name : undefined;

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -467,8 +467,9 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           // backfilled it (after the first load), so a not-yet-reconciled
           // "recipe not found" degrades to losing this one stamp rather than
           // rolling back the optimistic update or surfacing a toast for a
-          // low-stakes write.
-          if (projectId) {
+          // low-stakes write. An empty patch stays a true no-op (updateKeys is
+          // empty, so `every` is vacuously true — don't issue a mirror write).
+          if (projectId && updateKeys.length > 0) {
             await projectClient.updateRecipe(projectId, id, sanitizedUpdates).catch((error) => {
               logError("Failed to persist in-repo recipe usage metadata", error);
             });

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -280,7 +280,12 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     });
     try {
       const [globalRecipesRaw, projectRecipesResult, inRepoRecipesRaw] = await Promise.all([
-        globalRecipesClient.getRecipes(),
+        // Degrade each source independently: a transient read failure in one
+        // store (e.g. GlobalFileStore.getRecipes now rethrows non-ENOENT read
+        // errors) must not clear the other two. The global read previously
+        // swallowed errors itself; keep loadRecipes resilient now that it does
+        // not.
+        globalRecipesClient.getRecipes().catch(() => [] as TerminalRecipe[]),
         projectClient
           .getRecipes(projectId)
           .catch(() => ({ recipes: [] as TerminalRecipe[], collisions: [] })),
@@ -291,7 +296,19 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       }
       const globalRecipes = globalRecipesRaw.map(stripSessionOverridesFromRecipe);
       const projectRecipes = projectRecipesResult.recipes.map(stripSessionOverridesFromRecipe);
-      const inRepoRecipes = inRepoRecipesRaw.map(stripSessionOverridesFromRecipe);
+      // The canonical .daintree/recipes/*.json files intentionally omit
+      // machine-local frecency (lastUsedAt/usageHistory) — it lives only in the
+      // ProjectFileStore mirror (#11354). RecipeManager renders inRepoRecipes
+      // directly, so hydrate those fields from the mirror; otherwise team
+      // recipes read "Never used" after every reload despite being persisted.
+      const inRepoMirrorMeta = new Map(
+        projectRecipes.filter((r) => isInRepoRecipeId(r)).map((r) => [r.id, r] as const)
+      );
+      const inRepoRecipes = inRepoRecipesRaw.map(stripSessionOverridesFromRecipe).map((r) => {
+        const mirror = inRepoMirrorMeta.get(r.id);
+        if (!mirror) return r;
+        return { ...r, lastUsedAt: mirror.lastUsedAt, usageHistory: mirror.usageHistory };
+      });
       set({
         globalRecipes,
         projectRecipes,


### PR DESCRIPTION
## Summary
- `ProjectFileStore` and `GlobalFileStore` did a read-mutate-write for every recipe CRUD op with no queuing, so two near-simultaneous mutations for the same project (two windows open on it, a UI save racing the reconcile pass, an MCP action racing a UI action) would read the same on-disk snapshot and the second write silently clobbered the first.
- `recipeStore.updateRecipe` treated `lastUsedAt`/`usageHistory` changes on in-repo recipes as metadata-only and skipped IPC persistence entirely, so usage data vanished on every reload.
- Hardened per review: the canonical serializer now strips frecency fields before they hit tracked `.daintree/recipes/*.json`, and `GlobalFileStore` surfaces transient read errors instead of silently collapsing to an empty list.

Resolves #11354

## Changes
- Added `enqueueRecipesUpdate` to `ProjectFileStore`: a per-`projectId` promise-chain write queue mirroring the existing `ProjectStateManager.enqueueProjectStateUpdate` pattern (per-link catch, `.then(cleanup, cleanup)`, identity-guarded map cleanup). `GlobalFileStore` gets a single scalar queue tail since it only has one global state.
- Split each store's save path into a private unqueued `saveRecipesInner` (does the actual filesystem write) and a queued public entry point. The blind bulk `saveRecipes` now routes through the queue but performs no read of its own.
- Folded `ProjectStore.reconcileProjectRecipes`, a routine concurrent writer to the same `recipes.json` on every project load, into one queued turn, with collisions returned via a closure, so it can no longer race the CRUD operations.
- `recipeStore.updateRecipe` now persists `lastUsedAt`/`usageHistory` changes for in-repo recipes to the `ProjectFileStore` mirror (best-effort, logs on failure for a not-yet-reconciled entry), and `loadRecipes` hydrates that mirror's frecency data back into `inRepoRecipes`, which is what `RecipeManager` renders directly, so team recipes stop reading "Never used" after a reload.
- The canonical git-tracked serializer strips `lastUsedAt`/`usageHistory` so frecency data never leaks into tracked recipe files.
- `GlobalFileStore.getRecipes` rethrows transient read I/O errors instead of collapsing to `[]` (which would let a queued mutator overwrite from an empty base). `loadRecipes` degrades a failed global read to `[]` without clearing the other stores.

## Testing
Ran 290 targeted tests: concurrent-survival and per-project independence for both stores, queue cleanup/identity-guard, write-rejection recovery, blind-save race, reconcile-vs-CRUD race, canonical-strip behavior, and global read-error rethrow, plus persistence, graceful-degradation, and hydration coverage for the usage-metadata fix. All passing.

Known residuals, pre-existing and out of scope (not data-loss): `reconcile` still rewrites an identical mirror on every load since its no-op comparison doesn't normalize mirror-only fields, and migration 003's startup read/merge sits outside the write queue.
