### PR TITLE
fix(worktree): restore terminals when a delete is abandoned (#11344)

### DIFF
--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -5,6 +5,7 @@ import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 import { AlertTriangle, Trash2 } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
 import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
+import { collectRunningAgentTerminals } from "@/utils/destructiveSessionConfirm";
 import { deriveEffectiveTier } from "@/services/actions/deriveEffectiveTier";
 import {
   buildWorktreeDeletePreview,
@@ -57,7 +58,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     };
   }, []);
 
-  const { counts: terminalCounts } = useWorktreeTerminals(worktree.id);
+  const { counts: terminalCounts, terminals } = useWorktreeTerminals(worktree.id);
+  // Surface the risk-relevant subset (agents mid-work) in the D2 preview instead
+  // of a bare total — closing an idle shell is cheap, interrupting a running
+  // agent is not (#11344, mirrors the tracked/untracked split from #4927).
+  const runningAgentCount = collectRunningAgentTerminals(terminals).length;
 
   // Preview + tier derive from the FRESH fetch when available, else the prop
   // snapshot as an initial seed. A failed fetch fails closed via
@@ -344,6 +349,9 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               >
                 {terminalCounts.total} terminal{terminalCounts.total === 1 ? "" : "s"} will be
                 closed
+                {runningAgentCount > 0
+                  ? ` (${runningAgentCount} running an agent)`
+                  : ""}
               </li>
               <li
                 className={cn(

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -349,9 +349,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               >
                 {terminalCounts.total} terminal{terminalCounts.total === 1 ? "" : "s"} will be
                 closed
-                {runningAgentCount > 0
-                  ? ` (${runningAgentCount} running an agent)`
-                  : ""}
+                {runningAgentCount > 0 ? ` (${runningAgentCount} running an agent)` : ""}
               </li>
               <li
                 className={cn(

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -16,13 +16,19 @@ vi.stubGlobal(
   }
 );
 
-const { startDeleteMock, terminalCountsMock, devPreviewGetByWorktreeMock, buildPreviewMock } =
-  vi.hoisted(() => ({
-    startDeleteMock: vi.fn(),
-    terminalCountsMock: { total: 0 },
-    devPreviewGetByWorktreeMock: vi.fn(),
-    buildPreviewMock: vi.fn(),
-  }));
+const {
+  startDeleteMock,
+  terminalCountsMock,
+  terminalsMock,
+  devPreviewGetByWorktreeMock,
+  buildPreviewMock,
+} = vi.hoisted(() => ({
+  startDeleteMock: vi.fn(),
+  terminalCountsMock: { total: 0 },
+  terminalsMock: [] as Array<{ running?: boolean }>,
+  devPreviewGetByWorktreeMock: vi.fn(),
+  buildPreviewMock: vi.fn(),
+}));
 
 // Mock only the fresh-fetch builder; keep `summarizeWorktreeChanges` real so
 // the prop-seed path (existing render assertions) is exercised unchanged.
@@ -47,7 +53,14 @@ vi.mock("@/store/createWorktreeStore", () => ({
 }));
 
 vi.mock("@/hooks/useWorktreeTerminals", () => ({
-  useWorktreeTerminals: () => ({ counts: terminalCountsMock }),
+  useWorktreeTerminals: () => ({ counts: terminalCountsMock, terminals: terminalsMock }),
+}));
+
+// Agent detection is covered by its own unit suite; here we just steer the
+// running-agent subset directly so the D2 preview breakdown can be asserted.
+vi.mock("@/utils/destructiveSessionConfirm", () => ({
+  collectRunningAgentTerminals: (terminals: Array<{ running?: boolean }>) =>
+    terminals.filter((t) => t.running),
 }));
 
 vi.mock("@/components/ui/AppDialog", () => {
@@ -146,6 +159,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -313,6 +327,7 @@ describe("WorktreeDeleteDialog — body copy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -361,6 +376,25 @@ describe("WorktreeDeleteDialog — body copy", () => {
 
     expect(screen.getByText(/1 terminal will be closed/)).toBeDefined();
     expect(screen.queryByText(/1 terminals/)).toBeNull();
+  });
+
+  it("breaks out running agents in the terminals row when any are mid-work (#11344)", () => {
+    terminalCountsMock.total = 3;
+    terminalsMock.push({ running: true }, { running: true }, { running: false });
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.getByText(/3 terminals will be closed \(2 running an agent\)/)).toBeDefined();
+  });
+
+  it("omits the running-agent breakdown when no agent is mid-work", () => {
+    terminalCountsMock.total = 2;
+    terminalsMock.push({ running: false }, { running: false });
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.getByText(/2 terminals will be closed/)).toBeDefined();
+    expect(screen.queryByText(/running an agent/)).toBeNull();
   });
 
   it("renders the terminals row inactive when closeTerminals is unchecked", () => {
@@ -497,6 +531,7 @@ describe("WorktreeDeleteDialog — medium tier (no name confirmation)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -551,6 +586,7 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -719,6 +755,7 @@ describe("WorktreeDeleteDialog — immediate dismiss", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -754,6 +791,7 @@ describe("WorktreeDeleteDialog — dev preview disclosure (#9084)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -827,6 +865,7 @@ describe("WorktreeDeleteDialog — state reset", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     // Default: no fresh override → dialog uses the prop seed (existing tests).
     buildPreviewMock.mockResolvedValue(null);
@@ -863,6 +902,7 @@ describe("WorktreeDeleteDialog — fresh status verification (#11343)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalCountsMock.total = 0;
+    terminalsMock.length = 0;
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
     buildPreviewMock.mockResolvedValue(null);
   });

--- a/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
@@ -42,19 +42,19 @@ import {
 } from "@/components/Worktree/worktreeDeleteHelper";
 
 const getInfoMock = vi.fn<(id: string) => Promise<{ hasPty: boolean }>>();
-(globalThis as Record<string, unknown>).window = globalThis.window ?? {};
-(window as unknown as Record<string, unknown>).electron = {
-  ...((window as unknown as Record<string, unknown>).electron ?? {}),
-  terminal: { getInfo: getInfoMock },
-};
+// `waitForTerminalsToClose` reads `window.electron.terminal.getInfo`; stub just
+// that (node env has no window). vi.stubGlobal is typed, so no cast is needed.
+vi.stubGlobal("window", { electron: { terminal: { getInfo: getInfoMock } } });
 
-function ptyPanel(overrides: Record<string, unknown>): Record<string, unknown> {
+type SeedPanel = { id: string } & Record<string, unknown>;
+
+function ptyPanel(overrides: SeedPanel): SeedPanel {
   return { kind: "terminal", worktreeId: "wt-1", location: "grid", ...overrides };
 }
 
-function seed(panels: Array<Record<string, unknown>>): void {
-  mockState.panelIds = panels.map((p) => p.id as string);
-  mockState.panelsById = Object.fromEntries(panels.map((p) => [p.id as string, p]));
+function seed(panels: SeedPanel[]): void {
+  mockState.panelIds = panels.map((p) => p.id);
+  mockState.panelsById = Object.fromEntries(panels.map((p) => [p.id, p]));
 }
 
 beforeEach(() => {

--- a/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/utils/logger", () => ({
 }));
 
 import {
+  captureWorktreeTerminalSnapshot,
   closeTerminalsForWorktree,
   restoreClosedTerminals,
   getLiveTerminalIdsForWorktree,
@@ -74,55 +75,85 @@ beforeEach(() => {
 });
 
 describe("getLiveTerminalIdsForWorktree", () => {
-  it("returns only live, persistable PTY panels of the worktree", () => {
+  it("returns only live PTY terminals — excludes trash, other worktrees, ephemeral, and non-PTY panels", () => {
     seed([
       ptyPanel({ id: "keep" }),
       ptyPanel({ id: "other-wt", worktreeId: "wt-2" }),
       ptyPanel({ id: "trashed", location: "trash" }),
       ptyPanel({ id: "ephemeral", excludeFromPersistence: true }),
+      // Non-PTY panels hold no directory lock, so they are NOT hard-closed for
+      // the delete (they would otherwise be lost with no restore) (#11344).
+      { id: "browser", kind: "browser", worktreeId: "wt-1", location: "grid" },
+      { id: "review", kind: "review", worktreeId: "wt-1", location: "grid" },
     ]);
     expect(getLiveTerminalIdsForWorktree("wt-1")).toEqual(["keep"]);
   });
 });
 
-describe("closeTerminalsForWorktree", () => {
-  it("captures a relaunch snapshot, hard-removes each terminal, and waits for close", async () => {
+describe("captureWorktreeTerminalSnapshot", () => {
+  it("snapshots each live PTY terminal's relaunch metadata without mutating anything", () => {
     seed([
       ptyPanel({ id: "plain", cwd: "/repo/wt", title: "bash" }),
       ptyPanel({
         id: "agent",
         cwd: "/repo/wt",
         title: "claude",
+        titleMode: "pinned",
         launchAgentId: "claude",
         agentSessionId: "sess-1",
         agentLaunchFlags: ["--model", "opus"],
         agentModelId: "opus",
+        agentPresetId: "preset-a",
         command: "claude",
         location: "dock",
       }),
+      { id: "browser", kind: "browser", worktreeId: "wt-1", location: "grid" },
     ]);
 
-    const snapshot = await closeTerminalsForWorktree("wt-1");
+    const snapshot = captureWorktreeTerminalSnapshot("wt-1");
 
-    expect(removePanelMock.mock.calls.map((c) => c[0])).toEqual(["plain", "agent"]);
-    expect(getInfoMock).toHaveBeenCalled();
-    expect(snapshot).toHaveLength(2);
+    expect(removePanelMock).not.toHaveBeenCalled();
+    // The browser panel is not a terminal — it is not snapshotted.
+    expect(snapshot.map((s) => s.id)).toEqual(["plain", "agent"]);
     expect(snapshot[0]).toMatchObject({ id: "plain", cwd: "/repo/wt", location: "grid" });
     expect(snapshot[1]).toMatchObject({
       id: "agent",
+      title: "claude",
+      titleMode: "pinned",
       launchAgentId: "claude",
       agentSessionId: "sess-1",
       agentLaunchFlags: ["--model", "opus"],
       agentModelId: "opus",
+      agentPresetId: "preset-a",
       command: "claude",
       location: "dock",
     });
   });
 
-  it("returns an empty snapshot and does nothing when the worktree has no terminals", async () => {
+  it("returns an empty snapshot when the worktree has no terminals", () => {
     seed([ptyPanel({ id: "other", worktreeId: "wt-2" })]);
-    const snapshot = await closeTerminalsForWorktree("wt-1");
-    expect(snapshot).toEqual([]);
+    expect(captureWorktreeTerminalSnapshot("wt-1")).toEqual([]);
+  });
+});
+
+describe("closeTerminalsForWorktree", () => {
+  it("hard-removes each PTY terminal and waits for close, leaving non-PTY panels alone", async () => {
+    seed([
+      ptyPanel({ id: "plain" }),
+      ptyPanel({ id: "agent", launchAgentId: "claude" }),
+      { id: "browser", kind: "browser", worktreeId: "wt-1", location: "grid" },
+    ]);
+
+    await closeTerminalsForWorktree("wt-1");
+
+    // Only the two terminals are removed; the browser panel is untouched.
+    expect(removePanelMock.mock.calls.map((c) => c[0])).toEqual(["plain", "agent"]);
+    expect(getInfoMock).toHaveBeenCalled();
+  });
+
+  it("does nothing when the worktree has no terminals", async () => {
+    seed([ptyPanel({ id: "other", worktreeId: "wt-2" })]);
+    await closeTerminalsForWorktree("wt-1");
     expect(removePanelMock).not.toHaveBeenCalled();
   });
 });
@@ -166,6 +197,22 @@ describe("restoreClosedTerminals", () => {
     ]);
     expect(buildResumeCommandMock).not.toHaveBeenCalled();
     expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ command: "claude" }));
+  });
+
+  it("falls back to the stored command when the agent has a session but no resume support", async () => {
+    // buildResumeCommand returns undefined for agents without resume support.
+    buildResumeCommandMock.mockReturnValue(undefined);
+    await restoreClosedTerminals([
+      {
+        id: "agent",
+        location: "grid",
+        command: "codex",
+        launchAgentId: "codex",
+        agentSessionId: "sess-9",
+      },
+    ]);
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("codex", "sess-9", undefined);
+    expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ command: "codex" }));
   });
 
   it("relaunches a plain terminal with its stored command and never builds a resume command", async () => {

--- a/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
@@ -75,18 +75,17 @@ beforeEach(() => {
 });
 
 describe("getLiveTerminalIdsForWorktree", () => {
-  it("returns only live PTY terminals — excludes trash, other worktrees, ephemeral, and non-PTY panels", () => {
+  it("returns the worktree's live panels — excludes trash, other worktrees, and ephemeral PTYs", () => {
     seed([
       ptyPanel({ id: "keep" }),
       ptyPanel({ id: "other-wt", worktreeId: "wt-2" }),
       ptyPanel({ id: "trashed", location: "trash" }),
       ptyPanel({ id: "ephemeral", excludeFromPersistence: true }),
-      // Non-PTY panels hold no directory lock, so they are NOT hard-closed for
-      // the delete (they would otherwise be lost with no restore) (#11344).
+      // Non-PTY panels are still closed with the worktree (unchanged behavior);
+      // only the rollback snapshot is terminal-only.
       { id: "browser", kind: "browser", worktreeId: "wt-1", location: "grid" },
-      { id: "review", kind: "review", worktreeId: "wt-1", location: "grid" },
     ]);
-    expect(getLiveTerminalIdsForWorktree("wt-1")).toEqual(["keep"]);
+    expect(getLiveTerminalIdsForWorktree("wt-1")).toEqual(["keep", "browser"]);
   });
 });
 
@@ -137,7 +136,7 @@ describe("captureWorktreeTerminalSnapshot", () => {
 });
 
 describe("closeTerminalsForWorktree", () => {
-  it("hard-removes each PTY terminal and waits for close, leaving non-PTY panels alone", async () => {
+  it("hard-removes each of the worktree's live panels and waits for close", async () => {
     seed([
       ptyPanel({ id: "plain" }),
       ptyPanel({ id: "agent", launchAgentId: "claude" }),
@@ -146,12 +145,11 @@ describe("closeTerminalsForWorktree", () => {
 
     await closeTerminalsForWorktree("wt-1");
 
-    // Only the two terminals are removed; the browser panel is untouched.
-    expect(removePanelMock.mock.calls.map((c) => c[0])).toEqual(["plain", "agent"]);
+    expect(removePanelMock.mock.calls.map((c) => c[0])).toEqual(["plain", "agent", "browser"]);
     expect(getInfoMock).toHaveBeenCalled();
   });
 
-  it("does nothing when the worktree has no terminals", async () => {
+  it("does nothing when the worktree has no panels", async () => {
     seed([ptyPanel({ id: "other", worktreeId: "wt-2" })]);
     await closeTerminalsForWorktree("wt-1");
     expect(removePanelMock).not.toHaveBeenCalled();

--- a/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
+++ b/src/components/Worktree/__tests__/worktreeDeleteHelper.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { buildResumeCommandMock } = vi.hoisted(() => ({
+  buildResumeCommandMock:
+    vi.fn<
+      (agentId: string, sessionId: string, flags?: string[], base?: string) => string | undefined
+    >(),
+}));
+
+const removePanelMock = vi.fn<(id: string) => void>();
+const addPanelMock = vi.fn<(options: unknown) => Promise<string | null>>();
+
+interface MockPanelState {
+  panelIds: string[];
+  panelsById: Record<string, unknown>;
+  removePanel: typeof removePanelMock;
+  addPanel: typeof addPanelMock;
+}
+let mockState: MockPanelState;
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => mockState },
+}));
+
+vi.mock("@shared/types", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@shared/types")>();
+  return { ...actual, buildResumeCommand: buildResumeCommandMock };
+});
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+import {
+  closeTerminalsForWorktree,
+  restoreClosedTerminals,
+  getLiveTerminalIdsForWorktree,
+} from "@/components/Worktree/worktreeDeleteHelper";
+
+const getInfoMock = vi.fn<(id: string) => Promise<{ hasPty: boolean }>>();
+(globalThis as Record<string, unknown>).window = globalThis.window ?? {};
+(window as unknown as Record<string, unknown>).electron = {
+  ...((window as unknown as Record<string, unknown>).electron ?? {}),
+  terminal: { getInfo: getInfoMock },
+};
+
+function ptyPanel(overrides: Record<string, unknown>): Record<string, unknown> {
+  return { kind: "terminal", worktreeId: "wt-1", location: "grid", ...overrides };
+}
+
+function seed(panels: Array<Record<string, unknown>>): void {
+  mockState.panelIds = panels.map((p) => p.id as string);
+  mockState.panelsById = Object.fromEntries(panels.map((p) => [p.id as string, p]));
+}
+
+beforeEach(() => {
+  removePanelMock.mockReset();
+  addPanelMock.mockReset().mockResolvedValue("ok");
+  buildResumeCommandMock.mockReset();
+  // `waitForTerminalsToClose` treats a terminal as closed only once `getInfo`
+  // rejects (the backend has fully forgotten it) — `hasPty: false` alone is
+  // deliberately insufficient (the Windows cwd-lock window). Reject to simulate
+  // a fully torn-down terminal so the wait loop resolves immediately.
+  getInfoMock.mockReset().mockRejectedValue(new Error("terminal gone"));
+  mockState = {
+    panelIds: [],
+    panelsById: {},
+    removePanel: removePanelMock,
+    addPanel: addPanelMock,
+  };
+});
+
+describe("getLiveTerminalIdsForWorktree", () => {
+  it("returns only live, persistable PTY panels of the worktree", () => {
+    seed([
+      ptyPanel({ id: "keep" }),
+      ptyPanel({ id: "other-wt", worktreeId: "wt-2" }),
+      ptyPanel({ id: "trashed", location: "trash" }),
+      ptyPanel({ id: "ephemeral", excludeFromPersistence: true }),
+    ]);
+    expect(getLiveTerminalIdsForWorktree("wt-1")).toEqual(["keep"]);
+  });
+});
+
+describe("closeTerminalsForWorktree", () => {
+  it("captures a relaunch snapshot, hard-removes each terminal, and waits for close", async () => {
+    seed([
+      ptyPanel({ id: "plain", cwd: "/repo/wt", title: "bash" }),
+      ptyPanel({
+        id: "agent",
+        cwd: "/repo/wt",
+        title: "claude",
+        launchAgentId: "claude",
+        agentSessionId: "sess-1",
+        agentLaunchFlags: ["--model", "opus"],
+        agentModelId: "opus",
+        command: "claude",
+        location: "dock",
+      }),
+    ]);
+
+    const snapshot = await closeTerminalsForWorktree("wt-1");
+
+    expect(removePanelMock.mock.calls.map((c) => c[0])).toEqual(["plain", "agent"]);
+    expect(getInfoMock).toHaveBeenCalled();
+    expect(snapshot).toHaveLength(2);
+    expect(snapshot[0]).toMatchObject({ id: "plain", cwd: "/repo/wt", location: "grid" });
+    expect(snapshot[1]).toMatchObject({
+      id: "agent",
+      launchAgentId: "claude",
+      agentSessionId: "sess-1",
+      agentLaunchFlags: ["--model", "opus"],
+      agentModelId: "opus",
+      command: "claude",
+      location: "dock",
+    });
+  });
+
+  it("returns an empty snapshot and does nothing when the worktree has no terminals", async () => {
+    seed([ptyPanel({ id: "other", worktreeId: "wt-2" })]);
+    const snapshot = await closeTerminalsForWorktree("wt-1");
+    expect(snapshot).toEqual([]);
+    expect(removePanelMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("restoreClosedTerminals", () => {
+  it("relaunches with a resume command for a resume-capable agent session", async () => {
+    buildResumeCommandMock.mockReturnValue("claude --resume sess-1");
+
+    await restoreClosedTerminals([
+      {
+        id: "agent",
+        worktreeId: "wt-1",
+        cwd: "/repo/wt",
+        location: "grid",
+        command: "claude",
+        launchAgentId: "claude",
+        agentLaunchFlags: ["--flag"],
+        agentSessionId: "sess-1",
+      },
+    ]);
+
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("claude", "sess-1", ["--flag"]);
+    expect(addPanelMock).toHaveBeenCalledTimes(1);
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedId: "agent",
+        kind: "terminal",
+        worktreeId: "wt-1",
+        cwd: "/repo/wt",
+        command: "claude --resume sess-1",
+        launchAgentId: "claude",
+        bypassLimits: true,
+        focusPolicy: "preserve",
+      })
+    );
+  });
+
+  it("falls back to the stored launch command when there is no session id", async () => {
+    await restoreClosedTerminals([
+      { id: "agent", location: "grid", command: "claude", launchAgentId: "claude" },
+    ]);
+    expect(buildResumeCommandMock).not.toHaveBeenCalled();
+    expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ command: "claude" }));
+  });
+
+  it("relaunches a plain terminal with its stored command and never builds a resume command", async () => {
+    await restoreClosedTerminals([{ id: "plain", location: "grid", command: undefined }]);
+    expect(buildResumeCommandMock).not.toHaveBeenCalled();
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ requestedId: "plain", command: undefined })
+    );
+  });
+
+  it("is best-effort: a failed relaunch does not abort the rest", async () => {
+    addPanelMock.mockRejectedValueOnce(new Error("spawn failed")).mockResolvedValue("ok");
+    await expect(
+      restoreClosedTerminals([
+        { id: "a", location: "grid" },
+        { id: "b", location: "grid" },
+      ])
+    ).resolves.toBeUndefined();
+    expect(addPanelMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops on an empty snapshot", async () => {
+    await restoreClosedTerminals([]);
+    expect(addPanelMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Worktree/worktreeDeleteHelper.ts
+++ b/src/components/Worktree/worktreeDeleteHelper.ts
@@ -47,13 +47,23 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
+  const state = usePanelStore.getState();
+  return state.panelIds.filter((id) => {
+    const panel = state.panelsById[id];
+    return (
+      panel?.worktreeId === worktreeId &&
+      panel.location !== "trash" &&
+      (!isPtyPanel(panel) || panel.excludeFromPersistence !== true)
+    );
+  });
+}
+
 /**
- * The live PTY terminals of a worktree — the panels that hold the worktree
- * directory open and so must be killed before `git worktree remove`. Only PTY
- * ("terminal") panels are included: browser/review/file/dev-preview panels hold
- * no directory lock (dev servers are stopped separately), so they are left
- * untouched here and cleaned up when the worktree is actually removed. This
- * keeps a failed delete from destroying non-terminal panels it can't restore.
+ * The live PTY terminals of a worktree, for the rollback snapshot. Only PTY
+ * ("terminal") panels are captured: the restore relaunches terminals, and a dead
+ * PTY is the only thing a relaunch can recover. Browser/review/file panels are
+ * out of scope — restoring them is a separate concern from #11344.
  */
 function getLivePtyPanelsForWorktree(worktreeId: string): PtyPanelData[] {
   const state = usePanelStore.getState();
@@ -70,10 +80,6 @@ function getLivePtyPanelsForWorktree(worktreeId: string): PtyPanelData[] {
     }
   }
   return panels;
-}
-
-export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
-  return getLivePtyPanelsForWorktree(worktreeId).map((panel) => panel.id);
 }
 
 /** Capture a relaunch snapshot for a single live PTY panel. */
@@ -142,11 +148,13 @@ export async function waitForTerminalsToClose(terminalIds: string[]): Promise<vo
 }
 
 /**
- * Hard-close every live PTY terminal in a worktree ahead of `git worktree
- * remove`. The kill is immediate (not the trash TTL) so the worktree directory
- * is unlocked before the removal — see {@link WorktreeTerminalRestoreSnapshot}
- * for why trash-routing isn't used. Capture a rollback snapshot with
- * {@link captureWorktreeTerminalSnapshot} BEFORE calling this.
+ * Hard-close every live panel in a worktree ahead of `git worktree remove`. The
+ * kill is immediate (not the trash TTL) so the worktree directory is unlocked
+ * before the removal — see {@link WorktreeTerminalRestoreSnapshot} for why
+ * trash-routing isn't used. Only reachable when the user opts into closing
+ * terminals; otherwise the worktree's panels survive the removal as a
+ * deleted-worktree ghost row (#11232). Capture a rollback snapshot of the PTY
+ * terminals with {@link captureWorktreeTerminalSnapshot} BEFORE calling this.
  */
 export async function closeTerminalsForWorktree(worktreeId: string): Promise<void> {
   const terminalIds = getLiveTerminalIdsForWorktree(worktreeId);

--- a/src/components/Worktree/worktreeDeleteHelper.ts
+++ b/src/components/Worktree/worktreeDeleteHelper.ts
@@ -1,8 +1,41 @@
 import { usePanelStore } from "@/store/panelStore";
-import { isPtyPanel } from "@shared/types/panel";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { buildResumeCommand } from "@shared/types";
+import { logWarn } from "@/utils/logger";
 
 const WORKTREE_DELETE_TERMINAL_CLOSE_TIMEOUT_MS = 10_000;
 const WORKTREE_DELETE_TERMINAL_CLOSE_POLL_MS = 100;
+
+/**
+ * Everything needed to relaunch a terminal that was closed as part of a
+ * worktree delete, so it can be brought back if the delete never actually
+ * happens. Captured BEFORE the hard kill (the live PTY is gone once we've
+ * killed it), and replayed through {@link restoreClosedTerminals} on failure.
+ *
+ * We deliberately do NOT route the teardown through the trash/undo path
+ * (`trashPanel`): trash keeps the PTY alive under a 20s TTL, but the worktree
+ * delete must kill terminals BEFORE `git worktree remove` — on Windows a live
+ * process rooted in the worktree directory holds a lock that makes the removal
+ * fail outright. So the recoverability the trash path would give is provided
+ * here instead: kill now (Windows-safe, still journaled for launch agents),
+ * relaunch from this snapshot only if the delete is abandoned.
+ */
+export interface WorktreeTerminalRestoreSnapshot {
+  id: string;
+  title?: string;
+  titleMode?: PtyPanelData["titleMode"];
+  worktreeId?: string;
+  cwd?: string;
+  location: "grid" | "dock";
+  command?: string;
+  launchAgentId?: PtyPanelData["launchAgentId"];
+  agentModelId?: string;
+  agentLaunchFlags?: string[];
+  agentPresetId?: string;
+  agentPresetColor?: string;
+  originalPresetId?: string;
+  agentSessionId?: string;
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -18,6 +51,27 @@ export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
       (!isPtyPanel(panel) || panel.excludeFromPersistence !== true)
     );
   });
+}
+
+/** Capture a relaunch snapshot for a single live PTY panel. Only "grid"/"dock"
+ *  panels are recoverable — a trashed/dialog panel has no stable restore home. */
+function snapshotTerminal(panel: PtyPanelData): WorktreeTerminalRestoreSnapshot {
+  return {
+    id: panel.id,
+    title: panel.title,
+    titleMode: panel.titleMode,
+    worktreeId: panel.worktreeId,
+    cwd: panel.cwd,
+    location: panel.location === "dock" ? "dock" : "grid",
+    command: panel.command,
+    launchAgentId: panel.launchAgentId,
+    agentModelId: panel.agentModelId,
+    agentLaunchFlags: panel.agentLaunchFlags,
+    agentPresetId: panel.agentPresetId,
+    agentPresetColor: panel.agentPresetColor,
+    originalPresetId: panel.originalPresetId,
+    agentSessionId: panel.agentSessionId,
+  };
 }
 
 export async function waitForTerminalsToClose(terminalIds: string[]): Promise<void> {
@@ -52,11 +106,82 @@ export async function waitForTerminalsToClose(terminalIds: string[]): Promise<vo
   }
 }
 
-export async function closeTerminalsForWorktree(worktreeId: string): Promise<void> {
+/**
+ * Hard-close every live terminal in a worktree ahead of `git worktree remove`,
+ * returning a snapshot that {@link restoreClosedTerminals} can replay if the
+ * delete never lands. The kill is immediate (not the trash TTL) so the worktree
+ * directory is unlocked before the removal — see
+ * {@link WorktreeTerminalRestoreSnapshot} for why trash-routing isn't used.
+ */
+export async function closeTerminalsForWorktree(
+  worktreeId: string
+): Promise<WorktreeTerminalRestoreSnapshot[]> {
   const terminalIds = getLiveTerminalIdsForWorktree(worktreeId);
-  if (terminalIds.length === 0) return;
+  if (terminalIds.length === 0) return [];
 
   const store = usePanelStore.getState();
+  const snapshots: WorktreeTerminalRestoreSnapshot[] = [];
+  for (const id of terminalIds) {
+    const panel = store.panelsById[id];
+    if (panel && isPtyPanel(panel)) {
+      snapshots.push(snapshotTerminal(panel));
+    }
+  }
+
   terminalIds.forEach((id) => store.removePanel(id));
   await waitForTerminalsToClose(terminalIds);
+  return snapshots;
+}
+
+/**
+ * Bring back terminals closed by {@link closeTerminalsForWorktree} when the
+ * worktree delete was abandoned (a lock, a branch error, an exhausted retry).
+ * The original PTYs are already dead, so this relaunches fresh panels with the
+ * same ids into the still-present worktree, resuming the journaled agent
+ * session where the agent supports it. Best-effort: a single failed relaunch
+ * never blocks the rest.
+ */
+export async function restoreClosedTerminals(
+  snapshots: readonly WorktreeTerminalRestoreSnapshot[]
+): Promise<void> {
+  if (snapshots.length === 0) return;
+  const store = usePanelStore.getState();
+
+  for (const snap of snapshots) {
+    // Resume the journaled session for resume-capable agents; otherwise fall
+    // back to the stored launch command (fresh session). The dead PTY can't be
+    // resurrected, so a relaunch is the most recovery possible.
+    const resumeCommand =
+      snap.launchAgentId && snap.agentSessionId
+        ? buildResumeCommand(snap.launchAgentId, snap.agentSessionId, snap.agentLaunchFlags)
+        : undefined;
+
+    try {
+      await store.addPanel({
+        requestedId: snap.id,
+        kind: "terminal",
+        title: snap.title,
+        titleMode: snap.titleMode,
+        worktreeId: snap.worktreeId,
+        worktreeIdSource: "explicit",
+        cwd: snap.cwd,
+        location: snap.location,
+        command: resumeCommand ?? snap.command,
+        launchAgentId: snap.launchAgentId,
+        agentModelId: snap.agentModelId,
+        agentLaunchFlags: snap.agentLaunchFlags,
+        agentPresetId: snap.agentPresetId,
+        agentPresetColor: snap.agentPresetColor,
+        originalPresetId: snap.originalPresetId,
+        agentSessionId: snap.agentSessionId,
+        bypassLimits: true,
+        focusPolicy: "preserve",
+      });
+    } catch (error) {
+      logWarn("[WorktreeDelete] Failed to restore terminal after aborted delete", {
+        id: snap.id,
+        error,
+      });
+    }
+  }
 }

--- a/src/components/Worktree/worktreeDeleteHelper.ts
+++ b/src/components/Worktree/worktreeDeleteHelper.ts
@@ -19,6 +19,12 @@ const WORKTREE_DELETE_TERMINAL_CLOSE_POLL_MS = 100;
  * fail outright. So the recoverability the trash path would give is provided
  * here instead: kill now (Windows-safe, still journaled for launch agents),
  * relaunch from this snapshot only if the delete is abandoned.
+ *
+ * Best-effort by nature: the pre-kill snapshot can't carry the session id Main
+ * captures DURING the graceful kill, nor the rebuilt launch env, so a relaunched
+ * agent resumes only when a session id was already known and otherwise starts a
+ * fresh session. Restoring the panel (and its cwd) is the recovery; exact
+ * conversation continuity is not guaranteed.
  */
 export interface WorktreeTerminalRestoreSnapshot {
   id: string;
@@ -41,20 +47,36 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
+/**
+ * The live PTY terminals of a worktree — the panels that hold the worktree
+ * directory open and so must be killed before `git worktree remove`. Only PTY
+ * ("terminal") panels are included: browser/review/file/dev-preview panels hold
+ * no directory lock (dev servers are stopped separately), so they are left
+ * untouched here and cleaned up when the worktree is actually removed. This
+ * keeps a failed delete from destroying non-terminal panels it can't restore.
+ */
+function getLivePtyPanelsForWorktree(worktreeId: string): PtyPanelData[] {
   const state = usePanelStore.getState();
-  return state.panelIds.filter((id) => {
+  const panels: PtyPanelData[] = [];
+  for (const id of state.panelIds) {
     const panel = state.panelsById[id];
-    return (
+    if (
       panel?.worktreeId === worktreeId &&
       panel.location !== "trash" &&
-      (!isPtyPanel(panel) || panel.excludeFromPersistence !== true)
-    );
-  });
+      isPtyPanel(panel) &&
+      panel.excludeFromPersistence !== true
+    ) {
+      panels.push(panel);
+    }
+  }
+  return panels;
 }
 
-/** Capture a relaunch snapshot for a single live PTY panel. Only "grid"/"dock"
- *  panels are recoverable — a trashed/dialog panel has no stable restore home. */
+export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
+  return getLivePtyPanelsForWorktree(worktreeId).map((panel) => panel.id);
+}
+
+/** Capture a relaunch snapshot for a single live PTY panel. */
 function snapshotTerminal(panel: PtyPanelData): WorktreeTerminalRestoreSnapshot {
   return {
     id: panel.id,
@@ -72,6 +94,19 @@ function snapshotTerminal(panel: PtyPanelData): WorktreeTerminalRestoreSnapshot 
     originalPresetId: panel.originalPresetId,
     agentSessionId: panel.agentSessionId,
   };
+}
+
+/**
+ * Snapshot the worktree's live terminals for a potential rollback. Pure — it
+ * mutates nothing, so callers can capture BEFORE the destructive
+ * {@link closeTerminalsForWorktree}. That ordering matters: if the close then
+ * times out (a terminal that won't die), the caller still holds the snapshot to
+ * restore from, rather than losing it with the throw.
+ */
+export function captureWorktreeTerminalSnapshot(
+  worktreeId: string
+): WorktreeTerminalRestoreSnapshot[] {
+  return getLivePtyPanelsForWorktree(worktreeId).map(snapshotTerminal);
 }
 
 export async function waitForTerminalsToClose(terminalIds: string[]): Promise<void> {
@@ -107,37 +142,26 @@ export async function waitForTerminalsToClose(terminalIds: string[]): Promise<vo
 }
 
 /**
- * Hard-close every live terminal in a worktree ahead of `git worktree remove`,
- * returning a snapshot that {@link restoreClosedTerminals} can replay if the
- * delete never lands. The kill is immediate (not the trash TTL) so the worktree
- * directory is unlocked before the removal — see
- * {@link WorktreeTerminalRestoreSnapshot} for why trash-routing isn't used.
+ * Hard-close every live PTY terminal in a worktree ahead of `git worktree
+ * remove`. The kill is immediate (not the trash TTL) so the worktree directory
+ * is unlocked before the removal — see {@link WorktreeTerminalRestoreSnapshot}
+ * for why trash-routing isn't used. Capture a rollback snapshot with
+ * {@link captureWorktreeTerminalSnapshot} BEFORE calling this.
  */
-export async function closeTerminalsForWorktree(
-  worktreeId: string
-): Promise<WorktreeTerminalRestoreSnapshot[]> {
+export async function closeTerminalsForWorktree(worktreeId: string): Promise<void> {
   const terminalIds = getLiveTerminalIdsForWorktree(worktreeId);
-  if (terminalIds.length === 0) return [];
+  if (terminalIds.length === 0) return;
 
   const store = usePanelStore.getState();
-  const snapshots: WorktreeTerminalRestoreSnapshot[] = [];
-  for (const id of terminalIds) {
-    const panel = store.panelsById[id];
-    if (panel && isPtyPanel(panel)) {
-      snapshots.push(snapshotTerminal(panel));
-    }
-  }
-
   terminalIds.forEach((id) => store.removePanel(id));
   await waitForTerminalsToClose(terminalIds);
-  return snapshots;
 }
 
 /**
  * Bring back terminals closed by {@link closeTerminalsForWorktree} when the
  * worktree delete was abandoned (a lock, a branch error, an exhausted retry).
  * The original PTYs are already dead, so this relaunches fresh panels with the
- * same ids into the still-present worktree, resuming the journaled agent
+ * same ids into the still-present worktree, resuming the last known agent
  * session where the agent supports it. Best-effort: a single failed relaunch
  * never blocks the rest.
  */
@@ -148,7 +172,7 @@ export async function restoreClosedTerminals(
   const store = usePanelStore.getState();
 
   for (const snap of snapshots) {
-    // Resume the journaled session for resume-capable agents; otherwise fall
+    // Resume the last known session for resume-capable agents; otherwise fall
     // back to the stored launch command (fresh session). The dead PTY can't be
     // resurrected, so a relaunch is the most recovery possible.
     const resumeCommand =

--- a/src/services/actions/definitions/worktreeCreateActions.ts
+++ b/src/services/actions/definitions/worktreeCreateActions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { worktreeClient } from "@/clients";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import {
+  captureWorktreeTerminalSnapshot,
   closeTerminalsForWorktree,
   restoreClosedTerminals,
   type WorktreeTerminalRestoreSnapshot,
@@ -102,24 +103,34 @@ export function registerWorktreeCreateActions(
         closeTerminals: z.boolean().optional(),
       }),
       run: async ({ worktreeId, force, deleteBranch, closeTerminals }) => {
-        let restoreSnapshot: WorktreeTerminalRestoreSnapshot[] = [];
-        if (closeTerminals) {
-          restoreSnapshot = await closeTerminalsForWorktree(worktreeId);
-        }
-        // Stop any running dev preview BEFORE `git worktree remove` (#9084).
-        // Windows holds a directory lock while the dev server runs; removal
-        // fails outright if the server is still alive. `stopByWorktree` is
-        // a safe no-op when no session matches, so it's called
-        // unconditionally rather than gated on `getByWorktree` — that gate
-        // would miss multi-panel sessions sharing the same worktreeId.
-        await window.electron.devPreview.stopByWorktree({ worktreeId });
+        // Capture BEFORE closing so a close-wait timeout (or a stop-dev-preview
+        // failure) still leaves a snapshot to restore from (#11344).
+        const restoreSnapshot: WorktreeTerminalRestoreSnapshot[] = closeTerminals
+          ? captureWorktreeTerminalSnapshot(worktreeId)
+          : [];
         try {
+          if (closeTerminals) {
+            await closeTerminalsForWorktree(worktreeId);
+          }
+          // Stop any running dev preview BEFORE `git worktree remove` (#9084).
+          // Windows holds a directory lock while the dev server runs; removal
+          // fails outright if the server is still alive. `stopByWorktree` is
+          // a safe no-op when no session matches, so it's called
+          // unconditionally rather than gated on `getByWorktree` — that gate
+          // would miss multi-panel sessions sharing the same worktreeId.
+          await window.electron.devPreview.stopByWorktree({ worktreeId });
           await worktreeClient.delete(worktreeId, force, deleteBranch);
         } catch (error) {
-          // This action path has no outbox retry, so a throw here is the end of
-          // the delete — bring the closed terminals back rather than losing them
-          // to a delete that didn't happen (#11344), then surface the error.
-          void restoreClosedTerminals(restoreSnapshot);
+          // This action path has no outbox retry, so a throw here ends the
+          // delete. Bring the closed terminals back rather than losing them to a
+          // delete that didn't happen — but only if the worktree still exists: a
+          // branch-delete failure lands after `git worktree remove` succeeded, so
+          // relaunching then would strand terminals on a deleted worktree.
+          const stillExists = await worktreeClient
+            .getAll()
+            .then((worktrees) => worktrees.some((worktree) => worktree.id === worktreeId))
+            .catch(() => true);
+          if (stillExists) void restoreClosedTerminals(restoreSnapshot);
           throw error;
         }
       },

--- a/src/services/actions/definitions/worktreeCreateActions.ts
+++ b/src/services/actions/definitions/worktreeCreateActions.ts
@@ -3,7 +3,11 @@ import { defineAction } from "../defineAction";
 import { z } from "zod";
 import { worktreeClient } from "@/clients";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { closeTerminalsForWorktree } from "@/components/Worktree/worktreeDeleteHelper";
+import {
+  closeTerminalsForWorktree,
+  restoreClosedTerminals,
+  type WorktreeTerminalRestoreSnapshot,
+} from "@/components/Worktree/worktreeDeleteHelper";
 
 export function registerWorktreeCreateActions(
   actions: ActionRegistry,
@@ -98,8 +102,9 @@ export function registerWorktreeCreateActions(
         closeTerminals: z.boolean().optional(),
       }),
       run: async ({ worktreeId, force, deleteBranch, closeTerminals }) => {
+        let restoreSnapshot: WorktreeTerminalRestoreSnapshot[] = [];
         if (closeTerminals) {
-          await closeTerminalsForWorktree(worktreeId);
+          restoreSnapshot = await closeTerminalsForWorktree(worktreeId);
         }
         // Stop any running dev preview BEFORE `git worktree remove` (#9084).
         // Windows holds a directory lock while the dev server runs; removal
@@ -108,7 +113,15 @@ export function registerWorktreeCreateActions(
         // unconditionally rather than gated on `getByWorktree` — that gate
         // would miss multi-panel sessions sharing the same worktreeId.
         await window.electron.devPreview.stopByWorktree({ worktreeId });
-        await worktreeClient.delete(worktreeId, force, deleteBranch);
+        try {
+          await worktreeClient.delete(worktreeId, force, deleteBranch);
+        } catch (error) {
+          // This action path has no outbox retry, so a throw here is the end of
+          // the delete — bring the closed terminals back rather than losing them
+          // to a delete that didn't happen (#11344), then surface the error.
+          void restoreClosedTerminals(restoreSnapshot);
+          throw error;
+        }
       },
     })
   );

--- a/src/store/__tests__/createWorktreeStore.delete.test.ts
+++ b/src/store/__tests__/createWorktreeStore.delete.test.ts
@@ -13,6 +13,7 @@ function nextV(): WorktreeEventVersion {
 const {
   worktreeClientDeleteMock,
   closeTerminalsForWorktreeMock,
+  restoreClosedTerminalsMock,
   notifyMock,
   devPreviewGetByWorktreeMock,
   devPreviewStopByWorktreeMock,
@@ -21,7 +22,8 @@ const {
     vi.fn<
       (id: string, force?: boolean, deleteBranch?: boolean, mutationId?: string) => Promise<void>
     >(),
-  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<void>>(),
+  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<unknown[]>>(),
+  restoreClosedTerminalsMock: vi.fn<(snapshot: readonly unknown[]) => Promise<void>>(),
   notifyMock: vi.fn(),
   devPreviewGetByWorktreeMock: vi.fn(),
   devPreviewStopByWorktreeMock: vi.fn(),
@@ -49,6 +51,7 @@ vi.mock("@/clients", async () => {
 
 vi.mock("@/components/Worktree/worktreeDeleteHelper", () => ({
   closeTerminalsForWorktree: closeTerminalsForWorktreeMock,
+  restoreClosedTerminals: restoreClosedTerminalsMock,
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -82,11 +85,13 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
   beforeEach(() => {
     worktreeClientDeleteMock.mockReset();
     closeTerminalsForWorktreeMock.mockReset();
+    restoreClosedTerminalsMock.mockReset();
     notifyMock.mockReset();
     devPreviewGetByWorktreeMock.mockReset();
     devPreviewStopByWorktreeMock.mockReset();
     worktreeClientDeleteMock.mockResolvedValue();
-    closeTerminalsForWorktreeMock.mockResolvedValue();
+    closeTerminalsForWorktreeMock.mockResolvedValue([]);
+    restoreClosedTerminalsMock.mockResolvedValue();
     // Default: no dev preview session for the worktree. Tests opt-in by
     // overriding the mock per case.
     devPreviewGetByWorktreeMock.mockResolvedValue(null);
@@ -395,6 +400,77 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
     expect(store.getState().deleteErrorArgs.get("wt-1")).toEqual({
       closeTerminals: true,
       force: false,
+    });
+  });
+
+  describe("#11344 — restore closed terminals when the delete is abandoned", () => {
+    const SNAPSHOT = [{ id: "t-1", location: "grid" }];
+
+    it("relaunches the closed terminals on a permanent failure", async () => {
+      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      worktreeClientDeleteMock.mockRejectedValueOnce(new Error("worktree has uncommitted changes"));
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, force: false });
+      await flushPromises();
+      await flushPromises();
+
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledWith(SNAPSHOT);
+    });
+
+    it("does NOT relaunch on a connectivity failure — the delete stays pending for replay", async () => {
+      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      worktreeClientDeleteMock.mockRejectedValueOnce(new Error("HOST_EXITED: port gone"));
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, force: false });
+      await flushPromises();
+      await flushPromises();
+
+      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT relaunch on success — the worktree is gone, terminals stay closed", async () => {
+      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, force: false });
+      await flushPromises();
+      await flushPromises();
+
+      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT relaunch on the partial-success path — the worktree directory is already gone", async () => {
+      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      let rejectIpc: (reason: unknown) => void = () => {};
+      worktreeClientDeleteMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectIpc = reject;
+          })
+      );
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, deleteBranch: true });
+      await flushPromises();
+
+      // worktree-removed arrives before the branch-delete rejection.
+      store.getState().applyRemove("wt-1", nextV());
+      rejectIpc(new Error("Branch 'feature/x' has unmerged changes"));
+      await flushPromises();
+      await flushPromises();
+
+      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/__tests__/createWorktreeStore.delete.test.ts
+++ b/src/store/__tests__/createWorktreeStore.delete.test.ts
@@ -549,21 +549,20 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
       expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
     });
 
-    it("removes the worktree's leftover non-terminal panels when it is authoritatively removed", () => {
-      // PTY terminals are closed up front; browser/review panels are left alive
-      // (no directory lock) and reaped here when the worktree is truly gone.
+    it("leaves the worktree's surviving panels untouched on removal (ghost-row contract #11232)", () => {
+      // applyRemove must NOT reap the worktree's panels — the deleted-worktree
+      // ghost row keeps them alive until the user acts or the TTL trashes them.
       const store = createWorktreeStore();
       store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
 
       const removeSpy = vi
         .spyOn(usePanelStore.getState(), "removePanel")
         .mockImplementation(() => {});
-      usePanelStore.setState({ panelIdsByWorktreeId: { "wt-1": ["browser-1", "review-1"] } });
+      usePanelStore.setState({ panelIdsByWorktreeId: { "wt-1": ["browser-1", "agent-1"] } });
 
       try {
         store.getState().applyRemove("wt-1", nextV());
-        expect(removeSpy).toHaveBeenCalledWith("browser-1");
-        expect(removeSpy).toHaveBeenCalledWith("review-1");
+        expect(removeSpy).not.toHaveBeenCalled();
       } finally {
         removeSpy.mockRestore();
         usePanelStore.setState({ panelIdsByWorktreeId: {} });

--- a/src/store/__tests__/createWorktreeStore.delete.test.ts
+++ b/src/store/__tests__/createWorktreeStore.delete.test.ts
@@ -12,6 +12,7 @@ function nextV(): WorktreeEventVersion {
 
 const {
   worktreeClientDeleteMock,
+  captureWorktreeTerminalSnapshotMock,
   closeTerminalsForWorktreeMock,
   restoreClosedTerminalsMock,
   notifyMock,
@@ -22,7 +23,8 @@ const {
     vi.fn<
       (id: string, force?: boolean, deleteBranch?: boolean, mutationId?: string) => Promise<void>
     >(),
-  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<unknown[]>>(),
+  captureWorktreeTerminalSnapshotMock: vi.fn<(id: string) => unknown[]>(),
+  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<void>>(),
   restoreClosedTerminalsMock: vi.fn<(snapshot: readonly unknown[]) => Promise<void>>(),
   notifyMock: vi.fn(),
   devPreviewGetByWorktreeMock: vi.fn(),
@@ -50,6 +52,7 @@ vi.mock("@/clients", async () => {
 });
 
 vi.mock("@/components/Worktree/worktreeDeleteHelper", () => ({
+  captureWorktreeTerminalSnapshot: captureWorktreeTerminalSnapshotMock,
   closeTerminalsForWorktree: closeTerminalsForWorktreeMock,
   restoreClosedTerminals: restoreClosedTerminalsMock,
 }));
@@ -59,7 +62,8 @@ vi.mock("@/lib/notify", () => ({
 }));
 
 // Import after mocks so the store picks up the mocked deps.
-import { createWorktreeStore } from "@/store/createWorktreeStore";
+import { createWorktreeStore, OUTBOX_RETRY_CAP } from "@/store/createWorktreeStore";
+import { usePanelStore } from "@/store/panelStore";
 
 function makeSnapshot(id: string): WorktreeSnapshot {
   return {
@@ -84,13 +88,15 @@ function flushPromises(): Promise<void> {
 describe("createWorktreeStore — delete in-flight state (#8417)", () => {
   beforeEach(() => {
     worktreeClientDeleteMock.mockReset();
+    captureWorktreeTerminalSnapshotMock.mockReset();
     closeTerminalsForWorktreeMock.mockReset();
     restoreClosedTerminalsMock.mockReset();
     notifyMock.mockReset();
     devPreviewGetByWorktreeMock.mockReset();
     devPreviewStopByWorktreeMock.mockReset();
     worktreeClientDeleteMock.mockResolvedValue();
-    closeTerminalsForWorktreeMock.mockResolvedValue([]);
+    captureWorktreeTerminalSnapshotMock.mockReturnValue([]);
+    closeTerminalsForWorktreeMock.mockResolvedValue();
     restoreClosedTerminalsMock.mockResolvedValue();
     // Default: no dev preview session for the worktree. Tests opt-in by
     // overriding the mock per case.
@@ -407,7 +413,7 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
     const SNAPSHOT = [{ id: "t-1", location: "grid" }];
 
     it("relaunches the closed terminals on a permanent failure", async () => {
-      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      captureWorktreeTerminalSnapshotMock.mockReturnValueOnce(SNAPSHOT);
       worktreeClientDeleteMock.mockRejectedValueOnce(new Error("worktree has uncommitted changes"));
 
       const store = createWorktreeStore();
@@ -421,8 +427,74 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
       expect(restoreClosedTerminalsMock).toHaveBeenCalledWith(SNAPSHOT);
     });
 
+    it("captures BEFORE closing, so a close-wait timeout still restores at the retry cap", async () => {
+      captureWorktreeTerminalSnapshotMock.mockReturnValue(SNAPSHOT);
+      // The close itself times out before the git delete is even attempted.
+      closeTerminalsForWorktreeMock.mockRejectedValue(
+        new Error("Timed out waiting for 1 terminal(s) to close before deleting worktree")
+      );
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, force: false });
+      await flushPromises();
+      await flushPromises();
+      // Generic failure → still pending → not yet restored.
+      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+
+      // Drive the generic-retry budget to the cap.
+      for (let i = 1; i < OUTBOX_RETRY_CAP; i++) {
+        store.getState().retryDelete("wt-1");
+        await flushPromises();
+        await flushPromises();
+      }
+
+      // Never reached worktreeClient.delete, yet the captured snapshot survives
+      // the throw and restores exactly once at the cap.
+      expect(worktreeClientDeleteMock).not.toHaveBeenCalled();
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledWith(SNAPSHOT);
+    });
+
+    it("a rapid retry waits for the in-flight restore before closing terminals again", async () => {
+      captureWorktreeTerminalSnapshotMock.mockReturnValue(SNAPSHOT);
+      worktreeClientDeleteMock.mockRejectedValueOnce(new Error("worktree has uncommitted changes"));
+      // Hold the restore open so it is still in flight when the retry fires.
+      let resolveRestore: () => void = () => {};
+      restoreClosedTerminalsMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRestore = resolve;
+          })
+      );
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, force: false });
+      await flushPromises();
+      await flushPromises();
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
+
+      // Retry while the restore is still spawning panels.
+      closeTerminalsForWorktreeMock.mockClear();
+      worktreeClientDeleteMock.mockResolvedValueOnce();
+      store.getState().retryDelete("wt-1");
+      await flushPromises();
+      await flushPromises();
+      // Blocked on the in-flight restore — must not close terminals yet, which
+      // would strand the still-spawning panels against the git remove.
+      expect(closeTerminalsForWorktreeMock).not.toHaveBeenCalled();
+
+      resolveRestore();
+      await flushPromises();
+      await flushPromises();
+      expect(closeTerminalsForWorktreeMock).toHaveBeenCalledWith("wt-1");
+    });
+
     it("does NOT relaunch on a connectivity failure — the delete stays pending for replay", async () => {
-      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      captureWorktreeTerminalSnapshotMock.mockReturnValueOnce(SNAPSHOT);
       worktreeClientDeleteMock.mockRejectedValueOnce(new Error("HOST_EXITED: port gone"));
 
       const store = createWorktreeStore();
@@ -436,7 +508,7 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
     });
 
     it("does NOT relaunch on success — the worktree is gone, terminals stay closed", async () => {
-      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      captureWorktreeTerminalSnapshotMock.mockReturnValueOnce(SNAPSHOT);
 
       const store = createWorktreeStore();
       store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
@@ -449,7 +521,7 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
     });
 
     it("does NOT relaunch on the partial-success path — the worktree directory is already gone", async () => {
-      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      captureWorktreeTerminalSnapshotMock.mockReturnValueOnce(SNAPSHOT);
       let rejectIpc: (reason: unknown) => void = () => {};
       worktreeClientDeleteMock.mockImplementationOnce(
         () =>
@@ -464,6 +536,10 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
       store.getState().startDelete("wt-1", { closeTerminals: true, deleteBranch: true });
       await flushPromises();
 
+      // Guard against a spurious pass: the delete IPC must actually be in flight
+      // before we simulate the removed-then-branch-failed ordering.
+      expect(worktreeClientDeleteMock).toHaveBeenCalledTimes(1);
+
       // worktree-removed arrives before the branch-delete rejection.
       store.getState().applyRemove("wt-1", nextV());
       rejectIpc(new Error("Branch 'feature/x' has unmerged changes"));
@@ -471,6 +547,27 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
       await flushPromises();
 
       expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+    });
+
+    it("removes the worktree's leftover non-terminal panels when it is authoritatively removed", () => {
+      // PTY terminals are closed up front; browser/review panels are left alive
+      // (no directory lock) and reaped here when the worktree is truly gone.
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      const removeSpy = vi
+        .spyOn(usePanelStore.getState(), "removePanel")
+        .mockImplementation(() => {});
+      usePanelStore.setState({ panelIdsByWorktreeId: { "wt-1": ["browser-1", "review-1"] } });
+
+      try {
+        store.getState().applyRemove("wt-1", nextV());
+        expect(removeSpy).toHaveBeenCalledWith("browser-1");
+        expect(removeSpy).toHaveBeenCalledWith("review-1");
+      } finally {
+        removeSpy.mockRestore();
+        usePanelStore.setState({ panelIdsByWorktreeId: {} });
+      }
     });
   });
 

--- a/src/store/__tests__/createWorktreeStore.outbox.test.ts
+++ b/src/store/__tests__/createWorktreeStore.outbox.test.ts
@@ -19,6 +19,7 @@ const {
   worktreeClientAttachIssueMock,
   worktreeClientDetachIssueMock,
   closeTerminalsForWorktreeMock,
+  restoreClosedTerminalsMock,
   notifyMock,
   devPreviewGetByWorktreeMock,
   devPreviewStopByWorktreeMock,
@@ -30,7 +31,8 @@ const {
   worktreeClientAttachIssueMock:
     vi.fn<(payload: import("@shared/types").AttachIssuePayload) => Promise<void>>(),
   worktreeClientDetachIssueMock: vi.fn<(worktreeId: string) => Promise<void>>(),
-  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<void>>(),
+  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<unknown[]>>(),
+  restoreClosedTerminalsMock: vi.fn<(snapshot: readonly unknown[]) => Promise<void>>(),
   notifyMock: vi.fn(),
   devPreviewGetByWorktreeMock: vi.fn().mockResolvedValue(null),
   devPreviewStopByWorktreeMock: vi.fn().mockResolvedValue(undefined),
@@ -60,6 +62,7 @@ vi.mock("@/clients", async () => {
 
 vi.mock("@/components/Worktree/worktreeDeleteHelper", () => ({
   closeTerminalsForWorktree: closeTerminalsForWorktreeMock,
+  restoreClosedTerminals: restoreClosedTerminalsMock,
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -94,11 +97,13 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
     worktreeClientAttachIssueMock.mockReset();
     worktreeClientDetachIssueMock.mockReset();
     closeTerminalsForWorktreeMock.mockReset();
+    restoreClosedTerminalsMock.mockReset();
     notifyMock.mockReset();
     worktreeClientDeleteMock.mockResolvedValue();
     worktreeClientAttachIssueMock.mockResolvedValue();
     worktreeClientDetachIssueMock.mockResolvedValue();
-    closeTerminalsForWorktreeMock.mockResolvedValue();
+    closeTerminalsForWorktreeMock.mockResolvedValue([]);
+    restoreClosedTerminalsMock.mockResolvedValue();
   });
 
   afterEach(() => {
@@ -239,6 +244,38 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
       // Cap is OUTBOX_RETRY_CAP — third generic failure flips to failed.
       expect(entry.retryCount).toBe(OUTBOX_RETRY_CAP);
       expect(entry.status).toBe("failed");
+    });
+
+    it("restores closed terminals only when generic retries exhaust the cap, using the first snapshot (#11344)", async () => {
+      worktreeClientDeleteMock.mockRejectedValue(new Error("git error: ref already exists"));
+      const SNAPSHOT = [{ id: "t-1", location: "grid" }];
+      // Only the first attempt has live terminals to snapshot; every replay
+      // finds none (default `[]`), which must NOT clobber the held snapshot.
+      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startDelete("wt-1", { closeTerminals: true, force: false });
+      await flushPromises();
+      await flushPromises();
+      // Still pending (retry 1) — do not relaunch yet.
+      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+
+      store.getState().retryDelete("wt-1");
+      await flushPromises();
+      await flushPromises();
+      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+
+      store.getState().retryDelete("wt-1");
+      await flushPromises();
+      await flushPromises();
+
+      // Cap reached → failed → relaunch exactly once, with the original capture
+      // (the empty replays never overwrote it).
+      expect([...store.getState().mutationOutbox.values()][0]!.status).toBe("failed");
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledWith(SNAPSHOT);
     });
 
     it("connectivity errors leave entry pending and DO NOT charge the retry cap", async () => {

--- a/src/store/__tests__/createWorktreeStore.outbox.test.ts
+++ b/src/store/__tests__/createWorktreeStore.outbox.test.ts
@@ -18,6 +18,7 @@ const {
   worktreeClientDeleteMock,
   worktreeClientAttachIssueMock,
   worktreeClientDetachIssueMock,
+  captureWorktreeTerminalSnapshotMock,
   closeTerminalsForWorktreeMock,
   restoreClosedTerminalsMock,
   notifyMock,
@@ -31,7 +32,8 @@ const {
   worktreeClientAttachIssueMock:
     vi.fn<(payload: import("@shared/types").AttachIssuePayload) => Promise<void>>(),
   worktreeClientDetachIssueMock: vi.fn<(worktreeId: string) => Promise<void>>(),
-  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<unknown[]>>(),
+  captureWorktreeTerminalSnapshotMock: vi.fn<(id: string) => unknown[]>(),
+  closeTerminalsForWorktreeMock: vi.fn<(id: string) => Promise<void>>(),
   restoreClosedTerminalsMock: vi.fn<(snapshot: readonly unknown[]) => Promise<void>>(),
   notifyMock: vi.fn(),
   devPreviewGetByWorktreeMock: vi.fn().mockResolvedValue(null),
@@ -61,6 +63,7 @@ vi.mock("@/clients", async () => {
 });
 
 vi.mock("@/components/Worktree/worktreeDeleteHelper", () => ({
+  captureWorktreeTerminalSnapshot: captureWorktreeTerminalSnapshotMock,
   closeTerminalsForWorktree: closeTerminalsForWorktreeMock,
   restoreClosedTerminals: restoreClosedTerminalsMock,
 }));
@@ -96,13 +99,15 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
     worktreeClientDeleteMock.mockReset();
     worktreeClientAttachIssueMock.mockReset();
     worktreeClientDetachIssueMock.mockReset();
+    captureWorktreeTerminalSnapshotMock.mockReset();
     closeTerminalsForWorktreeMock.mockReset();
     restoreClosedTerminalsMock.mockReset();
     notifyMock.mockReset();
     worktreeClientDeleteMock.mockResolvedValue();
     worktreeClientAttachIssueMock.mockResolvedValue();
     worktreeClientDetachIssueMock.mockResolvedValue();
-    closeTerminalsForWorktreeMock.mockResolvedValue([]);
+    captureWorktreeTerminalSnapshotMock.mockReturnValue([]);
+    closeTerminalsForWorktreeMock.mockResolvedValue();
     restoreClosedTerminalsMock.mockResolvedValue();
   });
 
@@ -246,12 +251,15 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
       expect(entry.status).toBe("failed");
     });
 
-    it("restores closed terminals only when generic retries exhaust the cap, using the first snapshot (#11344)", async () => {
+    it("restores closed terminals only when generic retries exhaust the cap, using the FIRST snapshot (#11344)", async () => {
       worktreeClientDeleteMock.mockRejectedValue(new Error("git error: ref already exists"));
-      const SNAPSHOT = [{ id: "t-1", location: "grid" }];
-      // Only the first attempt has live terminals to snapshot; every replay
-      // finds none (default `[]`), which must NOT clobber the held snapshot.
-      closeTerminalsForWorktreeMock.mockResolvedValueOnce(SNAPSHOT);
+      const FIRST_SNAPSHOT = [{ id: "t-1", location: "grid" }];
+      const LATER_SNAPSHOT = [{ id: "t-2", location: "grid" }];
+      // The first attempt captures the real terminals; a later capture (e.g. the
+      // user opened a new terminal mid-retry) must NOT clobber the held snapshot.
+      captureWorktreeTerminalSnapshotMock
+        .mockReturnValueOnce(FIRST_SNAPSHOT)
+        .mockReturnValue(LATER_SNAPSHOT);
 
       const store = createWorktreeStore();
       store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
@@ -262,20 +270,17 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
       // Still pending (retry 1) — do not relaunch yet.
       expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
 
-      store.getState().retryDelete("wt-1");
-      await flushPromises();
-      await flushPromises();
-      expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+      for (let attempt = 1; attempt < OUTBOX_RETRY_CAP; attempt++) {
+        store.getState().retryDelete("wt-1");
+        await flushPromises();
+        await flushPromises();
+      }
 
-      store.getState().retryDelete("wt-1");
-      await flushPromises();
-      await flushPromises();
-
-      // Cap reached → failed → relaunch exactly once, with the original capture
-      // (the empty replays never overwrote it).
+      // Cap reached → failed → relaunch exactly once, with the FIRST capture
+      // (later non-empty captures never overwrote it).
       expect([...store.getState().mutationOutbox.values()][0]!.status).toBe("failed");
       expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
-      expect(restoreClosedTerminalsMock).toHaveBeenCalledWith(SNAPSHOT);
+      expect(restoreClosedTerminalsMock).toHaveBeenCalledWith(FIRST_SNAPSHOT);
     });
 
     it("connectivity errors leave entry pending and DO NOT charge the retry cap", async () => {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -3,6 +3,7 @@ import type { WorktreeSnapshot, WorktreeEventVersion, AttachIssuePayload } from 
 import { usePanelStore } from "./panelStore";
 import { worktreeClient } from "@/clients";
 import {
+  captureWorktreeTerminalSnapshot,
   closeTerminalsForWorktree,
   restoreClosedTerminals,
   type WorktreeTerminalRestoreSnapshot,
@@ -707,6 +708,24 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         version,
         tombstones,
       });
+
+      if (hadWorktree) {
+        // The worktree is authoritatively gone (#11344). Drop its restore
+        // bookkeeping so a snapshot from a since-superseded delete can't leak or
+        // replay, and remove any panels still pointing at it. PTY terminals were
+        // closed up front; this reaps the non-terminal panels (browser, review,
+        // …) that closeTerminalsForWorktree intentionally left alive because they
+        // hold no directory lock.
+        discardTerminalRestores(
+          worktreeId,
+          outboxEntries.map((entry) => entry.mutationId)
+        );
+        const panelStore = usePanelStore.getState();
+        const stalePanelIds = panelStore.panelIdsByWorktreeId[worktreeId];
+        if (stalePanelIds && stalePanelIds.length > 0) {
+          for (const panelId of [...stalePanelIds]) panelStore.removePanel(panelId);
+        }
+      }
     },
 
     startDelete(worktreeId: string, options: WorktreeDeleteOptions) {
@@ -1209,14 +1228,35 @@ function mintMutationId(): string {
  */
 const pendingTerminalRestores = new Map<string, WorktreeTerminalRestoreSnapshot[]>();
 
+/**
+ * In-flight relaunch per worktree. A relaunch is a sequence of async `addPanel`
+ * spawns; a fresh `runDeleteAsync` for the same worktree awaits this before
+ * closing terminals, so a rapid retry can't interleave its close with spawns
+ * still in flight (which would strand panels against the git remove or leak them
+ * onto a deleted worktree).
+ */
+const restoreInFlight = new Map<string, Promise<void>>();
+
 /** Relaunch the terminals closed for a delete that has been definitively
  *  abandoned (won't be auto-retried), then drop the snapshot. No-op when the
- *  delete closed no terminals or a prior branch already consumed it. */
-function consumeTerminalRestore(mutationId: string): void {
+ *  delete closed no terminals or a prior branch already consumed it. Tracks the
+ *  relaunch promise per worktree so a concurrent delete can await it. */
+function consumeTerminalRestore(worktreeId: string, mutationId: string): void {
   const snapshot = pendingTerminalRestores.get(mutationId);
   if (!snapshot) return;
   pendingTerminalRestores.delete(mutationId);
-  void restoreClosedTerminals(snapshot);
+  const done = restoreClosedTerminals(snapshot).finally(() => {
+    if (restoreInFlight.get(worktreeId) === done) restoreInFlight.delete(worktreeId);
+  });
+  restoreInFlight.set(worktreeId, done);
+}
+
+/** Drop any pending/in-flight restore bookkeeping for a worktree. Called when
+ *  the worktree is authoritatively gone (`applyRemove`) so the module maps don't
+ *  leak a snapshot that will never be replayed. */
+function discardTerminalRestores(worktreeId: string, mutationIds: readonly string[]): void {
+  for (const mutationId of mutationIds) pendingTerminalRestores.delete(mutationId);
+  restoreInFlight.delete(worktreeId);
 }
 
 /**
@@ -1245,11 +1285,23 @@ async function runDeleteAsync(
   mutationId: string
 ): Promise<void> {
   try {
+    // A rapid retry after a prior attempt's restore must not start closing
+    // terminals while that restore is still spawning panels (#11344) — wait it
+    // out so this attempt sees the fully-restored set.
+    const inFlightRestore = restoreInFlight.get(worktreeId);
+    if (inFlightRestore) await inFlightRestore;
+
     if (options.closeTerminals) {
-      const snapshot = await closeTerminalsForWorktree(worktreeId);
-      // Preserve the FIRST attempt's capture across retries — a replay finds no
-      // live terminals to snapshot, so an empty result must never clobber it.
-      if (snapshot.length > 0) pendingTerminalRestores.set(mutationId, snapshot);
+      // Capture BEFORE the destructive close so a close-wait timeout can't lose
+      // the snapshot. Set only on the FIRST attempt that finds live terminals —
+      // a retry replay finds none (already dead) and must not clobber it; a
+      // later non-empty capture (e.g. the user opened new terminals mid-retry)
+      // must not either.
+      const snapshot = captureWorktreeTerminalSnapshot(worktreeId);
+      if (snapshot.length > 0 && !pendingTerminalRestores.has(mutationId)) {
+        pendingTerminalRestores.set(mutationId, snapshot);
+      }
+      await closeTerminalsForWorktree(worktreeId);
     }
     // Stop any running dev preview BEFORE `git worktree remove` (#9084). On
     // Windows the dev server holds a directory lock and the removal would
@@ -1388,7 +1440,7 @@ function handleDeleteFailure(
     // No outbox entry — shouldn't happen since `startDelete` always creates
     // one, but defensive: still surface the error on the card. Nothing will
     // auto-retry this delete, so bring the closed terminals back (#11344).
-    consumeTerminalRestore(mutationId);
+    consumeTerminalRestore(worktreeId, mutationId);
     set({
       deletingIds: nextDeletingIds,
       deleteErrors: nextDeleteErrors,
@@ -1413,7 +1465,7 @@ function handleDeleteFailure(
   // replayed (reconnect or generic retry), so relaunching now would flicker the
   // terminals and re-close them on the next attempt. Restore solely on the
   // terminal transition (#11344).
-  if (nextStatus === "failed") consumeTerminalRestore(mutationId);
+  if (nextStatus === "failed") consumeTerminalRestore(worktreeId, mutationId);
 
   set({
     deletingIds: nextDeletingIds,

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -710,21 +710,16 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       });
 
       if (hadWorktree) {
-        // The worktree is authoritatively gone (#11344). Drop its restore
+        // The worktree is authoritatively gone (#11344): drop its restore
         // bookkeeping so a snapshot from a since-superseded delete can't leak or
-        // replay, and remove any panels still pointing at it. PTY terminals were
-        // closed up front; this reaps the non-terminal panels (browser, review,
-        // …) that closeTerminalsForWorktree intentionally left alive because they
-        // hold no directory lock.
+        // replay. Do NOT touch the worktree's panels here — the deleted-worktree
+        // ghost row (#11232) deliberately leaves surviving panels alive (their
+        // agent processes keep running) until the user acts or the auto-cleanup
+        // TTL trashes them.
         discardTerminalRestores(
           worktreeId,
           outboxEntries.map((entry) => entry.mutationId)
         );
-        const panelStore = usePanelStore.getState();
-        const stalePanelIds = panelStore.panelIdsByWorktreeId[worktreeId];
-        if (stalePanelIds && stalePanelIds.length > 0) {
-          for (const panelId of [...stalePanelIds]) panelStore.removePanel(panelId);
-        }
       }
     },
 

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -2,7 +2,11 @@ import { createStore, type StoreApi } from "zustand/vanilla";
 import type { WorktreeSnapshot, WorktreeEventVersion, AttachIssuePayload } from "@shared/types";
 import { usePanelStore } from "./panelStore";
 import { worktreeClient } from "@/clients";
-import { closeTerminalsForWorktree } from "@/components/Worktree/worktreeDeleteHelper";
+import {
+  closeTerminalsForWorktree,
+  restoreClosedTerminals,
+  type WorktreeTerminalRestoreSnapshot,
+} from "@/components/Worktree/worktreeDeleteHelper";
 import { logDebug } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -1193,6 +1197,29 @@ function mintMutationId(): string {
 }
 
 /**
+ * Terminals closed ahead of a `git worktree remove`, held by `mutationId` so
+ * they can be relaunched if the delete is ultimately abandoned (#11344). Keyed
+ * by mutationId — not worktreeId — so the snapshot survives the outbox retry
+ * loop: a connectivity or generic failure leaves the delete `pending` and
+ * replays `runDeleteAsync`, but the replay finds no live terminals to snapshot
+ * (they're already dead), so the ORIGINAL capture must persist here until the
+ * delete either succeeds (entry discarded) or is definitively abandoned (entry
+ * consumed to restore). In-memory only: a host crash mid-delete loses the
+ * snapshot, which is acceptable — the PTYs died with the host regardless.
+ */
+const pendingTerminalRestores = new Map<string, WorktreeTerminalRestoreSnapshot[]>();
+
+/** Relaunch the terminals closed for a delete that has been definitively
+ *  abandoned (won't be auto-retried), then drop the snapshot. No-op when the
+ *  delete closed no terminals or a prior branch already consumed it. */
+function consumeTerminalRestore(mutationId: string): void {
+  const snapshot = pendingTerminalRestores.get(mutationId);
+  if (!snapshot) return;
+  pendingTerminalRestores.delete(mutationId);
+  void restoreClosedTerminals(snapshot);
+}
+
+/**
  * Fire-and-forget delete async chain. The dialog dismisses immediately after
  * calling `startDelete`; this runs in the background driven by the store, so
  * `get()` / `set()` must never close over component state. The success cleanup
@@ -1219,7 +1246,10 @@ async function runDeleteAsync(
 ): Promise<void> {
   try {
     if (options.closeTerminals) {
-      await closeTerminalsForWorktree(worktreeId);
+      const snapshot = await closeTerminalsForWorktree(worktreeId);
+      // Preserve the FIRST attempt's capture across retries — a replay finds no
+      // live terminals to snapshot, so an empty result must never clobber it.
+      if (snapshot.length > 0) pendingTerminalRestores.set(mutationId, snapshot);
     }
     // Stop any running dev preview BEFORE `git worktree remove` (#9084). On
     // Windows the dev server holds a directory lock and the removal would
@@ -1246,11 +1276,13 @@ async function runDeleteAsync(
         transient: true,
       });
     }
-    // Success: `worktree-removed` will fire `applyRemove`, which clears
-    // `deletingIds` + delete-error maps. The outbox entry is pruned either by
-    // `applyRemove` (success path) or by the next `get-all-states` reply via
-    // `pruneAcknowledgedMutations` (post-crash replay path). Either way, no
-    // post-success bookkeeping is owned here.
+    // Success: the worktree is gone, so the closed terminals stay closed —
+    // discard their restore snapshot. `worktree-removed` will fire
+    // `applyRemove`, which clears `deletingIds` + delete-error maps. The outbox
+    // entry is pruned either by `applyRemove` (success path) or by the next
+    // `get-all-states` reply via `pruneAcknowledgedMutations` (post-crash replay
+    // path). Either way, no post-success bookkeeping is owned here.
+    pendingTerminalRestores.delete(mutationId);
     pruneOutboxEntry(get, set, mutationId);
   } catch (err) {
     const message = formatErrorMessage(err, "Failed to delete worktree");
@@ -1262,6 +1294,10 @@ async function runDeleteAsync(
     // learns the branch was not cleaned up. Without this, the failure is
     // silently swallowed (the original race guard's bug).
     if (!prev.deletingIds.has(worktreeId) && !prev.worktrees.has(worktreeId)) {
+      // The worktree directory is already gone (only the branch delete failed),
+      // so the closed terminals have no home to come back to — drop the snapshot
+      // rather than relaunch them against a deleted worktree.
+      pendingTerminalRestores.delete(mutationId);
       pruneOutboxEntry(get, set, mutationId);
       // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
       notify({
@@ -1350,7 +1386,9 @@ function handleDeleteFailure(
 
   if (!entry) {
     // No outbox entry — shouldn't happen since `startDelete` always creates
-    // one, but defensive: still surface the error on the card.
+    // one, but defensive: still surface the error on the card. Nothing will
+    // auto-retry this delete, so bring the closed terminals back (#11344).
+    consumeTerminalRestore(mutationId);
     set({
       deletingIds: nextDeletingIds,
       deleteErrors: nextDeleteErrors,
@@ -1370,6 +1408,12 @@ function handleDeleteFailure(
     retryCount: nextRetryCount,
     lastError: message,
   });
+
+  // Only a `failed` delete is definitively abandoned; a `pending` one will be
+  // replayed (reconnect or generic retry), so relaunching now would flicker the
+  // terminals and re-close them on the next attempt. Restore solely on the
+  // terminal transition (#11344).
+  if (nextStatus === "failed") consumeTerminalRestore(mutationId);
 
   set({
     deletingIds: nextDeletingIds,


### PR DESCRIPTION
## Summary

- Deleting a worktree with "close all terminals" checked used to hard-kill every terminal in it immediately, before the git delete even ran, with no distinction for terminals running agents mid-task. If the delete then failed, those terminals were gone for good.
- `closeTerminalsForWorktree` now captures a PTY-terminal relaunch snapshot before the pre-delete hard kill. The hard kill itself stays (it's what actually releases file locks on Windows), but terminals only get relaunched, resuming journaled agent sessions where the agent type supports it, when the delete is definitively abandoned: a permanent error or hitting the retry cap. Connectivity issues, pending outbox replay, and partial success (worktree already removed) never trigger a restore.
- The delete confirmation dialog now breaks the terminal count down into a running-agent breakdown instead of a bare number.

Resolves #11344

## Changes

- `closeTerminalsForWorktree` snapshots relaunch state per terminal before the hard kill, keyed by `mutationId` so it survives the retry loop.
- Restores are serialized per worktree so a rapid retry sequence can't strand duplicate spawns.
- Restore only fires on definitive abandonment (permanent error or retry-cap exhaustion), never on connectivity/pending states or partial success.
- Respects the deleted-worktree ghost-row contract from #11232: `applyRemove` still leaves surviving panels untouched.
- `WorktreeDeleteDialog` shows a running-agent breakdown alongside the terminal count.

## Testing

Full local test suite passed for the touched files, including new tests for the relaunch snapshot capture, the abandoned-delete restore path, retry-cap behavior, and the dialog breakdown.
