### PR TITLE
fix(terminal): route agent-terminal ArrowUp to terminal, not history

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -96,6 +96,7 @@ interface LatestState {
   projectId?: string;
   disabled: boolean;
   isInitializing: boolean;
+  isAgentTerminal: boolean;
   isInHistoryMode: boolean;
   isAutocompleteOpen: boolean;
   autocompleteItems: AutocompleteItem[];
@@ -397,6 +398,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         projectId,
         disabled,
         isInitializing,
+        isAgentTerminal,
         isInHistoryMode,
         isAutocompleteOpen,
         autocompleteItems,

--- a/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
@@ -25,6 +25,7 @@ function makeLatest(overrides: Partial<LatestShape> = {}): LatestShape {
     projectId: undefined,
     disabled: false,
     isInitializing: false,
+    isAgentTerminal: false,
     isInHistoryMode: false,
     isAutocompleteOpen: true,
     autocompleteItems: [fileItem],
@@ -45,12 +46,16 @@ describe("useEditorKeymap", () => {
   let setActiveCompletionContext: ReturnType<
     typeof vi.fn<Dispatch<SetStateAction<ActiveCompletionContext | null>>>
   >;
+  let handleHistoryNavigation: ReturnType<typeof vi.fn<(direction: "up" | "down") => boolean>>;
+  let setSelectedIndex: ReturnType<typeof vi.fn<Dispatch<SetStateAction<number>>>>;
 
   beforeEach(() => {
     applyAutocompleteSelection = vi.fn<(mode: "enter" | "complete") => boolean>(() => true);
     sendFromEditor = vi.fn<() => void>();
     cancelVoiceWaitSubmit = vi.fn<() => boolean>(() => false);
     setActiveCompletionContext = vi.fn<Dispatch<SetStateAction<ActiveCompletionContext | null>>>();
+    handleHistoryNavigation = vi.fn<(direction: "up" | "down") => boolean>(() => false);
+    setSelectedIndex = vi.fn<Dispatch<SetStateAction<number>>>();
   });
 
   function renderKeymap(latest: LatestShape) {
@@ -62,7 +67,7 @@ describe("useEditorKeymap", () => {
       editableCompartmentRef: { current: new Compartment() },
       historyPaletteOpenRef: { current: null },
       applyAutocompleteSelection,
-      handleHistoryNavigation: vi.fn<(direction: "up" | "down") => boolean>(() => false),
+      handleHistoryNavigation,
       sendFromEditor,
       startVoiceWaitSubmit: vi.fn<() => void>(),
       cancelVoiceWaitSubmit,
@@ -73,7 +78,7 @@ describe("useEditorKeymap", () => {
       >(() => undefined),
       setActiveCompletionContext,
       setIsExpanded: vi.fn<Dispatch<SetStateAction<boolean>>>(),
-      setSelectedIndex: vi.fn<Dispatch<SetStateAction<number>>>(),
+      setSelectedIndex,
     };
     const { result } = renderHook(() => useEditorKeymap(params));
     return { handlers: result.current.handlersRef.current! };
@@ -144,6 +149,167 @@ describe("useEditorKeymap", () => {
       const { handlers } = renderKeymap(makeLatest());
       expect(handlers.onEscape()).toBe(true);
       expect(setActiveCompletionContext).not.toHaveBeenCalled();
+    });
+  });
+
+  // Arrow routing between host prompt-history and the agent's own terminal TUI
+  // (e.g. Codex's `/model` picker). Regression matrix for issue #11218: empty
+  // ArrowUp on an agent terminal must reach the terminal, not recall history,
+  // while shell-terminal recall and mid-recall navigation stay intact.
+  describe("Arrow routing (issue #11218)", () => {
+    it("agent terminal: empty ArrowUp at rest forwards to the terminal, never host history", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      // Would recall a history entry if consulted — asserting it is not called
+      // directly reproduces and guards against the original bug.
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({ isAgentTerminal: true, isAutocompleteOpen: false, value: "", onSendKey })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(onSendKey).toHaveBeenCalledWith("up");
+      expect(handleHistoryNavigation).not.toHaveBeenCalled();
+    });
+
+    it("shell terminal: empty ArrowUp at rest recalls host history, not the terminal", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({ isAgentTerminal: false, isAutocompleteOpen: false, value: "", onSendKey })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("up");
+      expect(onSendKey).not.toHaveBeenCalled();
+    });
+
+    it("agent terminal: empty ArrowDown at rest forwards to the terminal (unchanged)", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(false);
+      const { handlers } = renderKeymap(
+        makeLatest({ isAgentTerminal: true, isAutocompleteOpen: false, value: "", onSendKey })
+      );
+      expect(handlers.onArrowDown()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("down");
+      expect(onSendKey).toHaveBeenCalledWith("down");
+    });
+
+    it("shell terminal: empty ArrowDown at rest forwards to the terminal (unchanged)", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(false);
+      const { handlers } = renderKeymap(
+        makeLatest({ isAgentTerminal: false, isAutocompleteOpen: false, value: "", onSendKey })
+      );
+      expect(handlers.onArrowDown()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("down");
+      expect(onSendKey).toHaveBeenCalledWith("down");
+    });
+
+    it("agent terminal: mid-recall ArrowUp still navigates host history", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: true,
+          isAutocompleteOpen: false,
+          isInHistoryMode: true,
+          value: "recalled command",
+          onSendKey,
+        })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("up");
+      expect(onSendKey).not.toHaveBeenCalled();
+    });
+
+    it("agent terminal: mid-recall ArrowDown still navigates host history", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: true,
+          isAutocompleteOpen: false,
+          isInHistoryMode: true,
+          value: "recalled command",
+          onSendKey,
+        })
+      );
+      expect(handlers.onArrowDown()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("down");
+      expect(onSendKey).not.toHaveBeenCalled();
+    });
+
+    it("shell terminal: mid-recall ArrowUp still navigates host history", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: false,
+          isAutocompleteOpen: false,
+          isInHistoryMode: true,
+          value: "recalled command",
+          onSendKey,
+        })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("up");
+      expect(onSendKey).not.toHaveBeenCalled();
+    });
+
+    it("agent terminal: whitespace-only ArrowUp is treated as empty and forwarded", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({ isAgentTerminal: true, isAutocompleteOpen: false, value: "   ", onSendKey })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(onSendKey).toHaveBeenCalledWith("up");
+      expect(handleHistoryNavigation).not.toHaveBeenCalled();
+    });
+
+    it("agent terminal: empty ArrowUp without onSendKey is unhandled and never recalls history", () => {
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: true,
+          isAutocompleteOpen: false,
+          value: "",
+          onSendKey: undefined,
+        })
+      );
+      expect(handlers.onArrowUp()).toBe(false);
+      expect(handleHistoryNavigation).not.toHaveBeenCalled();
+    });
+
+    it("agent terminal: an open autocomplete menu wins over terminal routing", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: true,
+          isAutocompleteOpen: true,
+          autocompleteItems: [fileItem],
+          value: "",
+          onSendKey,
+        })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(setSelectedIndex).toHaveBeenCalled();
+      expect(onSendKey).not.toHaveBeenCalled();
+      expect(handleHistoryNavigation).not.toHaveBeenCalled();
+    });
+
+    it("agent terminal: non-empty input outside history mode is left to CodeMirror", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: true,
+          isAutocompleteOpen: false,
+          isInHistoryMode: false,
+          value: "some draft",
+          onSendKey,
+        })
+      );
+      expect(handlers.onArrowUp()).toBe(false);
+      expect(onSendKey).not.toHaveBeenCalled();
+      expect(handleHistoryNavigation).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
@@ -311,5 +311,37 @@ describe("useEditorKeymap", () => {
       expect(onSendKey).not.toHaveBeenCalled();
       expect(handleHistoryNavigation).not.toHaveBeenCalled();
     });
+
+    it("agent terminal: empty ArrowUp in history mode navigates host history, not the terminal", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      // Guards the `!isInHistoryMode` half of the new predicate: an empty agent
+      // input already cycling host history must keep navigating it, not forward.
+      handleHistoryNavigation.mockReturnValue(true);
+      const { handlers } = renderKeymap(
+        makeLatest({
+          isAgentTerminal: true,
+          isAutocompleteOpen: false,
+          isInHistoryMode: true,
+          value: "",
+          onSendKey,
+        })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("up");
+      expect(onSendKey).not.toHaveBeenCalled();
+    });
+
+    it("shell terminal: empty ArrowUp with no host history falls through to the terminal", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      // Fresh shell with no Daintree prompt history — ArrowUp must still reach
+      // the shell/readline history via onSendKey.
+      handleHistoryNavigation.mockReturnValue(false);
+      const { handlers } = renderKeymap(
+        makeLatest({ isAgentTerminal: false, isAutocompleteOpen: false, value: "", onSendKey })
+      );
+      expect(handlers.onArrowUp()).toBe(true);
+      expect(handleHistoryNavigation).toHaveBeenCalledWith("up");
+      expect(onSendKey).toHaveBeenCalledWith("up");
+    });
   });
 });

--- a/src/components/Terminal/hooks/useEditorKeymap.ts
+++ b/src/components/Terminal/hooks/useEditorKeymap.ts
@@ -10,6 +10,7 @@ interface LatestRefShape {
   projectId?: string;
   disabled: boolean;
   isInitializing: boolean;
+  isAgentTerminal: boolean;
   isInHistoryMode: boolean;
   isAutocompleteOpen: boolean;
   autocompleteItems: AutocompleteItem[];
@@ -177,6 +178,21 @@ export function useEditorKeymap({
 
       const text = editorViewRef.current?.state.doc.toString() ?? latest.value;
       const isEmpty = text.trim().length === 0;
+
+      // Agent terminals: an empty-input ArrowUp at rest belongs to the agent's
+      // own TUI (e.g. Codex's `/model` picker), not host prompt-history recall.
+      // Forward it to the terminal and never fall back to history — this keeps
+      // ArrowUp symmetric with ArrowDown (which already reaches the terminal at
+      // rest) and leaves host history reachable via Mod-r. Mid-recall
+      // (isInHistoryMode) still navigates host history in the block below.
+      if (latest.isAgentTerminal && isEmpty && !latest.isInHistoryMode) {
+        if (latest.onSendKey) {
+          latest.onSendKey("up");
+          return true;
+        }
+        return false;
+      }
+
       const canNavigateHistory = isEmpty || latest.isInHistoryMode;
 
       if (canNavigateHistory) {


### PR DESCRIPTION
## Summary

- With the Ask Codex hybrid input focused and Codex's terminal-side `/model` picker open, ArrowDown moved the picker selection but ArrowUp recalled host prompt history instead, so the two keys behaved asymmetrically.
- Root cause: `terminalInputStore.navigateHistory("up")` at rest always returns the last history entry (a non-null recall), while `navigateHistory("down")` at rest returns `null` (a no-op). That's why ArrowUp got swallowed by host history and ArrowDown fell through to the terminal.
- Fix: forward an empty-input ArrowUp at rest straight to the terminal for agent terminals, mirroring what ArrowDown already does, before host-history recall gets a chance to run.

Resolves #11218

## Changes

- `useEditorKeymap.ts`: in `onArrowUp`, forward to the terminal when `isAgentTerminal && isEmpty && !isInHistoryMode`, matching the existing `onArrowDown` path, and never fall back to host history when `onSendKey` is unavailable.
- Threaded a new `isAgentTerminal` flag (`agentId !== undefined`) through `LatestRefShape` and `LatestState` into the keymap's latest-values ref (`useEditorKeymap.ts`, `HybridInputBar.tsx`).
- Left shell-terminal history recall (#1174) and mid-recall (`isInHistoryMode`) navigation for both terminal kinds untouched. Host prompt history is still reachable via the Mod-r history palette (`commandHistoryStore`), so nothing regresses there.

## Testing

- Reviewed by Codex in two parallel passes: no high or medium severity findings.
- Local suite: 104 tests across 6 files green, covering the keymap hook and `HybridInputBar`.
- Own-file prettier and eslint clean, zero errors.
