### PR TITLE
fix(sidebar): anchor deleted-worktree ghosts to a neighbour id, not a raw slot

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1259,10 +1259,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     const pinnedSet = new Set(pinnedWorktrees);
     let nextRowIndex = firstScrollableRowIndex;
 
-    // Deleted worktrees hold the slot their row occupied when it was deleted,
-    // so the terminals the user is looking for stay where they left them
-    // instead of jumping to an edge of the list (#11232). Ties and unknown
-    // positions fall back to deletion order for a stable render.
+    // Deleted worktrees anchor their row to the live neighbour it sat above
+    // when it was deleted, so the terminals the user is looking for stay where
+    // they left them instead of jumping to an edge of the list (#11232). Ties
+    // and gone anchors fall back to deletion order / trailing for a stable
+    // render. `dragStartOrder` is the live filtered id order (see line ~1060).
     const deletedList = Array.from(deletedWorktrees.values()).sort(
       (a, b) => a.deletedAt - b.deletedAt
     );
@@ -1271,7 +1272,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       groupSlot,
       byIndex: deletedByIndex,
       trailing: trailingDeleted,
-    } = planDeletedWorktreePlacement(deletedList, filteredWorktrees.length);
+    } = planDeletedWorktreePlacement(deletedList, dragStartOrder);
     const hasGroupSlot = groupSlot >= 0;
     const pushDeleted = (deleted: DeletedWorktree) => {
       items.push({

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1246,9 +1246,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // grouped path interleaves sticky header sentinels with static rows; the
   // ungrouped path emits sortable rows so dnd-kit's SortableContext can
   // wrap the whole Virtuoso surface.
-  // Publish the visible order so a worktree deleted later can pin its row to
-  // the slot it currently occupies (#11232). Recorded from an effect rather
-  // than during render because it is a write to module state — reading it
+  // Publish the visible order so a worktree deleted later can anchor its row to
+  // the live successor it currently precedes (#11232). Recorded from an effect
+  // rather than during render because it is a write to module state — reading it
   // happens once, at deletion, well after this has settled.
   useEffect(() => {
     recordSidebarWorktreeOrder(filteredWorktrees.map((w) => w.id));

--- a/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeCard.test.tsx
@@ -98,7 +98,7 @@ const worktree: DeletedWorktree = {
   deletedAt: 1000,
   expiresAt: null,
   holdReason: null,
-  pinnedIndex: 2,
+  pinnedBeforeWorktreeId: null,
 };
 
 const originalSelectWorktree = useWorktreeSelectionStore.getState().selectWorktree;

--- a/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
+++ b/src/components/Sidebar/__tests__/DeletedWorktreeGroup.test.tsx
@@ -96,7 +96,7 @@ function makeDeleted(id: string, title: string, expiresAt: number | null = null)
     deletedAt: 1000,
     expiresAt,
     holdReason: null,
-    pinnedIndex: -1,
+    pinnedBeforeWorktreeId: null,
   };
 }
 

--- a/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
+++ b/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 import { planDeletedWorktreePlacement } from "../deletedWorktreePlacement";
 import type { DeletedWorktree } from "@/store/worktreeStore";
 
-function deleted(id: string, pinnedIndex: number): DeletedWorktree {
+function deleted(id: string, pinnedBeforeWorktreeId: string | null): DeletedWorktree {
   return {
     id,
     title: id,
@@ -19,79 +19,150 @@ function deleted(id: string, pinnedIndex: number): DeletedWorktree {
     deletedAt: 1000,
     expiresAt: null,
     holdReason: null,
-    pinnedIndex,
+    pinnedBeforeWorktreeId,
   };
 }
 
 describe("planDeletedWorktreePlacement", () => {
-  it("leaves a lone deleted row ungrouped", () => {
-    const plan = planDeletedWorktreePlacement([deleted("a", 1)], 5);
+  it("leaves a lone deleted row ungrouped at its resolved anchor slot", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", "b")], ["x", "b", "c"]);
 
     expect(plan.isGrouped).toBe(false);
     expect(plan.groupSlot).toBe(-1);
     expect(plan.byIndex.get(1)).toHaveLength(1);
   });
 
-  it("groups from the second deleted row on", () => {
-    const plan = planDeletedWorktreePlacement([deleted("a", 1), deleted("b", 3)], 5);
+  it("resolves an anchor that sits at index 0", () => {
+    // Slot 0 must be treated as a resolved slot, not a falsy miss.
+    const plan = planDeletedWorktreePlacement([deleted("a", "b")], ["b"]);
 
-    expect(plan.isGrouped).toBe(true);
+    expect(plan.byIndex.get(0)?.map((d) => d.id)).toEqual(["a"]);
+    expect(plan.trailing).toHaveLength(0);
   });
 
-  it("puts the group at the earliest slot any member held", () => {
+  it("groups from the second deleted row on", () => {
     const plan = planDeletedWorktreePlacement(
-      [deleted("a", 3), deleted("b", 1), deleted("c", 4)],
-      5
+      [deleted("a", "b"), deleted("b", "d")],
+      ["x", "b", "y", "d"]
     );
 
-    expect(plan.groupSlot).toBe(1);
+    expect(plan.isGrouped).toBe(true);
   });
 
-  it("trails the group when no member held a visible slot", () => {
-    const plan = planDeletedWorktreePlacement([deleted("a", -1), deleted("b", -1)], 5);
+  it("puts the group at the earliest slot any member's anchor resolves to", () => {
+    const plan = planDeletedWorktreePlacement(
+      [deleted("a", "d"), deleted("b", "b"), deleted("c", "e")],
+      ["b", "c", "d", "e"]
+    );
+
+    // anchors resolve to: d→2, b→0, e→3; earliest is 0.
+    expect(plan.groupSlot).toBe(0);
+  });
+
+  it("trails the group when no member's anchor is visible", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", null), deleted("b", null)], ["x", "y"]);
 
     expect(plan.isGrouped).toBe(true);
     expect(plan.groupSlot).toBe(-1);
     expect(plan.trailing).toHaveLength(2);
   });
 
-  it("never claims a slot past the end of the filtered list", () => {
-    // A pin recorded before a filter narrowed the list points past the end.
-    // Claiming it would strand the group at an index the render loop never
-    // reaches, dropping every deleted row — and its rescuable terminals —
-    // out of the sidebar entirely.
-    const plan = planDeletedWorktreePlacement([deleted("a", 9), deleted("b", 7)], 3);
+  it("trails a row whose anchor was filtered out even when the list is non-empty", () => {
+    // The anchor is a real id, just not currently in the visible order — so the
+    // row cannot claim a slot; it trails rather than reclaiming a coincidental
+    // index.
+    const plan = planDeletedWorktreePlacement([deleted("a", "gone")], ["x", "y", "z"]);
 
-    expect(plan.groupSlot).toBe(-1);
-    expect(plan.trailing).toHaveLength(2);
     expect(plan.byIndex.size).toBe(0);
+    expect(plan.trailing.map((d) => d.id)).toEqual(["a"]);
   });
 
-  it("still uses an in-range slot when only some pins went out of range", () => {
-    const plan = planDeletedWorktreePlacement([deleted("a", 9), deleted("b", 2)], 3);
+  it("keeps a mixed group at the resolved slot with the unresolved member trailing", () => {
+    const plan = planDeletedWorktreePlacement(
+      [deleted("a", "gone"), deleted("b", "c")],
+      ["x", "c", "y"]
+    );
 
-    expect(plan.groupSlot).toBe(2);
+    expect(plan.isGrouped).toBe(true);
+    expect(plan.groupSlot).toBe(1);
     expect(plan.trailing.map((d) => d.id)).toEqual(["a"]);
   });
 
   it("handles an empty list without inventing a group", () => {
-    const plan = planDeletedWorktreePlacement([], 3);
+    const plan = planDeletedWorktreePlacement([], ["x", "y", "z"]);
 
     expect(plan.isGrouped).toBe(false);
     expect(plan.groupSlot).toBe(-1);
     expect(plan.trailing).toHaveLength(0);
   });
 
-  it("trails everything when the filtered list is empty", () => {
-    const plan = planDeletedWorktreePlacement([deleted("a", 0), deleted("b", 1)], 0);
+  it("trails everything when the visible list is empty", () => {
+    const plan = planDeletedWorktreePlacement([deleted("a", "b"), deleted("b", "c")], []);
 
     expect(plan.groupSlot).toBe(-1);
     expect(plan.trailing).toHaveLength(2);
+    expect(plan.byIndex.size).toBe(0);
   });
 
-  it("keeps several rows sharing one slot together in deletion order", () => {
-    const plan = planDeletedWorktreePlacement([deleted("a", 2), deleted("b", 2)], 5);
+  it("keeps several rows sharing one anchor together in deletion order", () => {
+    const plan = planDeletedWorktreePlacement(
+      [deleted("a", "c"), deleted("b", "c")],
+      ["x", "c", "y"]
+    );
 
-    expect(plan.byIndex.get(2)?.map((d) => d.id)).toEqual(["a", "b"]);
+    expect(plan.byIndex.get(1)?.map((d) => d.id)).toEqual(["a", "b"]);
+  });
+
+  it("re-resolves an anchor once it returns to the visible order", () => {
+    const ghosts = [deleted("a", "b")];
+
+    // Filtered out: the anchor "b" is absent, so the row trails.
+    expect(planDeletedWorktreePlacement(ghosts, ["x", "y"]).trailing.map((d) => d.id)).toEqual([
+      "a",
+    ]);
+
+    // Filter cleared: "b" is visible again, so the row reclaims its slot.
+    const restored = planDeletedWorktreePlacement(ghosts, ["x", "b", "y"]);
+    expect(restored.trailing).toHaveLength(0);
+    expect(restored.byIndex.get(1)?.map((d) => d.id)).toEqual(["a"]);
+  });
+
+  it("follows its anchor when the live rows are reordered (identity, not fixed slot)", () => {
+    const ghosts = [deleted("a", "c")];
+
+    // Anchor "c" at index 1 → ghost sits at slot 1 (before "c").
+    expect(planDeletedWorktreePlacement(ghosts, ["b", "c"]).byIndex.get(1)?.map((d) => d.id)).toEqual(
+      ["a"]
+    );
+
+    // User reorders live rows; the ghost tracks "c" to its new index 0.
+    const reordered = planDeletedWorktreePlacement(ghosts, ["c", "b"]);
+    expect(reordered.byIndex.get(0)?.map((d) => d.id)).toEqual(["a"]);
+    expect(reordered.byIndex.get(1)).toBeUndefined();
+  });
+
+  it("keeps a null-anchored ungrouped ghost behind a freshly created worktree (#11400)", () => {
+    // A single last-row deletion (no successor) must never jump ahead of a new
+    // worktree that later takes index 0.
+    const plan = planDeletedWorktreePlacement([deleted("old", null)], ["new"]);
+
+    expect(plan.byIndex.size).toBe(0);
+    expect(plan.trailing.map((d) => d.id)).toEqual(["old"]);
+  });
+
+  it("keeps a grouped deleted cohort behind a freshly created worktree (#11400)", () => {
+    // Bulk-delete all worktrees, then create one: the stale top-of-list pin used
+    // to reclaim slot 0 and bump the new worktree to second position. Anchored
+    // to now-gone ids, the whole cohort trails instead.
+    const ghosts = [deleted("old-a", "old-b"), deleted("old-b", null)];
+
+    // While the list is empty, the cohort trails.
+    expect(planDeletedWorktreePlacement(ghosts, []).groupSlot).toBe(-1);
+
+    // After a new, unrelated worktree is created it stays at index 0.
+    const afterCreate = planDeletedWorktreePlacement(ghosts, ["new"]);
+    expect(afterCreate.groupSlot).toBe(-1);
+    expect(afterCreate.byIndex.size).toBe(0);
+    expect(afterCreate.trailing.map((d) => d.id)).toEqual(["old-a", "old-b"]);
   });
 });

--- a/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
+++ b/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
@@ -121,7 +121,7 @@ describe("planDeletedWorktreePlacement", () => {
       "a",
     ]);
 
-    // Filter cleared: "b" is visible again, so the row reclaims its slot.
+    // Filter cleared: "b" is visible again, so the row resolves before it once more.
     const restored = planDeletedWorktreePlacement(ghosts, ["x", "b", "y"]);
     expect(restored.trailing).toHaveLength(0);
     expect(restored.byIndex.get(1)?.map((d) => d.id)).toEqual(["a"]);

--- a/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
+++ b/src/components/Sidebar/__tests__/deletedWorktreePlacement.test.ts
@@ -131,9 +131,11 @@ describe("planDeletedWorktreePlacement", () => {
     const ghosts = [deleted("a", "c")];
 
     // Anchor "c" at index 1 → ghost sits at slot 1 (before "c").
-    expect(planDeletedWorktreePlacement(ghosts, ["b", "c"]).byIndex.get(1)?.map((d) => d.id)).toEqual(
-      ["a"]
-    );
+    expect(
+      planDeletedWorktreePlacement(ghosts, ["b", "c"])
+        .byIndex.get(1)
+        ?.map((d) => d.id)
+    ).toEqual(["a"]);
 
     // User reorders live rows; the ghost tracks "c" to its new index 0.
     const reordered = planDeletedWorktreePlacement(ghosts, ["c", "b"]);

--- a/src/components/Sidebar/deletedWorktreePlacement.ts
+++ b/src/components/Sidebar/deletedWorktreePlacement.ts
@@ -4,8 +4,9 @@ export interface DeletedWorktreePlacement {
   /** Deleted rows collapse behind one summary item instead of rendering a card each. */
   isGrouped: boolean;
   /**
-   * Slot in the filtered worktree list the group is inserted before, or `-1`
-   * when no member's anchor is still visible and the group trails the list.
+   * Slot the collapsed deleted-worktree group is inserted before, or `-1` when
+   * the group trails — either because no member's anchor still resolves, or
+   * because the cohort is too small to group (`isGrouped` is false).
    */
   groupSlot: number;
   /**
@@ -14,7 +15,11 @@ export interface DeletedWorktreePlacement {
    * that index.
    */
   byIndex: Map<number, DeletedWorktree[]>;
-  /** Deleted rows whose anchor is gone (or was never visible), appended after the live rows. */
+  /**
+   * Deleted rows whose anchor is gone (or was never visible), for the ungrouped
+   * path — appended after the live rows. A collapsed group renders as one item
+   * from the full list at `groupSlot`, so it never consults this bucket.
+   */
   trailing: DeletedWorktree[];
 }
 

--- a/src/components/Sidebar/deletedWorktreePlacement.ts
+++ b/src/components/Sidebar/deletedWorktreePlacement.ts
@@ -5,45 +5,72 @@ export interface DeletedWorktreePlacement {
   isGrouped: boolean;
   /**
    * Slot in the filtered worktree list the group is inserted before, or `-1`
-   * when no member held a visible slot and the group trails the list.
+   * when no member's anchor is still visible and the group trails the list.
    */
   groupSlot: number;
-  /** Deleted rows keyed by the visible slot they held, for the ungrouped path. */
+  /**
+   * Deleted rows keyed by the current index of their resolved successor anchor,
+   * for the ungrouped path. The render loop inserts them before the live row at
+   * that index.
+   */
   byIndex: Map<number, DeletedWorktree[]>;
-  /** Deleted rows with no visible slot, appended after the live rows. */
+  /** Deleted rows whose anchor is gone (or was never visible), appended after the live rows. */
   trailing: DeletedWorktree[];
 }
 
 /**
  * Where a sidebar's deleted rows go (#11232, #11260).
  *
- * A deleted worktree holds the slot its row occupied so the terminals the user
- * is looking for stay put, but that slot is only meaningful while it still
- * addresses the current filtered list — a pin recorded before a filter narrowed
- * the list can point past the end. Both the grouped and ungrouped paths drop
- * such a pin and fall back to trailing placement; keeping them in agreement is
- * the whole reason this is one function rather than two call sites.
+ * A deleted row records the live worktree that immediately followed it in the
+ * last published sidebar order (`pinnedBeforeWorktreeId`). While that anchor is
+ * still visible the row renders immediately before its current position, so the
+ * terminals the user is looking for stay put; otherwise the row trails. Keying
+ * off an identity rather than a raw index is what stops an unrelated worktree
+ * added later from reclaiming a stale numeric slot once the list empties and
+ * regrows past it (#11400).
+ *
+ * Placement is identity-relative, not an absolute visual slot: if the user
+ * reorders the live rows, the row follows its former successor rather than
+ * pinning to a fixed position. Both the grouped and ungrouped paths resolve the
+ * anchor the same way and fall back to trailing together; keeping them in
+ * agreement is the whole reason this is one function rather than two call sites.
+ *
+ * The anchor is a single successor, so if that exact neighbour is itself
+ * deleted in the same burst the row trails; whether an adjacent removal trails
+ * or resolves to the next survivor depends on when the visible order was last
+ * republished, and either outcome is acceptable for a ghost.
  */
 export function planDeletedWorktreePlacement(
   deletedList: readonly DeletedWorktree[],
-  visibleWorktreeCount: number
+  visibleWorktreeIds: readonly string[]
 ): DeletedWorktreePlacement {
+  const indexById = new Map<string, number>();
+  for (let i = 0; i < visibleWorktreeIds.length; i++) {
+    // First occurrence wins; ids are unique in practice, so this just guards
+    // against a duplicate leaking in without letting it shift the anchor.
+    if (!indexById.has(visibleWorktreeIds[i]!)) indexById.set(visibleWorktreeIds[i]!, i);
+  }
+
   const byIndex = new Map<number, DeletedWorktree[]>();
   const trailing: DeletedWorktree[] = [];
   for (const deleted of deletedList) {
-    if (deleted.pinnedIndex >= 0 && deleted.pinnedIndex < visibleWorktreeCount) {
-      const bucket = byIndex.get(deleted.pinnedIndex);
-      if (bucket) bucket.push(deleted);
-      else byIndex.set(deleted.pinnedIndex, [deleted]);
-    } else {
+    const slot =
+      deleted.pinnedBeforeWorktreeId == null
+        ? undefined
+        : indexById.get(deleted.pinnedBeforeWorktreeId);
+    if (slot === undefined) {
       trailing.push(deleted);
+    } else {
+      const bucket = byIndex.get(slot);
+      if (bucket) bucket.push(deleted);
+      else byIndex.set(slot, [deleted]);
     }
   }
 
   const isGrouped = deletedList.length >= DELETED_WORKTREE_GROUP_THRESHOLD;
-  // Derived from `byIndex` rather than raw `pinnedIndex`, so an out-of-range
-  // pin can never claim a slot the render loop won't reach — that would drop
-  // every deleted row out of the sidebar instead of merely misplacing it.
+  // Derived from `byIndex` rather than any raw pin, so an unresolved anchor can
+  // never claim a slot the render loop won't reach — that would drop every
+  // deleted row out of the sidebar instead of merely misplacing it.
   let groupSlot = -1;
   if (isGrouped) {
     for (const slot of byIndex.keys()) {

--- a/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
+++ b/src/components/Terminal/__tests__/ContentGridEmptyState.workspace.test.tsx
@@ -420,7 +420,7 @@ describe("ContentGridEmptyState — workspace capabilities", () => {
         deletedAt: 1000,
         expiresAt: null,
         holdReason: null,
-        pinnedIndex: -1,
+        pinnedBeforeWorktreeId: null,
       });
       useWorktreeSelectionStore.setState({ activeWorktreeId: "ghost-1" });
     });

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -11,7 +11,7 @@ import type { PluginWorktreeLinked } from "@shared/types/plugin";
 import {
   useWorktreeSelectionStore,
   getDeletedWorktreeTerminalIds,
-  getPinnedDeletedWorktreeIndex,
+  getPinnedDeletedWorktreeAnchorId,
 } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { startDeletedWorktreeCleanup } from "@/store/deletedWorktreeCleanup";
@@ -453,7 +453,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             // already spent and no window to rescue anything (#11259).
             expiresAt: null,
             holdReason: null,
-            pinnedIndex: getPinnedDeletedWorktreeIndex(event.worktreeId),
+            pinnedBeforeWorktreeId: getPinnedDeletedWorktreeAnchorId(event.worktreeId),
           });
         }
       })

--- a/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.deletedWorktree.test.tsx
@@ -343,7 +343,7 @@ describe("WorktreeStoreProvider — surviving terminals on worktree removal", ()
     expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.title).toBe("wt-1");
   });
 
-  it("pins the row to the slot it held in the sidebar", async () => {
+  it("anchors the row to the live neighbour it sat above in the sidebar", async () => {
     const { store } = await renderProvider();
     act(() => {
       store.getState().applySnapshot([makeWorktree("wt-1")], nextV());
@@ -355,7 +355,9 @@ describe("WorktreeStoreProvider — surviving terminals on worktree removal", ()
       emit("worktree-removed", removeEvent("wt-1"));
     });
 
-    expect(useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.pinnedIndex).toBe(1);
+    expect(
+      useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1")?.pinnedBeforeWorktreeId
+    ).toBe("wt-2");
   });
 
   it("creates no row when the worktree held no terminals", async () => {

--- a/src/services/terminal/__tests__/crossWorktreeMove.test.ts
+++ b/src/services/terminal/__tests__/crossWorktreeMove.test.ts
@@ -76,7 +76,7 @@ function deletedRow(id: string): DeletedWorktree {
     deletedAt: 1000,
     expiresAt: null,
     holdReason: null,
-    pinnedIndex: 0,
+    pinnedBeforeWorktreeId: null,
   };
 }
 

--- a/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.lifecycle.test.ts
@@ -68,7 +68,7 @@ function addRow(overrides: Partial<DeletedWorktree> = {}): void {
     deletedAt: NOW,
     expiresAt: null,
     holdReason: null,
-    pinnedIndex: -1,
+    pinnedBeforeWorktreeId: null,
     ...overrides,
   });
 }

--- a/src/store/__tests__/deletedWorktreeCleanup.test.ts
+++ b/src/store/__tests__/deletedWorktreeCleanup.test.ts
@@ -47,7 +47,7 @@ function addRow(overrides: Partial<DeletedWorktree> = {}): void {
     deletedAt: 0,
     expiresAt: null,
     holdReason: null,
-    pinnedIndex: -1,
+    pinnedBeforeWorktreeId: null,
     ...overrides,
   });
 }

--- a/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
+++ b/src/store/__tests__/worktreeStore.deletedWorktrees.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 import {
   useWorktreeSelectionStore,
   getDeletedWorktreeTerminalIds,
-  getPinnedDeletedWorktreeIndex,
+  getPinnedDeletedWorktreeAnchorId,
   recordSidebarWorktreeOrder,
   type DeletedWorktree,
 } from "@/store/worktreeStore";
@@ -32,7 +32,7 @@ function makeDeleted(overrides: Partial<DeletedWorktree> = {}): DeletedWorktree 
     deletedAt: 1000,
     expiresAt: null,
     holdReason: null,
-    pinnedIndex: 0,
+    pinnedBeforeWorktreeId: null,
     ...overrides,
   };
 }
@@ -77,15 +77,20 @@ describe("getDeletedWorktreeTerminalIds", () => {
   });
 });
 
-describe("pinned index", () => {
-  it("reports the slot a worktree occupied in the last recorded sidebar order", () => {
+describe("placement anchor", () => {
+  it("reports the successor a worktree sat before in the last recorded sidebar order", () => {
     recordSidebarWorktreeOrder(["a", "b", "c"]);
-    expect(getPinnedDeletedWorktreeIndex("b")).toBe(1);
+    expect(getPinnedDeletedWorktreeAnchorId("b")).toBe("c");
   });
 
-  it("reports -1 for a worktree that was not visible", () => {
+  it("reports null for the last worktree in the order (no successor)", () => {
+    recordSidebarWorktreeOrder(["a", "b", "c"]);
+    expect(getPinnedDeletedWorktreeAnchorId("c")).toBeNull();
+  });
+
+  it("reports null for a worktree that was not visible", () => {
     recordSidebarWorktreeOrder(["a", "b"]);
-    expect(getPinnedDeletedWorktreeIndex("hidden")).toBe(-1);
+    expect(getPinnedDeletedWorktreeAnchorId("hidden")).toBeNull();
   });
 });
 
@@ -98,12 +103,12 @@ describe("addDeletedWorktree", () => {
 
   it("keeps the first record when the same id is added twice", () => {
     const store = useWorktreeSelectionStore.getState();
-    store.addDeletedWorktree(makeDeleted({ deletedAt: 1000, pinnedIndex: 2 }));
-    store.addDeletedWorktree(makeDeleted({ deletedAt: 9999, pinnedIndex: 7 }));
+    store.addDeletedWorktree(makeDeleted({ deletedAt: 1000, pinnedBeforeWorktreeId: "first" }));
+    store.addDeletedWorktree(makeDeleted({ deletedAt: 9999, pinnedBeforeWorktreeId: "second" }));
 
     const stored = useWorktreeSelectionStore.getState().deletedWorktrees.get("wt-1");
     expect(stored?.deletedAt).toBe(1000);
-    expect(stored?.pinnedIndex).toBe(2);
+    expect(stored?.pinnedBeforeWorktreeId).toBe("first");
   });
 });
 

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -80,16 +80,15 @@ export interface DeletedWorktree {
   /**
    * Identity anchor for where the row renders: the id of the live worktree that
    * sat immediately after this row in the last published sidebar order (its
-   * successor). While that anchor is still visible the row renders immediately
-   * before it, holding its old slot — without trusting a raw index that a
-   * later, unrelated worktree could reclaim once the list empties and regrows
-   * past it (#11400). `null` when the row was last in the order (no successor)
-   * or was not visible at all (filtered out, or deleted before the sidebar
-   * rendered it); either way the row trails.
-   *
-   * A deleted worktree cannot re-sort like a live worktree — the git status and
-   * activity timestamps its sort keys derive from froze at deletion — so its
-   * position is anchored once here rather than recomputed.
+   * successor). The successor identity is captured once, at deletion; its
+   * current position is re-resolved every render, so the row renders just
+   * before that neighbour wherever it now sits — and follows it through a
+   * reorder — never trusting a raw index that a later, unrelated worktree could
+   * reclaim once the list empties and regrows past it (#11400). `null` when the
+   * row was last in the order (no successor) or was not visible at all (filtered
+   * out, or deleted before the sidebar rendered it). An anchor that no longer
+   * resolves trails the list — or, inside a deleted-worktree group, defers to
+   * whichever sibling's anchor still resolves.
    */
   pinnedBeforeWorktreeId: string | null;
 }

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -78,21 +78,26 @@ export interface DeletedWorktree {
    */
   holdReason: DeletedWorktreeHoldReason | null;
   /**
-   * Index the row occupied in the sidebar's scrollable list when it was
-   * deleted, so the row holds its slot instead of jumping to an edge.
+   * Identity anchor for where the row renders: the id of the live worktree that
+   * sat immediately after this row in the last published sidebar order (its
+   * successor). While that anchor is still visible the row renders immediately
+   * before it, holding its old slot — without trusting a raw index that a
+   * later, unrelated worktree could reclaim once the list empties and regrows
+   * past it (#11400). `null` when the row was last in the order (no successor)
+   * or was not visible at all (filtered out, or deleted before the sidebar
+   * rendered it); either way the row trails.
    *
-   * A deleted worktree cannot re-sort like a live worktree — the git status and activity
-   * timestamps its sort keys derive from froze at deletion — so the position
-   * is pinned once here rather than recomputed. `-1` means the row was not
-   * visible (filtered out, or deleted before the sidebar ever rendered it),
-   * in which case the row appends.
+   * A deleted worktree cannot re-sort like a live worktree — the git status and
+   * activity timestamps its sort keys derive from froze at deletion — so its
+   * position is anchored once here rather than recomputed.
    */
-  pinnedIndex: number;
+  pinnedBeforeWorktreeId: string | null;
 }
 
 /**
  * The sidebar's most recent visible worktree order, published by
- * `SidebarContent` so a deleted worktree can be pinned to the slot its row occupied.
+ * `SidebarContent` so a deleted worktree can anchor its row to the live
+ * neighbour it sat above.
  *
  * Deliberately a module-level value rather than store state: it changes on
  * every filter/sort keystroke and is read exactly once (at deletion), so
@@ -105,8 +110,16 @@ export function recordSidebarWorktreeOrder(ids: readonly string[]): void {
   lastSidebarWorktreeOrder = ids;
 }
 
-export function getPinnedDeletedWorktreeIndex(worktreeId: string): number {
-  return lastSidebarWorktreeOrder.indexOf(worktreeId);
+/**
+ * The id of the worktree that immediately followed `worktreeId` in the last
+ * published sidebar order — the anchor a deleted row renders before. `null`
+ * when `worktreeId` was last (no successor) or absent from the order; both
+ * trail. Anchoring to an id rather than an index is what stops a stale slot
+ * from being reclaimed after the list empties and regrows (#11400).
+ */
+export function getPinnedDeletedWorktreeAnchorId(worktreeId: string): string | null {
+  const index = lastSidebarWorktreeOrder.indexOf(worktreeId);
+  return index === -1 ? null : (lastSidebarWorktreeOrder[index + 1] ?? null);
 }
 
 /**


### PR DESCRIPTION
## Summary

- A deleted-worktree ghost card could reclaim a stale sidebar slot once the worktree list emptied and regrew. The ghost was pinned to the raw index it held at deletion time (`pinnedIndex` on `DeletedWorktree`), guarded only by a range check: `0 <= pinnedIndex < visibleWorktreeCount`.
- Bulk-deleting all worktrees drops the count to 0, so the pin fails the range check and the ghost trails harmlessly. Creating one new worktree brings the count back to 1, and the stale `pinnedIndex` of 0 passes the check again, inserting the ghost before the new worktree and bumping it to second position. The grouped ghost-collapsing path had the same defect.
- Fixed by replacing the raw index with a successor identity anchor: a new `pinnedBeforeWorktreeId: string | null` field storing the id of the worktree that immediately followed the deleted row in the last published sidebar order.

Resolves #11400

## Changes

- `planDeletedWorktreePlacement` now resolves each ghost's slot by looking up its anchor id in the current live visible-worktree id list (via an id-to-index `Map`) instead of trusting a raw stored index.
- If the anchor worktree is gone, the ghost trails at the end instead of reclaiming a coincidental index.
- Placement is now identity-relative: a ghost follows its neighboring worktree through a reorder, consistent with the "derive index from identity" pattern from #11077.
- No persistence involved, so no migration surface.
- Touched: `worktreeStore.ts`, `deletedWorktreePlacement.ts`, `WorktreeStoreContext.tsx`, `SidebarContent.tsx`, plus 9 test files.

## Testing

208 targeted tests pass across 10 files, including grouped and ungrouped regression tests for #11400 at the pure-function level, slot-zero resolution, filter round-trip behavior, the drag-and-drop reorder identity contract, and a case where multiple ghosts share one anchor. Branch is rebased on `origin/develop`; changed files are clean on prettier/eslint.
