### PR TITLE
fix: protect uncommitted work from stale-scratch auto-cleanup (#11353)

### DIFF
--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -1,93 +1,237 @@
 /**
- * Startup auto-cleanup for stale scratch workspaces.
+ * Startup + periodic auto-cleanup for stale scratch workspaces.
  *
- * A scratch whose `lastOpened` predates `now - SCRATCH_CLEANUP_TTL_MS` has
- * its filesystem directory removed and its DB row tombstoned (`deleted_at`
- * set), then hard-deleted once `fs.rm` succeeds. Tombstoned rows are
- * filtered out of every renderer-facing query in `ScratchStore`, so the
- * renderer never sees them again. The current scratch (per
- * `app_state.currentScratchId`) is always excluded so an actively-open
- * workspace can never disappear under the user.
+ * A scratch becomes a cleanup candidate once its `lastOpened` predates
+ * `now - SCRATCH_CLEANUP_TTL_MS`. Cleanup is a two-phase, tombstone-first
+ * process spread across sweeps so that no directory is destroyed in the same
+ * sweep it is first found stale, and so a scratch that still holds live work is
+ * never touched:
  *
- * The sweep also retries already-tombstoned rows whose directory is still
- * present — this is the recovery path for a `removeScratch` that crashed
- * between tombstone and `fs.rm`. The row is hard-deleted once the directory
- * is gone.
+ *   Phase 1 (reap): rows tombstoned on a PRIOR sweep whose grace window
+ *   (`SCRATCH_CLEANUP_GRACE_MS`) has elapsed have their directory removed and
+ *   the row hard-deleted. This is also the recovery path for a `removeScratch`
+ *   that crashed between tombstone and `fs.rm`.
  *
- * Mirrors the fire-and-forget pattern of `initializeTrashedPidCleanup`:
- * called once at app boot, never awaited, never throws — a cleanup failure
- * must not block startup.
+ *   Phase 2 (inspect + tombstone): each live stale candidate is inspected for
+ *   signs of live work — uncommitted/untracked/unpushed git state, or recent
+ *   external filesystem activity. Only a scratch that positively proves
+ *   abandoned is tombstoned (its DB row marked `deleted_at`, hiding it from
+ *   every renderer-facing query). Its directory is NOT removed here; that waits
+ *   for a later sweep's reap phase past the grace window. Any uncertainty (git
+ *   error/timeout, unreadable directory) fails closed => the scratch is left
+ *   alone. Inspection is read-only.
+ *
+ * Tombstoning is unconditional with respect to disk-pressure write suppression
+ * (#6271/#9537): the row must leave `getAllScratches()` the instant it is
+ * chosen for deletion so the switcher never lists a scratch whose directory is
+ * about to vanish. Only the reap phase's hard-delete is deferred while writes
+ * are suppressed — the directory removal still runs, reclaiming space.
+ *
+ * The current scratch (per `app_state.currentScratchId`) is always excluded
+ * from Phase 2 so an actively-open workspace can never disappear under the
+ * user. A tombstoned row whose ID still matches `currentScratchId` is the
+ * crash-recovery case and IS reaped.
+ *
+ * Known limitations (documented, not silently overstated): a clean git repo
+ * holding only local unpushed commits with no configured upstream still looks
+ * abandoned; the activity scan reads only top-level entry mtimes and does not
+ * detect a content-only edit deep under an otherwise-old top-level directory.
+ *
+ * Mirrors the fire-and-forget pattern of `initializeTrashedPidCleanup`: never
+ * awaited by production callers, never throws — a cleanup failure must not
+ * block startup.
  */
 import fs from "fs/promises";
+import type { Dirent } from "node:fs";
+import path from "path";
+import PQueue from "p-queue";
 import { scratchStore as defaultScratchStore } from "./ScratchStore.js";
+import type { ScratchRow } from "./persistence/schema.js";
 import { logError, logInfo } from "../utils/logger.js";
-import { SCRATCH_CLEANUP_TTL_MS } from "../../shared/config/scratchCleanup.js";
+import {
+  SCRATCH_CLEANUP_TTL_MS,
+  SCRATCH_CLEANUP_GRACE_MS,
+} from "../../shared/config/scratchCleanup.js";
 import { getScratchDir, getScratchesRoot } from "./scratchStorePaths.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
+import { createHardenedGit, GIT_BLOCK_TIMEOUT_MS } from "../utils/hardenedGit.js";
 
 export interface ScratchCleanupResult {
   /** Total rows examined as candidates (live-stale plus already-tombstoned). */
   candidates: number;
-  /** Rows actually tombstoned during this sweep (excludes pre-tombstoned rows). */
+  /** Rows tombstoned during this sweep (excludes pre-tombstoned rows). */
   tombstoned: number;
-  /** Directories successfully removed (or already absent). */
+  /** Directories successfully removed (or already absent) during the reap phase. */
   directoriesRemoved: number;
   /** Directories that failed to remove (logged, not rethrown). */
   directoriesFailed: number;
+  /** Live stale candidates left alone because inspection found live work or
+   * could not prove the directory abandoned. */
+  protectedCount: number;
 }
 
 /**
- * Stale-scratch sweep — runs synchronously against the DB then asynchronously
- * for the filesystem deletes. Returns a summary for tests; production callers
- * use {@link initializeScratchCleanup} which discards the result.
+ * Outcome of inspecting one candidate directory. A discriminated union rather
+ * than a bare boolean so a mis-wired call site cannot silently invert into
+ * "delete" — the sweep only ever acts on an explicit `"safe"` disposition.
+ */
+export type ScratchCleanupSafetyDecision =
+  { disposition: "safe"; reason: string } | { disposition: "protect"; reason: string };
+
+/**
+ * Injectable per-candidate safety classifier. Given the directory that would be
+ * deleted, the activity cutoff (mtimes newer than this count as live), and an
+ * abort signal, returns whether the directory is safe to tombstone. Injectable
+ * so the sweep's orchestration can be tested without spawning real git.
+ */
+export type ScratchCleanupSafetyCheck = (
+  directory: string,
+  activityCutoffMs: number,
+  signal: AbortSignal
+) => Promise<ScratchCleanupSafetyDecision>;
+
+interface InspectionOutcome {
+  row: ScratchRow;
+  decision: ScratchCleanupSafetyDecision;
+}
+
+/**
+ * The slice of `ScratchStore` the sweep depends on. Declared as a narrow
+ * interface (which `ScratchStore` satisfies structurally) so tests can inject a
+ * lightweight fake without casting through the full store type.
+ */
+export interface ScratchCleanupStore {
+  getCurrentScratchId(): string | null;
+  getStaleScratchCandidates(cutoffMs: number): ScratchRow[];
+  tombstoneScratch(scratchId: string, deletedAt: number): void;
+  hardDeleteScratch(scratchId: string): void;
+  clearCurrentScratch(): void;
+}
+
+/** Top-level directory names whose recency never counts as live work. */
+const ACTIVITY_SCAN_IGNORED_DIRS = new Set(["node_modules", ".git", "dist", "build", ".cache"]);
+
+/**
+ * Bound concurrent git-status spawns across ALL overlapping sweeps (boot,
+ * periodic, disk-critical). Module-scoped on purpose: a per-run queue would let
+ * each of the three invocations spawn its own three git processes. Mirrors
+ * `WorkspaceService`'s shared poll queue.
+ */
+const inspectionQueue = new PQueue({ concurrency: 3 });
+
+function safe(reason: string): ScratchCleanupSafetyDecision {
+  return { disposition: "safe", reason };
+}
+
+function protect(reason: string): ScratchCleanupSafetyDecision {
+  return { disposition: "protect", reason };
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+/**
+ * Default safety classifier. Fails CLOSED — every path that cannot positively
+ * prove the directory abandoned returns `protect`, so uncertainty never leads
+ * to deletion (issue #11353).
+ */
+export async function inspectScratchForCleanup(
+  directory: string,
+  activityCutoffMs: number,
+  signal: AbortSignal
+): Promise<ScratchCleanupSafetyDecision> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    // A directory that has already vanished has nothing left to protect.
+    if (isNodeError(error) && error.code === "ENOENT") return safe("missing-directory");
+    // Any other read failure (EACCES, EIO, …) is uncertainty => protect.
+    return protect("readdir-failed");
+  }
+
+  // Only treat this as a git repo when it owns a top-level `.git` entry, so an
+  // ancestor repo (via `checkIsRepo`'s upward walk) can't misclassify a plain
+  // scratch, and non-git scratches never pay for a git spawn.
+  if (entries.some((entry) => entry.name === ".git")) {
+    try {
+      const git = await createHardenedGit(directory, signal);
+      if (await git.checkIsRepo()) {
+        const status = await git.status();
+        // Uncommitted or untracked changes are exactly the "work" #11353 exists
+        // to protect; ahead-of-upstream commits are unpushed local work.
+        if (status.files.length > 0) return protect("dirty-git");
+        if (status.ahead > 0) return protect("unpushed-commits");
+        return safe("clean-git");
+      }
+    } catch {
+      // Git spawn failed, timed out, or the signal aborted — cannot prove
+      // abandonment, so protect.
+      return protect("git-check-failed");
+    }
+  }
+
+  // Non-git scratch: fall back to a bounded top-level mtime scan for signs of
+  // recent external activity. Directories that hold generated output only are
+  // skipped so a stale `node_modules`/`dist` can't keep a dead scratch alive.
+  for (const entry of entries) {
+    if (signal.aborted) return protect("inspection-aborted");
+    if (entry.isDirectory() && ACTIVITY_SCAN_IGNORED_DIRS.has(entry.name)) continue;
+    try {
+      const stat = await fs.lstat(path.join(directory, entry.name));
+      if (stat.mtimeMs > activityCutoffMs) return protect("recent-activity");
+    } catch {
+      // A per-entry stat failure is uncertainty about that entry => protect.
+      return protect("stat-failed");
+    }
+  }
+  return safe("inactive-non-git");
+}
+
+/**
+ * Stale-scratch sweep — see the module header for the two-phase design. Returns
+ * a summary for tests; production callers use {@link initializeScratchCleanup}
+ * which discards the result. `safetyCheck` is injectable so orchestration tests
+ * never spawn real git.
  */
 export async function runScratchCleanup(
   now: number = Date.now(),
-  store = defaultScratchStore
+  store: ScratchCleanupStore = defaultScratchStore,
+  safetyCheck: ScratchCleanupSafetyCheck = inspectScratchForCleanup
 ): Promise<ScratchCleanupResult> {
   const result: ScratchCleanupResult = {
     candidates: 0,
     tombstoned: 0,
     directoriesRemoved: 0,
     directoriesFailed: 0,
+    protectedCount: 0,
   };
 
-  const cutoff = now - SCRATCH_CLEANUP_TTL_MS;
+  const staleCutoff = now - SCRATCH_CLEANUP_TTL_MS;
+  const reapCutoff = now - SCRATCH_CLEANUP_GRACE_MS;
+  const root = getScratchesRoot();
   const currentScratchId = store.getCurrentScratchId();
-  // Only protect the live current scratch — a tombstoned row whose ID still
-  // matches `currentScratchId` is the exact crash-recovery case (tombstone
-  // succeeded, `clearCurrentScratch` didn't), and the sweep must finish it.
-  const candidates = store
-    .getStaleScratchCandidates(cutoff)
-    .filter((row) => !(row.id === currentScratchId && row.deletedAt == null));
+
+  const candidates = store.getStaleScratchCandidates(staleCutoff);
   result.candidates = candidates.length;
 
-  for (const row of candidates) {
-    // Lesson #3721: never treat a falsy `lastOpened` on a live row as
-    // maximally stale — skip rather than tombstone. Tombstoned rows aren't
-    // subject to this check; they've already been chosen for deletion.
-    if (!row.lastOpened && row.deletedAt == null) continue;
+  // Rows tombstoned on a prior sweep, past the grace window — ready to reap.
+  const readyToReap = candidates.filter(
+    (row) => row.deletedAt != null && row.deletedAt < reapCutoff
+  );
+  // Live stale rows eligible for inspection. The current scratch is excluded so
+  // an open workspace can never be tombstoned. Lesson #3721: a falsy
+  // `lastOpened` on a live row is missing data, not maximal staleness — skip it.
+  const liveStale = candidates.filter(
+    (row) => row.deletedAt == null && !!row.lastOpened && row.id !== currentScratchId
+  );
 
-    if (row.deletedAt == null) {
-      // Under disk-pressure write suppression (#9537), skip the tombstone DB
-      // write but still fall through to the `fs.rm` below — reclaiming the
-      // directory is the whole point of running cleanup while suppressed.
-      // `getWritesSuppressed()` is re-read here (not cached at function entry)
-      // because the async `fs.rm` of a prior candidate yields the event loop,
-      // letting the disk monitor flip the flag mid-sweep. The live row stays a
-      // candidate and is finished on a later sweep once writes resume.
-      if (!getWritesSuppressed()) {
-        try {
-          store.tombstoneScratch(row.id, now);
-          result.tombstoned += 1;
-        } catch (error) {
-          logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
-          continue;
-        }
-      }
-    }
-
-    const dir = getScratchDir(getScratchesRoot(), row.id);
+  // Phase 1: reclaim directories tombstoned on a prior sweep past the grace
+  // window (and finish any `removeScratch` that crashed mid-flight). Reaping
+  // runs first so a disk-critical sweep can promptly free mature tombstones.
+  for (const row of readyToReap) {
+    const dir = getScratchDir(root, row.id);
     if (dir) {
       try {
         await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
@@ -99,24 +243,83 @@ export async function runScratchCleanup(
     }
 
     result.directoriesRemoved += 1;
-    // Same suppression guard as the tombstone above: the directory delete has
-    // already freed the disk space, so skip the hard-delete DB write while
-    // suppressed. The row is reclaimed on a later sweep once writes resume.
+    // The directory delete already freed the disk space, so the hard-delete DB
+    // write is safe to defer while writes are suppressed (#9537). The row stays
+    // tombstoned (already hidden) and is finished on a later sweep once writes
+    // resume. Re-read the flag here — a prior candidate's async `fs.rm` yields
+    // the event loop, letting the disk monitor flip it mid-sweep.
     if (getWritesSuppressed()) continue;
     try {
       store.hardDeleteScratch(row.id);
-      if (row.id === currentScratchId) {
-        store.clearCurrentScratch();
-      }
+      if (row.id === currentScratchId) store.clearCurrentScratch();
     } catch (error) {
       logError(`[ScratchCleanup] Failed to hard-delete scratch ${row.id}`, error);
     }
   }
 
-  if (result.tombstoned > 0 || result.directoriesRemoved > 0 || result.directoriesFailed > 0) {
+  // Phase 2: inspect live stale candidates for signs of live work, bounded to
+  // three concurrent git spawns via the shared queue. Inspection is read-only
+  // and fails closed.
+  const inspected = (
+    await Promise.all(
+      liveStale.map((row) =>
+        inspectionQueue.add(async (): Promise<InspectionOutcome> => {
+          const dir = getScratchDir(root, row.id);
+          if (!dir) return { row, decision: protect("invalid-scratch-dir") };
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), GIT_BLOCK_TIMEOUT_MS);
+          try {
+            const decision = await safetyCheck(dir, staleCutoff, controller.signal);
+            return { row, decision };
+          } catch (error) {
+            logError(`[ScratchCleanup] Safety inspection threw for ${row.id}`, error);
+            return { row, decision: protect("inspection-error") };
+          } finally {
+            clearTimeout(timer);
+          }
+        })
+      )
+    )
+  ).filter((outcome): outcome is InspectionOutcome => outcome != null);
+
+  // Re-validate against a fresh snapshot: an in-app open during the async
+  // inspection updates `lastOpened` and the current pointer, and must win over
+  // a tombstone decision made moments earlier.
+  const stillStale = new Set(
+    store
+      .getStaleScratchCandidates(staleCutoff)
+      .filter((row) => row.deletedAt == null && !!row.lastOpened && row.lastOpened < staleCutoff)
+      .map((row) => row.id)
+  );
+  const currentAfterInspect = store.getCurrentScratchId();
+
+  for (const { row, decision } of inspected) {
+    if (decision.disposition !== "safe") {
+      result.protectedCount += 1;
+      continue;
+    }
+    if (row.id === currentAfterInspect || !stillStale.has(row.id)) continue;
+    try {
+      // Unconditional with respect to disk-pressure suppression: the row must
+      // leave getAllScratches() the instant it is chosen for deletion so the
+      // switcher never lists a directory that is about to be reaped (#6271/#9537).
+      store.tombstoneScratch(row.id, now);
+      result.tombstoned += 1;
+    } catch (error) {
+      logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
+    }
+  }
+
+  if (
+    result.tombstoned > 0 ||
+    result.directoriesRemoved > 0 ||
+    result.directoriesFailed > 0 ||
+    result.protectedCount > 0
+  ) {
     logInfo(
       `[ScratchCleanup] sweep complete: ${result.tombstoned} tombstoned, ` +
-        `${result.directoriesRemoved} directories removed, ${result.directoriesFailed} failed`
+        `${result.directoriesRemoved} directories removed, ${result.directoriesFailed} failed, ` +
+        `${result.protectedCount} protected`
     );
   }
 

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -48,7 +48,6 @@
  * block startup.
  */
 import fs from "fs/promises";
-import type { Dirent } from "node:fs";
 import path from "path";
 import PQueue from "p-queue";
 import { scratchStore as defaultScratchStore } from "./ScratchStore.js";
@@ -155,37 +154,33 @@ export async function inspectScratchForCleanup(
   activityCutoffMs: number,
   signal: AbortSignal
 ): Promise<ScratchCleanupSafetyDecision> {
-  let entries: Dirent[];
+  // Probe `.git` directly (O(1)) rather than materializing a potentially huge
+  // root listing just to look for it. `fs.stat` catches both a `.git` directory
+  // and a worktree/submodule `.git` file. A `.git`-bearing directory is meant to
+  // be a repo, so git is authoritative — we never fall through to the mtime scan
+  // for it (a corrupt-but-recoverable repo must not be deleted as if it were
+  // plain files). Own-`.git` restriction also stops `checkIsRepo`'s upward walk
+  // from misclassifying a plain scratch via an ancestor repo.
   try {
-    entries = await fs.readdir(directory, { withFileTypes: true });
-  } catch (error) {
-    // A directory that has already vanished has nothing left to protect.
-    if (isNodeError(error) && error.code === "ENOENT") return safe("missing-directory");
-    // Any other read failure (EACCES, EIO, …) is uncertainty => protect.
-    return protect("readdir-failed");
-  }
-
-  // A top-level `.git` entry means this is meant to be a git repo (checking the
-  // name catches both a `.git` directory and a worktree/submodule `.git` file).
-  // Once we know that, git is authoritative: only a successfully-obtained clean
-  // status is safe. We never fall through to the mtime scan for a `.git`-bearing
-  // directory — a corrupt-but-recoverable repo must not be deleted as if it were
-  // plain files. Restricting the git path to an own `.git` entry also stops
-  // `checkIsRepo`'s upward walk from misclassifying a plain scratch via an
-  // ancestor repo, and spares non-git scratches a git spawn.
-  if (entries.some((entry) => entry.name === ".git")) {
+    await fs.stat(path.join(directory, ".git"));
     return inspectGitRepo(directory, signal);
+  } catch (error) {
+    // No `.git` here — fall through to the activity scan.
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return inspectNonGitActivity(directory, activityCutoffMs, signal);
+    }
+    // A non-ENOENT stat error on `.git` (EACCES, EIO) is uncertainty => protect.
+    return protect("git-probe-failed");
   }
-
-  return inspectNonGitActivity(directory, entries, activityCutoffMs, signal);
 }
 
 /**
  * Classify a git-repo scratch. Protects any repo that still holds local work
  * that a plain `git status` misses: staged/unstaged/untracked changes, stashes,
- * and commits reachable from a local ref but not from any remote-tracking ref
- * (unpushed work — including no-upstream repos and detached HEAD, which
- * `status.ahead` alone cannot see). Any probe failure fails closed.
+ * and commits reachable from a local ref OR the reflog but not from any
+ * remote-tracking ref (unpushed work — including no-upstream repos, detached
+ * HEAD, and commits reset away but still recoverable, which `status.ahead`
+ * alone cannot see). Any probe failure fails closed.
  */
 async function inspectGitRepo(
   directory: string,
@@ -203,10 +198,13 @@ async function inspectGitRepo(
     const stash = await git.stashList();
     if (stash.total > 0) return protect("stashed-work");
 
+    // `rev-list --count` prints exactly `0` for a repo with no local-only work
+    // (including an empty/unborn repo). Only that exact `"0"` is safe — any other
+    // value, or unexpected/empty output, protects (fail closed).
     const localOnly = (
-      await git.raw(["rev-list", "--count", "--all", "--not", "--remotes"])
+      await git.raw(["rev-list", "--count", "--all", "--reflog", "--not", "--remotes"])
     ).trim();
-    if (localOnly !== "" && localOnly !== "0") return protect("unpushed-commits");
+    if (localOnly !== "0") return protect("unpushed-commits");
 
     return safe("clean-git");
   } catch {
@@ -217,55 +215,64 @@ async function inspectGitRepo(
 }
 
 /**
- * Classify a non-git scratch by a bounded recursive mtime scan. Any file OR
- * directory whose mtime is newer than the cutoff is recent external activity
- * (a content edit updates the file's own mtime, so descending catches edits
- * deep under an otherwise-old top-level directory). Generated-output
- * directories are skipped at every level; a tree that exceeds the scan bounds
- * fails closed (protect) rather than be scanned unboundedly.
+ * Classify a non-git scratch by a bounded, streaming recursive mtime scan. Any
+ * file OR directory whose mtime is newer than the cutoff is recent external
+ * activity (a content edit updates the file's own mtime, so descending catches
+ * edits deep under an otherwise-old top-level directory). Generated-output
+ * directories are skipped at every level. Entries are streamed via `fs.opendir`
+ * and counted as discovered, so a pathologically large directory is bounded by
+ * the entry/depth limits without ever materializing a giant listing; exceeding
+ * a bound fails closed (protect).
  */
 async function inspectNonGitActivity(
   root: string,
-  rootEntries: Dirent[],
   activityCutoffMs: number,
   signal: AbortSignal
 ): Promise<ScratchCleanupSafetyDecision> {
-  const stack: Array<{ dir: string; entries: Dirent[]; depth: number }> = [
-    { dir: root, entries: rootEntries, depth: 0 },
-  ];
+  const stack: Array<{ dir: string; depth: number }> = [{ dir: root, depth: 0 }];
   let visited = 0;
 
   while (stack.length > 0) {
     if (signal.aborted) return protect("inspection-aborted");
-    const frame = stack.pop()!;
-    for (const entry of frame.entries) {
-      if (signal.aborted) return protect("inspection-aborted");
-      if (entry.isDirectory() && ACTIVITY_SCAN_IGNORED_DIRS.has(entry.name)) continue;
-      if (++visited > ACTIVITY_SCAN_MAX_ENTRIES) return protect("scan-too-large");
+    const { dir, depth } = stack.pop()!;
 
-      const full = path.join(frame.dir, entry.name);
-      let stat;
-      try {
-        stat = await fs.lstat(full);
-      } catch {
-        // A per-entry stat failure is uncertainty about that entry => protect.
-        return protect("stat-failed");
-      }
-      if (stat.mtimeMs > activityCutoffMs) return protect("recent-activity");
+    try {
+      // `for await` over an fs.Dir closes the handle on completion AND on early
+      // return/throw (the async iterator's `return()` is invoked), so no
+      // explicit close is needed. A `return` below exits the function directly
+      // and is not caught here; only a genuine I/O throw reaches the catch.
+      const handle = await fs.opendir(dir);
+      for await (const entry of handle) {
+        if (signal.aborted) return protect("inspection-aborted");
+        if (entry.isDirectory() && ACTIVITY_SCAN_IGNORED_DIRS.has(entry.name)) continue;
+        if (++visited > ACTIVITY_SCAN_MAX_ENTRIES) return protect("scan-too-large");
 
-      // Descend into real subdirectories only (isDirectory() is false for a
-      // symlink, so symlink cycles are never followed). A subtree deeper than
-      // the bound cannot be cheaply proven abandoned => protect.
-      if (entry.isDirectory()) {
-        if (frame.depth + 1 > ACTIVITY_SCAN_MAX_DEPTH) return protect("scan-too-deep");
-        let childEntries: Dirent[];
+        const full = path.join(dir, entry.name);
+        let stat;
         try {
-          childEntries = await fs.readdir(full, { withFileTypes: true });
+          stat = await fs.lstat(full);
         } catch {
-          return protect("readdir-failed");
+          // A per-entry stat failure is uncertainty about that entry => protect.
+          return protect("stat-failed");
         }
-        stack.push({ dir: full, entries: childEntries, depth: frame.depth + 1 });
+        if (stat.mtimeMs > activityCutoffMs) return protect("recent-activity");
+
+        // Descend into real subdirectories only (isDirectory() is false for a
+        // symlink, so symlink cycles are never followed). A subtree deeper than
+        // the bound cannot be cheaply proven abandoned => protect.
+        if (entry.isDirectory()) {
+          if (depth + 1 > ACTIVITY_SCAN_MAX_DEPTH) return protect("scan-too-deep");
+          stack.push({ dir: full, depth: depth + 1 });
+        }
       }
+    } catch (error) {
+      // The root vanishing means nothing is left to protect; a child dir
+      // vanishing (or an enumeration error) mid-scan is skipped/failed closed.
+      if (isNodeError(error) && error.code === "ENOENT") {
+        if (depth === 0) return safe("missing-directory");
+        continue;
+      }
+      return protect("readdir-failed");
     }
   }
 

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -32,10 +32,16 @@
  * user. A tombstoned row whose ID still matches `currentScratchId` is the
  * crash-recovery case and IS reaped.
  *
- * Known limitations (documented, not silently overstated): a clean git repo
- * holding only local unpushed commits with no configured upstream still looks
- * abandoned; the activity scan reads only top-level entry mtimes and does not
- * detect a content-only edit deep under an otherwise-old top-level directory.
+ * Known limitations (documented, not silently overstated): git-ignored files
+ * in an otherwise-clean repo are treated as disposable (git-ignored = declared
+ * disposable); the activity scan is bounded, so a non-git tree larger than the
+ * scan limits fails closed (protected, never reclaimed) rather than be scanned
+ * unboundedly; once a scratch is tombstoned, work that appears externally
+ * within the grace window is not re-inspected before the directory is reaped
+ * (a tombstone is a committed deletion decision — it may equally be a user
+ * `removeScratch` that crashed, which must not be resurrected); and a scratch
+ * open only in a non-current window is not distinguished from an idle one
+ * because `currentScratchId` is a single global pointer.
  *
  * Mirrors the fire-and-forget pattern of `initializeTrashedPidCleanup`: never
  * awaited by production callers, never throws — a cleanup failure must not
@@ -108,8 +114,16 @@ export interface ScratchCleanupStore {
   clearCurrentScratch(): void;
 }
 
-/** Top-level directory names whose recency never counts as live work. */
+/** Directory names (at any depth) whose recency never counts as live work. */
 const ACTIVITY_SCAN_IGNORED_DIRS = new Set(["node_modules", ".git", "dist", "build", ".cache"]);
+
+/**
+ * Bounds for the non-git recursive activity scan. A tree that exceeds either
+ * bound cannot be cheaply proven abandoned, so the scan fails closed (protect)
+ * rather than descend unboundedly at boot.
+ */
+const ACTIVITY_SCAN_MAX_ENTRIES = 5000;
+const ACTIVITY_SCAN_MAX_DEPTH = 8;
 
 /**
  * Bound concurrent git-status spawns across ALL overlapping sweeps (boot,
@@ -151,42 +165,126 @@ export async function inspectScratchForCleanup(
     return protect("readdir-failed");
   }
 
-  // Only treat this as a git repo when it owns a top-level `.git` entry, so an
-  // ancestor repo (via `checkIsRepo`'s upward walk) can't misclassify a plain
-  // scratch, and non-git scratches never pay for a git spawn.
+  // A top-level `.git` entry means this is meant to be a git repo (checking the
+  // name catches both a `.git` directory and a worktree/submodule `.git` file).
+  // Once we know that, git is authoritative: only a successfully-obtained clean
+  // status is safe. We never fall through to the mtime scan for a `.git`-bearing
+  // directory — a corrupt-but-recoverable repo must not be deleted as if it were
+  // plain files. Restricting the git path to an own `.git` entry also stops
+  // `checkIsRepo`'s upward walk from misclassifying a plain scratch via an
+  // ancestor repo, and spares non-git scratches a git spawn.
   if (entries.some((entry) => entry.name === ".git")) {
-    try {
-      const git = await createHardenedGit(directory, signal);
-      if (await git.checkIsRepo()) {
-        const status = await git.status();
-        // Uncommitted or untracked changes are exactly the "work" #11353 exists
-        // to protect; ahead-of-upstream commits are unpushed local work.
-        if (status.files.length > 0) return protect("dirty-git");
-        if (status.ahead > 0) return protect("unpushed-commits");
-        return safe("clean-git");
+    return inspectGitRepo(directory, signal);
+  }
+
+  return inspectNonGitActivity(directory, entries, activityCutoffMs, signal);
+}
+
+/**
+ * Classify a git-repo scratch. Protects any repo that still holds local work
+ * that a plain `git status` misses: staged/unstaged/untracked changes, stashes,
+ * and commits reachable from a local ref but not from any remote-tracking ref
+ * (unpushed work — including no-upstream repos and detached HEAD, which
+ * `status.ahead` alone cannot see). Any probe failure fails closed.
+ */
+async function inspectGitRepo(
+  directory: string,
+  signal: AbortSignal
+): Promise<ScratchCleanupSafetyDecision> {
+  try {
+    const git = await createHardenedGit(directory, signal);
+    // A `.git` entry that does not resolve to a repo (corrupt, unavailable
+    // common dir) is uncertainty, not a plain directory — protect.
+    if (!(await git.checkIsRepo())) return protect("git-repo-unverified");
+
+    const status = await git.status();
+    if (status.files.length > 0) return protect("dirty-git");
+
+    const stash = await git.stashList();
+    if (stash.total > 0) return protect("stashed-work");
+
+    const localOnly = (
+      await git.raw(["rev-list", "--count", "--all", "--not", "--remotes"])
+    ).trim();
+    if (localOnly !== "" && localOnly !== "0") return protect("unpushed-commits");
+
+    return safe("clean-git");
+  } catch {
+    // Git spawn failed, timed out, the signal aborted, or a probe errored —
+    // cannot prove abandonment, so protect.
+    return protect("git-check-failed");
+  }
+}
+
+/**
+ * Classify a non-git scratch by a bounded recursive mtime scan. Any file OR
+ * directory whose mtime is newer than the cutoff is recent external activity
+ * (a content edit updates the file's own mtime, so descending catches edits
+ * deep under an otherwise-old top-level directory). Generated-output
+ * directories are skipped at every level; a tree that exceeds the scan bounds
+ * fails closed (protect) rather than be scanned unboundedly.
+ */
+async function inspectNonGitActivity(
+  root: string,
+  rootEntries: Dirent[],
+  activityCutoffMs: number,
+  signal: AbortSignal
+): Promise<ScratchCleanupSafetyDecision> {
+  const stack: Array<{ dir: string; entries: Dirent[]; depth: number }> = [
+    { dir: root, entries: rootEntries, depth: 0 },
+  ];
+  let visited = 0;
+
+  while (stack.length > 0) {
+    if (signal.aborted) return protect("inspection-aborted");
+    const frame = stack.pop()!;
+    for (const entry of frame.entries) {
+      if (signal.aborted) return protect("inspection-aborted");
+      if (entry.isDirectory() && ACTIVITY_SCAN_IGNORED_DIRS.has(entry.name)) continue;
+      if (++visited > ACTIVITY_SCAN_MAX_ENTRIES) return protect("scan-too-large");
+
+      const full = path.join(frame.dir, entry.name);
+      let stat;
+      try {
+        stat = await fs.lstat(full);
+      } catch {
+        // A per-entry stat failure is uncertainty about that entry => protect.
+        return protect("stat-failed");
       }
-    } catch {
-      // Git spawn failed, timed out, or the signal aborted — cannot prove
-      // abandonment, so protect.
-      return protect("git-check-failed");
+      if (stat.mtimeMs > activityCutoffMs) return protect("recent-activity");
+
+      // Descend into real subdirectories only (isDirectory() is false for a
+      // symlink, so symlink cycles are never followed). A subtree deeper than
+      // the bound cannot be cheaply proven abandoned => protect.
+      if (entry.isDirectory()) {
+        if (frame.depth + 1 > ACTIVITY_SCAN_MAX_DEPTH) return protect("scan-too-deep");
+        let childEntries: Dirent[];
+        try {
+          childEntries = await fs.readdir(full, { withFileTypes: true });
+        } catch {
+          return protect("readdir-failed");
+        }
+        stack.push({ dir: full, entries: childEntries, depth: frame.depth + 1 });
+      }
     }
   }
 
-  // Non-git scratch: fall back to a bounded top-level mtime scan for signs of
-  // recent external activity. Directories that hold generated output only are
-  // skipped so a stale `node_modules`/`dist` can't keep a dead scratch alive.
-  for (const entry of entries) {
-    if (signal.aborted) return protect("inspection-aborted");
-    if (entry.isDirectory() && ACTIVITY_SCAN_IGNORED_DIRS.has(entry.name)) continue;
-    try {
-      const stat = await fs.lstat(path.join(directory, entry.name));
-      if (stat.mtimeMs > activityCutoffMs) return protect("recent-activity");
-    } catch {
-      // A per-entry stat failure is uncertainty about that entry => protect.
-      return protect("stat-failed");
-    }
-  }
+  if (signal.aborted) return protect("inspection-aborted");
   return safe("inactive-non-git");
+}
+
+/** Rejects when `signal` aborts, so a hung inspection is bounded by the runner's
+ * timeout (freeing its queue slot) instead of pinning it indefinitely. */
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("inspection-timed-out"));
+      return;
+    }
+    signal.addEventListener("abort", () => reject(new Error("inspection-timed-out")), {
+      once: true,
+    });
+  });
 }
 
 /**
@@ -269,10 +367,16 @@ export async function runScratchCleanup(
           const controller = new AbortController();
           const timer = setTimeout(() => controller.abort(), GIT_BLOCK_TIMEOUT_MS);
           try {
-            const decision = await safetyCheck(dir, staleCutoff, controller.signal);
+            // Race the classifier against the abort: a hung git/fs probe hits
+            // the timeout, rejects here, and frees its queue slot instead of
+            // starving every later sweep. A timeout is uncertainty => protect.
+            const decision = await Promise.race([
+              safetyCheck(dir, staleCutoff, controller.signal),
+              rejectOnAbort(controller.signal),
+            ]);
             return { row, decision };
           } catch (error) {
-            logError(`[ScratchCleanup] Safety inspection threw for ${row.id}`, error);
+            logError(`[ScratchCleanup] Safety inspection failed for ${row.id}`, error);
             return { row, decision: protect("inspection-error") };
           } finally {
             clearTimeout(timer);

--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -108,8 +108,10 @@ export class ScratchStore {
   /**
    * Returns raw rows the cleanup sweep should consider: live rows whose
    * `last_opened` predates the cutoff, plus any already-tombstoned rows. The
-   * tombstoned set is included so a `removeScratch` that crashed between
-   * tombstone and `fs.rm` is retried on next startup.
+   * tombstoned set is included so `ScratchCleanupService` can reap them once
+   * their grace window has elapsed, and so a `removeScratch` that crashed
+   * between tombstone and `fs.rm` is retried on a later sweep. The sweep
+   * partitions these rows by `deleted_at`; this query stays age-agnostic.
    */
   getStaleScratchCandidates(cutoffMs: number): ScratchRow[] {
     const db = getSharedDb();

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -2,9 +2,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { runScratchCleanup } from "../ScratchCleanupService.js";
+import {
+  runScratchCleanup,
+  inspectScratchForCleanup,
+  type ScratchCleanupStore,
+  type ScratchCleanupSafetyCheck,
+  type ScratchCleanupSafetyDecision,
+} from "../ScratchCleanupService.js";
 import { setWritesSuppressed, resetWritesSuppressedForTesting } from "../diskPressureState.js";
-import { SCRATCH_CLEANUP_TTL_MS as SCRATCH_TTL_MS } from "../../../shared/config/scratchCleanup.js";
+import {
+  SCRATCH_CLEANUP_TTL_MS as SCRATCH_TTL_MS,
+  SCRATCH_CLEANUP_GRACE_MS as GRACE_MS,
+} from "../../../shared/config/scratchCleanup.js";
+import { createHardenedGit } from "../../utils/hardenedGit.js";
 import type { ScratchRow } from "../persistence/schema.js";
 
 const scratchTestRoot = { current: "" };
@@ -21,14 +31,27 @@ vi.mock("../scratchStorePaths.js", () => ({
   getScratchDir: (root: string, id: string) => root + "/" + id,
 }));
 
-interface FakeStore {
+// Fully replace hardenedGit so the default classifier's git branch is driven by
+// a mock and no real git process is ever spawned. GIT_BLOCK_TIMEOUT_MS is a
+// plain constant the sweep only feeds to setTimeout, so a fixed stand-in is fine.
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(),
+  GIT_BLOCK_TIMEOUT_MS: 30_000,
+}));
+
+const mockedCreateHardenedGit = vi.mocked(createHardenedGit);
+
+/** Stub a git repo with the given status for the next `createHardenedGit` call. */
+function mockGit(status: { files: unknown[]; ahead: number }, isRepo = true): void {
+  mockedCreateHardenedGit.mockResolvedValue({
+    checkIsRepo: async () => isRepo,
+    status: async () => status,
+  } as unknown as Awaited<ReturnType<typeof createHardenedGit>>);
+}
+
+interface FakeStore extends ScratchCleanupStore {
   rows: ScratchRow[];
   currentScratchId: string | null;
-  getStaleScratchCandidates: (cutoffMs: number) => ScratchRow[];
-  tombstoneScratch: (scratchId: string, deletedAt: number) => void;
-  hardDeleteScratch: (scratchId: string) => void;
-  clearCurrentScratch: () => void;
-  getCurrentScratchId: () => string | null;
 }
 
 function makeStore(rows: ScratchRow[], currentScratchId: string | null = null): FakeStore {
@@ -71,11 +94,25 @@ function row(overrides: Partial<ScratchRow> & Pick<ScratchRow, "id" | "path">): 
   };
 }
 
+/** A safety check that always allows deletion — used to exercise orchestration
+ * without spawning git. */
+const ALWAYS_SAFE: ScratchCleanupSafetyCheck = async () => ({
+  disposition: "safe",
+  reason: "test-safe",
+});
+
+/** A safety check that always protects — simulates "live work found". */
+const ALWAYS_PROTECT: ScratchCleanupSafetyCheck = async () => ({
+  disposition: "protect",
+  reason: "test-protect",
+});
+
 let tmpDir: string;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "scratch-cleanup-test-"));
   scratchTestRoot.current = tmpDir;
+  mockedCreateHardenedGit.mockReset();
 });
 
 afterEach(async () => {
@@ -85,25 +122,24 @@ afterEach(async () => {
 
 const NOW = 1_700_000_000_000;
 
-describe("runScratchCleanup", () => {
-  it("does not touch scratches younger than the TTL", async () => {
+describe("runScratchCleanup — phase 2 (inspect + tombstone)", () => {
+  it("does not touch scratches younger than the TTL and never inspects them", async () => {
     const dir = path.join(tmpDir, "fresh");
     await fs.mkdir(dir, { recursive: true });
     const store = makeStore([
       row({ id: "fresh", path: dir, lastOpened: NOW - SCRATCH_TTL_MS / 2 }),
     ]);
+    const check = vi.fn(ALWAYS_SAFE);
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, check);
 
     expect(result.tombstoned).toBe(0);
+    expect(check).not.toHaveBeenCalled();
     expect(store.rows[0]!.deletedAt).toBeNull();
     await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 
-  it("tombstones and removes scratches older than the TTL", async () => {
+  it("tombstones a stale abandoned scratch but preserves its directory", async () => {
     const dir = path.join(tmpDir, "stale");
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(path.join(dir, "a.txt"), "hello");
@@ -111,68 +147,39 @@ describe("runScratchCleanup", () => {
       row({ id: "stale", path: dir, lastOpened: NOW - (SCRATCH_TTL_MS + 86_400_000) }),
     ]);
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
     expect(result.tombstoned).toBe(1);
-    expect(result.directoriesRemoved).toBe(1);
-    expect(store.rows).toHaveLength(0);
-    await expect(fs.access(dir)).rejects.toBeDefined();
+    expect(result.directoriesRemoved).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    // The directory survives until a later sweep past the grace window.
+    await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 
-  it("hard-deletes already-tombstoned rows whose directory is missing", async () => {
+  it("leaves a scratch alone when the safety check protects it", async () => {
+    const dir = path.join(tmpDir, "protected");
+    await fs.mkdir(dir, { recursive: true });
     const store = makeStore([
-      row({
-        id: "tombstoned",
-        path: path.join(tmpDir, "missing"),
-        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
-        deletedAt: NOW - 1000,
-      }),
+      row({ id: "protected", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
     ]);
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_PROTECT);
 
-    expect(result.candidates).toBe(1);
     expect(result.tombstoned).toBe(0);
-    expect(result.directoriesRemoved).toBe(1);
-    expect(store.rows).toHaveLength(0);
+    expect(result.protectedCount).toBe(1);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+    await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 
-  it("treats a missing directory as removed (no failure)", async () => {
-    const store = makeStore([
-      row({
-        id: "ghost",
-        path: path.join(tmpDir, "does-not-exist"),
-        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
-      }),
-    ]);
-
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
-
-    expect(result.tombstoned).toBe(1);
-    expect(result.directoriesRemoved).toBe(1);
-    expect(result.directoriesFailed).toBe(0);
-  });
-
-  it("skips rows with falsy lastOpened (PR #3721 lesson)", async () => {
+  it("skips rows with falsy lastOpened without inspecting them (PR #3721 lesson)", async () => {
     const store = makeStore([row({ id: "zero", path: tmpDir, lastOpened: 0 })]);
+    const check = vi.fn(ALWAYS_SAFE);
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, check);
 
-    // lastOpened 0 < cutoff so it surfaces as a candidate, but we skip it.
     expect(result.candidates).toBe(1);
     expect(result.tombstoned).toBe(0);
+    expect(check).not.toHaveBeenCalled();
     expect(store.rows[0]!.deletedAt).toBeNull();
   });
 
@@ -182,47 +189,13 @@ describe("runScratchCleanup", () => {
     await fs.mkdir(at, { recursive: true });
     const store = makeStore([row({ id: "boundary", path: at, lastOpened: NOW - SCRATCH_TTL_MS })]);
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
     expect(result.candidates).toBe(0);
     expect(store.rows[0]!.deletedAt).toBeNull();
   });
 
-  it("finishes a tombstoned-current scratch when removeScratch crashed mid-flight", async () => {
-    // removeScratch tombstones, then clears the current pointer, then rms.
-    // If the process dies between the tombstone and clearCurrentScratch, the
-    // next sweep sees a tombstoned row whose ID still equals currentScratchId.
-    // It must NOT be excluded by the active-scratch guard — the user already
-    // asked for it gone.
-    const dir = path.join(tmpDir, "stranded");
-    await fs.mkdir(dir, { recursive: true });
-    const store = makeStore(
-      [
-        row({
-          id: "stranded",
-          path: dir,
-          lastOpened: NOW - 1000,
-          deletedAt: NOW - 500,
-        }),
-      ],
-      "stranded"
-    );
-
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
-
-    expect(result.candidates).toBe(1);
-    expect(result.directoriesRemoved).toBe(1);
-    expect(store.rows).toHaveLength(0);
-    await expect(fs.access(dir)).rejects.toBeDefined();
-  });
-
-  it("never deletes the active scratch even when stale", async () => {
+  it("never inspects or tombstones the active scratch, even when stale", async () => {
     const activeDir = path.join(tmpDir, "active");
     await fs.mkdir(activeDir, { recursive: true });
     const otherDir = path.join(tmpDir, "other");
@@ -235,84 +208,227 @@ describe("runScratchCleanup", () => {
       "active"
     );
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
     expect(result.tombstoned).toBe(1);
     expect(store.rows.find((r) => r.id === "active")!.deletedAt).toBeNull();
-    expect(store.rows.find((r) => r.id === "other")).toBeUndefined();
+    expect(store.rows.find((r) => r.id === "other")!.deletedAt).toBe(NOW);
+    // Neither directory is removed in the tombstone phase.
     await expect(fs.access(activeDir)).resolves.toBeUndefined();
-    await expect(fs.access(otherDir)).rejects.toBeDefined();
+    await expect(fs.access(otherDir)).resolves.toBeUndefined();
   });
 
-  it("retries tombstoned rows whose directory still exists", async () => {
-    const ghost = path.join(tmpDir, "ghost");
-    await fs.mkdir(ghost, { recursive: true });
-    await fs.writeFile(path.join(ghost, "left.txt"), "leftover");
-    // A prior sweep (or a `removeScratch` call) tombstoned the row but failed
-    // to remove the directory. The next sweep must finish the job.
+  it("does not tombstone a candidate opened during inspection (race)", async () => {
+    const dir = path.join(tmpDir, "opened-midflight");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({ id: "opened-midflight", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+    // Simulate the user opening the scratch while git status runs: lastOpened
+    // becomes fresh, so the post-inspection re-validation must exclude it.
+    const check: ScratchCleanupSafetyCheck = async () => {
+      store.rows[0]!.lastOpened = NOW;
+      store.currentScratchId = "opened-midflight";
+      return { disposition: "safe", reason: "test-safe" };
+    };
+
+    const result = await runScratchCleanup(NOW, store, check);
+
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("never runs more than three safety inspections concurrently", async () => {
+    const rows: ScratchRow[] = [];
+    for (let i = 0; i < 9; i++) {
+      const dir = path.join(tmpDir, `c${i}`);
+      await fs.mkdir(dir, { recursive: true });
+      rows.push(row({ id: `c${i}`, path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }));
+    }
+    const store = makeStore(rows);
+
+    let active = 0;
+    let maxActive = 0;
+    const check: ScratchCleanupSafetyCheck = async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active -= 1;
+      return { disposition: "safe", reason: "test-safe" };
+    };
+
+    const result = await runScratchCleanup(NOW, store, check);
+
+    expect(result.tombstoned).toBe(9);
+    expect(maxActive).toBeLessThanOrEqual(3);
+    expect(maxActive).toBeGreaterThanOrEqual(2); // proves it is not serialized
+  });
+});
+
+describe("runScratchCleanup — phase 1 (reap after grace)", () => {
+  it("reaps a tombstoned scratch whose grace window has elapsed", async () => {
+    const dir = path.join(tmpDir, "mature");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "left.txt"), "leftover");
     const store = makeStore([
       row({
-        id: "ghost",
-        path: ghost,
+        id: "mature",
+        path: dir,
         lastOpened: NOW - 2 * SCRATCH_TTL_MS,
-        deletedAt: NOW - 86_400_000,
+        deletedAt: NOW - 2 * GRACE_MS,
       }),
     ]);
 
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
     expect(result.candidates).toBe(1);
     expect(result.tombstoned).toBe(0);
     expect(result.directoriesRemoved).toBe(1);
-    expect(result.directoriesFailed).toBe(0);
     expect(store.rows).toHaveLength(0);
-    await expect(fs.access(ghost)).rejects.toBeDefined();
+    await expect(fs.access(dir)).rejects.toBeDefined();
   });
 
-  it("leaves the row tombstoned when fs.rm fails, then completes on a retry sweep", async () => {
+  it("does not reap a tombstone still inside the grace window", async () => {
+    const dir = path.join(tmpDir, "young-tombstone");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "young-tombstone",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - GRACE_MS / 2,
+      }),
+    ]);
+
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(result.directoriesRemoved).toBe(0);
+    expect(store.rows).toHaveLength(1);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("treats a tombstone at exactly the grace cutoff as not-yet-ready", async () => {
+    // Uses strict `<`: deletedAt == reapCutoff is inside the window.
+    const dir = path.join(tmpDir, "edge");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "edge",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - GRACE_MS,
+      }),
+    ]);
+
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(result.directoriesRemoved).toBe(0);
+    expect(store.rows).toHaveLength(1);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("hard-deletes a mature tombstone whose directory is already missing", async () => {
+    const store = makeStore([
+      row({
+        id: "gone",
+        path: path.join(tmpDir, "missing"),
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 2 * GRACE_MS,
+      }),
+    ]);
+
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(result.candidates).toBe(1);
+    expect(result.tombstoned).toBe(0);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(store.rows).toHaveLength(0);
+  });
+
+  it("finishes a mature tombstoned-current scratch when removeScratch crashed mid-flight", async () => {
+    // removeScratch tombstones, clears the current pointer, then rms. If it dies
+    // between the tombstone and clearCurrentScratch, a later sweep sees a
+    // tombstoned row whose ID still equals currentScratchId; once past grace it
+    // must be reaped, not protected by the active-scratch guard.
+    const dir = path.join(tmpDir, "stranded");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore(
+      [
+        row({
+          id: "stranded",
+          path: dir,
+          lastOpened: NOW - 1000,
+          deletedAt: NOW - 2 * GRACE_MS,
+        }),
+      ],
+      "stranded"
+    );
+
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(result.candidates).toBe(1);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(store.rows).toHaveLength(0);
+    expect(store.currentScratchId).toBeNull();
+    await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+
+  it("leaves the row tombstoned when reap fs.rm fails, then completes on a retry sweep", async () => {
     const dir = path.join(tmpDir, "retry");
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(path.join(dir, "x.txt"), "data");
     const store = makeStore([
-      row({ id: "retry", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+      row({
+        id: "retry",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 2 * GRACE_MS,
+      }),
     ]);
 
     const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("EPERM"));
 
-    const first = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const first = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
-    expect(first.tombstoned).toBe(1);
     expect(first.directoriesRemoved).toBe(0);
     expect(first.directoriesFailed).toBe(1);
     expect(store.rows).toHaveLength(1);
-    expect(store.rows[0]!.deletedAt).toBe(NOW);
     await expect(fs.access(dir)).resolves.toBeUndefined();
 
     rmSpy.mockRestore();
 
-    const second = await runScratchCleanup(
-      NOW + 1,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const second = await runScratchCleanup(NOW + 1, store, ALWAYS_SAFE);
 
-    expect(second.candidates).toBe(1);
-    expect(second.tombstoned).toBe(0);
     expect(second.directoriesRemoved).toBe(1);
     expect(second.directoriesFailed).toBe(0);
     expect(store.rows).toHaveLength(0);
     await expect(fs.access(dir)).rejects.toBeDefined();
   });
 
-  it("reclaims the directory but skips the tombstone DB write while suppressed (#9537)", async () => {
+  it("tombstones this sweep, then reaps on a later sweep past the grace window", async () => {
+    const dir = path.join(tmpDir, "two-sweep");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "a.txt"), "data");
+    const store = makeStore([
+      row({ id: "two-sweep", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+
+    const first = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+    expect(first.tombstoned).toBe(1);
+    expect(first.directoriesRemoved).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+
+    const second = await runScratchCleanup(NOW + 2 * GRACE_MS, store, ALWAYS_SAFE);
+    expect(second.directoriesRemoved).toBe(1);
+    expect(store.rows).toHaveLength(0);
+    await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+});
+
+describe("runScratchCleanup — disk-pressure suppression (#9537/#11353)", () => {
+  it("tombstones unconditionally under suppression but does not reap the fresh directory", async () => {
     const dir = path.join(tmpDir, "suppressed");
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(path.join(dir, "a.txt"), "data");
@@ -320,70 +436,37 @@ describe("runScratchCleanup", () => {
       row({ id: "suppressed", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
     ]);
     const tombstoneSpy = vi.spyOn(store, "tombstoneScratch");
-    const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
 
     setWritesSuppressed(true);
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
-    // No DB writes while suppressed...
-    expect(tombstoneSpy).not.toHaveBeenCalled();
-    expect(hardDeleteSpy).not.toHaveBeenCalled();
-    expect(result.tombstoned).toBe(0);
-    expect(store.rows).toHaveLength(1);
-    expect(store.rows[0]!.deletedAt).toBeNull();
-    // ...but the directory was still reclaimed.
-    expect(result.directoriesRemoved).toBe(1);
-    await expect(fs.access(dir)).rejects.toBeDefined();
+    // The tombstone write is now unconditional so no live row dangles at a
+    // directory that is about to be reaped — this is the #11353 fix.
+    expect(tombstoneSpy).toHaveBeenCalledWith("suppressed", NOW);
+    expect(result.tombstoned).toBe(1);
+    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    // The directory is untouched — it will be reaped on a later sweep past grace.
+    expect(result.directoriesRemoved).toBe(0);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 
-  it("re-reads suppression at each write point, not once at function entry (#9537)", async () => {
-    const dir = path.join(tmpDir, "flip");
-    await fs.mkdir(dir, { recursive: true });
-    const store = makeStore([row({ id: "flip", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS })]);
-    const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
-
-    // Start suppressed so the tombstone is skipped, then lift suppression
-    // during the async fs.rm — exactly the event-loop yield the guard re-read
-    // is designed to catch. The post-fs.rm hard-delete must see the new value.
-    setWritesSuppressed(true);
-    const rmSpy = vi.spyOn(fs, "rm").mockImplementationOnce(async () => {
-      setWritesSuppressed(false);
-    });
-
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
-
-    expect(result.tombstoned).toBe(0); // tombstone skipped while suppressed
-    expect(hardDeleteSpy).toHaveBeenCalledWith("flip"); // hard-delete sees the lift
-    expect(store.rows).toHaveLength(0);
-
-    rmSpy.mockRestore();
-  });
-
-  it("skips hard-delete of an already-tombstoned row while suppressed but still removes the directory (#9537)", async () => {
-    const dir = path.join(tmpDir, "tombstoned-suppressed");
+  it("reaps a mature tombstone under suppression but defers the hard-delete", async () => {
+    const dir = path.join(tmpDir, "mature-suppressed");
     await fs.mkdir(dir, { recursive: true });
     const store = makeStore([
       row({
-        id: "tombstoned-suppressed",
+        id: "mature-suppressed",
         path: dir,
         lastOpened: NOW - 2 * SCRATCH_TTL_MS,
-        deletedAt: NOW - 1000,
+        deletedAt: NOW - 2 * GRACE_MS,
       }),
     ]);
     const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
 
     setWritesSuppressed(true);
-    const result = await runScratchCleanup(
-      NOW,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
 
+    // Space is reclaimed, but the hidden row lingers until writes resume.
     expect(hardDeleteSpy).not.toHaveBeenCalled();
     expect(store.rows).toHaveLength(1);
     expect(result.directoriesRemoved).toBe(1);
@@ -391,11 +474,173 @@ describe("runScratchCleanup", () => {
 
     // Once writes resume, the lingering row is finished on the next sweep.
     resetWritesSuppressedForTesting();
-    const second = await runScratchCleanup(
-      NOW + 1,
-      store as unknown as Parameters<typeof runScratchCleanup>[1]
-    );
+    const second = await runScratchCleanup(NOW + 1, store, ALWAYS_SAFE);
     expect(second.candidates).toBe(1);
     expect(store.rows).toHaveLength(0);
+  });
+
+  it("re-reads suppression at each reap write point, not once at entry", async () => {
+    const dir = path.join(tmpDir, "flip");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "flip",
+        path: dir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 2 * GRACE_MS,
+      }),
+    ]);
+    const hardDeleteSpy = vi.spyOn(store, "hardDeleteScratch");
+
+    // Start suppressed, then lift suppression during the async fs.rm — the guard
+    // re-read after the event-loop yield must see the new value.
+    setWritesSuppressed(true);
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementationOnce(async () => {
+      setWritesSuppressed(false);
+    });
+
+    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+
+    expect(result.directoriesRemoved).toBe(1);
+    expect(hardDeleteSpy).toHaveBeenCalledWith("flip");
+    expect(store.rows).toHaveLength(0);
+
+    rmSpy.mockRestore();
+  });
+});
+
+describe("inspectScratchForCleanup — default safety classifier", () => {
+  const cutoff = NOW - SCRATCH_TTL_MS;
+
+  function freshSignal(): AbortSignal {
+    return new AbortController().signal;
+  }
+
+  async function makeGitDir(name: string): Promise<string> {
+    const dir = path.join(tmpDir, name);
+    await fs.mkdir(path.join(dir, ".git"), { recursive: true });
+    return dir;
+  }
+
+  it("protects a git repo with uncommitted or untracked changes", async () => {
+    const dir = await makeGitDir("dirty");
+    mockGit({ files: [{ path: "a.txt" }], ahead: 0 });
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("dirty-git");
+  });
+
+  it("protects a git repo with unpushed (ahead) commits", async () => {
+    const dir = await makeGitDir("ahead");
+    mockGit({ files: [], ahead: 2 });
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("unpushed-commits");
+  });
+
+  it("marks a clean, synced git repo safe", async () => {
+    const dir = await makeGitDir("clean");
+    mockGit({ files: [], ahead: 0 });
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("safe");
+    expect(decision.reason).toBe("clean-git");
+  });
+
+  it("protects when the git check throws or times out (fail-closed)", async () => {
+    const dir = await makeGitDir("git-error");
+    mockedCreateHardenedGit.mockRejectedValue(new Error("git blew up"));
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("git-check-failed");
+  });
+
+  it("protects a non-git directory with a recent top-level entry", async () => {
+    const dir = path.join(tmpDir, "recent");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "notes.txt");
+    await fs.writeFile(file, "edited recently");
+    await fs.utimes(file, new Date(NOW), new Date(NOW)); // mtime newer than cutoff
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("recent-activity");
+    expect(mockedCreateHardenedGit).not.toHaveBeenCalled();
+  });
+
+  it("marks a non-git directory whose entries are all old safe", async () => {
+    const dir = path.join(tmpDir, "old");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "notes.txt");
+    await fs.writeFile(file, "ancient");
+    await fs.utimes(file, new Date(NOW - 2 * SCRATCH_TTL_MS), new Date(NOW - 2 * SCRATCH_TTL_MS));
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("safe");
+    expect(decision.reason).toBe("inactive-non-git");
+  });
+
+  it("ignores recent generated-directory churn (node_modules) in a non-git scratch", async () => {
+    const dir = path.join(tmpDir, "with-node-modules");
+    await fs.mkdir(path.join(dir, "node_modules"), { recursive: true });
+    // node_modules itself is fresh, but the only real content is old.
+    const file = path.join(dir, "notes.txt");
+    await fs.writeFile(file, "ancient");
+    await fs.utimes(file, new Date(NOW - 2 * SCRATCH_TTL_MS), new Date(NOW - 2 * SCRATCH_TTL_MS));
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("safe");
+  });
+
+  it("treats a missing directory as safe (nothing left to protect)", async () => {
+    const decision = await inspectScratchForCleanup(
+      path.join(tmpDir, "does-not-exist"),
+      cutoff,
+      freshSignal()
+    );
+
+    expect(decision.disposition).toBe("safe");
+    expect(decision.reason).toBe("missing-directory");
+  });
+
+  it("protects when readdir fails with a non-ENOENT error (fail-closed)", async () => {
+    const dir = path.join(tmpDir, "eacces");
+    await fs.mkdir(dir, { recursive: true });
+    const readdirSpy = vi
+      .spyOn(fs, "readdir")
+      .mockRejectedValueOnce(Object.assign(new Error("denied"), { code: "EACCES" }));
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("readdir-failed");
+    readdirSpy.mockRestore();
+  });
+
+  it("protects when the inspection signal is already aborted (non-git scan)", async () => {
+    const dir = path.join(tmpDir, "aborted");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "notes.txt"), "old");
+    const controller = new AbortController();
+    controller.abort();
+
+    const decision: ScratchCleanupSafetyDecision = await inspectScratchForCleanup(
+      dir,
+      cutoff,
+      controller.signal
+    );
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("inspection-aborted");
   });
 });

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -707,6 +707,17 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
     expect(decision.reason).toBe("clean-git");
   });
 
+  it("protects when the local-commit probe returns unexpected/empty output (fail-closed)", async () => {
+    const dir = await makeGitDir("weird-revlist");
+    // Only an exact "0" is treated as no-local-work; empty output must protect.
+    mockGit({ files: [], stashTotal: 0, localCommits: "" });
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("unpushed-commits");
+  });
+
   it("protects when the git check throws or times out (fail-closed)", async () => {
     const dir = await makeGitDir("git-error");
     mockedCreateHardenedGit.mockRejectedValue(new Error("git blew up"));
@@ -801,10 +812,10 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
     expect(decision.reason).toBe("missing-directory");
   });
 
-  it("protects when readdir fails with a non-ENOENT error (fail-closed)", async () => {
+  it("protects when directory enumeration fails with a non-ENOENT error (fail-closed)", async () => {
     const dir = path.join(tmpDir, "eacces");
     await fs.mkdir(dir, { recursive: true });
-    vi.spyOn(fs, "readdir").mockRejectedValueOnce(
+    vi.spyOn(fs, "opendir").mockRejectedValueOnce(
       Object.assign(new Error("denied"), { code: "EACCES" })
     );
 

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
@@ -41,12 +41,28 @@ vi.mock("../../utils/hardenedGit.js", () => ({
 
 const mockedCreateHardenedGit = vi.mocked(createHardenedGit);
 
-/** Stub a git repo with the given status for the next `createHardenedGit` call. */
-function mockGit(status: { files: unknown[]; ahead: number }, isRepo = true): void {
-  mockedCreateHardenedGit.mockResolvedValue({
-    checkIsRepo: async () => isRepo,
-    status: async () => status,
-  } as unknown as Awaited<ReturnType<typeof createHardenedGit>>);
+interface GitMock {
+  checkIsRepo: Mock;
+  status: Mock;
+  stashList: Mock;
+  raw: Mock;
+}
+
+/** Stub the next `createHardenedGit` with a repo of the given shape. Returns the
+ * mock so tests can assert which probes ran. */
+function mockGit(
+  opts: { isRepo?: boolean; files?: unknown[]; stashTotal?: number; localCommits?: string } = {}
+): GitMock {
+  const git: GitMock = {
+    checkIsRepo: vi.fn(async () => opts.isRepo ?? true),
+    status: vi.fn(async () => ({ files: opts.files ?? [] })),
+    stashList: vi.fn(async () => ({ total: opts.stashTotal ?? 0, all: [], latest: null })),
+    raw: vi.fn(async () => `${opts.localCommits ?? "0"}\n`),
+  };
+  mockedCreateHardenedGit.mockResolvedValue(
+    git as unknown as Awaited<ReturnType<typeof createHardenedGit>>
+  );
+  return git;
 }
 
 interface FakeStore extends ScratchCleanupStore {
@@ -94,8 +110,8 @@ function row(overrides: Partial<ScratchRow> & Pick<ScratchRow, "id" | "path">): 
   };
 }
 
-/** A safety check that always allows deletion — used to exercise orchestration
- * without spawning git. */
+/** A safety check that always allows deletion — exercises orchestration without
+ * spawning git. */
 const ALWAYS_SAFE: ScratchCleanupSafetyCheck = async () => ({
   disposition: "safe",
   reason: "test-safe",
@@ -116,6 +132,9 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Restore fs.* spies before the real-fs teardown, so a mid-test assertion
+  // failure can never leave a one-shot fs.rm/readdir mock stubbing teardown.
+  vi.restoreAllMocks();
   resetWritesSuppressedForTesting();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
@@ -195,7 +214,7 @@ describe("runScratchCleanup — phase 2 (inspect + tombstone)", () => {
     expect(store.rows[0]!.deletedAt).toBeNull();
   });
 
-  it("never inspects or tombstones the active scratch, even when stale", async () => {
+  it("inspects only the non-active stale scratch and tombstones it", async () => {
     const activeDir = path.join(tmpDir, "active");
     await fs.mkdir(activeDir, { recursive: true });
     const otherDir = path.join(tmpDir, "other");
@@ -207,28 +226,30 @@ describe("runScratchCleanup — phase 2 (inspect + tombstone)", () => {
       ],
       "active"
     );
+    const check = vi.fn(ALWAYS_SAFE);
 
-    const result = await runScratchCleanup(NOW, store, ALWAYS_SAFE);
+    const result = await runScratchCleanup(NOW, store, check);
 
     expect(result.tombstoned).toBe(1);
+    // The active scratch is never even inspected.
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(check.mock.calls[0]![0]).toContain("other");
     expect(store.rows.find((r) => r.id === "active")!.deletedAt).toBeNull();
     expect(store.rows.find((r) => r.id === "other")!.deletedAt).toBe(NOW);
-    // Neither directory is removed in the tombstone phase.
     await expect(fs.access(activeDir)).resolves.toBeUndefined();
     await expect(fs.access(otherDir)).resolves.toBeUndefined();
   });
 
-  it("does not tombstone a candidate opened during inspection (race)", async () => {
-    const dir = path.join(tmpDir, "opened-midflight");
+  it("does not tombstone a candidate whose lastOpened became fresh during inspection", async () => {
+    const dir = path.join(tmpDir, "reopened");
     await fs.mkdir(dir, { recursive: true });
     const store = makeStore([
-      row({ id: "opened-midflight", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+      row({ id: "reopened", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
     ]);
-    // Simulate the user opening the scratch while git status runs: lastOpened
-    // becomes fresh, so the post-inspection re-validation must exclude it.
+    // Only lastOpened is refreshed (the user opened it); the current pointer is
+    // left null to isolate the stale-recheck guard.
     const check: ScratchCleanupSafetyCheck = async () => {
       store.rows[0]!.lastOpened = NOW;
-      store.currentScratchId = "opened-midflight";
       return { disposition: "safe", reason: "test-safe" };
     };
 
@@ -236,33 +257,109 @@ describe("runScratchCleanup — phase 2 (inspect + tombstone)", () => {
 
     expect(result.tombstoned).toBe(0);
     expect(store.rows[0]!.deletedAt).toBeNull();
-    await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 
-  it("never runs more than three safety inspections concurrently", async () => {
-    const rows: ScratchRow[] = [];
-    for (let i = 0; i < 9; i++) {
-      const dir = path.join(tmpDir, `c${i}`);
-      await fs.mkdir(dir, { recursive: true });
-      rows.push(row({ id: `c${i}`, path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }));
-    }
-    const store = makeStore(rows);
-
-    let active = 0;
-    let maxActive = 0;
+  it("does not tombstone a candidate that became current during inspection", async () => {
+    const dir = path.join(tmpDir, "became-current");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({ id: "became-current", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+    // Only the current pointer changes (lastOpened stays stale) to isolate the
+    // current-scratch guard.
     const check: ScratchCleanupSafetyCheck = async () => {
-      active += 1;
-      maxActive = Math.max(maxActive, active);
-      await new Promise((r) => setTimeout(r, 10));
-      active -= 1;
+      store.currentScratchId = "became-current";
       return { disposition: "safe", reason: "test-safe" };
     };
 
     const result = await runScratchCleanup(NOW, store, check);
 
-    expect(result.tombstoned).toBe(9);
-    expect(maxActive).toBeLessThanOrEqual(3);
-    expect(maxActive).toBeGreaterThanOrEqual(2); // proves it is not serialized
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+  });
+
+  it("protects a candidate whose inspection throws, without aborting the batch", async () => {
+    const boomDir = path.join(tmpDir, "boom");
+    await fs.mkdir(boomDir, { recursive: true });
+    const okDir = path.join(tmpDir, "ok");
+    await fs.mkdir(okDir, { recursive: true });
+    const store = makeStore([
+      row({ id: "boom", path: boomDir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+      row({ id: "ok", path: okDir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+    const check: ScratchCleanupSafetyCheck = async (dir) => {
+      if (dir.includes("boom")) throw new Error("kaboom");
+      return { disposition: "safe", reason: "test-safe" };
+    };
+
+    const result = await runScratchCleanup(NOW, store, check);
+
+    expect(result.protectedCount).toBe(1);
+    expect(result.tombstoned).toBe(1);
+    expect(store.rows.find((r) => r.id === "boom")!.deletedAt).toBeNull();
+    expect(store.rows.find((r) => r.id === "ok")!.deletedAt).toBe(NOW);
+  });
+
+  it("protects a candidate whose inspection never settles once the timeout fires", async () => {
+    vi.useFakeTimers();
+    try {
+      const dir = path.join(tmpDir, "hang");
+      const store = makeStore([
+        row({ id: "hang", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+      ]);
+      const check: ScratchCleanupSafetyCheck = () =>
+        new Promise<ScratchCleanupSafetyDecision>(() => {
+          /* never settles — only the runner's abort timeout can end it */
+        });
+
+      const pending = runScratchCleanup(NOW, store, check);
+      await vi.runAllTimersAsync(); // fire the inspection abort timeout
+      const result = await pending;
+
+      expect(result.protectedCount).toBe(1);
+      expect(result.tombstoned).toBe(0);
+      expect(store.rows[0]!.deletedAt).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shares one concurrency-3 budget across concurrent sweeps (module-scoped queue)", async () => {
+    const makeRows = (prefix: string) =>
+      Array.from({ length: 4 }, (_, i) =>
+        row({
+          id: `${prefix}${i}`,
+          path: path.join(tmpDir, `${prefix}${i}`),
+          lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        })
+      );
+    const storeA = makeStore(makeRows("a"));
+    const storeB = makeStore(makeRows("b"));
+
+    let active = 0;
+    let maxActive = 0;
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const check: ScratchCleanupSafetyCheck = async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await barrier;
+      active -= 1;
+      return { disposition: "safe", reason: "test-safe" };
+    };
+
+    const sweepA = runScratchCleanup(NOW, storeA, check);
+    const sweepB = runScratchCleanup(NOW, storeB, check);
+    // Let the shared queue saturate — 8 tasks, 3 slots.
+    await new Promise((r) => setTimeout(r, 30));
+    // A per-sweep queue would allow 6 concurrent; the module-scoped one caps at 3.
+    expect(maxActive).toBe(3);
+
+    release();
+    await Promise.all([sweepA, sweepB]);
+    expect(maxActive).toBe(3);
   });
 });
 
@@ -425,6 +522,36 @@ describe("runScratchCleanup — phase 1 (reap after grace)", () => {
     expect(store.rows).toHaveLength(0);
     await expect(fs.access(dir)).rejects.toBeDefined();
   });
+
+  it("reaps a mature tombstone and tombstones a live stale row in the same sweep", async () => {
+    const matureDir = path.join(tmpDir, "batch-mature");
+    await fs.mkdir(matureDir, { recursive: true });
+    const liveDir = path.join(tmpDir, "batch-live");
+    await fs.mkdir(liveDir, { recursive: true });
+    const store = makeStore([
+      row({
+        id: "batch-mature",
+        path: matureDir,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 2 * GRACE_MS,
+      }),
+      row({ id: "batch-live", path: liveDir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+    const check = vi.fn(ALWAYS_SAFE);
+
+    const result = await runScratchCleanup(NOW, store, check);
+
+    expect(result.candidates).toBe(2);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(result.tombstoned).toBe(1);
+    // The safety check runs only for the live-stale row, never the tombstone.
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(check.mock.calls[0]![0]).toContain("batch-live");
+    expect(store.rows.find((r) => r.id === "batch-mature")).toBeUndefined();
+    expect(store.rows.find((r) => r.id === "batch-live")!.deletedAt).toBe(NOW);
+    await expect(fs.access(matureDir)).rejects.toBeDefined();
+    await expect(fs.access(liveDir)).resolves.toBeUndefined();
+  });
 });
 
 describe("runScratchCleanup — disk-pressure suppression (#9537/#11353)", () => {
@@ -447,6 +574,23 @@ describe("runScratchCleanup — disk-pressure suppression (#9537/#11353)", () =>
     expect(store.rows[0]!.deletedAt).toBe(NOW);
     // The directory is untouched — it will be reaped on a later sweep past grace.
     expect(result.directoriesRemoved).toBe(0);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("still inspects (and protects) live work under suppression — suppression never bypasses the gate", async () => {
+    const dir = path.join(tmpDir, "suppressed-dirty");
+    await fs.mkdir(path.join(dir, ".git"), { recursive: true });
+    mockGit({ files: [{ path: "wip.ts" }] });
+    const store = makeStore([
+      row({ id: "suppressed-dirty", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+
+    setWritesSuppressed(true);
+    const result = await runScratchCleanup(NOW, store); // default classifier
+
+    expect(result.protectedCount).toBe(1);
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
     await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 
@@ -524,7 +668,7 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
 
   it("protects a git repo with uncommitted or untracked changes", async () => {
     const dir = await makeGitDir("dirty");
-    mockGit({ files: [{ path: "a.txt" }], ahead: 0 });
+    mockGit({ files: [{ path: "a.txt" }] });
 
     const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
 
@@ -532,9 +676,20 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
     expect(decision.reason).toBe("dirty-git");
   });
 
-  it("protects a git repo with unpushed (ahead) commits", async () => {
-    const dir = await makeGitDir("ahead");
-    mockGit({ files: [], ahead: 2 });
+  it("protects a git repo with stashed work", async () => {
+    const dir = await makeGitDir("stashed");
+    const git = mockGit({ files: [], stashTotal: 2 });
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("stashed-work");
+    expect(git.raw).not.toHaveBeenCalled(); // short-circuits before rev-list
+  });
+
+  it("protects a git repo with unpushed local-only commits", async () => {
+    const dir = await makeGitDir("unpushed");
+    mockGit({ files: [], stashTotal: 0, localCommits: "3" });
 
     const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
 
@@ -542,9 +697,9 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
     expect(decision.reason).toBe("unpushed-commits");
   });
 
-  it("marks a clean, synced git repo safe", async () => {
+  it("marks a clean, fully-pushed git repo safe", async () => {
     const dir = await makeGitDir("clean");
-    mockGit({ files: [], ahead: 0 });
+    mockGit({ files: [], stashTotal: 0, localCommits: "0" });
 
     const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
 
@@ -562,6 +717,21 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
     expect(decision.reason).toBe("git-check-failed");
   });
 
+  it("protects a .git directory that does not resolve to a repo (never falls to mtime)", async () => {
+    const dir = await makeGitDir("corrupt-git");
+    // Recent file that a naive mtime fallthrough would have to inspect.
+    const file = path.join(dir, "notes.txt");
+    await fs.writeFile(file, "recent");
+    await fs.utimes(file, new Date(NOW), new Date(NOW));
+    const git = mockGit({ isRepo: false });
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("git-repo-unverified");
+    expect(git.status).not.toHaveBeenCalled();
+  });
+
   it("protects a non-git directory with a recent top-level entry", async () => {
     const dir = path.join(tmpDir, "recent");
     await fs.mkdir(dir, { recursive: true });
@@ -574,6 +744,23 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
     expect(decision.disposition).toBe("protect");
     expect(decision.reason).toBe("recent-activity");
     expect(mockedCreateHardenedGit).not.toHaveBeenCalled();
+  });
+
+  it("protects a non-git directory whose recent edit is nested below an old top-level dir", async () => {
+    const dir = path.join(tmpDir, "nested-recent");
+    const srcDir = path.join(dir, "src");
+    await fs.mkdir(srcDir, { recursive: true });
+    const deep = path.join(srcDir, "app.ts");
+    await fs.writeFile(deep, "edited today");
+    // The nested file is recent; the top-level dir is old (a content edit does
+    // not bump the parent directory's mtime — the recursive scan must find it).
+    await fs.utimes(deep, new Date(NOW), new Date(NOW));
+    await fs.utimes(srcDir, new Date(NOW - 2 * SCRATCH_TTL_MS), new Date(NOW - 2 * SCRATCH_TTL_MS));
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("recent-activity");
   });
 
   it("marks a non-git directory whose entries are all old safe", async () => {
@@ -591,8 +778,9 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
 
   it("ignores recent generated-directory churn (node_modules) in a non-git scratch", async () => {
     const dir = path.join(tmpDir, "with-node-modules");
-    await fs.mkdir(path.join(dir, "node_modules"), { recursive: true });
-    // node_modules itself is fresh, but the only real content is old.
+    const nodeModules = path.join(dir, "node_modules");
+    await fs.mkdir(nodeModules, { recursive: true });
+    await fs.utimes(nodeModules, new Date(NOW), new Date(NOW)); // fresh, but ignored
     const file = path.join(dir, "notes.txt");
     await fs.writeFile(file, "ancient");
     await fs.utimes(file, new Date(NOW - 2 * SCRATCH_TTL_MS), new Date(NOW - 2 * SCRATCH_TTL_MS));
@@ -616,15 +804,26 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
   it("protects when readdir fails with a non-ENOENT error (fail-closed)", async () => {
     const dir = path.join(tmpDir, "eacces");
     await fs.mkdir(dir, { recursive: true });
-    const readdirSpy = vi
-      .spyOn(fs, "readdir")
-      .mockRejectedValueOnce(Object.assign(new Error("denied"), { code: "EACCES" }));
+    vi.spyOn(fs, "readdir").mockRejectedValueOnce(
+      Object.assign(new Error("denied"), { code: "EACCES" })
+    );
 
     const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
 
     expect(decision.disposition).toBe("protect");
     expect(decision.reason).toBe("readdir-failed");
-    readdirSpy.mockRestore();
+  });
+
+  it("protects when an entry lstat fails (fail-closed)", async () => {
+    const dir = path.join(tmpDir, "lstat-fail");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "notes.txt"), "x");
+    vi.spyOn(fs, "lstat").mockRejectedValueOnce(Object.assign(new Error("io"), { code: "EIO" }));
+
+    const decision = await inspectScratchForCleanup(dir, cutoff, freshSignal());
+
+    expect(decision.disposition).toBe("protect");
+    expect(decision.reason).toBe("stat-failed");
   });
 
   it("protects when the inspection signal is already aborted (non-git scan)", async () => {
@@ -642,5 +841,62 @@ describe("inspectScratchForCleanup — default safety classifier", () => {
 
     expect(decision.disposition).toBe("protect");
     expect(decision.reason).toBe("inspection-aborted");
+  });
+});
+
+describe("runScratchCleanup — end-to-end with the real default classifier", () => {
+  it("protects a dirty git scratch through a full sweep (no injected checker)", async () => {
+    const dir = path.join(tmpDir, "e2e-dirty");
+    await fs.mkdir(path.join(dir, ".git"), { recursive: true });
+    mockGit({ files: [{ path: "wip.ts" }] });
+    const store = makeStore([
+      row({ id: "e2e-dirty", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+
+    const result = await runScratchCleanup(NOW, store); // default classifier
+
+    expect(result.protectedCount).toBe(1);
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("protects a non-git scratch with activity inside the TTL window (proves the cutoff is TTL, not now)", async () => {
+    const dir = path.join(tmpDir, "e2e-recent");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "notes.txt");
+    await fs.writeFile(file, "edited two weeks ago");
+    // Opened in-app 60 days ago (stale) but a file was touched ~15 days ago.
+    // A sweep passing `now` (instead of now-TTL) as the activity cutoff would
+    // treat this 15-day-old edit as safe-to-delete; the correct cutoff protects.
+    await fs.utimes(file, new Date(NOW - SCRATCH_TTL_MS / 2), new Date(NOW - SCRATCH_TTL_MS / 2));
+    const store = makeStore([
+      row({ id: "e2e-recent", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+
+    const result = await runScratchCleanup(NOW, store); // default classifier
+
+    expect(result.protectedCount).toBe(1);
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("tombstones a genuinely abandoned non-git scratch through a full sweep", async () => {
+    const dir = path.join(tmpDir, "e2e-abandoned");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "notes.txt");
+    await fs.writeFile(file, "old");
+    await fs.utimes(file, new Date(NOW - 2 * SCRATCH_TTL_MS), new Date(NOW - 2 * SCRATCH_TTL_MS));
+    const store = makeStore([
+      row({ id: "e2e-abandoned", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+
+    const result = await runScratchCleanup(NOW, store); // default classifier
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.directoriesRemoved).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
   });
 });

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -55,10 +55,12 @@ export const scratches = sqliteTable("scratches", {
   name: text("name").notNull(),
   createdAt: integer("created_at").notNull(),
   lastOpened: integer("last_opened").notNull(),
-  // Set when the auto-cleanup sweep tombstones a stale scratch. The DB row is
-  // retained as crash-safe state so a partially-deleted directory can be
-  // re-attempted on the next startup; rows with `deletedAt` set are filtered
-  // out of all renderer-facing queries.
+  // Millisecond timestamp set when the auto-cleanup sweep tombstones a stale
+  // scratch. The DB row is retained as crash-safe state: the directory is only
+  // physically reaped on a later sweep once this timestamp is older than the
+  // grace window (SCRATCH_CLEANUP_GRACE_MS), which also covers re-attempting a
+  // partially-deleted directory. Rows with `deletedAt` set are filtered out of
+  // all renderer-facing queries.
   deletedAt: integer("deleted_at"),
 });
 

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -341,8 +341,10 @@ export async function initGlobalServices(
               // space instead of waiting for the next boot or idle sweep
               // (#9537). This callback runs synchronously on the event loop, so
               // every reclamation routine is fire-and-forget and must never
-              // block or throw. The scratch sweep checks `getWritesSuppressed()`
-              // internally, so it deletes directories without writing the DB.
+              // block or throw. The scratch sweep reclaims mature tombstones
+              // immediately (its hard-delete DB write is what `getWritesSuppressed()`
+              // defers); newly-stale scratches are tombstoned now and reaped on a
+              // later sweep once past the grace window (#11353).
               runScratchCleanup().catch((err) => {
                 logError("[DiskSpaceMonitor] scratch cleanup threw", err);
               });

--- a/shared/config/scratchCleanup.ts
+++ b/shared/config/scratchCleanup.ts
@@ -5,11 +5,28 @@
  * deletion threshold.
  */
 
-/** A scratch is eligible for cleanup once `lastOpened` is older than this. */
+/**
+ * A scratch is eligible for cleanup once `lastOpened` is older than this. At the
+ * TTL the sweep tombstones the row (hiding it from every renderer-facing query),
+ * which is also the point the UI countdown reaches zero.
+ */
 export const SCRATCH_CLEANUP_TTL_DAYS = 30;
 
 /** TTL expressed in milliseconds for direct comparison against timestamps. */
 export const SCRATCH_CLEANUP_TTL_MS = SCRATCH_CLEANUP_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * Minimum delay between tombstoning a scratch and physically removing its
+ * directory. Tombstoning happens at the TTL; the directory is only reaped on a
+ * later sweep once the tombstone is older than this grace window, so no
+ * directory is destroyed in the same sweep it is first found stale. One day
+ * spans several of the periodic sweep's four-hour cycles while keeping disk
+ * reclamation prompt.
+ */
+export const SCRATCH_CLEANUP_GRACE_DAYS = 1;
+
+/** Grace window expressed in milliseconds for direct comparison against `deletedAt`. */
+export const SCRATCH_CLEANUP_GRACE_MS = SCRATCH_CLEANUP_GRACE_DAYS * 24 * 60 * 60 * 1000;
 
 /** Show the cleanup countdown in the UI when within this many days of expiry. */
 export const SCRATCH_CLEANUP_COUNTDOWN_VISIBLE_DAYS = 7;


### PR DESCRIPTION
## Summary

- The scratch cleanup sweep in `ScratchCleanupService.ts` used to force-delete (`fs.rm` recursive) any non-current scratch directory whose database `lastOpened` timestamp was over 30 days old. That timestamp only updates when a scratch is opened inside the app, so a scratch worked on externally (another editor, another machine, or a git repo initialized inside it) for 30 days could be silently and irrecoverably deleted at the next boot.
- Under disk-pressure write suppression, the sweep also skipped writing the tombstone record but still deleted the directory, leaving a live database row pointing at a directory that no longer existed.
- This adds a read-only safety gate ahead of every deletion decision and switches to a tombstone-first, two-phase design so nothing is destroyed the same sweep it's first found stale.

Resolves #11353

## Changes

- **Safety gate** (`ScratchCleanupService.ts`): before any deletion decision, each candidate scratch is inspected read-only. Git repos are protected if they have uncommitted or untracked changes, a stash, or any commit reachable from a local ref or the reflog but not present on a remote, using the existing `createHardenedGit` helper plus `checkIsRepo`, `status`, `stashList`, and `rev-list`. Non-git directories are protected by a bounded, streaming recursive mtime scan via `fs.opendir`. Every git error, timeout, or unreadable directory fails closed (protects rather than deletes). Concurrent git spawns are bounded by a module-scoped queue of 3, shared across the boot, periodic, and disk-critical sweep triggers, with a timeout on each inspection.
- **Two-phase, tombstone-first deletion**: a stale-and-safe scratch is tombstoned this sweep (hidden from the UI), and its directory is only reaped on a later sweep once a new 1-day grace window (`SCRATCH_CLEANUP_GRACE_MS` in `shared/config/scratchCleanup.ts`) has passed.
- **Disk-pressure fix**: the tombstone write is now unconditional, since it's cheap tier-1 visibility state. Only the reap-phase directory deletion stays deferred while writes are suppressed, which keeps the original space-reclaim intent from #6271/#9537.
- Comment-only clarifications in `ScratchStore.ts`, `electron/services/persistence/schema.ts`, and `electron/window/globalServicesInit.ts` describing the new grace-period and two-phase semantics.

Known limitations, documented in the module header as out of scope for this fix: no multi-window or global current-scratch-id awareness, no re-inspection of a tombstone before it's reaped (a tombstone may represent an explicit user removal), and no handling for reclaim under sustained disk pressure.

## Testing

- `electron/services/__tests__/ScratchCleanupService.test.ts` was rewritten around the two-phase semantics: 41 cases covering safety-gate protection paths, two-sweep grace boundaries, mixed reap-and-tombstone batches, disk-pressure suppression, concurrency, a mid-inspection race, timeouts, and end-to-end sweeps through the real classifier.
- All 96 tests across the 6 affected test files pass locally.
- `eslint` and `prettier` clean on all changed files.
