### PR TITLE
feat(voice): migrate dictation AI model to gpt-5.6-luna

### DIFF
--- a/e2e/full/platform/core-voice-input.spec.ts
+++ b/e2e/full/platform/core-voice-input.spec.ts
@@ -410,10 +410,13 @@ test.describe.serial("E2E: Voice Input — Settings Migration", () => {
     expect(migrated.openaiApiKey).toBe("sk-legacy-correction-key");
     expect(migrated.transcriptionModel).toBe("gpt-realtime-whisper");
     expect(migrated.correctionApiKey).toBeUndefined();
+    // The retired gpt-5-mini correction model migrates to gpt-5.6-luna (#11365).
+    expect(migrated.correctionModel).toBe("gpt-5.6-luna");
 
     expect(onDisk.voiceInput.openaiApiKey).toBe("sk-legacy-correction-key");
     expect(onDisk.voiceInput.correctionApiKey).toBeUndefined();
     expect(onDisk.voiceInput.transcriptionModel).toBe("gpt-realtime-whisper");
+    expect(onDisk.voiceInput.correctionModel).toBe("gpt-5.6-luna");
   });
 
   test("legacy apiKey field migrates into openaiApiKey when no correctionApiKey is present", async () => {
@@ -484,7 +487,7 @@ test.describe.serial("E2E: Voice Input — OpenAI Realtime IPC Lifecycle", () =>
       customDictionary: [],
       transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
-      correctionModel: "gpt-5-mini",
+      correctionModel: "gpt-5.6-luna",
       correctionCustomInstructions: "",
       paragraphingStrategy: "spoken-command",
       resolveFileLinks: true,

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -100,7 +100,7 @@ vi.mock("../../../store.js", () => ({
           enabled: true,
           openaiApiKey: "sk-test",
           correctionEnabled: true,
-          correctionModel: "gpt-5-mini",
+          correctionModel: "gpt-5.6-luna",
           customDictionary: [],
           correctionCustomInstructions: "",
           language: "en",
@@ -299,7 +299,7 @@ describe("voiceInput — IPC handler surface", () => {
       reason: "stop",
     });
     expect(shared.correctionCalls[0]?.settings).toMatchObject({
-      model: "gpt-5-mini",
+      model: "gpt-5.6-luna",
       apiKey: "sk-test",
     });
   });
@@ -446,7 +446,7 @@ describe("voiceInput — manual paragraphing strategy", () => {
       enabled: true,
       openaiApiKey: "sk-test",
       correctionEnabled: true,
-      correctionModel: "gpt-5-mini",
+      correctionModel: "gpt-5.6-luna",
       customDictionary: [],
       correctionCustomInstructions: "",
       language: "en",
@@ -506,7 +506,7 @@ describe("voiceInput — context keyterms wiring", () => {
       transcriptionProvider: provider,
       transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
-      correctionModel: "gpt-5-mini",
+      correctionModel: "gpt-5.6-luna",
       correctionCustomInstructions: "",
       paragraphingStrategy: "spoken-command",
       resolveFileLinks: true,
@@ -859,6 +859,40 @@ describe("getVoiceSettings migration", () => {
     } finally {
       delete process.env.WHISPER_API_KEY;
     }
+  });
+
+  it("normalizes a stale correctionModel to gpt-5.6-luna and persists the cleanup", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      correctionModel: "gpt-5-mini",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.correctionModel).toBe("gpt-5.6-luna");
+    // The read-time safety net writes the cleaned value through once so the
+    // stale model does not survive on disk (issue #11365).
+    expect(vi.mocked(store.set)).toHaveBeenCalledOnce();
+    const persisted = (
+      vi.mocked(store.set).mock.calls[0] as unknown as [string, Record<string, unknown>]
+    )[1];
+    expect(persisted.correctionModel).toBe("gpt-5.6-luna");
+  });
+
+  it("does not write back when correctionModel is already gpt-5.6-luna", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      correctionModel: "gpt-5.6-luna",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.correctionModel).toBe("gpt-5.6-luna");
+    expect(vi.mocked(store.set)).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -879,6 +879,25 @@ describe("getVoiceSettings migration", () => {
       vi.mocked(store.set).mock.calls[0] as unknown as [string, Record<string, unknown>]
     )[1];
     expect(persisted.correctionModel).toBe("gpt-5.6-luna");
+    // Normalization must write the full merged object, not a defaults-only one —
+    // sibling settings must survive the cleanup write.
+    expect(persisted.enabled).toBe(true);
+    expect(persisted.openaiApiKey).toBe("sk-present");
+  });
+
+  it("normalizes the retired gpt-5-nano correction model to gpt-5.6-luna on read", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+      correctionModel: "gpt-5-nano",
+    });
+
+    const settings = getVoiceSettings();
+
+    // Model-agnostic normalization: nano is not special-cased any more than mini.
+    expect(settings.correctionModel).toBe("gpt-5.6-luna");
+    expect(vi.mocked(store.set)).toHaveBeenCalledOnce();
   });
 
   it("does not write back when correctionModel is already gpt-5.6-luna", async () => {

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -15,6 +15,7 @@ import { logDebug } from "../../utils/logger.js";
 import { buildOpenAIHeaders } from "../../../shared/utils/openaiHeaders.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { applyDictationCommands } from "../../services/voiceDictationCommands.js";
+import { VOICE_DICTATION_AI_MODEL } from "../../../shared/config/voiceCorrection.js";
 import { assembleKeyterms } from "../../services/voiceContextKeyterms.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { voiceFileLinkResolver } from "../../services/VoiceFileLinkResolver.js";
@@ -51,7 +52,7 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
-  correctionModel: "gpt-5-mini",
+  correctionModel: VOICE_DICTATION_AI_MODEL,
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,
@@ -102,8 +103,17 @@ export function getVoiceSettings(): VoiceInputSettings {
   // The model union is single-valued, so this is a one-shot cleanup of legacy
   // Deepgram model strings ('nova-3' / 'nova-2'), not a user-choice revert —
   // the provider, not the model, is what selects the backend now.
-  const staleModel = merged.transcriptionModel !== "gpt-realtime-whisper";
-  if (staleModel) merged.transcriptionModel = "gpt-realtime-whisper";
+  const staleTranscriptionModel = merged.transcriptionModel !== "gpt-realtime-whisper";
+  if (staleTranscriptionModel) merged.transcriptionModel = "gpt-realtime-whisper";
+
+  // Same one-shot cleanup for the correction model: gpt-5.6-luna replaced the
+  // retired gpt-5-mini/gpt-5-nano tiers, so this union is single-valued too.
+  // migration025 upgrades stores on older schema versions; this read-time net
+  // catches stores already on the current version (never revisited by the
+  // migration), plus post-downgrade or hand-edited values. Not a user-choice
+  // revert — there is no correction-model choice left to preserve.
+  const staleCorrectionModel = merged.correctionModel !== VOICE_DICTATION_AI_MODEL;
+  if (staleCorrectionModel) merged.correctionModel = VOICE_DICTATION_AI_MODEL;
 
   // Normalize malformed recordingMode values in memory only (no write-back).
   if (merged.recordingMode !== "toggle" && merged.recordingMode !== "push-to-talk") {
@@ -117,7 +127,8 @@ export function getVoiceSettings(): VoiceInputSettings {
     apiKey !== undefined ||
     correctionApiKey !== undefined ||
     providerNeedsDefault ||
-    staleModel
+    staleTranscriptionModel ||
+    staleCorrectionModel
   ) {
     store.set("voiceInput", merged);
   }
@@ -580,7 +591,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
   };
 
   // Whole-passage cleanup pass. The renderer calls this once after recording
-  // stops, with the full dictated text; correction runs as a single gpt-5-mini
+  // stops, with the full dictated text; correction runs as a single gpt-5.6-luna
   // request rather than the old per-segment streaming pipeline.
   const handleCorrect = async (
     request: VoiceInputCorrectPayload

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2801,7 +2801,7 @@ function buildElectronApi(): ElectronAPI {
           transcriptionProvider: "openai" | "deepgram";
           transcriptionModel: "gpt-realtime-whisper";
           correctionEnabled: boolean;
-          correctionModel: "gpt-5-nano" | "gpt-5-mini";
+          correctionModel: "gpt-5.6-luna";
           correctionCustomInstructions: string;
           paragraphingStrategy: "spoken-command" | "manual";
           resolveFileLinks: boolean;

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { getCurrentDiskSpaceStatus } from "./DiskSpaceMonitor.js";
 
-export const LATEST_SCHEMA_VERSION = 24;
+export const LATEST_SCHEMA_VERSION = 25;
 
 export interface Migration {
   version: number;

--- a/electron/services/VoiceCorrectionService.ts
+++ b/electron/services/VoiceCorrectionService.ts
@@ -3,6 +3,8 @@ import {
   CORE_CORRECTION_PROMPT,
   CONFIDENCE_SKIP_THRESHOLD,
   FILE_LINK_DETECTION_PROMPT,
+  VOICE_DICTATION_AI_MODEL,
+  VOICE_DICTATION_REASONING_EFFORT,
   buildCorrectionSystemPrompt,
   type CorrectionPromptContext,
 } from "../../shared/config/voiceCorrection.js";
@@ -18,7 +20,6 @@ const LONG_CORRECTION_MIN_CHARS = 140;
 const MAX_OUTPUT_TOKENS = 1024;
 const FILE_LINK_MAX_OUTPUT_TOKENS = 256;
 const PROMPT_CACHE_PREFIX = "voice-correction-v7";
-const FILE_LINK_DETECTION_MODEL = "gpt-5-nano";
 const FILE_LINK_DETECTION_TIMEOUT_MS = 4000;
 const FILE_LINK_CACHE_PREFIX = "voice-file-link-v1";
 const LEADING_FILLER_RE = /^(?:\s*(?:um|uh)[\s,.;:!-]+)+/i;
@@ -290,12 +291,12 @@ export class VoiceCorrectionService {
         },
         signal: this.buildFetchSignal(FILE_LINK_DETECTION_TIMEOUT_MS),
         body: JSON.stringify({
-          model: FILE_LINK_DETECTION_MODEL,
+          model: VOICE_DICTATION_AI_MODEL,
           instructions: FILE_LINK_DETECTION_PROMPT,
           input: trimmed,
           prompt_cache_key: FILE_LINK_CACHE_PREFIX,
           service_tier: "auto",
-          reasoning: { effort: "minimal" },
+          reasoning: { effort: VOICE_DICTATION_REASONING_EFFORT },
           text: {
             format: {
               type: "json_schema",
@@ -368,10 +369,6 @@ export class VoiceCorrectionService {
     return SHORT_CORRECTION_TIMEOUT_MS;
   }
 
-  private getReasoningConfig(model: string): { effort: "low" } | undefined {
-    return model === "gpt-5-nano" ? { effort: "low" } : undefined;
-  }
-
   private normalizeCorrectedText(text: string): string {
     return text.replace(LEADING_FILLER_RE, "");
   }
@@ -418,7 +415,6 @@ export class VoiceCorrectionService {
       segmentCount: request.segmentCount ?? 0,
     });
 
-    const reasoningConfig = this.getReasoningConfig(model);
     const response = await fetch("https://api.openai.com/v1/responses", {
       method: "POST",
       headers: {
@@ -437,7 +433,9 @@ export class VoiceCorrectionService {
         ],
         prompt_cache_key: this.buildPromptCacheKey(settings),
         service_tier: "auto",
-        ...(reasoningConfig ? { reasoning: reasoningConfig } : {}),
+        // Explicit low-latency effort: gpt-5.6-luna defaults to "medium" when
+        // omitted, so we pin the lowest tier rather than inherit that default.
+        reasoning: { effort: VOICE_DICTATION_REASONING_EFFORT },
         text: {
           format: {
             type: "json_schema",

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -2,12 +2,15 @@ import { logDebug, logWarn } from "../utils/logger.js";
 import { fileSearchService } from "./FileSearchService.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { buildOpenAIHeaders } from "../../shared/utils/openaiHeaders.js";
+import {
+  VOICE_DICTATION_AI_MODEL,
+  VOICE_DICTATION_REASONING_EFFORT,
+} from "../../shared/config/voiceCorrection.js";
 
 const P = "[VoiceFileLinkResolver]";
 const NL_CONFIDENCE_THRESHOLD = 0.67;
 const MIN_MATCHING_TOKENS = 2;
 const AI_RERANK_TIMEOUT_MS = 4000;
-const AI_RERANK_MODEL = "gpt-5-nano";
 const AI_RERANK_CACHE_PREFIX = "voice-file-rerank-v1";
 
 const AI_RERANK_SCHEMA = {
@@ -152,13 +155,13 @@ export class VoiceFileLinkResolver {
           ? AbortSignal.any([signal, AbortSignal.timeout(AI_RERANK_TIMEOUT_MS)])
           : AbortSignal.timeout(AI_RERANK_TIMEOUT_MS),
         body: JSON.stringify({
-          model: AI_RERANK_MODEL,
+          model: VOICE_DICTATION_AI_MODEL,
           instructions:
             "Given a natural language description and a list of file paths from a project, return the path that best matches the description. If no path is a good match, return null.",
           input: `Description: ${description}\n\nCandidates:\n${candidates.map((c, i) => `${i + 1}. ${c}`).join("\n")}`,
           prompt_cache_key: AI_RERANK_CACHE_PREFIX,
           service_tier: "auto",
-          reasoning: { effort: "minimal" },
+          reasoning: { effort: VOICE_DICTATION_REASONING_EFFORT },
           text: {
             format: {
               type: "json_schema",

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -62,6 +62,7 @@ import { migrations } from "../migrations/index.js";
 import { migration002 } from "../migrations/002-add-terminal-location.js";
 import { migration003 } from "../migrations/003-migrate-recipes-to-project.js";
 import { migration004 } from "../migrations/004-upgrade-correction-model.js";
+import { migration025 } from "../migrations/025-upgrade-voice-correction-model.js";
 import { migration005 } from "../migrations/005-add-getting-started-checklist.js";
 import { migration007 } from "../migrations/007-reduce-default-terminal-scrollback.js";
 import { migration008 } from "../migrations/008-split-notification-sounds.js";
@@ -664,6 +665,61 @@ describe("MigrationRunner", () => {
     });
   });
 
+  describe("migration 025 — upgrade voice correction model to gpt-5.6-luna", () => {
+    it("upgrades gpt-5-mini to gpt-5.6-luna and preserves sibling fields", () => {
+      const store = createMockStore(storePath, {
+        voiceInput: { correctionModel: "gpt-5-mini", enabled: true, language: "en" },
+      });
+      migration025.up(store as never);
+      const voiceInput = store.data.voiceInput as Record<string, unknown>;
+      expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+      expect(voiceInput.enabled).toBe(true);
+      expect(voiceInput.language).toBe("en");
+    });
+
+    it("upgrades the retired gpt-5-nano tier to gpt-5.6-luna", () => {
+      const store = createMockStore(storePath, {
+        voiceInput: { correctionModel: "gpt-5-nano", enabled: true },
+      });
+      migration025.up(store as never);
+      const voiceInput = store.data.voiceInput as { correctionModel: string };
+      expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+    });
+
+    it("upgrades missing correctionModel to gpt-5.6-luna", () => {
+      const store = createMockStore(storePath, {
+        voiceInput: { enabled: true },
+      });
+      migration025.up(store as never);
+      const voiceInput = store.data.voiceInput as { correctionModel: string };
+      expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+    });
+
+    it("upgrades a malformed/unknown correctionModel value to gpt-5.6-luna", () => {
+      const store = createMockStore(storePath, {
+        voiceInput: { correctionModel: "some-old-junk", enabled: true },
+      });
+      migration025.up(store as never);
+      const voiceInput = store.data.voiceInput as { correctionModel: string };
+      expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+    });
+
+    it("leaves gpt-5.6-luna unchanged", () => {
+      const store = createMockStore(storePath, {
+        voiceInput: { correctionModel: "gpt-5.6-luna", enabled: true },
+      });
+      migration025.up(store as never);
+      const voiceInput = store.data.voiceInput as { correctionModel: string };
+      expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+    });
+
+    it("skips when no voiceInput settings exist", () => {
+      const store = createMockStore(storePath, {});
+      migration025.up(store as never);
+      expect(store.data.voiceInput).toBeUndefined();
+    });
+  });
+
   describe("migration 007 — reduce default terminal scrollback", () => {
     it("migrates scrollbackLines from 2500 to 1000 and preserves sibling fields", () => {
       const store = createMockStore(storePath, {
@@ -895,6 +951,22 @@ describe("MigrationRunner", () => {
   it("LATEST_SCHEMA_VERSION matches the highest version in the migrations barrel", () => {
     const highest = Math.max(...migrations.map((m) => m.version));
     expect(LATEST_SCHEMA_VERSION).toBe(highest);
+  });
+
+  it("runs migration025 from v24 under the full barrel, upgrading the voice correction model (#11365)", async () => {
+    const store = createMockStore(storePath, {
+      _schemaVersion: 24,
+      voiceInput: { correctionModel: "gpt-5-mini", enabled: true, language: "en" },
+    });
+    const runner = new MigrationRunner(store as never);
+
+    await runner.runMigrations(migrations);
+
+    expect(store.data._schemaVersion).toBe(LATEST_SCHEMA_VERSION);
+    const voiceInput = store.data.voiceInput as Record<string, unknown>;
+    expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+    expect(voiceInput.enabled).toBe(true);
+    expect(voiceInput.language).toBe("en");
   });
 
   it("runs migration021 from v20 under the full barrel, merging disabledBuiltins (#9284)", async () => {
@@ -1590,6 +1662,11 @@ describe("MigrationRunner", () => {
 
       // Verify migrations actually ran
       expect(store.data._schemaVersion).toBe(LATEST_SCHEMA_VERSION);
+
+      // Migration 025: the legacy gpt-5-nano correction model migrates to luna.
+      const migratedVoice = store.data.voiceInput as Record<string, unknown>;
+      expect(migratedVoice.correctionModel).toBe("gpt-5.6-luna");
+      expect(migratedVoice.enabled).toBe(true);
 
       // Migration 002: terminals should have location field
       const migratedTerminals = (store.data.appState as Record<string, unknown>).terminals as Array<

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -704,13 +704,17 @@ describe("MigrationRunner", () => {
       expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
     });
 
-    it("leaves gpt-5.6-luna unchanged", () => {
+    it("leaves gpt-5.6-luna unchanged without rewriting the store", () => {
       const store = createMockStore(storePath, {
         voiceInput: { correctionModel: "gpt-5.6-luna", enabled: true },
       });
+      const before = store.data.voiceInput;
       migration025.up(store as never);
       const voiceInput = store.data.voiceInput as { correctionModel: string };
       expect(voiceInput.correctionModel).toBe("gpt-5.6-luna");
+      // No write on the already-current path: store.set would replace the object
+      // (via spread), so an untouched reference proves the migration no-oped.
+      expect(store.data.voiceInput).toBe(before);
     });
 
     it("skips when no voiceInput settings exist", () => {

--- a/electron/services/__tests__/VoiceCorrectionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.integration.test.ts
@@ -91,7 +91,7 @@ describe("VoiceCorrectionService integration", () => {
   );
 
   it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-mini: corrects technical terms and removes fillers",
+    "gpt-5.6-luna: corrects technical terms and removes fillers",
     async () => {
       svc = new VoiceCorrectionService();
 
@@ -99,13 +99,13 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: input },
         {
-          model: "gpt-5-mini",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: ["React", "Daintree"],
         }
       );
 
-      console.log("Model:    ", "gpt-5-mini");
+      console.log("Model:    ", "gpt-5.6-luna");
       console.log("Raw:      ", input);
       console.log("Corrected:", result.confirmedText);
 
@@ -117,7 +117,7 @@ describe("VoiceCorrectionService integration", () => {
   );
 
   it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-mini: output contains no preamble, quotes, or explanatory text",
+    "gpt-5.6-luna: output contains no preamble, quotes, or explanatory text",
     async () => {
       svc = new VoiceCorrectionService();
 
@@ -125,13 +125,13 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: input },
         {
-          model: "gpt-5-mini",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: [],
         }
       );
 
-      console.log("Model:    ", "gpt-5-mini");
+      console.log("Model:    ", "gpt-5.6-luna");
       console.log("Raw:      ", input);
       console.log("Corrected:", result.confirmedText);
 
@@ -146,7 +146,7 @@ describe("VoiceCorrectionService integration", () => {
   );
 
   it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-mini: returns already-correct input verbatim (idempotency)",
+    "gpt-5.6-luna: returns already-correct input verbatim (idempotency)",
     async () => {
       svc = new VoiceCorrectionService();
 
@@ -154,13 +154,13 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: input },
         {
-          model: "gpt-5-mini",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: [],
         }
       );
 
-      console.log("Model:    ", "gpt-5-mini");
+      console.log("Model:    ", "gpt-5.6-luna");
       console.log("Raw:      ", input);
       console.log("Corrected:", result.confirmedText);
 
@@ -173,89 +173,7 @@ describe("VoiceCorrectionService integration", () => {
   );
 
   it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-nano: corrects technical terms and removes fillers",
-    async () => {
-      svc = new VoiceCorrectionService();
-
-      const input = "um so we need to like update the type script compiler";
-      const result = await svc.correct(
-        { rawText: input },
-        {
-          model: "gpt-5-nano",
-          apiKey: OPENAI_API_KEY,
-          customDictionary: ["React", "Daintree"],
-        }
-      );
-
-      console.log("Model:    ", "gpt-5-nano");
-      console.log("Raw:      ", input);
-      console.log("Corrected:", result.confirmedText);
-
-      expect(result).toBeTruthy();
-      expect(result.confirmedText).toContain("TypeScript");
-      expect(result.confirmedText.toLowerCase()).not.toMatch(/\bum\b/);
-    },
-    15_000
-  );
-
-  it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-nano: output contains no preamble, quotes, or explanatory text",
-    async () => {
-      svc = new VoiceCorrectionService();
-
-      const input = "the type script compiler is throwing errors on the racked component";
-      const result = await svc.correct(
-        { rawText: input },
-        {
-          model: "gpt-5-nano",
-          apiKey: OPENAI_API_KEY,
-          customDictionary: [],
-        }
-      );
-
-      console.log("Model:    ", "gpt-5-nano");
-      console.log("Raw:      ", input);
-      console.log("Corrected:", result.confirmedText);
-
-      expect(result.confirmedText).not.toMatch(
-        /^(here is|here's|the corrected|corrected:|sure[,!])/i
-      );
-      expect(result.confirmedText).not.toMatch(/^["'`]/);
-      expect(result.confirmedText).not.toContain("```");
-      expect(result.confirmedText.toLowerCase()).toContain("typescript");
-    },
-    15_000
-  );
-
-  it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-nano: returns already-correct input verbatim (idempotency)",
-    async () => {
-      svc = new VoiceCorrectionService();
-
-      const input = "The TypeScript compiler is throwing errors on the React component.";
-      const result = await svc.correct(
-        { rawText: input },
-        {
-          model: "gpt-5-nano",
-          apiKey: OPENAI_API_KEY,
-          customDictionary: [],
-        }
-      );
-
-      console.log("Model:    ", "gpt-5-nano");
-      console.log("Raw:      ", input);
-      console.log("Corrected:", result.confirmedText);
-
-      expect(result.confirmedText.toLowerCase()).toContain("typescript");
-      expect(result.confirmedText.toLowerCase()).toContain("react");
-      expect(result.confirmedText.toLowerCase()).toContain("compiler");
-      expect(result.confirmedText).not.toMatch(/^(here is|the corrected)/i);
-    },
-    15_000
-  );
-
-  it.skipIf(!OPENAI_API_KEY)(
-    "gpt-5-nano: handles paragraph-length input (multi-clause)",
+    "gpt-5.6-luna: handles paragraph-length input (multi-clause)",
     async () => {
       svc = new VoiceCorrectionService();
 
@@ -264,13 +182,13 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: input },
         {
-          model: "gpt-5-nano",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: [],
         }
       );
 
-      console.log("Model:    ", "gpt-5-nano");
+      console.log("Model:    ", "gpt-5.6-luna");
       console.log("Raw:      ", input);
       console.log("Corrected:", result.confirmedText);
 
@@ -282,47 +200,5 @@ describe("VoiceCorrectionService integration", () => {
       expect(result.confirmedText).not.toMatch(/^(here is|the corrected)/i);
     },
     20_000
-  );
-
-  it.skipIf(!OPENAI_API_KEY)(
-    "raw API call to diagnose response shape",
-    async () => {
-      const input = "um the type script compiler is throwing errors on the racked component";
-
-      for (const config of [
-        { model: "gpt-5-mini", effort: "medium" },
-        { model: "gpt-5-nano", effort: "low" },
-        { model: "gpt-5-nano", effort: "minimal" },
-      ]) {
-        const start = Date.now();
-        const response = await fetch("https://api.openai.com/v1/chat/completions", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${OPENAI_API_KEY}`,
-          },
-          body: JSON.stringify({
-            model: config.model,
-            messages: [
-              {
-                role: "system",
-                content:
-                  "You correct speech-to-text transcription errors. Fix phonetic errors, punctuation, and casing. Output ONLY the corrected text.",
-              },
-              { role: "user", content: `Correct this sentence:\n${input}` },
-            ],
-            reasoning_effort: config.effort,
-            max_completion_tokens: 1024,
-          }),
-        });
-        const elapsed = Date.now() - start;
-
-        const data = await response.json();
-        console.log(`\n--- ${config.model} effort=${config.effort} (${elapsed}ms) ---`);
-        console.log("Status:", response.status);
-        console.log("Response:", JSON.stringify(data, null, 2));
-      }
-    },
-    30_000
   );
 });

--- a/electron/services/__tests__/VoiceCorrectionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.integration.test.ts
@@ -21,7 +21,7 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: "um so we need to like update the racked component" },
         {
-          model: "gpt-4o-mini",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: ["React", "Daintree"],
         }
@@ -51,7 +51,7 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: input },
         {
-          model: "gpt-4o-mini",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: [],
         }
@@ -75,7 +75,7 @@ describe("VoiceCorrectionService integration", () => {
       const result = await svc.correct(
         { rawText: "we need to update the daintree work tree dashboard" },
         {
-          model: "gpt-4o-mini",
+          model: "gpt-5.6-luna",
           apiKey: OPENAI_API_KEY,
           customDictionary: ["Daintree", "Worktree"],
         }

--- a/electron/services/__tests__/VoiceCorrectionService.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../utils/logger.js", () => ({
 import { VoiceCorrectionService } from "../VoiceCorrectionService.js";
 
 const BASE_SETTINGS = {
-  model: "gpt-5-nano",
+  model: "gpt-5.6-luna",
   apiKey: "sk-test",
   customDictionary: [] as string[],
 };
@@ -355,32 +355,22 @@ describe("VoiceCorrectionService", () => {
     expect(userMessage).toContain("<right_context>");
   });
 
-  it("uses structured output without reasoning parameters for gpt-5-mini", async () => {
+  it("sends gpt-5.6-luna with explicit none reasoning effort and strict JSON output", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(makeFetchResponse({ corrected_text: "Corrected." }));
     vi.stubGlobal("fetch", fetchMock);
 
     const svc = new VoiceCorrectionService();
-    await svc.correct({ rawText: "test" }, { ...BASE_SETTINGS, model: "gpt-5-mini" });
+    await svc.correct({ rawText: "test" }, BASE_SETTINGS);
 
     const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
-    expect(body.reasoning).toBeUndefined();
+    // gpt-5.6-luna defaults reasoning to "medium" when omitted, so the request
+    // must pin "none" explicitly — never leave the field off (issue #11365).
+    expect(body.model).toBe("gpt-5.6-luna");
+    expect(body.reasoning).toEqual({ effort: "none" });
     expect(body.max_output_tokens).toBe(1024);
     expect(body.text.format.type).toBe("json_schema");
-  });
-
-  it("uses low reasoning effort for gpt-5-nano corrections", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(makeFetchResponse({ corrected_text: "Corrected." }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    const svc = new VoiceCorrectionService();
-    await svc.correct({ rawText: "test" }, { ...BASE_SETTINGS, model: "gpt-5-nano" });
-
-    const body = JSON.parse((fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string);
-    expect(body.reasoning).toEqual({ effort: "low" });
   });
 
   it("skips LLM call when all words are high confidence", async () => {
@@ -583,6 +573,10 @@ describe("VoiceCorrectionService", () => {
       const body = JSON.parse(init.body as string);
       expect(body.max_output_tokens).toBe(256);
       expect(body.prompt_cache_key).toBe("voice-file-link-v1");
+      // File-link detection shares the single voice model and the explicit
+      // low-latency reasoning effort (issue #11365).
+      expect(body.model).toBe("gpt-5.6-luna");
+      expect(body.reasoning).toEqual({ effort: "none" });
     });
 
     it("preserves all references in a multi-reference utterance (regression)", async () => {

--- a/electron/services/__tests__/VoiceCorrectionService.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.test.ts
@@ -371,6 +371,7 @@ describe("VoiceCorrectionService", () => {
     expect(body.reasoning).toEqual({ effort: "none" });
     expect(body.max_output_tokens).toBe(1024);
     expect(body.text.format.type).toBe("json_schema");
+    expect(body.text.format.strict).toBe(true);
   });
 
   it("skips LLM call when all words are high confidence", async () => {

--- a/electron/services/__tests__/VoiceFileLinkResolver.test.ts
+++ b/electron/services/__tests__/VoiceFileLinkResolver.test.ts
@@ -177,7 +177,7 @@ describe("VoiceFileLinkResolver", () => {
     expect(result).toBeNull();
   });
 
-  it("includes prompt_cache_key in AI rerank request body", async () => {
+  it("sends the shared voice model and explicit none reasoning in the rerank body", async () => {
     searchNaturalLanguageMock.mockResolvedValue([
       "src/components/Bar.tsx",
       "src/components/Input.tsx",
@@ -200,6 +200,10 @@ describe("VoiceFileLinkResolver", () => {
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
     expect(body.prompt_cache_key).toBe("voice-file-rerank-v1");
+    // Rerank shares the single voice model and pinned low-latency effort so it
+    // can't silently inherit gpt-5.6-luna's "medium" default (issue #11365).
+    expect(body.model).toBe("gpt-5.6-luna");
+    expect(body.reasoning).toEqual({ effort: "none" });
   });
 
   it("handles searchNaturalLanguage throwing", async () => {

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -32,7 +32,7 @@ describe("VoiceTranscriptionService integration", () => {
         transcriptionProvider: "openai",
         transcriptionModel: "gpt-realtime-whisper",
         correctionEnabled: false,
-        correctionModel: "gpt-5-mini",
+        correctionModel: "gpt-5.6-luna",
         correctionCustomInstructions: "",
         paragraphingStrategy: "spoken-command",
         resolveFileLinks: true,

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -182,7 +182,7 @@ const OPENAI_SETTINGS: VoiceInputSettings = {
   transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
-  correctionModel: "gpt-5-mini",
+  correctionModel: "gpt-5.6-luna",
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,

--- a/electron/services/migrations/025-upgrade-voice-correction-model.ts
+++ b/electron/services/migrations/025-upgrade-voice-correction-model.ts
@@ -1,0 +1,34 @@
+import type { Migration } from "../StoreMigrations.js";
+
+// Hard-coded target — a migration is an immutable snapshot. Do NOT import the
+// live VOICE_DICTATION_AI_MODEL constant: if the active voice model moves again,
+// this migration must still upgrade v24 stores to the value that was current
+// when schema v25 shipped, independent of whatever the constant becomes later.
+const TARGET_CORRECTION_MODEL = "gpt-5.6-luna";
+
+export const migration025: Migration = {
+  version: 25,
+  description: "Migrate voice correction model to gpt-5.6-luna (retires gpt-5-mini/gpt-5-nano)",
+  up: (store) => {
+    const voiceInput = store.get("voiceInput") as
+      { correctionModel?: string; [key: string]: unknown } | undefined;
+
+    if (!voiceInput) {
+      console.log("[Migration 025] No voiceInput settings found, skipping");
+      return;
+    }
+
+    // gpt-5.6-luna replaced both the gpt-5-mini and gpt-5-nano tiers, so the
+    // union is single-valued now — force every non-current value (missing,
+    // nano, mini, or malformed) to the target while preserving sibling fields.
+    if (voiceInput.correctionModel === TARGET_CORRECTION_MODEL) {
+      console.log(`[Migration 025] correctionModel already "${TARGET_CORRECTION_MODEL}", skipping`);
+      return;
+    }
+
+    console.log(
+      `[Migration 025] Upgrading correctionModel from "${voiceInput.correctionModel ?? "(unset)"}" to "${TARGET_CORRECTION_MODEL}"`
+    );
+    store.set("voiceInput", { ...voiceInput, correctionModel: TARGET_CORRECTION_MODEL });
+  },
+};

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -21,6 +21,7 @@ import { migration021 } from "./021-merge-disabled-plugins.js";
 import { migration022 } from "./022-audit-logs-store.js";
 import { migration023 } from "./023-audit-rings-to-audit-logs-store.js";
 import { migration024 } from "./024-backfill-github-forge-credential.js";
+import { migration025 } from "./025-upgrade-voice-correction-model.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -46,4 +47,5 @@ export const migrations: Migration[] = [
   migration022,
   migration023,
   migration024,
+  migration025,
 ];

--- a/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/DeepgramTranscriptionProvider.test.ts
@@ -161,7 +161,7 @@ const BASE_SETTINGS: VoiceInputSettings = {
   transcriptionProvider: "deepgram",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
-  correctionModel: "gpt-5-mini",
+  correctionModel: "gpt-5.6-luna",
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,

--- a/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
+++ b/electron/services/voice/__tests__/OpenAITranscriptionProvider.test.ts
@@ -236,7 +236,7 @@ const BASE_SETTINGS: VoiceInputSettings = {
   transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
-  correctionModel: "gpt-5-mini",
+  correctionModel: "gpt-5.6-luna",
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -601,7 +601,7 @@ const storeOptions = {
       transcriptionProvider: "openai",
       transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
-      correctionModel: "gpt-5-mini",
+      correctionModel: "gpt-5.6-luna",
       correctionCustomInstructions: "",
       paragraphingStrategy: "spoken-command",
       resolveFileLinks: true,

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -4,6 +4,24 @@ export const CONFIDENCE_SKIP_THRESHOLD = 0.85;
 /** Tag words below this confidence with <uncertain> in the LLM prompt. */
 export const CONFIDENCE_TAG_THRESHOLD = 0.8;
 
+/**
+ * The single OpenAI model backing every voice-dictation AI call: whole-passage
+ * correction, file-command detection, and ambiguous-file reranking. It replaces
+ * the retired gpt-5-mini/gpt-5-nano tiers, so all three roles share one ID.
+ * Migrations hard-code their own target literal and must not import this — the
+ * active model can move again, but a past migration's target is immutable.
+ */
+export const VOICE_DICTATION_AI_MODEL = "gpt-5.6-luna" as const;
+
+/**
+ * Reasoning effort sent explicitly on every voice-dictation Responses request.
+ * gpt-5.6-luna defaults to "medium" when the field is omitted — a latency/cost
+ * regression for these fast, strict-JSON tasks — so we pin the lowest tier at
+ * each call site rather than inheriting the model default. There is no minimum
+ * reasoning effort for strict json_schema output.
+ */
+export const VOICE_DICTATION_REASONING_EFFORT = "none" as const;
+
 const SHARED_TERMS_BLOCK = `<terms>
 racked/react: React
 type script: TypeScript

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -2058,7 +2058,15 @@ export type VoiceTranscriptionModel = "gpt-realtime-whisper";
  */
 export type VoiceTranscriptionProvider = "openai" | "deepgram";
 
-export type VoiceCorrectionModel = "gpt-5-nano" | "gpt-5-mini";
+/**
+ * The correction model is single-valued: gpt-5.6-luna replaced both the retired
+ * gpt-5-mini (quality) and gpt-5-nano (speed) tiers, so there is no longer a
+ * user-facing model choice. Kept as a named type (rather than inlining the
+ * literal) so the persisted setting, the runtime constant in
+ * `shared/config/voiceCorrection.ts` (`VOICE_DICTATION_AI_MODEL`), and this
+ * union stay recognizably one concept.
+ */
+export type VoiceCorrectionModel = "gpt-5.6-luna";
 
 /**
  * Paragraphing strategy for voice dictation.

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -29,12 +29,11 @@ import { logWarn } from "@/utils/logger";
 import { useAudioDevices, SYSTEM_DEFAULT_VALUE } from "@/hooks/useAudioDevices";
 import { useTabLoad } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
+import { CORE_CORRECTION_PROMPT, VOICE_DICTATION_AI_MODEL } from "@shared/config/voiceCorrection";
 import type {
   VoiceInputSettings,
   SuggestedDictionaryEntry,
   MicPermissionStatus,
-  VoiceCorrectionModel,
   VoiceParagraphingStrategy,
   VoiceTranscriptionProvider,
   VoiceRecordingMode,
@@ -51,23 +50,6 @@ const LANGUAGES = [
   { code: "pt", label: "Portuguese" },
   { code: "it", label: "Italian" },
   { code: "ru", label: "Russian" },
-];
-
-const CORRECTION_MODELS: {
-  value: VoiceCorrectionModel;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: "gpt-5-mini",
-    label: "GPT-5 Mini",
-    description: "Higher quality · recommended",
-  },
-  {
-    value: "gpt-5-nano",
-    label: "GPT-5 Nano",
-    description: "Faster · lower cost",
-  },
 ];
 
 const TRANSCRIPTION_PROVIDERS: {
@@ -96,7 +78,7 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
   transcriptionProvider: "openai",
   transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
-  correctionModel: "gpt-5-mini",
+  correctionModel: VOICE_DICTATION_AI_MODEL,
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,
@@ -453,7 +435,7 @@ export function VoiceInputSettingsTab() {
         <SettingsSection
           icon={Sparkles}
           title="AI text correction"
-          description="Post-process transcriptions with a GPT-5 reasoning model to fix technical terms, punctuation, and filler words. Optional."
+          description="Post-process transcriptions with GPT-5.6 Luna to fix technical terms, punctuation, and filler words. Optional."
           id="voice-ai-correction"
         >
           <SettingsSwitchCard
@@ -465,45 +447,30 @@ export function VoiceInputSettingsTab() {
             ariaLabel="Toggle AI text correction"
           />
 
-          {settings.correctionEnabled && (
+          {settings.correctionEnabled && settings.openaiApiKey && (
             <div className="space-y-4">
-              <SettingsSelect
-                label="Correction Model"
-                value={settings.correctionModel}
-                onValueChange={(v) => update({ correctionModel: v as VoiceCorrectionModel })}
-                options={CORRECTION_MODELS.map(({ value, label, description }) => ({
-                  value,
-                  label,
-                  description,
-                }))}
+              <SettingsSwitchCard
+                icon={FileSearch}
+                title="Resolve file references"
+                subtitle={
+                  'Voice commands like "link to the input component" insert @file references'
+                }
+                isEnabled={settings.resolveFileLinks}
+                onChange={() => update({ resolveFileLinks: !settings.resolveFileLinks })}
+                ariaLabel="Toggle file reference resolution from voice commands"
               />
 
-              {settings.openaiApiKey && (
-                <>
-                  <SettingsSwitchCard
-                    icon={FileSearch}
-                    title="Resolve file references"
-                    subtitle={
-                      'Voice commands like "link to the input component" insert @file references'
-                    }
-                    isEnabled={settings.resolveFileLinks}
-                    onChange={() => update({ resolveFileLinks: !settings.resolveFileLinks })}
-                    ariaLabel="Toggle file reference resolution from voice commands"
-                  />
+              <CustomInstructionsRow
+                value={settings.correctionCustomInstructions}
+                onChange={(v) => update({ correctionCustomInstructions: v })}
+              />
 
-                  <CustomInstructionsRow
-                    value={settings.correctionCustomInstructions}
-                    onChange={(v) => update({ correctionCustomInstructions: v })}
-                  />
+              <CorePromptViewer />
 
-                  <CorePromptViewer />
-
-                  <p className="text-xs text-daintree-text/40">
-                    Your project name and custom dictionary are included automatically. Prompt
-                    caching keeps costs minimal.
-                  </p>
-                </>
-              )}
+              <p className="text-xs text-daintree-text/40">
+                Your project name and custom dictionary are included automatically. Prompt caching
+                keeps costs minimal.
+              </p>
             </div>
           )}
         </SettingsSection>

--- a/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
@@ -100,7 +100,7 @@ function createVoiceInputApi(overrides: Partial<typeof window.electron.voiceInpu
       customDictionary: [],
       transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
-      correctionModel: "gpt-5-mini",
+      correctionModel: "gpt-5.6-luna",
       correctionCustomInstructions: "",
       paragraphingStrategy: "spoken-command",
       resolveFileLinks: true,
@@ -133,7 +133,7 @@ describe("VoiceInputSettingsTab", () => {
           customDictionary: [],
           transcriptionModel: "gpt-realtime-whisper",
           correctionEnabled: false,
-          correctionModel: "gpt-5-mini",
+          correctionModel: "gpt-5.6-luna",
           correctionCustomInstructions: "",
           paragraphingStrategy: "spoken-command",
           resolveFileLinks: true,
@@ -160,7 +160,7 @@ describe("VoiceInputSettingsTab", () => {
           customDictionary: [],
           transcriptionModel: "gpt-realtime-whisper",
           correctionEnabled: false,
-          correctionModel: "gpt-5-mini",
+          correctionModel: "gpt-5.6-luna",
           correctionCustomInstructions: "",
           paragraphingStrategy: "spoken-command",
           resolveFileLinks: true,
@@ -189,7 +189,7 @@ describe("VoiceInputSettingsTab", () => {
           customDictionary: [],
           transcriptionModel: "gpt-realtime-whisper",
           correctionEnabled: false,
-          correctionModel: "gpt-5-mini",
+          correctionModel: "gpt-5.6-luna",
           correctionCustomInstructions: "",
           paragraphingStrategy: "spoken-command",
           resolveFileLinks: true,
@@ -219,7 +219,7 @@ describe("VoiceInputSettingsTab", () => {
           customDictionary: [],
           transcriptionModel: "gpt-realtime-whisper",
           correctionEnabled: false,
-          correctionModel: "gpt-5-mini",
+          correctionModel: "gpt-5.6-luna",
           correctionCustomInstructions: "",
           paragraphingStrategy: "spoken-command",
           resolveFileLinks: true,
@@ -252,7 +252,7 @@ describe("VoiceInputSettingsTab", () => {
           customDictionary: [],
           transcriptionModel: "gpt-realtime-whisper",
           correctionEnabled: false,
-          correctionModel: "gpt-5-mini",
+          correctionModel: "gpt-5.6-luna",
           correctionCustomInstructions: "",
           paragraphingStrategy: "spoken-command",
           resolveFileLinks: true,
@@ -269,6 +269,35 @@ describe("VoiceInputSettingsTab", () => {
       expect(screen.getByText(/abuse-monitoring logs for up to 30 days/)).toBeTruthy();
       expect(screen.queryByText(/stored locally in plain text/)).toBeNull();
     });
+  });
+
+  it("does not render a correction-model selector when AI correction is enabled", async () => {
+    // gpt-5.6-luna replaced both the gpt-5-mini and gpt-5-nano tiers, so there
+    // is no longer a model choice to offer (issue #11365).
+    window.electron = {
+      voiceInput: createVoiceInputApi({
+        getSettings: vi.fn().mockResolvedValue({
+          enabled: true,
+          openaiApiKey: "sk-test",
+          language: "en",
+          customDictionary: [],
+          transcriptionModel: "gpt-realtime-whisper",
+          correctionEnabled: true,
+          correctionModel: "gpt-5.6-luna",
+          correctionCustomInstructions: "",
+          paragraphingStrategy: "spoken-command",
+          resolveFileLinks: true,
+          deviceId: "",
+        }),
+      }),
+    } as unknown as typeof window.electron;
+
+    render(<VoiceInputSettingsTab />);
+
+    // Wait for the async settings load to render a stable control before the
+    // negative assertion — a bare queryBy would pass before settings resolve.
+    await screen.findByTestId("settings-select-Language");
+    expect(screen.queryByTestId("settings-select-Correction Model")).toBeNull();
   });
 
   describe("microphone permission request on Windows", () => {
@@ -295,7 +324,7 @@ describe("VoiceInputSettingsTab", () => {
             customDictionary: [],
             transcriptionModel: "gpt-realtime-whisper",
             correctionEnabled: false,
-            correctionModel: "gpt-5-mini",
+            correctionModel: "gpt-5.6-luna",
             correctionCustomInstructions: "",
             paragraphingStrategy: "spoken-command",
             resolveFileLinks: true,

--- a/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/VoiceInputSettingsTab.test.tsx
@@ -294,9 +294,10 @@ describe("VoiceInputSettingsTab", () => {
 
     render(<VoiceInputSettingsTab />);
 
-    // Wait for the async settings load to render a stable control before the
-    // negative assertion — a bare queryBy would pass before settings resolve.
-    await screen.findByTestId("settings-select-Language");
+    // Anchor on the AI-correction subtree itself (gated on correctionEnabled &&
+    // openaiApiKey) so the negative assertion can't pass vacuously — not before
+    // the async load resolves, and not if that whole subtree stopped rendering.
+    await screen.findByText(/Prompt caching keeps costs minimal/i);
     expect(screen.queryByTestId("settings-select-Correction Model")).toBeNull();
   });
 

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -788,7 +788,7 @@ describe("requiresEnabled metadata", () => {
   });
 
   it("Voice AI correction sub-settings reference voice-ai-correction-enable", () => {
-    for (const id of ["voice-correction-model", "voice-custom-instructions"]) {
+    for (const id of ["voice-custom-instructions"]) {
       const entry = byId(id);
       expect(
         entry?.requiresEnabled?.settingId,
@@ -822,8 +822,8 @@ describe("requiresEnabled metadata", () => {
   });
 
   it("two-level dependency chain is fully connected", () => {
-    const correctionModel = byId("voice-correction-model");
-    expect(correctionModel?.requiresEnabled?.settingId).toBe("voice-ai-correction-enable");
+    const customInstructions = byId("voice-custom-instructions");
+    expect(customInstructions?.requiresEnabled?.settingId).toBe("voice-ai-correction-enable");
     const aiCorrection = byId("voice-ai-correction-enable");
     expect(aiCorrection?.requiresEnabled?.settingId).toBe("voice-enable");
     const voiceEnable = byId("voice-enable");

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -831,7 +831,7 @@ describe("requiresEnabled metadata", () => {
   });
 
   it("legacy voice registry IDs are not re-introduced", () => {
-    for (const id of ["voice-transcription-model", "voice-openai-key"]) {
+    for (const id of ["voice-transcription-model", "voice-openai-key", "voice-correction-model"]) {
       expect(
         byId(id),
         `${id} was removed for the OpenAI-only rebuild and must not return`

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1299,14 +1299,6 @@ export const SETTINGS_REGISTRY = [
         requiresEnabled: VOICE_REQUIRES_ENABLED,
       },
       {
-        id: "voice-correction-model",
-        section: "AI text correction",
-        title: "Correction model",
-        description: "Choose the OpenAI model used for text correction",
-        keywords: ["gpt", "model", "correction", "openai"],
-        requiresEnabled: VOICE_AI_REQUIRES_ENABLED,
-      },
-      {
         id: "voice-custom-instructions",
         section: "AI text correction",
         title: "Custom instructions",

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -1029,7 +1029,7 @@ class VoiceRecordingService {
   /**
    * Whole-passage AI cleanup pass. Runs once after a graceful stop: marks the
    * dictated range with the `cm-voice-pending-ai` decoration, sends the full
-   * dictated text to gpt-5-mini, and swaps in the cleaned result if the region
+   * dictated text to gpt-5.6-luna, and swaps in the cleaned result if the region
    * is still where we left it. Best-effort — any failure leaves the raw text.
    */
   private async runCorrection(target: VoiceRecordingTarget, stopGeneration: number): Promise<void> {


### PR DESCRIPTION
## Summary

- Migrates voice dictation's correction, file-link detection, and rerank calls off the retiring `gpt-5-nano`/`gpt-5-mini` models (OpenAI shuts these down December 11 2026) onto a single new model, `gpt-5.6-luna`.
- `gpt-5.6-luna` defaults `reasoning.effort` to `medium` when the field is omitted, which would be a real latency and cost regression for this workload. All three `/v1/responses` call sites now send explicit `reasoning: { effort: "none" }`, and the old model-conditional `getReasoningConfig` was removed since it's no longer needed with one model.
- Adds shared `VOICE_DICTATION_AI_MODEL` and `VOICE_DICTATION_REASONING_EFFORT` constants in `shared/config/voiceCorrection.ts` so correction, detection, rerank, and defaults all read from one source of truth, plus a store migration and a normalize-on-read safety net to move existing users off the old models.

Resolves #11365

## Changes

- `VoiceCorrectionModel` collapses to a single `"gpt-5.6-luna"` literal.
- New `migration025` force-upgrades any non-luna `correctionModel` in settings to the hard-coded target, preserving sibling settings. `getVoiceSettings` also normalizes on read as a second line of defense. `LATEST_SCHEMA_VERSION` bumps 24 → 25.
- Removes the now-meaningless correction-model dropdown from voice input settings and its settings-search entry, since both tiers collapse to one model. The AI-correction section description now names GPT-5.6 Luna.
- `docs/voice-input.md` is intentionally unchanged; project scope keeps doc edits to what's strictly necessary.

## Testing

- 443 targeted unit and component tests pass locally.
- New tests cover `migration025`, the normalize-on-read safety net, and assertions on the Responses API request body for `reasoning: none`.
- Real-API integration tests and e2e fixtures updated to reference luna.
- Two adversarial Codex review passes found no production defects.
- Two commits on the branch: implementation, then a test-hardening commit responding to review feedback.
