### PR TITLE
Route a backgrounded view's file browser to its own project's workspace host

### DIFF
--- a/e2e/full/worktree/core-project-switch-race.spec.ts
+++ b/e2e/full/worktree/core-project-switch-race.spec.ts
@@ -338,6 +338,23 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
     ).toBe(true);
     expect((listingA as { names: string[] }).names).toContain("README.md");
 
+    // Prove B's own host can serve its worktree right now, so the refusal
+    // below is conclusively an authorization decision, not an unready host.
+    const listingBFromB = await pageB.evaluate(async (wtId: string) => {
+      try {
+        const entries = await (window as any).electron.fileBrowser.listDirectory({
+          worktreeId: wtId,
+        });
+        return { ok: true as const, names: entries.map((e: { name: string }) => e.name) };
+      } catch (error) {
+        return { ok: false as const, error: String(error) };
+      }
+    }, worktreeB);
+    expect(
+      listingBFromB.ok,
+      `active view listing failed: ${"error" in listingBFromB ? listingBFromB.error : ""}`
+    ).toBe(true);
+
     // The scoping must be tighter than before, not looser: the cached A view
     // must NOT be able to list the active project B's worktree.
     const listingB = await pageA.evaluate(async (wtId: string) => {

--- a/e2e/full/worktree/core-project-switch-race.spec.ts
+++ b/e2e/full/worktree/core-project-switch-race.spec.ts
@@ -280,4 +280,78 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
       expect(t.projectId).toBe(projectA!.id);
     }
   });
+
+  test("backgrounded view's file browser queries its own project (#11366)", async () => {
+    test.slow();
+
+    // Start on Project A and capture its page + main worktree id while active.
+    await switchToProject(ctx.window, PROJECT_A_NAME);
+    const pageA = ctx.window;
+    await expect
+      .poll(
+        () =>
+          pageA
+            .evaluate(() => (window as any).electron.worktree.getAll())
+            .then((wts: Array<{ id: string }>) => wts.length),
+        { timeout: T_LONG }
+      )
+      .toBeGreaterThanOrEqual(1);
+    const worktreeA: string = await pageA.evaluate(async () => {
+      const wts = await (window as any).electron.worktree.getAll();
+      return wts[0].id;
+    });
+
+    // Switch to Project B — A's view is now cached in the same window, and
+    // windowToProject points at B. pageA keeps targeting the cached view.
+    const pageB = await switchToProject(ctx.window, PROJECT_B_NAME);
+    await expect
+      .poll(
+        () =>
+          pageB
+            .evaluate(() => (window as any).electron.worktree.getAll())
+            .then((wts: Array<{ id: string }>) => wts.length),
+        { timeout: T_LONG }
+      )
+      .toBeGreaterThanOrEqual(1);
+    const worktreeB: string = await pageB.evaluate(async () => {
+      const wts = await (window as any).electron.worktree.getAll();
+      return wts[0].id;
+    });
+    expect(worktreeB).not.toBe(worktreeA);
+
+    // The cached A view's listing must resolve against A's own workspace
+    // host — before #11366 this failed with "Worktree not found" because the
+    // request routed to the active project B's host.
+    const listingA = await pageA.evaluate(async (wtId: string) => {
+      try {
+        const entries = await (window as any).electron.fileBrowser.listDirectory({
+          worktreeId: wtId,
+        });
+        return { ok: true as const, names: entries.map((e: { name: string }) => e.name) };
+      } catch (error) {
+        return { ok: false as const, error: String(error) };
+      }
+    }, worktreeA);
+    expect(
+      listingA.ok,
+      `cached view listing failed: ${"error" in listingA ? listingA.error : ""}`
+    ).toBe(true);
+    expect((listingA as { names: string[] }).names).toContain("README.md");
+
+    // The scoping must be tighter than before, not looser: the cached A view
+    // must NOT be able to list the active project B's worktree.
+    const listingB = await pageA.evaluate(async (wtId: string) => {
+      try {
+        await (window as any).electron.fileBrowser.listDirectory({ worktreeId: wtId });
+        return { ok: true as const };
+      } catch (error) {
+        return { ok: false as const, error: String(error) };
+      }
+    }, worktreeB);
+    expect(listingB.ok).toBe(false);
+    expect((listingB as { error: string }).error).toMatch(/Worktree not found/);
+
+    // Restore the serial suite's baseline.
+    await switchToProject(ctx.window, PROJECT_A_NAME);
+  });
 });

--- a/electron/ipc/handlers/__tests__/fileBrowser.projectScope.test.ts
+++ b/electron/ipc/handlers/__tests__/fileBrowser.projectScope.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getProjectById: vi.fn(),
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: projectStoreMock,
+}));
+
+import { buildFileBrowserNamespace } from "../fileBrowser.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
+import type { HandlerDependencies, IpcContext } from "../../types.js";
+
+/**
+ * The #11366 scenario: project A's view is cached (backgrounded) in a window
+ * whose `windowToProject` mapping now points at the active project B. The
+ * sender's own project binding (`ctx.projectId`) must decide routing — the
+ * window-scoped state query must never be consulted.
+ */
+describe("fileBrowser listDirectory project scoping", () => {
+  const WT_A = "/projects/a/main";
+  const WT_B = "/projects/b/main";
+
+  let getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
+  let getAllStatesAsync: ReturnType<typeof vi.fn>;
+  let getFileTree: ReturnType<typeof vi.fn>;
+  let deps: HandlerDependencies;
+
+  const cachedSenderCtx = {
+    projectId: "project-a",
+    senderWindow: { id: 7 },
+  } as unknown as IpcContext;
+
+  function invoke(ctx: IpcContext, payload: { worktreeId: string; dirPath?: string }) {
+    const spec = buildFileBrowserNamespace(deps).ops.listDirectory;
+    return (spec.handler as (c: IpcContext, p: unknown) => Promise<unknown>)(ctx, payload);
+  }
+
+  beforeEach(() => {
+    _resetRateLimitQueuesForTest();
+    projectStoreMock.getProjectById.mockReset();
+    projectStoreMock.getProjectById.mockImplementation((id: string) =>
+      id === "project-a"
+        ? { id: "project-a", path: "/projects/a" }
+        : id === "project-b"
+          ? { id: "project-b", path: "/projects/b" }
+          : undefined
+    );
+
+    // Project-scoped query answers with the owning project's worktrees;
+    // the legacy window-scoped query would answer with the ACTIVE project's
+    // (B's) — reaching it at all is the bug.
+    getAllStatesForProjectAsync = vi.fn(async (projectPath: string) =>
+      projectPath === "/projects/a" ? [{ id: WT_A, path: WT_A }] : [{ id: WT_B, path: WT_B }]
+    );
+    getAllStatesAsync = vi.fn(async () => [{ id: WT_B, path: WT_B }]);
+    getFileTree = vi.fn(async () => ({ entries: [] }));
+
+    deps = {
+      worktreeService: {
+        getAllStatesForProjectAsync,
+        getAllStatesAsync,
+        getFileTree,
+      },
+    } as unknown as HandlerDependencies;
+  });
+
+  it("routes a cached view's listing to its own project's host", async () => {
+    await invoke(cachedSenderCtx, { worktreeId: WT_A });
+
+    expect(getAllStatesForProjectAsync).toHaveBeenCalledWith("/projects/a");
+    expect(getAllStatesAsync).not.toHaveBeenCalled();
+    expect(getFileTree).toHaveBeenCalledWith(WT_A, undefined, { includeIgnored: true });
+  });
+
+  it("refuses the active project's worktree id from the cached sender", async () => {
+    await expect(invoke(cachedSenderCtx, { worktreeId: WT_B })).rejects.toThrow(
+      /Worktree not found/
+    );
+    expect(getFileTree).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a sender with no project binding, even with a window", async () => {
+    const unboundCtx = { projectId: null, senderWindow: { id: 7 } } as unknown as IpcContext;
+    await expect(invoke(unboundCtx, { worktreeId: WT_A })).rejects.toThrow(
+      /requesting view's project/
+    );
+    expect(getAllStatesForProjectAsync).not.toHaveBeenCalled();
+    expect(getAllStatesAsync).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/fileBrowser.projectScope.test.ts
+++ b/electron/ipc/handlers/__tests__/fileBrowser.projectScope.test.ts
@@ -73,7 +73,7 @@ describe("fileBrowser listDirectory project scoping", () => {
   it("routes a cached view's listing to its own project's host", async () => {
     await invoke(cachedSenderCtx, { worktreeId: WT_A });
 
-    expect(getAllStatesForProjectAsync).toHaveBeenCalledWith("/projects/a");
+    expect(getAllStatesForProjectAsync).toHaveBeenCalledWith("/projects/a", "project-a");
     expect(getAllStatesAsync).not.toHaveBeenCalled();
     expect(getFileTree).toHaveBeenCalledWith(WT_A, undefined, { includeIgnored: true });
   });

--- a/electron/ipc/handlers/__tests__/fileBrowser.statPaths.test.ts
+++ b/electron/ipc/handlers/__tests__/fileBrowser.statPaths.test.ts
@@ -109,7 +109,7 @@ describe("fileBrowser statPaths", () => {
     );
   });
 
-  it("scopes the state query to the sender's own project path", async () => {
+  it("scopes the state query to the sender's own project path and id", async () => {
     const { invoke, deps } = makeHandler([{ id: root, path: root }]);
     await invoke(ctx, { worktreeId: root, paths: ["src"] });
     expect(projectStoreMock.getProjectById).toHaveBeenCalledWith("project-a");
@@ -119,7 +119,7 @@ describe("fileBrowser statPaths", () => {
           getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
         }
       ).getAllStatesForProjectAsync
-    ).toHaveBeenCalledWith(root);
+    ).toHaveBeenCalledWith(root, "project-a");
   });
 
   it("never reports kinds through a symlink that escapes the root", async () => {

--- a/electron/ipc/handlers/__tests__/fileBrowser.statPaths.test.ts
+++ b/electron/ipc/handlers/__tests__/fileBrowser.statPaths.test.ts
@@ -7,18 +7,26 @@ vi.mock("electron", () => ({
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
 }));
 
+const projectStoreMock = vi.hoisted(() => ({
+  getProjectById: vi.fn(),
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: projectStoreMock,
+}));
+
 import { buildFileBrowserNamespace } from "../fileBrowser.js";
 import { _resetRateLimitQueuesForTest } from "../../utils.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 
 describe("fileBrowser statPaths", () => {
   let root: string;
-  const ctx = { senderWindow: { id: 7 } } as unknown as IpcContext;
+  const ctx = { projectId: "project-a" } as unknown as IpcContext;
 
   function makeHandler(worktrees: Array<{ id: string; path: string }>) {
     const deps = {
       worktreeService: {
-        getAllStatesAsync: vi.fn(async () => worktrees),
+        getAllStatesForProjectAsync: vi.fn(async () => worktrees),
       },
     } as unknown as HandlerDependencies;
     const spec = buildFileBrowserNamespace(deps).ops.statPaths;
@@ -32,6 +40,8 @@ describe("fileBrowser statPaths", () => {
   beforeEach(async () => {
     _resetRateLimitQueuesForTest();
     root = await fs.mkdtemp(path.join(os.tmpdir(), "fb-statpaths-"));
+    projectStoreMock.getProjectById.mockReset();
+    projectStoreMock.getProjectById.mockReturnValue({ id: "project-a", path: root });
     await fs.mkdir(path.join(root, "src", "panels"), { recursive: true });
     await fs.writeFile(path.join(root, "src", "index.ts"), "export {}\n");
   });
@@ -54,24 +64,62 @@ describe("fileBrowser statPaths", () => {
     );
     // Validation failed before any worktree resolution happened.
     expect(
-      (deps.worktreeService as unknown as { getAllStatesAsync: ReturnType<typeof vi.fn> })
-        .getAllStatesAsync
+      (
+        deps.worktreeService as unknown as {
+          getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
+        }
+      ).getAllStatesForProjectAsync
     ).not.toHaveBeenCalled();
   });
 
-  it("refuses an unresolvable sender window", async () => {
-    const { invoke } = makeHandler([{ id: root, path: root }]);
-    const blindCtx = { senderWindow: undefined } as unknown as IpcContext;
-    await expect(invoke(blindCtx, { worktreeId: root, paths: ["src"] })).rejects.toThrow(
-      /requesting window/
+  it("refuses a sender with no project binding", async () => {
+    const { invoke, deps } = makeHandler([{ id: root, path: root }]);
+    const unboundCtx = { projectId: null } as unknown as IpcContext;
+    await expect(invoke(unboundCtx, { worktreeId: root, paths: ["src"] })).rejects.toThrow(
+      /requesting view's project/
     );
+    expect(
+      (
+        deps.worktreeService as unknown as {
+          getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
+        }
+      ).getAllStatesForProjectAsync
+    ).not.toHaveBeenCalled();
   });
 
-  it("rejects a worktree the sender's window does not own", async () => {
+  it("refuses a sender whose project no longer exists", async () => {
+    projectStoreMock.getProjectById.mockReturnValue(undefined);
+    const { invoke, deps } = makeHandler([{ id: root, path: root }]);
+    await expect(invoke(ctx, { worktreeId: root, paths: ["src"] })).rejects.toThrow(
+      /Unknown project/
+    );
+    expect(
+      (
+        deps.worktreeService as unknown as {
+          getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
+        }
+      ).getAllStatesForProjectAsync
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects a worktree the sender's project does not own", async () => {
     const { invoke } = makeHandler([{ id: "other", path: "/somewhere/else" }]);
     await expect(invoke(ctx, { worktreeId: root, paths: ["src"] })).rejects.toThrow(
       /Worktree not found/
     );
+  });
+
+  it("scopes the state query to the sender's own project path", async () => {
+    const { invoke, deps } = makeHandler([{ id: root, path: root }]);
+    await invoke(ctx, { worktreeId: root, paths: ["src"] });
+    expect(projectStoreMock.getProjectById).toHaveBeenCalledWith("project-a");
+    expect(
+      (
+        deps.worktreeService as unknown as {
+          getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
+        }
+      ).getAllStatesForProjectAsync
+    ).toHaveBeenCalledWith(root);
   });
 
   it("never reports kinds through a symlink that escapes the root", async () => {

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -26,6 +26,7 @@ const projectStoreMock = vi.hoisted(() => ({
   removeProject: vi.fn<(projectId: string) => Promise<void>>(),
   getCurrentProjectId: vi.fn<() => string | null>(),
   getProjectById: vi.fn(),
+  updateProject: vi.fn(),
 }));
 
 vi.mock("../../../services/ProjectStore.js", () => ({
@@ -283,5 +284,37 @@ describe("project:remove handler", () => {
     await expect(handler(fakeEvent, "")).rejects.toThrow("Invalid project ID");
     expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
     expect(projectStoreMock.removeProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("project:update handler", () => {
+  const fakeEvent = { senderFrame: { url: "http://localhost:5173" } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("strips identity fields — a renderer can never rewrite id or path", async () => {
+    projectStoreMock.updateProject.mockReturnValue({
+      id: "proj-1",
+      path: "/home/user/proj-1",
+      name: "Renamed",
+    });
+
+    const deps = { mainWindow: {} as unknown } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+    const handler = getHandler(CHANNELS.PROJECT_UPDATE);
+
+    // Rewriting a project's path to a sibling's would repoint path-keyed host
+    // authorization (fileBrowser project routing) at the sibling's workspace
+    // host — identity is main-owned, only metadata is renderer-writable.
+    await handler(fakeEvent, "proj-1", {
+      name: "Renamed",
+      id: "other-project",
+      path: "/home/user/sibling-project",
+      frecencyScore: 9999,
+    });
+
+    expect(projectStoreMock.updateProject).toHaveBeenCalledWith("proj-1", { name: "Renamed" });
   });
 });

--- a/electron/ipc/handlers/fileBrowser.ts
+++ b/electron/ipc/handlers/fileBrowser.ts
@@ -8,6 +8,7 @@ import {
   FileBrowserStatPathsPayloadSchema,
 } from "../../schemas/ipc.js";
 import { AppError } from "../../utils/errorTypes.js";
+import { projectStore } from "../../services/ProjectStore.js";
 import type { HandlerDependencies, IpcContext } from "../types.js";
 import type {
   FileBrowserListDirectoryPayload,
@@ -88,34 +89,47 @@ function assertRelativeDirPath(dirPath: string | undefined): void {
 
 export function buildFileBrowserNamespace(deps: HandlerDependencies) {
   /**
-   * Resolve a worktree by id, scoped to the *sender's* window.
+   * Resolve a worktree by id, scoped to the *sender view's own project*.
    *
-   * Reads the sender's window synchronously, before the first await: the view
-   * can be evicted while the workspace call is in flight, and a binding that
-   * vanishes mid-request would silently widen the scope. An unresolvable
-   * sender is refused rather than passed through as `undefined`, which
-   * `getAllStatesAsync` reads as "every host" — a wildcard is exactly the
-   * scope this gate exists to deny. Scoped by sender rather than
-   * `getMonitorAsync`, which scans every live workspace host and would happily
-   * resolve a worktree belonging to another project — worktree ids are
-   * normalized absolute paths, so a renderer could guess one and enumerate a
-   * sibling project's tree.
+   * `ctx.projectId` is the main-owned webContents→project binding
+   * (`viewToProject`), captured synchronously at dispatch — it survives the
+   * view being backgrounded and can't be spoofed or repointed by a project
+   * switch, unlike window-scoped lookups: `windowToProject` holds one project
+   * per window and is repointed to the incoming project the moment a switch
+   * starts, so a cached view's requests would resolve against the *active*
+   * project's host for the entire background period (#11366). A sender with
+   * no project binding is refused outright — null is an identity, not a
+   * wildcard, and falling through to an unscoped query is exactly the scope
+   * this gate exists to deny. Scoped by sender rather than `getMonitorAsync`,
+   * which scans every live workspace host and would happily resolve a
+   * worktree belonging to another project — worktree ids are normalized
+   * absolute paths, so a renderer could guess one and enumerate a sibling
+   * project's tree.
    */
   const resolveSenderWorktree = async (ctx: IpcContext, worktreeId: string) => {
     if (!deps.worktreeService) {
       throw new Error("Worktree service not available");
     }
 
-    const senderWindowId = ctx.senderWindow?.id;
-    if (senderWindowId === undefined) {
+    const senderProjectId = ctx.projectId;
+    if (senderProjectId === null) {
       throw new AppError({
         code: "INVALID_PATH",
-        message: "Unable to resolve the requesting window",
+        message: "Unable to resolve the requesting view's project",
         context: {},
       });
     }
 
-    const states = await deps.worktreeService.getAllStatesAsync(senderWindowId);
+    const project = projectStore.getProjectById(senderProjectId);
+    if (!project) {
+      throw new AppError({
+        code: "INVALID_PATH",
+        message: "Unknown project for the requesting view",
+        context: { projectId: senderProjectId },
+      });
+    }
+
+    const states = await deps.worktreeService.getAllStatesForProjectAsync(project.path);
     const worktree = states.find((state) => state.id === worktreeId);
 
     if (!worktree) {

--- a/electron/ipc/handlers/fileBrowser.ts
+++ b/electron/ipc/handlers/fileBrowser.ts
@@ -129,7 +129,10 @@ export function buildFileBrowserNamespace(deps: HandlerDependencies) {
       });
     }
 
-    const states = await deps.worktreeService.getAllStatesForProjectAsync(project.path);
+    const states = await deps.worktreeService.getAllStatesForProjectAsync(
+      project.path,
+      senderProjectId
+    );
     const worktree = states.find((state) => state.id === worktreeId);
 
     if (!worktree) {

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -136,7 +136,14 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     if (typeof updates !== "object" || updates === null) {
       throw new Error("Invalid updates object");
     }
+    // `id` and `path` are identity, not metadata: entry-scoped authorization
+    // (fileBrowser's project routing) resolves hosts by the row's path, so a
+    // renderer that could rewrite its own project's path to a sibling's would
+    // point that resolution at the sibling's host. Path changes stay exclusive
+    // to the main-owned relocation flow (#11282).
     const {
+      id: _id,
+      path: _path,
       inRepoSettings: _inRepo,
       frecencyScore: _fs,
       lastAccessedAt: _lat,

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -442,6 +442,44 @@ export class WorkspaceClient extends EventEmitter {
     return promise;
   }
 
+  /**
+   * States for one project's host, keyed by project path rather than window.
+   * `windowToProject` is repointed to the incoming project the moment a switch
+   * starts, so window-scoped lookups from a backgrounded view resolve against
+   * the active project's host; this resolves the host from the pool's
+   * project-path entries, which stay bound to their project for the host's
+   * lifetime. No host for the path returns `[]` — never a wildcard scan.
+   */
+  getAllStatesForProjectAsync(projectPath: string): Promise<WorktreeSnapshot[]> {
+    const normalized = this.pool.normalizeProjectPath(projectPath);
+    const key = `p:${normalized}`;
+    const existing = this._statesInflight.get(key);
+    if (existing) return existing;
+
+    const host = this.pool.getHostForProject(normalized);
+    const promise = (
+      host === undefined
+        ? Promise.resolve([] as WorktreeSnapshot[])
+        : host
+            .sendWithResponse<{ states: WorktreeSnapshot[] }>({
+              type: "get-all-states",
+              requestId: host.generateRequestId(),
+            })
+            .then((result) => result.states)
+    ).then(
+      (result) => {
+        setTimeout(() => this._statesInflight.delete(key), STATES_INFLIGHT_COALESCE_WINDOW_MS);
+        return result;
+      },
+      (error) => {
+        this._statesInflight.delete(key);
+        throw error;
+      }
+    );
+    this._statesInflight.set(key, promise);
+    return promise;
+  }
+
   private async _doGetAllStates(windowId?: number): Promise<WorktreeSnapshot[]> {
     if (windowId !== undefined) {
       const host = this.pool.resolveHostForWindow(windowId);

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -449,14 +449,25 @@ export class WorkspaceClient extends EventEmitter {
    * the active project's host; this resolves the host from the pool's
    * project-path entries, which stay bound to their project for the host's
    * lifetime. No host for the path returns `[]` — never a wildcard scan.
+   *
+   * `expectedProjectId` must match the entry's immutable `projectId` (resolved
+   * once at host construction). The project *row*'s path is mutable through
+   * `project:update`, so a path alone is not an authorization identity: a
+   * renderer that rewrote its own project's path to a sibling's would
+   * otherwise select the sibling's warm host. A mismatch returns `[]`.
    */
-  getAllStatesForProjectAsync(projectPath: string): Promise<WorktreeSnapshot[]> {
+  getAllStatesForProjectAsync(
+    projectPath: string,
+    expectedProjectId: string
+  ): Promise<WorktreeSnapshot[]> {
     const normalized = this.pool.normalizeProjectPath(projectPath);
-    const key = `p:${normalized}`;
+    const key = `p:${expectedProjectId}:${normalized}`;
     const existing = this._statesInflight.get(key);
     if (existing) return existing;
 
-    const host = this.pool.getHostForProject(normalized);
+    const entry = this.pool.entries.get(normalized);
+    const host =
+      entry !== undefined && entry.projectId === expectedProjectId ? entry.host : undefined;
     const promise = (
       host === undefined
         ? Promise.resolve([] as WorktreeSnapshot[])

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -373,6 +373,10 @@ describe("WorkspaceClient multi-process manager", () => {
   });
 
   describe("getAllStatesForProjectAsync", () => {
+    // Mirrors the ProjectStore mock: entry.projectId is minted from
+    // resolveProjectIdForPath(normalizedPath) at host construction.
+    const idFor = (p: string) => `id-for-${path.resolve(p)}`;
+
     it("routes to the project's own host even after its window was rebound (#11366)", async () => {
       const loadA = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
@@ -384,7 +388,7 @@ describe("WorkspaceClient multi-process manager", () => {
       await readyAndResolveLoad(1);
       await loadB;
 
-      const statesPromise = client.getAllStatesForProjectAsync("/project-a");
+      const statesPromise = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
       await tick();
       const req = h(0)
         .getAllRequests()
@@ -402,15 +406,98 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(hostBStateReqs).toHaveLength(0);
     });
 
+    it("keeps a request started before a rebind on the originally resolved host", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      // Start the A-scoped query first, THEN rebind the window to B while the
+      // request is still in flight — the captured host must not be re-resolved.
+      const statesPromise = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(req).toBeDefined();
+
+      const loadB = client.loadProject("/project-b", 1);
+      h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a" }] });
+      expect((await statesPromise).map((s: any) => s.id)).toEqual(["wt-a"]);
+
+      await readyAndResolveLoad(1);
+      await loadB;
+    });
+
     it("returns empty for an unknown project path without contacting any host", async () => {
       const loadA = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
       await loadA;
 
       const callsBefore = h(0).sendWithResponse.mock.calls.length;
-      const result = await client.getAllStatesForProjectAsync("/no-such-project");
+      const result = await client.getAllStatesForProjectAsync(
+        "/no-such-project",
+        idFor("/no-such-project")
+      );
       expect(result).toEqual([]);
       expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("returns empty when the entry's immutable projectId does not match the caller's", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      // A caller holding a different project identity but pointing at A's path
+      // (e.g. its project row's path was rewritten) must not reach A's host.
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      const result = await client.getAllStatesForProjectAsync("/project-a", idFor("/project-b"));
+      expect(result).toEqual([]);
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("normalizes the path before keying — equivalent spellings share one request", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const p1 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      const p2 = client.getAllStatesForProjectAsync("/project-a/", idFor("/project-a"));
+      const p3 = client.getAllStatesForProjectAsync("/other/../project-a", idFor("/project-a"));
+      expect(p2).toBe(p1);
+      expect(p3).toBe(p1);
+
+      await tick();
+      const reqs = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states");
+      expect(reqs).toHaveLength(1);
+      h(0).resolveRequest(reqs[0].requestId, { states: [{ id: "wt-a" }] });
+      await p1;
+    });
+
+    it("evicts the in-flight entry on error so the next call retries", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const p1 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      await tick();
+      const req1 = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states")[0];
+      h(0).rejectRequest(req1.requestId, new Error("host crashed"));
+      await expect(p1).rejects.toThrow("host crashed");
+
+      // Immediately after the error a fresh promise (and request) is issued —
+      // a cached rejection here would fail every file-browser retry for 150ms.
+      const p2 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      expect(p2).not.toBe(p1);
+      await tick();
+      const req2 = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states")[1];
+      h(0).resolveRequest(req2.requestId, { states: [{ id: "wt-ok" }] });
+      expect(await p2).toEqual([{ id: "wt-ok" }]);
     });
 
     it("coalesces concurrent calls per project path, separately per project", async () => {
@@ -422,9 +509,9 @@ describe("WorkspaceClient multi-process manager", () => {
       await readyAndResolveLoad(1);
       await loadB;
 
-      const p1 = client.getAllStatesForProjectAsync("/project-a");
-      const p2 = client.getAllStatesForProjectAsync("/project-a");
-      const p3 = client.getAllStatesForProjectAsync("/project-b");
+      const p1 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      const p2 = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      const p3 = client.getAllStatesForProjectAsync("/project-b", idFor("/project-b"));
       expect(p1).toBe(p2);
       expect(p3).not.toBe(p1);
 

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -372,6 +372,79 @@ describe("WorkspaceClient multi-process manager", () => {
     });
   });
 
+  describe("getAllStatesForProjectAsync", () => {
+    it("routes to the project's own host even after its window was rebound (#11366)", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      // Window 1 switches to project B — windowToProject now points at B,
+      // exactly the state a backgrounded A view lives in.
+      const loadB = client.loadProject("/project-b", 1);
+      await readyAndResolveLoad(1);
+      await loadB;
+
+      const statesPromise = client.getAllStatesForProjectAsync("/project-a");
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(req).toBeDefined();
+      h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a", name: "A" }] });
+
+      const result = await statesPromise;
+      expect(result.map((s: any) => s.id)).toEqual(["wt-a"]);
+
+      // B's host never saw a state query — no cross-project fan-out.
+      const hostBStateReqs = h(1)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states");
+      expect(hostBStateReqs).toHaveLength(0);
+    });
+
+    it("returns empty for an unknown project path without contacting any host", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      const result = await client.getAllStatesForProjectAsync("/no-such-project");
+      expect(result).toEqual([]);
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("coalesces concurrent calls per project path, separately per project", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const loadB = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await loadB;
+
+      const p1 = client.getAllStatesForProjectAsync("/project-a");
+      const p2 = client.getAllStatesForProjectAsync("/project-a");
+      const p3 = client.getAllStatesForProjectAsync("/project-b");
+      expect(p1).toBe(p2);
+      expect(p3).not.toBe(p1);
+
+      await tick();
+      const reqA = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states");
+      expect(reqA).toHaveLength(1);
+      h(0).resolveRequest(reqA[0].requestId, { states: [{ id: "wt-a" }] });
+      const reqB = h(1)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states");
+      expect(reqB).toHaveLength(1);
+      h(1).resolveRequest(reqB[0].requestId, { states: [{ id: "wt-b" }] });
+
+      expect(await p1).toEqual([{ id: "wt-a" }]);
+      expect(await p3).toEqual([{ id: "wt-b" }]);
+    });
+  });
+
   describe("singleflight cache", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -411,8 +411,9 @@ describe("WorkspaceClient multi-process manager", () => {
       await readyAndResolveLoad(0);
       await loadA;
 
-      // Start the A-scoped query first, THEN rebind the window to B while the
-      // request is still in flight — the captured host must not be re-resolved.
+      // Start the A-scoped query first, then COMPLETE the window's rebind to B
+      // while the request is still in flight — the captured host must not be
+      // re-resolved from the now-repointed window mapping.
       const statesPromise = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
       await tick();
       const req = h(0)
@@ -421,11 +422,17 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(req).toBeDefined();
 
       const loadB = client.loadProject("/project-b", 1);
+      await readyAndResolveLoad(1);
+      await loadB;
+
       h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a" }] });
       expect((await statesPromise).map((s: any) => s.id)).toEqual(["wt-a"]);
 
-      await readyAndResolveLoad(1);
-      await loadB;
+      // B's host answered no state query on behalf of the pre-rebind request.
+      const hostBStateReqs = h(1)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states");
+      expect(hostBStateReqs).toHaveLength(0);
     });
 
     it("returns empty for an unknown project path without contacting any host", async () => {
@@ -616,6 +623,37 @@ describe("WorkspaceClient multi-process manager", () => {
       h(0).resolveRequest(req2.requestId, { states: [{ id: "wt-ok" }] });
       const r2 = await p2;
       expect(r2).toEqual([{ id: "wt-ok" }]);
+    });
+
+    it("project-scoped cache also expires after TTL", async () => {
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoadFake(0);
+      await load;
+
+      const projectId = `id-for-${path.resolve("/project-a")}`;
+      const p1 = client.getAllStatesForProjectAsync("/project-a", projectId);
+      await vi.advanceTimersByTimeAsync(0);
+      const req1 = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states")[0];
+      h(0).resolveRequest(req1.requestId, { states: [{ id: "wt-1" }] });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Before TTL: same Promise
+      const p2 = client.getAllStatesForProjectAsync("/project-a", projectId);
+      expect(p2).toBe(p1);
+
+      // After TTL: new Promise, new host request
+      await vi.advanceTimersByTimeAsync(150);
+      const p3 = client.getAllStatesForProjectAsync("/project-a", projectId);
+      expect(p3).not.toBe(p1);
+
+      await vi.advanceTimersByTimeAsync(0);
+      const req2 = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states")[1];
+      h(0).resolveRequest(req2.requestId, { states: [{ id: "wt-2" }] });
+      expect(await p3).toEqual([{ id: "wt-2" }]);
     });
 
     it("different windowIds get separate cache entries", async () => {

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -24,15 +24,14 @@ const MAX_CONCURRENT_LISTINGS = 6;
 
 /**
  * Backoff schedule for silently retrying a failed *root* listing before
- * surfacing an error. Switching back to an idle project reactivates its view
- * and re-fetches the tree while the workspace host is still being repointed to
- * this window — `activateProjectView` sends `PROJECT_ON_SWITCH` before it awaits
- * `loadWorktrees` — so the first `listDirectory` can throw `Worktree not found`
- * for a few hundred ms before self-healing. Retrying instead of immediately
- * painting a red banner keeps that transient invisible; the banner is reserved
- * for a failure that persists across the whole schedule.
+ * surfacing an error. Listings are routed to the sender view's own project
+ * host (#11366), so window repointing during a switch is no longer a failure
+ * source — the grace window covers what remains: a cold or restarting
+ * workspace host, eviction, and transient IPC failures. Retrying instead of
+ * immediately painting a red banner keeps those transients invisible; the
+ * banner is reserved for a failure that persists across the whole schedule.
  *
- * 150ms first, because `getAllStatesAsync` coalesces its result for 150ms
+ * 150ms first, because state queries coalesce their result for 150ms
  * (`STATES_INFLIGHT_COALESCE_WINDOW_MS`) — a sooner retry would only replay the
  * same stale empty answer. Then 400ms and 800ms: `switch.ts`'s own comment puts
  * the warm-`loadProject` window at "several hundred ms" (prune/list/status


### PR DESCRIPTION
## Summary

- Fixes a bug where a backgrounded project view's file browser sends `listDirectory` requests to the *active* project's workspace host instead of its own, because routing was scoped by window id (`resolveSenderWorktree`) and `windowToProject` only ever holds one project per window, repointed to the incoming project the moment a switch starts.
- This is the root cause of #11320 resurfacing after #11326: the hidden view keeps polling for change ticks while backgrounded, every one of those requests fails with `Worktree not found`, and that burns through #11326's retry budget entirely off-screen. By the time the user switches back, the error banner is already showing.
- During review, closed a related authorization gap: a project row's `path` is renderer-mutable via `project:update`, so path alone can't be trusted as an identity check.

Resolves #11366

## Changes

- Route by the sender view's own `ctx.projectId` instead of its window, via a new main-owned `viewToProject` binding. This is strictly tighter scoping than window-level, since a window can host multiple project views over its lifetime but a view only ever belongs to one project.
- Add `WorkspaceClient.getAllStatesForProjectAsync(projectPath, expectedProjectId)`, which verifies the pool entry's immutable `projectId` matches before returning anything, and fails closed (returns nothing) when `projectId` is null rather than falling back to any host.
- Strip `id` and `path` out of the renderer-facing `project:update` IPC channel. Path alone isn't a safe authorization identity: a buggy or malicious renderer could rename its own project's path to collide with another project's and read its files. Legitimate path changes now go exclusively through the existing main-owned relocation flow.

## Testing

- 198 unit tests pass across the affected files, including new regression tests that pin the fixed behavior.
- `e2e/full/worktree/core-project-switch-race.spec.ts` passes 4/4 locally, including a new test for the cached-view scenario, which also proves the fix's refusal is an authorization decision, not just a routing accident.

## Known gaps left out of scope

- Removing then re-adding a project can reuse a path-derived project id while a stale cached view of the removed project still exists. This is systemic to every consumer of `ctx.projectId`, not specific to this handler.
- A restored file-browser panel can send a request with a null `projectId` during a startup window of just over 1.35 seconds, before view registration completes. This is pre-existing behavior, kept intentionally fail-closed.
