### PR TITLE
feat(panels): make panel kinds dockable by default with explicit opt-out

### DIFF
--- a/electron/schemas/__tests__/manifestContributionConsumers.test.ts
+++ b/electron/schemas/__tests__/manifestContributionConsumers.test.ts
@@ -215,6 +215,11 @@ const MANIFEST_CONTRIBUTION_FIELD_CONSUMERS = {
       consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
       note: "Registered as the panel kind palette visibility.",
     },
+    dockable: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin (panels loop) → registerPanelKind" }],
+      note: "Registered as the panel kind dock eligibility; undefined defaults to dockable, false opts out (panelKindIsDockable).",
+    },
   },
   toolbarButtons: {
     id: {

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -64,6 +64,10 @@ export const PanelContributionSchema = z
     canRestart: z.boolean().default(false),
     canConvert: z.boolean().default(false),
     showInPalette: z.boolean().default(true),
+    // Dockable by default (undefined). Declare `false` to opt a panel kind out
+    // of the dock — no default so absence flows through as `undefined` and
+    // `panelKindIsDockable` treats it as dockable.
+    dockable: z.boolean().optional(),
   })
   .strict();
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1283,6 +1283,10 @@ export class PluginService {
         canRestart: panel.canRestart,
         canConvert: panel.canConvert,
         showInPalette: panel.showInPalette,
+        // Dockable by default; only forward an explicit opt-out (or opt-in) so
+        // absence stays `undefined` and `panelKindIsDockable` applies the
+        // default. #11332.
+        ...(panel.dockable !== undefined ? { dockable: panel.dockable } : {}),
         extensionId: manifest.name,
         ...(view && !panel.hasPty
           ? { componentPath: buildPluginViewUrl(manifest.name, view.componentPath, viewGeneration) }

--- a/electron/services/__tests__/PluginService.core.test.ts
+++ b/electron/services/__tests__/PluginService.core.test.ts
@@ -301,6 +301,34 @@ describe("PluginService", () => {
     );
   });
 
+  it("forwards an explicit dockable:false from a panel contribution into registerPanelKind (#11332)", async () => {
+    await writePlugin("dock-plugin", {
+      name: "acme.dock-plugin",
+      version: "1.0.0",
+      contributes: {
+        panels: [
+          { id: "compact", name: "Compact", iconId: "eye", color: "#111", dockable: false },
+          { id: "wide", name: "Wide", iconId: "eye", color: "#222" },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // Explicit opt-out flows through verbatim.
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "acme.dock-plugin.compact", dockable: false })
+    );
+    // Absent flag never stamps a `dockable` key, so the registry default
+    // (dockable) applies — assert the key is not present on that call.
+    const wideCall = vi
+      .mocked(registerPanelKind)
+      .mock.calls.find((call) => call[0]?.id === "acme.dock-plugin.wide");
+    expect(wideCall).toBeDefined();
+    expect(Object.prototype.hasOwnProperty.call(wideCall![0], "dockable")).toBe(false);
+  });
+
   it("skips directories without plugin.json", async () => {
     await fs.mkdir(path.join(tmpDir, "empty-dir"));
 

--- a/electron/services/__tests__/PluginService.manifestSchema.test.ts
+++ b/electron/services/__tests__/PluginService.manifestSchema.test.ts
@@ -942,6 +942,42 @@ describe("PluginManifestSchema contributes strict validation", () => {
     }
   });
 
+  it("accepts an explicit dockable:false on a panel contribution (#11332)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: {
+        panels: [{ id: "p", name: "P", iconId: "eye", color: "#abc", dockable: false }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.panels[0]?.dockable).toBe(false);
+    }
+  });
+
+  it("leaves dockable undefined when a panel omits it — the dockable-by-default path (#11332)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: {
+        panels: [{ id: "p", name: "P", iconId: "eye", color: "#abc" }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.panels[0]?.dockable).toBeUndefined();
+    }
+  });
+
+  it("rejects a non-boolean dockable on a panel contribution (#11332)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: {
+        panels: [{ id: "p", name: "P", iconId: "eye", color: "#abc", dockable: "yes" }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("accepts the stable mcpServers key inside contributes (#10466)", () => {
     const result = getPluginManifestSchema(false).safeParse({
       ...validBase,

--- a/electron/services/__tests__/PluginService.manifestSchema.test.ts
+++ b/electron/services/__tests__/PluginService.manifestSchema.test.ts
@@ -964,7 +964,12 @@ describe("PluginManifestSchema contributes strict validation", () => {
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.contributes.panels[0]?.dockable).toBeUndefined();
+      // Assert the panel exists before checking key absence, so an empty
+      // panels array can't make `?.dockable` pass vacuously.
+      expect(result.data.contributes.panels).toHaveLength(1);
+      expect(
+        Object.prototype.hasOwnProperty.call(result.data.contributes.panels[0], "dockable")
+      ).toBe(false);
     }
   });
 

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1452,6 +1452,11 @@ interface PanelContribution {
     canRestart: boolean;
     canConvert: boolean;
     showInPalette: boolean;
+    /**
+     * Whether this panel kind can live in the dock. Dockable by default; set
+     * `false` to opt out (for a kind with no meaningful compact chip-row form).
+     */
+    dockable?: boolean;
 }
 interface ToolbarButtonContribution {
     id: string;

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -563,7 +563,10 @@ describe("panelKindIsDockable", () => {
   });
 
   it("an explicit dockable:false wins even for a PTY kind", () => {
-    // The opt-out is authoritative: `hasPty` no longer forces dockability.
+    // Predicate contract only: `hasPty` no longer forces dockability, so the
+    // implementation must be `dockable !== false`, not `hasPty || …`. (At the
+    // store boundary a spawned PTY panel collapses to kind `terminal`, so this
+    // combination can't describe a live panel — this pins the pure function.)
     registerPanelKind({
       ...makeExtensionConfig("ext-a.pty", "ext-a"),
       hasPty: true,

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -534,18 +534,42 @@ describe("getFirstRenderPreloadSeeds", () => {
 });
 
 describe("panelKindIsDockable", () => {
-  it("PTY kinds are always dockable", () => {
-    expect(panelKindIsDockable("terminal")).toBe(true);
+  afterEach(() => {
+    clearPanelKindRegistry();
   });
 
-  it("file and browser panels opt in via the dockable capability", () => {
+  it("registered kinds are dockable by default (opt-out model)", () => {
+    // PTY terminal and the non-PTY reading surfaces carry no `dockable` flag —
+    // the default is dockable, not the old opt-in.
+    expect(panelKindIsDockable("terminal")).toBe(true);
     expect(panelKindIsDockable("file")).toBe(true);
     expect(panelKindIsDockable("browser")).toBe(true);
   });
 
-  it("non-PTY kinds without the capability are not dockable", () => {
-    expect(panelKindIsDockable("dev-preview")).toBe(false);
-    expect(panelKindIsDockable("review")).toBe(false);
+  it("the four built-ins that opt out are not dockable", () => {
+    for (const kind of ["dev-preview", "review", "file-browser", "diff"]) {
+      expect(panelKindIsDockable(kind), `${kind} opts out via dockable:false`).toBe(false);
+    }
+  });
+
+  it("a plugin kind without an explicit flag is dockable", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    expect(panelKindIsDockable("ext-a.viewer")).toBe(true);
+  });
+
+  it("a plugin kind that declares dockable:false opts out", () => {
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), dockable: false });
+    expect(panelKindIsDockable("ext-a.viewer")).toBe(false);
+  });
+
+  it("an explicit dockable:false wins even for a PTY kind", () => {
+    // The opt-out is authoritative: `hasPty` no longer forces dockability.
+    registerPanelKind({
+      ...makeExtensionConfig("ext-a.pty", "ext-a"),
+      hasPty: true,
+      dockable: false,
+    });
+    expect(panelKindIsDockable("ext-a.pty")).toBe(false);
   });
 
   it("unknown kinds are not dockable", () => {

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -105,11 +105,13 @@ export interface PanelKindConfig {
   /** Whether this panel kind can convert to/from other types */
   canConvert: boolean;
   /**
-   * Whether a non-PTY kind can live in the dock. PTY kinds are always
-   * dockable; setting this opts a non-PTY kind into dock membership. The
-   * dock render path must have a chip for the kind (see `ContentDock`) —
-   * `DockPanelData` in shared/types/panel.ts is the type-level twin of this
-   * flag and the two must stay in sync.
+   * Whether a panel kind can live in the dock. Every registered kind is
+   * dockable by default (built-in and plugin alike); set `dockable: false` to
+   * opt a kind out — the explicit escape hatch for kinds with no meaningful
+   * compact chip-row form. The dock render path is generic (`ContentDock`
+   * renders any non-PTY dockable kind through `DockedNonPtyPanelItem`), so
+   * membership follows this flag via `panelKindIsDockable` / `isDockPanel`
+   * rather than a hard-coded kind list.
    */
   dockable?: boolean;
   /**
@@ -201,7 +203,8 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
-    dockable: true,
+    // Dockable by default (no explicit flag) — a reading surface with a
+    // meaningful compact chip form.
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
     searchAliases: ["web", "chrome", "internet", "www"],
@@ -219,6 +222,9 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
+    // Explicit opt-out: a live dev-server preview has no meaningful compact
+    // chip-row form (like file-browser, diff and review).
+    dockable: false,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
@@ -234,6 +240,9 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
+    // Explicit opt-out: a review surface has no meaningful compact chip-row
+    // form (like file-browser, diff and dev-preview).
+    dockable: false,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
@@ -253,7 +262,8 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
-    dockable: true,
+    // Dockable by default (no explicit flag) — a reading surface with a
+    // meaningful compact chip form.
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
@@ -272,9 +282,10 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
-    // Not dockable: the dock chip row shows one compact title per panel, and a
-    // two-pane browser has no meaningful compact form (review, diff and
-    // dev-preview are non-dockable reading surfaces for the same reason).
+    // Explicit opt-out: the dock chip row shows one compact title per panel,
+    // and a two-pane browser has no meaningful compact form (review, diff and
+    // dev-preview opt out for the same reason).
+    dockable: false,
     dialogFullHeight: true,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
@@ -296,8 +307,9 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
-    // Not dockable: the dock's chip row has no meaningful compact form for a
-    // diff (review and dev-preview are non-dockable reading surfaces too).
+    // Explicit opt-out: the dock's chip row has no meaningful compact form for
+    // a diff (review and dev-preview opt out for the same reason).
+    dockable: false,
     // Pin the dialog at the max height rather than sizing to content, so
     // stepping between files doesn't resize and re-center the whole frame
     // under the cursor (#11364) — same treatment as the file browser.
@@ -565,9 +577,12 @@ export function panelKindHasPty(kind: PanelKind): boolean {
 }
 
 /**
- * Check if a panel kind can live in the dock. PTY kinds always can; non-PTY
- * kinds opt in via `dockable` (the dock chip row and offscreen host render
- * them through `isDockPanel`).
+ * Check if a panel kind can live in the dock. Every registered kind is
+ * dockable by default (built-in and plugin alike); a kind opts out with
+ * `dockable: false` (the dock chip row and offscreen host render dockable
+ * kinds through `isDockPanel`). An unregistered kind is never dockable — a
+ * dock request for an unknown kind would strand the panel with no chip to
+ * render it (#11054).
  *
  * @param kind - The panel kind to check
  * @returns True if panels of this kind can be moved to the dock
@@ -575,7 +590,7 @@ export function panelKindHasPty(kind: PanelKind): boolean {
 export function panelKindIsDockable(kind: PanelKind): boolean {
   const config = getPanelKindConfig(kind);
   if (!config) return false;
-  return config.hasPty || config.dockable === true;
+  return config.dockable !== false;
 }
 
 /**

--- a/shared/types/__tests__/panel.test.ts
+++ b/shared/types/__tests__/panel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   isBuiltInPanelKind,
   isBrowserPanel,
@@ -10,7 +10,11 @@ import {
   type PanelLocation,
   type TerminalInstance,
 } from "../panel.js";
-import { BUILT_IN_PANEL_KINDS } from "../../config/panelKindRegistry.js";
+import {
+  BUILT_IN_PANEL_KINDS,
+  clearPanelKindRegistry,
+  registerPanelKind,
+} from "../../config/panelKindRegistry.js";
 
 describe("isBuiltInPanelKind", () => {
   // Hard-coded positives — kept independent of BUILT_IN_PANEL_KINDS so a
@@ -99,15 +103,61 @@ describe("panel variant guards", () => {
     expect(isDevPreviewPanel(legacy)).toBe(false);
   });
 
-  it("isDockPanel admits PTY, file, and browser panels but not dev-preview/review", () => {
-    // The dock render path only surfaces panels isDockPanel recognizes; browser
-    // must be admitted or it vanishes when moved to the dock (#11053).
+  it("isDockPanel admits dockable built-in kinds but not the opt-outs", () => {
+    // Membership follows the registry (`panelKindIsDockable`), not a fixed kind
+    // list: terminal/file/browser are dockable by default; the four kinds that
+    // declare `dockable: false` are excluded, or they vanish from the dock.
     const filePanel = { id: "p4", kind: "file", title: "t", location: "dock" } as PanelInstance;
-    const reviewPanel = { id: "p5", kind: "review", title: "t", location: "grid" } as PanelInstance;
     expect(isDockPanel(ptyPanel)).toBe(true);
     expect(isDockPanel(browserPanel)).toBe(true);
     expect(isDockPanel(filePanel)).toBe(true);
-    expect(isDockPanel(devPreviewPanel)).toBe(false);
-    expect(isDockPanel(reviewPanel)).toBe(false);
+    for (const kind of ["dev-preview", "review", "file-browser", "diff"]) {
+      const panel = { id: `opt-${kind}`, kind, title: "t", location: "grid" } as PanelInstance;
+      expect(isDockPanel(panel), `${kind} opts out of the dock`).toBe(false);
+    }
+  });
+});
+
+describe("isDockPanel — plugin kinds follow the registry", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  const makePluginPanel = (kind: string): PanelInstance =>
+    ({ id: `${kind}-1`, kind, title: "t", location: "dock", pluginId: "ext-a" }) as PanelInstance;
+
+  it("admits a registered plugin kind that is dockable by default", () => {
+    registerPanelKind({
+      id: "ext-a.viewer",
+      name: "Viewer",
+      iconId: "puzzle",
+      color: "#123456",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "ext-a",
+    });
+    expect(isDockPanel(makePluginPanel("ext-a.viewer"))).toBe(true);
+  });
+
+  it("excludes a registered plugin kind that declares dockable:false", () => {
+    registerPanelKind({
+      id: "ext-a.viewer",
+      name: "Viewer",
+      iconId: "puzzle",
+      color: "#123456",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      dockable: false,
+      extensionId: "ext-a",
+    });
+    expect(isDockPanel(makePluginPanel("ext-a.viewer"))).toBe(false);
+  });
+
+  it("excludes an unregistered plugin kind (registration not yet landed)", () => {
+    // Hydration can replay a persisted plugin panel before its kind registers;
+    // an unknown kind is never dockable, so it stays out of the dock render path.
+    expect(isDockPanel(makePluginPanel("ext-a.not-registered"))).toBe(false);
   });
 });

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -3,7 +3,11 @@ import type { TerminalCheckResult } from "./checkResult.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
 import type { BrowserHistory } from "./browser.js";
 import type { GitStatus, DiffChangeSetEntry } from "./git.js";
-import { BUILT_IN_PANEL_KINDS, type BuiltInPanelKind } from "../config/panelKindRegistry.js";
+import {
+  BUILT_IN_PANEL_KINDS,
+  panelKindIsDockable,
+  type BuiltInPanelKind,
+} from "../config/panelKindRegistry.js";
 
 export type { BuiltInPanelKind };
 
@@ -839,14 +843,18 @@ export function isDiffPanel(panel: PanelInstance | TerminalInstance): panel is D
 }
 
 /**
- * Panels that can live in the dock. Type-level twin of the registry's
- * `dockable` capability (`panelKindIsDockable`) — extend both together when a
- * new kind gains dock support, along with a chip branch in `ContentDock`.
+ * A panel known to be dockable. Dockability is runtime registry state, not a
+ * fixed kind list: any registered kind is dockable unless it declares
+ * `dockable: false` (see `panelKindIsDockable`), including plugin kinds cast
+ * into `PanelInstance` at creation. So this is `PanelInstance` — the guarantee
+ * lives in `isDockPanel`'s runtime check, and the dock render path narrows per
+ * kind (`isPtyPanel` for the terminal chip, `DockedNonPtyPanelItem` for the
+ * rest) rather than trusting this type to enumerate members.
  */
-export type DockPanelData = PtyPanelData | FilePanelData | BrowserPanelData;
+export type DockPanelData = PanelInstance;
 
 export function isDockPanel(panel: PanelInstance | TerminalInstance): panel is DockPanelData {
-  return isPtyPanel(panel) || isFilePanel(panel) || isBrowserPanel(panel);
+  return panelKindIsDockable(panel.kind ?? "terminal");
 }
 
 /**

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -31,6 +31,11 @@ export interface PanelContribution {
   canRestart: boolean;
   canConvert: boolean;
   showInPalette: boolean;
+  /**
+   * Whether this panel kind can live in the dock. Dockable by default; set
+   * `false` to opt out (for a kind with no meaningful compact chip-row form).
+   */
+  dockable?: boolean;
 }
 
 export interface ToolbarButtonContribution {

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -10,6 +10,7 @@ import { usePanelStore, useProjectStore, useWorktreeSelectionStore } from "@/sto
 import { useScratchStore } from "@/store/scratchStore";
 import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
 import {
+  isBrowserPanel,
   isDockPanel,
   isFilePanel,
   isPtyPanel,
@@ -19,7 +20,7 @@ import {
   type PanelInstance,
 } from "@shared/types/panel";
 import { extractHostPort } from "@/components/Browser/browserUtils";
-import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { getRenderablePanel } from "@/store/slices/panelRegistry/selectors";
 import { panelMatchesWorktreeScope } from "@/store/slices/panelRegistry/worktreeIndex";
 import type { TrashedTerminal } from "@/store/slices";
 import { DockedTerminalItem } from "./DockedTerminalItem";
@@ -116,6 +117,15 @@ function browserChipTitle(panel: BrowserPanelData): string {
   return host || panel.title || "Browser";
 }
 
+// Chip label for a non-PTY dock panel. File and browser get their kind-specific
+// derivations; every other dockable kind (dev-preview if opted in, plugin view
+// panels — #11332) falls back to the panel title so the chip is never blank.
+function dockChipTitle(panel: PanelInstance): string {
+  if (isFilePanel(panel)) return fileChipTitle(panel);
+  if (isBrowserPanel(panel)) return browserChipTitle(panel);
+  return panel.title;
+}
+
 export function ContentDock({ density = "normal" }: ContentDockProps) {
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
@@ -136,8 +146,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // Narrow dock subscriptions (#10908). Subscribing to the whole `panelsById`
   // re-rendered the dock on every panel's rAF status-buffer flush — including
   // grid agents that never appear here. Both selectors below react only to dock
-  // panels. Membership is `isDockPanel` (PTY panels plus the dockable file
-  // kind — #10985); each member kind has its own chip below. This is NOT the
+  // panels. Membership is `isDockPanel` — every registered kind that hasn't
+  // opted out with `dockable: false`, PTY and non-PTY alike, including plugin
+  // kinds (#11332). Panels are read through `getRenderablePanel` (not
+  // `getNarrowPanel`, which drops plugin kinds); the PTY chip and the generic
+  // `DockedNonPtyPanelItem` chip cover every member below. This is NOT the
   // #10512 grid render-eligibility predicate, which deliberately does not
   // apply to the dock.
   //
@@ -152,7 +165,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     useShallow((state) => {
       const result: string[] = [];
       for (const id of Object.keys(state.panelsById)) {
-        const terminal = getNarrowPanel(state.panelsById, id);
+        const terminal = getRenderablePanel(state.panelsById, id);
         if (
           terminal &&
           isDockPanel(terminal) &&
@@ -173,7 +186,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     useShallow((state) => {
       const result: DockPanelData[] = [];
       for (const id of state.panelIds) {
-        const terminal = getNarrowPanel(state.panelsById, id);
+        const terminal = getRenderablePanel(state.panelsById, id);
         if (
           terminal &&
           isDockPanel(terminal) &&
@@ -564,15 +577,10 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                           <SortableDockItem key={group.id} terminal={terminal} sourceIndex={index}>
                             {isPtyPanel(terminal) ? (
                               <DockedTerminalItem terminal={terminal} />
-                            ) : isFilePanel(terminal) ? (
-                              <DockedNonPtyPanelItem
-                                panel={terminal}
-                                displayTitle={fileChipTitle(terminal)}
-                              />
                             ) : (
                               <DockedNonPtyPanelItem
                                 panel={terminal}
-                                displayTitle={browserChipTitle(terminal)}
+                                displayTitle={dockChipTitle(terminal)}
                               />
                             )}
                           </SortableDockItem>

--- a/src/components/Layout/DockedNonPtyPanelItem.tsx
+++ b/src/components/Layout/DockedNonPtyPanelItem.tsx
@@ -5,7 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { cn } from "@/lib/utils";
 import { usePanelStore, useFocusStore } from "@/store";
-import type { BrowserPanelData, FilePanelData } from "@shared/types/panel";
+import type { PanelInstance } from "@shared/types/panel";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
@@ -20,14 +20,19 @@ import {
 import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
 interface DockedNonPtyPanelItemProps {
-  panel: FilePanelData | BrowserPanelData;
-  /** Chip label, derived per-kind by the caller (file name, browser host). */
+  /**
+   * Any non-PTY dock panel. The chip only reads `id`/`kind`/`title`, so it
+   * hosts file, browser, and plugin view kinds alike (#11332); the caller
+   * derives the label per kind via `dockChipTitle`.
+   */
+  panel: PanelInstance;
+  /** Chip label, derived per-kind by the caller (file name, browser host, …). */
   displayTitle: string;
 }
 
 /**
- * Dock chip for a non-PTY content panel (file viewer, browser). Mirrors
- * DockedTerminalItem's popover + stable-wrapper relocation flow, minus
+ * Dock chip for a non-PTY content panel (file viewer, browser, plugin view).
+ * Mirrors DockedTerminalItem's popover + stable-wrapper relocation flow, minus
  * everything PTY: no renderer policies, no xterm fit, no agent state. The
  * panel's React subtree lives in DockPanelOffscreenContainer and is moved (not
  * remounted) into this popover — a webview's guest survives the move too — so

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -19,6 +19,31 @@ describe("ContentDock regression test", () => {
     expect(content).not.toContain("if (groupPanels.length === 0) return null");
   });
 
+  // Issue #11332 — dock membership must follow the registry so plugin panels can
+  // dock. The dock selectors read `getRenderablePanel` (which keeps plugin
+  // kinds), NOT `getNarrowPanel` (which drops them, so plugin panels would never
+  // reach `isDockPanel`). Reverting either call site silently strands every
+  // dockable plugin panel, so pin the selector here.
+  it("reads dock panels through getRenderablePanel so plugin kinds are not dropped", () => {
+    const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+    // Target the call sites (not prose) so a doc mention can't mask a revert.
+    expect(content).toContain("getRenderablePanel(state.panelsById");
+    expect(content).not.toContain("getNarrowPanel(state.panelsById");
+  });
+
+  // Issue #11332 — the single-panel chip renders through the generic
+  // `DockedNonPtyPanelItem` with a kind-aware `dockChipTitle`, replacing the old
+  // three-way ternary whose `else` branch assumed browser and would mislabel a
+  // plugin panel's chip.
+  it("renders non-PTY dock chips through the generic dockChipTitle path", () => {
+    const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+    expect(content).toContain("displayTitle={dockChipTitle(terminal)}");
+    // The removed branch fed browserChipTitle to the ternary's non-file else.
+    expect(content).not.toMatch(/:\s*isFilePanel\(terminal\)\s*\?/);
+  });
+
   it("offscreen dock container closes stale active dock state", () => {
     const content = readFileSync(resolve(__dirname, "../DockPanelOffscreenContainer.tsx"), "utf-8");
 

--- a/src/components/Layout/__tests__/dockPanelVisibility.test.ts
+++ b/src/components/Layout/__tests__/dockPanelVisibility.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { isDockPanelRendered, type DockPanelScope } from "../dockPanelVisibility";
-import type { PtyPanelData, ReviewPanelData } from "@shared/types/panel";
+import type { PanelInstance, PtyPanelData, ReviewPanelData } from "@shared/types/panel";
+import {
+  clearPanelKindRegistry,
+  registerPanelKind,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
 
 function createDockPanel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
@@ -81,5 +86,52 @@ describe("isDockPanelRendered", () => {
     };
 
     expect(isDockPanelRendered(panel, createScope())).toBe(false);
+  });
+});
+
+describe("isDockPanelRendered — plugin kinds follow the registry (#11332)", () => {
+  const makePluginConfig = (id: string, dockable?: boolean): PanelKindConfig => ({
+    id,
+    name: `Plugin ${id}`,
+    iconId: "puzzle",
+    color: "#123456",
+    hasPty: false,
+    canRestart: false,
+    canConvert: false,
+    extensionId: "ext-a",
+    ...(dockable !== undefined ? { dockable } : {}),
+  });
+
+  const makePluginPanel = (id: string, kind: string): PanelInstance => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- plugin kinds are cast into the closed PanelInstance union (mirrors addPanel.ts)
+    return { id, kind, title: "Plugin", location: "dock", worktreeId: "wt-a" } as PanelInstance;
+  };
+
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("renders a docked panel of a default-dockable plugin kind", () => {
+    registerPanelKind(makePluginConfig("ext-a.viewer"));
+
+    expect(isDockPanelRendered(makePluginPanel("dock-1", "ext-a.viewer"), createScope())).toBe(
+      true
+    );
+  });
+
+  it("does not render a docked panel of a plugin kind that opts out (dockable:false)", () => {
+    registerPanelKind(makePluginConfig("ext-a.viewer", false));
+
+    expect(isDockPanelRendered(makePluginPanel("dock-1", "ext-a.viewer"), createScope())).toBe(
+      false
+    );
+  });
+
+  it("does not render a docked panel whose plugin kind is not registered yet", () => {
+    // Registration hasn't landed (or the plugin is disabled): an unknown kind
+    // is never dockable, so it stays out of the dock render path.
+    expect(
+      isDockPanelRendered(makePluginPanel("dock-1", "ext-a.unregistered"), createScope())
+    ).toBe(false);
   });
 });

--- a/src/components/Layout/dockRenderItems.ts
+++ b/src/components/Layout/dockRenderItems.ts
@@ -8,7 +8,8 @@ export interface DockRenderItem {
 
 export function buildDockRenderItems(
   tabGroups: TabGroup[],
-  // Tab groups stay PTY-only — dockable non-PTY panels (file, browser) dock as standalone chips.
+  // Tab groups stay PTY-only — every dockable non-PTY kind (file, browser and
+  // plugin view panels — #11332) docks as a standalone chip.
   resolvePanels: (groupId: string) => PtyPanelData[],
   excludedPanelId?: string | null,
   dockTerminals: DockPanelData[] = []

--- a/src/hooks/__tests__/usePluginPanelKinds.test.ts
+++ b/src/hooks/__tests__/usePluginPanelKinds.test.ts
@@ -138,8 +138,11 @@ describe("usePluginPanelKinds", () => {
 
     const dockable = pluginKind({ id: "acme.viewer", hasPty: false, componentPath: "./v.js" });
     act(() => emit!({ kinds: [dockable] }));
-    // Absent flag → dockable by default.
-    expect(getPanelKindConfig(dockable.id)?.dockable).toBeUndefined();
+    // Assert the kind registered before checking key absence, so a missing
+    // config can't make `?.dockable` pass vacuously.
+    const registered = getPanelKindConfig(dockable.id);
+    expect(registered).toBeDefined();
+    expect(registered?.dockable).toBeUndefined();
 
     const optedOut = { ...dockable, dockable: false };
     act(() => emit!({ kinds: [optedOut] }));

--- a/src/hooks/__tests__/usePluginPanelKinds.test.ts
+++ b/src/hooks/__tests__/usePluginPanelKinds.test.ts
@@ -117,6 +117,37 @@ describe("usePluginPanelKinds", () => {
     clearPanelKindRegistry();
   });
 
+  it("re-registers a kind when a push changes only its dockable flag (#11332)", async () => {
+    // `dockable` is in PANEL_KIND_META_KEYS, so a redeploy that flips only the
+    // dock opt-out must be detected as a change and re-applied to the registry
+    // — otherwise the stale config keeps the kind's old dockability.
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation(
+      (cb: (payload: { kinds: PanelKindConfig[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { getPanelKindConfig, clearPanelKindRegistry } =
+      await import("@shared/config/panelKindRegistry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+
+    const dockable = pluginKind({ id: "acme.viewer", hasPty: false, componentPath: "./v.js" });
+    act(() => emit!({ kinds: [dockable] }));
+    // Absent flag → dockable by default.
+    expect(getPanelKindConfig(dockable.id)?.dockable).toBeUndefined();
+
+    const optedOut = { ...dockable, dockable: false };
+    act(() => emit!({ kinds: [optedOut] }));
+    expect(getPanelKindConfig(dockable.id)?.dockable).toBe(false);
+
+    clearPanelKindRegistry();
+  });
+
   it("does not register a definition for non-PTY plugin kinds without componentPath", async () => {
     const nonPty = pluginKind({ id: "acme.note", hasPty: false });
     getPanelKindsMock.mockResolvedValue([nonPty]);

--- a/src/hooks/usePluginPanelKinds.ts
+++ b/src/hooks/usePluginPanelKinds.ts
@@ -51,6 +51,7 @@ const PANEL_KIND_META_KEYS = [
   "firstRenderRestore",
   "lazyImportPath",
   "showInPalette",
+  "dockable",
   "extensionId",
   "componentPath",
   "shortcut",

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -206,6 +206,16 @@ describe("panelStore.addPanel dockability for plugin kinds (#11332)", () => {
     ...(dockable !== undefined ? { dockable } : {}),
   });
 
+  // Extension kinds are intentionally excluded from the `AddPanelOptions` union
+  // (a `kind: string` member would defeat discriminated-union narrowing for
+  // built-in kinds). Widen at this spawn boundary, the documented pattern used
+  // by `panelCoreActions.ts` for launching a custom kind.
+  const spawnPluginPanel = (kind: string, location: "dock" | "grid") => {
+    const addPanel = usePanelStore.getState().addPanel;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- documented extension-panel spawn boundary (mirrors panelCoreActions.ts)
+    return addPanel({ kind, location } as Parameters<typeof addPanel>[0]);
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     resetState();
@@ -219,7 +229,7 @@ describe("panelStore.addPanel dockability for plugin kinds (#11332)", () => {
   it("honors a dock request for a plugin kind that is dockable by default", async () => {
     registerPanelKind(makePluginConfig("ext-a.viewer"));
 
-    const id = await usePanelStore.getState().addPanel({ kind: "ext-a.viewer", location: "dock" });
+    const id = await spawnPluginPanel("ext-a.viewer", "dock");
 
     expect(id).toBeTruthy();
     expect(usePanelStore.getState().panelsById[id!]?.location).toBe("dock");
@@ -228,7 +238,7 @@ describe("panelStore.addPanel dockability for plugin kinds (#11332)", () => {
   it("redirects a dock request for a plugin kind that opts out (dockable:false) to the grid", async () => {
     registerPanelKind(makePluginConfig("ext-a.viewer", false));
 
-    const id = await usePanelStore.getState().addPanel({ kind: "ext-a.viewer", location: "dock" });
+    const id = await spawnPluginPanel("ext-a.viewer", "dock");
 
     expect(id).toBeTruthy();
     expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -80,6 +80,11 @@ Object.defineProperty(window, "electron", {
 });
 
 import { usePanelStore } from "../panelStore";
+import {
+  clearPanelKindRegistry,
+  registerPanelKind,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
 
 function resetState() {
   usePanelStore.setState((s) => ({
@@ -185,5 +190,47 @@ describe("panelStore.addPanel dockability guard (#11054)", () => {
 
     expect(id).toBe("stranded-devpreview-1");
     expect(usePanelStore.getState().panelsById["stranded-devpreview-1"]?.location).toBe("grid");
+  });
+});
+
+describe("panelStore.addPanel dockability for plugin kinds (#11332)", () => {
+  const makePluginConfig = (id: string, dockable?: boolean): PanelKindConfig => ({
+    id,
+    name: `Plugin ${id}`,
+    iconId: "puzzle",
+    color: "#123456",
+    hasPty: false,
+    canRestart: false,
+    canConvert: false,
+    extensionId: "ext-a",
+    ...(dockable !== undefined ? { dockable } : {}),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+  });
+
+  afterEach(() => {
+    resetState();
+    clearPanelKindRegistry();
+  });
+
+  it("honors a dock request for a plugin kind that is dockable by default", async () => {
+    registerPanelKind(makePluginConfig("ext-a.viewer"));
+
+    const id = await usePanelStore.getState().addPanel({ kind: "ext-a.viewer", location: "dock" });
+
+    expect(id).toBeTruthy();
+    expect(usePanelStore.getState().panelsById[id!]?.location).toBe("dock");
+  });
+
+  it("redirects a dock request for a plugin kind that opts out (dockable:false) to the grid", async () => {
+    registerPanelKind(makePluginConfig("ext-a.viewer", false));
+
+    const id = await usePanelStore.getState().addPanel({ kind: "ext-a.viewer", location: "dock" });
+
+    expect(id).toBeTruthy();
+    expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
   });
 });


### PR DESCRIPTION
## Summary

- Flips panel-kind dockability from opt-in to opt-out: every registered kind, built-in and plugin alike, is now dockable unless it explicitly declares `dockable: false`.
- Dock render membership used to be a hard-coded list of kinds. It now follows the panel kind registry, so plugin view panels can dock.
- Built-in dock behavior is unchanged byte-for-byte; the four kinds without a meaningful compact chip form opt out explicitly instead of relying on the old default-deny.

Resolves #11332

## Changes

- `panelKindIsDockable` now returns `config.dockable !== false`, so unknown kinds stay non-dockable and an explicit `dockable: false` wins even over PTY.
- `file-browser`, `diff`, `review`, and `dev-preview` opt out explicitly; `browser` and `file` drop their now-redundant `dockable: true`.
- `isDockPanel` is registry-driven and `DockPanelData` is now just `PanelInstance`. `ContentDock` reads dock panels through `getRenderablePanel`, which preserves plugin kinds, and renders any non-PTY dockable kind through the generic `DockedNonPtyPanelItem` chip with a kind-aware `dockChipTitle`.
- Plugins get a new `dockable` field: added to the public `PanelContribution` type and `PanelContributionSchema`, plumbed through `PluginService.registerPanelKind`, added to `PANEL_KIND_META_KEYS` so a dockable-only redeploy re-registers, and documented in the manifest consumer map. Regenerated the plugin-sdk API report.

## Testing

- Registry predicate coverage: opt-out default, the four opt-outs, PTY opt-out, and unknown kinds.
- `isDockPanel` and dock render membership for plugin kinds, schema accept/reject cases, and `PluginService` pass-through.
- A guard test against reverting the `getRenderablePanel` swap in `ContentDock`.
- Reviewed with two adversarial Codex passes plus a confirmation pass; all targeted tests pass.

### Known follow-up (deliberately scoped out)

Making plugin panels dockable makes a few dock-stranding edge cases newly reachable: a persisted docked plugin panel returning to the grid on a restart that hydrates before plugin-kind registration, live `dockable: true` to `false` (or unregister) reconciliation, direct store-mutator dock writes bypassing the guard, and mixed-group drag-and-drop. These form a cohesive store-hardening workstream beyond this issue's scope and are tracked as a follow-up. The core feature here (default flip, registry-driven membership, plugin plumbing) preserves all existing behavior and is fully tested.
