### PR TITLE
feat(project): move or rename project dialog (#11282 phase 4)

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -29,6 +29,7 @@ const registerMocks = vi.hoisted(() => ({
   registerPaintFabricSurfaceHandlers: vi.fn(),
   registerAgentCliHandlers: vi.fn(),
   registerProjectCrudHandlers: vi.fn(),
+  registerProjectRelocationHandlers: vi.fn(),
   registerProjectRecipesHandlers: vi.fn(),
   registerProjectPresetsHandlers: vi.fn(),
   registerGlobalRecipesHandlers: vi.fn(),
@@ -119,6 +120,9 @@ vi.mock("../handlers/agentCli.js", () => ({
 }));
 vi.mock("../handlers/projectCrud/index.js", () => ({
   registerProjectCrudHandlers: registerMocks.registerProjectCrudHandlers,
+}));
+vi.mock("../handlers/projectRelocation.js", () => ({
+  registerProjectRelocationHandlers: registerMocks.registerProjectRelocationHandlers,
 }));
 vi.mock("../handlers/projectRecipes.js", () => ({
   registerProjectRecipesHandlers: registerMocks.registerProjectRecipesHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -278,6 +278,8 @@ export const CHANNELS = {
   PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
   PROJECT_CHECK_MISSING: "project:check-missing",
   PROJECT_LOCATE: "project:locate",
+  PROJECT_RELOCATION_PREVIEW: "project-relocation:preview",
+  PROJECT_RELOCATION_APPLY: "project-relocation:apply",
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",
   AGENT_SETTINGS_SET_GLOBAL: "agent-settings:set-global",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -8,6 +8,7 @@ import { registerEditorConfigHandlers } from "./handlers/editorConfig.js";
 import { registerPaintFabricSurfaceHandlers } from "./handlers/paintFabricSurface.js";
 import { registerAgentCliHandlers } from "./handlers/agentCli.js";
 import { registerProjectCrudHandlers } from "./handlers/projectCrud/index.js";
+import { registerProjectRelocationHandlers } from "./handlers/projectRelocation.js";
 import { registerProjectFreeMemoryHandlers } from "./handlers/projectFreeMemory.js";
 import { registerProjectRecipesHandlers } from "./handlers/projectRecipes.js";
 import { registerProjectPresetsHandlers } from "./handlers/projectPresets.js";
@@ -134,6 +135,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerPaintFabricSurfaceHandlers(deps));
     register(() => registerAgentCliHandlers(deps));
     register(() => registerProjectCrudHandlers(deps));
+    register(() => registerProjectRelocationHandlers(deps));
     register(() => registerProjectFreeMemoryHandlers(deps));
     register(() => registerProjectRecipesHandlers(deps));
     register(() => registerProjectPresetsHandlers(deps));

--- a/electron/ipc/handlers/projectRelocation.preload.ts
+++ b/electron/ipc/handlers/projectRelocation.preload.ts
@@ -1,0 +1,27 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const PROJECT_RELOCATION_METHOD_CHANNELS = {
+  preview: "project-relocation:preview",
+  apply: "project-relocation:apply",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof PROJECT_RELOCATION_METHOD_CHANNELS;
+
+export type ProjectRelocationPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildProjectRelocationPreloadBindings(
+  invoke: Invoker
+): ProjectRelocationPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(PROJECT_RELOCATION_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = PROJECT_RELOCATION_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as ProjectRelocationPreloadBindings;
+}

--- a/electron/ipc/handlers/projectRelocation.ts
+++ b/electron/ipc/handlers/projectRelocation.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { projectRelocationCoordinator } from "../../services/ProjectRelocationCoordinator.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { PROJECT_RELOCATION_METHOD_CHANNELS } from "./projectRelocation.preload.js";
@@ -36,6 +37,12 @@ function validateRelocationRequest(request: RelocationRequest): {
   }
   if (typeof newPath !== "string" || !newPath) {
     throw new Error("Invalid destination path");
+  }
+  // Require an absolute path: a relative value (e.g. ".") would otherwise resolve
+  // against the main-process CWD inside the coordinator, silently reattaching to
+  // an arbitrary folder.
+  if (!path.isAbsolute(newPath)) {
+    throw new Error("Destination path must be absolute");
   }
   return { projectId, mode, newPath };
 }

--- a/electron/ipc/handlers/projectRelocation.ts
+++ b/electron/ipc/handlers/projectRelocation.ts
@@ -1,0 +1,66 @@
+import { projectRelocationCoordinator } from "../../services/ProjectRelocationCoordinator.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { PROJECT_RELOCATION_METHOD_CHANNELS } from "./projectRelocation.preload.js";
+import type { HandlerDependencies } from "../types.js";
+import type { Project } from "../../types/index.js";
+import type {
+  RelocationPreview,
+  RelocationRequest,
+} from "../../../shared/types/projectRelocation.js";
+
+// Captured at registration so the ops can configure the coordinator with the
+// live runtime deps (PtyClient, WorkspaceClient, WindowRegistry, …) it needs to
+// quiesce/rebind an open project — mirroring the inline `configure(deps)` the
+// legacy `project:locate` handler does per call.
+let handlerDeps: HandlerDependencies | undefined;
+
+/**
+ * Validate an untrusted renderer relocation request into the exact shape the
+ * coordinator accepts. No silent fallback defaults (#7880) — a malformed field
+ * throws rather than substituting a guessed value on a destructive submit.
+ */
+function validateRelocationRequest(request: RelocationRequest): {
+  projectId: string;
+  mode: "move" | "reattach";
+  newPath: string;
+} {
+  if (!request || typeof request !== "object") {
+    throw new Error("Invalid relocation request");
+  }
+  const { projectId, mode, newPath } = request;
+  if (typeof projectId !== "string" || !projectId) {
+    throw new Error("Invalid project ID");
+  }
+  if (mode !== "move" && mode !== "reattach") {
+    throw new Error(`Invalid relocation mode: ${String(mode)}`);
+  }
+  if (typeof newPath !== "string" || !newPath) {
+    throw new Error("Invalid destination path");
+  }
+  return { projectId, mode, newPath };
+}
+
+export const projectRelocationNamespace = defineIpcNamespace({
+  name: "projectRelocation",
+  ops: {
+    preview: op(
+      PROJECT_RELOCATION_METHOD_CHANNELS.preview,
+      async (request: RelocationRequest): Promise<RelocationPreview> => {
+        if (handlerDeps) projectRelocationCoordinator.configure(handlerDeps);
+        return projectRelocationCoordinator.previewRelocate(validateRelocationRequest(request));
+      }
+    ),
+    apply: op(
+      PROJECT_RELOCATION_METHOD_CHANNELS.apply,
+      async (request: RelocationRequest): Promise<Project> => {
+        if (handlerDeps) projectRelocationCoordinator.configure(handlerDeps);
+        return projectRelocationCoordinator.relocate(validateRelocationRequest(request));
+      }
+    ),
+  },
+});
+
+export function registerProjectRelocationHandlers(deps: HandlerDependencies): () => void {
+  handlerDeps = deps;
+  return projectRelocationNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -74,6 +74,7 @@ import { buildMenuPreloadBindings } from "./ipc/handlers/menu.preload.js";
 import { buildCliPreloadBindings } from "./ipc/handlers/cli.preload.js";
 import { buildGlobalRecipesPreloadBindings } from "./ipc/handlers/globalRecipes.preload.js";
 import { buildEditorConfigPreloadBindings } from "./ipc/handlers/editorConfig.preload.js";
+import { buildProjectRelocationPreloadBindings } from "./ipc/handlers/projectRelocation.preload.js";
 import { buildPaintFabricSurfacePreloadBindings } from "./ipc/handlers/paintFabricSurface.preload.js";
 import { buildWebviewNavigationPreloadBindings } from "./ipc/handlers/webviewNavigation.preload.js";
 import { buildWebviewCapturePreloadBindings } from "./ipc/handlers/webviewCapture.preload.js";
@@ -1431,6 +1432,9 @@ function buildElectronApi(): ElectronAPI {
 
     // Editor API
     editor: buildEditorConfigPreloadBindings(_unwrappingInvoke),
+
+    // Move or rename project — preview + apply (#11282, phase 4)
+    projectRelocation: buildProjectRelocationPreloadBindings(_unwrappingInvoke),
 
     // Paint-fabric surface views (Phase 1V substrate)
     paintSurface: {

--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "fs";
+import { existsSync, lstatSync, statSync } from "fs";
 import { rename } from "fs/promises";
 import path from "path";
 import type { BrowserWindow, WebContents } from "electron";
@@ -172,6 +172,20 @@ export class ProjectRelocationCoordinator {
       throw new ProjectRelocationError("not-found", `Project not found: ${projectId}`);
     }
     const oldPath = project.path;
+    // Resolve ownership SYNCHRONOUSLY before any await (#11131), mirroring
+    // `relocate`. `apply` only quiesces (kills terminals, refuses on an active
+    // Assistant) when it runs `runPipeline` — every move, plus a reattach of an
+    // OPEN project. A reattach of a closed/missing project delegates straight to
+    // `ProjectStore.relocateProject`, which touches no runtimes, so the preview
+    // must NOT claim terminals will stop or block on a (possibly stale) Assistant
+    // record there.
+    const openAtEntry = collectActiveProjectIds(
+      projectViewManagersFrom(this.deps.windowRegistry),
+      projectStore.getCurrentProjectId(),
+      "project-relocation-preview"
+    ).has(projectId);
+    const usesPipeline = mode === "move" || openAtEntry;
+
     const blockers: RelocationBlocker[] = [];
     const pushBlocker = (error: unknown): void => {
       if (error instanceof ProjectRelocationError) {
@@ -213,28 +227,33 @@ export class ProjectRelocationCoordinator {
     }
 
     // Assistant guard, fail-closed — mirrors runPipeline's check but as a blocker.
-    try {
-      const assistant = await getAssistantBackend(projectId);
-      if (assistant) {
+    // Only relevant when apply will quiesce (the pipeline path); a closed reattach
+    // never stops the Assistant, so blocking on it there would be a phantom.
+    if (usesPipeline) {
+      try {
+        const assistant = await getAssistantBackend(projectId);
+        if (assistant) {
+          blockers.push({
+            reason: "assistant-active",
+            message: "Stop the Daintree Assistant for this project before moving it.",
+          });
+        }
+      } catch (error) {
+        logError("relocate-preview-assistant-check-failed", error, { projectId });
         blockers.push({
           reason: "assistant-active",
-          message: "Stop the Daintree Assistant for this project before moving it.",
+          message:
+            "Couldn't check the Daintree Assistant for this project — stop it and try again.",
         });
       }
-    } catch (error) {
-      logError("relocate-preview-assistant-check-failed", error, { projectId });
-      blockers.push({
-        reason: "assistant-active",
-        message:
-          "Couldn't check the Daintree Assistant for this project — stop it and try again.",
-      });
     }
 
     // Read-only enumeration. The folder sits at `oldPath` for a not-yet-run move
-    // and at `request.newPath` for an already-moved reattach.
+    // and at `request.newPath` for an already-moved reattach. Only the pipeline
+    // path gracefully stops terminals, so a closed reattach reports zero.
     const folderPath = mode === "reattach" ? request.newPath : oldPath;
     const [runningTerminalCount, linkedWorktrees, affectedPanelCount] = await Promise.all([
-      this.countRunningTerminals(projectId),
+      usesPipeline ? this.countRunningTerminals(projectId) : Promise.resolve(0),
       this.listLinkedWorktrees(folderPath),
       projectStore.countRebasedPanels(projectId, oldPath, newPath),
     ]);
@@ -467,8 +486,12 @@ export class ProjectRelocationCoordinator {
       let sameItem = false;
       if (caseOnly) {
         try {
-          const src = statSync(oldRoot);
-          const dst = statSync(newRoot);
+          // lstat, NOT stat: a destination that is a symlink pointing back at the
+          // project (`/x/foo` → `/x/Foo` on a case-sensitive volume) would share
+          // the target's inode under stat and be wrongly treated as "the same
+          // item"; lstat compares the symlink entry itself, so it stays blocked.
+          const src = lstatSync(oldRoot);
+          const dst = lstatSync(newRoot);
           sameItem =
             typeof src.ino === "number" &&
             src.ino !== 0 &&

--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -14,6 +14,13 @@ import type { WorkspaceClient } from "./WorkspaceClient.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import type { WorktreePortBroker } from "./WorktreePortBroker.js";
 import type { Project } from "../types/index.js";
+import type {
+  ProjectRelocationReason,
+  RelocationBlocker,
+  RelocationPreview,
+} from "../../shared/types/projectRelocation.js";
+
+export type { ProjectRelocationReason } from "../../shared/types/projectRelocation.js";
 
 // How long the state-write rewrite guard lingers after a relocation resolves, to
 // absorb a renderer layout write debounced with the old root (the persistence
@@ -45,15 +52,6 @@ const RELOCATION_GUARD_GRACE_MS = 3000;
 /** Phase 3 only implements `"refuse"`; the `"hibernate"` continuity path (which
  * tears down the Assistant's whole sub-agent tree) is deferred to phase 4/5. */
 export type AssistantDisposition = "refuse";
-
-export type ProjectRelocationReason =
-  | "not-found"
-  | "in-progress"
-  | "cross-volume"
-  | "assistant-active"
-  | "invalid-destination"
-  | "destination-exists"
-  | "same-path";
 
 export class ProjectRelocationError extends Error {
   constructor(
@@ -151,6 +149,130 @@ export class ProjectRelocationCoordinator {
       // write debounced with the old root can land after `relocate` resolves, and
       // must still be rebased. Released only if no newer relocation re-armed it.
       this.scheduleGuardRelease(projectId);
+    }
+  }
+
+  /**
+   * Read-only description of what a relocation WOULD do (#11282, phase 4). Runs
+   * the same preflight checks as {@link relocate} but converts each into a typed
+   * `blocker` instead of throwing, and enumerates the affected state — running
+   * terminals, linked worktrees, panels whose stored paths would be rewritten —
+   * without touching the filesystem, PTYs, hosts, views, or persisted state.
+   *
+   * Blockers ride the SUCCESSFUL result: a `ProjectRelocationError.reason` does
+   * not survive IPC error serialization, so the renderer dialog gets structured
+   * `{ reason, message }` to gate its confirm button on. `apply` re-validates —
+   * the preview is a description, never an authorization.
+   */
+  async previewRelocate(request: RelocateProjectRequest): Promise<RelocationPreview> {
+    const { projectId, mode } = request;
+
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new ProjectRelocationError("not-found", `Project not found: ${projectId}`);
+    }
+    const oldPath = project.path;
+    const blockers: RelocationBlocker[] = [];
+    const pushBlocker = (error: unknown): void => {
+      if (error instanceof ProjectRelocationError) {
+        blockers.push({ reason: error.reason, message: error.message });
+      } else {
+        throw error;
+      }
+    };
+
+    if (this.relocating.has(projectId)) {
+      blockers.push({
+        reason: "in-progress",
+        message: `A relocation is already running for "${project.name}".`,
+      });
+    }
+
+    // Resolve + validate the destination without side effects.
+    let newPath = normalizeProjectPath(request.newPath);
+    if (mode === "move") {
+      try {
+        newPath = this.validateManagedMove(oldPath, request.newPath);
+      } catch (error) {
+        pushBlocker(error);
+      }
+    } else if (!existsSync(request.newPath)) {
+      blockers.push({
+        reason: "invalid-destination",
+        message: `The folder to reattach doesn't exist: ${request.newPath}`,
+      });
+    }
+
+    // A destination already registered to a DIFFERENT project blocks either mode.
+    const conflict = await projectStore.getProjectByPath(newPath);
+    if (conflict && conflict.id !== projectId) {
+      blockers.push({
+        reason: "destination-exists",
+        message: `Another project ("${conflict.name}") is already registered at that location.`,
+      });
+    }
+
+    // Assistant guard, fail-closed — mirrors runPipeline's check but as a blocker.
+    try {
+      const assistant = await getAssistantBackend(projectId);
+      if (assistant) {
+        blockers.push({
+          reason: "assistant-active",
+          message: "Stop the Daintree Assistant for this project before moving it.",
+        });
+      }
+    } catch (error) {
+      logError("relocate-preview-assistant-check-failed", error, { projectId });
+      blockers.push({
+        reason: "assistant-active",
+        message:
+          "Couldn't check the Daintree Assistant for this project — stop it and try again.",
+      });
+    }
+
+    // Read-only enumeration. The folder sits at `oldPath` for a not-yet-run move
+    // and at `request.newPath` for an already-moved reattach.
+    const folderPath = mode === "reattach" ? request.newPath : oldPath;
+    const [runningTerminalCount, linkedWorktrees, affectedPanelCount] = await Promise.all([
+      this.countRunningTerminals(projectId),
+      this.listLinkedWorktrees(folderPath),
+      projectStore.countRebasedPanels(projectId, oldPath, newPath),
+    ]);
+
+    return {
+      mode,
+      oldPath,
+      newPath,
+      runningTerminalCount,
+      linkedWorktrees,
+      affectedPanelCount,
+      blockers,
+    };
+  }
+
+  private async countRunningTerminals(projectId: string): Promise<number> {
+    const { ptyClient } = this.deps;
+    if (!ptyClient) return 0;
+    try {
+      const stats = await ptyClient.getProjectStats(projectId);
+      return stats.terminalCount;
+    } catch (error) {
+      logError("relocate-preview-terminal-count-failed", error, { projectId });
+      return 0;
+    }
+  }
+
+  private async listLinkedWorktrees(folderPath: string): Promise<string[]> {
+    try {
+      // Dynamic import keeps GitService (and simple-git) out of the coordinator's
+      // eval graph, matching how the Assistant backend is loaded lazily below.
+      const { GitService } = await import("./GitService.js");
+      const worktrees = await new GitService(folderPath).listWorktrees();
+      return worktrees.filter((w) => !w.isMainWorktree).map((w) => w.path);
+    } catch {
+      // A repo we can't enumerate (folder missing, not a git repo) simply reports
+      // no linked worktrees — the preview stays best-effort, never fatal.
+      return [];
     }
   }
 
@@ -331,10 +453,37 @@ export class ProjectRelocationCoordinator {
       );
     }
     if (existsSync(newRoot)) {
-      throw new ProjectRelocationError(
-        "destination-exists",
-        `Something already exists at ${newRoot}.`
-      );
+      // On a case-insensitive volume (APFS by default, NTFS) a case-only rename
+      // (`Foo` → `foo`) resolves BOTH spellings to the same inode, so
+      // `existsSync(newRoot)` is a false positive — it's the project's OWN
+      // folder being re-cased, not a different item colliding. Allow it only
+      // when the roots differ by case alone AND both stat to the same
+      // device+inode; a genuinely different folder — or a case-SENSITIVE volume
+      // where `Foo` and `foo` coexist as distinct dirs — still blocks. Inode is
+      // unreliable (0/undefined) on some Windows volumes, so anything short of a
+      // real integer inode match falls through to the block: refusing an exotic
+      // case-only rename is safe, silently merging two folders is not.
+      const caseOnly = newRoot.toLowerCase() === oldRoot.toLowerCase();
+      let sameItem = false;
+      if (caseOnly) {
+        try {
+          const src = statSync(oldRoot);
+          const dst = statSync(newRoot);
+          sameItem =
+            typeof src.ino === "number" &&
+            src.ino !== 0 &&
+            src.ino === dst.ino &&
+            src.dev === dst.dev;
+        } catch {
+          sameItem = false;
+        }
+      }
+      if (!sameItem) {
+        throw new ProjectRelocationError(
+          "destination-exists",
+          `Something already exists at ${newRoot}.`
+        );
+      }
     }
     const parent = path.dirname(newRoot);
     let parentStat: ReturnType<typeof statSync>;

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1196,6 +1196,29 @@ export class ProjectStore {
     return this.stateManager.getProjectState(projectId);
   }
 
+  /**
+   * Count the persisted panels whose stored absolute paths a move from
+   * `oldPath` to `newPath` would rewrite (#11282, phase 4). Read-only: reuses
+   * the exact production rebase ({@link rewriteProjectStatePaths}) over the
+   * loaded state so the "panels with rewritten paths" preview can't drift from
+   * what an actual relocation rewrites. Returns 0 when nothing changes.
+   */
+  async countRebasedPanels(projectId: string, oldPath: string, newPath: string): Promise<number> {
+    if (normalizeProjectPath(oldPath) === normalizeProjectPath(newPath)) return 0;
+    const state = await this.getProjectState(projectId);
+    if (!state) return 0;
+    const rewritten = rewriteProjectStatePaths(state, oldPath, newPath);
+    // Same reference back ⇒ nothing rebased.
+    if (rewritten === state) return 0;
+    const before = Array.isArray(state.terminals) ? state.terminals : [];
+    const after = Array.isArray(rewritten.terminals) ? rewritten.terminals : [];
+    let count = 0;
+    for (let i = 0; i < before.length; i++) {
+      if (after[i] !== before[i]) count++;
+    }
+    return count;
+  }
+
   async getProjectStateWithRecovery(projectId: string): Promise<ProjectStateReadResult> {
     return this.stateManager.getProjectStateWithRecovery(projectId);
   }

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const fsState = vi.hoisted(() => ({
   existing: new Set<string>(),
   devByPath: new Map<string, number>(),
+  inoByPath: new Map<string, number>(),
   renameReject: null as Error | null,
   renameCalls: [] as Array<{ from: string; to: string }>,
 }));
@@ -17,7 +18,23 @@ vi.mock("fs", () => ({
       err.code = "ENOENT";
       throw err;
     }
-    return { dev: fsState.devByPath.get(p) ?? 1, isDirectory: () => true };
+    return {
+      dev: fsState.devByPath.get(p) ?? 1,
+      ino: fsState.inoByPath.get(p),
+      isDirectory: () => true,
+    };
+  },
+}));
+
+const mockListWorktrees = vi.hoisted(() =>
+  vi.fn(
+    async () =>
+      [] as Array<{ path: string; branch: string; bare: boolean; isMainWorktree: boolean }>
+  )
+);
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    listWorktrees = mockListWorktrees;
   },
 }));
 
@@ -38,6 +55,7 @@ const mockProjectStore = vi.hoisted(() => ({
   relocateProject: vi.fn(),
   beginRelocationRewrite: vi.fn(),
   endRelocationRewrite: vi.fn(),
+  countRebasedPanels: vi.fn(async () => 0),
 }));
 
 vi.mock("../ProjectStore.js", () => ({
@@ -103,6 +121,7 @@ function makeDeps(pvm: ReturnType<typeof makePvm> | null) {
   const ptyClient = {
     gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
     onProjectSwitch: vi.fn(),
+    getProjectStats: vi.fn(async () => ({ terminalCount: 0 })),
   };
   const worktreeService = {
     evictProjectForRelocation: vi.fn(),
@@ -128,6 +147,7 @@ beforeEach(() => {
     [OLD_ROOT, 10],
     ["/vol/projects", 10],
   ]);
+  fsState.inoByPath = new Map();
   fsState.renameReject = null;
   fsState.renameCalls = [];
   mockProjectStore.getProjectById.mockReturnValue(makeProject());
@@ -135,6 +155,8 @@ beforeEach(() => {
   mockProjectStore.getCurrentProjectId.mockReturnValue(null);
   mockProjectStore.finalizeRelocatedPath.mockResolvedValue(makeProject({ path: NEW_ROOT }));
   mockProjectStore.relocateProject.mockResolvedValue(makeProject({ path: NEW_ROOT }));
+  mockProjectStore.countRebasedPanels.mockResolvedValue(0);
+  mockListWorktrees.mockResolvedValue([]);
   mockAssistant.getAssistantBackend.mockReturnValue(null);
 });
 
@@ -388,6 +410,186 @@ describe("ProjectRelocationCoordinator — guards", () => {
 
     await expect(
       coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "not-found" });
+  });
+});
+
+// --- Case-only folder rename (#11282, phase 4) -----------------------------
+// A case-only rename on a case-insensitive volume (APFS/NTFS) resolves both
+// spellings to the same inode, so a naive existsSync(newRoot) check false-blocks
+// it as "destination-exists".
+
+describe("ProjectRelocationCoordinator — case-only rename", () => {
+  const CASE_ROOT = "/vol/projects/PROJ"; // same folder as OLD_ROOT, re-cased
+
+  it("allows a case-only rename when both spellings share one inode", async () => {
+    fsState.existing.add(CASE_ROOT);
+    fsState.devByPath.set(CASE_ROOT, 10);
+    fsState.inoByPath.set(OLD_ROOT, 555);
+    fsState.inoByPath.set(CASE_ROOT, 555);
+    mockProjectStore.finalizeRelocatedPath.mockResolvedValue(makeProject({ path: CASE_ROOT }));
+
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    const result = await coordinator.relocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: CASE_ROOT,
+    });
+
+    expect(fsState.renameCalls).toEqual([{ from: OLD_ROOT, to: CASE_ROOT }]);
+    expect(result.path).toBe(CASE_ROOT);
+  });
+
+  it("still blocks a case-variant destination that is a DIFFERENT inode", async () => {
+    fsState.existing.add(CASE_ROOT);
+    fsState.devByPath.set(CASE_ROOT, 10);
+    fsState.inoByPath.set(OLD_ROOT, 555);
+    fsState.inoByPath.set(CASE_ROOT, 777); // a genuinely different folder
+
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: CASE_ROOT })
+    ).rejects.toMatchObject({ reason: "destination-exists" });
+    expect(fsState.renameCalls).toEqual([]);
+  });
+
+  it("blocks an existing non-case-variant destination (unchanged behavior)", async () => {
+    fsState.existing.add(NEW_ROOT);
+    fsState.devByPath.set(NEW_ROOT, 10);
+    // No inode data — a real different folder; the inode guard falls through to block.
+
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    await expect(
+      coordinator.relocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
+    ).rejects.toMatchObject({ reason: "destination-exists" });
+    expect(fsState.renameCalls).toEqual([]);
+  });
+});
+
+// --- previewRelocate (#11282, phase 4) -------------------------------------
+
+describe("ProjectRelocationCoordinator — previewRelocate", () => {
+  it("returns affected state with no blockers for a clean managed move", async () => {
+    const deps = makeDeps(makePvm(PROJECT_ID));
+    deps.ptyClient.getProjectStats.mockResolvedValue({ terminalCount: 3 });
+    mockProjectStore.countRebasedPanels.mockResolvedValue(4);
+    mockListWorktrees.mockResolvedValue([
+      { path: OLD_ROOT, branch: "main", bare: false, isMainWorktree: true },
+      { path: "/vol/projects/proj-feature", branch: "feat", bare: false, isMainWorktree: false },
+    ]);
+
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    expect(preview.mode).toBe("move");
+    expect(preview.oldPath).toBe(OLD_ROOT);
+    expect(preview.newPath).toBe(NEW_ROOT);
+    expect(preview.runningTerminalCount).toBe(3);
+    expect(preview.affectedPanelCount).toBe(4);
+    // Main worktree excluded; only the linked one is listed.
+    expect(preview.linkedWorktrees).toEqual(["/vol/projects/proj-feature"]);
+    expect(preview.blockers).toEqual([]);
+  });
+
+  it("never mutates — no rename, quiesce, finalize, or rebind", async () => {
+    const deps = makeDeps(makePvm(PROJECT_ID));
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    expect(fsState.renameCalls).toEqual([]);
+    expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(deps.worktreeService.evictProjectForRelocation).not.toHaveBeenCalled();
+    expect(mockProjectStore.finalizeRelocatedPath).not.toHaveBeenCalled();
+    expect(mockProjectStore.beginRelocationRewrite).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a cross-volume move as a blocker, not a throw", async () => {
+    fsState.existing.add("/other");
+    fsState.devByPath.set("/other", 99);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: "/other/proj",
+    });
+
+    expect(preview.blockers.map((b) => b.reason)).toContain("cross-volume");
+  });
+
+  it("surfaces a destination already registered to another project", async () => {
+    mockProjectStore.getProjectByPath.mockResolvedValue({ id: "other", name: "Other" });
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    expect(preview.blockers.map((b) => b.reason)).toContain("destination-exists");
+  });
+
+  it("surfaces an active Assistant as a blocker", async () => {
+    mockAssistant.getAssistantBackend.mockReturnValue({ terminalId: "t9", webContentsId: 2 });
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    expect(preview.blockers.map((b) => b.reason)).toContain("assistant-active");
+  });
+
+  it("reattach preview lists worktrees from the destination folder", async () => {
+    fsState.existing.add(NEW_ROOT);
+    mockListWorktrees.mockResolvedValue([
+      { path: NEW_ROOT, branch: "main", bare: false, isMainWorktree: true },
+    ]);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "reattach",
+      newPath: NEW_ROOT,
+    });
+
+    expect(preview.mode).toBe("reattach");
+    expect(preview.blockers).toEqual([]);
+    expect(preview.linkedWorktrees).toEqual([]);
+  });
+
+  it("rejects a preview for an unknown project", async () => {
+    mockProjectStore.getProjectById.mockReturnValue(null);
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+
+    await expect(
+      coordinator.previewRelocate({ projectId: PROJECT_ID, mode: "move", newPath: NEW_ROOT })
     ).rejects.toMatchObject({ reason: "not-found" });
   });
 });

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -10,9 +10,8 @@ const fsState = vi.hoisted(() => ({
   renameCalls: [] as Array<{ from: string; to: string }>,
 }));
 
-vi.mock("fs", () => ({
-  existsSync: (p: string) => fsState.existing.has(p),
-  statSync: (p: string) => {
+vi.mock("fs", () => {
+  const statImpl = (p: string) => {
     if (!fsState.existing.has(p)) {
       const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException;
       err.code = "ENOENT";
@@ -23,8 +22,13 @@ vi.mock("fs", () => ({
       ino: fsState.inoByPath.get(p),
       isDirectory: () => true,
     };
-  },
-}));
+  };
+  return {
+    existsSync: (p: string) => fsState.existing.has(p),
+    statSync: statImpl,
+    lstatSync: statImpl,
+  };
+});
 
 const mockListWorktrees = vi.hoisted(() =>
   vi.fn(
@@ -503,8 +507,9 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
     expect(preview.blockers).toEqual([]);
   });
 
-  it("never mutates — no rename, quiesce, finalize, or rebind", async () => {
-    const deps = makeDeps(makePvm(PROJECT_ID));
+  it("never mutates — no rename, quiesce, finalize, rebind, broadcast, or reload", async () => {
+    const pvm = makePvm(PROJECT_ID);
+    const deps = makeDeps(pvm);
     const coordinator = new ProjectRelocationCoordinator();
     configure(coordinator, deps);
 
@@ -517,8 +522,12 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
     expect(fsState.renameCalls).toEqual([]);
     expect(deps.ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
     expect(deps.worktreeService.evictProjectForRelocation).not.toHaveBeenCalled();
+    expect(deps.worktreeService.loadProject).not.toHaveBeenCalled();
     expect(mockProjectStore.finalizeRelocatedPath).not.toHaveBeenCalled();
+    expect(mockProjectStore.relocateProject).not.toHaveBeenCalled();
     expect(mockProjectStore.beginRelocationRewrite).not.toHaveBeenCalled();
+    expect(pvm.rebindProjectPath).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
   });
 
   it("surfaces a cross-volume move as a blocker, not a throw", async () => {
@@ -568,9 +577,11 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
     fsState.existing.add(NEW_ROOT);
     mockListWorktrees.mockResolvedValue([
       { path: NEW_ROOT, branch: "main", bare: false, isMainWorktree: true },
+      { path: `${NEW_ROOT}/wt`, branch: "feat", bare: false, isMainWorktree: false },
     ]);
     const coordinator = new ProjectRelocationCoordinator();
-    configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
+    // Missing project → not open → closed-delegate reattach path.
+    configure(coordinator, makeDeps(makePvm(null)));
 
     const preview = await coordinator.previewRelocate({
       projectId: PROJECT_ID,
@@ -580,7 +591,29 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
 
     expect(preview.mode).toBe("reattach");
     expect(preview.blockers).toEqual([]);
-    expect(preview.linkedWorktrees).toEqual([]);
+    expect(preview.linkedWorktrees).toEqual([`${NEW_ROOT}/wt`]);
+  });
+
+  it("a CLOSED reattach ignores a stale Assistant record and reports no terminals", async () => {
+    fsState.existing.add(NEW_ROOT);
+    // A stale Assistant record survives a natural PTY exit; a closed reattach's
+    // apply path never checks it, so the preview must not block on it (fix B).
+    mockAssistant.getAssistantBackend.mockReturnValue({ terminalId: "t9", webContentsId: 2 });
+    const deps = makeDeps(makePvm(null)); // project not open anywhere
+    deps.ptyClient.getProjectStats.mockResolvedValue({ terminalCount: 5 });
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "reattach",
+      newPath: NEW_ROOT,
+    });
+
+    expect(preview.blockers.map((b) => b.reason)).not.toContain("assistant-active");
+    // The closed-delegate path stops nothing, so no terminals are reported.
+    expect(preview.runningTerminalCount).toBe(0);
+    expect(deps.ptyClient.getProjectStats).not.toHaveBeenCalled();
   });
 
   it("rejects a preview for an unknown project", async () => {

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -618,6 +618,14 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["privacy:set-telemetry-level"]["args"]
     ): Promise<IpcInvokeMap["privacy:set-telemetry-level"]["result"]>;
   };
+  projectRelocation: {
+    apply(
+      ...args: IpcInvokeMap["project-relocation:apply"]["args"]
+    ): Promise<IpcInvokeMap["project-relocation:apply"]["result"]>;
+    preview(
+      ...args: IpcInvokeMap["project-relocation:preview"]["args"]
+    ): Promise<IpcInvokeMap["project-relocation:preview"]["result"]>;
+  };
   runHistory: {
     append(
       ...args: IpcInvokeMap["run-history:append"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1172,6 +1172,14 @@ export interface GeneratedIpcInvokeMap {
     args: [level: "off" | "errors" | "full"];
     result: void;
   };
+  "project-relocation:apply": {
+    args: [request: import("../projectRelocation.js").RelocationRequest];
+    result: import("../project.js").Project;
+  };
+  "project-relocation:preview": {
+    args: [request: import("../projectRelocation.js").RelocationRequest];
+    result: import("../projectRelocation.js").RelocationPreview;
+  };
   "project:clone-cancel": {
     args: [];
     result: void;

--- a/shared/types/projectRelocation.ts
+++ b/shared/types/projectRelocation.ts
@@ -1,0 +1,62 @@
+/**
+ * Cross-process contract for the "Move or rename project" workflow (#11282,
+ * phase 4). The reason union and preview shape are shared so the renderer dialog
+ * can render an honest preview and branch on structured blockers without relying
+ * on Error properties surviving IPC serialization.
+ */
+
+/** Why a relocation cannot proceed. Every reason maps to a user-facing message. */
+export type ProjectRelocationReason =
+  | "not-found"
+  | "in-progress"
+  | "cross-volume"
+  | "assistant-active"
+  | "invalid-destination"
+  | "destination-exists"
+  | "same-path";
+
+/**
+ * `"move"` performs a Daintree-managed `fs.rename` (same-volume only for the
+ * first cut). `"reattach"` adopts a folder already sitting at the destination
+ * (moved externally).
+ */
+export type ProjectRelocationMode = "move" | "reattach";
+
+/** A preflight failure surfaced in the preview so the dialog can disable confirm. */
+export interface RelocationBlocker {
+  reason: ProjectRelocationReason;
+  message: string;
+}
+
+/**
+ * Renderer → main relocation request. Mirrors the coordinator's
+ * `RelocateProjectRequest` minus `assistantDisposition` (which the dialog never
+ * sets — it defaults to `"refuse"`).
+ */
+export interface RelocationRequest {
+  projectId: string;
+  mode: ProjectRelocationMode;
+  /** Managed move: the full destination root. Reattach: where the folder is now. */
+  newPath: string;
+}
+
+/**
+ * Read-only description of everything a relocation would affect, gathered
+ * without side effects. `blockers` is empty when the operation is clear to run;
+ * a non-empty list means the dialog must keep confirm disabled.
+ */
+export interface RelocationPreview {
+  mode: ProjectRelocationMode;
+  /** The project's current folder. */
+  oldPath: string;
+  /** The normalized destination the operation would land at. */
+  newPath: string;
+  /** Terminals/agents that will be gracefully stopped and session-preserved. */
+  runningTerminalCount: number;
+  /** Absolute paths of the linked (non-main) worktrees that will be repaired. */
+  linkedWorktrees: string[];
+  /** Count of persisted panels whose stored working directory will be rewritten. */
+  affectedPanelCount: number;
+  /** Preflight failures; non-empty ⇒ the operation cannot proceed. */
+  blockers: RelocationBlocker[];
+}

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -434,7 +434,12 @@ export function ModalHostLayer({
               onFreeMemoryProject={(projectId) =>
                 void projectSwitcherPalette.freeMemoryProject(projectId)
               }
-              onLocateProject={(projectId) => void projectSwitcherPalette.locateProject(projectId)}
+              onLocateProject={(projectId) => {
+                projectSwitcherPalette.locateProject(projectId);
+              }}
+              onMoveOrRenameProject={(projectId) => {
+                projectSwitcherPalette.moveOrRenameProject(projectId);
+              }}
               onTogglePinProject={(projectId) =>
                 void projectSwitcherPalette.togglePinProject(projectId)
               }

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -12,6 +12,7 @@ import type {
   TabGroup,
 } from "@shared/types";
 import type { NotificationSettings } from "@shared/types/ipc/api";
+import type { RelocationPreview, RelocationRequest } from "@shared/types/projectRelocation";
 import type { AgentPreset } from "@shared/config/agentRegistry";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
 import type {
@@ -144,6 +145,23 @@ export const projectClient = {
 
   openDialog: (): Promise<string | null> => {
     return window.electron.project.openDialog();
+  },
+
+  /**
+   * Read-only preview of what a move/reattach would affect (#11282, phase 4).
+   * Never mutates — the dialog gates its confirm on the returned blockers.
+   */
+  previewRelocation: (request: RelocationRequest): Promise<RelocationPreview> => {
+    return window.electron.projectRelocation.preview(request);
+  },
+
+  /**
+   * Commit a managed move (`fs.rename`) or reattach of an already-moved folder.
+   * Broadcasts `PROJECT_UPDATED` on success, so the local cache is invalidated.
+   */
+  applyRelocation: (request: RelocationRequest): Promise<Project> => {
+    invalidateCurrentCache();
+    return window.electron.projectRelocation.apply(request);
   },
 
   onSwitch: (

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -13,6 +13,7 @@ import { ThemeBrowser } from "../ThemeBrowser";
 import { FleetArmingRibbon } from "@/components/Fleet";
 import { TerminalDestructiveActionConfirmDialog } from "@/components/Terminal/TerminalDestructiveActionConfirmDialog";
 import { PortalCloseConfirmDialog } from "@/components/Portal/PortalCloseConfirmDialog";
+import { MoveOrRenameProjectDialog } from "@/components/Project/MoveOrRenameProjectDialog";
 import { ChordIndicator } from "./ChordIndicator";
 
 import { AllClearOverlay } from "../AllClearOverlay";
@@ -829,6 +830,7 @@ export function AppLayout({
       </div>
       <TerminalDestructiveActionConfirmDialog />
       <PortalCloseConfirmDialog />
+      <MoveOrRenameProjectDialog />
       <div
         {...(chromeInert ? { inert: true } : {})}
         className="flex-1 flex flex-col overflow-hidden"

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -633,7 +633,14 @@ export function Toolbar({
 
   const handleLocateProject = useCallback(
     (projectId: string) => {
-      void projectSwitcher.locateProject(projectId);
+      projectSwitcher.locateProject(projectId);
+    },
+    [projectSwitcher]
+  );
+
+  const handleMoveOrRenameProject = useCallback(
+    (projectId: string) => {
+      projectSwitcher.moveOrRenameProject(projectId);
     },
     [projectSwitcher]
   );
@@ -1607,6 +1614,7 @@ export function Toolbar({
                     onCloseProject={handleCloseProject}
                     onFreeMemoryProject={handleFreeMemoryProject}
                     onLocateProject={handleLocateProject}
+                    onMoveOrRenameProject={handleMoveOrRenameProject}
                     onTogglePinProject={projectSwitcher.togglePinProject}
                     onCopyPath={projectSwitcher.copyPath}
                     onOpenProjectSettings={currentProject ? handleOpenProjectSettings : undefined}

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -5,6 +5,7 @@ import {
   X,
   Rocket,
   Check,
+  FolderInput,
   FolderOpen,
   Copy,
   Palette,
@@ -24,6 +25,7 @@ import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { DaintreeMcpTier, Project } from "@shared/types/project";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { useProjectRelocationStore } from "@/store/projectRelocationStore";
 import { findDevServerCandidate } from "@/utils/devServerDetection";
 
 const DAINTREE_MCP_TIER_OPTIONS: readonly ChoiceboxOption<DaintreeMcpTier>[] = [
@@ -140,6 +142,17 @@ export function GeneralTab({
   const gitignoreCopyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const allDetectedRunners = useProjectSettingsStore((s) => s.allDetectedRunners);
+  const openRelocation = useProjectRelocationStore((s) => s.open);
+
+  const handleMoveOrRename = useCallback(() => {
+    if (!currentProject) return;
+    openRelocation({
+      projectId,
+      mode: "move",
+      oldPath: currentProject.path,
+      name: currentProject.name,
+    });
+  }, [openRelocation, projectId, currentProject]);
 
   const detectedCandidate = useMemo(() => {
     const candidate = findDevServerCandidate(allDetectedRunners, turbopackEnabled);
@@ -358,6 +371,24 @@ export function GeneralTab({
                 placeholder="My Awesome Project"
               />
             </div>
+          </div>
+
+          <div className="mt-3 flex items-center justify-between gap-3">
+            <p
+              className="min-w-0 flex-1 truncate text-xs font-mono text-daintree-text/40"
+              title={currentProject.path}
+            >
+              {currentProject.path}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleMoveOrRename}
+              className="shrink-0 gap-1.5"
+            >
+              <FolderInput className="h-3.5 w-3.5" />
+              Move or rename project…
+            </Button>
           </div>
         </div>
       )}

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -150,9 +150,13 @@ export function GeneralTab({
       projectId,
       mode: "move",
       oldPath: currentProject.path,
-      name: currentProject.name,
+      // Seed from the live Settings draft so an unsaved inline edit carries in,
+      // and sync the draft back on commit so the Settings close-flush can't
+      // revert the dialog's rename.
+      name,
+      onDisplayNameCommitted: onNameChange,
     });
-  }, [openRelocation, projectId, currentProject]);
+  }, [openRelocation, projectId, currentProject, name, onNameChange]);
 
   const detectedCandidate = useMemo(() => {
     const candidate = findDevServerCandidate(allDetectedRunners, turbopackEnabled);

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -58,8 +58,12 @@ function MoveOrRenameProjectDialogInner({
     : parentPath && folderName.trim() && !folderNameError
       ? join(parentPath, folderName.trim())
       : "";
-  const destinationChanged =
-    destinationPath !== "" && normPath(destinationPath) !== normPath(pending.oldPath);
+  // A reattach commits ANY selected folder — even the original path, e.g. a
+  // removable volume that reappeared — so it gates on "a target was picked", not
+  // "the path changed". A managed move requires a genuinely different path.
+  const destinationChanged = isReattach
+    ? reattachPath !== ""
+    : destinationPath !== "" && normPath(destinationPath) !== normPath(pending.oldPath);
 
   // A pure display-name edit stays a lightweight metadata write — no filesystem
   // op, no preview, no coordinator. Reattach never qualifies (the folder move is
@@ -73,13 +77,16 @@ function MoveOrRenameProjectDialogInner({
   // `preview = null` (the "not loaded" sentinel) before every request so confirm
   // stays gated; an empty preview array means "loaded, nothing affected".
   useEffect(() => {
+    // Invalidate any in-flight fetch on EVERY run — including this early return —
+    // so a response for an older destination can't repopulate state after the
+    // user reverts to an unchanged/empty folder.
+    const reqId = ++previewReqId.current;
     if (!destinationChanged || !destinationPath) {
       setPreview(null);
       setLoadError(null);
       setIsPreviewLoading(false);
       return;
     }
-    const reqId = ++previewReqId.current;
     setPreview(null);
     setLoadError(null);
     setIsPreviewLoading(true);
@@ -128,16 +135,25 @@ function MoveOrRenameProjectDialogInner({
     try {
       if (isMetadataOnly) {
         await updateProject(pending.projectId, { name: trimmedName });
+        pending.onDisplayNameCommitted?.(trimmedName);
       } else {
         await projectClient.applyRelocation({
           projectId: pending.projectId,
           mode: pending.mode,
           newPath: destinationPath,
         });
-        // Apply the display-name change only after the folder op succeeds, so a
-        // failed relocation never leaves a half-applied rename behind.
+        // The folder op is the committed, irreversible part. Apply the display
+        // name only AFTER it succeeds (never a half-applied rename on failure) —
+        // but in its OWN guard: a failure of this best-effort follow-up must not
+        // report the successful move as failed or strand an unretryable dialog
+        // (retrying the move would hit `same-path`).
         if (displayNameChanged) {
-          await updateProject(pending.projectId, { name: trimmedName });
+          try {
+            await updateProject(pending.projectId, { name: trimmedName });
+            pending.onDisplayNameCommitted?.(trimmedName);
+          } catch (nameErr) {
+            console.warn("[relocate] folder moved but display-name update failed:", nameErr);
+          }
         }
       }
       onClose();
@@ -150,17 +166,7 @@ function MoveOrRenameProjectDialogInner({
       );
       setIsApplying(false);
     }
-  }, [
-    isMetadataOnly,
-    isReattach,
-    updateProject,
-    pending.projectId,
-    pending.mode,
-    trimmedName,
-    displayNameChanged,
-    destinationPath,
-    onClose,
-  ]);
+  }, [isMetadataOnly, isReattach, updateProject, pending, trimmedName, displayNameChanged, destinationPath, onClose]);
 
   const hasBlockers = (preview?.blockers.length ?? 0) > 0;
   const nothingToDo = !destinationChanged && !displayNameChanged;

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
 import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
+import { notify } from "@/lib/notify";
 import { useDohertyGate } from "@/hooks";
 import {
   useProjectRelocationStore,
@@ -153,6 +154,17 @@ function MoveOrRenameProjectDialogInner({
             pending.onDisplayNameCommitted?.(trimmedName);
           } catch (nameErr) {
             console.warn("[relocate] folder moved but display-name update failed:", nameErr);
+            // The move (the irreversible part) succeeded, so we still close — but
+            // the user couldn't otherwise observe that the rename half didn't
+            // land, so surface it with a manual-recovery hint.
+            // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+            notify({
+              type: "warning",
+              title: "Name not updated",
+              message:
+                "The project moved, but its display name couldn't be updated. Rename it from Project Settings.",
+              context: { eventKind: "settings", projectId: pending.projectId },
+            });
           }
         }
       }

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -178,7 +178,16 @@ function MoveOrRenameProjectDialogInner({
       );
       setIsApplying(false);
     }
-  }, [isMetadataOnly, isReattach, updateProject, pending, trimmedName, displayNameChanged, destinationPath, onClose]);
+  }, [
+    isMetadataOnly,
+    isReattach,
+    updateProject,
+    pending,
+    trimmedName,
+    displayNameChanged,
+    destinationPath,
+    onClose,
+  ]);
 
   const hasBlockers = (preview?.blockers.length ?? 0) > 0;
   const nothingToDo = !destinationChanged && !displayNameChanged;
@@ -234,12 +243,18 @@ function MoveOrRenameProjectDialogInner({
           <>
             <div className="space-y-1.5">
               <span className="text-sm font-medium text-daintree-text/80">Original location</span>
-              <p className="text-xs font-mono text-daintree-text/50 break-all" title={pending.oldPath}>
+              <p
+                className="text-xs font-mono text-daintree-text/50 break-all"
+                title={pending.oldPath}
+              >
                 {pending.oldPath}
               </p>
             </div>
             <div className="space-y-1.5">
-              <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-existing">
+              <label
+                className="text-sm font-medium text-daintree-text/80"
+                htmlFor="relocate-existing"
+              >
                 Where is the folder now?
               </label>
               <div className="flex gap-2">
@@ -269,7 +284,10 @@ function MoveOrRenameProjectDialogInner({
         ) : (
           <>
             <div className="space-y-1.5">
-              <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-parent">
+              <label
+                className="text-sm font-medium text-daintree-text/80"
+                htmlFor="relocate-parent"
+              >
                 Parent folder
               </label>
               <div className="flex gap-2">
@@ -296,7 +314,10 @@ function MoveOrRenameProjectDialogInner({
               </div>
             </div>
             <div className="space-y-1.5">
-              <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-folder">
+              <label
+                className="text-sm font-medium text-daintree-text/80"
+                htmlFor="relocate-folder"
+              >
                 Folder name
               </label>
               <input
@@ -430,7 +451,9 @@ function RelocationPreviewSection({
           {preview.runningTerminalCount === 0 &&
             preview.linkedWorktrees.length === 0 &&
             preview.affectedPanelCount === 0 && (
-              <li className="text-daintree-text/40">No running terminals, worktrees, or panels affected</li>
+              <li className="text-daintree-text/40">
+                No running terminals, worktrees, or panels affected
+              </li>
             )}
         </ul>
       )}

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -1,0 +1,436 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FolderOpen, AlertTriangle } from "lucide-react";
+import { basename, dirname, join, normalize } from "@shared/utils/path";
+import { validateFolderName } from "@shared/utils/folderName";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { RelocationPreview } from "@shared/types/projectRelocation";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/Spinner";
+import { projectClient } from "@/clients";
+import { useProjectStore } from "@/store/projectStore";
+import { useDohertyGate } from "@/hooks";
+import {
+  useProjectRelocationStore,
+  type PendingProjectRelocation,
+} from "@/store/projectRelocationStore";
+
+/** NFC + separator normalization for comparing two folder paths for equality. */
+function normPath(value: string): string {
+  return normalize(value).normalize("NFC");
+}
+
+const INPUT_CLASS =
+  "w-full rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent aria-invalid:border-status-error";
+const READONLY_INPUT_CLASS =
+  "flex-1 rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm font-mono text-daintree-text/70 truncate";
+
+function MoveOrRenameProjectDialogInner({
+  pending,
+  onClose,
+}: {
+  pending: PendingProjectRelocation;
+  onClose: () => void;
+}) {
+  const isReattach = pending.mode === "reattach";
+  const updateProject = useProjectStore((s) => s.updateProject);
+
+  const [displayName, setDisplayName] = useState(pending.name);
+  const [parentPath, setParentPath] = useState(isReattach ? "" : dirname(pending.oldPath));
+  const [folderName, setFolderName] = useState(isReattach ? "" : basename(pending.oldPath));
+  const [reattachPath, setReattachPath] = useState("");
+
+  const [preview, setPreview] = useState<RelocationPreview | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [isApplying, setIsApplying] = useState(false);
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+  // Bumped on every fetch so a superseded response (folder edited again mid-flight)
+  // can't replace a newer preview — the #9575 stale-request guard.
+  const previewReqId = useRef(0);
+
+  const trimmedName = displayName.trim();
+  const displayNameChanged = trimmedName !== "" && trimmedName !== pending.name;
+
+  const folderNameError = isReattach || !folderName.trim() ? null : validateFolderName(folderName);
+  const destinationPath = isReattach
+    ? reattachPath
+    : parentPath && folderName.trim() && !folderNameError
+      ? join(parentPath, folderName.trim())
+      : "";
+  const destinationChanged =
+    destinationPath !== "" && normPath(destinationPath) !== normPath(pending.oldPath);
+
+  // A pure display-name edit stays a lightweight metadata write — no filesystem
+  // op, no preview, no coordinator. Reattach never qualifies (the folder move is
+  // mandatory), and a case-only folder rename stays a real move (case-sensitive
+  // comparison after NFC normalization).
+  const isMetadataOnly = !isReattach && !destinationChanged && displayNameChanged;
+
+  const showLoading = useDohertyGate(isPreviewLoading);
+
+  // Fetch the preview whenever there's a genuine folder change to describe. Sets
+  // `preview = null` (the "not loaded" sentinel) before every request so confirm
+  // stays gated; an empty preview array means "loaded, nothing affected".
+  useEffect(() => {
+    if (!destinationChanged || !destinationPath) {
+      setPreview(null);
+      setLoadError(null);
+      setIsPreviewLoading(false);
+      return;
+    }
+    const reqId = ++previewReqId.current;
+    setPreview(null);
+    setLoadError(null);
+    setIsPreviewLoading(true);
+    const timer = setTimeout(() => {
+      void projectClient
+        .previewRelocation({
+          projectId: pending.projectId,
+          mode: pending.mode,
+          newPath: destinationPath,
+        })
+        .then((result) => {
+          if (previewReqId.current !== reqId) return;
+          setPreview(result);
+          setIsPreviewLoading(false);
+        })
+        .catch((err) => {
+          if (previewReqId.current !== reqId) return;
+          setLoadError(formatErrorMessage(err, "Couldn't preview the changes"));
+          setIsPreviewLoading(false);
+        });
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [destinationChanged, destinationPath, pending.projectId, pending.mode]);
+
+  const handleBrowseParent = useCallback(async () => {
+    try {
+      const selected = await projectClient.openDialog();
+      if (selected) setParentPath(selected);
+    } catch {
+      setApplyError("Could not open the folder picker");
+    }
+  }, []);
+
+  const handleBrowseReattach = useCallback(async () => {
+    try {
+      const selected = await projectClient.openDialog();
+      if (selected) setReattachPath(selected);
+    } catch {
+      setApplyError("Could not open the folder picker");
+    }
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    setApplyError(null);
+    setIsApplying(true);
+    try {
+      if (isMetadataOnly) {
+        await updateProject(pending.projectId, { name: trimmedName });
+      } else {
+        await projectClient.applyRelocation({
+          projectId: pending.projectId,
+          mode: pending.mode,
+          newPath: destinationPath,
+        });
+        // Apply the display-name change only after the folder op succeeds, so a
+        // failed relocation never leaves a half-applied rename behind.
+        if (displayNameChanged) {
+          await updateProject(pending.projectId, { name: trimmedName });
+        }
+      }
+      onClose();
+    } catch (err) {
+      setApplyError(
+        formatErrorMessage(
+          err,
+          isReattach ? "Couldn't reattach the project" : "Couldn't move the project"
+        )
+      );
+      setIsApplying(false);
+    }
+  }, [
+    isMetadataOnly,
+    isReattach,
+    updateProject,
+    pending.projectId,
+    pending.mode,
+    trimmedName,
+    displayNameChanged,
+    destinationPath,
+    onClose,
+  ]);
+
+  const hasBlockers = (preview?.blockers.length ?? 0) > 0;
+  const nothingToDo = !destinationChanged && !displayNameChanged;
+  const confirmDisabled =
+    isApplying ||
+    nothingToDo ||
+    (isMetadataOnly
+      ? trimmedName === ""
+      : !destinationChanged ||
+        Boolean(folderNameError) ||
+        preview === null ||
+        Boolean(loadError) ||
+        hasBlockers);
+
+  const title = isReattach ? "Locate moved project" : "Move or rename project";
+  const confirmLabel = isMetadataOnly
+    ? "Rename project"
+    : isReattach
+      ? "Reattach project"
+      : "Move project";
+
+  return (
+    <ConfirmDialog
+      isOpen={true}
+      onClose={isApplying ? undefined : onClose}
+      title={title}
+      confirmLabel={confirmLabel}
+      cancelLabel="Cancel"
+      onConfirm={handleConfirm}
+      confirmDisabled={confirmDisabled}
+      isConfirmLoading={isApplying}
+      variant="default"
+      hasPreview={true}
+      zIndex="nested"
+    >
+      <div className="space-y-4" data-testid="move-or-rename-project-dialog">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-name">
+            Display name
+          </label>
+          <input
+            id="relocate-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className={INPUT_CLASS}
+            placeholder="My Awesome Project"
+            data-testid="relocate-name-input"
+          />
+        </div>
+
+        {isReattach ? (
+          <>
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium text-daintree-text/80">Original location</span>
+              <p className="text-xs font-mono text-daintree-text/50 break-all" title={pending.oldPath}>
+                {pending.oldPath}
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-existing">
+                Where is the folder now?
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="relocate-existing"
+                  type="text"
+                  readOnly
+                  aria-readonly="true"
+                  value={reattachPath}
+                  className={READONLY_INPUT_CLASS}
+                  placeholder="Select the project's folder…"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleBrowseReattach}
+                  disabled={isApplying}
+                  className="shrink-0 gap-1.5"
+                  data-testid="relocate-browse-existing"
+                >
+                  <FolderOpen className="h-3.5 w-3.5" />
+                  Browse
+                </Button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-parent">
+                Parent folder
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="relocate-parent"
+                  type="text"
+                  readOnly
+                  aria-readonly="true"
+                  value={parentPath}
+                  className={READONLY_INPUT_CLASS}
+                  placeholder="Select a parent folder…"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleBrowseParent}
+                  disabled={isApplying}
+                  className="shrink-0 gap-1.5"
+                  data-testid="relocate-browse-parent"
+                >
+                  <FolderOpen className="h-3.5 w-3.5" />
+                  Browse
+                </Button>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-daintree-text/80" htmlFor="relocate-folder">
+                Folder name
+              </label>
+              <input
+                id="relocate-folder"
+                type="text"
+                value={folderName}
+                onChange={(e) => setFolderName(e.target.value)}
+                aria-invalid={folderNameError != null}
+                className={INPUT_CLASS}
+                placeholder="my-project"
+                data-testid="relocate-folder-input"
+              />
+              {folderNameError && (
+                <p role="alert" className="text-xs text-status-error">
+                  {folderNameError}
+                </p>
+              )}
+            </div>
+          </>
+        )}
+
+        {destinationChanged && (
+          <RelocationPreviewSection
+            preview={preview}
+            showLoading={showLoading}
+            loadError={loadError}
+            oldPath={pending.oldPath}
+          />
+        )}
+
+        {applyError && (
+          <p role="alert" className="text-xs text-status-error" data-testid="relocate-apply-error">
+            {applyError}
+          </p>
+        )}
+      </div>
+    </ConfirmDialog>
+  );
+}
+
+function RelocationPreviewSection({
+  preview,
+  showLoading,
+  loadError,
+  oldPath,
+}: {
+  preview: RelocationPreview | null;
+  showLoading: boolean;
+  loadError: string | null;
+  oldPath: string;
+}) {
+  if (loadError) {
+    return (
+      <div
+        className="rounded-[var(--radius-md)] border border-status-error/20 bg-status-error/10 px-3 py-2 text-xs text-status-error"
+        data-testid="relocate-preview-error"
+      >
+        {loadError}
+      </div>
+    );
+  }
+
+  if (preview === null) {
+    return showLoading ? (
+      <div
+        className="flex items-center gap-2 text-xs text-daintree-text/60"
+        data-testid="relocate-preview-loading"
+      >
+        <Spinner className="h-3.5 w-3.5" />
+        Checking what will change…
+      </div>
+    ) : null;
+  }
+
+  return (
+    <div
+      className="space-y-3 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg px-3 py-3"
+      data-testid="relocate-preview"
+    >
+      <div className="space-y-1">
+        <span className="text-xs font-medium text-daintree-text/60">Folder</span>
+        <p className="text-xs font-mono text-daintree-text/50 break-all">{oldPath}</p>
+        <p className="text-xs font-mono text-daintree-text break-all">→ {preview.newPath}</p>
+      </div>
+
+      {preview.blockers.length > 0 ? (
+        <div className="space-y-1.5" data-testid="relocate-blockers">
+          {preview.blockers.map((blocker, i) => (
+            <div
+              key={`${blocker.reason}-${i}`}
+              className="flex items-start gap-2 rounded-[var(--radius-md)] bg-status-error/10 border border-status-error/20 px-2.5 py-2 text-xs text-status-error"
+            >
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+              <span>{blocker.message}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <ul className="space-y-1 text-xs text-daintree-text/70">
+          {preview.runningTerminalCount > 0 && (
+            <li>
+              {preview.runningTerminalCount === 1
+                ? "1 terminal will be gracefully stopped"
+                : `${preview.runningTerminalCount} terminals will be gracefully stopped`}{" "}
+              <span className="text-daintree-text/40">— sessions are preserved and restored</span>
+            </li>
+          )}
+          {preview.linkedWorktrees.length > 0 && (
+            <li>
+              <span>
+                {preview.linkedWorktrees.length === 1
+                  ? "1 linked worktree will be repaired:"
+                  : `${preview.linkedWorktrees.length} linked worktrees will be repaired:`}
+              </span>
+              <ul className="mt-1 space-y-0.5 pl-3">
+                {preview.linkedWorktrees.map((wt) => (
+                  <li key={wt} className="font-mono text-daintree-text/50 break-all">
+                    {wt}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          )}
+          {preview.affectedPanelCount > 0 && (
+            <li>
+              {preview.affectedPanelCount === 1
+                ? "1 panel will have its paths updated"
+                : `${preview.affectedPanelCount} panels will have their paths updated`}
+            </li>
+          )}
+          {preview.runningTerminalCount === 0 &&
+            preview.linkedWorktrees.length === 0 &&
+            preview.affectedPanelCount === 0 && (
+              <li className="text-daintree-text/40">No running terminals, worktrees, or panels affected</li>
+            )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Host-mounted singleton for the "Move or rename project" workflow (#11282,
+ * phase 4). Opened from Project Settings, the healthy-project context menu, and
+ * the missing-project recovery flow via {@link useProjectRelocationStore}.
+ * Remounts on each `open()` (keyed by `requestSeq`) so its form reseeds cleanly.
+ */
+export function MoveOrRenameProjectDialog() {
+  const pending = useProjectRelocationStore((s) => s.pending);
+  const requestSeq = useProjectRelocationStore((s) => s.requestSeq);
+  const close = useProjectRelocationStore((s) => s.close);
+
+  if (!pending) return null;
+  return <MoveOrRenameProjectDialogInner key={requestSeq} pending={pending} onClose={close} />;
+}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -110,7 +110,14 @@ export function ProjectSwitcher() {
 
   const handleLocateProject = useCallback(
     (projectId: string) => {
-      void projectSwitcher.locateProject(projectId);
+      projectSwitcher.locateProject(projectId);
+    },
+    [projectSwitcher]
+  );
+
+  const handleMoveOrRenameProject = useCallback(
+    (projectId: string) => {
+      projectSwitcher.moveOrRenameProject(projectId);
     },
     [projectSwitcher]
   );
@@ -196,6 +203,7 @@ export function ProjectSwitcher() {
             onCloseProject={handleCloseProject}
             onFreeMemoryProject={handleFreeMemoryProject}
             onLocateProject={handleLocateProject}
+            onMoveOrRenameProject={handleMoveOrRenameProject}
             onTogglePinProject={handleTogglePinProject}
             onCopyPath={projectSwitcher.copyPath}
             onSelectNewWindow={handleSelectNewWindow}
@@ -277,6 +285,7 @@ export function ProjectSwitcher() {
         onCloseProject={handleCloseProject}
         onFreeMemoryProject={handleFreeMemoryProject}
         onLocateProject={handleLocateProject}
+        onMoveOrRenameProject={handleMoveOrRenameProject}
         onTogglePinProject={handleTogglePinProject}
         onOpenProjectSettings={currentProject ? handleOpenSettings : undefined}
         onCopyPath={projectSwitcher.copyPath}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -7,6 +7,7 @@ import {
   Clipboard,
   Download,
   FileText,
+  FolderInput,
   FolderOpen,
   FolderPlus,
   FolderUp,
@@ -74,6 +75,7 @@ export interface ProjectSwitcherPaletteProps {
   onCloseProject?: (projectId: string) => void;
   onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
+  onMoveOrRenameProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
@@ -142,6 +144,7 @@ interface ProjectListItemProps {
   onCloseProject?: (projectId: string) => void;
   onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
+  onMoveOrRenameProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
@@ -194,6 +197,7 @@ function ProjectListItem({
   onCloseProject,
   onFreeMemoryProject,
   onLocateProject,
+  onMoveOrRenameProject,
   onTogglePinProject,
   onCopyPath,
   onSelectNewWindow,
@@ -309,7 +313,9 @@ function ProjectListItem({
     onCloseProject ||
     onFreeMemoryProject ||
     onCopyPath ||
-    onSelectNewWindow;
+    onSelectNewWindow ||
+    onMoveOrRenameProject ||
+    onLocateProject;
   if (!hasContextActions) return row;
 
   return (
@@ -343,6 +349,12 @@ function ProjectListItem({
             Copy path
           </ContextMenuItem>
         )}
+        {onMoveOrRenameProject && !project.isMissing && (
+          <ContextMenuItem onSelect={() => onMoveOrRenameProject(project.id)}>
+            <FolderInput className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+            Move or rename project…
+          </ContextMenuItem>
+        )}
         {(onTogglePinProject || onCopyPath) &&
           (onStopProject || onFreeMemoryProject || onCloseProject) && <ContextMenuSeparator />}
         {showStop && onStopProject && (
@@ -374,7 +386,7 @@ function ProjectListItem({
             <ContextMenuSeparator />
             <ContextMenuItem onSelect={() => onLocateProject(project.id)}>
               <FolderOpen className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
-              Locate folder
+              Locate moved project
             </ContextMenuItem>
           </>
         )}
@@ -406,6 +418,7 @@ interface ProjectListContentProps {
   onCloseProject?: (projectId: string) => void;
   onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
+  onMoveOrRenameProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
@@ -424,6 +437,7 @@ function ProjectListContent({
   onCloseProject,
   onFreeMemoryProject,
   onLocateProject,
+  onMoveOrRenameProject,
   onTogglePinProject,
   onCopyPath,
   onSelectNewWindow,
@@ -486,6 +500,7 @@ function ProjectListContent({
           onCloseProject={onCloseProject}
           onFreeMemoryProject={onFreeMemoryProject}
           onLocateProject={onLocateProject}
+          onMoveOrRenameProject={onMoveOrRenameProject}
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
           onSelectNewWindow={onSelectNewWindow}
@@ -956,6 +971,7 @@ interface ProjectPaletteInnerProps {
   onCloseProject?: (projectId: string) => void;
   onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
+  onMoveOrRenameProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onHoverProject?: (projectId: string, pointerType: string) => void;
@@ -990,6 +1006,7 @@ function ProjectPaletteInner({
   onCloseProject,
   onFreeMemoryProject,
   onLocateProject,
+  onMoveOrRenameProject,
   onTogglePinProject,
   onCopyPath,
   onHoverProject,
@@ -1114,6 +1131,7 @@ function ProjectPaletteInner({
           onCloseProject={onCloseProject}
           onFreeMemoryProject={onFreeMemoryProject}
           onLocateProject={onLocateProject}
+          onMoveOrRenameProject={onMoveOrRenameProject}
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
           onSelectNewWindow={onSelectNewWindow}
@@ -1240,6 +1258,7 @@ function ModalContent({
         onCloseProject={innerProps.onCloseProject}
         onFreeMemoryProject={innerProps.onFreeMemoryProject}
         onLocateProject={innerProps.onLocateProject}
+        onMoveOrRenameProject={innerProps.onMoveOrRenameProject}
         onTogglePinProject={innerProps.onTogglePinProject}
         onCopyPath={innerProps.onCopyPath}
         onSelectNewWindow={innerProps.onSelectNewWindow}
@@ -1346,6 +1365,7 @@ function DropdownContent({
           onCloseProject={innerProps.onCloseProject}
           onFreeMemoryProject={innerProps.onFreeMemoryProject}
           onLocateProject={innerProps.onLocateProject}
+          onMoveOrRenameProject={innerProps.onMoveOrRenameProject}
           onTogglePinProject={innerProps.onTogglePinProject}
           onCopyPath={innerProps.onCopyPath}
           onSelectNewWindow={innerProps.onSelectNewWindow}
@@ -1382,6 +1402,7 @@ export function ProjectSwitcherPalette({
   onCloseProject,
   onFreeMemoryProject,
   onLocateProject,
+  onMoveOrRenameProject,
   onTogglePinProject,
   onCopyPath,
   onSelectNewWindow,
@@ -1441,6 +1462,7 @@ export function ProjectSwitcherPalette({
         onCloseProject={onCloseProject}
         onFreeMemoryProject={onFreeMemoryProject}
         onLocateProject={onLocateProject}
+        onMoveOrRenameProject={onMoveOrRenameProject}
         onTogglePinProject={onTogglePinProject}
         onCopyPath={onCopyPath}
         onSelectNewWindow={onSelectNewWindow}
@@ -1478,6 +1500,7 @@ export function ProjectSwitcherPalette({
         onCloseProject={onCloseProject}
         onFreeMemoryProject={onFreeMemoryProject}
         onLocateProject={onLocateProject}
+        onMoveOrRenameProject={onMoveOrRenameProject}
         onTogglePinProject={onTogglePinProject}
         onCopyPath={onCopyPath}
         onSelectNewWindow={onSelectNewWindow}

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -31,6 +31,8 @@ vi.mock("@/store/projectStore", () => ({
     selector({ updateProject }),
 }));
 
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
 import { useProjectRelocationStore } from "@/store/projectRelocationStore";
 import { MoveOrRenameProjectDialog } from "../MoveOrRenameProjectDialog";
 

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { RelocationPreview } from "@shared/types/projectRelocation";
+
+// ConfirmDialog's scroll-shadow hook observes its scroll container, which jsdom
+// does not implement.
+class ResizeObserverStub implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) {}
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+globalThis.ResizeObserver ??= ResizeObserverStub;
+
+const { previewRelocation, applyRelocation, openDialog, updateProject } = vi.hoisted(() => ({
+  previewRelocation: vi.fn<(req: unknown) => Promise<RelocationPreview>>(),
+  applyRelocation: vi.fn<(req: unknown) => Promise<unknown>>(() => Promise.resolve({})),
+  openDialog: vi.fn<() => Promise<string | null>>(() => Promise.resolve(null)),
+  updateProject: vi.fn<(id: string, updates: unknown) => Promise<void>>(() =>
+    Promise.resolve()
+  ),
+}));
+
+vi.mock("@/clients", () => ({
+  projectClient: { previewRelocation, applyRelocation, openDialog },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { updateProject: typeof updateProject }) => unknown) =>
+    selector({ updateProject }),
+}));
+
+import { useProjectRelocationStore } from "@/store/projectRelocationStore";
+import { MoveOrRenameProjectDialog } from "../MoveOrRenameProjectDialog";
+
+const OLD_PATH = "/repos/proj";
+
+function cleanPreview(overrides: Partial<RelocationPreview> = {}): RelocationPreview {
+  return {
+    mode: "move",
+    oldPath: OLD_PATH,
+    newPath: "/repos/proj2",
+    runningTerminalCount: 0,
+    linkedWorktrees: [],
+    affectedPanelCount: 0,
+    blockers: [],
+    ...overrides,
+  };
+}
+
+function openMove(): void {
+  useProjectRelocationStore
+    .getState()
+    .open({ projectId: "p1", mode: "move", oldPath: OLD_PATH, name: "Proj" });
+}
+
+function confirmButton(): HTMLButtonElement {
+  return document.querySelector('[data-confirm-role="confirm"]') as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  previewRelocation.mockResolvedValue(cleanPreview());
+  applyRelocation.mockResolvedValue({});
+  openDialog.mockResolvedValue(null);
+  updateProject.mockResolvedValue();
+  useProjectRelocationStore.setState({ pending: null, requestSeq: 0 });
+});
+
+describe("MoveOrRenameProjectDialog", () => {
+  it("renders nothing when no relocation is pending", () => {
+    render(<MoveOrRenameProjectDialog />);
+    expect(document.querySelector('[data-testid="move-or-rename-project-dialog"]')).toBeNull();
+  });
+
+  it("move mode seeds the fields and starts with confirm disabled (nothing changed)", () => {
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    expect(screen.getByText("Move or rename project")).toBeTruthy();
+    expect((screen.getByTestId("relocate-name-input") as HTMLInputElement).value).toBe("Proj");
+    expect((screen.getByTestId("relocate-folder-input") as HTMLInputElement).value).toBe("proj");
+    expect(confirmButton().disabled).toBe(true);
+    expect(previewRelocation).not.toHaveBeenCalled();
+  });
+
+  it("a display-name-only change takes the lightweight updateProject fast path", async () => {
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-name-input"), { target: { value: "Renamed" } });
+
+    const btn = confirmButton();
+    expect(btn.textContent).toContain("Rename project");
+    expect(btn.disabled).toBe(false);
+
+    fireEvent.click(btn);
+    await waitFor(() => expect(updateProject).toHaveBeenCalledWith("p1", { name: "Renamed" }));
+    // No filesystem op — the fast path never touches the coordinator.
+    expect(previewRelocation).not.toHaveBeenCalled();
+    expect(applyRelocation).not.toHaveBeenCalled();
+    await waitFor(() => expect(useProjectRelocationStore.getState().pending).toBeNull());
+  });
+
+  it("keeps confirm disabled until the async preview loads (null sentinel)", async () => {
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+    // Folder changed, preview not yet loaded → confirm gated.
+    expect(confirmButton().disabled).toBe(true);
+
+    await waitFor(() => expect(previewRelocation).toHaveBeenCalled());
+    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+  });
+
+  it("blockers in the preview keep confirm disabled and surface their messages", async () => {
+    previewRelocation.mockResolvedValue(
+      cleanPreview({
+        blockers: [
+          { reason: "cross-volume", message: "Moving across volumes isn't supported yet." },
+        ],
+      })
+    );
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Moving across volumes isn't supported yet/)).toBeTruthy()
+    );
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it("a full move calls applyRelocation with the previewed destination", async () => {
+    previewRelocation.mockResolvedValue(cleanPreview({ runningTerminalCount: 2 }));
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+
+    fireEvent.click(confirmButton());
+    await waitFor(() =>
+      expect(applyRelocation).toHaveBeenCalledWith({
+        projectId: "p1",
+        mode: "move",
+        newPath: "/repos/proj2",
+      })
+    );
+  });
+
+  it("reattach mode browses to an existing folder then reattaches", async () => {
+    openDialog.mockResolvedValue("/moved/proj");
+    previewRelocation.mockResolvedValue(cleanPreview({ mode: "reattach", newPath: "/moved/proj" }));
+    useProjectRelocationStore
+      .getState()
+      .open({ projectId: "p1", mode: "reattach", oldPath: OLD_PATH, name: "Proj" });
+    render(<MoveOrRenameProjectDialog />);
+
+    expect(screen.getByText("Locate moved project")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("relocate-browse-existing"));
+
+    await waitFor(() => expect(previewRelocation).toHaveBeenCalled());
+    await waitFor(() => {
+      const btn = confirmButton();
+      expect(btn.textContent).toContain("Reattach project");
+      expect(btn.disabled).toBe(false);
+    });
+
+    fireEvent.click(confirmButton());
+    await waitFor(() =>
+      expect(applyRelocation).toHaveBeenCalledWith({
+        projectId: "p1",
+        mode: "reattach",
+        newPath: "/moved/proj",
+      })
+    );
+  });
+});

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -17,9 +17,7 @@ const { previewRelocation, applyRelocation, openDialog, updateProject } = vi.hoi
   previewRelocation: vi.fn<(req: unknown) => Promise<RelocationPreview>>(),
   applyRelocation: vi.fn<(req: unknown) => Promise<unknown>>(() => Promise.resolve({})),
   openDialog: vi.fn<() => Promise<string | null>>(() => Promise.resolve(null)),
-  updateProject: vi.fn<(id: string, updates: unknown) => Promise<void>>(() =>
-    Promise.resolve()
-  ),
+  updateProject: vi.fn<(id: string, updates: unknown) => Promise<void>>(() => Promise.resolve()),
 }));
 
 vi.mock("@/clients", () => ({

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -180,4 +180,66 @@ describe("MoveOrRenameProjectDialog", () => {
       })
     );
   });
+
+  it("reattach accepts the original path (a removable volume that reappeared)", async () => {
+    openDialog.mockResolvedValue(OLD_PATH);
+    previewRelocation.mockResolvedValue(cleanPreview({ mode: "reattach", newPath: OLD_PATH }));
+    useProjectRelocationStore
+      .getState()
+      .open({ projectId: "p1", mode: "reattach", oldPath: OLD_PATH, name: "Proj" });
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.click(screen.getByTestId("relocate-browse-existing"));
+    await waitFor(() => expect(previewRelocation).toHaveBeenCalled());
+    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+
+    fireEvent.click(confirmButton());
+    await waitFor(() =>
+      expect(applyRelocation).toHaveBeenCalledWith({
+        projectId: "p1",
+        mode: "reattach",
+        newPath: OLD_PATH,
+      })
+    );
+  });
+
+  it("calls onDisplayNameCommitted after a rename so Settings can resync", async () => {
+    const onCommitted = vi.fn();
+    useProjectRelocationStore.getState().open({
+      projectId: "p1",
+      mode: "move",
+      oldPath: OLD_PATH,
+      name: "Proj",
+      onDisplayNameCommitted: onCommitted,
+    });
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-name-input"), { target: { value: "Renamed" } });
+    fireEvent.click(confirmButton());
+
+    await waitFor(() => expect(onCommitted).toHaveBeenCalledWith("Renamed"));
+  });
+
+  it("ignores a stale preview response after the folder reverts", async () => {
+    let resolveA: (v: RelocationPreview) => void = () => {};
+    const deferredA = new Promise<RelocationPreview>((r) => {
+      resolveA = r;
+    });
+    previewRelocation.mockReturnValueOnce(deferredA);
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+    await waitFor(() => expect(previewRelocation).toHaveBeenCalledTimes(1));
+
+    // Revert to the original folder → destination unchanged → the in-flight
+    // request is invalidated by the bumped request id.
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj" } });
+
+    // The stale response lands AFTER the revert; it must not repopulate the preview.
+    resolveA(cleanPreview());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.querySelector('[data-testid="relocate-preview"]')).toBeNull();
+    expect(confirmButton().disabled).toBe(true);
+  });
 });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -5,6 +5,7 @@ import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { usePaletteStore } from "@/store/paletteStore";
+import { useProjectRelocationStore } from "@/store/projectRelocationStore";
 import { notify } from "@/lib/notify";
 import { closeAndAnnounce } from "@/lib/accessibility";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
@@ -114,7 +115,10 @@ export interface UseProjectSwitcherPaletteReturn {
    * silently otherwise. No-op (with a toast) for the active project.
    */
   freeMemoryProject: (projectId: string) => Promise<void>;
-  locateProject: (projectId: string) => Promise<void>;
+  /** Missing-project recovery: open the relocation dialog in reattach mode. */
+  locateProject: (projectId: string) => void;
+  /** Healthy-project "Move or rename": open the relocation dialog in move mode. */
+  moveOrRenameProject: (projectId: string) => void;
   togglePinProject: (projectId: string) => Promise<void>;
   /**
    * Write the project's absolute path to the clipboard and surface a transient
@@ -283,7 +287,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const closeActiveProject = useProjectStore((state) => state.closeActiveProject);
   const closeProject = useProjectStore((state) => state.closeProject);
   const removeProject = useProjectStore((state) => state.removeProject);
-  const locateProjectFn = useProjectStore((state) => state.locateProject);
+  const openRelocation = useProjectRelocationStore((state) => state.open);
   const projectStats = useProjectStatsStore((state) => state.stats);
 
   const { copy: copyToClipboard } = useCopyWithFeedback();
@@ -609,11 +613,28 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     useProjectStore.getState().openCloneRepoDialog();
   }, [close]);
 
-  const locateProject = useCallback(
-    async (projectId: string) => {
-      await locateProjectFn(projectId);
+  // "Locate moved project" (missing) and "Move or rename project" (healthy) both
+  // open the shared relocation dialog (#11282, phase 4), superseding the old
+  // picker-then-mutate `project:locate` path. The palette closes first so its
+  // overlay doesn't contend with the dialog's focus trap.
+  const openRelocationDialog = useCallback(
+    (projectId: string, mode: "move" | "reattach") => {
+      const project = projects.find((p) => p.id === projectId);
+      if (!project) return;
+      close();
+      openRelocation({ projectId, mode, oldPath: project.path, name: project.name });
     },
-    [locateProjectFn]
+    [projects, close, openRelocation]
+  );
+
+  const locateProject = useCallback(
+    (projectId: string) => openRelocationDialog(projectId, "reattach"),
+    [openRelocationDialog]
+  );
+
+  const moveOrRenameProject = useCallback(
+    (projectId: string) => openRelocationDialog(projectId, "move"),
+    [openRelocationDialog]
   );
 
   const copyPath = useCallback(
@@ -1169,6 +1190,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     removeProject: removeProjectFromList,
     freeMemoryProject,
     locateProject,
+    moveOrRenameProject,
     togglePinProject,
     copyPath,
     stopConfirmProjectId,

--- a/src/store/__tests__/projectRelocationStore.test.ts
+++ b/src/store/__tests__/projectRelocationStore.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  useProjectRelocationStore,
+  type PendingProjectRelocation,
+} from "@/store/projectRelocationStore";
+
+const TARGET: PendingProjectRelocation = {
+  projectId: "p1",
+  mode: "move",
+  oldPath: "/repos/proj",
+  name: "Proj",
+};
+
+describe("projectRelocationStore", () => {
+  beforeEach(() => {
+    useProjectRelocationStore.setState({ pending: null, requestSeq: 0 });
+  });
+
+  it("open() stores the exact target and bumps requestSeq", () => {
+    useProjectRelocationStore.getState().open(TARGET);
+    const state = useProjectRelocationStore.getState();
+    expect(state.pending).toEqual(TARGET);
+    expect(state.requestSeq).toBe(1);
+  });
+
+  it("a second open() supersedes the first and bumps requestSeq again", () => {
+    const { open } = useProjectRelocationStore.getState();
+    open(TARGET);
+    const next: PendingProjectRelocation = {
+      projectId: "p2",
+      mode: "reattach",
+      oldPath: "/repos/gone",
+      name: "Gone",
+    };
+    open(next);
+    const state = useProjectRelocationStore.getState();
+    expect(state.pending).toEqual(next);
+    expect(state.requestSeq).toBe(2);
+  });
+
+  it("close() clears pending without rewinding requestSeq", () => {
+    const { open, close } = useProjectRelocationStore.getState();
+    open(TARGET);
+    close();
+    const state = useProjectRelocationStore.getState();
+    expect(state.pending).toBeNull();
+    // The monotonic sequence is a re-init signal, not a counter of open dialogs —
+    // closing must not rewind it.
+    expect(state.requestSeq).toBe(1);
+  });
+});

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -60,6 +60,8 @@ const createMockProjectClient = () => ({
   disableInRepoSettings: vi.fn().mockResolvedValue({}),
   checkMissing: vi.fn().mockResolvedValue([]),
   locate: vi.fn().mockResolvedValue(null),
+  previewRelocation: vi.fn().mockResolvedValue({}),
+  applyRelocation: vi.fn().mockResolvedValue({}),
   cloneRepo: vi.fn().mockResolvedValue({ success: true }),
   onCloneProgress: vi.fn().mockReturnValue(() => {}),
   cancelClone: vi.fn().mockResolvedValue(undefined),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -52,6 +52,8 @@ const createMockProjectClient = () => ({
   disableInRepoSettings: vi.fn().mockResolvedValue({}),
   checkMissing: vi.fn().mockResolvedValue([]),
   locate: vi.fn().mockResolvedValue(null),
+  previewRelocation: vi.fn().mockResolvedValue({}),
+  applyRelocation: vi.fn().mockResolvedValue({}),
   cloneRepo: vi.fn().mockResolvedValue({ success: true }),
   onCloneProgress: vi.fn().mockReturnValue(() => {}),
   cancelClone: vi.fn().mockResolvedValue(undefined),

--- a/src/store/projectRelocationStore.ts
+++ b/src/store/projectRelocationStore.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import type { ProjectRelocationMode } from "@shared/types/projectRelocation";
+
+/**
+ * Ephemeral state for the "Move or rename project" dialog (#11282, phase 4).
+ * All three entry points — Project Settings, the healthy-project context menu,
+ * and the missing-project "Locate moved project" recovery flow — call `open()`;
+ * a single host-mounted dialog subscribes and renders. Not persisted.
+ */
+export interface PendingProjectRelocation {
+  projectId: string;
+  /** `"move"` for a healthy project, `"reattach"` for a missing one. */
+  mode: ProjectRelocationMode;
+  /** The project's current folder — seeds the dialog's folder/parent fields. */
+  oldPath: string;
+  /** The project's current display name — seeds the dialog's name field. */
+  name: string;
+}
+
+interface ProjectRelocationState {
+  pending: PendingProjectRelocation | null;
+  /**
+   * Bumped on every `open()`. Used as the dialog's re-init key so a second
+   * request (e.g. opening the dialog for a different project without an
+   * intervening close) reseeds the form from the new target.
+   */
+  requestSeq: number;
+  open: (target: PendingProjectRelocation) => void;
+  close: () => void;
+}
+
+export const useProjectRelocationStore = create<ProjectRelocationState>((set) => ({
+  pending: null,
+  requestSeq: 0,
+  open: (target) => set((state) => ({ pending: target, requestSeq: state.requestSeq + 1 })),
+  close: () => set({ pending: null }),
+}));

--- a/src/store/projectRelocationStore.ts
+++ b/src/store/projectRelocationStore.ts
@@ -15,6 +15,13 @@ export interface PendingProjectRelocation {
   oldPath: string;
   /** The project's current display name — seeds the dialog's name field. */
   name: string;
+  /**
+   * Invoked with the committed display name after a successful rename (fast path
+   * or move-with-rename). Lets an entry point that owns its own live name draft —
+   * the Project Settings form — resync, so its close-time flush doesn't revert
+   * the dialog's change. Entry points without a draft (context menus) omit it.
+   */
+  onDisplayNameCommitted?: (name: string) => void;
 }
 
 interface ProjectRelocationState {


### PR DESCRIPTION
## Summary

- Adds a single "Move or rename project" dialog for changing a project's display name, folder name, and/or location, reachable from Project Settings (next to the name field), the healthy-project context menu (`Move or rename project...`), and the missing-project recovery flow (`Locate moved project`).
- Backend: new read-only `ProjectRelocationCoordinator.previewRelocate()` runs a preflight check and returns typed blockers plus an enumeration of running terminals, linked worktrees, and panels whose paths would rewrite, with no side effects.
- Fixes `validateManagedMove` false-blocking a case-only folder rename (e.g. `Foo` to `foo`) on APFS and NTFS, using an `lstat` inode-and-device guard.

Part of #11282. Phase 5 (per-agent conversation continuity tiers) is still outstanding, so the issue stays open until that lands.

## Changes

- `ProjectStore.countRebasedPanels()` for the preview's panel-rewrite count.
- New codegenerated `projectRelocation` IPC namespace with `preview` and `apply` operations; rejects non-absolute destination paths.
- UI is a D2-tier `ConfirmDialog` with an async preview gated on a null sentinel, so confirm stays disabled until the preview loads or while blockers exist.
- Editing only the display name stays a lightweight fast path through the existing `updateProject` call.
- The move runs before the rename, so a failed rename never reports the already-committed move as failed.
- First version of managed moves is limited to same-volume renames via atomic `fs.rename`, per this phase's scope. Reattaching an already-externally-moved folder works independently of managed moves, including reattaching at the exact original path (covers a removable volume being reconnected).

Deliberately deferred:
- A canonical-path resolver shared between preview and apply isn't built yet; apply stays authoritative and fails safely in the meantime.
- Modal-palette focus restoration handoff isn't wired up yet.
- The legacy `project:locate` IPC handler is left dormant rather than removed.

## Testing

318 targeted and covering tests passing locally across 16 files. eslint and prettier are clean on all changed files. IPC codegen was regenerated and confirmed absent from the hand-written `maps.ts`.
