### PR TITLE
fix(panels): harden dock membership against stranding

### DIFF
--- a/electron/schemas/__tests__/manifestContributionConsumers.test.ts
+++ b/electron/schemas/__tests__/manifestContributionConsumers.test.ts
@@ -15,7 +15,7 @@ import {
   KeybindingContributionSchema,
   McpServerContributionSchema,
   MenuItemContributionSchema,
-  PanelContributionSchema,
+  PanelContributionObjectSchema,
   SettingDefinitionObjectSchema,
   SkillContributionSchema,
   ToolbarButtonContributionSchema,
@@ -87,7 +87,7 @@ const SKILL_REGISTRY = "electron/services/plugin/PluginSkillRegistry.ts";
  * field would otherwise be able to drift silently under a top-level kind).
  */
 const SWEPT_SCHEMAS = {
-  panels: PanelContributionSchema,
+  panels: PanelContributionObjectSchema,
   toolbarButtons: ToolbarButtonContributionSchema,
   menuItems: MenuItemContributionSchema,
   keybindings: KeybindingContributionSchema,
@@ -149,7 +149,7 @@ function shapeKeys(schema: z.ZodType): string[] {
  */
 type ForgeSlots = NonNullable<z.infer<typeof ForgeProviderContributionSchema>["slots"]>;
 type FieldConsumerCoverage = {
-  panels: Record<keyof z.infer<typeof PanelContributionSchema>, ConsumerDescriptor>;
+  panels: Record<keyof z.infer<typeof PanelContributionObjectSchema>, ConsumerDescriptor>;
   toolbarButtons: Record<keyof z.infer<typeof ToolbarButtonContributionSchema>, ConsumerDescriptor>;
   menuItems: Record<keyof z.infer<typeof MenuItemContributionSchema>, ConsumerDescriptor>;
   keybindings: Record<keyof z.infer<typeof KeybindingContributionSchema>, ConsumerDescriptor>;

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -54,7 +54,14 @@ const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set([
 // contribution wired to one is a dead button — reject it at parse time (#10580).
 const DENY_PLUGIN_DISPATCH_SET: ReadonlySet<string> = new Set(DENY_PLUGIN_DISPATCH_ACTION_IDS);
 
-export const PanelContributionSchema = z
+/**
+ * The unrefined object base — exported so the field-consumer contract test
+ * (`manifestContributionConsumers.test.ts`) can enumerate `.shape` without
+ * reaching through the `.superRefine` wrapper, mirroring
+ * {@link SettingDefinitionObjectSchema}. Runtime validation goes through
+ * {@link PanelContributionSchema} below.
+ */
+export const PanelContributionObjectSchema = z
   .object({
     id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
     name: z.string().min(1),
@@ -70,6 +77,28 @@ export const PanelContributionSchema = z
     dockable: z.boolean().optional(),
   })
   .strict();
+
+/**
+ * The validated `contributes.panels` entry: the object base plus a cross-field
+ * rule. `hasPty: true` with an explicit `dockable: false` is rejected — a
+ * PTY-backed plugin kind renders through `TerminalPane` and its kind collapses
+ * to the built-in dockable `terminal` at creation (`addPanel.ts`), so the
+ * opt-out could never be honored and would silently vanish. Plugin PTY kinds
+ * are unsupported in v1 anyway; surface the conflict to the author at
+ * manifest-write time instead of swallowing it at runtime (#11375). `hasPty`
+ * has already defaulted to `false` here, so an omitted `hasPty` never trips it.
+ */
+export const PanelContributionSchema = PanelContributionObjectSchema.superRefine((panel, ctx) => {
+  if (panel.hasPty === true && panel.dockable === false) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["dockable"],
+      message:
+        "A PTY-backed panel (hasPty: true) cannot opt out of the dock with dockable: false — plugin PTY panels render as terminals, which are always dockable. Remove the dockable flag.",
+      params: { errorCode: "pty_panel_dock_opt_out_unsupported" },
+    });
+  }
+});
 
 export const ToolbarButtonContributionSchema = z
   .object({

--- a/electron/services/__tests__/PluginService.manifestSchema.test.ts
+++ b/electron/services/__tests__/PluginService.manifestSchema.test.ts
@@ -1093,3 +1093,54 @@ describe("PluginManifestSchema contributes strict validation", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("panel contribution PTY / dockable cross-field rule (#11375)", () => {
+  const validBase = { name: "acme.panels", version: "1.0.0" };
+  const basePanel = {
+    id: "my-panel",
+    name: "My Panel",
+    iconId: "puzzle",
+    color: "#123456",
+  };
+
+  it("rejects hasPty:true combined with an explicit dockable:false", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: { panels: [{ ...basePanel, hasPty: true, dockable: false }] },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.includes("dockable") && i.path.includes("panels")
+      );
+      expect(issue, "expected an issue on the panel's dockable field").toBeDefined();
+      expect(issue?.message).toContain("dockable");
+    }
+  });
+
+  it("accepts hasPty:true with dockable:true", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: { panels: [{ ...basePanel, hasPty: true, dockable: true }] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts hasPty:true with dockable omitted (defaults to dockable)", () => {
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: { panels: [{ ...basePanel, hasPty: true }] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a non-PTY panel that opts out of the dock (dockable:false)", () => {
+    // `hasPty` defaults to false, so the explicit opt-out is the whole point of
+    // the flag for a non-PTY view — it must stay valid.
+    const result = getPluginManifestSchema(false).safeParse({
+      ...validBase,
+      contributes: { panels: [{ ...basePanel, dockable: false }] },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -10,9 +10,14 @@ import {
   onPanelKindUnregistered,
   panelKindUsesTerminalUi,
   panelKindIsDockable,
+  normalizeDockLocation,
+  normalizeGroupDockLocation,
   registerPanelKind,
+  unregisterPanelKind,
   unregisterPluginPanelKinds,
   clearPanelKindRegistry,
+  subscribeToPanelKindRegistry,
+  getPanelKindRegistrySnapshot,
   getBuiltInPanelKinds,
   getFirstRenderSeeds,
   getFirstRenderPreloadSeeds,
@@ -577,5 +582,125 @@ describe("panelKindIsDockable", () => {
 
   it("unknown kinds are not dockable", () => {
     expect(panelKindIsDockable("no-such-kind")).toBe(false);
+  });
+});
+
+describe("normalizeDockLocation", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("passes a dock location through for a dockable kind", () => {
+    expect(normalizeDockLocation("terminal", "dock")).toBe("dock");
+    expect(normalizeDockLocation("browser", "dock")).toBe("dock");
+  });
+
+  it("redirects a dock location to grid for a non-dockable built-in", () => {
+    expect(normalizeDockLocation("review", "dock")).toBe("grid");
+    expect(normalizeDockLocation("diff", "dock")).toBe("grid");
+  });
+
+  it("redirects a dock location to grid for an unknown kind", () => {
+    // An unregistered kind is never dockable — a dock request would strand it.
+    expect(normalizeDockLocation("no-such-kind", "dock")).toBe("grid");
+  });
+
+  it("treats a missing kind as the always-dockable legacy terminal", () => {
+    expect(normalizeDockLocation(undefined, "dock")).toBe("dock");
+  });
+
+  it("leaves non-dock locations untouched regardless of dockability", () => {
+    for (const location of ["grid", "overlay", "trash", "background", "dialog"] as const) {
+      expect(normalizeDockLocation("review", location)).toBe(location);
+      expect(normalizeDockLocation("terminal", location)).toBe(location);
+    }
+  });
+
+  it("follows a live dockable flip", () => {
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), dockable: true });
+    expect(normalizeDockLocation("ext-a.viewer", "dock")).toBe("dock");
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), dockable: false });
+    expect(normalizeDockLocation("ext-a.viewer", "dock")).toBe("grid");
+  });
+});
+
+describe("normalizeGroupDockLocation", () => {
+  it("keeps a dock target only when every member is dockable", () => {
+    expect(normalizeGroupDockLocation(["terminal", "browser", "file"], "dock")).toBe("dock");
+  });
+
+  it("rescues the whole group to grid when any member is non-dockable", () => {
+    // All-or-nothing: one non-dockable sibling redirects the entire group.
+    expect(normalizeGroupDockLocation(["terminal", "review"], "dock")).toBe("grid");
+    expect(normalizeGroupDockLocation(["diff", "terminal"], "dock")).toBe("grid");
+  });
+
+  it("treats an unknown or missing member kind as non-dockable (grid)", () => {
+    expect(normalizeGroupDockLocation(["terminal", "no-such-kind"], "dock")).toBe("grid");
+    expect(normalizeGroupDockLocation(["terminal", undefined], "dock")).toBe("dock");
+  });
+
+  it("passes a grid target through unchanged", () => {
+    expect(normalizeGroupDockLocation(["review", "diff"], "grid")).toBe("grid");
+  });
+
+  it("an empty group trivially satisfies the dock target", () => {
+    expect(normalizeGroupDockLocation([], "dock")).toBe("dock");
+  });
+});
+
+describe("panel kind registry external store", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("getSnapshot returns a stable reference until a mutation", () => {
+    const first = getPanelKindRegistrySnapshot();
+    expect(getPanelKindRegistrySnapshot()).toBe(first);
+  });
+
+  it("replaces the snapshot reference on register", () => {
+    const before = getPanelKindRegistrySnapshot();
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    const after = getPanelKindRegistrySnapshot();
+    expect(after).not.toBe(before);
+    expect(after["ext-a.viewer"]).toBeDefined();
+  });
+
+  it("notifies subscribers on register, flip, and unregister", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToPanelKindRegistry(listener);
+
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), dockable: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // A dockable-only flip re-registers the same id and must still notify.
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), dockable: false });
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unregisterPanelKind("ext-a.viewer");
+    expect(listener).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    registerPanelKind(makeExtensionConfig("ext-b.viewer", "ext-b"));
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it("emits once per batch unregister, not once per removed kind", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.one", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-a.two", "ext-a"));
+    const listener = vi.fn();
+    const unsubscribe = subscribeToPanelKindRegistry(listener);
+    unregisterPluginPanelKinds("ext-a");
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("does not notify when a batch unregister removes nothing", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToPanelKindRegistry(listener);
+    unregisterPluginPanelKinds("never-loaded");
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -1,4 +1,4 @@
-import type { PanelKind, TerminalInstance } from "../types/panel.js";
+import type { PanelKind, PanelLocation, TerminalInstance } from "../types/panel.js";
 import type { TerminalSnapshot } from "../types/project.js";
 import type { AddPanelOptions } from "../types/addPanelOptions.js";
 import { getAgentConfig } from "./agentRegistry.js";
@@ -398,6 +398,63 @@ function emitUnregistered(kindId: string): void {
 }
 
 /**
+ * Reactive snapshot of the metadata registry for `useSyncExternalStore`.
+ * Replaced (not mutated) on every registry change so React's `Object.is`
+ * identity check schedules a rerender — `ContentDock` /
+ * `DockPanelOffscreenContainer` observe it so a `dockable`-only flip or a
+ * plugin unregister re-evaluates their `isDockPanel` membership without waiting
+ * for an unrelated panel-store mutation (#11375). Mirrors the
+ * `definitionsSnapshot` pattern in `src/panels/registry.tsx`.
+ *
+ * IMPORTANT: `getPanelKindRegistrySnapshot` must return this stable reference,
+ * never a fresh `{ ...PANEL_KIND_REGISTRY }` per call — a new object every call
+ * makes React 19's `Object.is` guard see a perpetual change and loop.
+ */
+let panelKindRegistrySnapshot: Readonly<Record<string, PanelKindConfig>> = {
+  ...PANEL_KIND_REGISTRY,
+};
+const panelKindRegistryListeners = new Set<() => void>();
+
+/**
+ * Replace the snapshot with a fresh copy of the live registry and notify
+ * subscribers. Called once per public mutation (a batch removal emits one
+ * notification, not one per removed kind).
+ */
+function notifyPanelKindRegistry(): void {
+  panelKindRegistrySnapshot = { ...PANEL_KIND_REGISTRY };
+  for (const listener of panelKindRegistryListeners) {
+    try {
+      listener();
+    } catch (err) {
+      console.error("[panelKindRegistry] registry listener threw:", err);
+    }
+  }
+}
+
+/**
+ * Subscribe to any metadata-registry change (register, unregister, flip).
+ * Stable module-scope function so `useSyncExternalStore` never re-subscribes
+ * per render.
+ *
+ * @returns Unsubscribe function. Safe to call multiple times.
+ */
+export function subscribeToPanelKindRegistry(listener: () => void): () => void {
+  panelKindRegistryListeners.add(listener);
+  return () => {
+    panelKindRegistryListeners.delete(listener);
+  };
+}
+
+/**
+ * Snapshot for `useSyncExternalStore`. Returns the same reference until a
+ * registration changes the registry; React uses identity comparison to detect
+ * changes. Also serves as the SSR/getServerSnapshot value (identical set).
+ */
+export function getPanelKindRegistrySnapshot(): Readonly<Record<string, PanelKindConfig>> {
+  return panelKindRegistrySnapshot;
+}
+
+/**
  * Register a new panel kind configuration.
  * Used by extensions to add custom panel types.
  *
@@ -418,6 +475,7 @@ export function registerPanelKind(config: PanelKindConfig): void {
   if (config.extensionId !== undefined) {
     emitRegistered(config);
   }
+  notifyPanelKindRegistry();
 }
 
 /**
@@ -442,6 +500,9 @@ export function unregisterPluginPanelKinds(pluginId: string): void {
   for (const key of removed) {
     emitUnregistered(key);
   }
+  if (removed.length > 0) {
+    notifyPanelKindRegistry();
+  }
 }
 
 /**
@@ -458,6 +519,7 @@ export function unregisterPanelKind(kindId: string): boolean {
   if (!config || config.extensionId === undefined) return false;
   delete PANEL_KIND_REGISTRY[kindId];
   emitUnregistered(kindId);
+  notifyPanelKindRegistry();
   return true;
 }
 
@@ -594,6 +656,48 @@ export function panelKindIsDockable(kind: PanelKind): boolean {
 }
 
 /**
+ * Normalize a requested/restored panel location for a single panel of `kind`.
+ * A non-dockable kind can't live in the dock — `ContentDock` filters it out via
+ * `isDockPanel` while its stored `location:"dock"` keeps the grid from showing
+ * it, so it would strand invisibly (#11054, #11375). Redirect the dock landing
+ * to the grid; every other location passes through unchanged. This is the
+ * single guard the store mutators (move, reorder, undo, trash/background
+ * restore) call so a dockability flip can never leave a panel stranded.
+ *
+ * `kind ?? "terminal"` mirrors the legacy-PTY convention used across the
+ * dockability guards — a panel with no `kind` is a legacy terminal, always
+ * dockable. Sync and side-effect free: safe inside Zustand `set()` updaters.
+ *
+ * @returns The original location, or `"grid"` when a non-dockable kind
+ *   requested the dock.
+ */
+export function normalizeDockLocation<TLocation extends PanelLocation>(
+  kind: PanelKind | undefined,
+  location: TLocation
+): TLocation | "grid" {
+  return location === "dock" && !panelKindIsDockable(kind ?? "terminal") ? "grid" : location;
+}
+
+/**
+ * Normalize a group's target location. A tab group is atomic — every member
+ * shares one location — so a dock move is all-or-nothing: if ANY live member's
+ * kind is non-dockable, the whole group lands in the grid rather than splitting
+ * (a mixed-location group is invisible to `getPanelGroup` and corrupts
+ * persistence). Grid targets pass through unchanged.
+ *
+ * @param memberKinds The kinds of the group's live members (`undefined` → legacy terminal)
+ * @param location The requested group location
+ * @returns `"dock"` only when every member is dockable; otherwise `"grid"`
+ */
+export function normalizeGroupDockLocation(
+  memberKinds: ReadonlyArray<PanelKind | undefined>,
+  location: "grid" | "dock"
+): "grid" | "dock" {
+  if (location !== "dock") return location;
+  return memberKinds.every((kind) => panelKindIsDockable(kind ?? "terminal")) ? "dock" : "grid";
+}
+
+/**
  * Check if a panel kind can be restarted via the UI.
  * Uses the panel kind registry's canRestart property as the source of truth.
  *
@@ -721,5 +825,8 @@ export function clearPanelKindRegistry(): void {
   }
   for (const key of removed) {
     emitUnregistered(key);
+  }
+  if (removed.length > 0) {
+    notifyPanelKindRegistry();
   }
 }

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -109,10 +109,10 @@ import {
   findGroupIndex,
   filterOutDockDroppables,
   shouldCancelDrop,
+  dragCarriesNonDockableIntoDock,
   type OverDropData,
 } from "./dropResolution";
 import { useDragRecovery } from "./useDragRecovery";
-import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import {
   DURATION_100,
   DURATION_300,
@@ -145,6 +145,14 @@ interface DndPlaceholderContextValue {
   activeGroupId: string | null;
   /** If dragging a tab group, the panel IDs in the group */
   activeGroupPanelIds: string[] | null;
+  /**
+   * True when the active drag can't be dropped in the dock — its kind, or ANY
+   * live member's kind for a group drag, is non-dockable (#11375). Consumers
+   * (the dock's `cursor-no-drop` cue) read this instead of re-checking the lone
+   * representative kind, so the cue matches what `cancelDrop`/`collisionDetection`
+   * actually enforce for a mixed group.
+   */
+  activeDragRejectsDock: boolean;
 }
 
 const DndPlaceholderContext = createContext<DndPlaceholderContextValue>({
@@ -155,6 +163,7 @@ const DndPlaceholderContext = createContext<DndPlaceholderContextValue>({
   isWorktreeSortDragging: false,
   activeGroupId: null,
   activeGroupPanelIds: null,
+  activeDragRejectsDock: false,
 });
 
 export function useDndPlaceholder() {
@@ -1299,6 +1308,7 @@ export function DndProvider({ children }: DndProviderProps) {
         activeData: active.data.current,
         overData: over?.data.current as OverDropData | undefined,
         isWorktreeSort,
+        panelsById: usePanelStore.getState().panelsById,
       });
       if (cancel) setIsCancelDrop(true);
       return cancel;
@@ -1359,11 +1369,18 @@ export function DndProvider({ children }: DndProviderProps) {
       // SortableContext reflows during hover before `cancelDrop` snaps it back.
       // Filter the dock droppable (and its chip sortables) out of the candidate
       // set and skip the dock-specific closestCenter branch, so the dock is
-      // invisible to collision detection for this drag. Read the kind
-      // synchronously from the drag data (no ref) to keep this callback stable.
+      // invisible to collision detection for this drag. For a group drag EVERY
+      // member's kind is checked, not just the representative (#11375) — member
+      // kinds are resolved from the live store by id. Read synchronously (no
+      // ref) to keep this callback stable.
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- dnd-kit data.current is loosely typed
       const activeDragData = args.active.data.current as DragData | undefined;
-      const rejectsDock = !panelKindIsDockable(activeDragData?.terminal?.kind ?? "terminal");
+      const rejectsDock = dragCarriesNonDockableIntoDock(
+        "dock",
+        activeDragData?.terminal?.kind,
+        activeDragData?.groupId ? activeDragData?.groupPanelIds : undefined,
+        usePanelStore.getState().panelsById
+      );
       const effectiveArgs = rejectsDock
         ? { ...args, droppableContainers: filterOutDockDroppables(args.droppableContainers) }
         : args;
@@ -1396,6 +1413,18 @@ export function DndProvider({ children }: DndProviderProps) {
       isWorktreeSortDragging: isWorktreeSortActive,
       activeGroupId: activeData?.groupId ?? null,
       activeGroupPanelIds: activeData?.groupPanelIds ?? null,
+      // Group-aware dock-reject state for the dock's hover cue: for a group drag
+      // ANY non-dockable live member poisons the drop, resolved from the store
+      // by id (#11375). Non-reactive `getState()` read is fine — panel kinds
+      // don't change mid-drag, and this recomputes when the active drag changes.
+      activeDragRejectsDock:
+        activeTerminal !== null &&
+        dragCarriesNonDockableIntoDock(
+          "dock",
+          activeTerminal.kind,
+          activeData?.groupId ? activeData?.groupPanelIds : undefined,
+          usePanelStore.getState().panelsById
+        ),
     }),
     [
       placeholderIndex,

--- a/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 
 import { shouldCancelDrop, type OverDropData } from "../dropResolution";
+import type { PanelInstance } from "@shared/types/panel";
 
 // ── Helpers ──────────────────────────────────────────────
 
@@ -14,13 +15,15 @@ function run(params: {
   activeData?: unknown;
   isWorktreeSort?: boolean;
   hasOver?: boolean;
+  panelsById?: Record<string, PanelInstance | undefined>;
 }): boolean {
-  const { overData = null, activeData, isWorktreeSort = false, hasOver } = params;
+  const { overData = null, activeData, isWorktreeSort = false, hasOver, panelsById = {} } = params;
   return shouldCancelDrop({
     hasOver: hasOver ?? overData != null,
     activeData,
     overData: overData ?? undefined,
     isWorktreeSort,
+    panelsById,
   });
 }
 
@@ -130,6 +133,9 @@ describe("shouldCancelDrop", () => {
         get isWorktreeSort(): never {
           throw new Error("boom");
         },
+        get panelsById(): never {
+          throw new Error("boom");
+        },
       };
       expect(() => shouldCancelDrop(hostile)).not.toThrow();
       expect(shouldCancelDrop(hostile)).toBe(true);
@@ -192,6 +198,72 @@ describe("shouldCancelDrop", () => {
     it("does not cancel a dev-preview panel dropped on the grid (dock guard is target-scoped)", () => {
       expect(
         run({ overData: { container: "grid" }, activeData: makeDragDataOfKind("dev-preview") })
+      ).toBe(false);
+    });
+  });
+
+  describe("non-dockable group dock drop (#11375)", () => {
+    const kindPanel = (id: string, kind: string) =>
+      ({ id, kind, location: "grid" }) as unknown as PanelInstance;
+    const panelsById: Record<string, PanelInstance | undefined> = {
+      "panel-1": kindPanel("panel-1", "terminal"),
+      "panel-2": kindPanel("panel-2", "review"), // non-dockable
+      "panel-3": kindPanel("panel-3", "browser"),
+    };
+    const groupDrag = (memberIds: string[], repKind = "terminal") =>
+      makeDragData({
+        terminal: { id: memberIds[0], title: "T", kind: repKind, location: "grid" },
+        groupId: "group-1",
+        groupPanelIds: memberIds,
+      });
+
+    it("cancels a group whose representative is dockable but a member is not", () => {
+      expect(
+        run({
+          overData: { container: "dock" },
+          activeData: groupDrag(["panel-1", "panel-2"]),
+          panelsById,
+        })
+      ).toBe(true);
+    });
+
+    it("cancels the same mixed group dropped on a dock chip (sortable container)", () => {
+      expect(
+        run({
+          overData: { sortable: { containerId: "dock-container", index: 0 } },
+          activeData: groupDrag(["panel-1", "panel-2"]),
+          panelsById,
+        })
+      ).toBe(true);
+    });
+
+    it("allows a group where every member is dockable", () => {
+      expect(
+        run({
+          overData: { container: "dock" },
+          activeData: groupDrag(["panel-1", "panel-3"]),
+          panelsById,
+        })
+      ).toBe(false);
+    });
+
+    it("fails closed when a group member is missing from the store", () => {
+      expect(
+        run({
+          overData: { container: "dock" },
+          activeData: groupDrag(["panel-1", "gone"]),
+          panelsById,
+        })
+      ).toBe(true);
+    });
+
+    it("allows a mixed group dropped on the grid (dock guard is target-scoped)", () => {
+      expect(
+        run({
+          overData: { container: "grid" },
+          activeData: groupDrag(["panel-1", "panel-2"]),
+          panelsById,
+        })
       ).toBe(false);
     });
   });

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -8,10 +8,11 @@ import {
   resolveGridInsertionIndexFromRects,
   findGroupIndex,
   isNonDockableDockDrop,
+  dragCarriesNonDockableIntoDock,
   filterOutDockDroppables,
   type ClientRectLike,
 } from "../dropResolution";
-import type { PanelInstance } from "@shared/types/panel";
+import type { PanelInstance, PanelKind } from "@shared/types/panel";
 import type { TabGroup } from "@shared/types";
 
 function makeRect(left: number, top: number, width: number, height: number): ClientRectLike {
@@ -82,6 +83,62 @@ describe("isNonDockableDockDrop", () => {
   it("never rejects when the target is not the dock", () => {
     expect(isNonDockableDockDrop("grid", "dev-preview")).toBe(false);
     expect(isNonDockableDockDrop(null, "dev-preview")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dragCarriesNonDockableIntoDock (#11375) — group-aware dock rejection
+// ---------------------------------------------------------------------------
+describe("dragCarriesNonDockableIntoDock", () => {
+  const panel = (id: string, kind: PanelKind): PanelInstance =>
+    ({ ...makeTerminal(id, "grid"), kind }) as PanelInstance;
+  const panelsById: Record<string, PanelInstance | undefined> = {
+    t1: panel("t1", "terminal"),
+    b1: panel("b1", "browser"),
+    r1: panel("r1", "review"), // non-dockable
+    d1: panel("d1", "diff"), // non-dockable
+  };
+
+  it("falls back to the representative kind for a single-panel drag", () => {
+    expect(dragCarriesNonDockableIntoDock("dock", "review", undefined, panelsById)).toBe(true);
+    expect(dragCarriesNonDockableIntoDock("dock", "terminal", undefined, panelsById)).toBe(false);
+    // A single-item array is not a group drag — still uses the representative.
+    expect(dragCarriesNonDockableIntoDock("dock", "review", ["r1"], panelsById)).toBe(true);
+  });
+
+  it("rejects a group drag when ANY member is non-dockable", () => {
+    expect(dragCarriesNonDockableIntoDock("dock", "terminal", ["t1", "r1"], panelsById)).toBe(true);
+    expect(dragCarriesNonDockableIntoDock("dock", "browser", ["b1", "d1"], panelsById)).toBe(true);
+  });
+
+  it("allows a group drag when every member is dockable", () => {
+    expect(dragCarriesNonDockableIntoDock("dock", "terminal", ["t1", "b1"], panelsById)).toBe(
+      false
+    );
+  });
+
+  it("fails closed on a group member that resolves to no live panel", () => {
+    expect(dragCarriesNonDockableIntoDock("dock", "terminal", ["t1", "gone"], panelsById)).toBe(
+      true
+    );
+  });
+
+  it("fails closed on a non-string group member id", () => {
+    expect(
+      dragCarriesNonDockableIntoDock(
+        "dock",
+        "terminal",
+        ["t1", 42 as unknown as string],
+        panelsById
+      )
+    ).toBe(true);
+  });
+
+  it("never rejects when the target is not the dock, even for a mixed group", () => {
+    expect(dragCarriesNonDockableIntoDock("grid", "terminal", ["t1", "r1"], panelsById)).toBe(
+      false
+    );
+    expect(dragCarriesNonDockableIntoDock(null, "review", undefined, panelsById)).toBe(false);
   });
 });
 

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -113,6 +113,37 @@ export function isNonDockableDockDrop(
   return targetContainer === "dock" && !panelKindIsDockable(kind ?? "terminal");
 }
 
+/**
+ * Group-aware version of {@link isNonDockableDockDrop}. A tab-group drag carries
+ * every member into the dock, so the drop must be rejected if ANY live member's
+ * kind is non-dockable — checking only the dragged representative would let a
+ * dockable chip smuggle a `dockable:false` sibling into the dock (#11375). A
+ * single-panel drag falls back to the representative kind. The drag payload only
+ * carries member IDs, so kinds are resolved from the live `panelsById`. Fails
+ * closed: a member id that resolves to no live panel is treated as non-dockable
+ * so a mid-drag unmount can't sneak a phantom into the dock.
+ *
+ * @param groupPanelIds `active.data.current.groupPanelIds` (untyped from dnd-kit);
+ *   a real group drag is an array of length > 1, anything else is single-panel.
+ */
+export function dragCarriesNonDockableIntoDock(
+  targetContainer: "grid" | "dock" | null,
+  representativeKind: PanelKind | undefined,
+  groupPanelIds: unknown,
+  panelsById: Record<string, CarrierPanel | undefined>
+): boolean {
+  if (targetContainer !== "dock") return false;
+  if (Array.isArray(groupPanelIds) && groupPanelIds.length > 1) {
+    return groupPanelIds.some((memberId) => {
+      if (typeof memberId !== "string") return true;
+      const panel = panelsById[memberId];
+      if (!panel) return true;
+      return !panelKindIsDockable(panel.kind ?? "terminal");
+    });
+  }
+  return isNonDockableDockDrop(targetContainer, representativeKind);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -124,6 +155,8 @@ export interface CancelDropParams {
   activeData: unknown;
   overData: OverDropData | undefined;
   isWorktreeSort: boolean;
+  /** Live panel map, so a group drag resolves every member's kind for the dockability check (#11375). */
+  panelsById: Record<string, CarrierPanel | undefined>;
 }
 
 /**
@@ -135,7 +168,7 @@ export interface CancelDropParams {
  */
 export function shouldCancelDrop(params: CancelDropParams): boolean {
   try {
-    const { hasOver, activeData, overData, isWorktreeSort } = params;
+    const { hasOver, activeData, overData, isWorktreeSort, panelsById } = params;
     if (!hasOver) return true;
 
     // Worktree-sort drags own their drop logic in handleDragEnd; let every
@@ -153,15 +186,18 @@ export function shouldCancelDrop(params: CancelDropParams): boolean {
     if (isGroupDrag && isWorktreeDrop) return true;
 
     // A panel whose kind the dock can't render must never commit into the
-    // dock — it would strand invisibly (#11054). `cursor-no-drop` already
-    // signals this during hover and `collisionDetection` keeps the dock out
-    // of the hover candidates; this is the defensive final gate.
+    // dock — it would strand invisibly (#11054). For a group drag EVERY member
+    // is checked, not just the dragged representative (#11375). `cursor-no-drop`
+    // already signals this during hover and `collisionDetection` keeps the dock
+    // out of the hover candidates; this is the defensive final gate.
     const targetContainer =
       overData?.container ??
       (overData?.sortable?.containerId ? resolveContainerId(overData.sortable.containerId) : null);
-    return isNonDockableDockDrop(
+    return dragCarriesNonDockableIntoDock(
       targetContainer,
-      typeof kind === "string" ? (kind as PanelKind) : undefined
+      typeof kind === "string" ? (kind as PanelKind) : undefined,
+      isGroupDrag ? groupPanelIds : undefined,
+      panelsById
     );
   } catch {
     return true;

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useCallback, useLayoutEffect } from "react";
+import { useMemo, useRef, useCallback, useLayoutEffect, useSyncExternalStore } from "react";
 
 import { useShallow } from "zustand/react/shallow";
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
@@ -43,7 +43,10 @@ import {
   useIsWorktreeSortDragging,
   useDndPlaceholder,
 } from "@/components/DragDrop";
-import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
+import {
+  subscribeToPanelKindRegistry,
+  getPanelKindRegistrySnapshot,
+} from "@shared/config/panelKindRegistry";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useHorizontalScrollControls } from "@/hooks";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
@@ -127,6 +130,19 @@ function dockChipTitle(panel: PanelInstance): string {
 }
 
 export function ContentDock({ density = "normal" }: ContentDockProps) {
+  // Subscribe to panel-kind metadata changes (#11375). The dock-membership
+  // selectors below call `isDockPanel` (→ `panelKindIsDockable`), which reads
+  // the registry, not the panel store — so a `dockable`-only flip or a plugin
+  // unregister wouldn't re-run them on its own. This subscription forces a
+  // re-render on any registry change, and the re-render re-evaluates the Zustand
+  // selectors against the fresh registry. Return value intentionally unused —
+  // mirrors `GridPanel`/`DockedPanel`'s definition-registry subscription.
+  useSyncExternalStore(
+    subscribeToPanelKindRegistry,
+    getPanelKindRegistrySnapshot,
+    getPanelKindRegistrySnapshot
+  );
+
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
   const trashedTerminals = usePanelStore((state) => state.trashedTerminals);
@@ -421,13 +437,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const isWorktreeSortDragging = useIsWorktreeSortDragging();
 
   // A panel whose kind the dock can't render can't drop here either (#11054).
-  // Read the active drag from the placeholder context and gate on the same
-  // dockability predicate the store guards use, so the reject cue matches what
-  // `cancelDrop`/`collisionDetection` actually enforce.
-  const { activeTerminal } = useDndPlaceholder();
-  const isDraggingNonDockable =
-    activeTerminal !== null && !panelKindIsDockable(activeTerminal.kind ?? "terminal");
-  const isDockDropRejected = isWorktreeSortDragging || isDraggingNonDockable;
+  // `activeDragRejectsDock` is group-aware — for a group drag it reflects ANY
+  // non-dockable member, not just the dragged representative (#11375) — so the
+  // reject cue matches exactly what `cancelDrop`/`collisionDetection` enforce.
+  const { activeDragRejectsDock } = useDndPlaceholder();
+  const isDockDropRejected = isWorktreeSortDragging || activeDragRejectsDock;
 
   // Sync droppable ref with scroll container ref using stable callback
   // This prevents ResizeObserver thrashing that causes infinite update loops

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -1,8 +1,20 @@
-import { useEffect, useLayoutEffect, useCallback, useMemo, useState, useRef } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useMemo,
+  useState,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import { canDuplicatePanelKind } from "@/services/terminal/panelDuplicationService";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, useWorktreeSelectionStore } from "@/store";
+import {
+  subscribeToPanelKindRegistry,
+  getPanelKindRegistrySnapshot,
+} from "@shared/config/panelKindRegistry";
 import { isDockPanel, isPtyPanel, type DockPanelData } from "@shared/types/panel";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
@@ -31,6 +43,19 @@ interface DockPanelOffscreenContainerProps {
 }
 
 export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenContainerProps) {
+  // Subscribe to panel-kind metadata changes (#11375). This offscreen host is a
+  // React subtree disjoint from `ContentDock` (its bodies are portaled), so it
+  // needs its OWN registry subscription — a `ContentDock` re-render does not
+  // reach here. The `dockTerminals` selector below calls `isDockPanel`
+  // (→ `panelKindIsDockable`), which reads the registry rather than the panel
+  // store, so a `dockable`-only flip or unregister would otherwise leave a
+  // stale offscreen body mounted. Return value intentionally unused.
+  useSyncExternalStore(
+    subscribeToPanelKindRegistry,
+    getPanelKindRegistrySnapshot,
+    getPanelKindRegistrySnapshot
+  );
+
   // One stable wrapper <div> per dock panel. Each wrapper is created once and
   // is the permanent createPortal container for that panel — React never sees
   // it change identity, so opening/closing a popover (or switching tabs) never

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -81,18 +81,21 @@ describe("ContentDock regression test", () => {
 
   // Issue #8162 — drop the ambient in-flight rail tint; the only drag-state cue
   // is the armed isOver treatment, plus a cursor-no-drop rejection signal.
-  // Issue #11054 — the rejection cue now also fires for a drag whose panel kind
-  // the dock can't render, not just worktree-card sort drags, via the shared
+  // Issue #11054 — the rejection cue also fires for a drag whose panel kind the
+  // dock can't render, not just worktree-card sort drags, via the shared
   // `isDockDropRejected` gate. Both cases suppress the armed isOver treatment.
+  // Issue #11375 — the non-dockable check is now GROUP-AWARE: it reads
+  // `activeDragRejectsDock` off the placeholder context (which resolves every
+  // group member's kind), not the lone representative kind, so the cue matches
+  // what cancelDrop/collisionDetection enforce for a mixed group.
   it("removes ambient panel-drag tint and rejects non-dockable drags with cursor feedback", () => {
     const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
 
     expect(content).not.toContain("useIsDragging");
     expect(content).not.toContain('isPanelDragging && "bg-overlay-subtle"');
     expect(content).toContain('isDockDropRejected && "cursor-no-drop"');
-    // The reject gate folds in a non-dockable-kind check on the active drag.
-    expect(content).toContain("isDraggingNonDockable");
-    expect(content).toMatch(/panelKindIsDockable\(activeTerminal\.kind/);
+    // The reject gate folds in the group-aware dock-reject flag from the context.
+    expect(content).toContain("activeDragRejectsDock");
     expect(content).toMatch(/isDockDropRejected\s*=\s*isWorktreeSortDragging\s*\|\|/);
     expect(content).toMatch(/isOver\s*&&\s*[^]*?cursor-copy/);
   });

--- a/src/hooks/usePluginPanelKinds.ts
+++ b/src/hooks/usePluginPanelKinds.ts
@@ -9,6 +9,7 @@ import {
 import { registerPanelKindDefinition, unregisterPanelKindDefinition } from "@/registry";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { makePluginViewHost } from "@/components/Plugin/PluginViewHost";
+import { reconcileDockMembership } from "@/store/reconcileDockMembership";
 import { logWarn } from "@/utils/logger";
 
 /**
@@ -182,6 +183,13 @@ export function usePluginPanelKinds(): void {
 
         registeredByPlugin.set(pluginId, incomingIds);
       }
+
+      // A `dockable:true→false` flip or a plugin unregister above can strand
+      // panels currently living in the dock (the dock now filters them out while
+      // their stored location stays "dock"). Relocate them to the grid so they
+      // stay reachable (#11375). Cheap — it scans dock membership, which is
+      // small, and no-ops when nothing is stranded.
+      reconcileDockMembership();
     };
 
     const electron = typeof window !== "undefined" ? window.electron : undefined;

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -48,6 +48,7 @@ import { usePanelStore } from "../panelStore";
 import { useLayoutConfigStore } from "../layoutConfigStore";
 import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
 import type { PtyPanelData } from "@shared/types/panel";
+import type { TabGroup } from "@shared/types";
 
 let terminalCounter = 0;
 
@@ -693,6 +694,44 @@ describe("layoutUndoStore", () => {
       // The snapshot pointed activeDockTerminalId at t1, but t1 rescued to grid —
       // restoring the stale pointer would open the dock popover onto nothing.
       expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
+    });
+
+    it("adopts the active worktree on the group RECORD and members when a global dock group is rescued", () => {
+      const a = makeTerminal({ id: "ga", location: "dock" });
+      const b = makeTerminal({ id: "gb", location: "dock" });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: non-dockable kind on a PTY-shaped panel
+      (b as { kind: string }).kind = "review"; // one non-dockable member
+      delete (a as { worktreeId?: string }).worktreeId;
+      delete (b as { worktreeId?: string }).worktreeId;
+      seedTerminals([a, b]);
+      const dockGroup: TabGroup = {
+        id: "g1",
+        panelIds: ["ga", "gb"],
+        activeTabId: "ga",
+        location: "dock",
+      };
+      usePanelStore.setState({ tabGroups: new Map([["g1", dockGroup]]) });
+      useLayoutUndoStore.getState().pushLayoutSnapshot();
+      // Flip group + members to grid so undo reverts to the dock snapshot.
+      usePanelStore.setState({
+        panelsById: {
+          ga: { ...a, location: "grid" } as PtyPanelData,
+          gb: { ...b, location: "grid" } as PtyPanelData,
+        },
+        tabGroups: new Map([["g1", { ...dockGroup, location: "grid" }]]),
+      });
+
+      useLayoutUndoStore.getState().undo();
+
+      const state = usePanelStore.getState();
+      const group = state.tabGroups.get("g1");
+      // Group and members agree on grid + the adopted worktree — no split-brain
+      // between getTabGroups (filters the group by worktree) and getPanelGroup.
+      expect(group?.location).toBe("grid");
+      expect(group?.worktreeId).toBe("wt-active");
+      expect(state.panelsById["ga"]?.location).toBe("grid");
+      expect(state.panelsById["ga"]?.worktreeId).toBe("wt-active");
+      expect(state.panelsById["gb"]?.worktreeId).toBe("wt-active");
     });
   });
 });

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -46,6 +46,7 @@ vi.mock("@/clients/appClient", () => ({
 import { useLayoutUndoStore } from "../layoutUndoStore";
 import { usePanelStore } from "../panelStore";
 import { useLayoutConfigStore } from "../layoutConfigStore";
+import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
 import type { PtyPanelData } from "@shared/types/panel";
 
 let terminalCounter = 0;
@@ -622,6 +623,76 @@ describe("layoutUndoStore", () => {
       expect(state.panelsById["t1"]?.location).toBe("grid");
       expect(state.panelsById["t2"]?.location).toBe("grid");
       expect(state.panelsById["t3"]?.location).toBe("grid");
+    });
+  });
+
+  describe("dockability normalization on undo (#11375)", () => {
+    beforeEach(() => {
+      setWorktreeSelectionAccessor(() => ({
+        activeWorktreeId: "wt-active",
+        restoreWorktreeId: null,
+      }));
+    });
+
+    afterEach(() => {
+      setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+    });
+
+    it("restores a now-non-dockable panel to the grid instead of the dock", () => {
+      // The panel was dockable when it was docked; its kind now reports
+      // non-dockable (a plugin re-registered as dockable:false). Undo must not
+      // write it back into the dock — the dock filters it out and the grid
+      // excludes it while location stays "dock", so it would strand invisibly.
+      const docked = makeTerminal({ id: "t1", location: "dock", worktreeId: "wt-1" });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: a non-dockable kind on a PTY-shaped panel
+      (docked as { kind: string }).kind = "review";
+      seedTerminals([docked]);
+      useLayoutUndoStore.getState().pushLayoutSnapshot();
+      // Move to grid so undo has something to revert to the dock.
+      usePanelStore.setState({
+        panelsById: { t1: { ...docked, location: "grid" } as PtyPanelData },
+      });
+
+      useLayoutUndoStore.getState().undo();
+
+      expect(usePanelStore.getState().panelsById["t1"]?.location).toBe("grid");
+    });
+
+    it("adopts the active worktree when a rescued dock panel is worktree-less", () => {
+      const docked = makeTerminal({ id: "t1", location: "dock" });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: a non-dockable kind on a PTY-shaped panel
+      (docked as { kind: string }).kind = "review";
+      delete (docked as { worktreeId?: string }).worktreeId;
+      seedTerminals([docked]);
+      useLayoutUndoStore.getState().pushLayoutSnapshot();
+      usePanelStore.setState({
+        panelsById: { t1: { ...docked, location: "grid" } as PtyPanelData },
+      });
+
+      useLayoutUndoStore.getState().undo();
+
+      const panel = usePanelStore.getState().panelsById["t1"];
+      expect(panel?.location).toBe("grid");
+      expect(panel?.worktreeId).toBe("wt-active");
+    });
+
+    it("clears a snapshot activeDockTerminalId that no longer identifies a dock panel", () => {
+      const docked = makeTerminal({ id: "t1", location: "dock", worktreeId: "wt-1" });
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test carrier: a non-dockable kind on a PTY-shaped panel
+      (docked as { kind: string }).kind = "review";
+      seedTerminals([docked]);
+      usePanelStore.setState({ activeDockTerminalId: "t1" });
+      useLayoutUndoStore.getState().pushLayoutSnapshot();
+      usePanelStore.setState({
+        panelsById: { t1: { ...docked, location: "grid" } as PtyPanelData },
+        activeDockTerminalId: null,
+      });
+
+      useLayoutUndoStore.getState().undo();
+
+      // The snapshot pointed activeDockTerminalId at t1, but t1 rescued to grid —
+      // restoring the stale pointer would open the dock popover onto nothing.
+      expect(usePanelStore.getState().activeDockTerminalId).toBeNull();
     });
   });
 });

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/controllers", () => ({
   terminalRegistryController: {

--- a/src/store/__tests__/panelStore.dockability.test.ts
+++ b/src/store/__tests__/panelStore.dockability.test.ts
@@ -80,6 +80,7 @@ Object.defineProperty(window, "electron", {
 });
 
 import { usePanelStore } from "../panelStore";
+import { setWorktreeSelectionAccessor } from "@/store/storeAccessors";
 import {
   clearPanelKindRegistry,
   registerPanelKind,
@@ -242,5 +243,53 @@ describe("panelStore.addPanel dockability for plugin kinds (#11332)", () => {
 
     expect(id).toBeTruthy();
     expect(usePanelStore.getState().panelsById[id!]?.location).toBe("grid");
+  });
+});
+
+describe("panelStore.addPanel worktree adoption on dock→grid rescue (#11375 point 3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: "wt-active",
+      restoreWorktreeId: null,
+    }));
+  });
+
+  afterEach(() => {
+    resetState();
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+  });
+
+  it("a worktree-less dock request for a non-dockable kind adopts the active worktree", async () => {
+    // Without adoption the rescued panel lands worktree-less in the global-only
+    // grid bucket — invisible while a worktree is active (#11290), worse than
+    // the dock stranding the rescue fixes.
+    const id = await usePanelStore.getState().addPanel({ kind: "dev-preview", location: "dock" });
+
+    expect(id).toBeTruthy();
+    const panel = usePanelStore.getState().panelsById[id!];
+    expect(panel?.location).toBe("grid");
+    expect(panel?.worktreeId).toBe("wt-active");
+    // The adopted-worktree panel is treated as in the active worktree, so it
+    // renders (running), not backgrounded.
+    expect(panel?.isVisible).toBe(true);
+  });
+
+  it("does not override an explicit worktree when rescuing to the grid", async () => {
+    const id = await usePanelStore
+      .getState()
+      .addPanel({ kind: "dev-preview", location: "dock", worktreeId: "wt-explicit" });
+
+    expect(usePanelStore.getState().panelsById[id!]?.worktreeId).toBe("wt-explicit");
+  });
+
+  it("does not adopt a worktree for a dockable kind honored in the dock", async () => {
+    // No redirect happened, so no adoption — a global dock panel stays global.
+    const id = await usePanelStore.getState().addPanel({ kind: "file", location: "dock" });
+
+    const panel = usePanelStore.getState().panelsById[id!];
+    expect(panel?.location).toBe("dock");
+    expect(panel?.worktreeId).toBeUndefined();
   });
 });

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -528,7 +528,21 @@ function makeReviewPanel(id: string, worktreeId?: string) {
   };
 }
 
-describe("review-kind dock fallback (#8946 — previous-focused policy)", () => {
+// A DOCKABLE reading surface that shares review's `previous-focused` dock
+// fallback policy. Review itself is `dockable: false` and (post-#11375) can no
+// longer be moved to the dock, so the dock-move focus-policy cases below use a
+// browser panel — which CAN dock — to exercise the same policy on a real move.
+function makeBrowserPanel(id: string, worktreeId?: string) {
+  return {
+    id,
+    kind: "browser" as const,
+    worktreeId,
+    title: id,
+    location: "grid" as const,
+  };
+}
+
+describe("reading-surface dock/trash fallback (#8946 — previous-focused policy)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     const { reset } = usePanelStore.getState();
@@ -631,7 +645,47 @@ describe("review-kind dock fallback (#8946 — previous-focused policy)", () => 
     expect(usePanelStore.getState().focusedId).toBe("shell-1");
   });
 
-  it("moveTerminalToDock: review restores focus to previousFocusedId", () => {
+  it("moveTerminalToDock: dockable reading surface restores focus to previousFocusedId", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
+        "browser-1": makeBrowserPanel("browser-1", "wt-1"),
+      },
+      panelIds: ["shell-first", "shell-last", "browser-1"],
+      focusedId: "browser-1",
+      previousFocusedId: "shell-last",
+    });
+
+    usePanelStore.getState().moveTerminalToDock("browser-1");
+
+    // Without policy: would pick shell-first. With "previous-focused":
+    // restores shell-last as the user expected.
+    expect(usePanelStore.getState().focusedId).toBe("shell-last");
+  });
+
+  it("moveTerminalToPosition to dock: dockable reading surface restores focus to previousFocusedId", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
+        "browser-1": makeBrowserPanel("browser-1", "wt-1"),
+      },
+      panelIds: ["shell-first", "shell-last", "browser-1"],
+      focusedId: "browser-1",
+      previousFocusedId: "shell-last",
+    });
+
+    usePanelStore.getState().moveTerminalToPosition("browser-1", 0, "dock");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-last");
+  });
+
+  it("moveTerminalToDock: a non-dockable review panel is a no-op and keeps its focus (#11375)", () => {
+    // Review is `dockable: false` — the dock can't render it, so the move is
+    // rejected and the panel stays focused in the grid rather than falling back.
     useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
     usePanelStore.setState({
       panelsById: {
@@ -646,27 +700,8 @@ describe("review-kind dock fallback (#8946 — previous-focused policy)", () => 
 
     usePanelStore.getState().moveTerminalToDock("review-1");
 
-    // Without policy: would pick shell-first. With "previous-focused":
-    // restores shell-last as the user expected.
-    expect(usePanelStore.getState().focusedId).toBe("shell-last");
-  });
-
-  it("moveTerminalToPosition to dock: review restores focus to previousFocusedId", () => {
-    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
-    usePanelStore.setState({
-      panelsById: {
-        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
-        "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
-        "review-1": makeReviewPanel("review-1", "wt-1"),
-      },
-      panelIds: ["shell-first", "shell-last", "review-1"],
-      focusedId: "review-1",
-      previousFocusedId: "shell-last",
-    });
-
-    usePanelStore.getState().moveTerminalToPosition("review-1", 0, "dock");
-
-    expect(usePanelStore.getState().focusedId).toBe("shell-last");
+    expect(usePanelStore.getState().panelsById["review-1"]?.location).toBe("grid");
+    expect(usePanelStore.getState().focusedId).toBe("review-1");
   });
 
   it("terminal kind without policy still uses first-grid behavior (no regression)", () => {

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -1,7 +1,13 @@
 import { create } from "zustand";
 import { usePanelStore } from "./panelStore";
-import type { TabGroup } from "@shared/types";
-import type { PanelLocation } from "@shared/types/panel";
+import type { TabGroup, TabGroupLocation } from "@shared/types";
+import type { PanelKind, PanelLocation } from "@shared/types/panel";
+import {
+  normalizeDockLocation,
+  normalizeGroupDockLocation,
+  panelKindIsDockable,
+} from "@shared/config/panelKindRegistry";
+import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { buildWorktreeIndex } from "@/store/slices/panelRegistry/worktreeIndex";
 
@@ -71,6 +77,7 @@ function captureCurrentLayout(): LayoutSnapshot {
 function applySnapshot(snapshot: LayoutSnapshot): boolean {
   const state = usePanelStore.getState();
   const { panelsById, panelIds } = state;
+  const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
 
   const snapshotIds = new Set(snapshot.terminals.map((t) => t.id));
 
@@ -78,6 +85,28 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   for (const id of snapshotIds) {
     if (!panelsById[id]) {
       return false;
+    }
+  }
+
+  // Restore group metadata, but normalize any dock group whose live membership
+  // is no longer fully dockable back to grid (#11375). A tab group is atomic —
+  // it can't keep half its members in a dock the others can't render — so this
+  // is all-or-nothing. Members read their effective location from the (possibly
+  // rescued) group location below so a member and its group never disagree.
+  const restoredGroups = structuredClone(snapshot.tabGroups);
+  const groupLocationByPanelId = new Map<string, TabGroupLocation>();
+  for (const [groupId, group] of restoredGroups) {
+    const memberKinds: (PanelKind | undefined)[] = [];
+    for (const pid of group.panelIds) {
+      const member = panelsById[pid];
+      if (member) memberKinds.push(member.kind);
+    }
+    const effectiveGroupLocation = normalizeGroupDockLocation(memberKinds, group.location);
+    if (effectiveGroupLocation !== group.location) {
+      restoredGroups.set(groupId, { ...group, location: effectiveGroupLocation });
+    }
+    for (const pid of group.panelIds) {
+      groupLocationByPanelId.set(pid, effectiveGroupLocation);
     }
   }
 
@@ -105,15 +134,35 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   for (const entry of allEntries) {
     const current = panelsById[entry.id];
     if (!current) continue;
-    const restored: CarrierPanel = { ...current, location: entry.location };
+    // A grouped panel follows its group's (normalized) location; an ungrouped
+    // panel normalizes its own entry location. Either way a non-dockable kind
+    // never lands back in the dock (#11375).
+    const groupedLocation = groupLocationByPanelId.get(entry.id);
+    const restoredLocation = groupedLocation ?? normalizeDockLocation(current.kind, entry.location);
+    const restored: CarrierPanel = { ...current, location: restoredLocation };
+    // A worktree-less panel rescued dock→grid adopts the active worktree, else
+    // it strands in the global-only bucket while a worktree is active (#11290).
+    const rescuedToGrid = restoredLocation === "grid" && entry.location === "dock";
     if (entry.worktreeId !== undefined) {
       restored.worktreeId = entry.worktreeId;
+    } else if (rescuedToGrid && activeWorktreeId !== null) {
+      restored.worktreeId = activeWorktreeId;
     } else {
       delete restored.worktreeId;
     }
     newTerminalsById[entry.id] = restored;
     newTerminalIds.push(entry.id);
   }
+
+  // A snapshot `activeDockTerminalId` that no longer points at a panel currently
+  // living (and renderable) in the dock would open the popover onto nothing —
+  // clear it (#11375).
+  const restoredActiveDock = snapshot.activeDockTerminalId;
+  const activeDockPanel = restoredActiveDock ? newTerminalsById[restoredActiveDock] : undefined;
+  const activeDockStillValid =
+    !!activeDockPanel &&
+    activeDockPanel.location === "dock" &&
+    panelKindIsDockable(activeDockPanel.kind ?? "terminal");
 
   usePanelStore.setState({
     panelsById: newTerminalsById,
@@ -122,10 +171,10 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
     // index — sidebar summaries and worktree cycling read it and would
     // otherwise see stale buckets after an undo of a cross-worktree move.
     panelIdsByWorktreeId: buildWorktreeIndex(newTerminalIds, newTerminalsById),
-    tabGroups: structuredClone(snapshot.tabGroups),
+    tabGroups: restoredGroups,
     focusedId: snapshot.focusedId,
     maximizedId: snapshot.maximizedId,
-    activeDockTerminalId: snapshot.activeDockTerminalId,
+    activeDockTerminalId: activeDockStillValid ? restoredActiveDock : null,
   });
 
   return true;

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -94,7 +94,10 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   // is all-or-nothing. Members read their effective location from the (possibly
   // rescued) group location below so a member and its group never disagree.
   const restoredGroups = structuredClone(snapshot.tabGroups);
-  const groupLocationByPanelId = new Map<string, TabGroupLocation>();
+  const groupOverrideByPanelId = new Map<
+    string,
+    { location: TabGroupLocation; worktreeId?: string }
+  >();
   for (const [groupId, group] of restoredGroups) {
     const memberKinds: (PanelKind | undefined)[] = [];
     for (const pid of group.panelIds) {
@@ -102,11 +105,26 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
       if (member) memberKinds.push(member.kind);
     }
     const effectiveGroupLocation = normalizeGroupDockLocation(memberKinds, group.location);
-    if (effectiveGroupLocation !== group.location) {
-      restoredGroups.set(groupId, { ...group, location: effectiveGroupLocation });
+    // A worktree-less group rescued dock→grid adopts the active worktree — the
+    // group RECORD and every member together — so `getTabGroups` (which filters
+    // the group by worktree) and `getPanelGroup` never disagree (split-brain).
+    const rescuedToGrid = effectiveGroupLocation === "grid" && group.location === "dock";
+    const adoptedWorktreeId =
+      rescuedToGrid && group.worktreeId == null && activeWorktreeId !== null
+        ? activeWorktreeId
+        : null;
+    if (effectiveGroupLocation !== group.location || adoptedWorktreeId !== null) {
+      restoredGroups.set(groupId, {
+        ...group,
+        location: effectiveGroupLocation,
+        ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
+      });
     }
     for (const pid of group.panelIds) {
-      groupLocationByPanelId.set(pid, effectiveGroupLocation);
+      groupOverrideByPanelId.set(pid, {
+        location: effectiveGroupLocation,
+        ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
+      });
     }
   }
 
@@ -134,18 +152,22 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   for (const entry of allEntries) {
     const current = panelsById[entry.id];
     if (!current) continue;
-    // A grouped panel follows its group's (normalized) location; an ungrouped
-    // panel normalizes its own entry location. Either way a non-dockable kind
-    // never lands back in the dock (#11375).
-    const groupedLocation = groupLocationByPanelId.get(entry.id);
-    const restoredLocation = groupedLocation ?? normalizeDockLocation(current.kind, entry.location);
+    // A grouped panel follows its group's (normalized) location and adopted
+    // worktree; an ungrouped panel normalizes its own entry location. Either way
+    // a non-dockable kind never lands back in the dock (#11375).
+    const groupOverride = groupOverrideByPanelId.get(entry.id);
+    const restoredLocation =
+      groupOverride?.location ?? normalizeDockLocation(current.kind, entry.location);
     const restored: CarrierPanel = { ...current, location: restoredLocation };
-    // A worktree-less panel rescued dock→grid adopts the active worktree, else
-    // it strands in the global-only bucket while a worktree is active (#11290).
+    // A worktree-less ungrouped panel rescued dock→grid adopts the active
+    // worktree, else it strands in the global-only bucket while a worktree is
+    // active (#11290). Grouped members take the group's adopted worktree.
     const rescuedToGrid = restoredLocation === "grid" && entry.location === "dock";
-    if (entry.worktreeId !== undefined) {
+    if (groupOverride?.worktreeId !== undefined) {
+      restored.worktreeId = groupOverride.worktreeId;
+    } else if (entry.worktreeId !== undefined) {
       restored.worktreeId = entry.worktreeId;
-    } else if (rescuedToGrid && activeWorktreeId !== null) {
+    } else if (!groupOverride && rescuedToGrid && activeWorktreeId !== null) {
       restored.worktreeId = activeWorktreeId;
     } else {
       delete restored.worktreeId;

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -459,6 +459,11 @@ export const usePanelStore = create<PanelGridState>()(
         const group = registrySlice.getPanelGroup(id);
         registrySlice.moveTerminalToDock(id);
 
+        // The registry slice rejects a non-dockable kind (and a grouped move can
+        // be rescued to the grid), leaving the panel out of the dock (#11375) —
+        // skip the moved-to-dock focus/maximize cleanup when nothing docked.
+        if (get().panelsById[id]?.location !== "dock") return;
+
         const updates: Partial<PanelGridState> = {};
 
         if (state.focusedId === id) {
@@ -507,7 +512,13 @@ export const usePanelStore = create<PanelGridState>()(
         const moved = registrySlice.moveTabGroupToLocation(groupId, location);
         if (!moved || !groupBeforeMove) return moved;
 
-        if (location === "grid") {
+        // The registry slice rescues a dock request to the grid when a member
+        // kind is non-dockable (#11375), so branch on the COMMITTED location —
+        // not the caller's requested one — or focus/dock cleanup would treat a
+        // grid-rescued group as if it had docked.
+        const committedLocation = get().tabGroups.get(groupId)?.location ?? location;
+
+        if (committedLocation === "grid") {
           const activeDockTerminalId = get().activeDockTerminalId;
           const previousFocusedId = get().focusedId;
           const nextFocusedId = groupBeforeMove.panelIds.includes(groupBeforeMove.activeTabId)

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -518,6 +518,11 @@ export const usePanelStore = create<PanelGridState>()(
         // grid-rescued group as if it had docked.
         const committedLocation = get().tabGroups.get(groupId)?.location ?? location;
 
+        // A dock request rescued to the grid for a group already in the grid is a
+        // no-op — the group never moved, so running focus/maximize side effects
+        // (e.g. exiting fullscreen) would be a spurious change. Skip them.
+        if (committedLocation === groupBeforeMove.location) return moved;
+
         if (committedLocation === "grid") {
           const activeDockTerminalId = get().activeDockTerminalId;
           const previousFocusedId = get().focusedId;
@@ -1022,7 +1027,14 @@ export const usePanelStore = create<PanelGridState>()(
         const group = registrySlice.getPanelGroup(id);
         registrySlice.moveTerminalToPosition(id, toIndex, location, worktreeId);
 
-        if (location === "grid") {
+        // The ordering slice rescues a dock target to the grid for a non-dockable
+        // kind (#11375), so key the focus/maximize side effects off the COMMITTED
+        // location — branching on the raw request would run the dock
+        // focus-fallback + maximize-clear for a panel that actually landed in the
+        // grid.
+        const committedLocation = get().panelsById[id]?.location ?? location;
+
+        if (committedLocation === "grid") {
           const previousFocusedId = state.focusedId;
           set({
             focusedId: id,

--- a/src/store/reconcileDockMembership.ts
+++ b/src/store/reconcileDockMembership.ts
@@ -10,22 +10,48 @@ import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
  *
  * Delegates each move to the store's `moveTerminalToGrid`, which already handles
  * worktree adoption (a worktree-less panel adopts the active worktree so it
- * isn't stranded in the global-only grid bucket), whole-group moves, focus
- * reconciliation, and renderer policy — so affected panels land visibly in the
- * grid. Panels already in the grid are skipped, and `moveTerminalToGrid`
- * early-returns for the second member of a group already relocated by the first.
+ * isn't stranded in the global-only grid bucket), whole-group moves, and
+ * renderer policy — so affected panels land visibly in the grid.
  *
- * Snapshot the target list before mutating: `moveTerminalToGrid` changes the
- * store, so iterate a captured id list rather than a live one.
+ * Robustness details:
+ * - Scans `panelsById` keys, NOT `panelIds`: hydration/spawn batches commit a
+ *   panel to `panelsById` before the deferred `panelIds` flush, so a flip that
+ *   lands mid-batch would otherwise miss it and never be reconciled again.
+ * - Re-checks `location === "dock"` before each move: `moveTerminalToGrid`
+ *   delegates a grouped panel to a single whole-group move, so a later stranded
+ *   member of the same group is already in the grid — skip it rather than
+ *   re-run the group move (and its focus side effects) a second time.
+ * - Restores the pre-reconcile focus. This is a background reconciliation (a
+ *   plugin flipped a flag), not a user gesture, so `moveTerminalToGrid`'s
+ *   focus-steal must not stick — unless focus was itself on a relocated panel.
  */
 export function reconcileDockMembership(): void {
-  const state = usePanelStore.getState();
-  const stranded = state.panelIds.filter((id) => {
-    const panel = state.panelsById[id];
-    return !!panel && panel.location === "dock" && !panelKindIsDockable(panel.kind ?? "terminal");
-  });
+  const before = usePanelStore.getState();
+  const stranded: string[] = [];
+  const strandedSet = new Set<string>();
+  for (const id of Object.keys(before.panelsById)) {
+    const panel = before.panelsById[id];
+    if (panel && panel.location === "dock" && !panelKindIsDockable(panel.kind ?? "terminal")) {
+      stranded.push(id);
+      strandedSet.add(id);
+    }
+  }
   if (stranded.length === 0) return;
+
+  const focusBefore = before.focusedId;
   for (const id of stranded) {
-    usePanelStore.getState().moveTerminalToGrid(id);
+    if (usePanelStore.getState().panelsById[id]?.location === "dock") {
+      usePanelStore.getState().moveTerminalToGrid(id);
+    }
+  }
+
+  const after = usePanelStore.getState();
+  if (
+    focusBefore &&
+    focusBefore !== after.focusedId &&
+    !strandedSet.has(focusBefore) &&
+    after.panelsById[focusBefore]
+  ) {
+    usePanelStore.setState({ focusedId: focusBefore });
   }
 }

--- a/src/store/reconcileDockMembership.ts
+++ b/src/store/reconcileDockMembership.ts
@@ -1,4 +1,4 @@
-import { usePanelStore } from "@/store/panelStore";
+import { usePanelStore, type PanelGridState } from "@/store/panelStore";
 import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 
 /**
@@ -21,9 +21,12 @@ import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
  *   delegates a grouped panel to a single whole-group move, so a later stranded
  *   member of the same group is already in the grid — skip it rather than
  *   re-run the group move (and its focus side effects) a second time.
- * - Restores the pre-reconcile focus. This is a background reconciliation (a
- *   plugin flipped a flag), not a user gesture, so `moveTerminalToGrid`'s
- *   focus-steal must not stick — unless focus was itself on a relocated panel.
+ * - Restores the foreground focus / dock-activation / maximize tuple. This is a
+ *   BACKGROUND reconciliation (a plugin flipped a flag), not a user gesture, but
+ *   `moveTerminalToGrid` steals focus, closes the dock popover, and exits
+ *   maximize as foreground side effects. Restoring the pre-reconcile tuple keeps
+ *   the user's view untouched — only a dock activation that pointed at a
+ *   now-relocated panel legitimately changes (that panel left the dock).
  */
 export function reconcileDockMembership(): void {
   const before = usePanelStore.getState();
@@ -38,7 +41,15 @@ export function reconcileDockMembership(): void {
   }
   if (stranded.length === 0) return;
 
-  const focusBefore = before.focusedId;
+  const {
+    focusedId,
+    previousFocusedId,
+    activeDockTerminalId,
+    maximizedId,
+    maximizeTarget,
+    preMaximizeLayout,
+  } = before;
+
   for (const id of stranded) {
     if (usePanelStore.getState().panelsById[id]?.location === "dock") {
       usePanelStore.getState().moveTerminalToGrid(id);
@@ -46,12 +57,32 @@ export function reconcileDockMembership(): void {
   }
 
   const after = usePanelStore.getState();
+  const restore: Partial<
+    Pick<
+      PanelGridState,
+      | "focusedId"
+      | "previousFocusedId"
+      | "activeDockTerminalId"
+      | "maximizedId"
+      | "maximizeTarget"
+      | "preMaximizeLayout"
+    >
+  > = {};
+  // Restore verbatim (including a null value): a relocated stranded panel is now
+  // a visible grid panel, so a focus/maximize pointer at it stays valid.
+  if (after.focusedId !== focusedId) restore.focusedId = focusedId;
+  if (after.previousFocusedId !== previousFocusedId) restore.previousFocusedId = previousFocusedId;
+  if (after.maximizedId !== maximizedId) restore.maximizedId = maximizedId;
+  if (after.maximizeTarget !== maximizeTarget) restore.maximizeTarget = maximizeTarget;
+  if (after.preMaximizeLayout !== preMaximizeLayout) restore.preMaximizeLayout = preMaximizeLayout;
+  // The dock popover only survives if its panel is still in the dock; a
+  // relocated stranded panel left it, so keep the cleared value in that case.
   if (
-    focusBefore &&
-    focusBefore !== after.focusedId &&
-    !strandedSet.has(focusBefore) &&
-    after.panelsById[focusBefore]
+    after.activeDockTerminalId !== activeDockTerminalId &&
+    activeDockTerminalId != null &&
+    !strandedSet.has(activeDockTerminalId)
   ) {
-    usePanelStore.setState({ focusedId: focusBefore });
+    restore.activeDockTerminalId = activeDockTerminalId;
   }
+  if (Object.keys(restore).length > 0) usePanelStore.setState(restore);
 }

--- a/src/store/reconcileDockMembership.ts
+++ b/src/store/reconcileDockMembership.ts
@@ -1,0 +1,31 @@
+import { usePanelStore } from "@/store/panelStore";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
+
+/**
+ * Relocate every docked panel whose kind is no longer dockable back to the grid
+ * (#11375). Run after the plugin panel-kind registry reconciles: a
+ * `dockable:true→false` flip or a plugin unregister leaves docked panels of that
+ * kind stranded — the dock filters them out via `isDockPanel`, while the grid
+ * excludes them because their stored `location` is still `"dock"`.
+ *
+ * Delegates each move to the store's `moveTerminalToGrid`, which already handles
+ * worktree adoption (a worktree-less panel adopts the active worktree so it
+ * isn't stranded in the global-only grid bucket), whole-group moves, focus
+ * reconciliation, and renderer policy — so affected panels land visibly in the
+ * grid. Panels already in the grid are skipped, and `moveTerminalToGrid`
+ * early-returns for the second member of a group already relocated by the first.
+ *
+ * Snapshot the target list before mutating: `moveTerminalToGrid` changes the
+ * store, so iterate a captured id list rather than a live one.
+ */
+export function reconcileDockMembership(): void {
+  const state = usePanelStore.getState();
+  const stranded = state.panelIds.filter((id) => {
+    const panel = state.panelsById[id];
+    return !!panel && panel.location === "dock" && !panelKindIsDockable(panel.kind ?? "terminal");
+  });
+  if (stranded.length === 0) return;
+  for (const id of stranded) {
+    usePanelStore.getState().moveTerminalToGrid(id);
+  }
+}

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -821,4 +821,91 @@ describe("dock ↔ grid transitions", () => {
       expect(usePanelStore.getState().panelIds).toEqual(["gg", "b", "a"]);
     });
   });
+
+  describe("dockability write-site guards (#11375)", () => {
+    // A non-dockable panel shaped like a PTY carrier — the store keys the guard
+    // off `kind`, and "review" is a non-dockable built-in.
+    const nonDockable = (id: string, location: "grid" | "dock" = "grid"): PtyPanelData =>
+      ({ ...createMockTerminal(id, location), kind: "review" }) as unknown as PtyPanelData;
+
+    it("moveTerminalToDock leaves a non-dockable panel in the grid (direct-move reject)", () => {
+      setTerminals([nonDockable("t1", "grid")]);
+
+      usePanelStore.getState().moveTerminalToDock("t1");
+
+      expect(usePanelStore.getState().panelsById["t1"]?.location).toBe("grid");
+    });
+
+    it("moveTerminalToDock still docks a dockable panel", () => {
+      setTerminals([createMockTerminal("t1", "grid")]);
+
+      usePanelStore.getState().moveTerminalToDock("t1");
+
+      expect(usePanelStore.getState().panelsById["t1"]?.location).toBe("dock");
+    });
+
+    it("moveTerminalToPosition redirects a dock target for a non-dockable kind to the grid", () => {
+      setTerminals([nonDockable("t1", "grid")]);
+
+      usePanelStore.getState().moveTerminalToPosition("t1", 0, "dock", "wt-1");
+
+      const updated = usePanelStore.getState().panelsById["t1"];
+      expect(updated?.location).toBe("grid");
+      expect(updated?.isVisible).toBe(true);
+    });
+
+    it("moveTabGroupToLocation rescues a mixed group to the grid (all-or-nothing)", () => {
+      const a = createMockTerminal("a", "grid");
+      const b = nonDockable("b", "grid");
+      setTerminals([a, b]);
+      usePanelStore.setState({
+        tabGroups: new Map([["g1", createMockTabGroup("g1", ["a", "b"])]]),
+      });
+
+      usePanelStore.getState().moveTabGroupToLocation("g1", "dock");
+
+      // The whole group stays in the grid — one non-dockable member blocks the
+      // dock move; the group is never split across grid and dock.
+      const state = usePanelStore.getState();
+      expect(state.tabGroups.get("g1")?.location).toBe("grid");
+      expect(state.panelsById["a"]?.location).toBe("grid");
+      expect(state.panelsById["b"]?.location).toBe("grid");
+    });
+
+    it("moveTabGroupToLocation docks an all-dockable group", () => {
+      const a = createMockTerminal("a", "grid");
+      const b = createMockTerminal("b", "grid");
+      setTerminals([a, b]);
+      usePanelStore.setState({
+        tabGroups: new Map([["g1", createMockTabGroup("g1", ["a", "b"])]]),
+      });
+
+      usePanelStore.getState().moveTabGroupToLocation("g1", "dock");
+
+      const state = usePanelStore.getState();
+      expect(state.tabGroups.get("g1")?.location).toBe("dock");
+      expect(state.panelsById["a"]?.location).toBe("dock");
+      expect(state.panelsById["b"]?.location).toBe("dock");
+    });
+
+    it("reconcileDockMembership relocates a docked panel whose kind is no longer dockable", async () => {
+      // Simulate a live dockable→non-dockable flip: the panel is already docked
+      // (kind was dockable when it landed), then its kind reports non-dockable.
+      setTerminals([nonDockable("t1", "dock")]);
+      const { reconcileDockMembership } = await import("@/store/reconcileDockMembership");
+
+      reconcileDockMembership();
+
+      expect(usePanelStore.getState().panelsById["t1"]?.location).toBe("grid");
+    });
+
+    it("reconcileDockMembership leaves a dockable docked panel in place", async () => {
+      setTerminals([createMockTerminal("t1", "dock")]);
+      const { reconcileDockMembership } = await import("@/store/reconcileDockMembership");
+
+      reconcileDockMembership();
+
+      expect(usePanelStore.getState().panelsById["t1"]?.location).toBe("dock");
+    });
+  });
 });

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -933,5 +933,32 @@ describe("dock ↔ grid transitions", () => {
       expect(state.panelsById["s1"]?.location).toBe("grid");
       expect(state.panelsById["s2"]?.location).toBe("grid");
     });
+
+    it("reconcileDockMembership preserves an unrelated dock panel's open popover and focus", async () => {
+      const dockA = createMockTerminal("A", "dock"); // dockable terminal, popover open
+      const strandedB = nonDockable("B", "dock");
+      setTerminals([dockA, strandedB]);
+      usePanelStore.setState({ focusedId: "A", activeDockTerminalId: "A" });
+      const { reconcileDockMembership } = await import("@/store/reconcileDockMembership");
+
+      reconcileDockMembership();
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["B"]?.location).toBe("grid");
+      // Relocating B must not close A's popover or move focus off A.
+      expect(state.activeDockTerminalId).toBe("A");
+      expect(state.focusedId).toBe("A");
+    });
+
+    it("reconcileDockMembership restores a null prior focus rather than the relocated panel", async () => {
+      setTerminals([nonDockable("s1", "dock")]);
+      usePanelStore.setState({ focusedId: null });
+      const { reconcileDockMembership } = await import("@/store/reconcileDockMembership");
+
+      reconcileDockMembership();
+
+      expect(usePanelStore.getState().panelsById["s1"]?.location).toBe("grid");
+      expect(usePanelStore.getState().focusedId).toBeNull();
+    });
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -907,5 +907,31 @@ describe("dock ↔ grid transitions", () => {
 
       expect(usePanelStore.getState().panelsById["t1"]?.location).toBe("dock");
     });
+
+    it("reconcileDockMembership preserves the user's focus on an unrelated panel", async () => {
+      const focused = createMockTerminal("focused", "grid");
+      const stranded = nonDockable("stranded", "dock");
+      setTerminals([focused, stranded]);
+      usePanelStore.setState({ focusedId: "focused" });
+      const { reconcileDockMembership } = await import("@/store/reconcileDockMembership");
+
+      reconcileDockMembership();
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["stranded"]?.location).toBe("grid");
+      // A background flip must not steal focus from the panel the user was on.
+      expect(state.focusedId).toBe("focused");
+    });
+
+    it("reconcileDockMembership relocates every stranded dock panel exactly once", async () => {
+      setTerminals([nonDockable("s1", "dock"), nonDockable("s2", "dock")]);
+      const { reconcileDockMembership } = await import("@/store/reconcileDockMembership");
+
+      reconcileDockMembership();
+
+      const state = usePanelStore.getState();
+      expect(state.panelsById["s1"]?.location).toBe("grid");
+      expect(state.panelsById["s2"]?.location).toBe("grid");
+    });
   });
 });

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -9,7 +9,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import {
   panelKindUsesTerminalUi,
-  panelKindIsDockable,
+  normalizeDockLocation,
   getPanelKindConfig,
   getExtensionFallbackDefaults,
   resolvePanelKindPolicy,
@@ -203,6 +203,7 @@ export const createAddPanelActions = (
       // screen-fit cap any more. Honor the requested location directly; the
       // hard ceiling has already been enforced upstream by `panelLimitStore`.
       const requestedLocation = options.location || "grid";
+      const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
       // The dock only renders kinds it can host (`isDockPanel`). A dock request
       // for a non-dockable kind would strand the panel invisibly — still
       // persisted, still counted, unreachable from any UI (#11054). Redirect it
@@ -212,18 +213,27 @@ export const createAddPanelActions = (
       // of a non-dockable kind is returned to the grid on next load. Must run
       // before the `shouldBackground`/`runtimeStatus` derivation below, or a
       // redirected-to-grid panel would still get dock-flavored background state.
-      const location =
-        requestedLocation === "dock" && !panelKindIsDockable(requestedKind)
-          ? "grid"
-          : requestedLocation;
-      const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
+      const location = normalizeDockLocation(requestedKind, requestedLocation);
+      // A worktree-less panel redirected dock→grid must ALSO adopt the active
+      // worktree: the grid renders only the active worktree's index bucket, so a
+      // worktree-less grid panel is invisible whenever a worktree is active
+      // (#11290) — worse than the stranding this rescue is meant to fix (#11375).
+      // Mirrors the adoption in `moveTerminalToPosition`/`moveTerminalToGrid`.
+      const adoptedWorktreeId =
+        location === "grid" &&
+        requestedLocation === "dock" &&
+        (options.worktreeId ?? null) === null &&
+        activeWorktreeId !== null
+          ? activeWorktreeId
+          : null;
+      const effectiveWorktreeId = adoptedWorktreeId ?? options.worktreeId;
       // When activeWorktreeId is null (worktree store not yet hydrated — common
       // during a project switch), treat the panel as being in the active worktree
       // to avoid incorrectly backgrounding it. Mirrors the PTY branch guard
       // below; without it a non-PTY plugin panel spawned mid-switch is
       // mis-backgrounded (#10512).
       const isInActiveWorktree =
-        activeWorktreeId === null || (options.worktreeId ?? null) === (activeWorktreeId ?? null);
+        activeWorktreeId === null || (effectiveWorktreeId ?? null) === (activeWorktreeId ?? null);
       const shouldBackground = location === "dock" || (location === "grid" && !isInActiveWorktree);
       const runtimeStatus: TerminalRuntimeStatus = shouldBackground ? "background" : "running";
 
@@ -239,7 +249,7 @@ export const createAddPanelActions = (
         id,
         kind: requestedKind,
         title,
-        worktreeId: options.worktreeId,
+        worktreeId: effectiveWorktreeId,
         location,
         isVisible: location === "grid",
         runtimeStatus,
@@ -356,7 +366,14 @@ export const createAddPanelActions = (
     // The scrollable panel grid no longer caps panels at the screen-fit count
     // (#8805). Honor the requested location directly; the hardware-adaptive
     // hard ceiling is enforced upstream by `panelLimitStore`.
-    const location = options.location || "grid";
+    // Defense-in-depth: honor a non-dockable requested kind BEFORE the collapse
+    // to "terminal"/"dev-preview" above discards it (#11375). `hasPty:true` with
+    // `dockable:false` is rejected at the manifest gate and terminal/agent kinds
+    // are always dockable, so this only fires for a programmatic dock request of
+    // a non-dockable PTY kind — redirect it to the grid. No worktree adoption
+    // here (unlike the non-PTY branch): PTY restore paths reconcile worktree
+    // separately, and this defensive redirect never fires for a real launch.
+    const location = normalizeDockLocation(requestedKind, options.location || "grid");
     const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
     // When activeWorktreeId is null (worktree store not yet hydrated — common during
     // project switch), treat the terminal as being in the active worktree to avoid

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -1,14 +1,19 @@
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import {
+  panelKindHasPty,
+  normalizeDockLocation,
+  normalizeGroupDockLocation,
+} from "@shared/config/panelKindRegistry";
 import { getNarrowPanel } from "./selectors";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
-import { isDevPreviewPanel } from "@shared/types/panel";
+import { isDevPreviewPanel, type PanelKind } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 import {
   stopDevPreviewByPanelId,
   dissolvePanelFromGroup,
@@ -190,13 +195,24 @@ export const createBackgroundActions = (
       return;
     }
 
-    const restoreLocation = backgroundedInfo.originalLocation ?? "grid";
+    const rawRestoreLocation = backgroundedInfo.originalLocation ?? "grid";
     const terminal = get().panelsById[id];
+    // Normalize a persisted dock location to grid if the kind is no longer
+    // dockable (#11375); adopt the active worktree when a rescued worktree-less
+    // panel would otherwise strand in the global-only grid bucket (#11290).
+    const restoreLocation = normalizeDockLocation(terminal?.kind, rawRestoreLocation);
+    const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
 
     set((state) => {
       const t = state.panelsById[id];
       if (!t) return state;
-      const nextWorktreeId = targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId;
+      const rescuedToGrid = restoreLocation === "grid" && rawRestoreLocation === "dock";
+      const nextWorktreeId =
+        targetWorktreeId !== undefined
+          ? targetWorktreeId
+          : rescuedToGrid && t.worktreeId == null && activeWorktreeId !== null
+            ? activeWorktreeId
+            : t.worktreeId;
       const newById = {
         ...state.panelsById,
         [id]: {
@@ -252,14 +268,28 @@ export const createBackgroundActions = (
 
     if (groupPanels.length === 0) return;
 
-    const restoreLocation =
-      anchorPanel?.groupMetadata?.location ??
-      groupPanels[0]?.backgrounded?.originalLocation ??
-      "grid";
+    // A tab group is atomic — normalize a persisted dock location to grid when
+    // ANY live member's kind is no longer dockable (#11375), moving the whole
+    // group rather than splitting it, and adopt the active worktree for a
+    // rescued worktree-less group so it isn't stranded in the grid.
+    const rawGroupLocation: "grid" | "dock" =
+      (anchorPanel?.groupMetadata?.location ?? groupPanels[0]?.backgrounded?.originalLocation) ===
+      "dock"
+        ? "dock"
+        : "grid";
+    const groupMemberKinds: (PanelKind | undefined)[] = [];
+    for (const { id } of groupPanels) {
+      const t = get().panelsById[id];
+      if (t) groupMemberKinds.push(t.kind);
+    }
+    const restoreLocation = normalizeGroupDockLocation(groupMemberKinds, rawGroupLocation);
+    const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
+    const rescuedToGrid = restoreLocation === "grid" && rawGroupLocation === "dock";
     const worktreeId =
       targetWorktreeId !== undefined
         ? targetWorktreeId
-        : (anchorPanel?.groupMetadata?.worktreeId ?? undefined);
+        : (anchorPanel?.groupMetadata?.worktreeId ??
+          (rescuedToGrid && activeWorktreeId !== null ? activeWorktreeId : undefined));
 
     set((state) => {
       const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -4,7 +4,7 @@ import type { PanelInstance, PanelTitleMode } from "@shared/types/panel";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { panelKindHasPty, panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import { isDevPreviewPanel } from "@shared/types/panel";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
@@ -490,6 +490,11 @@ export const createCorePanelActions = (
 
     // Single ungrouped panel - move just this panel
     const terminal = get().panelsById[id];
+
+    // Direct moves reject a non-dockable kind (#11375): the dock filters it out
+    // via `isDockPanel`, so committing `location:"dock"` would strand it
+    // invisibly. Leave the panel where it is rather than dock it.
+    if (terminal && !panelKindIsDockable(terminal.kind ?? "terminal")) return;
 
     set((state) => {
       if (!terminal || terminal.location === "dock") return state;

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -1,5 +1,5 @@
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { panelKindHasPty, normalizeDockLocation } from "@shared/config/panelKindRegistry";
 import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -82,6 +82,13 @@ export const createOrderingActions = (
 
   moveTerminalToPosition: (id, toIndex, location, worktreeId) => {
     let backfilledWorktreeId: string | null = null;
+    // Normalize a dock target for a non-dockable kind to the grid (#11375): the
+    // dock filters it out via `isDockPanel`, so `location:"dock"` would strand
+    // it invisibly. Every scope/adoption/visibility/PTY-policy decision below
+    // keys off this effective location, including the post-`set` renderer tier.
+    const movingPanel = get().panelsById[id];
+    if (!movingPanel) return;
+    const effectiveLocation = normalizeDockLocation(movingPanel.kind ?? "terminal", location);
 
     set((state) => {
       const terminal = state.panelsById[id];
@@ -94,9 +101,10 @@ export const createOrderingActions = (
       // Same location-aware scope as reorderTerminals (#11289): a dock target
       // must count global panels when computing the insertion slot.
       const matchesWorktree = (t: CarrierPanel) =>
-        !hasWorktreeFilter || panelMatchesWorktreeScope(t.worktreeId, worktreeId, location);
+        !hasWorktreeFilter ||
+        panelMatchesWorktreeScope(t.worktreeId, worktreeId, effectiveLocation);
       const matchesLocation = (t: CarrierPanel) =>
-        location === "grid"
+        effectiveLocation === "grid"
           ? t.location === "grid" || t.location === undefined
           : t.location === "dock";
 
@@ -124,14 +132,14 @@ export const createOrderingActions = (
               ? scopedIndices[scopedCount - 1]! + 1
               : scopedIndices[clampedIndex]!;
 
-      const isVisible = location === "grid";
+      const isVisible = effectiveLocation === "grid";
       const ptyTerminal = isPtyPanel(terminal) ? terminal : undefined;
       // A worktree-less dock panel dropped into the grid adopts the drop
       // target's worktree — the grid renders only that worktree's index
       // bucket, so an unset worktreeId would strand it off-screen (#11290).
       // The rebuild below re-buckets the panel; a real attribution is kept.
       const adoptedWorktreeId =
-        location === "grid" && terminal.worktreeId == null && targetWorktreeId != null
+        effectiveLocation === "grid" && terminal.worktreeId == null && targetWorktreeId != null
           ? targetWorktreeId
           : null;
       backfilledWorktreeId = adoptedWorktreeId;
@@ -139,7 +147,7 @@ export const createOrderingActions = (
       const updatedTerminal = {
         ...terminal,
         ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
-        location,
+        location: effectiveLocation,
         isVisible,
         runtimeStatus: deriveRuntimeStatus(
           isVisible,
@@ -184,7 +192,7 @@ export const createOrderingActions = (
 
     const terminal = get().panelsById[id];
     if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-      if (location === "dock") {
+      if (effectiveLocation === "dock") {
         optimizeForDock(id);
       } else {
         terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -1,7 +1,7 @@
 import type { TabGroup, TabGroupLocation } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { type PanelInstance, isPtyPanel } from "@shared/types/panel";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { type PanelInstance, type PanelKind, isPtyPanel } from "@shared/types/panel";
+import { panelKindHasPty, normalizeGroupDockLocation } from "@shared/config/panelKindRegistry";
 import { getNarrowPanel } from "./selectors";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
@@ -396,7 +396,21 @@ export const createTabGroupActions = (
       return false;
     }
 
-    if (group.location === location) return true;
+    // A tab group is atomic — every member shares one location — so a dock move
+    // is all-or-nothing: if ANY live member's kind is non-dockable, the whole
+    // group lands in the grid rather than splitting (#11375). A mixed-location
+    // group is invisible to `getPanelGroup` and corrupts persistence. Skip trash
+    // members, matching the per-member relocation loop below.
+    const groupState = get();
+    const memberKinds: (PanelKind | undefined)[] = [];
+    for (const pid of group.panelIds) {
+      const t = groupState.panelsById[pid];
+      if (!t || t.location === "trash" || groupState.trashedTerminals.has(t.id)) continue;
+      memberKinds.push(t.kind);
+    }
+    const effectiveLocation = normalizeGroupDockLocation(memberKinds, location);
+
+    if (group.location === effectiveLocation) return true;
 
     // Scrollable grid (#8805): tab-group moves to the grid no longer gate on a
     // screen-fit cap. The grid scrolls vertically so the move always succeeds.
@@ -404,11 +418,12 @@ export const createTabGroupActions = (
     // A worktree-less dock group is visible in every worktree's dock, but the
     // grid renders only the active worktree's index bucket — landing there
     // without a worktreeId strands the whole group off-screen (#11290).
-    // Promotion adopts the active worktree for the group and every live
-    // member; a real existing group attribution is never changed.
+    // Promotion (including a dock request rescued to grid above) adopts the
+    // active worktree for the group and every live member; a real existing
+    // group attribution is never changed.
     const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
     const adoptedWorktreeId =
-      location === "grid" && group.worktreeId == null && activeWorktreeId !== null
+      effectiveLocation === "grid" && group.worktreeId == null && activeWorktreeId !== null
         ? activeWorktreeId
         : null;
     const backfilledPanelIds: string[] = [];
@@ -417,8 +432,8 @@ export const createTabGroupActions = (
       const newTabGroups = new Map(state.tabGroups);
       const updatedGroup: TabGroup =
         adoptedWorktreeId !== null
-          ? { ...group, location, worktreeId: adoptedWorktreeId }
-          : { ...group, location };
+          ? { ...group, location: effectiveLocation, worktreeId: adoptedWorktreeId }
+          : { ...group, location: effectiveLocation };
       newTabGroups.set(groupId, updatedGroup);
 
       const panelIdSet = new Set(group.panelIds);
@@ -432,10 +447,10 @@ export const createTabGroupActions = (
         newById[pid] = {
           ...t,
           ...(adoptedWorktreeId !== null && { worktreeId: adoptedWorktreeId }),
-          location,
-          isVisible: location === "grid",
+          location: effectiveLocation,
+          isVisible: effectiveLocation === "grid",
           runtimeStatus: deriveRuntimeStatus(
-            location === "grid",
+            effectiveLocation === "grid",
             ptyT?.flowStatus,
             ptyT?.runtimeStatus
           ),
@@ -474,7 +489,7 @@ export const createTabGroupActions = (
     for (const panelId of group.panelIds) {
       const terminal = get().panelsById[panelId];
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-        if (location === "dock") {
+        if (effectiveLocation === "dock") {
           optimizeForDock(panelId);
         } else {
           terminalInstanceService.applyRendererPolicy(panelId, TerminalRefreshTier.VISIBLE);
@@ -497,11 +512,25 @@ export const createTabGroupActions = (
     // Scrollable grid (#8805): no screen-fit cap — moving a group to another
     // worktree's grid always succeeds; the destination grid scrolls.
 
-    const targetLocation: TabGroupLocation = group.location === "grid" ? "grid" : "dock";
+    // Preserve the group's current location, but normalize a stale dock to grid
+    // if any live member's kind is no longer dockable (#11375) — else the whole
+    // group stays stranded in the dock after a dockability flip. All-or-nothing,
+    // mirroring moveTabGroupToLocation; the group and its members move together.
+    const worktreeMoveState = get();
+    const worktreeMemberKinds: (PanelKind | undefined)[] = [];
+    for (const pid of group.panelIds) {
+      const t = worktreeMoveState.panelsById[pid];
+      if (!t || t.location === "trash" || worktreeMoveState.trashedTerminals.has(t.id)) continue;
+      worktreeMemberKinds.push(t.kind);
+    }
+    const targetLocation: TabGroupLocation = normalizeGroupDockLocation(
+      worktreeMemberKinds,
+      group.location === "grid" ? "grid" : "dock"
+    );
 
     set((state) => {
       const newTabGroups = new Map(state.tabGroups);
-      const updatedGroup: TabGroup = { ...group, worktreeId };
+      const updatedGroup: TabGroup = { ...group, worktreeId, location: targetLocation };
       newTabGroups.set(groupId, updatedGroup);
 
       const panelIdSet = new Set(group.panelIds);

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -6,8 +6,12 @@ type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isDevPreviewPanel, isPtyPanel } from "@shared/types/panel";
+import {
+  panelKindHasPty,
+  normalizeDockLocation,
+  normalizeGroupDockLocation,
+} from "@shared/config/panelKindRegistry";
+import { isDevPreviewPanel, isPtyPanel, type PanelKind } from "@shared/types/panel";
 import { TRASH_TTL_MS } from "@shared/config/trash";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
@@ -19,6 +23,7 @@ import {
 } from "./helpers";
 import { logError } from "@/utils/logger";
 import { transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -235,8 +240,15 @@ export const createTrashActions = (
     restoreTerminal: (id, targetWorktreeId) => {
       clearTrashExpiryTimer(id);
       const trashedInfo = get().trashedTerminals.get(id);
-      const restoreLocation = trashedInfo?.originalLocation ?? "grid";
+      const rawRestoreLocation = trashedInfo?.originalLocation ?? "grid";
       const terminal = get().panelsById[id];
+      // Normalize a persisted dock location to grid if the kind is no longer
+      // dockable (#11375) — the dock filters it out, so it would strand while
+      // `location:"dock"` also keeps it out of the grid. `restoreTerminal`'s
+      // wrapper (panelStore.ts) then correctly treats a rescued panel as a
+      // visible grid panel for focus, instead of focusing an invisible one.
+      const restoreLocation = normalizeDockLocation(terminal?.kind, rawRestoreLocation);
+      const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
         terminalClient.restore(id).catch((error) => {
@@ -247,7 +259,15 @@ export const createTrashActions = (
       set((state) => {
         const t = state.panelsById[id];
         if (!t) return state;
-        const nextWorktreeId = targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId;
+        // A worktree-less panel rescued dock→grid adopts the active worktree so
+        // it lands in a visible bucket rather than the global-only one (#11290).
+        const rescuedToGrid = restoreLocation === "grid" && rawRestoreLocation === "dock";
+        const nextWorktreeId =
+          targetWorktreeId !== undefined
+            ? targetWorktreeId
+            : rescuedToGrid && t.worktreeId == null && activeWorktreeId !== null
+              ? activeWorktreeId
+              : t.worktreeId;
         const newById = {
           ...state.panelsById,
           [id]: {
@@ -315,12 +335,28 @@ export const createTrashActions = (
         }
       }
 
-      const restoreLocation =
-        anchorPanel?.groupMetadata?.location ?? groupPanels[0]?.trashed?.originalLocation ?? "grid";
+      // A tab group is atomic — normalize a persisted dock location to grid when
+      // ANY live member's kind is no longer dockable (#11375), moving the whole
+      // group rather than splitting it. Adopt the active worktree when a rescued
+      // worktree-less group would otherwise land in the global-only bucket.
+      const rawGroupLocation: "grid" | "dock" =
+        (anchorPanel?.groupMetadata?.location ?? groupPanels[0]?.trashed?.originalLocation) ===
+        "dock"
+          ? "dock"
+          : "grid";
+      const groupMemberKinds: (PanelKind | undefined)[] = [];
+      for (const { id } of groupPanels) {
+        const t = get().panelsById[id];
+        if (t) groupMemberKinds.push(t.kind);
+      }
+      const restoreLocation = normalizeGroupDockLocation(groupMemberKinds, rawGroupLocation);
+      const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
+      const rescuedToGrid = restoreLocation === "grid" && rawGroupLocation === "dock";
       const worktreeId =
         targetWorktreeId !== undefined
           ? targetWorktreeId
-          : (anchorPanel?.groupMetadata?.worktreeId ?? undefined);
+          : (anchorPanel?.groupMetadata?.worktreeId ??
+            (rescuedToGrid && activeWorktreeId !== null ? activeWorktreeId : undefined));
 
       set((state) => {
         const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));
@@ -434,22 +470,45 @@ export const createTrashActions = (
       const terminal = get().panelsById[id];
 
       const trashedInfo = get().trashedTerminals.get(id);
-      const restoreLocation =
+      const rawRestoreLocation =
         terminal && terminal.location !== "trash"
           ? terminal.location
           : (trashedInfo?.originalLocation ?? "grid");
+      // Final defensive boundary (#11375): normalize a dock location to grid if
+      // the kind is no longer dockable, adopting the active worktree when a
+      // rescued worktree-less panel would otherwise strand in the grid.
+      const restoreLocation = normalizeDockLocation(terminal?.kind, rawRestoreLocation);
+      const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
 
       set((state) => {
         const newTrashed = new Map(state.trashedTerminals);
         newTrashed.delete(id);
         const t = state.panelsById[id];
         if (!t) return { trashedTerminals: newTrashed };
+        const rescuedToGrid = restoreLocation === "grid" && rawRestoreLocation === "dock";
+        const nextWorktreeId =
+          rescuedToGrid && t.worktreeId == null && activeWorktreeId !== null
+            ? activeWorktreeId
+            : t.worktreeId;
         const newById = {
           ...state.panelsById,
-          [id]: { ...t, location: restoreLocation },
+          [id]: { ...t, location: restoreLocation, worktreeId: nextWorktreeId },
         };
+        const newIndex =
+          nextWorktreeId !== t.worktreeId
+            ? transferBetweenWorktreeIndex(
+                state.panelIdsByWorktreeId,
+                t.worktreeId,
+                nextWorktreeId,
+                id
+              )
+            : state.panelIdsByWorktreeId;
         saveNormalized(newById, state.panelIds);
-        return { trashedTerminals: newTrashed, panelsById: newById };
+        return {
+          trashedTerminals: newTrashed,
+          panelsById: newById,
+          panelIdsByWorktreeId: newIndex,
+        };
       });
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1506,6 +1506,71 @@ describe("buildArgsForNonPtyRecreation", () => {
     );
     expect(result.extensionState).toBeUndefined();
   });
+
+  describe("dock→grid rescue on hydration (#11375 point 3)", () => {
+    it("keeps a dockable dock panel in the dock and stays global", () => {
+      // `browser` is dockable — a persisted global dock browser stays in the
+      // dock (visible in every worktree's dock); no worktree is stamped.
+      const result = buildArgsForNonPtyRecreation(
+        { id: "b1", kind: "browser", title: "Browser", location: "dock" },
+        "browser",
+        "/project",
+        "wt-active"
+      );
+      expect(result.location).toBe("dock");
+      expect(result.worktreeId).toBeUndefined();
+    });
+
+    it("rescues a non-dockable dock panel to the grid and adopts the active worktree", () => {
+      // `dev-preview` is a non-dockable built-in. A persisted global dock
+      // dev-preview must land visibly in the active worktree's grid, not
+      // worktree-less in the global-only bucket.
+      const result = buildArgsForNonPtyRecreation(
+        { id: "d1", kind: "dev-preview", title: "Dev", location: "dock" },
+        "dev-preview",
+        "/project",
+        "wt-active"
+      );
+      expect(result.location).toBe("grid");
+      expect(result.worktreeId).toBe("wt-active");
+    });
+
+    it("rescues an unregistered (not-yet-loaded plugin) dock kind to the grid and adopts", () => {
+      // At hydration a plugin kind may not be registered yet — treated as
+      // non-dockable — so a global dock panel of that kind is rescued to the
+      // grid with the active worktree, returning visibly rather than stranding.
+      const result = buildArgsForNonPtyRecreation(
+        { id: "p1", kind: "acme.viewer", title: "Plugin", location: "dock" },
+        "acme.viewer",
+        "/project",
+        "wt-active"
+      );
+      expect(result.location).toBe("grid");
+      expect(result.worktreeId).toBe("wt-active");
+    });
+
+    it("does not override an explicit saved worktree when rescuing", () => {
+      const result = buildArgsForNonPtyRecreation(
+        { id: "d1", kind: "dev-preview", title: "Dev", location: "dock", worktreeId: "wt-saved" },
+        "dev-preview",
+        "/project",
+        "wt-active"
+      );
+      expect(result.location).toBe("grid");
+      expect(result.worktreeId).toBe("wt-saved");
+    });
+
+    it("rescues to the grid worktree-less when no active worktree is known", () => {
+      const result = buildArgsForNonPtyRecreation(
+        { id: "d1", kind: "dev-preview", title: "Dev", location: "dock" },
+        "dev-preview",
+        "/project",
+        null
+      );
+      expect(result.location).toBe("grid");
+      expect(result.worktreeId).toBeUndefined();
+    });
+  });
 });
 
 describe("buildArgsForOrphanedTerminal", () => {

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -442,7 +442,7 @@ export async function restorePanelsPhase(
               }
               logHydrationInfo(`Recreating ${kind} panel: ${saved.id}`);
               const nonPtyId = await addPanel(
-                buildArgsForNonPtyRecreation(saved, kind, projectRoot || "")
+                buildArgsForNonPtyRecreation(saved, kind, projectRoot || "", activeWorktreeId)
               );
               restoredIdsByIndex.set(capturedIndex, nonPtyId);
             }

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -25,6 +25,7 @@ import {
 } from "@shared/types";
 import { inferKind as inferKindShared } from "@shared/utils/inferPanelKind";
 import { isAbsolute } from "@shared/utils/path";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import { getDeserializer } from "@/config/panelKindSerialisers";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { resolveAgentRuntimeSettings } from "@/utils/agentRuntimeSettings";
@@ -671,15 +672,29 @@ export function buildArgsForRespawn(
 export function buildArgsForNonPtyRecreation(
   saved: SavedTerminalData,
   kind: PanelKind,
-  projectRoot: string
+  projectRoot: string,
+  activeWorktreeId?: string | null
 ): AddTerminalArgs {
-  const location = (saved.location === "dock" ? "dock" : "grid") as "grid" | "dock";
+  const savedLocation = (saved.location === "dock" ? "dock" : "grid") as "grid" | "dock";
+  // Rescue a persisted dock panel whose kind can't dock (or isn't registered yet
+  // during this hydration) HERE, where the saved active worktree is known —
+  // `addPanel`'s own dock→grid rescue runs too late to adopt a worktree (worktree
+  // selection hydrates AFTER panel restore), so a worktree-less rescued panel
+  // would strand in the global-only grid bucket, invisible once a worktree is
+  // active (#11375 point 3). A worktree-less panel adopts the active worktree so
+  // it returns VISIBLY to the grid; a dockable kind keeps its dock placement.
+  const rescueDockToGrid = savedLocation === "dock" && !panelKindIsDockable(kind);
+  const location = rescueDockToGrid ? "grid" : savedLocation;
+  const worktreeId =
+    rescueDockToGrid && saved.worktreeId == null && activeWorktreeId != null
+      ? activeWorktreeId
+      : saved.worktreeId;
   const base: AddTerminalArgs = {
     kind,
     title: saved.title,
     titleMode: saved.titleMode,
     cwd: resolveSavedCwd(saved.cwd, projectRoot),
-    worktreeId: saved.worktreeId,
+    worktreeId,
     location,
     requestedId: saved.id,
     exitBehavior: saved.exitBehavior,


### PR DESCRIPTION
## Summary

Hardening follow-up to #11332, which flipped panel-kind dockability to opt-out and made plugin view panels dockable. Two independent adversarial reviews of that PR surfaced five dock-stranding edge cases the new dockability made reachable. This PR closes all five.

Resolves #11375

## Changes

**1. Centralize dock-location normalization.** `normalizeDockLocation` and `normalizeGroupDockLocation` now guard every store dock-location write site: `moveTerminalToDock`, `moveTerminalToPosition`, tab-group move, worktree move, undo restore, and trash/background restore for both single panels and groups, plus `markAsRestored`. A non-dockable panel kind can no longer end up with a dock location. It gets redirected to the grid instead, adopting the active worktree.

**2. Make dock membership reactive.** The panel-kind metadata registry is now a subscribable external store. `ContentDock` and `DockPanelOffscreenContainer` re-evaluate membership reactively instead of only reacting to panel-store changes. A new `reconcileDockMembership` relocates already-docked panels to the grid when a live plugin flips `dockable` from `true` to `false`, or when a plugin unregisters.

**3. Fix the hydration-time rescue path.** The dock-to-grid rescue on hydration now adopts the saved active worktree, so a global dock panel returns visibly to the grid instead of stranding in the internal `__none__` worktree bucket.

**4. Check every group member on drag-and-drop.** Group DnD into the dock now checks the kind of every live member, not just the dragged representative, before allowing the drop.

**5. Reject an invalid manifest combination.** `PanelContributionSchema` now rejects `hasPty: true` paired with `dockable: false` via a `superRefine` check, closing off the PTY opt-out gap at the manifest boundary.

## Testing

925 targeted tests pass locally. Prettier and eslint are clean on all touched files, zero errors.