### PR TITLE
fix(recipe): specific consequence in recipe-delete confirm copy

### DIFF
--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -452,7 +452,7 @@ export function RecipesTab({
         description={
           deleteError
             ? `Error: ${deleteError}`
-            : "The recipe will be permanently removed. This cannot be undone."
+            : "Deletes this recipe — the terminals it launches and their settings. Committed in-repo recipes in .daintree/recipes/ can be restored from git; recipes stored only on this machine can't be recovered."
         }
         confirmLabel={deleteError ? "Retry delete" : "Delete recipe"}
         variant="destructive"

--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -43,7 +43,7 @@ export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps
       description={
         runner.deleteError
           ? `Error: ${runner.deleteError}`
-          : "The recipe will be permanently removed. This cannot be undone."
+          : "Deletes this recipe — the terminals it launches and their settings. Committed in-repo recipes in .daintree/recipes/ can be restored from git; recipes stored only on this machine can't be recovered."
       }
       confirmLabel={runner.deleteError ? "Retry delete" : "Delete recipe"}
       variant="destructive"

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -444,7 +444,7 @@ export function RecipeManager({
         description={
           deleteError
             ? `Error: ${deleteError}`
-            : "The recipe will be permanently removed. This cannot be undone."
+            : "Deletes this recipe — the terminals it launches and their settings. Committed in-repo recipes in .daintree/recipes/ can be restored from git; recipes stored only on this machine can't be recovered."
         }
         confirmLabel={deleteError ? "Retry delete" : "Delete recipe"}
         variant="destructive"


### PR DESCRIPTION
All three recipe-delete confirmation dialogs (`RecipeRunner`, `RecipesTab`, `RecipeManager`) shared the same generic body:

> The recipe will be permanently removed. This cannot be undone.

The dev-time microcopy checker in `ConfirmDialog` flags any body containing "cannot be undone", because the project rule is that a destructive body has to state the actual consequence: what gets deleted, where it lives, what recovery exists. Generic irreversibility copy tells the user nothing, so it fires a `console.error` in dev.

New copy:

> Deletes this recipe: the terminals it launches and their settings. Committed in-repo recipes in `.daintree/recipes/` can be restored from git; recipes stored only on this machine can't be recovered.

That names what's removed (the recipe's terminals and their settings) and the real recovery boundary. In-repo recipes live under `.daintree/recipes/` (git-tracked), so a committed one is restorable. Global and project-local recipes persist as JSON on the machine with no undo, so they're gone. I kept it as one accurate-across-all-scopes string rather than deriving each recipe's scope in three dialogs, which is more logic than a copy fix warrants.

## Scope

Only the recipe-delete dialogs. Other unrelated dialogs still contain the phrase, but they all share a single warn-once key (`body-cannot-be-undone`), so this doesn't silence the whole app. Cleaning those up is a separate pass.

## Notes

Codex flagged that the first draft overclaimed git recovery ("in-repo recipes can be restored" implied every in-repo recipe, but only committed ones are). The wording above hedges on "committed" for that reason.