### PR TITLE
fix: stop project views clobbering each other's persisted localStorage state (#11351)

### DIFF
--- a/src/store/__tests__/commandHistoryStore.test.ts
+++ b/src/store/__tests__/commandHistoryStore.test.ts
@@ -186,4 +186,61 @@ describe("commandHistoryStore persistence migration", () => {
     expect(parsed.state.history["proj1"]!.some((e) => e.prompt === "old")).toBe(true);
     expect(parsed.state.history["proj1"]!.some((e) => e.prompt === "new")).toBe(true);
   });
+
+  it("does not drop another project's history a sibling view recorded (#11351)", async () => {
+    const backing = installLocalStorage({});
+    const { useCommandHistoryStore: store } = await import("../commandHistoryStore");
+
+    // This view records project A's prompt to the shared partition.
+    store.getState().recordPrompt("proj-a", "hello", "claude");
+
+    // A sibling view (project B) records its own history directly to the shared blob.
+    const disk = JSON.parse(backing.get(STORAGE_KEY)!) as {
+      version: number;
+      state: { history: Record<string, PromptHistoryEntry[]> };
+    };
+    disk.state.history["proj-b"] = [
+      { id: "b-1", prompt: "sibling", agentId: "claude", addedAt: 1 },
+    ];
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This stale view — which never learned about B — records another prompt for A.
+    store.getState().recordPrompt("proj-a", "world", "claude");
+
+    const written = JSON.parse(backing.get(STORAGE_KEY)!) as {
+      state: { history: Record<string, PromptHistoryEntry[]> };
+    };
+    expect(Object.keys(written.state.history).sort()).toEqual(["proj-a", "proj-b"]);
+    expect(written.state.history["proj-a"]!.map((e) => e.prompt)).toEqual(["world", "hello"]);
+    expect(written.state.history["proj-b"]).toEqual([
+      { id: "b-1", prompt: "sibling", agentId: "claude", addedAt: 1 },
+    ]);
+  });
+
+  it("does not resurrect a project's history this view removed (#11351)", async () => {
+    const backing = installLocalStorage({});
+    const { useCommandHistoryStore: store } = await import("../commandHistoryStore");
+
+    store.getState().recordPrompt("proj-a", "hello", "claude");
+
+    const disk = JSON.parse(backing.get(STORAGE_KEY)!) as {
+      version: number;
+      state: { history: Record<string, PromptHistoryEntry[]> };
+    };
+    disk.state.history["proj-b"] = [
+      { id: "b-1", prompt: "sibling", agentId: "claude", addedAt: 1 },
+    ];
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // Removing this view's own project must not resurrect it, and must keep B.
+    store.getState().removeProjectHistory("proj-a");
+
+    const written = JSON.parse(backing.get(STORAGE_KEY)!) as {
+      state: { history: Record<string, PromptHistoryEntry[]> };
+    };
+    expect(written.state.history["proj-a"]).toBeUndefined();
+    expect(written.state.history["proj-b"]).toEqual([
+      { id: "b-1", prompt: "sibling", agentId: "claude", addedAt: 1 },
+    ]);
+  });
 });

--- a/src/store/__tests__/commandHistoryStore.test.ts
+++ b/src/store/__tests__/commandHistoryStore.test.ts
@@ -187,6 +187,35 @@ describe("commandHistoryStore persistence migration", () => {
     expect(parsed.state.history["proj1"]!.some((e) => e.prompt === "new")).toBe(true);
   });
 
+  it("a fresh view (null baseline) does not clobber a sibling's project bucket (#11351)", async () => {
+    const backing = installLocalStorage({});
+    const { useCommandHistoryStore: store } = await import("../commandHistoryStore");
+    // Store hydrated from empty (baseline null); a sibling then writes project B.
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 0,
+        state: {
+          history: {
+            "proj-b": [{ id: "b-1", prompt: "sibling", agentId: "claude", addedAt: 1 }],
+          },
+        },
+      })
+    );
+
+    // This view's first write records project A — its default empty map must not
+    // clobber the sibling's bucket.
+    store.getState().recordPrompt("proj-a", "hello", "claude");
+
+    const written = JSON.parse(backing.get(STORAGE_KEY)!) as {
+      state: { history: Record<string, PromptHistoryEntry[]> };
+    };
+    expect(Object.keys(written.state.history).sort()).toEqual(["proj-a", "proj-b"]);
+    expect(written.state.history["proj-b"]).toEqual([
+      { id: "b-1", prompt: "sibling", agentId: "claude", addedAt: 1 },
+    ]);
+  });
+
   it("does not drop another project's history a sibling view recorded (#11351)", async () => {
     const backing = installLocalStorage({});
     const { useCommandHistoryStore: store } = await import("../commandHistoryStore");

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -720,7 +720,7 @@ describe("helpPanelStore persistence migration", () => {
       };
     };
 
-    it("a stale view's hibernate write does not drop a sibling view's session", async () => {
+    it("a stale view's hibernate write does not drop a sibling view's session (disk read at flush)", async () => {
       vi.useFakeTimers();
       try {
         const backing = installLocalStorage({});
@@ -734,7 +734,15 @@ describe("helpPanelStore persistence migration", () => {
         });
         vi.advanceTimersByTime(400);
 
-        // A sibling view (project B) records its own session directly to the shared blob.
+        // This (stale) view updates project A again — enqueued, not yet flushed.
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+          sessionId: "a2",
+          cwd: "/a",
+          agentId: "claude",
+        });
+
+        // A sibling view (project B) writes its own session DURING the debounce
+        // window. The flush must read disk at flush time to preserve it.
         const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         disk.state.hibernateSessions["proj-b"] = {
           sessionId: "b1",
@@ -743,9 +751,170 @@ describe("helpPanelStore persistence migration", () => {
         };
         backing.set(STORAGE_KEY, JSON.stringify(disk));
 
-        // This (stale) view — which never learned about B — updates project A again.
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.hibernateSessions).toEqual({
+          "proj-a": { sessionId: "a2", cwd: "/a", agentId: "claude" },
+          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("a fresh view (null baseline) defers untouched fields to a sibling instead of clobbering with defaults", async () => {
+      vi.useFakeTimers();
+      try {
+        const backing = installLocalStorage({});
+        const mod = await import("../helpPanelStore");
+
+        // Before this freshly-hydrated view writes anything, a sibling view has
+        // already populated the shared blob (a session and a non-default width).
+        backing.set(
+          STORAGE_KEY,
+          JSON.stringify({
+            version: 5,
+            state: {
+              width: 500,
+              preferredAgentId: null,
+              autoLaunchEnabled: false,
+              introDismissed: false,
+              hibernateSessions: {
+                "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+              },
+            },
+          })
+        );
+
+        // This view's first write changes only its own field (width). Its null
+        // baseline must NOT let its default hibernateSessions {} / preferences
+        // clobber the sibling's blob.
+        mod.useHelpPanelStore.getState().setWidth(600);
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.width).toBe(600);
+        expect(written.state.hibernateSessions).toEqual({
+          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("a stale write does not clobber a sibling's width when the baseline held an out-of-range value", async () => {
+      vi.useFakeTimers();
+      try {
+        // Legacy/hand-edited blob with an out-of-range width. Hydration clamps it
+        // to HELP_PANEL_MAX_WIDTH in memory; the raw baseline must canonicalize to
+        // the same clamped value so an unrelated write doesn't read it as an edit.
+        const backing = installLocalStorage({
+          [STORAGE_KEY]: JSON.stringify({
+            version: 5,
+            state: {
+              width: HELP_PANEL_MAX_WIDTH + 1000,
+              preferredAgentId: null,
+              autoLaunchEnabled: false,
+              introDismissed: false,
+              hibernateSessions: {},
+            },
+          }),
+        });
+        const mod = await import("../helpPanelStore");
+        // Sanity: hydration clamped the in-memory width.
+        expect(mod.useHelpPanelStore.getState().width).toBe(HELP_PANEL_MAX_WIDTH);
+
+        // A sibling sets an in-range width on disk.
+        const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        disk.state.width = 500;
+        backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+        // An unrelated write (a hibernate capture) must not clobber the sibling's width.
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-x", {
+          sessionId: "x1",
+          cwd: "/x",
+          agentId: "claude",
+        });
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.width).toBe(500);
+        expect(written.state.hibernateSessions).toEqual({
+          "proj-x": { sessionId: "x1", cwd: "/x", agentId: "claude" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resurrect a session a sibling deleted that this view still holds unchanged", async () => {
+      vi.useFakeTimers();
+      try {
+        // Hydrate a blob holding two sessions, so both live in this view's memory.
+        const backing = installLocalStorage({
+          [STORAGE_KEY]: JSON.stringify({
+            version: 5,
+            state: {
+              width: HELP_PANEL_DEFAULT_WIDTH,
+              preferredAgentId: null,
+              autoLaunchEnabled: false,
+              introDismissed: false,
+              hibernateSessions: {
+                "proj-a": { sessionId: "a1", cwd: "/a", agentId: "claude" },
+                "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+              },
+            },
+          }),
+        });
+        const mod = await import("../helpPanelStore");
+
+        // A sibling deletes proj-b on disk.
+        const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        delete disk.state.hibernateSessions["proj-b"];
+        backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+        // This view writes an unrelated field; it still carries proj-b in memory,
+        // but must not resurrect the sibling's deletion.
+        mod.useHelpPanelStore.getState().setWidth(500);
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.hibernateSessions).toEqual({
+          "proj-a": { sessionId: "a1", cwd: "/a", agentId: "claude" },
+        });
+        expect(written.state.width).toBe(500);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("preserves the empty-sessionId resume-latest sentinel through a merge write (#8787)", async () => {
+      vi.useFakeTimers();
+      try {
+        const backing = installLocalStorage({});
+        const mod = await import("../helpPanelStore");
+
+        // A sibling captured a session for its own project.
+        backing.set(
+          STORAGE_KEY,
+          JSON.stringify({
+            version: 5,
+            state: {
+              width: HELP_PANEL_DEFAULT_WIDTH,
+              preferredAgentId: null,
+              autoLaunchEnabled: false,
+              introDismissed: false,
+              hibernateSessions: {
+                "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+              },
+            },
+          })
+        );
+
+        // This view captures a resume-latest sentinel (empty sessionId) for its project.
         mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
-          sessionId: "a2",
+          sessionId: "",
           cwd: "/a",
           agentId: "claude",
         });
@@ -753,7 +922,7 @@ describe("helpPanelStore persistence migration", () => {
 
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.hibernateSessions).toEqual({
-          "proj-a": { sessionId: "a2", cwd: "/a", agentId: "claude" },
+          "proj-a": { sessionId: "", cwd: "/a", agentId: "claude" },
           "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
         });
       } finally {

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -710,6 +710,118 @@ describe("helpPanelStore persistence migration", () => {
     });
   });
 
+  describe("cross-view write merge (#11351)", () => {
+    type PersistedBlob = {
+      version: number;
+      state: {
+        width: number;
+        preferredAgentId: string | null;
+        hibernateSessions: Record<string, unknown>;
+      };
+    };
+
+    it("a stale view's hibernate write does not drop a sibling view's session", async () => {
+      vi.useFakeTimers();
+      try {
+        const backing = installLocalStorage({});
+        const mod = await import("../helpPanelStore");
+
+        // This view captures project A's session and flushes it to the shared partition.
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+          sessionId: "a1",
+          cwd: "/a",
+          agentId: "claude",
+        });
+        vi.advanceTimersByTime(400);
+
+        // A sibling view (project B) records its own session directly to the shared blob.
+        const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        disk.state.hibernateSessions["proj-b"] = {
+          sessionId: "b1",
+          cwd: "/b",
+          agentId: "claude",
+        };
+        backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+        // This (stale) view — which never learned about B — updates project A again.
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+          sessionId: "a2",
+          cwd: "/a",
+          agentId: "claude",
+        });
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.hibernateSessions).toEqual({
+          "proj-a": { sessionId: "a2", cwd: "/a", agentId: "claude" },
+          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not resurrect a sibling's session when this view clears its own", async () => {
+      vi.useFakeTimers();
+      try {
+        const backing = installLocalStorage({});
+        const mod = await import("../helpPanelStore");
+
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+          sessionId: "a1",
+          cwd: "/a",
+          agentId: "claude",
+        });
+        vi.advanceTimersByTime(400);
+
+        const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        disk.state.hibernateSessions["proj-b"] = {
+          sessionId: "b1",
+          cwd: "/b",
+          agentId: "claude",
+        };
+        backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+        // Clearing this view's own project must not resurrect it, and must keep B.
+        mod.useHelpPanelStore.getState().clearHibernateSession("proj-a");
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.hibernateSessions).toEqual({
+          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("a stale scalar write does not clobber a sibling's preferredAgentId change", async () => {
+      vi.useFakeTimers();
+      try {
+        const backing = installLocalStorage({});
+        const mod = await import("../helpPanelStore");
+
+        mod.useHelpPanelStore.getState().setWidth(500);
+        vi.advanceTimersByTime(400);
+
+        // A sibling view changes preferredAgentId directly on the shared blob.
+        const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        disk.state.preferredAgentId = "codex";
+        backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+        // This stale view changes only width; its in-memory preferredAgentId is still null.
+        mod.useHelpPanelStore.getState().setWidth(600);
+        vi.advanceTimersByTime(400);
+
+        const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+        expect(written.state.width).toBe(600);
+        expect(written.state.preferredAgentId).toBe("codex");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("autoLaunchEnabled (#10699)", () => {
     it("starts false on a fresh install so opening the panel never auto-bills a session", async () => {
       installLocalStorage({});

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -716,6 +716,8 @@ describe("helpPanelStore persistence migration", () => {
       state: {
         width: number;
         preferredAgentId: string | null;
+        autoLaunchEnabled: boolean;
+        introDismissed: boolean;
         hibernateSessions: Record<string, unknown>;
       };
     };
@@ -770,7 +772,8 @@ describe("helpPanelStore persistence migration", () => {
         const mod = await import("../helpPanelStore");
 
         // Before this freshly-hydrated view writes anything, a sibling view has
-        // already populated the shared blob (a session and a non-default width).
+        // already populated the shared blob with a session and NON-DEFAULT
+        // preferences (so a defaults-clobbering merge would be caught).
         backing.set(
           STORAGE_KEY,
           JSON.stringify({
@@ -778,8 +781,8 @@ describe("helpPanelStore persistence migration", () => {
             state: {
               width: 500,
               preferredAgentId: null,
-              autoLaunchEnabled: false,
-              introDismissed: false,
+              autoLaunchEnabled: true,
+              introDismissed: true,
               hibernateSessions: {
                 "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
               },
@@ -795,6 +798,8 @@ describe("helpPanelStore persistence migration", () => {
 
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.width).toBe(600);
+        expect(written.state.autoLaunchEnabled).toBe(true);
+        expect(written.state.introDismissed).toBe(true);
         expect(written.state.hibernateSessions).toEqual({
           "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
         });

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -434,6 +434,59 @@ describe("persistence boundary hardening", () => {
     }
   });
 
+  it("createSafeJSONStorage mergeOnWrite re-applies a deletion even when the merged bytes repeat (#11351)", async () => {
+    const backing = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => backing.get(key) ?? null,
+      setItem: (key, value) => {
+        backing.set(key, value);
+      },
+      removeItem: (key) => {
+        backing.delete(key);
+      },
+    });
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const { mergeRecordByWriterDelta } = await import("../persistence/persistWriteMerge");
+
+    type Sessions = { sessions: Record<string, { v: string }> };
+    const mergeSessions: PersistWriteMerge<Sessions> = ({ baseline, onDisk, incoming }) => {
+      if (!onDisk) return incoming;
+      return {
+        version: incoming.version,
+        state: {
+          sessions: mergeRecordByWriterDelta(
+            baseline?.state.sessions ?? {},
+            incoming.state.sessions,
+            onDisk.state.sessions ?? {}
+          ),
+        },
+      };
+    };
+    const KEY = "merge-dedup";
+    const val = (sessions: Sessions["sessions"]) => ({ state: { sessions }, version: 1 });
+    const diskSessions = () =>
+      (JSON.parse(backing.get(KEY) ?? "null") as { state: Sessions } | null)?.state.sessions;
+
+    const viewA = createSafeJSONStorage<Sessions>({ mergeOnWrite: mergeSessions });
+    viewA.getItem(KEY); // baseline null
+    viewA.setItem(KEY, val({ a: { v: "a" } })); // disk { a }, baseline { a }
+
+    // A sibling deletes `a`; view A's unchanged write of `{a}` merges to `{}`
+    // (a is gone from disk and unchanged by A). This is the merged output a naive
+    // dedup would cache.
+    backing.set(KEY, JSON.stringify(val({})));
+    viewA.setItem(KEY, val({ a: { v: "a" } }));
+    expect(diskSessions()).toEqual({});
+
+    // A sibling re-adds `a`, then view A intentionally deletes it. The merge again
+    // yields `{}` — identical bytes — so a merged-output dedup would WRONGLY skip
+    // the write and leave the sibling's re-added `a` on disk.
+    backing.set(KEY, JSON.stringify(val({ a: { v: "sibling" } })));
+    viewA.setItem(KEY, val({}));
+    expect(diskSessions()).toEqual({});
+  });
+
   it("agentPreferencesStore boots cleanly when the legacy toolbar blob is corrupt JSON", async () => {
     // Realistic first-run upgrade scenario: primary key absent, legacy toolbar
     // key holds corrupt JSON. Zustand's persist skips merge() when the primary

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PersistWriteMerge } from "../persistence/persistWriteMerge";
 
 type StorageMock = {
   getItem: (key: string) => string | null;
@@ -259,6 +260,178 @@ describe("persistence boundary hardening", () => {
     storage.setItem("round-trip-key", { state: { value: 7 }, version: 1 });
 
     expect(storage.getItem("round-trip-key")).toEqual({ state: { value: 7 }, version: 1 });
+  });
+
+  it("createSafeJSONStorage mergeOnWrite reconciles concurrent project-view writes without clobbering (#11351)", async () => {
+    const backing = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => backing.get(key) ?? null,
+      setItem: (key, value) => {
+        backing.set(key, value);
+      },
+      removeItem: (key) => {
+        backing.delete(key);
+      },
+    });
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const { mergeRecordByWriterDelta } = await import("../persistence/persistWriteMerge");
+
+    type Sessions = { sessions: Record<string, { v: string }> };
+    const mergeSessions: PersistWriteMerge<Sessions> = ({ baseline, onDisk, incoming }) => {
+      if (!onDisk) return incoming;
+      return {
+        version: incoming.version,
+        state: {
+          sessions: mergeRecordByWriterDelta(
+            baseline?.state.sessions ?? {},
+            incoming.state.sessions,
+            onDisk.state.sessions ?? {}
+          ),
+        },
+      };
+    };
+    const KEY = "merge-sessions";
+    const val = (sessions: Sessions["sessions"]) => ({ state: { sessions }, version: 1 });
+    const diskSessions = () =>
+      (JSON.parse(backing.get(KEY) ?? "null") as { state: Sessions } | null)?.state.sessions;
+    const backupSessions = () =>
+      (JSON.parse(backing.get(`${KEY}.__bak`) ?? "null") as { state: Sessions } | null)?.state
+        .sessions;
+
+    // Two views hydrate the same (empty) shared baseline.
+    const viewA = createSafeJSONStorage<Sessions>({ mergeOnWrite: mergeSessions });
+    const viewB = createSafeJSONStorage<Sessions>({ mergeOnWrite: mergeSessions });
+    viewA.getItem(KEY);
+    viewB.getItem(KEY);
+
+    // View B writes its own project's session.
+    viewB.setItem(KEY, val({ b: { v: "b" } }));
+    // Stale view A — which never saw B's write — writes its own project's session.
+    viewA.setItem(KEY, val({ a: { v: "a" } }));
+
+    // Neither view's entry was dropped, and the backup tracks the merged result.
+    expect(diskSessions()).toEqual({ a: { v: "a" }, b: { v: "b" } });
+    expect(backupSessions()).toEqual({ a: { v: "a" }, b: { v: "b" } });
+
+    // A third view hydrated now, while both entries exist.
+    const viewC = createSafeJSONStorage<Sessions>({ mergeOnWrite: mergeSessions });
+    viewC.getItem(KEY);
+
+    // View A intentionally clears its own entry.
+    viewA.setItem(KEY, val({}));
+    expect(diskSessions()).toEqual({ b: { v: "b" } });
+
+    // The stale third view still carries `a` in memory and writes an unrelated
+    // addition — `a` must NOT be resurrected, and `b`/`c` survive.
+    viewC.setItem(KEY, val({ a: { v: "a" }, b: { v: "b" }, c: { v: "c" } }));
+    expect(diskSessions()).toEqual({ b: { v: "b" }, c: { v: "c" } });
+
+    // A freshly-hydrating view observes the final converged state.
+    const viewFresh = createSafeJSONStorage<Sessions>({ mergeOnWrite: mergeSessions });
+    expect(viewFresh.getItem(KEY)).toEqual(val({ b: { v: "b" }, c: { v: "c" } }));
+  });
+
+  it("createSafeJSONStorage mergeOnWrite advances the baseline to the writer's snapshot, not the merged result (#11351)", async () => {
+    const backing = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => backing.get(key) ?? null,
+      setItem: (key, value) => {
+        backing.set(key, value);
+      },
+      removeItem: (key) => {
+        backing.delete(key);
+      },
+    });
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const { mergeRecordByWriterDelta } = await import("../persistence/persistWriteMerge");
+
+    type Sessions = { sessions: Record<string, { v: string }> };
+    const mergeSessions: PersistWriteMerge<Sessions> = ({ baseline, onDisk, incoming }) => {
+      if (!onDisk) return incoming;
+      return {
+        version: incoming.version,
+        state: {
+          sessions: mergeRecordByWriterDelta(
+            baseline?.state.sessions ?? {},
+            incoming.state.sessions,
+            onDisk.state.sessions ?? {}
+          ),
+        },
+      };
+    };
+    const KEY = "merge-baseline";
+    const val = (sessions: Sessions["sessions"]) => ({ state: { sessions }, version: 1 });
+    const diskSessions = () =>
+      (JSON.parse(backing.get(KEY) ?? "null") as { state: Sessions } | null)?.state.sessions;
+
+    const viewA = createSafeJSONStorage<Sessions>({ mergeOnWrite: mergeSessions });
+    viewA.getItem(KEY);
+    viewA.setItem(KEY, val({ a: { v: "a" } })); // baseline advances to { a }
+
+    // A sibling adds `b` on disk; the merged disk is now { a, b } but view A's
+    // baseline must remain { a } — folding `b` into the baseline would make the
+    // next unchanged write look like an intentional deletion of `b`.
+    backing.set(KEY, JSON.stringify(val({ a: { v: "a" }, b: { v: "b" } })));
+
+    // View A writes an unchanged snapshot repeatedly; `b` must survive every time.
+    viewA.setItem(KEY, val({ a: { v: "a" } }));
+    expect(diskSessions()).toEqual({ a: { v: "a" }, b: { v: "b" } });
+    viewA.setItem(KEY, val({ a: { v: "a" } }));
+    expect(diskSessions()).toEqual({ a: { v: "a" }, b: { v: "b" } });
+  });
+
+  it("createDebouncedSafeJSONStorage mergeOnWrite reads disk at flush time, not enqueue time (#11351)", async () => {
+    vi.useFakeTimers();
+    try {
+      const backing = new Map<string, string>();
+      installLocalStorage({
+        getItem: (key) => backing.get(key) ?? null,
+        setItem: (key, value) => {
+          backing.set(key, value);
+        },
+        removeItem: (key) => {
+          backing.delete(key);
+        },
+      });
+
+      const { createDebouncedSafeJSONStorage } = await import("../persistence/safeStorage");
+      const { mergeRecordByWriterDelta } = await import("../persistence/persistWriteMerge");
+
+      type Sessions = { sessions: Record<string, { v: string }> };
+      const mergeSessions: PersistWriteMerge<Sessions> = ({ baseline, onDisk, incoming }) => {
+        if (!onDisk) return incoming;
+        return {
+          version: incoming.version,
+          state: {
+            sessions: mergeRecordByWriterDelta(
+              baseline?.state.sessions ?? {},
+              incoming.state.sessions,
+              onDisk.state.sessions ?? {}
+            ),
+          },
+        };
+      };
+      const KEY = "merge-debounced";
+      const val = (sessions: Sessions["sessions"]) => ({ state: { sessions }, version: 1 });
+      const diskSessions = () =>
+        (JSON.parse(backing.get(KEY) ?? "null") as { state: Sessions } | null)?.state.sessions;
+
+      const viewA = createDebouncedSafeJSONStorage<Sessions>(300, { mergeOnWrite: mergeSessions });
+      viewA.getItem(KEY); // hydrate empty → baseline null
+      viewA.setItem(KEY, val({ a: { v: "a" } }));
+      vi.advanceTimersByTime(400); // flush → disk { a }, baseline { a }
+
+      // Enqueue a change, THEN a sibling writes `b` before the debounce fires.
+      viewA.setItem(KEY, val({ a: { v: "a2" } }));
+      backing.set(KEY, JSON.stringify(val({ a: { v: "a" }, b: { v: "b" } })));
+      vi.advanceTimersByTime(400); // flush must read disk NOW and preserve `b`
+
+      expect(diskSessions()).toEqual({ a: { v: "a2" }, b: { v: "b" } });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("agentPreferencesStore boots cleanly when the legacy toolbar blob is corrupt JSON", async () => {

--- a/src/store/commandHistoryStore.ts
+++ b/src/store/commandHistoryStore.ts
@@ -34,8 +34,10 @@ interface CommandHistoryState {
   removeProjectHistory: (projectId: string) => void;
 }
 
+type CommandHistoryPersistedState = Pick<CommandHistoryState, "history">;
+
 function historyOf(
-  value: StorageValue<CommandHistoryState> | null
+  value: StorageValue<CommandHistoryPersistedState> | null
 ): Record<string, PromptHistoryEntry[]> {
   const history = value?.state?.history;
   return history !== null && typeof history === "object" ? history : {};
@@ -53,13 +55,12 @@ function mergeCommandHistoryPersistedWrite({
   baseline,
   onDisk,
   incoming,
-}: PersistWriteMergeContext<CommandHistoryState>): StorageValue<CommandHistoryState> {
+}: PersistWriteMergeContext<CommandHistoryPersistedState>): StorageValue<CommandHistoryPersistedState> {
   // No shared value on disk yet → nothing to reconcile against.
   if (!onDisk) return incoming;
   return {
     version: incoming.version,
     state: {
-      ...incoming.state,
       history: mergeRecordByWriterDelta(
         historyOf(baseline),
         historyOf(incoming),
@@ -129,12 +130,12 @@ export const useCommandHistoryStore = create<CommandHistoryState>()(
     }),
     {
       name: "daintree-command-history",
-      storage: createSafeJSONStorage<CommandHistoryState>({
+      storage: createSafeJSONStorage<CommandHistoryPersistedState>({
         mergeOnWrite: mergeCommandHistoryPersistedWrite,
       }),
       version: 0,
       migrate: (persistedState) => persistedState as CommandHistoryState,
-      partialize: (state) => ({ history: state.history }),
+      partialize: (state): CommandHistoryPersistedState => ({ history: state.history }),
     }
   )
 );

--- a/src/store/commandHistoryStore.ts
+++ b/src/store/commandHistoryStore.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  mergeRecordByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_HISTORY_SIZE = 100;
@@ -27,6 +32,41 @@ interface CommandHistoryState {
   getProjectHistory: (projectId: string | undefined) => PromptHistoryEntry[];
   getGlobalHistory: () => PromptHistoryEntry[];
   removeProjectHistory: (projectId: string) => void;
+}
+
+function historyOf(
+  value: StorageValue<CommandHistoryState> | null
+): Record<string, PromptHistoryEntry[]> {
+  const history = value?.state?.history;
+  return history !== null && typeof history === "object" ? history : {};
+}
+
+/**
+ * Baseline-aware three-way merge for command-history writes across project views
+ * (issue #11351). Each project's history array is one record value: a stale view
+ * writing its own project's bucket no longer drops another project's history a
+ * sibling view recorded, and a `removeProjectHistory` isn't resurrected.
+ * Concurrent writes to the *same* project bucket remain last-writer-wins (the
+ * separate same-project multi-window case).
+ */
+function mergeCommandHistoryPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<CommandHistoryState>): StorageValue<CommandHistoryState> {
+  // No shared value on disk yet → nothing to reconcile against.
+  if (!onDisk) return incoming;
+  return {
+    version: incoming.version,
+    state: {
+      ...incoming.state,
+      history: mergeRecordByWriterDelta(
+        historyOf(baseline),
+        historyOf(incoming),
+        historyOf(onDisk)
+      ),
+    },
+  };
 }
 
 export const useCommandHistoryStore = create<CommandHistoryState>()(
@@ -89,7 +129,9 @@ export const useCommandHistoryStore = create<CommandHistoryState>()(
     }),
     {
       name: "daintree-command-history",
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<CommandHistoryState>({
+        mergeOnWrite: mergeCommandHistoryPersistedWrite,
+      }),
       version: 0,
       migrate: (persistedState) => persistedState as CommandHistoryState,
       partialize: (state) => ({ history: state.history }),

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -185,7 +185,14 @@ const HELP_PANEL_PERSISTED_DEFAULTS: HelpPanelPersistedState = {
 function toHelpPanelPersisted(state: Partial<HelpPanelState> | undefined): HelpPanelPersistedState {
   if (!state) return HELP_PANEL_PERSISTED_DEFAULTS;
   return {
-    width: typeof state.width === "number" ? state.width : HELP_PANEL_PERSISTED_DEFAULTS.width,
+    // Clamp width exactly as the v5 hydration `merge` does, so a raw baseline
+    // holding an out-of-range value (legacy/hand-edited blob) canonicalizes to
+    // the same clamped value the store hydrated into memory — otherwise the
+    // clamp would read as a writer edit and clobber a sibling's width (#11351).
+    width:
+      typeof state.width === "number"
+        ? Math.min(Math.max(state.width, HELP_PANEL_MIN_WIDTH), HELP_PANEL_MAX_WIDTH)
+        : HELP_PANEL_PERSISTED_DEFAULTS.width,
     preferredAgentId: typeof state.preferredAgentId === "string" ? state.preferredAgentId : null,
     autoLaunchEnabled: state.autoLaunchEnabled === true,
     introDismissed: state.introDismissed === true,
@@ -199,14 +206,19 @@ function toHelpPanelPersisted(state: Partial<HelpPanelState> | undefined): HelpP
  * this writer changed them; `hibernateSessions` merges per project id so a stale
  * view neither drops a sibling's session nor resurrects one it (or a sibling)
  * intentionally cleared. Leaves the v5 hydration `merge` untouched.
+ *
+ * `preferredAgentId` is compared against the raw baseline, which is correct for
+ * built-in assistant agents (validated synchronously at hydration, so baseline
+ * and in-memory agree). The narrow residual: a user/plugin agent invalidated at
+ * hydration only because its registry had not loaded yet can, across two
+ * simultaneously-open views, converge to a null preference — recoverable by
+ * re-selecting it, and no worse than the pre-fix full-replace clobber.
  */
 function mergeHelpPanelPersistedWrite({
   baseline,
   onDisk,
   incoming,
-}: PersistWriteMergeContext<HelpPanelState & HelpPanelActions>): StorageValue<
-  HelpPanelState & HelpPanelActions
-> {
+}: PersistWriteMergeContext<HelpPanelPersistedState>): StorageValue<HelpPanelPersistedState> {
   // No shared value on disk yet → nothing to reconcile against.
   if (!onDisk) return incoming;
   const base = baseline ? toHelpPanelPersisted(baseline.state) : HELP_PANEL_PERSISTED_DEFAULTS;
@@ -235,7 +247,7 @@ function mergeHelpPanelPersistedWrite({
       disk.hibernateSessions
     ),
   };
-  return { version: incoming.version, state: { ...incoming.state, ...merged } };
+  return { version: incoming.version, state: merged };
 }
 
 export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
@@ -336,12 +348,12 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     }),
     {
       name: "help-panel-storage",
-      storage: createDebouncedSafeJSONStorage<HelpPanelState & HelpPanelActions>(300, {
+      storage: createDebouncedSafeJSONStorage<HelpPanelPersistedState>(300, {
         mergeOnWrite: mergeHelpPanelPersistedWrite,
       }),
       version: 5,
       migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
-      partialize: (state) => ({
+      partialize: (state): HelpPanelPersistedState => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,
         autoLaunchEnabled: state.autoLaunchEnabled,

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -1,6 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import { createDebouncedSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  mergeRecordByWriterDelta,
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { getAssistantSupportedAgentIds } from "../../shared/config/agentRegistry";
 import { isBuiltInAgentId } from "../../shared/config/agentIds";
@@ -155,6 +161,83 @@ function sanitizeHibernateSessions(value: unknown): Record<string, HelpHibernate
   return out;
 }
 
+type HelpPanelPersistedState = Pick<
+  HelpPanelState,
+  "width" | "preferredAgentId" | "autoLaunchEnabled" | "introDismissed" | "hibernateSessions"
+>;
+
+const HELP_PANEL_PERSISTED_DEFAULTS: HelpPanelPersistedState = {
+  width: HELP_PANEL_DEFAULT_WIDTH,
+  preferredAgentId: null,
+  autoLaunchEnabled: false,
+  introDismissed: false,
+  hibernateSessions: {},
+};
+
+/**
+ * Coerce a raw persisted blob (this view's baseline, disk, or incoming) to the
+ * canonical persisted shape so the write merge compares like with like. A
+ * missing/malformed field falls back to its default — the important case being
+ * an absent baseline (a fresh view), which normalizes to the defaults so its
+ * untouched fields compare equal to `incoming` and thus defer to a sibling's
+ * on-disk value instead of clobbering it (issue #11351).
+ */
+function toHelpPanelPersisted(state: Partial<HelpPanelState> | undefined): HelpPanelPersistedState {
+  if (!state) return HELP_PANEL_PERSISTED_DEFAULTS;
+  return {
+    width: typeof state.width === "number" ? state.width : HELP_PANEL_PERSISTED_DEFAULTS.width,
+    preferredAgentId: typeof state.preferredAgentId === "string" ? state.preferredAgentId : null,
+    autoLaunchEnabled: state.autoLaunchEnabled === true,
+    introDismissed: state.introDismissed === true,
+    hibernateSessions: sanitizeHibernateSessions(state.hibernateSessions),
+  };
+}
+
+/**
+ * Baseline-aware three-way merge for help-panel writes across project views
+ * (issue #11351). Scalar preferences defer to a sibling's on-disk value unless
+ * this writer changed them; `hibernateSessions` merges per project id so a stale
+ * view neither drops a sibling's session nor resurrects one it (or a sibling)
+ * intentionally cleared. Leaves the v5 hydration `merge` untouched.
+ */
+function mergeHelpPanelPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<HelpPanelState & HelpPanelActions>): StorageValue<
+  HelpPanelState & HelpPanelActions
+> {
+  // No shared value on disk yet → nothing to reconcile against.
+  if (!onDisk) return incoming;
+  const base = baseline ? toHelpPanelPersisted(baseline.state) : HELP_PANEL_PERSISTED_DEFAULTS;
+  const disk = toHelpPanelPersisted(onDisk.state);
+  const inc = toHelpPanelPersisted(incoming.state);
+  const merged: HelpPanelPersistedState = {
+    width: pickFieldByWriterDelta(base.width, inc.width, disk.width),
+    preferredAgentId: pickFieldByWriterDelta(
+      base.preferredAgentId,
+      inc.preferredAgentId,
+      disk.preferredAgentId
+    ),
+    autoLaunchEnabled: pickFieldByWriterDelta(
+      base.autoLaunchEnabled,
+      inc.autoLaunchEnabled,
+      disk.autoLaunchEnabled
+    ),
+    introDismissed: pickFieldByWriterDelta(
+      base.introDismissed,
+      inc.introDismissed,
+      disk.introDismissed
+    ),
+    hibernateSessions: mergeRecordByWriterDelta(
+      base.hibernateSessions,
+      inc.hibernateSessions,
+      disk.hibernateSessions
+    ),
+  };
+  return { version: incoming.version, state: { ...incoming.state, ...merged } };
+}
+
 export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
   persist(
     (set) => ({
@@ -253,7 +336,9 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     }),
     {
       name: "help-panel-storage",
-      storage: createDebouncedSafeJSONStorage(300),
+      storage: createDebouncedSafeJSONStorage<HelpPanelState & HelpPanelActions>(300, {
+        mergeOnWrite: mergeHelpPanelPersistedWrite,
+      }),
       version: 5,
       migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({

--- a/src/store/persistence/__tests__/persistWriteMerge.test.ts
+++ b/src/store/persistence/__tests__/persistWriteMerge.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { mergeRecordByWriterDelta, pickFieldByWriterDelta } from "../persistWriteMerge";
+
+interface Session {
+  sessionId: string;
+  cwd: string;
+}
+
+const A: Session = { sessionId: "a", cwd: "/a" };
+const A2: Session = { sessionId: "a2", cwd: "/a" };
+const B: Session = { sessionId: "b", cwd: "/b" };
+const B2: Session = { sessionId: "b2", cwd: "/b" };
+
+describe("mergeRecordByWriterDelta", () => {
+  it("keeps a key the writer added (absent from baseline)", () => {
+    // baseline: {}, incoming: {a}, disk: {}
+    expect(mergeRecordByWriterDelta({}, { a: A }, {})).toEqual({ a: A });
+  });
+
+  it("keeps a key the writer changed relative to its baseline", () => {
+    // writer owned `a` and updated it; a's new value wins over disk's old one
+    expect(mergeRecordByWriterDelta({ a: A }, { a: A2 }, { a: A })).toEqual({ a: A2 });
+  });
+
+  it("takes the on-disk value for a key the writer left unchanged (sibling edited it)", () => {
+    // writer didn't touch `a`; a sibling changed it on disk → sibling wins
+    expect(mergeRecordByWriterDelta({ a: A }, { a: A }, { a: A2 })).toEqual({ a: A2 });
+  });
+
+  it("does not resurrect a key a sibling deleted that the writer left unchanged", () => {
+    // writer still carries `a` (unchanged), but a sibling deleted it on disk → stays gone
+    expect(mergeRecordByWriterDelta({ a: A }, { a: A }, {})).toEqual({});
+  });
+
+  it("drops a key the writer intentionally deleted even if it lingers on disk", () => {
+    // writer knew `a` (baseline) and removed it (absent from incoming) → dropped
+    expect(mergeRecordByWriterDelta({ a: A }, {}, { a: A })).toEqual({});
+  });
+
+  it("preserves a sibling addition the writer never knew about", () => {
+    // `b` is absent from both baseline and incoming but present on disk → kept
+    expect(mergeRecordByWriterDelta({ a: A }, { a: A }, { a: A, b: B })).toEqual({ a: A, b: B });
+  });
+
+  it("resolves the canonical clobber: stale writer keeps its own key and a sibling's key", () => {
+    // writer owned `a`, updates it; a sibling concurrently added `b` on disk.
+    const result = mergeRecordByWriterDelta({ a: A }, { a: A2 }, { a: A, b: B });
+    expect(result).toEqual({ a: A2, b: B });
+  });
+
+  it("honors a writer deletion while preserving an unrelated sibling addition", () => {
+    // writer deletes `a`; sibling added `b` → a gone, b kept
+    expect(mergeRecordByWriterDelta({ a: A }, {}, { a: A, b: B })).toEqual({ b: B });
+  });
+
+  it("uses JSON-round-trip equality so an undefined-key no-op is not treated as a change", () => {
+    // `a` carries an explicit undefined field in incoming but is otherwise identical;
+    // it must count as unchanged, so a sibling's concurrent disk edit is preserved.
+    const baseline = { a: { sessionId: "a", cwd: "/a" } };
+    const incoming = { a: { sessionId: "a", cwd: "/a", extra: undefined } as unknown as Session };
+    const disk = { a: A2 };
+    expect(mergeRecordByWriterDelta(baseline, incoming, disk)).toEqual({ a: A2 });
+  });
+
+  it("accepts a custom equality predicate", () => {
+    // treat all sessions as equal → writer's `a` counts as unchanged → disk wins
+    const alwaysEqual = () => true;
+    expect(mergeRecordByWriterDelta({ a: A }, { a: A2 }, { a: B }, alwaysEqual)).toEqual({ a: B });
+  });
+
+  it("returns an empty record when every input is empty", () => {
+    expect(mergeRecordByWriterDelta({}, {}, {})).toEqual({});
+  });
+
+  it("preserves multiple sibling keys alongside the writer's own change", () => {
+    expect(mergeRecordByWriterDelta({ a: A }, { a: A2 }, { a: A, b: B, c: B2 })).toEqual({
+      a: A2,
+      b: B,
+      c: B2,
+    });
+  });
+});
+
+describe("pickFieldByWriterDelta", () => {
+  it("keeps the incoming value when the writer changed the field", () => {
+    expect(pickFieldByWriterDelta(380, 500, 420)).toBe(500);
+  });
+
+  it("keeps the on-disk value when the writer left the field unchanged", () => {
+    // writer's field equals its baseline → defer to whatever a sibling last wrote
+    expect(pickFieldByWriterDelta(380, 380, 420)).toBe(420);
+  });
+
+  it("treats a nulled field as a writer change over a sibling's value", () => {
+    expect(pickFieldByWriterDelta("claude", null, "codex")).toBeNull();
+  });
+
+  it("keeps a sibling's field value when the writer's value matches its baseline null", () => {
+    expect(pickFieldByWriterDelta(null, null, "claude")).toBe("claude");
+  });
+
+  it("uses JSON-round-trip equality for object fields", () => {
+    const baseline = { scope: "current", stateFilter: "all" };
+    const incoming = { scope: "current", stateFilter: "all", extra: undefined } as Record<
+      string,
+      unknown
+    >;
+    const disk = { scope: "all", stateFilter: "none" };
+    // incoming equals baseline under JSON semantics → the sibling's disk value wins
+    expect(pickFieldByWriterDelta(baseline, incoming, disk)).toEqual(disk);
+  });
+});

--- a/src/store/persistence/persistWriteMerge.ts
+++ b/src/store/persistence/persistWriteMerge.ts
@@ -1,0 +1,124 @@
+/**
+ * Baseline-aware three-way merge for persisted store writes shared across
+ * project views (issue #11351).
+ *
+ * The problem: every project view is its own WebContentsView / V8 context, but
+ * they all share one `persist:daintree` localStorage partition. Each view
+ * hydrates a persist store once, then serializes its whole in-memory snapshot
+ * back over the shared key on every write. A view holding a stale snapshot
+ * silently overwrites fields (or another project's map entries) that a sibling
+ * view wrote more recently — the assistant hibernate anchors being the
+ * highest-value casualty.
+ *
+ * The fix mirrors the concurrent-layout merge (#11350, `shared/utils/layoutMerge.ts`)
+ * but at the localStorage write boundary and keyed by record key rather than by
+ * array id. A writer's storage adapter retains the value it hydrated (or last
+ * durably wrote) as its `baseline`; at write time the merger sees three inputs:
+ *
+ *   - `baseline`: what this writer previously knew.
+ *   - `incoming`: this writer's current snapshot (what Zustand asked to persist).
+ *   - `onDisk`:   the freshest shared value read immediately before the write.
+ *
+ * Comparing `incoming` against `baseline` makes the writer's *intent*
+ * unambiguous without timestamps or tombstones, so a stale writer only ever
+ * affects the keys it actually touched and never resurrects a sibling's (or its
+ * own) intentional deletion. See {@link mergeRecordByWriterDelta} for the exact
+ * per-key semantics.
+ *
+ * Critical invariant (enforced by the storage adapter, not here): after a
+ * successful write the baseline advances to `incoming`, never to the merged
+ * result. The merged result may contain sibling-only keys this view never took
+ * into memory; folding those into the baseline would make them look like
+ * intentional deletions on the next write.
+ */
+
+import type { StorageValue } from "zustand/middleware";
+import { deepEqualIgnoringUndefined } from "@shared/utils/layoutMerge";
+
+export interface PersistWriteMergeContext<T> {
+  /**
+   * The value this writer last knew: what it hydrated, or its last durable
+   * write. `null` before the first hydration read — the store-specific merger
+   * normalizes that to its persisted defaults so a fresh view's untouched
+   * fields are not mistaken for edits.
+   */
+  baseline: StorageValue<T> | null;
+  /**
+   * The freshest shared value read from storage immediately before this write.
+   * `null` when the key is absent or its stored blob is unrecoverably corrupt.
+   */
+  onDisk: StorageValue<T> | null;
+  /** This writer's current snapshot — the value Zustand asked to persist. */
+  incoming: StorageValue<T>;
+}
+
+/**
+ * Store-specific reconciler invoked at the storage layer before a merge-enabled
+ * write. Returns the value that should actually be persisted. Must be pure and
+ * must return `incoming.version` (the persisted schema is unchanged by a merge).
+ */
+export type PersistWriteMerge<T> = (context: PersistWriteMergeContext<T>) => StorageValue<T>;
+
+function hasOwn(object: Readonly<Record<string, unknown>>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+/**
+ * Merge one `Record<string, V>` (e.g. a `Record<projectId, session>` map) using
+ * the writer's baseline to classify intent. Semantics per key:
+ *
+ *   - changed/added by the writer (absent from `baseline`, or `incoming` differs
+ *     from `baseline`) → the incoming value wins.
+ *   - unchanged by the writer and present on disk → the on-disk value is kept,
+ *     preserving a sibling view's concurrent edit.
+ *   - unchanged by the writer and absent from disk → dropped (a sibling deleted
+ *     it and the writer has no authority to resurrect it).
+ *   - present in `baseline` but absent from `incoming` → dropped (the writer
+ *     intentionally deleted it), even if it still lingers on disk.
+ *   - never known to the writer (absent from both `baseline` and `incoming`) but
+ *     present on disk → preserved, keeping a sibling's addition.
+ *
+ * Content equality defaults to {@link deepEqualIgnoringUndefined} so an entry
+ * that is identical after a JSON round-trip is not misread as a writer edit.
+ */
+export function mergeRecordByWriterDelta<V>(
+  baseline: Readonly<Record<string, V>>,
+  incoming: Readonly<Record<string, V>>,
+  onDisk: Readonly<Record<string, V>>,
+  equals: (left: V, right: V) => boolean = deepEqualIgnoringUndefined
+): Record<string, V> {
+  const result: Record<string, V> = {};
+
+  for (const key of Object.keys(incoming)) {
+    const incomingValue = incoming[key];
+    if (!hasOwn(baseline, key) || !equals(baseline[key], incomingValue)) {
+      // The writer added or changed this key since its baseline → it wins.
+      result[key] = incomingValue;
+    } else if (hasOwn(onDisk, key)) {
+      // The writer did not touch it; a sibling may have → keep the on-disk value.
+      result[key] = onDisk[key];
+    }
+    // else: the writer did not touch it and a sibling deleted it → do not
+    // resurrect.
+  }
+
+  for (const key of Object.keys(onDisk)) {
+    if (hasOwn(incoming, key)) continue; // already decided above
+    if (hasOwn(baseline, key)) continue; // in baseline, gone from incoming → writer deleted it
+    // A sibling addition the writer never knew about → preserve it.
+    result[key] = onDisk[key];
+  }
+
+  return result;
+}
+
+/**
+ * Merge a fixed-shape object's scalar fields using the writer's baseline: a
+ * field the writer changed wins; a field it left untouched keeps whatever a
+ * sibling last wrote on disk. Unlike {@link mergeRecordByWriterDelta} this never
+ * adds or drops keys — the persisted shape is fixed — so every field present in
+ * `incoming` is resolved and no field is invented.
+ */
+export function pickFieldByWriterDelta<V>(baselineValue: V, incomingValue: V, onDiskValue: V): V {
+  return deepEqualIgnoringUndefined(baselineValue, incomingValue) ? onDiskValue : incomingValue;
+}

--- a/src/store/persistence/persistWriteMerge.ts
+++ b/src/store/persistence/persistWriteMerge.ts
@@ -30,6 +30,23 @@
  * result. The merged result may contain sibling-only keys this view never took
  * into memory; folding those into the baseline would make them look like
  * intentional deletions on the next write.
+ *
+ * Scope / known limitations (this is the deterministic fix for the *sequential*
+ * stale-writer clobber the issue reports — switch to a cached view and touch a
+ * persisted store — not a general cross-process transaction):
+ *   - The storage adapter's read-then-write is not atomic across renderer
+ *     processes. Two views that both read the same value before either writes
+ *     can still race (get/get/set/set); localStorage exposes no compare-and-swap.
+ *     A fully linearizable guarantee needs a Main-process serialized owner
+ *     (tracked separately) — out of scope here.
+ *   - Concurrent edits to the *same* key are last-writer-wins on the whole value
+ *     (e.g. two views rebasing the same hibernate session's cwd): no entry is
+ *     lost, but a field-level conflict can be superseded — the same entry-level
+ *     limitation `layoutMerge.ts` documents.
+ *   - A deletion is only expressible for a key the writer's baseline knew. A key
+ *     removed by a view that never hydrated it (e.g. project-removal cleanup
+ *     fanned out to a view lacking that entry) can leave a disk-only value; it is
+ *     inert (keyed by a dead id) rather than incorrect.
  */
 
 import type { StorageValue } from "zustand/middleware";
@@ -59,10 +76,6 @@ export interface PersistWriteMergeContext<T> {
  */
 export type PersistWriteMerge<T> = (context: PersistWriteMergeContext<T>) => StorageValue<T>;
 
-function hasOwn(object: Readonly<Record<string, unknown>>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(object, key);
-}
-
 /**
  * Merge one `Record<string, V>` (e.g. a `Record<projectId, session>` map) using
  * the writer's baseline to classify intent. Semantics per key:
@@ -87,26 +100,33 @@ export function mergeRecordByWriterDelta<V>(
   onDisk: Readonly<Record<string, V>>,
   equals: (left: V, right: V) => boolean = deepEqualIgnoringUndefined
 ): Record<string, V> {
+  // Map lookups return `V | undefined`; a persisted record value is never
+  // `undefined`, so `undefined` unambiguously means "key absent". This keeps the
+  // merge sound under `noUncheckedIndexedAccess` without unsafe assertions — the
+  // same convention `layoutMerge.ts` uses for its by-id map.
+  const baselineMap = new Map<string, V>(Object.entries(baseline));
+  const onDiskMap = new Map<string, V>(Object.entries(onDisk));
+  const incomingMap = new Map<string, V>(Object.entries(incoming));
   const result: Record<string, V> = {};
 
-  for (const key of Object.keys(incoming)) {
-    const incomingValue = incoming[key];
-    if (!hasOwn(baseline, key) || !equals(baseline[key], incomingValue)) {
+  for (const [key, incomingValue] of incomingMap) {
+    const baselineValue = baselineMap.get(key);
+    if (baselineValue === undefined || !equals(baselineValue, incomingValue)) {
       // The writer added or changed this key since its baseline → it wins.
       result[key] = incomingValue;
-    } else if (hasOwn(onDisk, key)) {
-      // The writer did not touch it; a sibling may have → keep the on-disk value.
-      result[key] = onDisk[key];
+    } else {
+      // Unchanged by the writer: keep a sibling's concurrent on-disk value if
+      // present; if a sibling deleted it, do not resurrect it.
+      const onDiskValue = onDiskMap.get(key);
+      if (onDiskValue !== undefined) result[key] = onDiskValue;
     }
-    // else: the writer did not touch it and a sibling deleted it → do not
-    // resurrect.
   }
 
-  for (const key of Object.keys(onDisk)) {
-    if (hasOwn(incoming, key)) continue; // already decided above
-    if (hasOwn(baseline, key)) continue; // in baseline, gone from incoming → writer deleted it
+  for (const [key, onDiskValue] of onDiskMap) {
+    if (incomingMap.has(key)) continue; // already decided above
+    if (baselineMap.has(key)) continue; // in baseline, gone from incoming → writer deleted it
     // A sibling addition the writer never knew about → preserve it.
-    result[key] = onDisk[key];
+    result[key] = onDiskValue;
   }
 
   return result;

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -1,6 +1,18 @@
 import type { PersistStorage, StateStorage, StorageValue } from "zustand/middleware";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { PersistWriteMerge } from "./persistWriteMerge";
+
+export interface SafeJSONStorageOptions<T> {
+  /**
+   * Opt-in baseline-aware three-way write merge (issue #11351). When provided,
+   * every write first reads the current shared value and reconciles it against
+   * this writer's baseline and incoming snapshot, so a stale project view can't
+   * clobber a sibling view's concurrent writes. Omit it for view-local stores —
+   * the default full-replacement write is unchanged. See `persistWriteMerge.ts`.
+   */
+  mergeOnWrite?: PersistWriteMerge<T>;
+}
 
 const fallbackStorageData = new Map<string, string>();
 
@@ -303,37 +315,62 @@ function parseBackup<T>(raw: string | null): StorageValue<T> | null {
   }
 }
 
-export function createSafeJSONStorage<T>(): PersistStorage<T> {
+/**
+ * Read and parse the persisted value for `name`, recovering from the sibling
+ * `.__bak` copy when the live blob is present but corrupt (issue #9170/#9916),
+ * and returning `null` when absent or unrecoverable. Shared by hydration reads
+ * and the pre-write disk read that feeds the opt-in write merger, so both paths
+ * get identical corruption/backup handling.
+ */
+function readPersistedValue<T>(raw: ResilientStorage, name: string): StorageValue<T> | null {
+  const value = raw.getItem(name);
+  if (value instanceof Promise) return null;
+  if (value === null) return null;
+  try {
+    return parseJson<StorageValue<T>>(value);
+  } catch (error) {
+    // The live blob is corrupt but present — try the last known-good backup
+    // before discarding the user's config to defaults (issue #9170).
+    const recovered = parseBackup<T>(raw.readBackup(name));
+    if (recovered !== null) {
+      console.warn("[safeStorage] corrupt persisted state, recovered from backup", {
+        key: name,
+        error: formatErrorMessage(error, "Corrupt persisted state"),
+      });
+      return recovered;
+    }
+    console.warn("[safeStorage] corrupt persisted state, resetting to defaults", {
+      key: name,
+      error: formatErrorMessage(error, "Corrupt persisted state"),
+    });
+    return null;
+  }
+}
+
+export function createSafeJSONStorage<T>(options?: SafeJSONStorageOptions<T>): PersistStorage<T> {
   const raw = createResilientStorage(resolveLocalStorage());
   const lastWritten = new Map<string, string>();
+  const mergeOnWrite = options?.mergeOnWrite;
+  // What this writer last knew, per key — its hydration read or last durable
+  // write. Feeds the three-way merge so a stale snapshot can't clobber a
+  // sibling view (issue #11351). Only tracked when a merger is configured.
+  const baselines = new Map<string, StorageValue<T> | null>();
 
   return {
     getItem: (name) => {
-      const value = raw.getItem(name);
-      if (value instanceof Promise) return null;
-      if (value === null) return null;
-      try {
-        return parseJson<StorageValue<T>>(value);
-      } catch (error) {
-        // The live blob is corrupt but present — try the last known-good backup
-        // before discarding the user's config to defaults (issue #9170).
-        const recovered = parseBackup<T>(raw.readBackup(name));
-        if (recovered !== null) {
-          console.warn("[safeStorage] corrupt persisted state, recovered from backup", {
-            key: name,
-            error: formatErrorMessage(error, "Corrupt persisted state"),
-          });
-          return recovered;
-        }
-        console.warn("[safeStorage] corrupt persisted state, resetting to defaults", {
-          key: name,
-          error: formatErrorMessage(error, "Corrupt persisted state"),
-        });
-        return null;
-      }
+      const parsed = readPersistedValue<T>(raw, name);
+      if (mergeOnWrite) baselines.set(name, parsed);
+      return parsed;
     },
     setItem: (name, value) => {
-      const serialized = JSON.stringify(value);
+      const toWrite = mergeOnWrite
+        ? mergeOnWrite({
+            baseline: baselines.get(name) ?? null,
+            onDisk: readPersistedValue<T>(raw, name),
+            incoming: value,
+          })
+        : value;
+      const serialized = JSON.stringify(toWrite);
       if (lastWritten.get(name) === serialized) return;
       // Only advance the backup when the primary write actually reached durable
       // storage. On a quota failure the primary keeps its old value, so writing
@@ -345,9 +382,17 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
       } else if (result === "memory") {
         lastWritten.set(name, serialized);
       }
+      // Advance the baseline to the writer's own snapshot (never the merged
+      // result, which may hold sibling-only keys this view never took into
+      // memory) once the write actually landed. A transient quota failure keeps
+      // the old baseline so the next retry still merges correctly.
+      if (mergeOnWrite && result !== "quota") {
+        baselines.set(name, value);
+      }
     },
     removeItem: (name) => {
       lastWritten.delete(name);
+      baselines.delete(name);
       raw.removeItem(name);
       raw.removeBackup(name);
     },
@@ -361,19 +406,46 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
  * `clearAll` followed shortly by a tear-down can't be silently re-populated by
  * a stale write timer.
  */
-export function createDebouncedSafeJSONStorage<T>(delayMs: number): PersistStorage<T> {
+export function createDebouncedSafeJSONStorage<T>(
+  delayMs: number,
+  options?: SafeJSONStorageOptions<T>
+): PersistStorage<T> {
   const raw = createResilientStorage(resolveLocalStorage());
-  const pending = new Map<string, { timer: ReturnType<typeof setTimeout>; value: string }>();
+  // Retain the typed incoming value (not just its serialized form) so a
+  // merge-enabled flush can reconcile it against the freshest disk state read
+  // at flush time. `serialized` is kept purely to coalesce identical enqueues.
+  const pending = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout>; value: StorageValue<T>; serialized: string }
+  >();
+  const mergeOnWrite = options?.mergeOnWrite;
+  const baselines = new Map<string, StorageValue<T> | null>();
 
   const flush = (name: string): void => {
     const entry = pending.get(name);
     if (!entry) return;
     pending.delete(name);
+    // Merge against disk at flush time — not enqueue time — so a sibling view's
+    // write that landed during the debounce window is preserved (issue #11351).
+    const toWrite = mergeOnWrite
+      ? mergeOnWrite({
+          baseline: baselines.get(name) ?? null,
+          onDisk: readPersistedValue<T>(raw, name),
+          incoming: entry.value,
+        })
+      : entry.value;
+    const serialized = mergeOnWrite ? JSON.stringify(toWrite) : entry.serialized;
     // Only advance the backup when the primary write actually reached durable
     // storage. On a quota failure the primary keeps its old value, so writing
     // a newer backup would leave the two inconsistent and recover stale state.
-    if (raw.setItem(name, entry.value) === "durable") {
-      raw.writeBackup(name, entry.value);
+    const result = raw.setItem(name, serialized);
+    if (result === "durable") {
+      raw.writeBackup(name, serialized);
+    }
+    // Advance to the writer's own snapshot (never the merged result) once the
+    // write landed; a transient quota failure keeps the old baseline.
+    if (mergeOnWrite && result !== "quota") {
+      baselines.set(name, entry.value);
     }
   };
 
@@ -381,36 +453,17 @@ export function createDebouncedSafeJSONStorage<T>(delayMs: number): PersistStora
     getItem: (name) => {
       // Flush any pending write so reads-after-writes are coherent.
       flush(name);
-      const value = raw.getItem(name);
-      if (value instanceof Promise) return null;
-      if (value === null) return null;
-      try {
-        return parseJson<StorageValue<T>>(value);
-      } catch (error) {
-        // The live blob is corrupt but present — try the last known-good backup
-        // before discarding the user's config to defaults (issue #9170/#9916).
-        const recovered = parseBackup<T>(raw.readBackup(name));
-        if (recovered !== null) {
-          console.warn("[safeStorage] corrupt persisted state, recovered from backup", {
-            key: name,
-            error: formatErrorMessage(error, "Corrupt persisted state"),
-          });
-          return recovered;
-        }
-        console.warn("[safeStorage] corrupt persisted state, resetting to defaults", {
-          key: name,
-          error: formatErrorMessage(error, "Corrupt persisted state"),
-        });
-        return null;
-      }
+      const parsed = readPersistedValue<T>(raw, name);
+      if (mergeOnWrite) baselines.set(name, parsed);
+      return parsed;
     },
     setItem: (name, value) => {
       const serialized = JSON.stringify(value);
       const existing = pending.get(name);
-      if (existing?.value === serialized) return;
+      if (existing?.serialized === serialized) return;
       if (existing) clearTimeout(existing.timer);
       const timer = setTimeout(() => flush(name), delayMs);
-      pending.set(name, { timer, value: serialized });
+      pending.set(name, { timer, value, serialized });
     },
     removeItem: (name) => {
       const existing = pending.get(name);
@@ -418,6 +471,7 @@ export function createDebouncedSafeJSONStorage<T>(delayMs: number): PersistStora
         clearTimeout(existing.timer);
         pending.delete(name);
       }
+      baselines.delete(name);
       raw.removeItem(name);
       raw.removeBackup(name);
     },

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -363,14 +363,32 @@ export function createSafeJSONStorage<T>(options?: SafeJSONStorageOptions<T>): P
       return parsed;
     },
     setItem: (name, value) => {
-      const toWrite = mergeOnWrite
-        ? mergeOnWrite({
-            baseline: baselines.get(name) ?? null,
-            onDisk: readPersistedValue<T>(raw, name),
-            incoming: value,
-          })
-        : value;
-      const serialized = JSON.stringify(toWrite);
+      if (mergeOnWrite) {
+        // Merge against the freshest disk value every time. We must NOT dedup on
+        // the serialized output here: two writes with identical `value` can merge
+        // to different results as the shared disk changes between them, and — the
+        // inverse — two writes can merge to the SAME bytes against different disk
+        // states, so a merged-output dedup would skip a write that still needs to
+        // land (e.g. re-applying a deletion the disk resurrected). These stores
+        // write infrequently, so an unconditional read-merge-write is cheap.
+        const merged = mergeOnWrite({
+          baseline: baselines.get(name) ?? null,
+          onDisk: readPersistedValue<T>(raw, name),
+          incoming: value,
+        });
+        const serialized = JSON.stringify(merged);
+        const result = raw.setItem(name, serialized);
+        // Only advance the backup when the primary write actually reached durable
+        // storage (see the debounced flush for the full rationale).
+        if (result === "durable") raw.writeBackup(name, serialized);
+        // Advance the baseline to the writer's own snapshot (never the merged
+        // result, which may hold sibling-only keys this view never took into
+        // memory). A transient quota failure keeps the old baseline so the next
+        // retry still merges correctly.
+        if (result !== "quota") baselines.set(name, value);
+        return;
+      }
+      const serialized = JSON.stringify(value);
       if (lastWritten.get(name) === serialized) return;
       // Only advance the backup when the primary write actually reached durable
       // storage. On a quota failure the primary keeps its old value, so writing
@@ -381,13 +399,6 @@ export function createSafeJSONStorage<T>(options?: SafeJSONStorageOptions<T>): P
         raw.writeBackup(name, serialized);
       } else if (result === "memory") {
         lastWritten.set(name, serialized);
-      }
-      // Advance the baseline to the writer's own snapshot (never the merged
-      // result, which may hold sibling-only keys this view never took into
-      // memory) once the write actually landed. A transient quota failure keeps
-      // the old baseline so the next retry still merges correctly.
-      if (mergeOnWrite && result !== "quota") {
-        baselines.set(name, value);
       }
     },
     removeItem: (name) => {


### PR DESCRIPTION
## Summary

Every project view is its own `WebContentsView` with its own V8 context, but all views share one `persist:daintree` localStorage. Each zustand `persist` store was writing its entire in-memory snapshot to the shared key on every write, so a view holding a stale snapshot would clobber fields and per-project map entries a sibling view had written more recently. The highest-value casualty was the assistant hibernate/resume anchors: a parked assistant could no longer be resumed.

This adds a baseline-aware three-way write merge at the safeStorage layer, in a new `src/store/persistence/persistWriteMerge.ts`. It's the same approach as the concurrent-layout merge from #11350 (`shared/utils/layoutMerge.ts`), just keyed by record key instead of layout id. Each storage adapter keeps the value it hydrated (or last durably wrote) as its baseline. At write time the merger reconciles baseline, incoming snapshot, and a fresh disk read, so a stale writer only touches keys it actually changed and never resurrects a deletion. No timestamps or tombstones.

Part of #11351.

The merge is opt-in via a new `mergeOnWrite` option on `createSafeJSONStorage` and `createDebouncedSafeJSONStorage`; stores that don't opt in are byte-for-byte unchanged. I've applied it to `helpPanelStore` (per-field scalar prefs plus the `hibernateSessions` map keyed by project id) and `commandHistoryStore` (`history`, also keyed by project id). This is a partial fix, so it must not auto-close the issue: terminal search history and toolbar/pane preferences are named victims in the issue that are deferred as follow-ups.

### Scope and limits

Documented in code comments, but worth calling out here:

- This deterministically fixes the sequential stale-writer clobber the issue reports (switch to a cached view, touch a store). It's not a general cross-process transaction system.
- Same-key concurrent edits from two views at once are still last-writer-wins.
- Deleting a key that was never hydrated by any live view can leave an inert disk-only value behind.
- There's a narrow residual around `preferredAgentId` in an async registry that's no worse than the pre-fix full replace.

## Changes

- `src/store/persistence/persistWriteMerge.ts` (new): baseline-aware three-way merge, keyed by record key
- `src/store/persistence/safeStorage.ts`: opt-in `mergeOnWrite` for `createSafeJSONStorage` / `createDebouncedSafeJSONStorage`
- `src/store/helpPanelStore.ts`: opt in to merge for scalar prefs + `hibernateSessions`
- `src/store/commandHistoryStore.ts`: opt in to merge for `history`
- Four test files: new `persistWriteMerge.test.ts`, plus updates to `persistenceBoundaryHardening.test.ts`, `helpPanelStore.test.ts`, and `commandHistoryStore.test.ts`

## Testing

8 test files, 167 tests total:

- Primitive 7-case merge matrix
- Adapter-level two-view clobber/delete/baseline/backup/debounce-flush-timing behavior, plus a dedup-repeat-bytes deletion regression
- Store-level integration tests for both stores: fresh-view non-clobber, null-baseline non-clobber, out-of-range-width non-clobber, sibling-deletion-not-resurrected, empty-sessionId sentinel survival

Locally verified: `npx tsc --noEmit` clean, eslint and prettier clean on changed files, all 167 targeted tests passing.
