### PR TITLE
fix(pty): reject spawn when a terminal id already has a live owner

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -600,11 +600,13 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
     // Shells that can't host a startup wrapper (fish, nushell, unrecognized
     // Windows shells) launch bare and get the command typed in after spawn.
-    // Cache it on the spawn options so PtyClient owns the write and, crucially,
-    // re-injects it on every pendingSpawns replay — a pty-host crash respawn
-    // would otherwise bring these terminals back as an empty prompt, losing the
-    // (possibly resume) launch entirely (#11339). Wrapper shells already carry
-    // the command in `args`, so they replay faithfully with no postSpawnInput.
+    // Cache it on the spawn options so it rides every pendingSpawns replay — a
+    // pty-host crash respawn would otherwise bring these terminals back as an
+    // empty prompt, losing the (possibly resume) launch entirely (#11339). The
+    // pty-host spawn handler injects it, and only after a successful spawn, so a
+    // rejected spawn can't type it into a pre-existing live PTY (#11341).
+    // Wrapper shells already carry the command in `args`, so they replay
+    // faithfully with no postSpawnInput.
     const postSpawnInput =
       safeCommand.length > 0 && !commandLaunchShell ? `${safeCommand}\r` : undefined;
 

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -471,3 +471,92 @@ describe("lifecycle spawn — failed-to-start synthesizes an exit for launched a
     return ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>;
   }
 });
+
+describe("lifecycle spawn — TERMINAL_ALREADY_LIVE rejection protects the live owner (#11341)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function sentEvents(ctx: HostContext) {
+    return (ctx.sendEvent as ReturnType<typeof vi.fn>).mock.calls.map(([event]) => event);
+  }
+
+  function throwAlreadyLive(ctx: HostContext) {
+    (ctx.ptyManager.spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const error = new Error("Terminal t1 already has a live owner") as NodeJS.ErrnoException;
+      error.code = "TERMINAL_ALREADY_LIVE";
+      throw error;
+    });
+  }
+
+  it("preserves the TERMINAL_ALREADY_LIVE code on spawn-result", () => {
+    const ctx = makeCtx();
+    throwAlreadyLive(ctx);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+
+    const result = sentEvents(ctx).find((e) => e.type === "spawn-result") as {
+      result: { success: boolean; error?: { code: string } };
+    };
+    expect(result.result.success).toBe(false);
+    expect(result.result.error?.code).toBe("TERMINAL_ALREADY_LIVE");
+  });
+
+  it("does not synthesize an agent exit for a live-collision rejection", () => {
+    const ctx = makeCtx();
+    throwAlreadyLive(ctx);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    // launchAgentId is set, but the pre-existing agent is still running, so a
+    // synthetic "exited" would falsely mark the live agent dead.
+    dispatch({ type: "spawn", id: "t1", options: { launchAgentId: "claude" } });
+
+    const events = sentEvents(ctx);
+    expect(events.find((e) => e.type === "agent-spawned")).toBeUndefined();
+    expect(events.find((e) => e.type === "agent-state")).toBeUndefined();
+  });
+
+  it("keeps the live owner's pause coordinator on a rejection", () => {
+    const forceReleaseAll = vi.fn();
+    const pauseCoordinators = new Map([
+      ["t1", { forceReleaseAll }],
+    ]) as unknown as HostContext["pauseCoordinators"];
+    const ctx = makeCtx({ pauseCoordinators });
+    throwAlreadyLive(ctx);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+
+    // The retirement lives in the success path, so a rejected spawn never tears
+    // down the still-running terminal's coordinator.
+    expect(forceReleaseAll).not.toHaveBeenCalled();
+    expect(pauseCoordinators.has("t1")).toBe(true);
+  });
+
+  it("does not inject postSpawnInput into the pre-existing live PTY", () => {
+    const ctx = makeCtx();
+    throwAlreadyLive(ctx);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: { postSpawnInput: "claude\r" } });
+
+    expect(ctx.ptyManager.write).not.toHaveBeenCalled();
+  });
+
+  it("delivers postSpawnInput once on a successful spawn", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo(1234));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: { postSpawnInput: "claude\r" } });
+
+    expect(ctx.ptyManager.write).toHaveBeenCalledTimes(1);
+    expect(ctx.ptyManager.write).toHaveBeenCalledWith("t1", "claude\r");
+  });
+});

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -539,6 +539,29 @@ describe("lifecycle spawn — TERMINAL_ALREADY_LIVE rejection protects the live 
     expect(pauseCoordinators.has("t1")).toBe(true);
   });
 
+  it("retires the stale coordinator and creates a fresh one on a successful respawn", () => {
+    const forceReleaseAll = vi.fn();
+    const pauseCoordinators = new Map([
+      ["t1", { forceReleaseAll }],
+    ]) as unknown as HostContext["pauseCoordinators"];
+    const ctx = makeCtx({ pauseCoordinators });
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo(1234));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+
+    // A real respawn (dead/preserved entry replaced) still tears down the stale
+    // coordinator and eagerly creates the successor's — but only after the spawn
+    // committed, so the retirement can never strand a live owner.
+    expect(forceReleaseAll).toHaveBeenCalledTimes(1);
+    expect(pauseCoordinators.has("t1")).toBe(false);
+    expect(ctx.getOrCreatePauseCoordinator).toHaveBeenCalledWith("t1");
+    const spawnOrder = (ctx.ptyManager.spawn as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const retireOrder = forceReleaseAll.mock.invocationCallOrder[0];
+    expect(spawnOrder).toBeLessThan(retireOrder);
+  });
+
   it("does not inject postSpawnInput into the pre-existing live PTY", () => {
     const ctx = makeCtx();
     throwAlreadyLive(ctx);

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -48,14 +48,19 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
       markHostPerformance("agentlaunch.host-spawn:start", { terminalId: msg.id });
       let spawnResult: SpawnResult;
       try {
-        // Remove stale coordinator before spawn (handles ID respawn)
+        ptyManager.spawn(msg.id, msg.options);
+
+        // Spawn succeeded, so any prior incarnation of this id was just
+        // killed/replaced — retire its stale pause coordinator now (handles ID
+        // respawn). A duplicate spawn against a LIVE owner throws above
+        // (TERMINAL_ALREADY_LIVE, #11341) and never reaches here, so the running
+        // terminal keeps its coordinator instead of having it torn down.
         const staleCoord = pauseCoordinators.get(msg.id);
         if (staleCoord) {
           staleCoord.forceReleaseAll();
           pauseCoordinators.delete(msg.id);
         }
 
-        ptyManager.spawn(msg.id, msg.options);
         spawnResult = {
           success: true,
           id: msg.id,
@@ -74,13 +79,23 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
           // event and start monitoring (no node-pty event fires on its own).
           schedulePidRetry(msg.id);
         }
+
+        // Deliver a wrapper-less launch command now that the terminal is
+        // registered, and ONLY on a successful spawn. Binding delivery to
+        // success here (rather than an unconditional write queued from Main)
+        // stops a TERMINAL_ALREADY_LIVE rejection from injecting the command
+        // into the pre-existing live PTY (#11341, #11339).
+        if (msg.options.postSpawnInput) {
+          ptyManager.write(msg.id, msg.options.postSpawnInput);
+        }
       } catch (error) {
         console.error(`[PtyHost] Spawn failed for terminal ${msg.id}:`, error);
+        const parsedError = parseSpawnError(error);
         spawnResult = {
           success: false,
           id: msg.id,
           launchGeneration: msg.options.launchGeneration,
-          error: parseSpawnError(error),
+          error: parsedError,
         };
 
         // A failed-to-start spawn never produces a PTY, so no exit event ever
@@ -91,8 +106,12 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
         // so the store records "exited" and consumers see the crash (#10816).
         // Order matters: agent-spawned resets store state to "working" (and
         // clears stale exit metadata) before agent-state writes "exited".
+        //
+        // Skip this for a TERMINAL_ALREADY_LIVE rejection: the pre-existing
+        // agent is still running, so emitting "exited" would falsely mark the
+        // live agent dead and clobber its real state (#11341).
         const launchAgentId = msg.options.launchAgentId;
-        if (launchAgentId) {
+        if (launchAgentId && parsedError.code !== "TERMINAL_ALREADY_LIVE") {
           const timestamp = Date.now();
           sendEvent({
             type: "agent-spawned",

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -98,6 +98,19 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
           error: parsedError,
         };
 
+        // A genuine failed-to-start spawn (ENOENT, ctor throw, …) leaves no live
+        // terminal for this id, so retire any stale coordinator from a dead/
+        // preserved incarnation it was replacing — otherwise it would linger
+        // until a later exit/retry. A TERMINAL_ALREADY_LIVE rejection is the one
+        // failure that DOES leave a live owner, so its coordinator is preserved.
+        if (parsedError.code !== "TERMINAL_ALREADY_LIVE") {
+          const staleCoord = pauseCoordinators.get(msg.id);
+          if (staleCoord) {
+            staleCoord.forceReleaseAll();
+            pauseCoordinators.delete(msg.id);
+          }
+        }
+
         // A failed-to-start spawn never produces a PTY, so no exit event ever
         // fires and the main-side TerminalProcess never emits agent:spawned.
         // For a launched agent that means AgentAvailabilityStore retains the

--- a/electron/pty-host/spawnErrors.ts
+++ b/electron/pty-host/spawnErrors.ts
@@ -23,6 +23,12 @@ export function parseSpawnError(error: unknown): SpawnError {
       code = "ENXIO";
     } else if (nodeErr.code === "EBUSY") {
       code = "EBUSY";
+    } else if (nodeErr.code === "TERMINAL_ALREADY_LIVE") {
+      // Custom, non-errno code thrown by PtyManager.spawn() when the id already
+      // has a live owner (#11341). Preserved explicitly rather than by casting
+      // an arbitrary runtime string, so an unrelated code can't slip into the
+      // closed SpawnErrorCode union and break the renderer banner lookup.
+      code = "TERMINAL_ALREADY_LIVE";
     }
 
     return {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -789,28 +789,26 @@ export class PtyClient extends EventEmitter {
   }
 
   /**
-   * Send a spawn to a shard and, for command launches on shells that couldn't
-   * host a startup wrapper, re-inject the launch command right after it (#11339).
-   * The command rides `options.postSpawnInput` in `pendingSpawns`, so every
-   * replay path (initial pre-ready replay, crash respawn, crash-budget
-   * migration) funnels through here and the terminal comes back running its
-   * command — including a resume — instead of a bare prompt. The write is FIFO
-   * behind the spawn on the same channel and the host's spawn handler registers
-   * the terminal synchronously, so it lands on the live PTY.
+   * Send a spawn to a shard. For command launches on shells that couldn't host
+   * a startup wrapper, the launch command rides `options.postSpawnInput` in
+   * `pendingSpawns`, and the host's spawn handler injects it right after a
+   * successful spawn (#11339). Every replay path (initial pre-ready replay,
+   * crash respawn, crash-budget migration) funnels through here and re-sends the
+   * same options, so the terminal comes back running its command — including a
+   * resume — instead of a bare prompt. Delivery is bound to spawn success on the
+   * host: a rejected spawn (e.g. TERMINAL_ALREADY_LIVE, #11341) never injects
+   * the command into a pre-existing live PTY.
    */
   private sendSpawnWithPostInput(shard: PtyShard, id: string, options: PtyHostSpawnOptions): void {
     // Never deliver into a shard that isn't ready yet. A post-fork/pre-ready
-    // send is queued by the host AND re-sent by the first-ready replay below,
-    // which for a command launch would run the command (and any resume) twice.
-    // The entry is already in `pendingSpawns`, so the first-ready replay (which
-    // runs after `markReady`, i.e. once this guard passes) delivers it exactly
-    // once. This makes the "double-spawn-safe" invariant explicit rather than
-    // relying on the pre-fork transport drop.
+    // send is dropped here AND re-sent by the first-ready replay below, which
+    // for a command launch would run the command (and any resume) twice. The
+    // entry is already in `pendingSpawns`, so the first-ready replay (which runs
+    // after `markReady`, i.e. once this guard passes) delivers it exactly once.
+    // This makes the "double-spawn-safe" invariant explicit rather than relying
+    // on the pre-fork transport drop.
     if (!shard.isRunning()) return;
     shard.send({ type: "spawn", id, options });
-    if (options.postSpawnInput) {
-      shard.send({ type: "write", id, data: options.postSpawnInput });
-    }
   }
 
   private respawnPendingForShard(shard: PtyShard): void {

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -339,6 +339,18 @@ export class PtyManager extends EventEmitter {
     if (this.registry.has(id)) {
       const existing = this.registry.get(id);
       const existingInfo = existing?.getInfo();
+      // A spawn for an id whose terminal is still live must NOT silently kill it
+      // (#11341). Reject so the caller sees the collision instead of losing the
+      // running process. Only an exited or killed-but-preserved entry (retained
+      // in the registry for its scrollback snapshot) may be replaced by the
+      // kill-and-respawn path below — that keeps restart/resume working.
+      if (existingInfo && !existingInfo.wasKilled && !existingInfo.isExited) {
+        const error = new Error(
+          `Terminal ${id} already has a live owner; refusing to kill and respawn`
+        ) as NodeJS.ErrnoException;
+        error.code = "TERMINAL_ALREADY_LIVE";
+        throw error;
+      }
       logWarn(
         `Terminal ${id} already exists (projectId: ${existingInfo?.projectId?.slice(0, 8)}), killing to respawn with new projectId`
       );

--- a/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
@@ -180,8 +180,9 @@ describe("PtyClient lifecycle ledger", () => {
     // command on `postSpawnInput` instead of in `args`.
     client.spawn("t1", { ...baseOptions, postSpawnInput: "claude --resume s-1\r" });
 
-    // Initial spawn injects the command exactly once, right after the spawn.
-    expect(writeMessages(mockChild)).toEqual([{ id: "t1", data: "claude --resume s-1\r" }]);
+    // Delivery is bound to spawn success on the host (#11341), so Main sends no
+    // separate write — the command rides the spawn options instead.
+    expect(writeMessages(mockChild)).toEqual([]);
 
     const restartedChild = createMockChild();
     shared.forkMock.mockReturnValue(restartedChild);
@@ -192,10 +193,11 @@ describe("PtyClient lifecycle ledger", () => {
 
     const replayed = spawnMessages(restartedChild);
     expect(replayed).toHaveLength(1);
+    // The command survives replay on the spawn options, so the fresh host
+    // re-injects it exactly once on success — the terminal comes back running
+    // its command (here a resume), not a bare prompt. No separate Main write.
     expect(replayed[0]!.options.postSpawnInput).toBe("claude --resume s-1\r");
-    // Re-injected exactly once on the fresh host — the terminal comes back
-    // running its command (here a resume), not as a bare prompt and not twice.
-    expect(writeMessages(restartedChild)).toEqual([{ id: "t1", data: "claude --resume s-1\r" }]);
+    expect(writeMessages(restartedChild)).toEqual([]);
   });
 
   it("replays wrapper args verbatim on crash respawn — a resume survives (#11339)", () => {

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -276,6 +276,9 @@ describe("PtyManager adversarial", () => {
     const manager = new PtyManager();
 
     manager.spawn("t1", spawnOptions({ projectId: "project-a" }));
+    // Mark the first terminal killed-but-not-yet-reaped so the same-id respawn
+    // is allowed (a LIVE owner is now rejected — see DUPLICATE_LIVE_SPAWN_*).
+    shared.created[0]!.info.wasKilled = true;
     manager.spawn("t1", spawnOptions({ projectId: "project-a" }));
 
     const exits: Array<{ id: string; code: number }> = [];
@@ -315,16 +318,46 @@ describe("PtyManager adversarial", () => {
     expect(received).toEqual([{ id: "t1", data: "hello-a" }]);
   });
 
-  it("DUPLICATE_SPAWN_KILLS_PREVIOUS", () => {
+  it("DUPLICATE_LIVE_SPAWN_REJECTS_AND_PRESERVES_OWNER", () => {
     const manager = new PtyManager();
 
     manager.spawn("t1", spawnOptions({ projectId: "project-a" }));
     const original = shared.created[0]!;
 
-    manager.spawn("t1", spawnOptions({ projectId: "project-b" }));
+    let thrown: NodeJS.ErrnoException | undefined;
+    try {
+      manager.spawn("t1", spawnOptions({ projectId: "project-b" }));
+    } catch (error) {
+      thrown = error as NodeJS.ErrnoException;
+    }
 
-    expect(original.kill).toHaveBeenCalledTimes(1);
+    // A spawn against a LIVE id is rejected — the running terminal is untouched,
+    // not silently killed and replaced (#11341).
+    expect(thrown?.code).toBe("TERMINAL_ALREADY_LIVE");
+    expect(original.kill).not.toHaveBeenCalled();
+    expect(shared.created).toHaveLength(1); // no replacement TerminalProcess built
     expect(manager.getActiveTerminalIds()).toEqual(["t1"]);
+    expect(manager.getTerminal("t1")?.projectId).toBe("project-a");
+  });
+
+  it("SPAWN_REPLACES_EXITED_PRESERVED_OWNER", () => {
+    const manager = new PtyManager();
+
+    manager.spawn("t1", spawnOptions({ projectId: "project-a" }));
+    const original = shared.created[0]!;
+    // Terminal exited but is retained for its scrollback snapshot — a same-id
+    // spawn is allowed and replaces it, keeping restart/resume working.
+    original.info.isExited = true;
+
+    let thrown: unknown;
+    try {
+      manager.spawn("t1", spawnOptions({ projectId: "project-b" }));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeUndefined();
+    expect(shared.created).toHaveLength(2);
     expect(manager.getTerminal("t1")?.projectId).toBe("project-b");
   });
 

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -357,6 +357,9 @@ describe("PtyManager adversarial", () => {
     }
 
     expect(thrown).toBeUndefined();
+    // The preserved entry is torn down (kill-and-respawn), not silently
+    // overwritten — the old terminal's kill runs and a new process is built.
+    expect(original.kill).toHaveBeenCalledTimes(1);
     expect(shared.created).toHaveLength(2);
     expect(manager.getTerminal("t1")?.projectId).toBe("project-b");
   });

--- a/electron/services/__tests__/PtyManager.spawnFailure.test.ts
+++ b/electron/services/__tests__/PtyManager.spawnFailure.test.ts
@@ -30,7 +30,7 @@ vi.mock("../pty/index.js", async (importOriginal) => {
         if (shouldThrow) throw constructorError;
       }
       getInfo() {
-        return {};
+        return { wasKilled: false, isExited: false };
       }
       isAgentCurrentlyLive() {
         return false;
@@ -154,5 +154,26 @@ describe("PtyManager.spawn — PTY cleanup on constructor failure", () => {
 
     expect(manager.hasTerminal("t1")).toBe(true);
     expect(mockPty.kill).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate spawn against a live terminal with TERMINAL_ALREADY_LIVE", () => {
+    shouldThrow = false;
+
+    manager.spawn("t1", { cwd: "/tmp", cols: 80, rows: 24, kind: "terminal" });
+    expect(manager.hasTerminal("t1")).toBe(true);
+    vi.mocked(acquirePtyProcess).mockClear();
+
+    let thrown: NodeJS.ErrnoException | undefined;
+    try {
+      manager.spawn("t1", { cwd: "/tmp", cols: 80, rows: 24, kind: "terminal" });
+    } catch (error) {
+      thrown = error as NodeJS.ErrnoException;
+    }
+
+    // The second spawn is rejected before it ever acquires a PTY, and the
+    // original live terminal is left registered and untouched (#11341).
+    expect(thrown?.code).toBe("TERMINAL_ALREADY_LIVE");
+    expect(acquirePtyProcess).not.toHaveBeenCalled();
+    expect(manager.hasTerminal("t1")).toBe(true);
   });
 });

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -92,8 +92,10 @@ export interface PtyHostSpawnOptions {
    * Cached here so it rides `pendingSpawns` and is re-injected on every replay —
    * a pty-host crash respawn, a crash-budget migration, and the pre-ready
    * initial replay — so a resumed (or any) launch survives a crash on these
-   * shells instead of coming back as an empty prompt (#11339). Main owns the
-   * write: the pty-host ignores this field.
+   * shells instead of coming back as an empty prompt (#11339). The pty-host
+   * spawn handler injects it, and only after a successful spawn, so a rejected
+   * spawn (e.g. TERMINAL_ALREADY_LIVE) can't type it into a pre-existing live
+   * PTY (#11341).
    */
   postSpawnInput?: string;
 }

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -833,6 +833,7 @@ export type SpawnErrorCode =
   | "EBUSY" // Terminal device busy
   | "DISCONNECTED" // Terminal process no longer exists in backend (e.g., after project switch)
   | "PENDING_SPAWNS_CAPPED" // PtyClient.pendingSpawns admission cap hit (restart-storm guard)
+  | "TERMINAL_ALREADY_LIVE" // Spawn rejected: the id already has a live owner (#11341)
   | "UNKNOWN"; // Unknown error
 
 /** Result of a spawn operation */

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -49,6 +49,7 @@ const ALL_SPAWN_ERROR_CODES: readonly SpawnErrorCode[] = [
   "EBUSY",
   "DISCONNECTED",
   "PENDING_SPAWNS_CAPPED",
+  "TERMINAL_ALREADY_LIVE",
   "UNKNOWN",
 ] as const;
 
@@ -127,10 +128,27 @@ describe("SpawnErrorBanner", () => {
     ["EACCES", "Couldn't execute shell"],
     ["ENOTDIR", "Invalid working directory"],
     ["PENDING_SPAWNS_CAPPED", "Too many pending restarts"],
+    ["TERMINAL_ALREADY_LIVE", "Terminal already running"],
     ["UNKNOWN", "Couldn't start terminal"],
   ] as const)("renders the expected title for %s", (code, expected) => {
     renderBanner(code);
     expect(screen.getByText(expected)).toBeTruthy();
+  });
+
+  it("explains the kept-alive process and keeps Retry inline for TERMINAL_ALREADY_LIVE", () => {
+    const onRetry = vi.fn();
+    renderBanner("TERMINAL_ALREADY_LIVE", { onRetry });
+    expect(
+      screen.getByText(
+        "This terminal already has a running process, so the existing one was kept. Retry to restart it."
+      )
+    ).toBeTruthy();
+    // Retry is the sole inline primary action (outside the overflow) for this
+    // generic recovery — clicking it restarts the terminal.
+    const retry = screen.getByRole("button", { name: /retry starting terminal/i });
+    expect(overflow().contains(retry)).toBe(false);
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledWith("t-1");
   });
 
   it("renders the UNKNOWN code with the message as description", () => {

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -138,11 +138,10 @@ describe("SpawnErrorBanner", () => {
   it("explains the kept-alive process and keeps Retry inline for TERMINAL_ALREADY_LIVE", () => {
     const onRetry = vi.fn();
     renderBanner("TERMINAL_ALREADY_LIVE", { onRetry });
-    expect(
-      screen.getByText(
-        "This terminal already has a running process, so the existing one was kept. Retry to restart it."
-      )
-    ).toBeTruthy();
+    // Assert the semantic shape (why it happened + how to recover), not the
+    // exact literal — matching the whole source-of-truth string is tautological.
+    expect(screen.getByText(/already has a running process/i)).toBeTruthy();
+    expect(screen.getByText(/retry to restart it/i)).toBeTruthy();
     // Retry is the sole inline primary action (outside the overflow) for this
     // generic recovery — clicking it restarts the terminal.
     const retry = screen.getByRole("button", { name: /retry starting terminal/i });

--- a/src/components/Terminal/spawnErrorBannerCopy.ts
+++ b/src/components/Terminal/spawnErrorBannerCopy.ts
@@ -66,6 +66,11 @@ export const SPAWN_ERROR_BANNER_COPY = {
     description: () =>
       "Restart requests are being throttled to prevent a restart storm. Wait a moment and retry.",
   },
+  TERMINAL_ALREADY_LIVE: {
+    title: "Terminal already running",
+    description: () =>
+      "This terminal already has a running process, so the existing one was kept. Retry to restart it.",
+  },
   UNKNOWN: {
     title: "Couldn't start terminal",
     description: (error) => boundedErrorText(error.message),


### PR DESCRIPTION
## Summary

`PtyManager.spawn()` treated a spawn request for an already-registered terminal id as an implicit kill and replace. It logged a warning, called `this.kill(id)`, then respawned, silently destroying the user's running terminal. The check behind this was `registry.has(id)`, a bare map-presence check that couldn't tell a genuinely live terminal from one that had exited but was still preserved in the registry for its scrollback snapshot. The only thing stopping this in practice was a renderer-side convention (`isReconnect`), and anything that bypassed it (a retry, a hydration path, a direct caller) would silently kill a live terminal.

This adds an authoritative guard in the backend. A spawn against a genuinely live terminal now throws a new `TERMINAL_ALREADY_LIVE` error, surfaced back to the caller. Exited or killed-but-preserved terminals still take the kill-and-respawn path, so restart and resume are unaffected.

Resolves #11341.

## Changes

- `PtyManager.spawn()`: liveness guard throws `TERMINAL_ALREADY_LIVE` instead of silently killing a live terminal; dead/preserved entries take the existing kill-and-respawn path.
- `SpawnErrorCode` union gains `TERMINAL_ALREADY_LIVE`; `parseSpawnError` maps it explicitly; `SpawnErrorBanner` gets copy for it ("Terminal already running").
- pty-host spawn handler: preserves the live owner's pause coordinator on rejection instead of retiring it, skips firing a synthetic agent spawn/exit for this error code so a live agent isn't falsely marked exited, and only delivers `postSpawnInput` after a successful spawn.
- `PtyClient.sendSpawnWithPostInput` no longer sends a separate Main-side write. Delivery is host-side and bound to spawn success, so a rejection can't inject the launch command into the pre-existing live PTY (this interacts with the #11339 crash-resume path; replay coverage is preserved).
- Tests: duplicate-live-spawn rejection and exited/killed respawn cases in `PtyManager`, host-side collision coverage (coordinator preserved, no synthetic exit, `postSpawnInput` gated), banner copy.

## Local verification

- 205 tests / 13 files (`PtyManager` + `PtyClient` main-config suites): pass
- 39 pass / 1 skip / 4 files (integration config): pass
- Own files: clean under `prettier` and `eslint`
- Full end-to-end left to CI

## Known follow-up (out of scope here)

Review turned up a Main-side bookkeeping gap that only shows up in the bypass path this guard defends against (the renderer's `isReconnect` convention normally prevents it, and restart/resume is unaffected). On a `TERMINAL_ALREADY_LIVE` rejection, Main's `PtyClient` has already overwritten `terminalOwners`, `pendingSpawns`, and a ledger generation counter (and possibly rotated the live agent's MCP token) before the host adjudicates, and the generic failure path then deletes them, orphaning the still-live terminal from Main's bookkeeping. In rare cases a same-id spawn under a different project can even double-spawn across shards.

Fixing this properly needs a real redesign: provisional vs. committed spawn state, restore-on-rejection, owner-shard routing, and per-generation config staging. It can't be done as a small front-loaded fence because a normal agent restart (`gracefulKill` leaves `pendingSpawns` set, cleared racily) looks identical to a live duplicate from Main's point of view. Deferring it to a dedicated follow-up so restart/resume isn't destabilized. This PR delivers the core invariant: the live process is no longer silently killed.
