### PR TITLE
feat(project): let users set project name and emoji at creation

### DIFF
--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -55,21 +55,40 @@ export async function addProjectByPath(
   return project;
 }
 
+// Matches the in-repo `.daintree/project.json` cap so an identity chosen at
+// creation can't exceed what enabling in-repo settings would later accept.
+const MAX_CREATION_NAME_LENGTH = 100;
+// Generous next to any real emoji (a flag-with-modifier sequence is ~14 code
+// units) while still bounding what a compromised renderer can store.
+const MAX_CREATION_EMOJI_LENGTH = 32;
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1F\x7F]/;
+
 /**
  * Creation identity arrives from the renderer, so treat it as untrusted: keep
- * it only when both halves are non-empty strings. A partial or malformed
- * payload is dropped whole rather than half-applied, leaving `addProject` on
- * its normal basename + default-emoji path.
+ * it only when both halves are plain, bounded, control-character-free strings.
+ * A partial or malformed payload is dropped whole rather than half-applied,
+ * leaving `addProject` on its normal basename + default-emoji path.
+ *
+ * Reads own properties only and returns a fresh object, so neither inherited
+ * fields nor extra keys (`id`, `path`) can ride along into the insert.
  */
 function normalizeCreationIdentity(
   identity: ProjectCreationIdentity | undefined
 ): ProjectCreationIdentity | undefined {
-  if (!identity || typeof identity !== "object") return undefined;
+  if (!identity || typeof identity !== "object" || Array.isArray(identity)) return undefined;
+  if (!Object.hasOwn(identity, "name") || !Object.hasOwn(identity, "emoji")) return undefined;
+
   const { name, emoji } = identity;
   if (typeof name !== "string" || typeof emoji !== "string") return undefined;
+
   const trimmedName = name.trim();
   const trimmedEmoji = emoji.trim();
   if (!trimmedName || !trimmedEmoji) return undefined;
+  if (trimmedName.length > MAX_CREATION_NAME_LENGTH) return undefined;
+  if (trimmedEmoji.length > MAX_CREATION_EMOJI_LENGTH) return undefined;
+  if (CONTROL_CHARS.test(trimmedName) || CONTROL_CHARS.test(trimmedEmoji)) return undefined;
+
   return { name: trimmedName, emoji: trimmedEmoji };
 }
 

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -13,6 +13,7 @@ import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Project } from "../../../types/index.js";
+import type { ProjectCreationIdentity } from "../../../../shared/types/project.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
 import { pruneWindowStateForPath } from "../../../windowState.js";
@@ -39,20 +40,42 @@ const PROJECT_VISIBLE_MESSAGE =
  * Extracted from `handleProjectAdd` so other handlers (e.g. scratch
  * Save-as-Project) can register a path as a project without going through IPC.
  */
-export async function addProjectByPath(projectPath: string): Promise<Project> {
+export async function addProjectByPath(
+  projectPath: string,
+  identity?: ProjectCreationIdentity
+): Promise<Project> {
   if (typeof projectPath !== "string" || !projectPath) {
     throw new Error("Invalid project path");
   }
   if (!path.isAbsolute(projectPath)) {
     throw new Error("Project path must be absolute");
   }
-  const project = await projectStore.addProject(projectPath);
+  const project = await projectStore.addProject(projectPath, normalizeCreationIdentity(identity));
   broadcastToRenderer(CHANNELS.PROJECT_UPDATED, project);
   return project;
 }
 
+/**
+ * Creation identity arrives from the renderer, so treat it as untrusted: keep
+ * it only when both halves are non-empty strings. A partial or malformed
+ * payload is dropped whole rather than half-applied, leaving `addProject` on
+ * its normal basename + default-emoji path.
+ */
+function normalizeCreationIdentity(
+  identity: ProjectCreationIdentity | undefined
+): ProjectCreationIdentity | undefined {
+  if (!identity || typeof identity !== "object") return undefined;
+  const { name, emoji } = identity;
+  if (typeof name !== "string" || typeof emoji !== "string") return undefined;
+  const trimmedName = name.trim();
+  const trimmedEmoji = emoji.trim();
+  if (!trimmedName || !trimmedEmoji) return undefined;
+  return { name: trimmedName, emoji: trimmedEmoji };
+}
+
 export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () => void {
-  const handleProjectAdd = async (projectPath: string) => addProjectByPath(projectPath);
+  const handleProjectAdd = async (projectPath: string, identity?: ProjectCreationIdentity) =>
+    addProjectByPath(projectPath, identity);
 
   const handlers: Array<() => void> = [];
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -84,6 +84,7 @@ import { buildTerminalConfigPreloadBindings } from "./ipc/handlers/terminalConfi
 
 import type {
   Project,
+  ProjectCreationIdentity,
   ProjectSettings,
   TerminalSpawnOptions,
   CopyTreeOptions,
@@ -1708,7 +1709,12 @@ function buildElectronApi(): ElectronAPI {
 
       getCurrent: () => _unwrappingInvoke(CHANNELS.PROJECT_GET_CURRENT),
 
-      add: (path: string) => _unwrappingInvoke(CHANNELS.PROJECT_ADD, path),
+      // Forward the optional identity only when present — an open-existing-repo
+      // add stays a one-argument invoke, byte-identical to before.
+      add: (path: string, identity?: ProjectCreationIdentity) =>
+        identity
+          ? _unwrappingInvoke(CHANNELS.PROJECT_ADD, path, identity)
+          : _unwrappingInvoke(CHANNELS.PROJECT_ADD, path),
 
       remove: (projectId: string) => _unwrappingInvoke(CHANNELS.PROJECT_REMOVE, projectId),
 

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -412,6 +412,14 @@ export class ProjectStore {
     // independent.
     const normalizedPath = path.normalize(gitRoot).normalize("NFC");
 
+    // The registered project is the git ROOT, which is not always the path the
+    // caller handed us: creating `/repo/child` inside an existing repository
+    // resolves back to `/repo`. Identity chosen for the child must not be
+    // stamped onto the ancestor, so it only survives when the two agree.
+    const identityTargetsResolvedRoot =
+      normalizedPath === path.normalize(projectPath).normalize("NFC");
+    const mintIdentity = identityTargetsResolvedRoot ? creationIdentity : undefined;
+
     const existing = await this.getProjectByPath(normalizedPath);
     if (existing) {
       const now = Date.now();
@@ -455,8 +463,8 @@ export class ProjectStore {
     const project: Project = {
       id: mintProjectId(normalizedPath, (candidate) => this.isProjectIdTaken(candidate)),
       path: normalizedPath,
-      name: inRepo.name ?? creationIdentity?.name ?? path.basename(normalizedPath),
-      emoji: inRepo.emoji ?? creationIdentity?.emoji ?? DEFAULT_PROJECT_EMOJI,
+      name: inRepo.name ?? mintIdentity?.name ?? path.basename(normalizedPath),
+      emoji: inRepo.emoji ?? mintIdentity?.emoji ?? DEFAULT_PROJECT_EMOJI,
       lastOpened: now,
       status: "closed",
       frecencyScore: FRECENCY_COLD_START,

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -355,6 +355,20 @@ export class ProjectStore {
 
   // --- DB CRUD ---
 
+  /**
+   * Canonical spelling of a path for comparison against a resolved git root:
+   * realpath (resolving symlinks and case) then the same separator + NFC
+   * normalization the root gets. Returns null if the path can't be resolved,
+   * which compares unequal to every root — the safe direction.
+   */
+  private async canonicalizeForCompare(input: string): Promise<string | null> {
+    try {
+      return normalizeProjectPath(await fs.realpath(input));
+    } catch {
+      return null;
+    }
+  }
+
   private async getGitRoot(projectPath: string): Promise<string> {
     const gitService = new GitService(projectPath);
     const root = await gitService.getRepositoryRoot(projectPath);
@@ -416,9 +430,16 @@ export class ProjectStore {
     // caller handed us: creating `/repo/child` inside an existing repository
     // resolves back to `/repo`. Identity chosen for the child must not be
     // stamped onto the ancestor, so it only survives when the two agree.
-    const identityTargetsResolvedRoot =
-      normalizedPath === path.normalize(projectPath).normalize("NFC");
-    const mintIdentity = identityTargetsResolvedRoot ? creationIdentity : undefined;
+    //
+    // Both sides are canonicalized the same way (`normalizedPath` already comes
+    // from a realpath'd git root). A lexical-only comparison here would treat a
+    // symlinked path, a trailing separator, or different casing on a
+    // case-insensitive volume as a mismatch and silently discard an identity
+    // the user actually chose.
+    const mintIdentity =
+      (await this.canonicalizeForCompare(projectPath)) === normalizedPath
+        ? creationIdentity
+        : undefined;
 
     const existing = await this.getProjectByPath(normalizedPath);
     if (existing) {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -8,6 +8,7 @@ import type {
   TerminalRecipe,
   RecipeNameCollision,
 } from "../types/index.js";
+import type { ProjectCreationIdentity } from "../../shared/types/project.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
 import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
@@ -53,7 +54,8 @@ import { rewriteAgentSessionPathsForProject } from "./pty/agentSessionHistory.js
 import { getPendingHelpHibernationStore } from "./PendingHelpHibernationStore.js";
 import { repairMovedSubmodulePaths } from "./git/submodulePathRepair.js";
 
-export const DEFAULT_PROJECT_EMOJI = "🌲";
+export { DEFAULT_PROJECT_EMOJI } from "../../shared/utils/projectEmoji.js";
+import { DEFAULT_PROJECT_EMOJI } from "../../shared/utils/projectEmoji.js";
 
 /**
  * The single spelling of a project path used for identity comparisons. Separator
@@ -360,7 +362,17 @@ export class ProjectStore {
     return canonical;
   }
 
-  async addProject(projectPath: string): Promise<Project> {
+  /**
+   * `creationIdentity` is the name/emoji chosen in a creation dialog. It is
+   * consulted only where a brand-new row is minted below — every earlier return
+   * (already-registered path, adopted move, lost insert race) keeps the
+   * identity it already has, so re-adding a folder can never rename it.
+   * In-repo `.daintree/project.json` still wins field-wise.
+   */
+  async addProject(
+    projectPath: string,
+    creationIdentity?: ProjectCreationIdentity
+  ): Promise<Project> {
     let gitRoot: string;
     try {
       gitRoot = await this.getGitRoot(projectPath);
@@ -443,8 +455,8 @@ export class ProjectStore {
     const project: Project = {
       id: mintProjectId(normalizedPath, (candidate) => this.isProjectIdTaken(candidate)),
       path: normalizedPath,
-      name: inRepo.name ?? path.basename(normalizedPath),
-      emoji: inRepo.emoji ?? DEFAULT_PROJECT_EMOJI,
+      name: inRepo.name ?? creationIdentity?.name ?? path.basename(normalizedPath),
+      emoji: inRepo.emoji ?? creationIdentity?.emoji ?? DEFAULT_PROJECT_EMOJI,
       lastOpened: now,
       status: "closed",
       frecencyScore: FRECENCY_COLD_START,

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -253,6 +253,33 @@ describe("project identity across folder moves", () => {
       expect(reopened.emoji).not.toBe("💀");
     });
 
+    it("keeps the identity when the requested path is a symlink to the repo root", async () => {
+      // The ancestor guard compares canonical paths. Comparing the raw request
+      // instead would treat a symlink as "not the root" and silently drop an
+      // identity the user actually chose.
+      const real = await makeDir("real-repo");
+      const link = path.join(tmpRoot, "linked-repo");
+      await fs.promises.symlink(real, link);
+
+      const created = await store.addProject(link, { name: "Chosen", emoji: "🚀" });
+
+      expect(created.path).toBe(real);
+      expect(created.name).toBe("Chosen");
+      expect(created.emoji).toBe("🚀");
+    });
+
+    it("keeps the identity when the requested path has a trailing separator", async () => {
+      const dir = await makeDir("trailing");
+
+      const created = await store.addProject(`${dir}${path.sep}`, {
+        name: "Chosen",
+        emoji: "🚀",
+      });
+
+      expect(created.name).toBe("Chosen");
+      expect(created.emoji).toBe("🚀");
+    });
+
     it("does not stamp a child folder's identity onto its ancestor repository", async () => {
       // Creating `<root>/child` inside an existing repo resolves the git root
       // back to `<root>`, so the row minted is the ANCESTOR — the child's

--- a/electron/services/__tests__/ProjectStore.identity.test.ts
+++ b/electron/services/__tests__/ProjectStore.identity.test.ts
@@ -72,10 +72,14 @@ vi.mock("electron", () => ({
   app: { getPath: () => "/tmp/daintree-identity-test" },
 }));
 
+// Repository root normally IS the path handed in; set this to model the case
+// where the requested folder sits inside an existing repository.
+let repositoryRootOverride: string | null = null;
+
 vi.mock("../GitService.js", () => ({
   GitService: class {
     async getRepositoryRoot(p: string): Promise<string> {
-      return p;
+      return repositoryRootOverride ?? p;
     }
     repairWorktrees(...args: string[][]) {
       return repairWorktrees(...(args as []));
@@ -147,6 +151,7 @@ describe("project identity across folder moves", () => {
     rewriteAgentSessionPathsForProject.mockClear();
     rewriteHibernationProjectPath.mockClear();
     repairMovedSubmodulePaths.mockClear();
+    repositoryRootOverride = null;
     store = new ProjectStore();
   });
 
@@ -199,6 +204,68 @@ describe("project identity across folder moves", () => {
           status: "active",
         })
       ).rejects.toThrow(/moved concurrently/);
+    });
+  });
+
+  describe("creation identity", () => {
+    it("applies the chosen name and emoji when a new row is minted", async () => {
+      const dir = await makeDir("fresh");
+
+      const created = await store.addProject(dir, { name: "Chosen", emoji: "🚀" });
+
+      expect(created.name).toBe("Chosen");
+      expect(created.emoji).toBe("🚀");
+    });
+
+    it("falls back to basename and the default emoji without an identity", async () => {
+      const dir = await makeDir("fresh");
+
+      const created = await store.addProject(dir);
+
+      expect(created.name).toBe(path.basename(dir));
+      expect(created.emoji).toBe("🌲");
+    });
+
+    it("cannot rename an already-registered project by re-adding it", async () => {
+      const dir = await makeDir("existing");
+      const first = await store.addProject(dir, { name: "First", emoji: "🚀" });
+
+      const second = await store.addProject(dir, { name: "Hijacked", emoji: "💀" });
+
+      expect(second.id).toBe(first.id);
+      expect(second.name).toBe("First");
+      expect(second.emoji).toBe("🚀");
+      expect(store.getAllProjects()).toHaveLength(1);
+    });
+
+    it("cannot rename an adopted moved project by supplying an identity", async () => {
+      const original = await makeDir("original");
+      const registered = await store.addProject(original, { name: "Original", emoji: "🚀" });
+      await writeAnchor(original, registered.id);
+
+      const moved = path.join(tmpRoot, "renamed");
+      await fs.promises.rename(original, moved);
+      const canonicalMoved = await fs.promises.realpath(moved);
+
+      const reopened = await store.addProject(canonicalMoved, { name: "Hijacked", emoji: "💀" });
+
+      expect(reopened.id).toBe(registered.id);
+      expect(reopened.emoji).not.toBe("💀");
+    });
+
+    it("does not stamp a child folder's identity onto its ancestor repository", async () => {
+      // Creating `<root>/child` inside an existing repo resolves the git root
+      // back to `<root>`, so the row minted is the ANCESTOR — the child's
+      // chosen identity must not ride along onto it.
+      const root = await makeDir("repo-root");
+      const child = await makeDir("repo-root/child");
+      repositoryRootOverride = root;
+
+      const created = await store.addProject(child, { name: "Child", emoji: "🚀" });
+
+      expect(created.path).toBe(root);
+      expect(created.name).toBe(path.basename(root));
+      expect(created.emoji).toBe("🌲");
     });
   });
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -85,6 +85,7 @@ export type { BrowserHistory } from "./browser.js";
 export type {
   ProjectStatus,
   Project,
+  ProjectCreationIdentity,
   ProjectRepoStats,
   TerminalSnapshot,
   PanelSnapshot,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -5,6 +5,7 @@ import type { TabGroup } from "../panel.js";
 import type { WorktreeState } from "../worktree.js";
 import type {
   Project,
+  ProjectCreationIdentity,
   ProjectSettings,
   RecipeNameCollision,
   RunCommand,
@@ -535,7 +536,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   project: {
     getAll(): Promise<Project[]>;
     getCurrent(): Promise<Project | null>;
-    add(path: string): Promise<Project>;
+    add(path: string, identity?: ProjectCreationIdentity): Promise<Project>;
     remove(projectId: string): Promise<void>;
     update(projectId: string, updates: Partial<Project>): Promise<Project>;
     switch(

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -3,6 +3,7 @@ import type { AgentId } from "../agent.js";
 import type { VoiceInputError, VoiceInputStatus } from "../voice.js";
 import type {
   Project,
+  ProjectCreationIdentity,
   ProjectSettings,
   RecipeNameCollision,
   RunCommand,
@@ -590,7 +591,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: Project | null;
   };
   "project:add": {
-    args: [path: string];
+    args: [path: string, identity?: ProjectCreationIdentity];
     result: Project;
   };
   "project:remove": {

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -97,6 +97,17 @@ export interface Project {
   lastKnownStats?: ProjectRepoStats;
 }
 
+/**
+ * Identity chosen in a creation dialog and applied when the project row is
+ * first minted. Only consulted on that branch — an already-registered path, an
+ * adopted move, or an in-repo `.daintree/project.json` all keep their own
+ * identity, so this can never be used to rename by re-adding a folder.
+ */
+export interface ProjectCreationIdentity {
+  name: string;
+  emoji: string;
+}
+
 /** Panel snapshot for state preservation. */
 export interface PanelSnapshot {
   /** Terminal ID */

--- a/shared/utils/__tests__/projectEmoji.test.ts
+++ b/shared/utils/__tests__/projectEmoji.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "../projectEmoji.js";
+
+describe("suggestProjectEmoji", () => {
+  describe("unset input", () => {
+    it("returns the default tree for a blank name", () => {
+      expect(suggestProjectEmoji("")).toBe(DEFAULT_PROJECT_EMOJI);
+      expect(suggestProjectEmoji("   ")).toBe(DEFAULT_PROJECT_EMOJI);
+    });
+
+    it("returns the default tree for a non-string input", () => {
+      expect(suggestProjectEmoji(undefined as unknown as string)).toBe(DEFAULT_PROJECT_EMOJI);
+      expect(suggestProjectEmoji(null as unknown as string)).toBe(DEFAULT_PROJECT_EMOJI);
+    });
+  });
+
+  describe("keyword matching", () => {
+    it("matches a whole token regardless of separator style", () => {
+      const fromDash = suggestProjectEmoji("my-api-service");
+      const fromUnderscore = suggestProjectEmoji("my_api_service");
+      const fromSpace = suggestProjectEmoji("my api service");
+      expect(fromDash).toBe(fromUnderscore);
+      expect(fromDash).toBe(fromSpace);
+    });
+
+    it("splits camelCase into tokens", () => {
+      expect(suggestProjectEmoji("myMobileApp")).toBe(suggestProjectEmoji("my-mobile-app"));
+    });
+
+    it("is case-insensitive", () => {
+      expect(suggestProjectEmoji("DOCS")).toBe(suggestProjectEmoji("docs"));
+    });
+
+    it("does not match a keyword embedded inside a larger word", () => {
+      // "rapid" contains "api" but is not the token "api".
+      expect(suggestProjectEmoji("rapid")).not.toBe(suggestProjectEmoji("api"));
+    });
+
+    it("prefers the keyword appearing earliest in the name", () => {
+      // Both `mobile` and `docs` are keywords; name order decides.
+      expect(suggestProjectEmoji("mobile-docs")).toBe(suggestProjectEmoji("mobile"));
+      expect(suggestProjectEmoji("docs-mobile")).toBe(suggestProjectEmoji("docs"));
+    });
+
+    it("gives different keywords different emoji", () => {
+      const api = suggestProjectEmoji("api");
+      const docs = suggestProjectEmoji("docs");
+      const mobile = suggestProjectEmoji("mobile");
+      expect(new Set([api, docs, mobile]).size).toBe(3);
+    });
+  });
+
+  describe("hash fallback", () => {
+    it("is deterministic for the same name", () => {
+      const first = suggestProjectEmoji("zzquux-widget");
+      const second = suggestProjectEmoji("zzquux-widget");
+      expect(first).toBe(second);
+    });
+
+    it("normalizes separators and case before hashing", () => {
+      expect(suggestProjectEmoji("My-Zzquux Widget")).toBe(suggestProjectEmoji("my zzquux widget"));
+    });
+
+    it("never falls back to the default tree", () => {
+      // Any keyword-free name must produce a visibly distinct suggestion.
+      const names = Array.from({ length: 60 }, (_, i) => `zzquux-${i}`);
+      for (const name of names) {
+        expect(suggestProjectEmoji(name)).not.toBe(DEFAULT_PROJECT_EMOJI);
+      }
+    });
+
+    it("spreads keyword-free names across more than one emoji", () => {
+      const names = Array.from({ length: 60 }, (_, i) => `zzquux-${i}`);
+      const distinct = new Set(names.map(suggestProjectEmoji));
+      expect(distinct.size).toBeGreaterThan(1);
+    });
+
+    it("returns a non-empty string for names with no alphanumeric tokens", () => {
+      expect(suggestProjectEmoji("!!!")).toBeTruthy();
+      expect(suggestProjectEmoji("...")).toBeTruthy();
+    });
+  });
+});

--- a/shared/utils/__tests__/projectEmoji.test.ts
+++ b/shared/utils/__tests__/projectEmoji.test.ts
@@ -42,6 +42,16 @@ describe("suggestProjectEmoji", () => {
       expect(suggestProjectEmoji("docs-mobile")).toBe(suggestProjectEmoji("docs"));
     });
 
+    it("never resolves an inherited Object.prototype member as an emoji", () => {
+      // A plain-object keyword map would return `Object.prototype.constructor`
+      // — a function — for these names, which then reaches React and IPC.
+      for (const name of ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"]) {
+        const result = suggestProjectEmoji(name);
+        expect(typeof result).toBe("string");
+        expect(result.length).toBeGreaterThan(0);
+      }
+    });
+
     it("gives different keywords different emoji", () => {
       const api = suggestProjectEmoji("api");
       const docs = suggestProjectEmoji("docs");
@@ -78,6 +88,30 @@ describe("suggestProjectEmoji", () => {
     it("returns a non-empty string for names with no alphanumeric tokens", () => {
       expect(suggestProjectEmoji("!!!")).toBeTruthy();
       expect(suggestProjectEmoji("...")).toBeTruthy();
+    });
+  });
+
+  describe("unicode handling", () => {
+    it("splits case boundaries beyond ASCII", () => {
+      // An ASCII-only camelCase split would leave "δdocs" as one token and
+      // miss the keyword entirely.
+      expect(suggestProjectEmoji("δDocs")).toBe(suggestProjectEmoji("docs"));
+    });
+
+    it("keeps combining marks inside a token", () => {
+      // Marks are token characters, not separators. If they were stripped, a
+      // name and its mark-less skeleton would hash to the same suggestion.
+      const withMarks = "\u092a\u0930\u093f\u092f\u094b\u091c\u0928\u093e";
+      const withoutMarks = withMarks.replace(/\p{M}/gu, "");
+      expect(withoutMarks).not.toBe(withMarks);
+      expect(suggestProjectEmoji(withMarks)).not.toBe(suggestProjectEmoji(withoutMarks));
+    });
+
+    it("treats NFC and NFD spellings of the same name identically", () => {
+      const nfc = "caf\u00e9-app".normalize("NFC");
+      const nfd = "caf\u00e9-app".normalize("NFD");
+      expect(nfd).not.toBe(nfc);
+      expect(suggestProjectEmoji(nfd)).toBe(suggestProjectEmoji(nfc));
     });
   });
 });

--- a/shared/utils/hash.ts
+++ b/shared/utils/hash.ts
@@ -1,0 +1,15 @@
+/**
+ * Deterministic djb2 string hash. Stable across processes and runs, so it can
+ * back "always pick the same thing for the same name" selections (avatar
+ * colors, suggested project emoji) without persisting the choice.
+ *
+ * Returns a signed 32-bit integer — callers index with
+ * `Math.abs(djb2(key)) % list.length`.
+ */
+export function djb2(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return hash;
+}

--- a/shared/utils/projectEmoji.ts
+++ b/shared/utils/projectEmoji.ts
@@ -12,36 +12,38 @@ export const DEFAULT_PROJECT_EMOJI = "🌲";
  * name so `mobile-api` suggests 📱 (its first meaningful token) rather than
  * whichever key happens to sit earlier in this map.
  */
-const KEYWORD_EMOJI: Record<string, string> = {
-  api: "🔌",
-  server: "🖥️",
-  backend: "🖥️",
-  service: "🛎️",
-  web: "🌐",
-  frontend: "🎨",
-  ui: "🎨",
-  mobile: "📱",
-  ios: "📱",
-  android: "🤖",
-  docs: "📚",
-  documentation: "📚",
-  bot: "🤖",
-  agent: "🤖",
-  ai: "🧠",
-  data: "📊",
-  database: "🗄️",
-  db: "🗄️",
-  auth: "🔐",
-  security: "🔐",
-  cli: "⌨️",
-  terminal: "⌨️",
-  infra: "🏗️",
-  devops: "🏗️",
-  cloud: "☁️",
-  test: "🧪",
-  tests: "🧪",
-  game: "🎮",
-};
+const KEYWORD_EMOJI = new Map<string, string>(
+  Object.entries({
+    api: "🔌",
+    server: "🖥️",
+    backend: "🖥️",
+    service: "🛎️",
+    web: "🌐",
+    frontend: "🎨",
+    ui: "🎨",
+    mobile: "📱",
+    ios: "📱",
+    android: "🤖",
+    docs: "📚",
+    documentation: "📚",
+    bot: "🤖",
+    agent: "🤖",
+    ai: "🧠",
+    data: "📊",
+    database: "🗄️",
+    db: "🗄️",
+    auth: "🔐",
+    security: "🔐",
+    cli: "⌨️",
+    terminal: "⌨️",
+    infra: "🏗️",
+    devops: "🏗️",
+    cloud: "☁️",
+    test: "🧪",
+    tests: "🧪",
+    game: "🎮",
+  })
+);
 
 /**
  * Fallback pool for names with no keyword hit. Deliberately excludes
@@ -67,13 +69,19 @@ const FALLBACK_EMOJI = [
   "🏗️",
 ] as const;
 
-/** Split on separators and camelCase boundaries, lowercased and NFC-normalized. */
+/**
+ * Split on separators and camelCase boundaries, lowercased and NFC-normalized.
+ * The case boundary and the separator class are both Unicode-aware: an
+ * ASCII-only `[a-z][A-Z]` split misses `δDocs`, and dropping `\p{M}` would
+ * shred any script that writes with combining marks.
+ */
 function tokenize(name: string): string[] {
   return name
     .normalize("NFC")
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/(\p{Ll}|\p{N})(\p{Lu})/gu, "$1 $2")
     .toLowerCase()
-    .split(/[^\p{L}\p{N}]+/u)
+    .normalize("NFC")
+    .split(/[^\p{L}\p{N}\p{M}]+/u)
     .filter(Boolean);
 }
 
@@ -92,7 +100,10 @@ export function suggestProjectEmoji(name: string): string {
 
   const tokens = tokenize(trimmed);
   for (const token of tokens) {
-    const match = KEYWORD_EMOJI[token];
+    // A Map, not an object literal — a plain-object lookup would resolve
+    // `constructor`/`toString` to an inherited function and return it as the
+    // "emoji".
+    const match = KEYWORD_EMOJI.get(token);
     if (match) return match;
   }
 

--- a/shared/utils/projectEmoji.ts
+++ b/shared/utils/projectEmoji.ts
@@ -1,0 +1,103 @@
+import { djb2 } from "./hash.js";
+
+/**
+ * Emoji a project carries until someone chooses otherwise. Kept as the "unset"
+ * signal — the open-an-existing-repo path never overwrites it, so a plain tree
+ * still means "nobody has set an identity here".
+ */
+export const DEFAULT_PROJECT_EMOJI = "🌲";
+
+/**
+ * Whole-token keyword matches, checked in the order the tokens appear in the
+ * name so `mobile-api` suggests 📱 (its first meaningful token) rather than
+ * whichever key happens to sit earlier in this map.
+ */
+const KEYWORD_EMOJI: Record<string, string> = {
+  api: "🔌",
+  server: "🖥️",
+  backend: "🖥️",
+  service: "🛎️",
+  web: "🌐",
+  frontend: "🎨",
+  ui: "🎨",
+  mobile: "📱",
+  ios: "📱",
+  android: "🤖",
+  docs: "📚",
+  documentation: "📚",
+  bot: "🤖",
+  agent: "🤖",
+  ai: "🧠",
+  data: "📊",
+  database: "🗄️",
+  db: "🗄️",
+  auth: "🔐",
+  security: "🔐",
+  cli: "⌨️",
+  terminal: "⌨️",
+  infra: "🏗️",
+  devops: "🏗️",
+  cloud: "☁️",
+  test: "🧪",
+  tests: "🧪",
+  game: "🎮",
+};
+
+/**
+ * Fallback pool for names with no keyword hit. Deliberately excludes
+ * `DEFAULT_PROJECT_EMOJI` so a suggestion is always visibly distinct from the
+ * unset tree.
+ */
+const FALLBACK_EMOJI = [
+  "🚀",
+  "✨",
+  "🧭",
+  "🛠️",
+  "⚙️",
+  "🧩",
+  "📦",
+  "🧪",
+  "🔧",
+  "💡",
+  "🎯",
+  "🌐",
+  "🗂️",
+  "🪄",
+  "🛰️",
+  "🏗️",
+] as const;
+
+/** Split on separators and camelCase boundaries, lowercased and NFC-normalized. */
+function tokenize(name: string): string[] {
+  return name
+    .normalize("NFC")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean);
+}
+
+/**
+ * Suggest an emoji for a project from its folder or repository name: a small
+ * keyword map first, then a deterministic hash pick so the same name always
+ * yields the same emoji.
+ *
+ * Pure string logic — no fs, no DOM — so both the renderer dialogs and the
+ * main process can call it.
+ */
+export function suggestProjectEmoji(name: string): string {
+  if (typeof name !== "string") return DEFAULT_PROJECT_EMOJI;
+  const trimmed = name.trim();
+  if (!trimmed) return DEFAULT_PROJECT_EMOJI;
+
+  const tokens = tokenize(trimmed);
+  for (const token of tokens) {
+    const match = KEYWORD_EMOJI[token];
+    if (match) return match;
+  }
+
+  // Hash the normalized token join rather than the raw string so `My-API` and
+  // `my api` land on the same suggestion.
+  const key = tokens.length > 0 ? tokens.join(" ") : trimmed.normalize("NFC").toLowerCase();
+  return FALLBACK_EMOJI[Math.abs(djb2(key)) % FALLBACK_EMOJI.length]!;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import {
   useErrors,
   useReEntrySummary,
 } from "./hooks";
+import type { ProjectCreationIdentity } from "@shared/types";
 import { useActionRegistry } from "./hooks/useActionRegistry";
 import { usePluginActions } from "./hooks/usePluginActions";
 import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
@@ -177,6 +178,7 @@ function AppInner() {
   const currentProject = useProjectStore((state) => state.currentProject);
   const gitInitDialogOpen = useProjectStore((state) => state.gitInitDialogOpen);
   const gitInitDirectoryPath = useProjectStore((state) => state.gitInitDirectoryPath);
+  const gitInitIdentity = useProjectStore((state) => state.gitInitIdentity);
   const closeGitInitDialog = useProjectStore((state) => state.closeGitInitDialog);
   const handleGitInitSuccess = useProjectStore((state) => state.handleGitInitSuccess);
   const createFolderDialogOpen = useProjectStore((state) => state.createFolderDialogOpen);
@@ -189,16 +191,26 @@ function AppInner() {
   const shouldMountCreateFolderDialog = useKeepMounted(createFolderDialogOpen);
   const shouldMountCloneRepoDialog = useKeepMounted(cloneRepoDialogOpen);
   // GitInitDialog mounts on the directory path (its `directoryPath` prop is
-  // non-nullable), but closeGitInitDialog() clears both `gitInitDialogOpen` and
-  // `gitInitDirectoryPath` in one set(). Latch the last non-null path so the
-  // dialog keeps a valid prop through its exit animation window (#9917). On the
-  // next open the store sets the path before isOpen, so a fresh path wins.
+  // non-nullable), but closeGitInitDialog() clears `gitInitDialogOpen`,
+  // `gitInitDirectoryPath` and `gitInitIdentity` in one set(). Latch path and
+  // identity as ONE object so the dialog keeps valid props through its exit
+  // animation window (#9917) and the two can never be latched out of step. On
+  // the next open the store sets both before isOpen, so a fresh context wins.
   const shouldMountGitInitDialog = useKeepMounted(gitInitDialogOpen);
-  const [latchedGitInitPath, setLatchedGitInitPath] = useState<string | null>(null);
+  const [latchedGitInit, setLatchedGitInit] = useState<{
+    path: string;
+    identity: ProjectCreationIdentity | null;
+  } | null>(null);
   useEffect(() => {
-    if (gitInitDirectoryPath) setLatchedGitInitPath(gitInitDirectoryPath);
-  }, [gitInitDirectoryPath]);
-  const effectiveGitInitPath = gitInitDirectoryPath ?? latchedGitInitPath;
+    if (gitInitDirectoryPath) {
+      setLatchedGitInit({ path: gitInitDirectoryPath, identity: gitInitIdentity });
+    }
+  }, [gitInitDirectoryPath, gitInitIdentity]);
+  const effectiveGitInit = gitInitDirectoryPath
+    ? { path: gitInitDirectoryPath, identity: gitInitIdentity }
+    : latchedGitInit;
+  const effectiveGitInitPath = effectiveGitInit?.path ?? null;
+  const effectiveGitInitIdentity = effectiveGitInit?.identity ?? null;
   const { selectWorktree, activeWorktreeId, focusedWorktreeId } = useWorktreeSelectionStore(
     useShallow((state) => ({
       selectWorktree: state.selectWorktree,
@@ -587,6 +599,7 @@ function AppInner() {
                 gitInitDialogOpen={gitInitDialogOpen}
                 shouldMountGitInitDialog={shouldMountGitInitDialog}
                 effectiveGitInitPath={effectiveGitInitPath}
+                effectiveGitInitIdentity={effectiveGitInitIdentity}
                 handleGitInitSuccess={handleGitInitSuccess}
                 closeGitInitDialog={closeGitInitDialog}
                 createFolderDialogOpen={createFolderDialogOpen}

--- a/src/ModalHostLayer.tsx
+++ b/src/ModalHostLayer.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import type { WorktreeState, Project } from "@shared/types";
+import type { WorktreeState, Project, ProjectCreationIdentity } from "@shared/types";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 import type { UseQuickSwitcherReturn } from "./hooks/useQuickSwitcher";
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
@@ -137,14 +137,15 @@ interface ModalHostLayerProps {
   gitInitDialogOpen: boolean;
   shouldMountGitInitDialog: boolean;
   effectiveGitInitPath: string | null;
-  handleGitInitSuccess: () => Promise<void>;
+  effectiveGitInitIdentity: ProjectCreationIdentity | null;
+  handleGitInitSuccess: (identity?: ProjectCreationIdentity) => Promise<void>;
   closeGitInitDialog: () => void;
   createFolderDialogOpen: boolean;
   shouldMountCreateFolderDialog: boolean;
   closeCreateFolderDialog: () => void;
   cloneRepoDialogOpen: boolean;
   shouldMountCloneRepoDialog: boolean;
-  handleCloneSuccess: (clonedPath: string) => Promise<void>;
+  handleCloneSuccess: (clonedPath: string, identity?: ProjectCreationIdentity) => Promise<void>;
   closeCloneRepoDialog: () => void;
   reEntrySummary: ReEntrySummaryState;
   gettingStarted: GettingStartedChecklistState;
@@ -228,6 +229,7 @@ export function ModalHostLayer({
   gitInitDialogOpen,
   shouldMountGitInitDialog,
   effectiveGitInitPath,
+  effectiveGitInitIdentity,
   handleGitInitSuccess,
   closeGitInitDialog,
   createFolderDialogOpen,
@@ -767,6 +769,7 @@ export function ModalHostLayer({
             <LazyGitInitDialog
               isOpen={gitInitDialogOpen}
               directoryPath={effectiveGitInitPath}
+              initialIdentity={effectiveGitInitIdentity}
               onSuccess={handleGitInitSuccess}
               onCancel={closeGitInitDialog}
             />

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -1,5 +1,6 @@
 import type {
   Project,
+  ProjectCreationIdentity,
   ProjectSettings,
   RunCommand,
   ProjectCloseResult,
@@ -111,8 +112,8 @@ export const projectClient = {
     return inflight;
   },
 
-  add: (path: string): Promise<Project> => {
-    return window.electron.project.add(path);
+  add: (path: string, identity?: ProjectCreationIdentity): Promise<Project> => {
+    return window.electron.project.add(path, identity);
   },
 
   remove: (projectId: string): Promise<void> => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -98,6 +98,7 @@ import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import { LazyProjectSwitcherPalette } from "@/lazyPanels";
+import { ProjectIdentityEditor } from "@/components/Project/ProjectIdentityEditor";
 import { VoiceRecordingToolbarButton } from "./VoiceRecordingToolbarButton";
 import { useUIStore } from "@/store/uiStore";
 import { ForgeStatsToolbarButton, type ForgeStatsHandle } from "./ForgeStatsToolbarButton";
@@ -1583,8 +1584,10 @@ export function Toolbar({
         <div
           role="group"
           aria-label="Project"
-          className="app-no-drag flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
+          className="app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
         >
+          {/* Sibling of the pill, not a child — see ProjectIdentityEditor. */}
+          {currentProject && <ProjectIdentityEditor project={currentProject} />}
           <Tooltip
             open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
             onOpenChange={

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -201,7 +201,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
 
     it("marks the whole project switcher grid cell as no-drag", () => {
       expect(source).toContain(
-        "app-no-drag flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
+        "app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
       );
     });
 

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -200,9 +200,15 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
 
     it("marks the whole project switcher grid cell as no-drag", () => {
-      expect(source).toContain(
-        "app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
-      );
+      // Assert the load-bearing tokens on the center group, not the literal
+      // class string — a copied string forces the same edit as the source on
+      // any unrelated styling change.
+      const centerGroup = /aria-label="Project"[\s\S]{0,400}?className="([^"]+)"/.exec(source)?.[1];
+      expect(centerGroup).toBeDefined();
+      expect(centerGroup).toContain("app-no-drag");
+      expect(centerGroup).toContain("pointer-events-none");
+      // The identity trigger is absolutely positioned against this cell.
+      expect(centerGroup).toContain("relative");
     });
 
     it("does not depend on renderer or main-process drag-region recompute hooks", () => {

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Check, AlertCircle, FolderOpen, LogIn, X } from "lucide-react";
@@ -10,9 +10,12 @@ import { actionService } from "@/services/ActionService";
 import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { validateFolderName } from "@shared/utils/folderName";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
+import { ProjectEmojiButton } from "./ProjectEmojiButton";
 import { matchProviderForRemoteUrl } from "@shared/utils/forgeHostnames";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
+import type { ProjectCreationIdentity } from "@shared/types";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
 import { isClientGitError } from "@/utils/clientGitError";
 
@@ -29,7 +32,7 @@ interface CloneForgeProvider {
 
 interface CloneRepoDialogProps {
   isOpen: boolean;
-  onSuccess: (clonedPath: string) => void;
+  onSuccess: (clonedPath: string, identity?: ProjectCreationIdentity) => void;
   onCancel: () => void;
 }
 
@@ -74,6 +77,9 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const [parentPath, setParentPath] = useState("");
   const [folderName, setFolderName] = useState("");
   const [folderNameEdited, setFolderNameEdited] = useState(false);
+  // Suggestion follows the folder name (however it got there — URL-derived or
+  // typed) until the user picks explicitly; after that the pick sticks.
+  const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);
   const [shallowClone, setShallowClone] = useState(false);
   const [progressEvents, setProgressEvents] = useState<CloneRepoProgressEvent[]>([]);
   const [isCloning, setIsCloning] = useState(false);
@@ -90,11 +96,18 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const logEndRef = useRef<HTMLDivElement>(null);
   const hasFinalizedRef = useRef(false);
 
+  const suggestedEmoji = useMemo(() => {
+    const trimmed = folderName.trim();
+    return trimmed ? suggestProjectEmoji(trimmed) : DEFAULT_PROJECT_EMOJI;
+  }, [folderName]);
+  const effectiveEmoji = pickedEmoji ?? suggestedEmoji;
+
   const finalizeSuccess = useCallback(() => {
     if (hasFinalizedRef.current || !clonedPath) return;
     hasFinalizedRef.current = true;
-    onSuccess(clonedPath);
-  }, [onSuccess, clonedPath]);
+    const trimmedName = folderName.trim();
+    onSuccess(clonedPath, trimmedName ? { name: trimmedName, emoji: effectiveEmoji } : undefined);
+  }, [onSuccess, clonedPath, folderName, effectiveEmoji]);
 
   // Reset state when dialog opens/closes
   useEffect(() => {
@@ -103,6 +116,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       setParentPath("");
       setFolderName("");
       setFolderNameEdited(false);
+      setPickedEmoji(null);
       setShallowClone(false);
       setProgressEvents([]);
       setIsCloning(false);
@@ -312,21 +326,29 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         {/* Folder Name */}
         <div className="space-y-1.5">
           <label className="text-sm font-medium text-daintree-text/70">Folder Name</label>
-          <input
-            type="text"
-            value={folderName}
-            onChange={(e) => {
-              const next = e.target.value;
-              setFolderName(next);
-              // Clearing the field re-enables URL-derived auto-suggest so the
-              // user can recover after a manual edit they no longer want.
-              setFolderNameEdited(next !== "");
-            }}
-            onKeyDown={handleKeyDown}
-            disabled={isCloning || isComplete}
-            aria-invalid={folderNameError != null}
-            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
-          />
+          <div className="flex items-center gap-2">
+            <ProjectEmojiButton
+              emoji={effectiveEmoji}
+              onEmojiChange={setPickedEmoji}
+              disabled={isCloning || isComplete}
+              ariaLabel="Choose project emoji"
+            />
+            <input
+              type="text"
+              value={folderName}
+              onChange={(e) => {
+                const next = e.target.value;
+                setFolderName(next);
+                // Clearing the field re-enables URL-derived auto-suggest so the
+                // user can recover after a manual edit they no longer want.
+                setFolderNameEdited(next !== "");
+              }}
+              onKeyDown={handleKeyDown}
+              disabled={isCloning || isComplete}
+              aria-invalid={folderNameError != null}
+              className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
+            />
+          </div>
           {folderNameError && (
             <p role="alert" className="text-xs text-status-error">
               {folderNameError}

--- a/src/components/Project/CreateProjectFolderDialog.tsx
+++ b/src/components/Project/CreateProjectFolderDialog.tsx
@@ -7,6 +7,8 @@ import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { validateFolderName } from "@shared/utils/folderName";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
+import { ProjectEmojiButton } from "./ProjectEmojiButton";
 
 interface CreateProjectFolderDialogProps {
   isOpen: boolean;
@@ -16,6 +18,9 @@ interface CreateProjectFolderDialogProps {
 export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFolderDialogProps) {
   const [parentPath, setParentPath] = useState("");
   const [folderName, setFolderName] = useState("");
+  // Until the user opens the picker, the emoji tracks the folder name. After an
+  // explicit pick it stops moving — typing shouldn't undo a deliberate choice.
+  const [pickedEmoji, setPickedEmoji] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const folderNameInputRef = useRef<HTMLInputElement>(null);
@@ -27,6 +32,7 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
   useEffect(() => {
     if (!isOpen) {
       setFolderName("");
+      setPickedEmoji(null);
       setParentPath("");
       setError(null);
       setIsCreating(false);
@@ -69,6 +75,12 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
     }
   }, []);
 
+  const suggestedEmoji = useMemo(() => {
+    const trimmed = folderName.trim();
+    return trimmed ? suggestProjectEmoji(trimmed) : DEFAULT_PROJECT_EMOJI;
+  }, [folderName]);
+  const effectiveEmoji = pickedEmoji ?? suggestedEmoji;
+
   const handleCreate = useCallback(async () => {
     const validationError = validateFolderName(folderName);
     if (validationError) {
@@ -84,7 +96,7 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
     setError(null);
 
     try {
-      await createProjectFolder(parentPath, folderName.trim());
+      await createProjectFolder(parentPath, folderName.trim(), effectiveEmoji);
       // Close only after the folder is created (but addProjectByPath runs in the background)
       onClose();
     } catch (err) {
@@ -93,7 +105,7 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
     } finally {
       setIsCreating(false);
     }
-  }, [parentPath, folderName, createProjectFolder, onClose]);
+  }, [parentPath, folderName, effectiveEmoji, createProjectFolder, onClose]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -155,22 +167,30 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
           <label className="text-sm font-medium text-daintree-text/80" htmlFor="create-folder-name">
             Folder Name
           </label>
-          <input
-            ref={folderNameInputRef}
-            id="create-folder-name"
-            type="text"
-            value={folderName}
-            onChange={(e) => {
-              setFolderName(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={handleKeyDown}
-            aria-invalid={error != null}
-            aria-describedby={error ? errorId : undefined}
-            className="w-full rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent aria-invalid:border-status-error"
-            placeholder="my-project"
-            disabled={isCreating}
-          />
+          <div className="flex items-center gap-2">
+            <ProjectEmojiButton
+              emoji={effectiveEmoji}
+              onEmojiChange={setPickedEmoji}
+              disabled={isCreating}
+              ariaLabel="Choose project emoji"
+            />
+            <input
+              ref={folderNameInputRef}
+              id="create-folder-name"
+              type="text"
+              value={folderName}
+              onChange={(e) => {
+                setFolderName(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={handleKeyDown}
+              aria-invalid={error != null}
+              aria-describedby={error ? errorId : undefined}
+              className="w-full rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent aria-invalid:border-status-error"
+              placeholder="my-project"
+              disabled={isCreating}
+            />
+          </div>
           {error && (
             <p id={errorId} role="alert" className="text-xs text-status-error">
               {error}

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -75,10 +75,13 @@ export function GitInitDialog({
     if (!isOpen) return;
     setProjectName(seededName);
     setEmoji(seededEmoji);
-    // Seeds only on the open transition — re-seeding while open would discard
-    // edits the user is in the middle of making.
+    // Keyed on the folder as well as the open transition: a second git-init
+    // request arriving while this one is open swaps `directoryPath` under us,
+    // and leaving the identity behind would save folder B under folder A's
+    // name. Not keyed on the seed values themselves — that would re-seed on
+    // every render and discard edits in progress.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isOpen, directoryPath]);
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -7,23 +7,42 @@ import { FolderGit2 } from "@/components/icons";
 import { projectClient } from "@/clients";
 import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { basename } from "@shared/utils/path";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
+import { ProjectEmojiButton } from "./ProjectEmojiButton";
 import {
   GITIGNORE_TEMPLATE_OPTIONS,
   DEFAULT_GITIGNORE_TEMPLATE_ID,
   isGitignoreTemplateId,
 } from "@shared/config/gitignoreTemplates";
 import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
+import type { ProjectCreationIdentity } from "@shared/types";
 
 interface GitInitDialogProps {
   isOpen: boolean;
   directoryPath: string;
-  onSuccess: () => void;
+  /**
+   * Identity chosen one dialog earlier in the create-project flow. Present
+   * means "don't ask again, just show what they picked"; absent means this
+   * dialog was reached directly by opening a non-repo folder, so it derives a
+   * fresh suggestion from the folder name.
+   */
+  initialIdentity?: ProjectCreationIdentity | null;
+  onSuccess: (identity: ProjectCreationIdentity) => void;
   onCancel: () => void;
 }
 
 const AUTO_CLOSE_DELAY_MS = 2000;
 
-export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: GitInitDialogProps) {
+export function GitInitDialog({
+  isOpen,
+  directoryPath,
+  initialIdentity,
+  onSuccess,
+  onCancel,
+}: GitInitDialogProps) {
+  const [projectName, setProjectName] = useState("");
+  const [emoji, setEmoji] = useState(DEFAULT_PROJECT_EMOJI);
   const [gitignoreTemplate, setGitignoreTemplate] = useState(DEFAULT_GITIGNORE_TEMPLATE_ID);
   const [createInitialCommit, setCreateInitialCommit] = useState(true);
   const [initialCommitMessage, setInitialCommitMessage] = useState("Initial commit");
@@ -37,13 +56,29 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
   const sawTerminalEventRef = useRef(false);
   const sawErrorEventRef = useRef(false);
 
+  const trimmedProjectName = projectName.trim();
+
   const finalizeSuccess = useCallback(() => {
     if (hasFinalizedSuccessRef.current) {
       return;
     }
     hasFinalizedSuccessRef.current = true;
-    onSuccess();
-  }, [onSuccess]);
+    onSuccess({ name: trimmedProjectName, emoji });
+  }, [onSuccess, trimmedProjectName, emoji]);
+
+  // Seed the identity row on open: the create-project flow already asked, so
+  // reuse what it carried; reaching this dialog directly (opening a non-repo
+  // folder) derives a fresh suggestion from the folder name instead.
+  const seededName = initialIdentity?.name ?? basename(directoryPath);
+  const seededEmoji = initialIdentity?.emoji ?? suggestProjectEmoji(basename(directoryPath));
+  useEffect(() => {
+    if (!isOpen) return;
+    setProjectName(seededName);
+    setEmoji(seededEmoji);
+    // Seeds only on the open transition — re-seeding while open would discard
+    // edits the user is in the middle of making.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -164,20 +199,47 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
   const showConnecting = useDohertyGate(isInitializing && progressEvents.length === 0);
   const showProgress = showConnecting || progressEvents.length > 0;
   const configDisabled = isInitializing || isComplete;
-  const canStart = !createInitialCommit || initialCommitMessage.trim() !== "";
+  const canStart =
+    trimmedProjectName !== "" && (!createInitialCommit || initialCommitMessage.trim() !== "");
 
   return (
     <AppDialog isOpen={isOpen} onClose={handleClose} size="md" dismissible={!isInitializing}>
       <AppDialog.Header>
         <AppDialog.Title icon={<FolderGit2 className="h-5 w-5 text-daintree-accent" />}>
-          Initialize Git Repository
+          Set up project
         </AppDialog.Title>
         {!isInitializing && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-4">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="truncate">{directoryPath}</span>
+        <div className="space-y-1.5">
+          <label
+            htmlFor="git-init-project-name"
+            className="text-sm font-medium text-daintree-text/70"
+          >
+            Project name
+          </label>
+          <div className="flex items-center gap-2">
+            <ProjectEmojiButton
+              emoji={emoji}
+              onEmojiChange={setEmoji}
+              disabled={configDisabled}
+              ariaLabel="Choose project emoji"
+            />
+            <input
+              id="git-init-project-name"
+              type="text"
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value)}
+              disabled={configDisabled}
+              aria-invalid={trimmedProjectName === ""}
+              className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
+              placeholder="My project"
+            />
+          </div>
+          <p className="truncate text-xs font-mono text-daintree-text/40" title={directoryPath}>
+            {directoryPath}
+          </p>
         </div>
 
         <div className="space-y-1.5">

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Check, AlertCircle } from "lucide-react";
@@ -55,8 +55,12 @@ export function GitInitDialog({
   const inFlightRef = useRef(false);
   const sawTerminalEventRef = useRef(false);
   const sawErrorEventRef = useRef(false);
+  const nameErrorId = useId();
 
   const trimmedProjectName = projectName.trim();
+  // The name is seeded from the folder, so this only ever fires after the user
+  // clears the field — the one state where the start button silently disables.
+  const isNameMissing = trimmedProjectName === "";
 
   const finalizeSuccess = useCallback(() => {
     if (hasFinalizedSuccessRef.current) {
@@ -235,11 +239,17 @@ export function GitInitDialog({
               value={projectName}
               onChange={(e) => setProjectName(e.target.value)}
               disabled={configDisabled}
-              aria-invalid={trimmedProjectName === ""}
+              aria-invalid={isNameMissing}
+              aria-describedby={isNameMissing ? nameErrorId : undefined}
               className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
               placeholder="My project"
             />
           </div>
+          {isNameMissing && (
+            <p id={nameErrorId} role="alert" className="text-xs text-status-error">
+              Enter a project name
+            </p>
+          )}
           <p className="truncate text-xs font-mono text-daintree-text/40" title={directoryPath}>
             {directoryPath}
           </p>

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -71,17 +71,17 @@ export function GitInitDialog({
   // folder) derives a fresh suggestion from the folder name instead.
   const seededName = initialIdentity?.name ?? basename(directoryPath);
   const seededEmoji = initialIdentity?.emoji ?? suggestProjectEmoji(basename(directoryPath));
+  // Keyed on the folder as well as the open transition: a second git-init
+  // request arriving while this one is open swaps `directoryPath` under us, and
+  // leaving the identity behind would save folder B under folder A's name. The
+  // seeds are plain strings, so they only differ when their inputs actually
+  // change — depending on them costs no spurious re-seeds and keeps the
+  // component eligible for the React Compiler.
   useEffect(() => {
     if (!isOpen) return;
     setProjectName(seededName);
     setEmoji(seededEmoji);
-    // Keyed on the folder as well as the open transition: a second git-init
-    // request arriving while this one is open swaps `directoryPath` under us,
-    // and leaving the identity behind would save folder B under folder A's
-    // name. Not keyed on the seed values themselves — that would re-seed on
-    // every render and discard edits in progress.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, directoryPath]);
+  }, [isOpen, directoryPath, seededName, seededEmoji]);
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/components/Project/ProjectEmojiButton.tsx
+++ b/src/components/Project/ProjectEmojiButton.tsx
@@ -30,20 +30,22 @@ export function ProjectEmojiButton({
       <PopoverTrigger asChild>
         <button
           type="button"
-          aria-label={ariaLabel}
+          // Name carries the current value — the glyph is the button's only
+          // content, and an aria-label would otherwise hide what is selected.
+          aria-label={`${ariaLabel}, currently ${emoji}`}
           disabled={disabled}
           className={cn(
             "flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-md)]",
             "border border-daintree-border bg-muted/50 text-lg leading-none",
             "transition-colors hover:bg-muted disabled:opacity-50",
-            "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent",
+            "focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
             className
           )}
         >
           <span className="select-none">{emoji}</span>
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverContent className="w-auto p-0" align="start" aria-label="Choose project emoji">
         <EmojiPicker
           onEmojiSelect={({ emoji: picked }) => {
             onEmojiChange(picked);

--- a/src/components/Project/ProjectEmojiButton.tsx
+++ b/src/components/Project/ProjectEmojiButton.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { EmojiPicker } from "@/components/ui/emoji-picker";
+import { cn } from "@/lib/utils";
+
+interface ProjectEmojiButtonProps {
+  emoji: string;
+  onEmojiChange: (emoji: string) => void;
+  disabled?: boolean;
+  /** Accessible label — say which project or field the emoji belongs to. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Emoji swatch that opens the full picker in a popover. Same interaction as the
+ * project-settings identity block, sized for an inline dialog row.
+ */
+export function ProjectEmojiButton({
+  emoji,
+  onEmojiChange,
+  disabled = false,
+  ariaLabel = "Choose project emoji",
+  className,
+}: ProjectEmojiButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          disabled={disabled}
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-md)]",
+            "border border-daintree-border bg-muted/50 text-lg leading-none",
+            "transition-colors hover:bg-muted disabled:opacity-50",
+            "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent",
+            className
+          )}
+        >
+          <span className="select-none">{emoji}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <EmojiPicker
+          onEmojiSelect={({ emoji: picked }) => {
+            onEmojiChange(picked);
+            setIsOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { EmojiPicker } from "@/components/ui/emoji-picker";
 import { useProjectStore } from "@/store/projectStore";
@@ -8,6 +8,8 @@ import type { Project } from "@shared/types";
 interface ProjectIdentityEditorProps {
   project: Project;
 }
+
+const PILL_SELECTOR = '[data-testid="project-switcher-trigger"]';
 
 /**
  * One-click identity editing for the toolbar project pill: the emoji becomes
@@ -20,9 +22,15 @@ interface ProjectIdentityEditorProps {
  * nested-button markup and fires both handlers on one click (#6928). The
  * transparent overlay sits exactly over the pill's own emoji glyph, so the
  * pill's layout and styling are untouched.
+ *
+ * Being a sibling means the pill's Radix triggers never see pointer activity
+ * over this region, so right-click and hover are replayed onto the pill below
+ * (see `replayOnPill`) to keep the project context menu and the identity
+ * tooltip alive across the whole pill.
  */
 export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
   const updateProject = useProjectStore((state) => state.updateProject);
+  const overlayRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [draftName, setDraftName] = useState(project.name);
   // Only a name the user actually typed is worth writing back. Without this,
@@ -102,6 +110,27 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
       ? suggestProjectEmoji(draftName.trim() || project.name)
       : null;
 
+  // The pill renders alongside this overlay inside the toolbar's project group.
+  const findPill = useCallback(
+    () => overlayRef.current?.parentElement?.querySelector<HTMLElement>(PILL_SELECTOR) ?? null,
+    []
+  );
+
+  /**
+   * Re-fire a native event on the pill so its Radix triggers react as if the
+   * pointer had reached them. `PointerEvent` is not constructible in every test
+   * environment; `MouseEvent` carries everything these triggers read.
+   */
+  const replayOnPill = useCallback(
+    (type: string, init: MouseEventInit) => {
+      const pill = findPill();
+      if (!pill) return;
+      const Ctor: typeof MouseEvent = typeof PointerEvent === "function" ? PointerEvent : MouseEvent;
+      pill.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
+    },
+    [findPill]
+  );
+
   return (
     <Popover
       open={isOpen}
@@ -112,6 +141,7 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
     >
       <PopoverTrigger asChild>
         <button
+          ref={overlayRef}
           type="button"
           // Joins the toolbar's roving-tabindex domain in DOM order (it renders
           // just before the pill), so it is one arrow stop rather than a stray
@@ -119,6 +149,35 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
           data-toolbar-item=""
           data-project-identity-trigger=""
           aria-label={`Edit identity for ${project.name}, currently ${project.emoji}`}
+          // The pill owns the project context menu (pin, copy path, locate,
+          // settings, close); this overlay has none of its own, so hand the
+          // right-click straight down to it.
+          onContextMenu={(event) => {
+            event.preventDefault();
+            replayOnPill("contextmenu", {
+              cancelable: true,
+              clientX: event.clientX,
+              clientY: event.clientY,
+            });
+          }}
+          // Radix's tooltip trigger opens on `pointermove`, so one replayed
+          // move per entry is enough to raise the pill's identity tooltip.
+          onPointerEnter={(event) => {
+            if (event.pointerType === "touch") return;
+            replayOnPill("pointermove", {});
+          }}
+          onPointerLeave={(event) => {
+            const pill = findPill();
+            const next = event.relatedTarget;
+            // Sliding onto the rest of the pill leaves it natively hovered;
+            // closing here would blink the tooltip shut and straight back open.
+            if (!pill || (next instanceof Node && pill.contains(next))) return;
+            // React synthesises `onPointerLeave` from `pointerout`, so a raw
+            // `pointerleave` dispatch would never reach the trigger's handler.
+            // It also reports `window` when the pointer left the React tree
+            // entirely, which is not a valid `relatedTarget` to construct with.
+            replayOnPill("pointerout", { relatedTarget: next instanceof Element ? next : null });
+          }}
           className="pointer-events-auto absolute left-1.5 top-1/2 z-10 h-7 w-7 -translate-y-1/2 rounded-[var(--radius-md)] bg-transparent transition-colors hover:bg-overlay-subtle focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
         />
       </PopoverTrigger>

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -25,67 +25,122 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
   const updateProject = useProjectStore((state) => state.updateProject);
   const [isOpen, setIsOpen] = useState(false);
   const [draftName, setDraftName] = useState(project.name);
+  // Only a name the user actually typed is worth writing back. Without this,
+  // an untouched draft would overwrite a rename that landed from another
+  // window while this popover sat open.
+  const [isNameDirty, setIsNameDirty] = useState(false);
+
+  const resetDraft = useCallback(() => {
+    setDraftName(project.name);
+    setIsNameDirty(false);
+  }, [project.name]);
 
   // Re-seed when the popover opens, and whenever the project changes underneath
   // it, so a draft left over from another project can never be committed.
-  // Deliberately not keyed on `project.name` — that would wipe the field
-  // mid-edit as soon as an optimistic rename lands.
-  useEffect(() => {
+  // Adjusted during render rather than in an effect: keying an effect on
+  // `project.name` would wipe the field mid-edit the moment an optimistic
+  // rename lands, and omitting it needs an exhaustive-deps suppression that
+  // opts the whole component out of the React Compiler.
+  const seedKey = `${project.id}:${isOpen ? "open" : "closed"}`;
+  const [lastSeedKey, setLastSeedKey] = useState(seedKey);
+  if (lastSeedKey !== seedKey) {
+    setLastSeedKey(seedKey);
     setDraftName(project.name);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, project.id]);
+    setIsNameDirty(false);
+  }
 
-  const commitName = useCallback(() => {
-    const trimmed = draftName.trim();
-    // An emptied field means "no change" rather than "erase the name" — there
-    // is no such thing as a nameless project.
-    if (!trimmed || trimmed === project.name) {
-      setDraftName(project.name);
-      return;
-    }
-    void updateProject(project.id, { name: trimmed });
-  }, [draftName, project.id, project.name, updateProject]);
+  /**
+   * Single write path for both halves of the identity. The emoji picker closes
+   * the popover programmatically, which does NOT fire `onOpenChange`, so an
+   * emoji-only commit has to carry any pending name edit with it or the rename
+   * is silently dropped.
+   */
+  const commitIdentity = useCallback(
+    (pickedEmoji?: string) => {
+      const updates: { name?: string; emoji?: string } = {};
+
+      const trimmed = draftName.trim();
+      // An emptied field means "no change" rather than "erase the name" — there
+      // is no such thing as a nameless project.
+      if (isNameDirty && trimmed && trimmed !== project.name) {
+        updates.name = trimmed;
+      }
+      if (pickedEmoji !== undefined && pickedEmoji !== project.emoji) {
+        updates.emoji = pickedEmoji;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        resetDraft();
+        return;
+      }
+
+      // The store rolls back and rethrows on failure; swallow here so a failed
+      // write can't surface as an unhandled rejection. It already logs and sets
+      // the store's error state.
+      void updateProject(project.id, updates).catch(() => {
+        resetDraft();
+      });
+    },
+    [draftName, isNameDirty, project.id, project.name, project.emoji, updateProject, resetDraft]
+  );
 
   const handleEmojiSelect = useCallback(
     (picked: string) => {
-      if (picked !== project.emoji) {
-        void updateProject(project.id, { emoji: picked });
-      }
+      commitIdentity(picked);
       setIsOpen(false);
     },
-    [project.id, project.emoji, updateProject]
+    [commitIdentity]
   );
 
   // While a project still carries the default tree, offer the name-derived
-  // suggestion as a one-click accept. The tree is the "unset" signal, so the
-  // suggestion is shown here rather than silently stored at creation.
+  // suggestion as a one-click accept. Derived from the draft so renaming and
+  // accepting a suggestion in one pass suggests for the NEW name. The tree is
+  // the "unset" signal, so the suggestion is offered here rather than silently
+  // stored at creation.
   const suggestion =
-    project.emoji === DEFAULT_PROJECT_EMOJI ? suggestProjectEmoji(project.name) : null;
+    project.emoji === DEFAULT_PROJECT_EMOJI
+      ? suggestProjectEmoji(draftName.trim() || project.name)
+      : null;
 
   return (
     <Popover
       open={isOpen}
       onOpenChange={(next) => {
-        if (!next) commitName();
+        if (!next) commitIdentity();
         setIsOpen(next);
       }}
     >
       <PopoverTrigger asChild>
         <button
           type="button"
+          // Joins the toolbar's roving-tabindex domain in DOM order (it renders
+          // just before the pill), so it is one arrow stop rather than a stray
+          // extra Tab stop outside the model.
+          data-toolbar-item=""
           data-project-identity-trigger=""
-          aria-label={`Edit identity for ${project.name}`}
+          aria-label={`Edit identity for ${project.name}, currently ${project.emoji}`}
           className="pointer-events-auto absolute left-1.5 top-1/2 z-10 h-7 w-7 -translate-y-1/2 rounded-[var(--radius-md)] bg-transparent transition-colors hover:bg-overlay-subtle focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
         />
       </PopoverTrigger>
       <PopoverContent
         className="w-auto p-0"
         align="start"
+        aria-label="Edit project identity"
         data-project-identity-popover=""
         // Hand focus to the name field instead of letting Radix park it on the
         // popover container.
         onOpenAutoFocus={(event) => {
           event.preventDefault();
+        }}
+        // Escape means "cancel the edit". Radix's dismissable layer sees the
+        // key on a document CAPTURE listener, so its default dismissal would
+        // fire `onOpenChange` — and with it the commit — before any handler on
+        // the input could revert the draft. Take the close over manually so the
+        // revert lands first and no commit runs at all.
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          resetDraft();
+          setIsOpen(false);
         }}
       >
         <div className="flex flex-col">
@@ -96,24 +151,23 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
             >
               Project name
             </label>
-            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
             <input
               id="project-identity-name"
               type="text"
+              // The popover exists to edit this field, so it takes focus on
+              // open (onOpenAutoFocus above defers to it).
               autoFocus
               value={draftName}
-              onChange={(event) => setDraftName(event.target.value)}
+              onChange={(event) => {
+                setDraftName(event.target.value);
+                setIsNameDirty(true);
+              }}
               onKeyDown={(event) => {
+                // Escape is handled by onEscapeKeyDown on the content — Radix
+                // sees it first, on a document capture listener.
                 if (event.key === "Enter") {
                   event.preventDefault();
-                  commitName();
-                  setIsOpen(false);
-                } else if (event.key === "Escape") {
-                  // Cancel the edit without letting the keystroke also dismiss
-                  // the popover mid-revert.
-                  event.preventDefault();
-                  event.stopPropagation();
-                  setDraftName(project.name);
+                  commitIdentity();
                   setIsOpen(false);
                 }
               }}

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { EmojiPicker } from "@/components/ui/emoji-picker";
 import { useProjectStore } from "@/store/projectStore";
@@ -126,7 +126,6 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
         className="w-auto p-0"
         align="start"
         aria-label="Edit project identity"
-        data-project-identity-popover=""
         // Hand focus to the name field instead of letting Radix park it on the
         // popover container.
         onOpenAutoFocus={(event) => {

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -125,7 +125,8 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
     (type: string, init: MouseEventInit) => {
       const pill = findPill();
       if (!pill) return;
-      const Ctor: typeof MouseEvent = typeof PointerEvent === "function" ? PointerEvent : MouseEvent;
+      const Ctor: typeof MouseEvent =
+        typeof PointerEvent === "function" ? PointerEvent : MouseEvent;
       pill.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
     },
     [findPill]

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { EmojiPicker } from "@/components/ui/emoji-picker";
+import { useProjectStore } from "@/store/projectStore";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
+import type { Project } from "@shared/types";
+
+interface ProjectIdentityEditorProps {
+  project: Project;
+}
+
+/**
+ * One-click identity editing for the toolbar project pill: the emoji becomes
+ * its own target that opens a popover holding the name field and the full
+ * picker.
+ *
+ * Rendered as a SIBLING of the pill button, never nested inside it — the pill
+ * is already wrapped by the switcher popover, context-menu and tooltip
+ * triggers, and nesting a fourth interactive element there produces invalid
+ * nested-button markup and fires both handlers on one click (#6928). The
+ * transparent overlay sits exactly over the pill's own emoji glyph, so the
+ * pill's layout and styling are untouched.
+ */
+export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
+  const updateProject = useProjectStore((state) => state.updateProject);
+  const [isOpen, setIsOpen] = useState(false);
+  const [draftName, setDraftName] = useState(project.name);
+
+  // Re-seed when the popover opens, and whenever the project changes underneath
+  // it, so a draft left over from another project can never be committed.
+  // Deliberately not keyed on `project.name` — that would wipe the field
+  // mid-edit as soon as an optimistic rename lands.
+  useEffect(() => {
+    setDraftName(project.name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, project.id]);
+
+  const commitName = useCallback(() => {
+    const trimmed = draftName.trim();
+    // An emptied field means "no change" rather than "erase the name" — there
+    // is no such thing as a nameless project.
+    if (!trimmed || trimmed === project.name) {
+      setDraftName(project.name);
+      return;
+    }
+    void updateProject(project.id, { name: trimmed });
+  }, [draftName, project.id, project.name, updateProject]);
+
+  const handleEmojiSelect = useCallback(
+    (picked: string) => {
+      if (picked !== project.emoji) {
+        void updateProject(project.id, { emoji: picked });
+      }
+      setIsOpen(false);
+    },
+    [project.id, project.emoji, updateProject]
+  );
+
+  // While a project still carries the default tree, offer the name-derived
+  // suggestion as a one-click accept. The tree is the "unset" signal, so the
+  // suggestion is shown here rather than silently stored at creation.
+  const suggestion =
+    project.emoji === DEFAULT_PROJECT_EMOJI ? suggestProjectEmoji(project.name) : null;
+
+  return (
+    <Popover
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) commitName();
+        setIsOpen(next);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-project-identity-trigger=""
+          aria-label={`Edit identity for ${project.name}`}
+          className="pointer-events-auto absolute left-1.5 top-1/2 z-10 h-7 w-7 -translate-y-1/2 rounded-[var(--radius-md)] bg-transparent transition-colors hover:bg-overlay-subtle focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto p-0"
+        align="start"
+        data-project-identity-popover=""
+        // Hand focus to the name field instead of letting Radix park it on the
+        // popover container.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <div className="flex flex-col">
+          <div className="flex flex-col gap-1.5 border-b border-daintree-border p-3">
+            <label
+              htmlFor="project-identity-name"
+              className="text-xs font-medium text-daintree-text/60"
+            >
+              Project name
+            </label>
+            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+            <input
+              id="project-identity-name"
+              type="text"
+              autoFocus
+              value={draftName}
+              onChange={(event) => setDraftName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  commitName();
+                  setIsOpen(false);
+                } else if (event.key === "Escape") {
+                  // Cancel the edit without letting the keystroke also dismiss
+                  // the popover mid-revert.
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setDraftName(project.name);
+                  setIsOpen(false);
+                }
+              }}
+              className="w-[280px] rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
+              placeholder={project.name}
+            />
+            {suggestion && (
+              <button
+                type="button"
+                onClick={() => handleEmojiSelect(suggestion)}
+                className="flex items-center gap-2 self-start rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text/70 transition-colors hover:bg-overlay-subtle"
+              >
+                <span className="text-base leading-none">{suggestion}</span>
+                <span>Use suggested</span>
+              </button>
+            )}
+          </div>
+          <EmojiPicker onEmojiSelect={({ emoji }) => handleEmojiSelect(emoji)} />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1340,7 +1340,13 @@ function DropdownContent({
         }}
         onInteractOutside={(event) => {
           const target = event.target;
-          if (target instanceof HTMLElement && target.closest('[role="menu"]')) {
+          // The identity picker portals to the body, so Radix reads it as
+          // "outside" even though it belongs to the same pill. Keep the
+          // switcher open rather than dismissing it out from under an edit.
+          if (
+            target instanceof HTMLElement &&
+            target.closest('[role="menu"], [data-project-identity-popover]')
+          ) {
             event.preventDefault();
           }
         }}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1340,13 +1340,7 @@ function DropdownContent({
         }}
         onInteractOutside={(event) => {
           const target = event.target;
-          // The identity picker portals to the body, so Radix reads it as
-          // "outside" even though it belongs to the same pill. Keep the
-          // switcher open rather than dismissing it out from under an edit.
-          if (
-            target instanceof HTMLElement &&
-            target.closest('[role="menu"], [data-project-identity-popover]')
-          ) {
+          if (target instanceof HTMLElement && target.closest('[role="menu"]')) {
             event.preventDefault();
           }
         }}

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from "vite
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import type { ReactNode, ButtonHTMLAttributes } from "react";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
+import { suggestProjectEmoji } from "@shared/utils/projectEmoji";
 
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -296,7 +297,7 @@ describe("CloneRepoDialog", () => {
       () =>
         expect(onSuccess).toHaveBeenCalledWith("/tmp/my-repo", {
           name: "my-repo",
-          emoji: expect.any(String) as unknown as string,
+          emoji: suggestProjectEmoji("my-repo"),
         }),
       {
         timeout: 3000,

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -292,9 +292,16 @@ describe("CloneRepoDialog", () => {
 
     // Auto-close runs after AUTO_CLOSE_DELAY_MS (2s) — extend the waitFor
     // timeout so the assertion outlives the dialog's read-the-log delay.
-    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("/tmp/my-repo"), {
-      timeout: 3000,
-    });
+    await waitFor(
+      () =>
+        expect(onSuccess).toHaveBeenCalledWith("/tmp/my-repo", {
+          name: "my-repo",
+          emoji: expect.any(String) as unknown as string,
+        }),
+      {
+        timeout: 3000,
+      }
+    );
   });
 
   it("shows error and retry button on clone failure", async () => {

--- a/src/components/Project/__tests__/CreateProjectFolderDialog.test.tsx
+++ b/src/components/Project/__tests__/CreateProjectFolderDialog.test.tsx
@@ -73,7 +73,7 @@ function emojiTrigger() {
 }
 
 function folderInput() {
-  return screen.getByLabelText(/folder name/i) as HTMLInputElement;
+  return screen.getByLabelText<HTMLInputElement>(/folder name/i);
 }
 
 async function renderDialog() {
@@ -82,7 +82,7 @@ async function renderDialog() {
   // The dialog resolves the home directory on open; wait for it to land, or the
   // Create button stays disabled on a missing parent path.
   await waitFor(() =>
-    expect((screen.getByLabelText(/location/i) as HTMLInputElement).value).toBe("/Users/test")
+    expect(screen.getByLabelText<HTMLInputElement>(/location/i).value).toBe("/Users/test")
   );
   return { onClose, ...result };
 }

--- a/src/components/Project/__tests__/CreateProjectFolderDialog.test.tsx
+++ b/src/components/Project/__tests__/CreateProjectFolderDialog.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import type { ReactNode, ButtonHTMLAttributes } from "react";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
+
+const { createProjectFolderMock, openDialogMock, getHomeDirMock } = vi.hoisted(() => ({
+  createProjectFolderMock: vi.fn(),
+  openDialogMock: vi.fn(),
+  getHomeDirMock: vi.fn(),
+}));
+
+vi.mock("@/clients", () => ({
+  projectClient: { openDialog: openDialogMock },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (state: unknown) => unknown) =>
+    selector({ createProjectFolder: createProjectFolderMock }),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  interface AppDialogMockProps {
+    isOpen: boolean;
+    children: ReactNode;
+    onClose: () => void;
+  }
+  interface SectionProps {
+    children: ReactNode;
+  }
+
+  const AppDialog = ({ isOpen, children }: AppDialogMockProps) =>
+    isOpen ? <div data-testid="app-dialog">{children}</div> : null;
+
+  AppDialog.Header = ({ children }: SectionProps) => <div>{children}</div>;
+  AppDialog.Title = ({ children }: SectionProps) => <h2>{children}</h2>;
+  AppDialog.CloseButton = () => <button type="button">close</button>;
+  AppDialog.Body = ({ children }: SectionProps) => <div>{children}</div>;
+  AppDialog.Footer = ({ children }: SectionProps) => <div>{children}</div>;
+
+  return { AppDialog };
+});
+
+// Render the picker inline so a selection can be driven without Radix layout.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/emoji-picker", () => ({
+  EmojiPicker: ({ onEmojiSelect }: { onEmojiSelect: (e: { emoji: string }) => void }) => (
+    <button type="button" onClick={() => onEmojiSelect({ emoji: "🦄" })}>
+      pick-unicorn
+    </button>
+  ),
+}));
+
+import { CreateProjectFolderDialog } from "../CreateProjectFolderDialog";
+
+function emojiTrigger() {
+  return screen.getByRole("button", { name: /choose project emoji/i });
+}
+
+function folderInput() {
+  return screen.getByLabelText(/folder name/i) as HTMLInputElement;
+}
+
+async function renderDialog() {
+  const onClose = vi.fn();
+  const result = render(<CreateProjectFolderDialog isOpen={true} onClose={onClose} />);
+  // The dialog resolves the home directory on open; wait for it to land, or the
+  // Create button stays disabled on a missing parent path.
+  await waitFor(() =>
+    expect((screen.getByLabelText(/location/i) as HTMLInputElement).value).toBe("/Users/test")
+  );
+  return { onClose, ...result };
+}
+
+describe("CreateProjectFolderDialog identity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getHomeDirMock.mockResolvedValue("/Users/test");
+    createProjectFolderMock.mockResolvedValue(undefined);
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { system: { getHomeDir: getHomeDirMock } },
+    });
+  });
+
+  it("shows the unset tree before a folder name is typed", async () => {
+    await renderDialog();
+    expect(emojiTrigger().textContent).toBe(DEFAULT_PROJECT_EMOJI);
+  });
+
+  it("suggests an emoji derived from the folder name", async () => {
+    await renderDialog();
+
+    fireEvent.change(folderInput(), { target: { value: "my-api" } });
+
+    expect(emojiTrigger().textContent).toBe(suggestProjectEmoji("my-api"));
+    expect(emojiTrigger().textContent).not.toBe(DEFAULT_PROJECT_EMOJI);
+  });
+
+  it("updates the suggestion as the folder name changes", async () => {
+    await renderDialog();
+
+    fireEvent.change(folderInput(), { target: { value: "docs" } });
+    const forDocs = emojiTrigger().textContent;
+    fireEvent.change(folderInput(), { target: { value: "mobile" } });
+
+    expect(emojiTrigger().textContent).not.toBe(forDocs);
+    expect(emojiTrigger().textContent).toBe(suggestProjectEmoji("mobile"));
+  });
+
+  it("stops re-suggesting once the user picks explicitly", async () => {
+    await renderDialog();
+
+    fireEvent.change(folderInput(), { target: { value: "docs" } });
+    fireEvent.click(screen.getByText("pick-unicorn"));
+    expect(emojiTrigger().textContent).toBe("🦄");
+
+    // A later rename must not clobber the deliberate choice.
+    fireEvent.change(folderInput(), { target: { value: "mobile" } });
+    expect(emojiTrigger().textContent).toBe("🦄");
+  });
+
+  it("submits the folder name together with the explicitly chosen emoji", async () => {
+    await renderDialog();
+
+    fireEvent.change(folderInput(), { target: { value: "my-api" } });
+    fireEvent.click(screen.getByText("pick-unicorn"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    });
+
+    expect(createProjectFolderMock).toHaveBeenCalledWith("/Users/test", "my-api", "🦄");
+  });
+
+  it("submits the suggested emoji when the user leaves it alone", async () => {
+    await renderDialog();
+
+    fireEvent.change(folderInput(), { target: { value: "my-api" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    });
+
+    expect(createProjectFolderMock).toHaveBeenCalledWith(
+      "/Users/test",
+      "my-api",
+      suggestProjectEmoji("my-api")
+    );
+  });
+});

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -592,17 +592,27 @@ describe("GitInitDialog", () => {
       });
     });
 
-    it("re-seeds the identity when reopened for a different folder", () => {
+    it("re-seeds when a second request swaps the folder while still open", () => {
+      // Deliberately never closes: a request arriving on top of an open dialog
+      // swaps directoryPath in place. Seeding only on the open transition would
+      // leave folder A's identity attached to folder B's path.
       const props = { onSuccess: vi.fn(), onCancel: vi.fn() };
       const { rerender } = render(
         <GitInitDialog isOpen={true} directoryPath="/tmp/first-folder" {...props} />
       );
       expect(nameInput().value).toBe("first-folder");
 
-      rerender(<GitInitDialog isOpen={false} directoryPath="/tmp/first-folder" {...props} />);
-      rerender(<GitInitDialog isOpen={true} directoryPath="/tmp/second-folder" {...props} />);
+      rerender(
+        <GitInitDialog
+          isOpen={true}
+          directoryPath="/tmp/second-folder"
+          initialIdentity={{ name: "Second", emoji: "📦" }}
+          {...props}
+        />
+      );
 
-      expect(nameInput().value).toBe("second-folder");
+      expect(nameInput().value).toBe("Second");
+      expect(screen.getByRole("button", { name: /choose project emoji/i }).textContent).toBe("📦");
     });
   });
 });

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -577,6 +577,17 @@ describe("GitInitDialog", () => {
       expect(start.disabled).toBe(true);
     });
 
+    it("says why the button went dead instead of only painting the field red", () => {
+      renderDialog();
+      // Seeded from the folder, so nothing is wrong until the user clears it.
+      expect(screen.queryByRole("alert")).toBeNull();
+
+      fireEvent.change(nameInput(), { target: { value: "   " } });
+
+      const message = screen.getByRole("alert");
+      expect(nameInput().getAttribute("aria-describedby")).toBe(message.id);
+    });
+
     it("reports the edited identity on success", async () => {
       const onSuccess = vi.fn();
       renderDialog({ onSuccess });

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -541,4 +541,64 @@ describe("GitInitDialog", () => {
 
     await waitFor(() => expect(initGitGuidedMock).toHaveBeenCalledTimes(1));
   });
+
+  describe("project identity row", () => {
+    function nameInput() {
+      return screen.getByLabelText(/project name/i) as HTMLInputElement;
+    }
+
+    it("derives the name from the folder when reached without a carried identity", () => {
+      renderDialog();
+      expect(nameInput().value).toBe("new-repo");
+    });
+
+    it("prefills from the identity chosen one dialog earlier instead of re-deriving", () => {
+      render(
+        <GitInitDialog
+          isOpen={true}
+          directoryPath="/tmp/new-repo"
+          initialIdentity={{ name: "Chosen Name", emoji: "🚀" }}
+          onSuccess={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+      expect(nameInput().value).toBe("Chosen Name");
+      expect(screen.getByRole("button", { name: /choose project emoji/i }).textContent).toBe("🚀");
+    });
+
+    it("blocks initialization while the name is empty", () => {
+      renderDialog();
+      fireEvent.change(nameInput(), { target: { value: "   " } });
+
+      const start = screen.getByRole("button", { name: /initialize repository/i });
+      expect((start as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it("reports the edited identity on success", async () => {
+      const onSuccess = vi.fn();
+      renderDialog({ onSuccess });
+
+      fireEvent.change(nameInput(), { target: { value: "  Renamed  " } });
+      fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
+      expect(onSuccess).toHaveBeenCalledWith({
+        name: "Renamed",
+        emoji: expect.any(String) as unknown as string,
+      });
+    });
+
+    it("re-seeds the identity when reopened for a different folder", () => {
+      const props = { onSuccess: vi.fn(), onCancel: vi.fn() };
+      const { rerender } = render(
+        <GitInitDialog isOpen={true} directoryPath="/tmp/first-folder" {...props} />
+      );
+      expect(nameInput().value).toBe("first-folder");
+
+      rerender(<GitInitDialog isOpen={false} directoryPath="/tmp/first-folder" {...props} />);
+      rerender(<GitInitDialog isOpen={true} directoryPath="/tmp/second-folder" {...props} />);
+
+      expect(nameInput().value).toBe("second-folder");
+    });
+  });
 });

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -9,6 +9,7 @@ import {
   GITIGNORE_TEMPLATE_OPTIONS,
   DEFAULT_GITIGNORE_TEMPLATE_ID,
 } from "@shared/config/gitignoreTemplates";
+import { suggestProjectEmoji } from "@shared/utils/projectEmoji";
 
 const { initGitGuidedMock, onInitGitProgressMock } = vi.hoisted(() => ({
   initGitGuidedMock: vi.fn(),
@@ -544,7 +545,7 @@ describe("GitInitDialog", () => {
 
   describe("project identity row", () => {
     function nameInput() {
-      return screen.getByLabelText(/project name/i) as HTMLInputElement;
+      return screen.getByLabelText<HTMLInputElement>(/project name/i);
     }
 
     it("derives the name from the folder when reached without a carried identity", () => {
@@ -570,8 +571,10 @@ describe("GitInitDialog", () => {
       renderDialog();
       fireEvent.change(nameInput(), { target: { value: "   " } });
 
-      const start = screen.getByRole("button", { name: /initialize repository/i });
-      expect((start as HTMLButtonElement).disabled).toBe(true);
+      const start = screen.getByRole<HTMLButtonElement>("button", {
+        name: /initialize repository/i,
+      });
+      expect(start.disabled).toBe(true);
     });
 
     it("reports the edited identity on success", async () => {
@@ -582,9 +585,10 @@ describe("GitInitDialog", () => {
       fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
 
       await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
+      // Emoji is seeded from the folder name, and renaming must not re-derive it.
       expect(onSuccess).toHaveBeenCalledWith({
         name: "Renamed",
-        emoji: expect.any(String) as unknown as string,
+        emoji: suggestProjectEmoji("new-repo"),
       });
     });
 

--- a/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
+++ b/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
@@ -93,9 +93,9 @@ describe("ProjectIdentityEditor", () => {
       expect(container.querySelector("button button")).toBeNull();
     });
 
-    it("stamps the popover content so the switcher's outside-click guard can spot it", () => {
-      const { container } = render(<ProjectIdentityEditor project={makeProject()} />);
-      expect(container.querySelector("[data-project-identity-popover]")).not.toBeNull();
+    it("names the popover so it is not announced as a bare dialog", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+      expect(screen.getByLabelText("Edit project identity")).not.toBeNull();
     });
   });
 

--- a/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
+++ b/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { MouseEventHandler, PointerEventHandler, ReactNode } from "react";
 import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
 import type { Project } from "@shared/types";
 
@@ -22,7 +22,10 @@ vi.mock("@/store/projectStore", () => ({
 let escapeKeyDownHandler: ((event: { preventDefault: () => void }) => void) | null = null;
 
 vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  // Radix's Popover root renders no DOM of its own, and neither can this mock:
+  // the trigger locates the toolbar pill through its own parentElement, so an
+  // extra wrapper would hide the pill from it.
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
   PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   PopoverContent: ({
     children,
@@ -96,6 +99,74 @@ describe("ProjectIdentityEditor", () => {
     it("names the popover so it is not announced as a bare dialog", () => {
       render(<ProjectIdentityEditor project={makeProject()} />);
       expect(screen.getByLabelText("Edit project identity")).not.toBeNull();
+    });
+  });
+
+  describe("pill event forwarding", () => {
+    /**
+     * Mirrors the toolbar layout: the overlay is painted on top of the pill but
+     * is a DOM sibling, so events landing on it never reach the pill's Radix
+     * context-menu and tooltip triggers unless the overlay replays them.
+     */
+    function renderOverPill() {
+      const pillHandlers = {
+        onContextMenu: vi.fn<MouseEventHandler<HTMLButtonElement>>(),
+        onPointerMove: vi.fn<PointerEventHandler<HTMLButtonElement>>(),
+        onPointerLeave: vi.fn<PointerEventHandler<HTMLButtonElement>>(),
+      };
+      render(
+        <div>
+          <ProjectIdentityEditor project={makeProject()} />
+          <button type="button" data-testid="project-switcher-trigger" {...pillHandlers}>
+            <span data-testid="pill-label">my-api</span>
+          </button>
+        </div>
+      );
+      return {
+        overlay: screen.getByRole("button", { name: /edit identity/i }),
+        pill: screen.getByTestId("project-switcher-trigger"),
+        pillHandlers,
+      };
+    }
+
+    it("replays right-click onto the pill so the project context menu still opens", () => {
+      const { overlay, pillHandlers } = renderOverPill();
+
+      fireEvent.contextMenu(overlay, { clientX: 42, clientY: 7 });
+
+      expect(pillHandlers.onContextMenu).toHaveBeenCalledTimes(1);
+      // Radix anchors the context menu at the pointer, so the coordinates have
+      // to survive the replay or the menu lands in the corner.
+      const replayed = pillHandlers.onContextMenu.mock.calls[0]![0];
+      expect([replayed.clientX, replayed.clientY]).toEqual([42, 7]);
+    });
+
+    it("replays hover onto the pill so the identity tooltip still opens", () => {
+      const { overlay, pillHandlers } = renderOverPill();
+
+      fireEvent.pointerOver(overlay);
+
+      expect(pillHandlers.onPointerMove).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the pill's tooltip when the pointer leaves the pill entirely", () => {
+      const { overlay, pillHandlers } = renderOverPill();
+      fireEvent.pointerOver(overlay);
+
+      fireEvent.pointerOut(overlay, { relatedTarget: document.body });
+
+      expect(pillHandlers.onPointerLeave).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the tooltip up when the pointer slides from the overlay onto the pill", () => {
+      const { overlay, pillHandlers } = renderOverPill();
+      fireEvent.pointerOver(overlay);
+
+      // The pill is natively hovered from here on, so forwarding a leave would
+      // blink the tooltip shut and straight back open.
+      fireEvent.pointerOut(overlay, { relatedTarget: screen.getByTestId("pill-label") });
+
+      expect(pillHandlers.onPointerLeave).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
+++ b/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
+import type { Project } from "@shared/types";
+
+const { updateProjectMock } = vi.hoisted(() => ({ updateProjectMock: vi.fn() }));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (state: unknown) => unknown) =>
+    selector({ updateProject: updateProjectMock }),
+}));
+
+// Render popover content inline — this test is about the editing contract, not
+// Radix's positioning.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children, ...rest }: { children: ReactNode }) => (
+    <div {...rest}>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/emoji-picker", () => ({
+  EmojiPicker: ({ onEmojiSelect }: { onEmojiSelect: (e: { emoji: string }) => void }) => (
+    <button type="button" onClick={() => onEmojiSelect({ emoji: "🦄" })}>
+      pick-unicorn
+    </button>
+  ),
+}));
+
+import { ProjectIdentityEditor } from "../ProjectIdentityEditor";
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "p1",
+    path: "/repos/my-api",
+    name: "my-api",
+    emoji: DEFAULT_PROJECT_EMOJI,
+    lastOpened: 0,
+    ...overrides,
+  };
+}
+
+function nameField() {
+  return screen.getByLabelText(/project name/i) as HTMLInputElement;
+}
+
+describe("ProjectIdentityEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateProjectMock.mockResolvedValue(undefined);
+  });
+
+  describe("markup contract", () => {
+    it("renders the trigger as a standalone button, never nesting one inside another", () => {
+      const { container } = render(<ProjectIdentityEditor project={makeProject()} />);
+      // A nested <button> inside a <button> is invalid HTML and fires both
+      // handlers on one click — the #6928 failure mode.
+      expect(container.querySelector("button button")).toBeNull();
+    });
+
+    it("stamps the popover content so the switcher's outside-click guard can spot it", () => {
+      const { container } = render(<ProjectIdentityEditor project={makeProject()} />);
+      expect(container.querySelector("[data-project-identity-popover]")).not.toBeNull();
+    });
+  });
+
+  describe("emoji", () => {
+    it("persists an emoji picked from the full picker", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.click(screen.getByText("pick-unicorn"));
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", { emoji: "🦄" });
+    });
+
+    it("offers the name-derived suggestion while the project still shows the tree", () => {
+      render(<ProjectIdentityEditor project={makeProject({ name: "my-api" })} />);
+
+      const suggested = screen.getByRole("button", { name: /use suggested/i });
+      fireEvent.click(suggested);
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", {
+        emoji: suggestProjectEmoji("my-api"),
+      });
+    });
+
+    it("hides the suggestion once the project has a non-default emoji", () => {
+      render(<ProjectIdentityEditor project={makeProject({ emoji: "🚀" })} />);
+
+      expect(screen.queryByRole("button", { name: /use suggested/i })).toBeNull();
+    });
+
+    it("does not write when the picked emoji already matches", () => {
+      render(<ProjectIdentityEditor project={makeProject({ emoji: "🦄" })} />);
+
+      fireEvent.click(screen.getByText("pick-unicorn"));
+
+      expect(updateProjectMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("name", () => {
+    it("commits a renamed project on Enter", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.change(nameField(), { target: { value: "Renamed" } });
+      fireEvent.keyDown(nameField(), { key: "Enter" });
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", { name: "Renamed" });
+    });
+
+    it("trims before committing", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.change(nameField(), { target: { value: "   Spaced   " } });
+      fireEvent.keyDown(nameField(), { key: "Enter" });
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", { name: "Spaced" });
+    });
+
+    it("treats an emptied field as no change rather than erasing the name", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.change(nameField(), { target: { value: "   " } });
+      fireEvent.keyDown(nameField(), { key: "Enter" });
+
+      expect(updateProjectMock).not.toHaveBeenCalled();
+      expect(nameField().value).toBe("my-api");
+    });
+
+    it("does not write when the name is unchanged", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.keyDown(nameField(), { key: "Enter" });
+
+      expect(updateProjectMock).not.toHaveBeenCalled();
+    });
+
+    it("reverts the draft on Escape without writing", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.change(nameField(), { target: { value: "Abandoned" } });
+      fireEvent.keyDown(nameField(), { key: "Escape" });
+
+      expect(updateProjectMock).not.toHaveBeenCalled();
+      expect(nameField().value).toBe("my-api");
+    });
+
+    it("re-seeds the draft when the project changes underneath it", () => {
+      const { rerender } = render(<ProjectIdentityEditor project={makeProject()} />);
+      fireEvent.change(nameField(), { target: { value: "Draft" } });
+
+      rerender(<ProjectIdentityEditor project={makeProject({ id: "p2", name: "other" })} />);
+
+      // A stale draft must never be committable against a different project.
+      expect(nameField().value).toBe("other");
+    });
+  });
+});

--- a/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
+++ b/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
 import type { Project } from "@shared/types";
@@ -15,14 +15,44 @@ vi.mock("@/store/projectStore", () => ({
 }));
 
 // Render popover content inline — this test is about the editing contract, not
-// Radix's positioning.
+// Radix's positioning. `onEscapeKeyDown` is captured rather than swallowed:
+// Radix fires it from a document CAPTURE listener BEFORE the input's own
+// keydown, and the cancel-vs-commit ordering hangs on that. A mock that dropped
+// it would let a broken Escape path pass while production saved the edit.
+let escapeKeyDownHandler: ((event: { preventDefault: () => void }) => void) | null = null;
+
 vi.mock("@/components/ui/popover", () => ({
   Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-  PopoverContent: ({ children, ...rest }: { children: ReactNode }) => (
-    <div {...rest}>{children}</div>
-  ),
+  PopoverContent: ({
+    children,
+    onEscapeKeyDown,
+    onOpenAutoFocus: _onOpenAutoFocus,
+    ...rest
+  }: {
+    children: ReactNode;
+    onEscapeKeyDown?: (event: { preventDefault: () => void }) => void;
+    onOpenAutoFocus?: (event: { preventDefault: () => void }) => void;
+  }) => {
+    escapeKeyDownHandler = onEscapeKeyDown ?? null;
+    return <div {...rest}>{children}</div>;
+  },
 }));
+
+/** Drive Escape the way Radix does — via the content handler, not the input. */
+function pressEscape(): boolean {
+  let defaultPrevented = false;
+  // Invoked directly rather than through fireEvent, so the state updates it
+  // makes need an explicit act().
+  act(() => {
+    escapeKeyDownHandler?.({
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+    });
+  });
+  return defaultPrevented;
+}
 
 vi.mock("@/components/ui/emoji-picker", () => ({
   EmojiPicker: ({ onEmojiSelect }: { onEmojiSelect: (e: { emoji: string }) => void }) => (
@@ -46,7 +76,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
 }
 
 function nameField() {
-  return screen.getByLabelText(/project name/i) as HTMLInputElement;
+  return screen.getByLabelText<HTMLInputElement>(/project name/i);
 }
 
 describe("ProjectIdentityEditor", () => {
@@ -102,6 +132,33 @@ describe("ProjectIdentityEditor", () => {
 
       expect(updateProjectMock).not.toHaveBeenCalled();
     });
+
+    it("carries a pending name edit along when an emoji is picked", () => {
+      render(<ProjectIdentityEditor project={makeProject()} />);
+
+      fireEvent.change(nameField(), { target: { value: "Renamed" } });
+      // Picking closes the popover programmatically, which does NOT fire
+      // onOpenChange — so this write is the only chance the rename gets.
+      fireEvent.click(screen.getByText("pick-unicorn"));
+
+      expect(updateProjectMock).toHaveBeenCalledTimes(1);
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", {
+        name: "Renamed",
+        emoji: "🦄",
+      });
+    });
+
+    it("suggests from the edited draft, not the committed name", () => {
+      render(<ProjectIdentityEditor project={makeProject({ name: "plain" })} />);
+
+      fireEvent.change(nameField(), { target: { value: "docs" } });
+      fireEvent.click(screen.getByRole("button", { name: /use suggested/i }));
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", {
+        name: "docs",
+        emoji: suggestProjectEmoji("docs"),
+      });
+    });
   });
 
   describe("name", () => {
@@ -145,7 +202,9 @@ describe("ProjectIdentityEditor", () => {
       render(<ProjectIdentityEditor project={makeProject()} />);
 
       fireEvent.change(nameField(), { target: { value: "Abandoned" } });
-      fireEvent.keyDown(nameField(), { key: "Escape" });
+      // Radix dismisses on Escape by default, which would run the close-commit
+      // before any revert; the cancel path must take the close over itself.
+      expect(pressEscape()).toBe(true);
 
       expect(updateProjectMock).not.toHaveBeenCalled();
       expect(nameField().value).toBe("my-api");
@@ -159,6 +218,17 @@ describe("ProjectIdentityEditor", () => {
 
       // A stale draft must never be committable against a different project.
       expect(nameField().value).toBe("other");
+    });
+
+    it("does not write an untouched draft over a rename from elsewhere", () => {
+      const { rerender } = render(<ProjectIdentityEditor project={makeProject({ name: "A" })} />);
+      // Same project id, renamed in another window while this sat open and
+      // untouched. Closing must not resurrect the old name.
+      rerender(<ProjectIdentityEditor project={makeProject({ name: "B" })} />);
+
+      fireEvent.click(screen.getByText("pick-unicorn"));
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", { emoji: "🦄" });
     });
   });
 });

--- a/src/components/Worktree/WorktreeCard/CommitAuthorAvatar.tsx
+++ b/src/components/Worktree/WorktreeCard/CommitAuthorAvatar.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { CAT_COLOR_CLASSES } from "@/config/categoryColors";
 import { AGENT_REGISTRY, type AgentIconProps } from "@/config/agents";
 import { getGravatarUrl, isBotAuthor } from "@/utils/gravatar";
+import { djb2 } from "@shared/utils/hash";
 
 export interface CommitAuthor {
   name: string;
@@ -47,14 +48,6 @@ export function resolveCommitAgentIcon(author: CommitAuthor): ComponentType<Agen
 /** Square for AI agents and bots, circle for humans. */
 export function commitAvatarIsSquare(author: CommitAuthor): boolean {
   return resolveCommitAgentIcon(author) != null || isBotAuthor(author.name);
-}
-
-function djb2(input: string): number {
-  let hash = 5381;
-  for (let i = 0; i < input.length; i++) {
-    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
-  }
-  return hash;
 }
 
 function initialsOf(name: string): string {

--- a/src/store/__tests__/projectStore.addProject.test.ts
+++ b/src/store/__tests__/projectStore.addProject.test.ts
@@ -73,6 +73,10 @@ vi.mock("../slices", () => ({
 
 const { useProjectStore } = await import("../projectStore");
 
+// Exact store signature, so the mock needs no cast (which would trip the
+// no-unsafe-type-assertion ratchet).
+type AddProjectByPath = ReturnType<typeof useProjectStore.getState>["addProjectByPath"];
+
 // Capture original action references once — earlier tests replace them via
 // setState() which is a merge, so functions leak across tests without this.
 const originalAddProjectByPath = useProjectStore.getState().addProjectByPath;
@@ -179,11 +183,11 @@ describe("projectStore addProject", () => {
   });
 
   it("retries adding the project after successful initialization", async () => {
-    const addProjectByPathMock = vi.fn().mockResolvedValue(undefined);
+    const addProjectByPathMock = vi.fn<AddProjectByPath>().mockResolvedValue(undefined);
     useProjectStore.setState({
       gitInitDialogOpen: true,
       gitInitDirectoryPath: "/tmp/repo",
-      addProjectByPath: addProjectByPathMock as (path: string) => Promise<void>,
+      addProjectByPath: addProjectByPathMock,
     });
 
     await useProjectStore.getState().handleGitInitSuccess();
@@ -194,11 +198,11 @@ describe("projectStore addProject", () => {
   });
 
   it("passes the identity supplied at git-init completion through to the add", async () => {
-    const addProjectByPathMock = vi.fn().mockResolvedValue(undefined);
+    const addProjectByPathMock = vi.fn<AddProjectByPath>().mockResolvedValue(undefined);
     useProjectStore.setState({
       gitInitDialogOpen: true,
       gitInitDirectoryPath: "/tmp/repo",
-      addProjectByPath: addProjectByPathMock as (path: string) => Promise<void>,
+      addProjectByPath: addProjectByPathMock,
     });
 
     await useProjectStore.getState().handleGitInitSuccess({ name: "Edited", emoji: "🚀" });
@@ -209,12 +213,12 @@ describe("projectStore addProject", () => {
   });
 
   it("falls back to the identity carried in from the create-project dialog", async () => {
-    const addProjectByPathMock = vi.fn().mockResolvedValue(undefined);
+    const addProjectByPathMock = vi.fn<AddProjectByPath>().mockResolvedValue(undefined);
     useProjectStore.setState({
       gitInitDialogOpen: true,
       gitInitDirectoryPath: "/tmp/repo",
       gitInitIdentity: { name: "Carried", emoji: "📦" },
-      addProjectByPath: addProjectByPathMock as (path: string) => Promise<void>,
+      addProjectByPath: addProjectByPathMock,
     });
 
     await useProjectStore.getState().handleGitInitSuccess();

--- a/src/store/__tests__/projectStore.addProject.test.ts
+++ b/src/store/__tests__/projectStore.addProject.test.ts
@@ -9,6 +9,7 @@ const projectClientMock = {
   update: vi.fn().mockResolvedValue(undefined),
   switch: vi.fn().mockResolvedValue(null),
   openDialog: vi.fn(),
+  createFolder: vi.fn(),
   onSwitch: vi.fn(() => () => {}),
   onWorktreeLoadStatus: vi.fn(() => () => {}),
   getSettings: vi.fn(),
@@ -87,9 +88,45 @@ describe("projectStore addProject", () => {
       error: null,
       gitInitDialogOpen: false,
       gitInitDirectoryPath: null,
+      gitInitIdentity: null,
       addProjectByPath: originalAddProjectByPath,
       addProject: originalAddProject,
     });
+  });
+
+  it("carries the create-flow identity into the git-init dialog it always chains through", async () => {
+    projectClientMock.createFolder.mockResolvedValueOnce("/tmp/new-folder");
+    projectClientMock.add.mockRejectedValueOnce(new Error("Not a git repository: /tmp/new-folder"));
+
+    await useProjectStore.getState().createProjectFolder("/tmp", "new-folder", "🚀");
+
+    expect(useProjectStore.getState().gitInitDialogOpen).toBe(true);
+    expect(useProjectStore.getState().gitInitIdentity).toEqual({
+      name: "new-folder",
+      emoji: "🚀",
+    });
+  });
+
+  it("forwards the clone dialog's identity to the add call", async () => {
+    projectClientMock.add.mockResolvedValueOnce({ id: "p1", path: "/tmp/cloned" });
+
+    await useProjectStore
+      .getState()
+      .handleCloneSuccess("/tmp/cloned", { name: "cloned", emoji: "📦" });
+
+    expect(projectClientMock.add).toHaveBeenCalledWith("/tmp/cloned", {
+      name: "cloned",
+      emoji: "📦",
+    });
+  });
+
+  it("adds an existing repo with no identity argument", async () => {
+    projectClientMock.openDialog.mockResolvedValueOnce("/tmp/existing-repo");
+    projectClientMock.add.mockResolvedValueOnce({ id: "p2", path: "/tmp/existing-repo" });
+
+    await useProjectStore.getState().addProject();
+
+    expect(projectClientMock.add).toHaveBeenCalledWith("/tmp/existing-repo", undefined);
   });
 
   it("opens the guided git init dialog when add fails for non-git directories", async () => {
@@ -151,9 +188,56 @@ describe("projectStore addProject", () => {
 
     await useProjectStore.getState().handleGitInitSuccess();
 
-    expect(addProjectByPathMock).toHaveBeenCalledWith("/tmp/repo");
+    expect(addProjectByPathMock).toHaveBeenCalledWith("/tmp/repo", { identity: undefined });
     expect(useProjectStore.getState().gitInitDialogOpen).toBe(false);
     expect(useProjectStore.getState().gitInitDirectoryPath).toBeNull();
+  });
+
+  it("passes the identity supplied at git-init completion through to the add", async () => {
+    const addProjectByPathMock = vi.fn().mockResolvedValue(undefined);
+    useProjectStore.setState({
+      gitInitDialogOpen: true,
+      gitInitDirectoryPath: "/tmp/repo",
+      addProjectByPath: addProjectByPathMock as (path: string) => Promise<void>,
+    });
+
+    await useProjectStore.getState().handleGitInitSuccess({ name: "Edited", emoji: "🚀" });
+
+    expect(addProjectByPathMock).toHaveBeenCalledWith("/tmp/repo", {
+      identity: { name: "Edited", emoji: "🚀" },
+    });
+  });
+
+  it("falls back to the identity carried in from the create-project dialog", async () => {
+    const addProjectByPathMock = vi.fn().mockResolvedValue(undefined);
+    useProjectStore.setState({
+      gitInitDialogOpen: true,
+      gitInitDirectoryPath: "/tmp/repo",
+      gitInitIdentity: { name: "Carried", emoji: "📦" },
+      addProjectByPath: addProjectByPathMock as (path: string) => Promise<void>,
+    });
+
+    await useProjectStore.getState().handleGitInitSuccess();
+
+    expect(addProjectByPathMock).toHaveBeenCalledWith("/tmp/repo", {
+      identity: { name: "Carried", emoji: "📦" },
+    });
+  });
+
+  it("clears the carried identity together with the path on close", () => {
+    useProjectStore.getState().openGitInitDialog("/tmp/repo", { name: "N", emoji: "🚀" });
+    expect(useProjectStore.getState().gitInitIdentity).toEqual({ name: "N", emoji: "🚀" });
+
+    useProjectStore.getState().closeGitInitDialog();
+
+    expect(useProjectStore.getState().gitInitDirectoryPath).toBeNull();
+    expect(useProjectStore.getState().gitInitIdentity).toBeNull();
+  });
+
+  it("opens git-init with no identity when the folder was merely opened", () => {
+    useProjectStore.getState().openGitInitDialog("/tmp/plain-folder");
+
+    expect(useProjectStore.getState().gitInitIdentity).toBeNull();
   });
 
   describe("dubious ownership handling", () => {
@@ -219,7 +303,7 @@ describe("projectStore addProject", () => {
 
       expect(markSafeDirectoryMock).toHaveBeenCalledWith("/tmp/dubious-repo");
       expect(projectClientMock.add).toHaveBeenCalledTimes(2);
-      expect(projectClientMock.add).toHaveBeenLastCalledWith("/tmp/dubious-repo");
+      expect(projectClientMock.add).toHaveBeenLastCalledWith("/tmp/dubious-repo", undefined);
     });
 
     it("secondary action dispatches the errors.openLogs action", async () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -1,6 +1,6 @@
 import { create, type StateCreator } from "zustand";
 import { persist, subscribeWithSelector } from "zustand/middleware";
-import type { Project, ProjectCloseResult } from "@shared/types";
+import type { Project, ProjectCloseResult, ProjectCreationIdentity } from "@shared/types";
 import { projectClient } from "@/clients";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
@@ -159,6 +159,13 @@ interface ProjectState {
   worktreeLoadError: string | null;
   gitInitDialogOpen: boolean;
   gitInitDirectoryPath: string | null;
+  /**
+   * Identity carried in from the create-project dialog so the git-init step it
+   * always chains into prefills instead of asking a second time. Null when
+   * git-init was reached directly by opening a non-repo folder — that case
+   * derives its own suggestion. Cleared with the path, in the same set().
+   */
+  gitInitIdentity: ProjectCreationIdentity | null;
   createFolderDialogOpen: boolean;
   cloneRepoDialogOpen: boolean;
 
@@ -167,9 +174,9 @@ interface ProjectState {
   addProject: () => Promise<void>;
   addProjectByPath: (
     path: string,
-    options?: { skipDubiousOwnershipRetry?: boolean }
+    options?: { skipDubiousOwnershipRetry?: boolean; identity?: ProjectCreationIdentity }
   ) => Promise<void>;
-  createProjectFolder: (parentPath: string, folderName: string) => Promise<void>;
+  createProjectFolder: (parentPath: string, folderName: string, emoji?: string) => Promise<void>;
   switchProject: (
     projectId: string,
     options?: { focusIntent?: "focus-next-waiting" }
@@ -188,14 +195,14 @@ interface ProjectState {
   reopenProject: (projectId: string) => Promise<void>;
   checkMissingProjects: () => Promise<void>;
   locateProject: (projectId: string) => Promise<void>;
-  openGitInitDialog: (directoryPath: string) => void;
+  openGitInitDialog: (directoryPath: string, identity?: ProjectCreationIdentity) => void;
   closeGitInitDialog: () => void;
-  handleGitInitSuccess: () => Promise<void>;
+  handleGitInitSuccess: (identity?: ProjectCreationIdentity) => Promise<void>;
   openCreateFolderDialog: () => void;
   closeCreateFolderDialog: () => void;
   openCloneRepoDialog: () => void;
   closeCloneRepoDialog: () => void;
-  handleCloneSuccess: (clonedPath: string) => Promise<void>;
+  handleCloneSuccess: (clonedPath: string, identity?: ProjectCreationIdentity) => Promise<void>;
 }
 
 /**
@@ -423,6 +430,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   isBootstrapped: false,
   gitInitDialogOpen: false,
   gitInitDirectoryPath: null,
+  gitInitIdentity: null,
   createFolderDialogOpen: false,
   cloneRepoDialogOpen: false,
   error: null,
@@ -438,7 +446,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         return;
       }
 
-      const newProject = await projectClient.add(resolvedPath);
+      const newProject = await projectClient.add(resolvedPath, options?.identity);
 
       await get().loadProjects();
       await get().switchProject(newProject.id);
@@ -463,7 +471,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
           resolvedPath || path.trim() || errorMessage.match(/Not a git repository: (.+)/)?.[1];
         if (gitInitPath && isAbsolutePath(gitInitPath)) {
           set({ isLoading: false });
-          get().openGitInitDialog(gitInitPath);
+          get().openGitInitDialog(gitInitPath, options?.identity);
           return;
         }
       }
@@ -505,6 +513,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                   // error toast instead of showing the same CTA indefinitely.
                   await get().addProjectByPath(targetPath, {
                     skipDubiousOwnershipRetry: true,
+                    identity: options?.identity,
                   });
                 },
               },
@@ -540,7 +549,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
             label: "Try again",
             variant: "primary",
             onClick: () => {
-              void get().addProjectByPath(retryPath);
+              void get().addProjectByPath(retryPath, { identity: options?.identity });
             },
           },
         ],
@@ -964,19 +973,26 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     }
   },
 
-  openGitInitDialog: (directoryPath: string) => {
-    set({ gitInitDialogOpen: true, gitInitDirectoryPath: directoryPath });
+  openGitInitDialog: (directoryPath: string, identity?: ProjectCreationIdentity) => {
+    set({
+      gitInitDialogOpen: true,
+      gitInitDirectoryPath: directoryPath,
+      gitInitIdentity: identity ?? null,
+    });
   },
 
   closeGitInitDialog: () => {
-    set({ gitInitDialogOpen: false, gitInitDirectoryPath: null });
+    set({ gitInitDialogOpen: false, gitInitDirectoryPath: null, gitInitIdentity: null });
   },
 
-  handleGitInitSuccess: async () => {
+  handleGitInitSuccess: async (identity) => {
+    // Snapshot before closing — closeGitInitDialog() clears path and identity
+    // together, so anything read afterwards is already null.
     const directoryPath = get().gitInitDirectoryPath;
+    const carried = identity ?? get().gitInitIdentity ?? undefined;
     get().closeGitInitDialog();
     if (directoryPath) {
-      await get().addProjectByPath(directoryPath);
+      await get().addProjectByPath(directoryPath, { identity: carried });
     }
   },
 
@@ -988,9 +1004,14 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     set({ createFolderDialogOpen: false });
   },
 
-  createProjectFolder: async (parentPath, folderName) => {
+  createProjectFolder: async (parentPath, folderName, emoji) => {
     const newFolderPath = await projectClient.createFolder(parentPath, folderName);
-    await get().addProjectByPath(newFolderPath);
+    // A brand-new folder is never a repo, so this always lands in the
+    // NOT_A_GIT_REPO branch below and re-emerges in the git-init dialog — the
+    // identity rides along so that dialog prefills instead of re-asking.
+    await get().addProjectByPath(newFolderPath, {
+      identity: emoji ? { name: folderName, emoji } : undefined,
+    });
   },
 
   openCloneRepoDialog: () => {
@@ -1001,9 +1022,9 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     set({ cloneRepoDialogOpen: false });
   },
 
-  handleCloneSuccess: async (clonedPath: string) => {
+  handleCloneSuccess: async (clonedPath: string, identity?: ProjectCreationIdentity) => {
     get().closeCloneRepoDialog();
-    await get().addProjectByPath(clonedPath);
+    await get().addProjectByPath(clonedPath, { identity });
   },
 });
 


### PR DESCRIPTION
## Summary

- Projects have never had a name or emoji at creation, every one starts as 🌲 with a name derived from the folder basename, and the only way to fix that is a buried Project Settings tab. This adds identity inline wherever a dialog already exists, and gives the project switcher's pill a one-click editor for everything that predates the change.
- `CreateProjectFolderDialog` and `CloneRepoDialog` both get an inline emoji picker next to the folder name field. `GitInitDialog` gets a compact emoji + name row (it's the only setup moment for the open-a-non-git-folder flow), and gets retitled from "Initialize Git Repository" to "Set up project" to match. The toolbar's project pill emoji is now a one-click identity editor: name and the full emoji picker in a single popover.
- Opening an existing repo is unchanged: no new dialog, no stored emoji, 🌲 still means unset. The suggested emoji is offered as a one-click row in the toolbar editor instead, so old projects get the same affordance without any new prompt.

Resolves #11404

## Changes

- New `shared/utils/projectEmoji.ts` suggests an emoji from the folder/repo name: a 28-entry keyword map, falling back to a deterministic djb2 hash pick over a curated set of 16 emoji that deliberately excludes 🌲 (it's the existing "unset" default, not a real suggestion). `djb2` itself was pulled out to `shared/utils/hash.ts` so it's shared with `CommitAuthorAvatar` instead of duplicated.
- Persistence extends the existing `project:add` IPC call with an optional identity argument, applied only when a brand new database row is created. An already-registered path, a path that moved, a lost insert race, and an existing in-repo `.daintree/project.json` all keep whatever identity they already have, so re-adding a folder can never rename it. Went with this single-call approach over create-then-update because `addProjectByPath` already broadcasts `PROJECT_UPDATED`, so a two-step version would fire two broadcasts with two different identities.
- No new action ID, no new IPC channel.
- Escape in the toolbar editor is handled via `onEscapeKeyDown` rather than an input keydown handler, because the underlying Radix popover dismisses off a document-level capture listener. An input-level handler would fire after the edit already committed, saving the exact edit it was trying to cancel.
- The toolbar trigger button is a sibling of the project pill, not nested inside it (see #6928 on nested interactive elements), and carries `data-toolbar-item` so it joins the existing roving-tabindex domain.
- Identity is threaded through the create-folder → git-init dialog chain and latched atomically with the path in `App.tsx`, in the same vein as the race conditions fixed in #10253 and #9917.

## Testing

3837 tests across 172 files pass locally, typecheck is clean, and the lint ratchet improved from 1105 to 1102. New coverage: `shared/utils/__tests__/projectEmoji.test.ts`, `CreateProjectFolderDialog.test.tsx`, `ProjectIdentityEditor.test.tsx`, plus new cases in `ProjectStore.identity.test.ts` (identity precedence, ancestor-repo guard, symlink/trailing-separator paths), `GitInitDialog.test.tsx`, `CloneRepoDialog.test.tsx`, and `projectStore.addProject.test.ts`.

No end-to-end spec was added for the toolbar identity editor. Overlay geometry and real Radix popover nesting still run under unit mocks rather than end to end, worth a follow-up e2e case.
