### PR TITLE
feat(file): add reveal in file manager to the file viewer toolbar

### DIFF
--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -14,6 +14,7 @@ import { isFilePanel } from "@shared/types/panel";
 import type { GitStatus } from "@shared/types/git";
 import { isPathInside, normalize, toWorktreeRelative } from "@shared/utils/path";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import type { BuiltInRuntimeActionId } from "@shared/config/actionIds";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { FolderOpen } from "@/components/icons";
@@ -124,7 +125,7 @@ const EXTERNAL_ACTIONS = {
   reveal: "file.showItemInFolder",
   browser: "file.openInBrowser",
   editor: "file.openInEditor",
-} as const satisfies Record<ExternalTarget, string>;
+} as const satisfies Record<ExternalTarget, BuiltInRuntimeActionId>;
 
 // Button label comes from `revealCopy()` (platform-named); the failure banner's
 // title, retry name and dismiss name are resolved together with it so the three

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -16,6 +16,7 @@ import { isPathInside, normalize, toWorktreeRelative } from "@shared/utils/path"
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
+import { FolderOpen } from "@/components/icons";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { MarkdownViewer, type MarkdownViewerHandle } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
@@ -23,6 +24,7 @@ import { HtmlViewer } from "@/components/Html/HtmlViewer";
 import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
 import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
+import { revealCopy, type RevealCopy } from "@/components/FileViewer/revealCopy";
 import { FileImagePreview } from "@/components/FileViewer/FileImagePreview";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
 import {
@@ -51,6 +53,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useProjectStore } from "@/store/projectStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { isClientAppError } from "@/utils/clientAppError";
 import { logError } from "@/utils/logger";
@@ -112,6 +115,45 @@ function isUnderRoot(filePath: string, rootPath: string): boolean {
 // sanitized, then inlined, and a video streams from the same protocol into a
 // <video> element. None has readable text content.
 type LoadState = "idle" | "loading" | "loaded" | "error" | "image" | "svg" | "video";
+
+// Which external surface a toolbar action aims the current file at. `reveal` is
+// always offered; `browser`/`editor` is the mode-dependent open button.
+type ExternalTarget = "reveal" | "browser" | "editor";
+
+const EXTERNAL_ACTIONS = {
+  reveal: "file.showItemInFolder",
+  browser: "file.openInBrowser",
+  editor: "file.openInEditor",
+} as const satisfies Record<ExternalTarget, string>;
+
+// Button label comes from `revealCopy()` (platform-named); the failure banner's
+// title, retry name and dismiss name are resolved together with it so the three
+// can't drift. Browser/editor wording is static — only reveal is platform-bound.
+function externalTargetCopy(
+  target: ExternalTarget,
+  reveal: RevealCopy
+): { errorTitle: string; retryAriaLabel: string; dismissAriaLabel: string } {
+  switch (target) {
+    case "reveal":
+      return {
+        errorTitle: reveal.errorTitle,
+        retryAriaLabel: reveal.retryAriaLabel,
+        dismissAriaLabel: "Dismiss file manager error",
+      };
+    case "browser":
+      return {
+        errorTitle: "Couldn't open in browser",
+        retryAriaLabel: "Retry opening in browser",
+        dismissAriaLabel: "Dismiss browser error",
+      };
+    case "editor":
+      return {
+        errorTitle: "Couldn't open in editor",
+        retryAriaLabel: "Retry opening in editor",
+        dismissAriaLabel: "Dismiss editor error",
+      };
+  }
+}
 
 const SEARCH_DEBOUNCE_MS = 150;
 const COPY_FEEDBACK_MS = 2000;
@@ -580,63 +622,76 @@ export function FilePane({
   }, [filePath]);
 
   // Rendered HTML opens in the browser; every other view opens in the editor.
-  // The button and its failure banner follow this target.
+  // Reveal is a third, always-present target that sits alongside this one.
   const openTarget: "browser" | "editor" = isHtml && viewMode === "rendered" ? "browser" : "editor";
 
   // dispatch() resolves an ActionDispatchResult and never rejects, so a failed
   // open used to vanish entirely (#11114). Surface it inline on the pane that
-  // owns the button rather than through a global toast. The target is passed in
-  // by the caller — the toolbar button uses the live view's target, Retry reuses
-  // the banner's — so a mode toggle mid-launch can never relabel or re-aim it.
-  const [openError, setOpenError] = useState<{
+  // owns the button rather than through a global toast. `target` rides along so
+  // Retry re-aims at what actually failed, even after a mode toggle.
+  const [externalError, setExternalError] = useState<{
     message: string;
-    target: "browser" | "editor";
+    target: ExternalTarget;
   } | null>(null);
-  const [isOpening, setIsOpening] = useState(false);
-  const openAttemptRef = useRef(0);
+  // Tracked per target, not as one flag: revealing successfully says nothing
+  // about a missing editor, so the two must not clear or spin for each other.
+  const [pendingTargets, setPendingTargets] = useState<readonly ExternalTarget[]>([]);
+  // Bumped only by the reset below, so a still-running action is invalidated by
+  // the file changing under it — never by a sibling button starting.
+  const externalGenerationRef = useRef(0);
   // Synchronous re-entry guard: state can't stop a double-click in one tick.
-  // Without it a second launch could land after the first succeeded and report
-  // a failure over a file that was in fact opened.
-  const openInFlightRef = useRef(false);
+  const externalInFlightRef = useRef<Set<ExternalTarget>>(new Set());
 
   // A result that lands after the pane switched files (or panels) belongs to the
   // old file: drop it, and clear any banner the old file left behind.
   useEffect(() => {
-    openAttemptRef.current += 1;
-    openInFlightRef.current = false;
-    setOpenError(null);
-    setIsOpening(false);
+    externalGenerationRef.current += 1;
+    externalInFlightRef.current.clear();
+    setExternalError(null);
+    setPendingTargets([]);
   }, [id, filePath]);
 
   const handleOpenExternal = useCallback(
-    async (target: "browser" | "editor") => {
+    async (target: ExternalTarget) => {
       if (!filePath) return;
-      if (openInFlightRef.current) return;
-      openInFlightRef.current = true;
-      const attempt = ++openAttemptRef.current;
-      setIsOpening(true);
-      const result = await actionService.dispatch(
-        target === "browser" ? "file.openInBrowser" : "file.openInEditor",
-        { path: filePath },
-        { source: "user" }
-      );
-      // A newer attempt (or a file/panel switch) already reset the guard and owns
-      // the banner — an obsolete completion must not unlock it or overwrite state.
-      if (openAttemptRef.current !== attempt) return;
-      openInFlightRef.current = false;
-      setIsOpening(false);
-      if (result.ok) {
-        setOpenError(null);
-        return;
+      if (externalInFlightRef.current.has(target)) return;
+      externalInFlightRef.current.add(target);
+      const generation = externalGenerationRef.current;
+      setPendingTargets((current) => (current.includes(target) ? current : [...current, target]));
+      try {
+        const result = await actionService.dispatch(
+          EXTERNAL_ACTIONS[target],
+          { path: filePath },
+          { source: "user" }
+        );
+        // The file (or panel) changed while this was in flight: the result
+        // describes a file the pane no longer shows.
+        if (externalGenerationRef.current !== generation) return;
+        if (result.ok) {
+          // Clears only its own failure — a sibling's banner stands until that
+          // button's own retry succeeds.
+          setExternalError((current) => (current?.target === target ? null : current));
+          return;
+        }
+        logError(`[FilePane] ${EXTERNAL_ACTIONS[target]} failed`, result.error);
+        setExternalError({ message: result.error.message, target });
+      } finally {
+        // Releasing in `finally` keeps a rejection from wedging the button; the
+        // generation check leaves a reset's clean slate alone.
+        if (externalGenerationRef.current === generation) {
+          externalInFlightRef.current.delete(target);
+          setPendingTargets((current) => current.filter((t) => t !== target));
+        }
       }
-      logError(
-        `[FilePane] openIn${target === "browser" ? "Browser" : "Editor"} failed`,
-        result.error
-      );
-      setOpenError({ message: result.error.message, target });
     },
     [filePath]
   );
+
+  const isErrorTargetPending =
+    externalError !== null && pendingTargets.includes(externalError.target);
+  // Below the Doherty threshold a spinner is just a flash; `disabled` still
+  // blocks a double submit from the first millisecond.
+  const showRetrySpinner = useDohertyGate(isErrorTargetPending);
 
   const [pickerQuery, setPickerQuery] = useState("");
   const pickerRoot = worktreePath || projectPath;
@@ -650,6 +705,8 @@ export function FilePane({
     filePath && isUnderRoot(filePath, pickerRoot)
       ? toForwardSlashes(filePath).slice(toForwardSlashes(pickerRoot).replace(/\/$/, "").length + 1)
       : filePath && toForwardSlashes(filePath);
+  const reveal = revealCopy();
+  const errorCopy = externalError ? externalTargetCopy(externalError.target, reveal) : null;
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root>
@@ -676,6 +733,15 @@ export function FilePane({
           <FileViewerToolbar.IconButton label="Refresh" onClick={handleToolbarRefresh}>
             <SpinningIcon icon={RefreshCw} active={refreshingMode !== null} className="w-4 h-4" />
           </FileViewerToolbar.IconButton>
+          {/* Reveal is always offered, even for a file the viewer can't render
+              (oversized, unsupported video) — the OS file manager is then the
+              only way forward. */}
+          <FileViewerToolbar.IconButton
+            label={reveal.label}
+            onClick={() => void handleOpenExternal("reveal")}
+          >
+            <FolderOpen className="w-4 h-4" />
+          </FileViewerToolbar.IconButton>
           <FileViewerToolbar.IconButton
             label={openTarget === "browser" ? "Open in browser" : "Open in editor"}
             onClick={() => void handleOpenExternal(openTarget)}
@@ -698,30 +764,24 @@ export function FilePane({
           action={{ id: "refresh-diff", label: "Refresh", icon: RefreshCw, onClick: retryDiff }}
         />
       )}
-      {openError && (
+      {externalError && errorCopy && (
         <InlineStatusBanner
           icon={XCircle}
-          title={
-            openError.target === "browser" ? "Couldn't open in browser" : "Couldn't open in editor"
-          }
-          description={openError.message}
+          title={errorCopy.errorTitle}
+          description={externalError.message}
           severity="error"
           action={{
             id: "retry-open-external",
             label: "Retry",
             icon: RefreshCw,
             variant: "dangerFilled",
-            loading: isOpening,
-            onClick: () => void handleOpenExternal(openError.target),
-            ariaLabel:
-              openError.target === "browser"
-                ? "Retry opening in browser"
-                : "Retry opening in editor",
+            loading: showRetrySpinner,
+            disabled: isErrorTargetPending,
+            onClick: () => void handleOpenExternal(externalError.target),
+            ariaLabel: errorCopy.retryAriaLabel,
           }}
-          onClose={() => setOpenError(null)}
-          closeAriaLabel={
-            openError.target === "browser" ? "Dismiss browser error" : "Dismiss editor error"
-          }
+          onClose={() => setExternalError(null)}
+          closeAriaLabel={errorCopy.dismissAriaLabel}
         />
       )}
     </>

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -400,9 +400,8 @@ describe("FilePane reveal in file manager (#11386)", () => {
   // hardcoding a per-OS string that would fail on the other platform's CI.
   const revealLabel = revealCopy().label;
 
-  function renderFilePane(filePath = PATH) {
-    panelsById["file-1"] = { id: "file-1", kind: "file", filePath };
-    return render(
+  function paneElement(filePath: string) {
+    return (
       <TooltipProvider>
         <FilePane
           id="file-1"
@@ -414,6 +413,11 @@ describe("FilePane reveal in file manager (#11386)", () => {
         />
       </TooltipProvider>
     );
+  }
+
+  function renderFilePane(filePath = PATH) {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath };
+    return render(paneElement(filePath));
   }
 
   function findButton(container: HTMLElement, label: string): HTMLButtonElement {
@@ -479,9 +483,13 @@ describe("FilePane reveal in file manager (#11386)", () => {
     expect(notifyMock).not.toHaveBeenCalled();
 
     dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+    // Cleared so the assertion can't be satisfied by the original failed
+    // dispatch — a Retry that merely cleared the banner would then fail here.
+    dispatchMock.mockClear();
     await click(findButton(container, revealCopy().retryAriaLabel));
 
-    expect(dispatchMock).toHaveBeenLastCalledWith(
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
       "file.showItemInFolder",
       { path: PATH },
       { source: "user" }
@@ -534,8 +542,79 @@ describe("FilePane reveal in file manager (#11386)", () => {
     // Revealing the file did nothing to configure an editor, so the editor's
     // failure is still true and its banner must stand.
     dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+    dispatchMock.mockClear();
     await click(findButton(container, revealLabel));
+
+    // The reveal really ran (not swallowed by the editor's error state) yet the
+    // editor's own banner is untouched.
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "file.showItemInFolder",
+      { path: PATH },
+      { source: "user" }
+    );
     expect(container.querySelector('[role="alert"]')?.textContent).toContain("No editor configured");
+  });
+
+  it("leaves a target's Retry usable while only a sibling target is pending", async () => {
+    dispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "No editor configured" },
+    });
+    const { container } = renderFilePane();
+    await click(findButton(container, "Open in editor"));
+
+    // A reveal held in flight must not disable the editor's Retry — pending is
+    // per target, so a slow sibling says nothing about the editor's own state.
+    const revealGate = deferred();
+    dispatchMock.mockReturnValue(revealGate.promise);
+    act(() => {
+      findButton(container, revealLabel).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(
+      findButton(container, "Retry opening in editor").hasAttribute("disabled")
+    ).toBe(false);
+
+    await act(async () => {
+      revealGate.resolve({ ok: true, result: undefined });
+      await revealGate.promise;
+    });
+  });
+
+  it("won't let a superseded reveal unlock the attempt that replaced it", async () => {
+    const staleReveal = deferred();
+    const liveReveal = deferred();
+    dispatchMock.mockReturnValueOnce(staleReveal.promise).mockReturnValueOnce(liveReveal.promise);
+    const { container, rerender } = renderFilePane();
+
+    act(() => {
+      findButton(container, revealLabel).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // Switch files: the reset bumps the generation so the first reveal's later
+    // completion belongs to a file the pane no longer shows.
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/src/other.ts" };
+    rerender(paneElement("/repo/src/other.ts"));
+    act(() => {
+      findButton(container, revealLabel).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    // The stale reveal lands last. Releasing the in-flight guard on its way out
+    // would hand the live reveal's slot away and permit a duplicate OS launch.
+    await act(async () => {
+      staleReveal.resolve({ ok: true, result: undefined });
+      await staleReveal.promise;
+    });
+    act(() => {
+      findButton(container, revealLabel).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      liveReveal.resolve({ ok: true, result: undefined });
+      await liveReveal.promise;
+    });
   });
 });
 
@@ -648,14 +727,42 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     );
   });
 
-  it("retries a failed browser open as a browser open, not an editor open", async () => {
+  it("retries a failed browser open as a browser open even after the view switches to source", async () => {
     dispatchMock.mockResolvedValue({
       ok: false,
       error: { code: "EXECUTION_ERROR", message: "Launch failed" },
     });
-    const { container } = renderPane("/repo/dist/report.html", "rendered");
+    const { container, rerender } = renderPane("/repo/dist/report.html", "rendered");
     await clickOpen("Open in browser");
 
+    // Flip the live view to source so the toolbar's own open button now targets
+    // the editor — the banner's Retry must still fire the browser open it owns,
+    // not follow the live target. Same file, so the failure banner survives.
+    panelsById["file-1"] = {
+      id: "file-1",
+      kind: "file",
+      filePath: "/repo/dist/report.html",
+      fileViewMode: "source",
+    };
+    await act(async () => {
+      rerender(
+        <TooltipProvider>
+          <FilePane
+            id="file-1"
+            title="report.html"
+            isFocused={false}
+            location="grid"
+            onFocus={() => {}}
+            onClose={() => {}}
+          />
+        </TooltipProvider>
+      );
+    });
+    // The live open button really did change target away from browser.
+    expect(await screen.findByLabelText("Open in editor")).toBeTruthy();
+
+    // Cleared so the assertion can't be satisfied by the original failed open.
+    dispatchMock.mockClear();
     const retry = Array.from(container.querySelectorAll("button")).find((b) =>
       b.textContent?.includes("Retry")
     );
@@ -663,8 +770,8 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
       retry!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    // Retry must re-aim at the banner's action even if the view mode changed.
-    expect(dispatchMock).toHaveBeenLastCalledWith(
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
       "file.openInBrowser",
       { path: "/repo/dist/report.html" },
       { source: "user" }

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -537,7 +537,9 @@ describe("FilePane reveal in file manager (#11386)", () => {
     });
     const { container } = renderFilePane();
     await click(findButton(container, "Open in editor"));
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain("No editor configured");
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "No editor configured"
+    );
 
     // Revealing the file did nothing to configure an editor, so the editor's
     // failure is still true and its banner must stand.
@@ -552,7 +554,9 @@ describe("FilePane reveal in file manager (#11386)", () => {
       { path: PATH },
       { source: "user" }
     );
-    expect(container.querySelector('[role="alert"]')?.textContent).toContain("No editor configured");
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "No editor configured"
+    );
   });
 
   it("leaves a target's Retry usable while only a sibling target is pending", async () => {
@@ -571,9 +575,7 @@ describe("FilePane reveal in file manager (#11386)", () => {
       findButton(container, revealLabel).dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(
-      findButton(container, "Retry opening in editor").hasAttribute("disabled")
-    ).toBe(false);
+    expect(findButton(container, "Retry opening in editor").hasAttribute("disabled")).toBe(false);
 
     await act(async () => {
       revealGate.resolve({ ok: true, result: undefined });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -140,6 +140,7 @@ vi.mock("@/components/Html/HtmlViewer", () => ({
 import { FilePane } from "../FilePane";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
+import { revealCopy } from "@/components/FileViewer/revealCopy";
 
 function lastContentPanelProps(): Record<string, unknown> {
   const props = contentPanelProps.at(-1);
@@ -385,6 +386,156 @@ describe("FilePane open-in-editor failure feedback (#11114)", () => {
       { source: "user" }
     );
     expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});
+
+// #11386: the read-only viewer gains a "Reveal in file manager" button so the
+// file can be opened in Finder/Explorer even when the viewer can't render it
+// (oversized, unsupported video). Reveal and the browser/editor open button are
+// concurrently clickable, so external-open state is tracked per target.
+describe("FilePane reveal in file manager (#11386)", () => {
+  const PATH = "/repo/src/index.ts";
+
+  // Platform-derived, so resolve it the same way the component does rather than
+  // hardcoding a per-OS string that would fail on the other platform's CI.
+  const revealLabel = revealCopy().label;
+
+  function renderFilePane(filePath = PATH) {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath };
+    return render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title={filePath.split("/").pop() ?? filePath}
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+  }
+
+  function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === label
+    );
+    if (!button) throw new Error(`${label} button not rendered`);
+    return button;
+  }
+
+  function click(button: HTMLElement) {
+    return act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  function deferred() {
+    let resolve: (value: unknown) => void = () => {};
+    const promise = new Promise((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it("dispatches file.showItemInFolder with the file's absolute path", async () => {
+    const { container } = renderFilePane();
+    await click(findButton(container, revealLabel));
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "file.showItemInFolder",
+      { path: PATH },
+      { source: "user" }
+    );
+  });
+
+  it("still offers reveal for a file the viewer can't render", async () => {
+    // An unsupported video never reaches a playable/text surface — revealing it
+    // in the OS file manager is the whole point of the button.
+    const { container } = renderFilePane("/repo/media/demo.mov");
+    await act(async () => {});
+    expect(container.querySelector("video")).toBeNull();
+
+    await click(findButton(container, revealLabel));
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "file.showItemInFolder",
+      { path: "/repo/media/demo.mov" },
+      { source: "user" }
+    );
+  });
+
+  it("surfaces a reveal failure inline and retries reveal, without a global toast", async () => {
+    dispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "File no longer exists" },
+    });
+    const { container } = renderFilePane();
+    await click(findButton(container, revealLabel));
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert!.textContent).toContain("File no longer exists");
+    // Tier 3 is pane-local — the failure must not also fire a global toast.
+    expect(notifyMock).not.toHaveBeenCalled();
+
+    dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+    await click(findButton(container, revealCopy().retryAriaLabel));
+
+    expect(dispatchMock).toHaveBeenLastCalledWith(
+      "file.showItemInFolder",
+      { path: PATH },
+      { source: "user" }
+    );
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("runs reveal and editor concurrently without one invalidating the other", async () => {
+    const revealGate = deferred();
+    // Reveal is held open; the editor click that follows resolves immediately.
+    dispatchMock.mockReturnValueOnce(revealGate.promise).mockResolvedValue({
+      ok: true,
+      result: undefined,
+    });
+    const { container } = renderFilePane();
+
+    act(() => {
+      findButton(container, revealLabel).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    // A slow reveal must not swallow the click on the editor button.
+    await click(findButton(container, "Open in editor"));
+    expect(dispatchMock.mock.calls.map(([actionId]) => actionId)).toEqual([
+      "file.showItemInFolder",
+      "file.openInEditor",
+    ]);
+
+    // The editor completing must not mark the still-pending reveal stale: its
+    // late failure has to surface, not be silently dropped by a shared counter.
+    await act(async () => {
+      revealGate.resolve({
+        ok: false,
+        error: { code: "EXECUTION_ERROR", message: "reveal came back after the editor" },
+      });
+      await revealGate.promise;
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "reveal came back after the editor"
+    );
+  });
+
+  it("keeps a failed target's banner when a sibling action succeeds", async () => {
+    dispatchMock.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "No editor configured" },
+    });
+    const { container } = renderFilePane();
+    await click(findButton(container, "Open in editor"));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("No editor configured");
+
+    // Revealing the file did nothing to configure an editor, so the editor's
+    // failure is still true and its banner must stand.
+    dispatchMock.mockResolvedValue({ ok: true, result: undefined });
+    await click(findButton(container, revealLabel));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("No editor configured");
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a "Reveal in file manager" button to the read-only file viewer's toolbar (`src/panels/file/FilePane.tsx`), used both as a dialog and as a promoted grid panel.
- The button uses a `FolderOpen` icon with a platform-named label ("Reveal in Finder" / "Show in Explorer" / "Show in folder") via `revealCopy()`, and dispatches the already-registered `file.showItemInFolder` action.
- It's always offered whenever a file is open, including files the viewer can't render (oversized `>500KB`, unsupported video), where the OS file manager is the only way forward. That's the motivating case for the issue.

Resolves #11386

## Changes

- Migrated `FilePane`'s single-flag external-open state to the per-target model already proven in `DiffPane`/`FileBrowserViewer`: an `ExternalTarget` type (`"reveal" | "browser" | "editor"`) with per-target pending state, a `Set`-based re-entry guard, and a generation guard keyed on `[id, filePath]`, plus the `useDohertyGate` retry spinner.
- Needed because the toolbar now has two buttons that can be clicked concurrently (reveal, and the existing mode-dependent open-in-browser/open-in-editor button), and they can't be allowed to clobber each other's spinner, error banner, or guard state.
- No new IPC channel, action, or icon. Everything is reused from existing code.

## Testing

Added a "reveal in file manager (#11386)" block to `FilePane.test.tsx` covering: dispatch with an absolute path and source, the reveal button being offered for non-renderable files, failure and retry without a global toast, reveal/editor concurrency, sibling-target success not clearing the other's error banner, a guard against a superseded reveal call, and per-target Retry button enablement. Also strengthened the existing HTML browser-retry test.

66 tests pass; eslint and prettier are clean on both changed files.
