### PR TITLE
feat(file-viewer): support inline video playback

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2210,6 +2210,16 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     expect(response.status).toBe(416);
   });
 
+  it("returns 416 for a zero-length suffix (bytes=-0 names no byte)", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=-0" })
+    );
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("Content-Range")).toBe("bytes */16");
+  });
+
   it("returns 416 with Content-Range */size for an unsatisfiable range", async () => {
     const handle = makeVideoHandle();
     await installHandle(handle);

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import path from "path";
+import { Readable } from "node:stream";
 
 type WebContentsCreatedListener = (event: unknown, contents: MockWebContents) => void;
 
@@ -85,7 +86,7 @@ const fsPromisesMocks = vi.hoisted(() => ({
   realpath: vi.fn(),
   stat: vi.fn(),
   open: vi.fn(),
-  constants: { O_RDONLY: 0, O_NOFOLLOW: 0x100 },
+  constants: { O_RDONLY: 0, O_NOFOLLOW: 0x100, O_NONBLOCK: 0x4 },
 }));
 
 vi.mock("fs/promises", () => ({
@@ -1985,6 +1986,281 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     } finally {
       relativeSpy.mockRestore();
     }
+  });
+});
+
+describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () => {
+  type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
+
+  async function captureHandler(): Promise<ProtocolHandler> {
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+    const call = handle.mock.calls.find((c) => c[0] === "daintree-file");
+    if (!call) throw new Error("handler for daintree-file not registered");
+    return call[1] as ProtocolHandler;
+  }
+
+  function makeVideoRequest(
+    filePath: string,
+    rootPath: string,
+    init?: { method?: string; range?: string }
+  ): GlobalRequest {
+    const url = new URL("daintree-file://serve");
+    url.searchParams.set("path", filePath);
+    url.searchParams.set("root", rootPath);
+    return new Request(url.toString(), {
+      method: init?.method ?? "GET",
+      ...(init?.range && { headers: { Range: init.range } }),
+    }) as GlobalRequest;
+  }
+
+  const VIDEO_BYTES = Buffer.from("0123456789abcdef");
+
+  function makeVideoHandle(
+    content: Buffer = VIDEO_BYTES,
+    { size = content.length, isFile = true } = {}
+  ) {
+    return {
+      stat: vi.fn().mockResolvedValue({ size, isFile: () => isFile }),
+      createReadStream: vi.fn(({ start, end }: { start: number; end: number }) =>
+        Readable.from([content.subarray(start, Math.min(end + 1, content.length))])
+      ),
+      close: vi.fn().mockResolvedValue(undefined),
+      // The buffered core's entry point — a video must never reach it.
+      readFile: vi.fn(),
+    };
+  }
+
+  function installHandle(handle: ReturnType<typeof makeVideoHandle>) {
+    return import("fs/promises").then((fs) =>
+      vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>)
+    );
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.open).mockResolvedValue(
+      makeVideoHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("video/mp4");
+  });
+
+  it("streams a 200 with Accept-Ranges and no whole-file cap, bypassing the buffered core", async () => {
+    // Far beyond both the 512 KB text cap and the 25 MB image ceiling — videos
+    // are streamed in bounded chunks, so no whole-file cap applies.
+    const size = 600 * 1024 * 1024;
+    const handle = makeVideoHandle(VIDEO_BYTES, { size });
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe(String(size));
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(response.headers.get("Content-Type")).toBe("video/mp4");
+    expect(handle.readFile).not.toHaveBeenCalled();
+    expect(handle.createReadStream).toHaveBeenCalledWith({
+      start: 0,
+      end: size - 1,
+      autoClose: true,
+    });
+  });
+
+  it("opens with O_RDONLY | O_NOFOLLOW | O_NONBLOCK (FIFO-swap TOCTOU hardening)", async () => {
+    const fs = await import("fs/promises");
+    const handler = await captureHandler();
+    await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+    expect(fs.open).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.open).mock.calls[0][1]).toBe(
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK
+    );
+  });
+
+  it("rejects a non-regular file after the fd-level stat and closes the handle", async () => {
+    // O_NOFOLLOW only blocks symlink swaps; a FIFO swapped in after the realpath
+    // check passes the open, so the post-open fstat is the guard that catches it.
+    const handle = makeVideoHandle(VIDEO_BYTES, { isFile: false });
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+    expect(response.status).toBe(404);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+    expect(handle.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it("serves an exact 206 for an explicit byte range", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=2-5" })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 2-5/16");
+    expect(response.headers.get("Content-Length")).toBe("4");
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe("2345");
+  });
+
+  it("clamps an open-ended range to EOF", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=4-" })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 4-15/16");
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe("456789abcdef");
+  });
+
+  it("serves a suffix range (last N bytes)", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=-4" })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 12-15/16");
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe("cdef");
+  });
+
+  it("clamps a past-EOF explicit end to EOF", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=10-9999" })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 10-15/16");
+  });
+
+  it("bounds any single ranged response to the per-range ceiling", async () => {
+    // An open-ended range on a huge file must not stream the whole remainder in
+    // one response; Chromium re-requests successive chunks as playback advances.
+    const size = 100 * 1024 * 1024;
+    const rangeMax = 8 * 1024 * 1024;
+    const handle = makeVideoHandle(VIDEO_BYTES, { size });
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=0-" })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe(`bytes 0-${rangeMax - 1}/${size}`);
+    expect(response.headers.get("Content-Length")).toBe(String(rangeMax));
+    expect(handle.createReadStream).toHaveBeenCalledWith({
+      start: 0,
+      end: rangeMax - 1,
+      autoClose: true,
+    });
+  });
+
+  it("returns 416 with Content-Range */size for an unsatisfiable range", async () => {
+    const handle = makeVideoHandle();
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=99-" })
+    );
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("Content-Range")).toBe("bytes */16");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(handle.close).toHaveBeenCalledTimes(1);
+    expect(handle.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it.each(["bytes=abc", "bytes=0-1,4-5", "items=0-4", "bytes=5-2"])(
+    "ignores unsupported Range header %s and serves a full 200 (RFC 9110)",
+    async (range) => {
+      const handler = await captureHandler();
+      const response = await handler(makeVideoRequest("/project/clip.mp4", "/project", { range }));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Length")).toBe("16");
+    }
+  );
+
+  it("answers HEAD with metadata and Accept-Ranges without opening a stream", async () => {
+    // Chromium probes with HEAD before issuing ranged GETs.
+    const handle = makeVideoHandle();
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { method: "HEAD" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe("16");
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(response.headers.get("Content-Type")).toBe("video/mp4");
+    expect(handle.createReadStream).not.toHaveBeenCalled();
+    expect(handle.readFile).not.toHaveBeenCalled();
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves an empty video as an empty 200 without a stream", async () => {
+    const handle = makeVideoHandle(Buffer.alloc(0));
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe("0");
+    expect(handle.createReadStream).not.toHaveBeenCalled();
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits the hardened response header set on streamed responses", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=0-3" })
+    );
+
+    expect(response.headers.get("Content-Security-Policy")).toBe("sandbox; default-src 'none'");
+    expect(response.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("applies realpath containment to video paths (out-of-root symlink → 404)", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    const projectRoot = path.normalize("/project");
+    const escapeIn = path.normalize("/project/escape.mp4");
+    realpath.mockImplementation((p) => {
+      if (p === projectRoot) return Promise.resolve(projectRoot);
+      if (p === escapeIn) return Promise.resolve(path.normalize("/etc/evil.mp4"));
+      return Promise.resolve(p as string);
+    });
+
+    const handler = await captureHandler();
+    const response = await handler(makeVideoRequest("/project/escape.mp4", "/project"));
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the video open is rejected with ELOOP (symlink swap)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.open).mockRejectedValue(Object.assign(new Error("ELOOP"), { code: "ELOOP" }));
+
+    const handler = await captureHandler();
+    const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2141,11 +2141,10 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     expect(response.headers.get("Content-Range")).toBe("bytes 10-15/16");
   });
 
-  it("bounds any single ranged response to the per-range ceiling", async () => {
-    // An open-ended range on a huge file must not stream the whole remainder in
-    // one response; Chromium re-requests successive chunks as playback advances.
+  it("bounds an open-ended range on a huge file to a partial chunk", async () => {
+    // `bytes=N-` asks for "everything from N"; the handler must not stream the
+    // whole remainder in one response — Chromium re-requests successive chunks.
     const size = 100 * 1024 * 1024;
-    const rangeMax = 8 * 1024 * 1024;
     const handle = makeVideoHandle(VIDEO_BYTES, { size });
     await installHandle(handle);
 
@@ -2155,13 +2154,60 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     );
 
     expect(response.status).toBe(206);
-    expect(response.headers.get("Content-Range")).toBe(`bytes 0-${rangeMax - 1}/${size}`);
-    expect(response.headers.get("Content-Length")).toBe(String(rangeMax));
-    expect(handle.createReadStream).toHaveBeenCalledWith({
-      start: 0,
-      end: rangeMax - 1,
-      autoClose: true,
-    });
+    // Invariants, not the clamp constant: the response covers a strict prefix
+    // of the file, and headers agree with the stream bounds actually used.
+    const args = handle.createReadStream.mock.calls[0][0] as { start: number; end: number };
+    expect(args.start).toBe(0);
+    expect(args.end).toBeLessThan(size - 1);
+    const length = args.end - args.start + 1;
+    expect(response.headers.get("Content-Length")).toBe(String(length));
+    expect(response.headers.get("Content-Range")).toBe(`bytes ${args.start}-${args.end}/${size}`);
+  });
+
+  it("serves an over-cap suffix range exactly (the tail carries mp4 moov metadata)", async () => {
+    // Clamping a suffix from its start would drop EOF — the very bytes a
+    // suffix request exists to fetch. Client-bounded forms are served whole.
+    const size = 100 * 1024 * 1024;
+    const suffix = 16 * 1024 * 1024;
+    const handle = makeVideoHandle(VIDEO_BYTES, { size });
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: `bytes=-${suffix}` })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe(
+      `bytes ${size - suffix}-${size - 1}/${size}`
+    );
+    expect(response.headers.get("Content-Length")).toBe(String(suffix));
+  });
+
+  it("serves a large explicit range exactly (client-bounded, no clamp)", async () => {
+    const size = 100 * 1024 * 1024;
+    const end = 20 * 1024 * 1024 - 1;
+    const handle = makeVideoHandle(VIDEO_BYTES, { size });
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: `bytes=0-${end}` })
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe(`bytes 0-${end}/${size}`);
+    expect(response.headers.get("Content-Length")).toBe(String(end + 1));
+  });
+
+  it("returns 416 for a start past the safe-integer range (necessarily past EOF)", async () => {
+    // Ignoring it would serve the whole file for a range that names no real byte.
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=9007199254740992-" })
+    );
+
+    expect(response.status).toBe(416);
   });
 
   it("returns 416 with Content-Range */size for an unsatisfiable range", async () => {
@@ -2207,6 +2253,21 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     expect(response.headers.get("Content-Type")).toBe("video/mp4");
     expect(handle.createReadStream).not.toHaveBeenCalled();
     expect(handle.readFile).not.toHaveBeenCalled();
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("HEAD ignores Range entirely (RFC 9110 defines range handling for GET only)", async () => {
+    // Even an unsatisfiable Range must not turn HEAD into a 416.
+    const handle = makeVideoHandle();
+    await installHandle(handle);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeVideoRequest("/project/clip.mp4", "/project", { method: "HEAD", range: "bytes=99-" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe("16");
     expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
@@ -2261,6 +2322,38 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
 
     expect(response.status).toBe(404);
+  });
+
+  it("routes a video-suffixed alias of a non-video through the buffered path", async () => {
+    // On Windows O_NOFOLLOW is a no-op, so an in-root `clip.mp4 → notes.txt`
+    // symlink opens fine — classification must follow the canonical target,
+    // which lands this request on the capped buffered path with a text MIME.
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    const alias = path.normalize("/project/clip.mp4");
+    const target = path.normalize("/project/notes.txt");
+    vi.mocked(fs.realpath).mockImplementation((p) =>
+      Promise.resolve(p === alias ? target : (p as string))
+    );
+    vi.mocked(appProtocol.getMimeType).mockImplementation((p: string) =>
+      p.endsWith(".mp4") ? "video/mp4" : "text/plain"
+    );
+    vi.mocked(fs.stat).mockResolvedValue({ size: 4 } as Awaited<ReturnType<typeof fs.stat>>);
+    const bufferedHandle = {
+      readFile: vi.fn().mockResolvedValue(Buffer.from("data")),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(fs.open).mockResolvedValue(
+      bufferedHandle as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    // Buffered semantics: the whole (capped) read, not a stream.
+    expect(bufferedHandle.readFile).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -4,6 +4,7 @@ import { getWindowForWebContents, getAppWebContents } from "../window/webContent
 import path from "path";
 import fs from "fs/promises";
 import { readFileSync } from "node:fs";
+import { Readable } from "node:stream";
 import {
   resolveAppUrlToDistPath,
   getMimeType,
@@ -216,23 +217,172 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
   };
 }
 
+// Videos are streamed, not buffered, so the whole-file caps above don't apply —
+// no response ever holds more than a stream chunk in memory (the caps exist to
+// bound buffered bytes reaching the renderer, a model that doesn't fit ranged
+// streaming; see maxBytesForFile). A per-range clamp still bounds any single
+// response body: an open-ended `Range: bytes=0-` on a multi-GB file is served
+// in successive bounded chunks that Chromium re-requests as playback advances.
+const DAINTREE_VIDEO_RANGE_MAX_BYTES = 8 * 1024 * 1024;
+
+function isVideoMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("video/");
+}
+
+type ParsedByteRange = { start: number; end: number } | "unsatisfiable" | null;
+
 /**
- * Shared read core for daintree-file:// and daintree-html://: realpath
- * containment, a size cap (per maxBytesForFile — larger for raster images when
- * allowLargeImages is set), and O_RDONLY|O_NOFOLLOW open. Returns the file bytes
- * plus the canonical path (for MIME), or an error Response. Callers own the
- * success headers so each scheme sets its own CSP. The flow (realpath →
- * path.relative → stat → O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
+ * Parse a single-range `Range: bytes=…` header against a known file size.
+ * Null means "serve the whole file as 200": header absent, non-bytes unit,
+ * syntactically malformed, or multi-range — RFC 9110 permits ignoring all of
+ * these, and Chromium's <video> only sends single ranges. "unsatisfiable"
+ * means a well-formed range no byte can satisfy (416).
  */
-// Return type is inferred, not annotated: annotating `buffer: Buffer` widens it
-// to `Buffer<ArrayBufferLike>`, which `new Response(...)` rejects as a BodyInit.
-// Inference preserves the exact `readFile()` result type the Response accepts.
-async function readContainedDaintreeFile(
-  normalizedRoot: string,
+function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRange {
+  if (!rangeHeader) return null;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match) return null;
+  const [, startRaw, endRaw] = match;
+  if (startRaw === "" && endRaw === "") return null;
+  if (size === 0) return "unsatisfiable";
+
+  if (startRaw === "") {
+    // Suffix form `bytes=-N`: the last N bytes. An unsafe-integer N is beyond
+    // any real file, so it degrades to "the whole file" rather than an error.
+    const suffix = Number(endRaw);
+    if (suffix === 0) return "unsatisfiable";
+    const start = Number.isSafeInteger(suffix) ? Math.max(0, size - suffix) : 0;
+    return { start, end: size - 1 };
+  }
+
+  const start = Number(startRaw);
+  if (!Number.isSafeInteger(start)) return null;
+  if (start >= size) return "unsatisfiable";
+  // An unsafe-integer or past-EOF end clamps to EOF per RFC; an inverted range
+  // is malformed and ignored.
+  const end = Number(endRaw === "" ? size - 1 : Number(endRaw));
+  if (Number.isSafeInteger(end) && end < start) return null;
+  return { start, end: Number.isSafeInteger(end) ? Math.min(end, size - 1) : size - 1 };
+}
+
+/**
+ * Serve an already-containment-checked video file as a Range-aware stream.
+ *
+ * Bypasses readContainedDaintreeFile's buffer-and-cap core deliberately:
+ * <video> seeks via byte ranges and a multi-hundred-MB recording must never be
+ * read whole. The open-and-stream flow keeps the same TOCTOU discipline as
+ * diffMedia.ts's readWorkingSide — O_NOFOLLOW rejects a final-component
+ * symlink swap after the realpath check, O_NONBLOCK (no-op on Windows) keeps a
+ * FIFO swapped in its place from wedging the open, and the post-open fd-level
+ * stat rejects anything that isn't a regular file. Range bounds derive from
+ * that fd stat, so they describe the exact file that was opened.
+ */
+async function streamContainedVideoFile(
   normalizedFile: string,
-  allowLargeImages: boolean
-) {
-  // Resolve symlinks before containment to block in-root symlinks pointing outside root (CVE-2025-53109 / CVE-2025-54794 class).
+  mimeType: string,
+  request: GlobalRequest
+): Promise<Response> {
+  let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    fileHandle = await fs.open(
+      normalizedFile,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | (fs.constants.O_NONBLOCK ?? 0)
+    );
+  } catch (err) {
+    const errCode = (err as NodeJS.ErrnoException).code;
+    if (errCode === "ELOOP" || errCode === "ENOENT") {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    throw err;
+  }
+
+  let size: number;
+  try {
+    const fdStat = await fileHandle.stat();
+    if (!fdStat.isFile()) {
+      await fileHandle.close().catch(() => {});
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
+    }
+    size = fdStat.size;
+  } catch (err) {
+    await fileHandle.close().catch(() => {});
+    throw err;
+  }
+
+  const range = parseByteRange(request.headers.get("range"), size);
+  if (range === "unsatisfiable") {
+    await fileHandle.close().catch(() => {});
+    return new Response("Range Not Satisfiable", {
+      status: 416,
+      headers: {
+        ...buildDaintreeFileErrorHeaders(),
+        "Content-Range": `bytes */${size}`,
+      },
+    });
+  }
+
+  // Chromium probes with HEAD before issuing ranged GETs; answer with the
+  // metadata (and Accept-Ranges, so seeking is offered) without reading a byte.
+  if (request.method === "HEAD") {
+    await fileHandle.close().catch(() => {});
+    return new Response(null, {
+      status: 200,
+      headers: {
+        ...buildDaintreeFileHeaders(mimeType, size),
+        "Accept-Ranges": "bytes",
+      },
+    });
+  }
+
+  if (size === 0) {
+    await fileHandle.close().catch(() => {});
+    return new Response(null, {
+      status: 200,
+      headers: {
+        ...buildDaintreeFileHeaders(mimeType, 0),
+        "Accept-Ranges": "bytes",
+      },
+    });
+  }
+
+  const start = range ? range.start : 0;
+  const end = range
+    ? Math.min(range.end, range.start + DAINTREE_VIDEO_RANGE_MAX_BYTES - 1)
+    : size - 1;
+  const contentLength = end - start + 1;
+
+  // autoClose ties the fd's lifetime to the stream: it closes on end, error,
+  // and destroy — including the destroy toWeb() issues when the renderer
+  // cancels the response body (pane closed, seek abandoned mid-request).
+  const nodeStream = fileHandle.createReadStream({ start, end, autoClose: true });
+  const body = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+
+  return new Response(body, {
+    status: range ? 206 : 200,
+    headers: {
+      ...buildDaintreeFileHeaders(mimeType, contentLength),
+      "Accept-Ranges": "bytes",
+      ...(range && { "Content-Range": `bytes ${start}-${end}/${size}` }),
+    },
+  });
+}
+
+/**
+ * Realpath containment shared by the buffered read core and the video
+ * streaming path: resolve symlinks before comparing so an in-root symlink
+ * pointing outside root is rejected (CVE-2025-53109 / CVE-2025-54794 class).
+ * Returns the canonical file path, or the 404 Response to relay.
+ */
+async function resolveContainedRealPath(
+  normalizedRoot: string,
+  normalizedFile: string
+): Promise<{ realFile: string } | Response> {
   let realRoot: string;
   let realFile: string;
   try {
@@ -253,6 +403,29 @@ async function readContainedDaintreeFile(
       headers: buildDaintreeFileErrorHeaders(),
     });
   }
+
+  return { realFile };
+}
+
+/**
+ * Shared read core for daintree-file:// and daintree-html://: realpath
+ * containment, a size cap (per maxBytesForFile — larger for raster images when
+ * allowLargeImages is set), and O_RDONLY|O_NOFOLLOW open. Returns the file bytes
+ * plus the canonical path (for MIME), or an error Response. Callers own the
+ * success headers so each scheme sets its own CSP. The flow (realpath →
+ * path.relative → stat → O_NOFOLLOW open) and its TOCTOU defenses are unchanged.
+ */
+// Return type is inferred, not annotated: annotating `buffer: Buffer` widens it
+// to `Buffer<ArrayBufferLike>`, which `new Response(...)` rejects as a BodyInit.
+// Inference preserves the exact `readFile()` result type the Response accepts.
+async function readContainedDaintreeFile(
+  normalizedRoot: string,
+  normalizedFile: string,
+  allowLargeImages: boolean
+) {
+  const contained = await resolveContainedRealPath(normalizedRoot, normalizedFile);
+  if (contained instanceof Response) return contained;
+  const { realFile } = contained;
 
   // Stat the realpath-resolved path for an accurate size before any read.
   let fileStat: Awaited<ReturnType<typeof fs.stat>>;
@@ -351,11 +524,21 @@ function createDaintreeFileProtocolHandler() {
         });
       }
 
-      const result = await readContainedDaintreeFile(
-        path.normalize(rootPath),
-        path.normalize(filePath),
-        true
-      );
+      const normalizedRoot = path.normalize(rootPath);
+      const normalizedFile = path.normalize(filePath);
+
+      // Videos take the streaming path instead of the buffer-and-cap core.
+      // Classifying by the request path (not the realpath) is safe: both paths
+      // open with O_NOFOLLOW, so a final-component symlink never serves and the
+      // two spellings agree for every servable file.
+      const mimeType = getMimeType(normalizedFile);
+      if (isVideoMimeType(mimeType)) {
+        const contained = await resolveContainedRealPath(normalizedRoot, normalizedFile);
+        if (contained instanceof Response) return contained;
+        return await streamContainedVideoFile(normalizedFile, mimeType, request);
+      }
+
+      const result = await readContainedDaintreeFile(normalizedRoot, normalizedFile, true);
       if (result instanceof Response) return result;
 
       // Content-Length reflects the bytes actually returned. If the file

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -223,20 +223,25 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
 // streaming; see maxBytesForFile). A per-range clamp still bounds any single
 // response body: an open-ended `Range: bytes=0-` on a multi-GB file is served
 // in successive bounded chunks that Chromium re-requests as playback advances.
+// An un-ranged GET does stream the whole file in one 200 — required for a
+// spec-correct response, and accepted: <video> always issues ranged requests,
+// and main-process memory stays chunk-bounded regardless of response size.
 const DAINTREE_VIDEO_RANGE_MAX_BYTES = 8 * 1024 * 1024;
 
 function isVideoMimeType(mimeType: string): boolean {
   return mimeType.startsWith("video/");
 }
 
-type ParsedByteRange = { start: number; end: number } | "unsatisfiable" | null;
+type ParsedByteRange = { start: number; end: number; openEnded: boolean } | "unsatisfiable" | null;
 
 /**
  * Parse a single-range `Range: bytes=…` header against a known file size.
  * Null means "serve the whole file as 200": header absent, non-bytes unit,
- * syntactically malformed, or multi-range — RFC 9110 permits ignoring all of
- * these, and Chromium's <video> only sends single ranges. "unsatisfiable"
- * means a well-formed range no byte can satisfy (416).
+ * syntactically malformed, multi-range, or inverted — RFC 9110 permits
+ * ignoring all of these, and Chromium's <video> only sends single ranges.
+ * "unsatisfiable" means a well-formed range no byte can satisfy (416).
+ * `openEnded` marks `bytes=N-`, the only form whose extent the client didn't
+ * bound — the caller clamps just that one.
  */
 function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRange {
   if (!rangeHeader) return null;
@@ -244,25 +249,32 @@ function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRan
   if (!match) return null;
   const [, startRaw, endRaw] = match;
   if (startRaw === "" && endRaw === "") return null;
-  if (size === 0) return "unsatisfiable";
 
   if (startRaw === "") {
     // Suffix form `bytes=-N`: the last N bytes. An unsafe-integer N is beyond
     // any real file, so it degrades to "the whole file" rather than an error.
+    if (size === 0) return "unsatisfiable";
     const suffix = Number(endRaw);
     if (suffix === 0) return "unsatisfiable";
     const start = Number.isSafeInteger(suffix) ? Math.max(0, size - suffix) : 0;
-    return { start, end: size - 1 };
+    return { start, end: size - 1, openEnded: false };
   }
 
   const start = Number(startRaw);
-  if (!Number.isSafeInteger(start)) return null;
-  if (start >= size) return "unsatisfiable";
-  // An unsafe-integer or past-EOF end clamps to EOF per RFC; an inverted range
-  // is malformed and ignored.
-  const end = Number(endRaw === "" ? size - 1 : Number(endRaw));
-  if (Number.isSafeInteger(end) && end < start) return null;
-  return { start, end: Number.isSafeInteger(end) ? Math.min(end, size - 1) : size - 1 };
+  // A digits-only start past the safe-integer range is beyond any real file's
+  // EOF — unsatisfiable, not ignorable (ignoring would serve the whole file).
+  if (!Number.isSafeInteger(start)) return "unsatisfiable";
+  const end = endRaw === "" ? null : Number(endRaw);
+  // Inverted ranges are invalid range specs per RFC 9110 → ignore the header,
+  // whatever the file size.
+  if (end !== null && Number.isSafeInteger(end) && end < start) return null;
+  if (size === 0 || start >= size) return "unsatisfiable";
+  // An unsafe-integer or past-EOF end clamps to EOF per RFC.
+  return {
+    start,
+    end: end !== null && Number.isSafeInteger(end) ? Math.min(end, size - 1) : size - 1,
+    openEnded: end === null,
+  };
 }
 
 /**
@@ -302,7 +314,10 @@ async function streamContainedVideoFile(
   let size: number;
   try {
     const fdStat = await fileHandle.stat();
-    if (!fdStat.isFile()) {
+    // The fd-level stat rejects both type swaps (FIFO) and sizes that break
+    // JS integer arithmetic (a sparse file can exceed 2^53 bytes; stream
+    // start/end and Content-Range math would silently corrupt).
+    if (!fdStat.isFile() || !Number.isSafeInteger(fdStat.size)) {
       await fileHandle.close().catch(() => {});
       return new Response("Not Found", {
         status: 404,
@@ -315,6 +330,20 @@ async function streamContainedVideoFile(
     throw err;
   }
 
+  // HEAD ignores Range by definition (RFC 9110 defines range handling for GET
+  // only). Chromium probes with HEAD before issuing ranged GETs; answer with
+  // the metadata (and Accept-Ranges, so seeking is offered) without a read.
+  if (request.method === "HEAD") {
+    await fileHandle.close().catch(() => {});
+    return new Response(null, {
+      status: 200,
+      headers: {
+        ...buildDaintreeFileHeaders(mimeType, size),
+        "Accept-Ranges": "bytes",
+      },
+    });
+  }
+
   const range = parseByteRange(request.headers.get("range"), size);
   if (range === "unsatisfiable") {
     await fileHandle.close().catch(() => {});
@@ -323,19 +352,6 @@ async function streamContainedVideoFile(
       headers: {
         ...buildDaintreeFileErrorHeaders(),
         "Content-Range": `bytes */${size}`,
-      },
-    });
-  }
-
-  // Chromium probes with HEAD before issuing ranged GETs; answer with the
-  // metadata (and Accept-Ranges, so seeking is offered) without reading a byte.
-  if (request.method === "HEAD") {
-    await fileHandle.close().catch(() => {});
-    return new Response(null, {
-      status: 200,
-      headers: {
-        ...buildDaintreeFileHeaders(mimeType, size),
-        "Accept-Ranges": "bytes",
       },
     });
   }
@@ -352,16 +368,34 @@ async function streamContainedVideoFile(
   }
 
   const start = range ? range.start : 0;
-  const end = range
-    ? Math.min(range.end, range.start + DAINTREE_VIDEO_RANGE_MAX_BYTES - 1)
-    : size - 1;
+  // Clamp only open-ended ranges: explicit and suffix ranges are already
+  // bounded by what the client asked for (clamping a suffix would drop the
+  // file tail — exactly what an mp4 with trailing moov metadata needs), but
+  // `bytes=N-` requests "everything from N". Serving that in bounded chunks is
+  // safe: the Content-Range total tells Chromium more remains and it
+  // re-requests as playback advances.
+  const end =
+    range && range.openEnded
+      ? Math.min(range.end, range.start + DAINTREE_VIDEO_RANGE_MAX_BYTES - 1)
+      : range
+        ? range.end
+        : size - 1;
   const contentLength = end - start + 1;
 
   // autoClose ties the fd's lifetime to the stream: it closes on end, error,
   // and destroy — including the destroy toWeb() issues when the renderer
   // cancels the response body (pane closed, seek abandoned mid-request).
-  const nodeStream = fileHandle.createReadStream({ start, end, autoClose: true });
-  const body = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+  // Until that handoff succeeds, the fd is still ours to close.
+  let body: ReadableStream;
+  let nodeStream: ReturnType<typeof fileHandle.createReadStream> | undefined;
+  try {
+    nodeStream = fileHandle.createReadStream({ start, end, autoClose: true });
+    body = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+  } catch (err) {
+    nodeStream?.destroy();
+    await fileHandle.close().catch(() => {});
+    throw err;
+  }
 
   return new Response(body, {
     status: range ? 206 : 200,
@@ -528,14 +562,20 @@ function createDaintreeFileProtocolHandler() {
       const normalizedFile = path.normalize(filePath);
 
       // Videos take the streaming path instead of the buffer-and-cap core.
-      // Classifying by the request path (not the realpath) is safe: both paths
-      // open with O_NOFOLLOW, so a final-component symlink never serves and the
-      // two spellings agree for every servable file.
-      const mimeType = getMimeType(normalizedFile);
-      if (isVideoMimeType(mimeType)) {
+      // Classification must come from the canonical path, not the request
+      // path: on Windows O_NOFOLLOW is a no-op, so a final-component symlink
+      // (`clip.mp4` → `notes.txt`) opens fine, and request-path routing would
+      // stream a non-video uncapped under a video MIME. On POSIX ELOOP rejects
+      // that symlink at open, so the two spellings agree either way.
+      if (isVideoMimeType(getMimeType(normalizedFile))) {
         const contained = await resolveContainedRealPath(normalizedRoot, normalizedFile);
         if (contained instanceof Response) return contained;
-        return await streamContainedVideoFile(normalizedFile, mimeType, request);
+        const realMimeType = getMimeType(contained.realFile);
+        if (isVideoMimeType(realMimeType)) {
+          return await streamContainedVideoFile(normalizedFile, realMimeType, request);
+        }
+        // A video-suffixed alias of a non-video — fall through to the buffered
+        // path, which redoes containment and applies its usual caps.
       }
 
       const result = await readContainedDaintreeFile(normalizedRoot, normalizedFile, true);

--- a/electron/utils/__tests__/appProtocol.test.ts
+++ b/electron/utils/__tests__/appProtocol.test.ts
@@ -26,6 +26,25 @@ describe("appProtocol utilities", () => {
       expect(getMimeType("hero.avif")).toBe("image/avif");
     });
 
+    it("should return video MIME types for containers Chromium plays natively", () => {
+      // Drives the daintree-file:// handler's video-vs-buffered routing AND the
+      // Content-Type on streamed responses — nosniff makes a wrong type fatal.
+      expect(getMimeType("clip.mp4")).toBe("video/mp4");
+      expect(getMimeType("clip.m4v")).toBe("video/mp4");
+      expect(getMimeType("clip.webm")).toBe("video/webm");
+      expect(getMimeType("clip.ogv")).toBe("video/ogg");
+      expect(getMimeType("CLIP.MP4")).toBe("video/mp4");
+    });
+
+    it("should not map containers Chromium can't demux to a video MIME", () => {
+      // mov/mkv/avi/wmv are excluded from the playable set — mapping them to
+      // video/* would route them into the streaming path and a broken <video>.
+      expect(getMimeType("clip.mov")).toBe("application/octet-stream");
+      expect(getMimeType("clip.mkv")).toBe("application/octet-stream");
+      expect(getMimeType("clip.avi")).toBe("application/octet-stream");
+      expect(getMimeType("clip.wmv")).toBe("application/octet-stream");
+    });
+
     it("should return default MIME type for unknown extensions", () => {
       expect(getMimeType("file.xyz")).toBe("application/octet-stream");
       expect(getMimeType("noext")).toBe("application/octet-stream");

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -62,6 +62,10 @@ const MIME_TYPES: Record<string, string> = {
   ".wav": "audio/wav",
   ".mp3": "audio/mpeg",
   ".ogg": "audio/ogg",
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".webm": "video/webm",
+  ".ogv": "video/ogg",
 };
 
 export function getMimeType(filePath: string): string {

--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -124,6 +124,22 @@ describe("Daintree app CSP", () => {
     });
   });
 
+  describe("daintree-file: scheme in media-src (#11382)", () => {
+    // The file viewer plays videos via <video src="daintree-file://…">, Range-
+    // streamed by the protocol handler. media-src is the directive that governs
+    // that load; without the scheme the element is silently blocked with only a
+    // devtools warning — every protocol/MIME fix upstream still fails.
+    it("allows daintree-file: in media-src in production", () => {
+      const mediaSrc = getDaintreeAppProdCSP().match(/media-src ([^;]*);/)?.[1];
+      expect(mediaSrc).toContain("daintree-file:");
+    });
+
+    it("allows daintree-file: in media-src in development", () => {
+      const mediaSrc = getDaintreeAppDevCSP().match(/media-src ([^;]*);/)?.[1];
+      expect(mediaSrc).toContain("daintree-file:");
+    });
+  });
+
   describe("daintree.org doc images in img-src (#9828)", () => {
     // The `help.displayImage` MCP tool surfaces documentation images served
     // from daintree.org. Chromium 148 does not match the apex against a

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -105,7 +105,9 @@ export function getDaintreeAppProdCSP(options?: DaintreeCspOptions): string {
     `connect-src 'self' ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
     `img-src 'self' ${GITHUB_AVATARS} ${GRAVATAR} ${DAINTREE_DOCS} ${FILE_SCHEMES} data: blob:`,
     "font-src 'self' data:",
-    "media-src 'self'",
+    // FILE_SCHEMES: the file viewer plays videos straight from daintree-file://
+    // (Range-streamed by the protocol handler) via <video src>.
+    `media-src 'self' ${FILE_SCHEMES}`,
     "worker-src 'self' blob:",
     `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",
@@ -139,7 +141,7 @@ export function getDaintreeAppDevCSP(): string {
     `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
     `img-src 'self' ${origins} ${GITHUB_AVATARS} ${GRAVATAR} ${DAINTREE_DOCS} ${FILE_SCHEMES} data: blob:`,
     `font-src 'self' ${origins} data:`,
-    "media-src 'self'",
+    `media-src 'self' ${FILE_SCHEMES}`,
     "worker-src 'self' blob:",
     `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -39,7 +39,8 @@ export function FileVideoPreview({
   const src = useMemo(() => {
     const url = buildDaintreeFileUrl(filePath, rootPath);
     // Cache-busting query param only — the protocol handler ignores it.
-    return reloadKey ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
+    // Null-checked, not truthiness: a numeric key of 0 is a valid value.
+    return reloadKey != null ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
   }, [filePath, rootPath, reloadKey]);
 
   return (

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import { buildDaintreeFileUrl } from "./filePreviewKinds";
+
+interface FileVideoPreviewProps {
+  /** Absolute path of the video being previewed. */
+  filePath: string;
+  /** Known root the `daintree-file://` protocol resolves the path against. */
+  rootPath: string;
+  /** Accessible label — the file name, so a failed video still names its file. */
+  label: string;
+  /**
+   * Changed to force a fresh media request for the same path — the protocol
+   * serves `no-store`, but the <video> element itself never re-fetches unless
+   * its src changes, so a rewritten file needs a new URL to show new bytes.
+   */
+  reloadKey?: string | number;
+  onError?: () => void;
+  /** Height cap for the preview surface — dialogs and panes want different ones. */
+  maxHeightClassName?: string;
+}
+
+/**
+ * Renders an inline video player for the formats Chromium decodes natively.
+ *
+ * Shared by `FilePane`, `FileBrowserViewer`, and `DiffPane` so every surface
+ * plays the same files the same way — mirroring `FileImagePreview`'s role for
+ * images. The bytes stream straight from the `daintree-file://` protocol
+ * (Range-aware, so seeking works without buffering the file); nothing
+ * round-trips through IPC.
+ */
+export function FileVideoPreview({
+  filePath,
+  rootPath,
+  label,
+  reloadKey,
+  onError,
+  maxHeightClassName = "max-h-[70vh]",
+}: FileVideoPreviewProps) {
+  const src = useMemo(() => {
+    const url = buildDaintreeFileUrl(filePath, rootPath);
+    // Cache-busting query param only — the protocol handler ignores it.
+    return reloadKey ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
+  }, [filePath, rootPath, reloadKey]);
+
+  return (
+    <div className="flex items-center justify-center p-6 min-h-[300px]">
+      <video
+        // Keyed by src so switching files (or reloading) remounts the element
+        // rather than continuing playback of the previous source.
+        key={src}
+        src={src}
+        controls
+        preload="metadata"
+        aria-label={label}
+        className={`max-w-full ${maxHeightClassName} rounded`}
+        onError={onError}
+      />
+    </div>
+  );
+}

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+/**
+ * Shared video preview (#11382).
+ *
+ * jsdom does not decode media, so these tests pin the element contract — the
+ * protocol URL, native controls, metadata-only preload, reload semantics — and
+ * dispatch the error event manually rather than waiting on playback.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { afterEach } from "vitest";
+import { FileVideoPreview } from "../FileVideoPreview";
+
+afterEach(cleanup);
+
+describe("FileVideoPreview", () => {
+  it("renders a native-controls video sourced from the daintree-file protocol", () => {
+    const { container } = render(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" />
+    );
+
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute("src")).toBe(
+      "daintree-file://load?path=%2Frepo%2Fdemo.mp4&root=%2Frepo"
+    );
+    expect(video?.hasAttribute("controls")).toBe(true);
+    expect(video?.getAttribute("preload")).toBe("metadata");
+    expect(video?.getAttribute("aria-label")).toBe("demo.mp4");
+  });
+
+  it("appends the reload key as a cache-busting param", () => {
+    const { container } = render(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={3} />
+    );
+
+    expect(container.querySelector("video")?.getAttribute("src")).toContain("&v=3");
+  });
+
+  it("changes src when the reload key changes, forcing a fresh media request", () => {
+    const { container, rerender } = render(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={1} />
+    );
+    const before = container.querySelector("video")?.getAttribute("src");
+
+    rerender(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={2} />
+    );
+    const after = container.querySelector("video")?.getAttribute("src");
+
+    expect(before).not.toBe(after);
+  });
+
+  it("forwards media errors to onError", () => {
+    const onError = vi.fn();
+    const { container } = render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        onError={onError}
+      />
+    );
+
+    fireEvent.error(container.querySelector("video")!);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDaintreeFileUrl,
+  isImageFilePath,
+  isSvgFilePath,
+  isUnsupportedVideoFilePath,
+  isVideoFilePath,
+} from "../filePreviewKinds";
+
+describe("filePreviewKinds", () => {
+  describe("isVideoFilePath", () => {
+    it.each(["clip.mp4", "clip.m4v", "clip.webm", "clip.ogv", "CLIP.MP4", "a/b/c.demo.webm"])(
+      "accepts %s",
+      (path) => {
+        expect(isVideoFilePath(path)).toBe(true);
+      }
+    );
+
+    it.each([
+      // Containers Chromium can't demux stay out so a <video> element is never
+      // offered for a file it cannot play.
+      "clip.mov",
+      "clip.mkv",
+      "clip.avi",
+      "clip.wmv",
+      // Lookalikes and non-videos. (A bare extensionless name like "mp4" is
+      // NOT here: extensionOf treats it as its own extension, matching the
+      // long-standing isImageFilePath("png") behavior.)
+      "clip.mp4.txt",
+      "clip",
+      "photo.png",
+      "notes.md",
+    ])("rejects %s", (path) => {
+      expect(isVideoFilePath(path)).toBe(false);
+    });
+
+    it("never overlaps the image classifier", () => {
+      for (const path of ["clip.mp4", "clip.webm", "clip.m4v", "clip.ogv"]) {
+        expect(isImageFilePath(path)).toBe(false);
+        expect(isSvgFilePath(path)).toBe(false);
+      }
+    });
+  });
+
+  describe("isUnsupportedVideoFilePath", () => {
+    it.each(["clip.mov", "clip.mkv", "clip.avi", "clip.wmv", "CLIP.MOV"])("accepts %s", (path) => {
+      expect(isUnsupportedVideoFilePath(path)).toBe(true);
+    });
+
+    it("is disjoint from the playable set", () => {
+      for (const path of ["clip.mp4", "clip.webm", "clip.m4v", "clip.ogv"]) {
+        expect(isUnsupportedVideoFilePath(path)).toBe(false);
+      }
+    });
+  });
+
+  describe("buildDaintreeFileUrl", () => {
+    it("encodes path and root as query params", () => {
+      const url = buildDaintreeFileUrl("/a dir/clip.mp4", "/a dir");
+      expect(url).toBe("daintree-file://load?path=%2Fa%20dir%2Fclip.mp4&root=%2Fa%20dir");
+    });
+  });
+});

--- a/src/components/FileViewer/filePreviewKinds.ts
+++ b/src/components/FileViewer/filePreviewKinds.ts
@@ -9,6 +9,18 @@
 const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "ico"]);
 const SVG_EXTENSION = "svg";
 
+// Containers Chromium's media pipeline demuxes natively (stock Electron ships
+// H.264/AAC, so mp4/m4v are safe). mov/mkv/avi/wmv are deliberately absent:
+// Chromium doesn't parse those containers even when the inner codec is
+// supported, so offering a <video> element for them would just show a decode
+// error instead of a clear message.
+const VIDEO_EXTENSIONS = new Set(["mp4", "m4v", "webm", "ogv"]);
+
+// Video containers users plausibly open but Chromium cannot demux. Classified
+// separately so the viewer can say "can't play this format" rather than
+// falling through to the text path's misleading size/binary errors.
+const UNSUPPORTED_VIDEO_EXTENSIONS = new Set(["mov", "mkv", "avi", "wmv"]);
+
 function extensionOf(filePath: string): string {
   return filePath.split(".").pop()?.toLowerCase() ?? "";
 }
@@ -23,6 +35,20 @@ export function isImageFilePath(filePath: string): boolean {
 export function isSvgFilePath(filePath: string): boolean {
   return extensionOf(filePath) === SVG_EXTENSION;
 }
+
+/** Videos Chromium plays natively — served via daintree-file:// to a <video> element. */
+export function isVideoFilePath(filePath: string): boolean {
+  return VIDEO_EXTENSIONS.has(extensionOf(filePath));
+}
+
+/** Video containers Chromium can't demux — recognized only to explain why they won't play. */
+export function isUnsupportedVideoFilePath(filePath: string): boolean {
+  return UNSUPPORTED_VIDEO_EXTENSIONS.has(extensionOf(filePath));
+}
+
+/** Copy for containers in the unsupported set — shared so both panes say the same thing. */
+export const UNSUPPORTED_VIDEO_MESSAGE =
+  "Can't play this video format — only MP4, WebM, and Ogg are supported";
 
 /**
  * URL for the custom `daintree-file://` protocol, which serves a file from

--- a/src/components/FileViewer/fileReadErrors.ts
+++ b/src/components/FileViewer/fileReadErrors.ts
@@ -3,7 +3,7 @@ import type { FileReadErrorCode } from "@shared/types/ipc/files";
 /** User-facing messages for files.read failures — shared by the file viewer modal and the markdown panel. */
 export const FILE_READ_ERROR_MESSAGES: Record<FileReadErrorCode, string> = {
   BINARY_FILE: "Binary file — cannot display",
-  FILE_TOO_LARGE: "File too large to display (> 500 KB)",
+  FILE_TOO_LARGE: "File too large to display as text (> 500 KB)",
   LFS_POINTER: "Git LFS pointer — run `git lfs pull` to download the file contents",
   NOT_FOUND: "File no longer exists",
   OUTSIDE_ROOT: "File is outside the project root",

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -268,9 +268,11 @@ export function DiffPane({
   // file may be unreadable — surface that instead of a dead native control.
   const [videoPlaybackFailed, setVideoPlaybackFailed] = useState(false);
   useEffect(() => {
-    // A new file or an explicit refresh gets a fresh attempt.
+    // Any change to the playback attempt's identity — file, resolved root, or
+    // an explicit refresh — gets a fresh attempt. absolutePath covers a
+    // worktree move that filePath (relative) alone would miss.
     setVideoPlaybackFailed(false);
-  }, [filePath, videoReloadNonce]);
+  }, [filePath, absolutePath, worktreePath, videoReloadNonce]);
 
   const [pathCopied, setPathCopied] = useState(false);
   const handleCopyPath = useCallback(() => {

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -20,6 +20,8 @@ import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
+import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
+import { isVideoFilePath } from "@/components/FileViewer/filePreviewKinds";
 import { ImageDiffViewer, isImageDiffCandidate } from "@/components/FileViewer/ImageDiffViewer";
 import { DiffViewer, FULL_FILE_MAX_LINES } from "@/components/Worktree/DiffViewer";
 import type { FullFileUnavailableReason } from "@/components/Worktree/DiffViewer";
@@ -259,6 +261,10 @@ export function DiffPane({
   const currentEntry = currentIndex === -1 ? undefined : changeSet?.[currentIndex];
   const isViewed = currentEntry ? viewedSet.has(currentEntry.viewedKey) : false;
 
+  // Forces a fresh media request in video mode — the diff content hooks don't
+  // carry video bytes, so Refresh has to re-request the protocol URL itself.
+  const [videoReloadNonce, setVideoReloadNonce] = useState(0);
+
   const [pathCopied, setPathCopied] = useState(false);
   const handleCopyPath = useCallback(() => {
     if (!filePath) return;
@@ -377,6 +383,10 @@ export function DiffPane({
   const isImageMode = Boolean(
     filePath && fileStatus && isImageDiffCandidate(filePath) && panel?.diffSource !== "base-branch"
   );
+  // Videos show only the current working-tree version (no side-by-side diff —
+  // the media pipeline has no cheap "old vs new frame" comparison), so unlike
+  // isImageMode this applies to every diff source, base-branch included.
+  const isVideoMode = Boolean(filePath && isVideoFilePath(filePath));
   // Sentinels the viewer turns into empty states rather than a rendered diff.
   // `NO_CHANGES`/`ERROR` gate the pane's own branches below; the binary and
   // oversized ones matter to the full-file scope, which has nothing to expand
@@ -402,9 +412,11 @@ export function DiffPane({
     ? sourceAvailability
     : isImageMode
       ? { available: false, reason: "This view already shows the whole image" }
-      : !hasDiff
-        ? { available: false, reason: "There's no diff to expand yet" }
-        : { available: true };
+      : isVideoMode
+        ? { available: false, reason: "This view already shows the whole video" }
+        : !hasDiff
+          ? { available: false, reason: "There's no diff to expand yet" }
+          : { available: true };
 
   // The hunks and the file on disk must describe the same revision. Once the
   // store reports the file changed, they demonstrably don't: the check inside
@@ -439,9 +451,11 @@ export function DiffPane({
 
   // Only the diff is retried: clearing it drops `hasDiff`, which disables the
   // source hook and invalidates its read, and the source is fetched again when
-  // the new diff lands. Retrying both here would issue that read twice.
+  // the new diff lands. Retrying both here would issue that read twice. The
+  // video nonce bump is a no-op outside video mode (nothing renders it).
   const refreshAll = useCallback(() => {
     retry();
+    setVideoReloadNonce((nonce) => nonce + 1);
   }, [retry]);
 
   // One line explaining why a requested whole-file view isn't on screen. The
@@ -497,7 +511,7 @@ export function DiffPane({
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
-        {!isImageMode && (
+        {!isImageMode && !isVideoMode && (
           <div role="group" aria-label="Diff layout">
             <SegmentedToggle<DiffViewType>
               options={[
@@ -521,7 +535,7 @@ export function DiffPane({
         )}
         <FileViewerToolbar.Path path={filePath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
-          {!isImageMode && (
+          {!isImageMode && !isVideoMode && (
             <FileViewerToolbar.IconButton
               label="Wrap long lines"
               pressed={diffWrapLines}
@@ -708,7 +722,29 @@ export function DiffPane({
               </div>
             )}
 
-            {filePath && subject && !isImageMode && content && (
+            {filePath &&
+              subject &&
+              isVideoMode &&
+              (fileStatus === "deleted" || !absolutePath ? (
+                <div className="flex h-full w-full items-center justify-center p-6">
+                  <EmptyState
+                    variant="zero-data"
+                    scale="canvas"
+                    title="No working-tree version to play"
+                    description="This video was deleted, and the diff view can only play the current file."
+                  />
+                </div>
+              ) : (
+                <FileVideoPreview
+                  filePath={absolutePath}
+                  rootPath={worktreePath}
+                  label={fileName ?? filePath}
+                  reloadKey={videoReloadNonce}
+                  maxHeightClassName="max-h-full"
+                />
+              ))}
+
+            {filePath && subject && !isImageMode && !isVideoMode && content && (
               <DiffViewer
                 diff={content}
                 viewType={diffViewType}
@@ -721,7 +757,7 @@ export function DiffPane({
               />
             )}
 
-            {filePath && subject && !isImageMode && !content && (
+            {filePath && subject && !isImageMode && !isVideoMode && !content && (
               <div className="p-4 space-y-3">
                 <Skeleton label="Loading diff">
                   <SkeletonBone className="h-7 w-3/4" />

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -264,6 +264,13 @@ export function DiffPane({
   // Forces a fresh media request in video mode — the diff content hooks don't
   // carry video bytes, so Refresh has to re-request the protocol URL itself.
   const [videoReloadNonce, setVideoReloadNonce] = useState(0);
+  // An allowlisted container can still hold a codec Chromium lacks, or the
+  // file may be unreadable — surface that instead of a dead native control.
+  const [videoPlaybackFailed, setVideoPlaybackFailed] = useState(false);
+  useEffect(() => {
+    // A new file or an explicit refresh gets a fresh attempt.
+    setVideoPlaybackFailed(false);
+  }, [filePath, videoReloadNonce]);
 
   const [pathCopied, setPathCopied] = useState(false);
   const handleCopyPath = useCallback(() => {
@@ -544,7 +551,7 @@ export function DiffPane({
               <WrapText className="w-4 h-4" />
             </FileViewerToolbar.IconButton>
           )}
-          <FileViewerToolbar.IconButton label="Refresh" onClick={retry}>
+          <FileViewerToolbar.IconButton label="Refresh" onClick={refreshAll}>
             <RefreshCw className="w-4 h-4" />
           </FileViewerToolbar.IconButton>
           {absolutePath && (
@@ -734,12 +741,22 @@ export function DiffPane({
                     description="This video was deleted, and the diff view can only play the current file."
                   />
                 </div>
+              ) : videoPlaybackFailed ? (
+                <div className="flex h-full w-full items-center justify-center p-6">
+                  <EmptyState
+                    variant="zero-data"
+                    scale="canvas"
+                    title="This video couldn't be played"
+                    description="The container is supported but the codec may not be — Refresh to try again."
+                  />
+                </div>
               ) : (
                 <FileVideoPreview
                   filePath={absolutePath}
                   rootPath={worktreePath}
                   label={fileName ?? filePath}
                   reloadKey={videoReloadNonce}
+                  onError={() => setVideoPlaybackFailed(true)}
                   maxHeightClassName="max-h-full"
                 />
               ))}

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -586,6 +586,38 @@ describe("DiffPane — video current-version mode (#11382)", () => {
     expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
   });
 
+  it("reloads the video from the toolbar Refresh (nonce-busted URL)", () => {
+    seedPanel({
+      filePath: "media/demo.mp4",
+      fileStatus: "modified",
+      changeSet: [entry("media/demo.mp4")],
+    });
+    const { container } = renderPane();
+    const before = container.querySelector("video")?.getAttribute("src");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    const after = container.querySelector("video")?.getAttribute("src");
+    expect(after).not.toBe(before);
+  });
+
+  it("shows a playback-failure state instead of a dead control on media error", () => {
+    seedPanel({
+      filePath: "media/demo.mp4",
+      fileStatus: "modified",
+      changeSet: [entry("media/demo.mp4")],
+    });
+    const { container } = renderPane();
+
+    fireEvent.error(container.querySelector("video")!);
+
+    expect(container.querySelector("video")).toBeNull();
+    const titles = Array.from(container.querySelectorAll('[data-testid="empty-state-mock"]')).map(
+      (el) => el.getAttribute("data-title")
+    );
+    expect(titles).toContain("This video couldn't be played");
+  });
+
   it("shows a quiet empty state for a deleted video (no working-tree bytes to play)", () => {
     seedPanel({
       filePath: "media/demo.mp4",

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -586,7 +586,9 @@ describe("DiffPane — video current-version mode (#11382)", () => {
     expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
   });
 
-  it("reloads the video from the toolbar Refresh (nonce-busted URL)", () => {
+  it("reloads the video from the toolbar Refresh (nonce-busted URL) and still retries the diff", () => {
+    const retry = vi.fn();
+    useDiffContentMock.mockReturnValue({ content: "diff --git a/x b/x", stale: false, retry });
     seedPanel({
       filePath: "media/demo.mp4",
       fileStatus: "modified",
@@ -594,11 +596,14 @@ describe("DiffPane — video current-version mode (#11382)", () => {
     });
     const { container } = renderPane();
     const before = container.querySelector("video")?.getAttribute("src");
+    expect(before).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 
     const after = container.querySelector("video")?.getAttribute("src");
+    expect(after).toBeTruthy();
     expect(after).not.toBe(before);
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 
   it("shows a playback-failure state instead of a dead control on media error", () => {

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -559,3 +559,45 @@ describe("DiffPane — unresolvable subject", () => {
     expect(screen.queryByTestId("empty-state-mock")).toBeNull();
   });
 });
+
+describe("DiffPane — video current-version mode (#11382)", () => {
+  it("plays the working-tree version instead of rendering a diff", () => {
+    const changeSet = [entry("media/demo.mp4")];
+    seedPanel({ filePath: "media/demo.mp4", fileStatus: "modified", changeSet });
+    const { container } = renderPane();
+
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    // The absolute working-tree path rides the protocol URL — no diff content,
+    // no base64 diffMedia IPC (8 MB cap, unsuited to video).
+    expect(video?.getAttribute("src")).toContain(encodeURIComponent("/repo/media/demo.mp4"));
+    expect(screen.queryByTestId("diff-viewer-mock")).toBeNull();
+  });
+
+  it("hides the text-diff layout controls in video mode", () => {
+    seedPanel({
+      filePath: "media/demo.mp4",
+      fileStatus: "modified",
+      changeSet: [entry("media/demo.mp4")],
+    });
+    renderPane();
+
+    expect(screen.queryByRole("button", { name: "Unified" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
+  });
+
+  it("shows a quiet empty state for a deleted video (no working-tree bytes to play)", () => {
+    seedPanel({
+      filePath: "media/demo.mp4",
+      fileStatus: "deleted",
+      changeSet: [entry("media/demo.mp4", "deleted")],
+    });
+    const { container } = renderPane();
+
+    expect(container.querySelector("video")).toBeNull();
+    const titles = Array.from(container.querySelectorAll('[data-testid="empty-state-mock"]')).map(
+      (el) => el.getAttribute("data-title")
+    );
+    expect(titles).toContain("No working-tree version to play");
+  });
+});

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -15,7 +15,14 @@ import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
 import { ZoomableImage } from "@/components/FileViewer/ZoomableImage";
-import { isImageFilePath, isSvgFilePath } from "@/components/FileViewer/filePreviewKinds";
+import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
+import {
+  isImageFilePath,
+  isSvgFilePath,
+  isUnsupportedVideoFilePath,
+  isVideoFilePath,
+  UNSUPPORTED_VIDEO_MESSAGE,
+} from "@/components/FileViewer/filePreviewKinds";
 import { MarkdownViewer } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
 import { HtmlViewer } from "@/components/Html/HtmlViewer";
@@ -70,6 +77,7 @@ type ViewerState =
   | { status: "html"; content: string; previewUrl: string | null }
   | { status: "svg"; markup: string | null }
   | { status: "image" }
+  | { status: "video" }
   | { status: "error"; message: string };
 
 // Markdown gets a Source/Rendered switch mirroring FilePane's toggle. Typed at
@@ -130,6 +138,20 @@ export function FileBrowserViewer({
     // `daintree-file://` protocol serves them straight to the <img>.
     if (isImage && !isSvg) {
       setState({ status: "image" });
+      return;
+    }
+
+    // Videos stream from the same protocol into a <video> element; the text
+    // path would reject them with a misleading size/binary error.
+    if (isVideoFilePath(filePath)) {
+      setState({ status: "video" });
+      return;
+    }
+
+    // Containers Chromium can't demux get a truthful "can't play" message
+    // instead of falling through to the text path's size cap.
+    if (isUnsupportedVideoFilePath(filePath)) {
+      setState({ status: "error", message: UNSUPPORTED_VIDEO_MESSAGE });
       return;
     }
 
@@ -435,6 +457,22 @@ export function FileBrowserViewer({
               rootPath={rootPath}
               alt={fileName}
               sanitizedSvg={state.markup}
+              maxHeightClassName="max-h-full"
+            />
+          </div>
+        );
+
+      case "video":
+        return (
+          <div className="h-full w-full overflow-auto">
+            <FileVideoPreview
+              filePath={filePath}
+              rootPath={rootPath}
+              label={fileName}
+              reloadKey={revision}
+              onError={() =>
+                setState({ status: "error", message: "This video couldn't be played" })
+              }
               maxHeightClassName="max-h-full"
             />
           </div>

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -465,11 +465,14 @@ export function FileBrowserViewer({
       case "video":
         return (
           <div className="h-full w-full overflow-auto">
+            {/* Deliberately NOT keyed on `revision`: it ticks on every worktree
+                write, and remounting the player would reset playback whenever
+                an agent touches any file. A rewritten video shows its new bytes
+                on re-selection — continuity beats freshness mid-playback. */}
             <FileVideoPreview
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              reloadKey={revision}
               onError={() =>
                 setState({ status: "error", message: "This video couldn't be played" })
               }

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -246,3 +246,26 @@ describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
     expect(onToggleSidebar).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("FileBrowserViewer video preview (#11382)", () => {
+  it("renders a <video> for a playable container without reading the file as text", async () => {
+    const { container } = renderViewer("/repo/media/demo.webm");
+    await act(async () => {});
+
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute("src")).toContain("daintree-file://");
+    // The bytes stream through the protocol handler; the text-read IPC path
+    // (whose 500 KB cap produced the misleading error) must never run.
+    expect(readMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a format message for a container Chromium can't demux, not the size cap", async () => {
+    const { container } = renderViewer("/repo/media/demo.mkv");
+    await act(async () => {});
+
+    expect(container.querySelector("video")).toBeNull();
+    expect(readMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Can't play this video format/)).toBeTruthy();
+  });
+});

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -24,7 +24,14 @@ import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
-import { isImageFilePath, isSvgFilePath } from "@/components/FileViewer/filePreviewKinds";
+import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
+import {
+  isImageFilePath,
+  isSvgFilePath,
+  isUnsupportedVideoFilePath,
+  isVideoFilePath,
+  UNSUPPORTED_VIDEO_MESSAGE,
+} from "@/components/FileViewer/filePreviewKinds";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 import { formatBytes } from "@/lib/formatBytes";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
@@ -100,10 +107,11 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
   return toForwardSlashes(filePath).startsWith(root);
 }
 
-// "image" and "svg" are terminal preview states: an image is handed to the
-// `daintree-file://` protocol as an <img> src, and an SVG is read as text,
-// sanitized, then inlined. Neither has readable text content.
-type LoadState = "idle" | "loading" | "loaded" | "error" | "image" | "svg";
+// "image", "svg", and "video" are terminal preview states: an image is handed
+// to the `daintree-file://` protocol as an <img> src, an SVG is read as text,
+// sanitized, then inlined, and a video streams from the same protocol into a
+// <video> element. None has readable text content.
+type LoadState = "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video";
 
 const SEARCH_DEBOUNCE_MS = 150;
 const COPY_FEEDBACK_MS = 2000;
@@ -406,6 +414,29 @@ export function FilePane({
         setLoadState("image");
         setErrorCode(null);
         setErrorMessage(null);
+        return;
+      }
+
+      // Videos stream from the protocol handler into a <video> element; the
+      // text path would reject them with a misleading size/binary error.
+      if (isVideoFilePath(filePath)) {
+        setContent(null);
+        setSanitizedSvg(null);
+        setReloadNonce((nonce) => nonce + 1);
+        setLoadState("video");
+        setErrorCode(null);
+        setErrorMessage(null);
+        return;
+      }
+
+      // Containers Chromium can't demux get a truthful "can't play" message
+      // instead of falling through to the text path's size cap.
+      if (isUnsupportedVideoFilePath(filePath)) {
+        setContent(null);
+        setSanitizedSvg(null);
+        setErrorCode("BINARY_FILE");
+        setErrorMessage(UNSUPPORTED_VIDEO_MESSAGE);
+        setLoadState("error");
         return;
       }
 
@@ -825,6 +856,23 @@ export function FilePane({
             sanitizedSvg={loadState === "svg" ? sanitizedSvg : null}
             onError={() => {
               setErrorCode("NOT_FOUND");
+              setLoadState("error");
+            }}
+            maxHeightClassName="max-h-full"
+          />
+        )}
+
+        {filePath && viewMode !== "diff" && loadState === "video" && (
+          <FileVideoPreview
+            filePath={filePath}
+            rootPath={effectiveRootPath}
+            label={fileName ?? filePath}
+            reloadKey={reloadNonce}
+            onError={() => {
+              // An allowlisted container can still hold a codec Chromium lacks;
+              // name that instead of implying the file is missing.
+              setErrorCode("BINARY_FILE");
+              setErrorMessage("This video couldn't be played");
               setLoadState("error");
             }}
             maxHeightClassName="max-h-full"

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -422,7 +422,10 @@ export function FilePane({
       if (isVideoFilePath(filePath)) {
         setContent(null);
         setSanitizedSvg(null);
-        setReloadNonce((nonce) => nonce + 1);
+        // Only an explicit load (open, toolbar Refresh) re-requests the media —
+        // a silent background pass must not remount the player and reset
+        // playback while someone is watching.
+        if (!silent) setReloadNonce((nonce) => nonce + 1);
         setLoadState("video");
         setErrorCode(null);
         setErrorMessage(null);
@@ -837,14 +840,18 @@ export function FilePane({
             <p className="text-sm text-muted-foreground">
               {errorMessage ?? FILE_READ_ERROR_MESSAGES[errorCode]}
             </p>
-            <button
-              type="button"
-              onClick={() => loadFile(false)}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
-            >
-              <RefreshCw className="w-3.5 h-3.5" />
-              Retry
-            </button>
+            {/* An unsupported container is deterministic — retrying the same
+                extension can never succeed, so the action would be dead. */}
+            {!isUnsupportedVideoFilePath(filePath) && (
+              <button
+                type="button"
+                onClick={() => loadFile(false)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-daintree-text bg-daintree-border hover:bg-daintree-border/80 rounded transition-colors"
+              >
+                <RefreshCw className="w-3.5 h-3.5" />
+                Retry
+              </button>
+            )}
           </div>
         )}
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -752,6 +752,27 @@ describe("FilePane diff mode (#11274)", () => {
     });
   });
 
+  describe("video preview (#11382)", () => {
+    it("renders a <video> for a playable container without reading the file as text", async () => {
+      const { container } = await renderPane({ filePath: "/repo/media/demo.mp4" });
+
+      const video = container.querySelector("video");
+      expect(video).not.toBeNull();
+      expect(video?.getAttribute("src")).toContain("daintree-file://");
+      // The bytes stream through the protocol handler; the text-read IPC path
+      // (whose 500 KB cap produced the misleading error) must never run.
+      expect(readMock).not.toHaveBeenCalled();
+    });
+
+    it("shows a format message for a container Chromium can't demux, not the size cap", async () => {
+      const { container } = await renderPane({ filePath: "/repo/media/demo.mov" });
+
+      expect(container.querySelector("video")).toBeNull();
+      expect(readMock).not.toHaveBeenCalled();
+      expect(screen.getByText(/Can't play this video format/)).toBeTruthy();
+    });
+  });
+
   describe("change lookup", () => {
     it("matches a change stored as an absolute path", async () => {
       seedWorktree([{ path: "/repo/src/index.ts", status: "modified" }]);


### PR DESCRIPTION
## Summary

- Videos (`mp4`, `m4v`, `webm`, `ogv`) were falling through to the generic file viewer, which only knows raster images and SVG, and hit a misleading "file too large" error regardless of actual size. They now get an inline player. Unplayable container formats (`mov`, `mkv`, `avi`, `wmv`) get an honest "can't play this format" message instead.
- The `daintree-file://` protocol handler used to buffer whole files into memory with a size cap and no Range support. It now has a streaming path with HTTP Range/206 partial content and HEAD request support, so `<video>` seeking works without loading a multi-hundred-MB file into memory.
- A shared `FileVideoPreview` component is wired into the file pane, the file browser's inline viewer, and the diff pane.

Resolves #11382

## Changes

- `filePreviewKinds.ts`: video/unplayable-video classification by extension.
- `fileReadErrors.ts`: clarified `FILE_TOO_LARGE` copy.
- `electron/setup/protocols.ts`: streaming Range/206 + HEAD path for video. Byte ranges are derived from the open file descriptor; open-ended ranges are clamped to 8 MiB chunks; suffix and explicit ranges are served exactly as requested. No whole-file size cap applies to the video path (the cap still applies to the old buffered path for non-video files). Keeps the existing hardening: `O_NOFOLLOW`/`O_NONBLOCK` on open, plus a stat check performed after opening the file descriptor to catch races, per the lesson from #11028 on time-of-check-to-time-of-use bugs. MIME classification now resolves the real path first, closing a hole where a symlink/alias could disguise a file's real type on Windows.
- `shared/config/csp.ts`: added `daintree-file:` to `media-src` in both production and development configs. Without this, video silently fails to load because Chromium blocks it at the CSP layer, so this is load-bearing, not cosmetic.
- `FileVideoPreview.tsx`: shared player component, wired into `FilePane.tsx`, `FileBrowserViewer.tsx`, and `DiffPane.tsx`. The diff pane only shows the current working-tree version (no side-by-side video diffing), with an empty state for a deleted video and a state for playback failures.

## Testing

- 477 targeted vitest tests passing, plus a clean `tsc` run.
- Own-file prettier/eslint clean (three pre-existing warnings in touched files left untouched, out of scope).
- Deliberately skipped an E2E test with a real video fixture: hand-crafting a small WebM file for the suite risks a latent, flaky release-gate failure. The CSP regression is instead pinned by unit tests in `csp.test.ts`. A manual playback check is recommended as a follow-up.
