### PR TITLE
feat(file-browser): copy the root path on click when the tree is re-rooted

### DIFF
--- a/src/hooks/__tests__/useCopyWithFeedback.test.tsx
+++ b/src/hooks/__tests__/useCopyWithFeedback.test.tsx
@@ -80,6 +80,44 @@ describe("useCopyWithFeedback", () => {
     expect(result.current.copied).toBe(false);
   });
 
+  it("names the copied text so callers can tell which value the flag describes", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback());
+    expect(result.current.copiedText).toBeNull();
+
+    await act(async () => {
+      await result.current.copy("/repo/a");
+    });
+    expect(result.current.copiedText).toBe("/repo/a");
+
+    // A second copy re-points it rather than leaving the first value standing.
+    await act(async () => {
+      await result.current.copy("/repo/b");
+    });
+    expect(result.current.copiedText).toBe("/repo/b");
+
+    act(() => {
+      vi.advanceTimersByTime(UI_ACTION_SUCCESS_DWELL_MS);
+    });
+    expect(result.current.copiedText).toBeNull();
+    // The flag and the value it names can never disagree.
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("leaves copiedText untouched when the write fails", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback());
+    await act(async () => {
+      await result.current.copy("/repo/a");
+    });
+
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    await act(async () => {
+      await result.current.copy("/repo/b");
+    });
+
+    // A failed write must not claim the new path was copied.
+    expect(result.current.copiedText).toBe("/repo/a");
+  });
+
   it("returns false and stays silent when clipboard rejects", async () => {
     writeText.mockRejectedValueOnce(new Error("denied"));
     const { result } = renderHook(() => useCopyWithFeedback());

--- a/src/hooks/useCopyWithFeedback.ts
+++ b/src/hooks/useCopyWithFeedback.ts
@@ -11,6 +11,13 @@ export interface UseCopyWithFeedbackOptions {
 
 export interface UseCopyWithFeedbackResult {
   copied: boolean;
+  /**
+   * The text the live `copied` window describes, or null while idle. Callers
+   * whose copy target can change under them (a path label that re-roots) gate
+   * their feedback on this rather than on `copied`, so the flag and the value
+   * it refers to can never be read apart.
+   */
+  copiedText: string | null;
   copy: (text: string) => Promise<boolean>;
 }
 
@@ -24,7 +31,10 @@ export function useCopyWithFeedback(
   options: UseCopyWithFeedbackOptions = {}
 ): UseCopyWithFeedbackResult {
   const { dwellMs = UI_ACTION_SUCCESS_DWELL_MS, announcement = "Copied" } = options;
-  const [copied, setCopied] = useState(false);
+  // One state, not a flag beside a value: `announce` below can drive a
+  // synchronous external-store commit, which would otherwise let a render
+  // observe the raised flag while the text still names the previous copy.
+  const [copiedText, setCopiedText] = useState<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
 
@@ -48,13 +58,13 @@ export function useCopyWithFeedback(
       }
       if (!isMountedRef.current) return true;
 
-      setCopied(true);
+      setCopiedText(text);
       useAnnouncerStore.getState().announce(announcement, "polite");
 
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       timeoutRef.current = setTimeout(() => {
         if (!isMountedRef.current) return;
-        setCopied(false);
+        setCopiedText(null);
         timeoutRef.current = null;
       }, dwellMs);
 
@@ -63,5 +73,5 @@ export function useCopyWithFeedback(
     [announcement, dwellMs]
   );
 
-  return { copied, copy };
+  return { copied: copiedText !== null, copiedText, copy };
 }

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -479,14 +479,13 @@ export function FileBrowserPane({
     rootPath === "" || worktreePath === "" ? "" : join(worktreePath, rootPath);
   const rootHoverPath = rootPath === "" ? worktreePath : `${basename(worktreePath)}/${rootPath}`;
 
-  const { copied: rootPathCopied, copy: copyRootPath } = useCopyWithFeedback({
+  const { copiedText: copiedRootPath, copy: copyRootPath } = useCopyWithFeedback({
     announcement: "Path copied",
   });
-  // Keyed by the path that was copied, not a bare flag: re-rooting inside the
-  // dwell window would otherwise leave the success color describing a folder
-  // the header no longer points at.
-  const [copiedRootPath, setCopiedRootPath] = useState<string | null>(null);
-  const showRootPathCopied = rootPathCopied && copiedRootPath === rootAbsolutePath;
+  // Matched against the path actually copied, not a bare flag: re-rooting
+  // inside the dwell window would otherwise leave the success color describing
+  // a folder the header no longer points at.
+  const showRootPathCopied = copiedRootPath === rootAbsolutePath;
 
   const handleCopyRootPath = useCallback(() => {
     if (rootAbsolutePath === "") return;
@@ -494,20 +493,21 @@ export function FileBrowserPane({
     // second attempt still flashes and announces.
     const attempt = () => {
       void copyRootPath(rootAbsolutePath).then((copied) => {
-        if (copied) {
-          setCopiedRootPath(rootAbsolutePath);
-          return;
-        }
+        if (copied) return;
         notify({
           type: "error",
           title: "Couldn't copy path",
           message: "The clipboard rejected the write.",
+          // uiFeedback is passive, and the inbox keeps only actionId actions —
+          // resolving to "low" would strip the Retry this toast exists for.
+          priority: "high",
+          context: { eventKind: "uiFeedback", panelId: id, worktreeId },
           action: { label: "Retry", onClick: attempt },
         });
       });
     };
     attempt();
-  }, [rootAbsolutePath, copyRootPath]);
+  }, [rootAbsolutePath, copyRootPath, id, worktreeId]);
 
   const reveal = useMemo(() => revealCopy(), []);
   const handleReveal = useCallback(
@@ -693,8 +693,17 @@ export function FileBrowserPane({
                       {rootPath}
                     </button>
                   </TooltipTrigger>
+                  {/* The path stays put through the dwell — it's the reason
+                      this tooltip exists — so success appends rather than
+                      replaces. aria-hidden because the live region already
+                      announced it; the description must not change. */}
                   <TooltipContent side="bottom" className="break-words">
-                    {showRootPathCopied ? "Copied!" : rootHoverPath}
+                    {rootHoverPath}
+                    {showRootPathCopied && (
+                      <span aria-hidden="true" className="block text-status-success">
+                        Copied!
+                      </span>
+                    )}
                   </TooltipContent>
                 </Tooltip>
               ) : (

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -500,14 +500,17 @@ export function FileBrowserPane({
           message: "The clipboard rejected the write.",
           // uiFeedback is passive, and the inbox keeps only actionId actions —
           // resolving to "low" would strip the Retry this toast exists for.
+          // No panelId/worktreeId: those mark the origin surface as already
+          // showing the failure, which suppresses the toast outright — and this
+          // label renders nothing when a write fails.
           priority: "high",
-          context: { eventKind: "uiFeedback", panelId: id, worktreeId },
+          context: { eventKind: "uiFeedback" },
           action: { label: "Retry", onClick: attempt },
         });
       });
     };
     attempt();
-  }, [rootAbsolutePath, copyRootPath, id, worktreeId]);
+  }, [rootAbsolutePath, copyRootPath]);
 
   const reveal = useMemo(() => revealCopy(), []);
   const handleReveal = useCallback(

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -12,7 +12,9 @@ import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
 import { ContextMenuItem, ContextMenuSeparator } from "@/components/ui/context-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { folderIncludePattern } from "@/lib/copyTreeFormat";
 import { notify } from "@/lib/notify";
@@ -470,6 +472,43 @@ export function FileBrowserPane({
     [copyToClipboard]
   );
 
+  // The header label copies the folder the tree is rooted at. Only a re-rooted
+  // tree has a path worth copying — at the worktree root the label is a bare
+  // basename, so the affordance stays absent rather than disabled.
+  const rootAbsolutePath =
+    rootPath === "" || worktreePath === "" ? "" : join(worktreePath, rootPath);
+  const rootHoverPath = rootPath === "" ? worktreePath : `${basename(worktreePath)}/${rootPath}`;
+
+  const { copied: rootPathCopied, copy: copyRootPath } = useCopyWithFeedback({
+    announcement: "Path copied",
+  });
+  // Keyed by the path that was copied, not a bare flag: re-rooting inside the
+  // dwell window would otherwise leave the success color describing a folder
+  // the header no longer points at.
+  const [copiedRootPath, setCopiedRootPath] = useState<string | null>(null);
+  const showRootPathCopied = rootPathCopied && copiedRootPath === rootAbsolutePath;
+
+  const handleCopyRootPath = useCallback(() => {
+    if (rootAbsolutePath === "") return;
+    // Retry re-enters the whole gesture, so a write that only succeeds on the
+    // second attempt still flashes and announces.
+    const attempt = () => {
+      void copyRootPath(rootAbsolutePath).then((copied) => {
+        if (copied) {
+          setCopiedRootPath(rootAbsolutePath);
+          return;
+        }
+        notify({
+          type: "error",
+          title: "Couldn't copy path",
+          message: "The clipboard rejected the write.",
+          action: { label: "Retry", onClick: attempt },
+        });
+      });
+    };
+    attempt();
+  }, [rootAbsolutePath, copyRootPath]);
+
   const reveal = useMemo(() => revealCopy(), []);
   const handleReveal = useCallback(
     (path: string) => {
@@ -632,12 +671,40 @@ export function FileBrowserPane({
                   <FolderRoot className="h-4 w-4" />
                 </span>
               )}
-              <span
-                className="min-w-0 flex-1 truncate font-mono text-[11px] text-daintree-text/40"
-                title={rootPath ? `${basename(worktreePath)}/${rootPath}` : worktreePath}
-              >
-                {rootPath || (worktreePath ? basename(worktreePath) : "")}
-              </span>
+              {/* Re-rooted, so the label names a real folder: it copies the
+                  absolute path, matching a row's "Copy full path". The tooltip
+                  carries the untruncated path the `title` used to show, and
+                  hosts the copied confirmation; autoDismiss is off because the
+                  path IS the tooltip's body. */}
+              {rootAbsolutePath !== "" ? (
+                <Tooltip autoDismiss={false}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={handleCopyRootPath}
+                      aria-label={`Copy folder path: ${rootAbsolutePath}`}
+                      className={cn(
+                        "min-w-0 flex-1 cursor-pointer truncate text-left font-mono text-[11px] transition-colors duration-150 ease-out",
+                        showRootPathCopied
+                          ? "text-status-success"
+                          : "text-daintree-text/40 hover:text-daintree-text/70"
+                      )}
+                    >
+                      {rootPath}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="break-words">
+                    {showRootPathCopied ? "Copied!" : rootHoverPath}
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                <span
+                  className="min-w-0 flex-1 truncate font-mono text-[11px] text-daintree-text/40"
+                  title={rootHoverPath}
+                >
+                  {rootPath || (worktreePath ? basename(worktreePath) : "")}
+                </span>
+              )}
               {rootPath !== "" && (
                 <FileViewerToolbar.IconButton label="Up one level" onClick={handleUpOneLevel}>
                   <CornerLeftUp className="h-4 w-4" />

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -917,6 +917,12 @@ describe("tree-header root path copy (#11407)", () => {
     expect(payload?.action?.label).toBe("Retry");
     // The inbox drops onClick actions, so a demoted toast would lose the Retry.
     expect(payload?.priority).toBe("high");
+    expect(payload?.context?.eventKind).toBe("uiFeedback");
+    // Naming the origin surface marks the failure as already visible there and
+    // suppresses the toast — but this label shows nothing when a write fails,
+    // so the Retry would become unreachable.
+    expect(payload?.context?.panelId).toBeUndefined();
+    expect(payload?.context?.worktreeId).toBeUndefined();
     // Nothing claims success: no announcement, no lit label.
     expect(lastAnnouncement()?.id).toBe(announcedBefore?.id);
     expect(copyButton().className).toBe(idle);

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -98,6 +98,17 @@ vi.mock("../FileTreeView", () => ({
   FileTreeView: () => <div data-testid="file-tree-view" role="tree" tabIndex={-1} />,
 }));
 
+// The header's copy affordance raises the pane's clipboard-failure toast. Only
+// `notify` is replaced — the module's other exports stay real, since shadowing
+// them breaks unrelated consumers in this tree.
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn<(payload: import("@/lib/notify").NotifyPayload) => void>(),
+}));
+vi.mock("@/lib/notify", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/notify")>()),
+  notify: notifyMock,
+}));
+
 // ContentPanel is chrome around the body; render just the children so the
 // pane's own layout is what's under test.
 vi.mock("@/components/Panel/ContentPanel", () => ({
@@ -116,6 +127,8 @@ vi.mock("@/components/FileViewer/CodeViewer", () => ({
 vi.mock("@/components/Html/HtmlViewer", () => ({ HtmlViewer: () => null }));
 
 import { FileBrowserPane } from "../FileBrowserPane";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
 import {
   FILE_BROWSER_SIDEBAR_DEFAULT_WIDTH as DEFAULT_W,
   FILE_BROWSER_SIDEBAR_MIN_WIDTH as MIN_W,
@@ -145,11 +158,21 @@ function classToken(el: Element, predicate: (cls: string) => boolean): string | 
   return Array.from(el.classList).find(predicate);
 }
 
+// jsdom ships no `navigator.clipboard`; the header copy gesture writes through it.
+let writeTextMock: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+
 beforeEach(() => {
   setFileBrowserViewMock.mockReset();
   readMock.mockReset();
   readMock.mockResolvedValue({ content: "hello" });
   flushPanelPersistenceMock.mockReset();
+  notifyMock.mockReset();
+  writeTextMock = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    writable: true,
+    configurable: true,
+    value: { writeText: writeTextMock },
+  });
   treeState.rows = defaultRows;
   treeState.rootError = null;
   treeState.isInitialLoading = false;
@@ -703,5 +726,180 @@ describe("FileBrowserPane resizable sidebar (#11331)", () => {
     fireEvent.mouseMove(document, { clientX: 400, buttons: 1 });
 
     expect(setFileBrowserViewMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("tree-header root path copy (#11407)", () => {
+  const ROOT = "src/panels";
+  // The worktree in the store mock is `/repo`, so this is what a row's
+  // "Copy full path" would produce for the same folder.
+  const ABSOLUTE = "/repo/src/panels";
+
+  const paneJsx = () => (
+    <TooltipProvider>
+      <FileBrowserPane
+        id="fb-1"
+        title="Files"
+        worktreeId="wt-1"
+        isFocused
+        location="grid"
+        onFocus={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+
+  function copyButton(): HTMLElement {
+    return screen.getByRole("button", { name: /copy folder path/i });
+  }
+
+  /** The header label, whichever element currently occupies that slot. */
+  function label(): HTMLElement {
+    const treeColumn = document.getElementById(
+      screen.getByTestId("file-browser-sidebar-toggle").getAttribute("aria-controls")!
+    )!;
+    const header = treeColumn.querySelector<HTMLElement>(":scope > div")!;
+    return header.querySelector<HTMLElement>("[class~='flex-1']")!;
+  }
+
+  function lastAnnouncement() {
+    return useAnnouncerStore.getState().polite;
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("leaves the label inert at the worktree root", () => {
+    // No rootPath — the label is a bare basename, not a path worth copying.
+    render(paneJsx());
+
+    expect(screen.queryByRole("button", { name: /copy folder path/i })).toBeNull();
+
+    const el = label();
+    expect(el.tagName).toBe("SPAN");
+    // Not focusable, and the hover text still resolves the worktree.
+    expect(el.hasAttribute("tabindex")).toBe(false);
+    expect(el.getAttribute("title")).toBe("/repo");
+
+    fireEvent.click(el);
+    expect(writeTextMock).not.toHaveBeenCalled();
+  });
+
+  it("copies the absolute path, not the relative text it displays", async () => {
+    mockPanel.browserRootPath = ROOT;
+    render(paneJsx());
+
+    const button = copyButton();
+    // The visible label stays the compact relative path…
+    expect(button.textContent).toBe(ROOT);
+    // …while the accessible name names what actually lands on the clipboard.
+    expect(button.getAttribute("aria-label")).toContain(ABSOLUTE);
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    expect(writeTextMock).toHaveBeenCalledWith(ABSOLUTE);
+  });
+
+  it("announces the copy and keeps the accessible name stable", async () => {
+    mockPanel.browserRootPath = ROOT;
+    render(paneJsx());
+
+    const button = copyButton();
+    const nameBefore = button.getAttribute("aria-label");
+    const announcedBefore = lastAnnouncement();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    const announced = lastAnnouncement();
+    expect(announced?.msg).toBe("Path copied");
+    // A fresh entry, not the one some earlier test left behind.
+    expect(announced?.id).not.toBe(announcedBefore?.id);
+    // The live region is the sole SR signal; a label that flipped to "Copied"
+    // would double-announce.
+    expect(button.getAttribute("aria-label")).toBe(nameBefore);
+  });
+
+  it("shows copied feedback for the dwell window, then restores the idle styling", async () => {
+    vi.useFakeTimers();
+    mockPanel.browserRootPath = ROOT;
+    render(paneJsx());
+
+    const idle = copyButton().className;
+
+    await act(async () => {
+      fireEvent.click(copyButton());
+    });
+    const copied = copyButton().className;
+    expect(copied).not.toBe(idle);
+
+    // Still lit just before the shared dwell elapses.
+    act(() => {
+      vi.advanceTimersByTime(UI_ACTION_SUCCESS_DWELL_MS - 1);
+    });
+    expect(copyButton().className).toBe(copied);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(copyButton().className).toBe(idle);
+  });
+
+  it("drops stale feedback when the tree is re-rooted inside the dwell window", async () => {
+    vi.useFakeTimers();
+    mockPanel.browserRootPath = ROOT;
+    const { rerender } = render(paneJsx());
+
+    const idle = copyButton().className;
+    await act(async () => {
+      fireEvent.click(copyButton());
+    });
+    expect(copyButton().className).not.toBe(idle);
+
+    // Up one level, well inside the dwell: the success color would otherwise
+    // describe a folder the header no longer points at.
+    mockPanel.browserRootPath = "src";
+    rerender(paneJsx());
+
+    expect(copyButton().className).toBe(idle);
+  });
+
+  it("reports a failed write and lets Retry complete the copy", async () => {
+    mockPanel.browserRootPath = ROOT;
+    writeTextMock.mockRejectedValueOnce(new Error("denied"));
+    render(paneJsx());
+
+    const announcedBefore = lastAnnouncement();
+    const idle = copyButton().className;
+
+    await act(async () => {
+      fireEvent.click(copyButton());
+    });
+
+    // A silent failure would leave the previous clipboard contents in place.
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    const payload = notifyMock.mock.calls[0]?.[0] as {
+      type: string;
+      action?: { label: string; onClick: () => void };
+    };
+    expect(payload.type).toBe("error");
+    expect(payload.action?.label).toBe("Retry");
+    // Nothing claims success: no announcement, no lit label.
+    expect(lastAnnouncement()?.id).toBe(announcedBefore?.id);
+    expect(copyButton().className).toBe(idle);
+
+    await act(async () => {
+      payload.action!.onClick();
+    });
+
+    expect(writeTextMock).toHaveBeenLastCalledWith(ABSOLUTE);
+    // The retry re-enters the whole gesture, so feedback lands on the second try.
+    expect(lastAnnouncement()?.msg).toBe("Path copied");
+    expect(copyButton().className).not.toBe(idle);
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -102,7 +102,7 @@ vi.mock("../FileTreeView", () => ({
 // `notify` is replaced — the module's other exports stay real, since shadowing
 // them breaks unrelated consumers in this tree.
 const { notifyMock } = vi.hoisted(() => ({
-  notifyMock: vi.fn<(payload: import("@/lib/notify").NotifyPayload) => void>(),
+  notifyMock: vi.fn<typeof import("@/lib/notify").notify>(),
 }));
 vi.mock("@/lib/notify", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/notify")>()),
@@ -167,6 +167,9 @@ beforeEach(() => {
   readMock.mockResolvedValue({ content: "hello" });
   flushPanelPersistenceMock.mockReset();
   notifyMock.mockReset();
+  // Module-global and never reset by the store itself, so a message left by an
+  // earlier test would satisfy the next one's announcement assertion.
+  useAnnouncerStore.setState({ polite: null, assertive: null });
   writeTextMock = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
   Object.defineProperty(navigator, "clipboard", {
     writable: true,
@@ -786,11 +789,37 @@ describe("tree-header root path copy (#11407)", () => {
     expect(writeTextMock).not.toHaveBeenCalled();
   });
 
+  it("stays inert when the root is set but the worktree cannot be resolved", () => {
+    // A restored panel can carry a root for a worktree the store has not (or no
+    // longer) resolves — there is no absolute path to build, so no affordance.
+    mockPanel.browserRootPath = ROOT;
+    render(
+      <TooltipProvider>
+        <FileBrowserPane
+          id="fb-1"
+          title="Files"
+          worktreeId="wt-missing"
+          isFocused
+          location="grid"
+          onFocus={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.queryByRole("button", { name: /copy folder path/i })).toBeNull();
+    expect(label().tagName).toBe("SPAN");
+  });
+
   it("copies the absolute path, not the relative text it displays", async () => {
     mockPanel.browserRootPath = ROOT;
     render(paneJsx());
 
     const button = copyButton();
+    // A native button, not a role-annotated div: that's what makes it reachable
+    // by Tab and activatable by Enter/Space without bespoke key handling.
+    expect(button.tagName).toBe("BUTTON");
+    expect(button.getAttribute("type")).toBe("button");
     // The visible label stays the compact relative path…
     expect(button.textContent).toBe(ROOT);
     // …while the accessible name names what actually lands on the clipboard.
@@ -883,23 +912,29 @@ describe("tree-header root path copy (#11407)", () => {
 
     // A silent failure would leave the previous clipboard contents in place.
     expect(notifyMock).toHaveBeenCalledTimes(1);
-    const payload = notifyMock.mock.calls[0]?.[0] as {
-      type: string;
-      action?: { label: string; onClick: () => void };
-    };
-    expect(payload.type).toBe("error");
-    expect(payload.action?.label).toBe("Retry");
+    const payload = notifyMock.mock.calls[0]?.[0];
+    expect(payload?.type).toBe("error");
+    expect(payload?.action?.label).toBe("Retry");
+    // The inbox drops onClick actions, so a demoted toast would lose the Retry.
+    expect(payload?.priority).toBe("high");
     // Nothing claims success: no announcement, no lit label.
     expect(lastAnnouncement()?.id).toBe(announcedBefore?.id);
     expect(copyButton().className).toBe(idle);
 
     await act(async () => {
-      payload.action!.onClick();
+      await payload?.action?.onClick();
     });
 
-    expect(writeTextMock).toHaveBeenLastCalledWith(ABSOLUTE);
+    // A Retry that never re-wrote would still satisfy a "last call" assertion,
+    // since the failed attempt already passed ABSOLUTE — so count the writes.
+    expect(writeTextMock).toHaveBeenCalledTimes(2);
+    expect(writeTextMock.mock.calls[1]?.[0]).toBe(ABSOLUTE);
     // The retry re-enters the whole gesture, so feedback lands on the second try.
-    expect(lastAnnouncement()?.msg).toBe("Path copied");
+    const announced = lastAnnouncement();
+    expect(announced?.msg).toBe("Path copied");
+    expect(announced?.id).not.toBe(announcedBefore?.id);
     expect(copyButton().className).not.toBe(idle);
+    // The successful retry raises no second toast.
+    expect(notifyMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- The file browser's tree header showed where the tree is rooted as an inert span, so the only way to get that folder's path onto the clipboard was to right-click a row and use "Copy full path", which copies the row, not the folder.
- When the tree is re-rooted to a subfolder, the label is now a native `<button>` that copies the folder's absolute path, the same value a row's "Copy full path" produces.
- At the worktree root the label is just a basename, not a path, so it stays exactly as it was: an inert `<span>`, no pointer cursor, no hover affordance, not focusable. This mirrors the conditional swap the sibling root/up-one-level icon buttons already do on the same empty `rootPath` condition.

Resolves #11407

## How

- The label slot renders a native `<button>` when there's an absolute path to copy, otherwise the original `<span>` verbatim. A native button is Tab-reachable and Enter/Space-activatable with no bespoke key handling. Tailwind v4 preflight zeroes button padding/border/margin and sets `font: inherit`, so the swap causes no layout shift; `text-left` covers the one thing preflight doesn't reset.
- Copy goes through the existing shared `useCopyWithFeedback` hook, already used for the toolbar path pill with the same "Path copied" announcement, so it gets the dwell flash, the polite live-region announcement, and unmount-safe timer cleanup for free.
- The full path moved from the native `title` into the tooltip, which keeps it visible on hover at all times and appends the copied confirmation rather than replacing it (`aria-hidden`, so the description stays stable while the live region carries the announcement).
- A failed write raises the pane's clipboard-failure toast with a Retry that re-enters the whole gesture, so a write that only succeeds on the second attempt still flashes and announces.

## Notable

- `useCopyWithFeedback` now keeps its `copied` flag and the text it describes in one piece of state (`copied` is derived from a new `copiedText` field) instead of a bare boolean beside a separate value. `announce()` can drive a synchronous external-store commit, which could otherwise let a render observe the flag raised while the text still named an earlier copy, lighting the success color for the wrong folder. Callers whose copy target can change under them, like a path label that re-roots, now gate on `copiedText`. Purely additive: `copied` keeps identical semantics and all 13 existing consumers are unaffected.
- The failure toast deliberately carries no `panelId`/`worktreeId` in its notify context. Naming the origin surface marks the failure as already visible there, which suppresses the toast and strips the callback-only Retry with it, and this label renders nothing when a write fails.
- Known, deliberate gap: the header's failure message is the generic "The clipboard rejected the write.", where the row context menu additionally distinguishes `NotAllowedError`. Closing that needs either a breaking change to the shared hook's `Promise<boolean>` return (13 consumers) or ref indirection to break the circularity between an `onError` option and the Retry closure. Not worth it for one differing sentence: title, recovery action, and the fact of failure are identical.

## Testing

- 515 tests pass across 21 files, covering the pane, the shared hook, and all 13 of its consumer sites.
- New coverage: inert at the worktree root; inert when `rootPath` is set but the worktree can't be resolved; copies the absolute path rather than the truncated relative text it displays; announces once with a stable accessible name; the flash appears and reverts exactly at the dwell boundary; re-rooting inside the dwell drops stale feedback; a failed write reports and Retry completes the copy (asserting the write count, since the failed attempt already passed the same argument); `copiedText` naming and its failure case.
- eslint/prettier clean on all four changed files; lint ratchet at 1102/1102 baseline.
