### PR TITLE
fix(store): opt project-scoped stores into cross-view write merge

### DIFF
--- a/src/store/__tests__/panelLimitStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/panelLimitStore.crossViewMerge.test.ts
@@ -41,7 +41,8 @@ describe("panelLimitStore cross-view write merge (#11351)", () => {
   }
 
   function readBlob(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob;
   }
 
   beforeEach(() => {
@@ -98,7 +99,7 @@ describe("panelLimitStore cross-view write merge (#11351)", () => {
 
     // A transient, non-persisted state change (requestSeq/pendingConfirm) still
     // triggers a persist write of this stale view's unchanged limits.
-    store.getState().requestConfirmation(10, null);
+    void store.getState().requestConfirmation(10, null);
 
     const written = readBlob(backing);
     expect(written.state.hardLimit).toBe(50); // sibling's edit not clobbered

--- a/src/store/__tests__/panelLimitStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/panelLimitStore.crossViewMerge.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). The limit fields aren't project-scoped, but they're set from
+ * multiple independent surfaces across views — and the store's transient setters
+ * (`requestConfirmation` bumping `requestSeq`) trigger a persist write of the
+ * unchanged limits, so a stale view would otherwise clobber a sibling's edit.
+ */
+describe("panelLimitStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-panel-limits";
+  const VERSION = 1;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = { version: number; state: Record<string, unknown> };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readBlob(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's limit change preserves a sibling's other limit fields", async () => {
+    const backing = installLocalStorage({});
+    const { usePanelLimitStore: store } = await import("../panelLimitStore");
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({ version: VERSION, state: { confirmationLimit: 25, warningsDisabled: true } })
+    );
+
+    store.getState().setSoftWarningLimit(15);
+
+    const written = readBlob(backing);
+    expect(written.state.softWarningLimit).toBe(15); // this view's change
+    expect(written.state.confirmationLimit).toBe(25); // sibling's field survived
+    expect(written.state.warningsDisabled).toBe(true); // sibling's field survived
+  });
+
+  it("independent threshold edits from two views both survive", async () => {
+    const backing = installLocalStorage({});
+    const { usePanelLimitStore: store } = await import("../panelLimitStore");
+
+    store.getState().setSoftWarningLimit(15);
+
+    const disk = readBlob(backing);
+    disk.state.hardLimit = 50;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setConfirmationLimit(25);
+
+    const written = readBlob(backing);
+    expect(written.state.softWarningLimit).toBe(15);
+    expect(written.state.confirmationLimit).toBe(25); // this view's change
+    expect(written.state.hardLimit).toBe(50); // sibling's change survived
+  });
+
+  it("a transient confirmation-state write does not clobber a sibling's edited limit", async () => {
+    const backing = installLocalStorage({});
+    const { usePanelLimitStore: store } = await import("../panelLimitStore");
+
+    // A sibling edits the hard limit on disk.
+    backing.set(STORAGE_KEY, JSON.stringify({ version: VERSION, state: { hardLimit: 50 } }));
+
+    // A transient, non-persisted state change (requestSeq/pendingConfirm) still
+    // triggers a persist write of this stale view's unchanged limits.
+    store.getState().requestConfirmation(10, null);
+
+    const written = readBlob(backing);
+    expect(written.state.hardLimit).toBe(50); // sibling's edit not clobbered
+
+    store.getState().resolveConfirmation(false); // settle the pending promise
+  });
+});

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -12,7 +12,17 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
   const VERSION = 13;
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
 
-  type PersistedBlob = { version: number; state: Record<string, unknown> };
+  type PersistedBlob = {
+    version: number;
+    state: {
+      lastSelectedWorktreeRecipeIdByProject?: Record<string, string | null | undefined>;
+      skipPushConfirmByWorktreePath?: Record<string, boolean>;
+      showProjectPulse?: boolean;
+      reduceAnimations?: boolean;
+      dockDensity?: string;
+      [key: string]: unknown;
+    };
+  };
 
   function installLocalStorage(initial: Record<string, string>): Map<string, string> {
     const backing = new Map<string, string>(Object.entries(initial));
@@ -41,15 +51,16 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
   }
 
   function readBlob(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob;
   }
 
-  function recipeMap(blob: PersistedBlob): Record<string, unknown> {
-    return blob.state.lastSelectedWorktreeRecipeIdByProject as Record<string, unknown>;
+  function recipeMap(blob: PersistedBlob): Record<string, string | null | undefined> {
+    return blob.state.lastSelectedWorktreeRecipeIdByProject ?? {};
   }
 
-  function skipMap(blob: PersistedBlob): Record<string, unknown> {
-    return blob.state.skipPushConfirmByWorktreePath as Record<string, unknown>;
+  function skipMap(blob: PersistedBlob): Record<string, boolean> {
+    return blob.state.skipPushConfirmByWorktreePath ?? {};
   }
 
   beforeEach(() => {
@@ -92,7 +103,9 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
 
     // Sibling opts out of push-confirm for another worktree and enables reduce-motion.
     const disk = readBlob(backing);
-    (disk.state.skipPushConfirmByWorktreePath as Record<string, boolean>)["/path-b"] = true;
+    const skip = disk.state.skipPushConfirmByWorktreePath ?? {};
+    skip["/path-b"] = true;
+    disk.state.skipPushConfirmByWorktreePath = skip;
     disk.state.reduceAnimations = true;
     backing.set(STORAGE_KEY, JSON.stringify(disk));
 
@@ -112,8 +125,9 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     store.getState().setLastSelectedWorktreeRecipeIdByProject("proj-a", "recipe-a");
 
     const disk = readBlob(backing);
-    (disk.state.lastSelectedWorktreeRecipeIdByProject as Record<string, unknown>)["proj-b"] =
-      "recipe-b";
+    const recipes = disk.state.lastSelectedWorktreeRecipeIdByProject ?? {};
+    recipes["proj-b"] = "recipe-b";
+    disk.state.lastSelectedWorktreeRecipeIdByProject = recipes;
     backing.set(STORAGE_KEY, JSON.stringify(disk));
 
     // Clearing proj-a (undefined) is a deletion — it must not resurrect on merge.

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). The two id-keyed maps are the primary victims —
+ * `lastSelectedWorktreeRecipeIdByProject` (per project) and
+ * `skipPushConfirmByWorktreePath` (per worktree path). A stale view must not wipe
+ * a sibling's map entries, and every scalar defers to a sibling unless changed.
+ */
+describe("preferencesStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-preferences";
+  const VERSION = 13;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = { version: number; state: Record<string, unknown> };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readBlob(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+  }
+
+  function recipeMap(blob: PersistedBlob): Record<string, unknown> {
+    return blob.state.lastSelectedWorktreeRecipeIdByProject as Record<string, unknown>;
+  }
+
+  function skipMap(blob: PersistedBlob): Record<string, unknown> {
+    return blob.state.skipPushConfirmByWorktreePath as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's recipe write preserves a sibling project's recipe and non-default scalar", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: VERSION,
+        state: {
+          lastSelectedWorktreeRecipeIdByProject: { "proj-b": "recipe-b" },
+          showProjectPulse: false,
+        },
+      })
+    );
+
+    store.getState().setLastSelectedWorktreeRecipeIdByProject("proj-a", "recipe-a");
+
+    const written = readBlob(backing);
+    expect(recipeMap(written)).toEqual({ "proj-a": "recipe-a", "proj-b": "recipe-b" });
+    expect(written.state.showProjectPulse).toBe(false);
+  });
+
+  it("independent map and scalar changes from two views both survive", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setSkipPushConfirmForWorktree("/path-a", true);
+
+    // Sibling opts out of push-confirm for another worktree and enables reduce-motion.
+    const disk = readBlob(backing);
+    (disk.state.skipPushConfirmByWorktreePath as Record<string, boolean>)["/path-b"] = true;
+    disk.state.reduceAnimations = true;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This stale view changes a different scalar.
+    store.getState().setDockDensity("compact");
+
+    const written = readBlob(backing);
+    expect(skipMap(written)).toEqual({ "/path-a": true, "/path-b": true });
+    expect(written.state.dockDensity).toBe("compact"); // this view's change survived
+    expect(written.state.reduceAnimations).toBe(true); // sibling's change survived
+  });
+
+  it("does not resurrect a recipe entry this view cleared, and keeps a sibling's", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setLastSelectedWorktreeRecipeIdByProject("proj-a", "recipe-a");
+
+    const disk = readBlob(backing);
+    (disk.state.lastSelectedWorktreeRecipeIdByProject as Record<string, unknown>)["proj-b"] =
+      "recipe-b";
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // Clearing proj-a (undefined) is a deletion — it must not resurrect on merge.
+    store.getState().setLastSelectedWorktreeRecipeIdByProject("proj-a", undefined);
+
+    const written = readBlob(backing);
+    expect("proj-a" in recipeMap(written)).toBe(false);
+    expect(recipeMap(written)["proj-b"]).toBe("recipe-b");
+  });
+});

--- a/src/store/__tests__/terminalSearchHistoryStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/terminalSearchHistoryStore.crossViewMerge.test.ts
@@ -43,7 +43,8 @@ describe("terminalSearchHistoryStore cross-view write merge (#11351)", () => {
   }
 
   function readBlob(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob;
   }
 
   beforeEach(() => {

--- a/src/store/__tests__/terminalSearchHistoryStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/terminalSearchHistoryStore.crossViewMerge.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). A stale project view must not clobber a sibling view's
+ * concurrent writes to the same key. Mirrors the commandHistoryStore pattern:
+ * a Map-backed fake localStorage, a fresh module per test (fresh baseline =
+ * fresh WebContentsView), and a sibling simulated by mutating the backing map.
+ */
+describe("terminalSearchHistoryStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-terminal-search-history";
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = {
+    version: number;
+    state: { searches: string[]; caseSensitive: boolean; regexEnabled: boolean };
+  };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readBlob(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's toggle change preserves a sibling's searches and non-default toggle", async () => {
+    const backing = installLocalStorage({});
+    const { useTerminalSearchHistoryStore: store } = await import("../terminalSearchHistoryStore");
+
+    // A sibling view populated the shared blob before this fresh view writes.
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 0,
+        state: { searches: ["sibling"], caseSensitive: true, regexEnabled: false },
+      })
+    );
+
+    // This fresh view (null baseline) changes only a toggle — its default empty
+    // searches / regex must not clobber the sibling.
+    store.getState().setToggles(true, true);
+
+    const written = readBlob(backing);
+    expect(written.state.searches).toEqual(["sibling"]);
+    expect(written.state.caseSensitive).toBe(true);
+    expect(written.state.regexEnabled).toBe(true);
+  });
+
+  it("a stale view's addSearch preserves a sibling's concurrent search (MRU replay)", async () => {
+    const backing = installLocalStorage({});
+    const { useTerminalSearchHistoryStore: store } = await import("../terminalSearchHistoryStore");
+
+    // This view records "a" to the shared partition.
+    store.getState().addSearch("a");
+
+    // A sibling view records "b" directly to the shared blob.
+    const disk = readBlob(backing);
+    disk.state.searches = ["b", "a"];
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This stale view — which never learned about "b" — records "c".
+    store.getState().addSearch("c");
+
+    const written = readBlob(backing);
+    // "c" moves to front; the sibling's "b" survives.
+    expect(written.state.searches).toEqual(["c", "b", "a"]);
+  });
+
+  it("a toggle-only write keeps a sibling's searches and applies the independent toggle", async () => {
+    const backing = installLocalStorage({});
+    const { useTerminalSearchHistoryStore: store } = await import("../terminalSearchHistoryStore");
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 0,
+        state: { searches: ["s1", "s2"], caseSensitive: false, regexEnabled: false },
+      })
+    );
+
+    store.getState().setToggles(true, false);
+
+    const written = readBlob(backing);
+    expect(written.state.searches).toEqual(["s1", "s2"]);
+    expect(written.state.caseSensitive).toBe(true);
+    expect(written.state.regexEnabled).toBe(false);
+  });
+});

--- a/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). Focuses on the genuinely-mergeable persisted units: the
+ * `pinnedButtons` map (per button id) and the launcher scalars. A stale project
+ * view must not drop or resurrect a sibling view's plugin pin, nor revert a
+ * sibling's launcher change.
+ */
+describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-toolbar-preferences";
+  const VERSION = 11;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type Layout = {
+    leftButtons: string[];
+    rightButtons: string[];
+    pinnedButtons: Record<string, boolean>;
+  };
+  type PersistedBlob = {
+    version: number;
+    state: {
+      layout: Layout;
+      launcher: { alwaysShowDevServer: boolean; defaultSelection?: string };
+    };
+  };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readBlob(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+  }
+
+  function siblingBlob(overrides: Partial<PersistedBlob["state"]>): string {
+    return JSON.stringify({
+      version: VERSION,
+      state: {
+        layout: { leftButtons: [], rightButtons: [], pinnedButtons: {} },
+        launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
+        ...overrides,
+      },
+    });
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's pin toggle preserves a sibling's pin and non-default launcher", async () => {
+    const backing = installLocalStorage({});
+    const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
+
+    // A sibling populated the shared blob before this fresh view writes.
+    backing.set(
+      STORAGE_KEY,
+      siblingBlob({
+        layout: { leftButtons: [], rightButtons: [], pinnedButtons: { "pluginX.btn": true } },
+        launcher: { alwaysShowDevServer: true },
+      })
+    );
+
+    store.getState().toggleButtonVisibility("voice-recording", "right");
+
+    const written = readBlob(backing);
+    expect(written.state.layout.pinnedButtons["voice-recording"]).toBe(false);
+    expect(written.state.layout.pinnedButtons["pluginX.btn"]).toBe(true);
+    expect(written.state.launcher.alwaysShowDevServer).toBe(true);
+  });
+
+  it("a stale view's pin write preserves a sibling's concurrent pin and launcher change", async () => {
+    const backing = installLocalStorage({});
+    const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
+
+    // This view promotes plugin A.
+    store.getState().setPluginButtonPromoted("pluginA.btn", true);
+
+    // A sibling promotes plugin B and enables the dev-server launcher on disk.
+    const disk = readBlob(backing);
+    disk.state.layout.pinnedButtons["pluginB.btn"] = true;
+    disk.state.launcher.alwaysShowDevServer = true;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This stale view — unaware of B — promotes plugin C.
+    store.getState().setPluginButtonPromoted("pluginC.btn", true);
+
+    const written = readBlob(backing);
+    expect(written.state.layout.pinnedButtons).toMatchObject({
+      "pluginA.btn": true,
+      "pluginB.btn": true,
+      "pluginC.btn": true,
+    });
+    expect(written.state.launcher.alwaysShowDevServer).toBe(true);
+  });
+
+  it("does not resurrect a pin a sibling deleted that this view still holds unchanged", async () => {
+    const backing = installLocalStorage({
+      [STORAGE_KEY]: JSON.stringify({
+        version: VERSION,
+        state: {
+          layout: {
+            leftButtons: [],
+            rightButtons: [],
+            pinnedButtons: { "pluginA.btn": true, "pluginB.btn": true },
+          },
+          launcher: { alwaysShowDevServer: false },
+        },
+      }),
+    });
+    const { useToolbarPreferencesStore: store } = await import("../toolbarPreferencesStore");
+
+    // A sibling demotes (deletes) plugin B on disk.
+    const disk = readBlob(backing);
+    delete disk.state.layout.pinnedButtons["pluginB.btn"];
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // An unrelated write from this (stale, still-holds-B) view must not resurrect B.
+    store.getState().setAlwaysShowDevServer(true);
+
+    const written = readBlob(backing);
+    expect(written.state.layout.pinnedButtons["pluginA.btn"]).toBe(true);
+    expect("pluginB.btn" in written.state.layout.pinnedButtons).toBe(false);
+    expect(written.state.launcher.alwaysShowDevServer).toBe(true);
+  });
+});

--- a/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.crossViewMerge.test.ts
@@ -52,7 +52,8 @@ describe("toolbarPreferencesStore cross-view write merge (#11351)", () => {
   }
 
   function readBlob(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob;
   }
 
   function siblingBlob(overrides: Partial<PersistedBlob["state"]>): string {

--- a/src/store/__tests__/twoPaneSplitStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/twoPaneSplitStore.crossViewMerge.test.ts
@@ -48,7 +48,8 @@ describe("twoPaneSplitStore cross-view write merge (#11351)", () => {
   }
 
   function readBlob(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob;
   }
 
   beforeEach(() => {

--- a/src/store/__tests__/twoPaneSplitStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/twoPaneSplitStore.crossViewMerge.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { WorktreeRatioEntry } from "../twoPaneSplitStore";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). `ratioByWorktreeId` is keyed by worktree id, so a stale view
+ * writing one worktree's ratio must not wipe a sibling worktree's ratio; the
+ * `config` scalars defer to a sibling unless this writer changed them.
+ */
+describe("twoPaneSplitStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-two-pane-split";
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = {
+    version: number;
+    state: {
+      config: { enabled: boolean; defaultRatio: number; preferPreview: boolean };
+      ratioByWorktreeId: Record<string, WorktreeRatioEntry>;
+    };
+  };
+
+  const siblingRatio: WorktreeRatioEntry = { ratio: 0.7, panels: [null, null] };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readBlob(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's ratio write preserves a sibling worktree's ratio and non-default config", async () => {
+    const backing = installLocalStorage({});
+    const { useTwoPaneSplitStore: store } = await import("../twoPaneSplitStore");
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: {
+          config: { enabled: false, defaultRatio: 0.3, preferPreview: true },
+          ratioByWorktreeId: { "wt-b": siblingRatio },
+        },
+      })
+    );
+
+    store.getState().setWorktreeRatio("wt-a", 0.6, ["p1", "p2"]);
+
+    const written = readBlob(backing);
+    expect(Object.keys(written.state.ratioByWorktreeId).sort()).toEqual(["wt-a", "wt-b"]);
+    expect(written.state.ratioByWorktreeId["wt-b"]).toEqual(siblingRatio);
+    expect(written.state.config).toEqual({ enabled: false, defaultRatio: 0.3, preferPreview: true });
+  });
+
+  it("independent config and ratio changes from two views both survive", async () => {
+    const backing = installLocalStorage({});
+    const { useTwoPaneSplitStore: store } = await import("../twoPaneSplitStore");
+
+    store.getState().setWorktreeRatio("wt-a", 0.6, ["p1", "p2"]);
+
+    // Sibling adds a worktree ratio and disables the split on disk.
+    const disk = readBlob(backing);
+    disk.state.ratioByWorktreeId["wt-b"] = siblingRatio;
+    disk.state.config.enabled = false;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This stale view changes a different config field.
+    store.getState().setPreferPreview(true);
+
+    const written = readBlob(backing);
+    expect(written.state.config.enabled).toBe(false); // sibling's change survived
+    expect(written.state.config.preferPreview).toBe(true); // this view's change survived
+    expect(Object.keys(written.state.ratioByWorktreeId).sort()).toEqual(["wt-a", "wt-b"]);
+    expect(written.state.ratioByWorktreeId["wt-b"]).toEqual(siblingRatio);
+  });
+
+  it("does not resurrect a worktree ratio this view reset, and keeps a sibling's", async () => {
+    const backing = installLocalStorage({});
+    const { useTwoPaneSplitStore: store } = await import("../twoPaneSplitStore");
+
+    store.getState().setWorktreeRatio("wt-a", 0.6, ["p1", "p2"]);
+
+    const disk = readBlob(backing);
+    disk.state.ratioByWorktreeId["wt-b"] = siblingRatio;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().resetWorktreeRatio("wt-a");
+
+    const written = readBlob(backing);
+    expect(written.state.ratioByWorktreeId["wt-a"]).toBeUndefined();
+    expect(written.state.ratioByWorktreeId["wt-b"]).toEqual(siblingRatio);
+  });
+});

--- a/src/store/__tests__/twoPaneSplitStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/twoPaneSplitStore.crossViewMerge.test.ts
@@ -82,7 +82,11 @@ describe("twoPaneSplitStore cross-view write merge (#11351)", () => {
     const written = readBlob(backing);
     expect(Object.keys(written.state.ratioByWorktreeId).sort()).toEqual(["wt-a", "wt-b"]);
     expect(written.state.ratioByWorktreeId["wt-b"]).toEqual(siblingRatio);
-    expect(written.state.config).toEqual({ enabled: false, defaultRatio: 0.3, preferPreview: true });
+    expect(written.state.config).toEqual({
+      enabled: false,
+      defaultRatio: 0.3,
+      preferPreview: true,
+    });
   });
 
   it("independent config and ratio changes from two views both survive", async () => {

--- a/src/store/__tests__/urlHistoryStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/urlHistoryStore.crossViewMerge.test.ts
@@ -48,7 +48,8 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
   }
 
   function readBlob(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob;
   }
 
   beforeEach(() => {
@@ -86,17 +87,19 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
     const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
     vi.advanceTimersByTime(400);
 
-    // This view records project A.
+    // This view records project A and lets it settle.
     store.getState().recordVisit("proj-a", "https://a.example/");
     vi.advanceTimersByTime(400);
 
-    // A sibling records project B directly to the shared blob.
+    // This view enqueues a SECOND A visit — pending, not yet flushed.
+    store.getState().recordVisit("proj-a", "https://a2.example/");
+
+    // A sibling records project B directly to disk DURING the pending debounce
+    // window. The flush must read disk at flush time to preserve it.
     const disk = readBlob(backing);
     disk.state.entries["proj-b"] = [siblingEntry];
     backing.set(STORAGE_KEY, JSON.stringify(disk));
 
-    // This stale view records another A visit.
-    store.getState().recordVisit("proj-a", "https://a2.example/");
     vi.advanceTimersByTime(400);
 
     const written = readBlob(backing);

--- a/src/store/__tests__/urlHistoryStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/urlHistoryStore.crossViewMerge.test.ts
@@ -14,11 +14,15 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
 
   type PersistedBlob = { version: number; state: { entries: Record<string, UrlHistoryEntry[]> } };
 
+  // Pinned clock so the sibling entry stays inside the 90-day retention window the
+  // reconciler's `migrateEntries` normalization enforces on every input.
+  const NOW = 1_800_000_000_000;
+
   const siblingEntry: UrlHistoryEntry = {
     url: "https://sibling.example/",
     title: "Sibling",
     visitCount: 3,
-    lastVisitAt: 1_700_000_000_000,
+    lastVisitAt: NOW - 1000,
   };
 
   function installLocalStorage(initial: Record<string, string>): Map<string, string> {
@@ -55,6 +59,7 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.useFakeTimers();
+    vi.setSystemTime(NOW);
   });
 
   afterEach(() => {
@@ -79,7 +84,8 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
 
     const written = readBlob(backing);
     expect(Object.keys(written.state.entries).sort()).toEqual(["proj-a", "proj-b"]);
-    expect(written.state.entries["proj-b"]).toEqual([siblingEntry]);
+    expect(written.state.entries["proj-b"]).toHaveLength(1);
+    expect(written.state.entries["proj-b"]?.[0]?.title).toBe("Sibling");
   });
 
   it("a sibling's visit written during the debounce window survives this view's flush", async () => {
@@ -104,11 +110,9 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
 
     const written = readBlob(backing);
     expect(Object.keys(written.state.entries).sort()).toEqual(["proj-a", "proj-b"]);
-    expect(written.state.entries["proj-b"]).toEqual([siblingEntry]);
-    expect(written.state.entries["proj-a"]!.map((e) => e.url).sort()).toEqual([
-      "https://a.example/",
-      "https://a2.example/",
-    ]);
+    expect(written.state.entries["proj-b"]).toHaveLength(1);
+    expect(written.state.entries["proj-b"]?.[0]?.title).toBe("Sibling");
+    expect(written.state.entries["proj-a"]).toHaveLength(2);
   });
 
   it("does not resurrect a project's history this view removed, and keeps a sibling's", async () => {
@@ -128,6 +132,7 @@ describe("urlHistoryStore cross-view write merge (#11351)", () => {
 
     const written = readBlob(backing);
     expect(written.state.entries["proj-a"]).toBeUndefined();
-    expect(written.state.entries["proj-b"]).toEqual([siblingEntry]);
+    expect(written.state.entries["proj-b"]).toHaveLength(1);
+    expect(written.state.entries["proj-b"]?.[0]?.title).toBe("Sibling");
   });
 });

--- a/src/store/__tests__/urlHistoryStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/urlHistoryStore.crossViewMerge.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { UrlHistoryEntry } from "@shared/types/browser";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). Direct analog to commandHistoryStore: `entries` is a
+ * `Record<projectId, UrlHistoryEntry[]>`, so a stale view writing its own project
+ * must not wipe a sibling project's history. Storage is debounced (300ms), so
+ * writes are driven with fake timers.
+ */
+describe("urlHistoryStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-url-history";
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = { version: number; state: { entries: Record<string, UrlHistoryEntry[]> } };
+
+  const siblingEntry: UrlHistoryEntry = {
+    url: "https://sibling.example/",
+    title: "Sibling",
+    visitCount: 3,
+    lastVisitAt: 1_700_000_000_000,
+  };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readBlob(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's visit does not clobber a sibling project's history", async () => {
+    const backing = installLocalStorage({});
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    vi.advanceTimersByTime(400); // drain any hydration-triggered write
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({ version: 1, state: { entries: { "proj-b": [siblingEntry] } } })
+    );
+
+    store.getState().recordVisit("proj-a", "https://a.example/");
+    vi.advanceTimersByTime(400);
+
+    const written = readBlob(backing);
+    expect(Object.keys(written.state.entries).sort()).toEqual(["proj-a", "proj-b"]);
+    expect(written.state.entries["proj-b"]).toEqual([siblingEntry]);
+  });
+
+  it("a sibling's visit written during the debounce window survives this view's flush", async () => {
+    const backing = installLocalStorage({});
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    vi.advanceTimersByTime(400);
+
+    // This view records project A.
+    store.getState().recordVisit("proj-a", "https://a.example/");
+    vi.advanceTimersByTime(400);
+
+    // A sibling records project B directly to the shared blob.
+    const disk = readBlob(backing);
+    disk.state.entries["proj-b"] = [siblingEntry];
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    // This stale view records another A visit.
+    store.getState().recordVisit("proj-a", "https://a2.example/");
+    vi.advanceTimersByTime(400);
+
+    const written = readBlob(backing);
+    expect(Object.keys(written.state.entries).sort()).toEqual(["proj-a", "proj-b"]);
+    expect(written.state.entries["proj-b"]).toEqual([siblingEntry]);
+    expect(written.state.entries["proj-a"]!.map((e) => e.url).sort()).toEqual([
+      "https://a.example/",
+      "https://a2.example/",
+    ]);
+  });
+
+  it("does not resurrect a project's history this view removed, and keeps a sibling's", async () => {
+    const backing = installLocalStorage({});
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    vi.advanceTimersByTime(400);
+
+    store.getState().recordVisit("proj-a", "https://a.example/");
+    vi.advanceTimersByTime(400);
+
+    const disk = readBlob(backing);
+    disk.state.entries["proj-b"] = [siblingEntry];
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().removeProjectHistory("proj-a");
+    vi.advanceTimersByTime(400);
+
+    const written = readBlob(backing);
+    expect(written.state.entries["proj-a"]).toBeUndefined();
+    expect(written.state.entries["proj-b"]).toEqual([siblingEntry]);
+  });
+});

--- a/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { RecentDictationTarget } from "../voiceRecordingStore";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). `recentTargets` is one global MRU list (cap 3) that any view
+ * appends to; the store's high-frequency transient setters trigger debounced
+ * persist writes of it, so a stale view's flush must not drop a sibling's
+ * just-recorded target. The merge unions by logical identity, keeps the
+ * more-recently-used entry, and caps to the three most-recent.
+ */
+describe("voiceRecordingStore cross-view write merge (#11351)", () => {
+  const STORAGE_KEY = "daintree-voice-recording";
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = { version: number; state: { recentTargets: RecentDictationTarget[] } };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readTargets(backing: Map<string, string>): RecentDictationTarget[] {
+    return (JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob).state.recentTargets;
+  }
+
+  function writeDisk(backing: Map<string, string>, targets: RecentDictationTarget[]): void {
+    backing.set(STORAGE_KEY, JSON.stringify({ version: 0, state: { recentTargets: targets } }));
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's recorded target preserves a sibling's recent target", async () => {
+    const backing = installLocalStorage({});
+    const { useVoiceRecordingStore: store } = await import("../voiceRecordingStore");
+    vi.advanceTimersByTime(400); // drain any hydration-triggered write
+
+    vi.setSystemTime(5000);
+    writeDisk(backing, [{ panelTitle: "Sib", worktreeId: "wt-sib", lastUsedAt: 1000 }]);
+
+    store.getState().recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
+    vi.advanceTimersByTime(400);
+
+    const written = readTargets(backing);
+    const titles = written.map((t) => t.panelTitle).sort();
+    expect(titles).toEqual(["Mine", "Sib"]);
+  });
+
+  it("merges the writer's and sibling's targets in MRU order without dropping the sibling", async () => {
+    const backing = installLocalStorage({});
+    const { useVoiceRecordingStore: store } = await import("../voiceRecordingStore");
+    vi.advanceTimersByTime(400);
+
+    // This view records an OLDER target; a sibling has a NEWER one on disk.
+    vi.setSystemTime(2000);
+    writeDisk(backing, [{ panelTitle: "Sib", worktreeId: "wt-sib", lastUsedAt: 8000 }]);
+
+    store.getState().recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
+    vi.advanceTimersByTime(400);
+
+    const written = readTargets(backing);
+    expect(written.map((t) => t.panelTitle)).toEqual(["Sib", "Mine"]); // newest first
+  });
+
+  it("dedupes a same-identity target to the newer entry and keeps other sibling targets", async () => {
+    const backing = installLocalStorage({});
+    const { useVoiceRecordingStore: store } = await import("../voiceRecordingStore");
+    vi.advanceTimersByTime(400);
+
+    vi.setSystemTime(5000);
+    writeDisk(backing, [
+      { panelTitle: "Shared", worktreeId: "wt-1", lastUsedAt: 1000 },
+      { panelTitle: "Other", worktreeId: "wt-2", lastUsedAt: 2000 },
+    ]);
+
+    // Re-record the same logical target (wt-1 / "Shared") — newer than the disk copy.
+    store
+      .getState()
+      .recordRecentTarget({ panelId: "p1", panelTitle: "Shared", worktreeId: "wt-1" });
+    vi.advanceTimersByTime(400);
+
+    const written = readTargets(backing);
+    const shared = written.find((t) => t.worktreeId === "wt-1");
+    const other = written.find((t) => t.worktreeId === "wt-2");
+    expect(shared?.lastUsedAt).toBe(5000); // newer entry won the collision
+    expect(other).toBeDefined(); // the other sibling target survived
+    expect(written).toHaveLength(2);
+  });
+});

--- a/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
@@ -42,7 +42,8 @@ describe("voiceRecordingStore cross-view write merge (#11351)", () => {
   }
 
   function readTargets(backing: Map<string, string>): RecentDictationTarget[] {
-    return (JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob).state.recentTargets;
+    const blob: PersistedBlob = JSON.parse(backing.get(STORAGE_KEY)!);
+    return blob.state.recentTargets;
   }
 
   function writeDisk(backing: Map<string, string>, targets: RecentDictationTarget[]): void {
@@ -91,6 +92,35 @@ describe("voiceRecordingStore cross-view write merge (#11351)", () => {
 
     const written = readTargets(backing);
     expect(written.map((t) => t.panelTitle)).toEqual(["Sib", "Mine"]); // newest first
+  });
+
+  it("a stale view's transient flush preserves a sibling's recorded target", async () => {
+    const backing = installLocalStorage({});
+    const { useVoiceRecordingStore: store } = await import("../voiceRecordingStore");
+    vi.advanceTimersByTime(400);
+
+    // This view records its own target and lets it settle into a durable baseline.
+    vi.setSystemTime(3000);
+    store
+      .getState()
+      .recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
+    vi.advanceTimersByTime(400);
+
+    // A sibling records a newer target directly to disk.
+    writeDisk(backing, [
+      ...readTargets(backing),
+      { panelTitle: "Sib", worktreeId: "wt-sib", lastUsedAt: 9000 },
+    ]);
+
+    // A transient, non-persisted change (audio level) triggers a debounced flush
+    // of this stale view's unchanged recentTargets.
+    store.getState().setAudioLevel(0.5);
+    vi.advanceTimersByTime(400);
+
+    const titles = readTargets(backing)
+      .map((t) => t.panelTitle)
+      .sort();
+    expect(titles).toEqual(["Mine", "Sib"]); // sibling target not clobbered
   });
 
   it("dedupes a same-identity target to the newer entry and keeps other sibling targets", async () => {

--- a/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
@@ -151,4 +151,39 @@ describe("voiceRecordingStore cross-view write merge (#11351)", () => {
     expect(other).toBeDefined(); // the other sibling target survived
     expect(written).toHaveLength(2);
   });
+
+  it("drops the superseded entry when the same panel is re-recorded under a new title", async () => {
+    const backing = installLocalStorage({});
+    const { useVoiceRecordingStore: store } = await import("../voiceRecordingStore");
+    vi.advanceTimersByTime(400);
+
+    // A genuinely distinct target the user should keep seeing after restart.
+    vi.setSystemTime(1000);
+    store
+      .getState()
+      .recordRecentTarget({ panelId: "p0", panelTitle: "Alpha", worktreeId: "wt-alpha" });
+    vi.advanceTimersByTime(400);
+
+    // The same panel is dictated into three times while its title changes (agent
+    // task-title composition retitles panels mid-session). In memory each
+    // re-record supersedes the previous one (dedup is by panelId), so disk must
+    // follow — persisted identity is (worktreeId, panelTitle), which shifts.
+    for (const [at, title] of [
+      [2000, "Fix the parser"],
+      [3000, "Fix the parser bug"],
+      [4000, "Ship the parser fix"],
+    ] as const) {
+      vi.setSystemTime(at);
+      store.getState().recordRecentTarget({ panelId: "p1", panelTitle: title, worktreeId: "wt-1" });
+      vi.advanceTimersByTime(400);
+    }
+
+    expect(store.getState().recentTargets.map((t) => t.panelTitle)).toEqual([
+      "Ship the parser fix",
+      "Alpha",
+    ]);
+    // Disk mirrors memory: one entry per panel, and the older distinct target was
+    // not evicted by stale duplicates of the retitled one.
+    expect(readTargets(backing).map((t) => t.panelTitle)).toEqual(["Ship the parser fix", "Alpha"]);
+  });
 });

--- a/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/voiceRecordingStore.crossViewMerge.test.ts
@@ -70,7 +70,9 @@ describe("voiceRecordingStore cross-view write merge (#11351)", () => {
     vi.setSystemTime(5000);
     writeDisk(backing, [{ panelTitle: "Sib", worktreeId: "wt-sib", lastUsedAt: 1000 }]);
 
-    store.getState().recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
+    store
+      .getState()
+      .recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
     vi.advanceTimersByTime(400);
 
     const written = readTargets(backing);
@@ -87,7 +89,9 @@ describe("voiceRecordingStore cross-view write merge (#11351)", () => {
     vi.setSystemTime(2000);
     writeDisk(backing, [{ panelTitle: "Sib", worktreeId: "wt-sib", lastUsedAt: 8000 }]);
 
-    store.getState().recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
+    store
+      .getState()
+      .recordRecentTarget({ panelId: "p1", panelTitle: "Mine", worktreeId: "wt-mine" });
     vi.advanceTimersByTime(400);
 
     const written = readTargets(backing);

--- a/src/store/__tests__/worktreeFilterStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.crossViewMerge.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Cross-view write-merge coverage for the shared localStorage partition
+ * (issue #11351). Only the GLOBAL prefs sub-store (`daintree-worktree-filters`)
+ * needs the merge: its five fields share one literal key across views. The
+ * per-project sub-store (`daintree-worktree-filters:{projectId}`) is exempt — its
+ * key already embeds the project id — and must stay untouched by a global write.
+ */
+describe("worktreeFilterStore cross-view write merge (#11351)", () => {
+  const GLOBAL_KEY = "daintree-worktree-filters";
+  // jsdom resolves no projectId → the per-project store keys off "default".
+  const PROJECT_KEY = "daintree-worktree-filters:default";
+  const VERSION = 1;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+  type PersistedBlob = { version: number; state: Record<string, unknown> };
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  function readGlobal(backing: Map<string, string>): PersistedBlob {
+    return JSON.parse(backing.get(GLOBAL_KEY)!) as PersistedBlob;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("a fresh view's orderBy change preserves a sibling's non-default global pref", async () => {
+    const backing = installLocalStorage({});
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    backing.set(
+      GLOBAL_KEY,
+      JSON.stringify({
+        version: VERSION,
+        state: {
+          orderBy: "created",
+          groupByType: false,
+          alwaysShowActive: false,
+          alwaysShowWaiting: true,
+          hideMainWorktree: false,
+        },
+      })
+    );
+
+    store.getState().setOrderBy("alpha");
+
+    const written = readGlobal(backing);
+    expect(written.state.orderBy).toBe("alpha"); // this view's change
+    expect(written.state.alwaysShowActive).toBe(false); // sibling's non-default survived
+  });
+
+  it("independent global pref changes both survive and the project key stays untouched", async () => {
+    const backing = installLocalStorage({});
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    store.getState().setAlwaysShowActive(false);
+
+    // Sibling hides the main worktree on disk.
+    const disk = readGlobal(backing);
+    disk.state.hideMainWorktree = true;
+    backing.set(GLOBAL_KEY, JSON.stringify(disk));
+
+    const projectKeyBefore = backing.get(PROJECT_KEY) ?? null;
+
+    store.getState().setAlwaysShowWaiting(false);
+
+    const written = readGlobal(backing);
+    expect(written.state.alwaysShowWaiting).toBe(false); // this view's change
+    expect(written.state.hideMainWorktree).toBe(true); // sibling's change survived
+    expect(written.state.alwaysShowActive).toBe(false);
+    // The per-project store keys off its own project-scoped key — a global write
+    // must not touch it.
+    expect(backing.get(PROJECT_KEY) ?? null).toBe(projectKeyBefore);
+  });
+
+  it("normalizes an invalid manual + groupByType combination produced by a merge", async () => {
+    const backing = installLocalStorage({});
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    // A sibling left `manual` ordering on disk (valid while not grouping).
+    backing.set(
+      GLOBAL_KEY,
+      JSON.stringify({
+        version: VERSION,
+        state: {
+          orderBy: "manual",
+          groupByType: false,
+          alwaysShowActive: true,
+          alwaysShowWaiting: true,
+          hideMainWorktree: false,
+        },
+      })
+    );
+
+    // This view enables grouping (its own orderBy is the default "created"). The
+    // merge would recombine grouping (this view) with the sibling's `manual`
+    // order — an invalid pair the reconciler must normalize back to "created".
+    store.getState().setGroupByType(true);
+
+    const written = readGlobal(backing);
+    expect(written.state.groupByType).toBe(true);
+    expect(written.state.orderBy).toBe("created");
+  });
+});

--- a/src/store/__tests__/worktreeFilterStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.crossViewMerge.test.ts
@@ -43,14 +43,19 @@ describe("worktreeFilterStore cross-view write merge (#11351)", () => {
   }
 
   function readGlobal(backing: Map<string, string>): PersistedBlob {
-    return JSON.parse(backing.get(GLOBAL_KEY)!) as PersistedBlob;
+    const blob: PersistedBlob = JSON.parse(backing.get(GLOBAL_KEY)!);
+    return blob;
   }
 
   beforeEach(() => {
     vi.resetModules();
+    // The per-project sub-store is debounced; the global sub-store is synchronous
+    // and unaffected by fake timers.
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     restoreLocalStorage();
     vi.resetModules();
     vi.restoreAllMocks();
@@ -109,7 +114,8 @@ describe("worktreeFilterStore cross-view write merge (#11351)", () => {
     const backing = installLocalStorage({});
     const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
 
-    // A sibling left `manual` ordering on disk (valid while not grouping).
+    // A sibling left `manual` ordering (valid while not grouping) plus a
+    // non-default `alwaysShowActive` on disk.
     backing.set(
       GLOBAL_KEY,
       JSON.stringify({
@@ -117,7 +123,7 @@ describe("worktreeFilterStore cross-view write merge (#11351)", () => {
         state: {
           orderBy: "manual",
           groupByType: false,
-          alwaysShowActive: true,
+          alwaysShowActive: false,
           alwaysShowWaiting: true,
           hideMainWorktree: false,
         },
@@ -125,12 +131,49 @@ describe("worktreeFilterStore cross-view write merge (#11351)", () => {
     );
 
     // This view enables grouping (its own orderBy is the default "created"). The
-    // merge would recombine grouping (this view) with the sibling's `manual`
-    // order — an invalid pair the reconciler must normalize back to "created".
+    // merge pulls in the sibling's `manual` order, recombining it with grouping —
+    // an invalid pair the reconciler must normalize back to "created".
     store.getState().setGroupByType(true);
 
     const written = readGlobal(backing);
     expect(written.state.groupByType).toBe(true);
     expect(written.state.orderBy).toBe("created");
+    // Proves the merge ran (without it, this view would rewrite the default true).
+    expect(written.state.alwaysShowActive).toBe(false);
+  });
+
+  it("a stale same-project window's filter write preserves a sibling window's pin", async () => {
+    const backing = installLocalStorage({});
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+    vi.advanceTimersByTime(400); // drain any hydration write on the debounced project store
+
+    // A sibling window on the SAME project (which shares the per-project key)
+    // pinned a worktree.
+    backing.set(
+      PROJECT_KEY,
+      JSON.stringify({
+        version: 2,
+        state: {
+          query: "",
+          statusFilters: [],
+          typeFilters: [],
+          prIssueFilters: [],
+          sessionFilters: [],
+          activityFilters: [],
+          pinnedWorktrees: ["wt-1"],
+          collapsedWorktrees: [],
+          manualOrder: [],
+        },
+      })
+    );
+
+    // This stale window (never saw the pin) changes its filter query.
+    store.getState().setQuery("needle");
+    vi.advanceTimersByTime(400);
+
+    const projectBlob: { version: number; state: { pinnedWorktrees: string[]; query: string } } =
+      JSON.parse(backing.get(PROJECT_KEY)!);
+    expect(projectBlob.state.pinnedWorktrees).toEqual(["wt-1"]); // sibling's pin survived
+    expect(projectBlob.state.query).toBe("needle"); // this window's change applied
   });
 });

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { notify } from "@/lib/notify";
 
@@ -83,6 +88,101 @@ export function shouldShowSoftWarning(
 }
 
 let _initPromise: Promise<void> | null = null;
+
+type PanelLimitPersistedState = Pick<
+  PanelLimitState,
+  | "softWarningLimit"
+  | "confirmationLimit"
+  | "hardLimit"
+  | "warningsDisabled"
+  | "hardwareDefaultsApplied"
+  | "lastSoftWarningDismissedAt"
+>;
+
+const PANEL_LIMIT_PERSISTED_DEFAULTS: PanelLimitPersistedState = {
+  softWarningLimit: DEFAULT_SOFT_WARNING_LIMIT,
+  confirmationLimit: DEFAULT_CONFIRMATION_LIMIT,
+  hardLimit: DEFAULT_HARD_LIMIT,
+  warningsDisabled: false,
+  hardwareDefaultsApplied: false,
+  lastSoftWarningDismissedAt: null,
+};
+
+function toPanelLimitPersisted(
+  state: Partial<PanelLimitState> | null | undefined
+): PanelLimitPersistedState {
+  const raw = (state ?? {}) as Record<string, unknown>;
+  const d = PANEL_LIMIT_PERSISTED_DEFAULTS;
+  return {
+    softWarningLimit: typeof raw.softWarningLimit === "number" ? raw.softWarningLimit : d.softWarningLimit,
+    confirmationLimit:
+      typeof raw.confirmationLimit === "number" ? raw.confirmationLimit : d.confirmationLimit,
+    hardLimit: typeof raw.hardLimit === "number" ? raw.hardLimit : d.hardLimit,
+    warningsDisabled:
+      typeof raw.warningsDisabled === "boolean" ? raw.warningsDisabled : d.warningsDisabled,
+    hardwareDefaultsApplied:
+      typeof raw.hardwareDefaultsApplied === "boolean"
+        ? raw.hardwareDefaultsApplied
+        : d.hardwareDefaultsApplied,
+    lastSoftWarningDismissedAt:
+      typeof raw.lastSoftWarningDismissedAt === "number" ? raw.lastSoftWarningDismissedAt : null,
+  };
+}
+
+/**
+ * Baseline-aware three-way merge for panel-limit writes across project views
+ * (issue #11351). Every persisted field is an independently-set scalar, so a
+ * field defers to a sibling's on-disk value unless this writer changed it. This
+ * matters even though the fields aren't project-scoped: the store's transient
+ * setters (`requestConfirmation` bumping `requestSeq`, `resolveConfirmation`
+ * clearing `pendingConfirm`) trigger a persist write of the *unchanged*
+ * partialized limits, so without the merge a stale view's first such write
+ * reserializes and clobbers a sibling's just-edited limit.
+ */
+function mergePanelLimitPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<PanelLimitPersistedState>): StorageValue<PanelLimitPersistedState> {
+  if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  const disk = toPanelLimitPersisted(onDisk.state);
+  const inc = toPanelLimitPersisted(incoming.state);
+  if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
+    return { version: incoming.version, state: disk };
+  }
+  const base = toPanelLimitPersisted(baseline?.state);
+  return {
+    version: incoming.version,
+    state: {
+      softWarningLimit: pickFieldByWriterDelta(
+        base.softWarningLimit,
+        inc.softWarningLimit,
+        disk.softWarningLimit
+      ),
+      confirmationLimit: pickFieldByWriterDelta(
+        base.confirmationLimit,
+        inc.confirmationLimit,
+        disk.confirmationLimit
+      ),
+      hardLimit: pickFieldByWriterDelta(base.hardLimit, inc.hardLimit, disk.hardLimit),
+      warningsDisabled: pickFieldByWriterDelta(
+        base.warningsDisabled,
+        inc.warningsDisabled,
+        disk.warningsDisabled
+      ),
+      hardwareDefaultsApplied: pickFieldByWriterDelta(
+        base.hardwareDefaultsApplied,
+        inc.hardwareDefaultsApplied,
+        disk.hardwareDefaultsApplied
+      ),
+      lastSoftWarningDismissedAt: pickFieldByWriterDelta(
+        base.lastSoftWarningDismissedAt,
+        inc.lastSoftWarningDismissedAt,
+        disk.lastSoftWarningDismissedAt
+      ),
+    },
+  };
+}
 
 export const usePanelLimitStore = create<PanelLimitState>()(
   persist(
@@ -184,7 +284,9 @@ export const usePanelLimitStore = create<PanelLimitState>()(
     {
       name: STORAGE_KEY,
       version: 1,
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<PanelLimitPersistedState>({
+        mergeOnWrite: mergePanelLimitPersistedWrite,
+      }),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -114,7 +114,8 @@ function toPanelLimitPersisted(
   const raw = (state ?? {}) as Record<string, unknown>;
   const d = PANEL_LIMIT_PERSISTED_DEFAULTS;
   return {
-    softWarningLimit: typeof raw.softWarningLimit === "number" ? raw.softWarningLimit : d.softWarningLimit,
+    softWarningLimit:
+      typeof raw.softWarningLimit === "number" ? raw.softWarningLimit : d.softWarningLimit,
     confirmationLimit:
       typeof raw.confirmationLimit === "number" ? raw.confirmationLimit : d.confirmationLimit,
     hardLimit: typeof raw.hardLimit === "number" ? raw.hardLimit : d.hardLimit,

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -287,17 +287,19 @@ export const usePanelLimitStore = create<PanelLimitState>()(
       storage: createSafeJSONStorage<PanelLimitPersistedState>({
         mergeOnWrite: mergePanelLimitPersistedWrite,
       }),
-      migrate: (persisted, version) => {
-        const state = persisted as Record<string, unknown>;
+      migrate: (persisted, version): PanelLimitPersistedState => {
+        const migrated = toPanelLimitPersisted(persisted as Partial<PanelLimitState>);
         if (version === 0) {
+          // Pre-hardware-defaults blobs keep their existing limits and are marked
+          // as already-applied so hardware defaults don't overwrite them.
           return {
-            ...state,
+            ...migrated,
             warningsDisabled: false,
             hardwareDefaultsApplied: true,
             lastSoftWarningDismissedAt: null,
           };
         }
-        return state;
+        return migrated;
       },
       partialize: (state) => ({
         softWarningLimit: state.softWarningLimit,

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -297,7 +297,9 @@ function toPreferencesPersisted(
     diffFullFile: coerceBool(raw.diffFullFile, d.diffFullFile),
     diffFontSize: isDiffFontSize(raw.diffFontSize) ? raw.diffFontSize : d.diffFontSize,
     markdownWrapLines: coerceBool(raw.markdownWrapLines, d.markdownWrapLines),
-    deletedWorktreeCleanupSeconds: isDeletedWorktreeCleanupSeconds(raw.deletedWorktreeCleanupSeconds)
+    deletedWorktreeCleanupSeconds: isDeletedWorktreeCleanupSeconds(
+      raw.deletedWorktreeCleanupSeconds
+    )
       ? raw.deletedWorktreeCleanupSeconds
       : d.deletedWorktreeCleanupSeconds,
     lastSelectedWorktreeRecipeIdByProject: normalizeRecipeMap(

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -1,6 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  mergeRecordByWriterDelta,
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export type DockDensity = "compact" | "normal" | "comfortable";
@@ -192,6 +198,226 @@ function sanitizePersistedPreferences(
   return sanitized;
 }
 
+type PreferencesPersistedState = Pick<
+  PreferencesState,
+  | "showProjectPulse"
+  | "showDeveloperTools"
+  | "showGridAgentHighlights"
+  | "showAgentTaskTitles"
+  | "showDockAgentHighlights"
+  | "dockDensity"
+  | "assignWorktreeToSelf"
+  | "reduceAnimations"
+  | "diffViewType"
+  | "diffWrapLines"
+  | "diffIgnoreWhitespace"
+  | "diffShowFileList"
+  | "diffFullFile"
+  | "diffFontSize"
+  | "markdownWrapLines"
+  | "deletedWorktreeCleanupSeconds"
+  | "lastSelectedWorktreeRecipeIdByProject"
+  | "skipPushConfirmByWorktreePath"
+  | "fileBrowserAlwaysHiddenPatterns"
+>;
+
+const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
+  showProjectPulse: true,
+  showDeveloperTools: false,
+  showGridAgentHighlights: false,
+  showAgentTaskTitles: true,
+  showDockAgentHighlights: false,
+  dockDensity: "normal",
+  assignWorktreeToSelf: false,
+  reduceAnimations: false,
+  diffViewType: "split",
+  diffWrapLines: false,
+  diffIgnoreWhitespace: false,
+  diffShowFileList: true,
+  diffFullFile: false,
+  diffFontSize: "m",
+  markdownWrapLines: true,
+  deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
+  lastSelectedWorktreeRecipeIdByProject: {},
+  skipPushConfirmByWorktreePath: {},
+  fileBrowserAlwaysHiddenPatterns: [...DEFAULT_FILE_BROWSER_ALWAYS_HIDDEN],
+};
+
+function coerceBool(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+/**
+ * Coerce the per-project recipe map, dropping `undefined` values: JSON omits them
+ * on disk, and `mergeRecordByWriterDelta` reads `undefined` as "key absent", so an
+ * explicit `undefined` (a cleared selection — semantically a deletion) must not
+ * reach the diff as a live value.
+ */
+function normalizeRecipeMap(value: unknown): Record<string, string | null> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, string | null> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === null || typeof entry === "string") result[key] = entry;
+  }
+  return result;
+}
+
+function normalizeSkipMap(value: unknown): Record<string, boolean> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, boolean> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === "boolean") result[key] = entry;
+  }
+  return result;
+}
+
+/**
+ * Coerce a persisted (or in-memory) snapshot into a fully-defined persisted shape
+ * so the write merge compares canonical values (issue #11351). Reuses the store's
+ * closed-set guards and the pattern sanitizers.
+ */
+function toPreferencesPersisted(
+  state: Partial<PreferencesState> | null | undefined
+): PreferencesPersistedState {
+  const raw = (state ?? {}) as Record<string, unknown>;
+  const d = PREFERENCES_PERSISTED_DEFAULTS;
+  return {
+    showProjectPulse: coerceBool(raw.showProjectPulse, d.showProjectPulse),
+    showDeveloperTools: coerceBool(raw.showDeveloperTools, d.showDeveloperTools),
+    showGridAgentHighlights: coerceBool(raw.showGridAgentHighlights, d.showGridAgentHighlights),
+    showAgentTaskTitles: coerceBool(raw.showAgentTaskTitles, d.showAgentTaskTitles),
+    showDockAgentHighlights: coerceBool(raw.showDockAgentHighlights, d.showDockAgentHighlights),
+    dockDensity: isDockDensity(raw.dockDensity) ? raw.dockDensity : d.dockDensity,
+    assignWorktreeToSelf: coerceBool(raw.assignWorktreeToSelf, d.assignWorktreeToSelf),
+    reduceAnimations: coerceBool(raw.reduceAnimations, d.reduceAnimations),
+    diffViewType: isDiffViewType(raw.diffViewType) ? raw.diffViewType : d.diffViewType,
+    diffWrapLines: coerceBool(raw.diffWrapLines, d.diffWrapLines),
+    diffIgnoreWhitespace: coerceBool(raw.diffIgnoreWhitespace, d.diffIgnoreWhitespace),
+    diffShowFileList: coerceBool(raw.diffShowFileList, d.diffShowFileList),
+    diffFullFile: coerceBool(raw.diffFullFile, d.diffFullFile),
+    diffFontSize: isDiffFontSize(raw.diffFontSize) ? raw.diffFontSize : d.diffFontSize,
+    markdownWrapLines: coerceBool(raw.markdownWrapLines, d.markdownWrapLines),
+    deletedWorktreeCleanupSeconds: isDeletedWorktreeCleanupSeconds(raw.deletedWorktreeCleanupSeconds)
+      ? raw.deletedWorktreeCleanupSeconds
+      : d.deletedWorktreeCleanupSeconds,
+    lastSelectedWorktreeRecipeIdByProject: normalizeRecipeMap(
+      raw.lastSelectedWorktreeRecipeIdByProject
+    ),
+    skipPushConfirmByWorktreePath: normalizeSkipMap(raw.skipPushConfirmByWorktreePath),
+    fileBrowserAlwaysHiddenPatterns: sanitizeAlwaysHiddenPatterns(
+      raw.fileBrowserAlwaysHiddenPatterns
+    ),
+  };
+}
+
+/**
+ * Baseline-aware three-way merge for preferences writes across project views
+ * (issue #11351). The two id-keyed maps are the primary victims —
+ * `lastSelectedWorktreeRecipeIdByProject` (per project) and
+ * `skipPushConfirmByWorktreePath` (per worktree path): each view writes its own
+ * keys, so a stale whole-snapshot write must not wipe a sibling's entries. Every
+ * scalar (and the Settings-edited hidden-patterns list) defers to a sibling's
+ * on-disk value unless this writer changed it. Version guards keep the raw
+ * (un-migrated) reads from diffing a foreign schema across the v13 migrate chain.
+ */
+function mergePreferencesPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<PreferencesPersistedState>): StorageValue<PreferencesPersistedState> {
+  if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  const disk = toPreferencesPersisted(onDisk.state);
+  const inc = toPreferencesPersisted(incoming.state);
+  if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
+    return { version: incoming.version, state: disk };
+  }
+  const base = toPreferencesPersisted(baseline?.state);
+  return {
+    version: incoming.version,
+    state: {
+      showProjectPulse: pickFieldByWriterDelta(
+        base.showProjectPulse,
+        inc.showProjectPulse,
+        disk.showProjectPulse
+      ),
+      showDeveloperTools: pickFieldByWriterDelta(
+        base.showDeveloperTools,
+        inc.showDeveloperTools,
+        disk.showDeveloperTools
+      ),
+      showGridAgentHighlights: pickFieldByWriterDelta(
+        base.showGridAgentHighlights,
+        inc.showGridAgentHighlights,
+        disk.showGridAgentHighlights
+      ),
+      showAgentTaskTitles: pickFieldByWriterDelta(
+        base.showAgentTaskTitles,
+        inc.showAgentTaskTitles,
+        disk.showAgentTaskTitles
+      ),
+      showDockAgentHighlights: pickFieldByWriterDelta(
+        base.showDockAgentHighlights,
+        inc.showDockAgentHighlights,
+        disk.showDockAgentHighlights
+      ),
+      dockDensity: pickFieldByWriterDelta(base.dockDensity, inc.dockDensity, disk.dockDensity),
+      assignWorktreeToSelf: pickFieldByWriterDelta(
+        base.assignWorktreeToSelf,
+        inc.assignWorktreeToSelf,
+        disk.assignWorktreeToSelf
+      ),
+      reduceAnimations: pickFieldByWriterDelta(
+        base.reduceAnimations,
+        inc.reduceAnimations,
+        disk.reduceAnimations
+      ),
+      diffViewType: pickFieldByWriterDelta(base.diffViewType, inc.diffViewType, disk.diffViewType),
+      diffWrapLines: pickFieldByWriterDelta(
+        base.diffWrapLines,
+        inc.diffWrapLines,
+        disk.diffWrapLines
+      ),
+      diffIgnoreWhitespace: pickFieldByWriterDelta(
+        base.diffIgnoreWhitespace,
+        inc.diffIgnoreWhitespace,
+        disk.diffIgnoreWhitespace
+      ),
+      diffShowFileList: pickFieldByWriterDelta(
+        base.diffShowFileList,
+        inc.diffShowFileList,
+        disk.diffShowFileList
+      ),
+      diffFullFile: pickFieldByWriterDelta(base.diffFullFile, inc.diffFullFile, disk.diffFullFile),
+      diffFontSize: pickFieldByWriterDelta(base.diffFontSize, inc.diffFontSize, disk.diffFontSize),
+      markdownWrapLines: pickFieldByWriterDelta(
+        base.markdownWrapLines,
+        inc.markdownWrapLines,
+        disk.markdownWrapLines
+      ),
+      deletedWorktreeCleanupSeconds: pickFieldByWriterDelta(
+        base.deletedWorktreeCleanupSeconds,
+        inc.deletedWorktreeCleanupSeconds,
+        disk.deletedWorktreeCleanupSeconds
+      ),
+      lastSelectedWorktreeRecipeIdByProject: mergeRecordByWriterDelta(
+        base.lastSelectedWorktreeRecipeIdByProject,
+        inc.lastSelectedWorktreeRecipeIdByProject,
+        disk.lastSelectedWorktreeRecipeIdByProject
+      ),
+      skipPushConfirmByWorktreePath: mergeRecordByWriterDelta(
+        base.skipPushConfirmByWorktreePath,
+        inc.skipPushConfirmByWorktreePath,
+        disk.skipPushConfirmByWorktreePath
+      ),
+      fileBrowserAlwaysHiddenPatterns: pickFieldByWriterDelta(
+        base.fileBrowserAlwaysHiddenPatterns,
+        inc.fileBrowserAlwaysHiddenPatterns,
+        disk.fileBrowserAlwaysHiddenPatterns
+      ),
+    },
+  };
+}
+
 export const usePreferencesStore = create<PreferencesState>()(
   persist(
     (set) => ({
@@ -262,8 +488,34 @@ export const usePreferencesStore = create<PreferencesState>()(
     }),
     {
       name: "daintree-preferences",
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<PreferencesPersistedState>({
+        mergeOnWrite: mergePreferencesPersistedWrite,
+      }),
       version: 13,
+      // Explicit persisted subset — matches the pre-existing default (setters are
+      // dropped by JSON serialization); named so the write merge (#11351) has a
+      // typed persisted shape to reconcile.
+      partialize: (state): PreferencesPersistedState => ({
+        showProjectPulse: state.showProjectPulse,
+        showDeveloperTools: state.showDeveloperTools,
+        showGridAgentHighlights: state.showGridAgentHighlights,
+        showAgentTaskTitles: state.showAgentTaskTitles,
+        showDockAgentHighlights: state.showDockAgentHighlights,
+        dockDensity: state.dockDensity,
+        assignWorktreeToSelf: state.assignWorktreeToSelf,
+        reduceAnimations: state.reduceAnimations,
+        diffViewType: state.diffViewType,
+        diffWrapLines: state.diffWrapLines,
+        diffIgnoreWhitespace: state.diffIgnoreWhitespace,
+        diffShowFileList: state.diffShowFileList,
+        diffFullFile: state.diffFullFile,
+        diffFontSize: state.diffFontSize,
+        markdownWrapLines: state.markdownWrapLines,
+        deletedWorktreeCleanupSeconds: state.deletedWorktreeCleanupSeconds,
+        lastSelectedWorktreeRecipeIdByProject: state.lastSelectedWorktreeRecipeIdByProject,
+        skipPushConfirmByWorktreePath: state.skipPushConfirmByWorktreePath,
+        fileBrowserAlwaysHiddenPatterns: state.fileBrowserAlwaysHiddenPatterns,
+      }),
       // Runs on every hydration (unlike `migrate`, which Zustand skips when the
       // persisted version matches). Closed-set normalisation lives here so a
       // corrupt-but-parseable value is clamped even at the current version.

--- a/src/store/terminalSearchHistoryStore.ts
+++ b/src/store/terminalSearchHistoryStore.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_HISTORY_SIZE = 50;
@@ -11,6 +16,99 @@ interface TerminalSearchHistoryState {
   regexEnabled: boolean;
   addSearch: (term: string) => void;
   setToggles: (caseSensitive: boolean, regexEnabled: boolean) => void;
+}
+
+type TerminalSearchPersistedState = Pick<
+  TerminalSearchHistoryState,
+  "searches" | "caseSensitive" | "regexEnabled"
+>;
+
+const TERMINAL_SEARCH_PERSISTED_DEFAULTS: TerminalSearchPersistedState = {
+  searches: [],
+  caseSensitive: false,
+  regexEnabled: false,
+};
+
+/**
+ * Coerce a persisted (or in-memory) snapshot into the exact persisted subset,
+ * mapping a null/malformed blob to defaults. Mirrors the defensive coercions in
+ * `migrate` so the write merge compares canonical values (issue #11351).
+ */
+function toTerminalSearchPersisted(
+  state: Partial<TerminalSearchPersistedState> | null | undefined
+): TerminalSearchPersistedState {
+  const raw = state ?? {};
+  return {
+    searches: Array.isArray(raw.searches)
+      ? raw.searches.filter((entry): entry is string => typeof entry === "string")
+      : [],
+    caseSensitive: typeof raw.caseSensitive === "boolean" ? raw.caseSensitive : false,
+    regexEnabled: typeof raw.regexEnabled === "boolean" ? raw.regexEnabled : false,
+  };
+}
+
+function sameStringList(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Baseline-aware three-way merge for terminal-search writes across project views
+ * (issue #11351). The two toggles defer to a sibling's on-disk value unless this
+ * writer changed them. `searches` is one shared MRU list mutated a single entry
+ * at a time (`addSearch` unshifts one trimmed term), so a stale whole-snapshot
+ * write would rewind a sibling's concurrent search. We replay this writer's one
+ * touched term (`incoming[0]`) onto the freshest on-disk list instead: a
+ * toggle-only write (searches unchanged vs. baseline) keeps the disk list
+ * wholesale; an `addSearch` moves its term to the front of the disk list,
+ * deduped and capped, preserving the sibling's other entries.
+ */
+function mergeTerminalSearchPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<TerminalSearchPersistedState>): StorageValue<TerminalSearchPersistedState> {
+  // No shared value on disk yet → nothing to reconcile against.
+  if (!onDisk) return incoming;
+  const base = baseline
+    ? toTerminalSearchPersisted(baseline.state)
+    : TERMINAL_SEARCH_PERSISTED_DEFAULTS;
+  const disk = toTerminalSearchPersisted(onDisk.state);
+  const inc = toTerminalSearchPersisted(incoming.state);
+
+  let searches: string[];
+  if (sameStringList(base.searches, inc.searches)) {
+    // This write left the MRU untouched (e.g. a toggle change) → keep whatever a
+    // sibling last wrote.
+    searches = disk.searches;
+  } else {
+    const touched = inc.searches[0];
+    if (touched === undefined) {
+      // Defensive: the writer emptied its list (no clear API today) — honor it.
+      searches = [];
+    } else {
+      searches = [touched, ...disk.searches.filter((term) => term !== touched)].slice(
+        0,
+        MAX_HISTORY_SIZE
+      );
+    }
+  }
+
+  return {
+    version: incoming.version,
+    state: {
+      searches,
+      caseSensitive: pickFieldByWriterDelta(
+        base.caseSensitive,
+        inc.caseSensitive,
+        disk.caseSensitive
+      ),
+      regexEnabled: pickFieldByWriterDelta(base.regexEnabled, inc.regexEnabled, disk.regexEnabled),
+    },
+  };
 }
 
 export const useTerminalSearchHistoryStore = create<TerminalSearchHistoryState>()(
@@ -33,7 +131,9 @@ export const useTerminalSearchHistoryStore = create<TerminalSearchHistoryState>(
     }),
     {
       name: "daintree-terminal-search-history",
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<TerminalSearchPersistedState>({
+        mergeOnWrite: mergeTerminalSearchPersistedWrite,
+      }),
       version: 0,
       migrate: (persistedState, _version) => {
         const state = (persistedState ?? {}) as Partial<TerminalSearchHistoryState>;

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import type {
   ToolbarPreferences,
   ToolbarButtonId,
@@ -8,6 +9,11 @@ import type {
   ToolbarPinnedState,
 } from "@/../../shared/types/toolbar";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  mergeRecordByWriterDelta,
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { BUILT_IN_AGENT_IDS, LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 
@@ -83,6 +89,129 @@ function mergeButtonList(
   }
 
   return sanitizeButtonList(result);
+}
+
+/**
+ * The exact subset persisted by `partialize` (note: the launcher's `defaultAgent`
+ * is deliberately not persisted). The write merge (#11351) reconciles against
+ * this shape, not the full runtime state.
+ */
+type ToolbarPreferencesPersistedState = {
+  layout: ToolbarPreferences["layout"];
+  launcher: Pick<ToolbarPreferences["launcher"], "alwaysShowDevServer" | "defaultSelection">;
+};
+
+function asButtonList(value: unknown): AnyToolbarButtonId[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((id): id is AnyToolbarButtonId => typeof id === "string")
+    : undefined;
+}
+
+function normalizePinnedButtons(value: unknown): ToolbarPinnedState {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: ToolbarPinnedState = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === "boolean") result[key as AnyToolbarButtonId] = entry;
+  }
+  return result;
+}
+
+/**
+ * Coerce a persisted (or in-memory) snapshot into the canonical persisted shape.
+ * Button lists route through `mergeButtonList` — the same normalization the
+ * hydration `merge()` applies — so the baseline (raw from disk) compares equal to
+ * the in-memory snapshot (which already carries the defaults `merge()` folded in);
+ * otherwise every write would read as a list edit. A null/malformed blob maps to
+ * defaults (issue #11351).
+ */
+function toToolbarPersisted(
+  state: Partial<ToolbarPreferencesState> | null | undefined
+): ToolbarPreferencesPersistedState {
+  const layout = state?.layout;
+  const launcher = state?.launcher;
+  return {
+    layout: {
+      leftButtons: mergeButtonList(asButtonList(layout?.leftButtons), DEFAULT_LEFT_BUTTONS),
+      rightButtons: mergeButtonList(asButtonList(layout?.rightButtons), DEFAULT_RIGHT_BUTTONS),
+      pinnedButtons: normalizePinnedButtons(layout?.pinnedButtons),
+    },
+    launcher: {
+      alwaysShowDevServer:
+        typeof launcher?.alwaysShowDevServer === "boolean" ? launcher.alwaysShowDevServer : false,
+      defaultSelection: launcher?.defaultSelection,
+    },
+  };
+}
+
+/**
+ * Baseline-aware three-way merge for toolbar-preferences writes across project
+ * views (issue #11351). Button orderings and launcher scalars defer to a
+ * sibling's on-disk value unless this writer changed them (two divergent
+ * orderings can't be meaningfully merged, so it's whole-list-if-changed);
+ * `pinnedButtons` merges per button id so a stale view neither drops nor
+ * resurrects a sibling's plugin pin/hide.
+ *
+ * Migration coexistence: `onDisk` is read raw (no `migrate`), so the reconciler
+ * must never diff against a foreign schema version — the 11-step migrate chain
+ * reshapes the persisted blob (e.g. v7 `hiddenButtons` array → v8 `pinnedButtons`
+ * map, v10 `github-stats` → `forge-stats`). Two guards cover the app-upgrade
+ * window: a foreign on-disk version skips the merge outright; a foreign
+ * *baseline* version (this writer's first post-migrate write, before any user
+ * edit) defers wholesale to the sibling's already-current disk value rather than
+ * mistaking the migration for an edit.
+ */
+function mergeToolbarPreferencesPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<ToolbarPreferencesPersistedState>): StorageValue<ToolbarPreferencesPersistedState> {
+  // Disk absent, or disk is a foreign (unmigrated) schema version we can't safely
+  // diff against → take this writer's already-migrated snapshot.
+  if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  const disk = toToolbarPersisted(onDisk.state);
+  const inc = toToolbarPersisted(incoming.state);
+  // This writer's baseline predates a migration: its first post-migrate write
+  // carries no user edit yet, so defer to the sibling's already-current value
+  // instead of reading the migration as an edit. (`migrate` runs only on the
+  // numeric-version branch, so an unversioned baseline is not "foreign".)
+  if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
+    return { version: incoming.version, state: disk };
+  }
+  const base = toToolbarPersisted(baseline?.state);
+  return {
+    version: incoming.version,
+    state: {
+      layout: {
+        leftButtons: pickFieldByWriterDelta(
+          base.layout.leftButtons,
+          inc.layout.leftButtons,
+          disk.layout.leftButtons
+        ),
+        rightButtons: pickFieldByWriterDelta(
+          base.layout.rightButtons,
+          inc.layout.rightButtons,
+          disk.layout.rightButtons
+        ),
+        pinnedButtons: mergeRecordByWriterDelta(
+          base.layout.pinnedButtons,
+          inc.layout.pinnedButtons,
+          disk.layout.pinnedButtons
+        ),
+      },
+      launcher: {
+        alwaysShowDevServer: pickFieldByWriterDelta(
+          base.launcher.alwaysShowDevServer,
+          inc.launcher.alwaysShowDevServer,
+          disk.launcher.alwaysShowDevServer
+        ),
+        defaultSelection: pickFieldByWriterDelta(
+          base.launcher.defaultSelection,
+          inc.launcher.defaultSelection,
+          disk.launcher.defaultSelection
+        ),
+      },
+    },
+  };
 }
 
 interface ToolbarPreferencesState extends ToolbarPreferences {
@@ -246,7 +375,9 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     {
       name: "daintree-toolbar-preferences",
       version: 11,
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<ToolbarPreferencesPersistedState>({
+        mergeOnWrite: mergeToolbarPreferencesPersistedWrite,
+      }),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version < 1) {

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -109,20 +109,23 @@ function asButtonList(value: unknown): AnyToolbarButtonId[] | undefined {
 
 function normalizePinnedButtons(value: unknown): ToolbarPinnedState {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
-  const result: ToolbarPinnedState = {};
+  // Keyed by plain string then returned as ToolbarPinnedState
+  // (Partial<Record<AnyToolbarButtonId, boolean>>) — a total string→boolean map
+  // is assignable to it, so no per-key assertion is needed.
+  const result: Record<string, boolean> = {};
   for (const [key, entry] of Object.entries(value)) {
-    if (typeof entry === "boolean") result[key as AnyToolbarButtonId] = entry;
+    if (typeof entry === "boolean") result[key] = entry;
   }
   return result;
 }
 
 /**
  * Coerce a persisted (or in-memory) snapshot into the canonical persisted shape.
- * Button lists route through `mergeButtonList` — the same normalization the
- * hydration `merge()` applies — so the baseline (raw from disk) compares equal to
- * the in-memory snapshot (which already carries the defaults `merge()` folded in);
- * otherwise every write would read as a list edit. A null/malformed blob maps to
- * defaults (issue #11351).
+ * Button lists are only deduped/fixed-stripped via `sanitizeButtonList` (NOT
+ * `mergeButtonList`): the reconciler takes the writer's own list verbatim rather
+ * than diffing it, so there's no need to re-materialize defaults — and doing so
+ * would duplicate a button the user moved across sides. A null/malformed blob
+ * maps to defaults (issue #11351).
  */
 function toToolbarPersisted(
   state: Partial<ToolbarPreferencesState> | null | undefined
@@ -131,8 +134,8 @@ function toToolbarPersisted(
   const launcher = state?.launcher;
   return {
     layout: {
-      leftButtons: mergeButtonList(asButtonList(layout?.leftButtons), DEFAULT_LEFT_BUTTONS),
-      rightButtons: mergeButtonList(asButtonList(layout?.rightButtons), DEFAULT_RIGHT_BUTTONS),
+      leftButtons: sanitizeButtonList(asButtonList(layout?.leftButtons) ?? DEFAULT_LEFT_BUTTONS),
+      rightButtons: sanitizeButtonList(asButtonList(layout?.rightButtons) ?? DEFAULT_RIGHT_BUTTONS),
       pinnedButtons: normalizePinnedButtons(layout?.pinnedButtons),
     },
     launcher: {
@@ -145,11 +148,11 @@ function toToolbarPersisted(
 
 /**
  * Baseline-aware three-way merge for toolbar-preferences writes across project
- * views (issue #11351). Button orderings and launcher scalars defer to a
- * sibling's on-disk value unless this writer changed them (two divergent
- * orderings can't be meaningfully merged, so it's whole-list-if-changed);
- * `pinnedButtons` merges per button id so a stale view neither drops nor
- * resurrects a sibling's plugin pin/hide.
+ * views (issue #11351). `pinnedButtons` merges per button id so a stale view
+ * neither drops nor resurrects a sibling's plugin pin/hide; launcher scalars
+ * defer to a sibling's on-disk value unless this writer changed them. Button
+ * orderings are the writer's own arrangement — two divergent orders can't be
+ * merged, so they're taken verbatim (last-writer-wins).
  *
  * Migration coexistence: `onDisk` is read raw (no `migrate`), so the reconciler
  * must never diff against a foreign schema version — the 11-step migrate chain
@@ -182,16 +185,10 @@ function mergeToolbarPreferencesPersistedWrite({
     version: incoming.version,
     state: {
       layout: {
-        leftButtons: pickFieldByWriterDelta(
-          base.layout.leftButtons,
-          inc.layout.leftButtons,
-          disk.layout.leftButtons
-        ),
-        rightButtons: pickFieldByWriterDelta(
-          base.layout.rightButtons,
-          inc.layout.rightButtons,
-          disk.layout.rightButtons
-        ),
+        // Take the writer's own ordering verbatim (last-writer-wins) — see the
+        // JSDoc; this also avoids re-materializing a moved default onto both sides.
+        leftButtons: inc.layout.leftButtons,
+        rightButtons: inc.layout.rightButtons,
         pinnedButtons: mergeRecordByWriterDelta(
           base.layout.pinnedButtons,
           inc.layout.pinnedButtons,

--- a/src/store/twoPaneSplitStore.ts
+++ b/src/store/twoPaneSplitStore.ts
@@ -1,6 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  mergeRecordByWriterDelta,
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export interface TwoPaneSplitConfig {
@@ -65,6 +71,81 @@ const DEFAULT_CONFIG: TwoPaneSplitConfig = {
   defaultRatio: 0.5,
   preferPreview: false,
 };
+
+type TwoPaneSplitPersistedState = Pick<TwoPaneSplitState, "config" | "ratioByWorktreeId">;
+
+/**
+ * Coerce a persisted (or in-memory) snapshot into the canonical persisted shape,
+ * mapping a null/malformed blob to defaults so the write merge compares canonical
+ * values (issue #11351).
+ */
+function toTwoPaneSplitPersisted(
+  state: Partial<TwoPaneSplitState> | null | undefined
+): TwoPaneSplitPersistedState {
+  const config = state?.config;
+  const ratios = state?.ratioByWorktreeId;
+  return {
+    config: {
+      enabled: typeof config?.enabled === "boolean" ? config.enabled : DEFAULT_CONFIG.enabled,
+      defaultRatio:
+        typeof config?.defaultRatio === "number"
+          ? config.defaultRatio
+          : DEFAULT_CONFIG.defaultRatio,
+      preferPreview:
+        typeof config?.preferPreview === "boolean"
+          ? config.preferPreview
+          : DEFAULT_CONFIG.preferPreview,
+    },
+    ratioByWorktreeId:
+      ratios !== null && typeof ratios === "object" && !Array.isArray(ratios) ? ratios : {},
+  };
+}
+
+/**
+ * Baseline-aware three-way merge for two-pane-split writes across project views
+ * (issue #11351). `ratioByWorktreeId` merges per worktree id so a stale view
+ * writing one worktree's ratio no longer wipes a sibling worktree's ratio another
+ * view committed; the three `config` fields defer to a sibling's on-disk value
+ * unless this writer changed them. The version guards keep the raw (un-migrated)
+ * `onDisk`/`baseline` reads from diffing a foreign schema — the v0→v1 migration
+ * reshapes each ratio from a scalar into a `WorktreeRatioEntry`.
+ */
+function mergeTwoPaneSplitPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<TwoPaneSplitPersistedState>): StorageValue<TwoPaneSplitPersistedState> {
+  if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  const disk = toTwoPaneSplitPersisted(onDisk.state);
+  const inc = toTwoPaneSplitPersisted(incoming.state);
+  if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
+    return { version: incoming.version, state: disk };
+  }
+  const base = toTwoPaneSplitPersisted(baseline?.state);
+  return {
+    version: incoming.version,
+    state: {
+      config: {
+        enabled: pickFieldByWriterDelta(base.config.enabled, inc.config.enabled, disk.config.enabled),
+        defaultRatio: pickFieldByWriterDelta(
+          base.config.defaultRatio,
+          inc.config.defaultRatio,
+          disk.config.defaultRatio
+        ),
+        preferPreview: pickFieldByWriterDelta(
+          base.config.preferPreview,
+          inc.config.preferPreview,
+          disk.config.preferPreview
+        ),
+      },
+      ratioByWorktreeId: mergeRecordByWriterDelta(
+        base.ratioByWorktreeId,
+        inc.ratioByWorktreeId,
+        disk.ratioByWorktreeId
+      ),
+    },
+  };
+}
 
 export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
   persist(
@@ -134,7 +215,16 @@ export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
     {
       name: "daintree-two-pane-split",
       version: 1,
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<TwoPaneSplitPersistedState>({
+        mergeOnWrite: mergeTwoPaneSplitPersistedWrite,
+      }),
+      // Persisted subset — matches the pre-existing default (setters are dropped
+      // by JSON serialization); named explicitly so the write merge (#11351) has a
+      // typed persisted shape to reconcile.
+      partialize: (state): TwoPaneSplitPersistedState => ({
+        config: state.config,
+        ratioByWorktreeId: state.ratioByWorktreeId,
+      }),
       migrate: (persisted: unknown, fromVersion: number) => {
         if (fromVersion === 0) {
           const old = persisted as { ratioByWorktreeId?: Record<string, number> } & Record<

--- a/src/store/twoPaneSplitStore.ts
+++ b/src/store/twoPaneSplitStore.ts
@@ -88,7 +88,7 @@ function toTwoPaneSplitPersisted(
     config: {
       enabled: typeof config?.enabled === "boolean" ? config.enabled : DEFAULT_CONFIG.enabled,
       defaultRatio:
-        typeof config?.defaultRatio === "number"
+        typeof config?.defaultRatio === "number" && Number.isFinite(config.defaultRatio)
           ? config.defaultRatio
           : DEFAULT_CONFIG.defaultRatio,
       preferPreview:
@@ -159,9 +159,11 @@ export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
         })),
 
       setDefaultRatio: (ratio) =>
-        set((state) => ({
-          config: { ...state.config, defaultRatio: Math.max(0.2, Math.min(0.8, ratio)) },
-        })),
+        set((state) =>
+          Number.isFinite(ratio)
+            ? { config: { ...state.config, defaultRatio: Math.max(0.2, Math.min(0.8, ratio)) } }
+            : state
+        ),
 
       setPreferPreview: (prefer) =>
         set((state) => ({
@@ -169,12 +171,16 @@ export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
         })),
 
       setWorktreeRatio: (worktreeId, ratio, panels) =>
-        set((state) => ({
-          ratioByWorktreeId: {
-            ...state.ratioByWorktreeId,
-            [worktreeId]: { ratio: Math.max(0.2, Math.min(0.8, ratio)), panels },
-          },
-        })),
+        set((state) =>
+          Number.isFinite(ratio)
+            ? {
+                ratioByWorktreeId: {
+                  ...state.ratioByWorktreeId,
+                  [worktreeId]: { ratio: Math.max(0.2, Math.min(0.8, ratio)), panels },
+                },
+              }
+            : state
+        ),
 
       commitRatioIfChanged: (worktreeId, pendingRatio, panels) => {
         if (pendingRatio === null || !Number.isFinite(pendingRatio)) return;
@@ -225,20 +231,20 @@ export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
         config: state.config,
         ratioByWorktreeId: state.ratioByWorktreeId,
       }),
-      migrate: (persisted: unknown, fromVersion: number) => {
+      migrate: (persisted: unknown, fromVersion: number): TwoPaneSplitPersistedState => {
+        const migrated = toTwoPaneSplitPersisted(persisted as Partial<TwoPaneSplitState>);
         if (fromVersion === 0) {
-          const old = persisted as { ratioByWorktreeId?: Record<string, number> } & Record<
-            string,
-            unknown
-          >;
-          const entries = old.ratioByWorktreeId ?? {};
-          const migrated: Record<string, WorktreeRatioEntry> = {};
-          for (const [id, scalar] of Object.entries(entries)) {
-            migrated[id] = { ratio: scalar, panels: [null, null] };
+          // v0 stored each ratio as a bare number; reshape into WorktreeRatioEntry.
+          const old = (persisted ?? {}) as { ratioByWorktreeId?: Record<string, unknown> };
+          const reshaped: Record<string, WorktreeRatioEntry> = {};
+          for (const [id, scalar] of Object.entries(old.ratioByWorktreeId ?? {})) {
+            if (typeof scalar === "number" && Number.isFinite(scalar)) {
+              reshaped[id] = { ratio: scalar, panels: [null, null] };
+            }
           }
-          return { ...old, ratioByWorktreeId: migrated };
+          return { config: migrated.config, ratioByWorktreeId: reshaped };
         }
-        return persisted;
+        return migrated;
       },
     }
   )

--- a/src/store/twoPaneSplitStore.ts
+++ b/src/store/twoPaneSplitStore.ts
@@ -126,7 +126,11 @@ function mergeTwoPaneSplitPersistedWrite({
     version: incoming.version,
     state: {
       config: {
-        enabled: pickFieldByWriterDelta(base.config.enabled, inc.config.enabled, disk.config.enabled),
+        enabled: pickFieldByWriterDelta(
+          base.config.enabled,
+          inc.config.enabled,
+          disk.config.enabled
+        ),
         defaultRatio: pickFieldByWriterDelta(
           base.config.defaultRatio,
           inc.config.defaultRatio,

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -80,13 +80,15 @@ function entriesOf(
  * resurrected. Concurrent writes to the *same* project bucket stay
  * last-writer-wins (the separate same-project multi-window case).
  *
- * Only the `baseline` is normalized through `migrateEntries` (the same
- * canonicalize + prune-expired transform the hydration `merge` applies): the
- * in-memory `incoming` already passed through it, but `baseline` is raw JSON, so
- * diffing a raw baseline against a pruned incoming would misread a
- * hydration-pruned project as a writer deletion and drop a sibling's re-added
- * bucket. `onDisk` stays raw so a sibling's freshly-written bucket is preserved
- * verbatim (it was already normalized by the sibling that wrote it).
+ * All three inputs are normalized through `migrateEntries` (the same
+ * canonicalize + prune-expired transform the hydration `merge` applies) against a
+ * single captured `now`, so the writer-delta diff compares like-for-like. Without
+ * it, a raw baseline diffed against a pruned incoming would misread a
+ * hydration-pruned project as a writer deletion (dropping a sibling's re-added
+ * bucket); and a lone-normalized baseline would misread an entry that expired
+ * after hydration (still present in raw incoming) as a writer add (clobbering a
+ * sibling's fresh replacement). Sharing one `now` keeps an entry from being
+ * pruned in one input but kept in another at the retention boundary.
  */
 function mergeUrlHistoryPersistedWrite({
   baseline,
@@ -95,13 +97,14 @@ function mergeUrlHistoryPersistedWrite({
 }: PersistWriteMergeContext<UrlHistoryPersistedState>): StorageValue<UrlHistoryPersistedState> {
   // No shared value on disk yet → nothing to reconcile against.
   if (!onDisk) return incoming;
+  const now = Date.now();
   return {
     version: incoming.version,
     state: {
       entries: mergeRecordByWriterDelta(
-        migrateEntries(entriesOf(baseline)),
-        entriesOf(incoming),
-        entriesOf(onDisk)
+        migrateEntries(entriesOf(baseline), now),
+        migrateEntries(entriesOf(incoming), now),
+        migrateEntries(entriesOf(onDisk), now)
       ),
     },
   };
@@ -112,9 +115,9 @@ function pruneStaleEntries(entries: UrlHistoryEntry[], now: number): UrlHistoryE
 }
 
 function migrateEntries(
-  rawEntries: Record<string, UrlHistoryEntry[]>
+  rawEntries: Record<string, UrlHistoryEntry[]>,
+  now: number = Date.now()
 ): Record<string, UrlHistoryEntry[]> {
-  const now = Date.now();
   const result: Record<string, UrlHistoryEntry[]> = {};
   for (const [projectId, projectEntries] of Object.entries(rawEntries)) {
     if (!Array.isArray(projectEntries)) continue;

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -79,6 +79,14 @@ function entriesOf(
  * history a sibling view recorded, and a `removeProjectHistory` isn't
  * resurrected. Concurrent writes to the *same* project bucket stay
  * last-writer-wins (the separate same-project multi-window case).
+ *
+ * Only the `baseline` is normalized through `migrateEntries` (the same
+ * canonicalize + prune-expired transform the hydration `merge` applies): the
+ * in-memory `incoming` already passed through it, but `baseline` is raw JSON, so
+ * diffing a raw baseline against a pruned incoming would misread a
+ * hydration-pruned project as a writer deletion and drop a sibling's re-added
+ * bucket. `onDisk` stays raw so a sibling's freshly-written bucket is preserved
+ * verbatim (it was already normalized by the sibling that wrote it).
  */
 function mergeUrlHistoryPersistedWrite({
   baseline,
@@ -90,7 +98,11 @@ function mergeUrlHistoryPersistedWrite({
   return {
     version: incoming.version,
     state: {
-      entries: mergeRecordByWriterDelta(entriesOf(baseline), entriesOf(incoming), entriesOf(onDisk)),
+      entries: mergeRecordByWriterDelta(
+        migrateEntries(entriesOf(baseline)),
+        entriesOf(incoming),
+        entriesOf(onDisk)
+      ),
     },
   };
 }

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -1,8 +1,13 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import type { UrlHistoryEntry } from "@shared/types/browser";
 import { sanitizeUrlForHistory } from "@shared/utils/urlHistory";
 import { createDebouncedSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  mergeRecordByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_ENTRIES_PER_PROJECT = 500;
@@ -56,6 +61,38 @@ interface UrlHistoryState {
   updateFavicon: (projectId: string, url: string, favicon: string) => void;
   removeUrl: (projectId: string, url: string) => void;
   removeProjectHistory: (projectId: string) => void;
+}
+
+type UrlHistoryPersistedState = Pick<UrlHistoryState, "entries">;
+
+function entriesOf(
+  value: StorageValue<UrlHistoryPersistedState> | null
+): Record<string, UrlHistoryEntry[]> {
+  const entries = value?.state?.entries;
+  return entries !== null && typeof entries === "object" ? entries : {};
+}
+
+/**
+ * Baseline-aware three-way merge for URL-history writes across project views
+ * (issue #11351). Each project's entry list is one record value keyed by project
+ * id, so a stale view writing its own project no longer wipes another project's
+ * history a sibling view recorded, and a `removeProjectHistory` isn't
+ * resurrected. Concurrent writes to the *same* project bucket stay
+ * last-writer-wins (the separate same-project multi-window case).
+ */
+function mergeUrlHistoryPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<UrlHistoryPersistedState>): StorageValue<UrlHistoryPersistedState> {
+  // No shared value on disk yet → nothing to reconcile against.
+  if (!onDisk) return incoming;
+  return {
+    version: incoming.version,
+    state: {
+      entries: mergeRecordByWriterDelta(entriesOf(baseline), entriesOf(incoming), entriesOf(onDisk)),
+    },
+  };
 }
 
 function pruneStaleEntries(entries: UrlHistoryEntry[], now: number): UrlHistoryEntry[] {
@@ -183,7 +220,9 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
     }),
     {
       name: "daintree-url-history",
-      storage: createDebouncedSafeJSONStorage(300),
+      storage: createDebouncedSafeJSONStorage<UrlHistoryPersistedState>(300, {
+        mergeOnWrite: mergeUrlHistoryPersistedWrite,
+      }),
       version: 1,
       migrate: (persistedState) => persistedState as UrlHistoryState,
       merge: (persistedState, currentState) => {

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -3,7 +3,10 @@ import { persist } from "zustand/middleware";
 import type { StorageValue } from "zustand/middleware";
 import type { VoiceInputError, VoiceInputStatus, VoiceTranscriptPhase } from "@shared/types";
 import { createDebouncedSafeJSONStorage } from "./persistence/safeStorage";
-import type { PersistWriteMergeContext } from "./persistence/persistWriteMerge";
+import {
+  mergeRecordByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export interface VoiceRecordingTarget {
@@ -73,34 +76,63 @@ function recentTargetIdentity(target: RecentDictationTarget): string {
 }
 
 /**
+ * Index a recent-targets list by logical identity, keeping the more-recently-used
+ * entry when one list holds two entries with the same identity.
+ */
+function toTargetsByIdentity(
+  value: StorageValue<VoiceRecordingPersistedState> | null
+): Record<string, RecentDictationTarget> {
+  const byIdentity: Record<string, RecentDictationTarget> = {};
+  for (const target of toRecentTargets(value)) {
+    const identity = recentTargetIdentity(target);
+    const existing = byIdentity[identity];
+    if (!existing || target.lastUsedAt > existing.lastUsedAt) byIdentity[identity] = target;
+  }
+  return byIdentity;
+}
+
+/**
  * Baseline-aware three-way merge for voice-recording writes across project views
  * (issue #11351). `recentTargets` is one global MRU list (cap 3) that any view
  * appends to, and the store's high-frequency transient setters (`setAudioLevel`,
  * `setElapsedSeconds`) trigger debounced persist writes of it — so a stale view's
- * flush would otherwise drop a sibling's just-recorded target. We union this
- * writer's list with the freshest on-disk list by logical identity, keep the
- * more-recently-used entry on collision, and re-sort/cap to the globally three
- * most-recent — the same recency semantics the store's own `recordRecentTarget`
- * applies within a single view.
+ * flush would otherwise drop a sibling's just-recorded target.
+ *
+ * All three inputs are keyed by logical identity and reconciled with the same
+ * writer-delta semantics the other stores use: an entry this writer added or
+ * changed wins, one it left untouched defers to disk, and one that was in its
+ * baseline but is gone from its snapshot is dropped. That last case is what a
+ * plain union gets wrong: `recordRecentTarget` dedupes in memory by `panelId`,
+ * but a persisted entry's identity is `(worktreeId, panelTitle)` — so re-dictating
+ * into a panel whose title changed mid-session supersedes the old entry in memory,
+ * and without the baseline the stale title would linger on disk forever, evicting
+ * genuinely distinct targets through the cap. On a same-identity collision the
+ * more-recently-used copy still wins, so a sibling's fresher timestamp is never
+ * rolled back. The result is re-sorted and capped to the globally three
+ * most-recent — the same recency semantics `recordRecentTarget` applies in a
+ * single view.
  */
 function mergeVoiceRecordingPersistedWrite({
+  baseline,
   onDisk,
   incoming,
 }: PersistWriteMergeContext<VoiceRecordingPersistedState>): StorageValue<VoiceRecordingPersistedState> {
   // No shared value on disk yet → nothing to reconcile against.
   if (!onDisk) return incoming;
-  const byIdentity = new Map<string, RecentDictationTarget>();
-  for (const target of [...toRecentTargets(incoming), ...toRecentTargets(onDisk)]) {
-    const identity = recentTargetIdentity(target);
-    const existing = byIdentity.get(identity);
-    if (!existing || target.lastUsedAt > existing.lastUsedAt) {
-      byIdentity.set(identity, target);
-    }
-  }
-  const merged = [...byIdentity.values()]
+  const disk = toTargetsByIdentity(onDisk);
+  const merged = mergeRecordByWriterDelta(
+    toTargetsByIdentity(baseline),
+    toTargetsByIdentity(incoming),
+    disk
+  );
+  const recentTargets = Object.entries(merged)
+    .map(([identity, target]) => {
+      const diskTarget = disk[identity];
+      return diskTarget && diskTarget.lastUsedAt > target.lastUsedAt ? diskTarget : target;
+    })
     .sort((a, b) => b.lastUsedAt - a.lastUsedAt)
     .slice(0, MAX_RECENT_TARGETS);
-  return { version: incoming.version, state: { recentTargets: merged } };
+  return { version: incoming.version, state: { recentTargets } };
 }
 
 interface VoiceTranscriptBuffer {

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -53,11 +53,16 @@ function toRecentTargets(
  * Logical identity of a persisted recent target. Persisted entries have `panelId`
  * stripped (partialize), so identity is the `(worktreeId, panelTitle)` tuple the
  * store uses to resolve a rehydrated entry back to a live panel. An entry with
- * neither has no stable identity (`null`) and is kept as-is rather than merged.
+ * neither has no stable logical key, so it is fingerprinted by its full persisted
+ * content (`lastUsedAt` included): identical copies from two views collapse
+ * instead of duplicating across flushes, while genuinely distinct anonymous
+ * entries stay separate.
  */
-function recentTargetIdentity(target: RecentDictationTarget): string | null {
-  if (!target.worktreeId && !target.panelTitle) return null;
-  return `wt:${target.worktreeId ?? ""}|pt:${target.panelTitle ?? ""}`;
+function recentTargetIdentity(target: RecentDictationTarget): string {
+  if (target.worktreeId || target.panelTitle) {
+    return `id:${target.worktreeId ?? ""}|${target.panelTitle ?? ""}`;
+  }
+  return `anon:${target.projectId ?? ""}|${target.projectName ?? ""}|${target.worktreeLabel ?? ""}|${target.lastUsedAt}`;
 }
 
 /**
@@ -78,19 +83,14 @@ function mergeVoiceRecordingPersistedWrite({
   // No shared value on disk yet → nothing to reconcile against.
   if (!onDisk) return incoming;
   const byIdentity = new Map<string, RecentDictationTarget>();
-  const anonymous: RecentDictationTarget[] = [];
   for (const target of [...toRecentTargets(incoming), ...toRecentTargets(onDisk)]) {
     const identity = recentTargetIdentity(target);
-    if (identity === null) {
-      anonymous.push(target);
-      continue;
-    }
     const existing = byIdentity.get(identity);
     if (!existing || target.lastUsedAt > existing.lastUsedAt) {
       byIdentity.set(identity, target);
     }
   }
-  const merged = [...byIdentity.values(), ...anonymous]
+  const merged = [...byIdentity.values()]
     .sort((a, b) => b.lastUsedAt - a.lastUsedAt)
     .slice(0, MAX_RECENT_TARGETS);
   return { version: incoming.version, state: { recentTargets: merged } };
@@ -523,15 +523,15 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()(
       storage: createDebouncedSafeJSONStorage<VoiceRecordingPersistedState>(300, {
         mergeOnWrite: mergeVoiceRecordingPersistedWrite,
       }),
+      // No `migrate`: at v0 the persisted blob is a forward-compatible subset of
+      // the current shape (only `recentTargets`), and a version-0 store never sees
+      // a version mismatch — so an explicit no-op migration would only muddy the
+      // inferred persisted type.
       version: 0,
-      // No structural migration yet — at v0 the persisted blob is a
-      // forward-compatible subset of the current shape (only `recentTargets`),
-      // so we pass it through unchanged.
-      migrate: (persistedState) => persistedState,
       // Persist only the recent-targets list. Strip the live `panelId` on each
       // entry so a stale id cannot silently re-route dictation after restart —
       // panelIds are ephemeral. Lock state and session state are runtime-only.
-      partialize: (state) => ({
+      partialize: (state): VoiceRecordingPersistedState => ({
         recentTargets: state.recentTargets.map(({ panelId: _panelId, ...rest }) => rest),
       }),
     }

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -59,10 +59,17 @@ function toRecentTargets(
  * entries stay separate.
  */
 function recentTargetIdentity(target: RecentDictationTarget): string {
+  // JSON-encode the key fields so a value containing the delimiter can't forge a
+  // collision with a different target.
   if (target.worktreeId || target.panelTitle) {
-    return `id:${target.worktreeId ?? ""}|${target.panelTitle ?? ""}`;
+    return `id:${JSON.stringify([target.worktreeId ?? "", target.panelTitle ?? ""])}`;
   }
-  return `anon:${target.projectId ?? ""}|${target.projectName ?? ""}|${target.worktreeLabel ?? ""}|${target.lastUsedAt}`;
+  return `anon:${JSON.stringify([
+    target.projectId ?? "",
+    target.projectName ?? "",
+    target.worktreeLabel ?? "",
+    target.lastUsedAt,
+  ])}`;
 }
 
 /**

--- a/src/store/voiceRecordingStore.ts
+++ b/src/store/voiceRecordingStore.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import type { VoiceInputError, VoiceInputStatus, VoiceTranscriptPhase } from "@shared/types";
 import { createDebouncedSafeJSONStorage } from "./persistence/safeStorage";
+import type { PersistWriteMergeContext } from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export interface VoiceRecordingTarget {
@@ -33,6 +35,66 @@ export interface RecentDictationTarget {
 }
 
 const MAX_RECENT_TARGETS = 3;
+
+type VoiceRecordingPersistedState = { recentTargets: RecentDictationTarget[] };
+
+function toRecentTargets(
+  value: StorageValue<VoiceRecordingPersistedState> | null
+): RecentDictationTarget[] {
+  const list = value?.state?.recentTargets;
+  if (!Array.isArray(list)) return [];
+  return list.filter(
+    (entry): entry is RecentDictationTarget =>
+      entry !== null && typeof entry === "object" && typeof entry.lastUsedAt === "number"
+  );
+}
+
+/**
+ * Logical identity of a persisted recent target. Persisted entries have `panelId`
+ * stripped (partialize), so identity is the `(worktreeId, panelTitle)` tuple the
+ * store uses to resolve a rehydrated entry back to a live panel. An entry with
+ * neither has no stable identity (`null`) and is kept as-is rather than merged.
+ */
+function recentTargetIdentity(target: RecentDictationTarget): string | null {
+  if (!target.worktreeId && !target.panelTitle) return null;
+  return `wt:${target.worktreeId ?? ""}|pt:${target.panelTitle ?? ""}`;
+}
+
+/**
+ * Baseline-aware three-way merge for voice-recording writes across project views
+ * (issue #11351). `recentTargets` is one global MRU list (cap 3) that any view
+ * appends to, and the store's high-frequency transient setters (`setAudioLevel`,
+ * `setElapsedSeconds`) trigger debounced persist writes of it — so a stale view's
+ * flush would otherwise drop a sibling's just-recorded target. We union this
+ * writer's list with the freshest on-disk list by logical identity, keep the
+ * more-recently-used entry on collision, and re-sort/cap to the globally three
+ * most-recent — the same recency semantics the store's own `recordRecentTarget`
+ * applies within a single view.
+ */
+function mergeVoiceRecordingPersistedWrite({
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<VoiceRecordingPersistedState>): StorageValue<VoiceRecordingPersistedState> {
+  // No shared value on disk yet → nothing to reconcile against.
+  if (!onDisk) return incoming;
+  const byIdentity = new Map<string, RecentDictationTarget>();
+  const anonymous: RecentDictationTarget[] = [];
+  for (const target of [...toRecentTargets(incoming), ...toRecentTargets(onDisk)]) {
+    const identity = recentTargetIdentity(target);
+    if (identity === null) {
+      anonymous.push(target);
+      continue;
+    }
+    const existing = byIdentity.get(identity);
+    if (!existing || target.lastUsedAt > existing.lastUsedAt) {
+      byIdentity.set(identity, target);
+    }
+  }
+  const merged = [...byIdentity.values(), ...anonymous]
+    .sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+    .slice(0, MAX_RECENT_TARGETS);
+  return { version: incoming.version, state: { recentTargets: merged } };
+}
 
 interface VoiceTranscriptBuffer {
   liveText: string;
@@ -458,7 +520,9 @@ export const useVoiceRecordingStore = create<VoiceRecordingState>()(
       // `setElapsedSeconds` per second) trigger persist writes regardless of
       // whether the partialized output changed. Coalescing to a trailing-edge
       // 300ms write avoids burning the localStorage write queue mid-session.
-      storage: createDebouncedSafeJSONStorage(300),
+      storage: createDebouncedSafeJSONStorage<VoiceRecordingPersistedState>(300, {
+        mergeOnWrite: mergeVoiceRecordingPersistedWrite,
+      }),
       version: 0,
       // No structural migration yet — at v0 the persisted blob is a
       // forward-compatible subset of the current shape (only `recentTargets`),

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -467,7 +467,11 @@ function mergeProjectFiltersPersistedWrite({
         inc.statusFilters,
         disk.statusFilters
       ),
-      typeFilters: pickFieldByWriterDelta(base?.typeFilters ?? [], inc.typeFilters, disk.typeFilters),
+      typeFilters: pickFieldByWriterDelta(
+        base?.typeFilters ?? [],
+        inc.typeFilters,
+        disk.typeFilters
+      ),
       prIssueFilters: pickFieldByWriterDelta(
         base?.prIssueFilters ?? [],
         inc.prIssueFilters,
@@ -493,7 +497,11 @@ function mergeProjectFiltersPersistedWrite({
         inc.collapsedWorktrees,
         disk.collapsedWorktrees
       ),
-      manualOrder: pickFieldByWriterDelta(base?.manualOrder ?? [], inc.manualOrder, disk.manualOrder),
+      manualOrder: pickFieldByWriterDelta(
+        base?.manualOrder ?? [],
+        inc.manualOrder,
+        disk.manualOrder
+      ),
     },
   };
 }

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -435,6 +435,31 @@ const _globalPrefsStore = create<GlobalPrefsState>()(
 );
 
 /**
+ * Coerce a persisted (or baseline) per-project blob to the exact
+ * `ProjectPersistedShape`, substituting the store's defaults for any field with
+ * the wrong runtime type. Mirrors `toGlobalPrefsPersisted`: without it a corrupt
+ * on-disk field (e.g. `statusFilters` stored as a string) would be treated as
+ * "unchanged by this writer" and written straight back on every write, so the
+ * blob never self-heals and the bad value reaches `new Set(...)` at hydration.
+ */
+function toProjectFiltersPersisted(
+  state: Partial<ProjectPersistedShape> | null | undefined
+): ProjectPersistedShape {
+  const raw = (state ?? {}) as Record<string, unknown>;
+  return {
+    query: typeof raw.query === "string" ? raw.query : "",
+    statusFilters: arrayOrUndefined<StatusFilter>(raw.statusFilters) ?? [],
+    typeFilters: arrayOrUndefined<TypeFilter>(raw.typeFilters) ?? [],
+    prIssueFilters: arrayOrUndefined<PrIssueFilter>(raw.prIssueFilters) ?? [],
+    sessionFilters: arrayOrUndefined<SessionFilter>(raw.sessionFilters) ?? [],
+    activityFilters: arrayOrUndefined<ActivityFilter>(raw.activityFilters) ?? [],
+    pinnedWorktrees: arrayOrUndefined<string>(raw.pinnedWorktrees) ?? [],
+    collapsedWorktrees: arrayOrUndefined<string>(raw.collapsedWorktrees) ?? [],
+    manualOrder: arrayOrUndefined<string>(raw.manualOrder) ?? [],
+  };
+}
+
+/**
  * Baseline-aware three-way merge for the PER-PROJECT worktree-filter state
  * (issue #11351). Its storage key already embeds the project id
  * (`daintree-worktree-filters:{projectId}`), so it's immune to CROSS-project
@@ -452,56 +477,48 @@ function mergeProjectFiltersPersistedWrite({
   incoming,
 }: PersistWriteMergeContext<ProjectPersistedShape>): StorageValue<ProjectPersistedShape> {
   if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  const disk = toProjectFiltersPersisted(onDisk.state);
+  const inc = toProjectFiltersPersisted(incoming.state);
   if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
-    return { version: incoming.version, state: onDisk.state };
+    return { version: incoming.version, state: disk };
   }
-  const base = baseline?.state;
-  const inc = incoming.state;
-  const disk = onDisk.state;
+  const base = toProjectFiltersPersisted(baseline?.state);
   return {
     version: incoming.version,
     state: {
-      query: pickFieldByWriterDelta(base?.query ?? "", inc.query, disk.query),
+      query: pickFieldByWriterDelta(base.query, inc.query, disk.query),
       statusFilters: pickFieldByWriterDelta(
-        base?.statusFilters ?? [],
+        base.statusFilters,
         inc.statusFilters,
         disk.statusFilters
       ),
-      typeFilters: pickFieldByWriterDelta(
-        base?.typeFilters ?? [],
-        inc.typeFilters,
-        disk.typeFilters
-      ),
+      typeFilters: pickFieldByWriterDelta(base.typeFilters, inc.typeFilters, disk.typeFilters),
       prIssueFilters: pickFieldByWriterDelta(
-        base?.prIssueFilters ?? [],
+        base.prIssueFilters,
         inc.prIssueFilters,
         disk.prIssueFilters
       ),
       sessionFilters: pickFieldByWriterDelta(
-        base?.sessionFilters ?? [],
+        base.sessionFilters,
         inc.sessionFilters,
         disk.sessionFilters
       ),
       activityFilters: pickFieldByWriterDelta(
-        base?.activityFilters ?? [],
+        base.activityFilters,
         inc.activityFilters,
         disk.activityFilters
       ),
       pinnedWorktrees: pickFieldByWriterDelta(
-        base?.pinnedWorktrees ?? [],
+        base.pinnedWorktrees,
         inc.pinnedWorktrees,
         disk.pinnedWorktrees
       ),
       collapsedWorktrees: pickFieldByWriterDelta(
-        base?.collapsedWorktrees ?? [],
+        base.collapsedWorktrees,
         inc.collapsedWorktrees,
         disk.collapsedWorktrees
       ),
-      manualOrder: pickFieldByWriterDelta(
-        base?.manualOrder ?? [],
-        inc.manualOrder,
-        disk.manualOrder
-      ),
+      manualOrder: pickFieldByWriterDelta(base.manualOrder, inc.manualOrder, disk.manualOrder),
     },
   };
 }

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -333,10 +333,11 @@ function toGlobalPrefsPersisted(
  * project views (issue #11351). These five fields share one literal key
  * (`daintree-worktree-filters`) and are set independently, so each defers to a
  * sibling's on-disk value unless this writer changed it. The per-project store
- * (`_projectStore`) needs no merge — its key already embeds the project id
- * (`…:{projectId}`), so each project view writes a disjoint key. After merging,
- * we reapply the `merge()`-time invariant that `manual` order is invalid while
- * grouping (a cross-view merge could otherwise recombine them).
+ * (`_projectStore`) has its own reconciler below — its key embeds the project id,
+ * so it's immune to cross-project clobber, but two windows on the same project
+ * still share it. After merging, we reapply the `merge()`-time invariant that
+ * `manual` order is invalid while grouping (a cross-view merge could otherwise
+ * recombine them).
  */
 function mergeGlobalPrefsPersistedWrite({
   baseline,
@@ -433,6 +434,70 @@ const _globalPrefsStore = create<GlobalPrefsState>()(
   )
 );
 
+/**
+ * Baseline-aware three-way merge for the PER-PROJECT worktree-filter state
+ * (issue #11351). Its storage key already embeds the project id
+ * (`daintree-worktree-filters:{projectId}`), so it's immune to CROSS-project
+ * clobber — but two windows showing the SAME project share this key (see
+ * `ProjectViewManager`), and a stale window's write (even the transient
+ * `setLiveQuery` on every keystroke persists this partialized snapshot) would
+ * otherwise wipe a sibling window's pin/filter. Each persisted field defers to a
+ * sibling's on-disk value unless this writer changed it; divergent filter/list
+ * values across two windows can't be element-merged, so it's whole-value
+ * last-writer-wins on a genuine concurrent edit.
+ */
+function mergeProjectFiltersPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<ProjectPersistedShape>): StorageValue<ProjectPersistedShape> {
+  if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
+    return { version: incoming.version, state: onDisk.state };
+  }
+  const base = baseline?.state;
+  const inc = incoming.state;
+  const disk = onDisk.state;
+  return {
+    version: incoming.version,
+    state: {
+      query: pickFieldByWriterDelta(base?.query ?? "", inc.query, disk.query),
+      statusFilters: pickFieldByWriterDelta(
+        base?.statusFilters ?? [],
+        inc.statusFilters,
+        disk.statusFilters
+      ),
+      typeFilters: pickFieldByWriterDelta(base?.typeFilters ?? [], inc.typeFilters, disk.typeFilters),
+      prIssueFilters: pickFieldByWriterDelta(
+        base?.prIssueFilters ?? [],
+        inc.prIssueFilters,
+        disk.prIssueFilters
+      ),
+      sessionFilters: pickFieldByWriterDelta(
+        base?.sessionFilters ?? [],
+        inc.sessionFilters,
+        disk.sessionFilters
+      ),
+      activityFilters: pickFieldByWriterDelta(
+        base?.activityFilters ?? [],
+        inc.activityFilters,
+        disk.activityFilters
+      ),
+      pinnedWorktrees: pickFieldByWriterDelta(
+        base?.pinnedWorktrees ?? [],
+        inc.pinnedWorktrees,
+        disk.pinnedWorktrees
+      ),
+      collapsedWorktrees: pickFieldByWriterDelta(
+        base?.collapsedWorktrees ?? [],
+        inc.collapsedWorktrees,
+        disk.collapsedWorktrees
+      ),
+      manualOrder: pickFieldByWriterDelta(base?.manualOrder ?? [], inc.manualOrder, disk.manualOrder),
+    },
+  };
+}
+
 const _projectStore = create<ProjectScopedState>()(
   persist(
     (): ProjectScopedState => ({
@@ -452,7 +517,9 @@ const _projectStore = create<ProjectScopedState>()(
     {
       name: PROJECT_KEY,
       version: 2,
-      storage: createDebouncedSafeJSONStorage(300),
+      storage: createDebouncedSafeJSONStorage<ProjectPersistedShape>(300, {
+        mergeOnWrite: mergeProjectFiltersPersistedWrite,
+      }),
       partialize: (state): ProjectPersistedShape => ({
         query: state.query,
         statusFilters: Array.from(state.statusFilters),

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -1,11 +1,16 @@
 import { create, useStore } from "zustand";
 import { persist } from "zustand/middleware";
+import type { StorageValue } from "zustand/middleware";
 import {
   createSafeJSONStorage,
   createDebouncedSafeJSONStorage,
   readLocalStorageItemSafely,
   safeJSONParse,
 } from "./persistence/safeStorage";
+import {
+  pickFieldByWriterDelta,
+  type PersistWriteMergeContext,
+} from "./persistence/persistWriteMerge";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import type { QuickStateFilter } from "@/lib/worktreeFilters";
 
@@ -294,6 +299,84 @@ function loadLegacySeedForProject(): Partial<ProjectPersistedShape> {
 
 const _legacySeed = loadLegacySeedForProject();
 
+const GLOBAL_PREFS_PERSISTED_DEFAULTS: GlobalPersistedShape = {
+  orderBy: "created",
+  groupByType: false,
+  alwaysShowActive: true,
+  alwaysShowWaiting: true,
+  hideMainWorktree: false,
+};
+
+function isOrderBy(value: unknown): value is OrderBy {
+  return value === "recent" || value === "created" || value === "alpha" || value === "manual";
+}
+
+function toGlobalPrefsPersisted(
+  state: Partial<GlobalPrefsState> | null | undefined
+): GlobalPersistedShape {
+  const raw = (state ?? {}) as Record<string, unknown>;
+  const d = GLOBAL_PREFS_PERSISTED_DEFAULTS;
+  return {
+    orderBy: isOrderBy(raw.orderBy) ? raw.orderBy : d.orderBy,
+    groupByType: typeof raw.groupByType === "boolean" ? raw.groupByType : d.groupByType,
+    alwaysShowActive:
+      typeof raw.alwaysShowActive === "boolean" ? raw.alwaysShowActive : d.alwaysShowActive,
+    alwaysShowWaiting:
+      typeof raw.alwaysShowWaiting === "boolean" ? raw.alwaysShowWaiting : d.alwaysShowWaiting,
+    hideMainWorktree:
+      typeof raw.hideMainWorktree === "boolean" ? raw.hideMainWorktree : d.hideMainWorktree,
+  };
+}
+
+/**
+ * Baseline-aware three-way merge for the GLOBAL worktree-filter prefs across
+ * project views (issue #11351). These five fields share one literal key
+ * (`daintree-worktree-filters`) and are set independently, so each defers to a
+ * sibling's on-disk value unless this writer changed it. The per-project store
+ * (`_projectStore`) needs no merge — its key already embeds the project id
+ * (`…:{projectId}`), so each project view writes a disjoint key. After merging,
+ * we reapply the `merge()`-time invariant that `manual` order is invalid while
+ * grouping (a cross-view merge could otherwise recombine them).
+ */
+function mergeGlobalPrefsPersistedWrite({
+  baseline,
+  onDisk,
+  incoming,
+}: PersistWriteMergeContext<GlobalPersistedShape>): StorageValue<GlobalPersistedShape> {
+  if (!onDisk || onDisk.version !== incoming.version) return incoming;
+  const disk = toGlobalPrefsPersisted(onDisk.state);
+  const inc = toGlobalPrefsPersisted(incoming.state);
+  if (baseline && typeof baseline.version === "number" && baseline.version !== incoming.version) {
+    return { version: incoming.version, state: disk };
+  }
+  const base = toGlobalPrefsPersisted(baseline?.state);
+  const groupByType = pickFieldByWriterDelta(base.groupByType, inc.groupByType, disk.groupByType);
+  const rawOrderBy = pickFieldByWriterDelta(base.orderBy, inc.orderBy, disk.orderBy);
+  const orderBy: OrderBy = groupByType && rawOrderBy === "manual" ? "created" : rawOrderBy;
+  return {
+    version: incoming.version,
+    state: {
+      orderBy,
+      groupByType,
+      alwaysShowActive: pickFieldByWriterDelta(
+        base.alwaysShowActive,
+        inc.alwaysShowActive,
+        disk.alwaysShowActive
+      ),
+      alwaysShowWaiting: pickFieldByWriterDelta(
+        base.alwaysShowWaiting,
+        inc.alwaysShowWaiting,
+        disk.alwaysShowWaiting
+      ),
+      hideMainWorktree: pickFieldByWriterDelta(
+        base.hideMainWorktree,
+        inc.hideMainWorktree,
+        disk.hideMainWorktree
+      ),
+    },
+  };
+}
+
 const _globalPrefsStore = create<GlobalPrefsState>()(
   persist(
     (): GlobalPrefsState => ({
@@ -306,7 +389,9 @@ const _globalPrefsStore = create<GlobalPrefsState>()(
     {
       name: GLOBAL_KEY,
       version: 1,
-      storage: createSafeJSONStorage(),
+      storage: createSafeJSONStorage<GlobalPersistedShape>({
+        mergeOnWrite: mergeGlobalPrefsPersistedWrite,
+      }),
       partialize: (state): GlobalPersistedShape => ({
         orderBy: state.orderBy,
         groupByType: state.groupByType,


### PR DESCRIPTION
## Summary

- Follow-up to #11379, which built the baseline-aware three-way write-merge mechanism (`mergeOnWrite`, in `persistWriteMerge.ts` and `safeStorage.ts`) and applied it to `helpPanelStore` and `commandHistoryStore`. That fixed a bug where a stale project view's Zustand persist write could clobber a sibling project view's writes, since every project view shares one `persist:daintree` localStorage partition.
- This PR opts the remaining project-scoped persist stores into that same mechanism so a stale view can no longer wipe out a sibling view's writes.
- All 8 stores below are wired; `agentPreferencesStore` is deliberately left untouched and documented, since it's a genuinely app-global scalar with no per-view divergence.

Resolves #11351

## Changes

- `terminalSearchHistoryStore`: merges the searches MRU list via action-replay, plus the toggle flags.
- `toolbarPreferencesStore`: per-id merge for `pinnedButtons`, last-writer-wins for the button order arrays, scalar launcher settings, plus version/foreign-baseline migration guards.
- `urlHistoryStore`: merges entries keyed by `projectId`, with normalized `migrateEntries` inputs.
- `preferencesStore`: merges the `lastSelectedWorktreeRecipeIdByProject` and `skipPushConfirmByWorktreePath` maps, plus 16 scalar preference fields and the hidden-patterns list.
- `twoPaneSplitStore`: merges the `ratioByWorktreeId` map plus config.
- `panelLimitStore`: merges 6 panel limit fields, fixing a transient `requestSeq` clobber along the way.
- `worktreeFilterStore`: both sub-stores (global prefs and per-project prefs) are wired, since two windows open on the same project share the same per-project storage key.
- `voiceRecordingStore`: merges the `recentTargets` MRU list by identity, capped at 3 entries.
- `agentPreferencesStore` left as-is and documented inline as intentional.

## Testing

- Full store test suite (492 tests) passes: 8 new `*.crossViewMerge.test.ts` suites covering 27 scenarios, plus the 8 existing store suites and the 4 existing mechanism regression suites.
- Typecheck passes, Prettier is clean, ESLint shows 0 errors on changed files.
- Reviewed across two Codex passes; all confirmed findings fixed.
