### PR TITLE
Fix video playback in the file browser

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -124,10 +124,18 @@ protocol.registerSchemesAsPrivileged([
     },
   },
   {
+    // corsEnabled lets the trusted renderer fetch() video bytes for blob-URL
+    // playback (Chromium's custom-scheme media loader can't consume follow-up
+    // range requests — electron#51442). It only makes the scheme *eligible*
+    // for cross-origin fetch: reads still require the handler to echo
+    // Access-Control-Allow-Origin, which it does solely for trusted app
+    // origins (see daintreeFileCorsOrigin in setup/protocols.ts), so browser
+    // panels hosting remote sites gain no access.
     scheme: "daintree-file",
     privileges: {
       secure: true,
       supportFetchAPI: true,
+      corsEnabled: true,
     },
   },
   {

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2004,14 +2004,17 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
   function makeVideoRequest(
     filePath: string,
     rootPath: string,
-    init?: { method?: string; range?: string }
+    init?: { method?: string; range?: string; origin?: string }
   ): GlobalRequest {
     const url = new URL("daintree-file://serve");
     url.searchParams.set("path", filePath);
     url.searchParams.set("root", rootPath);
     return new Request(url.toString(), {
       method: init?.method ?? "GET",
-      ...(init?.range && { headers: { Range: init.range } }),
+      headers: {
+        ...(init?.range && { Range: init.range }),
+        ...(init?.origin && { Origin: init.origin }),
+      },
     }) as GlobalRequest;
   }
 
@@ -2050,8 +2053,8 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
   });
 
   it("streams a 200 with Accept-Ranges and no whole-file cap, bypassing the buffered core", async () => {
-    // Far beyond both the 512 KB text cap and the 25 MB image ceiling — videos
-    // are streamed in bounded chunks, so no whole-file cap applies.
+    // Far beyond both the 512 KB text cap and the 25 MB image ceiling — video
+    // responses are backpressured streams, so no whole-file cap applies.
     const size = 600 * 1024 * 1024;
     const handle = makeVideoHandle(VIDEO_BYTES, { size });
     await installHandle(handle);
@@ -2068,6 +2071,50 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
       start: 0,
       end: size - 1,
       autoClose: true,
+    });
+  });
+
+  describe("CORS gate (blob-URL playback fetch)", () => {
+    // corsEnabled on the scheme only makes cross-origin fetch possible;
+    // these pin the actual grant: ACAO echoed solely for the trusted app
+    // origin, never for arbitrary web content in a browser panel.
+    it("echoes Access-Control-Allow-Origin for the trusted app origin", async () => {
+      const handler = await captureHandler();
+      const response = await handler(
+        makeVideoRequest("/project/clip.mp4", "/project", { origin: "app://daintree" })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("app://daintree");
+    });
+
+    it("omits the grant for a foreign origin", async () => {
+      const handler = await captureHandler();
+      const response = await handler(
+        makeVideoRequest("/project/clip.mp4", "/project", { origin: "https://evil.example" })
+      );
+
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+
+    it("omits the grant when no Origin header is present", async () => {
+      const handler = await captureHandler();
+      const response = await handler(makeVideoRequest("/project/clip.mp4", "/project"));
+
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+
+    it("carries the grant on error responses so fetch() can read the status", async () => {
+      const handler = await captureHandler();
+      const response = await handler(
+        makeVideoRequest("/project/clip.mp4", "/project", {
+          origin: "app://daintree",
+          range: "bytes=99-",
+        })
+      );
+
+      expect(response.status).toBe(416);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("app://daintree");
     });
   });
 

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -2141,27 +2141,28 @@ describe("createDaintreeFileProtocolHandler — video streaming (#11382)", () =>
     expect(response.headers.get("Content-Range")).toBe("bytes 10-15/16");
   });
 
-  it("bounds an open-ended range on a huge file to a partial chunk", async () => {
-    // `bytes=N-` asks for "everything from N"; the handler must not stream the
-    // whole remainder in one response — Chromium re-requests successive chunks.
+  it("serves an open-ended range on a huge file to EOF, never a shorter chunk", async () => {
+    // Chromium's custom-scheme media loader is single-shot: a 206 that ends
+    // before the requested range is treated as the whole resource and never
+    // re-requested, so serving `bytes=N-` in bounded chunks truncates playback
+    // at the first chunk. The full remainder must stream in one response.
     const size = 100 * 1024 * 1024;
     const handle = makeVideoHandle(VIDEO_BYTES, { size });
     await installHandle(handle);
 
     const handler = await captureHandler();
     const response = await handler(
-      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=0-" })
+      makeVideoRequest("/project/clip.mp4", "/project", { range: "bytes=4-" })
     );
 
     expect(response.status).toBe(206);
-    // Invariants, not the clamp constant: the response covers a strict prefix
-    // of the file, and headers agree with the stream bounds actually used.
-    const args = handle.createReadStream.mock.calls[0][0] as { start: number; end: number };
-    expect(args.start).toBe(0);
-    expect(args.end).toBeLessThan(size - 1);
-    const length = args.end - args.start + 1;
-    expect(response.headers.get("Content-Length")).toBe(String(length));
-    expect(response.headers.get("Content-Range")).toBe(`bytes ${args.start}-${args.end}/${size}`);
+    expect(handle.createReadStream).toHaveBeenCalledWith({
+      start: 4,
+      end: size - 1,
+      autoClose: true,
+    });
+    expect(response.headers.get("Content-Length")).toBe(String(size - 4));
+    expect(response.headers.get("Content-Range")).toBe(`bytes 4-${size - 1}/${size}`);
   });
 
   it("serves an over-cap suffix range exactly (the tail carries mp4 moov metadata)", async () => {

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -220,19 +220,18 @@ function buildDaintreeFileErrorHeaders(): Record<string, string> {
 // Videos are streamed, not buffered, so the whole-file caps above don't apply —
 // no response ever holds more than a stream chunk in memory (the caps exist to
 // bound buffered bytes reaching the renderer, a model that doesn't fit ranged
-// streaming; see maxBytesForFile). A per-range clamp still bounds any single
-// response body: an open-ended `Range: bytes=0-` on a multi-GB file is served
-// in successive bounded chunks that Chromium re-requests as playback advances.
-// An un-ranged GET does stream the whole file in one 200 — required for a
-// spec-correct response, and accepted: <video> always issues ranged requests,
-// and main-process memory stays chunk-bounded regardless of response size.
-const DAINTREE_VIDEO_RANGE_MAX_BYTES = 8 * 1024 * 1024;
-
+// streaming; see maxBytesForFile). Every range form is served exactly as
+// requested, to EOF for `bytes=N-`. Chromium treats a custom-scheme media load
+// as single-shot: a 206 shorter than the requested range is taken as the whole
+// resource and never re-requested (unlike http(s), where the multibuffer loader
+// issues follow-up ranges), so a server-side chunk clamp truncates playback at
+// the clamp — verified against Electron 42 / Chromium 148. Backpressure on the
+// response stream keeps main-process memory chunk-bounded regardless of size.
 function isVideoMimeType(mimeType: string): boolean {
   return mimeType.startsWith("video/");
 }
 
-type ParsedByteRange = { start: number; end: number; openEnded: boolean } | "unsatisfiable" | null;
+type ParsedByteRange = { start: number; end: number } | "unsatisfiable" | null;
 
 /**
  * Parse a single-range `Range: bytes=…` header against a known file size.
@@ -240,8 +239,6 @@ type ParsedByteRange = { start: number; end: number; openEnded: boolean } | "uns
  * syntactically malformed, multi-range, or inverted — RFC 9110 permits
  * ignoring all of these, and Chromium's <video> only sends single ranges.
  * "unsatisfiable" means a well-formed range no byte can satisfy (416).
- * `openEnded` marks `bytes=N-`, the only form whose extent the client didn't
- * bound — the caller clamps just that one.
  */
 function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRange {
   if (!rangeHeader) return null;
@@ -257,7 +254,7 @@ function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRan
     const suffix = Number(endRaw);
     if (suffix === 0) return "unsatisfiable";
     const start = Number.isSafeInteger(suffix) ? Math.max(0, size - suffix) : 0;
-    return { start, end: size - 1, openEnded: false };
+    return { start, end: size - 1 };
   }
 
   const start = Number(startRaw);
@@ -273,7 +270,6 @@ function parseByteRange(rangeHeader: string | null, size: number): ParsedByteRan
   return {
     start,
     end: end !== null && Number.isSafeInteger(end) ? Math.min(end, size - 1) : size - 1,
-    openEnded: end === null,
   };
 }
 
@@ -367,19 +363,13 @@ async function streamContainedVideoFile(
     });
   }
 
+  // Serve the requested range in full — never a shorter chunk. Chromium's
+  // custom-scheme media loader is single-shot: it treats a response body that
+  // ends before the requested range as the entire resource (the Content-Range
+  // total is not consulted for a re-request), so a truncated 206 silently cuts
+  // the video off at the truncation point (#11382 follow-up).
   const start = range ? range.start : 0;
-  // Clamp only open-ended ranges: explicit and suffix ranges are already
-  // bounded by what the client asked for (clamping a suffix would drop the
-  // file tail — exactly what an mp4 with trailing moov metadata needs), but
-  // `bytes=N-` requests "everything from N". Serving that in bounded chunks is
-  // safe: the Content-Range total tells Chromium more remains and it
-  // re-requests as playback advances.
-  const end =
-    range && range.openEnded
-      ? Math.min(range.end, range.start + DAINTREE_VIDEO_RANGE_MAX_BYTES - 1)
-      : range
-        ? range.end
-        : size - 1;
+  const end = range ? range.end : size - 1;
   const contentLength = end - start + 1;
 
   // autoClose ties the fd's lifetime to the stream: it closes on end, error,

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -525,7 +525,14 @@ function daintreeFileCorsOrigin(request: GlobalRequest): string | null {
   const origin = request.headers.get("origin");
   if (!origin) return null;
   if (origin === "app://daintree") return origin;
-  if (process.env.NODE_ENV === "development" && getDevServerOrigins().includes(origin)) {
+  // The dev-server allowance additionally requires an unpackaged build so a
+  // packaged app launched with NODE_ENV=development in its environment can't
+  // widen the trust set to localhost origins.
+  if (
+    !app.isPackaged &&
+    process.env.NODE_ENV === "development" &&
+    getDevServerOrigins().includes(origin)
+  ) {
     return origin;
   }
   return null;

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -18,6 +18,7 @@ import {
   DAINTREE_APP_PERMISSIONS_POLICY,
   buildAppPermissionsPolicy,
 } from "../../shared/config/permissionsPolicy.js";
+import { getDevServerOrigins } from "../../shared/config/devServer.js";
 import {
   classifyPartition,
   getDaintreeAppCSP,
@@ -511,9 +512,43 @@ async function readContainedDaintreeFile(
 }
 
 /**
+ * The origin allowed to read this daintree-file:// response via cross-origin
+ * fetch(), or null for everyone else. The scheme is corsEnabled so the file
+ * viewer can fetch() video bytes for blob-URL playback, but eligibility alone
+ * must not grant reads: a browser panel hosting an arbitrary remote site
+ * shares the scheme registration, and echoing its origin here would hand it
+ * the user's local files. Only the trusted app document qualifies — app:// in
+ * production, the Vite dev-server origins in development. Tag loads (<img>,
+ * <video>) are no-cors and never consult this.
+ */
+function daintreeFileCorsOrigin(request: GlobalRequest): string | null {
+  const origin = request.headers.get("origin");
+  if (!origin) return null;
+  if (origin === "app://daintree") return origin;
+  if (process.env.NODE_ENV === "development" && getDevServerOrigins().includes(origin)) {
+    return origin;
+  }
+  return null;
+}
+
+/**
  * Create the daintree-file:// protocol handler function.
  */
 function createDaintreeFileProtocolHandler() {
+  const handleRequest = createDaintreeFileRequestCore();
+  return async (request: GlobalRequest) => {
+    const response = await handleRequest(request);
+    // Constructed Responses have mutable headers, so the CORS grant rides on
+    // every path (success and error alike) — a blocked error response would
+    // otherwise surface as an opaque TypeError instead of a readable status.
+    const corsOrigin = daintreeFileCorsOrigin(request);
+    if (corsOrigin) response.headers.set("Access-Control-Allow-Origin", corsOrigin);
+    return response;
+  };
+}
+
+/** The daintree-file:// request core, minus the CORS header pass. */
+function createDaintreeFileRequestCore() {
   return async (request: GlobalRequest) => {
     if (request.method !== "GET" && request.method !== "HEAD") {
       return new Response("Method Not Allowed", {

--- a/scripts/baselines/eslint-warnings-baseline.json
+++ b/scripts/baselines/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1105,
+  "count": 1102,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 51,
     "@typescript-eslint/no-floating-promises": 85,
-    "@typescript-eslint/no-unsafe-type-assertion": 485,
+    "@typescript-eslint/no-unsafe-type-assertion": 483,
     "no-restricted-imports": 5,
-    "no-restricted-syntax": 371,
+    "no-restricted-syntax": 370,
     "no-useless-assignment": 16,
     "preserve-caught-error": 42,
     "react-compiler/react-compiler": 15,
-    "react-hooks/exhaustive-deps": 35
+    "react-hooks/exhaustive-deps": 34
   },
-  "updatedAt": "2026-07-22T18:23:09.562Z"
+  "updatedAt": "2026-07-24T04:37:26.251Z"
 }

--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -125,10 +125,13 @@ describe("Daintree app CSP", () => {
   });
 
   describe("daintree-file: scheme in media-src (#11382)", () => {
-    // The file viewer plays videos via <video src="daintree-file://…">, Range-
-    // streamed by the protocol handler. media-src is the directive that governs
-    // that load; without the scheme the element is silently blocked with only a
-    // devtools warning — every protocol/MIME fix upstream still fails.
+    // The file viewer fetch()es video bytes from daintree-file:// and plays
+    // them through a blob object URL (Chromium's custom-scheme media loader
+    // can't consume follow-up range requests — electron#51442), so media-src
+    // must allow blob:. daintree-file: stays for consumers that stream media
+    // from the scheme without the blob detour. Without either entry the
+    // element is silently blocked with only a devtools warning — every
+    // protocol/MIME fix upstream still fails.
     it("allows daintree-file: in media-src in production", () => {
       const mediaSrc = getDaintreeAppProdCSP().match(/media-src ([^;]*);/)?.[1];
       expect(mediaSrc).toContain("daintree-file:");
@@ -137,6 +140,16 @@ describe("Daintree app CSP", () => {
     it("allows daintree-file: in media-src in development", () => {
       const mediaSrc = getDaintreeAppDevCSP().match(/media-src ([^;]*);/)?.[1];
       expect(mediaSrc).toContain("daintree-file:");
+    });
+
+    it("allows blob: in media-src in production", () => {
+      const mediaSrc = getDaintreeAppProdCSP().match(/media-src ([^;]*);/)?.[1];
+      expect(mediaSrc).toContain("blob:");
+    });
+
+    it("allows blob: in media-src in development", () => {
+      const mediaSrc = getDaintreeAppDevCSP().match(/media-src ([^;]*);/)?.[1];
+      expect(mediaSrc).toContain("blob:");
     });
   });
 

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -105,9 +105,12 @@ export function getDaintreeAppProdCSP(options?: DaintreeCspOptions): string {
     `connect-src 'self' ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
     `img-src 'self' ${GITHUB_AVATARS} ${GRAVATAR} ${DAINTREE_DOCS} ${FILE_SCHEMES} data: blob:`,
     "font-src 'self' data:",
-    // FILE_SCHEMES: the file viewer plays videos straight from daintree-file://
-    // (Range-streamed by the protocol handler) via <video src>.
-    `media-src 'self' ${FILE_SCHEMES}`,
+    // blob:: the file viewer fetch()es video bytes from daintree-file:// and
+    // plays them through a blob object URL — Chromium's custom-scheme media
+    // loader can't consume follow-up range requests (electron#51442), so
+    // <video src> never points at FILE_SCHEMES directly. FILE_SCHEMES stays
+    // for WebAudio-style consumers that stream media without the blob detour.
+    `media-src 'self' ${FILE_SCHEMES} blob:`,
     "worker-src 'self' blob:",
     `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",
@@ -141,7 +144,8 @@ export function getDaintreeAppDevCSP(): string {
     `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
     `img-src 'self' ${origins} ${GITHUB_AVATARS} ${GRAVATAR} ${DAINTREE_DOCS} ${FILE_SCHEMES} data: blob:`,
     `font-src 'self' ${origins} data:`,
-    `media-src 'self' ${FILE_SCHEMES}`,
+    // blob: mirrors the production policy — see getDaintreeAppProdCSP.
+    `media-src 'self' ${FILE_SCHEMES} blob:`,
     "worker-src 'self' blob:",
     `frame-src 'self' ${HTML_PREVIEW_SCHEME} ${FRAME_LOCALHOST}`,
     "object-src 'none'",

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -51,6 +51,10 @@ export function FileVideoPreview({
         key={src}
         src={src}
         controls
+        // No fullscreen or PiP: both detach playback from the pane into
+        // window-level surfaces the IDE's window/view management doesn't own.
+        controlsList="nofullscreen"
+        disablePictureInPicture
         preload="metadata"
         aria-label={label}
         className={`max-w-full ${maxHeightClassName} rounded`}

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import { Spinner } from "@/components/ui/Spinner";
 import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
@@ -9,7 +9,7 @@ import { buildDaintreeFileUrl } from "./filePreviewKinds";
 // runs ~10MB/min; 1GiB covers over an hour before the viewer says no.
 const VIDEO_PREVIEW_MAX_BYTES = 1024 * 1024 * 1024;
 
-export const VIDEO_TOO_LARGE_MESSAGE = "This video is too large to preview";
+const VIDEO_TOO_LARGE_MESSAGE = "This video is too large to preview";
 
 interface FileVideoPreviewProps {
   /** Absolute path of the video being previewed. */
@@ -65,11 +65,10 @@ export function FileVideoPreview({
   const [fetching, setFetching] = useState(true);
   const showSpinner = useDeferredLoading(fetching, UI_DOHERTY_THRESHOLD);
 
-  // Ref'd so the fetch effect keys on `src` alone — callers pass inline
-  // closures, and refetching the file on every parent render would discard
-  // playback position each time anything else in the pane changes.
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  // Effect events so the fetch effect keys on `src` alone — callers pass
+  // inline closures, and refetching the file on every parent render would
+  // discard playback position each time anything else in the pane changes.
+  const reportError = useEffectEvent((message?: string) => onError?.(message));
 
   useEffect(() => {
     const controller = new AbortController();
@@ -79,18 +78,25 @@ export function FileVideoPreview({
 
     void fetch(src, { signal: controller.signal })
       .then(async (response) => {
+        // Guarded before any state write: an already-settled fetch promise can
+        // run this reaction after cleanup aborted it, and reporting then would
+        // clear the spinner / flag an error on the file shown NEXT.
+        if (controller.signal.aborted) return;
         if (!response.ok) throw new Error(`daintree-file responded ${response.status}`);
         const declaredLength = Number(response.headers.get("content-length"));
         if (Number.isFinite(declaredLength) && declaredLength > VIDEO_PREVIEW_MAX_BYTES) {
+          // Drop the unread body so the protocol stream (and its fd) closes
+          // now rather than when the response gets collected.
+          void response.body?.cancel().catch(() => {});
           setFetching(false);
-          onErrorRef.current?.(VIDEO_TOO_LARGE_MESSAGE);
+          reportError(VIDEO_TOO_LARGE_MESSAGE);
           return;
         }
         const blob = await response.blob();
         if (controller.signal.aborted) return;
         if (blob.size > VIDEO_PREVIEW_MAX_BYTES) {
           setFetching(false);
-          onErrorRef.current?.(VIDEO_TOO_LARGE_MESSAGE);
+          reportError(VIDEO_TOO_LARGE_MESSAGE);
           return;
         }
         url = URL.createObjectURL(blob);
@@ -100,7 +106,7 @@ export function FileVideoPreview({
       .catch(() => {
         if (controller.signal.aborted) return;
         setFetching(false);
-        onErrorRef.current?.();
+        reportError();
       });
 
     return () => {
@@ -127,7 +133,7 @@ export function FileVideoPreview({
           preload="metadata"
           aria-label={label}
           className={`max-w-full ${maxHeightClassName} rounded`}
-          onError={() => onErrorRef.current?.()}
+          onError={() => onError?.()}
         />
       ) : showSpinner ? (
         <Spinner size="xl" className="text-text-secondary" />

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useEffectEvent, useMemo, useState } from "react";
-import { Spinner } from "@/components/ui/Spinner";
-import { useDeferredLoading } from "@/hooks";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { buildDaintreeFileUrl } from "./filePreviewKinds";
 
 // Blob previews hold the whole file in Chromium's blob storage (memory, then
@@ -9,7 +8,21 @@ import { buildDaintreeFileUrl } from "./filePreviewKinds";
 // runs ~10MB/min; 1GiB covers over an hour before the viewer says no.
 const VIDEO_PREVIEW_MAX_BYTES = 1024 * 1024 * 1024;
 
-const VIDEO_TOO_LARGE_MESSAGE = "This video is too large to preview";
+/** Why a preview couldn't play, split so callers can render a headline and a way forward. */
+export interface VideoPreviewError {
+  /** Names what happened. Callers with a titled error surface use it as the title. */
+  title: string;
+  /** Second line naming the next action. */
+  description?: string;
+  /** Read-error code for panes that gate their error surface on one. */
+  code?: FileReadErrorCode;
+}
+
+const VIDEO_TOO_LARGE_ERROR: VideoPreviewError = {
+  title: "This video is too large to preview",
+  description: "Open it outside Daintree to watch it.",
+  code: "FILE_TOO_LARGE",
+};
 
 interface FileVideoPreviewProps {
   /** Absolute path of the video being previewed. */
@@ -24,8 +37,8 @@ interface FileVideoPreviewProps {
    * rewritten file needs a new URL to show new bytes.
    */
   reloadKey?: string | number;
-  /** Called when the video can't be fetched or played; a message overrides the caller's generic copy. */
-  onError?: (message?: string) => void;
+  /** Called when the video can't be fetched or played; an error overrides the caller's generic copy. */
+  onError?: (error?: VideoPreviewError) => void;
   /** Height cap for the preview surface — dialogs and panes want different ones. */
   maxHeightClassName?: string;
 }
@@ -63,12 +76,11 @@ export function FileVideoPreview({
 
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const [fetching, setFetching] = useState(true);
-  const showSpinner = useDeferredLoading(fetching, UI_DOHERTY_THRESHOLD);
 
   // Effect events so the fetch effect keys on `src` alone — callers pass
   // inline closures, and refetching the file on every parent render would
   // discard playback position each time anything else in the pane changes.
-  const reportError = useEffectEvent((message?: string) => onError?.(message));
+  const reportError = useEffectEvent((error?: VideoPreviewError) => onError?.(error));
 
   useEffect(() => {
     const controller = new AbortController();
@@ -80,7 +92,7 @@ export function FileVideoPreview({
       .then(async (response) => {
         // Guarded before any state write: an already-settled fetch promise can
         // run this reaction after cleanup aborted it, and reporting then would
-        // clear the spinner / flag an error on the file shown NEXT.
+        // clear the skeleton / flag an error on the file shown NEXT.
         if (controller.signal.aborted) return;
         if (!response.ok) throw new Error(`daintree-file responded ${response.status}`);
         const declaredLength = Number(response.headers.get("content-length"));
@@ -89,14 +101,14 @@ export function FileVideoPreview({
           // now rather than when the response gets collected.
           void response.body?.cancel().catch(() => {});
           setFetching(false);
-          reportError(VIDEO_TOO_LARGE_MESSAGE);
+          reportError(VIDEO_TOO_LARGE_ERROR);
           return;
         }
         const blob = await response.blob();
         if (controller.signal.aborted) return;
         if (blob.size > VIDEO_PREVIEW_MAX_BYTES) {
           setFetching(false);
-          reportError(VIDEO_TOO_LARGE_MESSAGE);
+          reportError(VIDEO_TOO_LARGE_ERROR);
           return;
         }
         url = URL.createObjectURL(blob);
@@ -135,8 +147,19 @@ export function FileVideoPreview({
           className={`max-w-full ${maxHeightClassName} rounded`}
           onError={() => onError?.()}
         />
-      ) : showSpinner ? (
-        <Spinner size="xl" className="text-text-secondary" />
+      ) : fetching ? (
+        // The whole file downloads before playback starts, so this wait is
+        // routinely past a second and, on a long recording, past five — a
+        // skeleton in the player's shape, not a spinner. `SkeletonBone` carries
+        // the 400ms anti-flicker gate.
+        <div className="flex w-full max-w-md flex-col items-center gap-3">
+          <Skeleton label="Loading video" className="w-full">
+            <SkeletonBone className="aspect-video w-full" />
+          </Skeleton>
+          {/* Sibling, never nested: the wrapper's aria-busy silences mutations
+              inside its own subtree. */}
+          <SkeletonHint />
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -1,5 +1,15 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Spinner } from "@/components/ui/Spinner";
+import { useDeferredLoading } from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { buildDaintreeFileUrl } from "./filePreviewKinds";
+
+// Blob previews hold the whole file in Chromium's blob storage (memory, then
+// disk-backed), so cap what one preview may pull in. A 4K screen recording
+// runs ~10MB/min; 1GiB covers over an hour before the viewer says no.
+const VIDEO_PREVIEW_MAX_BYTES = 1024 * 1024 * 1024;
+
+export const VIDEO_TOO_LARGE_MESSAGE = "This video is too large to preview";
 
 interface FileVideoPreviewProps {
   /** Absolute path of the video being previewed. */
@@ -10,11 +20,12 @@ interface FileVideoPreviewProps {
   label: string;
   /**
    * Changed to force a fresh media request for the same path — the protocol
-   * serves `no-store`, but the <video> element itself never re-fetches unless
-   * its src changes, so a rewritten file needs a new URL to show new bytes.
+   * serves `no-store`, but the blob is a byte-snapshot of the fetch, so a
+   * rewritten file needs a new URL to show new bytes.
    */
   reloadKey?: string | number;
-  onError?: () => void;
+  /** Called when the video can't be fetched or played; a message overrides the caller's generic copy. */
+  onError?: (message?: string) => void;
   /** Height cap for the preview surface — dialogs and panes want different ones. */
   maxHeightClassName?: string;
 }
@@ -24,9 +35,16 @@ interface FileVideoPreviewProps {
  *
  * Shared by `FilePane`, `FileBrowserViewer`, and `DiffPane` so every surface
  * plays the same files the same way — mirroring `FileImagePreview`'s role for
- * images. The bytes stream straight from the `daintree-file://` protocol
- * (Range-aware, so seeking works without buffering the file); nothing
- * round-trips through IPC.
+ * images.
+ *
+ * The bytes are fetch()ed from the `daintree-file://` protocol into a Blob and
+ * played through an object URL rather than pointing `<video src>` at the
+ * protocol directly. Chromium's custom-scheme media loader is single-shot: it
+ * cannot consume any follow-up range request for the same resource, so every
+ * video whose moov atom trails the mdat (the default mp4 layout from most
+ * recorders) dies with a demuxer error moments after playback starts
+ * (electron/electron#51442; verified against Electron 42). fetch() doesn't go
+ * through the media loader, and a blob URL is fully seekable in-renderer.
  */
 export function FileVideoPreview({
   filePath,
@@ -43,23 +61,77 @@ export function FileVideoPreview({
     return reloadKey != null ? `${url}&v=${encodeURIComponent(reloadKey)}` : url;
   }, [filePath, rootPath, reloadKey]);
 
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [fetching, setFetching] = useState(true);
+  const showSpinner = useDeferredLoading(fetching, UI_DOHERTY_THRESHOLD);
+
+  // Ref'd so the fetch effect keys on `src` alone — callers pass inline
+  // closures, and refetching the file on every parent render would discard
+  // playback position each time anything else in the pane changes.
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let url: string | null = null;
+    setFetching(true);
+    setObjectUrl(null);
+
+    void fetch(src, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`daintree-file responded ${response.status}`);
+        const declaredLength = Number(response.headers.get("content-length"));
+        if (Number.isFinite(declaredLength) && declaredLength > VIDEO_PREVIEW_MAX_BYTES) {
+          setFetching(false);
+          onErrorRef.current?.(VIDEO_TOO_LARGE_MESSAGE);
+          return;
+        }
+        const blob = await response.blob();
+        if (controller.signal.aborted) return;
+        if (blob.size > VIDEO_PREVIEW_MAX_BYTES) {
+          setFetching(false);
+          onErrorRef.current?.(VIDEO_TOO_LARGE_MESSAGE);
+          return;
+        }
+        url = URL.createObjectURL(blob);
+        setObjectUrl(url);
+        setFetching(false);
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setFetching(false);
+        onErrorRef.current?.();
+      });
+
+    return () => {
+      controller.abort();
+      // Safe while the <video> below is unmounting with it: revoking detaches
+      // the URL from the blob for new loads; the element is gone either way.
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [src]);
+
   return (
     <div className="flex items-center justify-center p-6 min-h-[300px]">
-      <video
-        // Keyed by src so switching files (or reloading) remounts the element
-        // rather than continuing playback of the previous source.
-        key={src}
-        src={src}
-        controls
-        // No fullscreen or PiP: both detach playback from the pane into
-        // window-level surfaces the IDE's window/view management doesn't own.
-        controlsList="nofullscreen"
-        disablePictureInPicture
-        preload="metadata"
-        aria-label={label}
-        className={`max-w-full ${maxHeightClassName} rounded`}
-        onError={onError}
-      />
+      {objectUrl ? (
+        <video
+          // Keyed by the object URL so switching files (or reloading) remounts
+          // the element rather than continuing playback of the previous source.
+          key={objectUrl}
+          src={objectUrl}
+          controls
+          // No fullscreen or PiP: both detach playback from the pane into
+          // window-level surfaces the IDE's window/view management doesn't own.
+          controlsList="nofullscreen"
+          disablePictureInPicture
+          preload="metadata"
+          aria-label={label}
+          className={`max-w-full ${maxHeightClassName} rounded`}
+          onError={() => onErrorRef.current?.()}
+        />
+      ) : showSpinner ? (
+        <Spinner size="xl" className="text-text-secondary" />
+      ) : null}
     </div>
   );
 }

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -2,56 +2,135 @@
 /**
  * Shared video preview (#11382).
  *
- * jsdom does not decode media, so these tests pin the element contract — the
- * protocol URL, native controls, metadata-only preload, reload semantics — and
- * dispatch the error event manually rather than waiting on playback.
+ * jsdom does not decode media, so these tests pin the fetch→blob→object-URL
+ * contract — Chromium's custom-scheme media loader can't consume follow-up
+ * range requests (electron#51442), so the component must never point the
+ * <video> at daintree-file:// directly — and dispatch the error event manually
+ * rather than waiting on playback.
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, cleanup, fireEvent } from "@testing-library/react";
-import { afterEach } from "vitest";
-import { FileVideoPreview } from "../FileVideoPreview";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { FileVideoPreview, VIDEO_TOO_LARGE_MESSAGE } from "../FileVideoPreview";
 
-afterEach(cleanup);
+const fetchMock = vi.fn();
+const createObjectURL = vi.fn();
+const revokeObjectURL = vi.fn();
+
+function respondWith(blob: Blob, headers: Record<string, string> = {}) {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(headers),
+    blob: () => Promise.resolve(blob),
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  let nextUrl = 0;
+  createObjectURL.mockImplementation(() => `blob:app://daintree/${nextUrl++}`);
+  URL.createObjectURL = createObjectURL;
+  URL.revokeObjectURL = revokeObjectURL;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+  createObjectURL.mockReset();
+  revokeObjectURL.mockReset();
+});
 
 describe("FileVideoPreview", () => {
-  it("renders a native-controls video sourced from the daintree-file protocol", () => {
+  it("fetches from the daintree-file protocol and plays through a blob object URL", async () => {
+    respondWith(new Blob(["x"]));
     const { container } = render(
       <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" />
     );
 
-    const video = container.querySelector("video");
-    expect(video).not.toBeNull();
-    expect(video?.getAttribute("src")).toBe(
-      "daintree-file://load?path=%2Frepo%2Fdemo.mp4&root=%2Frepo"
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "daintree-file://load?path=%2Frepo%2Fdemo.mp4&root=%2Frepo",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
+    const video = container.querySelector("video");
+    expect(video?.getAttribute("src")).toMatch(/^blob:/);
     expect(video?.hasAttribute("controls")).toBe(true);
-    expect(video?.getAttribute("preload")).toBe("metadata");
+    expect(video?.getAttribute("controlslist")).toBe("nofullscreen");
+    expect(video?.hasAttribute("disablepictureinpicture")).toBe(true);
     expect(video?.getAttribute("aria-label")).toBe("demo.mp4");
   });
 
-  it("appends the reload key as a cache-busting param", () => {
-    const { container } = render(
-      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={3} />
-    );
-
-    expect(container.querySelector("video")?.getAttribute("src")).toContain("&v=3");
-  });
-
-  it("changes src when the reload key changes, forcing a fresh media request", () => {
-    const { container, rerender } = render(
+  it("refetches with the cache-busting param when the reload key changes", async () => {
+    respondWith(new Blob(["x"]));
+    const { rerender, container } = render(
       <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={1} />
     );
-    const before = container.querySelector("video")?.getAttribute("src");
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    expect(fetchMock.mock.calls[0]?.[0]).toContain("&v=1");
 
     rerender(
       <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={2} />
     );
-    const after = container.querySelector("video")?.getAttribute("src");
 
-    expect(before).not.toBe(after);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1]?.[0]).toContain("&v=2");
   });
 
-  it("forwards media errors to onError", () => {
+  it("revokes the object URL when the source changes", async () => {
+    respondWith(new Blob(["x"]));
+    const { rerender, container } = render(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={1} />
+    );
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const firstUrl = container.querySelector("video")?.getAttribute("src");
+
+    rerender(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" reloadKey={2} />
+    );
+
+    await waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith(firstUrl));
+  });
+
+  it("reports a fetch failure to onError", async () => {
+    fetchMock.mockRejectedValue(new Error("boom"));
+    const onError = vi.fn();
+    render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(onError).toHaveBeenCalledWith();
+  });
+
+  it("rejects an over-cap video by declared length without reading the body", async () => {
+    const blob = { size: 1 } as Blob;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(2 * 1024 * 1024 * 1024) }),
+      blob: () => Promise.resolve(blob),
+    });
+    const onError = vi.fn();
+    render(
+      <FileVideoPreview
+        filePath="/repo/huge.mp4"
+        rootPath="/repo"
+        label="huge.mp4"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(VIDEO_TOO_LARGE_MESSAGE));
+  });
+
+  it("forwards media element errors to onError", async () => {
+    respondWith(new Blob(["x"]));
     const onError = vi.fn();
     const { container } = render(
       <FileVideoPreview
@@ -62,6 +141,7 @@ describe("FileVideoPreview", () => {
       />
     );
 
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
     fireEvent.error(container.querySelector("video")!);
     expect(onError).toHaveBeenCalledTimes(1);
   });

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -61,6 +61,19 @@ describe("FileVideoPreview", () => {
     expect(video?.getAttribute("aria-label")).toBe("demo.mp4");
   });
 
+  it("holds a skeleton surface while the whole file downloads", () => {
+    // Never settles: the download of a large recording is exactly the wait the
+    // skeleton exists for, so the surface must be an aria-busy status region
+    // rather than an ungated spinner.
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    const { container, getByRole } = render(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" />
+    );
+
+    expect(getByRole("status").getAttribute("aria-busy")).toBe("true");
+    expect(container.querySelector("video")).toBeNull();
+  });
+
   it("refetches with the cache-busting param when the reload key changes", async () => {
     respondWith(new Blob(["x"]));
     const { rerender, container } = render(
@@ -129,9 +142,14 @@ describe("FileVideoPreview", () => {
       />
     );
 
-    // A distinct message (not the callers' generic "couldn't be played" copy)
-    // — the exact wording is the component's own to choose.
-    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(String)));
+    // A distinct titled reason (not the callers' generic "couldn't be played"
+    // copy) — the exact wording is the component's own to choose. The
+    // description carries the next action so a titled surface can show both.
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.any(String), description: expect.any(String) })
+      )
+    );
     expect(blobSpy).not.toHaveBeenCalled();
   });
 
@@ -154,7 +172,9 @@ describe("FileVideoPreview", () => {
       />
     );
 
-    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(String)));
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ title: expect.any(String) }))
+    );
   });
 
   it("does not report an error when unmounted mid-fetch", async () => {

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { FileVideoPreview, VIDEO_TOO_LARGE_MESSAGE } from "../FileVideoPreview";
+import { FileVideoPreview } from "../FileVideoPreview";
 
 const fetchMock = vi.fn();
 const createObjectURL = vi.fn();
@@ -105,16 +105,19 @@ describe("FileVideoPreview", () => {
     );
 
     await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
-    expect(onError).toHaveBeenCalledWith();
+    // No specific message — callers fall back to their generic copy.
+    expect(onError.mock.calls[0]?.[0]).toBeUndefined();
   });
 
   it("rejects an over-cap video by declared length without reading the body", async () => {
-    const blob = { size: 1 } as Blob;
+    // The declared-length gate fires before blob() is consulted, so the body
+    // can stay tiny — asserted below via the untouched blob spy.
+    const blobSpy = vi.fn(() => Promise.resolve(new Blob(["x"])));
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
       headers: new Headers({ "content-length": String(2 * 1024 * 1024 * 1024) }),
-      blob: () => Promise.resolve(blob),
+      blob: blobSpy,
     });
     const onError = vi.fn();
     render(
@@ -126,7 +129,59 @@ describe("FileVideoPreview", () => {
       />
     );
 
-    await waitFor(() => expect(onError).toHaveBeenCalledWith(VIDEO_TOO_LARGE_MESSAGE));
+    // A distinct message (not the callers' generic "couldn't be played" copy)
+    // — the exact wording is the component's own to choose.
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(String)));
+    expect(blobSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an over-cap video by blob size when no length was declared", async () => {
+    const oversized = new Blob(["x"]);
+    Object.defineProperty(oversized, "size", { value: 2 * 1024 * 1024 * 1024 });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(oversized),
+    });
+    const onError = vi.fn();
+    render(
+      <FileVideoPreview
+        filePath="/repo/huge.mp4"
+        rootPath="/repo"
+        label="huge.mp4"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(String)));
+  });
+
+  it("does not report an error when unmounted mid-fetch", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    fetchMock.mockImplementation(
+      (_url: string, opts: { signal: AbortSignal }) =>
+        new Promise((resolve, reject) => {
+          resolveFetch = resolve;
+          opts.signal.addEventListener("abort", () => reject(new DOMException("", "AbortError")));
+        })
+    );
+    const onError = vi.fn();
+    const { unmount } = render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        onError={onError}
+      />
+    );
+
+    unmount();
+    resolveFetch(undefined);
+    // Flush any queued reactions before asserting silence.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onError).not.toHaveBeenCalled();
+    expect(createObjectURL).not.toHaveBeenCalled();
   });
 
   it("forwards media element errors to onError", async () => {

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -21,6 +21,7 @@ import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
+import type { VideoPreviewError } from "@/components/FileViewer/FileVideoPreview";
 import { isVideoFilePath } from "@/components/FileViewer/filePreviewKinds";
 import { ImageDiffViewer, isImageDiffCandidate } from "@/components/FileViewer/ImageDiffViewer";
 import { DiffViewer, FULL_FILE_MAX_LINES } from "@/components/Worktree/DiffViewer";
@@ -60,6 +61,13 @@ const FULL_FILE_FALLBACK_MESSAGES: Record<FullFileUnavailableReason, string> = {
   "source-mismatch": "The file changed after this diff loaded, so only changed lines are shown",
   "too-large": `Files over ${FULL_FILE_MAX_LINES.toLocaleString()} lines stay on changed lines to keep the diff responsive`,
   unsupported: "The whole file can't be shown for this diff",
+};
+
+// Used when the preview reports a failure it can't name — a decode error gives
+// the media element no detail beyond "this didn't play".
+const GENERIC_VIDEO_ERROR: VideoPreviewError = {
+  title: "This video couldn't be played",
+  description: "The container is supported but the codec may not be — Refresh to try again.",
 };
 
 // Mirrors the ladder the modal used, so the preference keeps meaning the same
@@ -267,7 +275,7 @@ export function DiffPane({
   // An allowlisted container can still hold a codec Chromium lacks, or the
   // file may be unreadable — surface that instead of a dead native control.
   // Holds the preview's specific reason (e.g. too large) when it gives one.
-  const [videoPlaybackError, setVideoPlaybackError] = useState<string | null>(null);
+  const [videoPlaybackError, setVideoPlaybackError] = useState<VideoPreviewError | null>(null);
   useEffect(() => {
     // Any change to the playback attempt's identity — file, resolved root, or
     // an explicit refresh — gets a fresh attempt. absolutePath covers a
@@ -749,11 +757,8 @@ export function DiffPane({
                   <EmptyState
                     variant="zero-data"
                     scale="canvas"
-                    title="This video couldn't be played"
-                    description={
-                      videoPlaybackError ||
-                      "The container is supported but the codec may not be — Refresh to try again."
-                    }
+                    title={videoPlaybackError.title}
+                    description={videoPlaybackError.description}
                   />
                 </div>
               ) : (
@@ -762,7 +767,7 @@ export function DiffPane({
                   rootPath={worktreePath}
                   label={fileName ?? filePath}
                   reloadKey={videoReloadNonce}
-                  onError={(message) => setVideoPlaybackError(message ?? "")}
+                  onError={(error) => setVideoPlaybackError(error ?? GENERIC_VIDEO_ERROR)}
                   maxHeightClassName="max-h-full"
                 />
               ))}

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -266,12 +266,13 @@ export function DiffPane({
   const [videoReloadNonce, setVideoReloadNonce] = useState(0);
   // An allowlisted container can still hold a codec Chromium lacks, or the
   // file may be unreadable — surface that instead of a dead native control.
-  const [videoPlaybackFailed, setVideoPlaybackFailed] = useState(false);
+  // Holds the preview's specific reason (e.g. too large) when it gives one.
+  const [videoPlaybackError, setVideoPlaybackError] = useState<string | null>(null);
   useEffect(() => {
     // Any change to the playback attempt's identity — file, resolved root, or
     // an explicit refresh — gets a fresh attempt. absolutePath covers a
     // worktree move that filePath (relative) alone would miss.
-    setVideoPlaybackFailed(false);
+    setVideoPlaybackError(null);
   }, [filePath, absolutePath, worktreePath, videoReloadNonce]);
 
   const [pathCopied, setPathCopied] = useState(false);
@@ -743,13 +744,16 @@ export function DiffPane({
                     description="This video was deleted, and the diff view can only play the current file."
                   />
                 </div>
-              ) : videoPlaybackFailed ? (
+              ) : videoPlaybackError !== null ? (
                 <div className="flex h-full w-full items-center justify-center p-6">
                   <EmptyState
                     variant="zero-data"
                     scale="canvas"
                     title="This video couldn't be played"
-                    description="The container is supported but the codec may not be — Refresh to try again."
+                    description={
+                      videoPlaybackError ||
+                      "The container is supported but the codec may not be — Refresh to try again."
+                    }
                   />
                 </div>
               ) : (
@@ -758,7 +762,7 @@ export function DiffPane({
                   rootPath={worktreePath}
                   label={fileName ?? filePath}
                   reloadKey={videoReloadNonce}
-                  onError={() => setVideoPlaybackFailed(true)}
+                  onError={(message) => setVideoPlaybackError(message ?? "")}
                   maxHeightClassName="max-h-full"
                 />
               ))}

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -44,8 +44,12 @@ vi.mock("@/components/FileViewer/ImageDiffViewer", () => ({
   isImageDiffCandidate: isImageDiffCandidateMock,
 }));
 vi.mock("@/components/ui/EmptyState", () => ({
-  EmptyState: (props: { title: string }) => (
-    <div data-testid="empty-state-mock" data-title={props.title} />
+  EmptyState: (props: { title: string; description?: string }) => (
+    <div
+      data-testid="empty-state-mock"
+      data-title={props.title}
+      data-description={props.description}
+    />
   ),
 }));
 
@@ -650,6 +654,33 @@ describe("DiffPane — video current-version mode (#11382)", () => {
       (el) => el.getAttribute("data-title")
     );
     expect(titles).toContain("This video couldn't be played");
+  });
+
+  it("headlines the preview's own reason rather than repeating it under a generic title", async () => {
+    videoFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(2 * 1024 * 1024 * 1024) }),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    seedPanel({
+      filePath: "media/demo.mp4",
+      fileStatus: "modified",
+      changeSet: [entry("media/demo.mp4")],
+    });
+    const { container } = renderPane();
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="empty-state-mock"]')).not.toBeNull()
+    );
+    const state = container.querySelector('[data-testid="empty-state-mock"]')!;
+    const title = state.getAttribute("data-title") ?? "";
+    const description = state.getAttribute("data-description") ?? "";
+    // The refusal is its own headline — the generic playback-failure title would
+    // be wrong (nothing failed to play) and would restate the description.
+    expect(title).not.toBe("This video couldn't be played");
+    expect(description).toBeTruthy();
+    expect(description).not.toContain(title);
   });
 
   it("shows a quiet empty state for a deleted video (no working-tree bytes to play)", () => {

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { ReactNode } from "react";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitStatus } from "@shared/types/git";
 import type { DiffChangeSetEntry } from "@shared/types/git";
@@ -561,16 +561,38 @@ describe("DiffPane — unresolvable subject", () => {
 });
 
 describe("DiffPane — video current-version mode (#11382)", () => {
-  it("plays the working-tree version instead of rendering a diff", () => {
+  // FileVideoPreview fetch()es the bytes and plays a blob object URL —
+  // Chromium's custom-scheme media loader can't do follow-up range requests
+  // (electron#51442) — so the suite stubs the fetch/object-URL boundary.
+  const videoFetchMock = vi.fn();
+  beforeEach(() => {
+    videoFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    vi.stubGlobal("fetch", videoFetchMock);
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/video-${objectUrlSequence++}`);
+    URL.revokeObjectURL = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    videoFetchMock.mockReset();
+  });
+
+  it("plays the working-tree version instead of rendering a diff", async () => {
     const changeSet = [entry("media/demo.mp4")];
     seedPanel({ filePath: "media/demo.mp4", fileStatus: "modified", changeSet });
     const { container } = renderPane();
 
-    const video = container.querySelector("video");
-    expect(video).not.toBeNull();
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
     // The absolute working-tree path rides the protocol URL — no diff content,
     // no base64 diffMedia IPC (8 MB cap, unsuited to video).
-    expect(video?.getAttribute("src")).toContain(encodeURIComponent("/repo/media/demo.mp4"));
+    expect(String(videoFetchMock.mock.calls[0]?.[0])).toContain(
+      encodeURIComponent("/repo/media/demo.mp4")
+    );
     expect(screen.queryByTestId("diff-viewer-mock")).toBeNull();
   });
 
@@ -586,7 +608,7 @@ describe("DiffPane — video current-version mode (#11382)", () => {
     expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
   });
 
-  it("reloads the video from the toolbar Refresh (nonce-busted URL) and still retries the diff", () => {
+  it("reloads the video from the toolbar Refresh (nonce-busted refetch) and still retries the diff", async () => {
     const retry = vi.fn();
     useDiffContentMock.mockReturnValue({ content: "diff --git a/x b/x", stale: false, retry });
     seedPanel({
@@ -595,24 +617,31 @@ describe("DiffPane — video current-version mode (#11382)", () => {
       changeSet: [entry("media/demo.mp4")],
     });
     const { container } = renderPane();
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
     const before = container.querySelector("video")?.getAttribute("src");
-    expect(before).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 
-    const after = container.querySelector("video")?.getAttribute("src");
-    expect(after).toBeTruthy();
-    expect(after).not.toBe(before);
+    // A bumped nonce must produce a fresh protocol fetch (new &v= param) and a
+    // new blob URL — the old element would otherwise keep playing stale bytes.
+    await waitFor(() => expect(videoFetchMock).toHaveBeenCalledTimes(2));
+    expect(String(videoFetchMock.mock.calls[1]?.[0])).not.toBe(
+      String(videoFetchMock.mock.calls[0]?.[0])
+    );
+    await waitFor(() =>
+      expect(container.querySelector("video")?.getAttribute("src")).not.toBe(before)
+    );
     expect(retry).toHaveBeenCalledTimes(1);
   });
 
-  it("shows a playback-failure state instead of a dead control on media error", () => {
+  it("shows a playback-failure state instead of a dead control on media error", async () => {
     seedPanel({
       filePath: "media/demo.mp4",
       fileStatus: "modified",
       changeSet: [entry("media/demo.mp4")],
     });
     const { container } = renderPane();
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
 
     fireEvent.error(container.querySelector("video")!);
 

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -473,8 +473,11 @@ export function FileBrowserViewer({
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              onError={(message) =>
-                setState({ status: "error", message: message ?? "This video couldn't be played" })
+              onError={(error) =>
+                setState({
+                  status: "error",
+                  message: error?.title ?? "This video couldn't be played",
+                })
               }
               maxHeightClassName="max-h-full"
             />

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -473,8 +473,8 @@ export function FileBrowserViewer({
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              onError={() =>
-                setState({ status: "error", message: "This video couldn't be played" })
+              onError={(message) =>
+                setState({ status: "error", message: message ?? "This video couldn't be played" })
               }
               maxHeightClassName="max-h-full"
             />

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, act, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // FileBrowserViewer is the read-only preview beside the tree. #11319 adds a
 // Source/Rendered toggle for markdown, mirroring FilePane. Mock the heavy leaf
@@ -248,15 +248,34 @@ describe("FileBrowserViewer tree-sidebar toggle (#11328)", () => {
 });
 
 describe("FileBrowserViewer video preview (#11382)", () => {
+  // FileVideoPreview fetch()es the bytes and plays a blob object URL —
+  // Chromium's custom-scheme media loader can't do follow-up range requests
+  // (electron#51442) — so the suite stubs the fetch/object-URL boundary.
+  const videoFetchMock = vi.fn();
+  beforeEach(() => {
+    videoFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    vi.stubGlobal("fetch", videoFetchMock);
+    URL.createObjectURL = vi.fn(() => "blob:app://daintree/video-preview");
+    URL.revokeObjectURL = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    videoFetchMock.mockReset();
+  });
+
   it("renders a <video> for a playable container without reading the file as text", async () => {
     const { container } = renderViewer("/repo/media/demo.webm");
-    await act(async () => {});
 
-    const video = container.querySelector("video");
-    expect(video).not.toBeNull();
-    expect(video?.getAttribute("src")).toContain("daintree-file://");
-    // The bytes stream through the protocol handler; the text-read IPC path
-    // (whose 500 KB cap produced the misleading error) must never run.
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    // The bytes come from the protocol handler via fetch; the text-read IPC
+    // path (whose 500 KB cap produced the misleading error) must never run.
+    expect(String(videoFetchMock.mock.calls[0]?.[0])).toContain("daintree-file://");
+    expect(container.querySelector("video")?.getAttribute("src")).toMatch(/^blob:/);
     expect(readMock).not.toHaveBeenCalled();
   });
 

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -936,11 +936,11 @@ export function FilePane({
             rootPath={effectiveRootPath}
             label={fileName ?? filePath}
             reloadKey={reloadNonce}
-            onError={() => {
+            onError={(message) => {
               // An allowlisted container can still hold a codec Chromium lacks;
               // name that instead of implying the file is missing.
               setErrorCode("BINARY_FILE");
-              setErrorMessage("This video couldn't be played");
+              setErrorMessage(message ?? "This video couldn't be played");
               setLoadState("error");
             }}
             maxHeightClassName="max-h-full"

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -936,11 +936,11 @@ export function FilePane({
             rootPath={effectiveRootPath}
             label={fileName ?? filePath}
             reloadKey={reloadNonce}
-            onError={(message) => {
+            onError={(error) => {
               // An allowlisted container can still hold a codec Chromium lacks;
               // name that instead of implying the file is missing.
-              setErrorCode("BINARY_FILE");
-              setErrorMessage(message ?? "This video couldn't be played");
+              setErrorCode(error?.code ?? "BINARY_FILE");
+              setErrorMessage(error?.title ?? "This video couldn't be played");
               setLoadState("error");
             }}
             maxHeightClassName="max-h-full"

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1013,14 +1013,34 @@ describe("FilePane diff mode (#11274)", () => {
   });
 
   describe("video preview (#11382)", () => {
+    // FileVideoPreview fetch()es the bytes and plays a blob object URL —
+    // Chromium's custom-scheme media loader can't do follow-up range requests
+    // (electron#51442) — so the suite stubs the fetch/object-URL boundary.
+    const videoFetchMock = vi.fn();
+    beforeEach(() => {
+      videoFetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      });
+      vi.stubGlobal("fetch", videoFetchMock);
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/video-preview");
+      URL.revokeObjectURL = vi.fn();
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      videoFetchMock.mockReset();
+    });
+
     it("renders a <video> for a playable container without reading the file as text", async () => {
       const { container } = await renderPane({ filePath: "/repo/media/demo.mp4" });
 
-      const video = container.querySelector("video");
-      expect(video).not.toBeNull();
-      expect(video?.getAttribute("src")).toContain("daintree-file://");
-      // The bytes stream through the protocol handler; the text-read IPC path
-      // (whose 500 KB cap produced the misleading error) must never run.
+      await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+      // The bytes come from the protocol handler via fetch; the text-read IPC
+      // path (whose 500 KB cap produced the misleading error) must never run.
+      expect(String(videoFetchMock.mock.calls[0]?.[0])).toContain("daintree-file://");
+      expect(container.querySelector("video")?.getAttribute("src")).toMatch(/^blob:/);
       expect(readMock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Videos opened in the file browser played for under a second and then showed a playback error. The root cause is that Chromium's custom-scheme media loader is single-shot: it can't consume a second range request for the same resource (electron/electron#51442), so any mp4 with its moov index at the end of the file always failed. We were also clamping open-ended ranges to 8MB in the protocol handler, and since Chromium treats a truncated response as the whole resource, even well-formed faststart files were cut off.

The fix is to have the video preview component fetch the bytes over the `daintree-file://` protocol and play them through a blob object URL. This gives a fully seekable video without touching the broken media loader path.

Supporting changes:

- The `daintree-file` scheme is now `corsEnabled`, with `Access-Control-Allow-Origin` echoed only for trusted app origins (`app://daintree` in production, dev-server origins in unpackaged dev builds). Browser panels never get the protocol registered, so remote content gains no access.
- `blob:` added to the `media-src` content security policy.
- The 8MB range clamp is removed, so `bytes=N-` requests stream to the end of the file. Memory stays chunk-bounded since the response is a backpressured stream.
- Videos over 1GiB show a specific too-large message instead of loading into blob storage.
- The fullscreen and picture-in-picture buttons are removed from the player controls. Both detach playback into window-level surfaces the IDE doesn't manage.

The diagnosis was verified with a standalone Electron 42 repro. Unit tests cover the CORS gate, and the full local CI suite passes (check, all unit tests, build, smoke).