### PR TITLE
fix(terminal): persist typed drafts on window close

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -805,6 +805,86 @@ describe("project:switch outgoing tabGroups pre-apply (#5001)", () => {
   });
 });
 
+describe("project:switch outgoing draftInputs merge (#11352)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProjectForWebContents.mockReturnValue("proj-old");
+  });
+
+  async function runSwitchWithDrafts(
+    existingDrafts: Record<string, string>,
+    outgoingState: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const mockView = {
+      webContents: { id: 100, isDestroyed: () => false, send: vi.fn() },
+    };
+    const pvm = {
+      switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew: false }),
+      getProjectIdForWebContents: vi.fn(),
+    };
+    mockGetWindowForWebContents.mockReturnValue(null);
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-old");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New Project",
+      path: "/projects/new",
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+    projectStoreMock.getProjectState.mockResolvedValue({
+      projectId: "proj-old",
+      sidebarWidth: 350,
+      terminals: [],
+      tabGroups: [],
+      draftInputs: existingDrafts,
+    });
+    projectStoreMock.saveProjectState.mockResolvedValue(undefined);
+
+    const deps = {
+      mainWindow: { id: 1 } as unknown,
+      projectViewManager: pvm,
+    } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+    const handler = handleMap.get(CHANNELS.PROJECT_SWITCH);
+    await handler!({ sender: { id: 99 } }, "proj-new", outgoingState);
+    return projectStoreMock.saveProjectState.mock.calls[0]?.[1] as Record<string, unknown>;
+  }
+
+  it("merges draftInputs by terminal id, preserving a sibling window's draft", async () => {
+    const saved = await runSwitchWithDrafts(
+      { t1: "old", sib: "sibling draft" },
+      {
+        draftInputs: { t1: "new" },
+        draftDelta: { changedIds: ["t1"], removedIds: [] },
+      }
+    );
+    expect(saved.draftInputs).toEqual({ t1: "new", sib: "sibling draft" });
+  });
+
+  it("tombstones a cleared draft via draftDelta without wiping siblings", async () => {
+    const saved = await runSwitchWithDrafts(
+      { t1: "gone", sib: "keep" },
+      {
+        draftInputs: {},
+        draftDelta: { changedIds: [], removedIds: ["t1"] },
+      }
+    );
+    expect(saved.draftInputs).toEqual({ sib: "keep" });
+  });
+
+  it("falls back to a full replace when no draftDelta is present (legacy)", async () => {
+    const saved = await runSwitchWithDrafts(
+      { t1: "old", sib: "would be lost" },
+      { draftInputs: { t1: "new" } }
+    );
+    expect(saved.draftInputs).toEqual({ t1: "new" });
+  });
+});
+
 describe("project:switch worktree-load-status (#8400)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -25,6 +25,13 @@ const setTabGroups = terminalLayoutNamespace.ops.setTabGroups.handler as (payloa
   removedIds?: string[];
 }) => Promise<void>;
 
+const setDraftInputs = terminalLayoutNamespace.ops.setDraftInputs.handler as (payload: {
+  projectId: string;
+  draftInputs: Record<string, string>;
+  changedIds?: string[];
+  removedIds?: string[];
+}) => Promise<void>;
+
 function term(id: string, location: "grid" | "dock" = "grid"): TerminalSnapshot {
   // `cwd` is required by TerminalSnapshotSchema's refine for PTY-backed kinds
   // (kind defaults to "terminal"); without it sanitizeTerminals drops the entry.
@@ -204,5 +211,58 @@ describe("setTabGroups merge (#11350)", () => {
       removedIds: ["g2"],
     });
     expect(ids(saved()?.tabGroups)).toEqual(["g1"]);
+  });
+});
+
+const draftState = (draftInputs: Record<string, string>): ProjectState => ({
+  projectId: "p1",
+  sidebarWidth: 350,
+  terminals: [],
+  tabGroups: [],
+  draftInputs,
+});
+
+describe("setDraftInputs merge (#11352)", () => {
+  it("preserves a sibling window's draft the writer never knew", async () => {
+    const saved = onDisk(draftState({ t1: "old", sib: "sibling draft" }));
+    await setDraftInputs({
+      projectId: "p1",
+      draftInputs: { t1: "new" },
+      changedIds: ["t1"],
+      removedIds: [],
+    });
+    expect(saved()?.draftInputs).toEqual({ t1: "new", sib: "sibling draft" });
+  });
+
+  it("removes a cleared draft via removedIds while keeping siblings — the tombstone case", async () => {
+    const saved = onDisk(draftState({ t1: "gone", sib: "keep" }));
+    // Current record is empty (draft was cleared) but removedIds carries the
+    // tombstone; a naive `{}` full-replace would wipe the sibling too.
+    await setDraftInputs({
+      projectId: "p1",
+      draftInputs: {},
+      changedIds: [],
+      removedIds: ["t1"],
+    });
+    expect(saved()?.draftInputs).toEqual({ sib: "keep" });
+  });
+
+  it("does not resurrect a sibling-deleted draft the writer did not change", async () => {
+    // Disk no longer has t2 (a sibling cleared it); a stale writer still carries
+    // it but only added t3.
+    const saved = onDisk(draftState({ t1: "a" }));
+    await setDraftInputs({
+      projectId: "p1",
+      draftInputs: { t1: "a", t2: "stale", t3: "added" },
+      changedIds: ["t3"],
+      removedIds: [],
+    });
+    expect(saved()?.draftInputs).toEqual({ t1: "a", t3: "added" });
+  });
+
+  it("falls back to a full replace when no delta metadata is present (legacy)", async () => {
+    const saved = onDisk(draftState({ t1: "old", sib: "would be lost" }));
+    await setDraftInputs({ projectId: "p1", draftInputs: { t1: "new" } });
+    expect(saved()?.draftInputs).toEqual({ t1: "new" });
   });
 });

--- a/electron/ipc/handlers/__tests__/terminalLayout.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalLayout.test.ts
@@ -265,4 +265,29 @@ describe("setDraftInputs merge (#11352)", () => {
     await setDraftInputs({ projectId: "p1", draftInputs: { t1: "new" } });
     expect(saved()?.draftInputs).toEqual({ t1: "new" });
   });
+
+  it("does not recreate a deleted state file for a pure-removal write", async () => {
+    // Project state was deleted (close-with-kill / removal); a late teardown
+    // flush emits only a tombstone. With no existing state and nothing left to
+    // persist, the updater returns null so the file stays deleted.
+    const saved = onDisk(null);
+    await setDraftInputs({
+      projectId: "p1",
+      draftInputs: {},
+      changedIds: [],
+      removedIds: ["t1"],
+    });
+    expect(saved()).toBeNull();
+  });
+
+  it("still persists a genuine first draft on a project with no prior state", async () => {
+    const saved = onDisk(null);
+    await setDraftInputs({
+      projectId: "p1",
+      draftInputs: { t1: "first draft" },
+      changedIds: ["t1"],
+      removedIds: [],
+    });
+    expect(saved()?.draftInputs).toEqual({ t1: "first draft" });
+  });
 });

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -20,7 +20,7 @@ import {
   sanitizeDraftInputs,
 } from "../terminalLayout.js";
 import { sanitizeTabGroups } from "../../../schemas/index.js";
-import { mergeIdArray } from "../../../../shared/utils/layoutMerge.js";
+import { mergeIdArray, mergeRecord } from "../../../../shared/utils/layoutMerge.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 import type { ProjectSwitchOutgoingState } from "../../../../shared/types/ipc/project.js";
@@ -326,12 +326,27 @@ async function persistOutgoingProjectState(
               tabGroupDelta.removedIds
             )
           : validTabGroups;
+    const draftDelta = outgoingState.draftDelta;
+    // Merge drafts by terminal id so a stale outgoing snapshot only affects the
+    // drafts this window changed, preserving a sibling window's concurrent
+    // drafts (#11352). Without a delta, fall back to the legacy full replace.
+    const mergedDrafts =
+      validDrafts === undefined
+        ? undefined
+        : draftDelta
+          ? mergeRecord(
+              sanitizeDraftInputs((existing?.draftInputs ?? {}) as Record<string, unknown>),
+              validDrafts,
+              draftDelta.changedIds,
+              draftDelta.removedIds
+            )
+          : validDrafts;
     return {
       ...(existing ?? { projectId: previousProjectId, sidebarWidth: 350, terminals: [] }),
       projectId: previousProjectId,
       ...(mergedTerminals !== undefined && { terminals: mergedTerminals }),
       ...(validSizes !== undefined && { terminalSizes: validSizes }),
-      ...(validDrafts !== undefined && { draftInputs: validDrafts }),
+      ...(mergedDrafts !== undefined && { draftInputs: mergedDrafts }),
       ...(mergedTabGroups !== undefined && { tabGroups: mergedTabGroups }),
       activeWorktreeId: outgoingState.activeWorktreeId,
     };

--- a/electron/ipc/handlers/terminalLayout.preload.ts
+++ b/electron/ipc/handlers/terminalLayout.preload.ts
@@ -54,7 +54,16 @@ export interface TerminalLayoutPreloadBindings {
     focusPanelState?: FocusPanelState
   ): Promise<void>;
   getDraftInputs(projectId: string): Promise<Record<string, string>>;
-  setDraftInputs(projectId: string, draftInputs: Record<string, string>): Promise<void>;
+  // `changedIds`/`removedIds` (terminal ids) describe what this renderer changed
+  // relative to its last-persisted baseline so Main can merge concurrent writes
+  // from sibling windows of the same project (#11352). Omit both for a full
+  // replace.
+  setDraftInputs(
+    projectId: string,
+    draftInputs: Record<string, string>,
+    changedIds?: string[],
+    removedIds?: string[]
+  ): Promise<void>;
 }
 
 type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
@@ -102,10 +111,12 @@ export function buildTerminalLayoutPreloadBindings(invoke: Invoker): TerminalLay
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.getDraftInputs, projectId) as Promise<
         Record<string, string>
       >,
-    setDraftInputs: (projectId, draftInputs) =>
+    setDraftInputs: (projectId, draftInputs, changedIds, removedIds) =>
       invoke(TERMINAL_LAYOUT_METHOD_CHANNELS.setDraftInputs, {
         projectId,
         draftInputs,
+        changedIds,
+        removedIds,
       }) as Promise<void>,
   };
 }

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -7,7 +7,7 @@ import {
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalSnapshot, TabGroup } from "../../types/index.js";
 import { defineIpcNamespace, op } from "../define.js";
-import { mergeIdArray } from "../../../shared/utils/layoutMerge.js";
+import { mergeIdArray, mergeRecord } from "../../../shared/utils/layoutMerge.js";
 import { TERMINAL_LAYOUT_METHOD_CHANNELS } from "./terminalLayout.preload.js";
 
 /**
@@ -327,6 +327,8 @@ export const terminalLayoutNamespace = defineIpcNamespace({
       async (payload: {
         projectId: string;
         draftInputs: Record<string, string>;
+        changedIds?: string[];
+        removedIds?: string[];
       }): Promise<void> => {
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
@@ -345,6 +347,11 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         }
 
         const sanitized = sanitizeDraftInputs(draftInputs as Record<string, unknown>);
+        // Delta metadata lets Main merge concurrent draft writes from sibling
+        // windows of the same project instead of blindly replacing the record
+        // (#11352). Absent metadata = legacy full-replace write.
+        const changedIds = sanitizeIdList(payload.changedIds);
+        const removedIds = sanitizeIdList(payload.removedIds);
 
         await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
           projectId,
@@ -356,7 +363,15 @@ export const terminalLayoutNamespace = defineIpcNamespace({
           focusMode: existingState?.focusMode,
           focusPanelState: existingState?.focusPanelState,
           terminalSizes: existingState?.terminalSizes,
-          draftInputs: sanitized,
+          draftInputs:
+            changedIds === undefined
+              ? sanitized
+              : mergeRecord(
+                  sanitizeDraftInputs((existingState?.draftInputs ?? {}) as Record<string, unknown>),
+                  sanitized,
+                  changedIds,
+                  removedIds ?? []
+                ),
         }));
       }
     ),

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -353,17 +353,8 @@ export const terminalLayoutNamespace = defineIpcNamespace({
         const changedIds = sanitizeIdList(payload.changedIds);
         const removedIds = sanitizeIdList(payload.removedIds);
 
-        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => ({
-          projectId,
-          activeWorktreeId: existingState?.activeWorktreeId,
-          sidebarWidth: existingState?.sidebarWidth ?? 350,
-          terminals: existingState?.terminals ?? [],
-          tabGroups: existingState?.tabGroups ?? [],
-          terminalLayout: existingState?.terminalLayout,
-          focusMode: existingState?.focusMode,
-          focusPanelState: existingState?.focusPanelState,
-          terminalSizes: existingState?.terminalSizes,
-          draftInputs:
+        await projectStore.enqueueProjectStateUpdate(projectId, (existingState) => {
+          const mergedDrafts =
             changedIds === undefined
               ? sanitized
               : mergeRecord(
@@ -371,8 +362,30 @@ export const terminalLayoutNamespace = defineIpcNamespace({
                   sanitized,
                   changedIds,
                   removedIds ?? []
-                ),
-        }));
+                );
+          // Don't recreate a project's deleted state file just to record draft
+          // removals. A teardown flush can fire after the project was closed
+          // (killTerminals) or removed — its persisted state gone — and emit a
+          // pure-removal tombstone. With no existing state and nothing left to
+          // persist, skip the write so a deleted state file stays deleted
+          // (#11352). A genuine first draft on a new project still persists,
+          // because mergedDrafts is non-empty there.
+          if (!existingState && Object.keys(mergedDrafts).length === 0) {
+            return null;
+          }
+          return {
+            projectId,
+            activeWorktreeId: existingState?.activeWorktreeId,
+            sidebarWidth: existingState?.sidebarWidth ?? 350,
+            terminals: existingState?.terminals ?? [],
+            tabGroups: existingState?.tabGroups ?? [],
+            terminalLayout: existingState?.terminalLayout,
+            focusMode: existingState?.focusMode,
+            focusPanelState: existingState?.focusPanelState,
+            terminalSizes: existingState?.terminalSizes,
+            draftInputs: mergedDrafts,
+          };
+        });
       }
     ),
   },

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -358,7 +358,9 @@ export const terminalLayoutNamespace = defineIpcNamespace({
             changedIds === undefined
               ? sanitized
               : mergeRecord(
-                  sanitizeDraftInputs((existingState?.draftInputs ?? {}) as Record<string, unknown>),
+                  sanitizeDraftInputs(
+                    (existingState?.draftInputs ?? {}) as Record<string, unknown>
+                  ),
                   sanitized,
                   changedIds,
                   removedIds ?? []

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -670,9 +670,18 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getDraftInputs(projectId: string): Promise<Record<string, string>>;
     /**
      * Save draft inputs for a project.
-     * Used for preserving hybrid input bar drafts when switching away from a project.
+     * Used for preserving hybrid input bar drafts when switching away from a
+     * project and when a view is torn down (window close, #11352).
+     * `changedIds`/`removedIds` (terminal ids) let Main merge concurrent writes
+     * from sibling windows of the same project instead of full-replacing the
+     * record. Omit both for a legacy full replace.
      */
-    setDraftInputs(projectId: string, draftInputs: Record<string, string>): Promise<void>;
+    setDraftInputs(
+      projectId: string,
+      draftInputs: Record<string, string>,
+      changedIds?: string[],
+      removedIds?: string[]
+    ): Promise<void>;
     /**
      * Get tab groups for a project.
      * Used for restoring tab groups when switching to a project.

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1208,7 +1208,14 @@ export interface GeneratedIpcInvokeMap {
     result: import("../project.js").PanelSnapshot[];
   };
   "project:set-draft-inputs": {
-    args: [payload: { projectId: string; draftInputs: Record<string, string> }];
+    args: [
+      payload: {
+        projectId: string;
+        draftInputs: Record<string, string>;
+        changedIds?: string[] | undefined;
+        removedIds?: string[] | undefined;
+      },
+    ];
     result: void;
   };
   "project:set-focus-mode": {

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -24,6 +24,14 @@ export interface ProjectSwitchOutgoingState {
    */
   terminalDelta?: IdArrayDelta;
   tabGroupDelta?: IdArrayDelta;
+  /**
+   * What this window changed in `draftInputs` relative to its last-persisted
+   * baseline (`changedIds`/`removedIds` are terminal ids). When present, Main
+   * merges the draft record by key instead of full-replacing, so switching away
+   * doesn't clobber a sibling window's drafts (#11352). Absent = legacy full
+   * replace.
+   */
+  draftDelta?: IdArrayDelta;
 }
 
 /** Payload for project:on-switch event with cancellation token */

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { computeIdArrayDelta, mergeIdArray, deepEqualIgnoringUndefined } from "../layoutMerge.js";
+import {
+  computeIdArrayDelta,
+  mergeIdArray,
+  deepEqualIgnoringUndefined,
+  computeRecordDelta,
+  mergeRecord,
+} from "../layoutMerge.js";
 
 interface Entry {
   id: string;
@@ -202,6 +208,89 @@ describe("mergeIdArray", () => {
     const { changedIds, removedIds } = computeIdArrayDelta(base, current, eq);
     // Disk still equals the shared baseline (no sibling activity).
     const merged = mergeIdArray(base, current, changedIds, removedIds);
+    expect(merged).toEqual(current);
+  });
+});
+
+describe("computeRecordDelta (draft inputs, #11352)", () => {
+  it("reports an added key as changed", () => {
+    const delta = computeRecordDelta({ a: "x" }, { a: "x", b: "y" });
+    expect(delta.changedIds).toEqual(["b"]);
+    expect(delta.removedIds).toEqual([]);
+  });
+
+  it("reports an edited value as changed", () => {
+    const delta = computeRecordDelta({ a: "x" }, { a: "x2" });
+    expect(delta.changedIds).toEqual(["a"]);
+    expect(delta.removedIds).toEqual([]);
+  });
+
+  it("derives a removal tombstone from a key absent in current — the core #11352 case", () => {
+    // A cleared/sent draft is dropped from the live map, so removal can ONLY be
+    // seen by diffing against the remembered baseline.
+    const delta = computeRecordDelta({ a: "x", b: "y" }, { b: "y" });
+    expect(delta.changedIds).toEqual([]);
+    expect(delta.removedIds).toEqual(["a"]);
+  });
+
+  it("produces an empty delta when nothing changed", () => {
+    const delta = computeRecordDelta({ a: "x", b: "y" }, { a: "x", b: "y" });
+    expect(delta.changedIds).toEqual([]);
+    expect(delta.removedIds).toEqual([]);
+  });
+
+  it("handles simultaneous add, edit, and remove", () => {
+    const delta = computeRecordDelta({ a: "x", b: "y" }, { a: "x2", c: "z" });
+    expect(new Set(delta.changedIds)).toEqual(new Set(["a", "c"]));
+    expect(delta.removedIds).toEqual(["b"]);
+  });
+});
+
+describe("mergeRecord (draft inputs, #11352)", () => {
+  it("preserves a sibling's draft the writer never knew", () => {
+    // Disk has a sibling window's draft for terminal 'sib'; the writer only
+    // changed 'a'.
+    const merged = mergeRecord({ a: "old", sib: "keep" }, { a: "new" }, ["a"], []);
+    expect(merged).toEqual({ a: "new", sib: "keep" });
+  });
+
+  it("applies the writer's addition and edit (last-writer-wins on a shared key)", () => {
+    const merged = mergeRecord({ a: "disk" }, { a: "mine", b: "added" }, ["a", "b"], []);
+    expect(merged).toEqual({ a: "mine", b: "added" });
+  });
+
+  it("removes an explicitly-removed key while keeping siblings", () => {
+    const merged = mergeRecord({ a: "x", sib: "keep" }, {}, [], ["a"]);
+    expect(merged).toEqual({ sib: "keep" });
+  });
+
+  it("does not resurrect a key present in incoming but absent from changedIds", () => {
+    // A sibling deleted 'a' (not on disk); a stale writer still carries it but
+    // did not change it, so it must not come back.
+    const merged = mergeRecord({ b: "y" }, { a: "stale", b: "y" }, [], []);
+    expect(merged).toEqual({ b: "y" });
+  });
+
+  it("lets removal win over a malformed changed/removed overlap", () => {
+    const merged = mergeRecord({ a: "x" }, { a: "new" }, ["a"], ["a"]);
+    expect(merged).toEqual({});
+  });
+
+  it("drops empty/malformed on-disk values so they don't survive forever", () => {
+    const merged = mergeRecord(
+      { a: "", b: "keep" } as Record<string, string>,
+      { c: "add" },
+      ["c"],
+      []
+    );
+    expect(merged).toEqual({ b: "keep", c: "add" });
+  });
+
+  it("round-trips a delta computed from a shared baseline (no sibling activity)", () => {
+    const base = { a: "x", b: "y" };
+    const current = { a: "x2", c: "z" }; // edited a, removed b, added c
+    const { changedIds, removedIds } = computeRecordDelta(base, current);
+    const merged = mergeRecord(base, current, changedIds, removedIds);
     expect(merged).toEqual(current);
   });
 });

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -276,6 +276,22 @@ describe("mergeRecord (draft inputs, #11352)", () => {
     expect(merged).toEqual({});
   });
 
+  it("treats a changed id missing from incoming as a defensive deletion", () => {
+    // Malformed delta: 'a' is flagged changed but absent/empty in the incoming
+    // record; it must be dropped, not left stale, and siblings preserved.
+    const merged = mergeRecord({ a: "old", sib: "keep" }, {}, ["a"], []);
+    expect(merged).toEqual({ sib: "keep" });
+  });
+
+  it("does not mistake a prototype key for present state", () => {
+    // `constructor`/`toString` exist on Object.prototype; own-property checks
+    // must keep them from being seen as present-on-base or present-in-incoming.
+    const delta = computeRecordDelta({}, { constructor: "real" });
+    expect(delta.changedIds).toEqual(["constructor"]);
+    const merged = mergeRecord({}, { constructor: "real" }, ["constructor"], []);
+    expect(merged).toEqual({ constructor: "real" });
+  });
+
   it("drops empty/malformed on-disk values so they don't survive forever", () => {
     const merged = mergeRecord(
       { a: "", b: "keep" } as Record<string, string>,

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -209,16 +209,21 @@ export function computeRecordDelta(
   base: Readonly<Record<string, string>>,
   current: Readonly<Record<string, string>>
 ): IdArrayDelta {
+  const hasOwn = (obj: Readonly<Record<string, string>>, key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(obj, key);
+
   const changedIds: string[] = [];
   for (const [id, value] of Object.entries(current)) {
-    if (base[id] !== value) {
+    // Own-property compare so an id like `toString`/`constructor` isn't
+    // mistaken for present-on-base via the prototype chain.
+    if (!hasOwn(base, id) || base[id] !== value) {
       changedIds.push(id);
     }
   }
 
   const removedIds: string[] = [];
   for (const id of Object.keys(base)) {
-    if (!(id in current)) {
+    if (!hasOwn(current, id)) {
       removedIds.push(id);
     }
   }
@@ -257,7 +262,11 @@ export function mergeRecord(
   const removed = new Set(removedIds);
   for (const id of changedIds) {
     if (removed.has(id)) continue;
-    const value = incoming[id];
+    // Own-property read so a `constructor`/`toString` id can't pull a function
+    // off the prototype chain.
+    const value = Object.prototype.hasOwnProperty.call(incoming, id)
+      ? incoming[id]
+      : undefined;
     if (typeof value === "string" && value !== "") {
       result[id] = value;
     } else {

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -193,3 +193,81 @@ export function mergeIdArray<T extends { id: string }>(
 
   return result;
 }
+
+/**
+ * Record counterpart to {@link computeIdArrayDelta} for a flat
+ * `Record<terminalId, draftText>` (terminal draft inputs, #11352). The map is
+ * keyed by id and has no meaningful order, so equality is plain string
+ * comparison and there is no reorder concern.
+ *
+ * `changedIds` are keys present in `current` whose value differs from `base`
+ * (added or edited). `removedIds` are keys present in `base` but gone from
+ * `current` — the only way to derive a tombstone, since a cleared draft is
+ * dropped from the live map entirely and cannot be seen in `current` alone.
+ */
+export function computeRecordDelta(
+  base: Readonly<Record<string, string>>,
+  current: Readonly<Record<string, string>>
+): IdArrayDelta {
+  const changedIds: string[] = [];
+  for (const [id, value] of Object.entries(current)) {
+    if (base[id] !== value) {
+      changedIds.push(id);
+    }
+  }
+
+  const removedIds: string[] = [];
+  for (const id of Object.keys(base)) {
+    if (!(id in current)) {
+      removedIds.push(id);
+    }
+  }
+
+  return { changedIds, removedIds };
+}
+
+/**
+ * Record counterpart to {@link mergeIdArray}. Merges a writer's `changedIds` /
+ * `removedIds` into the on-disk `existing` record, preserving every key the
+ * writer did not touch — including sibling-window keys it never knew (#11352).
+ *
+ * Semantics per key:
+ *   - in `removedIds`  → deleted (the writer cleared/sent it). Removal wins over
+ *     a malformed overlap where the same key also appears in `changedIds`.
+ *   - in `changedIds`  → the incoming value wins (added/edited by the writer);
+ *     a missing/empty incoming value is treated as a defensive deletion.
+ *   - otherwise         → the on-disk value is kept (a sibling's concurrent
+ *     edit survives; a key the writer never knew is preserved).
+ * A key present in `incoming` but not in `changedIds` is never resurrected.
+ * Empty/malformed on-disk values are dropped so they don't survive forever.
+ */
+export function mergeRecord(
+  existing: Readonly<Record<string, string>>,
+  incoming: Readonly<Record<string, string>>,
+  changedIds: readonly string[],
+  removedIds: readonly string[]
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [id, value] of Object.entries(existing)) {
+    if (id && typeof value === "string" && value !== "") {
+      result[id] = value;
+    }
+  }
+
+  const removed = new Set(removedIds);
+  for (const id of changedIds) {
+    if (removed.has(id)) continue;
+    const value = incoming[id];
+    if (typeof value === "string" && value !== "") {
+      result[id] = value;
+    } else {
+      delete result[id];
+    }
+  }
+
+  for (const id of removedIds) {
+    delete result[id];
+  }
+
+  return result;
+}

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -264,9 +264,7 @@ export function mergeRecord(
     if (removed.has(id)) continue;
     // Own-property read so a `constructor`/`toString` id can't pull a function
     // off the prototype chain.
-    const value = Object.prototype.hasOwnProperty.call(incoming, id)
-      ? incoming[id]
-      : undefined;
+    const value = Object.prototype.hasOwnProperty.call(incoming, id) ? incoming[id] : undefined;
     if (typeof value === "string" && value !== "") {
       result[id] = value;
     } else {

--- a/src/clients/__tests__/projectClient.test.ts
+++ b/src/clients/__tests__/projectClient.test.ts
@@ -380,3 +380,36 @@ describe("projectClient getSettings caching", () => {
     expect(fresh).toBe(settingsB);
   });
 });
+
+describe("projectClient.setDraftInputs delta forwarding (#11352)", () => {
+  let setDraftInputsMock: ReturnType<typeof vi.fn>;
+  let client: typeof import("../projectClient").projectClient;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    setDraftInputsMock = vi.fn().mockResolvedValue(undefined);
+    typedGlobal.window = {
+      electron: {
+        project: {
+          onSwitch: vi.fn(() => () => {}),
+          setDraftInputs: setDraftInputsMock,
+        },
+      },
+    };
+    client = (await import("../projectClient")).projectClient;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("forwards changedIds and removedIds unchanged to the IPC layer", async () => {
+    await client.setDraftInputs("proj-1", { t1: "draft" }, ["t1"], ["t2"]);
+    expect(setDraftInputsMock).toHaveBeenCalledWith("proj-1", { t1: "draft" }, ["t1"], ["t2"]);
+  });
+
+  it("passes undefined delta args through for a legacy full-replace call", async () => {
+    await client.setDraftInputs("proj-1", { t1: "draft" });
+    expect(setDraftInputsMock).toHaveBeenCalledWith("proj-1", { t1: "draft" }, undefined, undefined);
+  });
+});

--- a/src/clients/__tests__/projectClient.test.ts
+++ b/src/clients/__tests__/projectClient.test.ts
@@ -410,6 +410,11 @@ describe("projectClient.setDraftInputs delta forwarding (#11352)", () => {
 
   it("passes undefined delta args through for a legacy full-replace call", async () => {
     await client.setDraftInputs("proj-1", { t1: "draft" });
-    expect(setDraftInputsMock).toHaveBeenCalledWith("proj-1", { t1: "draft" }, undefined, undefined);
+    expect(setDraftInputsMock).toHaveBeenCalledWith(
+      "proj-1",
+      { t1: "draft" },
+      undefined,
+      undefined
+    );
   });
 });

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -354,8 +354,13 @@ export const projectClient = {
     return window.electron.project.getDraftInputs(projectId);
   },
 
-  setDraftInputs: (projectId: string, draftInputs: Record<string, string>): Promise<void> => {
-    return window.electron.project.setDraftInputs(projectId, draftInputs);
+  setDraftInputs: (
+    projectId: string,
+    draftInputs: Record<string, string>,
+    changedIds?: string[],
+    removedIds?: string[]
+  ): Promise<void> => {
+    return window.electron.project.setDraftInputs(projectId, draftInputs, changedIds, removedIds);
   },
 
   getTabGroups: (projectId: string): Promise<TabGroup[]> => {

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -90,6 +90,7 @@ vi.mock("../persistence/draftInputPersistence", () => ({
     flushAll: vi.fn(),
     primeProject: vi.fn(),
     whenIdle: vi.fn(() => Promise.resolve()),
+    clearProject: vi.fn(),
   },
 }));
 
@@ -198,6 +199,7 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
   it("threads draftDelta through the outgoing switch state (#11352)", async () => {
     const { useProjectStore } = await import("../projectStore");
     const { useTerminalInputStore } = await import("../terminalInputStore");
+    const { draftInputPersistence } = await import("../persistence/draftInputPersistence");
 
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
     useTerminalInputStore.getState().setDraftInput("terminal-1", "hello", projectA.id);
@@ -205,6 +207,11 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     await useProjectStore.getState().switchProject(projectB.id);
     await Promise.resolve();
 
+    // computeDelta receives the outgoing project's id and its live draft
+    // snapshot (not a hand-fed fixture) — proving the real capture flows in.
+    expect(draftInputPersistence.computeDelta).toHaveBeenCalledWith(projectA.id, {
+      "terminal-1": "hello",
+    });
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
       expect.objectContaining({ draftDelta: { changedIds: ["terminal-1"], removedIds: [] } }),

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -84,6 +84,15 @@ vi.mock("../persistence/panelPersistence", () => ({
   })),
 }));
 
+vi.mock("../persistence/draftInputPersistence", () => ({
+  draftInputPersistence: {
+    computeDelta: vi.fn(() => ({ changedIds: ["terminal-1"], removedIds: [] })),
+    flushAll: vi.fn(),
+    primeProject: vi.fn(),
+    whenIdle: vi.fn(() => Promise.resolve()),
+  },
+}));
+
 vi.mock("@/lib/notify", () => ({
   notify: vi.fn(),
 }));
@@ -182,6 +191,23 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
       expect.objectContaining({ draftInputs: { "terminal-1": "hello world" } }),
+      undefined
+    );
+  });
+
+  it("threads draftDelta through the outgoing switch state (#11352)", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    const { useTerminalInputStore } = await import("../terminalInputStore");
+
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+    useTerminalInputStore.getState().setDraftInput("terminal-1", "hello", projectA.id);
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await Promise.resolve();
+
+    expect(projectClientMock.switch).toHaveBeenCalledWith(
+      projectB.id,
+      expect.objectContaining({ draftDelta: { changedIds: ["terminal-1"], removedIds: [] } }),
       undefined
     );
   });

--- a/src/store/__tests__/terminalInputStore.test.ts
+++ b/src/store/__tests__/terminalInputStore.test.ts
@@ -663,6 +663,31 @@ describe("terminalInputStore", () => {
     });
   });
 
+  describe("getDraftProjectIds (#11352)", () => {
+    it("returns the distinct project ids that hold a draft", () => {
+      const store = useTerminalInputStore.getState();
+      store.setDraftInput("term-1", "a", "project-a");
+      store.setDraftInput("term-2", "b", "project-a");
+      store.setDraftInput("term-3", "c", "project-b");
+
+      expect(new Set(useTerminalInputStore.getState().getDraftProjectIds())).toEqual(
+        new Set(["project-a", "project-b"])
+      );
+    });
+
+    it("returns an empty array when no drafts exist", () => {
+      expect(useTerminalInputStore.getState().getDraftProjectIds()).toEqual([]);
+    });
+
+    it("ignores bare terminal-id keys with no project context", () => {
+      const store = useTerminalInputStore.getState();
+      store.setDraftInput("term-1", "no project"); // key is just the terminalId
+      store.setDraftInput("term-2", "scoped", "project-a");
+
+      expect(useTerminalInputStore.getState().getDraftProjectIds()).toEqual(["project-a"]);
+    });
+  });
+
   describe("restoreProjectDraftInputs", () => {
     it("should restore drafts with the project prefix", () => {
       useTerminalInputStore.getState().restoreProjectDraftInputs("project-a", {

--- a/src/store/listeners/panel/__tests__/resource.test.ts
+++ b/src/store/listeners/panel/__tests__/resource.test.ts
@@ -6,6 +6,11 @@ vi.mock("@/store/slices", () => ({
   flushPanelPersistence: flushPanelPersistenceMock,
 }));
 
+const flushDraftsMock = vi.hoisted(() => vi.fn());
+vi.mock("@/store/persistence/draftInputPersistence", () => ({
+  draftInputPersistence: { flushAll: flushDraftsMock },
+}));
+
 vi.mock("@/store/resourceMonitoringStore", () => ({
   useResourceMonitoringStore: {
     getState: () => ({ enabled: false, updateMetrics: vi.fn() }),
@@ -32,13 +37,14 @@ describe("setupResourceListeners — persistence flush on hide (#9914)", () => {
     setHidden(false);
   });
 
-  it("flushes panel persistence when the document becomes hidden", () => {
+  it("flushes panel and draft persistence when the document becomes hidden", () => {
     const d = setupResourceListeners();
 
     setHidden(true);
     document.dispatchEvent(new Event("visibilitychange"));
 
     expect(flushPanelPersistenceMock).toHaveBeenCalledTimes(1);
+    expect(flushDraftsMock).toHaveBeenCalledTimes(1);
     d.dispose();
   });
 
@@ -49,6 +55,7 @@ describe("setupResourceListeners — persistence flush on hide (#9914)", () => {
     document.dispatchEvent(new Event("visibilitychange"));
 
     expect(flushPanelPersistenceMock).not.toHaveBeenCalled();
+    expect(flushDraftsMock).not.toHaveBeenCalled();
     d.dispose();
   });
 
@@ -60,13 +67,15 @@ describe("setupResourceListeners — persistence flush on hide (#9914)", () => {
     document.dispatchEvent(new Event("visibilitychange"));
 
     expect(flushPanelPersistenceMock).not.toHaveBeenCalled();
+    expect(flushDraftsMock).not.toHaveBeenCalled();
   });
 
-  it("flushes immediately when the document is already hidden at registration", () => {
+  it("flushes both immediately when the document is already hidden at registration", () => {
     setHidden(true);
     const d = setupResourceListeners();
 
     expect(flushPanelPersistenceMock).toHaveBeenCalledTimes(1);
+    expect(flushDraftsMock).toHaveBeenCalledTimes(1);
     d.dispose();
   });
 

--- a/src/store/listeners/panel/resource.ts
+++ b/src/store/listeners/panel/resource.ts
@@ -1,5 +1,6 @@
 import { useResourceMonitoringStore } from "@/store/resourceMonitoringStore";
 import { flushPanelPersistence } from "@/store/slices";
+import { draftInputPersistence } from "@/store/persistence/draftInputPersistence";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 
 export function setupResourceListeners(): DisposableStore {
@@ -17,15 +18,22 @@ export function setupResourceListeners(): DisposableStore {
     )
   );
 
-  // Flush pending terminal persistence before the view is torn down to
-  // prevent data loss. `beforeunload` does NOT fire on WebContentsView detach
-  // (project switch, window close, app quit) in Electron — `visibilitychange`
-  // is the reliable signal, firing on detach while the renderer is still alive
-  // and IPC channels are open, so the async flush completes (#9914). Matches
-  // the pattern documented in `useFlushOnHide`.
+  // Flush pending terminal persistence — panel/tab-group layout and draft
+  // inputs (#11352) — before the view is torn down to prevent data loss.
+  // `beforeunload` does NOT fire on WebContentsView detach (project switch,
+  // single-window close) in Electron — `visibilitychange` is the reliable
+  // signal, firing on detach while the renderer is still alive and IPC channels
+  // are open, so the async flush completes (#9914). Matches the pattern
+  // documented in `useFlushOnHide`. (Full app quit ends in `app.exit()`, which
+  // may not surface a renderer visibility flush — that gap is pre-existing and
+  // shared with panel persistence, out of scope here.)
+  const flushOnHide = () => {
+    flushPanelPersistence();
+    draftInputPersistence.flushAll();
+  };
   const handleVisibilityChange = () => {
     if (!document.hidden) return;
-    flushPanelPersistence();
+    flushOnHide();
   };
   document.addEventListener("visibilitychange", handleVisibilityChange);
   d.add(
@@ -33,7 +41,7 @@ export function setupResourceListeners(): DisposableStore {
   );
   // Cover the race where the document is already hidden when listeners
   // register (e.g. a fast project switch between render and this effect).
-  if (document.hidden) flushPanelPersistence();
+  if (document.hidden) flushOnHide();
 
   return d;
 }

--- a/src/store/persistence/__tests__/draftInputPersistence.test.ts
+++ b/src/store/persistence/__tests__/draftInputPersistence.test.ts
@@ -182,31 +182,17 @@ describe("draftInputPersistence.flushAll — close-time draft flush (#11352)", (
     expect(new Set(setDraftInputsMock.mock.calls[1]![2] as string[])).toEqual(new Set(["t1", "t2"]));
   });
 
-  it("clearProject stops a teardown flush from recreating a deleted project's state", async () => {
+  it("clearProject forgets a project's baseline so it is no longer enumerated", async () => {
     const projectId = freshProjectId();
-    // Hydrated draft on disk, then the close path wiped the live drafts.
     draftInputPersistence.primeProject(projectId, { t1: "on disk" });
     draftInputPersistence.clearProject(projectId);
 
+    // With the baseline forgotten and no live drafts, flushAll has nothing to
+    // enumerate for this project.
     draftInputPersistence.flushAll();
     await draftInputPersistence.whenIdle();
 
     expect(setDraftInputsMock).not.toHaveBeenCalled();
-  });
-
-  it("without clearProject a wiped-store project still tombstones from its baseline (the hazard)", async () => {
-    const projectId = freshProjectId();
-    // Baseline retained but live drafts wiped (e.g. clearAllDraftInputs on
-    // close) — flushAll enumerates the project via its baseline and emits a
-    // removal that would recreate the just-deleted state file. This is exactly
-    // what clearProject in the close/remove paths prevents.
-    draftInputPersistence.primeProject(projectId, { t1: "on disk" });
-
-    draftInputPersistence.flushAll();
-    await draftInputPersistence.whenIdle();
-
-    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
-    expect(setDraftInputsMock.mock.calls[0]![3]).toEqual(["t1"]); // removedIds tombstone
   });
 
   it("flushes each project independently", async () => {

--- a/src/store/persistence/__tests__/draftInputPersistence.test.ts
+++ b/src/store/persistence/__tests__/draftInputPersistence.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const setDraftInputsMock =
+  vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve()));
+
+vi.mock("@/clients", () => ({
+  projectClient: { setDraftInputs: setDraftInputsMock },
+}));
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+const { draftInputPersistence } = await import("../draftInputPersistence");
+const { useTerminalInputStore } = await import("@/store/terminalInputStore");
+
+let projectSeq = 0;
+const createdProjectIds: string[] = [];
+function freshProjectId(): string {
+  projectSeq += 1;
+  const id = `proj-${projectSeq}`;
+  createdProjectIds.push(id);
+  return id;
+}
+
+function setDraft(projectId: string, terminalId: string, value: string): void {
+  useTerminalInputStore.getState().setDraftInput(terminalId, value, projectId);
+}
+
+beforeEach(() => {
+  setDraftInputsMock.mockClear();
+  setDraftInputsMock.mockImplementation(() => Promise.resolve());
+  useTerminalInputStore.setState({ draftInputs: new Map() });
+});
+
+afterEach(async () => {
+  // The persistence singleton's baselines accumulate across tests; flushAll
+  // enumerates them, so drop this test's projects to keep tests isolated.
+  await draftInputPersistence.whenIdle();
+  for (const id of createdProjectIds) {
+    draftInputPersistence.clearProject(id);
+  }
+  createdProjectIds.length = 0;
+});
+
+describe("draftInputPersistence.flushAll — close-time draft flush (#11352)", () => {
+  it("persists a new draft as a changed key with no baseline", async () => {
+    const projectId = freshProjectId();
+    setDraft(projectId, "t1", "half-written prompt");
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+    const [pid, drafts, changedIds, removedIds] = setDraftInputsMock.mock.calls[0]!;
+    expect(pid).toBe(projectId);
+    expect(drafts).toEqual({ t1: "half-written prompt" });
+    expect(changedIds).toEqual(["t1"]);
+    expect(removedIds).toEqual([]);
+  });
+
+  it("emits a removal tombstone when a hydrated draft is cleared, even though current is empty", async () => {
+    const projectId = freshProjectId();
+    // Simulate hydration priming the baseline from the on-disk record.
+    draftInputPersistence.primeProject(projectId, { t1: "on disk" });
+    // User clears it this session — the live map no longer holds it.
+    // (No setDraft call; getProjectDraftInputs returns {}.)
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+    const [pid, drafts, changedIds, removedIds] = setDraftInputsMock.mock.calls[0]!;
+    expect(pid).toBe(projectId);
+    expect(drafts).toEqual({});
+    expect(changedIds).toEqual([]);
+    expect(removedIds).toEqual(["t1"]);
+  });
+
+  it("does not write when the current drafts already equal the baseline", async () => {
+    const projectId = freshProjectId();
+    setDraft(projectId, "t1", "same");
+    draftInputPersistence.primeProject(projectId, { t1: "same" });
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).not.toHaveBeenCalled();
+  });
+
+  it("advances the baseline on success so an unchanged re-flush is a no-op", async () => {
+    const projectId = freshProjectId();
+    setDraft(projectId, "t1", "v1");
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+    // No new draft change, baseline advanced → still just the one write.
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the baseline unchanged on failure so the next flush resends", async () => {
+    const projectId = freshProjectId();
+    setDraft(projectId, "t1", "retry-me");
+    setDraftInputsMock.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+    // First write rejected → baseline not advanced → resent.
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(2);
+    expect(setDraftInputsMock.mock.calls[1]![2]).toEqual(["t1"]);
+  });
+
+  it("flushes each project independently", async () => {
+    const projectA = freshProjectId();
+    const projectB = freshProjectId();
+    setDraft(projectA, "a1", "alpha");
+    setDraft(projectB, "b1", "beta");
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(2);
+    const byProject = new Map(setDraftInputsMock.mock.calls.map((c) => [c[0], c[1]]));
+    expect(byProject.get(projectA)).toEqual({ a1: "alpha" });
+    expect(byProject.get(projectB)).toEqual({ b1: "beta" });
+  });
+});
+
+describe("draftInputPersistence.computeDelta / primeProject", () => {
+  it("computes the delta a switch caller sends, diffed against the primed baseline", () => {
+    const projectId = freshProjectId();
+    draftInputPersistence.primeProject(projectId, { t1: "old", t2: "gone" });
+
+    const delta = draftInputPersistence.computeDelta(projectId, { t1: "new", t3: "added" });
+    expect(new Set(delta.changedIds)).toEqual(new Set(["t1", "t3"]));
+    expect(delta.removedIds).toEqual(["t2"]);
+  });
+
+  it("does not overwrite an already-established baseline on a late prime", async () => {
+    const projectId = freshProjectId();
+    setDraft(projectId, "t1", "live");
+    // First flush establishes baseline {t1:"live"}.
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+    setDraftInputsMock.mockClear();
+
+    // A late hydration result must not clobber the acknowledged baseline.
+    draftInputPersistence.primeProject(projectId, { t1: "stale-from-disk" });
+    const delta = draftInputPersistence.computeDelta(projectId, { t1: "live" });
+    expect(delta.changedIds).toEqual([]);
+    expect(delta.removedIds).toEqual([]);
+  });
+});

--- a/src/store/persistence/__tests__/draftInputPersistence.test.ts
+++ b/src/store/persistence/__tests__/draftInputPersistence.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const setDraftInputsMock =
-  vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve()));
+const setDraftInputsMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      projectId: string,
+      draftInputs: Record<string, string>,
+      changedIds?: string[],
+      removedIds?: string[]
+    ) => Promise<void>
+  >(() => Promise.resolve())
+);
 
 vi.mock("@/clients", () => ({
   projectClient: { setDraftInputs: setDraftInputsMock },
@@ -179,7 +187,7 @@ describe("draftInputPersistence.flushAll — close-time draft flush (#11352)", (
 
     // #1 rejected → baseline unchanged; #2 proceeds and resends both drafts.
     expect(setDraftInputsMock).toHaveBeenCalledTimes(2);
-    expect(new Set(setDraftInputsMock.mock.calls[1]![2] as string[])).toEqual(new Set(["t1", "t2"]));
+    expect(new Set(setDraftInputsMock.mock.calls[1]![2])).toEqual(new Set(["t1", "t2"]));
   });
 
   it("clearProject forgets a project's baseline so it is no longer enumerated", async () => {

--- a/src/store/persistence/__tests__/draftInputPersistence.test.ts
+++ b/src/store/persistence/__tests__/draftInputPersistence.test.ts
@@ -24,6 +24,12 @@ function setDraft(projectId: string, terminalId: string, value: string): void {
   useTerminalInputStore.getState().setDraftInput(terminalId, value, projectId);
 }
 
+// Drain the microtask queue so a fire-and-forget flush's queued send actually
+// reaches the mocked projectClient before we assert on it.
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   setDraftInputsMock.mockClear();
   setDraftInputsMock.mockImplementation(() => Promise.resolve());
@@ -113,6 +119,94 @@ describe("draftInputPersistence.flushAll — close-time draft flush (#11352)", (
     // First write rejected → baseline not advanced → resent.
     expect(setDraftInputsMock).toHaveBeenCalledTimes(2);
     expect(setDraftInputsMock.mock.calls[1]![2]).toEqual(["t1"]);
+  });
+
+  it("serializes overlapping same-project flushes so the second diffs against the advanced baseline", async () => {
+    const projectId = freshProjectId();
+    // Prime a baseline (as hydration would) so the project stays enumerable via
+    // its baseline even after its only live draft is cleared.
+    draftInputPersistence.primeProject(projectId, { t1: "seed" });
+    let resolveFirst!: () => void;
+    const firstSend = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+    setDraftInputsMock.mockImplementationOnce(() => firstSend);
+
+    setDraft(projectId, "t1", "draft");
+    draftInputPersistence.flushAll(); // send #1 — stays pending
+    await flushMicrotasks();
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+    expect(setDraftInputsMock.mock.calls[0]![2]).toEqual(["t1"]); // changedIds
+
+    // Clear the draft and flush again BEFORE #1 resolves. Without the write
+    // tail the second flush would diff against the original empty baseline and
+    // omit the removal tombstone entirely.
+    useTerminalInputStore.getState().setDraftInput("t1", "", projectId);
+    draftInputPersistence.flushAll();
+    await flushMicrotasks();
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1); // queued behind #1
+
+    resolveFirst();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(2);
+    const [pid, drafts, changedIds, removedIds] = setDraftInputsMock.mock.calls[1]!;
+    expect(pid).toBe(projectId);
+    expect(drafts).toEqual({});
+    expect(changedIds).toEqual([]);
+    expect(removedIds).toEqual(["t1"]);
+  });
+
+  it("resumes a queued flush after the in-flight one rejects", async () => {
+    const projectId = freshProjectId();
+    let rejectFirst!: (e: Error) => void;
+    const firstSend = new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    setDraftInputsMock.mockImplementationOnce(() => firstSend);
+
+    setDraft(projectId, "t1", "one");
+    draftInputPersistence.flushAll(); // #1 pending
+    await flushMicrotasks();
+
+    setDraft(projectId, "t2", "two");
+    draftInputPersistence.flushAll(); // queued behind #1
+    await flushMicrotasks();
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+
+    rejectFirst(new Error("boom"));
+    await draftInputPersistence.whenIdle();
+
+    // #1 rejected → baseline unchanged; #2 proceeds and resends both drafts.
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(2);
+    expect(new Set(setDraftInputsMock.mock.calls[1]![2] as string[])).toEqual(new Set(["t1", "t2"]));
+  });
+
+  it("clearProject stops a teardown flush from recreating a deleted project's state", async () => {
+    const projectId = freshProjectId();
+    // Hydrated draft on disk, then the close path wiped the live drafts.
+    draftInputPersistence.primeProject(projectId, { t1: "on disk" });
+    draftInputPersistence.clearProject(projectId);
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).not.toHaveBeenCalled();
+  });
+
+  it("without clearProject a wiped-store project still tombstones from its baseline (the hazard)", async () => {
+    const projectId = freshProjectId();
+    // Baseline retained but live drafts wiped (e.g. clearAllDraftInputs on
+    // close) — flushAll enumerates the project via its baseline and emits a
+    // removal that would recreate the just-deleted state file. This is exactly
+    // what clearProject in the close/remove paths prevents.
+    draftInputPersistence.primeProject(projectId, { t1: "on disk" });
+
+    draftInputPersistence.flushAll();
+    await draftInputPersistence.whenIdle();
+
+    expect(setDraftInputsMock).toHaveBeenCalledTimes(1);
+    expect(setDraftInputsMock.mock.calls[0]![3]).toEqual(["t1"]); // removedIds tombstone
   });
 
   it("flushes each project independently", async () => {

--- a/src/store/persistence/draftInputPersistence.ts
+++ b/src/store/persistence/draftInputPersistence.ts
@@ -1,0 +1,114 @@
+import { projectClient } from "@/clients";
+import { useTerminalInputStore } from "@/store/terminalInputStore";
+import { computeRecordDelta, type IdArrayDelta } from "@shared/utils/layoutMerge";
+import { logError } from "@/utils/logger";
+
+/**
+ * Renderer-owned persistence for terminal draft inputs (#11352).
+ *
+ * Drafts (unsent compose text) live only in `terminalInputStore`. A project
+ * switch relays them into outgoing state, but window/view teardown never
+ * persisted them, so a half-written prompt was lost when the window closed.
+ * This module flushes drafts on view teardown (via `resource.ts`'s
+ * `visibilitychange` handler) using the same merge-safe delta contract the
+ * layout persistence uses for terminals/tab groups: the writer sends what it
+ * changed relative to its last-acknowledged baseline so Main merges concurrent
+ * writes from sibling windows of the same project instead of clobbering them.
+ *
+ * The baseline (`persistedByProject`) is separate from the Zustand store on
+ * purpose: a cleared/sent draft is dropped from the live map entirely, so a
+ * removal tombstone can only be derived by diffing the current record against a
+ * remembered prior key set. Keeping the baseline out of the store also means
+ * `clearAllDraftInputs` can't accidentally erase the very key set that produces
+ * those tombstones. Seed it from hydration via {@link primeProject}.
+ */
+class DraftInputPersistence {
+  private readonly persistedByProject = new Map<string, Record<string, string>>();
+  // Per-project write tail: each flush chains its delta computation and send
+  // onto the previous write for the same project so the baseline advances in
+  // send order and overlapping flushes never diff against a stale baseline
+  // (mirrors PanelPersistence, #11350/#11352). Rejections are swallowed so a
+  // failed write never blocks the next one.
+  private readonly writeTailByProject = new Map<string, Promise<void>>();
+
+  /**
+   * Seed the last-persisted baseline from hydration, before drafts are restored
+   * into the store. Primes even for an empty record so that clearing a
+   * hydrated draft later produces a proper `removedIds` tombstone rather than
+   * silently resurrecting on next load. Only primes if not already present so a
+   * late hydration result can't overwrite an already-acknowledged live write.
+   */
+  primeProject(projectId: string, drafts: Record<string, string>): void {
+    if (this.persistedByProject.has(projectId)) return;
+    this.persistedByProject.set(projectId, { ...drafts });
+  }
+
+  /**
+   * Delta a caller outside this module (the synchronous project-switch outgoing
+   * capture) should send so Main merges drafts by key instead of full-replacing
+   * and clobbering a sibling window's drafts (#11352).
+   */
+  computeDelta(projectId: string, current: Record<string, string>): IdArrayDelta {
+    return computeRecordDelta(this.persistedByProject.get(projectId) ?? {}, current);
+  }
+
+  /**
+   * Persist drafts for every project the store currently holds — plus any
+   * project with a baseline (so a project whose drafts were all cleared still
+   * emits its tombstones). Called on view teardown.
+   */
+  flushAll(): void {
+    const state = useTerminalInputStore.getState();
+    const projectIds = new Set<string>(state.getDraftProjectIds());
+    for (const projectId of this.persistedByProject.keys()) {
+      projectIds.add(projectId);
+    }
+    for (const projectId of projectIds) {
+      this.flushProject(projectId, state.getProjectDraftInputs(projectId));
+    }
+  }
+
+  private flushProject(projectId: string, current: Record<string, string>): void {
+    // Snapshot synchronously — the map may mutate before the queued send runs.
+    const snapshot = { ...current };
+    const prior = this.writeTailByProject.get(projectId) ?? Promise.resolve();
+    const run = prior
+      .catch(() => {})
+      .then(async () => {
+        const { changedIds, removedIds } = computeRecordDelta(
+          this.persistedByProject.get(projectId) ?? {},
+          snapshot
+        );
+        if (changedIds.length === 0 && removedIds.length === 0) {
+          return;
+        }
+        try {
+          await projectClient.setDraftInputs(projectId, snapshot, changedIds, removedIds);
+          this.persistedByProject.set(projectId, snapshot);
+        } catch (error) {
+          // Leave the baseline untouched so the next flush resends the
+          // unacknowledged delta.
+          logError("Failed to persist draft inputs", error);
+          throw error;
+        }
+      });
+    this.writeTailByProject.set(
+      projectId,
+      run.catch(() => {})
+    );
+    // Prevent an unhandled rejection warning for the background send.
+    run.catch(() => {});
+  }
+
+  /** Await all in-flight per-project writes. Primarily for tests. */
+  async whenIdle(): Promise<void> {
+    await Promise.all(this.writeTailByProject.values());
+  }
+
+  /** Drop a project's baseline (project removed, or test cleanup). */
+  clearProject(projectId: string): void {
+    this.persistedByProject.delete(projectId);
+  }
+}
+
+export const draftInputPersistence = new DraftInputPersistence();

--- a/src/store/persistence/draftInputPersistence.ts
+++ b/src/store/persistence/draftInputPersistence.ts
@@ -105,9 +105,17 @@ class DraftInputPersistence {
     await Promise.all(this.writeTailByProject.values());
   }
 
-  /** Drop a project's baseline (project removed, or test cleanup). */
+  /**
+   * Drop a project's persisted baseline and pending write tail. Call this when
+   * the project's durable state is intentionally deleted (close-with-kill,
+   * project removal) so a later teardown {@link flushAll} does not recreate the
+   * just-deleted state from a stale baseline (#11352). The caller must clear the
+   * live drafts from the store in the same synchronous step, otherwise the next
+   * flush would resend them; the panel-store close path already does.
+   */
   clearProject(projectId: string): void {
     this.persistedByProject.delete(projectId);
+    this.writeTailByProject.delete(projectId);
   }
 }
 

--- a/src/store/persistence/draftInputPersistence.ts
+++ b/src/store/persistence/draftInputPersistence.ts
@@ -106,12 +106,11 @@ class DraftInputPersistence {
   }
 
   /**
-   * Drop a project's persisted baseline and pending write tail. Call this when
-   * the project's durable state is intentionally deleted (close-with-kill,
-   * project removal) so a later teardown {@link flushAll} does not recreate the
-   * just-deleted state from a stale baseline (#11352). The caller must clear the
-   * live drafts from the store in the same synchronous step, otherwise the next
-   * flush would resend them; the panel-store close path already does.
+   * Forget a project's persisted baseline and pending write tail. Recreation of
+   * a project's deleted state file by a late teardown flush is prevented in Main
+   * (the `setDraftInputs` handler skips a pure-removal write when no state
+   * exists), so this is not required on the close/remove paths; it exists for
+   * test cleanup and callers that need to reset a project's draft-flush state.
    */
   clearProject(projectId: string): void {
     this.persistedByProject.delete(projectId);

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -845,11 +845,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       clearFleetArmingThroughAccessor();
       set({ currentProject: null, worktreeLoadError: null });
       clearPanelStoreForSwitchThroughAccessor();
-      // clearPanelStoreForSwitchThroughAccessor emptied the live drafts; drop
-      // the persisted baseline in the SAME synchronous step so a teardown
-      // visibility flush computes an empty delta instead of tombstoning the
-      // baseline and recreating the state file main just deleted (#11352).
-      draftInputPersistence.clearProject(projectId);
       await get().loadProjects();
 
       return result;

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -845,6 +845,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       clearFleetArmingThroughAccessor();
       set({ currentProject: null, worktreeLoadError: null });
       clearPanelStoreForSwitchThroughAccessor();
+      // clearPanelStoreForSwitchThroughAccessor emptied the live drafts; drop
+      // the persisted baseline in the SAME synchronous step so a teardown
+      // visibility flush computes an empty delta instead of tombstoning the
+      // baseline and recreating the state file main just deleted (#11352).
+      draftInputPersistence.clearProject(projectId);
       await get().loadProjects();
 
       return result;

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -11,6 +11,7 @@ import { useHelpPanelStore } from "./helpPanelStore";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistence";
+import { draftInputPersistence } from "./persistence/draftInputPersistence";
 import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -45,6 +46,11 @@ function shouldPersistTerminal(t: NonNullable<CarrierPanel>): boolean {
 
 function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   const draftInputs = useTerminalInputStore.getState().getProjectDraftInputs(projectId);
+  // Diff against this window's last-persisted baseline so Main merges drafts by
+  // terminal id rather than full-replacing — otherwise a stale outgoing snapshot
+  // silently drops a sibling window's concurrent drafts (#11352). Same delta
+  // contract as terminals/tab groups.
+  const draftDelta = draftInputPersistence.computeDelta(projectId, draftInputs);
   // Persist the *durable* selection, not whatever is incidentally active. A
   // focus promotion (e.g. a temporary PR worktree spun up by a batch merge)
   // leaves `restoreWorktreeId` pointing at the last deliberate selection, so it
@@ -64,7 +70,7 @@ function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   // flushed yet.  Uses the same filter as PanelPersistence.save().
   const terminalState = getPanelStoreSnapshot();
   if (!terminalState) {
-    return { draftInputs, activeWorktreeId };
+    return { draftInputs, draftDelta, activeWorktreeId };
   }
 
   const { panelsById, panelIds, tabGroups } = terminalState;
@@ -97,6 +103,7 @@ function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
     activeWorktreeId,
     terminalDelta,
     tabGroupDelta,
+    draftDelta,
   };
 }
 

--- a/src/store/terminalInputStore.ts
+++ b/src/store/terminalInputStore.ts
@@ -149,6 +149,9 @@ export interface TerminalInputState {
   resetForProjectSwitch: (projectId: string, preserveTerminalIds?: Set<string>) => void;
   getProjectDraftInputs: (projectId: string) => Record<string, string>;
   restoreProjectDraftInputs: (projectId: string, inputs: Record<string, string>) => void;
+  /** Distinct project ids that currently hold at least one draft key. Used by
+   *  the close-time draft flush to know which projects to persist (#11352). */
+  getDraftProjectIds: () => string[];
 }
 
 export const useTerminalInputStore = create<TerminalInputState>()((set, get) => ({
@@ -517,4 +520,17 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
       }
       return { draftInputs: newDraftInputs };
     }),
+
+  getDraftProjectIds: () => {
+    const ids = new Set<string>();
+    for (const key of get().draftInputs.keys()) {
+      // Composite keys are `${projectId}:${terminalId}`; a bare terminalId key
+      // (no project context) has no per-project persistence target, so skip it.
+      const idx = key.indexOf(":");
+      if (idx > 0) {
+        ids.add(key.slice(0, idx));
+      }
+    }
+    return [...ids];
+  },
 }));

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -19,6 +19,7 @@ import { inferKind } from "./statePatcher";
 import { RECONNECT_TIMEOUT_MS } from "./reconnectManager";
 import type { ActionFrecencyEntry, ActionUsageEntry } from "@shared/types/actions";
 import { panelPersistence } from "@/store/persistence/panelPersistence";
+import { draftInputPersistence } from "@/store/persistence/draftInputPersistence";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { logDebug, logInfo, logWarn, logError } from "@/utils/logger";
 import { PERF_MARKS } from "@shared/perf/marks";
@@ -351,6 +352,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     if (currentProjectId) {
       try {
         const draftInputs = await draftInputsPromise;
+        // Seed the close-flush baseline from the authoritative on-disk record
+        // (even when empty) BEFORE restoring into the store, so a later clear of
+        // a hydrated draft yields a removal tombstone instead of resurrecting on
+        // next load (#11352).
+        draftInputPersistence.primeProject(currentProjectId, draftInputs);
         if (Object.keys(draftInputs).length > 0) {
           useTerminalInputStore.getState().restoreProjectDraftInputs(currentProjectId, draftInputs);
         }


### PR DESCRIPTION
## Summary
- Typed but unsent terminal drafts were lost when the window closed. They lived only in the in-memory `terminalInputStore`; a project switch relayed them into outgoing state, but view teardown never persisted them.
- Drafts now flush on view teardown through the existing `visibilitychange` handler in `resource.ts`, alongside the panel-persistence flush. `beforeunload`/`pagehide` don't fire reliably on Electron 42 `WebContentsView` detach, so `visibilitychange` is the reliable signal (`#9914`).
- Both main-process writers were changed from whole-record overwrites to merge-safe writes, so a sibling window's concurrent drafts survive.

Resolves #11352

## Changes
- New `draftInputPersistence` module: tracks a per-project last-persisted baseline (primed from hydration) so a cleared or sent draft emits a removal tombstone via `changedIds`/`removedIds` instead of resurrecting on reload, plus a per-project write tail that serializes overlapping flushes.
- `mergeRecord`/`computeRecordDelta` added to `layoutMerge`, mirroring the `mergeIdArray` contract from `#11350`, so draft writes merge by terminal id.
- `setDraftInputs` handler and the project-switch persist path both moved from whole-record overwrites to merge-safe writes.
- `setDraftInputs` now returns `null` (skips the save) when no state exists and the merged record is empty, so a late teardown flush can't recreate a closed or removed project's just-deleted state file.
- IPC types regenerated (`npm run codegen:ipc`).

## Testing
- Added/updated: `layoutMerge` record helpers, the new `draftInputPersistence` module (baseline, tombstone, write-tail, failure/retry), resource flush wiring, `getDraftProjectIds`, main handler merge and deleted-state guard, switch-path merge, `projectClient` delta forwarding, switch `draftDelta` threading.
- 261 targeted tests pass locally.