### PR TITLE
feat(git-init): default to Minimal gitignore and expand the template set

### DIFF
--- a/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
+++ b/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
@@ -23,6 +23,40 @@ function resolve(id: string): string {
   return content;
 }
 
+/**
+ * Negations whose target sits inside a literally excluded parent directory.
+ * Git refuses to descend into an excluded directory, so those lines are dead:
+ * `dir/*` keeps the directory traversable, `dir/` and `dir` do not. Pruning is
+ * not order-sensitive the way last-match-wins is, so a parent excluded anywhere
+ * in the file counts — unless that parent is itself re-included.
+ */
+function unreachableNegations(lines: string[]): string[] {
+  const dead: string[] = [];
+
+  for (const line of lines) {
+    if (!line.startsWith("!")) continue;
+    const segments = line.slice(1).replace(/\/$/, "").split("/");
+
+    for (let depth = 1; depth < segments.length; depth++) {
+      const parent = segments.slice(0, depth).join("/");
+      if (!parent) continue;
+
+      const spellings = [parent, `${parent}/`];
+      const reincluded = lines.some(
+        (other) => other.startsWith("!") && spellings.includes(other.slice(1))
+      );
+      if (reincluded) continue;
+
+      if (lines.some((other) => spellings.includes(other))) {
+        dead.push(line);
+        break;
+      }
+    }
+  }
+
+  return dead;
+}
+
 describe("gitignore template registry", () => {
   it("exposes unique ids", () => {
     expect(new Set(TEMPLATE_IDS).size).toBe(TEMPLATE_IDS.length);
@@ -54,23 +88,34 @@ describe("gitignore template registry", () => {
   it("returns null for unknown templates", () => {
     expect(getGitignoreTemplate("unknown")).toBeNull();
   });
+
+  // Guards the `Object.hasOwn` lookup against regressing to `in`, which would
+  // accept inherited prototype keys and resolve them to garbage content.
+  it("does not treat inherited object properties as templates", () => {
+    for (const key of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      expect(isGitignoreTemplateId(key), `${key} is not a template`).toBe(false);
+      expect(getGitignoreTemplate(key), `${key} should not resolve`).toBeNull();
+    }
+  });
 });
 
 describe("gitignore template composition", () => {
-  it("layers every language template on top of the full minimal baseline", () => {
-    const minimal = resolve("minimal");
+  // Anchored on the default rather than on "minimal" so that promoting a
+  // language template to the default fails here instead of quietly redefining
+  // what every other template is built on.
+  it("layers every other template on top of the full default baseline", () => {
+    const baseline = resolve(DEFAULT_GITIGNORE_TEMPLATE_ID);
     for (const id of LANGUAGE_IDS) {
       const content = resolve(id);
-      expect(content.startsWith(`${minimal}\n`), `${id} should open with minimal`).toBe(true);
+      expect(content.startsWith(`${baseline}\n`), `${id} should open with the baseline`).toBe(true);
     }
   });
 
   it("adds language-specific rules beyond the baseline", () => {
-    const minimalLineCount = activeLines(resolve("minimal")).length;
+    const baseline = new Set(activeLines(resolve(DEFAULT_GITIGNORE_TEMPLATE_ID)));
     for (const id of LANGUAGE_IDS) {
-      expect(activeLines(resolve(id)).length, `${id} should add rules`).toBeGreaterThan(
-        minimalLineCount
-      );
+      const added = activeLines(resolve(id)).filter((line) => !baseline.has(line));
+      expect(added.length, `${id} should add rules the baseline lacks`).toBeGreaterThan(0);
     }
   });
 
@@ -99,26 +144,43 @@ describe("gitignore pattern semantics", () => {
     }
   });
 
-  // Git refuses to descend into an excluded directory, so a negation is dead if
-  // one of its parent directories is excluded outright. `dir/*` keeps the
-  // directory traversable; `dir/` or `dir` does not.
-  it("keeps every negation reachable", () => {
+  it("never negates inside a literally excluded parent directory", () => {
     for (const id of TEMPLATE_IDS.filter((candidate) => candidate !== "none")) {
-      const lines = activeLines(resolve(id));
-
-      lines.forEach((line, index) => {
-        if (!line.startsWith("!")) return;
-
-        const segments = line.slice(1).replace(/\/$/, "").split("/");
-        const earlier = lines.slice(0, index);
-
-        for (let depth = 1; depth < segments.length; depth++) {
-          const parent = segments.slice(0, depth).join("/");
-          const blocked = earlier.filter((prior) => prior === parent || prior === `${parent}/`);
-          expect(blocked, `${id}: "${line}" is unreachable — "${parent}" is excluded`).toEqual([]);
-        }
-      });
+      expect(unreachableNegations(activeLines(resolve(id))), `${id} has dead negations`).toEqual(
+        []
+      );
     }
+  });
+});
+
+describe("unreachableNegations", () => {
+  it("flags a parent excluded as a bare directory", () => {
+    expect(unreachableNegations([".vscode/", "!.vscode/settings.json"])).toEqual([
+      "!.vscode/settings.json",
+    ]);
+    expect(unreachableNegations([".yarn", "!.yarn/patches"])).toEqual(["!.yarn/patches"]);
+  });
+
+  it("flags a parent excluded after the negation", () => {
+    expect(unreachableNegations(["foo/*", "!foo/keep", "foo/"])).toEqual(["!foo/keep"]);
+  });
+
+  it("accepts the traversable dir/* form", () => {
+    expect(unreachableNegations([".vscode/*", "!.vscode/settings.json"])).toEqual([]);
+    expect(unreachableNegations(["/log/*", "!/log/.keep"])).toEqual([]);
+  });
+
+  it("accepts negations with no directory component", () => {
+    expect(unreachableNegations([".env.*", "!.env.example"])).toEqual([]);
+    expect(unreachableNegations([".aider*", "!.aider.conf.yml", "!.aiderignore"])).toEqual([]);
+  });
+
+  it("accepts a parent that is explicitly re-included", () => {
+    expect(unreachableNegations(["foo/", "!foo/", "!foo/keep"])).toEqual([]);
+  });
+
+  it("accepts a negation whose parent is only matched by a glob", () => {
+    expect(unreachableNegations(["**/build/", "!**/src/**/build/"])).toEqual([]);
   });
 });
 

--- a/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
+++ b/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
@@ -222,4 +222,34 @@ describe("computeMissingTemplateEntries", () => {
     const existing = "  .env  \n .DS_Store \n";
     expect(computeMissingTemplateEntries(existing, template)).toEqual([]);
   });
+
+  it("never reports a negation as missing", () => {
+    const template = ".env\n!.env.example\n.yarn/*\n!.yarn/patches\n";
+    expect(computeMissingTemplateEntries("", template)).toEqual([".env", ".yarn/*"]);
+  });
+
+  it("reports nothing when only negations are absent from the existing file", () => {
+    const template = ".env\n!.env.example\n";
+    const existing = ".env\n";
+    expect(computeMissingTemplateEntries(existing, template)).toEqual([]);
+  });
+
+  it("ignores negations the existing file happens to carry", () => {
+    const template = ".env\n.DS_Store\n";
+    const existing = "!.env\n.DS_Store\n";
+    expect(computeMissingTemplateEntries(existing, template)).toEqual([".env"]);
+  });
+
+  it("keeps every shipped template's missing count free of negations", () => {
+    for (const id of LANGUAGE_IDS.concat("minimal")) {
+      const missing = computeMissingTemplateEntries("", resolve(id));
+      expect(missing.filter((entry) => entry.startsWith("!")), `${id} reported negations`).toEqual(
+        []
+      );
+      expect(missing.length, `${id} reported no entries`).toBeGreaterThan(0);
+      expect(missing.length, `${id} counted every active line`).toBeLessThan(
+        activeLines(resolve(id)).length
+      );
+    }
+  });
 });

--- a/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
+++ b/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
@@ -1,39 +1,124 @@
 import { describe, it, expect } from "vitest";
-import { getGitignoreTemplate, computeMissingTemplateEntries } from "../projectCrud/gitInit.js";
+import { computeMissingTemplateEntries } from "../projectCrud/gitInit.js";
+import { getGitignoreTemplate } from "../projectCrud/gitignoreTemplates.js";
+import {
+  GITIGNORE_TEMPLATE_OPTIONS,
+  DEFAULT_GITIGNORE_TEMPLATE_ID,
+  isGitignoreTemplateId,
+} from "../../../../shared/config/gitignoreTemplates.js";
 
-describe("getGitignoreTemplate", () => {
-  it("node template excludes env files and build outputs", () => {
-    const content = getGitignoreTemplate("node");
-    expect(content).not.toBeNull();
-    expect(content).toMatch(/^\.env$/m);
-    expect(content).toMatch(/^\.env\.\*$/m);
-    expect(content).toMatch(/^!\.env\.example$/m);
-    expect(content).toMatch(/^\.env\.local$/m);
-    expect(content).toMatch(/^\.env\.\*\.local$/m);
-    expect(content).toMatch(/^node_modules\/$/m);
+const TEMPLATE_IDS = GITIGNORE_TEMPLATE_OPTIONS.map((option) => option.value);
+const LANGUAGE_IDS = TEMPLATE_IDS.filter((id) => id !== "minimal" && id !== "none");
+
+function activeLines(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+}
+
+function resolve(id: string): string {
+  const content = getGitignoreTemplate(id);
+  if (content === null) throw new Error(`Expected template "${id}" to resolve`);
+  return content;
+}
+
+describe("gitignore template registry", () => {
+  it("exposes unique ids", () => {
+    expect(new Set(TEMPLATE_IDS).size).toBe(TEMPLATE_IDS.length);
   });
 
-  it("python template includes secret/env coverage", () => {
-    const content = getGitignoreTemplate("python");
-    expect(content).not.toBeNull();
-    expect(content).toMatch(/^\.env$/m);
-    expect(content).toMatch(/^\.env\.\*$/m);
-    expect(content).toMatch(/^!\.env\.example$/m);
-    expect(content).toMatch(/^__pycache__\/$/m);
+  it("defaults to the first listed option", () => {
+    expect(DEFAULT_GITIGNORE_TEMPLATE_ID).toBe(TEMPLATE_IDS[0]);
   });
 
-  it("minimal template includes secret/env coverage", () => {
-    const content = getGitignoreTemplate("minimal");
-    expect(content).not.toBeNull();
-    expect(content).toMatch(/^\.env$/m);
-    expect(content).toMatch(/^\.env\.\*$/m);
-    expect(content).toMatch(/^!\.env\.example$/m);
-    expect(content).toMatch(/^\*\.pem$/m);
-    expect(content).toMatch(/^\*\.key$/m);
+  it("resolves content for every id except the opt-out one", () => {
+    for (const id of TEMPLATE_IDS) {
+      const content = getGitignoreTemplate(id);
+      if (id === "none") {
+        expect(content, `${id} should not produce a file`).toBeNull();
+      } else {
+        expect(content, `${id} should produce a file`).not.toBeNull();
+      }
+    }
+  });
+
+  it("recognises exactly the registered ids", () => {
+    for (const id of TEMPLATE_IDS) {
+      expect(isGitignoreTemplateId(id)).toBe(true);
+    }
+    expect(isGitignoreTemplateId("unknown")).toBe(false);
+    expect(isGitignoreTemplateId(undefined)).toBe(false);
   });
 
   it("returns null for unknown templates", () => {
     expect(getGitignoreTemplate("unknown")).toBeNull();
+  });
+});
+
+describe("gitignore template composition", () => {
+  it("layers every language template on top of the full minimal baseline", () => {
+    const minimal = resolve("minimal");
+    for (const id of LANGUAGE_IDS) {
+      const content = resolve(id);
+      expect(content.startsWith(`${minimal}\n`), `${id} should open with minimal`).toBe(true);
+    }
+  });
+
+  it("adds language-specific rules beyond the baseline", () => {
+    const minimalLineCount = activeLines(resolve("minimal")).length;
+    for (const id of LANGUAGE_IDS) {
+      expect(activeLines(resolve(id)).length, `${id} should add rules`).toBeGreaterThan(
+        minimalLineCount
+      );
+    }
+  });
+
+  it("gives each language template distinct content", () => {
+    const rendered = LANGUAGE_IDS.map((id) => resolve(id));
+    expect(new Set(rendered).size).toBe(LANGUAGE_IDS.length);
+  });
+
+  it("ends every template with a single trailing newline", () => {
+    for (const id of TEMPLATE_IDS.filter((candidate) => candidate !== "none")) {
+      const content = resolve(id);
+      expect(content.endsWith("\n"), `${id} should end with a newline`).toBe(true);
+      expect(content.endsWith("\n\n"), `${id} should not end with a blank line`).toBe(false);
+    }
+  });
+});
+
+describe("gitignore pattern semantics", () => {
+  // `*.key` also matches Apple Keynote documents, so a broad rule silently
+  // swallows real files. Scoped rules like `/storage/*.key` are still fine.
+  it("never ignores every .key file", () => {
+    for (const id of TEMPLATE_IDS.filter((candidate) => candidate !== "none")) {
+      expect(activeLines(resolve(id)), `${id} should not blanket-ignore .key`).not.toContain(
+        "*.key"
+      );
+    }
+  });
+
+  // Git refuses to descend into an excluded directory, so a negation is dead if
+  // one of its parent directories is excluded outright. `dir/*` keeps the
+  // directory traversable; `dir/` or `dir` does not.
+  it("keeps every negation reachable", () => {
+    for (const id of TEMPLATE_IDS.filter((candidate) => candidate !== "none")) {
+      const lines = activeLines(resolve(id));
+
+      lines.forEach((line, index) => {
+        if (!line.startsWith("!")) return;
+
+        const segments = line.slice(1).replace(/\/$/, "").split("/");
+        const earlier = lines.slice(0, index);
+
+        for (let depth = 1; depth < segments.length; depth++) {
+          const parent = segments.slice(0, depth).join("/");
+          const blocked = earlier.filter((prior) => prior === parent || prior === `${parent}/`);
+          expect(blocked, `${id}: "${line}" is unreachable — "${parent}" is excluded`).toEqual([]);
+        }
+      });
+    }
   });
 });
 

--- a/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
+++ b/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
@@ -42,12 +42,16 @@ function unreachableNegations(lines: string[]): string[] {
       if (!parent) continue;
 
       const spellings = [parent, `${parent}/`];
-      const reincluded = lines.some(
-        (other) => other.startsWith("!") && spellings.includes(other.slice(1))
-      );
-      if (reincluded) continue;
 
-      if (lines.some((other) => spellings.includes(other))) {
+      // Whether git descends is decided by the LAST rule literally naming the
+      // parent, so a re-inclusion only helps if nothing excludes it again after.
+      let excluded = false;
+      for (const other of lines) {
+        if (spellings.includes(other)) excluded = true;
+        else if (other.startsWith("!") && spellings.includes(other.slice(1))) excluded = false;
+      }
+
+      if (excluded) {
         dead.push(line);
         break;
       }
@@ -177,6 +181,10 @@ describe("unreachableNegations", () => {
 
   it("accepts a parent that is explicitly re-included", () => {
     expect(unreachableNegations(["foo/", "!foo/", "!foo/keep"])).toEqual([]);
+  });
+
+  it("flags a parent re-excluded after being re-included", () => {
+    expect(unreachableNegations(["foo/", "!foo/", "foo/", "!foo/keep"])).toEqual(["!foo/keep"]);
   });
 
   it("accepts a negation whose parent is only matched by a glob", () => {

--- a/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
+++ b/electron/ipc/handlers/__tests__/gitInit.templates.test.ts
@@ -241,11 +241,12 @@ describe("computeMissingTemplateEntries", () => {
   });
 
   it("keeps every shipped template's missing count free of negations", () => {
-    for (const id of LANGUAGE_IDS.concat("minimal")) {
+    for (const id of TEMPLATE_IDS.filter((candidate) => candidate !== "none")) {
       const missing = computeMissingTemplateEntries("", resolve(id));
-      expect(missing.filter((entry) => entry.startsWith("!")), `${id} reported negations`).toEqual(
-        []
-      );
+      expect(
+        missing.filter((entry) => entry.startsWith("!")),
+        `${id} reported negations`
+      ).toEqual([]);
       expect(missing.length, `${id} reported no entries`).toBeGreaterThan(0);
       expect(missing.length, `${id} counted every active line`).toBeLessThan(
         activeLines(resolve(id)).length

--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -198,11 +198,17 @@ export function registerGitInitHandlers(): () => void {
   return () => handlers.forEach((cleanup) => cleanup());
 }
 
+/**
+ * Collects the exclusion patterns from a .gitignore, dropping comments, blank
+ * lines, and negations. A negation only re-includes something an exclusion took
+ * away, so it is meaningless on its own — reporting `!.env.example` as "missing"
+ * from a file that never excluded `.env.example` would be noise.
+ */
 function parseGitignoreLines(content: string): Set<string> {
   const lines = new Set<string>();
   for (const raw of content.split(/\r?\n/)) {
     const line = raw.trim();
-    if (!line || line.startsWith("#")) continue;
+    if (!line || line.startsWith("#") || line.startsWith("!")) continue;
     lines.add(line);
   }
   return lines;

--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -14,7 +14,9 @@ import type {
   GitInitProgressEvent,
 } from "../../../../shared/types/ipc/gitInit.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { DEFAULT_GITIGNORE_TEMPLATE_ID } from "../../../../shared/config/gitignoreTemplates.js";
 import { AppError } from "../../../utils/errorTypes.js";
+import { getGitignoreTemplate } from "./gitignoreTemplates.js";
 
 export function registerGitInitHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -53,7 +55,7 @@ export function registerGitInitHandlers(): () => void {
       createInitialCommit = true,
       initialCommitMessage = "Initial commit",
       createGitignore = true,
-      gitignoreTemplate = "node",
+      gitignoreTemplate = DEFAULT_GITIGNORE_TEMPLATE_ID,
     } = options;
 
     if (typeof directoryPath !== "string" || !directoryPath) {
@@ -128,9 +130,10 @@ export function registerGitInitHandlers(): () => void {
             if (missing.length === 0) {
               skipMessage = "Existing .gitignore kept — covers all template entries";
             } else {
-              const preview = missing.slice(0, 5).join(", ");
-              const overflow = missing.length > 5 ? `, and ${missing.length - 5} more` : "";
-              skipMessage = `Existing .gitignore kept — missing template entries: ${preview}${overflow}`;
+              // Templates are large enough that itemising the diff is noise —
+              // report the size and point at the part that actually matters.
+              const label = missing.length === 1 ? "entry" : "entries";
+              skipMessage = `Existing .gitignore kept — missing ${missing.length} template ${label}; review it for secrets`;
             }
           } catch {
             // Fall through to default message
@@ -216,101 +219,4 @@ export function computeMissingTemplateEntries(
     if (!existing.has(entry)) missing.push(entry);
   }
   return missing;
-}
-
-export function getGitignoreTemplate(template: string): string | null {
-  switch (template) {
-    case "node":
-      return `# Node.js
-node_modules/
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-.npm
-.yarn
-.pnp.*
-
-# Environment
-.env
-.env.*
-!.env.example
-.env.local
-.env.*.local
-
-# Build outputs
-dist/
-build/
-out/
-.next/
-.nuxt/
-
-# OS
-.DS_Store
-Thumbs.db
-
-# IDE
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
-`;
-    case "python":
-      return `# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.Python
-env/
-venv/
-ENV/
-.venv
-
-# Distribution
-build/
-dist/
-*.egg-info/
-
-# Testing
-.pytest_cache/
-.coverage
-htmlcov/
-
-# Environment / secrets
-.env
-.env.*
-!.env.example
-.env.local
-.env.*.local
-
-# OS
-.DS_Store
-Thumbs.db
-
-# IDE
-.vscode/
-.idea/
-*.swp
-`;
-    case "minimal":
-      return `# Secrets
-.env
-.env.*
-!.env.example
-*.pem
-*.key
-
-# OS
-.DS_Store
-Thumbs.db
-
-# IDE
-.vscode/
-.idea/
-*.swp
-`;
-    default:
-      return null;
-  }
 }

--- a/electron/ipc/handlers/projectCrud/gitignoreTemplates.ts
+++ b/electron/ipc/handlers/projectCrud/gitignoreTemplates.ts
@@ -67,6 +67,7 @@ AGENTS.local.md
 .codex/sessions/
 .aider*
 !.aider.conf.yml
+!.aiderignore
 .cursor/rules/personal.mdc
 .specstory/
 .windsurf/

--- a/electron/ipc/handlers/projectCrud/gitignoreTemplates.ts
+++ b/electron/ipc/handlers/projectCrud/gitignoreTemplates.ts
@@ -68,6 +68,8 @@ AGENTS.local.md
 .aider*
 !.aider.conf.yml
 !.aiderignore
+!.aider.model.settings.yml
+!.aider.model.metadata.json
 .cursor/rules/personal.mdc
 .specstory/
 .windsurf/

--- a/electron/ipc/handlers/projectCrud/gitignoreTemplates.ts
+++ b/electron/ipc/handlers/projectCrud/gitignoreTemplates.ts
@@ -1,0 +1,373 @@
+import type { GitignoreTemplateId } from "../../../../shared/config/gitignoreTemplates.js";
+
+type LanguageTemplateId = Exclude<GitignoreTemplateId, "minimal" | "none">;
+
+// Baseline every language template is composed on top of. Patterns are ordered
+// deliberately: a negation only takes effect after the rule it undoes, and git
+// cannot re-include a file whose parent directory is excluded — hence
+// `.vscode/*` rather than `.vscode/`. Do not sort or deduplicate.
+const MINIMAL_TEMPLATE = `# Environment and secrets
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+*.pem
+*.p12
+*.pfx
+*.jks
+*.keystore
+.netrc
+id_rsa
+id_ecdsa
+id_ed25519
+
+# Logs
+*.log
+logs/
+
+# macOS
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+
+# Windows
+Thumbs.db
+ehthumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/
+
+# Linux
+.Trash-*
+.fuse_hidden*
+.directory
+
+# Editors
+*.swp
+*.swo
+*~
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/shelf/
+*.iml
+
+# AI agent local state
+.claude/settings.local.json
+CLAUDE.local.md
+AGENTS.local.md
+.codex/auth.json
+.codex/sessions/
+.aider*
+!.aider.conf.yml
+.cursor/rules/personal.mdc
+.specstory/
+.windsurf/
+
+# Daintree
+.daintree/*.local.json
+`;
+
+// Language-specific layers only — the Minimal baseline above supplies the OS,
+// editor, secrets and agent-state coverage, so none of these restate it.
+const LANGUAGE_LAYERS = {
+  node: `# Dependencies
+node_modules/
+jspm_packages/
+web_modules/
+
+# Yarn Berry (commit releases, plugins, patches, sdks)
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+.yarn-integrity
+
+# npm / pnpm
+.npm
+.pnpm-store/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Build output
+/dist/
+/build/
+/out/
+.next/
+.nuxt/
+.svelte-kit/
+.astro/
+.angular/
+.output/
+.vercel/
+
+# Caches
+.turbo/
+.parcel-cache/
+.rollup.cache/
+.vite/
+.eslintcache
+.stylelintcache
+*.tsbuildinfo
+
+# Test and coverage
+coverage/
+*.lcov
+.nyc_output/
+/test-results/
+/playwright-report/
+
+# Runtime
+pids/
+*.pid
+*.seed
+*.pid.lock
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+*.tgz
+`,
+
+  python: `# Bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Virtual environments (anchored, so src/env/ survives)
+/env/
+/venv/
+/ENV/
+/.venv/
+/.pixi/
+
+# Packaging
+/build/
+/dist/
+*.egg-info/
+.eggs/
+*.egg
+MANIFEST
+
+# Tooling caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.tox/
+.nox/
+.dmypy.json
+.pdm-build/
+
+# Coverage
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Notebooks
+.ipynb_checkpoints/
+
+# direnv
+.envrc
+`,
+
+  rust: `# Cargo build output
+target/
+debug/
+
+# rustfmt backups
+**/*.rs.bk
+
+# MSVC debug info
+*.pdb
+
+# cargo-mutants
+**/mutants.out*/
+`,
+
+  go: `# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binaries and coverage
+*.test
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Workspace files (local only)
+go.work
+go.work.sum
+
+# Vendor directory. Uncomment if you rely on the module proxy instead.
+# vendor/
+`,
+
+  java: `# Compiled output
+*.class
+target/
+**/build/
+!**/src/**/build/
+
+# Gradle
+.gradle/
+.kotlin/
+gradle-app.setting
+.gradletasknamecache
+
+# Wrappers must stay committed
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
+!.mvn/wrapper/maven-wrapper.jar
+
+# Maven
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# JVM crash logs
+hs_err_pid*
+replay_pid*
+
+# Eclipse
+.project
+.classpath
+.settings/
+.factorypath
+`,
+
+  php: `# Dependencies
+/vendor/
+composer.phar
+
+# Laravel runtime
+/bootstrap/cache/*
+!/bootstrap/cache/.gitignore
+/storage/*.key
+/storage/pail
+/public/build
+/public/hot
+
+# public/storage is a symlink, not real content
+/public/storage
+/public_html/storage
+/public_html/hot
+
+# Local config and secrets
+.env.backup
+Homestead.yaml
+Homestead.json
+/.vagrant
+auth.json
+
+# Testing
+.phpunit.result.cache
+.phpactor.json
+`,
+
+  ruby: `# Logs and temp
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# ActiveStorage local disk
+/storage/*
+!/storage/.keep
+
+# Bundler
+/.bundle
+/vendor/bundle
+
+# Credentials keys (never commit)
+/config/master.key
+/config/credentials/*.key
+
+# Databases
+/db/*.sqlite3
+/db/*.sqlite3-journal
+/db/*.sqlite3-[0-9]*
+
+# Test artifacts
+/coverage/
+/spec/tmp
+capybara-*.html
+rerun.txt
+*.rbc
+`,
+
+  dotnet: `# Build output
+[Bb]in/
+[Oo]bj/
+[Dd]ebug/
+[Rr]elease/
+[Ll]og/
+[Ll]ogs/
+
+# User files
+*.user
+*.userosscache
+*.suo
+*.sln.docstates
+*.userprefs
+
+# Test results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# Local secrets
+appsettings.Development.json
+appsettings.Local.json
+*.publishsettings
+`,
+
+  web: `# Dependencies (Tailwind, Vite, PostCSS and friends)
+node_modules/
+
+# Build output
+/dist/
+/build/
+/_site/
+/public/build/
+
+# Tool caches
+.sass-cache/
+.parcel-cache/
+.eslintcache
+.cache/
+`,
+} satisfies Record<LanguageTemplateId, string>;
+
+function isLanguageTemplateId(value: string): value is LanguageTemplateId {
+  return Object.hasOwn(LANGUAGE_LAYERS, value);
+}
+
+/**
+ * Resolves a template id to `.gitignore` content. Returns `null` for `"none"`
+ * and for unknown ids — the caller treats both as "nothing to write".
+ */
+export function getGitignoreTemplate(template: string): string | null {
+  if (template === "minimal") return MINIMAL_TEMPLATE;
+  if (!isLanguageTemplateId(template)) return null;
+  return `${MINIMAL_TEMPLATE}\n${LANGUAGE_LAYERS[template]}`;
+}

--- a/shared/config/gitignoreTemplates.ts
+++ b/shared/config/gitignoreTemplates.ts
@@ -1,0 +1,24 @@
+// Order drives the git-init dialog dropdown. Minimal is first because it is
+// the default: it covers secrets, OS junk, editor state and AI-agent local
+// state, and every language template is composed on top of it.
+export const GITIGNORE_TEMPLATE_OPTIONS = [
+  { value: "minimal", label: "Minimal", description: "OS, editor, secrets, agent state" },
+  { value: "node", label: "Node / TypeScript", description: "node_modules, build output, caches" },
+  { value: "python", label: "Python", description: "__pycache__, venvs, tooling caches" },
+  { value: "rust", label: "Rust", description: "target/, rustfmt backups" },
+  { value: "go", label: "Go", description: "binaries, test output, workspace files" },
+  { value: "java", label: "Java / JVM", description: "Gradle and Maven output, class files" },
+  { value: "php", label: "PHP / Laravel", description: "vendor/, storage, compiled assets" },
+  { value: "ruby", label: "Ruby on Rails", description: "logs, tmp, bundler, credentials keys" },
+  { value: "dotnet", label: "C# / .NET", description: "bin/, obj/, user files" },
+  { value: "web", label: "Static web", description: "build output, tool caches" },
+  { value: "none", label: "None", description: "Don't create a .gitignore" },
+] as const;
+
+export type GitignoreTemplateId = (typeof GITIGNORE_TEMPLATE_OPTIONS)[number]["value"];
+
+export const DEFAULT_GITIGNORE_TEMPLATE_ID: GitignoreTemplateId = "minimal";
+
+export function isGitignoreTemplateId(value: unknown): value is GitignoreTemplateId {
+  return GITIGNORE_TEMPLATE_OPTIONS.some((option) => option.value === value);
+}

--- a/shared/types/ipc/gitInit.ts
+++ b/shared/types/ipc/gitInit.ts
@@ -2,6 +2,8 @@
  * Git initialization workflow types
  */
 
+import type { GitignoreTemplateId } from "../../config/gitignoreTemplates.js";
+
 export interface GitInitOptions {
   /** Directory path to initialize */
   directoryPath: string;
@@ -11,8 +13,8 @@ export interface GitInitOptions {
   initialCommitMessage?: string;
   /** Create a .gitignore file (default: true) */
   createGitignore?: boolean;
-  /** Gitignore template to use (default: "node") */
-  gitignoreTemplate?: "node" | "python" | "minimal" | "none";
+  /** Gitignore template to use (default: "minimal") */
+  gitignoreTemplate?: GitignoreTemplateId;
 }
 
 export type GitInitStepType = "init" | "gitignore" | "add" | "commit" | "complete" | "error";

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -12,6 +12,7 @@ import type {
   FileBrowserTreeSnapshot,
 } from "./panel.js";
 import type { CommandOverride } from "./commands.js";
+import type { GitignoreTemplateId } from "../config/gitignoreTemplates.js";
 import type { GitStatus } from "./git.js";
 import type { EditorConfig } from "./editor.js";
 import type { NotificationSettings } from "./ipc/api.js";
@@ -538,8 +539,8 @@ export interface ProjectSettings {
     initialCommitMessage?: string;
     /** Create a .gitignore file (default: true) */
     createGitignore?: boolean;
-    /** Gitignore template to use (default: "node") */
-    gitignoreTemplate?: "node" | "python" | "minimal" | "none";
+    /** Gitignore template to use (default: "minimal") */
+    gitignoreTemplate?: GitignoreTemplateId;
   };
   /** Preferred external editor for this project */
   preferredEditor?: EditorConfig;

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -7,7 +7,12 @@ import { FolderGit2 } from "@/components/icons";
 import { projectClient } from "@/clients";
 import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import type { GitInitOptions, GitInitProgressEvent } from "@shared/types/ipc/gitInit";
+import {
+  GITIGNORE_TEMPLATE_OPTIONS,
+  DEFAULT_GITIGNORE_TEMPLATE_ID,
+  isGitignoreTemplateId,
+} from "@shared/config/gitignoreTemplates";
+import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
 
 interface GitInitDialogProps {
   isOpen: boolean;
@@ -18,17 +23,8 @@ interface GitInitDialogProps {
 
 const AUTO_CLOSE_DELAY_MS = 2000;
 
-type GitignoreTemplate = NonNullable<GitInitOptions["gitignoreTemplate"]>;
-
-const TEMPLATE_OPTIONS: Array<{ value: GitignoreTemplate; label: string; description: string }> = [
-  { value: "node", label: "Node", description: "node_modules, build outputs, .env" },
-  { value: "python", label: "Python", description: "__pycache__, venv, .env" },
-  { value: "minimal", label: "Minimal", description: "OS files, IDE files, .env" },
-  { value: "none", label: "None", description: "Don't create a .gitignore" },
-];
-
 export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: GitInitDialogProps) {
-  const [gitignoreTemplate, setGitignoreTemplate] = useState<GitignoreTemplate>("node");
+  const [gitignoreTemplate, setGitignoreTemplate] = useState(DEFAULT_GITIGNORE_TEMPLATE_ID);
   const [createInitialCommit, setCreateInitialCommit] = useState(true);
   const [initialCommitMessage, setInitialCommitMessage] = useState("Initial commit");
   const [progressEvents, setProgressEvents] = useState<GitInitProgressEvent[]>([]);
@@ -51,7 +47,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
 
   useEffect(() => {
     if (!isOpen) {
-      setGitignoreTemplate("node");
+      setGitignoreTemplate(DEFAULT_GITIGNORE_TEMPLATE_ID);
       setCreateInitialCommit(true);
       setInitialCommitMessage("Initial commit");
       setProgressEvents([]);
@@ -191,11 +187,13 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
           <select
             id="git-init-template"
             value={gitignoreTemplate}
-            onChange={(e) => setGitignoreTemplate(e.target.value as GitignoreTemplate)}
+            onChange={(e) => {
+              if (isGitignoreTemplateId(e.target.value)) setGitignoreTemplate(e.target.value);
+            }}
             disabled={configDisabled}
             className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
           >
-            {TEMPLATE_OPTIONS.map((opt) => (
+            {GITIGNORE_TEMPLATE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label} — {opt.description}
               </option>

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -5,6 +5,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import type { ReactNode, ButtonHTMLAttributes } from "react";
 import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
+import {
+  GITIGNORE_TEMPLATE_OPTIONS,
+  DEFAULT_GITIGNORE_TEMPLATE_ID,
+} from "@shared/config/gitignoreTemplates";
 
 const { initGitGuidedMock, onInitGitProgressMock } = vi.hoisted(() => ({
   initGitGuidedMock: vi.fn(),
@@ -120,11 +124,21 @@ describe("GitInitDialog", () => {
           directoryPath: "/tmp/new-repo",
           createInitialCommit: true,
           createGitignore: true,
-          gitignoreTemplate: "node",
+          gitignoreTemplate: DEFAULT_GITIGNORE_TEMPLATE_ID,
           initialCommitMessage: "feat: init",
         })
       );
     });
+  });
+
+  it("offers every registry template in order and preselects the default", () => {
+    renderDialog();
+
+    const select = screen.getByLabelText(/gitignore template/i) as HTMLSelectElement;
+    expect(Array.from(select.options).map((option) => option.value)).toEqual(
+      GITIGNORE_TEMPLATE_OPTIONS.map((option) => option.value)
+    );
+    expect(select.value).toBe(DEFAULT_GITIGNORE_TEMPLATE_ID);
   });
 
   it("pre-fills the commit message and submits the default without editing", async () => {
@@ -158,7 +172,7 @@ describe("GitInitDialog", () => {
     expect(initGitGuidedMock).not.toHaveBeenCalled();
   });
 
-  it("resets the commit message to the default when reopened", () => {
+  it("resets the commit message and template to the defaults when reopened", () => {
     const onSuccess = vi.fn();
     const onCancel = vi.fn();
     const dialogProps = {
@@ -171,12 +185,17 @@ describe("GitInitDialog", () => {
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: custom" },
     });
+    fireEvent.change(screen.getByLabelText(/gitignore template/i), {
+      target: { value: "python" },
+    });
 
     rerender(<GitInitDialog isOpen={false} {...dialogProps} />);
     rerender(<GitInitDialog isOpen={true} {...dialogProps} />);
 
     const input = screen.getByLabelText(/initial commit message/i) as HTMLInputElement;
     expect(input.value).toBe("Initial commit");
+    const select = screen.getByLabelText(/gitignore template/i) as HTMLSelectElement;
+    expect(select.value).toBe(DEFAULT_GITIGNORE_TEMPLATE_ID);
   });
 
   it("clears the missing-status warning when a late success event arrives", async () => {


### PR DESCRIPTION
## Summary

The git-init dialog defaulted the gitignore template dropdown to Node, and only offered four templates whose text had drifted and carried real defects. This flips the default to Minimal, rewrites Minimal into a comprehensive baseline, and expands the set to eleven templates that are each composed on top of that baseline.

Resolves #11403.

## Changes

- `shared/config/gitignoreTemplates.ts` (new): ordered registry of `{value, label, description}`; `GitignoreTemplateId` is derived from it via `as const`; `DEFAULT_GITIGNORE_TEMPLATE_ID`; `isGitignoreTemplateId` guard.
- `electron/ipc/handlers/projectCrud/gitignoreTemplates.ts` (new): `MINIMAL_TEMPLATE` plus nine language layers and a `getGitignoreTemplate` resolver.
- `electron/ipc/handlers/projectCrud/gitInit.ts`: uses the shared default and the new resolver, the inline switch is gone, and the existing-`.gitignore` message now reports a count.
- `shared/types/ipc/gitInit.ts`, `shared/types/project.ts`: both duplicated unions replaced by the derived `GitignoreTemplateId`.
- `src/components/Project/GitInitDialog.tsx`: renders the shared registry, uses the shared default, and an unsafe cast is replaced with the type guard.
- Two test files rewritten and extended.

### Default is Minimal everywhere

`"node"` was hardcoded as the default in four places. There's a fifth: `ProjectSettings.gitInitDefaults` in `shared/types/project.ts`. All five now point at Minimal. The `"node"` value itself is unchanged, so persisted settings stay valid. Only the label changed, to "Node / TypeScript".

### Every language layer sits on top of Minimal

Each template is composed as Minimal, a blank line, then a language-specific layer, so picking Python can't lose you the secrets or agent-state coverage that Minimal gives you. That composition is enforced by a test, and `satisfies Record<LanguageTemplateId, string>` makes a missing layer a compile error rather than a runtime gap.

### Template text and fixes

The template text comes from the issue, adapted from [github/gitignore](https://github.com/github/gitignore) (CC0). Notable fixes it carries:

- `*.key` is gone from Minimal. It was matching Keynote decks. `*.p12`, `*.pfx`, `*.jks` and `*.keystore` cover the private-key formats that actually leak.
- `.yarn/*` with negations instead of a bare `.yarn`, so Yarn Berry releases, plugins, patches and sdks stay committed.
- `.vscode/*` with negations instead of blanket `.vscode/`.
- Python venv directories are anchored, so `src/env/` survives.

### Tests are invariant-based, not text-literal

Per the repo's rule against tautological assertions, the old suite asserted `/^\*\.key$/m`, which was locking in the exact defect this PR fixes. The new suite asserts: every template contains the full baseline; no template blanket-ignores `*.key`; no negation sits inside a literally-excluded parent directory (the `.vscode/` vs `.vscode/*` trap), with that guard itself covered by seven fixtures so it's proven to actually bite; registry and resolver parity; and inherited prototype keys are rejected as ids.

### Beyond the issue's scope

Added negated entries for `.aiderignore`, `.aider.model.settings.yml` and `.aider.model.metadata.json`. A bare `.aider*` pattern was swallowing them, which contradicts the issue's own stated principle for that block: commit the instructions, ignore the session state, caches and credentials. Those three are shared repo config that aider auto-loads.

### Existing-`.gitignore` progress message

It now reports a count ("missing 47 template entries; review it for secrets") instead of itemizing five entries plus an "and N more" tail, which had become noise at this template size. The issue flagged this as worth deciding; this is the smallest change that fixes the noise without touching the diff or tests around it.

## Open questions on template content

A few places in the issue's specified template text are arguably over-broad. Each is a judgment call in the curated text rather than a mechanical error, so I left them as specified. Happy to change any of these, they're all one-liners:

- **dotnet**: ignores `appsettings.Development.json`. ASP.NET Core scaffolds this file and normally commits it.
- **go**: ignores `*.out` and `coverage.*`. `*.out` can also match `testdata/*.out` golden files, and `coverage.*` can match a `coverage.go` source file.
- **python**: ignores `.envrc`. direnv projects commonly commit `.envrc` and ignore `.direnv/` instead.
- **go**: ignores `go.work` and `go.work.sum`. These can define a required multi-module workspace topology rather than being purely local.
- **php**: ignores an unanchored `auth.json`, which also matches `tests/fixtures/auth.json`.
- **minimal**: ignores `*.iml`, which is required project metadata for IntelliJ-native projects.
- Several templates ignore unanchored `logs/`, and dotnet's `[Dd]ebug/` / `[Rr]elease/` and rust's `debug/` can all collide with source directory names.

## Testing

- 423 tests pass across the ten test files covering every changed module.
- eslint and prettier clean on all changed files.
- Full `npm run typecheck` clean.
- Lint ratchet passes with warnings decreased by 1 (the removed unsafe cast). The two `no-restricted-syntax` typedHandle warnings in `gitInit.ts` are pre-existing and untouched by this PR.
