### PR TITLE
fix(worktree): preserve panels when a worktree moves

### DIFF
--- a/electron/services/__tests__/projectPathStateRewrite.test.ts
+++ b/electron/services/__tests__/projectPathStateRewrite.test.ts
@@ -20,7 +20,7 @@ describe("rewriteProjectStatePaths", () => {
     expect(rewriteProjectStatePaths(state, OLD, NEW).activeWorktreeId).toBe("/new/renamed");
   });
 
-  it("rebases panel cwd, worktreeId, filePath and legacy markdownFilePath", () => {
+  it("rebases panel cwd, worktreeId, worktreeGitDir, filePath and legacy markdownFilePath", () => {
     const state = baseState({
       terminals: [
         {
@@ -29,6 +29,7 @@ describe("rewriteProjectStatePaths", () => {
           location: "grid",
           cwd: "/old/project/sub",
           worktreeId: "/old/project",
+          worktreeGitDir: "/old/project/.git/worktrees/sub",
           filePath: "/old/project/README.md",
           markdownFilePath: "/old/project/notes.md",
         },
@@ -37,6 +38,7 @@ describe("rewriteProjectStatePaths", () => {
     const panel = rewriteProjectStatePaths(state, OLD, NEW).terminals[0];
     expect(panel.cwd).toBe("/new/renamed/sub");
     expect(panel.worktreeId).toBe("/new/renamed");
+    expect(panel.worktreeGitDir).toBe("/new/renamed/.git/worktrees/sub");
     expect(panel.filePath).toBe("/new/renamed/README.md");
     expect(panel.markdownFilePath).toBe("/new/renamed/notes.md");
   });

--- a/electron/services/projectPathStateRewrite.ts
+++ b/electron/services/projectPathStateRewrite.ts
@@ -8,8 +8,9 @@ import { rebaseAbsolutePath, rebaseMruEntry } from "../../shared/utils/projectPa
  *
  * Only fields whose values are genuine absolute filesystem paths are rebased:
  * PTY `cwd`, file-panel `filePath`/`markdownFilePath`, `worktreeId` (a worktree
- * id is a normalized absolute path), `activeWorktreeId`, tab-group worktree
- * bindings, and `worktree:` MRU entries. Deliberately excluded — they are not
+ * id is a normalized absolute path), the `worktreeGitDir` handle (#11388),
+ * `activeWorktreeId`, tab-group worktree bindings, and `worktree:` MRU entries.
+ * Deliberately excluded — they are not
  * absolute filesystem bindings and blanket substitution would corrupt them:
  *   - `browserRootPath` / `browserSelectedPath` / `browserExpandedPaths` are
  *     worktree-RELATIVE and move with the folder untouched.
@@ -89,7 +90,9 @@ function rewritePanelPaths(panel: PanelSnapshot, oldRoot: string, newRoot: strin
   const patch: Partial<PanelSnapshot> = {};
   let changed = false;
 
-  const rebaseField = (key: "cwd" | "worktreeId" | "filePath" | "markdownFilePath"): void => {
+  const rebaseField = (
+    key: "cwd" | "worktreeId" | "worktreeGitDir" | "filePath" | "markdownFilePath"
+  ): void => {
     const value = panel[key];
     if (value === undefined) return;
     const next = rebaseAbsolutePath(value, oldRoot, newRoot);
@@ -101,6 +104,9 @@ function rewritePanelPaths(panel: PanelSnapshot, oldRoot: string, newRoot: strin
 
   rebaseField("cwd");
   rebaseField("worktreeId");
+  // The gitDir handle (#11388) is an absolute path under the repo root, so a
+  // project move must rebase it too or the next worktree move can't correlate.
+  rebaseField("worktreeGitDir");
   rebaseField("filePath");
   rebaseField("markdownFilePath");
 

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -86,6 +86,13 @@ export interface TerminalState {
   cwd?: string;
   /** Associated worktree ID */
   worktreeId?: string;
+  /**
+   * The worktree's stable `.git/worktrees/<name>` admin-dir handle persisted at
+   * save time (#11388). Used at restore to remap a `worktreeId` whose path
+   * changed via `git worktree move` back to the worktree's new id. Absent on
+   * legacy snapshots.
+   */
+  worktreeGitDir?: string;
   /** Location in the UI - grid or dock */
   location?: PanelLocation;
   /** Command to execute after shell starts (e.g., 'claude' for AI agents) */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -116,6 +116,14 @@ export interface PanelSnapshot {
   cwd?: string;
   /** Associated worktree ID */
   worktreeId?: string;
+  /**
+   * The worktree's stable `.git/worktrees/<name>` admin-dir handle, captured at
+   * save time (#11388). A worktree id is its normalized path, which changes on
+   * `git worktree move`; this handle survives the move, so restore can match a
+   * stale `worktreeId` to the worktree's new path instead of orphaning the panel
+   * and re-homing it to the active worktree. Absent on legacy snapshots.
+   */
+  worktreeGitDir?: string;
   /** Location in the UI - grid or dock */
   location: PanelLocation;
   /** Command to execute after shell starts (e.g., 'claude --model sonnet-4' for AI agents) */

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -723,6 +723,36 @@ describe("PanelPersistence", () => {
         setWorktreeGitDirAccessor(() => undefined);
       }
     });
+
+    it("carries the previous worktreeGitDir when the live store can't answer, only for the same worktree (#11388)", () => {
+      // First capture a snapshot with the handle from a populated store.
+      setWorktreeGitDirAccessor((id) =>
+        id === "wt-1" ? "/repo/.git/worktrees/wt-1" : undefined
+      );
+      const prev = panelToSnapshot(createMockTerminal({ id: "p1", worktreeId: "wt-1" }));
+      expect(prev.worktreeGitDir).toBe("/repo/.git/worktrees/wt-1");
+
+      try {
+        // Simulate the #11234 empty-list race: the view store can't answer yet.
+        setWorktreeGitDirAccessor(() => undefined);
+
+        // Same worktree ⇒ the durable handle is preserved, not erased.
+        const unchanged = panelToSnapshot(
+          createMockTerminal({ id: "p1", worktreeId: "wt-1" }),
+          prev
+        );
+        expect(unchanged.worktreeGitDir).toBe("/repo/.git/worktrees/wt-1");
+
+        // Panel now bound to a DIFFERENT worktree ⇒ the stale handle is dropped.
+        const moved = panelToSnapshot(
+          createMockTerminal({ id: "p1", worktreeId: "wt-2" }),
+          prev
+        );
+        expect(moved).not.toHaveProperty("worktreeGitDir");
+      } finally {
+        setWorktreeGitDirAccessor(() => undefined);
+      }
+    });
   });
 
   describe("unregistered extension kind", () => {

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { initBuiltInPanelKinds } from "@/panels/registry";
 import { PanelPersistence, panelToSnapshot } from "../panelPersistence";
+import { setWorktreeGitDirAccessor } from "@/store/storeAccessors";
 import type { TerminalInstance, TerminalSnapshot } from "@/types";
 
 initBuiltInPanelKinds();
@@ -700,6 +701,27 @@ describe("PanelPersistence", () => {
       const panel = createMockTerminal({ id: "no-plugin", kind: "browser" });
       const snapshot = panelToSnapshot(panel);
       expect(snapshot).not.toHaveProperty("pluginId");
+    });
+
+    it("stamps worktreeGitDir from the worktree store, omitting it when unknown (#11388)", () => {
+      // The stable admin-dir handle lets restore survive a `git worktree move`.
+      setWorktreeGitDirAccessor((id) =>
+        id === "wt-1" ? "/repo/.git/worktrees/wt-1" : undefined
+      );
+      try {
+        const withHandle = panelToSnapshot(
+          createMockTerminal({ id: "p1", worktreeId: "wt-1" })
+        );
+        expect(withHandle.worktreeGitDir).toBe("/repo/.git/worktrees/wt-1");
+
+        // No handle available (unknown / legacy worktree) ⇒ field omitted.
+        const noHandle = panelToSnapshot(
+          createMockTerminal({ id: "p2", worktreeId: "wt-unknown" })
+        );
+        expect(noHandle).not.toHaveProperty("worktreeGitDir");
+      } finally {
+        setWorktreeGitDirAccessor(() => undefined);
+      }
     });
   });
 

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -705,13 +705,9 @@ describe("PanelPersistence", () => {
 
     it("stamps worktreeGitDir from the worktree store, omitting it when unknown (#11388)", () => {
       // The stable admin-dir handle lets restore survive a `git worktree move`.
-      setWorktreeGitDirAccessor((id) =>
-        id === "wt-1" ? "/repo/.git/worktrees/wt-1" : undefined
-      );
+      setWorktreeGitDirAccessor((id) => (id === "wt-1" ? "/repo/.git/worktrees/wt-1" : undefined));
       try {
-        const withHandle = panelToSnapshot(
-          createMockTerminal({ id: "p1", worktreeId: "wt-1" })
-        );
+        const withHandle = panelToSnapshot(createMockTerminal({ id: "p1", worktreeId: "wt-1" }));
         expect(withHandle.worktreeGitDir).toBe("/repo/.git/worktrees/wt-1");
 
         // No handle available (unknown / legacy worktree) ⇒ field omitted.
@@ -726,9 +722,7 @@ describe("PanelPersistence", () => {
 
     it("carries the previous worktreeGitDir when the live store can't answer, only for the same worktree (#11388)", () => {
       // First capture a snapshot with the handle from a populated store.
-      setWorktreeGitDirAccessor((id) =>
-        id === "wt-1" ? "/repo/.git/worktrees/wt-1" : undefined
-      );
+      setWorktreeGitDirAccessor((id) => (id === "wt-1" ? "/repo/.git/worktrees/wt-1" : undefined));
       const prev = panelToSnapshot(createMockTerminal({ id: "p1", worktreeId: "wt-1" }));
       expect(prev.worktreeGitDir).toBe("/repo/.git/worktrees/wt-1");
 
@@ -744,10 +738,7 @@ describe("PanelPersistence", () => {
         expect(unchanged.worktreeGitDir).toBe("/repo/.git/worktrees/wt-1");
 
         // Panel now bound to a DIFFERENT worktree ⇒ the stale handle is dropped.
-        const moved = panelToSnapshot(
-          createMockTerminal({ id: "p1", worktreeId: "wt-2" }),
-          prev
-        );
+        const moved = panelToSnapshot(createMockTerminal({ id: "p1", worktreeId: "wt-2" }), prev);
         expect(moved).not.toHaveProperty("worktreeGitDir");
       } finally {
         setWorktreeGitDirAccessor(() => undefined);

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -48,9 +48,17 @@ export function panelToSnapshot(
 ): PanelSnapshot {
   // Capture the worktree's stable admin-dir handle alongside the (path-derived,
   // move-fragile) worktreeId so restore can survive a `git worktree move`
-  // (#11388). Absent when the worktree/gitDir is unknown — restore falls back to
-  // its existing re-home behavior for those panels.
-  const worktreeGitDir = t.worktreeId ? getWorktreeGitDirById(t.worktreeId) : undefined;
+  // (#11388). When the live worktree store can't answer — e.g. the #11234
+  // empty-list readiness race, where a save can fire before the view store is
+  // populated — carry the handle already on the previous snapshot rather than
+  // dropping it, so a transient blank store doesn't erase a durable handle. Only
+  // preserved while the panel is still bound to the SAME worktree, so a genuine
+  // move to a different worktree never carries a stale handle forward. Absent
+  // when nothing is known — restore then re-homes as before.
+  const liveGitDir = t.worktreeId ? getWorktreeGitDirById(t.worktreeId) : undefined;
+  const worktreeGitDir =
+    liveGitDir ??
+    (previousSnapshot?.worktreeId === t.worktreeId ? previousSnapshot?.worktreeGitDir : undefined);
   const base: PanelSnapshot = {
     id: t.id,
     kind: t.kind,

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -10,6 +10,7 @@ import {
   type IdArrayDelta,
 } from "@shared/utils/layoutMerge";
 import { logError } from "@/utils/logger";
+import { getWorktreeGitDirById } from "@/store/storeAccessors";
 
 type ProjectClientType = typeof projectClient;
 
@@ -32,6 +33,7 @@ const BASE_PANEL_FIELDS = [
   "title",
   "titleMode",
   "worktreeId",
+  "worktreeGitDir",
   "location",
   "extensionState",
   "pluginId",
@@ -44,12 +46,18 @@ export function panelToSnapshot(
   t: TerminalInstance,
   previousSnapshot?: PanelSnapshot
 ): PanelSnapshot {
+  // Capture the worktree's stable admin-dir handle alongside the (path-derived,
+  // move-fragile) worktreeId so restore can survive a `git worktree move`
+  // (#11388). Absent when the worktree/gitDir is unknown — restore falls back to
+  // its existing re-home behavior for those panels.
+  const worktreeGitDir = t.worktreeId ? getWorktreeGitDirById(t.worktreeId) : undefined;
   const base: PanelSnapshot = {
     id: t.id,
     kind: t.kind,
     title: t.title,
     ...(t.titleMode !== undefined && { titleMode: t.titleMode }),
     worktreeId: t.worktreeId,
+    ...(worktreeGitDir !== undefined && { worktreeGitDir }),
     location: t.location === "trash" || t.location === "background" ? "grid" : t.location,
     ...(t.extensionState !== undefined && { extensionState: t.extensionState }),
     ...(t.pluginId !== undefined && { pluginId: t.pluginId }),

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -25,6 +25,7 @@ import {
   setPanelStoreClearForSwitchAccessor,
   setWorktreeSelectionAccessor,
   setWorktreeIdSetAccessor,
+  setWorktreeGitDirAccessor,
   setFleetArmingClearAccessor,
   setFleetArmedIdsAccessor,
   setFleetLastArmedIdAccessor,
@@ -75,6 +76,11 @@ export function initStoreOrchestrator(): () => void {
     const viewStore = getCurrentViewStoreOrNull();
     if (!viewStore) return null;
     return new Set(viewStore.getState().worktrees.keys());
+  });
+  setWorktreeGitDirAccessor((worktreeId) => {
+    const viewStore = getCurrentViewStoreOrNull();
+    if (!viewStore) return undefined;
+    return viewStore.getState().worktrees.get(worktreeId)?.gitDir || undefined;
   });
   setFleetArmingClearAccessor(() => {
     useFleetArmingStore.getState().clear();

--- a/src/store/storeAccessors.ts
+++ b/src/store/storeAccessors.ts
@@ -22,6 +22,7 @@ export interface WorktreeSelectionSnapshot {
 let _getPanelStoreState: (() => PanelStoreSnapshot) | null = null;
 let _getWorktreeSelectionState: (() => WorktreeSelectionSnapshot) | null = null;
 let _getWorktreeIdSet: (() => Set<string> | null) | null = null;
+let _getWorktreeGitDirById: ((worktreeId: string) => string | undefined) | null = null;
 let _clearPanelStoreForSwitch: (() => void) | null = null;
 let _clearFleetArming: (() => void) | null = null;
 let _getFleetArmedIds: (() => Set<string>) | null = null;
@@ -54,6 +55,21 @@ export function setWorktreeIdSetAccessor(getter: () => Set<string> | null): void
  */
 export function getWorktreeIdSet(): Set<string> | null {
   return _getWorktreeIdSet?.() ?? null;
+}
+
+export function setWorktreeGitDirAccessor(
+  getter: (worktreeId: string) => string | undefined
+): void {
+  _getWorktreeGitDirById = getter;
+}
+
+/**
+ * The stable `.git/worktrees/<name>` handle for a worktree in the current view,
+ * or `undefined` when unknown / no view store is mounted. Persisted with each
+ * panel so restore can survive a worktree path change (#11388).
+ */
+export function getWorktreeGitDirById(worktreeId: string): string | undefined {
+  return _getWorktreeGitDirById?.(worktreeId);
 }
 
 export function setPanelStoreClearForSwitchAccessor(callback: () => void): void {
@@ -92,6 +108,7 @@ export function resetStoreAccessorsForTesting(): void {
   _getPanelStoreState = null;
   _getWorktreeSelectionState = null;
   _getWorktreeIdSet = null;
+  _getWorktreeGitDirById = null;
   _clearPanelStoreForSwitch = null;
   _clearFleetArming = null;
   _getFleetArmedIds = null;

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -894,3 +894,62 @@ describe("restorePanelsPhase — panels outliving their worktree (issue #11232)"
     expect(ctx.addPanel.mock.calls[1]![0]).toMatchObject({ worktreeId: "wC" });
   });
 });
+
+describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)", () => {
+  // A worktree id is its path, so `git worktree move` gives it a new id while
+  // its `.git/worktrees/<name>` handle (gitDir) is preserved. The pre-pass reads
+  // id + gitDir off the current list to correlate a stale worktreeId.
+  const worktreeList = (...worktrees: Array<{ id: string; gitDir?: string }>) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    Promise.resolve(
+      worktrees.map((w) => ({ id: w.id, path: w.id, gitDir: w.gitDir })) as never
+    );
+
+  const GITDIR = "/repo/.git/worktrees/feature";
+
+  it("remaps a moved worktree's panel to the new id instead of re-homing it", async () => {
+    // The worktree moved from /old/feature to /new/feature; its gitDir handle is
+    // unchanged, so the panel must follow to the new id, not collapse into wA.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    await restorePanelsPhase(
+      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR })],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "/new/feature" });
+  });
+
+  it("still re-homes a genuinely-deleted worktree (no gitDir match)", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA", gitDir: "/repo/.git" }),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    await restorePanelsPhase(
+      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR })],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+  });
+
+  it("re-homes a legacy snapshot with no stored gitDir handle", async () => {
+    // Pre-#11388 snapshots carry no gitDir, so a move can't be correlated — the
+    // panel falls through to the existing re-home behavior.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+
+    await restorePanelsPhase([panel("t1", { worktreeId: "/old/feature" })], ctx);
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "wA" });
+  });
+});

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -907,12 +907,81 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
 
   const GITDIR = "/repo/.git/worktrees/feature";
 
-  it("remaps a moved worktree's panel to the new id instead of re-homing it", async () => {
+  it("remaps a moved backend PTY to the new id and rebases its live cwd", async () => {
     // The worktree moved from /old/feature to /new/feature; its gitDir handle is
-    // unchanged, so the panel must follow to the new id, not collapse into wA.
+    // unchanged, so the panel must follow to the new id (not collapse into wA),
+    // and its surviving-PTY cwd (reported at the old path) must be rebased.
     const ctx = makeContext({
       activeWorktreeId: "wA",
       worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1", { cwd: "/old/feature/pkg" }));
+
+    await restorePanelsPhase(
+      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR, cwd: "/old/feature/pkg" })],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({
+      worktreeId: "/new/feature",
+      cwd: "/new/feature/pkg",
+    });
+  });
+
+  it("remaps a respawned (cold) PTY and rebases its saved cwd", async () => {
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+
+    await restorePanelsPhase(
+      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR, cwd: "/old/feature/sub" })],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({
+      worktreeId: "/new/feature",
+      cwd: "/new/feature/sub",
+    });
+  });
+
+  it("remaps a moved non-PTY panel (browser) and rebases its cwd", async () => {
+    // Non-PTY panels never went through the re-home fallback, but the pre-pass
+    // rewrites saved.worktreeId/cwd before buildArgsForNonPtyRecreation reads it.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+
+    await restorePanelsPhase(
+      [
+        panel("b1", {
+          kind: "browser",
+          worktreeId: "/old/feature",
+          worktreeGitDir: GITDIR,
+          cwd: "/old/feature",
+        }),
+      ],
+      ctx
+    );
+
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({
+      worktreeId: "/new/feature",
+      cwd: "/new/feature",
+    });
+  });
+
+  it("follows the handle when the old path was taken over by another worktree", async () => {
+    // A moved /old/feature→/new/feature (handle GITDIR); a DIFFERENT worktree now
+    // occupies /old/feature. The panel must follow its handle to /new/feature,
+    // not bind to the squatter still sitting at the old id.
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList(
+        { id: "/old/feature", gitDir: "/repo/.git/worktrees/other" },
+        { id: "/new/feature", gitDir: GITDIR }
+      ),
     });
     ctx.backendTerminalMap.set("t1", backend("t1"));
 
@@ -922,6 +991,26 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
     );
 
     expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "/new/feature" });
+  });
+
+  it("remaps every panel sharing one moved worktree", async () => {
+    const ctx = makeContext({
+      activeWorktreeId: "wA",
+      worktreesPromise: worktreeList({ id: "wA" }, { id: "/new/feature", gitDir: GITDIR }),
+    });
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    ctx.backendTerminalMap.set("t2", backend("t2"));
+
+    await restorePanelsPhase(
+      [
+        panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR }),
+        panel("t2", { worktreeId: "/old/feature", worktreeGitDir: GITDIR }),
+      ],
+      ctx
+    );
+
+    const homes = ctx.addPanel.mock.calls.map((c) => (c[0] as { worktreeId?: string }).worktreeId);
+    expect(homes).toEqual(["/new/feature", "/new/feature"]);
   });
 
   it("still re-homes a genuinely-deleted worktree (no gitDir match)", async () => {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -901,9 +901,7 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
   // id + gitDir off the current list to correlate a stale worktreeId.
   const worktreeList = (...worktrees: Array<{ id: string; gitDir?: string }>) =>
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    Promise.resolve(
-      worktrees.map((w) => ({ id: w.id, path: w.id, gitDir: w.gitDir })) as never
-    );
+    Promise.resolve(worktrees.map((w) => ({ id: w.id, path: w.id, gitDir: w.gitDir })) as never);
 
   const GITDIR = "/repo/.git/worktrees/feature";
 
@@ -918,7 +916,13 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
     ctx.backendTerminalMap.set("t1", backend("t1", { cwd: "/old/feature/pkg" }));
 
     await restorePanelsPhase(
-      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR, cwd: "/old/feature/pkg" })],
+      [
+        panel("t1", {
+          worktreeId: "/old/feature",
+          worktreeGitDir: GITDIR,
+          cwd: "/old/feature/pkg",
+        }),
+      ],
       ctx
     );
 
@@ -936,7 +940,13 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
     });
 
     await restorePanelsPhase(
-      [panel("t1", { worktreeId: "/old/feature", worktreeGitDir: GITDIR, cwd: "/old/feature/sub" })],
+      [
+        panel("t1", {
+          worktreeId: "/old/feature",
+          worktreeGitDir: GITDIR,
+          cwd: "/old/feature/sub",
+        }),
+      ],
       ctx
     );
 
@@ -1009,8 +1019,11 @@ describe("restorePanelsPhase — panels surviving a worktree move (issue #11388)
       ctx
     );
 
-    const homes = ctx.addPanel.mock.calls.map((c) => (c[0] as { worktreeId?: string }).worktreeId);
-    expect(homes).toEqual(["/new/feature", "/new/feature"]);
+    // Both share one moved worktree; order across the restore tier is not fixed,
+    // so assert each landed on the new id rather than a positional sequence.
+    expect(ctx.addPanel).toHaveBeenCalledTimes(2);
+    expect(ctx.addPanel.mock.calls[0]![0]).toMatchObject({ worktreeId: "/new/feature" });
+    expect(ctx.addPanel.mock.calls[1]![0]).toMatchObject({ worktreeId: "/new/feature" });
   });
 
   it("still re-homes a genuinely-deleted worktree (no gitDir match)", async () => {

--- a/src/utils/stateHydration/__tests__/worktreeMoveRemap.test.ts
+++ b/src/utils/stateHydration/__tests__/worktreeMoveRemap.test.ts
@@ -70,14 +70,16 @@ describe("resolveMovedWorktreeId", () => {
     expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBeUndefined();
   });
 
-  it("returns undefined when the matched worktree is the saved id itself", () => {
-    // Defensive: an id absent from knownIds is the precondition, so this can only
-    // happen with an inconsistent context — never remap onto the same id.
-    const ctx: WorktreeMoveContext = {
-      knownIds: new Set(["/repo/other"]),
-      gitDirToId: new Map([[GITDIR, OLD]]),
-    };
-    expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBeUndefined();
+  it("follows the handle when the old path is now occupied by another worktree", () => {
+    // The saved id still appears in the list, but with a DIFFERENT handle — a new
+    // worktree took over the freed path while the original moved to NEW. Keying
+    // on the handle (not the still-present id) sends the panel to NEW, not the
+    // squatter at OLD.
+    const ctx = ctxWith([
+      { id: OLD, gitDir: "/repo/.git/worktrees/other" },
+      { id: NEW, gitDir: GITDIR },
+    ]);
+    expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBe(NEW);
   });
 });
 

--- a/src/utils/stateHydration/__tests__/worktreeMoveRemap.test.ts
+++ b/src/utils/stateHydration/__tests__/worktreeMoveRemap.test.ts
@@ -10,9 +10,7 @@ const OLD = "/repo/wt-feature";
 const NEW = "/elsewhere/wt-feature";
 const GITDIR = "/repo/.git/worktrees/wt-feature";
 
-function ctxWith(
-  worktrees: Array<{ id: string; gitDir?: string }>
-): WorktreeMoveContext {
+function ctxWith(worktrees: Array<{ id: string; gitDir?: string }>): WorktreeMoveContext {
   const ctx = buildWorktreeMoveContext(worktrees);
   if (ctx === null) throw new Error("expected a non-null context");
   return ctx;
@@ -86,9 +84,7 @@ describe("resolveMovedWorktreeId", () => {
 describe("resolveWorktreeMovePatch", () => {
   it("returns null when the worktree did not move", () => {
     const ctx = ctxWith([{ id: OLD, gitDir: GITDIR }]);
-    expect(
-      resolveWorktreeMovePatch({ worktreeId: OLD, worktreeGitDir: GITDIR }, ctx)
-    ).toBeNull();
+    expect(resolveWorktreeMovePatch({ worktreeId: OLD, worktreeGitDir: GITDIR }, ctx)).toBeNull();
   });
 
   it("returns null for a legacy snapshot with no stored gitDir", () => {
@@ -118,10 +114,7 @@ describe("resolveWorktreeMovePatch", () => {
 
   it("remaps the id only when there are no path-bearing fields", () => {
     const ctx = ctxWith([{ id: NEW, gitDir: GITDIR }]);
-    const patch = resolveWorktreeMovePatch(
-      { worktreeId: OLD, worktreeGitDir: GITDIR },
-      ctx
-    );
+    const patch = resolveWorktreeMovePatch({ worktreeId: OLD, worktreeGitDir: GITDIR }, ctx);
     expect(patch).toEqual({ worktreeId: NEW });
   });
 

--- a/src/utils/stateHydration/__tests__/worktreeMoveRemap.test.ts
+++ b/src/utils/stateHydration/__tests__/worktreeMoveRemap.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildWorktreeMoveContext,
+  resolveMovedWorktreeId,
+  resolveWorktreeMovePatch,
+  type WorktreeMoveContext,
+} from "../worktreeMoveRemap";
+
+const OLD = "/repo/wt-feature";
+const NEW = "/elsewhere/wt-feature";
+const GITDIR = "/repo/.git/worktrees/wt-feature";
+
+function ctxWith(
+  worktrees: Array<{ id: string; gitDir?: string }>
+): WorktreeMoveContext {
+  const ctx = buildWorktreeMoveContext(worktrees);
+  if (ctx === null) throw new Error("expected a non-null context");
+  return ctx;
+}
+
+describe("buildWorktreeMoveContext", () => {
+  it("returns null for an empty or absent list (treated as not-ready, #11234)", () => {
+    expect(buildWorktreeMoveContext([])).toBeNull();
+    expect(buildWorktreeMoveContext(null)).toBeNull();
+    expect(buildWorktreeMoveContext(undefined)).toBeNull();
+  });
+
+  it("indexes ids and gitDir handles, skipping empty gitDir", () => {
+    const ctx = ctxWith([
+      { id: "/repo/main", gitDir: "/repo/.git" },
+      { id: NEW, gitDir: GITDIR },
+      { id: "/repo/no-handle", gitDir: "" },
+      { id: "/repo/undef-handle" },
+    ]);
+    expect(ctx.knownIds).toEqual(
+      new Set(["/repo/main", NEW, "/repo/no-handle", "/repo/undef-handle"])
+    );
+    expect(ctx.gitDirToId.get(GITDIR)).toBe(NEW);
+    expect(ctx.gitDirToId.get("/repo/.git")).toBe("/repo/main");
+    expect(ctx.gitDirToId.has("")).toBe(false);
+  });
+});
+
+describe("resolveMovedWorktreeId", () => {
+  it("returns undefined when the context is null (list not ready)", () => {
+    expect(resolveMovedWorktreeId(OLD, GITDIR, null)).toBeUndefined();
+  });
+
+  it("returns undefined without a saved id or gitDir (legacy snapshot)", () => {
+    const ctx = ctxWith([{ id: NEW, gitDir: GITDIR }]);
+    expect(resolveMovedWorktreeId(undefined, GITDIR, ctx)).toBeUndefined();
+    expect(resolveMovedWorktreeId(OLD, undefined, ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when the saved id still exists (not moved)", () => {
+    const ctx = ctxWith([{ id: OLD, gitDir: GITDIR }]);
+    expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBeUndefined();
+  });
+
+  it("returns the new id when the saved id is gone but its gitDir matches a moved worktree", () => {
+    const ctx = ctxWith([
+      { id: "/repo/main", gitDir: "/repo/.git" },
+      { id: NEW, gitDir: GITDIR },
+    ]);
+    expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBe(NEW);
+  });
+
+  it("returns undefined when the saved gitDir matches nothing (genuinely deleted)", () => {
+    const ctx = ctxWith([{ id: "/repo/main", gitDir: "/repo/.git" }]);
+    expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when the matched worktree is the saved id itself", () => {
+    // Defensive: an id absent from knownIds is the precondition, so this can only
+    // happen with an inconsistent context — never remap onto the same id.
+    const ctx: WorktreeMoveContext = {
+      knownIds: new Set(["/repo/other"]),
+      gitDirToId: new Map([[GITDIR, OLD]]),
+    };
+    expect(resolveMovedWorktreeId(OLD, GITDIR, ctx)).toBeUndefined();
+  });
+});
+
+describe("resolveWorktreeMovePatch", () => {
+  it("returns null when the worktree did not move", () => {
+    const ctx = ctxWith([{ id: OLD, gitDir: GITDIR }]);
+    expect(
+      resolveWorktreeMovePatch({ worktreeId: OLD, worktreeGitDir: GITDIR }, ctx)
+    ).toBeNull();
+  });
+
+  it("returns null for a legacy snapshot with no stored gitDir", () => {
+    const ctx = ctxWith([{ id: NEW, gitDir: GITDIR }]);
+    expect(resolveWorktreeMovePatch({ worktreeId: OLD }, ctx)).toBeNull();
+  });
+
+  it("remaps the worktree id and rebases cwd/filePath/markdownFilePath onto the new root", () => {
+    const ctx = ctxWith([{ id: NEW, gitDir: GITDIR }]);
+    const patch = resolveWorktreeMovePatch(
+      {
+        worktreeId: OLD,
+        worktreeGitDir: GITDIR,
+        cwd: `${OLD}/packages/app`,
+        filePath: `${OLD}/src/index.ts`,
+        markdownFilePath: `${OLD}/README.md`,
+      },
+      ctx
+    );
+    expect(patch).toEqual({
+      worktreeId: NEW,
+      cwd: `${NEW}/packages/app`,
+      filePath: `${NEW}/src/index.ts`,
+      markdownFilePath: `${NEW}/README.md`,
+    });
+  });
+
+  it("remaps the id only when there are no path-bearing fields", () => {
+    const ctx = ctxWith([{ id: NEW, gitDir: GITDIR }]);
+    const patch = resolveWorktreeMovePatch(
+      { worktreeId: OLD, worktreeGitDir: GITDIR },
+      ctx
+    );
+    expect(patch).toEqual({ worktreeId: NEW });
+  });
+
+  it("leaves a path outside the moved worktree root untouched", () => {
+    const ctx = ctxWith([{ id: NEW, gitDir: GITDIR }]);
+    const patch = resolveWorktreeMovePatch(
+      { worktreeId: OLD, worktreeGitDir: GITDIR, cwd: "/somewhere/else" },
+      ctx
+    );
+    // Path prefix doesn't match the old worktree root, so it is preserved.
+    expect(patch).toEqual({ worktreeId: NEW, cwd: "/somewhere/else" });
+  });
+});

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -14,6 +14,11 @@ import type { ResourceProfile } from "@shared/types/resourceProfile";
 import { type TerminalRestoreTask, getRestoreBatchParams, delay } from "./batchScheduler";
 import { reconnectWithTimeout } from "./reconnectManager";
 import {
+  buildWorktreeMoveContext,
+  resolveWorktreeMovePatch,
+  type WorktreeMoveContext,
+} from "./worktreeMoveRemap";
+import {
   inferKind,
   resolveAgentId,
   buildArgsForBackendTerminal,
@@ -150,12 +155,16 @@ export async function restorePanelsPhase(
   // worktree — so [] only ever means "not ready", never a real count. Treating
   // it as authoritative re-homed every panel to the active worktree, and the
   // save loop then persisted that, compounding across restarts.
-  let knownWorktreeIdsPromise: Promise<Set<string> | null> | null = null;
-  const getKnownWorktreeIds = (): Promise<Set<string> | null> => {
-    knownWorktreeIdsPromise ??= worktreesPromise.then((list) =>
-      list && list.length > 0 ? new Set(list.map((w) => w.id)) : null
-    );
-    return knownWorktreeIdsPromise;
+  // A single memoized correlation context off the in-flight worktree list,
+  // shared by the known-id guard and the worktree-move remap below (#11388).
+  let worktreeMoveContextPromise: Promise<WorktreeMoveContext | null> | null = null;
+  const getWorktreeMoveContext = (): Promise<WorktreeMoveContext | null> => {
+    worktreeMoveContextPromise ??= worktreesPromise.then((list) => buildWorktreeMoveContext(list));
+    return worktreeMoveContextPromise;
+  };
+  const getKnownWorktreeIds = async (): Promise<Set<string> | null> => {
+    const ctx = await getWorktreeMoveContext();
+    return ctx?.knownIds ?? null;
   };
   const resolveRestoredWorktreeId = async (
     worktreeId: string | undefined
@@ -169,6 +178,25 @@ export async function restorePanelsPhase(
   };
 
   if (savedPanels && savedPanels.length > 0) {
+    // #11388: a worktree move (`git worktree move` or an external relocation)
+    // changes its path-derived id while its stable `.git/worktrees/<name>`
+    // handle is preserved. Remap panels whose worktree moved — matched via the
+    // gitDir persisted with each panel — to the worktree's new id (rebasing
+    // cwd/filePath) BEFORE anything keys off saved.worktreeId, so a moved
+    // worktree's panels stay put instead of being treated as deleted. Legacy
+    // snapshots without a stored gitDir, and genuinely-deleted worktrees, are
+    // left untouched here and handled by resolveRestoredWorktreeId's re-home
+    // below. The context is null when the list isn't ready (#11234), so this is
+    // a no-op in that race — identical to the pre-#11388 behavior.
+    const moveContext = await getWorktreeMoveContext();
+    const panels = moveContext
+      ? savedPanels.map((saved) => {
+          if (saved === undefined) return saved;
+          const patch = resolveWorktreeMovePatch(saved, moveContext);
+          return patch ? { ...saved, ...patch } : saved;
+        })
+      : savedPanels;
+
     // Build a single-pass map of worktreeId → highest lastActiveAt across saved
     // panels. The restore predicate uses this to promote each non-active
     // worktree's most-recently-focused panel to the priority sequential tier,
@@ -179,7 +207,7 @@ export async function restorePanelsPhase(
     // `Number.isFinite` rejects NaN and ±Infinity so corrupted persisted
     // values never seed the map with values that would silently mis-promote.
     const maxLastActiveAtByWorktree = new Map<string, number>();
-    for (const saved of savedPanels) {
+    for (const saved of panels) {
       if (saved === undefined) continue;
       if (saved.worktreeId === undefined) continue;
       if (!Number.isFinite(saved.lastActiveAt) || (saved.lastActiveAt ?? 0) <= 0) continue;
@@ -193,8 +221,8 @@ export async function restorePanelsPhase(
     const panelTasks: PanelRestoreTaskEntry[] = [];
     const restoredIdsByIndex = new Map<number, string>();
 
-    for (let savedIndex = 0; savedIndex < savedPanels.length; savedIndex++) {
-      const saved = savedPanels[savedIndex];
+    for (let savedIndex = 0; savedIndex < panels.length; savedIndex++) {
+      const saved = panels[savedIndex];
       if (saved === undefined) continue;
       if (isSmokeTestTerminalId(saved.id)) {
         logHydrationInfo(`Skipping smoke test terminal snapshot: ${saved.id}`);

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -18,6 +18,7 @@ import {
   resolveWorktreeMovePatch,
   type WorktreeMoveContext,
 } from "./worktreeMoveRemap";
+import { rebaseAbsolutePath } from "@shared/utils/projectPathRelocation";
 import {
   inferKind,
   resolveAgentId,
@@ -37,6 +38,20 @@ import {
 
 type AddPanelFn = HydrationOptions["addPanel"];
 type RestoreTerminalOrderFn = NonNullable<HydrationOptions["restoreTerminalOrder"]>;
+
+/**
+ * Rebase a restore arg's `cwd` from a moved worktree's old root to its new one.
+ * No-op when the panel's worktree didn't move or the arg carries no cwd. Used on
+ * the surviving-PTY paths, whose cwd comes from the live backend record (the old
+ * path) rather than the already-rebased `saved.cwd` (#11388).
+ */
+function rebaseMovedArgsCwd(
+  args: { cwd?: string },
+  move: { oldRoot: string; newRoot: string } | undefined
+): void {
+  if (move === undefined || typeof args.cwd !== "string") return;
+  args.cwd = rebaseAbsolutePath(args.cwd, move.oldRoot, move.newRoot);
+}
 
 export interface PanelRestoreContext {
   addPanel: AddPanelFn;
@@ -188,12 +203,27 @@ export async function restorePanelsPhase(
     // left untouched here and handled by resolveRestoredWorktreeId's re-home
     // below. The context is null when the list isn't ready (#11234), so this is
     // a no-op in that race — identical to the pre-#11388 behavior.
-    const moveContext = await getWorktreeMoveContext();
+    // Skip the correlation — and its worktree-list await — entirely when no
+    // saved panel even carries a gitDir handle. Legacy snapshots and
+    // browser-only sessions then restore without waiting on worktree
+    // enumeration, preserving the pre-#11388 time-to-first-panel.
+    const anyMoveCandidate = savedPanels.some(
+      (saved) =>
+        saved !== undefined && saved.worktreeId !== undefined && saved.worktreeGitDir !== undefined
+    );
+    const moveContext = anyMoveCandidate ? await getWorktreeMoveContext() : null;
+    // old→new root per remapped panel, so the surviving-PTY paths below (which
+    // take cwd from the live backend record, not saved.cwd) can rebase it too.
+    const movedRootsById = new Map<string, { oldRoot: string; newRoot: string }>();
     const panels = moveContext
       ? savedPanels.map((saved) => {
           if (saved === undefined) return saved;
           const patch = resolveWorktreeMovePatch(saved, moveContext);
-          return patch ? { ...saved, ...patch } : saved;
+          if (!patch) return saved;
+          if (saved.worktreeId !== undefined) {
+            movedRootsById.set(saved.id, { oldRoot: saved.worktreeId, newRoot: patch.worktreeId });
+          }
+          return { ...saved, ...patch };
         })
       : savedPanels;
 
@@ -281,6 +311,10 @@ export async function restorePanelsPhase(
             // Assign to the active worktree when the terminal has no worktree,
             // or names one that no longer exists.
             args.worktreeId = await resolveRestoredWorktreeId(args.worktreeId);
+            // A surviving backend PTY reports its live (old-path) cwd; rebase it
+            // onto the moved worktree's new root so persisted state and a later
+            // respawn don't reference the vanished path (#11388).
+            rebaseMovedArgsCwd(args, movedRootsById.get(saved.id));
             const location = args.location as "grid" | "dock";
 
             logHydrationInfo(`[HYDRATION] Adding terminal from backend:`, {
@@ -359,6 +393,9 @@ export async function restorePanelsPhase(
                 reconnectArgs.worktreeId = await resolveRestoredWorktreeId(
                   reconnectArgs.worktreeId
                 );
+                // Rebase the reconnected PTY's live (old-path) cwd onto the
+                // moved worktree's new root, like the matched-backend path.
+                rebaseMovedArgsCwd(reconnectArgs, movedRootsById.get(saved.id));
                 const restoredTerminalId = await addPanel(reconnectArgs);
                 restoredIdsByIndex.set(capturedIndex, restoredTerminalId);
 

--- a/src/utils/stateHydration/worktreeMoveRemap.ts
+++ b/src/utils/stateHydration/worktreeMoveRemap.ts
@@ -10,6 +10,13 @@ import { rebaseAbsolutePath } from "@shared/utils/projectPathRelocation";
  * pairs the set of current ids with a `gitDir → current id` index so a saved
  * panel whose `worktreeId` no longer matches can be remapped to the worktree's
  * new id instead of being orphaned and re-homed to the active worktree.
+ *
+ * Known limitation: a `gitDir` name is unique only among concurrently-registered
+ * worktrees, not forever — after a linked worktree is pruned, Git can reuse
+ * `.git/worktrees/<name>` for a later same-basename worktree. A snapshot for the
+ * deleted worktree could then correlate to the unrelated reuse. Closing that
+ * needs a main-process incarnation fingerprint (filesystem identity), which is
+ * out of scope for the path-change fix; the common move case is handled here.
  */
 export interface WorktreeMoveContext {
   /** Ids of all worktrees currently known to the view. */
@@ -63,14 +70,17 @@ export function buildWorktreeMoveContext(
 }
 
 /**
- * Resolve a saved `worktreeId` that may have moved to a new path.
+ * Resolve a saved `worktreeId` whose worktree may have moved to a new path.
  *
- * Returns the worktree's NEW id only when the saved id is no longer present but
- * its persisted `gitDir` handle matches a current worktree at a different path
- * (i.e. the worktree was moved). Returns `undefined` in every other case —
- * including a still-present id, a genuinely-deleted worktree (no `gitDir`
- * match), and legacy snapshots with no stored `gitDir` — so the caller keeps its
- * existing behavior (re-home to the active worktree).
+ * The `gitDir` handle is the stable identity, so it is the primary key: the
+ * panel belongs to whichever worktree currently carries its handle. Returns that
+ * worktree's id when the handle maps to a DIFFERENT id than the saved one —
+ * covering both a plain `git worktree move` and the case where the saved path
+ * was taken over by an unrelated worktree while the original moved elsewhere
+ * (matching on the still-present old id would wrongly bind the panel to the
+ * squatter). Returns `undefined` — so the caller keeps its re-home behavior —
+ * when the handle maps to no current worktree (genuinely deleted), maps to the
+ * same id (unchanged), or is absent (legacy snapshot with no stored handle).
  */
 export function resolveMovedWorktreeId(
   savedWorktreeId: string | undefined,
@@ -79,11 +89,9 @@ export function resolveMovedWorktreeId(
 ): string | undefined {
   if (ctx === null) return undefined;
   if (!savedWorktreeId || !savedGitDir) return undefined;
-  // Still present at its old path ⇒ not moved.
-  if (ctx.knownIds.has(savedWorktreeId)) return undefined;
-  const newId = ctx.gitDirToId.get(savedGitDir);
-  if (newId !== undefined && newId !== savedWorktreeId) return newId;
-  return undefined;
+  const currentId = ctx.gitDirToId.get(savedGitDir);
+  if (currentId === undefined || currentId === savedWorktreeId) return undefined;
+  return currentId;
 }
 
 /**

--- a/src/utils/stateHydration/worktreeMoveRemap.ts
+++ b/src/utils/stateHydration/worktreeMoveRemap.ts
@@ -1,0 +1,115 @@
+import type { WorktreeState } from "@shared/types";
+import { rebaseAbsolutePath } from "@shared/utils/projectPathRelocation";
+
+/**
+ * Correlation context for detecting worktree moves at restore time (#11388).
+ *
+ * A worktree id is its normalized absolute path, so `git worktree move` (or an
+ * external relocation) gives a worktree a brand-new id while its stable
+ * `.git/worktrees/<name>` admin-dir handle (`gitDir`) is preserved. This context
+ * pairs the set of current ids with a `gitDir → current id` index so a saved
+ * panel whose `worktreeId` no longer matches can be remapped to the worktree's
+ * new id instead of being orphaned and re-homed to the active worktree.
+ */
+export interface WorktreeMoveContext {
+  /** Ids of all worktrees currently known to the view. */
+  knownIds: Set<string>;
+  /** Stable `gitDir` handle → the worktree's current (path-derived) id. */
+  gitDirToId: Map<string, string>;
+}
+
+/**
+ * A minimal panel-snapshot shape used to detect and apply a worktree move. Kept
+ * structural so both `PanelSnapshot` (save side) and `TerminalState` (restore
+ * side) satisfy it without importing either concrete type.
+ */
+export interface WorktreeMoveRemappable {
+  worktreeId?: string;
+  worktreeGitDir?: string;
+  cwd?: string;
+  filePath?: string;
+  markdownFilePath?: string;
+}
+
+/** Path-bearing fields to rewrite when a panel's worktree has moved. */
+export interface WorktreeMovePatch {
+  worktreeId: string;
+  cwd?: string;
+  filePath?: string;
+  markdownFilePath?: string;
+}
+
+/**
+ * Build a {@link WorktreeMoveContext} from the current worktree list.
+ *
+ * Returns `null` for an empty/absent list. Per #11234 an empty list means "not
+ * ready yet", never "every worktree is gone" — a null context makes callers skip
+ * remapping entirely and keep saved ids untouched, exactly like the existing
+ * re-home guard.
+ */
+export function buildWorktreeMoveContext(
+  worktrees: readonly Pick<WorktreeState, "id" | "gitDir">[] | null | undefined
+): WorktreeMoveContext | null {
+  if (!worktrees || worktrees.length === 0) return null;
+  const knownIds = new Set<string>();
+  const gitDirToId = new Map<string, string>();
+  for (const wt of worktrees) {
+    knownIds.add(wt.id);
+    // gitDir (.git/worktrees/<name>) is a 1:1 stable handle for a worktree, so
+    // this index never collides. Empty string counts as absent.
+    if (wt.gitDir) gitDirToId.set(wt.gitDir, wt.id);
+  }
+  return { knownIds, gitDirToId };
+}
+
+/**
+ * Resolve a saved `worktreeId` that may have moved to a new path.
+ *
+ * Returns the worktree's NEW id only when the saved id is no longer present but
+ * its persisted `gitDir` handle matches a current worktree at a different path
+ * (i.e. the worktree was moved). Returns `undefined` in every other case —
+ * including a still-present id, a genuinely-deleted worktree (no `gitDir`
+ * match), and legacy snapshots with no stored `gitDir` — so the caller keeps its
+ * existing behavior (re-home to the active worktree).
+ */
+export function resolveMovedWorktreeId(
+  savedWorktreeId: string | undefined,
+  savedGitDir: string | undefined,
+  ctx: WorktreeMoveContext | null
+): string | undefined {
+  if (ctx === null) return undefined;
+  if (!savedWorktreeId || !savedGitDir) return undefined;
+  // Still present at its old path ⇒ not moved.
+  if (ctx.knownIds.has(savedWorktreeId)) return undefined;
+  const newId = ctx.gitDirToId.get(savedGitDir);
+  if (newId !== undefined && newId !== savedWorktreeId) return newId;
+  return undefined;
+}
+
+/**
+ * Compute the path-bearing rewrite for a saved panel whose worktree moved, or
+ * `null` when it did not move (or cannot be correlated). The new worktree id is
+ * a normalized path, so `cwd`/`filePath`/`markdownFilePath` — which live under
+ * the old worktree root — are rebased onto the new root with the same
+ * segment-boundary primitive the project-move relocation uses (#11282).
+ */
+export function resolveWorktreeMovePatch(
+  saved: WorktreeMoveRemappable,
+  ctx: WorktreeMoveContext | null
+): WorktreeMovePatch | null {
+  const oldId = saved.worktreeId;
+  const newId = resolveMovedWorktreeId(oldId, saved.worktreeGitDir, ctx);
+  if (newId === undefined || oldId === undefined) return null;
+
+  const patch: WorktreeMovePatch = { worktreeId: newId };
+  if (typeof saved.cwd === "string") {
+    patch.cwd = rebaseAbsolutePath(saved.cwd, oldId, newId);
+  }
+  if (typeof saved.filePath === "string") {
+    patch.filePath = rebaseAbsolutePath(saved.filePath, oldId, newId);
+  }
+  if (typeof saved.markdownFilePath === "string") {
+    patch.markdownFilePath = rebaseAbsolutePath(saved.markdownFilePath, oldId, newId);
+  }
+  return patch;
+}


### PR DESCRIPTION
## Summary
- Worktree ids are normalized absolute paths, so `git worktree move` (or an external relocation) hands a worktree a new id, and every panel that was pinned to the old id gets silently re-homed to the active worktree on the next restore.
- Panels now persist a stable `.git/worktrees/<name>` admin-dir handle (`worktreeGitDir`) alongside `worktreeId`. Git only rewrites the gitdir pointer file on a move, never the admin-dir name, so the handle survives.
- Restore now runs a pre-pass that uses the handle to correlate a stale `worktreeId` to the worktree's current id and rebases `cwd`/`filePath` onto the new root, before falling back to the existing re-home-to-active behavior for genuinely deleted worktrees and legacy snapshots with no handle.

Resolves #11388

## Changes
- Add `worktreeGitDir` to `PanelSnapshot` and `TerminalState`, and a `getWorktreeGitDirById` store accessor to resolve it at save time.
- New `src/utils/stateHydration/worktreeMoveRemap.ts`: correlates saved panels to their worktree's new id by matching `worktreeGitDir`, wired into `panelRestorePhase.ts`. Skips entirely when no saved panel carries a handle, so time-to-first-panel is unaffected on the common path.
- Rebase live `cwd` for surviving/reconnected PTYs, not just the persisted snapshot.
- Preserve `worktreeGitDir` across the #11234 empty-list save race, and rebase it in the project-move state rewrite (`electron/services/projectPathStateRewrite.ts`).
- Known limitation, documented in code: a pruned worktree's admin-dir name can be reused by a later worktree with the same basename. Closing that needs a main-process filesystem-identity fingerprint, which is out of scope here.

## Testing
- 122 targeted tests pass (new `worktreeMoveRemap.test.ts`, plus updates to `panelRestorePhase.test.ts`, `panelPersistence.test.ts`, `projectPathStateRewrite.test.ts`).
- Own-file eslint clean (0 errors), `tsc --noEmit` clean.