### PR TITLE
feat(file-browser): show the last-known tree instantly on switch-back

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -6,6 +6,7 @@ import type {
   ViewportPresetId,
   FileViewMode,
   DiffSource,
+  FileBrowserTreeSnapshot,
 } from "./panel.js";
 import type { GitStatus, DiffChangeSetEntry } from "./git.js";
 import type { BrowserHistory } from "./browser.js";
@@ -274,6 +275,8 @@ export interface FileBrowserPanelOptions extends AddPanelOptionsBase {
   browserRootPath?: string;
   /** Whether the tree sidebar starts collapsed; absent or false = open */
   browserSidebarCollapsed?: boolean;
+  /** Last-known tree structure to paint before the first live listing (#11367) */
+  browserTreeSnapshot?: FileBrowserTreeSnapshot;
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -698,6 +698,36 @@ export interface DiffPanelData extends BasePanelData {
   viewedKey?: string;
 }
 
+/** One directory entry in a persisted file-browser tree snapshot. */
+export interface FileBrowserSnapshotNode {
+  /** Entry basename. */
+  name: string;
+  /** Worktree-relative path. */
+  path: string;
+  isDirectory: boolean;
+}
+
+/** One directory's listing in a persisted file-browser tree snapshot. */
+export interface FileBrowserTreeSnapshotEntry {
+  /** Worktree-relative directory path; "" = the browse root's own listing. */
+  dirPath: string;
+  nodes: FileBrowserSnapshotNode[];
+}
+
+/**
+ * Structure-only snapshot of a file browser's last-known tree (#11367): entry
+ * names, paths and directory bits — never contents, sizes or timestamps.
+ * Tagged with the identity it was captured under so a worktree switch or
+ * re-root can't seed the wrong tree; a mismatch just cold-starts. Arrays
+ * rather than a Map because it round-trips through JSON persistence.
+ */
+export interface FileBrowserTreeSnapshot {
+  worktreeId: string;
+  /** Worktree-relative browse root at capture time; "" = the worktree root. */
+  rootPath: string;
+  listings: FileBrowserTreeSnapshotEntry[];
+}
+
 /**
  * File browser panel — a lazily-expanded directory tree over one worktree with
  * a read-only viewer beside it. Every field is worktree-relative rather than
@@ -736,6 +766,14 @@ export interface FileBrowserPanelData extends BasePanelData {
    * default); only `true` is persisted, so an open panel stays sparse.
    */
   browserSidebarCollapsed?: boolean;
+  /**
+   * Last-known tree structure, captured when the view goes away and painted
+   * back instantly on restore while a live refresh runs (#11367). Derived
+   * data, unlike every other field here — but it must live on the panel
+   * record because the renderer (and any cache in it) is destroyed on LRU
+   * eviction; only the persisted record survives.
+   */
+  browserTreeSnapshot?: FileBrowserTreeSnapshot;
 }
 
 export type PanelInstance =

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -9,6 +9,7 @@ import type {
   ViewportPresetId,
   FileViewMode,
   DiffSource,
+  FileBrowserTreeSnapshot,
 } from "./panel.js";
 import type { CommandOverride } from "./commands.js";
 import type { GitStatus } from "./git.js";
@@ -169,6 +170,8 @@ export interface PanelSnapshot {
   browserRootPath?: string;
   /** Whether a file browser panel's tree sidebar is collapsed (only `true` persisted) */
   browserSidebarCollapsed?: boolean;
+  /** Last-known tree structure of a file browser panel (#11367) */
+  browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /** Legacy pre-file-panel field: absolute path shown in a markdown panel */
   markdownFilePath?: string;
   /** Legacy pre-file-panel field: markdown panel view mode */

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -207,6 +207,125 @@ describe("panelKindSerialisers", () => {
       expect(output.browserHideDotfiles).toBeUndefined();
       expect(output).not.toHaveProperty("browserShowIgnored");
     });
+
+    describe("browserTreeSnapshot (#11367)", () => {
+      const validSnapshot = {
+        worktreeId: "wt-1",
+        rootPath: "",
+        listings: [
+          {
+            dirPath: "",
+            nodes: [
+              { name: "src", path: "src", isDirectory: true },
+              { name: "README.md", path: "README.md", isDirectory: false },
+            ],
+          },
+          {
+            dirPath: "src",
+            nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }],
+          },
+        ],
+      };
+
+      it("restores a well-formed snapshot intact", () => {
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: validSnapshot }).browserTreeSnapshot
+        ).toEqual(validSnapshot);
+      });
+
+      it("restores a snapshot rooted at a subfolder whose root listing is present", () => {
+        const rooted = {
+          worktreeId: "wt-1",
+          rootPath: "src",
+          listings: [
+            { dirPath: "src", nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }] },
+          ],
+        };
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: rooted }).browserTreeSnapshot
+        ).toEqual(rooted);
+      });
+
+      it("drops the whole snapshot on any malformed element rather than partially trusting it", () => {
+        // A partially trusted snapshot could seed rows for paths that were
+        // never listed; the cost of dropping is only a cold start.
+        const malformed: unknown[] = [
+          "not an object",
+          42,
+          [],
+          { ...validSnapshot, worktreeId: "" },
+          { ...validSnapshot, worktreeId: 7 },
+          { ...validSnapshot, rootPath: "../escape" },
+          { ...validSnapshot, listings: "nope" },
+          // Duplicate directory keys.
+          {
+            ...validSnapshot,
+            listings: [validSnapshot.listings[0], validSnapshot.listings[0]],
+          },
+          // Escaping node path.
+          {
+            ...validSnapshot,
+            listings: [{ dirPath: "", nodes: [{ name: "x", path: "../x", isDirectory: false }] }],
+          },
+          // Separator inside a basename.
+          {
+            ...validSnapshot,
+            listings: [{ dirPath: "", nodes: [{ name: "a/b", path: "a", isDirectory: false }] }],
+          },
+          // Non-boolean directory bit.
+          {
+            ...validSnapshot,
+            listings: [{ dirPath: "", nodes: [{ name: "a", path: "a", isDirectory: "yes" }] }],
+          },
+        ];
+        for (const value of malformed) {
+          expect(
+            deserialize()({ id: "fb1", browserTreeSnapshot: value }).browserTreeSnapshot,
+            `should drop: ${JSON.stringify(value)}`
+          ).toBeUndefined();
+        }
+      });
+
+      it("drops a snapshot missing its own root listing — there is nothing to paint from", () => {
+        const rootless = {
+          worktreeId: "wt-1",
+          rootPath: "",
+          listings: [
+            { dirPath: "src", nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }] },
+          ],
+        };
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: rootless }).browserTreeSnapshot
+        ).toBeUndefined();
+      });
+
+      it("drops a snapshot that exceeds the node budget instead of truncating it", () => {
+        const oversized = {
+          worktreeId: "wt-1",
+          rootPath: "",
+          listings: [
+            {
+              dirPath: "",
+              nodes: Array.from({ length: 10_001 }, (_, i) => ({
+                name: `f-${i}`,
+                path: `f-${i}`,
+                isDirectory: false,
+              })),
+            },
+          ],
+        };
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: oversized }).browserTreeSnapshot
+        ).toBeUndefined();
+      });
+
+      it("keeps an empty root listing — an empty worktree is a real last-known state", () => {
+        const empty = { worktreeId: "wt-1", rootPath: "", listings: [{ dirPath: "", nodes: [] }] };
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: empty }).browserTreeSnapshot
+        ).toEqual(empty);
+      });
+    });
   });
 
   describe("unknown kind", () => {

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -332,6 +332,26 @@ describe("panelKindSerialisers", () => {
             ...validSnapshot,
             listings: [{ dirPath: "", nodes: [{ name: "..", path: "..", isDirectory: true }] }],
           },
+          {
+            ...validSnapshot,
+            listings: [{ dirPath: "", nodes: [{ name: ".", path: ".", isDirectory: true }] }],
+          },
+          // Control characters survive the canonical-join check alone; the
+          // composite path must still pass the character screen.
+          {
+            ...validSnapshot,
+            listings: [
+              {
+                dirPath: "",
+                nodes: [{ name: "bad\u0000name", path: "bad\u0000name", isDirectory: false }],
+              },
+            ],
+          },
+          // Drive-qualified basename at the root.
+          {
+            ...validSnapshot,
+            listings: [{ dirPath: "", nodes: [{ name: "C:", path: "C:", isDirectory: true }] }],
+          },
           // Unbounded worktree id.
           { ...validSnapshot, worktreeId: "w".repeat(5000) },
         ];
@@ -381,6 +401,26 @@ describe("panelKindSerialisers", () => {
         expect(
           deserialize()({ id: "fb1", browserTreeSnapshot: empty }).browserTreeSnapshot
         ).toEqual(empty);
+      });
+
+      it("counts listing keys against the text budget, not just node text", () => {
+        // 200 empty listings with ~4k-character keys carry real bytes even
+        // with zero nodes — the budget must see them.
+        const longDir = "d".repeat(3900);
+        const bloatedKeys = {
+          worktreeId: "wt-1",
+          rootPath: "",
+          listings: [
+            { dirPath: "", nodes: [] },
+            ...Array.from({ length: 200 }, (_, i) => ({
+              dirPath: `${longDir}-${i}`,
+              nodes: [],
+            })),
+          ],
+        };
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: bloatedKeys }).browserTreeSnapshot
+        ).toBeUndefined();
       });
 
       it("drops a snapshot whose aggregate text exceeds the byte budget", () => {

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -472,9 +472,11 @@ describe("panelKindSerialisers", () => {
         };
         const persisted = JSON.parse(JSON.stringify(serializeFileBrowser(panel)));
         const restoredArgs = deserialize()({ id: "fb1", ...persisted });
+        // Spread first, then pin the discriminant: restoredArgs' type carries
+        // the open PanelKind union, which must not widen the literal.
         const defaults = createFileBrowserDefaults({
-          kind: "file-browser",
           ...restoredArgs,
+          kind: "file-browser",
         });
         expect(defaults.browserTreeSnapshot).toBeDefined();
 

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect } from "vitest";
+import type { FileTreeNode } from "@shared/types";
+import type { FileBrowserPanelData } from "@shared/types/panel";
+import {
+  flattenTree,
+  listingsFromSnapshot,
+  snapshotFromListings,
+} from "@/panels/file-browser/fileBrowserTree";
+import { serializeFileBrowser } from "@/panels/file-browser/serializer";
+import { createFileBrowserDefaults } from "@/panels/file-browser/defaults";
 import { getDeserializer } from "../panelKindSerialisers";
 
 describe("panelKindSerialisers", () => {
@@ -277,6 +286,54 @@ describe("panelKindSerialisers", () => {
             ...validSnapshot,
             listings: [{ dirPath: "", nodes: [{ name: "a", path: "a", isDirectory: "yes" }] }],
           },
+          // Non-canonical child edge: the node's path is not dirPath/name, so
+          // it could impersonate a row that was never listed under this parent
+          // (and dodge the per-name visibility filter).
+          {
+            ...validSnapshot,
+            listings: [
+              { dirPath: "", nodes: [{ name: "README.md", path: ".env", isDirectory: false }] },
+            ],
+          },
+          // Self-cycle with a duplicate edge: `a` listing `a` twice. Each
+          // traversal level would double until the depth guard — the
+          // canonical-edge rule (a child path is strictly longer than its
+          // parent's) is what rules this class out entirely.
+          {
+            worktreeId: "wt-1",
+            rootPath: "",
+            listings: [
+              { dirPath: "", nodes: [{ name: "a", path: "a", isDirectory: true }] },
+              {
+                dirPath: "a",
+                nodes: [
+                  { name: "a", path: "a", isDirectory: true },
+                  { name: "a", path: "a", isDirectory: true },
+                ],
+              },
+            ],
+          },
+          // Duplicate names within one listing → duplicate row paths, and
+          // FlatTreeRow.path doubles as the React key.
+          {
+            ...validSnapshot,
+            listings: [
+              {
+                dirPath: "",
+                nodes: [
+                  { name: "src", path: "src", isDirectory: true },
+                  { name: "src", path: "src", isDirectory: false },
+                ],
+              },
+            ],
+          },
+          // Traversal-shaped basenames.
+          {
+            ...validSnapshot,
+            listings: [{ dirPath: "", nodes: [{ name: "..", path: "..", isDirectory: true }] }],
+          },
+          // Unbounded worktree id.
+          { ...validSnapshot, worktreeId: "w".repeat(5000) },
         ];
         for (const value of malformed) {
           expect(
@@ -324,6 +381,68 @@ describe("panelKindSerialisers", () => {
         expect(
           deserialize()({ id: "fb1", browserTreeSnapshot: empty }).browserTreeSnapshot
         ).toEqual(empty);
+      });
+
+      it("drops a snapshot whose aggregate text exceeds the byte budget", () => {
+        // Node and listing counts alone don't bound serialized size; a few
+        // hundred long paths must trip the text budget instead.
+        const longName = "n".repeat(4000);
+        const oversizedText = {
+          worktreeId: "wt-1",
+          rootPath: "",
+          listings: [
+            {
+              dirPath: "",
+              nodes: Array.from({ length: 100 }, (_, i) => ({
+                name: `${longName}-${i}`,
+                path: `${longName}-${i}`,
+                isDirectory: false,
+              })),
+            },
+          ],
+        };
+        expect(
+          deserialize()({ id: "fb1", browserTreeSnapshot: oversizedText }).browserTreeSnapshot
+        ).toBeUndefined();
+      });
+
+      it("round-trips capture → serialize → JSON → sanitize → seed back to the same painted rows", () => {
+        // The full carrier chain a real restore takes. A break at any stage —
+        // capture shape, serializer omission, sanitizer over-strictness,
+        // seed decoding — fails here even if each stage's own tests pass.
+        const live = new Map<string, readonly FileTreeNode[]>([
+          [
+            "",
+            [
+              { name: "src", path: "src", isDirectory: true, size: 0 },
+              { name: "README.md", path: "README.md", isDirectory: false, size: 120 },
+            ],
+          ],
+          ["src", [{ name: "app.ts", path: "src/app.ts", isDirectory: false, size: 99 }]],
+        ]);
+        const captured = snapshotFromListings(live, "wt-1", "");
+        expect(captured).not.toBeNull();
+
+        const panel: FileBrowserPanelData = {
+          id: "fb1",
+          title: "Files",
+          location: "grid",
+          kind: "file-browser",
+          browserTreeSnapshot: captured!,
+        };
+        const persisted = JSON.parse(JSON.stringify(serializeFileBrowser(panel)));
+        const restoredArgs = deserialize()({ id: "fb1", ...persisted });
+        const defaults = createFileBrowserDefaults({
+          kind: "file-browser",
+          ...restoredArgs,
+        });
+        expect(defaults.browserTreeSnapshot).toBeDefined();
+
+        const seeded = listingsFromSnapshot(defaults.browserTreeSnapshot!);
+        const rows = flattenTree(seeded, new Set(["src"]), new Set());
+        expect(rows.map((row) => row.path)).toEqual(
+          flattenTree(live, new Set(["src"]), new Set()).map((row) => row.path)
+        );
       });
     });
   });

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -1,9 +1,13 @@
 import type { BuiltInPanelKind, PanelKind, ViewportPresetId } from "@/types";
-import type { FileViewMode, DiffSource } from "@shared/types/panel";
+import type { FileViewMode, DiffSource, FileBrowserTreeSnapshot } from "@shared/types/panel";
 import type { GitStatus } from "@shared/types/git";
 import type { AddTerminalArgs, SavedTerminalData } from "@/utils/stateHydration/statePatcher";
 import { VIEWPORT_PRESETS } from "@/panels/dev-preview/viewportPresets";
-import { canonicalizeRootPath } from "@/panels/file-browser/fileBrowserTree";
+import {
+  canonicalizeRootPath,
+  MAX_SNAPSHOT_LISTINGS,
+  MAX_SNAPSHOT_NODES,
+} from "@/panels/file-browser/fileBrowserTree";
 
 type PanelKindDeserializer = (saved: SavedTerminalData) => Partial<AddTerminalArgs>;
 
@@ -100,6 +104,65 @@ function sanitizeExpandedPaths(value: unknown): string[] | undefined {
   return [...seen];
 }
 
+/** A snapshot directory key: "" is the worktree root; anything else must be safe. */
+function isSnapshotDirPath(value: unknown): value is string {
+  return value === "" || isSafeRelativePath(value);
+}
+
+/** An entry basename: plain, separator-free, and bounded. */
+function isSnapshotNodeName(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_RESTORED_PATH_LENGTH &&
+    !value.includes("/") &&
+    !value.includes("\\")
+  );
+}
+
+/**
+ * Coerce a persisted last-known tree snapshot (#11367), dropping the whole
+ * value on any malformed element — a partially trusted snapshot could seed
+ * rows for paths that were never listed, and the cost of dropping is only a
+ * cold start. Bounds mirror the capture side's, so a snapshot that was legal
+ * to write is legal to restore.
+ */
+function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const candidate = value as Record<string, unknown>;
+  const { worktreeId, rootPath, listings } = candidate;
+  if (typeof worktreeId !== "string" || worktreeId.length === 0) return undefined;
+  if (!isSnapshotDirPath(rootPath)) return undefined;
+  if (!Array.isArray(listings) || listings.length > MAX_SNAPSHOT_LISTINGS) return undefined;
+
+  let totalNodes = 0;
+  const seenDirs = new Set<string>();
+  const sanitizedListings: FileBrowserTreeSnapshot["listings"] = [];
+  for (const entry of listings) {
+    if (typeof entry !== "object" || entry === null) return undefined;
+    const { dirPath, nodes } = entry as Record<string, unknown>;
+    if (!isSnapshotDirPath(dirPath) || seenDirs.has(dirPath)) return undefined;
+    seenDirs.add(dirPath);
+    if (!Array.isArray(nodes)) return undefined;
+    totalNodes += nodes.length;
+    if (totalNodes > MAX_SNAPSHOT_NODES) return undefined;
+    const sanitizedNodes: FileBrowserTreeSnapshot["listings"][number]["nodes"] = [];
+    for (const node of nodes) {
+      if (typeof node !== "object" || node === null) return undefined;
+      const { name, path, isDirectory } = node as Record<string, unknown>;
+      if (!isSnapshotNodeName(name)) return undefined;
+      if (!isSafeRelativePath(path)) return undefined;
+      if (typeof isDirectory !== "boolean") return undefined;
+      sanitizedNodes.push({ name, path, isDirectory });
+    }
+    sanitizedListings.push({ dirPath, nodes: sanitizedNodes });
+  }
+  // A snapshot without its own root listing has nothing to paint from —
+  // seeding it would show an empty tree where a skeleton belongs.
+  if (!seenDirs.has(rootPath)) return undefined;
+  return { worktreeId, rootPath, listings: sanitizedListings };
+}
+
 /**
  * Built-in deserializer table ratcheted against `BuiltInPanelKind` so adding
  * a new built-in kind without an entry fails at compile time. `null` marks an
@@ -153,6 +216,7 @@ const BUILT_IN_DESERIALIZERS = {
     // Only a literal `true` restores collapsed: a hand-edited or corrupted
     // snapshot holding a string or object must fall back to the open default.
     browserSidebarCollapsed: saved.browserSidebarCollapsed === true ? true : undefined,
+    browserTreeSnapshot: sanitizeTreeSnapshot(saved.browserTreeSnapshot),
   }),
   diff: (saved) => ({
     filePath: saved.filePath,

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -164,6 +164,9 @@ function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefin
     if (!Array.isArray(nodes)) return undefined;
     totalNodes += nodes.length;
     if (totalNodes > MAX_SNAPSHOT_NODES) return undefined;
+    // Listing keys count against the text budget too, mirroring capture.
+    totalChars += dirPath.length;
+    if (totalChars > MAX_SNAPSHOT_TEXT_CHARS) return undefined;
     const seenNames = new Set<string>();
     const sanitizedNodes: FileBrowserTreeSnapshot["listings"][number]["nodes"] = [];
     for (const node of nodes) {
@@ -172,6 +175,10 @@ function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefin
       if (!isSnapshotNodeName(name) || seenNames.has(name)) return undefined;
       seenNames.add(name);
       if (path !== (dirPath === "" ? name : `${dirPath}/${name}`)) return undefined;
+      // Canonical shape alone doesn't make the composite safe: the joined
+      // path must also pass the same character/length screen every other
+      // restored path does (control characters, drive prefixes, 4096 cap).
+      if (!isSafeRelativePath(path)) return undefined;
       if (typeof isDirectory !== "boolean") return undefined;
       totalChars += name.length + path.length;
       if (totalChars > MAX_SNAPSHOT_TEXT_CHARS) return undefined;

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -105,6 +105,11 @@ function sanitizeExpandedPaths(value: unknown): string[] | undefined {
   return [...seen];
 }
 
+/** Plain-object guard so untrusted JSON can be field-checked without assertions. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /** A snapshot directory key: "" is the worktree root; anything else must be safe. */
 function isSnapshotDirPath(value: unknown): value is string {
   return value === "" || isSafeRelativePath(value);
@@ -139,9 +144,8 @@ function isSnapshotNodeName(value: unknown): value is string {
  * keys (`FlatTreeRow.path` doubles as the key).
  */
 function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefined {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
-  const candidate = value as Record<string, unknown>;
-  const { worktreeId, rootPath, listings } = candidate;
+  if (!isRecord(value)) return undefined;
+  const { worktreeId, rootPath, listings } = value;
   if (
     typeof worktreeId !== "string" ||
     worktreeId.length === 0 ||
@@ -157,8 +161,8 @@ function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefin
   const seenDirs = new Set<string>();
   const sanitizedListings: FileBrowserTreeSnapshot["listings"] = [];
   for (const entry of listings) {
-    if (typeof entry !== "object" || entry === null) return undefined;
-    const { dirPath, nodes } = entry as Record<string, unknown>;
+    if (!isRecord(entry)) return undefined;
+    const { dirPath, nodes } = entry;
     if (!isSnapshotDirPath(dirPath) || seenDirs.has(dirPath)) return undefined;
     seenDirs.add(dirPath);
     if (!Array.isArray(nodes)) return undefined;
@@ -170,8 +174,8 @@ function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefin
     const seenNames = new Set<string>();
     const sanitizedNodes: FileBrowserTreeSnapshot["listings"][number]["nodes"] = [];
     for (const node of nodes) {
-      if (typeof node !== "object" || node === null) return undefined;
-      const { name, path, isDirectory } = node as Record<string, unknown>;
+      if (!isRecord(node)) return undefined;
+      const { name, path, isDirectory } = node;
       if (!isSnapshotNodeName(name) || seenNames.has(name)) return undefined;
       seenNames.add(name);
       if (path !== (dirPath === "" ? name : `${dirPath}/${name}`)) return undefined;

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -7,6 +7,7 @@ import {
   canonicalizeRootPath,
   MAX_SNAPSHOT_LISTINGS,
   MAX_SNAPSHOT_NODES,
+  MAX_SNAPSHOT_TEXT_CHARS,
 } from "@/panels/file-browser/fileBrowserTree";
 
 type PanelKindDeserializer = (saved: SavedTerminalData) => Partial<AddTerminalArgs>;
@@ -109,12 +110,14 @@ function isSnapshotDirPath(value: unknown): value is string {
   return value === "" || isSafeRelativePath(value);
 }
 
-/** An entry basename: plain, separator-free, and bounded. */
+/** An entry basename: plain, separator-free, non-traversal, and bounded. */
 function isSnapshotNodeName(value: unknown): value is string {
   return (
     typeof value === "string" &&
     value.length > 0 &&
     value.length <= MAX_RESTORED_PATH_LENGTH &&
+    value !== "." &&
+    value !== ".." &&
     !value.includes("/") &&
     !value.includes("\\")
   );
@@ -124,18 +127,33 @@ function isSnapshotNodeName(value: unknown): value is string {
  * Coerce a persisted last-known tree snapshot (#11367), dropping the whole
  * value on any malformed element — a partially trusted snapshot could seed
  * rows for paths that were never listed, and the cost of dropping is only a
- * cold start. Bounds mirror the capture side's, so a snapshot that was legal
- * to write is legal to restore.
+ * cold start. Count and text bounds mirror the capture side's, so a snapshot
+ * that was legal to write is legal to restore.
+ *
+ * Every node must be a *canonical child edge*: `path` is exactly
+ * `dirPath/name`, unique within its listing. That is what the real listing
+ * service produces, and it structurally rules out the pathological shapes a
+ * hand-edited snapshot could otherwise smuggle in: self-cycles and duplicate
+ * edges (whose traversal is exponential under the depth guard), row paths
+ * that dodge the visibility filter's per-name checks, and duplicate React
+ * keys (`FlatTreeRow.path` doubles as the key).
  */
 function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
   const candidate = value as Record<string, unknown>;
   const { worktreeId, rootPath, listings } = candidate;
-  if (typeof worktreeId !== "string" || worktreeId.length === 0) return undefined;
+  if (
+    typeof worktreeId !== "string" ||
+    worktreeId.length === 0 ||
+    worktreeId.length > MAX_RESTORED_PATH_LENGTH
+  ) {
+    return undefined;
+  }
   if (!isSnapshotDirPath(rootPath)) return undefined;
   if (!Array.isArray(listings) || listings.length > MAX_SNAPSHOT_LISTINGS) return undefined;
 
   let totalNodes = 0;
+  let totalChars = 0;
   const seenDirs = new Set<string>();
   const sanitizedListings: FileBrowserTreeSnapshot["listings"] = [];
   for (const entry of listings) {
@@ -146,13 +164,17 @@ function sanitizeTreeSnapshot(value: unknown): FileBrowserTreeSnapshot | undefin
     if (!Array.isArray(nodes)) return undefined;
     totalNodes += nodes.length;
     if (totalNodes > MAX_SNAPSHOT_NODES) return undefined;
+    const seenNames = new Set<string>();
     const sanitizedNodes: FileBrowserTreeSnapshot["listings"][number]["nodes"] = [];
     for (const node of nodes) {
       if (typeof node !== "object" || node === null) return undefined;
       const { name, path, isDirectory } = node as Record<string, unknown>;
-      if (!isSnapshotNodeName(name)) return undefined;
-      if (!isSafeRelativePath(path)) return undefined;
+      if (!isSnapshotNodeName(name) || seenNames.has(name)) return undefined;
+      seenNames.add(name);
+      if (path !== (dirPath === "" ? name : `${dirPath}/${name}`)) return undefined;
       if (typeof isDirectory !== "boolean") return undefined;
+      totalChars += name.length + path.length;
+      if (totalChars > MAX_SNAPSHOT_TEXT_CHARS) return undefined;
       sanitizedNodes.push({ name, path, isDirectory });
     }
     sanitizedListings.push({ dirPath, nodes: sanitizedNodes });

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -281,6 +281,10 @@ const FILE_BROWSER_FIELD_CLASSIFICATION = {
   browserHideDotfiles: true,
   browserRootPath: true,
   browserSidebarCollapsed: true,
+  // The one derived persisted field: the last-known tree snapshot (#11367)
+  // must ride the panel record because nothing renderer-side survives LRU
+  // eviction.
+  browserTreeSnapshot: true,
   // BasePanelData carrier-bookkeeping timestamps — written by the base
   // serialization layer in panelToSnapshot, not per-kind serializers.
   createdAt: false,
@@ -447,6 +451,17 @@ const savedFile: SavedTerminalData = {
   fileViewMode: "source",
 };
 
+const browserTreeSnapshotFixture = {
+  worktreeId: "wt-1",
+  rootPath: "src",
+  listings: [
+    {
+      dirPath: "src",
+      nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }],
+    },
+  ],
+};
+
 const fileBrowserFixture: FileBrowserPanelData = {
   id: "panel-file-browser",
   title: "Panel",
@@ -457,6 +472,7 @@ const fileBrowserFixture: FileBrowserPanelData = {
   browserHideDotfiles: true,
   browserRootPath: "src",
   browserSidebarCollapsed: true,
+  browserTreeSnapshot: browserTreeSnapshotFixture,
 };
 
 const savedFileBrowser: SavedTerminalData = {
@@ -467,6 +483,7 @@ const savedFileBrowser: SavedTerminalData = {
   browserHideDotfiles: true,
   browserRootPath: "src",
   browserSidebarCollapsed: true,
+  browserTreeSnapshot: browserTreeSnapshotFixture,
 };
 
 const diffFixture: DiffPanelData = {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -172,10 +172,12 @@ export function FileBrowserPane({
 
   // Persist the last-known tree at going-away points only (#11367): the view
   // being hidden (project switch, window close, app quit — `visibilitychange`
-  // is the reliable detach signal, see #9914 in `resource.ts`) and unmount
-  // (which covers dialog → grid promotion re-seeding the same panel id).
-  // Never on a change tick — the snapshot rides the panel record, and dirtying
-  // it on every filesystem tick would turn each into a layout write.
+  // is the reliable detach signal, see #9914 in `resource.ts`) and unmount,
+  // which records the outgoing tree (dialog close, re-root) for the *next*
+  // restore — a dialog → grid promotion's replacement pane mounts before this
+  // cleanup writes, so it still cold-fetches. Never on a change tick — the
+  // snapshot rides the panel record, and dirtying it on every filesystem tick
+  // would turn each into a layout write.
   useEffect(() => {
     const capture = () => {
       const snapshot = captureSnapshot();

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { CornerLeftUp, EyeOff, FolderRoot, FolderTree, RefreshCw } from "lucide-react";
 import { basename, join } from "@shared/utils/path";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
@@ -16,6 +16,7 @@ import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
+import { flushPanelPersistence } from "@/store/slices";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { FileTreeView } from "./FileTreeView";
 import { FileBrowserViewer } from "./FileBrowserViewer";
@@ -106,6 +107,15 @@ export function FileBrowserPane({
       [id]
     )
   );
+  const treeSnapshot = usePanelStore(
+    useCallback(
+      (state) => {
+        const panel = state.panelsById[id];
+        return panel?.kind === "file-browser" ? panel.browserTreeSnapshot : undefined;
+      },
+      [id]
+    )
+  );
 
   // Resolved fresh from the worktree store rather than persisted, so a rename
   // or move is reflected without restarting the panel.
@@ -149,6 +159,7 @@ export function FileBrowserPane({
     ensureLoaded,
     refresh,
     isRefreshing,
+    captureSnapshot,
   } = useFileBrowserTree({
     worktreeId,
     expandedPaths: stableExpandedPaths,
@@ -156,7 +167,37 @@ export function FileBrowserPane({
     alwaysHiddenPatterns,
     rootPath,
     changeTick,
+    treeSnapshot,
   });
+
+  // Persist the last-known tree at going-away points only (#11367): the view
+  // being hidden (project switch, window close, app quit — `visibilitychange`
+  // is the reliable detach signal, see #9914 in `resource.ts`) and unmount
+  // (which covers dialog → grid promotion re-seeding the same panel id).
+  // Never on a change tick — the snapshot rides the panel record, and dirtying
+  // it on every filesystem tick would turn each into a layout write.
+  useEffect(() => {
+    const capture = () => {
+      const snapshot = captureSnapshot();
+      if (snapshot) setFileBrowserView(id, { browserTreeSnapshot: snapshot });
+    };
+    const handleVisibilityChange = () => {
+      if (!document.hidden) return;
+      capture();
+      // The 500ms persistence debounce usually completes while the hidden
+      // renderer stays alive, but flush anyway: on app quit there is no later
+      // tick, and the capture above must make this save, not the next one.
+      flushPanelPersistence();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      // On an identity change this cleanup runs before the new identity's
+      // listings commit, so it still captures the outgoing tree under the
+      // identity it belongs to (the closed-over captureSnapshot).
+      capture();
+    };
+  }, [id, captureSnapshot, setFileBrowserView]);
 
   const handleToggleExpanded = useCallback(
     (path: string, expand: boolean) => {
@@ -512,7 +553,11 @@ export function FileBrowserPane({
       );
     }
 
-    if (rootError !== null) {
+    // The full-pane error is reserved for genuinely having nothing to show
+    // (#11367): with rows on screen — live or seeded from the last-known
+    // snapshot — a root failure renders inline above them instead, in the
+    // populated branch below. An error must never blank a populated tree.
+    if (rootError !== null && rows.length === 0) {
       return (
         <div className="p-2">
           <InlineStatusBanner
@@ -575,6 +620,21 @@ export function FileBrowserPane({
 
     return (
       <>
+        {/* A root failure with a tree on screen: the banner sits above the
+            rows rather than replacing them (same shape as FilePane's stale
+            strip), so the last-known files stay usable while the error is
+            visible and retryable. */}
+        {rootError !== null && (
+          <div className="shrink-0 p-2">
+            <InlineStatusBanner
+              severity="error"
+              icon={FolderTree}
+              title={rootPath ? "Couldn't refresh this folder" : "Couldn't refresh this worktree"}
+              description={`Showing the last known files. ${rootError}`}
+              action={{ id: "retry", label: "Retry", onClick: handleRefresh }}
+            />
+          </div>
+        )}
         <FileTreeView
           rows={rows}
           selectedPath={selectedPath}

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -395,7 +395,7 @@ describe("last-known tree capture (#11367)", () => {
     expect(flushPanelPersistenceMock).toHaveBeenCalled();
   });
 
-  it("captures on unmount so dialog → grid promotion re-seeds the same panel id", () => {
+  it("captures the outgoing tree on unmount for the next restore", () => {
     treeState.captureSnapshot = () => snapshot;
     const { unmount } = renderPane();
     unmount();

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, act, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // FileBrowserPane hosts the tree column beside the viewer. #11328 adds a
 // collapse toggle (in the viewer's header) that unmounts the tree column and a
@@ -9,10 +9,43 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // FileBrowserViewer so the toggle and the shared toolbar `Root` actually render
 // — that's what makes the aria-controls and header-alignment invariants real.
 
-const { setFileBrowserViewMock, readMock } = vi.hoisted(() => ({
-  setFileBrowserViewMock: vi.fn(),
-  readMock: vi.fn(),
-}));
+const { setFileBrowserViewMock, readMock, treeState, defaultRows } = vi.hoisted(() => {
+  const defaultRows = [
+    {
+      path: "src",
+      name: "src",
+      isDirectory: true,
+      depth: 0,
+      isExpanded: true,
+      isLoading: false,
+    },
+    // A file row so a selection can resolve a real viewer path.
+    {
+      path: "src/app.ts",
+      name: "app.ts",
+      isDirectory: false,
+      depth: 1,
+      isExpanded: false,
+      isLoading: false,
+    },
+  ];
+  return {
+    setFileBrowserViewMock: vi.fn(),
+    readMock: vi.fn(),
+    defaultRows,
+    // Mutable so individual tests can drive error/loading/capture states.
+    treeState: {
+      rows: defaultRows as typeof defaultRows,
+      isInitialLoading: false,
+      rootError: null as string | null,
+      hasHiddenDotfiles: false,
+      ensureLoaded: vi.fn(),
+      refresh: vi.fn(),
+      isRefreshing: false,
+      captureSnapshot: (() => null) as () => unknown,
+    },
+  };
+});
 
 interface MockPanel {
   id: string;
@@ -44,37 +77,20 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
     }),
 }));
 
-// The tree data hook does real IPC + virtualization; stub it to a single row so
-// the tree column renders its header (and the FileTreeView stub below), without
-// touching filesClient.
+// The tree data hook does real IPC + virtualization; stub it to a mutable
+// state bag so the tree column renders its header (and the FileTreeView stub
+// below) without touching filesClient, and tests can drive error states.
 vi.mock("../useFileBrowserTree", () => ({
-  useFileBrowserTree: () => ({
-    rows: [
-      {
-        path: "src",
-        name: "src",
-        isDirectory: true,
-        depth: 0,
-        isExpanded: true,
-        isLoading: false,
-      },
-      // A file row so a selection can resolve a real viewer path.
-      {
-        path: "src/app.ts",
-        name: "app.ts",
-        isDirectory: false,
-        depth: 1,
-        isExpanded: false,
-        isLoading: false,
-      },
-    ],
-    isInitialLoading: false,
-    rootError: null,
-    hasHiddenDotfiles: false,
-    ensureLoaded: vi.fn(),
-    refresh: vi.fn(),
-    isRefreshing: false,
-  }),
+  useFileBrowserTree: () => ({ ...treeState }),
+}));
+
+// The pane flushes panel persistence when the view hides; the real module
+// drags the whole store graph into the suite.
+const { flushPanelPersistenceMock } = vi.hoisted(() => ({
+  flushPanelPersistenceMock: vi.fn(),
+}));
+vi.mock("@/store/slices", () => ({
+  flushPanelPersistence: flushPanelPersistenceMock,
 }));
 
 vi.mock("../FileTreeView", () => ({
@@ -125,6 +141,11 @@ beforeEach(() => {
   setFileBrowserViewMock.mockReset();
   readMock.mockReset();
   readMock.mockResolvedValue({ content: "hello" });
+  flushPanelPersistenceMock.mockReset();
+  treeState.rows = defaultRows;
+  treeState.rootError = null;
+  treeState.isInitialLoading = false;
+  treeState.captureSnapshot = () => null;
   mockPanel.browserSidebarCollapsed = undefined;
   mockPanel.browserSelectedPath = undefined;
   mockPanel.browserRootPath = undefined;
@@ -315,5 +336,82 @@ describe("FileBrowserPane collapsible sidebar (#11328)", () => {
     // The single persistent Root keeps the same toggle node, so focus survives
     // the tree column unmounting rather than falling to <body>.
     expect(document.activeElement).toBe(screen.getByTestId("file-browser-sidebar-toggle"));
+  });
+});
+
+describe("root error rendering (#11367)", () => {
+  it("renders the error inline above a populated tree rather than replacing it", () => {
+    treeState.rootError = "boom";
+    renderPane();
+
+    // Both at once: the banner names a refresh failure, the last-known rows
+    // stay on screen beneath it.
+    expect(screen.getByText("Couldn't refresh this worktree")).toBeTruthy();
+    expect(screen.getByTestId("file-tree-view")).toBeTruthy();
+  });
+
+  it("keeps the full-pane error when there are genuinely no rows to show", () => {
+    treeState.rootError = "boom";
+    treeState.rows = [];
+    renderPane();
+
+    expect(screen.getByText("Couldn't read this worktree")).toBeTruthy();
+    expect(screen.queryByTestId("file-tree-view")).toBeNull();
+  });
+});
+
+describe("last-known tree capture (#11367)", () => {
+  const snapshot = {
+    worktreeId: "wt-1",
+    rootPath: "",
+    listings: [{ dirPath: "", nodes: [{ name: "src", path: "src", isDirectory: true }] }],
+  };
+
+  function hideDocument() {
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+  });
+
+  it("captures and flushes when the view hides — the going-away point that precedes eviction", () => {
+    treeState.captureSnapshot = () => snapshot;
+    renderPane();
+    expect(setFileBrowserViewMock).not.toHaveBeenCalledWith("fb-1", {
+      browserTreeSnapshot: snapshot,
+    });
+
+    hideDocument();
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserTreeSnapshot: snapshot,
+    });
+    // The hidden renderer may be torn down before the 500ms persistence
+    // debounce fires; the flush is what makes this save real on app quit.
+    expect(flushPanelPersistenceMock).toHaveBeenCalled();
+  });
+
+  it("captures on unmount so dialog → grid promotion re-seeds the same panel id", () => {
+    treeState.captureSnapshot = () => snapshot;
+    const { unmount } = renderPane();
+    unmount();
+
+    expect(setFileBrowserViewMock).toHaveBeenCalledWith("fb-1", {
+      browserTreeSnapshot: snapshot,
+    });
+  });
+
+  it("writes nothing when there is nothing worth keeping", () => {
+    treeState.captureSnapshot = () => null;
+    const { unmount } = renderPane();
+    hideDocument();
+    unmount();
+
+    // A null capture must not clobber a previously persisted snapshot.
+    expect(setFileBrowserViewMock).not.toHaveBeenCalled();
   });
 });

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -6,10 +6,14 @@ import {
   createVisibilityFilter,
   flattenTree,
   isRowPathVisible,
+  listingsFromSnapshot,
+  MAX_SNAPSHOT_LISTINGS,
+  MAX_SNAPSHOT_NODES,
   parentRootPath,
   pruneListings,
   refreshTargets,
   resolveTreeKey,
+  snapshotFromListings,
   type FlatTreeRow,
 } from "../fileBrowserTree";
 
@@ -475,5 +479,107 @@ describe("isRowPathVisible", () => {
   it("treats the root itself as visible — the pump gate must never drop the root target", () => {
     expect(isRowPathVisible("src", "src", showAll)).toBe(true);
     expect(isRowPathVisible(".github", ".github", hideDotfiles)).toBe(true);
+  });
+});
+
+describe("snapshotFromListings", () => {
+  it("captures structure only — size and children never reach the snapshot", () => {
+    const listings = listingsOf({
+      "": [dir("src"), file("README.md", { size: 1234 })],
+      src: [{ name: "app.ts", path: "src/app.ts", isDirectory: false, size: 99, children: [] }],
+    });
+
+    const snapshot = snapshotFromListings(listings, "wt-1", "");
+
+    expect(snapshot).toEqual({
+      worktreeId: "wt-1",
+      rootPath: "",
+      listings: [
+        {
+          dirPath: "",
+          nodes: [
+            { name: "src", path: "src", isDirectory: true },
+            { name: "README.md", path: "README.md", isDirectory: false },
+          ],
+        },
+        {
+          dirPath: "src",
+          nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }],
+        },
+      ],
+    });
+  });
+
+  it("returns null before the root listing has ever arrived", () => {
+    // Only a non-root directory somehow present: nothing worth painting from.
+    expect(snapshotFromListings(listingsOf({ src: [file("src/app.ts")] }), "wt-1", "")).toBeNull();
+    expect(snapshotFromListings(new Map(), "wt-1", "")).toBeNull();
+  });
+
+  it("keeps an empty root listing — an empty worktree is a real last-known state", () => {
+    const snapshot = snapshotFromListings(listingsOf({ "": [] }), "wt-1", "");
+    expect(snapshot).toEqual({
+      worktreeId: "wt-1",
+      rootPath: "",
+      listings: [{ dirPath: "", nodes: [] }],
+    });
+  });
+
+  it("sorts entries by path so identical content is deep-equal regardless of insertion order", () => {
+    const a = new Map([
+      ["", [dir("src"), dir("lib")]],
+      ["src", [file("src/a.ts")]],
+      ["lib", [file("lib/b.ts")]],
+    ]);
+    const b = new Map([
+      ["lib", [file("lib/b.ts")]],
+      ["", [dir("src"), dir("lib")]],
+      ["src", [file("src/a.ts")]],
+    ]);
+
+    // The persistence layer's dirty diff depends on this to skip no-op writes.
+    expect(snapshotFromListings(a, "wt-1", "")).toEqual(snapshotFromListings(b, "wt-1", ""));
+  });
+
+  it("returns null rather than truncating when the tree exceeds the persistence bounds", () => {
+    const wideRoot = listingsOf({
+      "": Array.from({ length: MAX_SNAPSHOT_NODES + 1 }, (_, i) => file(`f-${i}`)),
+    });
+    expect(snapshotFromListings(wideRoot, "wt-1", "")).toBeNull();
+
+    const manyListings = new Map([
+      ["", [dir("d-0")]],
+      ...Array.from({ length: MAX_SNAPSHOT_LISTINGS }, (_, i): [string, FileTreeNode[]] => [
+        `d-${i}`,
+        [],
+      ]),
+    ]);
+    expect(snapshotFromListings(manyListings, "wt-1", "")).toBeNull();
+  });
+
+  it("captures relative to a re-rooted browse root", () => {
+    const listings = listingsOf({ src: [file("src/app.ts")] });
+    const snapshot = snapshotFromListings(listings, "wt-1", "src");
+    expect(snapshot?.rootPath).toBe("src");
+    expect(snapshot?.listings).toEqual([
+      { dirPath: "src", nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }] },
+    ]);
+  });
+});
+
+describe("listingsFromSnapshot", () => {
+  it("round-trips a captured snapshot back into a renderable listings map", () => {
+    const listings = listingsOf({
+      "": [dir("src"), file("README.md")],
+      src: [file("src/app.ts")],
+    });
+
+    const snapshot = snapshotFromListings(listings, "wt-1", "");
+    const restored = listingsFromSnapshot(snapshot!);
+
+    // The restored map must flatten to the same rows the live tree showed.
+    expect(pathsOf(flattenTree(restored, new Set(["src"]), new Set()))).toEqual(
+      pathsOf(flattenTree(listings, new Set(["src"]), new Set()))
+    );
   });
 });

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -9,6 +9,7 @@ import {
   listingsFromSnapshot,
   MAX_SNAPSHOT_LISTINGS,
   MAX_SNAPSHOT_NODES,
+  MAX_SNAPSHOT_TEXT_CHARS,
   parentRootPath,
   pruneListings,
   refreshTargets,
@@ -555,6 +556,16 @@ describe("snapshotFromListings", () => {
       ]),
     ]);
     expect(snapshotFromListings(manyListings, "wt-1", "")).toBeNull();
+  });
+
+  it("returns null when aggregate text exceeds the byte budget, independent of node count", () => {
+    // Counts alone don't bound serialized size — a few hundred long paths
+    // must trip the text budget well before the 10k-node cap.
+    const longName = "n".repeat(Math.ceil(MAX_SNAPSHOT_TEXT_CHARS / 100));
+    const listings = listingsOf({
+      "": Array.from({ length: 100 }, (_, i) => file(`${longName}-${i}`)),
+    });
+    expect(snapshotFromListings(listings, "wt-1", "")).toBeNull();
   });
 
   it("captures relative to a re-rooted browse root", () => {

--- a/src/panels/file-browser/__tests__/serializer.test.ts
+++ b/src/panels/file-browser/__tests__/serializer.test.ts
@@ -95,6 +95,26 @@ describe("serializeFileBrowser", () => {
     expect(serializeFileBrowser(open)).toEqual({});
     expect(serializeFileBrowser(basePanel)).toEqual({});
   });
+
+  it("round-trips the last-known tree snapshot (#11367)", () => {
+    const treeSnapshot = {
+      worktreeId: "wt-1",
+      rootPath: "",
+      listings: [
+        {
+          dirPath: "",
+          nodes: [{ name: "src", path: "src", isDirectory: true }],
+        },
+      ],
+    };
+    const panel: FileBrowserPanelData = { ...basePanel, browserTreeSnapshot: treeSnapshot };
+
+    const restored = createFileBrowserDefaults(asOptions(serializeFileBrowser(panel)));
+
+    expect(restored).toEqual({ browserTreeSnapshot: treeSnapshot });
+    // A panel that never captured one stays sparse.
+    expect(serializeFileBrowser(basePanel)).toEqual({});
+  });
 });
 
 describe("createFileBrowserDefaults", () => {

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type { FileTreeNode } from "@shared/types";
 import type { FileBrowserListDirectoryPayload } from "@shared/types/ipc/fileBrowser";
 import { useFileBrowserTree } from "../useFileBrowserTree";
@@ -1199,6 +1199,31 @@ describe("stale-while-revalidate seeding (#11367)", () => {
     expect(result.current.isInitialLoading).toBe(false);
   });
 
+  it("has the seeded rows in the very first render pass — not one loading frame later", () => {
+    listDirectory.mockReturnValue(deferred<FileTreeNode[]>().promise);
+
+    // Observed at render time, not through renderHook's result: passive
+    // effects have already flushed by the time result.current is readable,
+    // so an effect-only seed (one blank committed frame — the flash #11367
+    // removes) would be invisible to an after-the-fact assertion.
+    const renderPasses: string[][] = [];
+    function Probe() {
+      const { rows } = useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: ["src"],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        treeSnapshot: snapshot,
+      });
+      renderPasses.push(rows.map((row) => row.path));
+      return null;
+    }
+    render(<Probe />);
+
+    expect(renderPasses[0]).toEqual(["src", "src/app.ts", "README.md"]);
+  });
+
   it("ignores a snapshot captured under another identity and cold-starts as before", () => {
     listDirectory.mockReturnValue(deferred<FileTreeNode[]>().promise);
 
@@ -1331,6 +1356,61 @@ describe("stale-while-revalidate seeding (#11367)", () => {
         "src/app.ts",
         "README.md",
       ]);
+    });
+
+    it("promotes the root retry ahead of a saturated descendant backlog", async () => {
+      // A wide seeded restore: 10 expanded directories revalidate alongside
+      // the root, overflowing the 6-slot concurrency ceiling so a backlog is
+      // queued when the root's retry fires. The retry must jump that queue —
+      // appended at the tail it would wait out hundreds of listings and gut
+      // the 150/400/800ms schedule.
+      const dirNames = Array.from({ length: 10 }, (_, i) => `d${i}`);
+      const dirDeferreds = new Map(dirNames.map((name) => [name, deferred<FileTreeNode[]>()]));
+      let rootAttempts = 0;
+      listDirectory.mockImplementation(({ dirPath }) => {
+        if (dirPath === undefined) {
+          rootAttempts += 1;
+          return rootAttempts === 1
+            ? Promise.reject(new Error("transient"))
+            : Promise.resolve(dirNames.map((name) => dir(name)));
+        }
+        return dirDeferreds.get(dirPath)!.promise;
+      });
+
+      renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: dirNames,
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          treeSnapshot: {
+            worktreeId: "wt-1",
+            rootPath: "",
+            listings: [
+              {
+                dirPath: "",
+                nodes: dirNames.map((name) => ({ name, path: name, isDirectory: true })),
+              },
+            ],
+          },
+        })
+      );
+
+      // Root + d0..d4 fill the 6 slots; the root's failure frees one, so d5
+      // starts; d6..d9 remain queued when the 150ms retry fires.
+      await flush();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+      const callsBeforeSlotFrees = listDirectory.mock.calls.length;
+
+      // Freeing one slot must start the promoted ROOT retry, not d6.
+      await act(async () => {
+        dirDeferreds.get("d0")!.resolve([]);
+      });
+      const nextCall = listDirectory.mock.calls[callsBeforeSlotFrees];
+      expect(nextCall?.[0].dirPath).toBeUndefined();
     });
   });
 });

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -1138,3 +1138,199 @@ describe("useFileBrowserTree", () => {
     expect(result.current.isRefreshing).toBe(false);
   });
 });
+
+describe("stale-while-revalidate seeding (#11367)", () => {
+  beforeEach(() => {
+    listDirectory.mockReset();
+  });
+
+  const snapshot = {
+    worktreeId: "wt-1",
+    rootPath: "",
+    listings: [
+      {
+        dirPath: "",
+        nodes: [
+          { name: "src", path: "src", isDirectory: true },
+          { name: "README.md", path: "README.md", isDirectory: false },
+        ],
+      },
+      {
+        dirPath: "src",
+        nodes: [{ name: "app.ts", path: "src/app.ts", isDirectory: false }],
+      },
+    ],
+  };
+
+  it("paints seeded rows instantly and revalidates the root plus seeded expanded directories", async () => {
+    const root = deferred<FileTreeNode[]>();
+    const src = deferred<FileTreeNode[]>();
+    listDirectory.mockImplementation(({ dirPath }) =>
+      dirPath === undefined ? root.promise : src.promise
+    );
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: ["src"],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        treeSnapshot: snapshot,
+      })
+    );
+
+    // The whole last-known tree is on screen before any listing resolves —
+    // no skeleton, and both painted directories are already revalidating.
+    expect(result.current.isInitialLoading).toBe(false);
+    expect(result.current.rows.map((row) => row.path)).toEqual(["src", "src/app.ts", "README.md"]);
+    expect(listDirectory).toHaveBeenCalledTimes(2);
+    expect(listDirectory.mock.calls.map(([payload]) => payload.dirPath)).toEqual([
+      undefined,
+      "src",
+    ]);
+
+    // Live results replace the stale seed as they land.
+    await act(async () => {
+      root.resolve([dir("src"), file("CHANGED.md")]);
+      src.resolve([file("src/new.ts")]);
+    });
+    expect(result.current.rows.map((row) => row.path)).toEqual(["src", "src/new.ts", "CHANGED.md"]);
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+
+  it("ignores a snapshot captured under another identity and cold-starts as before", () => {
+    listDirectory.mockReturnValue(deferred<FileTreeNode[]>().promise);
+
+    const otherWorktree = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-2",
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+        treeSnapshot: snapshot,
+      })
+    );
+    expect(otherWorktree.result.current.isInitialLoading).toBe(true);
+    expect(otherWorktree.result.current.rows).toEqual([]);
+
+    const otherRoot = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        rootPath: "src",
+        changeTick: undefined,
+        treeSnapshot: snapshot,
+      })
+    );
+    expect(otherRoot.result.current.isInitialLoading).toBe(true);
+    expect(otherRoot.result.current.rows).toEqual([]);
+  });
+
+  it("captures a structure-only snapshot of the loaded tree, and nothing before the root lands", async () => {
+    const slow = deferred<FileTreeNode[]>();
+    listDirectory.mockReturnValue(slow.promise);
+
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: "wt-1",
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+      })
+    );
+
+    // Nothing worth keeping yet — a capture here must not clobber a previous
+    // snapshot with an empty one.
+    expect(result.current.captureSnapshot()).toBeNull();
+
+    await act(async () => {
+      slow.resolve([
+        { name: "big.bin", path: "big.bin", isDirectory: false, size: 4096 },
+        dir("src"),
+      ]);
+    });
+
+    // Size is filesystem metadata, not structure — it must not persist.
+    expect(result.current.captureSnapshot()).toEqual({
+      worktreeId: "wt-1",
+      rootPath: "",
+      listings: [
+        {
+          dirPath: "",
+          nodes: [
+            { name: "big.bin", path: "big.bin", isDirectory: false },
+            { name: "src", path: "src", isDirectory: true },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("captures nothing without a worktree", () => {
+    const { result } = renderHook(() =>
+      useFileBrowserTree({
+        worktreeId: undefined,
+        expandedPaths: [],
+        hideDotfiles: false,
+        alwaysHiddenPatterns: [],
+        changeTick: undefined,
+      })
+    );
+    expect(result.current.captureSnapshot()).toBeNull();
+  });
+
+  describe("root failure over a seeded tree", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    async function flush() {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    it("keeps the seeded rows on screen when the whole retry budget fails — the error joins the tree instead of replacing it", async () => {
+      listDirectory.mockRejectedValue(new Error("host still repointing"));
+
+      const { result } = renderHook(() =>
+        useFileBrowserTree({
+          worktreeId: "wt-1",
+          expandedPaths: ["src"],
+          hideDotfiles: false,
+          alwaysHiddenPatterns: [],
+          changeTick: undefined,
+          treeSnapshot: snapshot,
+        })
+      );
+
+      // Seeded immediately; the failing revalidation never blanks it.
+      expect(result.current.rows.length).toBeGreaterThan(0);
+      await flush();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+        await vi.advanceTimersByTimeAsync(400);
+        await vi.advanceTimersByTimeAsync(800);
+      });
+
+      expect(result.current.rootError).toContain("host still repointing");
+      expect(result.current.isInitialLoading).toBe(false);
+      expect(result.current.rows.map((row) => row.path)).toEqual([
+        "src",
+        "src/app.ts",
+        "README.md",
+      ]);
+    });
+  });
+});

--- a/src/panels/file-browser/defaults.ts
+++ b/src/panels/file-browser/defaults.ts
@@ -26,5 +26,8 @@ export function createFileBrowserDefaults(
     // Only a collapsed sidebar materializes a field: `false` and absent are the
     // same open state, so we never stamp a default the serializer then drops.
     ...(options.browserSidebarCollapsed === true && { browserSidebarCollapsed: true }),
+    ...(options.browserTreeSnapshot != null && {
+      browserTreeSnapshot: options.browserTreeSnapshot,
+    }),
   };
 }

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -339,6 +339,9 @@ export function snapshotFromListings(
   for (const [dirPath, nodes] of listings) {
     totalNodes += nodes.length;
     if (totalNodes > MAX_SNAPSHOT_NODES) return null;
+    // Listing keys count against the budget too — 500 deep dirPaths carry
+    // real bytes even with few nodes.
+    totalChars += dirPath.length;
     for (const node of nodes) {
       totalChars += node.name.length + node.path.length;
     }

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -1,4 +1,5 @@
 import type { FileTreeNode } from "@shared/types";
+import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
 
 /**
  * One rendered line of the tree. The tree is rendered as a flat array rather
@@ -298,6 +299,66 @@ export function pruneListings(
     if (dirPath === rootPath || expandedPaths.has(dirPath)) next.set(dirPath, nodes);
   }
   return next;
+}
+
+/**
+ * Bounds on a persisted tree snapshot (#11367). Listings mirror
+ * `MAX_RESTORED_EXPANDED_PATHS` (the snapshot only ever holds the root plus
+ * expanded directories); the node cap keeps a pathologically wide tree from
+ * bloating the panel record. Capture returns null rather than truncating —
+ * a partial directory presented as complete would be a lie the refresh can't
+ * distinguish from a deletion — leaving any previous snapshot in place.
+ */
+export const MAX_SNAPSHOT_LISTINGS = 500;
+export const MAX_SNAPSHOT_NODES = 10_000;
+
+/**
+ * Structure-only snapshot of the current listings for persistence (#11367):
+ * names, paths and directory bits — `size` and `children` are deliberately
+ * dropped. Null when there is nothing worth keeping (root never loaded) or
+ * the tree exceeds the persistence bounds. Entries are sorted by path so two
+ * captures of identical content are deep-equal regardless of Map insertion
+ * order — the persistence layer's dirty diff relies on that to skip no-op
+ * writes.
+ */
+export function snapshotFromListings(
+  listings: DirectoryListings,
+  worktreeId: string,
+  rootPath: string
+): FileBrowserTreeSnapshot | null {
+  if (!listings.has(rootPath)) return null;
+  if (listings.size > MAX_SNAPSHOT_LISTINGS) return null;
+  let totalNodes = 0;
+  const entries: FileBrowserTreeSnapshot["listings"] = [];
+  for (const [dirPath, nodes] of listings) {
+    totalNodes += nodes.length;
+    if (totalNodes > MAX_SNAPSHOT_NODES) return null;
+    entries.push({
+      dirPath,
+      nodes: nodes.map((node) => ({
+        name: node.name,
+        path: node.path,
+        isDirectory: node.isDirectory,
+      })),
+    });
+  }
+  entries.sort((a, b) => (a.dirPath < b.dirPath ? -1 : a.dirPath > b.dirPath ? 1 : 0));
+  return { worktreeId, rootPath, listings: entries };
+}
+
+/**
+ * Rebuild a listings map from a persisted snapshot. The snapshot nodes are
+ * already structure-only, so they slot directly into the `FileTreeNode` shape
+ * the tree renders from (`size`/`children` are optional there).
+ */
+export function listingsFromSnapshot(
+  snapshot: FileBrowserTreeSnapshot
+): Map<string, readonly FileTreeNode[]> {
+  const listings = new Map<string, readonly FileTreeNode[]>();
+  for (const entry of snapshot.listings) {
+    listings.set(entry.dirPath, entry.nodes);
+  }
+  return listings;
 }
 
 /**

--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -305,12 +305,17 @@ export function pruneListings(
  * Bounds on a persisted tree snapshot (#11367). Listings mirror
  * `MAX_RESTORED_EXPANDED_PATHS` (the snapshot only ever holds the root plus
  * expanded directories); the node cap keeps a pathologically wide tree from
- * bloating the panel record. Capture returns null rather than truncating —
- * a partial directory presented as complete would be a lie the refresh can't
- * distinguish from a deletion — leaving any previous snapshot in place.
+ * bloating the panel record, and the text budget bounds the *bytes* the
+ * counts alone would not — 10k nodes of 4k-character paths would be tens of
+ * megabytes serialized into every project-state save. Capture returns null
+ * rather than truncating — a partial directory presented as complete would
+ * be a lie the refresh can't distinguish from a deletion — leaving any
+ * previous snapshot in place.
  */
 export const MAX_SNAPSHOT_LISTINGS = 500;
 export const MAX_SNAPSHOT_NODES = 10_000;
+/** Aggregate cap on name+path characters across the whole snapshot (~1MB UTF-16). */
+export const MAX_SNAPSHOT_TEXT_CHARS = 512_000;
 
 /**
  * Structure-only snapshot of the current listings for persistence (#11367):
@@ -329,10 +334,15 @@ export function snapshotFromListings(
   if (!listings.has(rootPath)) return null;
   if (listings.size > MAX_SNAPSHOT_LISTINGS) return null;
   let totalNodes = 0;
+  let totalChars = 0;
   const entries: FileBrowserTreeSnapshot["listings"] = [];
   for (const [dirPath, nodes] of listings) {
     totalNodes += nodes.length;
     if (totalNodes > MAX_SNAPSHOT_NODES) return null;
+    for (const node of nodes) {
+      totalChars += node.name.length + node.path.length;
+    }
+    if (totalChars > MAX_SNAPSHOT_TEXT_CHARS) return null;
     entries.push({
       dirPath,
       nodes: nodes.map((node) => ({

--- a/src/panels/file-browser/serializer.ts
+++ b/src/panels/file-browser/serializer.ts
@@ -4,9 +4,11 @@ import type { PanelSnapshot } from "@shared/types/project";
 /**
  * Every field persists, unlike the diff panel's runtime-only change set: the
  * issue's contract is that a pinned browser keeps its root, expansion,
- * selection and layout, all user intent rather than derived data. A path that
- * has since been deleted simply doesn't resolve to a row on restore, which is
- * the same outcome as never having expanded it.
+ * selection and layout, all user intent rather than derived data — plus the
+ * last-known tree snapshot (#11367), the one derived field, which must ride
+ * persistence because it exists precisely to outlive the renderer. A path
+ * that has since been deleted simply doesn't resolve to a row on restore,
+ * which is the same outcome as never having expanded it.
  */
 export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnapshot> {
   return {
@@ -19,5 +21,6 @@ export function serializeFileBrowser(t: FileBrowserPanelData): Partial<PanelSnap
     // Truthiness, not `!= null`: `false` is the default open state, the same as
     // the field being absent, so only a collapsed sidebar earns a persisted bit.
     ...(t.browserSidebarCollapsed ? { browserSidebarCollapsed: true } : {}),
+    ...(t.browserTreeSnapshot != null && { browserTreeSnapshot: t.browserTreeSnapshot }),
   };
 }

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -142,7 +142,15 @@ export function useFileBrowserTree({
   changeTick,
   treeSnapshot,
 }: UseFileBrowserTreeArgs): UseFileBrowserTreeResult {
-  const [listings, setListings] = useState<Map<string, readonly FileTreeNode[]>>(new Map());
+  // Seeded via lazy initializers, not just the identity effect: passive
+  // effects run after paint, so an effect-only seed would commit one loading
+  // frame before the last-known tree appears — the exact flash #11367 exists
+  // to remove. The initializers read props (immutable for this render), so
+  // StrictMode's double-invoke is harmless; identity *changes* re-seed in the
+  // identity-reset effect below.
+  const [listings, setListings] = useState<Map<string, readonly FileTreeNode[]>>(
+    () => seedListings(treeSnapshot, worktreeId, rootPath) ?? new Map()
+  );
   const [loadingPaths, setLoadingPaths] = useState<ReadonlySet<string>>(new Set());
   const [rootError, setRootError] = useState<string | null>(null);
   const [hasLoadedRoot, setHasLoadedRoot] = useState(false);
@@ -150,7 +158,9 @@ export function useFileBrowserTree({
   // snapshot (#11367). Distinct from `hasLoadedRoot`, which stays false until
   // the *live* root lands: the seeded tree suppresses the skeleton, while
   // change-tick deferral and the expansion effect still wait for real data.
-  const [hasSeededRoot, setHasSeededRoot] = useState(false);
+  const [hasSeededRoot, setHasSeededRoot] = useState(
+    () => seedListings(treeSnapshot, worktreeId, rootPath) !== null
+  );
   // True from a manual refresh press until its listings fully drain. A ref
   // mirrors it so the drain check in `pump` (which runs off refs, not state)
   // can decide whether a completed drain belongs to a manual refresh.
@@ -318,7 +328,15 @@ export function useFileBrowserTree({
               // fetchDirectory directly: it dedups against any root work a manual
               // refresh already queued or put in flight, and honours the
               // concurrency ceiling instead of firing a seventh request past it.
-              enqueueTargets([rootPath], generation);
+              // Front of the queue, though — a seeded restore can have hundreds
+              // of descendant re-lists waiting, and the backoff schedule's whole
+              // point is resolving the root's fate quickly (#11367).
+              if (
+                !inFlightRef.current.has(rootPath) &&
+                !queueRef.current.some((entry) => entry.dirPath === rootPath)
+              ) {
+                queueRef.current.unshift({ dirPath: rootPath, generation });
+              }
               pumpRef.current();
             }, delay);
             rootRetryTimerRef.current = handle;
@@ -349,7 +367,7 @@ export function useFileBrowserTree({
         pumpRef.current();
       }
     },
-    [worktreeId, rootPath, clearRootRetryTimer, resetRootRetryState, enqueueTargets]
+    [worktreeId, rootPath, clearRootRetryTimer, resetRootRetryState]
   );
 
   const pump = useCallback((): void => {
@@ -495,23 +513,18 @@ export function useFileBrowserTree({
     // Stale-while-revalidate (#11367): a persisted snapshot captured under
     // this exact identity seeds the listings so the tree paints instantly;
     // anything else — no snapshot, another worktree, another root — starts
-    // from the empty map and the skeleton, exactly as before.
-    const snapshot = treeSnapshotRef.current;
-    const seeded =
-      worktreeId !== undefined &&
-      snapshot !== undefined &&
-      snapshot.worktreeId === worktreeId &&
-      snapshot.rootPath === rootPath
-        ? listingsFromSnapshot(snapshot)
-        : null;
-    const seededRoot = seeded !== null && seeded.has(rootPath);
-    setListings(seededRoot ? seeded : new Map());
+    // from the empty map and the skeleton, exactly as before. On mount this
+    // re-derives what the lazy initializers already seeded (same content),
+    // which keeps a single code path for mount and identity change.
+    const seeded = seedListings(treeSnapshotRef.current, worktreeId, rootPath);
+    const seededRoot = seeded !== null;
+    setListings(seeded ?? new Map());
     setLoadingPaths(new Set());
     setRootError(null);
     setHasLoadedRoot(false);
     setHasSeededRoot(seededRoot);
     if (!worktreeId) return;
-    if (seededRoot) {
+    if (seeded !== null) {
       // Revalidate everything the seed painted — the root plus every seeded
       // expanded directory — through the shared queue so a wide restored tree
       // honours the concurrency ceiling. The refs read here are published in a
@@ -603,6 +616,28 @@ export function useFileBrowserTree({
     isRefreshing,
     captureSnapshot,
   };
+}
+
+/**
+ * The listings to seed a fresh identity from, or null to cold-start: the
+ * snapshot must exist, match the identity it was captured under exactly, and
+ * carry its own root listing (#11367).
+ */
+function seedListings(
+  snapshot: FileBrowserTreeSnapshot | undefined,
+  worktreeId: string | undefined,
+  rootPath: string
+): Map<string, readonly FileTreeNode[]> | null {
+  if (
+    worktreeId === undefined ||
+    snapshot === undefined ||
+    snapshot.worktreeId !== worktreeId ||
+    snapshot.rootPath !== rootPath
+  ) {
+    return null;
+  }
+  const seeded = listingsFromSnapshot(snapshot);
+  return seeded.has(rootPath) ? seeded : null;
 }
 
 /**

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FileTreeNode } from "@shared/types";
+import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
 import { fileBrowserClient } from "@/clients/fileBrowserClient";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -7,8 +8,10 @@ import {
   createVisibilityFilter,
   flattenTree,
   isRowPathVisible,
+  listingsFromSnapshot,
   pruneListings,
   refreshTargets,
+  snapshotFromListings,
   type FlatTreeRow,
 } from "./fileBrowserTree";
 
@@ -61,6 +64,13 @@ export interface UseFileBrowserTreeArgs {
    * hundreds — the tree does not need its own debounce on top.
    */
   changeTick: number | undefined;
+  /**
+   * Last-known tree structure from the panel record (#11367). When it matches
+   * the current identity, the identity reset seeds the listings from it and
+   * paints instantly while the live refresh runs; a mismatch (other worktree,
+   * other root) is ignored and the tree cold-starts as before.
+   */
+  treeSnapshot?: FileBrowserTreeSnapshot;
 }
 
 export interface UseFileBrowserTreeResult {
@@ -89,6 +99,14 @@ export interface UseFileBrowserTreeResult {
    * the button doesn't spin on every filesystem change.
    */
   isRefreshing: boolean;
+  /**
+   * Structure-only snapshot of the current tree for persistence (#11367), or
+   * null when there is nothing worth keeping (root never loaded, or the tree
+   * exceeds the persistence bounds). Synchronous and side-effect free — the
+   * pane calls it at going-away points (view hidden, unmount), never on a
+   * change tick, so persistence writes stay off the refresh path.
+   */
+  captureSnapshot: () => FileBrowserTreeSnapshot | null;
 }
 
 interface QueueEntry {
@@ -122,11 +140,17 @@ export function useFileBrowserTree({
   alwaysHiddenPatterns,
   rootPath = "",
   changeTick,
+  treeSnapshot,
 }: UseFileBrowserTreeArgs): UseFileBrowserTreeResult {
   const [listings, setListings] = useState<Map<string, readonly FileTreeNode[]>>(new Map());
   const [loadingPaths, setLoadingPaths] = useState<ReadonlySet<string>>(new Set());
   const [rootError, setRootError] = useState<string | null>(null);
   const [hasLoadedRoot, setHasLoadedRoot] = useState(false);
+  // True when the current identity's listings were seeded from a persisted
+  // snapshot (#11367). Distinct from `hasLoadedRoot`, which stays false until
+  // the *live* root lands: the seeded tree suppresses the skeleton, while
+  // change-tick deferral and the expansion effect still wait for real data.
+  const [hasSeededRoot, setHasSeededRoot] = useState(false);
   // True from a manual refresh press until its listings fully drain. A ref
   // mirrors it so the drain check in `pump` (which runs off refs, not state)
   // can decide whether a completed drain belongs to a manual refresh.
@@ -169,6 +193,12 @@ export function useFileBrowserTree({
 
   const expandedSet = useMemo(() => new Set(expandedPaths), [expandedPaths]);
   const expandedSetRef = useRef(expandedSet);
+
+  // Latest persisted snapshot, read only inside the identity-reset effect. A
+  // ref rather than a dependency: capture writes a fresh snapshot object into
+  // the panel record on every hide, and re-running the identity reset for it
+  // would wipe the live tree the snapshot was just taken of.
+  const treeSnapshotRef = useRef(treeSnapshot);
 
   // Per-entry visibility for the current junk list + dotfile toggle. Filters
   // rows at render time, but is also read by the fetch machinery (through
@@ -378,7 +408,8 @@ export function useFileBrowserTree({
     expandedSetRef.current = expandedSet;
     isVisibleRef.current = isVisible;
     pumpRef.current = pump;
-  }, [listings, expandedSet, isVisible, pump]);
+    treeSnapshotRef.current = treeSnapshot;
+  }, [listings, expandedSet, isVisible, pump, treeSnapshot]);
 
   // Cancel a pending root retry synchronously when the identity changes or the
   // panel unmounts. The generation bump that would invalidate the retry lives in
@@ -461,13 +492,39 @@ export function useFileBrowserTree({
     // the icon stuck.
     isRefreshingRef.current = false;
     setIsRefreshing(false);
-    setListings(new Map());
+    // Stale-while-revalidate (#11367): a persisted snapshot captured under
+    // this exact identity seeds the listings so the tree paints instantly;
+    // anything else — no snapshot, another worktree, another root — starts
+    // from the empty map and the skeleton, exactly as before.
+    const snapshot = treeSnapshotRef.current;
+    const seeded =
+      worktreeId !== undefined &&
+      snapshot !== undefined &&
+      snapshot.worktreeId === worktreeId &&
+      snapshot.rootPath === rootPath
+        ? listingsFromSnapshot(snapshot)
+        : null;
+    const seededRoot = seeded !== null && seeded.has(rootPath);
+    setListings(seededRoot ? seeded : new Map());
     setLoadingPaths(new Set());
     setRootError(null);
     setHasLoadedRoot(false);
+    setHasSeededRoot(seededRoot);
     if (!worktreeId) return;
-    void fetchDirectory(rootPath, generationRef.current);
-  }, [worktreeId, rootPath, fetchDirectory, resetRootRetryState]);
+    if (seededRoot) {
+      // Revalidate everything the seed painted — the root plus every seeded
+      // expanded directory — through the shared queue so a wide restored tree
+      // honours the concurrency ceiling. The refs read here are published in a
+      // layout effect, so they are current before this passive effect runs.
+      enqueueTargets(
+        refreshTargets(seeded, expandedSetRef.current, rootPath, isVisibleRef.current),
+        generationRef.current
+      );
+      pumpRef.current();
+    } else {
+      void fetchDirectory(rootPath, generationRef.current);
+    }
+  }, [worktreeId, rootPath, fetchDirectory, resetRootRetryState, enqueueTargets]);
 
   // Expanding a directory is what triggers its fetch; a restored panel expands
   // several at once, and each is requested the first time it becomes visible.
@@ -529,14 +586,22 @@ export function useFileBrowserTree({
     return rootNodes.some((node) => node.name.startsWith(".") && notJunk(node.name));
   }, [listings, rootPath, alwaysHiddenPatterns]);
 
+  const captureSnapshot = useCallback((): FileBrowserTreeSnapshot | null => {
+    if (!worktreeId) return null;
+    return snapshotFromListings(listingsRef.current, worktreeId, rootPath);
+  }, [worktreeId, rootPath]);
+
   return {
     rows,
-    isInitialLoading: Boolean(worktreeId) && !hasLoadedRoot,
+    // A seeded tree is content, not loading: the skeleton is reserved for
+    // genuinely having nothing to paint (#11367).
+    isInitialLoading: Boolean(worktreeId) && !hasLoadedRoot && !hasSeededRoot,
     rootError,
     hasHiddenDotfiles,
     ensureLoaded,
     refresh,
     isRefreshing,
+    captureSnapshot,
   };
 }
 

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -330,11 +330,12 @@ export function useFileBrowserTree({
               // concurrency ceiling instead of firing a seventh request past it.
               // Front of the queue, though — a seeded restore can have hundreds
               // of descendant re-lists waiting, and the backoff schedule's whole
-              // point is resolving the root's fate quickly (#11367).
-              if (
-                !inFlightRef.current.has(rootPath) &&
-                !queueRef.current.some((entry) => entry.dirPath === rootPath)
-              ) {
+              // point is resolving the root's fate quickly (#11367). A root a
+              // manual refresh already queued mid-backoff is promoted rather
+              // than left at its tail position.
+              if (!inFlightRef.current.has(rootPath)) {
+                const queuedAt = queueRef.current.findIndex((entry) => entry.dirPath === rootPath);
+                if (queuedAt >= 0) queueRef.current.splice(queuedAt, 1);
                 queueRef.current.unshift({ dirPath: rootPath, generation });
               }
               pumpRef.current();

--- a/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/fileBrowser.test.ts
@@ -136,6 +136,33 @@ describe("setFileBrowserView", () => {
     expect(store.get().panelsById["panel-1"]).toBe(before);
   });
 
+  it("stores a tree snapshot and treats a deep-equal recapture as a no-op (#11367)", () => {
+    const snapshot = {
+      worktreeId: "wt-1",
+      rootPath: "",
+      listings: [{ dirPath: "", nodes: [{ name: "src", path: "src", isDirectory: true }] }],
+    };
+    setFileBrowserView("panel-1", { browserTreeSnapshot: snapshot });
+    expect(store.get().panelsById["panel-1"]).toMatchObject({ browserTreeSnapshot: snapshot });
+
+    // Capture builds a fresh object on every hide; identical content must not
+    // dirty the panel entry (and with it the persisted layout).
+    const before = store.get().panelsById["panel-1"];
+    setFileBrowserView("panel-1", {
+      browserTreeSnapshot: structuredClone(snapshot),
+    });
+    expect(store.get().panelsById["panel-1"]).toBe(before);
+
+    // Real structural change writes.
+    setFileBrowserView("panel-1", {
+      browserTreeSnapshot: {
+        ...snapshot,
+        listings: [{ dirPath: "", nodes: [] }],
+      },
+    });
+    expect(store.get().panelsById["panel-1"]).not.toBe(before);
+  });
+
   it("preserves other browser fields when the sidebar collapses", () => {
     setFileBrowserView("panel-1", { browserSelectedPath: "src/app.ts" });
     setFileBrowserView("panel-1", { browserSidebarCollapsed: true });

--- a/src/store/slices/panelRegistry/fileBrowser.ts
+++ b/src/store/slices/panelRegistry/fileBrowser.ts
@@ -1,3 +1,5 @@
+import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
+import { deepEqualIgnoringUndefined } from "@shared/utils/layoutMerge";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { saveNormalized } from "./persistence";
 
@@ -11,6 +13,8 @@ export interface FileBrowserViewPatch {
   browserRootPath?: string;
   /** `true` collapses the tree sidebar; `false` and absent both mean open. */
   browserSidebarCollapsed?: boolean;
+  /** Last-known tree structure, captured as the view goes away (#11367). */
+  browserTreeSnapshot?: FileBrowserTreeSnapshot;
 }
 
 function sameStringList(a: string[] | undefined, b: string[]): boolean {
@@ -52,6 +56,12 @@ export const createFileBrowserPanelActions = (
       const collapsedUnchanged =
         patch.browserSidebarCollapsed === undefined ||
         (patch.browserSidebarCollapsed === true) === (panel.browserSidebarCollapsed === true);
+      // Deep rather than reference equality: capture builds a fresh snapshot
+      // object on every hide, and most hides change nothing — a reference
+      // check would dirty the panel entry (and the persisted layout) each time.
+      const treeSnapshotUnchanged =
+        patch.browserTreeSnapshot === undefined ||
+        deepEqualIgnoringUndefined(patch.browserTreeSnapshot, panel.browserTreeSnapshot);
 
       // Bail on a no-op write. The tree calls this on every arrow key, and a
       // fresh panel object each time would re-render every panel-store
@@ -61,7 +71,8 @@ export const createFileBrowserPanelActions = (
         expandedUnchanged &&
         hideDotfilesUnchanged &&
         rootUnchanged &&
-        collapsedUnchanged
+        collapsedUnchanged &&
+        treeSnapshotUnchanged
       )
         return state;
 
@@ -81,6 +92,9 @@ export const createFileBrowserPanelActions = (
         }),
         ...(patch.browserSidebarCollapsed !== undefined && {
           browserSidebarCollapsed: patch.browserSidebarCollapsed,
+        }),
+        ...(patch.browserTreeSnapshot !== undefined && {
+          browserTreeSnapshot: patch.browserTreeSnapshot,
         }),
       };
 

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -4,6 +4,7 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type {
   FileViewMode,
   DiffSource,
+  FileBrowserTreeSnapshot,
   PanelExitBehavior,
   PanelTitleMode,
 } from "@shared/types/panel";
@@ -64,6 +65,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   browserHideDotfiles?: boolean;
   browserRootPath?: string;
   browserSidebarCollapsed?: boolean;
+  browserTreeSnapshot?: FileBrowserTreeSnapshot;
   /**
    * Preserved user-initiated focus timestamp from the saved snapshot. The
    * post-hydration focus picker in `useAppHydration` reads this off
@@ -126,6 +128,7 @@ export interface SavedTerminalData {
   browserHideDotfiles?: unknown;
   browserRootPath?: unknown;
   browserSidebarCollapsed?: unknown;
+  browserTreeSnapshot?: unknown;
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];


### PR DESCRIPTION
## Summary

Implements stale-while-revalidate for the file browser tree, per #11367. Right now switching back to a project shows a loading skeleton instead of the tree you were just looking at, and a listing error blanks the whole tree instead of showing a warning above it. This fixes both.

Resolves #11367

## Approach

**Snapshotting.** Added a structure-only snapshot type, `FileBrowserTreeSnapshot` (`{worktreeId, rootPath, listings: [{dirPath, nodes: [{name, path, isDirectory}]}]}`), persisted as an optional `FileBrowserPanelData.browserTreeSnapshot` field through the existing panel persistence pipeline. That means it survives both LRU eviction (which destroys the renderer's V8 context) and a full app restart. No migration needed since it's an additive optional field and the main-process `TerminalSnapshotSchema` is passthrough.

Capture only happens at points where the tree is reliably in a good state: `visibilitychange` to hidden (the dependable `WebContentsView` detach signal from #9914, with an explicit `flushPanelPersistence()`), and pane unmount. Not on every change tick, deliberately, to keep snapshot writes off the `layoutMerge` dirty path (#11350 hardening). `setFileBrowserView` also does a deep-equal no-op bail so an unchanged tree never dirties the panel entry.

**Seeding.** `useFileBrowserTree` seeds listings from an identity-matching snapshot inside lazy `useState` initializers, so the last-known tree is in the very first committed frame rather than flashing empty first. It re-derives on identity resets. Revalidation of the root plus any seeded expanded directories runs through the existing bounded queue (6 concurrent), with root retries promoted to the front of the queue so a wide restored tree can't starve the 150/400/800ms backoff schedule.

**Error rendering.** A root-listing failure with rows already on screen now shows an `InlineStatusBanner` above the still-rendered tree ("Couldn't refresh this worktree, showing the last known files"). The full-pane banner is reserved for genuinely having nothing to show. An error should never blank a populated tree, and now it doesn't.

**Restore hardening.** Snapshot data crossing the deserializer boundary is adversarial until proven otherwise, so there's a sanitizer that whole-drops anything malformed: canonical child edges (`path === dirPath/name`, which rules out cyclic or duplicate-edge shapes with exponential traversal cost), per-listing name uniqueness, safe-path screening of composite paths, count bounds (500 listings / 10k nodes), an aggregate 512k-char text budget that counts listing keys, and a bounded `worktreeId`.

## Testing

446 targeted tests green locally, covering capture/decode helpers, hook seeding (including a first-render probe and saturated-backlog retry-promotion discriminators), pane banner/capture wiring, sanitizer adversarial cases, slice no-op equality, and an integration test that round-trips capture through serialize, JSON, sanitize, and seed. Lint and format are clean on the files touched, no new ratchet warnings.

## Known deferrals

A few things I looked at and decided weren't worth blocking this on:

- Project relocation doesn't rebase the nested snapshot's `worktreeId`. The identity mismatch just cold-starts the panel, which is graceful, not broken.
- Cross-window entry-level `layoutMerge` authority on snapshot writes matches the existing (pre-existing) merge granularity, nothing new here.
- Flush durability across renderer teardown matches the existing panel-persistence architecture (`resource.ts`).
- A pane that mounts while the document is already hidden captures nothing new, but the previous snapshot is still there and still used.
- Dialog to grid promotion still cold-fetches, since the replacement pane mounts before the outgoing pane's capture lands. The snapshot it writes still benefits the next restore, just not this one.

Related: #11320, #11366 (independent of this fix, this resolves the blanking regardless of the misroute).
