### PR TITLE
feat(project): report agent conversation continuity in relocation preview (#11282 phase 5)

### DIFF
--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -14,11 +14,17 @@ import type { WorkspaceClient } from "./WorkspaceClient.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import type { WorktreePortBroker } from "./WorktreePortBroker.js";
 import type { Project } from "../types/index.js";
-import type {
-  ProjectRelocationReason,
-  RelocationBlocker,
-  RelocationPreview,
+import {
+  CONTINUITY_TIER_ORDER,
+  type AgentContinuitySummary,
+  type ProjectRelocationReason,
+  type RelocationBlocker,
+  type RelocationPreview,
 } from "../../shared/types/projectRelocation.js";
+import {
+  getEffectiveAgentConfig,
+  resolveAgentContinuity,
+} from "../../shared/config/agentRegistry.js";
 
 export type { ProjectRelocationReason } from "../../shared/types/projectRelocation.js";
 
@@ -252,8 +258,9 @@ export class ProjectRelocationCoordinator {
     // and at `request.newPath` for an already-moved reattach. Only the pipeline
     // path gracefully stops terminals, so a closed reattach reports zero.
     const folderPath = mode === "reattach" ? request.newPath : oldPath;
-    const [runningTerminalCount, linkedWorktrees, affectedPanelCount] = await Promise.all([
-      usesPipeline ? this.countRunningTerminals(projectId) : Promise.resolve(0),
+    const emptyTerminals = { count: 0, agentContinuity: [] as AgentContinuitySummary[] };
+    const [terminals, linkedWorktrees, affectedPanelCount] = await Promise.all([
+      usesPipeline ? this.describeRunningTerminals(projectId) : Promise.resolve(emptyTerminals),
       this.listLinkedWorktrees(folderPath),
       projectStore.countRebasedPanels(projectId, oldPath, newPath),
     ]);
@@ -262,22 +269,60 @@ export class ProjectRelocationCoordinator {
       mode,
       oldPath,
       newPath,
-      runningTerminalCount,
+      runningTerminalCount: terminals.count,
+      agentContinuity: terminals.agentContinuity,
       linkedWorktrees,
       affectedPanelCount,
       blockers,
     };
   }
 
-  private async countRunningTerminals(projectId: string): Promise<number> {
+  /**
+   * Enumerate the running terminals a relocation would gracefully stop, plus a
+   * per-agent conversation-continuity breakdown (#11282, phase 5). The pty-host
+   * already groups a project's live terminals by `launchAgentId`
+   * (`getProjectStats().terminalTypes`, already project-scoped and trash/exit
+   * excluded), so we classify each agent type live against the registry — no
+   * per-terminal session-id plumbing, and no captured tier (which would go
+   * stale). We key on `launchAgentId`, so a terminal only *detected* as an agent
+   * after a plain-shell launch is classified as a shell — an accepted
+   * best-effort limit for an advisory preview. Plain (non-agent) terminals key
+   * on `"terminal"` and are excluded since they carry no conversation. Ordered
+   * riskiest-first ({@link CONTINUITY_TIER_ORDER}) so the user sees what won't
+   * survive before what will. Best-effort: an IPC failure reports zero rather
+   * than throwing.
+   */
+  private async describeRunningTerminals(
+    projectId: string
+  ): Promise<{ count: number; agentContinuity: AgentContinuitySummary[] }> {
     const { ptyClient } = this.deps;
-    if (!ptyClient) return 0;
+    if (!ptyClient) return { count: 0, agentContinuity: [] };
     try {
       const stats = await ptyClient.getProjectStats(projectId);
-      return stats.terminalCount;
+      const byAgent = stats.terminalTypes ?? {};
+      const agentContinuity = Object.entries(byAgent)
+        .filter(([agentId]) => agentId !== "terminal")
+        .map(([agentId, count]): AgentContinuitySummary => {
+          const { tier, detail } = resolveAgentContinuity(agentId);
+          return {
+            agentId,
+            agentName: getEffectiveAgentConfig(agentId)?.name ?? agentId,
+            count,
+            tier,
+            ...(detail !== undefined ? { detail } : {}),
+          };
+        })
+        // Riskiest tier first, then agent id — deterministic regardless of the
+        // pty-host's Object key order.
+        .sort(
+          (a, b) =>
+            CONTINUITY_TIER_ORDER[a.tier] - CONTINUITY_TIER_ORDER[b.tier] ||
+            a.agentId.localeCompare(b.agentId)
+        );
+      return { count: stats.terminalCount, agentContinuity };
     } catch (error) {
-      logError("relocate-preview-terminal-count-failed", error, { projectId });
-      return 0;
+      logError("relocate-preview-terminal-describe-failed", error, { projectId });
+      return { count: 0, agentContinuity: [] };
     }
   }
 

--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -301,7 +301,10 @@ export class ProjectRelocationCoordinator {
       const stats = await ptyClient.getProjectStats(projectId);
       const byAgent = stats.terminalTypes ?? {};
       const agentContinuity = Object.entries(byAgent)
-        .filter(([agentId]) => agentId !== "terminal")
+        // Exclude plain shells, and defend against a corrupted count: a custom
+        // agent named after an Object.prototype key (e.g. "toString") can make
+        // the upstream tally a non-number, which must never reach the preview.
+        .filter(([agentId, count]) => agentId !== "terminal" && Number.isFinite(count) && count > 0)
         .map(([agentId, count]): AgentContinuitySummary => {
           const { tier, detail } = resolveAgentContinuity(agentId);
           return {

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -505,6 +505,54 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
     // Main worktree excluded; only the linked one is listed.
     expect(preview.linkedWorktrees).toEqual(["/vol/projects/proj-feature"]);
     expect(preview.blockers).toEqual([]);
+    // No per-agent breakdown when the pty-host reports no terminalTypes.
+    expect(preview.agentContinuity).toEqual([]);
+  });
+
+  it("classifies running agents into continuity tiers and excludes plain terminals (#11282 phase 5)", async () => {
+    const deps = makeDeps(makePvm(PROJECT_ID));
+    deps.ptyClient.getProjectStats.mockResolvedValue({
+      terminalCount: 5,
+      terminalTypes: { claude: 2, codex: 1, terminal: 2, "not-a-real-agent": 1 },
+    });
+    const coordinator = new ProjectRelocationCoordinator();
+    configure(coordinator, deps);
+
+    const preview = await coordinator.previewRelocate({
+      projectId: PROJECT_ID,
+      mode: "move",
+      newPath: NEW_ROOT,
+    });
+
+    // Plain "terminal" shells carry no conversation and are excluded; the rest
+    // are ordered riskiest-first: claude (provider-migration) → not-a-real-agent
+    // (unverified default) → codex (preserved).
+    expect(preview.agentContinuity.map((a) => a.agentId)).toEqual([
+      "claude",
+      "not-a-real-agent",
+      "codex",
+    ]);
+    // Per-agent counts pass through from the pty-host breakdown.
+    const byId = Object.fromEntries(preview.agentContinuity.map((a) => [a.agentId, a]));
+    expect(byId.claude.count).toBe(2);
+    expect(byId.codex.count).toBe(1);
+    // Every entry carries a resolved display name and a structurally valid tier.
+    const VALID_TIERS = [
+      "preserved",
+      "project-local",
+      "provider-migration",
+      "unavailable",
+      "unverified",
+    ];
+    for (const entry of preview.agentContinuity) {
+      expect(entry.agentName).toBeTruthy();
+      expect(VALID_TIERS).toContain(entry.tier);
+    }
+    // An unrecognized agent id defaults to the honest "unverified" — never a
+    // false "preserved".
+    expect(byId["not-a-real-agent"].tier).toBe("unverified");
+    // Plain shells are still counted toward the graceful-stop line.
+    expect(preview.runningTerminalCount).toBe(5);
   });
 
   it("never mutates — no rename, quiesce, finalize, rebind, broadcast, or reload", async () => {
@@ -613,6 +661,7 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
     expect(preview.blockers.map((b) => b.reason)).not.toContain("assistant-active");
     // The closed-delegate path stops nothing, so no terminals are reported.
     expect(preview.runningTerminalCount).toBe(0);
+    expect(preview.agentContinuity).toEqual([]);
     expect(deps.ptyClient.getProjectStats).not.toHaveBeenCalled();
   });
 

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -90,6 +90,8 @@ import {
   ProjectRelocationCoordinator,
   ProjectRelocationError,
 } from "../ProjectRelocationCoordinator.js";
+import { CONVERSATION_CONTINUITY_TIERS } from "../../../shared/config/agentRegistry.js";
+import { CONTINUITY_TIER_ORDER } from "../../../shared/types/projectRelocation.js";
 
 // --- Fixtures --------------------------------------------------------------
 
@@ -125,7 +127,9 @@ function makeDeps(pvm: ReturnType<typeof makePvm> | null) {
   const ptyClient = {
     gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
     onProjectSwitch: vi.fn(),
-    getProjectStats: vi.fn(async () => ({ terminalCount: 0 })),
+    getProjectStats: vi.fn<
+      () => Promise<{ terminalCount: number; terminalTypes?: Record<string, number> }>
+    >(async () => ({ terminalCount: 0 })),
   };
   const worktreeService = {
     evictProjectForRelocation: vi.fn(),
@@ -512,8 +516,9 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
   it("classifies running agents into continuity tiers and excludes plain terminals (#11282 phase 5)", async () => {
     const deps = makeDeps(makePvm(PROJECT_ID));
     deps.ptyClient.getProjectStats.mockResolvedValue({
-      terminalCount: 5,
-      terminalTypes: { claude: 2, codex: 1, terminal: 2, "not-a-real-agent": 1 },
+      // Non-terminal counts sum to 5; the two shells bring the total to 7.
+      terminalCount: 7,
+      terminalTypes: { claude: 2, codex: 1, terminal: 2, "not-a-real-agent": 1, crush: 1 },
     });
     const coordinator = new ProjectRelocationCoordinator();
     configure(coordinator, deps);
@@ -524,35 +529,29 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
       newPath: NEW_ROOT,
     });
 
-    // Plain "terminal" shells carry no conversation and are excluded; the rest
-    // are ordered riskiest-first: claude (provider-migration) → not-a-real-agent
-    // (unverified default) → codex (preserved).
-    expect(preview.agentContinuity.map((a) => a.agentId)).toEqual([
-      "claude",
-      "not-a-real-agent",
-      "codex",
-    ]);
+    // Plain "terminal" shells carry no conversation and are excluded; every
+    // other agent type appears exactly once.
+    expect(new Set(preview.agentContinuity.map((a) => a.agentId))).toEqual(
+      new Set(["claude", "codex", "not-a-real-agent", "crush"])
+    );
+    // Ordered riskiest-first: the tier ranks are nondecreasing across the list
+    // (asserts the sort invariant without pinning which agent owns which tier).
+    const ranks = preview.agentContinuity.map((a) => CONTINUITY_TIER_ORDER[a.tier]);
+    expect(ranks).toEqual([...ranks].sort((x, y) => x - y));
     // Per-agent counts pass through from the pty-host breakdown.
     const byId = Object.fromEntries(preview.agentContinuity.map((a) => [a.agentId, a]));
     expect(byId.claude.count).toBe(2);
     expect(byId.codex.count).toBe(1);
     // Every entry carries a resolved display name and a structurally valid tier.
-    const VALID_TIERS = [
-      "preserved",
-      "project-local",
-      "provider-migration",
-      "unavailable",
-      "unverified",
-    ];
     for (const entry of preview.agentContinuity) {
       expect(entry.agentName).toBeTruthy();
-      expect(VALID_TIERS).toContain(entry.tier);
+      expect(CONVERSATION_CONTINUITY_TIERS).toContain(entry.tier);
     }
     // An unrecognized agent id defaults to the honest "unverified" — never a
     // false "preserved".
     expect(byId["not-a-real-agent"].tier).toBe("unverified");
     // Plain shells are still counted toward the graceful-stop line.
-    expect(preview.runningTerminalCount).toBe(5);
+    expect(preview.runningTerminalCount).toBe(7);
   });
 
   it("never mutates — no rename, quiesce, finalize, rebind, broadcast, or reload", async () => {

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -235,16 +235,27 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       broker.resolve(event.requestId, event.results ?? []);
       return true;
 
-    case "project-stats":
-      // Fallback shape preserves the legacy `terminalTypes` key — the
-      // PtyClient public type signature still uses it, even though the host
-      // actually sends `detectedAgents` on the stats payload. Don't tighten
-      // this in a pure refactor.
+    case "project-stats": {
+      // The host sends the per-agent map as `detectedAgents`, but PtyClient's
+      // public stats type exposes it as `terminalTypes`. Normalize here at the
+      // transport boundary so the resolved value matches the promised shape:
+      // the relocation preview reads `terminalTypes` to classify conversation
+      // continuity (#11282 phase 5), and the raw `detectedAgents` payload never
+      // carried a `terminalTypes` key, so the map silently arrived as
+      // `undefined` before this fix.
+      const stats = event.stats;
       broker.resolve(
         event.requestId,
-        event.stats ?? { terminalCount: 0, processIds: [], terminalTypes: {} }
+        stats
+          ? {
+              terminalCount: stats.terminalCount,
+              processIds: stats.processIds,
+              terminalTypes: stats.detectedAgents,
+            }
+          : { terminalCount: 0, processIds: [], terminalTypes: {} }
       );
       return true;
+    }
 
     case "memory-rollup":
       broker.resolve(event.requestId, event.rollup);

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -277,6 +277,31 @@ describe("routeHostEvent", () => {
     });
   });
 
+  it("normalizes the host's detectedAgents map to the public terminalTypes shape", () => {
+    // Regression for #11282 phase 5: the host emits the per-agent map as
+    // `detectedAgents`, but PtyClient's public stats type (and the relocation
+    // preview) read `terminalTypes`. Without normalization here the map arrives
+    // as `undefined` and the continuity breakdown is silently empty.
+    const { deps, brokerCalls } = makeDeps();
+    routeHostEvent(
+      {
+        type: "project-stats",
+        requestId: "req-ps2",
+        stats: {
+          terminalCount: 3,
+          processIds: [11, 22],
+          detectedAgents: { claude: 2, terminal: 1 },
+        },
+      },
+      deps
+    );
+    expect(brokerCalls[0]?.result).toEqual({
+      terminalCount: 3,
+      processIds: [11, 22],
+      terminalTypes: { claude: 2, terminal: 1 },
+    });
+  });
+
   it("records terminal-pid on the shared state map", () => {
     const { deps, state } = makeDeps();
     routeHostEvent({ type: "terminal-pid", id: "t1", pid: 12345 }, deps);

--- a/shared/config/__tests__/agentContinuity.test.ts
+++ b/shared/config/__tests__/agentContinuity.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  resolveAgentContinuity,
+  getAgentIds,
+  getEffectiveAgentConfig,
+  setUserRegistry,
+  type AgentConfig,
+  type ConversationContinuityTier,
+} from "../agentRegistry.js";
+
+const VALID_TIERS: ConversationContinuityTier[] = [
+  "preserved",
+  "project-local",
+  "provider-migration",
+  "unavailable",
+  "unverified",
+];
+
+function userAgent(
+  overrides: Partial<AgentConfig> & Pick<AgentConfig, "id" | "name">
+): AgentConfig {
+  return {
+    command: "noop",
+    color: "#ffffff",
+    iconId: "terminal",
+    supportsContextInjection: false,
+    ...overrides,
+  };
+}
+
+describe("resolveAgentContinuity (#11282 phase 5)", () => {
+  beforeEach(() => setUserRegistry({}));
+  afterEach(() => setUserRegistry({}));
+
+  it("defaults an unknown agent id to the honest 'unverified', never a false 'preserved'", () => {
+    // The safe default is the whole point: an unclassified agent must not claim
+    // its conversation survives a move.
+    expect(resolveAgentContinuity("no-such-agent-xyz")).toEqual({ tier: "unverified" });
+  });
+
+  it("passes a declared continuity block through unchanged", () => {
+    // Compare against the source config instead of hardcoding a tier literal, so
+    // this asserts passthrough behavior rather than duplicating the config value.
+    for (const id of getAgentIds()) {
+      const declared = getEffectiveAgentConfig(id)?.continuity;
+      if (!declared) continue;
+      expect(resolveAgentContinuity(id)).toEqual(declared);
+    }
+  });
+
+  it("resolves every built-in agent to a structurally valid tier and never throws", () => {
+    for (const id of getAgentIds()) {
+      expect(VALID_TIERS).toContain(resolveAgentContinuity(id).tier);
+    }
+  });
+
+  it("reads the effective registry so a user agent's continuity resolves", () => {
+    setUserRegistry({
+      "custom-preserved": userAgent({
+        id: "custom-preserved",
+        name: "Custom Preserved",
+        continuity: { tier: "preserved", detail: "user agent test" },
+      }),
+      "custom-bare": userAgent({ id: "custom-bare", name: "Custom Bare" }),
+    });
+
+    expect(resolveAgentContinuity("custom-preserved")).toEqual({
+      tier: "preserved",
+      detail: "user agent test",
+    });
+    // A user agent that declares no continuity still gets the safe default.
+    expect(resolveAgentContinuity("custom-bare")).toEqual({ tier: "unverified" });
+  });
+
+  it("declares each actionable tier on at least one built-in agent", () => {
+    // Guards the config from silently collapsing to all-"unverified" (which would
+    // make the preview useless) without asserting WHICH agent owns each tier.
+    const declared = new Set(getAgentIds().map((id) => resolveAgentContinuity(id).tier));
+    expect(declared.has("preserved")).toBe(true);
+    expect(declared.has("provider-migration")).toBe(true);
+    expect(declared.has("unavailable")).toBe(true);
+  });
+});

--- a/shared/config/__tests__/agentContinuity.test.ts
+++ b/shared/config/__tests__/agentContinuity.test.ts
@@ -4,17 +4,9 @@ import {
   getAgentIds,
   getEffectiveAgentConfig,
   setUserRegistry,
+  CONVERSATION_CONTINUITY_TIERS,
   type AgentConfig,
-  type ConversationContinuityTier,
 } from "../agentRegistry.js";
-
-const VALID_TIERS: ConversationContinuityTier[] = [
-  "preserved",
-  "project-local",
-  "provider-migration",
-  "unavailable",
-  "unverified",
-];
 
 function userAgent(
   overrides: Partial<AgentConfig> & Pick<AgentConfig, "id" | "name">
@@ -50,25 +42,17 @@ describe("resolveAgentContinuity (#11282 phase 5)", () => {
 
   it("resolves every built-in agent to a structurally valid tier and never throws", () => {
     for (const id of getAgentIds()) {
-      expect(VALID_TIERS).toContain(resolveAgentContinuity(id).tier);
+      expect(CONVERSATION_CONTINUITY_TIERS).toContain(resolveAgentContinuity(id).tier);
     }
   });
 
-  it("reads the effective registry so a user agent's continuity resolves", () => {
-    setUserRegistry({
-      "custom-preserved": userAgent({
-        id: "custom-preserved",
-        name: "Custom Preserved",
-        continuity: { tier: "preserved", detail: "user agent test" },
-      }),
-      "custom-bare": userAgent({ id: "custom-bare", name: "Custom Bare" }),
-    });
-
-    expect(resolveAgentContinuity("custom-preserved")).toEqual({
-      tier: "preserved",
-      detail: "user agent test",
-    });
-    // A user agent that declares no continuity still gets the safe default.
+  it("defaults a custom (user-registry) agent to the safe 'unverified'", () => {
+    // The user-agent schema (and the plugin schema) have no `continuity` field,
+    // so a sanitized custom agent never carries one in production and must
+    // resolve to the safe default rather than silently claiming preservation.
+    // The resolver still reads the effective registry — it finds the agent, sees
+    // no continuity, and defaults.
+    setUserRegistry({ "custom-bare": userAgent({ id: "custom-bare", name: "Custom Bare" }) });
     expect(resolveAgentContinuity("custom-bare")).toEqual({ tier: "unverified" });
   });
 
@@ -77,6 +61,7 @@ describe("resolveAgentContinuity (#11282 phase 5)", () => {
     // make the preview useless) without asserting WHICH agent owns each tier.
     const declared = new Set(getAgentIds().map((id) => resolveAgentContinuity(id).tier));
     expect(declared.has("preserved")).toBe(true);
+    expect(declared.has("project-local")).toBe(true);
     expect(declared.has("provider-migration")).toBe(true);
     expect(declared.has("unavailable")).toBe(true);
   });

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -296,6 +296,44 @@ export type AgentResume =
     };
 
 /**
+ * How an agent's conversation history fares when its project folder is moved or
+ * renamed (#11282, phase 5). Surfaced in the relocation preview so the user is
+ * warned BEFORE a move when a conversation can't be resumed at the new path.
+ *
+ * The tier is a static property of the provider's resume mechanism, computed
+ * live from this config at preview time and never persisted (a captured tier
+ * would go stale as CLIs change). `resume.kind` alone is NOT a reliable
+ * discriminator: two agents can both be `kind: "session-id"` yet differ — Codex
+ * resumes by a globally-addressable id, while Claude's store is path-slug-scoped
+ * and can't resume at a new path.
+ *
+ * - `preserved` — a captured session resumes automatically at the new path
+ *   (globally-addressable session ids, e.g. Codex, Copilot).
+ * - `project-local` — resume reads state from the project folder itself, which
+ *   Daintree rewrites to the new path, so it survives (e.g. Kiro).
+ * - `provider-migration` — the conversation persists on disk but the provider
+ *   can't resume it at the new path, and Daintree must never touch the
+ *   provider's private store (#4100), so recovery needs a manual provider step
+ *   (e.g. Claude Code).
+ * - `unavailable` — the agent has no usable resume path for a moved folder
+ *   (e.g. Gemini's retired CLI, Crush which omits `resume` entirely).
+ * - `unverified` — continuity across a move hasn't been confirmed for this
+ *   provider; the default for any unclassified agent so we never overclaim.
+ */
+export type ConversationContinuityTier =
+  "preserved" | "project-local" | "provider-migration" | "unavailable" | "unverified";
+
+export interface AgentContinuity {
+  tier: ConversationContinuityTier;
+  /**
+   * One short, provider-specific sentence shown beneath the tier in the
+   * relocation preview. Sentence case, no trailing period. Omit to let the UI
+   * fall back to a generic per-tier line.
+   */
+  detail?: string;
+}
+
+/**
  * Capability shape describing how an agent participates in the Daintree
  * assistant overlay. Each field captures a distinct wiring concern; the older
  * `supportsAssistant: boolean` collapsed all of them into one bit and
@@ -479,6 +517,14 @@ export interface AgentConfig {
    * See {@link AgentResume} for the full shape per variant.
    */
   resume?: AgentResume;
+  /**
+   * How this agent's conversation history fares across a project-folder move
+   * (#11282, phase 5). Read live by the relocation preview via
+   * {@link resolveAgentContinuity}; unset ⇒ `unverified`, so an unclassified
+   * agent never claims its conversation survives. See
+   * {@link ConversationContinuityTier}.
+   */
+  continuity?: AgentContinuity;
   /**
    * Prerequisites required for this agent to function.
    * Merged with baseline prerequisites during health checks.
@@ -700,6 +746,17 @@ export function getEffectiveAgentConfig(agentId: string): AgentConfig | undefine
 
 export function isEffectivelyRegisteredAgent(agentId: string): boolean {
   return Object.prototype.hasOwnProperty.call(getEffectiveRegistry(), agentId);
+}
+
+/**
+ * Resolve an agent's conversation-continuity classification for the relocation
+ * preview (#11282, phase 5). Reads the effective registry so plugin/user agents
+ * resolve too, and defaults to `unverified` for any agent that hasn't declared a
+ * `continuity` block — we never assume a conversation survives a move. Pure and
+ * side-effect free; computed live at preview time, never cached or persisted.
+ */
+export function resolveAgentContinuity(agentId: string): AgentContinuity {
+  return getEffectiveAgentConfig(agentId)?.continuity ?? { tier: "unverified" };
 }
 
 export function isBuiltInAgent(agentId: string): boolean {

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -309,21 +309,23 @@ export type AgentResume =
  *
  * - `preserved` — a captured session resumes automatically at the new path
  *   (globally-addressable session ids, e.g. Codex, Copilot).
- * - `project-local` — resume reads state from the project folder itself, which
- *   Daintree rewrites to the new path, so it survives (e.g. Kiro).
+ * - `project-local` — the history physically lives inside the project folder, so
+ *   it travels with the move and resumes at the new path (e.g. Aider, which
+ *   writes `.aider.chat.history.md` into the git root). A cwd-scoped LOOKUP into
+ *   a home-dir store is NOT this tier — that's `provider-migration`.
  * - `provider-migration` — the conversation persists on disk but the provider
  *   can't resume it at the new path, and Daintree must never touch the
  *   provider's private store (#4100), so recovery needs a manual provider step
- *   (e.g. Claude Code).
+ *   (e.g. Claude Code's path-slug store, Kiro's absolute-path-keyed SQLite).
  * - `unavailable` — the agent has no usable resume path for a moved folder
  *   (e.g. Gemini's retired CLI, Crush which omits `resume` entirely).
  * - `unverified` — continuity across a move hasn't been confirmed for this
  *   provider; the default for any unclassified agent so we never overclaim.
- */
-/**
- * Canonical runtime list of continuity tiers; the type is derived from it so a
- * single source of truth backs both. Tests iterate this tuple instead of
- * re-declaring the union (which would just duplicate a typed literal).
+ *
+ * `CONVERSATION_CONTINUITY_TIERS` below is the canonical runtime list; the type
+ * is derived from it so a single source of truth backs both. Tests iterate that
+ * tuple instead of re-declaring the union (which would just duplicate a typed
+ * literal).
  */
 export const CONVERSATION_CONTINUITY_TIERS = [
   "preserved",

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -320,8 +320,20 @@ export type AgentResume =
  * - `unverified` — continuity across a move hasn't been confirmed for this
  *   provider; the default for any unclassified agent so we never overclaim.
  */
-export type ConversationContinuityTier =
-  "preserved" | "project-local" | "provider-migration" | "unavailable" | "unverified";
+/**
+ * Canonical runtime list of continuity tiers; the type is derived from it so a
+ * single source of truth backs both. Tests iterate this tuple instead of
+ * re-declaring the union (which would just duplicate a typed literal).
+ */
+export const CONVERSATION_CONTINUITY_TIERS = [
+  "preserved",
+  "project-local",
+  "provider-migration",
+  "unavailable",
+  "unverified",
+] as const;
+
+export type ConversationContinuityTier = (typeof CONVERSATION_CONTINUITY_TIERS)[number];
 
 export interface AgentContinuity {
   tier: ConversationContinuityTier;

--- a/shared/config/agents/aider.ts
+++ b/shared/config/agents/aider.ts
@@ -10,6 +10,16 @@ export const config: AgentConfig = {
   color: "#14B014",
   iconId: "aider",
   supportsContextInjection: true,
+  // #11282 phase 5: Aider is the genuine project-local case — it writes
+  // `.aider.chat.history.md` and `.aider.input.history` into the git root (cwd
+  // when there's no repo) and `--restore-chat-history` reads them back from
+  // whatever directory it's launched in. There's no home-dir conversation store
+  // and no absolute-path key, so the history physically travels with the folder
+  // and resumes at the new path.
+  continuity: {
+    tier: "project-local",
+    detail: "Aider keeps its chat history in the project folder, so it moves with it",
+  },
   // Aider has no MCP-client wiring of its own — it operates as a self-contained
   // git-aware editor with model providers configured directly via CLI flags.
   // The Daintree assistant overlay relies on injecting MCP servers into the

--- a/shared/config/agents/antigravity.ts
+++ b/shared/config/agents/antigravity.ts
@@ -7,6 +7,13 @@ export const config: AgentConfig = {
   color: "#4285F4",
   iconId: "antigravity",
   supportsContextInjection: true,
+  // #11282 phase 5: Daintree resumes Antigravity via `--conversation <id>` (not
+  // the path-scoped `-c` shorthand), but whether that id survives a folder move
+  // isn't confirmed — stay honest rather than overclaim.
+  continuity: {
+    tier: "unverified",
+    detail: "Resuming this conversation after a move isn't confirmed",
+  },
   // Antigravity's HelpSession wiring (workspace settings overlay, MCP
   // injection key, plan/read-only approval flag) requires investigation
   // against a running `agy` install before it can ship. Leave `supports`

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -17,6 +17,13 @@ export const config: AgentConfig = {
   iconId: "claude",
   tooltip: "Anthropic's CLI",
   supportsContextInjection: true,
+  // #11282 phase 5: Claude Code stores sessions per-folder under
+  // ~/.claude/projects/<cwd-slug>/ with no cross-path resume and no documented
+  // migration command; Daintree must not touch that private store (#4100).
+  continuity: {
+    tier: "provider-migration",
+    detail: "Claude Code stores this conversation per-folder and can't resume it after the move",
+  },
   supports: {
     mcpInjection: "project-config",
     settingsOverlay: true,

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -16,7 +16,7 @@ export const config: AgentConfig = {
   // any folder via `codex resume <id>` — a move preserves the conversation.
   continuity: {
     tier: "preserved",
-    detail: "Codex resumes this conversation by session id from any folder",
+    detail: "Codex can resume this conversation by session ID from any folder",
   },
   supports: {
     mcpInjection: "cli-flags",

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -12,6 +12,12 @@ export const config: AgentConfig = {
   color: "#10a37f",
   iconId: "codex",
   supportsContextInjection: true,
+  // #11282 phase 5: Codex sessions are UUID-keyed rollout files, resumable from
+  // any folder via `codex resume <id>` — a move preserves the conversation.
+  continuity: {
+    tier: "preserved",
+    detail: "Codex resumes this conversation by session id from any folder",
+  },
   supports: {
     mcpInjection: "cli-flags",
     settingsOverlay: false,

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -7,11 +7,16 @@ export const config: AgentConfig = {
   color: "#8957e5",
   iconId: "copilot",
   supportsContextInjection: true,
-  // #11282 phase 5: Copilot sessions are cloud-persisted and globally
-  // addressable by id, so a folder move preserves the conversation.
+  // #11282 phase 5: `--resume=<id>` reads the LOCAL home-dir store
+  // (~/.copilot/session-state/<uuid>/events.jsonl, indexed by
+  // ~/.copilot/session-store.db) — the GitHub cloud sync is a history-query /
+  // cross-machine feature, not the resume path. The store is global rather than
+  // path-keyed, so a captured id resumes from any cwd. Caveat: the session's
+  // workspace.yaml keeps the ORIGINAL absolute path and recent CLIs auto-cd back
+  // to it, so a resumed session may need `/cwd <new path>` to follow the move.
   continuity: {
     tier: "preserved",
-    detail: "Copilot can restore this conversation from its cloud session",
+    detail: "Copilot can resume this conversation by session ID from any folder",
   },
   // Copilot help sessions read MCP from `.mcp.json` written into the
   // per-session cwd (root key `mcpServers`, `type: "http"`, `$VAR` env-var

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -11,7 +11,7 @@ export const config: AgentConfig = {
   // addressable by id, so a folder move preserves the conversation.
   continuity: {
     tier: "preserved",
-    detail: "Copilot restores this conversation from its cloud session",
+    detail: "Copilot can restore this conversation from its cloud session",
   },
   // Copilot help sessions read MCP from `.mcp.json` written into the
   // per-session cwd (root key `mcpServers`, `type: "http"`, `$VAR` env-var

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -7,6 +7,12 @@ export const config: AgentConfig = {
   color: "#8957e5",
   iconId: "copilot",
   supportsContextInjection: true,
+  // #11282 phase 5: Copilot sessions are cloud-persisted and globally
+  // addressable by id, so a folder move preserves the conversation.
+  continuity: {
+    tier: "preserved",
+    detail: "Copilot restores this conversation from its cloud session",
+  },
   // Copilot help sessions read MCP from `.mcp.json` written into the
   // per-session cwd (root key `mcpServers`, `type: "http"`, `$VAR` env-var
   // substitution in headers). `--plan` is appended at spawn time via

--- a/shared/config/agents/crush.ts
+++ b/shared/config/agents/crush.ts
@@ -12,6 +12,12 @@ export const config: AgentConfig = {
   color: "#E864A4",
   iconId: "crush",
   supportsContextInjection: true,
+  // #11282 phase 5: Crush omits `resume` (its `--continue` isn't stable yet), so
+  // there's no conversation to preserve across a move by design.
+  continuity: {
+    tier: "unavailable",
+    detail: "Crush doesn't support resuming a conversation",
+  },
   tooltip: "Charm's CLI",
   usageUrl: "https://github.com/charmbracelet/crush",
   version: {

--- a/shared/config/agents/gemini.ts
+++ b/shared/config/agents/gemini.ts
@@ -9,6 +9,12 @@ export const config: AgentConfig = {
   color: "#4285F4",
   iconId: "gemini",
   supportsContextInjection: true,
+  // #11282 phase 5: the Gemini CLI was retired (2026-06-18) and its checkpoints
+  // were SHA-256-path-hash-scoped, so a moved folder can't resume either way.
+  continuity: {
+    tier: "unavailable",
+    detail: "The Gemini CLI was retired and can't resume this conversation",
+  },
   // Marked `"deprecated"`: Gemini is excluded from the assistant overlay
   // (picker and help-session launch path) following the Antigravity
   // migration (#8808, #8811), but still launches normally from the main

--- a/shared/config/agents/grok.ts
+++ b/shared/config/agents/grok.ts
@@ -19,7 +19,7 @@ export const config: AgentConfig = {
   // resume after a move — isn't verified yet.
   continuity: {
     tier: "unverified",
-    detail: "Grok's session capture on exit isn't fully verified yet",
+    detail: "Resuming this conversation after a move isn't confirmed for Grok yet",
   },
   // Launch-only for now. Grok Build reads project MCP config + AGENTS.md, so
   // assistant-overlay wiring (`supports: { mcpInjection: "project-config", … }`)

--- a/shared/config/agents/grok.ts
+++ b/shared/config/agents/grok.ts
@@ -14,6 +14,13 @@ export const config: AgentConfig = {
   color: "#E8E8E8",
   iconId: "grok",
   supportsContextInjection: true,
+  // #11282 phase 5: Grok resumes by session id, but its `sessionIdPattern` is
+  // still provisional (see `resume` below), so capture on exit — and thus
+  // resume after a move — isn't verified yet.
+  continuity: {
+    tier: "unverified",
+    detail: "Grok's session capture on exit isn't fully verified yet",
+  },
   // Launch-only for now. Grok Build reads project MCP config + AGENTS.md, so
   // assistant-overlay wiring (`supports: { mcpInjection: "project-config", … }`)
   // is plausible, but the exact injection format needs verification before it's

--- a/shared/config/agents/kimi.ts
+++ b/shared/config/agents/kimi.ts
@@ -8,6 +8,13 @@ export const config: AgentConfig = {
   color: "#1E90FF",
   iconId: "kimi",
   supportsContextInjection: true,
+  // #11282 phase 5: Kimi is rolling-history (`--continue`, no session id
+  // captured), so whether "continue" lands on the right conversation after a
+  // move isn't confirmed.
+  continuity: {
+    tier: "unverified",
+    detail: "Kimi continues its most recent session; resuming after a move isn't confirmed",
+  },
   tooltip: "Moonshot AI's CLI",
   usageUrl: "https://github.com/MoonshotAI/kimi-cli",
   packages: {

--- a/shared/config/agents/kiro.ts
+++ b/shared/config/agents/kiro.ts
@@ -7,12 +7,20 @@ export const config: AgentConfig = {
   color: "#7C3AED",
   iconId: "kiro",
   supportsContextInjection: true,
-  // #11282 phase 5: Kiro resumes project-scoped state from the working directory
-  // itself (`chat --resume`), and Daintree rewrites the cwd to the new path, so
-  // the conversation survives the move.
+  // #11282 phase 5: `chat --resume` is project-SCOPED, not project-LOCAL. Kiro
+  // keeps conversations in a global home-dir SQLite store (macOS
+  // ~/Library/Application Support/kiro-cli/data.sqlite3, Linux
+  // ~/.local/share/kiro-cli/data.sqlite3; table `conversations_v2` keyed by the
+  // ABSOLUTE workspace path). Nothing conversation-bearing lives in the project
+  // folder, so a move leaves the row stranded under the old path and
+  // `chat --resume` at the new cwd starts fresh. The history is still on disk —
+  // recovery is `kiro-cli chat --resume-id <uuid>` or `--resume-picker`, both
+  // manual: our `resume` block is `kind: "project-scoped"` and captures no
+  // session id, and reaching into Kiro's private store is off-limits (#4100).
   continuity: {
-    tier: "project-local",
-    detail: "Kiro resumes from the project folder, which Daintree updates to the new path",
+    tier: "provider-migration",
+    detail:
+      "Kiro looks up conversations by folder path — recover with kiro-cli chat --resume-picker",
   },
   tooltip: "Amazon's CLI",
   usageUrl: "https://kiro.dev/",

--- a/shared/config/agents/kiro.ts
+++ b/shared/config/agents/kiro.ts
@@ -7,6 +7,13 @@ export const config: AgentConfig = {
   color: "#7C3AED",
   iconId: "kiro",
   supportsContextInjection: true,
+  // #11282 phase 5: Kiro resumes project-scoped state from the working directory
+  // itself (`chat --resume`), and Daintree rewrites the cwd to the new path, so
+  // the conversation survives the move.
+  continuity: {
+    tier: "project-local",
+    detail: "Kiro resumes from the project folder, which Daintree updates to the new path",
+  },
   tooltip: "Amazon's CLI",
   usageUrl: "https://kiro.dev/",
   externalLinks: [{ label: "View docs", url: "https://kiro.dev/docs/" }],

--- a/shared/types/projectRelocation.ts
+++ b/shared/types/projectRelocation.ts
@@ -57,8 +57,10 @@ export interface AgentContinuitySummary {
  * and tests don't depend on registry key order.
  */
 export const CONTINUITY_TIER_ORDER: Record<ConversationContinuityTier, number> = {
-  "provider-migration": 0,
-  unavailable: 1,
+  // Unrecoverable loss ranks above a recoverable one: `unavailable` has no
+  // resume path at all, while `provider-migration` at least persists on disk.
+  unavailable: 0,
+  "provider-migration": 1,
   unverified: 2,
   "project-local": 3,
   preserved: 4,

--- a/shared/types/projectRelocation.ts
+++ b/shared/types/projectRelocation.ts
@@ -5,6 +5,8 @@
  * on Error properties surviving IPC serialization.
  */
 
+import type { ConversationContinuityTier } from "../config/agentRegistry.js";
+
 /** Why a relocation cannot proceed. Every reason maps to a user-facing message. */
 export type ProjectRelocationReason =
   | "not-found"
@@ -27,6 +29,40 @@ export interface RelocationBlocker {
   reason: ProjectRelocationReason;
   message: string;
 }
+
+/**
+ * Per-agent conversation-continuity outcome for the running terminals a
+ * relocation would gracefully stop (#11282, phase 5). One entry per distinct
+ * agent type; plain (non-agent) terminals are excluded because they carry no
+ * conversation. The `tier` is computed live from the agent registry at preview
+ * time via `resolveAgentContinuity` — never persisted, so it can't go stale.
+ */
+export interface AgentContinuitySummary {
+  /** Agent registry id (e.g. `"claude"`). */
+  agentId: string;
+  /** Display name from the agent config (e.g. `"Claude Code"`). */
+  agentName: string;
+  /** How many running terminals of this agent the relocation would stop. */
+  count: number;
+  /** Whether — and how — this agent's conversation survives the move. */
+  tier: ConversationContinuityTier;
+  /** Optional provider-specific one-liner; falls back to a generic per-tier line. */
+  detail?: string;
+}
+
+/**
+ * Preview display order for continuity tiers — riskiest first, so the user sees
+ * what WON'T survive before what will (#11282, phase 5). Lower rank sorts
+ * earlier. Shared so the coordinator can pre-sort the breakdown deterministically
+ * and tests don't depend on registry key order.
+ */
+export const CONTINUITY_TIER_ORDER: Record<ConversationContinuityTier, number> = {
+  "provider-migration": 0,
+  unavailable: 1,
+  unverified: 2,
+  "project-local": 3,
+  preserved: 4,
+};
 
 /**
  * Renderer → main relocation request. Mirrors the coordinator's
@@ -53,6 +89,13 @@ export interface RelocationPreview {
   newPath: string;
   /** Terminals/agents that will be gracefully stopped and session-preserved. */
   runningTerminalCount: number;
+  /**
+   * Per-agent conversation-continuity breakdown for the running terminals
+   * (#11282, phase 5). Empty when no agents are running (or on a closed
+   * reattach, which stops nothing). Lets the dialog warn BEFORE the move when a
+   * conversation can't be resumed at the new path.
+   */
+  agentContinuity: AgentContinuitySummary[];
   /** Absolute paths of the linked (non-main) worktrees that will be repaired. */
   linkedWorktrees: string[];
   /** Count of persisted panels whose stored working directory will be rewritten. */

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -475,7 +475,12 @@ function RelocationPreviewSection({
               <span className="text-daintree-text/70">Agent conversations</span>
               <ul className="mt-1 space-y-1.5 pl-3">
                 {preview.agentContinuity.map((agent) => {
-                  const p = CONTINUITY_PRESENTATION[agent.tier];
+                  // Defense in depth: no plugin or user-registry agent can carry
+                  // a `continuity` block today, but an unknown tier arriving from
+                  // a future source must degrade to the honest neutral row rather
+                  // than crash on an undefined presentation.
+                  const p =
+                    CONTINUITY_PRESENTATION[agent.tier] ?? CONTINUITY_PRESENTATION.unverified;
                   const Icon = p.icon;
                   return (
                     <li

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -35,8 +35,10 @@ const CONTINUITY_PRESENTATION: Record<
   preserved: {
     icon: CheckCircle2,
     className: "text-status-success",
-    label: "Conversation preserved",
-    detailFallback: "Resumes automatically at the new location",
+    // Capability language, not a guarantee: session capture on graceful stop can
+    // still miss (timeout / unmatched exit output), so we say "expected", not "will".
+    label: "Resume supported",
+    detailFallback: "Expected to resume automatically at the new location",
   },
   "project-local": {
     icon: CheckCircle2,
@@ -59,7 +61,7 @@ const CONTINUITY_PRESENTATION: Record<
   unverified: {
     icon: HelpCircle,
     className: "text-daintree-text/50",
-    label: "Resume unverified",
+    label: "Resume after move unverified",
     detailFallback: "Resuming this conversation after a move isn't confirmed",
   },
 };

--- a/src/components/Project/MoveOrRenameProjectDialog.tsx
+++ b/src/components/Project/MoveOrRenameProjectDialog.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { FolderOpen, AlertTriangle } from "lucide-react";
+import { FolderOpen, AlertTriangle, CheckCircle2, HelpCircle, type LucideIcon } from "lucide-react";
 import { basename, dirname, join, normalize } from "@shared/utils/path";
 import { validateFolderName } from "@shared/utils/folderName";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import type { RelocationPreview } from "@shared/types/projectRelocation";
+import type { AgentContinuitySummary, RelocationPreview } from "@shared/types/projectRelocation";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
@@ -20,6 +20,49 @@ import {
 function normPath(value: string): string {
   return normalize(value).normalize("NFC");
 }
+
+/**
+ * How each conversation-continuity tier renders in the preview (#11282, phase 5).
+ * `label` is the sentence-case headline; `detailFallback` is used when the agent
+ * config supplies no provider-specific `detail`. Preserved/project-local read as
+ * calm success; provider-migration/unavailable warn the user before the move;
+ * unverified stays neutral so we neither alarm nor overclaim.
+ */
+const CONTINUITY_PRESENTATION: Record<
+  AgentContinuitySummary["tier"],
+  { icon: LucideIcon; className: string; label: string; detailFallback: string }
+> = {
+  preserved: {
+    icon: CheckCircle2,
+    className: "text-status-success",
+    label: "Conversation preserved",
+    detailFallback: "Resumes automatically at the new location",
+  },
+  "project-local": {
+    icon: CheckCircle2,
+    className: "text-status-success",
+    label: "Conversation stays with the folder",
+    detailFallback: "Resumes from the project folder, which moves with it",
+  },
+  "provider-migration": {
+    icon: AlertTriangle,
+    className: "text-status-warning",
+    label: "Provider migration required",
+    detailFallback: "The provider can't resume this conversation at the new path",
+  },
+  unavailable: {
+    icon: AlertTriangle,
+    className: "text-status-warning",
+    label: "Conversation can't be resumed",
+    detailFallback: "This agent has no way to resume the conversation after a move",
+  },
+  unverified: {
+    icon: HelpCircle,
+    className: "text-daintree-text/50",
+    label: "Resume unverified",
+    detailFallback: "Resuming this conversation after a move isn't confirmed",
+  },
+};
 
 const INPUT_CLASS =
   "w-full rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent aria-invalid:border-status-error";
@@ -422,7 +465,42 @@ function RelocationPreviewSection({
               {preview.runningTerminalCount === 1
                 ? "1 terminal will be gracefully stopped"
                 : `${preview.runningTerminalCount} terminals will be gracefully stopped`}{" "}
-              <span className="text-daintree-text/40">— sessions are preserved and restored</span>
+              <span className="text-daintree-text/40">— they restart at the new location</span>
+            </li>
+          )}
+          {preview.agentContinuity.length > 0 && (
+            <li data-testid="relocate-continuity">
+              <span className="text-daintree-text/70">Agent conversations</span>
+              <ul className="mt-1 space-y-1.5 pl-3">
+                {preview.agentContinuity.map((agent) => {
+                  const p = CONTINUITY_PRESENTATION[agent.tier];
+                  const Icon = p.icon;
+                  return (
+                    <li
+                      key={agent.agentId}
+                      className="flex items-start gap-2"
+                      data-testid={`relocate-continuity-${agent.agentId}`}
+                    >
+                      <Icon
+                        className={`h-3.5 w-3.5 shrink-0 mt-0.5 ${p.className}`}
+                        aria-hidden="true"
+                      />
+                      <div className="space-y-0.5">
+                        <div>
+                          {agent.count === 1
+                            ? agent.agentName
+                            : `${agent.agentName} (${agent.count})`}{" "}
+                          <span className="text-daintree-text/40">—</span>{" "}
+                          <span className={p.className}>{p.label}</span>
+                        </div>
+                        <div className="text-daintree-text/40">
+                          {agent.detail ?? p.detailFallback}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
             </li>
           )}
           {preview.linkedWorktrees.length > 0 && (

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -182,11 +182,47 @@ describe("MoveOrRenameProjectDialog", () => {
     // Provider-specific detail is shown verbatim…
     expect(screen.getByText("Claude Code can't resume this after the move")).toBeTruthy();
     // …and an agent without a detail falls back to the generic per-tier line.
-    expect(screen.getByText("Resumes automatically at the new location")).toBeTruthy();
+    expect(screen.getByText("Expected to resume automatically at the new location")).toBeTruthy();
     // Count > 1 is surfaced next to the agent name.
     expect(screen.getByText(/Codex \(2\)/)).toBeTruthy();
     // Continuity is informational — it must NOT disable confirm (only blockers do).
     await waitFor(() => expect(confirmButton().disabled).toBe(false));
+  });
+
+  it("renders a single-terminal agent without a count suffix (#11282 phase 5)", async () => {
+    previewRelocation.mockResolvedValue(
+      cleanPreview({
+        runningTerminalCount: 1,
+        agentContinuity: [{ agentId: "codex", agentName: "Codex", count: 1, tier: "preserved" }],
+      })
+    );
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+
+    await waitFor(() => expect(screen.getByTestId("relocate-continuity-codex")).toBeTruthy());
+    const row = screen.getByTestId("relocate-continuity-codex").textContent ?? "";
+    // count === 1 → bare agent name, no "(1)" suffix.
+    expect(row).toContain("Codex");
+    expect(row).not.toContain("(1)");
+  });
+
+  it("shows no continuity section when only plain terminals run, and states terminals restart (#11282 phase 5)", async () => {
+    previewRelocation.mockResolvedValue(
+      cleanPreview({ runningTerminalCount: 2, agentContinuity: [] })
+    );
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+
+    await waitFor(() => expect(confirmButton().disabled).toBe(false));
+    // No agents → no continuity section.
+    expect(screen.queryByTestId("relocate-continuity")).toBeNull();
+    // The terminal line describes restart, not conversation preservation.
+    expect(screen.getByText(/they restart at the new location/)).toBeTruthy();
+    expect(screen.queryByText(/sessions are preserved and restored/)).toBeNull();
   });
 
   it("reattach mode browses to an existing folder then reattaches", async () => {

--- a/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
+++ b/src/components/Project/__tests__/MoveOrRenameProjectDialog.test.tsx
@@ -42,6 +42,7 @@ function cleanPreview(overrides: Partial<RelocationPreview> = {}): RelocationPre
     oldPath: OLD_PATH,
     newPath: "/repos/proj2",
     runningTerminalCount: 0,
+    agentContinuity: [],
     linkedWorktrees: [],
     affectedPanelCount: 0,
     blockers: [],
@@ -151,6 +152,41 @@ describe("MoveOrRenameProjectDialog", () => {
         newPath: "/repos/proj2",
       })
     );
+  });
+
+  it("surfaces per-agent conversation continuity without blocking confirm (#11282 phase 5)", async () => {
+    previewRelocation.mockResolvedValue(
+      cleanPreview({
+        runningTerminalCount: 3,
+        agentContinuity: [
+          {
+            agentId: "claude",
+            agentName: "Claude Code",
+            count: 1,
+            tier: "provider-migration",
+            detail: "Claude Code can't resume this after the move",
+          },
+          // No `detail` → the component falls back to the per-tier line.
+          { agentId: "codex", agentName: "Codex", count: 2, tier: "preserved" },
+        ],
+      })
+    );
+    openMove();
+    render(<MoveOrRenameProjectDialog />);
+
+    fireEvent.change(screen.getByTestId("relocate-folder-input"), { target: { value: "proj2" } });
+
+    await waitFor(() => expect(screen.getByTestId("relocate-continuity")).toBeTruthy());
+    // The riskiest tier's warning label renders.
+    expect(screen.getByText("Provider migration required")).toBeTruthy();
+    // Provider-specific detail is shown verbatim…
+    expect(screen.getByText("Claude Code can't resume this after the move")).toBeTruthy();
+    // …and an agent without a detail falls back to the generic per-tier line.
+    expect(screen.getByText("Resumes automatically at the new location")).toBeTruthy();
+    // Count > 1 is surfaced next to the agent name.
+    expect(screen.getByText(/Codex \(2\)/)).toBeTruthy();
+    // Continuity is informational — it must NOT disable confirm (only blockers do).
+    await waitFor(() => expect(confirmButton().disabled).toBe(false));
   });
 
   it("reattach mode browses to an existing folder then reattaches", async () => {


### PR DESCRIPTION
## Summary

- Phase 5 (final) of #11282. Phases 1-4 already landed the actual move/rename mechanics; this phase adds agent conversation continuity reporting to the move/rename preview.
- Before a folder move, the preview now classifies every running agent's conversation into one of five tiers, Preserved, Project-local, Provider migration required, Unavailable, or Unverified, and warns the user up front. It doesn't gate or block the confirm button, it just makes the tradeoff visible before the move happens.
- Tiers are computed live from a new `AgentConfig.continuity` field on the agent registry via a new `resolveAgentContinuity` function. Unknown or custom agents default to unverified, so a move can never falsely claim a conversation will survive.

Resolves #11282

## Changes

- Added `continuity` to `AgentConfig` and set it per agent: Codex and Copilot are preserved, Claude is provider migration required, Kiro is project-local, Gemini and Crush are unavailable, Grok, Kimi, and Antigravity are unverified.
- Added `resolveAgentContinuity` and wired continuity classification into `ProjectRelocationCoordinator`'s preview output.
- Verified retention of captured session IDs for non-resumable providers was already handled by phase 2's `rewriteAgentSessionPathsForProject`, no new storage needed.
- Fixed a latent wire-shape bug found in review: the pty-host process emitted the per-agent map as `detectedAgents`, but `PtyClient.getProjectStats` declared the field as `terminalTypes`, so the agent breakdown was silently coming through empty. Normalized this at the `PtyEventRouter` transport boundary.
- Updated `MoveOrRenameProjectDialog` to render the continuity tiers in the preview.

## Testing

- New resolver test suite for `resolveAgentContinuity`.
- Coordinator classification and ordering tests.
- `PtyEventRouter` boundary regression test covering the `detectedAgents`/`terminalTypes` fix.
- Dialog rendering tests for the continuity preview.
- 322 targeted tests pass locally. Prettier and eslint are clean on the changed files.