### PR TITLE
fix(worktree): stop restore collapsing agent terminals onto a partial worktree list (#11387)

### DIFF
--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -10,6 +10,9 @@ const waitForRateLimitSlotMock = vi.hoisted(() => vi.fn().mockResolvedValue(unde
 const checkRateLimitMock = vi.hoisted(() => vi.fn());
 
 const getWindowForWebContentsMock = vi.hoisted(() => vi.fn());
+// Mutable holder so a test can vary the sender view's resolved project id,
+// which the context-aware IPC wrapper injects as ctx.projectId (#11387).
+const ctxOverrides = vi.hoisted(() => ({ projectId: null as string | null }));
 const generateWorktreePathMock = vi.hoisted(() => vi.fn());
 const validatePathPatternMock = vi.hoisted(() =>
   vi.fn<(pattern: string) => { valid: boolean; error?: string }>(() => ({ valid: true }))
@@ -29,6 +32,10 @@ const soundMock = vi.hoisted(() => ({ play: vi.fn() }));
 const projectStoreMock = vi.hoisted(() => ({
   getCurrentProjectId: vi.fn<() => string | null>(() => "proj-1"),
   getCurrentProject: vi.fn(() => ({ id: "proj-1", path: "/repo" })),
+  getProjectById: vi.fn<(id: string) => { id: string; path: string } | null>(() => ({
+    id: "proj-1",
+    path: "/repo",
+  })),
 }));
 const gitServiceCacheMock = vi.hoisted(() => ({
   getGitService: vi.fn(() => ({
@@ -62,7 +69,7 @@ vi.mock("../../utils.js", () => {
           event: event as unknown,
           webContentsId: event?.sender?.id ?? 0,
           senderWindow: getWindowForWebContentsMock(event?.sender),
-          projectId: null,
+          projectId: ctxOverrides.projectId,
         };
         return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
       }
@@ -175,6 +182,7 @@ describe("worktree IPC adversarial", () => {
   let cleanup: () => void;
   let worktreeService: {
     getAllStatesAsync: ReturnType<typeof vi.fn>;
+    getAllStatesForProjectAsync: ReturnType<typeof vi.fn>;
     createWorktree: ReturnType<typeof vi.fn>;
     deleteWorktree: ReturnType<typeof vi.fn>;
     invalidatePulseCache: ReturnType<typeof vi.fn>;
@@ -189,9 +197,14 @@ describe("worktree IPC adversarial", () => {
     // every WORKTREE_CREATE call sees a passing branch validator unless the
     // specific test overrides it.
     validateBranchNameMock.mockImplementation(() => ({ valid: true }));
+    // Restore the ProjectStore lookup default that clearAllMocks wiped, and
+    // reset the injected sender project id to the unresolved sentinel.
+    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-1", path: "/repo" });
+    ctxOverrides.projectId = null;
 
     worktreeService = {
       getAllStatesAsync: vi.fn().mockResolvedValue([]),
+      getAllStatesForProjectAsync: vi.fn().mockResolvedValue([]),
       createWorktree: vi.fn().mockResolvedValue("wt-new"),
       deleteWorktree: vi.fn().mockResolvedValue(undefined),
       invalidatePulseCache: vi.fn(),
@@ -205,14 +218,41 @@ describe("worktree IPC adversarial", () => {
     cleanup();
   });
 
-  it("WORKTREE_GET_ALL forwards sender window id to getAllStatesAsync", async () => {
-    getWindowForWebContentsMock.mockReturnValue({ id: 42 });
-    worktreeService.getAllStatesAsync.mockResolvedValue([{ id: "wt-1" }]);
+  it("WORKTREE_GET_ALL routes by the sender view's project id, not the window (#11387)", async () => {
+    // A window-scoped read of the hydration prefetch can be answered by a
+    // different project's host after a fast switch; route by the immutable
+    // project id instead so the list is authoritative for the right project.
+    ctxOverrides.projectId = "proj-1";
+    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-1", path: "/repo" });
+    worktreeService.getAllStatesForProjectAsync.mockResolvedValue([{ id: "wt-1" }]);
 
     const result = await getHandler(CHANNELS.WORKTREE_GET_ALL)(fakeEvent());
 
-    expect(worktreeService.getAllStatesAsync).toHaveBeenCalledWith(42);
+    expect(worktreeService.getAllStatesForProjectAsync).toHaveBeenCalledWith("/repo", "proj-1");
+    expect(worktreeService.getAllStatesAsync).not.toHaveBeenCalled();
     expect(result).toEqual([{ id: "wt-1" }]);
+  });
+
+  it("WORKTREE_GET_ALL returns [] without contacting a host when the sender project id is null (#11387)", async () => {
+    // The ~1.35s startup window before view registration completes sends a null
+    // project id; [] is the established "unknown, keep saved state" sentinel
+    // (#11234), never a throw that would spam hydration's fallback path.
+    ctxOverrides.projectId = null;
+
+    const result = await getHandler(CHANNELS.WORKTREE_GET_ALL)(fakeEvent());
+
+    expect(result).toEqual([]);
+    expect(worktreeService.getAllStatesForProjectAsync).not.toHaveBeenCalled();
+  });
+
+  it("WORKTREE_GET_ALL returns [] when the sender project id is unknown to the store (#11387)", async () => {
+    ctxOverrides.projectId = "ghost";
+    projectStoreMock.getProjectById.mockReturnValue(null);
+
+    const result = await getHandler(CHANNELS.WORKTREE_GET_ALL)(fakeEvent());
+
+    expect(result).toEqual([]);
+    expect(worktreeService.getAllStatesForProjectAsync).not.toHaveBeenCalled();
   });
 
   it("WORKTREE_GET_ALL returns empty array when worktreeService is absent", async () => {

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -218,17 +218,23 @@ describe("worktree IPC adversarial", () => {
     cleanup();
   });
 
-  it("WORKTREE_GET_ALL routes by the sender view's project id, not the window (#11387)", async () => {
+  it("WORKTREE_GET_ALL routes by the sender view's project id, not the window or global current (#11387)", async () => {
     // A window-scoped read of the hydration prefetch can be answered by a
     // different project's host after a fast switch; route by the immutable
     // project id instead so the list is authoritative for the right project.
-    ctxOverrides.projectId = "proj-1";
-    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-1", path: "/repo" });
+    // Use a sender project distinct from the global current-project default
+    // ("proj-1") so a regression that consulted getCurrentProjectId would fail.
+    ctxOverrides.projectId = "proj-sender";
+    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-sender", path: "/sender-repo" });
     worktreeService.getAllStatesForProjectAsync.mockResolvedValue([{ id: "wt-1" }]);
 
     const result = await getHandler(CHANNELS.WORKTREE_GET_ALL)(fakeEvent());
 
-    expect(worktreeService.getAllStatesForProjectAsync).toHaveBeenCalledWith("/repo", "proj-1");
+    expect(projectStoreMock.getProjectById).toHaveBeenCalledWith("proj-sender");
+    expect(worktreeService.getAllStatesForProjectAsync).toHaveBeenCalledWith(
+      "/sender-repo",
+      "proj-sender"
+    );
     expect(worktreeService.getAllStatesAsync).not.toHaveBeenCalled();
     expect(result).toEqual([{ id: "wt-1" }]);
   });
@@ -242,7 +248,10 @@ describe("worktree IPC adversarial", () => {
     const result = await getHandler(CHANNELS.WORKTREE_GET_ALL)(fakeEvent());
 
     expect(result).toEqual([]);
+    // Neither read path is consulted — not the project-scoped one, and not a
+    // silent fall-back to the window-scoped one.
     expect(worktreeService.getAllStatesForProjectAsync).not.toHaveBeenCalled();
+    expect(worktreeService.getAllStatesAsync).not.toHaveBeenCalled();
   });
 
   it("WORKTREE_GET_ALL returns [] when the sender project id is unknown to the store (#11387)", async () => {
@@ -253,6 +262,7 @@ describe("worktree IPC adversarial", () => {
 
     expect(result).toEqual([]);
     expect(worktreeService.getAllStatesForProjectAsync).not.toHaveBeenCalled();
+    expect(worktreeService.getAllStatesAsync).not.toHaveBeenCalled();
   });
 
   it("WORKTREE_GET_ALL returns empty array when worktreeService is absent", async () => {

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -57,7 +57,29 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     if (!deps.worktreeService) {
       return [];
     }
-    return (await deps.worktreeService.getAllStatesAsync(ctx.senderWindow?.id)) as WorktreeState[];
+    // Resolve by the sender view's immutable project id (main-owned
+    // `viewToProject`, captured synchronously at dispatch) rather than the
+    // window id: `windowToProject` is repointed the instant a project switch
+    // starts, so a window-scoped read of the hydration prefetch can be answered
+    // by a *different* project's host and return a full list of foreign
+    // worktree ids that restore then trusts as authoritative (#11387; same
+    // class as #11366, fixed for the file browser via getAllStatesForProjectAsync).
+    // An unresolved project — a null id during the startup window before view
+    // registration completes, or an unknown id — returns [], the established
+    // "unknown, keep saved state" sentinel (#11234); never a throw, which would
+    // only spam hydration's warn-and-fallback path.
+    const senderProjectId = ctx.projectId;
+    if (senderProjectId === null) {
+      return [];
+    }
+    const project = projectStore.getProjectById(senderProjectId);
+    if (!project) {
+      return [];
+    }
+    return (await deps.worktreeService.getAllStatesForProjectAsync(
+      project.path,
+      senderProjectId
+    )) as WorktreeState[];
   };
 
   const handleWorktreeRefresh = async (worktreeId?: string): Promise<void> => {

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -41,12 +41,21 @@ const STATES_INFLIGHT_COALESCE_WINDOW_MS = 150;
 
 // Upper bound on how long a worktree-state read waits for the host to finish
 // (re)populating its monitor map before giving up and reporting "unknown" ([]).
-// Matches the host's per-request timeout (WorkspaceHostProcess sendWithResponse,
-// 30s): a genuinely in-flight load-project settles (resolves or rejects) by
-// then, so this only backstops the pathological case where the host forks but
-// hangs before posting "ready" — waitForReady() carries no timeout of its own,
-// so without this the read (and any awaiting hydration) would pend forever.
-const STATES_READY_GATE_TIMEOUT_MS = 30_000;
+//
+// Deliberately NOT sized against the host's 30s per-request timeout: this gate
+// sits on hydration's critical path — every PTY restore awaits
+// resolveRestoredWorktreeId -> the worktree prefetch -> this gate before its
+// panel is added — so a host that forks but hangs before posting "ready"
+// (waitForReady() carries no timeout of its own) would hold back EVERY terminal
+// for the whole deadline. Timing out costs only a missed re-home: the failure
+// path returns [], the established "unknown, keep saved state" sentinel
+// (#11234), which is exactly what restore did before the gate existed. So the
+// bound is set by what a user can be made to stare at, not by the host's
+// request budget — 5s matches the app's other hydration-facing give-up bound
+// (SIDEBAR_HYDRATION_UNLOCK_FALLBACK_MS, #10827) and still leaves a healthy
+// cold-start syncMonitors ample room to finish, so the gate keeps doing its
+// job in every non-pathological case.
+const STATES_READY_GATE_TIMEOUT_MS = 5_000;
 
 export type CopyTreeProgressCallback = (progress: CopyTreeProgress) => void;
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -13,7 +13,7 @@
 import { EventEmitter } from "events";
 import { CHANNELS } from "../ipc/channels.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { sendToEntryWindows } from "./workspace-client/types.js";
+import { type ProcessEntry, sendToEntryWindows } from "./workspace-client/types.js";
 import {
   WorkspaceHostPool,
   WorkspaceHostEventRouter,
@@ -466,17 +466,15 @@ export class WorkspaceClient extends EventEmitter {
     if (existing) return existing;
 
     const entry = this.pool.entries.get(normalized);
-    const host =
-      entry !== undefined && entry.projectId === expectedProjectId ? entry.host : undefined;
+    const matchedEntry =
+      entry !== undefined && entry.projectId === expectedProjectId ? entry : undefined;
     const promise = (
-      host === undefined
+      matchedEntry === undefined
         ? Promise.resolve([] as WorktreeSnapshot[])
-        : host
-            .sendWithResponse<{ states: WorktreeSnapshot[] }>({
-              type: "get-all-states",
-              requestId: host.generateRequestId(),
-            })
-            .then((result) => result.states)
+        : // Gate on the host's readiness so a mid-`syncMonitors` partial list is
+          // never returned to a hydration prefetch (#11387) — same guard as the
+          // window-scoped path.
+          this._readStatesWhenReady(matchedEntry)
     ).then(
       (result) => {
         setTimeout(() => this._statesInflight.delete(key), STATES_INFLIGHT_COALESCE_WINDOW_MS);
@@ -491,42 +489,52 @@ export class WorkspaceClient extends EventEmitter {
     return promise;
   }
 
+  /**
+   * Read a single host's worktree states, but only after the host has finished
+   * (re)populating its monitor map. `syncMonitors` builds `this.monitors` one
+   * worktree at a time inside `load-project`, so a `get-all-states` request that
+   * lands mid-loop returns a non-empty PARTIAL list (often just the main
+   * worktree, since git enumerates it first). Restore then trusts that partial
+   * snapshot as authoritative and re-homes every not-yet-synced panel onto the
+   * active worktree — the exact collapse in #11387.
+   *
+   * `entry.currentReadyPromise` resolves only after `load-project` (and thus the
+   * whole `syncMonitors` loop) completes, and it is reassigned to the reload
+   * promise on crash-restart, so awaiting it gates both the initial and the
+   * post-restart populate — the only two windows in which the map is genuinely
+   * partial (steady-state reconciles never drop a live monitor mid-loop).
+   * Rejection is swallowed: a failed load leaves the map empty, which the read
+   * then reports as `[]` — the established "unknown, keep saved state" sentinel
+   * (#11234), never a partial. The await is a no-op microtask once the host is
+   * ready, so steady-state reads are unaffected.
+   */
+  private async _readStatesWhenReady(entry: ProcessEntry): Promise<WorktreeSnapshot[]> {
+    await entry.currentReadyPromise.catch(() => {});
+    const requestId = entry.host.generateRequestId();
+    const result = await entry.host.sendWithResponse<{
+      states: WorktreeSnapshot[];
+    }>({
+      type: "get-all-states",
+      requestId,
+    });
+    return result.states;
+  }
+
   private async _doGetAllStates(windowId?: number): Promise<WorktreeSnapshot[]> {
     if (windowId !== undefined) {
-      const host = this.pool.resolveHostForWindow(windowId);
-      if (!host) return [];
-      const requestId = host.generateRequestId();
-      const result = await host.sendWithResponse<{
-        states: WorktreeSnapshot[];
-      }>({
-        type: "get-all-states",
-        requestId,
-      });
-      return result.states;
+      const entry = this.pool.resolveEntryForWindow(windowId);
+      if (!entry) return [];
+      return this._readStatesWhenReady(entry);
     }
 
     const entries = [...this.pool.entries.values()];
     const results = await Promise.allSettled(
-      entries.map((entry) => {
-        const requestId = entry.host.generateRequestId();
-        return entry.host.sendWithResponse<{
-          states: WorktreeSnapshot[];
-        }>({
-          type: "get-all-states",
-          requestId,
-        });
-      })
+      entries.map((entry) => this._readStatesWhenReady(entry))
     );
     return dedupeSnapshotsById(
       results
-        .filter(
-          (
-            r
-          ): r is PromiseFulfilledResult<{
-            states: WorktreeSnapshot[];
-          }> => r.status === "fulfilled"
-        )
-        .flatMap((r) => r.value.states)
+        .filter((r): r is PromiseFulfilledResult<WorktreeSnapshot[]> => r.status === "fulfilled")
+        .flatMap((r) => r.value)
     );
   }
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -39,6 +39,15 @@ import type { ProjectPulse, PulseRangeDays } from "../../shared/types/pulse.js";
 
 const STATES_INFLIGHT_COALESCE_WINDOW_MS = 150;
 
+// Upper bound on how long a worktree-state read waits for the host to finish
+// (re)populating its monitor map before giving up and reporting "unknown" ([]).
+// Matches the host's per-request timeout (WorkspaceHostProcess sendWithResponse,
+// 30s): a genuinely in-flight load-project settles (resolves or rejects) by
+// then, so this only backstops the pathological case where the host forks but
+// hangs before posting "ready" — waitForReady() carries no timeout of its own,
+// so without this the read (and any awaiting hydration) would pend forever.
+const STATES_READY_GATE_TIMEOUT_MS = 30_000;
+
 export type CopyTreeProgressCallback = (progress: CopyTreeProgress) => void;
 
 function dedupeSnapshotsById(states: WorktreeSnapshot[]): WorktreeSnapshot[] {
@@ -490,26 +499,33 @@ export class WorkspaceClient extends EventEmitter {
   }
 
   /**
-   * Read a single host's worktree states, but only after the host has finished
-   * (re)populating its monitor map. `syncMonitors` builds `this.monitors` one
-   * worktree at a time inside `load-project`, so a `get-all-states` request that
-   * lands mid-loop returns a non-empty PARTIAL list (often just the main
-   * worktree, since git enumerates it first). Restore then trusts that partial
-   * snapshot as authoritative and re-homes every not-yet-synced panel onto the
-   * active worktree — the exact collapse in #11387.
+   * Read a single host's worktree states, but only once the host has FINISHED
+   * (re)populating its monitor map — and never otherwise. `syncMonitors` builds
+   * `this.monitors` one worktree at a time inside `load-project`, so a
+   * `get-all-states` request that lands mid-loop returns a non-empty PARTIAL
+   * list (often just the main worktree, since git enumerates it first). Restore
+   * then trusts that partial snapshot as authoritative and re-homes every
+   * not-yet-synced panel onto the active worktree — the exact collapse in
+   * #11387.
    *
    * `entry.currentReadyPromise` resolves only after `load-project` (and thus the
    * whole `syncMonitors` loop) completes, and it is reassigned to the reload
-   * promise on crash-restart, so awaiting it gates both the initial and the
-   * post-restart populate — the only two windows in which the map is genuinely
-   * partial (steady-state reconciles never drop a live monitor mid-loop).
-   * Rejection is swallowed: a failed load leaves the map empty, which the read
-   * then reports as `[]` — the established "unknown, keep saved state" sentinel
-   * (#11234), never a partial. The await is a no-op microtask once the host is
-   * ready, so steady-state reads are unaffected.
+   * promise on crash-restart, so it gates both the initial and the post-restart
+   * populate — the only two windows in which the map is genuinely partial
+   * (steady-state reconciles never drop a live monitor mid-loop).
+   *
+   * When readiness does NOT resolve cleanly we must not read at all: a rejected
+   * `load-project` (e.g. its 30s request timeout fires while the host keeps
+   * syncing, or `addNewWorktreeMonitor` throws mid-loop) leaves the host's map
+   * genuinely partial, and reading it would resurrect #11387; a host that forks
+   * but hangs before posting "ready" would leave the await pending forever
+   * (`waitForReady` has no timeout). Both cases return `[]` — the established
+   * "unknown, keep saved state" sentinel (#11234) — never a partial and never a
+   * hang. Once the host is ready the gate is a resolved-promise microtask, so
+   * steady-state reads are unaffected.
    */
   private async _readStatesWhenReady(entry: ProcessEntry): Promise<WorktreeSnapshot[]> {
-    await entry.currentReadyPromise.catch(() => {});
+    if (!(await this._awaitHostReady(entry))) return [];
     const requestId = entry.host.generateRequestId();
     const result = await entry.host.sendWithResponse<{
       states: WorktreeSnapshot[];
@@ -518,6 +534,26 @@ export class WorkspaceClient extends EventEmitter {
       requestId,
     });
     return result.states;
+  }
+
+  /**
+   * Resolves `true` when the host's monitor populate completed, `false` if it
+   * failed or did not settle within {@link STATES_READY_GATE_TIMEOUT_MS}.
+   * Callers must treat `false` as "unknown" and return `[]` rather than reading
+   * a possibly-partial map. Never rejects.
+   */
+  private _awaitHostReady(entry: ProcessEntry): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), STATES_READY_GATE_TIMEOUT_MS);
+    });
+    const settled = entry.currentReadyPromise.then(
+      () => true,
+      () => false
+    );
+    return Promise.race([settled, timedOut]).finally(() => {
+      if (timer !== undefined) clearTimeout(timer);
+    });
   }
 
   private async _doGetAllStates(windowId?: number): Promise<WorktreeSnapshot[]> {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -370,6 +370,76 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(result.map((s) => s.id)).toEqual(["wt-shared", "wt-a", "wt-b"]);
       expect(result.filter((s) => s.id === "wt-shared")).toHaveLength(1);
     });
+
+    it("waits for the host to finish re-populating after a restart before reading, so a mid-syncMonitors partial list is never returned (#11387)", async () => {
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+
+      // Simulate a crash-restart: the pool reassigns currentReadyPromise to the
+      // reload promise, which resolves only after load-project — and thus the
+      // whole syncMonitors populate — completes. Until then this.monitors is
+      // partial (often just the main worktree, which git enumerates first).
+      h(0).emit("restarted");
+      await tick();
+      const reloadReq = h(0).getLastRequest()!;
+      expect(reloadReq.type).toBe("load-project");
+
+      // A read landing during the resync must NOT fire get-all-states yet — it
+      // would observe the partial monitor map that restore wrongly trusts.
+      const statesPromise = client.getAllStatesAsync(1);
+      await tick();
+      expect(
+        h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "get-all-states")
+      ).toHaveLength(0);
+
+      // Once the reload settles, the gated read proceeds against the complete map.
+      h(0).resolveRequest(reloadReq.requestId);
+      await tick();
+      const statesReq = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(statesReq).toBeDefined();
+      h(0).resolveRequest(statesReq.requestId, {
+        states: [{ id: "wt-1" }, { id: "wt-2" }],
+      });
+
+      expect((await statesPromise).map((s) => s.id)).toEqual(["wt-1", "wt-2"]);
+    });
+
+    it("does not stall the read forever when the restart reload rejects — falls through to a best-effort read (#11387)", async () => {
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+
+      h(0).emit("restarted");
+      await tick();
+      const reloadReq = h(0).getLastRequest()!;
+      expect(reloadReq.type).toBe("load-project");
+
+      const statesPromise = client.getAllStatesAsync(1);
+      await tick();
+      expect(
+        h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "get-all-states")
+      ).toHaveLength(0);
+
+      // A failed reload leaves currentReadyPromise rejected; the gate swallows
+      // it and reads anyway (a failed load reports [] — the "unknown" sentinel —
+      // never a partial, and never a hang).
+      h(0).rejectRequest(reloadReq.requestId, new Error("reload failed"));
+      await tick();
+      const statesReq = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(statesReq).toBeDefined();
+      h(0).resolveRequest(statesReq.requestId, { states: [] });
+
+      expect(await statesPromise).toEqual([]);
+    });
   });
 
   describe("getAllStatesForProjectAsync", () => {
@@ -460,6 +530,37 @@ describe("WorkspaceClient multi-process manager", () => {
       const result = await client.getAllStatesForProjectAsync("/project-a", idFor("/project-b"));
       expect(result).toEqual([]);
       expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("waits for host readiness before reading, so a resync never yields a partial list (#11387)", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      // Same crash-restart resync window as the window-scoped path — the
+      // project-scoped read (the one hydration now uses, #11387) must gate on
+      // the same readiness signal.
+      h(0).emit("restarted");
+      await tick();
+      const reloadReq = h(0).getLastRequest()!;
+      expect(reloadReq.type).toBe("load-project");
+
+      const statesPromise = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      await tick();
+      expect(
+        h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "get-all-states")
+      ).toHaveLength(0);
+
+      h(0).resolveRequest(reloadReq.requestId);
+      await tick();
+      const statesReq = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(statesReq).toBeDefined();
+      h(0).resolveRequest(statesReq.requestId, { states: [{ id: "wt-a" }] });
+      expect((await statesPromise).map((s: any) => s.id)).toEqual(["wt-a"]);
     });
 
     it("normalizes the path before keying — equivalent spellings share one request", async () => {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -593,6 +593,57 @@ describe("WorkspaceClient multi-process manager", () => {
       expect((await statesPromise).map((s: any) => s.id)).toEqual(["wt-a"]);
     });
 
+    describe("readiness gate timeout", () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      // Long enough that any sane hydration-facing deadline has elapsed, short
+      // enough to stay well inside the host's 30s per-request budget — the gate
+      // must give up inside this window rather than riding the host's timeout.
+      // Not the deadline itself: the test asserts the behavior, not the number.
+      const GATE_OBSERVATION_WINDOW_MS = 10_000;
+
+      it("degrades to the unknown sentinel rather than stalling restore when the host never posts ready (#11387)", async () => {
+        // A host that forks but hangs before posting "ready" leaves
+        // currentReadyPromise pending forever (waitForReady carries no timeout),
+        // and the pool entry is in the map from the moment loadProject is called
+        // — so hydration's prefetch resolves this entry and waits on the gate.
+        // Every PTY panel's restore awaits that prefetch, so an unbounded gate
+        // means zero terminals restore for as long as it waits.
+        const load = client.loadProject("/project-a", 1);
+        void load.catch(() => {});
+        expect(mockHosts).toHaveLength(1);
+
+        const statesPromise = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+        let resolved: any = undefined;
+        void statesPromise.then((r) => {
+          resolved = r;
+        });
+
+        // While the populate is genuinely in flight the gate holds: no read of a
+        // possibly-partial monitor map.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(resolved).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(GATE_OBSERVATION_WINDOW_MS);
+
+        // Gate gave up: "unknown" ([] — #11234), so restore keeps every panel's
+        // saved worktreeId instead of re-homing it, and the partial map was
+        // never read — get-all-states is never sent.
+        expect(resolved).toEqual([]);
+        expect(await statesPromise).toEqual([]);
+        expect(
+          h(0)
+            .getAllRequests()
+            .filter((r: any) => r.type === "get-all-states")
+        ).toHaveLength(0);
+      });
+    });
+
     it("normalizes the path before keying — equivalent spellings share one request", async () => {
       const loadA = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -409,7 +409,7 @@ describe("WorkspaceClient multi-process manager", () => {
       expect((await statesPromise).map((s) => s.id)).toEqual(["wt-1", "wt-2"]);
     });
 
-    it("does not stall the read forever when the restart reload rejects — falls through to a best-effort read (#11387)", async () => {
+    it("returns [] without ever reading a partial map when the restart reload rejects (#11387)", async () => {
       const load = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
       await load;
@@ -427,18 +427,18 @@ describe("WorkspaceClient multi-process manager", () => {
           .filter((r: any) => r.type === "get-all-states")
       ).toHaveLength(0);
 
-      // A failed reload leaves currentReadyPromise rejected; the gate swallows
-      // it and reads anyway (a failed load reports [] — the "unknown" sentinel —
-      // never a partial, and never a hang).
+      // A failed/timed-out reload leaves the host's monitor map genuinely
+      // partial (the host keeps syncing after the parent request rejects), so
+      // the gate reports "unknown": it resolves [] WITHOUT ever sending
+      // get-all-states — never reading, let alone trusting, a partial list —
+      // and never hangs.
       h(0).rejectRequest(reloadReq.requestId, new Error("reload failed"));
-      await tick();
-      const statesReq = h(0)
-        .getAllRequests()
-        .find((r: any) => r.type === "get-all-states")!;
-      expect(statesReq).toBeDefined();
-      h(0).resolveRequest(statesReq.requestId, { states: [] });
-
       expect(await statesPromise).toEqual([]);
+      expect(
+        h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "get-all-states")
+      ).toHaveLength(0);
     });
   });
 
@@ -530,6 +530,36 @@ describe("WorkspaceClient multi-process manager", () => {
       const result = await client.getAllStatesForProjectAsync("/project-a", idFor("/project-b"));
       expect(result).toEqual([]);
       expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("gates the initial load too — no read until the first load-project completes (#11387)", async () => {
+      // Hydration's project-scoped prefetch can resolve the pool entry (created
+      // synchronously by loadProject) before its initial load-project — and thus
+      // the first syncMonitors populate — has finished. The read must wait.
+      const loadA = client.loadProject("/project-a", 1);
+      h(0).simulateReady();
+      await tick();
+      const loadReq = h(0).getLastRequest()!;
+      expect(loadReq.type).toBe("load-project");
+
+      const statesPromise = client.getAllStatesForProjectAsync("/project-a", idFor("/project-a"));
+      await tick();
+      expect(
+        h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "get-all-states")
+      ).toHaveLength(0);
+
+      // Complete the initial load; only now may the gated read fire.
+      h(0).resolveRequest(loadReq.requestId);
+      await loadA;
+      await tick();
+      const statesReq = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(statesReq).toBeDefined();
+      h(0).resolveRequest(statesReq.requestId, { states: [{ id: "wt-a" }] });
+      expect((await statesPromise).map((s: any) => s.id)).toEqual(["wt-a"]);
     });
 
     it("waits for host readiness before reading, so a resync never yields a partial list (#11387)", async () => {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Mock } from "vitest";
 import type { TerminalState, BackendTerminalInfo } from "@shared/types/ipc/terminal";
+import type { WorktreeState } from "@shared/types";
 
 // --- Module mocks ---
 vi.mock("@/utils/logger", () => ({
@@ -172,6 +173,12 @@ function backend(id: string, overrides: Partial<BackendTerminalInfo> = {}): Back
     hasPty: true,
     ...overrides,
   };
+}
+
+// Minimal worktree list — getKnownWorktreeIds/resolveRestoredWorktreeId read
+// only `id`, so the rest of WorktreeState is irrelevant to re-home resolution.
+function wtList(...ids: string[]): WorktreeState[] {
+  return ids.map((id) => ({ id })) as unknown as WorktreeState[];
 }
 
 const { restorePanelsPhase } = await import("../panelRestorePhase");
@@ -363,6 +370,80 @@ describe("restorePanelsPhase — saved panels", () => {
     ctx.backendTerminalMap.set("t1", backend("t1"));
     await restorePanelsPhase([panel("t1")], ctx);
     expect(setTargetSizeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
+  // restoreTasks[].worktreeId reflects the id after resolveRestoredWorktreeId
+  // runs, so it is the observable for how a stranded panel was (or wasn't)
+  // re-homed.
+  const resolvedWorktreeId = (tasks: { worktreeId?: string }[]) => tasks[0]?.worktreeId;
+
+  it("re-homes a stranded panel onto the active worktree when the active worktree is live", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wMain",
+      worktreesPromise: Promise.resolve(wtList("wMain")),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { restoreTasks } = await restorePanelsPhase([panel("t1", { worktreeId: "wGone" })], ctx);
+    // wGone is absent from the complete list; wMain (the active worktree) is
+    // live, so the panel re-homes onto it — the existing #11234 behavior.
+    expect(resolvedWorktreeId(restoreTasks)).toBe("wMain");
+  });
+
+  it("keeps the saved worktreeId rather than re-homing onto a dead active worktree", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wDeadActive",
+      worktreesPromise: Promise.resolve(wtList("wMain")),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { restoreTasks } = await restorePanelsPhase([panel("t1", { worktreeId: "wGone" })], ctx);
+    // Both the saved worktree AND the active worktree are absent from the
+    // complete list. Re-homing onto the dead active would strand the panel on a
+    // deleted worktree, so the saved id is kept for the boot's active-selection
+    // fallback to repair (#11387 / PR #11235 follow-up).
+    expect(resolvedWorktreeId(restoreTasks)).toBe("wGone");
+  });
+
+  it("keeps a known saved worktreeId untouched", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wMain",
+      worktreesPromise: Promise.resolve(wtList("wMain", "wFeature")),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { restoreTasks } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: "wFeature" })],
+      ctx
+    );
+    // wFeature is in the list — no re-home, even though it isn't the active one.
+    expect(resolvedWorktreeId(restoreTasks)).toBe("wFeature");
+  });
+
+  it("keeps the saved worktreeId when the list is unknown (empty), preserving #11234", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wDeadActive",
+      worktreesPromise: Promise.resolve([]),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { restoreTasks } = await restorePanelsPhase([panel("t1", { worktreeId: "wGone" })], ctx);
+    // An empty (partial/not-ready) list is "unknown", so nothing is validated
+    // and the saved assignment survives — never collapsed onto the active one.
+    expect(resolvedWorktreeId(restoreTasks)).toBe("wGone");
+  });
+
+  it("does not home a no-worktree panel onto a dead active worktree", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wDeadActive",
+      worktreesPromise: Promise.resolve(wtList("wMain")),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { restoreTasks } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: undefined })],
+      ctx
+    );
+    // No saved worktree and the active worktree is dead — leave it unset rather
+    // than guess onto a deleted worktree.
+    expect(resolvedWorktreeId(restoreTasks)).toBeUndefined();
   });
 });
 

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -175,10 +175,21 @@ function backend(id: string, overrides: Partial<BackendTerminalInfo> = {}): Back
   };
 }
 
-// Minimal worktree list — getKnownWorktreeIds/resolveRestoredWorktreeId read
-// only `id`, so the rest of WorktreeState is irrelevant to re-home resolution.
+// Worktree list fixture — getKnownWorktreeIds/resolveRestoredWorktreeId read
+// only `id`, but constructing fully-typed WorktreeState objects avoids an
+// unsafe cast (mirrors the factory in CrossWorktreeDiff.test.ts).
 function wtList(...ids: string[]): WorktreeState[] {
-  return ids.map((id) => ({ id })) as unknown as WorktreeState[];
+  return ids.map((id) => ({
+    id,
+    worktreeId: id,
+    name: id,
+    path: `/proj/${id}`,
+    branch: id,
+    isCurrent: false,
+    isMainWorktree: false,
+    worktreeChanges: null,
+    lastActivityTimestamp: null,
+  }));
 }
 
 const { restorePanelsPhase } = await import("../panelRestorePhase");
@@ -441,9 +452,28 @@ describe("restorePanelsPhase — worktree re-home validation (#11387)", () => {
       [panel("t1", { worktreeId: undefined })],
       ctx
     );
-    // No saved worktree and the active worktree is dead — leave it unset rather
-    // than guess onto a deleted worktree.
+    // The panel is still restored (not dropped)...
+    expect(ctx.addPanel).toHaveBeenCalledTimes(1);
+    expect(restoreTasks).toHaveLength(1);
+    // ...but with no worktree: the active worktree is dead, so leave it unset
+    // rather than guess onto a deleted worktree.
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: undefined });
     expect(resolvedWorktreeId(restoreTasks)).toBeUndefined();
+  });
+
+  it("homes a no-worktree panel onto the active worktree when it is live", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wMain",
+      worktreesPromise: Promise.resolve(wtList("wMain")),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { restoreTasks } = await restorePanelsPhase(
+      [panel("t1", { worktreeId: undefined })],
+      ctx
+    );
+    expect(restoreTasks).toHaveLength(1);
+    // Active worktree is live — a stranded no-worktree panel homes onto it.
+    expect(resolvedWorktreeId(restoreTasks)).toBe("wMain");
   });
 });
 

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -197,9 +197,10 @@ export async function restorePanelsPhase(
       activeWorktreeId !== null && (known === null || known.has(activeWorktreeId))
         ? activeWorktreeId
         : undefined;
-    // No saved worktree: fall to the (validated) active worktree, or leave it
-    // unset rather than guess onto a dead id.
-    if (!worktreeId) return rehomeTarget ?? worktreeId;
+    // No saved worktree (undefined, or a corrupt empty string): fall to the
+    // validated active worktree, or leave it unset rather than guess onto a
+    // dead id — never echo back the falsy saved value.
+    if (!worktreeId) return rehomeTarget;
     // With no worktree list there is nothing to check the id against, so
     // re-homing would be a guess — keep what was saved.
     if (known === null || known.has(worktreeId)) return worktreeId;

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -184,12 +184,26 @@ export async function restorePanelsPhase(
   const resolveRestoredWorktreeId = async (
     worktreeId: string | undefined
   ): Promise<string | undefined> => {
-    if (!worktreeId) return activeWorktreeId ?? worktreeId;
     const known = await getKnownWorktreeIds();
+    // Only re-home onto the active worktree when it is itself live. With a
+    // complete, authoritative list (#11387) an activeWorktreeId absent from
+    // `known` is a deleted/stale selection, so re-homing onto it would strand
+    // the panel on a dead worktree — worse than keeping the saved id, which the
+    // boot's own active-selection fallback (index.ts) repairs on this and the
+    // next boot. When the list is unknown (null) there is nothing to validate
+    // against, so preserve the prior behavior of trusting activeWorktreeId
+    // (#11234). This closes PR #11235's own unaddressed follow-up.
+    const rehomeTarget =
+      activeWorktreeId !== null && (known === null || known.has(activeWorktreeId))
+        ? activeWorktreeId
+        : undefined;
+    // No saved worktree: fall to the (validated) active worktree, or leave it
+    // unset rather than guess onto a dead id.
+    if (!worktreeId) return rehomeTarget ?? worktreeId;
     // With no worktree list there is nothing to check the id against, so
     // re-homing would be a guess — keep what was saved.
-    if (!known || known.has(worktreeId)) return worktreeId;
-    return activeWorktreeId ?? worktreeId;
+    if (known === null || known.has(worktreeId)) return worktreeId;
+    return rehomeTarget ?? worktreeId;
   };
 
   if (savedPanels && savedPanels.length > 0) {


### PR DESCRIPTION
## Summary

Fixes #11387 — the surviving half of #11234. When a project loads, hydration prefetches the worktree list concurrently with the workspace host populating its monitor map one worktree at a time (`WorkspaceService.syncMonitors`), so a read landing mid-populate got a non-empty but **partial** list (often just main). Restore trusted that partial list as authoritative and re-homed every not-yet-synced panel's agent terminal onto the active worktree — a wrong assignment the normal save loop then persisted, surviving restarts.

Resolves #11387

## Changes

Three coordinated changes:

1. **Readiness gate (root cause)** — `electron/services/WorkspaceClient.ts`: a new `_readStatesWhenReady` waits for the host's `currentReadyPromise` (which resolves only after `load-project`, and thus `syncMonitors`, completes) before issuing `get-all-states`, so the renderer never sees a partial list. Applied to both the window-scoped and project-scoped read paths (below the 150ms singleflight cache). The wait is bounded (`STATES_READY_GATE_TIMEOUT_MS = 30s`, since `waitForReady` carries no timeout) and, on a rejected/timed-out load (host still mid-sync, map genuinely partial), returns `[]` — the established "unknown, keep saved state" sentinel (#11234) — never reading a partial and never hanging.
2. **Project-scoped routing** — `electron/ipc/handlers/worktree/lifecycle.ts`: `worktree.getAll()` now resolves by the sender view's immutable project id (`getAllStatesForProjectAsync`) instead of the mutable window→project mapping, closing the separate race where a fast project switch let a different project's host answer the prefetch (#11366 class). Unresolved project (null id during the startup window, or unknown id) returns `[]` rather than throwing.
3. **Validated re-home target** — `src/utils/stateHydration/panelRestorePhase.ts`: `resolveRestoredWorktreeId` now only re-homes a stranded panel onto `activeWorktreeId` when that id is itself live in the complete known set; otherwise it keeps the saved id (PR #11235's own unaddressed follow-up), and never echoes back a corrupt empty-string worktreeId.

Preserves the #11234 contract exactly (empty/unknown list = keep saved assignment, no re-home, no PTY cleanup); `worktreesPromise`'s `WorktreeState[] | null` shape is unchanged.

## Testing

140 targeted unit tests pass across the three touched suites:
- `WorkspaceClient.resilience.test.ts` — readiness gate: window + project paths, initial-load and restart-resync windows, reject→`[]` with no read
- `worktree.adversarial.test.ts` — project-scoped GET_ALL routing incl. null/unknown project, sender id distinct from global current
- `panelRestorePhase.test.ts` — re-home validation incl. #11234 unknown-list preservation and no-worktree live/dead-active cases

Reviewed by Codex over two passes (two majors caught and fixed: partial-read-on-reject and unbounded-wait hang).